### PR TITLE
Allow internal ingress to agents sandbox

### DIFF
--- a/k8s/clusters/folly/sandbox/agents-sandbox-allow-gateway.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-allow-gateway.yaml
@@ -13,8 +13,9 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: kube-system
-          podSelector:
-            matchLabels:
-              k8s-app: cilium-envoy
         - ipBlock:
-            cidr: 10.3.0.0/24
+            cidr: 10.0.0.0/8
+        - ipBlock:
+            cidr: 172.16.0.0/12
+        - ipBlock:
+            cidr: 192.168.0.0/16


### PR DESCRIPTION
## Summary
- broaden agents-sandbox allow-gateway-ingress to allow internal RFC1918 sources (kube-system + internal networks)

## Testing
- not run (manifest change)