### PR TITLE
fix(ai-agent): persist Walter OpenClaw plugins

### DIFF
--- a/charts/ai-agent/templates/sandboxtemplate.yaml
+++ b/charts/ai-agent/templates/sandboxtemplate.yaml
@@ -26,7 +26,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
-      {{- if or .Values.npmTools .Values.configFiles }}
+      {{- if or .Values.npmTools .Values.configFiles .Values.openclawPlugins }}
       initContainers:
         {{- range .Values.configFiles }}
         - name: install-config-{{ .name }}
@@ -59,12 +59,23 @@ spec:
           command:
             - sh
             - -c
+            {{- if eq .Values.npmToolInstaller "bun" }}
+            - bun add --global {{ .Values.npmTools | join " " }}
+            {{- else }}
             - npm install -g --prefix /home/agent/.local {{ .Values.npmTools | join " " }}
+            {{- end }}
           env:
             - name: HOME
               value: /tmp
+            {{- if eq .Values.npmToolInstaller "bun" }}
+            - name: BUN_INSTALL
+              value: /home/agent/.local
+            - name: BUN_INSTALL_CACHE_DIR
+              value: /tmp/.bun
+            {{- else }}
             - name: NPM_CONFIG_CACHE
               value: /tmp/.npm
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
@@ -81,6 +92,38 @@ spec:
             - mountPath: /home/agent/.local
               name: agent-npm-tools
             {{- end }}
+        {{- end }}
+        {{- if .Values.openclawPlugins }}
+        - name: install-openclaw-plugins
+          image: {{ .Values.image | quote }}
+          command:
+            - sh
+            - -c
+            - |
+              set -eu
+              {{- range .Values.openclawPlugins }}
+              openclaw plugins install --force {{ . | quote }}
+              {{- end }}
+          env:
+            - name: HOME
+              value: /home/agent
+            - name: OPENCLAW_STATE_DIR
+              value: {{ .Values.openclawStateDir }}
+            {{- if .Values.workspaceDir }}
+            - name: OPENCLAW_WORKSPACE_DIR
+              value: {{ .Values.workspaceDir }}
+            {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            seccompProfile:
+              type: RuntimeDefault
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: {{ .Values.agentHomeMountPath }}
+              name: agent-config
         {{- end }}
       {{- end }}
       containers:
@@ -102,6 +145,8 @@ spec:
             - {{ .Values.command | quote }}
           {{- end }}
           env:
+            - name: HOME
+              value: /home/agent
             - name: OPENCLAW_STATE_DIR
               value: {{ .Values.openclawStateDir }}
             - name: OPENCLAW_NO_RESPAWN

--- a/charts/ai-agent/values.yaml
+++ b/charts/ai-agent/values.yaml
@@ -32,6 +32,14 @@ ingress:
 npmTools: []
 # - "@moonpay/cli"
 npmInstallImage: node:24-bookworm
+npmToolInstaller: npm
+
+# OpenClaw plugins to install into OPENCLAW_STATE_DIR before the gateway starts.
+# Use this for plugins that must survive restarts, e.g. chat channel bridges.
+openclawPlugins: []
+# - "@openclaw/slack@2026.5.20"
+# - "@openclaw/discord@2026.5.22"
+
 configInstallImage: busybox:1.38.0
 
 # secrets: config that CONTAINS secret material. Synced from 1Password via an

--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -27,7 +27,8 @@ spec:
       limits:
         memory: 8Gi
         cpu: 4000m
-    npmInstallImage: node:24-bookworm
+    npmInstallImage: oven/bun:1
+    npmToolInstaller: bun
     agentHomeMountPath: /home/agent
     openclawStateDir: /home/agent/.openclaw
     workspaceDir: /home/agent/workspace
@@ -35,6 +36,10 @@ spec:
       enabled: false
     npmTools:
       - "@moonpay/cli"
+    openclawPlugins:
+      - "@openclaw/slack@2026.5.20"
+      - "@openclaw/discord@2026.5.22"
+      - "@openclaw/codex"
     envSecrets:
       - name: op-service-account-token
         envVar: OP_SERVICE_ACCOUNT_TOKEN


### PR DESCRIPTION
## Summary
- add declarative OpenClaw plugin install support to the ai-agent chart
- configure Walter to install Slack, Discord, and Codex plugins before startup
- switch Walter npmTools install to bun while keeping npm as the chart default

## Validation
- helm template Walter/default ai-agent renders
- kubectl kustomize k8s/folly/apps
- git diff --check
- live temp bun global install smoke test in Walter

## Notes
- OpenClaw plugins still use `openclaw plugins install` so OpenClaw registry/config metadata stays correct.