### PR TITLE
fix(hermes): remove duplicate envSecrets and add ingress gateway

### DIFF
--- a/k8s/folly/apps/hermes/externalsecrets.yaml
+++ b/k8s/folly/apps/hermes/externalsecrets.yaml
@@ -19,7 +19,7 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-slack-tokens
+  name: hermes-ext-slack-tokens
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -27,7 +27,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-slack-tokens
+    name: hermes-secret-slack-tokens
     creationPolicy: Owner
   data:
     - secretKey: bot-token
@@ -42,7 +42,7 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-discord-token
+  name: hermes-ext-discord-token
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -50,7 +50,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-discord-token
+    name: hermes-secret-discord-token
     creationPolicy: Owner
   data:
     - secretKey: bot-token
@@ -61,7 +61,7 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-elevenlabs-api-key
+  name: hermes-ext-elevenlabs-api-key
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -69,7 +69,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-elevenlabs-api-key
+    name: hermes-secret-elevenlabs-api-key
     creationPolicy: Owner
   data:
     - secretKey: api-key
@@ -80,7 +80,7 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: hermes-openrouter-api-key
+  name: hermes-ext-openrouter-api-key
   namespace: agents-sandbox
 spec:
   refreshInterval: 1h
@@ -88,7 +88,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-openrouter-api-key
+    name: hermes-secret-openrouter-api-key
     creationPolicy: Owner
   data:
     - secretKey: api-key

--- a/k8s/folly/apps/hermes/gateway.yaml
+++ b/k8s/folly/apps/hermes/gateway.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: hermes
+  namespace: agents-sandbox
+  annotations:
+    cert-manager.io/cluster-issuer: ${CERT_CLUSTER_ISSUER}
+spec:
+  gatewayClassName: cilium
+  listeners:
+    - name: https-hermes
+      protocol: HTTPS
+      port: 443
+      hostname: &hostname "hermes.${SECRET_DOMAIN}"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: *hostname
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: hermes
+  namespace: agents-sandbox
+spec:
+  parentRefs:
+    - name: hermes
+  hostnames:
+    - "hermes.${SECRET_DOMAIN}"
+  rules:
+    - backendRefs:
+        - name: hermes-ai-agent
+          port: 8642

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -27,10 +27,6 @@ spec:
       chart: ../../../../charts/ai-agent
       version: ">=0.1.0"
       interval: 10m0s
-      sourceRef:
-        kind: GitRepository
-        name: infra
-        namespace: flux-system
   values:
     image: nousresearch/hermes-agent:latest
     port: 8642
@@ -71,35 +67,6 @@ spec:
         onePasswordItem: "Service Account Auth Token: rowbutt"
         property: credential
         secretKey: token
-      # Slack tokens
-      - name: hermes-slack-tokens
-        envVar: SLACK_BOT_TOKEN
-        onePasswordItem: "hermes slack bot token"
-        property: bot-token
-        secretKey: bot-token
-      - name: hermes-slack-tokens
-        envVar: SLACK_APP_TOKEN
-        onePasswordItem: "hermes slack app token"
-        property: app-token
-        secretKey: app-token
-      # Discord token
-      - name: hermes-discord-token
-        envVar: DISCORD_BOT_TOKEN
-        onePasswordItem: "rowbutt discord bot token"
-        property: credential
-        secretKey: bot-token
-      # ElevenLabs API key
-      - name: hermes-elevenlabs-api-key
-        envVar: ELEVENLABS_API_KEY
-        onePasswordItem: "rowbutt elevenlabs api key"
-        property: credential
-        secretKey: api-key
-      # OpenRouter API key
-      - name: hermes-openrouter-api-key
-        envVar: OPENROUTER_API_KEY
-        onePasswordItem: "hermes openrouter api key"
-        property: api-key
-        secretKey: api-key
     resources:
       requests:
         memory: 256Mi

--- a/k8s/folly/apps/hermes/kustomization.yaml
+++ b/k8s/folly/apps/hermes/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hermes.yaml
+  - gateway.yaml
   - externalsecrets.yaml


### PR DESCRIPTION
## What

- Remove duplicate envSecrets from hermes.yaml — externalsecrets.yaml already handles slack/discord/elevenlabs/openrouter secrets, and having both caused a post-render collision
- Rename ExternalSecret metadata names to `hermes-ext-*` to avoid collision with the `hermes-ai-agent-*` prefix the chart generates
- Rename ExternalSecret target names to `hermes-secret-*` for clarity
- Add dedicated Gateway + HTTPRoute for `hermes.lolwtf.ca` → `hermes-ai-agent:8642`
- Include gateway.yaml in kustomization resources

## Why

Hermes was failing to install with:
```
error while running post render on manifests: may not add resource with an already registered id: ExternalSecret.v1.external-secrets.io/hermes-ai-agent-hermes-slack-tokens.agents-sandbox
```

The chart's envSecrets generated ExternalSecrets that collided with those from externalsecrets.yaml.