### PR TITLE
fix(gcp): allow canadian view-counter deploy

### DIFF
--- a/.github/workflows/view-counter.yml
+++ b/.github/workflows/view-counter.yml
@@ -61,6 +61,7 @@ jobs:
         name: Deploy
         run: |
           gcloud beta run deploy "$SERVICE" \
+            --endpoint-mode=regional-preferred \
             --project="$PROJECT_ID" \
             --region="$REGION" \
             --source="$RUNNER_TEMP/view-counter-source" \

--- a/terraform/gcp/projects/homelab-ng/policy.tf
+++ b/terraform/gcp/projects/homelab-ng/policy.tf
@@ -155,6 +155,7 @@ resource "google_org_policy_policy" "allowed_locations" {
     rules {
       values {
         allowed_values = [
+          "in:northamerica-northeast1-locations",
           "in:us-east1-locations" # free tier compute engine
         ]
       }


### PR DESCRIPTION
## Summary
Keep the view-counter Cloud Run deploy in `northamerica-northeast1` and allow that Canadian region in the `homelab-ng` resource locations policy so source staging can create its regional bucket.

## Changes
- fix(gcp): allow canadian view-counter deploy

## Test Plan
- [x] `terraform -chdir=terraform/gcp/projects/homelab-ng fmt`
- [x] `terraform -chdir=terraform/gcp/projects/homelab-ng validate`
- [x] `git diff --check -- .github/workflows/view-counter.yml terraform/gcp/projects/homelab-ng/policy.tf`

## Context
`gcloud beta run deploy --source` already uses `--region=northamerica-northeast1`; there is no separate `--location` flag for the staging bucket. The deploy failed because `constraints/gcp.resourceLocations` only allowed `us-east1`, so the Cloud Run source staging bucket in `northamerica-northeast1` was rejected.
