### PR TITLE
fix(nix): apply dotfiles from in-repo source, drop WSL build-time seeding

### DIFF
--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -37,55 +37,12 @@ jobs:
           skipPush: ${{ github.ref != 'refs/heads/main' }}
       - run: nix build .#${{ inputs.image }}
 
-      - name: Prepare WSL dotfiles
-        if: ${{ inputs.image == 'wsl' }}
-        run: |
-          set -euo pipefail
-
-          wsl_user="$(nix eval --raw .#nixosConfigurations.wsl.config.wsl.defaultUser)"
-          wsl_home="$(nix eval --raw ".#nixosConfigurations.wsl.config.users.users.${wsl_user}.home")"
-          wsl_uid="$(nix eval ".#nixosConfigurations.wsl.config.users.users.${wsl_user}.uid")"
-          wsl_gid="$(nix eval .#nixosConfigurations.wsl.config.users.groups.users.gid)"
-
-          extra_files="wsl-extra-files"
-          staged_home="${extra_files}${wsl_home}"
-          chezmoi_source="${staged_home}/.local/share/chezmoi"
-          chezmoi_runtime="${PWD}/.cache/chezmoi"
-
-          mkdir -p "${chezmoi_source}" "${chezmoi_runtime}"
-          # Dotfiles are part of this repo (dotfiles/), already on disk from the
-          # checkout — seed the image's chezmoi source from it instead of
-          # re-cloning over the network.
-          cp -a "${GITHUB_WORKSPACE}/dotfiles/." "${chezmoi_source}/"
-          nix build .#legacyPackages.x86_64-linux.chezmoi -o chezmoi-result
-
-          # Seed chezmoi's config data map and override the kernel release there.
-          # chezmoi 2.66.x can panic when --override-data is used with no config data.
-          cat > "${chezmoi_runtime}/chezmoi.yaml" <<'EOF'
-          data:
-            chezmoi:
-              kernel:
-                osrelease: microsoft-standard-WSL2
-          EOF
-
-          HOME="${wsl_home}" \
-            USER="${wsl_user}" \
-            LOGNAME="${wsl_user}" \
-            ./chezmoi-result/bin/chezmoi \
-              --source "${chezmoi_source}" \
-              --destination "${staged_home}" \
-              --cache "${chezmoi_runtime}/cache" \
-              --persistent-state "${chezmoi_runtime}/state.db" \
-              --config "${chezmoi_runtime}/chezmoi.yaml" \
-              --refresh-externals=always \
-              apply --exclude scripts --force --no-tty
-
-          echo "WSL_EXTRA_FILES=${extra_files}" >> "${GITHUB_ENV}"
-          echo "WSL_CHOWN=${wsl_home} ${wsl_uid}:${wsl_gid}" >> "${GITHUB_ENV}"
-
       - name: Build WSL tarball
         if: ${{ inputs.image == 'wsl' }}
-        run: sudo ./result/bin/nixos-wsl-tarball-builder --extra-files "${WSL_EXTRA_FILES}" --chown ${WSL_CHOWN} ./nixos.wsl
+        # Dotfiles ship in-repo (dotfiles/) and are applied by
+        # nix/system/chezmoi.nix from the system closure on first boot, so the
+        # tarball needs no build-time dotfiles seeding.
+        run: sudo ./result/bin/nixos-wsl-tarball-builder ./nixos.wsl
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' || inputs.image == 'wsl' }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,8 +164,8 @@ First-party code and container/image builds, separate from the infra layers:
 Dotfiles live in-repo under `dotfiles/` (formerly the standalone `jonpulsifer/dotfiles` repo, merged in via `git filter-repo`). They are **chezmoi-managed**, not a flake input — there is no `dotfiles` flake input and no home-manager.
 
 - The repo-root `.chezmoiroot` contains `dotfiles`, so chezmoi treats the `dotfiles/` subdirectory as its source root.
-- On NixOS hosts, `nix/system/chezmoi.nix` runs `chezmoi init github:jonpulsifer/infra` then `chezmoi apply` in an activation script (for the `jawn` user). `infra` is a public repo, so this clones without credentials.
-- The WSL image (`.github/workflows/nix-image-builder.yaml`) clones `github:jonpulsifer/infra` into the staged `~/.local/share/chezmoi` and applies via chezmoi, which honours `.chezmoiroot`.
+- On NixOS hosts, `nix/system/chezmoi.nix` carries the `dotfiles/` tree into the system closure (via the flake source) and runs `chezmoi apply --source <store-path>` in an activation script (for the `jawn` user) — no network clone, and it self-heals on every rebuild/boot. The module is imported on cluster/Pi hosts through `nix/services/common.nix`, and directly by the WSL image (`nix/images/wsl.nix`).
+- The WSL image (`.github/workflows/nix-image-builder.yaml`) builds a plain tarball; dotfiles are applied by that same activation script on first boot, so the workflow does no build-time chezmoi seeding.
 
 Editing dotfiles (e.g. zsh config in `dotfiles/dot_config/zsh/`) ships to hosts on the next `chezmoi apply` / rebuild — no separate repo to update.
 

