### PR TITLE
fix: masquerade folly pod egress to offsite

### DIFF
--- a/k8s/folly/networking/cilium/helm-release.yaml
+++ b/k8s/folly/networking/cilium/helm-release.yaml
@@ -35,6 +35,14 @@ spec:
     enableIPv4Masquerade: true
     bpf:
       masquerade: true
+    ipMasqAgent:
+      enabled: true
+      config:
+        nonMasqueradeCIDRs:
+          - 10.3.0.0/24
+          - 10.10.0.0/16
+          - ${CILIUM_POD_CIDR}
+        masqLinkLocal: false
     ipam:
       mode: multi-pool
     enableXTSocketFallback: false


### PR DESCRIPTION
## Summary
Enable Cilium's eBPF ip-masq-agent on folly so pod egress to offsite node and load balancer CIDRs is SNATed through node/Tailscale routing.

## Changes
- Configure folly Cilium `ipMasqAgent` with local-only non-masquerade CIDRs
- Preserve unmasqueraded traffic for folly node/LB, service, and pod networks

## Test Plan
- [x] `kubectl kustomize k8s/folly/networking/cilium`
- [x] `kubectl kustomize k8s/folly/networking`

## Notes
After Flux rolls Cilium, verify from Walter:

```sh
curl -vk https://dave.lolwtf.ca
curl -vk https://atlantis.lolwtf.ca
curl -k https://10.89.0.10:6443/version
```
