### PR TITLE
Allow gateway ingress to agents sandbox

### DIFF
--- a/k8s/clusters/folly/sandbox/agents-sandbox-allow-gateway.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-allow-gateway.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-gateway-ingress
+  namespace: agents-sandbox
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: cilium-envoy

--- a/k8s/clusters/folly/sandbox/kustomization.yaml
+++ b/k8s/clusters/folly/sandbox/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - agents-sandbox-templates.yaml
   - agents-sandbox-claims.yaml
   - agents-sandbox-routes.yaml
+  - agents-sandbox-allow-gateway.yaml


### PR DESCRIPTION
## Summary
- add NetworkPolicy to allow ingress from cilium-envoy (gateway) in kube-system to agents-sandbox pods

## Testing
- not run (manifest change)