### PR TITLE
fix: update k8s→clusters documentation references

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -117,7 +117,7 @@ Reusable configuration profiles in `profiles/`:
 
 Custom service modules in `services/`:
 
-- **`k8s/`** - Kubernetes cluster configuration
+- **`k8s/`** - NixOS service helpers for Kubernetes (Cilium CNI, Longhorn storage, gVisor runtime) — not the cluster manifests, which live in `clusters/`
 - **`common.nix`** - Base server configuration with SSH, Tailscale, monitoring
 - **`jellyfin.nix`** - Media server
 - **`github-runner.nix`** - Self-hosted GitHub Actions runners


### PR DESCRIPTION
## What

Following the k8s/→clusters/ directory rename in the infra repo, this PR updates a stale reference in nix/README.md that described k8s/ as containing Kubernetes cluster configuration — which is now inaccurate since k8s/ in nix/services/ contains NixOS service helpers (Cilium CNI, Longhorn storage, gVisor runtime), while the actual cluster manifests live in clusters/ managed by Flux.

## Live cluster fix (already applied)

The folly cluster's Flux Kustomizations were also patched live to point at the new clusters/ paths so Flux could reconcile. All 22 Kustomizations are now ReconciliationSucceeded.

## Testing

- [x] All folly Kustomizations: `ReconciliationSucceeded`
- [x] flux reconcile source git infra -n flux-system ✓
- [x] kubectl kustomize clusters/folly/flux-system ✓