### PR TITLE
fix(jellyfin): reduce to 1 replica to fit single GPU node

### DIFF
--- a/k8s/folly/apps/jellyfin/deployment.yaml
+++ b/k8s/folly/apps/jellyfin/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app.kubernetes.io/name: jellyfin
     app.kubernetes.io/part-of: jellyfin
 spec:
+  replicas: 1
   selector:
     matchLabels: *labels
   template:


### PR DESCRIPTION
Jellyfin has 2 replicas but only 1 GPU node (riptide). This causes the second pod to stay Pending indefinitely. Reducing to 1 replica until a second GPU node is added.