### PR TITLE
feat(nixos): declarative disko layout for x86 hosts + live ISO installer

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,6 +20,26 @@
         "type": "github"
       }
     },
+    "disko": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1780048612,
+        "narHash": "sha256-Md/eOK5OjmvvHc2H52pLZe4zpP4XyfiS5vHqfRCz2HU=",
+        "owner": "nix-community",
+        "repo": "disko",
+        "rev": "caa775cf67bfdc47f940edd96c975b5016df9059",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "disko",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -43,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779976382,
-        "narHash": "sha256-wt5NGa4K8/vda669UYUmTUt+BR9X5fPnuTZFfQdpLYo=",
+        "lastModified": 1779554529,
+        "narHash": "sha256-v71G9aslDyyy7NNf4D4JtlyQ9ZIBRZ4wNcgYfl4aryU=",
         "owner": "StevenBlack",
         "repo": "hosts",
-        "rev": "d3e838712512490260f051150e3573eeebecfadb",
+        "rev": "c23f146657534a547190ed71f58b56d603718c99",
         "type": "github"
       },
       "original": {
@@ -69,15 +89,12 @@
       }
     },
     "nixos-hardware": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
       "locked": {
-        "lastModified": 1780065812,
-        "narHash": "sha256-SCSLUKBmwlSLGQ8Xbr8PjRFtiHNk0l9ktqkcmqdBkfE=",
+        "lastModified": 1779258371,
+        "narHash": "sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "b76b5639c0593e0aeb0b5879ad62d4b30596c144",
+        "rev": "c97bc4d15bd3473dd095e8e8ba57330ab1943a77",
         "type": "github"
       },
       "original": {
@@ -110,24 +127,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
-        "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1779796641,
-        "narHash": "sha256-ZsIrKmhp4vbBXoXXmR/tBXA/UCsAQiJL9vsgZEduhVY=",
+        "lastModified": 1779467186,
+        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "25f538306313eae3927264466c70d7001dcea1df",
+        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
         "type": "github"
       },
       "original": {
@@ -140,22 +144,23 @@
     "root": {
       "inputs": {
         "ddnsd": "ddnsd",
+        "disko": "disko",
         "hosts": "hosts",
         "keys": "keys",
         "nixos-hardware": "nixos-hardware",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "unstable": "unstable",
         "wannabekeys": "wannabekeys"
       }
     },
     "unstable": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,11 @@
     };
     unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
+    disko = {
+      url = "github:nix-community/disko";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     hosts = {
       url = "github:StevenBlack/hosts";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -74,12 +79,15 @@
         optiplex = mkHost "optiplex" {
           role = "control-plane";
           tags = [ "folly" ];
+          extraConfig.homelab.disko.device = "/dev/sda";
         };
         riptide = mkHost "riptide" {
           tags = [ "folly" ];
+          extraConfig.homelab.disko.device = "/dev/nvme0n1";
         };
         shale = mkHost "shale" {
           tags = [ "folly" ];
+          extraConfig.homelab.disko.device = "/dev/sda";
         };
 
         oldschool = mkHost "oldschool" {
@@ -91,11 +99,13 @@
           ];
           extraConfig = {
             virtualisation.docker.enable = true;
+            homelab.disko.device = "/dev/sda";
           };
         };
         retrofit = mkHost "retrofit" {
           tags = [ "offsite" ];
           role = "control-plane";
+          extraConfig.homelab.disko.device = "/dev/sda";
         };
 
         cloudpi4 = mkHost "cloudpi4" {

--- a/nix/disko/default.nix
+++ b/nix/disko/default.nix
@@ -1,0 +1,73 @@
+{
+  inputs,
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.homelab.disko;
+in
+{
+  imports = [ inputs.disko.nixosModules.disko ];
+
+  options.homelab.disko = {
+    device = lib.mkOption {
+      type = lib.types.str;
+      default = "/dev/sda";
+      description = "Whole-disk device to partition for this host.";
+    };
+    rootSize = lib.mkOption {
+      type = lib.types.str;
+      default = "100G";
+      description = "Size of the root partition; storage takes the rest.";
+    };
+  };
+
+  # GPT, EFI-only. disko owns the partitioning and generates fileSystems
+  # (by-partlabel: /dev/disk/by-partlabel/disk-main-{ESP,nixos,storage}).
+  config.disko.devices.disk.main = {
+    type = "disk";
+    device = cfg.device;
+    content = {
+      type = "gpt";
+      partitions = {
+        # EFI system partition; systemd-boot is installed here.
+        ESP = {
+          priority = 1;
+          size = "512M";
+          type = "EF00";
+          content = {
+            type = "filesystem";
+            format = "vfat";
+            mountpoint = "/boot";
+            mountOptions = [ "umask=0077" ];
+          };
+        };
+        # Root.
+        nixos = {
+          priority = 2;
+          size = cfg.rootSize;
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/";
+          };
+        };
+        # Bulk storage fills the remainder of the disk.
+        storage = {
+          priority = 3;
+          size = "100%";
+          content = {
+            type = "filesystem";
+            format = "ext4";
+            mountpoint = "/mnt/disks";
+            mountOptions = [
+              "nofail"
+              "relatime"
+            ];
+          };
+        };
+      };
+    };
+  };
+}

--- a/nix/hardware/x86/default.nix
+++ b/nix/hardware/x86/default.nix
@@ -41,24 +41,9 @@
     ];
   };
 
