### PR TITLE
fix(gateway-api): add spec.from to ReferenceGrant for agents-sandbox

### DIFF
--- a/k8s/offsite/networking/gateway-api/dave-agents-sandbox.yaml
+++ b/k8s/offsite/networking/gateway-api/dave-agents-sandbox.yaml
@@ -7,6 +7,11 @@ metadata:
   name: agents-sandbox-to-default-gateway
   namespace: agents-sandbox
 spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: cluster-gateway
+      namespace: default
   to:
     - group: ""
       kind: Service


### PR DESCRIPTION
spec.from is required on ReferenceGrant; the field was missing causing a dry-run validation failure that blocked the entire gateway-api-cluster-gateway kustomization from reconciling.