### PR TITLE
feat(nix): require initrd emergency password

### DIFF
--- a/nix/services/common.nix
+++ b/nix/services/common.nix
@@ -28,6 +28,8 @@
   i18n.defaultLocale = lib.mkDefault "en_US.UTF-8";
   time.timeZone = lib.mkDefault "Canada/Atlantic";
 
+  boot.initrd.systemd.emergencyAccess = lib.mkDefault "$6$O2c3xQdTDkatgXua$9v3NubfrpZsTK7i5AiufpgB0j4Xt1lv2PTEtpzAb0Vh5sKIeXs9S8cohd2XgTe2NYZNeRxW3Q0xvU9.26Lucp1";
+
   environment.systemPackages = with pkgs; [
     bash
     bash-completion

--- a/nix/system/user.nix
+++ b/nix/system/user.nix
@@ -11,6 +11,8 @@ in
 {
   programs.zsh.enable = true;
   users.mutableUsers = false;
+  users.users.root.hashedPassword = "$6$MyfHzd0UhaiNWR2.$e3CjotacfdkRzNBs/AyIGLkneJCeIZcIVd2zLm5cEoJbSCpKB2ilEAIBtqZQl6xiNgngoFH6dyqyabhwjYVQU/";
+
   users.users.jawn = {
     uid = lib.mkForce 1337;
     isNormalUser = true;


### PR DESCRIPTION
## Summary
- Configure `boot.initrd.systemd.emergencyAccess` with a SHA-512 hashed passphrase by default.
- Set `users.users.root.hashedPassword` with a separate SHA-512 hash of the same passphrase.
- Update the `NixOS initrd emergency root` item in 1Password with the actual passphrase plus concealed hash fields.

## Validation
- `nix fmt -- nix/services/common.nix nix/system/user.nix`
- `nix eval --json .#nixosConfigurations.optiplex.config.boot.initrd.systemd.emergencyAccess`
- `nix eval --json .#nixosConfigurations.optiplex.config.users.users.root.hashedPassword`
