### PR TITLE
fix(hermes): use native s6-overlay entrypoint and correct security context

### DIFF
--- a/charts/ai-agent/templates/hermes-deployment.yaml
+++ b/charts/ai-agent/templates/hermes-deployment.yaml
@@ -52,17 +52,22 @@ spec:
         {{- include "ai-agent.selectorLabels" . | nindent 8 }}
     spec:
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-        fsGroup: 1000
+        # Hermes must run as root (or its own UID 10000). s6-overlay stage2-hook.sh
+        # rejects arbitrary UIDs. Run as root here; stage2-hook remaps to hermes
+        # UID internally via HERMES_UID/HERMES_GID env vars.
+        runAsNonRoot: false
+        runAsUser: 0
+        runAsGroup: 0
+        fsGroup: 0
         seccompProfile:
           type: RuntimeDefault
       containers:
         - name: agent
           image: {{ .Values.image }}
           imagePullPolicy: IfNotPresent
-          command: ["/opt/hermes/.venv/bin/hermes"]
+          # Use native s6-overlay entrypoint (PID 1 = /init, then main-wrapper.sh).
+          # main-wrapper.sh handles UID remap, npm install, and drop to hermes user.
+          # Bypassing this with a hardcoded command breaks the entire bootstrap.
           args: ["gateway", "run"]
           securityContext:
             allowPrivilegeEscalation: false
@@ -76,7 +81,17 @@ spec:
               protocol: TCP
           env:
             - name: HOME
-              value: /opt/hermes
+              value: /opt/data
+            - name: HERMES_HOME
+              value: /opt/data
+            - name: HERMES_UID
+              value: "1000"
+            - name: HERMES_GID
+              value: "1000"
+            - name: HERMES_TUI_DIR
+              value: /opt/hermes/ui-tui
+            - name: PLAYWRIGHT_BROWSERS_PATH
+              value: /opt/hermes/.playwright
             # Inject envSecrets (1Password-backed ExternalSecrets)
             {{- range .Values.envSecrets }}
             - name: {{ .envVar }}
@@ -97,14 +112,10 @@ spec:
             - name: hermes-data
               mountPath: /opt/data
             {{- end }}
-            - name: hermes-home
-              mountPath: /opt/hermes
       volumes:
         {{- if .Values.hermes.dataVolume.enabled }}
         - name: hermes-data
           persistentVolumeClaim:
             claimName: {{ include "ai-agent.fullname" . }}-hermes-data
         {{- end }}
-        - name: hermes-home
-          emptyDir: {}
 {{- end }}


### PR DESCRIPTION
## Root Cause

The Hermes deployment had **two compounding bugs** causing CrashLoopBackOff:

### 1. Bypassed s6-overlay bootstrap
The chart hardcoded `command: ["/opt/hermes/.venv/bin/hermes"] args: ["gateway", "run"]`, which bypasses the image's native ENTRYPOINT (`/init` → `main-wrapper.sh`). The stage2-hook bootstrap never ran, so:
- No `npm install` inside the container
- No UID remapping
- No `s6-setuidgid` privilege drop

The binary itself might not even exist in the expected form factor.

### 2. Forbidden runAsUser=1000
`s6-overlay stage2-hook.sh` **explicitly rejects** arbitrary non-root, non-hermes UIDs with a hard error on startup. The chart set `runAsUser: 1000` which Hermes refuses.

### 3. emptyDir wiping /opt/hermes
The chart mounted an emptyDir at `/opt/hermes`, which overwrites the image's pre-baked Python venv and npm modules — making the binary even more broken.

## Fix

| Before | After |
|--------|-------|
| `command: ["/opt/hermes/.venv/bin/hermes"]` | Use native ENTRYPOINT, just `args: ["gateway", "run"]` |
| `runAsUser: 1000` | `runAsUser: 0` (s6-overlay stage2 handles the drop) |
| `runAsNonRoot: true` | `runAsNonRoot: false` |
| emptyDir at `/opt/hermes` | Only PVC at `/opt/data` |

Also adds `HERMES_UID=1000` / `HERMES_GID=1000` env vars so s6-overlay remaps the hermes user to a k8s-friendly UID that matches the host volume ownership.

## Manual Prerequisite

Before merging, these **1Password items must exist** in the Homelab vault (the ExternalSecrets are failing because they don't):

| Item | Property |
|------|----------|
| `hermes slack bot token` | `bot-token` |
| `hermes slack app token` | `app-token` |
| `hermes openrouter api key` | `api-key` |

Already exists (no action needed): `rowbutt discord bot token`, `rowbutt elevenlabs api key`, `Service Account Auth Token: rowbutt`.

## Note

PR #853 attempted a different fix (switching to openclaw) — that was incorrect. This PR supersedes it and should be merged instead.