### PR TITLE
Add agents sandbox templates and routes

### DIFF
--- a/k8s/clusters/folly/networking/gateway-api/cluster-gateway.yaml
+++ b/k8s/clusters/folly/networking/gateway-api/cluster-gateway.yaml
@@ -12,5 +12,7 @@ spec:
       protocol: HTTP
       port: 80
       allowedRoutes:
+        namespaces:
+          from: All
         kinds:
           - kind: HTTPRoute

--- a/k8s/clusters/folly/sandbox/agents-sandbox-claims.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-claims.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: openclaw
+  namespace: agents-sandbox
+spec:
+  sandboxTemplateRef:
+    name: openclaw
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxClaim
+metadata:
+  name: ai-agents
+  namespace: agents-sandbox
+spec:
+  sandboxTemplateRef:
+    name: ai-agents

--- a/k8s/clusters/folly/sandbox/agents-sandbox-namespace.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: agents-sandbox
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/k8s/clusters/folly/sandbox/agents-sandbox-routes.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-routes.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openclaw
+  namespace: agents-sandbox
+spec:
+  selector:
+    app: openclaw
+  ports:
+    - name: ui
+      protocol: TCP
+      port: 18789
+      targetPort: 18789
+    - name: gateway
+      protocol: TCP
+      port: 18790
+      targetPort: 18790
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: openclaw-ui
+  namespace: agents-sandbox
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: default
+  hostnames:
+    - "openclaw.${SECRET_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: openclaw
+          port: 18789
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: openclaw-gateway
+  namespace: agents-sandbox
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: default
+  hostnames:
+    - "openclaw-gateway.${SECRET_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: openclaw
+          port: 18790
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ai-agents
+  namespace: agents-sandbox
+spec:
+  selector:
+    app: ai-agents
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: ai-agents
+  namespace: agents-sandbox
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: default
+  hostnames:
+    - "ai-agents.${SECRET_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: ai-agents
+          port: 8080

--- a/k8s/clusters/folly/sandbox/agents-sandbox-templates.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-templates.yaml
@@ -1,0 +1,122 @@
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: openclaw
+  namespace: agents-sandbox
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        app: openclaw
+        sandbox: openclaw
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 1337
+        runAsGroup: 1337
+        fsGroup: 1337
+        runAsNonRoot: true
+      containers:
+        - name: openclaw
+          image: docker.io/jonpulsifer/ai-agents:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: OPENCLAW_GATEWAY_TOKEN
+              value: "changeme"
+          command:
+            - openclaw
+            - gateway
+            - --bind=lan
+            - --port
+            - "18789"
+            - --allow-unconfigured
+            - --verbose
+          ports:
+            - containerPort: 18789
+            - containerPort: 18790
+          volumeMounts:
+            - mountPath: /home/agent/.openclaw
+              name: openclaw-config
+            - mountPath: /home/agent/.openclaw/workspace
+              name: openclaw-workspace
+      volumes:
+        - name: openclaw-config
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi
+        - name: openclaw-workspace
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi
+---
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxTemplate
+metadata:
+  name: ai-agents
+  namespace: agents-sandbox
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        app: ai-agents
+        sandbox: ai-agents
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 1337
+        runAsGroup: 1337
+        fsGroup: 1337
+        runAsNonRoot: true
+      containers:
+        - name: ai-agents
+          image: docker.io/jonpulsifer/ai-agents:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - mountPath: /home/agent/.openclaw
+              name: openclaw-config
+            - mountPath: /home/agent/.openclaw/workspace
+              name: openclaw-workspace
+      volumes:
+        - name: openclaw-config
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi
+        - name: openclaw-workspace
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes:
+                  - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 2Gi

--- a/k8s/clusters/folly/sandbox/kustomization.yaml
+++ b/k8s/clusters/folly/sandbox/kustomization.yaml
@@ -3,3 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - agent-sandbox.yaml
+  - agents-sandbox-namespace.yaml
+  - agents-sandbox-templates.yaml
+  - agents-sandbox-claims.yaml
+  - agents-sandbox-routes.yaml


### PR DESCRIPTION
## Summary
- add agents-sandbox namespace with restricted PSA labels
- add SandboxTemplates for openclaw + ai-agents (ephemeral PVCs)
- add SandboxClaims to deploy both sandboxes
- add Services + HTTPRoutes (openclaw UI + gateway, ai-agents UI)
- allow cluster-gateway routes from all namespaces

## Testing
- not run (manifests only)