### PR TITLE
Use trusted-proxy auth for OpenClaw

### DIFF
--- a/k8s/clusters/folly/sandbox/agents-sandbox-routes.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-routes.yaml
@@ -25,7 +25,13 @@ spec:
   hostnames:
     - "openclaw.lolwtf.ca"
   rules:
-    - backendRefs:
+    - filters:
+        - type: RequestHeaderModifier
+          requestHeaderModifier:
+            set:
+              - name: X-Forwarded-User
+                value: jonathan
+      backendRefs:
         - name: openclaw
           port: 18789
 ---

--- a/k8s/clusters/folly/sandbox/agents-sandbox-templates.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-templates.yaml
@@ -29,13 +29,17 @@ spec:
               cat <<'EOF' > /home/agent/.openclaw/config.json5
               {
                 gateway: {
+                  trustedProxies: ["10.3.0.10", "10.3.0.12"],
                   auth: {
-                    mode: "none"
+                    mode: "trusted-proxy",
+                    trustedProxy: {
+                      userHeader: "x-forwarded-user",
+                      allowUsers: ["jonathan"]
+                    }
                   },
                   controlUi: {
                     allowedOrigins: ["https://openclaw.lolwtf.ca", "http://openclaw.lolwtf.ca"],
-                    dangerouslyAllowHostHeaderOriginFallback: true,
-                    dangerouslyDisableDeviceAuth: true
+                    dangerouslyAllowHostHeaderOriginFallback: true
                   }
                 }
               }


### PR DESCRIPTION
## Summary
- switch OpenClaw gateway auth to trusted-proxy
- trust cilium-envoy (node IPs 10.3.0.10/10.3.0.12)
- inject X-Forwarded-User via HTTPRoute for zero-click Control UI

## Testing
- not run (manifest change)