### PR TITLE
feat(k8s): add agent-sandbox to folly and offsite clusters

### DIFF
--- a/k8s/clusters/folly/flux-system/sandbox.yaml
+++ b/k8s/clusters/folly/flux-system/sandbox.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sandbox
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./k8s/clusters/folly/sandbox
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  dependsOn:
+    - name: config

--- a/k8s/clusters/folly/sandbox/agent-sandbox.yaml
+++ b/k8s/clusters/folly/sandbox/agent-sandbox.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agent-sandbox-crds
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./k8s/crds
+  prune: false
+  sourceRef:
+    kind: GitRepository
+    name: agent-sandbox
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agent-sandbox-controller
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./k8s
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: agent-sandbox
+  dependsOn:
+    - name: agent-sandbox-crds
+  patches:
+    - target:
+        kind: Deployment
+        name: agent-sandbox-controller
+      patch: |
+        - op: replace
+          path: /spec/template/spec/containers/0/image
+          value: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.2.1
+        - op: add
+          path: /spec/template/spec/containers/0/args/-
+          value: "--extensions"

--- a/k8s/clusters/folly/sandbox/kustomization.yaml
+++ b/k8s/clusters/folly/sandbox/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - agent-sandbox.yaml

--- a/k8s/clusters/folly/sources/git/agent-sandbox.yaml
+++ b/k8s/clusters/folly/sources/git/agent-sandbox.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: agent-sandbox
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://github.com/kubernetes-sigs/agent-sandbox
+  ref:
+    tag: v0.2.1
+  ignore: |
+    # exclude all
+    /*
+    # include CRDs
+    !/k8s/crds/
+    # include controller manifests (excluding extensions.controller.yaml to avoid duplicate Deployment)
+    !/k8s/controller.yaml
+    !/k8s/rbac.generated.yaml
+    !/k8s/extensions-rbac.generated.yaml
+    !/k8s/extensions.yaml

--- a/k8s/clusters/folly/sources/git/kustomization.yaml
+++ b/k8s/clusters/folly/sources/git/kustomization.yaml
@@ -2,6 +2,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - agent-sandbox.yaml
   # - assemblyline.yaml
   - gateway-api.yaml
   - local-path-provisioner.yaml

--- a/k8s/clusters/offsite/flux/sandbox.yaml
+++ b/k8s/clusters/offsite/flux/sandbox.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sandbox
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./k8s/clusters/folly/sandbox
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  dependsOn:
+    - name: config


### PR DESCRIPTION
## Summary
Deploy [kubernetes-sigs/agent-sandbox](https://github.com/kubernetes-sigs/agent-sandbox) v0.2.1 to both the folly and offsite clusters for managing isolated, stateful workloads (AI agent runtimes, dev environments, etc.).

## Changes
- Add `agent-sandbox` GitRepository source syncing from upstream with selective ignore filter (CRDs + controller manifests only, excluding `extensions.controller.yaml` to avoid duplicate Deployment)
- Create `sandbox/` category in folly with FluxCD Kustomizations:
  - `agent-sandbox-crds` — syncs 4 CRDs from `./k8s/crds` with `prune: false`
  - `agent-sandbox-controller` — syncs controller from `./k8s` with patches to replace `ko://` placeholder image and add `--extensions` flag
- Add top-level FluxCD Kustomization for both clusters (offsite shares folly's sandbox directory, like sources and storage)
- gVisor/runsc runtime already wired up on all k8s nodes via `nix/services/k8s/gvisor.nix` — no NixOS changes needed

## Test Plan
- [x] Verify FluxCD reconciles the new `sandbox` kustomization: `flux get kustomizations -A | grep sandbox`
- [x] Confirm CRDs are installed: `kubectl get crd sandboxes.agents.x-k8s.io`
- [x] Confirm controller is running: `kubectl get pods -n agent-sandbox-system`
- [ ] Create a test Sandbox CR to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)