### PR TITLE
ci(wsl): preinstall dotfiles in image

### DIFF
--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -37,9 +37,44 @@ jobs:
           skipPush: ${{ github.ref != 'refs/heads/main' }}
       - run: nix build .#${{ inputs.image }}
 
+      - name: Prepare WSL dotfiles
+        if: ${{ inputs.image == 'wsl' }}
+        run: |
+          set -euo pipefail
+
+          wsl_user="$(nix eval --raw .#nixosConfigurations.wsl.config.wsl.defaultUser)"
+          wsl_home="$(nix eval --raw ".#nixosConfigurations.wsl.config.users.users.${wsl_user}.home")"
+          wsl_uid="$(nix eval ".#nixosConfigurations.wsl.config.users.users.${wsl_user}.uid")"
+          wsl_gid="$(nix eval .#nixosConfigurations.wsl.config.users.groups.users.gid)"
+
+          extra_files="wsl-extra-files"
+          staged_home="${extra_files}${wsl_home}"
+          chezmoi_source="${staged_home}/.local/share/chezmoi"
+          chezmoi_runtime="${PWD}/.cache/chezmoi"
+
+          mkdir -p "$(dirname "${chezmoi_source}")" "${chezmoi_runtime}"
+          git clone https://github.com/jonpulsifer/dotfiles.git "${chezmoi_source}"
+          nix build .#legacyPackages.x86_64-linux.chezmoi -o chezmoi-result
+
+          HOME="${wsl_home}" \
+            USER="${wsl_user}" \
+            LOGNAME="${wsl_user}" \
+            ./chezmoi-result/bin/chezmoi \
+              --source "${chezmoi_source}" \
+              --destination "${staged_home}" \
+              --cache "${chezmoi_runtime}/cache" \
+              --persistent-state "${chezmoi_runtime}/state.db" \
+              --config "${chezmoi_runtime}/chezmoi.yaml" \
+              --override-data '{"chezmoi":{"kernel":{"osrelease":"microsoft-standard-WSL2"}}}' \
+              --refresh-externals=always \
+              apply --exclude scripts --force --no-tty
+
+          echo "WSL_EXTRA_FILES=${extra_files}" >> "${GITHUB_ENV}"
+          echo "WSL_CHOWN=${wsl_home} ${wsl_uid}:${wsl_gid}" >> "${GITHUB_ENV}"
+
       - name: Build WSL tarball
         if: ${{ inputs.image == 'wsl' }}
-        run: sudo ./result/bin/nixos-wsl-tarball-builder ./nixos.wsl
+        run: sudo ./result/bin/nixos-wsl-tarball-builder --extra-files "${WSL_EXTRA_FILES}" --chown ${WSL_CHOWN} ./nixos.wsl
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' || inputs.image == 'wsl' }}

--- a/nix/images/wsl.nix
+++ b/nix/images/wsl.nix
@@ -1,7 +1,6 @@
 {
   lib,
   pkgs,
-  config,
   inputs,
   ...
 }:


### PR DESCRIPTION
## Summary
Preinstall the dotfiles checkout and rendered chezmoi-managed shell configuration into the WSL image during the image-builder workflow.

## Changes
- ci(wsl): preinstall dotfiles in image

## Test Plan
- [x] `git diff --check -- nix/images/wsl.nix .github/workflows/nix-image-builder.yaml`
- [x] Locally verified the `chezmoi` command shape with a staged destination, WSL template override, and `.git` checkout preserved
- [ ] `gh workflow run nix-image-builder.yaml -f image=wsl --ref main` after merge

## Context
- The image build now clones `jonpulsifer/dotfiles` into the staged WSL home, renders chezmoi files into that staged home with WSL template data, preserves the real `.git` checkout, and passes it into `nixos-wsl-tarball-builder --extra-files` with the Nix-derived user UID/GID.
- `mise` and `chezmoi` are not installed into the image by Nix.
