### PR TITLE
Add shale Kubernetes node labels

### DIFF
--- a/k8s/node-labels.tf
+++ b/k8s/node-labels.tf
@@ -8,6 +8,10 @@ locals {
       "node-role.kubernetes.io/worker" = ""
       "bgp-enabled"                    = "true"
     },
+    "shale" = {
+      "node-role.kubernetes.io/worker" = ""
+      "bgp-enabled"                    = "true"
+    },
     "optiplex" = {
       "node-role.kubernetes.io/control-plane" = ""
       "bgp-enabled"                           = "true"
@@ -34,4 +38,3 @@ resource "kubernetes_labels" "nodes" {
   }
   labels = each.value
 }
-


### PR DESCRIPTION
## Summary
- add shale to Terraform-managed Kubernetes node labels
- enable worker role and BGP label for Cilium BGP selection

## Validation
- terraform fmt -check k8s/node-labels.tf
- kubectl --context folly get nodes -o wide shows shale Ready as worker
- kubectl --context folly -n kube-system get ciliumbgpnodeconfigs shows shale present