### PR TITLE
feat(folly): add spore NFS PersistentVolume

### DIFF
--- a/clusters/folly/flux-system/storage.yaml
+++ b/clusters/folly/flux-system/storage.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h0m0s
-  path: ./clusters/base/storage
+  path: ./clusters/folly/storage
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/folly/storage/kustomization.yaml
+++ b/clusters/folly/storage/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/storage
+  - spore-pv.yaml

--- a/clusters/folly/storage/spore-pv.yaml
+++ b/clusters/folly/storage/spore-pv.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: spore
+  labels:
+    type: nfs
+spec:
+  capacity:
+    storage: 50Gi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: nfs
+  nfs:
+    server: spore.lolwtf.ca
+    path: /nfs/data/k8s/


### PR DESCRIPTION
## Summary
Adds a folly-specific NFS `PersistentVolume` backed by `spore.lolwtf.ca:/nfs/data/k8s/`.

- New `clusters/folly/storage/` overlay that layers `spore-pv.yaml` on top of the shared `../../base/storage`
- PV named `spore`, `storageClassName: nfs`, `ReadWriteMany`, `Retain`, 50Gi
- Repoints the folly `storage` Kustomization from `./clusters/base/storage` → `./clusters/folly/storage`

Kept out of `base/storage` since `spore.lolwtf.ca` is a folly/LAN host — offsite continues to consume `base/storage` unchanged, and folly still pulls in the shared `local-path-provisioner` via the overlay.

## Notes
- No `StorageClass` object is required for a static PV; the name is just a matching label. A PVC must request `storageClassName: nfs` + `accessModes: [ReadWriteMany]` to bind.
- `kustomize build clusters/folly/storage` verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)