### PR TITLE
fix(ai-agent): deliver openclaw config via configFiles, decouple workspace PVC

### DIFF
--- a/charts/ai-agent/templates/configmap.yaml
+++ b/charts/ai-agent/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- range .Values.configFiles }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ai-agent.fullname" $ }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ai-agent.labels" $ | nindent 4 }}
+data:
+  {{ .mountKey }}: |-
+    {{- .content | nindent 4 }}
+{{- end }}

--- a/charts/ai-agent/templates/pvc.yaml
+++ b/charts/ai-agent/templates/pvc.yaml
@@ -11,7 +11,7 @@ spec:
   resources:
     requests:
       storage: {{ .Values.storageSize }}
-{{- if not .Values.secrets }}
+{{- if .Values.workspaceVolume.enabled }}
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/charts/ai-agent/templates/sandboxtemplate.yaml
+++ b/charts/ai-agent/templates/sandboxtemplate.yaml
@@ -12,6 +12,10 @@ spec:
       labels:
         {{- include "ai-agent.selectorLabels" . | nindent 8 }}
         sandbox: {{ include "ai-agent.fullname" . }}
+      {{- if .Values.configFiles }}
+      annotations:
+        checksum/config: {{ toYaml .Values.configFiles | sha256sum }}
+      {{- end }}
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -21,8 +25,34 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      {{- if .Values.npmTools }}
+      {{- if or .Values.npmTools .Values.configFiles }}
       initContainers:
