### PR TITLE
feat(view-counter): deploy with cloud run no-build

### DIFF
--- a/.github/workflows/view-counter.yml
+++ b/.github/workflows/view-counter.yml
@@ -7,6 +7,13 @@ on:
       - 'apps/view-counter/**'
       - '.github/workflows/view-counter.yml'
 
+env:
+  PROJECT_ID: homelab-ng
+  REGION: northamerica-northeast1
+  SERVICE: view-counter
+  RUNTIME_BASE_IMAGE: northamerica-northeast1-docker.pkg.dev/serverless-runtimes/google-24/runtimes/go126
+  RUNTIME_SERVICE_ACCOUNT: view-counter@homelab-ng.iam.gserviceaccount.com
+
 concurrency:
   group: view-counter-${{ github.ref }}
   cancel-in-progress: true
@@ -21,21 +28,48 @@ jobs:
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: apps/view-counter/go.mod
+          cache-dependency-path: apps/view-counter/go.sum
+
+      - name: Test
+        working-directory: apps/view-counter
+        env:
+          GCP_PROJECT: ${{ env.PROJECT_ID }}
+        run: go test ./...
+
+      - name: Build deploy artifact
+        working-directory: apps/view-counter
+        env:
+          CGO_ENABLED: 0
+          GOOS: linux
+          GOARCH: amd64
+        run: |
+          mkdir -p "$RUNNER_TEMP/view-counter-source"
+          go build -trimpath -ldflags="-s -w" -o "$RUNNER_TEMP/view-counter-source/view-counter" ./cmd
+
       - id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/github
           service_account: github-actions@homelab-ng.iam.gserviceaccount.com
 
-      - id: deploy
-        uses: google-github-actions/deploy-cloud-functions@ab10d6b9be21630aafc15ced4c464c16cd6640d6 # v4
+      - uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3.0.1
         with:
-          name: view-counter
-          # 2nd-gen (Cloud Run) function on the latest Go runtime.
-          runtime: go126
-          region: northamerica-northeast1
-          source_dir: apps/view-counter
-          entry_point: ViewCounter
-          project_id: homelab-ng
-          service_account: view-counter@homelab-ng.iam.gserviceaccount.com
-          environment_variables: GCP_PROJECT=homelab-ng
+          install_components: beta
+
+      - id: deploy
+        name: Deploy
+        run: |
+          gcloud beta run deploy "$SERVICE" \
+            --project="$PROJECT_ID" \
+            --region="$REGION" \
+            --source="$RUNNER_TEMP/view-counter-source" \
+            --no-build \
+            --base-image="$RUNTIME_BASE_IMAGE" \
+            --command=./view-counter \
+            --service-account="$RUNTIME_SERVICE_ACCOUNT" \
+            --set-env-vars="GCP_PROJECT=$PROJECT_ID" \
+            --allow-unauthenticated \
+            --quiet

