### PR TITLE
fix(ai-agent chart): skip generic Service when hermes.enabled=true

### DIFF
--- a/charts/ai-agent/templates/service.yaml
+++ b/charts/ai-agent/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.hermes.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,3 +15,4 @@ spec:
       protocol: TCP
       port: {{ .Values.port }}
       targetPort: {{ .Values.port }}
+{{- end }}

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -27,6 +27,10 @@ spec:
       chart: ../../../../charts/ai-agent
       version: ">=0.1.0"
       interval: 10m0s
+      sourceRef:
+        kind: GitRepository
+        name: infra
+        namespace: flux-system
   values:
     image: nousresearch/hermes-agent:latest
     port: 8642


### PR DESCRIPTION
The generic service.yaml and hermes-deployment.yaml both create a Service named hermes-ai-agent when hermes.enabled=true, causing a helm post-render collision.

Make the generic Service conditional — only render when hermes.enabled is false.