### PR TITLE
chore(walter): prepare agent storage for migration

### DIFF
--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -17,7 +17,7 @@ spec:
     image: docker.io/jonpulsifer/ai-agents:latest
     port: 18789
     hostname: walter.lolwtf.ca
-    storageSize: 2Gi
+    storageSize: 10Gi
     command: "openclaw gateway --bind=lan --port 18789 --allow-unconfigured --verbose"
     resources:
       requests:
@@ -28,6 +28,8 @@ spec:
         cpu: 4000m
     npmInstallImage: node:24-bookworm
     workspaceDir: /home/agent/config/workspace
+    workspaceVolume:
+      enabled: false
     npmTools:
       - "@moonpay/cli"
     ingress:


### PR DESCRIPTION
## Summary
- increase Walter's ai-agent PVC request from 2Gi to 10Gi
- explicitly keep the active OpenClaw workspace on the config PVC at `/home/agent/config/workspace`
- document that the separate `/home/agent/workspace` scratch PVC is disabled for Walter

## Context
Rowbutt/OpenClaw state has been live-migrated into Walter's config PVC. The copied state is about 790Mi today, so the old 2Gi PVC request is too tight for Walter to become the primary home.

## Validation
- `kubectl kustomize k8s/folly/apps` rendered successfully
- `git diff --check` passed
- `kubectl apply --dry-run=server -k k8s/folly/apps` was attempted but blocked by encrypted SOPS Secret manifests being sent directly to the API server, which is expected outside Flux/SOPS decryption
