### PR TITLE
grants: allow owner to reach k8s-offsite-lb

### DIFF
--- a/charts/ai-agent/templates/sandboxtemplate.yaml
+++ b/charts/ai-agent/templates/sandboxtemplate.yaml
@@ -64,8 +64,11 @@ spec:
             - -c
             - {{ .Values.command | quote }}
           {{- end }}
-          {{- if or .Values.secrets .Values.npmTools }}
           env:
+            - name: OPENCLAW_STATE_DIR
+              value: /home/agent/config/.openclaw
+            - name: OPENCLAW_NO_RESPAWN
+              value: "1"
             {{- if .Values.npmTools }}
             - name: PATH
               value: /home/agent/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -76,7 +79,6 @@ spec:
               value: {{ .mountPath }}
             {{- end }}
             {{- end }}
-          {{- end }}
           ports:
             - containerPort: {{ .Values.port }}
           resources:

--- a/tailscale/policy.hujson
+++ b/tailscale/policy.hujson
@@ -73,6 +73,11 @@
 		},
 		{
 			"src": ["autogroup:owner"],
+			"dst": ["ipset:k8s-offsite-lb"],
+			"ip":  ["*"],
+		},
+		{
+			"src": ["autogroup:owner"],
 			"dst": ["autogroup:owner"],
 			"ip":  ["*"],
 		},


### PR DESCRIPTION
Allow `autogroup:owner` to talk to `ipset:k8s-offsite-lb` (`10.89.0.64/26`).