### PR TITLE
Add HTTPRoute ingress for Hermes agent

### DIFF
--- a/gcp/projects/lolcorp/.terraform.lock.hcl
+++ b/gcp/projects/lolcorp/.terraform.lock.hcl
@@ -2,32 +2,32 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "7.34.0"
+  version     = "7.35.0"
   constraints = "~> 7.25"
   hashes = [
-    "h1:+fBF3vvQhhxF9IOsY2wNJnIgc+ZgbqXZDO6oxjpXS8g=",
-    "h1:/GPPpK47KEu0crFoRRFs4sbrYFwWzSnEbCNLyP4ghgU=",
-    "h1:8O8OVpSoQWmc+FBKk0sU1R6Esp3Ilsq0E/LJcsesqZs=",
-    "h1:8e/qvNnbslkbJw/UVAePdmlOsoW8G3YRIo+grCqLp/M=",
-    "h1:9QgBib/ID/c8aDjHibC+ZowRVjb8+jP72cDoas+SpBc=",
-    "h1:EaKQXM9bnoIh62mTGdjYBq6L2g5a7+jeVia/4XirzDE=",
-    "h1:HV+j6Xcj52Nc5ZlAxNRIy9RccGqq6ObLGVR67i48SO8=",
-    "h1:RjuauQlxpwtG8w5VuRofWQTIwKmZ+9A1Uy1EleT+paM=",
-    "h1:i4IKZaHiILB4RChYsNAzLVjO/N4wk9iWmIQBhUsl8mw=",
-    "h1:m6b6Jpu4IhrvJ47o+JpRY3FNNiPzHW3ZiWiqyZClpYE=",
-    "h1:nOb+xcCmXZvjTInt0t4kYusGliT8XeLlu87mFuAvVyI=",
-    "zh:0d824f222454358a9686ead2b75059777dcfd8006ed929c514ba3454d2cd91ef",
-    "zh:3e59be6923aeef1669c122711f62f9d01880308dfe08fc2817807309be46e417",
-    "zh:809458bac1ea6f372934d28295ecacffd0cd5b31df117b9bbeed2b91b0cd6b98",
-    "zh:ac7178ed164abfbb058e4439aaff7dd1b06f56194440c46a89c0915aef39a35a",
-    "zh:b4bef4c098a7223a7d56c33324f03fafe91eee8f5a2874bf64a6d3e87fc46613",
-    "zh:bf659617d992c93aa02cf909fa940e21f8b90e662876d38aa8cdb27eac857adc",
-    "zh:cbfa1b666caf1f4497ef95b9beff7ba1911ee042e6c0a3f19478b5ff450fb507",
-    "zh:dcacfa747673ee2cf0d6b84d5f155ab0702210146d76402ecef719a1a8c16c1e",
-    "zh:f15751387ef9844c91f2e37e82e8693758a4f7802defb1543a55713a62306875",
+    "h1:1AXr7ewbcviMDTLWFLLaOnLWoZDBvqhwtBeimcFDL7U=",
+    "h1:4oWOgXvYMHJZBbqn3GgmVoPpNfqxFO6vvNC+xJIkpPA=",
+    "h1:5DA7egCBtfnvm2HjQqySEDnwGuqrlKXvdpOgCMkCW88=",
+    "h1:7n727Y4eGRZZeaLOl7ghl0AB19lqboIHPp8YybXZ7eA=",
+    "h1:TxwVeWqrOSDIDr4rqhLY2rRAc/r1N8x3E6DzSaKtLk8=",
+    "h1:XAylXifJWH0cT4xd2V3qwx9A0JA8iCoh/j5vcyCHCXU=",
+    "h1:bdeRQQryMBpaVs5RIu19ykR2j1QXmi4Q3T8g/Ha36tM=",
+    "h1:f8F2hiF7qq2uGgUHu9Sh+ZcLplOdcbABPrZPvgfk5uA=",
+    "h1:gAidkRft5lNmG8k2sPwFJ0KSOc9h+I8EEJPMo+nChpI=",
+    "h1:reD5VR1Je0YElmqhBkluWjtVwILyx6bbeU1RvI2PFHM=",
+    "h1:vtro33fElaQMJNmeXOBeXyX55vD0zVx4TlvJRMxSX0E=",
+    "zh:02c62a2fdf8f9b268054a7a7c3478760e5149889e0c47572940a5503291bb8a5",
+    "zh:1ca325734f7c4a0f39c86caef38d618db64ca2d9b052f763f469af4e41fb8ea6",
+    "zh:5777b1dd32e3705735743c3749ccf826ebd2ca3ab774f912379fee2ad235e242",
+    "zh:61ea1eb889bd037ccf39d5108d686aff67474c1696496567eaf10c4f583e5a3d",
+    "zh:77308f5d2e1923dab36e320aa9774e8c09e1e4d0185d68f36eedeacd176c7a43",
+    "zh:841c40ba2141654aa17ab22c3690fea6fd7c2be0cdb96e519ea6360cab20a54f",
+    "zh:8bea49dabe822f3a852d22e30cd2faf233437b56fa102f9087cfd40b026c2fca",
+    "zh:8d94331d0dd2b200594aade652f78647377d79d863bcb0e17e3bf4b0a8fe3b73",
+    "zh:a1c8a93728b0bf7072e69846380bebee985ebc40e0f6a9277f6ba0c3b9541137",
+    "zh:bee175415263afe9953a5af2180db5cbba653505707d6f88e6d8dd0b04c990b5",
+    "zh:cd63ba21833277871da2390865fcec8317bc3513cf91bd2d5ef6144192207b76",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f7009e2aa90b8637ffd6727ffb4358100389903c3510e4899f8ed6020c0ebb9e",
-    "zh:fcfa7e41fcaf19ee809d70d45222ce0e87782bac3515b5ca5ea4f8209d86cd04",
   ]
 }
 

