### PR TITLE
TEMP: allow all ingress to agents sandbox

### DIFF
--- a/k8s/clusters/folly/sandbox/agents-sandbox-allow-all-ingress.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-allow-all-ingress.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-all-ingress-temporary
+  namespace: agents-sandbox
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+  ingress:
+    - {}

--- a/k8s/clusters/folly/sandbox/kustomization.yaml
+++ b/k8s/clusters/folly/sandbox/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - agents-sandbox-claims.yaml
   - agents-sandbox-routes.yaml
   - agents-sandbox-allow-gateway.yaml
+  - agents-sandbox-allow-all-ingress.yaml


### PR DESCRIPTION
## Summary
- temporary NetworkPolicy to allow all ingress in agents-sandbox for debugging

## Testing
- not run (debug change)

> NOTE: remove after validation