### PR TITLE
fix(agent-sandbox): bump controller to v0.4.6 and track via renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -57,6 +57,20 @@
       ],
       datasourceTemplate: '{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}',
     },
+    {
+      customType: 'regex',
+      description: 'Image overrides inside Flux Kustomization JSON6902 patches',
+      managerFilePatterns: [
+        '/k8s/.+\\.ya?ml$/',
+      ],
+      matchStrings: [
+        // # renovate: datasource=docker
+        // value: registry.k8s.io/owner/image:v1.2.3
+        '# renovate: datasource=(?<datasource>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*value:\\s*(?<depName>[^:\\s]+):(?<currentValue>\\S+)',
+      ],
+      datasourceTemplate: '{{#if datasource}}{{{datasource}}}{{else}}docker{{/if}}',
+      versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}',
+    },
   ],
   packageRules: [
     // ============================================================

--- a/k8s/base/platform/agent-sandbox/agent-sandbox.yaml
+++ b/k8s/base/platform/agent-sandbox/agent-sandbox.yaml
@@ -33,7 +33,8 @@ spec:
       patch: |
         - op: replace
           path: /spec/template/spec/containers/0/image
-          value: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.2.1
+          # renovate: datasource=docker
+          value: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.6
         - op: add
           path: /spec/template/spec/containers/0/args/-
           value: "--extensions"


### PR DESCRIPTION
## Why

The `agent-sandbox` `GitRepository` is pinned to **v0.4.6** (latest), but the controller **image** in the Flux Kustomization JSON6902 patch was still **v0.2.1** (released 2026-03-14) — a stale controller running against v0.4.6 CRDs/manifests.

Upstream `k8s/controller.yaml` ships a `ko://sigs.k8s.io/...` placeholder image (not pullable), so the kustomize patch override is required. This bumps the override to match the source tag.

## Changes

- `k8s/base/platform/agent-sandbox/agent-sandbox.yaml`: controller image `v0.2.1` → `v0.4.6`. Confirmed `registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.4.6` exists and matches the v0.4.6 release `manifest.yaml`.
- `.github/renovate.json5`: add a regex `customManager` for image overrides inside Flux JSON6902 patches, plus an inline `# renovate: datasource=docker` hint above the `value:` line so the override stays current automatically.

## Validation

- `kustomize build k8s/base/platform/agent-sandbox` renders cleanly (comment preserved inside the patch; `v0.4.6` + `--extensions` intact).
- renovate.json5 parses; the regex matches the annotated `value:` line and ignores the adjacent `--extensions` value.
- Shared base — applies to both folly and offsite clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)