### PR TITLE
chore(tooling): prefer mise for portable tools

### DIFF
--- a/.agents/skills/validate-build/SKILL.md
+++ b/.agents/skills/validate-build/SKILL.md
@@ -7,17 +7,17 @@ description: >-
 
 ## Environment
 
-Tools come from the flake. Prefer the dev shell so `kustomize`, `terraform`, etc. are on `PATH`:
+Prefer `mise` for portable repo tooling. Use the Nix dev shell only for Nix-specific builds or formatters.
 
 ```bash
-nix develop
+mise install
 ```
 
 ## Kubernetes / Kustomize
 
 Build the **kustomization root that includes your change** (the directory with `kustomization.yaml` that lists your file, or a parent Flux kustomization).
 
-Use `kubectl kustomize` (kustomize is not a standalone binary in this flake):
+Use either `kubectl kustomize` or the mise-managed standalone `kustomize`:
 
 ```bash
 kubectl kustomize k8s/folly/sandbox

--- a/.mise.toml
+++ b/.mise.toml
@@ -10,7 +10,14 @@ eza = "latest"
 flux2 = "latest"
 fzf = "latest"
 gcloud = "latest"
+helm = "latest"
+k9s = "latest"
+kubectl = "latest"
+kustomize = "latest"
+sops = "latest"
 terraform = "latest"
+terraform-docs = "latest"
+vault = "latest"
 
 [tasks.devshell]
 description = "Enter the Nix dev shell"
@@ -20,7 +27,7 @@ run = "nix develop"
 description = "Format Nix + Terraform"
 run = [
   "nix develop -c nix fmt",
-  "nix develop -c terraform fmt -recursive",
+  "terraform fmt -recursive",
 ]
 
 [tasks."nix:fmt"]
@@ -29,23 +36,23 @@ run = "nix develop -c nix fmt"
 
 [tasks."tf:fmt"]
 description = "Format Terraform files"
-run = "nix develop -c terraform fmt -recursive"
+run = "terraform fmt -recursive"
 
 [tasks."tf:init"]
 description = "Initialize Terraform modules without backends"
 run = [
-  "nix develop -c bash -lc 'for d in argo cloudflare tailscale unifi vault gcp/organization gcp/projects/*; do [ -d \"$d\" ] || continue; echo \"==> terraform init -backend=false $d\"; terraform -chdir=\"$d\" init -backend=false -input=false; done'",
+  "bash -lc 'for d in argo cloudflare tailscale unifi vault gcp/organization gcp/projects/*; do [ -d \"$d\" ] || continue; echo \"==> terraform init -backend=false $d\"; terraform -chdir=\"$d\" init -backend=false -input=false; done'",
 ]
 
 [tasks."tf:validate"]
 description = "Validate Terraform modules"
 depends = ["tf:init"]
 run = [
-  "nix develop -c bash -lc 'for d in argo cloudflare tailscale unifi vault gcp/organization gcp/projects/*; do [ -d \"$d\" ] || continue; echo \"==> terraform validate $d\"; terraform -chdir=\"$d\" validate; done'",
+  "bash -lc 'for d in argo cloudflare tailscale unifi vault gcp/organization gcp/projects/*; do [ -d \"$d\" ] || continue; echo \"==> terraform validate $d\"; terraform -chdir=\"$d\" validate; done'",
 ]
 
 [tasks."tf:plan"]
 description = "Run Terraform plan for one module (set TF_DIR)"
 run = [
-  "nix develop -c bash -lc 'if [ -z \"$TF_DIR\" ]; then echo \"Set TF_DIR, e.g. TF_DIR=unifi mise run tf:plan\"; exit 1; fi; terraform -chdir=\"$TF_DIR\" init -input=false && terraform -chdir=\"$TF_DIR\" plan'",
+  "bash -lc 'if [ -z \"$TF_DIR\" ]; then echo \"Set TF_DIR, e.g. TF_DIR=unifi mise run tf:plan\"; exit 1; fi; terraform -chdir=\"$TF_DIR\" init -input=false && terraform -chdir=\"$TF_DIR\" plan'",
 ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,11 +8,19 @@ Multi-layer homelab infrastructure managed as code: NixOS bare metal hosts, Kube
 
 ## Development Environment
 
-All tools are provided by the Nix flake. Enter the shell before doing anything:
+Prefer `mise` for portable repo tooling:
+
+```bash
+mise install
+```
+
+This provides common Kubernetes, Terraform, SOPS, Vault, and cloud CLIs without
+requiring a Nix-capable host. Use the Nix flake for NixOS-specific builds,
+formatting, and deploy workflows:
 
 ```bash
 nix develop
-# Provides: kubectl, helm, terraform, vault, sops, fluxcd, cilium-cli, gcloud, nixos-rebuild
+# Provides: nixos-rebuild and the full Nix development shell
 ```
 
 ## How Changes Ship (GitOps + Atlantis)

--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ Infrastructure-as-code for a multi-cloud homelab environment. This repository ma
 
 ### Development Environment
 
-This repository uses Nix flakes for a reproducible development environment:
+This repository uses `mise` for portable repo tooling and Nix flakes for NixOS-specific workflows:
 
 ```bash
-# Enter development shell with all tools
-nix develop
+# Install portable tools
+mise install
 
-# Tools included: kubectl, helm, terraform, vault, sops, fluxcd, cilium-cli, gcloud, mise
+# Optional: enter the full Nix development shell
+nix develop
 ```
 
 **Preferred task runner: `mise`**


### PR DESCRIPTION
## Summary
- add Kubernetes, secrets, Terraform docs, and kustomize tools to the repo mise config
- run Terraform tasks directly through mise-managed tools instead of shelling through nix develop
- document mise as the portable repo tooling layer while keeping Nix for NixOS-specific workflows

## Testing
- /home/agent/.local/bin/mise install kustomize
- /home/agent/.local/bin/mise run tf:fmt
- /home/agent/.local/bin/mise exec -- kustomize version