### PR TITLE
Wire Walter OP service account secret

### DIFF
--- a/charts/ai-agent/templates/externalsecret.yaml
+++ b/charts/ai-agent/templates/externalsecret.yaml
@@ -18,6 +18,29 @@ spec:
   data:
     - secretKey: {{ .mountKey }}
       remoteRef:
-        key: {{ .onePasswordItem }}
-        property: {{ .property }}
+        key: {{ .onePasswordItem | quote }}
+        property: {{ .property | quote }}
+{{- end }}
+{{- range .Values.envSecrets }}
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "ai-agent.fullname" $ }}-{{ .name }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "ai-agent.labels" $ | nindent 4 }}
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: {{ include "ai-agent.fullname" $ }}-{{ .name }}
+    creationPolicy: Owner
+  data:
+    - secretKey: {{ default .envVar .secretKey }}
+      remoteRef:
+        key: {{ .onePasswordItem | quote }}
+        property: {{ .property | quote }}
 {{- end }}

--- a/charts/ai-agent/templates/sandboxtemplate.yaml
+++ b/charts/ai-agent/templates/sandboxtemplate.yaml
@@ -114,6 +114,13 @@ spec:
               value: {{ .mountPath }}
             {{- end }}
             {{- end }}
+            {{- range .Values.envSecrets }}
+            - name: {{ .envVar }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-agent.fullname" $ }}-{{ .name }}
+                  key: {{ default .envVar .secretKey }}
+            {{- end }}
             {{- range .Values.configFiles }}
             {{- if .envVar }}
             - name: {{ .envVar }}

--- a/charts/ai-agent/values.yaml
+++ b/charts/ai-agent/values.yaml
@@ -39,6 +39,15 @@ secrets: []
 #   mountKey: config.json
 #   envVar: CONFIG_PATH
 
+# envSecrets: secret values synced from 1Password via ExternalSecret and
+# projected directly into the agent container environment.
+envSecrets: []
+# - name: op-service-account-token
+#   envVar: OP_SERVICE_ACCOUNT_TOKEN
+#   onePasswordItem: "Service Account Auth Token: rowbutt"
+#   property: credential
+#   secretKey: token
+
 # configFiles: non-secret config. Rendered into a ConfigMap and copied into the
 # config PVC at startup (writable by the agent). Use this when the config has no
 # secrets; deliver any secrets the agent needs separately (e.g. via .env/secrets).

--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -32,6 +32,12 @@ spec:
       enabled: false
     npmTools:
       - "@moonpay/cli"
+    envSecrets:
+      - name: op-service-account-token
+        envVar: OP_SERVICE_ACCOUNT_TOKEN
+        onePasswordItem: "Service Account Auth Token: rowbutt"
+        property: credential
+        secretKey: token
     ingress:
       enabled: true
       mode: shared


### PR DESCRIPTION
## Summary
- add `envSecrets` support to the `ai-agent` chart using the existing 1Password Connect `ClusterSecretStore`
- project env-var secrets into the agent container with `valueFrom.secretKeyRef`
- wire Walter's `OP_SERVICE_ACCOUNT_TOKEN` from `Service Account Auth Token: rowbutt` / `credential`

## Validation
- `kubectl kustomize k8s/folly/apps`
- `helm template walter charts/ai-agent --namespace agents-sandbox -f /tmp/walter-values.yaml`
- `kubectl apply --dry-run=server -f /tmp/walter-rendered.yaml`