-  fileSystems."/boot" = {
-    device = "/dev/disk/by-label/boot";
-    fsType = "vfat";
-  };
-
-  fileSystems."/" = lib.mkDefault {
-    device = "/dev/disk/by-label/nixos";
-    fsType = "ext4";
-  };
-
-  fileSystems."/mnt/disks" = {
-    device = "/dev/disk/by-label/storage";
-    fsType = "ext4";
-    options = [
-      "nofail"
-      "relatime"
-    ];
-  };
+  # Disk layout and fileSystems are declared by disko (see ../../disko) for
+  # k8s nodes. The install ISO imports this hardware module too but gets its
+  # root filesystem from installation-cd-minimal.nix, so nothing is declared here.
 
   swapDevices = [ ];
 }

--- a/nix/images/INSTALL.md
+++ b/nix/images/INSTALL.md
@@ -1,0 +1,61 @@
+# Homelab live installer
+
+You are booted into the jonpulsifer/infra live NixOS installer.
+
+## Quick install (disko)
+
+1. Get on the network — DHCP is automatic, check with `ip a`. For Wi-Fi use `wpa_cli`.
+2. Identify the target disk: `lsblk`
+3. Install this host:
+
+   ```
+   sudo homelab-install <host>
+   ```
+
+   | host      | disk           | cluster / role          |
+   |-----------|----------------|-------------------------|
+   | optiplex  | /dev/sda       | folly, control-plane    |
+   | riptide   | /dev/nvme0n1   | folly                   |
+   | shale     | /dev/sda       | folly                   |
+   | oldschool | /dev/sda       | offsite                 |
+   | retrofit  | /dev/sda       | offsite, control-plane  |
+
+   This DESTROYS the target disk, partitions it (GPT: boot → nixos → storage),
+   formats, mounts at `/mnt`, and installs NixOS. Config is pulled from
+   `github:jonpulsifer/infra` by default.
+
+   Install from a branch or a local checkout instead:
+
+   ```
+   sudo homelab-install riptide github:jonpulsifer/infra/my-branch
+   sudo homelab-install riptide /mnt/infra
+   ```
+
+4. Reboot: `sudo reboot`
+
+## Manual steps (what homelab-install runs)
+
+```
+sudo disko --mode destroy,format,mount --flake github:jonpulsifer/infra#<host>
+sudo nixos-install --flake github:jonpulsifer/infra#<host> --no-root-passwd
+sudo reboot
+```
+
+## Remote install (from your laptop; target booted into this ISO)
+
+```
+nix run github:nix-community/nixos-anywhere -- \
+  --flake .#<host> --target-host root@<ip>
+```
+
+## Layout
+
+GPT, EFI-only, single disk per host (systemd-boot):
+
+- `ESP`     — 512M, vfat, `/boot` (`umask=0077`), type EF00
+- `nixos`   — 100G, ext4, `/`
+- `storage` — rest, ext4, `/mnt/disks` (`nofail,relatime`)
+
+The target disk and root size come from `homelab.disko.{device,rootSize}` in the
+host config (see `nix/disko/default.nix`). Adjust in `flake.nix` before installing
+if a host's hardware differs.