--- a/k8s/folly/apps/hermes/externalsecrets.yaml
+++ b/k8s/folly/apps/hermes/externalsecrets.yaml
@@ -19,7 +19,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-slack-tokens
+  name: hermes-ext-slack-tokens
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -27,7 +27,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-slack-tokens
+    name: hermes-secret-slack-tokens
     creationPolicy: Owner
   data:
     - secretKey: bot-token
@@ -42,7 +42,7 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-discord-token
+  name: hermes-ext-discord-token
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -50,7 +50,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-discord-token
+    name: hermes-secret-discord-token
     creationPolicy: Owner
   data:
     - secretKey: bot-token
@@ -61,7 +61,7 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-elevenlabs-api-key
+  name: hermes-ext-elevenlabs-api-key
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -69,7 +69,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-elevenlabs-api-key
+    name: hermes-secret-elevenlabs-api-key
     creationPolicy: Owner
   data:
     - secretKey: api-key
@@ -80,7 +80,7 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-openrouter-api-key
+  name: hermes-ext-openrouter-api-key
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -88,7 +88,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-openrouter-api-key
+    name: hermes-secret-openrouter-api-key
     creationPolicy: Owner
   data:
     - secretKey: api-key

--- a/k8s/folly/apps/hermes/gateway.yaml
+++ b/k8s/folly/apps/hermes/gateway.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: hermes
+  namespace: agents-sandbox
+  annotations:
+    cert-manager.io/cluster-issuer: ${CERT_CLUSTER_ISSUER}
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https-hermes
+      protocol: HTTPS
+      port: 443
+      hostname: &hostname "hermes.${SECRET_DOMAIN}"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: *hostname
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: hermes
+  namespace: agents-sandbox
+spec:
+  parentRefs:
+    - name: hermes
+  hostnames:
+    - "hermes.${SECRET_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: hermes-ai-agent
+          port: 8642

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -72,30 +72,30 @@ spec:
         property: credential
         secretKey: token
       # Slack tokens
