### PR TITLE
fix(walter): use bookworm for npm install and set workspaceDir

### DIFF
--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -26,6 +26,8 @@ spec:
       limits:
         memory: 8Gi
         cpu: 4000m
+    npmInstallImage: node:24-bookworm
+    workspaceDir: /home/agent/config/workspace
     npmTools:
       - "@moonpay/cli"
     ingress:


### PR DESCRIPTION
## Problem

Walter's init container keeps crashing with:
```
npm error gyp ERR! find Python - Could not find any Python installation to use
```

The init container uses `node:24-alpine` (old chart default), which lacks Python. The `@moonpay/cli` package has a `usb` dependency that requires `node-gyp` to compile, which needs Python.

Additionally, like Dave, Walter lacks `workspaceDir` so OpenClaw tries to write to `/home/agent/.openclaw/workspace` in the read-only image layer.

## Fix

1. Set `npmInstallImage: node:24-bookworm` — Debian-based, has Python
2. Set `workspaceDir: /home/agent/config/workspace` — workspace lives in PVC

## Testing

After merge, Flux will reconcile and Walter's pod will restart with the new init image. Init should complete successfully and the agent container should start.