### PR TITLE
ci: fix terraform/containers failures, trim CI churn

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -16,6 +16,12 @@ on:
       - 'packages/**'
       - 'images/**'
       - '.github/workflows/containers.yml'
+
+# Cancel superseded runs on the same ref instead of letting them pile up.
+concurrency:
+  group: containers-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -66,7 +72,9 @@ jobs:
         if: steps.changed-files.outputs.any_modified == 'true'
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
       - name: Login to DockerHub
-        if: steps.changed-files.outputs.any_modified == 'true'
+        # Only needed for the push (on main); PRs build to validate without pushing,
+        # so they don't require — or have access to, from forks — the registry creds.
+        if: steps.changed-files.outputs.any_modified == 'true' && github.event_name != 'pull_request'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -8,18 +8,11 @@ on:
   pull_request:
     paths:
       - '**/*.tf'
-  workflow_dispatch:
-    inputs:
-      regenerate_docs:
-        description: 'Regenerate documentation for all Terraform modules'
-        required: true
-        type: boolean
-        default: true
-      format_terraform:
-        description: 'Format all Terraform files recursively'
-        required: true
-        type: boolean
-        default: true
+
+# Cancel superseded runs on the same ref instead of letting them pile up.
+concurrency:
+  group: terraform-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   changed-directories:
@@ -90,66 +83,17 @@ jobs:
         id: validate
         run: terraform validate
 
-  format:
-    needs: [changed-directories, validate]
+  # Formatting is enforced on the PR (a check), not auto-committed to main —
+  # branch protection rejects bot pushes, and a PR check also avoids the
+  # noise-commit -> re-trigger-CI cascade the old auto-format job caused.
+  # Fix drift locally with `mise run tf:fmt` (and `mise run tf:docs`).
+  fmt:
+    needs: [changed-directories]
     runs-on: ubuntu-latest
-    # Run IF:
-    # 1. It's a push to main AND there are changed terraform files
-    # OR
-    # 2. It's a manual dispatch AND the format_terraform input is true
-    if: |
-      always() && (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.changed-directories.outputs.any_changed == 'true') ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.format_terraform == 'true')
-      )
-    permissions:
-      contents: write
+    if: needs.changed-directories.outputs.any_changed == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: main
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
-      - name: Terraform fmt
-        run: terraform fmt -recursive
-      - name: Check for changes
-        id: check-changes
-        run: |
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-      - name: Commit changes
-        if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add \*.tf
-          git commit -m "style: format terraform files"
-      - name: Push changes
-        if: steps.check-changes.outputs.changed == 'true'
-        run: git push
-
-  docs:
-    needs: [format]
-    runs-on: ubuntu-latest
-    # Run IF:
-    # 1. It's a push to main AND there are changed terraform   files
-    # OR
-    # 2. It's a manual dispatch AND the regenerate_docs input is true
-    if: |
-      always() && (
-        (github.event_name == 'push' && github.ref == 'refs/heads/main' && (needs.changed-directories.outputs.any_changed == 'true')) ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.regenerate_docs)
-      )
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          ref: main
-      - name: Render terraform docs and push changes back to PR
-        uses: terraform-docs/gh-actions@6de6da0cefcc6b4b7a5cbea4d79d97060733093c # v1.4.1
-        with:
-          find-dir: .
-          git-push: true
-          git-commit-message: "docs: regenerate terraform documentation"
+      - name: Terraform fmt check
+        run: terraform fmt -check -recursive

--- a/mise.toml
+++ b/mise.toml
@@ -50,6 +50,12 @@ run = [
   "bash -lc 'for d in terraform/argo terraform/cloudflare terraform/tailscale terraform/unifi terraform/vault terraform/google-workspace terraform/k8s terraform/gcp/organization terraform/gcp/projects/*; do [ -d \"$d\" ] || continue; echo \"==> terraform validate $d\"; terraform -chdir=\"$d\" validate; done'",
 ]
 