-      - name: hermes-slack-tokens
+      - name: hermes-secret-slack-tokens
         envVar: SLACK_BOT_TOKEN
         onePasswordItem: "hermes slack bot token"
         property: bot-token
         secretKey: bot-token
-      - name: hermes-slack-tokens
+      - name: hermes-secret-slack-tokens
         envVar: SLACK_APP_TOKEN
         onePasswordItem: "hermes slack app token"
         property: app-token
         secretKey: app-token
       # Discord token
-      - name: hermes-discord-token
+      - name: hermes-secret-discord-token
         envVar: DISCORD_BOT_TOKEN
         onePasswordItem: "rowbutt discord bot token"
         property: credential
         secretKey: bot-token
       # ElevenLabs API key
-      - name: hermes-elevenlabs-api-key
+      - name: hermes-secret-elevenlabs-api-key
         envVar: ELEVENLABS_API_KEY
         onePasswordItem: "rowbutt elevenlabs api key"
         property: credential
         secretKey: api-key
       # OpenRouter API key
-      - name: hermes-openrouter-api-key
+      - name: hermes-secret-openrouter-api-key
         envVar: OPENROUTER_API_KEY
         onePasswordItem: "hermes openrouter api key"
         property: api-key

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -27,6 +27,10 @@ spec:
       chart: ../../../../charts/ai-agent
       version: ">=0.1.0"
       interval: 10m0s
+      sourceRef:
+        kind: GitRepository
+        name: infra
+        namespace: flux-system
   values:
     image: nousresearch/hermes-agent:latest
     port: 8642

--- a/k8s/folly/apps/hermes/kustomization.yaml
+++ b/k8s/folly/apps/hermes/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hermes.yaml
+  - gateway.yaml
   - externalsecrets.yaml

