### PR TITLE
fix: harden terraform renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,6 +15,9 @@
   ],
   dependencyDashboardTitle: 'Renovate Dashboard',
   dependencyDashboard: true,
+  lockFileMaintenance: {
+    enabled: true,
+  },
   suppressNotifications: [
     'prEditedNotification',
     'prIgnoreNotification',
@@ -134,14 +137,25 @@
         commitMessageTopic: '{{{groupName}}} group',
       },
     },
-    // Terraform — refresh .terraform.lock.hcl alongside provider bumps so
-    // Atlantis (which runs `terraform init` without -upgrade) doesn't choke.
+    // Terraform Google providers are coupled across root stacks and child modules.
+    // Keep GA and Beta on one branch so Atlantis does not see mixed constraints.
     {
       matchManagers: ['terraform'],
-      groupName: 'terraform {{depName}}',
+      matchDatasources: ['terraform-provider'],
+      matchPackageNames: ['google', 'google-beta'],
+      groupName: 'terraform google providers',
+      rangeStrategy: 'update-lockfile',
       automerge: true,
       automergeType: 'pr',
-      postUpdateOptions: ['terraformLock'],
+    },
+    // Terraform provider bumps are low-risk after validation; lockfiles are
+    // maintained by Renovate's Terraform lock file support, not postUpdateOptions.
+    {
+      matchManagers: ['terraform'],
+      matchDatasources: ['terraform-provider'],
+      rangeStrategy: 'update-lockfile',
+      automerge: true,
+      automergeType: 'pr',
     },
     // Flux helm charts
     {

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Output a JSON string list of unique directories containing changed files matching the patterns
-      directories: ${{ steps.changed-directories.outputs.all_changed_files }} 
+      directories: ${{ steps.expand-directories.outputs.directories }}
       # Output 'true' or 'false' as a string
       any_changed: ${{ steps.changed-directories.outputs.any_changed }}
     steps:
@@ -44,6 +44,29 @@ jobs:
           files: |
             **/*.tf
             **/.terraform.lock.hcl
+      - name: Expand Terraform root directories
+        id: expand-directories
+        if: steps.changed-directories.outputs.any_changed == 'true'
+        env:
+          CHANGED_DIRECTORIES: ${{ steps.changed-directories.outputs.all_changed_files }}
+        run: |
+          set -euo pipefail
+
+          declare -A directories=()
+          while IFS= read -r dir; do
+            while [[ -n "$dir" && "$dir" != "." ]]; do
+              if compgen -G "$dir/*.tf" > /dev/null; then
+                directories["$dir"]=1
+              fi
+              if [[ "$dir" != */* ]]; then
+                break
+              fi
+              dir="${dir%/*}"
+            done
+          done < <(jq -r '.[]' <<< "$CHANGED_DIRECTORIES")
+
+          matrix="$(printf '%s\n' "${!directories[@]}" | sort | jq -R -s -c 'split("\n")[:-1]')"
+          echo "directories=$matrix" >> "$GITHUB_OUTPUT"
 
   validate:
     needs: [changed-directories]


### PR DESCRIPTION
## Summary
- group Terraform Google GA/Beta provider updates into one Renovate branch
- use Terraform `rangeStrategy: update-lockfile` and enable Renovate lock file maintenance
- remove invalid `postUpdateOptions: [terraformLock]`
- expand Terraform CI validation to include ancestor root stacks when nested modules change

## Why
Atlantis can initialize parent stacks that GitHub Actions was not validating. A Renovate update to `gcp/organization/modules/project` can make the parent `gcp/organization` see mixed provider constraints while its root lockfile remains pinned to the old provider version.

## Verification
- `npx --yes --package renovate renovate-config-validator .github/renovate.json5`
- `git diff --check`
- locally tested the workflow directory expansion for `gcp/organization/modules/project`, which returns both `gcp/organization/modules/project` and `gcp/organization`

References:
- Renovate Terraform lock file support: https://docs.renovatebot.com/modules/manager/terraform/#lock-file-maintenance
- Renovate `rangeStrategy: update-lockfile`: https://docs.renovatebot.com/configuration-options/#rangestrategy
