### PR TITLE
Add TLS listeners for agents sandbox

### DIFF
--- a/k8s/clusters/folly/networking/gateway-api/cluster-gateway.yaml
+++ b/k8s/clusters/folly/networking/gateway-api/cluster-gateway.yaml
@@ -16,3 +16,42 @@ spec:
           from: All
         kinds:
           - kind: HTTPRoute
+    - name: https-openclaw
+      protocol: HTTPS
+      port: 443
+      hostname: openclaw.lolwtf.ca
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: openclaw.lolwtf.ca
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: HTTPRoute
+    - name: https-openclaw-gateway
+      protocol: HTTPS
+      port: 443
+      hostname: openclaw-gateway.lolwtf.ca
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: openclaw-gateway.lolwtf.ca
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: HTTPRoute
+    - name: https-ai-agents
+      protocol: HTTPS
+      port: 443
+      hostname: ai-agents.lolwtf.ca
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: ai-agents.lolwtf.ca
+      allowedRoutes:
+        namespaces:
+          from: All
+        kinds:
+          - kind: HTTPRoute


### PR DESCRIPTION
## Summary
- add HTTPS listeners on cluster-gateway for openclaw + openclaw-gateway + ai-agents
- use cert-manager cluster issuer with per-hostname Secret refs

## Testing
- not run (manifest change)