### PR TITLE
feat(k8s): add kro helm release to folly cluster

### DIFF
--- a/k8s/clusters/folly/flux-system/kro.yaml
+++ b/k8s/clusters/folly/flux-system/kro.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kro
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./k8s/clusters/folly/kro
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  dependsOn:
+    - name: config

--- a/k8s/clusters/folly/kro/helm-release.yaml
+++ b/k8s/clusters/folly/kro/helm-release.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kro
+  namespace: kro-system
+spec:
+  interval: 24h
+  chart:
+    spec:
+      chart: kro
+      version: 0.8.5
+      sourceRef:
+        kind: HelmRepository
+        name: kro
+        namespace: flux-system
+      interval: 24h
+  install:
+    createNamespace: true
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  values: {}

--- a/k8s/clusters/folly/kro/kustomization.yaml
+++ b/k8s/clusters/folly/kro/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/k8s/clusters/folly/sources/helm/kro.yaml
+++ b/k8s/clusters/folly/sources/helm/kro.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kro
+  namespace: flux-system
+spec:
+  interval: 24h
+  type: oci
+  url: oci://registry.k8s.io/kro/charts

--- a/k8s/clusters/folly/sources/helm/kustomization.yaml
+++ b/k8s/clusters/folly/sources/helm/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
   - intel.yaml
   - jetstack.yaml
   - jonpulsifer.yaml
+  - kro.yaml
   - longhorn.yaml
   - metrics-server.yaml
   - node-feature-discovery.yaml


### PR DESCRIPTION
## Summary
Add kro v0.8.5 operator to the folly cluster via FluxCD, using the OCI registry at `registry.k8s.io/kro/charts`.

## Changes
- Add OCI HelmRepository source for kro (`sources/helm/kro.yaml`)
- Add HelmRelease for kro v0.8.5 deploying to `kro-system` namespace (`kro/helm-release.yaml`)
- Add FluxCD Kustomization for kro (`flux-system/kro.yaml`)
- CRD management enabled on both install and upgrade (`crds: CreateReplace`)

## Test Plan
- [ ] Verify FluxCD reconciles the new HelmRepository source
- [ ] Verify kro deploys to `kro-system` namespace
- [ ] Verify kro CRDs are installed (`kubectl get crds | grep kro`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)