### PR TITLE
fix(nix): include shale in deploy apps

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
       deployHosts = [
         "optiplex"
         "riptide"
+        "shale"
         "oldschool"
         "retrofit"
         "cloudpi4"


### PR DESCRIPTION
## Summary
- add shale to deployHosts so the repo generates the host-specific nix app helper
- keeps the deploy helper inventory aligned with the existing shale NixOS configuration

## Testing
- Not run: nix is not available in this agent runtime yet.