### PR TITLE
fix(view-counter): avoid project env in tests

### DIFF
--- a/.agents/skills/terraform/SKILL.md
+++ b/.agents/skills/terraform/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: terraform
-description: Work with Terraform modules in this infra repo (everything under terraform/: gcp, cloudflare, vault, argo, unifi, tailscale, google-workspace, k8s). Covers workflow, CI behaviour, and module layout.
+description: >-
+  Work with Terraform modules in this infra repo (everything under terraform/:
+  gcp, cloudflare, vault, argo, unifi, tailscale, google-workspace, k8s).
+  Covers workflow, CI behaviour, and module layout.
 ---
 
 ## Module Layout

--- a/.github/workflows/view-counter.yml
+++ b/.github/workflows/view-counter.yml
@@ -35,8 +35,6 @@ jobs:
 
       - name: Test
         working-directory: apps/view-counter
-        env:
-          GCP_PROJECT: ${{ env.PROJECT_ID }}
         run: go test ./...
 
       - name: Build deploy artifact
@@ -70,6 +68,6 @@ jobs:
             --base-image="$RUNTIME_BASE_IMAGE" \
             --command=./view-counter \
             --service-account="$RUNTIME_SERVICE_ACCOUNT" \
-            --set-env-vars="GCP_PROJECT=$PROJECT_ID" \
+            --set-env-vars="GOOGLE_CLOUD_PROJECT=$PROJECT_ID" \
             --allow-unauthenticated \
             --quiet

--- a/apps/view-counter/view_counter.go
+++ b/apps/view-counter/view_counter.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 	"os"
-
 	"strconv"
+	"sync"
 
 	"cloud.google.com/go/firestore"
 	"github.com/GoogleCloudPlatform/functions-framework-go/functions"
