### PR TITLE
fix(user.nix): add Rowbutt's current SSH key to NixOS hosts

### DIFF
--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -26,6 +26,8 @@ spec:
       limits:
         memory: 8Gi
         cpu: 4000m
+    npmInstallImage: node:24-bookworm
+    workspaceDir: /home/agent/config/workspace
     npmTools:
       - "@moonpay/cli"
     ingress:

--- a/nix/system/user.nix
+++ b/nix/system/user.nix
@@ -40,6 +40,7 @@ in
     ++ lib.optionals (config.virtualisation.docker.enable) [ "docker" ];
     openssh.authorizedKeys.keys = [
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKhYENJ/NOSUFerGNB5eIxjxeMNhmosbX62hLgZKNbUp"
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBEjjytlZ6wzNpjkYNVPZm631HvbfqQu94FsoiNflUO1 rowbutt@homelab"
     ];
     shell = pkgs.zsh;
     packages = with pkgs; [


### PR DESCRIPTION
Adds the newly generated ed25519 key for `rowbutt@homelab` to the `rowbutt` user on all NixOS hosts (optiplex, riptide, oldschool, retrofit, etc).