--- a/nix/images/homelab-install.sh
+++ b/nix/images/homelab-install.sh
@@ -1,0 +1,54 @@
+flake_default="github:jonpulsifer/infra"
+
+usage() {
+  cat <<EOF
+homelab-install — partition, format, and install a homelab host with disko
+
+Usage: homelab-install <host> [flake-ref]
+
+  <host>       NixOS host name (optiplex, riptide, shale, oldschool, retrofit)
+  [flake-ref]  Flake to install from (default: ${flake_default})
+                 branch: github:jonpulsifer/infra/my-branch
+                 local:  /mnt/infra  or  .
+
+DESTROYS all data on the target disk (homelab.disko.device in the host config),
+partitions GPT boot/nixos/storage, formats, mounts at /mnt, and installs NixOS.
+You will be asked to confirm.
+EOF
+}
+
+if [[ $# -lt 1 || "$1" == "-h" || "$1" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+host="$1"
+flake="${2:-$flake_default}"
+target="${flake}#${host}"
+
+echo ">> Host:  ${host}"
+echo ">> Flake: ${flake}"
+echo ">> Resolving target disk from the host config ..."
+device="$(nix eval --raw "${flake}#nixosConfigurations.${host}.config.homelab.disko.device" 2>/dev/null || true)"
+if [[ -n "${device}" ]]; then
+  echo ">> Target disk: ${device}"
+  lsblk "${device}" || true
+else
+  echo "!! Could not read homelab.disko.device; disko will use the configured device."
+fi
+
+echo ""
+echo "!! This DESTROYS all data on the target disk and installs NixOS."
+read -rp "Type the host name '${host}' to continue: " confirm
+if [[ "${confirm}" != "${host}" ]]; then
+  echo "Aborted."
+  exit 1
+fi
+
+echo ">> Partitioning + formatting + mounting with disko ..."
+disko --mode destroy,format,mount --flake "${target}"
+
+echo ">> Installing NixOS to /mnt ..."
+nixos-install --flake "${target}" --no-root-passwd
+
+echo ">> Done. Reboot when ready:  sudo reboot"

--- a/nix/images/iso.nix
+++ b/nix/images/iso.nix
@@ -1,15 +1,46 @@
 {
   config,
   lib,
+  pkgs,
+  inputs,
   modulesPath,
   ...
 }:
+let
+  disko = inputs.disko.packages.${pkgs.system}.disko;
+
+  homelab-install = pkgs.writeShellApplication {
+    name = "homelab-install";
+    runtimeInputs = [
+      disko
+      pkgs.nixos-install-tools
+      pkgs.util-linux
+    ];
+    text = builtins.readFile ./homelab-install.sh;
+  };
+in
 {
   imports = [
     (modulesPath + "/installer/cd-dvd/installation-cd-minimal.nix")
     ../hardware/x86
     ../services/common.nix
   ];
+
+  # Provisioning tooling + instructions baked into the live image.
+  environment.systemPackages = [
+    disko
+    homelab-install
+  ];
+
+  environment.etc."README".source = ./INSTALL.md;
+
+  users.motd = ''
+
+    === jonpulsifer/infra live installer ===
+    Install a host:   sudo homelab-install <host>
+    Full guide:       less /etc/README
+    Hosts:            optiplex riptide shale oldschool retrofit
+  '';
 
   users.users = {
     # Remove initialHashedPassword for root and nixos

--- a/nix/profiles/k8s-node.nix
+++ b/nix/profiles/k8s-node.nix
@@ -5,6 +5,7 @@
 {
   imports = [
     ../hardware/x86
+    ../disko
     ../services/common.nix
     ../services/k8s
   ];


### PR DESCRIPTION
## What

Make the x86 k8s nodes' disk layout declarative with [disko](https://github.com/nix-community/disko), and bake provisioning into the live ISO so a fresh host can be installed with one command. EFI-only, systemd-boot.

### Disko layout (`nix/disko/default.nix`)
Clean GPT layout per host (follows the canonical disko EFI example):

| partition | size | fs | mount | notes |
|-----------|------|----|-------|-------|
| `ESP` | 512M | vfat (EF00) | `/boot` | `umask=0077` |
| `nixos` | 100G | ext4 | `/` | |
| `storage` | rest | ext4 | `/mnt/disks` | `nofail,relatime` |

- Per-host target disk via `homelab.disko.device` (**riptide = `/dev/nvme0n1`**, others = `/dev/sda`); root size via `homelab.disko.rootSize`.
- disko owns the `fileSystems` for k8s nodes (imported via `nix/profiles/k8s-node.nix`), generated by-partlabel (`/dev/disk/by-partlabel/disk-main-*`). No legacy by-label forcing or BIOS/EF02 partition — pure EFI.
- The manual `fileSystems` block is removed from `nix/hardware/x86`; boot stays on systemd-boot (`efi.canTouchEfiVariables`).
- Hosts: `optiplex`, `riptide`, `shale`, `oldschool`, `retrofit`. Pis (SD images) untouched.

### Live ISO installer (`nix/images/iso.nix`)
- `homelab-install <host>` wrapper: confirm -> `disko --mode destroy,format,mount` -> `nixos-install`. Defaults to `github:jonpulsifer/infra`; accepts a branch or local path.
- `disko` CLI on `PATH`, an `/etc/README` guide, and an MOTD hint appended under the existing banner.

## Provisioning / migration note
This is a fresh-install layout. Existing nodes should be **reprovisioned** with disko (via `homelab-install` or `nixos-anywhere`) to adopt the 512M ESP / by-partlabel scheme — a plain `nixos-rebuild` is not a migration path since on-disk partition labels change.

## Verification
- `nix flake check` — all checks passed.
- Built `...system.build.toplevel` for optiplex, riptide, shale, oldschool, retrofit, and the ISO.
- Generated fstab: `/dev/disk/by-partlabel/disk-main-ESP /boot vfat umask=0077`, root `ext4 x-initrd.mount`, storage `nofail,relatime`. `diskoScript` creates the ESP at `+512M` type EF00; riptide targets `/dev/nvme0n1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)