### PR TITLE
fix(walter): use npm for MoonPay CLI install

### DIFF
--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -27,8 +27,7 @@ spec:
       limits:
         memory: 8Gi
         cpu: 4000m
-    npmInstallImage: oven/bun:1
-    npmToolInstaller: bun
+    npmInstallImage: node:24-bookworm
     agentHomeMountPath: /home/agent
     openclawStateDir: /home/agent/.openclaw
     workspaceDir: /home/agent/workspace


### PR DESCRIPTION
## Summary
- keep Walter on npm for `@moonpay/cli` install
- leave declarative OpenClaw plugin install in place

## Why
`bun add --global @moonpay/cli` fails in the Walter PVC-backed home with `Failed to link @moonpay/cli: EACCES`, even after validating uid 1337 can write the target dirs and trying `--force --backend=copyfile`. npm succeeds and Walter is currently recovered with an operational live patch.

## Validation
- helm template Walter ai-agent renders npm install initContainer
- kubectl kustomize k8s/folly/apps
- git diff --check
- live Walter recovered: pod Running/Ready with npm + OpenClaw plugin init containers