### PR TITLE
ci: limit nix workflow triggers

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -1,6 +1,13 @@
 name: nix
 on:
   push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/nix-ci.yaml
+      - flake.lock
+      - "**/*.nix"
+  pull_request:
     paths:
       - .github/workflows/nix-ci.yaml
       - flake.lock


### PR DESCRIPTION
- Run nix CI on pull_request paths (nix/flake/workflow files)\n- Run nix CI on pushes to main only, with same paths filter\n\nThis avoids running nix on renovate branch rebases that don't touch nix files.