--- a/apps/view-counter/cmd/main.go
+++ b/apps/view-counter/cmd/main.go
@@ -4,9 +4,10 @@ import (
 	"log"
 	"os"
 
-	// Blank-import the function package so the init() runs
-	_ "github.com/jonpulsifer/view-counter"
 	"github.com/GoogleCloudPlatform/functions-framework-go/funcframework"
+
+	// Blank-import the function package so the init() runs
+	_ "github.com/jonpulsifer/infra/apps/view-counter"
 )
 
 func main() {

--- a/apps/view-counter/go.mod
+++ b/apps/view-counter/go.mod
@@ -5,7 +5,6 @@ go 1.26.4
 require (
 	cloud.google.com/go/firestore v1.22.0
 	github.com/GoogleCloudPlatform/functions-framework-go v1.9.2
-	github.com/jonpulsifer/view-counter v0.0.0-20230929001618-37e0ebdd7da0
 	google.golang.org/grpc v1.81.1
 )
 

--- a/apps/view-counter/go.sum
+++ b/apps/view-counter/go.sum
@@ -48,8 +48,6 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.14 h1:yh8ncqsbUY4shRD5dA
 github.com/googleapis/enterprise-certificate-proxy v0.3.14/go.mod h1:vqVt9yG9480NtzREnTlmGSBmFrA+bzb0yl0TxoBQXOg=
 github.com/googleapis/gax-go/v2 v2.21.0 h1:h45NjjzEO3faG9Lg/cFrBh2PgegVVgzqKzuZl/wMbiI=
 github.com/googleapis/gax-go/v2 v2.21.0/go.mod h1:But/NJU6TnZsrLai/xBAQLLz+Hc7fHZJt/hsCz3Fih4=
-github.com/jonpulsifer/view-counter v0.0.0-20230929001618-37e0ebdd7da0 h1:6+vgGkKLGTXDHpVmu+k7BODxy0SyfLH3/Bzy6tLebv8=
-github.com/jonpulsifer/view-counter v0.0.0-20230929001618-37e0ebdd7da0/go.mod h1:obVWU1glVHhTZ3EfQXJa78p2CYRrbNyUo65uCeWrM5M=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/terraform/gcp/projects/homelab-ng/README.md
+++ b/terraform/gcp/projects/homelab-ng/README.md
@@ -2,31 +2,31 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.3 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.34.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.35.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.34.0 |
 | <a name="requirement_onepassword"></a> [onepassword](#requirement\_onepassword) | ~> 3.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.19.1 |
-| <a name="provider_google"></a> [google](#provider\_google) | 7.34.0 |
-| <a name="provider_google.free-tier"></a> [google.free-tier](#provider\_google.free-tier) | 7.34.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 7.35.0 |
+| <a name="provider_google.free-tier"></a> [google.free-tier](#provider\_google.free-tier) | 7.35.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_network"></a> [network](#module\_network) | ../../../modules/gce-vpc | n/a |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [google_compute_disk.oldboy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_disk) | resource |
 | [google_compute_image.nixos](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_image) | resource |
 | [google_compute_instance.oldboy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance) | resource |
@@ -56,7 +56,8 @@
 | [google_project_iam_binding.firestore_database_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
 | [google_project_iam_member.ddnsbot](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.ddnsd](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.github_actions_function_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.github_actions_run_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.github_actions_service_usage_consumer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_service_account.ddns](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |

--- a/terraform/gcp/projects/homelab-ng/README.md
+++ b/terraform/gcp/projects/homelab-ng/README.md
@@ -58,7 +58,6 @@
 | [google_project_iam_member.ddnsd](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_run_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_run_source_developer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
-| [google_project_iam_member.github_actions_service_usage_consumer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
 | [google_service_account.ddns](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |

--- a/terraform/gcp/projects/homelab-ng/README.md
+++ b/terraform/gcp/projects/homelab-ng/README.md
@@ -57,6 +57,7 @@
 | [google_project_iam_member.ddnsbot](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.ddnsd](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_run_admin](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.github_actions_run_source_developer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.github_actions_service_usage_consumer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_service.service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |

--- a/terraform/gcp/projects/homelab-ng/iam.tf
+++ b/terraform/gcp/projects/homelab-ng/iam.tf
@@ -44,7 +44,7 @@ data "google_iam_policy" "github_actions" {
   binding {
     role = "roles/iam.workloadIdentityUser"
     members = [
-      "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.homelab.name}/attribute.repository_owner/jonpulsifer"
+      "principal://iam.googleapis.com/${google_iam_workload_identity_pool.homelab.name}/subject/${local.github_actions_subject}"
     ]
   }
 }

--- a/terraform/gcp/projects/homelab-ng/iam.tf
+++ b/terraform/gcp/projects/homelab-ng/iam.tf
@@ -59,15 +59,21 @@ resource "google_service_account_iam_policy" "github_actions" {
   policy_data        = data.google_iam_policy.github_actions.policy_data
 }
 
-resource "google_project_iam_member" "github_actions_function_admin" {
+resource "google_project_iam_member" "github_actions_run_admin" {
   project = "homelab-ng"
-  role    = "roles/cloudfunctions.admin"
+  role    = "roles/run.admin"
+  member  = google_service_account.github_actions.member
+}
+
+resource "google_project_iam_member" "github_actions_service_usage_consumer" {
+  project = "homelab-ng"
+  role    = "roles/serviceusage.serviceUsageConsumer"
   member  = google_service_account.github_actions.member
 }
 
 resource "google_service_account" "view_counter" {
   account_id   = "view-counter"
-  display_name = "View Counter Cloud Function"
+  display_name = "View Counter Cloud Run Function"
 }
 
 resource "google_service_account_iam_member" "github_actions_view_counter" {

--- a/terraform/gcp/projects/homelab-ng/iam.tf
+++ b/terraform/gcp/projects/homelab-ng/iam.tf
@@ -44,7 +44,7 @@ data "google_iam_policy" "github_actions" {
   binding {
     role = "roles/iam.workloadIdentityUser"
     members = [
-      "principal://iam.googleapis.com/${google_iam_workload_identity_pool.homelab.name}/subject/${local.github_actions_subject}"
+      "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.homelab.name}/attribute.repository_id/952814997"
     ]
   }
 }
@@ -68,12 +68,6 @@ resource "google_project_iam_member" "github_actions_run_admin" {
 resource "google_project_iam_member" "github_actions_run_source_developer" {
   project = "homelab-ng"
   role    = "roles/run.sourceDeveloper"
-  member  = google_service_account.github_actions.member
-}
-
-resource "google_project_iam_member" "github_actions_service_usage_consumer" {
-  project = "homelab-ng"
-  role    = "roles/serviceusage.serviceUsageConsumer"
   member  = google_service_account.github_actions.member
 }
 

--- a/terraform/gcp/projects/homelab-ng/iam.tf
+++ b/terraform/gcp/projects/homelab-ng/iam.tf
@@ -65,6 +65,12 @@ resource "google_project_iam_member" "github_actions_run_admin" {
   member  = google_service_account.github_actions.member
 }
 
+resource "google_project_iam_member" "github_actions_run_source_developer" {
+  project = "homelab-ng"
+  role    = "roles/run.sourceDeveloper"
+  member  = google_service_account.github_actions.member
+}
+
 resource "google_project_iam_member" "github_actions_service_usage_consumer" {
   project = "homelab-ng"
   role    = "roles/serviceusage.serviceUsageConsumer"

--- a/terraform/gcp/projects/homelab-ng/services.tf
+++ b/terraform/gcp/projects/homelab-ng/services.tf
@@ -32,6 +32,7 @@ resource "google_project_service" "service" {
     "serviceusage.googleapis.com",
     "storage-api.googleapis.com",
     "storage-component.googleapis.com",
+    "storage.googleapis.com",
     "vision.googleapis.com",
     "websecurityscanner.googleapis.com",
   ])

--- a/terraform/gcp/projects/homelab-ng/workload-identity.tf
+++ b/terraform/gcp/projects/homelab-ng/workload-identity.tf
@@ -1,3 +1,7 @@
+locals {
+  github_actions_subject = "repo:jonpulsifer@5461940/infra@952814997"
+}
+
 resource "google_iam_workload_identity_pool" "homelab" {
   workload_identity_pool_id = "homelab"
 }
@@ -6,18 +10,20 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.homelab.workload_identity_pool_id
   workload_identity_pool_provider_id = "github"
   attribute_mapping = {
-    "google.subject"             = "assertion.sub"
-    "attribute.actor"            = "assertion.actor"
-    "attribute.repository"       = "assertion.repository"
-    "attribute.repository_owner" = "assertion.repository_owner"
-    "attribute.repo_and_branch"  = "assertion.repository + '/' + assertion.ref"
-    "attribute.workflow"         = "assertion.job_workflow_ref"
+    "google.subject"                = "assertion.sub"
+    "attribute.actor"               = "assertion.actor"
+    "attribute.repository"          = "assertion.repository"
+    "attribute.repository_id"       = "assertion.repository_id"
+    "attribute.repository_owner"    = "assertion.repository_owner"
+    "attribute.repository_owner_id" = "assertion.repository_owner_id"
+    "attribute.repo_and_branch"     = "assertion.repository + '/' + assertion.ref"
+    "attribute.workflow"            = "assertion.job_workflow_ref"
   }
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
-  attribute_condition = "assertion.repository_owner == 'jonpulsifer'"
+  attribute_condition = "assertion.repository_owner_id == '5461940' && assertion.repository_id == '952814997'"
   depends_on          = [google_org_policy_policy.allowed_workload_identity_providers]
 }
 

--- a/terraform/gcp/projects/homelab-ng/workload-identity.tf
+++ b/terraform/gcp/projects/homelab-ng/workload-identity.tf
@@ -1,5 +1,5 @@
 locals {
-  github_actions_subject = "repo:jonpulsifer@5461940/infra@952814997"
+  github_actions_subject_prefix = "repo:jonpulsifer@5461940/infra@952814997"
 }
 
 resource "google_iam_workload_identity_pool" "homelab" {
@@ -23,7 +23,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
-  attribute_condition = "assertion.repository_owner_id == '5461940' && assertion.repository_id == '952814997'"
+  attribute_condition = "assertion.sub.startsWith('${local.github_actions_subject_prefix}') && assertion.repository_owner_id == '5461940' && assertion.repository_id == '952814997'"
   depends_on          = [google_org_policy_policy.allowed_workload_identity_providers]
 }
 


### PR DESCRIPTION
## Summary
Migrate `view-counter` from the Cloud Functions deploy action to Cloud Run no-build source deploy using Google's Go 1.26 runtime base image. Tighten GitHub Actions OIDC trust to immutable repository identifiers.

## Changes
- feat(view-counter): deploy with cloud run no-build
- fix(view-counter): grant source deploy permissions
- fix(gcp): restrict github oidc trust
- fix(gcp): use immutable github subject prefix

## Test Plan
- [x] `cd apps/view-counter && GCP_PROJECT=homelab-ng go test ./...`
- [x] `cd apps/view-counter && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags='-s -w' -o /tmp/view-counter ./cmd`
- [x] `terraform -chdir=terraform/gcp/projects/homelab-ng validate`
- [x] `terraform fmt -check -recursive`
- [x] Targeted Terraform plans for Cloud Run deploy IAM and GitHub OIDC changes

## Context
- `.agent/context/main/context.md`
- `.agent/context/plan.md`
