### PR TITLE
ci(nix): use NixOS installer action

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -20,9 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+      - uses: NixOS/nix-installer-action@main
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          extra-conf: |
+            experimental-features = nix-command flakes
       - uses: DeterminateSystems/flake-checker-action@89c01715e5d0dfdc0a1bfe9d59891ee4945c1483 # main
       - run: nix flake check
   nixos:
@@ -30,9 +31,10 @@ jobs:
     needs: check
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+      - uses: NixOS/nix-installer-action@main
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          extra-conf: |
+            experimental-features = nix-command flakes
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: jonpulsifer

--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -26,9 +26,10 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+      - uses: NixOS/nix-installer-action@main
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          extra-conf: |
+            experimental-features = nix-command flakes
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: jonpulsifer


### PR DESCRIPTION
## Summary
Switch the repo's Nix GitHub Actions workflows from the DeterminateSystems installer to the NixOS nix-installer-action and enable flakes/nix-command explicitly.

## Changes
- ci(nix): use NixOS installer action

## Test Plan
- [x] `git diff --check -- .github/workflows/nix-ci.yaml .github/workflows/nix-image-builder.yaml`
- [ ] GitHub Actions PR checks

## Context
- Requested replacement: `NixOS/nix-installer-action@main` with `extra-conf` enabling `nix-command flakes`