+[tasks."tf:docs"]
+description = "Regenerate terraform-docs READMEs (inject) for every module with TF_DOCS markers"
+run = [
+  "bash -lc 'grep -rl BEGIN_TF_DOCS terraform --include=README.md | xargs -r -n1 dirname | sort -u | while read -r d; do echo \"==> $d\"; terraform-docs markdown table --output-file README.md --output-mode inject \"$d\" >/dev/null; done'",
+]
+
 [tasks."tf:plan"]
 description = "Run Terraform plan for one module (set TF_DIR)"
 run = [

--- a/terraform/modules/gce-igm-shielded/variables.tf
+++ b/terraform/modules/gce-igm-shielded/variables.tf
@@ -92,7 +92,7 @@ variable "protocol" {
 }
 
 variable "target_pools" {
-  type        = list
+  type        = list(any)
   description = "List of the target pools this igm belongs to"
   default     = []
 }

--- a/terraform/modules/gke-cluster/variables.tf
+++ b/terraform/modules/gke-cluster/variables.tf
@@ -114,7 +114,7 @@ variable "kubernetes_version" {
 
 variable "network_config" {
   description = "VPC network configuration for the cluster"
-  type        = map
+  type        = map(any)
 
   default = {
     enable_natgw   = false
@@ -130,12 +130,12 @@ variable "network_config" {
 
 variable "master_authorized_networks" {
   description = "Map of cidrs that can access the master network"
-  type        = map
+  type        = map(any)
   default     = {}
 }
 
 variable "labels" {
   description = "List of Kubernetes labels to apply to the nodes"
-  type        = map
+  type        = map(any)
   default     = {}
 }

--- a/terraform/modules/gke-nodepool/variables.tf
+++ b/terraform/modules/gke-nodepool/variables.tf
@@ -53,7 +53,7 @@ variable "node_metadata" {
 
 variable "metadata_cos" {
   description = "GCE instance metadata pairs assigned to the instances in the group"
-  type        = map
+  type        = map(any)
   default = {
     disable-legacy-endpoints = "true"
     enable-guest-attributes  = "false"
@@ -64,7 +64,7 @@ variable "metadata_cos" {
 
 variable "metadata_ubuntu" {
   description = "GCE instance metadata pairs assigned to the instances in the group"
-  type        = map
+  type        = map(any)
   default = {
     disable-legacy-endpoints = "true"
     enable-guest-attributes  = "true"
@@ -74,17 +74,17 @@ variable "metadata_ubuntu" {
 }
 
 variable "taints" {
-  type    = list
+  type    = list(any)
   default = []
 }
 
 variable "tags" {
-  type    = list
+  type    = list(any)
   default = []
 }
 
 variable "labels" {
-  type    = map
+  type    = map(any)
   default = {}
 }
 


### PR DESCRIPTION
Follow-up to #858. The restructure surfaced three pre-existing CI failures (each also failed on the earlier "Merge terraform-modules" commit). This fixes the two that are addressable in-repo and trims some churn.

## Terraform
The `format` and `docs` jobs auto-committed `terraform fmt`/terraform-docs **directly to `main`**, which branch protection rejects (`GH013: Repository rule violations`). They'd fail on every TF-touching merge.

- **Drop both push-back jobs.** Enforce formatting as a **PR check** (`terraform fmt -check -recursive`) instead — no bot pushes to `main`, and it kills the noise-commit → re-trigger-CI cascade.
- Add `mise run tf:docs` to regenerate terraform-docs READMEs locally.
- Formatted the three merged `terraform/modules/*/variables.tf` files (never `fmt`'d in the old standalone repo) so the new check starts green.

## containers
DockerHub login ran on every build (now that all image paths changed) and failed without creds.

- **Only log in for the push (on `main`).** PRs build the Dockerfiles to validate them without pushing, so they no longer need — or, from forks, have access to — registry creds. (Secrets are now set, so `main` pushes will work.)

## CI optimization (kept focused)
- Add `concurrency: cancel-in-progress` to both workflows so superseded runs on a ref are cancelled rather than piling up.
- **Left as separate follow-ups:** the Trivy findings (real pre-existing IaC issues in `images/base`, `terraform/modules`, …) and any broader workflow consolidation.

## Validation
- Both workflows parse (`yq`); jobs: terraform → `changed-directories`, `validate`, `fmt`; containers → `build`.
- `terraform fmt -check -recursive` is clean locally after formatting the merged modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)