### PR TITLE
fix(k8s): resolve Trivy HIGH findings in folly apps

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -52,6 +52,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Run Trivy vulnerability scanner in IaC mode
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        env:
+          TRIVY_IGNOREFILE: ${{ github.workspace }}/.trivyignore.yaml
         with:
           scan-type: config
           scan-ref: ${{ matrix.dir }}

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,19 @@
+# Trivy misconfiguration suppressions — documented, intentional risk acceptance.
+# Loaded in CI via TRIVY_IGNOREFILE (see .github/workflows/trivy.yml).
+# Path globs cover both whole-dir scans (e.g. "pbx/pbx.yaml") and per-app
+# matrix scans (e.g. "pbx.yaml"), since scan-ref varies with what changed.
+misconfigurations:
+  # pbx (Asterisk SIP/PBX) is a telephony workload that legitimately requires:
+  #   - host ports for SIP signalling (UDP/TCP 5060/5061) — KSV-0024
+  #   - root + a writable runtime for Asterisk state/spool/logs — KSV-0014, KSV-0118
+  # Hardening these into non-root / read-only would break call handling, so they
+  # are accepted rather than "fixed".
+  - id: AVD-KSV-0024
+    paths: ["**/pbx.yaml", "pbx.yaml"]
+    statement: "Asterisk SIP needs host ports to receive VoIP traffic on the node."
+  - id: AVD-KSV-0014
+    paths: ["**/pbx.yaml", "pbx.yaml"]
+    statement: "Asterisk writes runtime state/spool/logs; read-only rootfs is impractical."
+  - id: AVD-KSV-0118
+    paths: ["**/pbx.yaml", "pbx.yaml"]
+    statement: "Asterisk telephony container runs as root by design."

--- a/k8s/folly/apps/dump/dump.yaml
+++ b/k8s/folly/apps/dump/dump.yaml
@@ -19,10 +19,25 @@ spec:
         app.kubernetes.io/name: dump
         app.kubernetes.io/part-of: dump
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: dump
         image: nginx:alpine
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
         ports:
         - containerPort: 8080
           protocol: TCP
@@ -32,10 +47,22 @@ spec:
           mountPath: /var/lib/dump
         - name: nginx-config
           mountPath: /etc/nginx/conf.d
+        - name: nginx-cache
+          mountPath: /var/cache/nginx
+        - name: nginx-run
+          mountPath: /var/run
+        - name: tmp
+          mountPath: /tmp
       volumes:
       - name: nginx-config
         configMap:
           name: nginx-config
+      - name: nginx-cache
+        emptyDir: {}
+      - name: nginx-run
+        emptyDir: {}
+      - name: tmp
+        emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: dump-data

--- a/k8s/folly/apps/jellyfin/deployment.yaml
+++ b/k8s/folly/apps/jellyfin/deployment.yaml
@@ -30,8 +30,8 @@ spec:
               gpu.intel.com/i915: 1
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
-              add: ["SYS_ADMIN"]
               drop: ["ALL"]
             privileged: false
           volumeMounts:
@@ -43,7 +43,15 @@ spec:
               readOnly: false
             - name: hardware-acceleration
               mountPath: /dev/dri
+            - name: cache
+              mountPath: /cache
+            - name: tmp
+              mountPath: /tmp
       volumes:
+        - name: cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
         - name: jellyfin-config
           persistentVolumeClaim:
             claimName: jellyfin-config

--- a/k8s/folly/apps/satisfactory/statefulset.yaml
+++ b/k8s/folly/apps/satisfactory/statefulset.yaml
@@ -28,6 +28,7 @@ spec:
           image: wolveix/satisfactory-server
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
           ports:
@@ -84,6 +85,11 @@ spec:
           volumeMounts:
             - name: satisfactory-data
               mountPath: /config
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}
   volumeClaimTemplates:
     - metadata:
         name: satisfactory-data


### PR DESCRIPTION
## What

Resolves the 13 Trivy HIGH misconfigurations across `k8s/folly/apps` that were surfaced by the ai-agent config PR (#794) scan. Each finding is either properly remediated or accepted with documented justification.

## Real hardening

| App | Findings | Fix |
|-----|----------|-----|
| **dump** (nginx) | KSV-0014, KSV-0118 ×2 | Run non-root (uid/gid 101), drop `ALL` caps, `readOnlyRootFilesystem: true`, `seccompProfile: RuntimeDefault`; emptyDirs for `/var/cache/nginx`, `/var/run`, `/tmp`. Serves from the existing PVC on :8080. |
| **jellyfin** | KSV-0005, KSV-0014 | Drop the `SYS_ADMIN` capability — not needed for Intel QSV, `/dev/dri` access comes from the GPU device plugin + hostPath. Add `readOnlyRootFilesystem: true` with emptyDirs for `/cache` and `/tmp` (data stays on the `/config` PVC). |
| **satisfactory** | KSV-0014 | Add `readOnlyRootFilesystem: true` with a `/tmp` emptyDir (saves live on the `/config` PVC; already ran non-root). |

## Documented risk acceptance

`pbx` (Asterisk SIP/PBX) legitimately needs host ports for SIP signalling, root, and a writable runtime — hardening would break call handling. These are accepted via a new **`.trivyignore.yaml`** (wired through `TRIVY_IGNOREFILE` in the workflow), scoped to `pbx.yaml` with per-finding justifications so signal elsewhere is preserved:

- `KSV-0024` host ports — SIP needs to receive VoIP on the node
- `KSV-0118` root — telephony container runs as root by design
- `KSV-0014` read-only rootfs — Asterisk writes runtime state/spool/logs

## Verification

```
trivy config k8s/folly/apps --severity CRITICAL,HIGH  → exit 0 (no failures)
kubectl kustomize k8s/folly/apps                      → builds clean
```
Tested against both scan shapes (whole-dir and per-app matrix scan-ref).

## ⚠️ Watch after rollout

`readOnlyRootFilesystem` changes are the riskiest part. Please confirm after Flux reconciles:
- **jellyfin** — transcoding still works (writes go to `/config`/`/cache`/`/tmp`).
- **satisfactory** — server boots and saves (if the image writes outside `/config`, add an emptyDir for that path).

`dump` non-root + the `pbx` suppression carry no runtime risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)