### PR TITLE
charts/ai-agent: add workspaceDir to fix Dave heartbeat EACCES

### DIFF
--- a/charts/ai-agent/templates/sandboxtemplate.yaml
+++ b/charts/ai-agent/templates/sandboxtemplate.yaml
@@ -69,6 +69,10 @@ spec:
               value: /home/agent/config/.openclaw
             - name: OPENCLAW_NO_RESPAWN
               value: "1"
+            {{- if .Values.workspaceDir }}
+            - name: OPENCLAW_WORKSPACE_DIR
+              value: {{ .Values.workspaceDir }}
+            {{- end }}
             {{- if .Values.npmTools }}
             - name: PATH
               value: /home/agent/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/charts/ai-agent/values.yaml
+++ b/charts/ai-agent/values.yaml
@@ -3,6 +3,7 @@ port: 8080
 hostname: ""
 storageSize: 2Gi
 command: ""
+workspaceDir: ""
 
 resources:
   requests:

--- a/k8s/offsite/apps/dave.yaml
+++ b/k8s/offsite/apps/dave.yaml
@@ -32,6 +32,7 @@ spec:
       enabled: true
       mode: shared
       forwardedUser: jonathan
+    workspaceDir: /home/agent/config/workspace
     secrets:
       - name: config
         onePasswordItem: openclaw-config


### PR DESCRIPTION
## Problem

Dave's pod (dave-ai-agent in agents-sandbox) is failing all heartbeats with:

```
EACCES: permission denied, mkdir '/home/agent/.openclaw/workspace'
```

When `secrets` are configured in the HelmRelease, the workspace PVC is not mounted. OpenClaw then defaults to `/home/agent/.openclaw/workspace` which is in the read-only image layer — hence the EACCES.

## Fix

1. **charts/ai-agent/values.yaml** — add optional `workspaceDir` value
2. **charts/ai-agent/templates/sandboxtemplate.yaml** — emit `OPENCLAW_WORKSPACE_DIR` env var when `workspaceDir` is set
3. **k8s/offsite/apps/dave.yaml** — set `workspaceDir: /home/agent/config/workspace` so the workspace lives inside the agent-config PVC

After Flux reconciles this, Dave's next pod should have `OPENCLAW_WORKSPACE_DIR=/home/agent/config/workspace` and heartbeats should clear up.