--- a/workspace/.terraform.lock.hcl
+++ b/workspace/.terraform.lock.hcl
@@ -18,32 +18,32 @@ provider "registry.terraform.io/1password/onepassword" {
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "7.34.0"
+  version     = "7.35.0"
   constraints = "~> 7.0"
   hashes = [
-    "h1:+fBF3vvQhhxF9IOsY2wNJnIgc+ZgbqXZDO6oxjpXS8g=",
-    "h1:/GPPpK47KEu0crFoRRFs4sbrYFwWzSnEbCNLyP4ghgU=",
-    "h1:8O8OVpSoQWmc+FBKk0sU1R6Esp3Ilsq0E/LJcsesqZs=",
-    "h1:8e/qvNnbslkbJw/UVAePdmlOsoW8G3YRIo+grCqLp/M=",
-    "h1:9QgBib/ID/c8aDjHibC+ZowRVjb8+jP72cDoas+SpBc=",
-    "h1:EaKQXM9bnoIh62mTGdjYBq6L2g5a7+jeVia/4XirzDE=",
-    "h1:HV+j6Xcj52Nc5ZlAxNRIy9RccGqq6ObLGVR67i48SO8=",
-    "h1:RjuauQlxpwtG8w5VuRofWQTIwKmZ+9A1Uy1EleT+paM=",
-    "h1:i4IKZaHiILB4RChYsNAzLVjO/N4wk9iWmIQBhUsl8mw=",
-    "h1:m6b6Jpu4IhrvJ47o+JpRY3FNNiPzHW3ZiWiqyZClpYE=",
-    "h1:nOb+xcCmXZvjTInt0t4kYusGliT8XeLlu87mFuAvVyI=",
-    "zh:0d824f222454358a9686ead2b75059777dcfd8006ed929c514ba3454d2cd91ef",
-    "zh:3e59be6923aeef1669c122711f62f9d01880308dfe08fc2817807309be46e417",
-    "zh:809458bac1ea6f372934d28295ecacffd0cd5b31df117b9bbeed2b91b0cd6b98",
-    "zh:ac7178ed164abfbb058e4439aaff7dd1b06f56194440c46a89c0915aef39a35a",
-    "zh:b4bef4c098a7223a7d56c33324f03fafe91eee8f5a2874bf64a6d3e87fc46613",
-    "zh:bf659617d992c93aa02cf909fa940e21f8b90e662876d38aa8cdb27eac857adc",
-    "zh:cbfa1b666caf1f4497ef95b9beff7ba1911ee042e6c0a3f19478b5ff450fb507",
-    "zh:dcacfa747673ee2cf0d6b84d5f155ab0702210146d76402ecef719a1a8c16c1e",
-    "zh:f15751387ef9844c91f2e37e82e8693758a4f7802defb1543a55713a62306875",
+    "h1:1AXr7ewbcviMDTLWFLLaOnLWoZDBvqhwtBeimcFDL7U=",
+    "h1:4oWOgXvYMHJZBbqn3GgmVoPpNfqxFO6vvNC+xJIkpPA=",
+    "h1:5DA7egCBtfnvm2HjQqySEDnwGuqrlKXvdpOgCMkCW88=",
+    "h1:7n727Y4eGRZZeaLOl7ghl0AB19lqboIHPp8YybXZ7eA=",
+    "h1:TxwVeWqrOSDIDr4rqhLY2rRAc/r1N8x3E6DzSaKtLk8=",
+    "h1:XAylXifJWH0cT4xd2V3qwx9A0JA8iCoh/j5vcyCHCXU=",
+    "h1:bdeRQQryMBpaVs5RIu19ykR2j1QXmi4Q3T8g/Ha36tM=",
+    "h1:f8F2hiF7qq2uGgUHu9Sh+ZcLplOdcbABPrZPvgfk5uA=",
+    "h1:gAidkRft5lNmG8k2sPwFJ0KSOc9h+I8EEJPMo+nChpI=",
+    "h1:reD5VR1Je0YElmqhBkluWjtVwILyx6bbeU1RvI2PFHM=",
+    "h1:vtro33fElaQMJNmeXOBeXyX55vD0zVx4TlvJRMxSX0E=",
+    "zh:02c62a2fdf8f9b268054a7a7c3478760e5149889e0c47572940a5503291bb8a5",
+    "zh:1ca325734f7c4a0f39c86caef38d618db64ca2d9b052f763f469af4e41fb8ea6",
+    "zh:5777b1dd32e3705735743c3749ccf826ebd2ca3ab774f912379fee2ad235e242",
+    "zh:61ea1eb889bd037ccf39d5108d686aff67474c1696496567eaf10c4f583e5a3d",
+    "zh:77308f5d2e1923dab36e320aa9774e8c09e1e4d0185d68f36eedeacd176c7a43",
+    "zh:841c40ba2141654aa17ab22c3690fea6fd7c2be0cdb96e519ea6360cab20a54f",
+    "zh:8bea49dabe822f3a852d22e30cd2faf233437b56fa102f9087cfd40b026c2fca",
+    "zh:8d94331d0dd2b200594aade652f78647377d79d863bcb0e17e3bf4b0a8fe3b73",
+    "zh:a1c8a93728b0bf7072e69846380bebee985ebc40e0f6a9277f6ba0c3b9541137",
+    "zh:bee175415263afe9953a5af2180db5cbba653505707d6f88e6d8dd0b04c990b5",
+    "zh:cd63ba21833277871da2390865fcec8317bc3513cf91bd2d5ef6144192207b76",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:f7009e2aa90b8637ffd6727ffb4358100389903c3510e4899f8ed6020c0ebb9e",
-    "zh:fcfa7e41fcaf19ee809d70d45222ce0e87782bac3515b5ca5ea4f8209d86cd04",
   ]
 }
 


### PR DESCRIPTION
Create a dedicated Gateway + HTTPRoute to expose the Hermes agent at `hermes.lolwtf.ca`.

- **Gateway**: HTTPS :443 in `agents-sandbox`, using the wildcard cert
- **HTTPRoute**: routes `hermes.lolwtf.ca` → `hermes-ai-agent:8642`
- Includes `gateway.yaml` in kustomization resources