### PR TITLE
fix(gateway-api): allow agents-sandbox namespace on offsite cluster-gateway

### DIFF
--- a/k8s/offsite/networking/cert-manager/certificates/dave.yaml
+++ b/k8s/offsite/networking/cert-manager/certificates/dave.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dave.${SECRET_DOMAIN}
+  namespace: default
+spec:
+  secretName: dave.${SECRET_DOMAIN}
+  dnsNames:
+    - dave.${SECRET_DOMAIN}
+  issuerRef:
+    name: letsencrypt-production
+    kind: ClusterIssuer
+    group: cert-manager.io

--- a/k8s/offsite/networking/cert-manager/kustomization.yaml
+++ b/k8s/offsite/networking/cert-manager/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - namespace.yaml
   - ../../../base/networking/cert-manager
   - cloudflare-secret.sops.yaml
+  - certificates/

--- a/k8s/offsite/networking/gateway-api/cluster-gateway.yaml
+++ b/k8s/offsite/networking/gateway-api/cluster-gateway.yaml
@@ -12,6 +12,27 @@ spec:
       protocol: HTTP
       port: 80
       allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              kubernetes.io/metadata.name: agents-sandbox
+        kinds:
+          - kind: HTTPRoute
+    - name: dave-tls
+      protocol: HTTPS
+      port: 443
+      hostname: &hostname "dave.${SECRET_DOMAIN}"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: *hostname
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchLabels:
+              kubernetes.io/metadata.name: agents-sandbox
         kinds:
           - kind: HTTPRoute
     - name: bittorrent-tls

--- a/k8s/offsite/networking/gateway-api/dave-agents-sandbox.yaml
+++ b/k8s/offsite/networking/gateway-api/dave-agents-sandbox.yaml
@@ -1,0 +1,13 @@
+---
+# Allow the cluster-gateway in `default` to route to services in `agents-sandbox`
+# for the dave-ai-agent HTTPRoute.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: agents-sandbox-to-default-gateway
+  namespace: agents-sandbox
+spec:
+  to:
+    - group: ""
+      kind: Service
+      name: dave-ai-agent

--- a/k8s/offsite/networking/gateway-api/kustomization.yaml
+++ b/k8s/offsite/networking/gateway-api/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - radarr.yaml
   - prowlarr.yaml
   - bazarr.yaml
+  - dave-agents-sandbox.yaml


### PR DESCRIPTION
## What this fixes

The `dave-ai-agent` HTTPRoute lives in `agents-sandbox` namespace but the offsite `cluster-gateway` listeners were rejecting it due to namespace restrictions.

## Changes

1. **http-gateway listener** — add `allowedRoutes.namespaces.selector` for `kubernetes.io/metadata.name: agents-sandbox` so cross-namespace routes are permitted over HTTP
2. **dave-tls listener** — new HTTPS listener (port 443) with cert reference `dave.${SECRET_DOMAIN}`, also allowing `agents-sandbox` routes
3. **Certificate** — `dave.${SECRET_DOMAIN}` in `default` namespace via `letsencrypt-production` cluster issuer
4. **ReferenceGrant** — allow the Gateway in `default` to route to the `dave-ai-agent` service in `agents-sandbox`
5. **Kustomizations** — updated to include new `certificates/dave.yaml` and `dave-agents-sandbox.yaml` resources