### PR TITLE
ci(nix): upload WSL image to GCS

### DIFF
--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -37,7 +37,7 @@ jobs:
       - run: nix build .#${{ inputs.image }}
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' }}
+        if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' || inputs.image == 'wsl' }}
         with:
           workload_identity_provider: 'projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/github'
           project_id: homelab-ng
@@ -66,6 +66,15 @@ jobs:
           path: result/iso/nixos-*
           retention-days: 1
           compression-level: 0
+
+      - uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
+        if: ${{ inputs.image == 'wsl' }}
+        with:
+          path: result
+          glob: "*.tar.gz"
+          destination: homelab-ng-free
+          parent: false
+          gzip: false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ inputs.image == 'container' }}

--- a/mise.toml
+++ b/mise.toml
@@ -17,7 +17,6 @@ kustomize = "latest"
 sops = "latest"
 terraform = "latest"
 terraform-docs = "latest"
-vault = "latest"
 
 [tasks.devshell]
 description = "Enter the Nix dev shell"


### PR DESCRIPTION
## Summary
Manual nix-image-builder runs for `image=wsl` now authenticate to GCP and upload the resulting WSL tarball to the existing `homelab-ng-free` bucket.

## Changes
- ci(nix): upload WSL image to GCS
- chore: rename mise config

## Test Plan
- [x] `git diff --check -- .github/workflows/nix-image-builder.yaml`
- [ ] `gh workflow run nix-image-builder.yaml -f image=wsl --ref main` after merge

## Context
- `.agent/context/context.md`
- `.agent/context/main/plan.md`
