### PR TITLE
fix(terraform): include organization root in provider bumps

### DIFF
--- a/gcp/organization/versions.tf
+++ b/gcp/organization/versions.tf
@@ -26,11 +26,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7"
+      version = "~> 7.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7"
+      version = "~> 7.30.0"
     }
   }
   required_version = ">= 1.8.3"


### PR DESCRIPTION
## Summary
- align the `gcp/organization` root Google provider constraints with the local project module
- make Renovate treat the parent Terraform root as part of Google provider bumps so its lockfile gets refreshed

## Root cause
Renovate was updating `gcp/organization/modules/project`, including that module lockfile, but Atlantis plans `gcp/organization` as the root. The parent root used broad `>= 7` constraints, while the local module used `~> 7.30.0`, so the parent lockfile kept the old combined constraints and was left out of provider update PRs.

## Validation
- `nix develop -c terraform fmt gcp/organization/versions.tf`
- `nix develop -c terraform -chdir=gcp/organization init -backend=false`
- `nix develop -c terraform -chdir=gcp/organization validate`