### PR TITLE
fix(hermes): restore required sourceRef in chart spec

### DIFF
--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -27,6 +27,10 @@ spec:
       chart: ../../../../charts/ai-agent
       version: ">=0.1.0"
       interval: 10m0s
+      sourceRef:
+        kind: GitRepository
+        name: infra
+        namespace: flux-system
   values:
     image: nousresearch/hermes-agent:latest
     port: 8642


### PR DESCRIPTION
The sourceRef field in the HelmRelease chart spec is required. This was accidentally removed.