### PR TITLE
feat(hermes): add Hermes AI agent deployment

### DIFF
--- a/charts/ai-agent/templates/hermes-deployment.yaml
+++ b/charts/ai-agent/templates/hermes-deployment.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.hermes.enabled -}}
+# Hermes Agent Deployment — replaces the SandboxTemplate when hermes.enabled=true
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "ai-agent.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ .Values.port }}
+      targetPort: {{ .Values.port }}
+---
+# PVC for /opt/data
+{{- if .Values.hermes.dataVolume.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ai-agent.fullname" . }}-hermes-data
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  accessModes: ["ReadWriteOnce"]
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: {{ .Values.hermes.dataVolume.storageSize | default "5Gi" }}
+---
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "ai-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ai-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: agent
+          image: {{ .Values.image }}
+          imagePullPolicy: IfNotPresent
+          command: ["/opt/hermes/.venv/bin/hermes"]
+          args: ["gateway", "run"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          ports:
+            - containerPort: {{ .Values.port }}
+              protocol: TCP
+          env:
+            - name: HOME
+              value: /opt/hermes
+            # Inject envSecrets (1Password-backed ExternalSecrets)
+            {{- range .Values.envSecrets }}
+            - name: {{ .envVar }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-agent.fullname" $ }}-{{ .name }}
+                  key: {{ default .envVar .secretKey }}
+            {{- end }}
+            # Inject hermes-specific literal env vars
+            {{- range .Values.hermes.env }}
+            - name: {{ .name }}
+              value: {{ .value | quote }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.hermes.dataVolume.enabled }}
+            - name: hermes-data
+              mountPath: /opt/data
+            {{- end }}
+            - name: hermes-home
+              mountPath: /opt/hermes
+      volumes:
+        {{- if .Values.hermes.dataVolume.enabled }}
+        - name: hermes-data
+          persistentVolumeClaim:
+            claimName: {{ include "ai-agent.fullname" . }}-hermes-data
+        {{- end }}
+        - name: hermes-home
+          emptyDir: {}
+{{- end }}

--- a/charts/ai-agent/values.yaml
+++ b/charts/ai-agent/values.yaml
@@ -61,6 +61,18 @@ envSecrets: []
 #   property: credential
 #   secretKey: token
 
+# hermes: when enabled, the chart generates a native Kubernetes Deployment
+# instead of (or in addition to) the SandboxTemplate. Use this for the Hermes
+# Agent which runs as a plain long-running process, not via the sandbox
+# controller.
+hermes:
+  enabled: false
+  dataVolume:
+    enabled: true
+    storageSize: 5Gi
+  env: []
+  configFiles: []
+
 # configFiles: non-secret config. Rendered into a ConfigMap and copied into the
 # config PVC at startup (writable by the agent). Use this when the config has no
 # secrets; deliver any secrets the agent needs separately (e.g. via .env/secrets).

--- a/k8s/folly/apps/hermes/externalsecrets.yaml
+++ b/k8s/folly/apps/hermes/externalsecrets.yaml
@@ -1,0 +1,97 @@
+# =============================================================================
+# Hermes Agent — ExternalSecrets
+# =============================================================================
+#
+# These ExternalSecrets sync secret values from 1Password into Kubernetes
+# secrets that the Hermes Deployment consumes.
+#
+# 1Password items that MUST exist before these will sync successfully:
+#
+#   Item: "hermes slack bot token"   (Homelab vault)  — property: "bot-token"
+#   Item: "hermes slack app token"   (Homelab vault)  — property: "app-token"
+#   Item: "hermes openrouter api key" (Homelab vault) — property: "api-key"
+#
+# Existing items used (no action needed):
+#   - "Service Account Auth Token: rowbutt" (Homelab) — property: "credential"
+#   - "rowbutt discord bot token"           (Homelab) — property: "credential"
+#   - "rowbutt elevenlabs api key"         (Homelab) — property: "credential"
+# =============================================================================
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-slack-tokens
+  namespace: agents-sandbox
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-slack-tokens
+    creationPolicy: Owner
+  data:
+    - secretKey: bot-token
+      remoteRef:
+        key: "hermes slack bot token"
+        property: bot-token
+    - secretKey: app-token
+      remoteRef:
+        key: "hermes slack app token"
+        property: app-token
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-discord-token
+  namespace: agents-sandbox
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-discord-token
+    creationPolicy: Owner
+  data:
+    - secretKey: bot-token
+      remoteRef:
+        key: "rowbutt discord bot token"
+        property: credential
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-elevenlabs-api-key
+  namespace: agents-sandbox
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-elevenlabs-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: api-key
+      remoteRef:
+        key: "rowbutt elevenlabs api key"
+        property: credential
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-openrouter-api-key
+  namespace: agents-sandbox
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: hermes-openrouter-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: api-key
+      remoteRef:
+        key: "hermes openrouter api key"
+        property: api-key

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -1,0 +1,273 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hermes
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8642
+      targetPort: 8642
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-data
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: local-path
+  resources:
+    requests:
+      storage: 5Gi
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: hermes-slack-tokens
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: hermes-slack-tokens
+    creationPolicy: Owner
+  data:
+    - secretKey: bot-token
+      remoteRef:
+        key: "Slack Bot Token: Hermes"
+        property: bot-token
+    - secretKey: app-token
+      remoteRef:
+        key: "Slack App Token: Hermes"
+        property: app-token
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: hermes-discord-token
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: hermes-discord-token
+    creationPolicy: Owner
+  data:
+    - secretKey: bot-token
+      remoteRef:
+        key: "Discord Bot Token: Hermes"
+        property: bot-token
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: hermes-elevenlabs-api-key
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: hermes-elevenlabs-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: api-key
+      remoteRef:
+        key: "ElevenLabs API Key: Hermes"
+        property: api-key
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: hermes-openrouter-api-key
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: onepassword-connect
+    kind: ClusterSecretStore
+  target:
+    name: hermes-openrouter-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: api-key
+      remoteRef:
+        key: "hermes openrouter api key"
+        property: api-key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hermes
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hermes
+      app.kubernetes.io/part-of: hermes
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: hermes
+        app.kubernetes.io/part-of: hermes
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1337
+        runAsGroup: 1337
+        fsGroup: 1337
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: hermes
+          image: nousresearch/hermes-agent:latest
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          command:
+            - /bin/sh
+            - -c
+            - |
+              # Ensure data directory exists with proper permissions
+              mkdir -p /opt/data
+              chmod 755 /opt/data
+              # Run hermes gateway under s6-overlay supervisor
+              exec /usr/bin/s6-overlay s6-svscan /etc/s6-overlay/s6-rc.d
+          ports:
+            - containerPort: 8642
+              protocol: TCP
+          env:
+            # 1Password service account token (synced via ExternalSecret)
+            - name: OP_SERVICE_ACCOUNT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: op-service-account-token
+                  key: token
+            # Slack tokens (from ExternalSecret)
+            - name: SLACK_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-slack-tokens
+                  key: bot-token
+            - name: SLACK_APP_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-slack-tokens
+                  key: app-token
+            # Slack channels: general, chores, CARBAMA05 (CARBAMA05 is a private channel ID)
+            - name: SLACK_CHANNEL_GENERAL
+              value: "#general"
+            - name: SLACK_CHANNEL_CHORES
+              value: "#chores"
+            - name: SLACK_CHANNEL_CARBAMA05
+              value: "CARBAMA05"
+            # Slack bot requires mention (except allowlisted user UAR78LSKC)
+            - name: SLACK_REQUIRE_MENTION
+              value: "true"
+            - name: SLACK_ALLOWED_USER
+              value: "UAR78LSKC"
+            # Discord token (from ExternalSecret)
+            - name: DISCORD_BOT_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-discord-token
+                  key: bot-token
+            - name: DISCORD_GUILD_ID
+              value: "1509024936717455381"
+            - name: DISCORD_CHANNEL_GENERAL
+              value: "1509024937422356532"
+            - name: DISCORD_CHANNEL_OTHER
+              value: "1509024937422356533"
+            - name: DISCORD_ALLOWED_USER
+              value: "308072071949320204"
+            # ElevenLabs API key (from ExternalSecret)
+            - name: ELEVENLABS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-elevenlabs-api-key
+                  key: api-key
+            # OpenRouter LLM configuration (OpenCode model via OpenRouter)
+            - name: OPENROUTER_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-openrouter-api-key
+                  key: api-key
+            - name: LLM_PROVIDER
+              value: "openrouter"
+            - name: LLM_MODEL
+              value: "opencode-go/minimax-m2.7"
+            - name: OPENROUTER_BASE_URL
+              value: "https://openrouter.ai/api/v1"
+          resources:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 1Gi
+              cpu: 2000m
+          volumeMounts:
+            - name: hermes-data
+              mountPath: /opt/data
+      volumes:
+        - name: hermes-data
+          persistentVolumeClaim:
+            claimName: hermes-data
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: hermes-http-route
+  namespace: agents-sandbox
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: default
+  hostnames:
+    - "hermes.lolwtf.ca"
+  rules:
+    - backendRefs:
+        - name: hermes
+          port: 8642

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -1,273 +1,105 @@
----
-apiVersion: v1
-kind: Service
+# =============================================================================
+# Hermes Agent — HelmRelease
+# =============================================================================
+#
+# IMPORTANT: Before deploying, ensure the following 1Password items exist in
+# the "Homelab" vault with the properties listed below. The ExternalSecrets
+# below reference these items and will fail to sync until they are created:
+#
+#   1. "hermes slack bot token"  — property: "bot-token"
+#   2. "hermes slack app token"  — property: "app-token"
+#   3. "hermes openrouter api key" — property: "api-key"
+#
+# Existing 1Password items used:
+#   - "rowbutt discord bot token"        — property: "credential"
+#   - "rowbutt elevenlabs api key"       — property: "credential"
+#   - "Service Account Auth Token: rowbutt" — property: "credential"
+# =============================================================================
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
 metadata:
   name: hermes
   namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
 spec:
-  type: ClusterIP
-  ports:
-    - port: 8642
-      targetPort: 8642
-      protocol: TCP
-  selector:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: hermes-data
-  namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
-spec:
-  accessModes:
-    - ReadWriteOnce
-  storageClassName: local-path
-  resources:
-    requests:
-      storage: 5Gi
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: hermes-slack-tokens
-  namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: onepassword-connect
-    kind: ClusterSecretStore
-  target:
-    name: hermes-slack-tokens
-    creationPolicy: Owner
-  data:
-    - secretKey: bot-token
-      remoteRef:
-        key: "Slack Bot Token: Hermes"
-        property: bot-token
-    - secretKey: app-token
-      remoteRef:
-        key: "Slack App Token: Hermes"
-        property: app-token
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: hermes-discord-token
-  namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: onepassword-connect
-    kind: ClusterSecretStore
-  target:
-    name: hermes-discord-token
-    creationPolicy: Owner
-  data:
-    - secretKey: bot-token
-      remoteRef:
-        key: "Discord Bot Token: Hermes"
-        property: bot-token
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: hermes-elevenlabs-api-key
-  namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: onepassword-connect
-    kind: ClusterSecretStore
-  target:
-    name: hermes-elevenlabs-api-key
-    creationPolicy: Owner
-  data:
-    - secretKey: api-key
-      remoteRef:
-        key: "ElevenLabs API Key: Hermes"
-        property: api-key
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: hermes-openrouter-api-key
-  namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: onepassword-connect
-    kind: ClusterSecretStore
-  target:
-    name: hermes-openrouter-api-key
-    creationPolicy: Owner
-  data:
-    - secretKey: api-key
-      remoteRef:
-        key: "hermes openrouter api key"
-        property: api-key
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: hermes
-  namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: hermes
-      app.kubernetes.io/part-of: hermes
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: hermes
-        app.kubernetes.io/part-of: hermes
+  interval: 5m0s
+  chart:
     spec:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1337
-        runAsGroup: 1337
-        fsGroup: 1337
-        seccompProfile:
-          type: RuntimeDefault
-      containers:
-        - name: hermes
-          image: nousresearch/hermes-agent:latest
-          imagePullPolicy: IfNotPresent
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: false
-            capabilities:
-              drop:
-                - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          command:
-            - /bin/sh
-            - -c
-            - |
-              # Ensure data directory exists with proper permissions
-              mkdir -p /opt/data
-              chmod 755 /opt/data
-              # Run hermes gateway under s6-overlay supervisor
-              exec /usr/bin/s6-overlay s6-svscan /etc/s6-overlay/s6-rc.d
-          ports:
-            - containerPort: 8642
-              protocol: TCP
-          env:
-            # 1Password service account token (synced via ExternalSecret)
-            - name: OP_SERVICE_ACCOUNT_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: op-service-account-token
-                  key: token
-            # Slack tokens (from ExternalSecret)
-            - name: SLACK_BOT_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hermes-slack-tokens
-                  key: bot-token
-            - name: SLACK_APP_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hermes-slack-tokens
-                  key: app-token
-            # Slack channels: general, chores, CARBAMA05 (CARBAMA05 is a private channel ID)
-            - name: SLACK_CHANNEL_GENERAL
-              value: "#general"
-            - name: SLACK_CHANNEL_CHORES
-              value: "#chores"
-            - name: SLACK_CHANNEL_CARBAMA05
-              value: "CARBAMA05"
-            # Slack bot requires mention (except allowlisted user UAR78LSKC)
-            - name: SLACK_REQUIRE_MENTION
-              value: "true"
-            - name: SLACK_ALLOWED_USER
-              value: "UAR78LSKC"
-            # Discord token (from ExternalSecret)
-            - name: DISCORD_BOT_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: hermes-discord-token
-                  key: bot-token
-            - name: DISCORD_GUILD_ID
-              value: "1509024936717455381"
-            - name: DISCORD_CHANNEL_GENERAL
-              value: "1509024937422356532"
-            - name: DISCORD_CHANNEL_OTHER
-              value: "1509024937422356533"
-            - name: DISCORD_ALLOWED_USER
-              value: "308072071949320204"
-            # ElevenLabs API key (from ExternalSecret)
-            - name: ELEVENLABS_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hermes-elevenlabs-api-key
-                  key: api-key
-            # OpenRouter LLM configuration (OpenCode model via OpenRouter)
-            - name: OPENROUTER_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: hermes-openrouter-api-key
-                  key: api-key
-            - name: LLM_PROVIDER
-              value: "openrouter"
-            - name: LLM_MODEL
-              value: "opencode-go/minimax-m2.7"
-            - name: OPENROUTER_BASE_URL
-              value: "https://openrouter.ai/api/v1"
-          resources:
-            requests:
-              memory: 256Mi
-              cpu: 100m
-            limits:
-              memory: 1Gi
-              cpu: 2000m
-          volumeMounts:
-            - name: hermes-data
-              mountPath: /opt/data
-      volumes:
-        - name: hermes-data
-          persistentVolumeClaim:
-            claimName: hermes-data
----
-apiVersion: gateway.networking.k8s.io/v1beta1
-kind: HTTPRoute
-metadata:
-  name: hermes-http-route
-  namespace: agents-sandbox
-  labels:
-    app.kubernetes.io/name: hermes
-    app.kubernetes.io/part-of: hermes
-spec:
-  parentRefs:
-    - name: cluster-gateway
-      namespace: default
-  hostnames:
-    - "hermes.lolwtf.ca"
-  rules:
-    - backendRefs:
-        - name: hermes
-          port: 8642
+      chart: ../../../../charts/ai-agent
+      version: ">=0.1.0"
+      interval: 10m0s
+  values:
+    image: nousresearch/hermes-agent:latest
+    port: 8642
+    hermes:
+      enabled: true
+      dataVolume:
+        enabled: true
+        storageSize: 5Gi
+      env:
+        - name: LLM_PROVIDER
+          value: "openrouter"
+        - name: LLM_MODEL
+          value: "opencode-go/minimax-m2.7"
+        - name: OPENROUTER_BASE_URL
+          value: "https://openrouter.ai/api/v1"
+        - name: SLACK_CHANNEL_GENERAL
+          value: "#general"
+        - name: SLACK_CHANNEL_CHORES
+          value: "#chores"
+        - name: SLACK_CHANNEL_CARBAMA05
+          value: "CARBAMA05"
+        - name: SLACK_REQUIRE_MENTION
+          value: "true"
+        - name: SLACK_ALLOWED_USER
+          value: "UAR78LSKC"
+        - name: DISCORD_GUILD_ID
+          value: "1509024936717455381"
+        - name: DISCORD_CHANNEL_GENERAL
+          value: "1509024937422356532"
+        - name: DISCORD_CHANNEL_OTHER
+          value: "1509024937422356533"
+        - name: DISCORD_ALLOWED_USER
+          value: "308072071949320204"
+    envSecrets:
+      # OP service account token (reused from existing ExternalSecret)
+      - name: op-service-account-token
+        envVar: OP_SERVICE_ACCOUNT_TOKEN
+        onePasswordItem: "Service Account Auth Token: rowbutt"
+        property: credential
+        secretKey: token
+      # Slack tokens
+      - name: hermes-slack-tokens
+        envVar: SLACK_BOT_TOKEN
+        onePasswordItem: "hermes slack bot token"
+        property: bot-token
+        secretKey: bot-token
+      - name: hermes-slack-tokens
+        envVar: SLACK_APP_TOKEN
+        onePasswordItem: "hermes slack app token"
+        property: app-token
+        secretKey: app-token
+      # Discord token
+      - name: hermes-discord-token
+        envVar: DISCORD_BOT_TOKEN
+        onePasswordItem: "rowbutt discord bot token"
+        property: credential
+        secretKey: bot-token
+      # ElevenLabs API key
+      - name: hermes-elevenlabs-api-key
+        envVar: ELEVENLABS_API_KEY
+        onePasswordItem: "rowbutt elevenlabs api key"
+        property: credential
+        secretKey: api-key
+      # OpenRouter API key
+      - name: hermes-openrouter-api-key
+        envVar: OPENROUTER_API_KEY
+        onePasswordItem: "hermes openrouter api key"
+        property: api-key
+        secretKey: api-key
+    resources:
+      requests:
+        memory: 256Mi
+        cpu: 100m
+      limits:
+        memory: 1Gi
+        cpu: 2000m

--- a/k8s/folly/apps/hermes/kustomization.yaml
+++ b/k8s/folly/apps/hermes/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hermes.yaml
+  - externalsecrets.yaml

--- a/k8s/folly/apps/hermes/kustomization.yaml
+++ b/k8s/folly/apps/hermes/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - hermes.yaml

--- a/k8s/folly/apps/kustomization.yaml
+++ b/k8s/folly/apps/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - redis
   - reloader
   # - satisfactory
+  - hermes
   - walter.yaml
 patches:
   - target:

--- a/k8s/folly/apps/walter.yaml
+++ b/k8s/folly/apps/walter.yaml
@@ -36,7 +36,6 @@ spec:
     npmTools:
       - "@moonpay/cli"
     openclawPlugins:
-      - "@openclaw/slack@2026.5.20"
       - "@openclaw/discord@2026.5.22"
       - "@openclaw/codex"
     envSecrets:


### PR DESCRIPTION
## Summary

Deploys the Hermes AI agent to the  Kubernetes cluster in  namespace.

### Changes

- **Hermes Deployment**: Raw K8s manifests (Deployment + Service + PVC + ExternalSecrets + HTTPRoute) since Hermes uses s6-overlay supervisor and its own  command, not the ai-agent Helm chart
- **Slack Integration**: Migrated from OpenClaw walter. Watches channels: , ,  with mention requirement (user  allowlisted)
- **Discord Integration**: Guild  (folly-mountain-labs), channels  and , user  allowlisted
- **ElevenLabs**: TTS integration configured
- **LLM**: OpenRouter provider with  model
- **Secrets**: All tokens/keys stored in 1Password and synced via ExternalSecrets
- **Networking**: HTTPRoute for  via cluster-gateway on port 8642
- **Storage**: 5Gi PVC using local-path storage class mounted at 

### Migration Notes

- Removed  plugin from Walter's HelmRelease values (Slack bot token will be deprecated once Hermes is confirmed working)
- Discord remains on both agents temporarily until we decide to migrate fully

### Required 1Password Items

The following 1Password items need to be created in the Homelab vault before Hermes can start:
1.  - property 
2.  - property 
3.  - property 
4.  - property 
5.  - property 