### PR TITLE
fix: narrow folly cilium native routing cidr

### DIFF
--- a/k8s/folly/networking/cilium/helm-release.yaml
+++ b/k8s/folly/networking/cilium/helm-release.yaml
@@ -31,7 +31,7 @@ spec:
     k8sServiceHost: ${API_SERVER_IP}
     k8sServicePort: ${API_SERVER_PORT}
     routingMode: native
-    ipv4NativeRoutingCIDR: ${CILIUM_NATIVE_ROUTING_CIDR}
+    ipv4NativeRoutingCIDR: ${CILIUM_POD_CIDR}
     enableIPv4Masquerade: true
     bpf:
       masquerade: true


### PR DESCRIPTION
## Summary
Fix folly pod egress to offsite Tailscale-routed node and load balancer CIDRs by narrowing Cilium's native routing CIDR to the folly pod CIDR.

## Changes
- Set folly Cilium `ipv4NativeRoutingCIDR` to `${CILIUM_POD_CIDR}` so offsite `10.89.0.0/28` and `10.89.0.64/26` traffic is masqueraded instead of treated as natively routable

## Test Plan
- [x] `kubectl kustomize k8s/folly/networking/cilium`
- [x] `kubectl kustomize k8s/folly/networking`
- [x] Live patched folly HelmRelease, restarted Cilium, and verified from Walter:
  - `atlantis.lolwtf.ca` -> `200 10.89.0.65 rc=0`
  - `dave.lolwtf.ca` -> `200 10.89.0.66 rc=0`
  - `argo.lolwtf.ca` -> `200 10.3.0.70 rc=0`

## Notes
Cilium needed a DaemonSet restart after the ConfigMap changed for `ipv4-native-routing-cidr` to take effect.
