### PR TITLE
Allow remote-node ingress for agents sandbox

### DIFF
--- a/k8s/clusters/folly/sandbox/agents-sandbox-allow-remote-node.yaml
+++ b/k8s/clusters/folly/sandbox/agents-sandbox-allow-remote-node.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: allow-remote-node-ingress
+  namespace: agents-sandbox
+spec:
+  endpointSelector: {}
+  ingress:
+    - fromEntities:
+        - remote-node
+        - host

--- a/k8s/clusters/folly/sandbox/kustomization.yaml
+++ b/k8s/clusters/folly/sandbox/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - agents-sandbox-claims.yaml
   - agents-sandbox-routes.yaml
   - agents-sandbox-allow-gateway.yaml
+  - agents-sandbox-allow-remote-node.yaml


### PR DESCRIPTION
## Summary
- add CiliumNetworkPolicy allowing ingress from remote-node/host to agents-sandbox pods (required for cilium-envoy hostNetwork)

## Testing
- not run (manifest change)