### PR TITLE
fix(hermes): wire slack/openrouter/discord/elevenlabs secrets into env vars

### DIFF
--- a/k8s/folly/apps/hermes/externalsecrets.yaml
+++ b/k8s/folly/apps/hermes/externalsecrets.yaml
@@ -7,9 +7,9 @@
 #
 # 1Password items that MUST exist before these will sync successfully:
 #
-#   Item: "hermes slack bot token"   (Homelab vault)  — property: "bot-token"
-#   Item: "hermes slack app token"   (Homelab vault)  — property: "app-token"
-#   Item: "hermes openrouter api key" (Homelab vault) — property: "api-key"
+#   Item: "rowbutt slack bot token"   (Homelab vault)  — property: "credential"
+#   Item: "rowbutt slack app token"   (Homelab vault)  — property: "credential"
+#   Item: "rowbutt openrouter api key" (Homelab vault) — property: "credential"
 #
 # Existing items used (no action needed):
 #   - "Service Account Auth Token: rowbutt" (Homelab) — property: "credential"
@@ -27,17 +27,17 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-secret-slack-tokens
+    name: hermes-ai-agent-hermes-secret-slack-tokens
     creationPolicy: Owner
   data:
     - secretKey: bot-token
       remoteRef:
-        key: "hermes slack bot token"
-        property: bot-token
+        key: "rowbutt slack bot token"
+        property: credential
     - secretKey: app-token
       remoteRef:
-        key: "hermes slack app token"
-        property: app-token
+        key: "rowbutt slack app token"
+        property: credential
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
@@ -50,7 +50,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-secret-discord-token
+    name: hermes-ai-agent-hermes-secret-discord-token
     creationPolicy: Owner
   data:
     - secretKey: bot-token
@@ -69,7 +69,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-secret-elevenlabs-api-key
+    name: hermes-ai-agent-hermes-secret-elevenlabs-api-key
     creationPolicy: Owner
   data:
     - secretKey: api-key
@@ -88,10 +88,10 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: hermes-secret-openrouter-api-key
+    name: hermes-ai-agent-hermes-secret-openrouter-api-key
     creationPolicy: Owner
   data:
     - secretKey: api-key
       remoteRef:
-        key: "hermes openrouter api key"
-        property: api-key
+        key: "rowbutt openrouter api key"
+        property: credential

--- a/k8s/folly/apps/hermes/hermes.yaml
+++ b/k8s/folly/apps/hermes/hermes.yaml
@@ -6,9 +6,9 @@
 # the "Homelab" vault with the properties listed below. The ExternalSecrets
 # below reference these items and will fail to sync until they are created:
 #
-#   1. "hermes slack bot token"  — property: "bot-token"
-#   2. "hermes slack app token"  — property: "app-token"
-#   3. "hermes openrouter api key" — property: "api-key"
+#   1. "rowbutt slack bot token"  — property: "credential"
+#   2. "rowbutt slack app token"  — property: "credential"
+#   3. "rowbutt openrouter api key" — property: "credential"
 #
 # Existing 1Password items used:
 #   - "rowbutt discord bot token"        — property: "credential"
@@ -73,6 +73,25 @@ spec:
         onePasswordItem: "Service Account Auth Token: rowbutt"
         property: credential
         secretKey: token
+      # Slack tokens (ExternalSecret: hermes-ext-slack-tokens → hermes-secret-slack-tokens)
+      - name: hermes-secret-slack-tokens
+        envVar: SLACK_BOT_TOKEN
+        property: bot-token
+      - name: hermes-secret-slack-tokens
+        envVar: SLACK_APP_TOKEN
+        property: app-token
+      # Discord bot token (ExternalSecret: hermes-ext-discord-token → hermes-secret-discord-token)
+      - name: hermes-secret-discord-token
+        envVar: DISCORD_BOT_TOKEN
+        property: bot-token
+      # ElevenLabs API key (ExternalSecret: hermes-ext-elevenlabs-api-key → hermes-secret-elevenlabs-api-key)
+      - name: hermes-secret-elevenlabs-api-key
+        envVar: ELEVENLABS_API_KEY
+        property: api-key
+      # OpenRouter API key (ExternalSecret: hermes-ext-openrouter-api-key → hermes-secret-openrouter-api-key)
+      - name: hermes-secret-openrouter-api-key
+        envVar: OPENROUTER_API_KEY
+        property: api-key
     resources:
       requests:
         memory: 256Mi


### PR DESCRIPTION
## Summary

Adds the missing secret wiring from #854 — the externalsecrets.yaml was updated to point to the correct 1Password items (rowbutt-prefixed), but:

1. ExternalSecret `target.name` didn't match what the chart template generates for secret refs
2. HelmRelease had no envSecrets entries for slack/openrouter/discord/elevenlabs keys

## Changes

### k8s/folly/apps/hermes/externalsecrets.yaml
- Fix `target.name` to match chart-generated ref pattern: `hermes-ai-agent-hermes-secret-*`
- Update 1Password item refs from `hermes-*` → `rowbutt-*` prefix (items already exist)

### k8s/folly/apps/hermes/hermes.yaml  
- Add envSecrets entries for:
  - `SLACK_BOT_TOKEN` / `SLACK_APP_TOKEN` (from `hermes-secret-slack-tokens`)
  - `DISCORD_BOT_TOKEN` (from `hermes-secret-discord-token`)
  - `ELEVENLABS_API_KEY` (from `hermes-secret-elevenlabs-api-key`)
  - `OPENROUTER_API_KEY` (from `hermes-secret-openrouter-api-key`)
- Update header comments to reflect correct 1Password item names