### PR TITLE
fix(ai-agent): persist walter home on existing pvc

### DIFF
--- a/charts/ai-agent/templates/sandboxtemplate.yaml
+++ b/charts/ai-agent/templates/sandboxtemplate.yaml
@@ -1,3 +1,4 @@
+{{- $persistHome := eq .Values.agentHomeMountPath "/home/agent" -}}
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
@@ -47,7 +48,7 @@ spec:
               drop:
                 - ALL
           volumeMounts:
-            - mountPath: /home/agent/config
+            - mountPath: {{ $.Values.agentHomeMountPath }}
               name: agent-config
             - mountPath: /config-src
               name: config-{{ .name }}
@@ -73,8 +74,13 @@ spec:
               drop:
                 - ALL
           volumeMounts:
+            {{- if $persistHome }}
+            - mountPath: {{ .Values.agentHomeMountPath }}
+              name: agent-config
+            {{- else }}
             - mountPath: /home/agent/.local
               name: agent-npm-tools
+            {{- end }}
         {{- end }}
       {{- end }}
       containers:
@@ -97,7 +103,7 @@ spec:
           {{- end }}
           env:
             - name: OPENCLAW_STATE_DIR
-              value: /home/agent/config/.openclaw
+              value: {{ .Values.openclawStateDir }}
             - name: OPENCLAW_NO_RESPAWN
               value: "1"
             {{- if .Values.workspaceDir }}
@@ -137,9 +143,9 @@ spec:
               memory: {{ .Values.resources.limits.memory }}
               cpu: {{ .Values.resources.limits.cpu }}
           volumeMounts:
-            - mountPath: /home/agent/config
+            - mountPath: {{ .Values.agentHomeMountPath }}
               name: agent-config
-            {{- if .Values.npmTools }}
+            {{- if and .Values.npmTools (not $persistHome) }}
             - mountPath: /home/agent/.local
               name: agent-npm-tools
             {{- end }}
@@ -154,7 +160,7 @@ spec:
               readOnly: true
             {{- end }}
       volumes:
-        {{- if .Values.npmTools }}
+        {{- if and .Values.npmTools (not $persistHome) }}
         - name: agent-npm-tools
           emptyDir: {}
         {{- end }}

--- a/charts/ai-agent/values.yaml
+++ b/charts/ai-agent/values.yaml
@@ -4,6 +4,11 @@ hostname: ""
 storageSize: 2Gi
 command: ""
 workspaceDir: ""
+openclawStateDir: /home/agent/config/.openclaw
+
+# Path where the existing *-agent-config PVC is mounted. Keep the default for
+# config-only persistence, or set to /home/agent to persist the whole home dir.
+agentHomeMountPath: /home/agent/config
 
 # Dedicated scratch workspace PVC mounted at /home/agent/workspace.
 # Leave disabled when the agent keeps its workspace on the config PVC

--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -28,7 +28,9 @@ spec:
         memory: 8Gi
         cpu: 4000m
     npmInstallImage: node:24-bookworm
-    workspaceDir: /home/agent/config/workspace
+    agentHomeMountPath: /home/agent
+    openclawStateDir: /home/agent/.openclaw
+    workspaceDir: /home/agent/workspace
     workspaceVolume:
       enabled: false
     npmTools:


### PR DESCRIPTION
## Summary
Persist Walter's entire `/home/agent` directory on the existing agent config PVC so GitHub/XDG/OpenClaw state survives container restarts without replacing the current PVC data.

## Changes
- fix(ai-agent): persist walter home on existing pvc

## Test Plan
- [x] `nix develop -c helm template walter charts/ai-agent -n agents-sandbox --set storageSize=10Gi --set agentHomeMountPath=/home/agent --set openclawStateDir=/home/agent/.openclaw --set workspaceDir=/home/agent/workspace --set "npmTools[0]=@moonpay/cli"`
- [x] `nix develop -c helm template default charts/ai-agent -n agents-sandbox --set "npmTools[0]=@moonpay/cli"`
- [x] `nix develop -c kubectl kustomize k8s/folly/apps`

## Context
- `.agent/context/context.md`
- `.agent/context/plan.md`
