### PR TITLE
fix(kube-prometheus): reduce storage to 50Gi and retention to 30d

### DIFF
--- a/k8s/folly/monitoring/kube-prometheus.yaml
+++ b/k8s/folly/monitoring/kube-prometheus.yaml
@@ -54,7 +54,8 @@ spec:
               - *prom
         pathType: Prefix
       prometheusSpec:
-        retention: 90d
+        retention: 30d
+        retentionSize: 40GB
         additionalScrapeConfigs:
           - job_name: node-exporter
             scrape_interval: 30s
@@ -80,7 +81,7 @@ spec:
               accessModes: ["ReadWriteOnce"]
               resources:
                 requests:
-                  storage: 75Gi
+                  storage: 50Gi
     grafana:
       admin:
         existingSecret: grafana-admin-user


### PR DESCRIPTION
## Problem

riptide's /mnt/disks was 95% full (only ~7G free on 143G partition). Prometheus PVC was 75Gi with 90d retention, contributing ~33G across two stale volumes.

## Fix

1. **Reduce PVC from 75Gi → 50Gi** — still plenty for 30d retention
2. **Reduce retention 90d → 30d** — aligns with storage constraints
3. **Add retentionSize: 40GB** — hard cap on TSDB block storage (Prometheus refuses to ingest if exceeded)
4. **Deleted orphaned 25G PVC data** from /mnt/disks on riptide

After merge, Flux will reconcile and the prometheus pod may need to be restarted to re-size. Check for `Pending` PVC if storage reduction requires pod migration.