### PR TITLE
fix(external-secrets): remove disableWait field from HelmRelease

### DIFF
--- a/k8s/base/platform/external-secrets-operator/helm-release.yaml
+++ b/k8s/base/platform/external-secrets-operator/helm-release.yaml
@@ -10,9 +10,6 @@ metadata:
 spec:
   interval: 1m0s
   maxHistory: 2
-  # Avoid Helm timeout waiting for CRD rollout during upgrades — ESO deploys
-  # CRDs via installCRDs:true which can exceed the default Helm wait window.
-  disableWait: true
   chart:
     spec:
       chart: external-secrets


### PR DESCRIPTION
The `disableWait: true` field in the HelmRelease manifest is not declared in the Flux HelmRelease CRD schema on this cluster, causing Kustomization dry-run to fail with:

``\nunknown field "spec.disableWait"\n```

This blocks both `external-secrets-operator` and `onepassword-connect` Kustomizations from reconciling.

**Fix:** Remove the field. The HelmRelease itself is already applied and healthy — the Kustomization just can't do server-side dry-run with an unknown field present.