### PR TITLE
fix: drop bad hub image override

### DIFF
--- a/k8s/apps/folly/argo/applications.yaml
+++ b/k8s/apps/folly/argo/applications.yaml
@@ -12,8 +12,6 @@ spec:
     path: apps/hub/k8s
     kustomize:
       namespace: hub
-      images:
-        - ghcr.io/jonpulsifer/does-not-exist=ghcr.io/jonpulsifer/hub:latest
   destination:
     server: https://kubernetes.default.svc
     namespace: hub


### PR DESCRIPTION
## Summary
Remove the incorrect ArgoCD kustomize image override for the hub app so the repo kustomization controls the image mapping.

## Changes
- Delete the ghcr.io/jonpulsifer/does-not-exist image override from the hub Application

## Test Plan
- [ ] Flux sync applies the updated Application and ArgoCD uses the kustomize images override from apps/hub/k8s

Signed-off-by: rowbutt <rowbutt@users.noreply.github.com>