### PR TITLE
fix(hermes): disable chart's built-in ingress to avoid HTTPRoute collision

### DIFF
--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -34,6 +34,8 @@ spec:
   values:
     image: nousresearch/hermes-agent:latest
     port: 8642
+    ingress:
+      enabled: false
     hermes:
       enabled: true
       dataVolume:


### PR DESCRIPTION
Disable the chart's built-in ingress since we manage our own Gateway+HTTPRoute via gateway.yaml. The chart's httproute.yaml generates a null hostname when ingress is left at default.