### PR TITLE
fix(nix): configure oldschool offsite network

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,10 +53,12 @@
         optiplex = {
           tags = [ "folly" ];
           module = "k8s-node";
-          modules = [{
-            config.services.k8s.role = "control-plane";
-            config.services.k8s.network = "folly";
-          }];
+          modules = [
+            {
+              config.services.k8s.role = "control-plane";
+              config.services.k8s.network = "folly";
+            }
+          ];
         };
         riptide = {
           tags = [ "folly" ];
@@ -71,14 +73,21 @@
         oldschool = {
           tags = [ "offsite" ];
           module = "k8s-node";
+          modules = [
+            {
+              config.services.k8s.network = "offsite";
+            }
+          ];
         };
         retrofit = {
           tags = [ "offsite" ];
           module = "k8s-node";
-          modules = [{
-            config.services.k8s.role = "control-plane";
-            config.services.k8s.network = "offsite";
-          }];
+          modules = [
+            {
+              config.services.k8s.role = "control-plane";
+              config.services.k8s.network = "offsite";
+            }
+          ];
         };
 
         # raspberry pis


### PR DESCRIPTION
## Summary
- set `oldschool` to use the offsite Kubernetes network in the NixOS flake host spec
- keep `oldschool` on the shared `k8s-node` module, which imports the shared `rowbutt` user
- run `nix fmt` over `flake.nix`

## Validation
- `nix eval .#nixosConfigurations.oldschool.config.users.users.rowbutt.name --raw`
- `nix eval .#nixosConfigurations.oldschool.config.services.k8s.network --raw`
- `nix build .#nixosConfigurations.oldschool.config.system.build.toplevel --no-link`
- `git diff --check`
