### PR TITLE
fix(netboot): add k8s-node profile so netboot image joins the cluster

### DIFF
--- a/nix/images/netboot.nix
+++ b/nix/images/netboot.nix
@@ -1,15 +1,18 @@
 {
   config,
   lib,
+  name ? "k8s-node",
+  tags ? [ "folly" ],
   modulesPath,
   ...
 }:
 {
   imports = [
     (modulesPath + "/installer/netboot/netboot-minimal.nix")
-    ../hardware/x86
-    ../services/common.nix
+    ../profiles/k8s-node.nix
   ];
+
+  networking.hostName = name;
 
   users.users = {
     # Remove initialHashedPassword for root and nixos
@@ -20,9 +23,7 @@
   networking.useDHCP = lib.mkForce true;
   networking.useNetworkd = lib.mkForce true;
   networking.networkmanager.enable = lib.mkForce false;
-
-  networking.hostName = "nixos-netboot";
-  networking.wireless.enable = true;
+  networking.wireless.enable = false;
 
   # why is this a thing that exists
   services.openssh.settings.PermitRootLogin = lib.mkForce "no";


### PR DESCRIPTION
## What

Makes the netboot image a proper k8s worker node by importing `k8s-node.nix` which brings in the k8s service, common.nix, and x86 hardware profile.

## Why

The HP 800 G2 (rosie) is being repurposed as a k8s worker via PXE boot. The current netboot image was just a minimal rescue image — now it includes the k8s agent so it can join the folly cluster automatically.

## Changes

- Adds `../profiles/k8s-node.nix` to imports (brings common.nix + hardware/x86 + k8s service)
- Added `name` and `tags` params (defaults to `k8s-node`, `[\folly\]`)
- Disabled wireless (wired PXE boot only)
- Moved hostName into body since k8s-node.nix reads it from the name arg