### PR TITLE
fix(walter): boot from migrated state config

### DIFF
--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -36,25 +36,3 @@ spec:
       enabled: true
       mode: shared
       forwardedUser: jonathan
-    configFiles:
-      - name: config
-        mountPath: /home/agent/config/openclaw-config.json5
-        mountKey: config.json5
-        envVar: OPENCLAW_CONFIG_PATH
-        content: |
-          {
-            gateway: {
-              trustedProxies: ["10.3.0.0/24", "10.100.0.0/20"],
-              auth: {
-                mode: "trusted-proxy",
-                trustedProxy: {
-                  userHeader: "x-forwarded-user",
-                  allowUsers: ["jonathan"]
-                }
-              },
-              controlUi: {
-                allowedOrigins: ["https://walter.lolwtf.ca"],
-                dangerouslyDisableDeviceAuth: true
-              }
-            }
-          }


### PR DESCRIPTION
## Summary
- remove Walter's generated ConfigMap config file
- let OpenClaw boot from the migrated state config at `${OPENCLAW_STATE_DIR}/openclaw.json`

## Context
After migrating Rowbutt's state into Walter, the pod was still booting from `/home/agent/config/openclaw-config.json5`, which only contained gateway settings. That prevented migrated channel configuration, including Discord and Slack, from being active on Walter.

Walter's state config has been updated in-place on the PVC to keep the trusted-proxy gateway settings while enabling migrated Discord/Slack channels.

## Validation
- `kubectl kustomize k8s/folly/apps` rendered successfully
- `git diff --check` passed
