### PR TITLE
fix(external-secrets): disable wait to avoid Helm upgrade timeout

### DIFF
--- a/k8s/base/platform/external-secrets-operator/helm-release.yaml
+++ b/k8s/base/platform/external-secrets-operator/helm-release.yaml
@@ -10,6 +10,9 @@ metadata:
 spec:
   interval: 1m0s
   maxHistory: 2
+  # Avoid Helm timeout waiting for CRD rollout during upgrades — ESO deploys
+  # CRDs via installCRDs:true which can exceed the default Helm wait window.
+  disableWait: true
   chart:
     spec:
       chart: external-secrets


### PR DESCRIPTION
ESO deploys CRDs via `installCRDs:true` which can exceed the default Helm wait window, causing upgrade timeouts and Flux `Stalled` state. Setting `disableWait:true` lets Flux handle rollout tracking instead.

**Changes:**
- `k8s/base/platform/external-secrets-operator/helm-release.yaml`: added `disableWait: true` to spec

**Testing:**
- All 3 ESO deployments healthy on both folly and offsite clusters (pre-fix verified manually)