### PR TITLE
Repackage ai-agent chart on source revisions

### DIFF
--- a/charts/ai-agent/Chart.yaml
+++ b/charts/ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ai-agent
 description: An opinionated Helm chart for deploying AI agents with sandbox isolation
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"

--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/ai-agent
+      reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
         name: infra

--- a/k8s/offsite/apps/dave.yaml
+++ b/k8s/offsite/apps/dave.yaml
@@ -9,6 +9,7 @@ spec:
   chart:
     spec:
       chart: charts/ai-agent
+      reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
         name: infra


### PR DESCRIPTION
## Summary
- bump the local `ai-agent` chart version so Flux repackages the chart with the env secret template changes
- set Walter and Dave HelmRelease chart packaging to `reconcileStrategy: Revision` so future local chart edits are picked up from Git revisions

## Validation
- `kubectl kustomize k8s/folly/apps`
- `kubectl kustomize k8s/offsite/apps`
- `git diff --check`
