### PR TITLE
fix(ai-agent): repair npm tool init installs

### DIFF
--- a/charts/ai-agent/templates/sandboxtemplate.yaml
+++ b/charts/ai-agent/templates/sandboxtemplate.yaml
@@ -24,7 +24,7 @@ spec:
       {{- if .Values.npmTools }}
       initContainers:
         - name: install-npm-tools
-          image: node:24-alpine
+          image: {{ .Values.npmInstallImage | quote }}
           command:
             - sh
             - -c
@@ -32,6 +32,8 @@ spec:
           env:
             - name: HOME
               value: /tmp
+            - name: NPM_CONFIG_CACHE
+              value: /tmp/.npm
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/charts/ai-agent/values.yaml
+++ b/charts/ai-agent/values.yaml
@@ -19,6 +19,7 @@ ingress:
 
 npmTools: []
 # - "@moonpay/cli"
+npmInstallImage: node:24-bookworm
 
 secrets: []
 # - name: config


### PR DESCRIPTION
## Summary
- move npm cache for ai-agent npm tool init installs to `/tmp/.npm` so non-root pods can write it
- make the npm install image configurable and default it to `node:24-bookworm` so native npm dependencies can build

## Root cause
Dave was stuck before the main agent container started. On `retrofit`, the `dave-ai-agent` pod was repeatedly exiting in `install-npm-tools` with `EACCES` writing `/.npm`. After reproducing locally, `@moonpay/cli` also needs Python/make/g++ for its native `usb` dependency, which `node:24-alpine` does not provide.

## Validation
- inspected offsite node runtime with `crictl` and confirmed `dave-ai-agent` was failing in `install-npm-tools`
- reproduced the non-root npm install locally with `node:24-alpine` and saw the native dependency failure
- reproduced the non-root npm install locally with `node:24-bookworm`, `HOME=/tmp`, `NPM_CONFIG_CACHE=/tmp/.npm`, and a mounted `/home/agent/.local`; install succeeded and created `moonpay`/`mp`
- `helm template dave charts/ai-agent ...` renders the new init image/cache env
- `helm lint charts/ai-agent`