### PR TITLE
Remove deprecated Falco gRPC values

### DIFF
--- a/k8s/folly/apps/falco/helm-release.yaml
+++ b/k8s/folly/apps/falco/helm-release.yaml
@@ -39,11 +39,6 @@ spec:
           condition: or (container.image.repository in (docker.io/kiwigrid/k8s-sidecar, quay.io/kiwigrid/k8s-sidecar))
           override:
             condition: append
-    falco:
-      grpc:
-        enabled: true
-      grpc_output:
-        enabled: true
     resources:
       requests:
         memory: 2Gi


### PR DESCRIPTION
## Summary
- remove falco.grpc and falco.grpc_output values rejected by Falco chart 9.0.0
- leave open-webui unchanged; refreshing the Flux HelmRepository fixed the stale chart index and live release reconciled to 14.7.0

## Validation
- kustomize build k8s/folly/apps/falco
- helm template falco falcosecurity/falco --version 9.0.0 with rendered values
- flux --context folly reconcile source helm open-webui -n flux-system
- flux --context folly reconcile helmrelease open-webui -n open-webui