### PR TITLE
Allow gateway ingress from node IPs

### DIFF
--- a/k8s/clusters/folly/sandbox/agents-sandbox-allow-gateway.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-allow-gateway.yaml
@@ -16,3 +16,5 @@ spec:
           podSelector:
             matchLabels:
               k8s-app: cilium-envoy
+        - ipBlock:
+            cidr: 10.3.0.0/24


### PR DESCRIPTION
## Summary
- extend agents-sandbox allow-gateway-ingress NetworkPolicy to allow node IPs (cilium-envoy is hostNetwork)

## Testing
- not run (manifest change)