+        {{- range .Values.configFiles }}
+        - name: install-config-{{ .name }}
+          image: {{ $.Values.configInstallImage | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              mkdir -p "$(dirname {{ .mountPath | quote }})"
+              cp {{ printf "/config-src/%s" .mountKey | quote }} {{ .mountPath | quote }}
+              chmod 0640 {{ .mountPath | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /home/agent/config
+              name: agent-config
+            - mountPath: /config-src
+              name: config-{{ .name }}
+        {{- end }}
+        {{- if .Values.npmTools }}
         - name: install-npm-tools
           image: {{ .Values.npmInstallImage | quote }}
           command:
@@ -45,6 +75,7 @@ spec:
           volumeMounts:
             - mountPath: /home/agent/.local
               name: agent-npm-tools
+        {{- end }}
       {{- end }}
       containers:
         - name: agent
@@ -83,6 +114,12 @@ spec:
               value: {{ .mountPath }}
             {{- end }}
             {{- end }}
+            {{- range .Values.configFiles }}
+            {{- if .envVar }}
+            - name: {{ .envVar }}
+              value: {{ .mountPath }}
+            {{- end }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.port }}
           resources:
@@ -99,7 +136,7 @@ spec:
             - mountPath: /home/agent/.local
               name: agent-npm-tools
             {{- end }}
-            {{- if not .Values.secrets }}
+            {{- if .Values.workspaceVolume.enabled }}
             - mountPath: /home/agent/workspace
               name: agent-workspace
             {{- end }}
@@ -117,7 +154,7 @@ spec:
         - name: agent-config
           persistentVolumeClaim:
             claimName: {{ include "ai-agent.fullname" . }}-agent-config
-        {{- if not .Values.secrets }}
+        {{- if .Values.workspaceVolume.enabled }}
         - name: agent-workspace
           persistentVolumeClaim:
             claimName: {{ include "ai-agent.fullname" . }}-agent-workspace
@@ -126,6 +163,14 @@ spec:
         - name: secret-{{ .name }}
           secret:
             secretName: {{ include "ai-agent.fullname" $ }}-{{ .name }}
+            items:
+              - key: {{ .mountKey }}
+                path: {{ .mountKey }}
+        {{- end }}
+        {{- range .Values.configFiles }}
+        - name: config-{{ .name }}
+          configMap:
+            name: {{ include "ai-agent.fullname" $ }}-{{ .name }}
             items:
               - key: {{ .mountKey }}
                 path: {{ .mountKey }}

--- a/charts/ai-agent/values.yaml
+++ b/charts/ai-agent/values.yaml
@@ -5,6 +5,12 @@ storageSize: 2Gi
 command: ""
 workspaceDir: ""
 
+# Dedicated scratch workspace PVC mounted at /home/agent/workspace.
+# Leave disabled when the agent keeps its workspace on the config PVC
+# (set workspaceDir to a path under /home/agent/config instead).
+workspaceVolume:
+  enabled: false
+
 resources:
   requests:
     memory: 256Mi
@@ -21,7 +27,10 @@ ingress:
 npmTools: []
 # - "@moonpay/cli"
 npmInstallImage: node:24-bookworm
+configInstallImage: busybox:1.37.0
 
+# secrets: config that CONTAINS secret material. Synced from 1Password via an
+# ExternalSecret (refreshInterval: 1h keeps it up to date) and mounted read-only.
 secrets: []
 # - name: config
 #   onePasswordItem: my-app-config
@@ -29,3 +38,15 @@ secrets: []
 #   mountPath: /config/config.json
 #   mountKey: config.json
 #   envVar: CONFIG_PATH
+
+# configFiles: non-secret config. Rendered into a ConfigMap and copied into the
+# config PVC at startup (writable by the agent). Use this when the config has no
+# secrets; deliver any secrets the agent needs separately (e.g. via .env/secrets).
+# A checksum annotation rolls the sandbox when content changes.
+configFiles: []
+# - name: config
+#   mountPath: /config/config.json
+#   mountKey: config.json
+#   envVar: CONFIG_PATH
+#   content: |
+#     {}

--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -34,10 +34,25 @@ spec:
       enabled: true
       mode: shared
       forwardedUser: jonathan
-    secrets:
+    configFiles:
       - name: config
-        onePasswordItem: openclaw-config
-        property: config.json5
-        mountPath: /home/agent/.openclaw/config.json5
+        mountPath: /home/agent/config/openclaw-config.json5
         mountKey: config.json5
         envVar: OPENCLAW_CONFIG_PATH
+        content: |
+          {
+            gateway: {
+              trustedProxies: ["10.3.0.0/24", "10.100.0.0/20"],
+              auth: {
+                mode: "trusted-proxy",
+                trustedProxy: {
+                  userHeader: "x-forwarded-user",
+                  allowUsers: ["jonathan"]
+                }
+              },
+              controlUi: {
+                allowedOrigins: ["https://walter.lolwtf.ca"],
+                dangerouslyDisableDeviceAuth: true
+              }
+            }
+          }

--- a/k8s/offsite/apps/dave.yaml
+++ b/k8s/offsite/apps/dave.yaml
@@ -33,10 +33,25 @@ spec:
       mode: shared
       forwardedUser: jonathan
     workspaceDir: /home/agent/config/workspace
-    secrets:
+    configFiles:
       - name: config
-        onePasswordItem: openclaw-config
-        property: config.json5
-        mountPath: /home/agent/.openclaw/config.json5
+        mountPath: /home/agent/config/openclaw-config.json5
         mountKey: config.json5
         envVar: OPENCLAW_CONFIG_PATH
+        content: |
+          {
+            gateway: {
+              trustedProxies: ["10.89.0.0/28", "10.101.0.0/20"],
+              auth: {
+                mode: "trusted-proxy",
+                trustedProxy: {
+                  userHeader: "x-forwarded-user",
+                  allowUsers: ["jonathan"]
+                }
+              },
+              controlUi: {
+                allowedOrigins: ["https://dave.lolwtf.ca"],
+                dangerouslyDisableDeviceAuth: true
+              }
+            }
+          }


### PR DESCRIPTION
## What

Walter and dave's openclaw gateway configs contain **no secrets** (only trusted-proxy CIDRs, allowed users, allowed origins), so this moves them off the 1Password `secrets` path onto a plain ConfigMap (`configFiles`) copied into the writable config PVC at startup — and fixes the bunged-up wiring that move introduced.

## Why it was broken

Switching walter/dave from `secrets:` to `configFiles:` flipped `{{ if not .Values.secrets }}`, which was being abused as an "unconfigured agent" predicate. Result: both agents started provisioning a phantom `-agent-workspace` PVC mounted at `/home/agent/workspace`, unused since their workspace lives at `/home/agent/config/workspace` on the config PVC.

## Changes

- **Decouple the scratch workspace PVC** from `not .Values.secrets` onto an explicit `workspaceVolume.enabled` (default `false`). No more phantom PVC.
- **Add a `checksum/config` annotation** on the podTemplate (gated on `configFiles`) so ConfigMap edits roll the sandbox pod — "keep it up to date."
- **Drop the redundant `chown`** in the config init container (`CAP_CHOWN` is dropped; the file is already uid/gid 1337 via `runAsUser`+`fsGroup`).
- **Fix the stray leading blank line** rendered into the ConfigMap value.
- **Document the decision rule** in `values.yaml`: `secrets:` for config containing secret material (1Password → ExternalSecret, kept in sync); `configFiles:` for non-secret config (ConfigMap, secrets via `.env`).

## Design

The chart now cleanly supports both paths; walter/dave use `configFiles` because their config is non-secret.

> Note: the json5 now lives in git as plaintext (it's non-secret). If a secret is ever added to that config, move it back to the `secrets:` path so it flows through 1Password instead of the repo.

## Validation

`helm lint` + `helm template` pass for both agents; only the `agent-config` PVC renders; ConfigMap is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)