### PR TITLE
feat(nix): add rowbutt ssh user

### DIFF
--- a/k8s/offsite/apps/atlantis/policies/only-me.rego
+++ b/k8s/offsite/apps/atlantis/policies/only-me.rego
@@ -4,6 +4,7 @@ import rego.v1
 
 atlantis_users := {
     "jonpulsifer",
+    "rowbutt",
     "renovate[bot]",
 }
 

--- a/nix/system/user.nix
+++ b/nix/system/user.nix
@@ -27,4 +27,23 @@ in
       gnupg
     ];
   };
+
+  users.users.rowbutt = {
+    uid = 1339;
+    isNormalUser = true;
+    extraGroups = [
+      "wheel"
+      "tty"
+    ]
+    ++ lib.optionals (config.virtualisation.docker.enable) [ "docker" ];
+    openssh.authorizedKeys.keys = [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKhYENJ/NOSUFerGNB5eIxjxeMNhmosbX62hLgZKNbUp"
+    ];
+    shell = pkgs.zsh;
+    packages = with pkgs; [
+      git
+      unzip
+      gnupg
+    ];
+  };
 }


### PR DESCRIPTION
## Summary
- add a declarative rowbutt user to the shared NixOS user module
- authorize Rowbutt's local ed25519 SSH public key for passwordless login
- mirror the existing admin groups/shell/tooling used by the primary user

## Test
- nix fmt nix/system/user.nix
- nix build .#nixosConfigurations.retrofit.config.system.build.toplevel --no-link