--- a/nix/images/wsl.nix
+++ b/nix/images/wsl.nix
@@ -9,6 +9,7 @@
     inputs.nixos-wsl.nixosModules.default
     ../system/user.nix
     ../system/nixos.nix
+    ../system/chezmoi.nix
   ];
 
   nixpkgs.config.allowUnfree = true;

--- a/nix/system/chezmoi.nix
+++ b/nix/system/chezmoi.nix
@@ -2,13 +2,20 @@
   config,
   pkgs,
   lib,
+  inputs,
   ...
 }:
 let
   user = config.users.users.jawn;
-  # Dotfiles now live in this monorepo under dotfiles/; the repo-root
-  # .chezmoiroot points chezmoi at that subdirectory.
-  dotfilesRepo = "github:jonpulsifer/infra";
+  # Dotfiles live in this monorepo under dotfiles/ (the repo-root .chezmoiroot
+  # points chezmoi at that subdirectory). Carry just that subtree into the
+  # system closure via the flake source so chezmoi applies from a local store
+  # path — no network clone, no build-time seeding, and it self-heals on every
+  # activation.
+  chezmoiSource = builtins.path {
+    path = "${inputs.self}/dotfiles";
+    name = "chezmoi-dotfiles";
+  };
 in
 lib.mkIf (user.isNormalUser or false) {
   environment.systemPackages = [ pkgs.chezmoi ];
@@ -19,18 +26,11 @@ lib.mkIf (user.isNormalUser or false) {
       "groups"
     ];
     text = ''
-      source_dir="${user.home}/.local/share/chezmoi"
-      chezmoi="${pkgs.chezmoi}/bin/chezmoi"
-      if [ ! -d "$source_dir/.git" ]; then
-        HOME="${user.home}" \
-        ${pkgs.sudo}/bin/sudo --preserve-env=HOME -u ${user.name} \
-          $chezmoi init ${dotfilesRepo} 2>/dev/null || true
-      fi
-      if [ -d "$source_dir" ]; then
-        HOME="${user.home}" \
-        ${pkgs.sudo}/bin/sudo --preserve-env=HOME -u ${user.name} \
-          $chezmoi apply --no-tty --force 2>/dev/null || true
-      fi
+      HOME="${user.home}" \
+      ${pkgs.sudo}/bin/sudo --preserve-env=HOME -u ${user.name} \
+        ${pkgs.chezmoi}/bin/chezmoi apply \
+          --source ${chezmoiSource} \
+          --no-tty --force 2>/dev/null || true
     '';
   };
 }


### PR DESCRIPTION
## Summary
Unify dotfiles delivery on the in-repo `dotfiles/` source now that it ships with the repo. `nix/system/chezmoi.nix` applies from the system closure instead of cloning over the network, and the WSL image self-heals on first boot, so the image-builder workflow no longer needs its build-time seeding step.

## Changes
- `chezmoi.nix`: `builtins.path` carries only the `dotfiles/` subtree into the closure; activation runs `chezmoi apply --source <store-path>` — no `chezmoi init`, no network clone, re-applies every rebuild/boot.
- `wsl.nix`: import `../system/chezmoi.nix` (the only host that previously lacked it, hence the build-time seeding dependency).
- `nix-image-builder.yaml`: drop the ~45-line "Prepare WSL dotfiles" step and `--extra-files`/`--chown`; the WSL build is now just `nixos-wsl-tarball-builder ./nixos.wsl`.
- `AGENTS.md`: document the closure-based apply flow.

## Notes
- Fixes the latent `~/.dotfiles` broken-symlink bug (sourceDir now resolves to the in-closure store path).
- WSL templates now read the real `.chezmoi.kernel.osrelease` at first-boot apply instead of the hard-coded build-time override.
- `run_once_` scripts (mise) and `.chezmoiexternal.yaml` (zsh plugins) now run at first boot with network rather than at image-build time; `|| true` keeps a transient hiccup from blocking activation.

## Test Plan
- [ ] `nix eval .#nixosConfigurations.wsl.config.system.activationScripts.chezmoi.text` resolves to the `chezmoi-dotfiles` store path (verified locally for `wsl` and `optiplex`)
- [ ] `nix build .#wsl` succeeds end-to-end (not yet run locally)
- [ ] Boot the WSL tarball and confirm dotfiles + zsh plugins land for `jawn`
