### PR TITLE
fix: harden cloudflared and ddns pods

### DIFF
--- a/k8s/clusters/folly/networking/cloudflare/cloudflared.yaml
+++ b/k8s/clusters/folly/networking/cloudflare/cloudflared.yaml
@@ -18,6 +18,10 @@ spec:
         app.kubernetes.io/name: cloudflared
         app.kubernetes.io/part-of: cloudflared
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: cloudflared
         image: cloudflare/cloudflared:2026.2.0
@@ -38,12 +42,23 @@ spec:
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
+        securityContext:
+          runAsUser: 65532
+          runAsGroup: 65532
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         volumeMounts:
           - name: tunnel-token
             mountPath: /etc/cloudflared/token
             subPath: token
             readOnly: true
+          - name: tmp
+            mountPath: /tmp
       volumes:
       - name: tunnel-token
         secret:
           secretName: cloudflared
+      - name: tmp
+        emptyDir: {}

--- a/k8s/clusters/folly/networking/cloudflare/ddns.yaml
+++ b/k8s/clusters/folly/networking/cloudflare/ddns.yaml
@@ -15,6 +15,10 @@ spec:
       ttlSecondsAfterFinished: 300
       template:
         spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           restartPolicy: Never
           containers:
             - name: ddns
@@ -25,11 +29,20 @@ spec:
               command:
                 - "/bin/bash"
                 - "/app/ddns.sh"
+              securityContext:
+                runAsUser: 65532
+                runAsGroup: 65532
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               volumeMounts:
                 - name: ddns
                   mountPath: /app/ddns.sh
                   subPath: ddns.sh
                   readOnly: true
+                - name: tmp
+                  mountPath: /tmp
           volumes:
             - name: ddns
               projected:
@@ -40,3 +53,5 @@ spec:
                       items:
                         - key: ddns.sh
                           path: ddns.sh
+            - name: tmp
+              emptyDir: {}

--- a/k8s/clusters/offsite/networking/cloudflare/cloudflared.yaml
+++ b/k8s/clusters/offsite/networking/cloudflare/cloudflared.yaml
@@ -18,6 +18,10 @@ spec:
         app.kubernetes.io/name: cloudflared
         app.kubernetes.io/part-of: cloudflared
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: cloudflared
         image: cloudflare/cloudflared:2026.2.0
@@ -38,12 +42,23 @@ spec:
           failureThreshold: 1
           initialDelaySeconds: 10
           periodSeconds: 10
+        securityContext:
+          runAsUser: 65532
+          runAsGroup: 65532
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         volumeMounts:
           - name: tunnel-token
             mountPath: /etc/cloudflared/token
             subPath: token
             readOnly: true
+          - name: tmp
+            mountPath: /tmp
       volumes:
       - name: tunnel-token
         secret:
           secretName: cloudflared
+      - name: tmp
+        emptyDir: {}

--- a/k8s/clusters/offsite/networking/cloudflare/ddns.yaml
+++ b/k8s/clusters/offsite/networking/cloudflare/ddns.yaml
@@ -15,6 +15,10 @@ spec:
       ttlSecondsAfterFinished: 300
       template:
         spec:
+          securityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           restartPolicy: Never
           containers:
             - name: ddns
@@ -25,11 +29,20 @@ spec:
               command:
                 - "/bin/bash"
                 - "/app/ddns.sh"
+              securityContext:
+                runAsUser: 65532
+                runAsGroup: 65532
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               volumeMounts:
                 - name: ddns
                   mountPath: /app/ddns.sh
                   subPath: ddns.sh
                   readOnly: true
+                - name: tmp
+                  mountPath: /tmp
           volumes:
             - name: ddns
               projected:
@@ -40,3 +53,5 @@ spec:
                       items:
                         - key: ddns.sh
                           path: ddns.sh
+            - name: tmp
+              emptyDir: {}


### PR DESCRIPTION
## Summary\n- add pod/container securityContext defaults for cloudflared and ddns\n- set readOnlyRootFilesystem, drop caps, disable privilege escalation\n- add /tmp emptyDir for read-only rootfs\n\n## Testing\n- not run (manifest-only change)