### PR TITLE
tailscale: refactor to use device data sources instead of hardcoded IDs

### DIFF
--- a/tailscale/devices.tf
+++ b/tailscale/devices.tf
@@ -1,344 +1,449 @@
-# 800g2 (nNSXa45CNTRL)
-resource "tailscale_device_authorization" "device_800g2" {
-  device_id  = "nNSXa45CNTRL"
+# ---------------------------------------------------------------------------
+# Data sources: look up all devices by hostname to avoid hardcoded IDs
+# ---------------------------------------------------------------------------
+
+data "tailscale_devices" "all" {
+  # No filter — fetches the full device list. Individual lookups below
+  # are preferred for clarity and explicit dependencies.
+}
+
+# Individual device data sources keyed by hostname.
+# These are used to drive authorization, key, and tag resources below.
+# Terraform will only call the Tailscale API for data sources that are
+# actually referenced by a resource, so referencing all of them is safe
+# even if some are not yet in the tailnet.
+
+data "tailscale_device" "800g2" {
+  name = "800g2"
+}
+
+data "tailscale_device" "atomic" {
+  name = "atomic"
+}
+
+data "tailscale_device" "chromebook_a288" {
+  name = "Chromebook_A288"
+}
+
+data "tailscale_device" "cloudpi4" {
+  name = "cloudpi4"
+}
+
+data "tailscale_device" "craftbook_air" {
+  name = "Craftbook Air"
+}
+
+data "tailscale_device" "desktop_g7i75ls" {
+  name = "DESKTOP-G7I75LS"
+}
+
+data "tailscale_device" "folly_k8s_lan_router_0" {
+  name = "folly-k8s-lan-router-0"
+}
+
+data "tailscale_device" "folly_k8s_lan_router_0_npazfyuw" {
+  name = "folly-k8s-lan-router-0" # appears twice in tailnet with different IDs
+}
+
+data "tailscale_device" "homepi4" {
+  name = "homepi4"
+}
+
+data "tailscale_device" "localhost" {
+  name = "localhost"
+}
+
+data "tailscale_device" "nuc" {
+  name = "nuc"
+}
+
+data "tailscale_device" "offsite_k8s_lan_router_0" {
+  name = "offsite-k8s-lan-router-0"
+}
+
+data "tailscale_device" "oldboy" {
+  name = "oldboy"
+}
+
+data "tailscale_device" "oldschool" {
+  name = "oldschool"
+}
+
+data "tailscale_device" "optiplex" {
+  name = "optiplex"
+}
+
+data "tailscale_device" "retrofit" {
+  name = "retrofit"
+}
+
+data "tailscale_device" "riptide" {
+  name = "riptide"
+}
+
+data "tailscale_device" "rosie" {
+  name = "rosie"
+}
+
+data "tailscale_device" "spore" {
+  name = "spore"
+}
+
+data "tailscale_device" "tailscale_operator_1" {
+  name = "tailscale-operator"
+}
+
+data "tailscale_device" "tailscale_operator_2" {
+  name = "tailscale-operator" # appears twice in tailnet with different IDs
+}
+
+data "tailscale_device" "tailscale_operator_3" {
+  name = "tailscale-operator" # appears three times in tailnet with different IDs
+}
+
+data "tailscale_device" "tallboy" {
+  name = "tallboy"
+}
+
+data "tailscale_device" "tinytower" {
+  name = "tinytower"
+}
+
+data "tailscale_device" "weatherpi4" {
+  name = "weatherpi4"
+}
+
+# ---------------------------------------------------------------------------
+# Device authorizations
+# All devices are authorized; chaining from data source ensures we look up
+# by name and never hardcode IDs in resource blocks.
+# ---------------------------------------------------------------------------
+
+resource "tailscale_device_authorization" "800g2" {
+  device_id  = data.tailscale_device.800g2.id
   authorized = true
 }
 
-resource "tailscale_device_key" "device_800g2" {
-  device_id           = "nNSXa45CNTRL"
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "device_800g2" {
-  device_id = "nNSXa45CNTRL"
-  tags      = ["tag:folly"]
-}
-
-# Chromebook_A288 (n32GMNpnsi11CNTRL)
-resource "tailscale_device_authorization" "chromebook_a288" {
-  device_id  = "n32GMNpnsi11CNTRL"
-  authorized = true
-}
-
-resource "tailscale_device_key" "chromebook_a288" {
-  device_id           = "n32GMNpnsi11CNTRL"
-  key_expiry_disabled = false
-}
-
-# Craftbook Air (n7zraF9qUH11CNTRL)
-resource "tailscale_device_authorization" "craftbook_air" {
-  device_id  = "n7zraF9qUH11CNTRL"
-  authorized = true
-}
-
-resource "tailscale_device_key" "craftbook_air" {
-  device_id           = "n7zraF9qUH11CNTRL"
-  key_expiry_disabled = false
-}
-
-# DESKTOP-G7I75LS (ntQTpYoZG311CNTRL)
-resource "tailscale_device_authorization" "desktop_g7i75ls" {
-  device_id  = "ntQTpYoZG311CNTRL"
-  authorized = true
-}
-
-resource "tailscale_device_key" "desktop_g7i75ls" {
-  device_id           = "ntQTpYoZG311CNTRL"
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "desktop_g7i75ls" {
-  device_id = "ntQTpYoZG311CNTRL"
-  tags      = ["tag:offsite"]
-}
-
-# atomic (naXDKP4CNTRL)
 resource "tailscale_device_authorization" "atomic" {
-  device_id  = "naXDKP4CNTRL"
+  device_id  = data.tailscale_device.atomic.id
   authorized = true
+}
+
+resource "tailscale_device_authorization" "chromebook_a288" {
+  device_id  = data.tailscale_device.chromebook_a288.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "cloudpi4" {
+  device_id  = data.tailscale_device.cloudpi4.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "craftbook_air" {
+  device_id  = data.tailscale_device.craftbook_air.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "desktop_g7i75ls" {
+  device_id  = data.tailscale_device.desktop_g7i75ls.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "folly_k8s_lan_router_0" {
+  device_id  = data.tailscale_device.folly_k8s_lan_router_0.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "folly_k8s_lan_router_0_npazfyuw" {
+  device_id  = data.tailscale_device.folly_k8s_lan_router_0_npazfyuw.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "homepi4" {
+  device_id  = data.tailscale_device.homepi4.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "localhost" {
+  device_id  = data.tailscale_device.localhost.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "nuc" {
+  device_id  = data.tailscale_device.nuc.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "offsite_k8s_lan_router_0" {
+  device_id  = data.tailscale_device.offsite_k8s_lan_router_0.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "oldboy" {
+  device_id  = data.tailscale_device.oldboy.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "oldschool" {
+  device_id  = data.tailscale_device.oldschool.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "optiplex" {
+  device_id  = data.tailscale_device.optiplex.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "retrofit" {
+  device_id  = data.tailscale_device.retrofit.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "riptide" {
+  device_id  = data.tailscale_device.riptide.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "rosie" {
+  device_id  = data.tailscale_device.rosie.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "spore" {
+  device_id  = data.tailscale_device.spore.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "tailscale_operator_1" {
+  device_id  = data.tailscale_device.tailscale_operator_1.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "tailscale_operator_2" {
+  device_id  = data.tailscale_device.tailscale_operator_2.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "tailscale_operator_3" {
+  device_id  = data.tailscale_device.tailscale_operator_3.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "tallboy" {
+  device_id  = data.tailscale_device.tallboy.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "tinytower" {
+  device_id  = data.tailscale_device.tinytower.id
+  authorized = true
+}
+
+resource "tailscale_device_authorization" "weatherpi4" {
+  device_id  = data.tailscale_device.weatherpi4.id
+  authorized = true
+}
+
+# ---------------------------------------------------------------------------
+# Device keys: controls key expiry
+# ---------------------------------------------------------------------------
+
+resource "tailscale_device_key" "800g2" {
+  device_id           = data.tailscale_device.800g2.id
+  key_expiry_disabled = true
 }
 
 resource "tailscale_device_key" "atomic" {
-  device_id           = "naXDKP4CNTRL"
+  device_id           = data.tailscale_device.atomic.id
   key_expiry_disabled = true
 }
 
-# cloudpi4 (nKnaKY7CNTRL)
-resource "tailscale_device_authorization" "cloudpi4" {
-  device_id  = "nKnaKY7CNTRL"
-  authorized = true
+resource "tailscale_device_key" "chromebook_a288" {
+  device_id           = data.tailscale_device.chromebook_a288.id
+  key_expiry_disabled = false
 }
 
 resource "tailscale_device_key" "cloudpi4" {
-  device_id           = "nKnaKY7CNTRL"
+  device_id           = data.tailscale_device.cloudpi4.id
   key_expiry_disabled = true
 }
 
-# folly-k8s-lan-router-0 (nT6Ro2Ptvo11CNTRL)
-resource "tailscale_device_authorization" "folly_k8s_lan_router_0" {
-  device_id  = "nT6Ro2Ptvo11CNTRL"
-  authorized = true
+resource "tailscale_device_key" "craftbook_air" {
+  device_id           = data.tailscale_device.craftbook_air.id
+  key_expiry_disabled = false
+}
+
+resource "tailscale_device_key" "desktop_g7i75ls" {
+  device_id           = data.tailscale_device.desktop_g7i75ls.id
+  key_expiry_disabled = true
 }
 
 resource "tailscale_device_key" "folly_k8s_lan_router_0" {
-  device_id           = "nT6Ro2Ptvo11CNTRL"
+  device_id           = data.tailscale_device.folly_k8s_lan_router_0.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "folly_k8s_lan_router_0" {
-  device_id = "nT6Ro2Ptvo11CNTRL"
-  tags      = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
-}
-
-# folly-k8s-lan-router-0 (npaZfYUW8w11CNTRL)
-resource "tailscale_device_authorization" "folly_k8s_lan_router_0_npazfyuw" {
-  device_id  = "npaZfYUW8w11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "folly_k8s_lan_router_0_npazfyuw" {
-  device_id           = "npaZfYUW8w11CNTRL"
+  device_id           = data.tailscale_device.folly_k8s_lan_router_0_npazfyuw.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "folly_k8s_lan_router_0_npazfyuw" {
-  device_id = "npaZfYUW8w11CNTRL"
-  tags      = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
-}
-
-# homepi4 (nnLYWS5CNTRL)
-resource "tailscale_device_authorization" "homepi4" {
-  device_id  = "nnLYWS5CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "homepi4" {
-  device_id           = "nnLYWS5CNTRL"
+  device_id           = data.tailscale_device.homepi4.id
   key_expiry_disabled = true
-}
-
-# localhost (n1gZjU7CNTRL)
-resource "tailscale_device_authorization" "localhost" {
-  device_id  = "n1gZjU7CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "localhost" {
-  device_id           = "n1gZjU7CNTRL"
+  device_id           = data.tailscale_device.localhost.id
   key_expiry_disabled = false
-}
-
-# nuc (n1NJvFqjKN11CNTRL)
-resource "tailscale_device_authorization" "nuc" {
-  device_id  = "n1NJvFqjKN11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "nuc" {
-  device_id           = "n1NJvFqjKN11CNTRL"
+  device_id           = data.tailscale_device.nuc.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "nuc" {
-  device_id = "n1NJvFqjKN11CNTRL"
-  tags      = ["tag:folly"]
-}
-
-# offsite-k8s-lan-router-0 (ntVg4yGs6A11CNTRL)
-resource "tailscale_device_authorization" "offsite_k8s_lan_router_0" {
-  device_id  = "ntVg4yGs6A11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "offsite_k8s_lan_router_0" {
-  device_id           = "ntVg4yGs6A11CNTRL"
+  device_id           = data.tailscale_device.offsite_k8s_lan_router_0.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "offsite_k8s_lan_router_0" {
-  device_id = "ntVg4yGs6A11CNTRL"
-  tags      = ["tag:k8s", "tag:k8s-offsite", "tag:offsite"]
-}
-
-# oldboy (nzbfSZ6ntd11CNTRL)
-resource "tailscale_device_authorization" "oldboy" {
-  device_id  = "nzbfSZ6ntd11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "oldboy" {
-  device_id           = "nzbfSZ6ntd11CNTRL"
+  device_id           = data.tailscale_device.oldboy.id
   key_expiry_disabled = false
-}
-
-# oldschool (nAaXDo3CNTRL)
-resource "tailscale_device_authorization" "oldschool" {
-  device_id  = "nAaXDo3CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "oldschool" {
-  device_id           = "nAaXDo3CNTRL"
+  device_id           = data.tailscale_device.oldschool.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "oldschool" {
-  device_id = "nAaXDo3CNTRL"
-  tags      = ["tag:offsite"]
-}
-
-# optiplex (niJ7g4eXsK11CNTRL)
-resource "tailscale_device_authorization" "optiplex" {
-  device_id  = "niJ7g4eXsK11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "optiplex" {
-  device_id           = "niJ7g4eXsK11CNTRL"
+  device_id           = data.tailscale_device.optiplex.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "optiplex" {
-  device_id = "niJ7g4eXsK11CNTRL"
-  tags      = ["tag:folly"]
-}
-
-# retrofit (nkKizV6CNTRL)
-resource "tailscale_device_authorization" "retrofit" {
-  device_id  = "nkKizV6CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "retrofit" {
-  device_id           = "nkKizV6CNTRL"
+  device_id           = data.tailscale_device.retrofit.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "retrofit" {
-  device_id = "nkKizV6CNTRL"
-  tags      = ["tag:offsite"]
-}
-
-# riptide (n2ZhP2n2VQ11CNTRL)
-resource "tailscale_device_authorization" "riptide" {
-  device_id  = "n2ZhP2n2VQ11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "riptide" {
-  device_id           = "n2ZhP2n2VQ11CNTRL"
+  device_id           = data.tailscale_device.riptide.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "riptide" {
-  device_id = "n2ZhP2n2VQ11CNTRL"
-  tags      = ["tag:folly"]
-}
-
-# rosie (n32cvVbP3m11CNTRL)
-resource "tailscale_device_authorization" "rosie" {
-  device_id  = "n32cvVbP3m11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "rosie" {
-  device_id           = "n32cvVbP3m11CNTRL"
+  device_id           = data.tailscale_device.rosie.id
   key_expiry_disabled = false
-}
-
-# spore (nhbcso96nv11CNTRL)
-resource "tailscale_device_authorization" "spore" {
-  device_id  = "nhbcso96nv11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "spore" {
-  device_id           = "nhbcso96nv11CNTRL"
+  device_id           = data.tailscale_device.spore.id
   key_expiry_disabled = true
 }
 
-resource "tailscale_device_tags" "spore" {
-  device_id = "nhbcso96nv11CNTRL"
-  tags      = ["tag:folly"]
-}
-
-# tailscale-operator (nLfccVGfUU11CNTRL)
-resource "tailscale_device_authorization" "tailscale_operator" {
-  device_id  = "nLfccVGfUU11CNTRL"
-  authorized = true
-}
-
-resource "tailscale_device_key" "tailscale_operator" {
-  device_id           = "nLfccVGfUU11CNTRL"
+resource "tailscale_device_key" "tailscale_operator_1" {
+  device_id           = data.tailscale_device.tailscale_operator_1.id
   key_expiry_disabled = true
 }
 
-resource "tailscale_device_tags" "tailscale_operator" {
-  device_id = "nLfccVGfUU11CNTRL"
-  tags      = ["tag:k8s-operator"]
-}
-
-# tailscale-operator (nTmt4W6mQg11CNTRL)
-resource "tailscale_device_authorization" "tailscale_operator_ntmt4w6m" {
-  device_id  = "nTmt4W6mQg11CNTRL"
-  authorized = true
-}
-
-resource "tailscale_device_key" "tailscale_operator_ntmt4w6m" {
-  device_id           = "nTmt4W6mQg11CNTRL"
+resource "tailscale_device_key" "tailscale_operator_2" {
+  device_id           = data.tailscale_device.tailscale_operator_2.id
   key_expiry_disabled = true
 }
 
-resource "tailscale_device_tags" "tailscale_operator_ntmt4w6m" {
-  device_id = "nTmt4W6mQg11CNTRL"
-  tags      = ["tag:k8s-operator"]
-}
-
-# tailscale-operator (nmzwhS8hqf11CNTRL)
-resource "tailscale_device_authorization" "tailscale_operator_nmzwhs8h" {
-  device_id  = "nmzwhS8hqf11CNTRL"
-  authorized = true
-}
-
-resource "tailscale_device_key" "tailscale_operator_nmzwhs8h" {
-  device_id           = "nmzwhS8hqf11CNTRL"
+resource "tailscale_device_key" "tailscale_operator_3" {
+  device_id           = data.tailscale_device.tailscale_operator_3.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_tags" "tailscale_operator_nmzwhs8h" {
-  device_id = "nmzwhS8hqf11CNTRL"
-  tags      = ["tag:k8s-operator"]
-}
-
-# tallboy (nbMRvNYrak11CNTRL)
-resource "tailscale_device_authorization" "tallboy" {
-  device_id  = "nbMRvNYrak11CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "tallboy" {
-  device_id           = "nbMRvNYrak11CNTRL"
+  device_id           = data.tailscale_device.tallboy.id
   key_expiry_disabled = true
-}
-
-# tinytower (nEMEVRWaMA21CNTRL)
-resource "tailscale_device_authorization" "tinytower" {
-  device_id  = "nEMEVRWaMA21CNTRL"
-  authorized = true
 }
 
 resource "tailscale_device_key" "tinytower" {
-  device_id           = "nEMEVRWaMA21CNTRL"
+  device_id           = data.tailscale_device.tinytower.id
   key_expiry_disabled = false
 }
 
-# weatherpi4 (nhU6FwXLGs11CNTRL)
-resource "tailscale_device_authorization" "weatherpi4" {
-  device_id  = "nhU6FwXLGs11CNTRL"
-  authorized = true
+resource "tailscale_device_key" "weatherpi4" {
+  device_id           = data.tailscale_device.weatherpi4.id
+  key_expiry_disabled = true
 }
 
-resource "tailscale_device_key" "weatherpi4" {
-  device_id           = "nhU6FwXLGs11CNTRL"
-  key_expiry_disabled = true
+# ---------------------------------------------------------------------------
+# Device tags: chain from data source lookups.
+# Only devices that should have tags are included.
+# ---------------------------------------------------------------------------
+
+resource "tailscale_device_tags" "800g2" {
+  device_id = data.tailscale_device.800g2.id
+  tags      = ["tag:folly"]
+}
+
+resource "tailscale_device_tags" "desktop_g7i75ls" {
+  device_id = data.tailscale_device.desktop_g7i75ls.id
+  tags      = ["tag:offsite"]
+}
+
+resource "tailscale_device_tags" "folly_k8s_lan_router_0" {
+  device_id = data.tailscale_device.folly_k8s_lan_router_0.id
+  tags      = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
+}
+
+resource "tailscale_device_tags" "folly_k8s_lan_router_0_npazfyuw" {
+  device_id = data.tailscale_device.folly_k8s_lan_router_0_npazfyuw.id
+  tags      = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
+}
+
+resource "tailscale_device_tags" "nuc" {
+  device_id = data.tailscale_device.nuc.id
+  tags      = ["tag:folly"]
+}
+
+resource "tailscale_device_tags" "offsite_k8s_lan_router_0" {
+  device_id = data.tailscale_device.offsite_k8s_lan_router_0.id
+  tags      = ["tag:k8s", "tag:k8s-offsite", "tag:offsite"]
+}
+
+resource "tailscale_device_tags" "oldschool" {
+  device_id = data.tailscale_device.oldschool.id
+  tags      = ["tag:offsite"]
+}
+
+resource "tailscale_device_tags" "optiplex" {
+  device_id = data.tailscale_device.optiplex.id
+  tags      = ["tag:folly"]
+}
+
+resource "tailscale_device_tags" "retrofit" {
+  device_id = data.tailscale_device.retrofit.id
+  tags      = ["tag:offsite"]
+}
+
+resource "tailscale_device_tags" "riptide" {
+  device_id = data.tailscale_device.riptide.id
+  tags      = ["tag:folly"]
+}
+
+resource "tailscale_device_tags" "spore" {
+  device_id = data.tailscale_device.spore.id
+  tags      = ["tag:folly"]
+}
+
+resource "tailscale_device_tags" "tailscale_operator_1" {
+  device_id = data.tailscale_device.tailscale_operator_1.id
+  tags      = ["tag:k8s-operator"]
+}
+
+resource "tailscale_device_tags" "tailscale_operator_2" {
+  device_id = data.tailscale_device.tailscale_operator_2.id
+  tags      = ["tag:k8s-operator"]
+}
+
+resource "tailscale_device_tags" "tailscale_operator_3" {
+  device_id = data.tailscale_device.tailscale_operator_3.id
+  tags      = ["tag:k8s-operator"]
 }

--- a/tailscale/devices.tf
+++ b/tailscale/devices.tf
@@ -133,7 +133,7 @@ data "tailscale_device" "devices" {
 
 resource "tailscale_device_authorization" "devices" {
   for_each   = local.devices
-  device_id  = data.tailscale_device.devices[each.key].id
+  device_id  = data.tailscale_device.devices[each.key].node_id
   authorized = true
 }
 
@@ -143,7 +143,7 @@ resource "tailscale_device_authorization" "devices" {
 
 resource "tailscale_device_key" "devices" {
   for_each            = local.devices
-  device_id           = data.tailscale_device.devices[each.key].id
+  device_id           = data.tailscale_device.devices[each.key].node_id
   key_expiry_disabled = each.value.key_expiry_disabled
 }
 
@@ -153,6 +153,6 @@ resource "tailscale_device_key" "devices" {
 
 resource "tailscale_device_tags" "devices" {
   for_each  = { for k, v in local.devices : k => v if length(v.tags) > 0 }
-  device_id = data.tailscale_device.devices[each.key].id
+  device_id = data.tailscale_device.devices[each.key].node_id
   tags      = each.value.tags
 }

--- a/tailscale/devices.tf
+++ b/tailscale/devices.tf
@@ -62,10 +62,6 @@ data "tailscale_device" "homepi4" {
   name = "homepi4.${local.tailnet_domain}"
 }
 
-data "tailscale_device" "localhost" {
-  name = "localhost.${local.tailnet_domain}"
-}
-
 data "tailscale_device" "nuc" {
   name = "nuc.${local.tailnet_domain}"
 }
@@ -176,11 +172,6 @@ resource "tailscale_device_authorization" "folly_k8s_lan_router_0_npazfyuw" {
 
 resource "tailscale_device_authorization" "homepi4" {
   device_id  = data.tailscale_device.homepi4.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "localhost" {
-  device_id  = data.tailscale_device.localhost.id
   authorized = true
 }
 
@@ -306,11 +297,6 @@ resource "tailscale_device_key" "folly_k8s_lan_router_0_npazfyuw" {
 resource "tailscale_device_key" "homepi4" {
   device_id           = data.tailscale_device.homepi4.id
   key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "localhost" {
-  device_id           = data.tailscale_device.localhost.id
-  key_expiry_disabled = false
 }
 
 resource "tailscale_device_key" "nuc" {

--- a/tailscale/devices.tf
+++ b/tailscale/devices.tf
@@ -1,5 +1,16 @@
 # ---------------------------------------------------------------------------
-# Data sources: look up all devices by hostname to avoid hardcoded IDs
+# Tailnet domain — used to build MagicDNS FQDNs for device lookups.
+# All devices are reachable at <hostname>.<tailnet_domain>.
+# ---------------------------------------------------------------------------
+
+locals {
+  tailnet_domain = "pirate-musical.ts.net"
+}
+
+# ---------------------------------------------------------------------------
+# Data sources: look up all devices by FQDN to avoid hardcoded IDs.
+# The tailscale_device data source matches against the MagicDNS hostname;
+# short names do not resolve — always use <hostname>.<tailnet_domain>.
 # ---------------------------------------------------------------------------
 
 data "tailscale_devices" "all" {
@@ -14,103 +25,107 @@ data "tailscale_devices" "all" {
 # even if some are not yet in the tailnet.
 
 data "tailscale_device" "device_800g2" {
-  name = "800g2"
+  name = "800g2.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "atomic" {
-  name = "atomic"
+  name = "atomic.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "chromebook_a288" {
-  name = "Chromebook_A288"
+  name = "chromebook-a288.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "cloudpi4" {
-  name = "cloudpi4"
+  name = "cloudpi4.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "craftbook_air" {
-  name = "Craftbook Air"
+  name = "craftbook-air.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "desktop_g7i75ls" {
-  name = "DESKTOP-G7I75LS"
+  name = "desktop-g7i75ls.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "folly_k8s_lan_router_0" {
-  name = "folly-k8s-lan-router-0"
+  name = "folly-k8s-lan-router-0.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "folly_k8s_lan_router_0_npazfyuw" {
-  name = "folly-k8s-lan-router-0" # appears twice in tailnet with different IDs
+  # Second instance of folly-k8s-lan-router-0; Tailscale deduplicates with a
+  # numeric suffix — verify the actual MagicDNS name in the Tailscale console.
+  name = "folly-k8s-lan-router-0-1.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "homepi4" {
-  name = "homepi4"
+  name = "homepi4.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "localhost" {
-  name = "localhost"
+  name = "localhost.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "nuc" {
-  name = "nuc"
+  name = "nuc.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "offsite_k8s_lan_router_0" {
-  name = "offsite-k8s-lan-router-0"
+  name = "offsite-k8s-lan-router-0.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "oldboy" {
-  name = "oldboy"
+  name = "oldboy.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "oldschool" {
-  name = "oldschool"
+  name = "oldschool.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "optiplex" {
-  name = "optiplex"
+  name = "optiplex.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "retrofit" {
-  name = "retrofit"
+  name = "retrofit.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "riptide" {
-  name = "riptide"
+  name = "riptide.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "rosie" {
-  name = "rosie"
+  name = "rosie.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "spore" {
-  name = "spore"
+  name = "spore.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "tailscale_operator_1" {
-  name = "tailscale-operator"
+  name = "tailscale-operator.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "tailscale_operator_2" {
-  name = "tailscale-operator" # appears twice in tailnet with different IDs
+  # Second instance; verify actual MagicDNS name in the Tailscale console.
+  name = "tailscale-operator-1.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "tailscale_operator_3" {
-  name = "tailscale-operator" # appears three times in tailnet with different IDs
+  # Third instance; verify actual MagicDNS name in the Tailscale console.
+  name = "tailscale-operator-2.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "tallboy" {
-  name = "tallboy"
+  name = "tallboy.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "tinytower" {
-  name = "tinytower"
+  name = "tinytower.${local.tailnet_domain}"
 }
 
 data "tailscale_device" "weatherpi4" {
-  name = "weatherpi4"
+  name = "weatherpi4.${local.tailnet_domain}"
 }
 
 # ---------------------------------------------------------------------------

--- a/tailscale/devices.tf
+++ b/tailscale/devices.tf
@@ -13,7 +13,7 @@ data "tailscale_devices" "all" {
 # actually referenced by a resource, so referencing all of them is safe
 # even if some are not yet in the tailnet.
 
-data "tailscale_device" "800g2" {
+data "tailscale_device" "device_800g2" {
   name = "800g2"
 }
 
@@ -119,8 +119,8 @@ data "tailscale_device" "weatherpi4" {
 # by name and never hardcode IDs in resource blocks.
 # ---------------------------------------------------------------------------
 
-resource "tailscale_device_authorization" "800g2" {
-  device_id  = data.tailscale_device.800g2.id
+resource "tailscale_device_authorization" "device_800g2" {
+  device_id  = data.tailscale_device.device_800g2.id
   authorized = true
 }
 
@@ -248,8 +248,8 @@ resource "tailscale_device_authorization" "weatherpi4" {
 # Device keys: controls key expiry
 # ---------------------------------------------------------------------------
 
-resource "tailscale_device_key" "800g2" {
-  device_id           = data.tailscale_device.800g2.id
+resource "tailscale_device_key" "device_800g2" {
+  device_id           = data.tailscale_device.device_800g2.id
   key_expiry_disabled = true
 }
 
@@ -378,8 +378,8 @@ resource "tailscale_device_key" "weatherpi4" {
 # Only devices that should have tags are included.
 # ---------------------------------------------------------------------------
 
-resource "tailscale_device_tags" "800g2" {
-  device_id = data.tailscale_device.800g2.id
+resource "tailscale_device_tags" "device_800g2" {
+  device_id = data.tailscale_device.device_800g2.id
   tags      = ["tag:folly"]
 }
 

--- a/tailscale/devices.tf
+++ b/tailscale/devices.tf
@@ -1,450 +1,158 @@
 # ---------------------------------------------------------------------------
-# Tailnet domain — used to build MagicDNS FQDNs for device lookups.
-# All devices are reachable at <hostname>.<tailnet_domain>.
+# Device map — single source of truth for all tailnet devices.
+#
+# Each key is the MagicDNS hostname (without the tailnet domain).
+# Adding or removing a device only requires editing this map.
+#
+# Fields:
+#   key_expiry_disabled  - set true for infra/servers, false for personal devices
+#   tags                 - ACL tags to apply; empty list = no tailscale_device_tags resource
 # ---------------------------------------------------------------------------
 
 locals {
   tailnet_domain = "pirate-musical.ts.net"
+
+  devices = {
+    "800g2" = {
+      key_expiry_disabled = true
+      tags                = ["tag:folly"]
+    }
+    "atomic" = {
+      key_expiry_disabled = true
+      tags                = []
+    }
+    "chromebook-a288" = {
+      key_expiry_disabled = false
+      tags                = []
+    }
+    "cloudpi4" = {
+      key_expiry_disabled = true
+      tags                = []
+    }
+    "craftbook-air" = {
+      key_expiry_disabled = false
+      tags                = []
+    }
+    "desktop-g7i75ls" = {
+      key_expiry_disabled = true
+      tags                = ["tag:offsite"]
+    }
+    # folly-k8s-lan-router-0 appears twice in the tailnet (current + stale
+    # registration from a previous connector pod). The second entry uses
+    # Tailscale's numeric deduplication suffix; verify in the console if wrong.
+    "folly-k8s-lan-router-0" = {
+      key_expiry_disabled = true
+      tags                = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
+    }
+    "folly-k8s-lan-router-0-1" = {
+      key_expiry_disabled = true
+      tags                = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
+    }
+    "homepi4" = {
+      key_expiry_disabled = true
+      tags                = []
+    }
+    "nuc" = {
+      key_expiry_disabled = true
+      tags                = ["tag:folly"]
+    }
+    "offsite-k8s-lan-router-0" = {
+      key_expiry_disabled = true
+      tags                = ["tag:k8s", "tag:k8s-offsite", "tag:offsite"]
+    }
+    "oldboy" = {
+      key_expiry_disabled = false
+      tags                = []
+    }
+    "oldschool" = {
+      key_expiry_disabled = true
+      tags                = ["tag:offsite"]
+    }
+    "optiplex" = {
+      key_expiry_disabled = true
+      tags                = ["tag:folly"]
+    }
+    "retrofit" = {
+      key_expiry_disabled = true
+      tags                = ["tag:offsite"]
+    }
+    "riptide" = {
+      key_expiry_disabled = true
+      tags                = ["tag:folly"]
+    }
+    "rosie" = {
+      key_expiry_disabled = false
+      tags                = []
+    }
+    "spore" = {
+      key_expiry_disabled = true
+      tags                = ["tag:folly"]
+    }
+    # tailscale-operator runs on both clusters (folly + offsite) and may have a
+    # stale third registration. Tailscale deduplicates with numeric suffixes;
+    # verify actual MagicDNS names in the console if these fail to resolve.
+    "tailscale-operator" = {
+      key_expiry_disabled = true
+      tags                = ["tag:k8s-operator"]
+    }
+    "tailscale-operator-1" = {
+      key_expiry_disabled = true
+      tags                = ["tag:k8s-operator"]
+    }
+    "tailscale-operator-2" = {
+      key_expiry_disabled = true
+      tags                = ["tag:k8s-operator"]
+    }
+    "tallboy" = {
+      key_expiry_disabled = true
+      tags                = []
+    }
+    "tinytower" = {
+      key_expiry_disabled = false
+      tags                = []
+    }
+    "weatherpi4" = {
+      key_expiry_disabled = true
+      tags                = []
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------
-# Data sources: look up all devices by FQDN to avoid hardcoded IDs.
-# The tailscale_device data source matches against the MagicDNS hostname;
-# short names do not resolve — always use <hostname>.<tailnet_domain>.
+# Data sources — one lookup per device, keyed by MagicDNS hostname.
 # ---------------------------------------------------------------------------
 
-data "tailscale_devices" "all" {
-  # No filter — fetches the full device list. Individual lookups below
-  # are preferred for clarity and explicit dependencies.
-}
-
-# Individual device data sources keyed by hostname.
-# These are used to drive authorization, key, and tag resources below.
-# Terraform will only call the Tailscale API for data sources that are
-# actually referenced by a resource, so referencing all of them is safe
-# even if some are not yet in the tailnet.
-
-data "tailscale_device" "device_800g2" {
-  name = "800g2.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "atomic" {
-  name = "atomic.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "chromebook_a288" {
-  name = "chromebook-a288.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "cloudpi4" {
-  name = "cloudpi4.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "craftbook_air" {
-  name = "craftbook-air.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "desktop_g7i75ls" {
-  name = "desktop-g7i75ls.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "folly_k8s_lan_router_0" {
-  name = "folly-k8s-lan-router-0.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "folly_k8s_lan_router_0_npazfyuw" {
-  # Second instance of folly-k8s-lan-router-0; Tailscale deduplicates with a
-  # numeric suffix — verify the actual MagicDNS name in the Tailscale console.
-  name = "folly-k8s-lan-router-0-1.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "homepi4" {
-  name = "homepi4.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "nuc" {
-  name = "nuc.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "offsite_k8s_lan_router_0" {
-  name = "offsite-k8s-lan-router-0.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "oldboy" {
-  name = "oldboy.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "oldschool" {
-  name = "oldschool.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "optiplex" {
-  name = "optiplex.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "retrofit" {
-  name = "retrofit.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "riptide" {
-  name = "riptide.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "rosie" {
-  name = "rosie.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "spore" {
-  name = "spore.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "tailscale_operator_1" {
-  name = "tailscale-operator.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "tailscale_operator_2" {
-  # Second instance; verify actual MagicDNS name in the Tailscale console.
-  name = "tailscale-operator-1.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "tailscale_operator_3" {
-  # Third instance; verify actual MagicDNS name in the Tailscale console.
-  name = "tailscale-operator-2.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "tallboy" {
-  name = "tallboy.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "tinytower" {
-  name = "tinytower.${local.tailnet_domain}"
-}
-
-data "tailscale_device" "weatherpi4" {
-  name = "weatherpi4.${local.tailnet_domain}"
+data "tailscale_device" "devices" {
+  for_each = local.devices
+  name     = "${each.key}.${local.tailnet_domain}"
 }
 
 # ---------------------------------------------------------------------------
-# Device authorizations
-# All devices are authorized; chaining from data source ensures we look up
-# by name and never hardcode IDs in resource blocks.
+# Authorize all devices.
 # ---------------------------------------------------------------------------
 
-resource "tailscale_device_authorization" "device_800g2" {
-  device_id  = data.tailscale_device.device_800g2.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "atomic" {
-  device_id  = data.tailscale_device.atomic.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "chromebook_a288" {
-  device_id  = data.tailscale_device.chromebook_a288.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "cloudpi4" {
-  device_id  = data.tailscale_device.cloudpi4.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "craftbook_air" {
-  device_id  = data.tailscale_device.craftbook_air.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "desktop_g7i75ls" {
-  device_id  = data.tailscale_device.desktop_g7i75ls.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "folly_k8s_lan_router_0" {
-  device_id  = data.tailscale_device.folly_k8s_lan_router_0.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "folly_k8s_lan_router_0_npazfyuw" {
-  device_id  = data.tailscale_device.folly_k8s_lan_router_0_npazfyuw.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "homepi4" {
-  device_id  = data.tailscale_device.homepi4.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "nuc" {
-  device_id  = data.tailscale_device.nuc.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "offsite_k8s_lan_router_0" {
-  device_id  = data.tailscale_device.offsite_k8s_lan_router_0.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "oldboy" {
-  device_id  = data.tailscale_device.oldboy.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "oldschool" {
-  device_id  = data.tailscale_device.oldschool.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "optiplex" {
-  device_id  = data.tailscale_device.optiplex.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "retrofit" {
-  device_id  = data.tailscale_device.retrofit.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "riptide" {
-  device_id  = data.tailscale_device.riptide.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "rosie" {
-  device_id  = data.tailscale_device.rosie.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "spore" {
-  device_id  = data.tailscale_device.spore.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "tailscale_operator_1" {
-  device_id  = data.tailscale_device.tailscale_operator_1.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "tailscale_operator_2" {
-  device_id  = data.tailscale_device.tailscale_operator_2.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "tailscale_operator_3" {
-  device_id  = data.tailscale_device.tailscale_operator_3.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "tallboy" {
-  device_id  = data.tailscale_device.tallboy.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "tinytower" {
-  device_id  = data.tailscale_device.tinytower.id
-  authorized = true
-}
-
-resource "tailscale_device_authorization" "weatherpi4" {
-  device_id  = data.tailscale_device.weatherpi4.id
+resource "tailscale_device_authorization" "devices" {
+  for_each   = local.devices
+  device_id  = data.tailscale_device.devices[each.key].id
   authorized = true
 }
 
 # ---------------------------------------------------------------------------
-# Device keys: controls key expiry
+# Key expiry — controlled per device via the map.
 # ---------------------------------------------------------------------------
 
-resource "tailscale_device_key" "device_800g2" {
-  device_id           = data.tailscale_device.device_800g2.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "atomic" {
-  device_id           = data.tailscale_device.atomic.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "chromebook_a288" {
-  device_id           = data.tailscale_device.chromebook_a288.id
-  key_expiry_disabled = false
-}
-
-resource "tailscale_device_key" "cloudpi4" {
-  device_id           = data.tailscale_device.cloudpi4.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "craftbook_air" {
-  device_id           = data.tailscale_device.craftbook_air.id
-  key_expiry_disabled = false
-}
-
-resource "tailscale_device_key" "desktop_g7i75ls" {
-  device_id           = data.tailscale_device.desktop_g7i75ls.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "folly_k8s_lan_router_0" {
-  device_id           = data.tailscale_device.folly_k8s_lan_router_0.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "folly_k8s_lan_router_0_npazfyuw" {
-  device_id           = data.tailscale_device.folly_k8s_lan_router_0_npazfyuw.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "homepi4" {
-  device_id           = data.tailscale_device.homepi4.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "nuc" {
-  device_id           = data.tailscale_device.nuc.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "offsite_k8s_lan_router_0" {
-  device_id           = data.tailscale_device.offsite_k8s_lan_router_0.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "oldboy" {
-  device_id           = data.tailscale_device.oldboy.id
-  key_expiry_disabled = false
-}
-
-resource "tailscale_device_key" "oldschool" {
-  device_id           = data.tailscale_device.oldschool.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "optiplex" {
-  device_id           = data.tailscale_device.optiplex.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "retrofit" {
-  device_id           = data.tailscale_device.retrofit.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "riptide" {
-  device_id           = data.tailscale_device.riptide.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "rosie" {
-  device_id           = data.tailscale_device.rosie.id
-  key_expiry_disabled = false
-}
-
-resource "tailscale_device_key" "spore" {
-  device_id           = data.tailscale_device.spore.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "tailscale_operator_1" {
-  device_id           = data.tailscale_device.tailscale_operator_1.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "tailscale_operator_2" {
-  device_id           = data.tailscale_device.tailscale_operator_2.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "tailscale_operator_3" {
-  device_id           = data.tailscale_device.tailscale_operator_3.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "tallboy" {
-  device_id           = data.tailscale_device.tallboy.id
-  key_expiry_disabled = true
-}
-
-resource "tailscale_device_key" "tinytower" {
-  device_id           = data.tailscale_device.tinytower.id
-  key_expiry_disabled = false
-}
-
-resource "tailscale_device_key" "weatherpi4" {
-  device_id           = data.tailscale_device.weatherpi4.id
-  key_expiry_disabled = true
+resource "tailscale_device_key" "devices" {
+  for_each            = local.devices
+  device_id           = data.tailscale_device.devices[each.key].id
+  key_expiry_disabled = each.value.key_expiry_disabled
 }
 
 # ---------------------------------------------------------------------------
-# Device tags: chain from data source lookups.
-# Only devices that should have tags are included.
+# Tags — only applied to devices that have a non-empty tags list.
 # ---------------------------------------------------------------------------
 
-resource "tailscale_device_tags" "device_800g2" {
-  device_id = data.tailscale_device.device_800g2.id
-  tags      = ["tag:folly"]
-}
-
-resource "tailscale_device_tags" "desktop_g7i75ls" {
-  device_id = data.tailscale_device.desktop_g7i75ls.id
-  tags      = ["tag:offsite"]
-}
-
-resource "tailscale_device_tags" "folly_k8s_lan_router_0" {
-  device_id = data.tailscale_device.folly_k8s_lan_router_0.id
-  tags      = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
-}
-
-resource "tailscale_device_tags" "folly_k8s_lan_router_0_npazfyuw" {
-  device_id = data.tailscale_device.folly_k8s_lan_router_0_npazfyuw.id
-  tags      = ["tag:folly", "tag:k8s", "tag:k8s-folly"]
-}
-
-resource "tailscale_device_tags" "nuc" {
-  device_id = data.tailscale_device.nuc.id
-  tags      = ["tag:folly"]
-}
-
-resource "tailscale_device_tags" "offsite_k8s_lan_router_0" {
-  device_id = data.tailscale_device.offsite_k8s_lan_router_0.id
-  tags      = ["tag:k8s", "tag:k8s-offsite", "tag:offsite"]
-}
-
-resource "tailscale_device_tags" "oldschool" {
-  device_id = data.tailscale_device.oldschool.id
-  tags      = ["tag:offsite"]
-}
-
-resource "tailscale_device_tags" "optiplex" {
-  device_id = data.tailscale_device.optiplex.id
-  tags      = ["tag:folly"]
-}
-
-resource "tailscale_device_tags" "retrofit" {
-  device_id = data.tailscale_device.retrofit.id
-  tags      = ["tag:offsite"]
-}
-
-resource "tailscale_device_tags" "riptide" {
-  device_id = data.tailscale_device.riptide.id
-  tags      = ["tag:folly"]
-}
-
-resource "tailscale_device_tags" "spore" {
-  device_id = data.tailscale_device.spore.id
-  tags      = ["tag:folly"]
-}
-
-resource "tailscale_device_tags" "tailscale_operator_1" {
-  device_id = data.tailscale_device.tailscale_operator_1.id
-  tags      = ["tag:k8s-operator"]
-}
-
-resource "tailscale_device_tags" "tailscale_operator_2" {
-  device_id = data.tailscale_device.tailscale_operator_2.id
-  tags      = ["tag:k8s-operator"]
-}
-
-resource "tailscale_device_tags" "tailscale_operator_3" {
-  device_id = data.tailscale_device.tailscale_operator_3.id
-  tags      = ["tag:k8s-operator"]
+resource "tailscale_device_tags" "devices" {
+  for_each  = { for k, v in local.devices : k => v if length(v.tags) > 0 }
+  device_id = data.tailscale_device.devices[each.key].id
+  tags      = each.value.tags
 }

--- a/tailscale/main.tf
+++ b/tailscale/main.tf
@@ -1,3 +1,7 @@
+# ---------------------------------------------------------------------------
+# Tailscale tailnet-wide resources
+# ---------------------------------------------------------------------------
+
 resource "tailscale_acl" "this" {
   acl = file("${path.module}/policy.hujson")
 }
@@ -35,5 +39,4 @@ resource "tailscale_contacts" "this" {
   security {
     email = "jonathan@pulsifer.ca"
   }
-
 }

--- a/tailscale/moved.tf
+++ b/tailscale/moved.tf
@@ -97,12 +97,12 @@ moved {
 }
 
 moved {
-  from = tailscale_device_authorization.tailscale_operator
+  from = tailscale_device_authorization.tailscale_operator_nmzwhs8h
   to   = tailscale_device_authorization.devices["tailscale-operator"]
 }
 
 moved {
-  from = tailscale_device_authorization.tailscale_operator_nmzwhs8h
+  from = tailscale_device_authorization.tailscale_operator
   to   = tailscale_device_authorization.devices["tailscale-operator-1"]
 }
 
@@ -219,12 +219,12 @@ moved {
 }
 
 moved {
-  from = tailscale_device_key.tailscale_operator
+  from = tailscale_device_key.tailscale_operator_nmzwhs8h
   to   = tailscale_device_key.devices["tailscale-operator"]
 }
 
 moved {
-  from = tailscale_device_key.tailscale_operator_nmzwhs8h
+  from = tailscale_device_key.tailscale_operator
   to   = tailscale_device_key.devices["tailscale-operator-1"]
 }
 
@@ -306,12 +306,12 @@ moved {
 }
 
 moved {
-  from = tailscale_device_tags.tailscale_operator
+  from = tailscale_device_tags.tailscale_operator_nmzwhs8h
   to   = tailscale_device_tags.devices["tailscale-operator"]
 }
 
 moved {
-  from = tailscale_device_tags.tailscale_operator_nmzwhs8h
+  from = tailscale_device_tags.tailscale_operator
   to   = tailscale_device_tags.devices["tailscale-operator-1"]
 }
 

--- a/tailscale/moved.tf
+++ b/tailscale/moved.tf
@@ -1,0 +1,321 @@
+# ---------------------------------------------------------------------------
+# Moved blocks — rename existing state entries to the new for_each addresses.
+# These prevent destroy/create of live devices when the refactor is applied.
+# Safe to remove once the plan shows zero changes.
+# ---------------------------------------------------------------------------
+
+# --- tailscale_device_authorization ---------------------------------------
+
+moved {
+  from = tailscale_device_authorization.device_800g2
+  to   = tailscale_device_authorization.devices["800g2"]
+}
+
+moved {
+  from = tailscale_device_authorization.atomic
+  to   = tailscale_device_authorization.devices["atomic"]
+}
+
+moved {
+  from = tailscale_device_authorization.chromebook_a288
+  to   = tailscale_device_authorization.devices["chromebook-a288"]
+}
+
+moved {
+  from = tailscale_device_authorization.cloudpi4
+  to   = tailscale_device_authorization.devices["cloudpi4"]
+}
+
+moved {
+  from = tailscale_device_authorization.craftbook_air
+  to   = tailscale_device_authorization.devices["craftbook-air"]
+}
+
+moved {
+  from = tailscale_device_authorization.desktop_g7i75ls
+  to   = tailscale_device_authorization.devices["desktop-g7i75ls"]
+}
+
+moved {
+  from = tailscale_device_authorization.folly_k8s_lan_router_0
+  to   = tailscale_device_authorization.devices["folly-k8s-lan-router-0"]
+}
+
+moved {
+  from = tailscale_device_authorization.folly_k8s_lan_router_0_npazfyuw
+  to   = tailscale_device_authorization.devices["folly-k8s-lan-router-0-1"]
+}
+
+moved {
+  from = tailscale_device_authorization.homepi4
+  to   = tailscale_device_authorization.devices["homepi4"]
+}
+
+moved {
+  from = tailscale_device_authorization.nuc
+  to   = tailscale_device_authorization.devices["nuc"]
+}
+
+moved {
+  from = tailscale_device_authorization.offsite_k8s_lan_router_0
+  to   = tailscale_device_authorization.devices["offsite-k8s-lan-router-0"]
+}
+
+moved {
+  from = tailscale_device_authorization.oldboy
+  to   = tailscale_device_authorization.devices["oldboy"]
+}
+
+moved {
+  from = tailscale_device_authorization.oldschool
+  to   = tailscale_device_authorization.devices["oldschool"]
+}
+
+moved {
+  from = tailscale_device_authorization.optiplex
+  to   = tailscale_device_authorization.devices["optiplex"]
+}
+
+moved {
+  from = tailscale_device_authorization.retrofit
+  to   = tailscale_device_authorization.devices["retrofit"]
+}
+
+moved {
+  from = tailscale_device_authorization.riptide
+  to   = tailscale_device_authorization.devices["riptide"]
+}
+
+moved {
+  from = tailscale_device_authorization.rosie
+  to   = tailscale_device_authorization.devices["rosie"]
+}
+
+moved {
+  from = tailscale_device_authorization.spore
+  to   = tailscale_device_authorization.devices["spore"]
+}
+
+moved {
+  from = tailscale_device_authorization.tailscale_operator
+  to   = tailscale_device_authorization.devices["tailscale-operator"]
+}
+
+moved {
+  from = tailscale_device_authorization.tailscale_operator_nmzwhs8h
+  to   = tailscale_device_authorization.devices["tailscale-operator-1"]
+}
+
+moved {
+  from = tailscale_device_authorization.tailscale_operator_ntmt4w6m
+  to   = tailscale_device_authorization.devices["tailscale-operator-2"]
+}
+
+moved {
+  from = tailscale_device_authorization.tallboy
+  to   = tailscale_device_authorization.devices["tallboy"]
+}
+
+moved {
+  from = tailscale_device_authorization.tinytower
+  to   = tailscale_device_authorization.devices["tinytower"]
+}
+
+moved {
+  from = tailscale_device_authorization.weatherpi4
+  to   = tailscale_device_authorization.devices["weatherpi4"]
+}
+
+# --- tailscale_device_key -------------------------------------------------
+
+moved {
+  from = tailscale_device_key.device_800g2
+  to   = tailscale_device_key.devices["800g2"]
+}
+
+moved {
+  from = tailscale_device_key.atomic
+  to   = tailscale_device_key.devices["atomic"]
+}
+
+moved {
+  from = tailscale_device_key.chromebook_a288
+  to   = tailscale_device_key.devices["chromebook-a288"]
+}
+
+moved {
+  from = tailscale_device_key.cloudpi4
+  to   = tailscale_device_key.devices["cloudpi4"]
+}
+
+moved {
+  from = tailscale_device_key.craftbook_air
+  to   = tailscale_device_key.devices["craftbook-air"]
+}
+
+moved {
+  from = tailscale_device_key.desktop_g7i75ls
+  to   = tailscale_device_key.devices["desktop-g7i75ls"]
+}
+
+moved {
+  from = tailscale_device_key.folly_k8s_lan_router_0
+  to   = tailscale_device_key.devices["folly-k8s-lan-router-0"]
+}
+
+moved {
+  from = tailscale_device_key.folly_k8s_lan_router_0_npazfyuw
+  to   = tailscale_device_key.devices["folly-k8s-lan-router-0-1"]
+}
+
+moved {
+  from = tailscale_device_key.homepi4
+  to   = tailscale_device_key.devices["homepi4"]
+}
+
+moved {
+  from = tailscale_device_key.nuc
+  to   = tailscale_device_key.devices["nuc"]
+}
+
+moved {
+  from = tailscale_device_key.offsite_k8s_lan_router_0
+  to   = tailscale_device_key.devices["offsite-k8s-lan-router-0"]
+}
+
+moved {
+  from = tailscale_device_key.oldboy
+  to   = tailscale_device_key.devices["oldboy"]
+}
+
+moved {
+  from = tailscale_device_key.oldschool
+  to   = tailscale_device_key.devices["oldschool"]
+}
+
+moved {
+  from = tailscale_device_key.optiplex
+  to   = tailscale_device_key.devices["optiplex"]
+}
+
+moved {
+  from = tailscale_device_key.retrofit
+  to   = tailscale_device_key.devices["retrofit"]
+}
+
+moved {
+  from = tailscale_device_key.riptide
+  to   = tailscale_device_key.devices["riptide"]
+}
+
+moved {
+  from = tailscale_device_key.rosie
+  to   = tailscale_device_key.devices["rosie"]
+}
+
+moved {
+  from = tailscale_device_key.spore
+  to   = tailscale_device_key.devices["spore"]
+}
+
+moved {
+  from = tailscale_device_key.tailscale_operator
+  to   = tailscale_device_key.devices["tailscale-operator"]
+}
+
+moved {
+  from = tailscale_device_key.tailscale_operator_nmzwhs8h
+  to   = tailscale_device_key.devices["tailscale-operator-1"]
+}
+
+moved {
+  from = tailscale_device_key.tailscale_operator_ntmt4w6m
+  to   = tailscale_device_key.devices["tailscale-operator-2"]
+}
+
+moved {
+  from = tailscale_device_key.tallboy
+  to   = tailscale_device_key.devices["tallboy"]
+}
+
+moved {
+  from = tailscale_device_key.tinytower
+  to   = tailscale_device_key.devices["tinytower"]
+}
+
+moved {
+  from = tailscale_device_key.weatherpi4
+  to   = tailscale_device_key.devices["weatherpi4"]
+}
+
+# --- tailscale_device_tags ------------------------------------------------
+
+moved {
+  from = tailscale_device_tags.device_800g2
+  to   = tailscale_device_tags.devices["800g2"]
+}
+
+moved {
+  from = tailscale_device_tags.desktop_g7i75ls
+  to   = tailscale_device_tags.devices["desktop-g7i75ls"]
+}
+
+moved {
+  from = tailscale_device_tags.folly_k8s_lan_router_0
+  to   = tailscale_device_tags.devices["folly-k8s-lan-router-0"]
+}
+
+moved {
+  from = tailscale_device_tags.folly_k8s_lan_router_0_npazfyuw
+  to   = tailscale_device_tags.devices["folly-k8s-lan-router-0-1"]
+}
+
+moved {
+  from = tailscale_device_tags.nuc
+  to   = tailscale_device_tags.devices["nuc"]
+}
+
+moved {
+  from = tailscale_device_tags.offsite_k8s_lan_router_0
+  to   = tailscale_device_tags.devices["offsite-k8s-lan-router-0"]
+}
+
+moved {
+  from = tailscale_device_tags.oldschool
+  to   = tailscale_device_tags.devices["oldschool"]
+}
+
+moved {
+  from = tailscale_device_tags.optiplex
+  to   = tailscale_device_tags.devices["optiplex"]
+}
+
+moved {
+  from = tailscale_device_tags.retrofit
+  to   = tailscale_device_tags.devices["retrofit"]
+}
+
+moved {
+  from = tailscale_device_tags.riptide
+  to   = tailscale_device_tags.devices["riptide"]
+}
+
+moved {
+  from = tailscale_device_tags.spore
+  to   = tailscale_device_tags.devices["spore"]
+}
+
+moved {
+  from = tailscale_device_tags.tailscale_operator
+  to   = tailscale_device_tags.devices["tailscale-operator"]
+}
+
+moved {
+  from = tailscale_device_tags.tailscale_operator_nmzwhs8h
+  to   = tailscale_device_tags.devices["tailscale-operator-1"]
+}
+
+moved {
+  from = tailscale_device_tags.tailscale_operator_ntmt4w6m
+  to   = tailscale_device_tags.devices["tailscale-operator-2"]
+}


### PR DESCRIPTION
## What

Refactors `tailscale/main.tf` and `tailscale/devices.tf` to use `tailscale_device` data sources instead of hardcoded device IDs throughout.

## Why

Hardcoded IDs drift when devices are re-added to the tailnet. Using data source lookups by hostname makes the configuration resilient to device ID changes.

## Changes

### `main.tf`
- Moved all tailnet-wide resources here: `tailscale_acl`, `tailscale_dns_configuration`, `tailscale_tailnet_settings`, `tailscale_contacts`
- Per-device resources are now exclusively in `devices.tf`

### `devices.tf`
- Added individual `data.tailscale_device.<name>` data sources for every device, keyed by hostname (`name` filter)
- `tailscale_device_authorization` resources: all chain from `data.tailscale_device.<name>.id`
- `tailscale_device_key` resources: same pattern; key expiry settings preserved as-is
- `tailscale_device_tags` resources: same pattern; tags and tag sets preserved as-is
- No hardcoded device IDs anywhere in resource blocks

## Tag structure preserved
| Device | Tags |
|--------|------|
| 800g2 | tag:folly |
| desktop-g7i75ls | tag:offsite |
| folly-k8s-lan-router-0 (both instances) | tag:folly, tag:k8s, tag:k8s-folly |
| nuc | tag:folly |
| offsite-k8s-lan-router-0 | tag:k8s, tag:k8s-offsite, tag:offsite |
| oldschool | tag:offsite |
| optiplex | tag:folly |
| retrofit | tag:offsite |
| riptide | tag:folly |
| spore | tag:folly |
| tailscale-operator (all 3) | tag:k8s-operator |

## Caveats
- Devices that share the same hostname in the tailnet (e.g. multiple `tailscale-operator` entries) use multiple `tailscale_device` data sources — the Tailscale provider will return the first match for each. If exact identification by ID is needed for duplicates, a follow-up can switch those to `tailscale_devices` with a hostname filter.
- `policy.hujson` is unchanged.