@@ -15,16 +15,21 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var client *firestore.Client
+var (
+	defaultStoreMu sync.Mutex
+	defaultStore   counterStore
+)
 
 func init() {
-	projectID := os.Getenv("GCP_PROJECT")
-	var err error
-	client, err = firestore.NewClient(context.Background(), projectID)
-	if err != nil {
-		log.Fatalf("firestore.NewClient: %v", err)
-	}
 	functions.HTTP("ViewCounter", viewCounter)
+}
+
+type counterStore interface {
+	Next(context.Context, string) (int64, error)
+}
+
+type firestoreCounterStore struct {
+	client *firestore.Client
 }
 
 type document struct {
@@ -48,6 +53,7 @@ const (
 	defaultLabelWidth   float32 = 12
 	defaultLabel        string  = "View Count"
 )
+
 const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="{{.BadgeWidth}}" height="{{.BadgeHeight}}">
     <linearGradient id="b" x2="0" y2="100%">
         <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
@@ -72,76 +78,113 @@ const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="{{.BadgeWidth}}" hei
 
 // viewCounter is an HTTP Cloud Function.
 func viewCounter(w http.ResponseWriter, r *http.Request) {
-	t, err := template.New("counter").Parse(svg)
+	store, err := getDefaultStore(r.Context())
 	if err != nil {
+		log.Printf("firestore.NewClient: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
-	label := defaultLabel
-	urlLabel := r.URL.Query().Get("label")
-	if urlLabel != "" {
-		label = urlLabel
+	viewCounterWithStore(store).ServeHTTP(w, r)
+}
+
+func viewCounterWithStore(store counterStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		t, err := template.New("counter").Parse(svg)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		label := defaultLabel
+		urlLabel := r.URL.Query().Get("label")
+		if urlLabel != "" {
+			label = urlLabel
+		}
+
+		counter, err := store.Next(r.Context(), label)
+		if err != nil {
+			log.Printf("firestore: could not update counter: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		counterStringLength := len(strconv.Itoa(int(counter)))
+		counterWidth := defaultCounterWidth + (float32(counterStringLength) * 5)
+		labelWidth := defaultLabelWidth + (float32(len(label)) * 7)
+
+		svg := imageData{
+			BadgeHeight:   defaultBadgeHeight,
+			BadgeWidth:    labelWidth + counterWidth,
+			Counter:       counter,
+			CounterOffset: labelWidth + (counterWidth / 2),
+			CounterWidth:  counterWidth,
+			Label:         label,
+			LabelOffset:   labelWidth / 2,
+			LabelWidth:    labelWidth,
+		}
+
+		w.Header().Set("Content-Type", "image/svg+xml")
+		w.Header().Set("Cache-Control", "no-store, max-age=0")
+		if err := t.Execute(w, svg); err != nil {
+			log.Printf("template: could not render svg: %v", err)
+		}
+	}
+}
+
+func getDefaultStore(ctx context.Context) (counterStore, error) {
+	defaultStoreMu.Lock()
+	defer defaultStoreMu.Unlock()
+
+	if defaultStore != nil {
+		return defaultStore, nil
 	}
 
-	ctx := context.Background()
+	client, err := firestore.NewClient(ctx, projectIDFromEnv())
+	if err != nil {
+		return nil, err
+	}
 
-	collection := "views"
-	doc := client.Collection(collection).Doc(label)
+	defaultStore = &firestoreCounterStore{client: client}
+	return defaultStore, nil
+}
+
+func projectIDFromEnv() string {
+	if projectID := os.Getenv("GOOGLE_CLOUD_PROJECT"); projectID != "" {
+		return projectID
+	}
+
+	return os.Getenv("GCP_PROJECT")
+}
+
+func (s *firestoreCounterStore) Next(ctx context.Context, label string) (int64, error) {
+	doc := s.client.Collection("views").Doc(label)
 
 	snapshot, err := doc.Get(ctx)
-	if err != nil {
-		if status.Code(err) != codes.NotFound {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
+	if err != nil && status.Code(err) != codes.NotFound {
+		return 0, err
 	}
 
-	var counter int64
-	if snapshot.Exists() {
+	counter := int64(1)
+	if err == nil && snapshot.Exists() {
 		var current document
-		err = snapshot.DataTo(&current)
-		if err != nil {
-			log.Printf("firestore: could not get data from ref: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+		if err := snapshot.DataTo(&current); err != nil {
+			return 0, err
 		}
-		counter += current.Count
 
+		counter = current.Count + 1
 		_, err := doc.Update(ctx, []firestore.Update{
 			{Path: "count", Value: firestore.Increment(1)},
 		})
 		if err != nil {
-			log.Printf("firestore: could not update record: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+			return 0, err
 		}
 	} else {
-		counter = 1
 		_, err := doc.Set(ctx, map[string]interface{}{"count": counter}, firestore.MergeAll)
 		if err != nil {
-			log.Printf("firestore: could not upsert: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
+			return 0, err
 		}
 	}
 
-	counterStringLength := len(strconv.Itoa(int(counter)))
-	counterWidth := defaultCounterWidth + (float32(counterStringLength) * 5)
-	labelWidth := defaultLabelWidth + (float32(len(label)) * 7)
-
-	svg := imageData{
-		BadgeHeight:   defaultBadgeHeight,
-		BadgeWidth:    labelWidth + counterWidth,
-		Counter:       counter,
-		CounterOffset: labelWidth + (counterWidth / 2),
-		CounterWidth:  counterWidth,
-		Label:         label,
-		LabelOffset:   labelWidth / 2,
-		LabelWidth:    labelWidth,
-	}
-
-	w.Header().Set("Content-Type", "image/svg+xml")
-	w.Header().Set("Cache-Control", "no-store, max-age=0")
-	t.Execute(w, svg)
+	return counter, nil
 }

--- a/apps/view-counter/view_counter_test.go
+++ b/apps/view-counter/view_counter_test.go
@@ -1,53 +1,69 @@
 package view_counter
 
 import (
+	"context"
+	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"sync"
 	"testing"
 )
 
-func TestViewCounterGet(t *testing.T) {
-	// TODO: make a firestore test :O
-	t.Skip("this test doesn't work with firestore")
+type inMemoryCounterStore struct {
+	mu     sync.Mutex
+	counts map[string]int64
+}
 
-	req := httptest.NewRequest("GET", "/", nil)
+func newInMemoryCounterStore() *inMemoryCounterStore {
+	return &inMemoryCounterStore{counts: map[string]int64{}}
+}
+
+func (s *inMemoryCounterStore) Next(_ context.Context, label string) (int64, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.counts[label]++
+	return s.counts[label], nil
+}
+
+func TestViewCounterGet(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "")
+	t.Setenv("GCP_PROJECT", "")
+
+	handler := viewCounterWithStore(newInMemoryCounterStore())
+
+	body := performRequest(t, handler, "/")
+	assertSVGText(t, body, "1")
+
+	body = performRequest(t, handler, "/")
+	assertSVGText(t, body, "2")
+
+	body = performRequest(t, handler, "/?label=TestLabel")
+	assertSVGText(t, body, "TestLabel")
+	assertSVGText(t, body, "1")
+}
+
+func performRequest(t *testing.T, handler http.Handler, path string) string {
+	t.Helper()
+
+	req := httptest.NewRequest("GET", path, nil)
 	rr := httptest.NewRecorder()
 
-	// make a request
-	viewCounter(rr, req)
+	handler.ServeHTTP(rr, req)
 
-	// validate content type
 	contentType := "image/svg+xml"
 	if got := rr.Header().Get("Content-Type"); got != contentType {
-		t.Errorf("Wrong Content-Type. got: %q, want: %q", got, contentType)
+		t.Fatalf("Wrong Content-Type. got: %q, want: %q", got, contentType)
 	}
 
-	// check that the response body has the svg text "1"
-	r, _ := regexp.Compile("<text.+>1</text>")
-	if got := rr.Body.String(); !r.MatchString(got) {
-		t.Errorf("Could not find SVG text \"1\", got: %q", got)
-	}
+	return rr.Body.String()
+}
 
-	// make another request to increment the counter, check that it is "2"
-	viewCounter(rr, req)
-	r, _ = regexp.Compile("<text.+>2</text>")
-	if got := rr.Body.String(); !r.MatchString(got) {
-		t.Errorf("Could not find SVG text \"2\", got: %q", got)
-	}
+func assertSVGText(t *testing.T, body, text string) {
+	t.Helper()
 
-	// make a request with a new label
-	req = httptest.NewRequest("GET", "/?label=TestLabel", nil)
-	viewCounter(rr, req)
-
-	// check that the response body has the svg text "TestLabel"
-	r, _ = regexp.Compile("<text.+>TestLabel</text>")
-	if got := rr.Body.String(); !r.MatchString(got) {
-		t.Errorf("Could not find SVG text \"TestLabel\", got: %q", got)
-	}
-
-	// check that the response body has the svg text "1"
-	r, _ = regexp.Compile("<text.+>1</text>")
-	if got := rr.Body.String(); !r.MatchString(got) {
-		t.Errorf("Could not find SVG text \"1\", got: %q", got)
+	r := regexp.MustCompile("<text.+>" + regexp.QuoteMeta(text) + "</text>")
+	if !r.MatchString(body) {
+		t.Fatalf("Could not find SVG text %q, got: %q", text, body)
 	}
 }


### PR DESCRIPTION
## Summary
Fix the Terraform skill metadata parse error and make view-counter tests independent of gcloud, ADC, or a configured GCP project ID.

## Changes
- fix(view-counter): avoid project env in tests

## Test Plan
- [x] `cd apps/view-counter && env -u GCP_PROJECT -u GOOGLE_CLOUD_PROJECT go test -count=1 ./...`
- [x] `cd apps/view-counter && go vet ./...`
- [x] `git diff --check -- .agents/skills/terraform/SKILL.md .github/workflows/view-counter.yml apps/view-counter/view_counter.go apps/view-counter/view_counter_test.go`

## Context
- `.agent/context/context.md`
- `.agent/context/plan.md`
