### PR TITLE
chore(ai-agent): bump chart to 0.1.2

### DIFF
--- a/charts/ai-agent/Chart.yaml
+++ b/charts/ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ai-agent
 description: An opinionated Helm chart for deploying AI agents with sandbox isolation
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "latest"

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -25,7 +25,7 @@ spec:
   chart:
     spec:
       chart: ../../../../charts/ai-agent
-      version: ">=0.1.0"
+      version: ">=0.1.2"
       interval: 10m0s
       sourceRef:
         kind: GitRepository


### PR DESCRIPTION
Bump chart version to 0.1.2 and update hermes.yaml constraint to pick up the service.yaml template fix.