### PR TITLE
fix(unifi): update provider and remove invalid client

### DIFF
--- a/terraform/unifi/.terraform.lock.hcl
+++ b/terraform/unifi/.terraform.lock.hcl
@@ -24,54 +24,59 @@ provider "registry.terraform.io/1password/onepassword" {
 }
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "5.19.1"
+  version     = "5.21.0"
   constraints = "~> 5.1"
   hashes = [
-    "h1:mopYISyLkUVUwMjJbuPenxIUVDrna1/7ACB1hfMfciU=",
-    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
-    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
-    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
-    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
-    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
-    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
-    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
-    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "h1:GHS9VFEa0rXjux9Cipqy2QGEmQ0bst6Xqd5WUUJsOwI=",
+    "zh:2d3dc17f27dcf308f52bdede3b7bb00e6cda6c1a9fbdafd1bfe4a915e75fdc44",
+    "zh:413e3569ad0cc89f8ac425d8a197d9e892ff356ac24dedde386820cf5880a48e",
+    "zh:59f262b9af9a8845afeb2734a6bd83b260aa2c521e5c318850745823ef62b38d",
+    "zh:7d42963a47ff6dda8aada0cb73a26eb6807c7ff6bb4419cb91b32ce2412c8362",
+    "zh:89cad3906c9affa0f2947607d316d70c38541c399d0519ebee1f1ccc8aaf5675",
+    "zh:d5c7ff6c39d895e5746fed74ecc3f284c91c8c1f502da2e93f5c581f41f87f25",
+    "zh:dc425b5f40e94165e563dc55bd6e49cedfe879a03e668168610459ef071b1a87",
+    "zh:f0665907dd24ae93f9511216052d653bba0823c933e888cf02a4abf95f73dfe0",
     "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }
 
-provider "registry.terraform.io/ubiquiti-community/unifi" {
-  version     = "0.41.25"
-  constraints = "~> 0.41"
+provider "registry.terraform.io/hashicorp/vault" {
+  version = "5.9.0"
   hashes = [
-    "h1:4mGCL6zQKr6HPpHeyqnh6wcdYgFJZbQKEwev+vZxwr8=",
-    "h1:4tJ2d187bjWqYD/kZUX+D3NAzRxxGESZkkBiBfyV0C0=",
-    "h1:EkPFtdqAA/caW0ga2K02U0IMu0Ah6+l19P9DW5RdIUc=",
-    "h1:JzfLlbDSRkA6HSiyMvITbRx8uSA2xCbjRjuQh0x23Es=",
-    "h1:ObpY+fyKv6NiPHP3N2dWoBH2KrDAOTLEVk751LMcmJw=",
-    "h1:W2Hq8zrAKEyXFWmKQ3QpkhzOE7R5yDPlhsKsgaSb8nk=",
-    "h1:Za2/cwdUxCdPJ54z55vY0CubZmE3Nn6ywsDwFK6hfnw=",
-    "h1:bu734fY5JpfcsyMHV58ONfcMAHmKZwLYRYW6sL6f4Tc=",
-    "h1:gZLa2/SRB4S5NeqZj6EXgsIoCoUZ2RgfExhkOGYsnz4=",
-    "h1:h/UH+UkGx7C8zAYV44JP9xfoOXwtGYYKRYlcQlfR2tA=",
-    "h1:qNDjP4zAmEyur6gPkE7+voulKbdKshcQuKBjepJrniM=",
-    "h1:qRFnztw0TZG/RQVLHe2Pjz5U/IOY0g+8ESV1AwzIEWU=",
-    "h1:xXIK0qO12AM7W2EtydqFcTXOfT4/ZhYTklT/YIVkxlk=",
-    "h1:zwJDyrNyfxz3/iHXVSRO3mVxMrE5VAOM2Q8g7Z2yOnI=",
-    "zh:1f45ce17895b191156c1556cb704e022c903afce13d4d0eb9c7a8c2ba1d5c882",
-    "zh:25350e49be814fa80b0831d598773ef5ca6349875fc84ae8c68c5aeecc8546a6",
-    "zh:2782b11d6d05a30a794b627026057f2a5cd1795c658e0fab35d3b779aa238f42",
-    "zh:2997d531fbccec09ceb5cabba6a8af4c9a346e09ce3dbe659385ada8ae9efca5",
-    "zh:32a715e6249b14b62b5b9dbb99c4879b6f5937da2f1c2c8e5ae567c640836fdf",
-    "zh:42d4dda9ac0113318b8032ce78699131fdb0ae535f477ce3b9f686c0c371cfdf",
-    "zh:439d03f851fc29aa517d886c4e81998b5950a7c8c94fba9091819dd26d2b1910",
-    "zh:44cd68b8d00c41d9de7394ed3f75f8f76de0502d412c42fd6f8ba587a8632ddd",
-    "zh:58c7d69284a9942296e5e9751b368836a958fb07faa729951e2775761ce58f6c",
-    "zh:7b2acfa58bee36965874b1f79269e129b7826edd57c2ece138eb3aedaea3cd1f",
+    "h1:8wcXxEMo7XvCnrtZHSpAuWmRfYiZkWn2tssshB1BDzo=",
+    "zh:16e23a37c0965938544af282a7bc13dabca445f462ab27829f98e936ace4d263",
+    "zh:249fcf9da1a690fe9aa44a7421fad89a425afb0c2ce7eaf306d75daddd691af5",
+    "zh:3d92af386049a229a428f21b938a22df61703447c8ceed65c73f111a64e627d2",
+    "zh:4033fedf9d4f54f0aacf7c4a79e20978bcd67c0a8ab9411acd447db1469108a4",
+    "zh:51c78d0dc378037bbaf3cd26ff29fae7c40d7b134b40d059b982257987c15f9f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:86e414b7327343de676ec506d30c557a514dbd992b27a2670466adaf9ed69718",
+    "zh:879c3a61ed8d183a68ddb590e63a7e0d6aab8d8044fd4a13658e7b1661395a9d",
+    "zh:8d548617543ee2ce0340972a5df93e7ac37b7895d4bf506bd587f8daac58e6d6",
+    "zh:8d75b3bbfd9a536c8c1d84504cb3d1c8e1a3fd30e377a51a6311476632363103",
+    "zh:922f625a36642c49daa432e07c12e72ff75025e0b9afda8d7240f38c6789fe46",
+    "zh:fbceae685b395acaff6c820ed7d7eaa6250ef4769e04481145dc50e09b89db2f",
+  ]
+}
+
+provider "registry.terraform.io/ubiquiti-community/unifi" {
+  version     = "0.52.4"
+  constraints = "~> 0.52"
+  hashes = [
+    "h1:6eItCf5QherQo4qUDUWtdA+/iBQ18jLBbYYQrICyCaI=",
+    "zh:038f06b4e8522a61b38a500a1f50718b1791c090b5b95d72ce7ac1cf6ef560bf",
+    "zh:257d292abd2442cd5e33778f63680dd1573ae625ff32afec633ed85082d9e128",
+    "zh:338b54987cfbcce10aab42ec820567177aed84d986ae5d96d7e14d588004ae2a",
+    "zh:3a2e1bde0cc10160684795a1e92715f93f852a1e469dcb1560bbedffe4c2a8db",
+    "zh:4a5c9503fbcf2a862da5f89b7bf48fbd64992f700d7da3bf80e9642a0c325e11",
+    "zh:4f3ca35df1ee838619ad514ab1365680c0262c65c6d8a5f0ba21109765b9a398",
+    "zh:67332ca394e07b839dd6fe1fb4f0f77c3bb2d489b6e5742c40b5ee8b2e3d1487",
+    "zh:741b85047d6a1979bb5135dc495b9983f6283bada027e953a01bc41ad7492ce4",
+    "zh:7b613f99779d1f7eeb730363f5f52da3981dd597ae2a1a244d95e5b15156e65d",
     "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:8c6b8d2faca5defb41c001c83985a91c9b8f9e81caec0e5653add5f7e80fe95f",
-    "zh:96d147ee8f62d15e20260de8b04cd1aebed3f76ca81223cdafcb522d88bb90ad",
-    "zh:98f39a5d41aed24290150c10bd7582672df6d9be9789245dd49b6935b2a0557e",
-    "zh:9e287652665f9cfde532855b0b4e2a09f7661ba88d594e36a9169a4acafe7852",
+    "zh:9c4ddf24f45d5769c5ab829d1e559593235380f09e2c1c116d0bb3a498893855",
+    "zh:c7c52bb823c7d23d97a9af1a96eac6cbecc68212ccb0fd77bc223a14278aa7e1",
+    "zh:df5d6660c498c6f378a19b03744ec459f2f683b493da5290646ec292e4b87588",
+    "zh:fcf81f1ca36cc93aa24d5c5f0b0f0327e85027af692743c1683135c0d730bdda",
   ]
 }

--- a/terraform/unifi/clients.yaml
+++ b/terraform/unifi/clients.yaml
@@ -144,9 +144,6 @@ desktops:
 laptops:
   Constance's Macbook Pro:
     mac: f0:18:98:54:4b:32
-  Hackbook Pro:
-    mac: 00:00:00:00:00:00
-    dev-id: 4664
   Hackbook Pro Wifi:
     mac: f8:4d:89:81:c0:2d
     dev-id: 4664

--- a/terraform/unifi/home.tf
+++ b/terraform/unifi/home.tf
@@ -3,8 +3,8 @@ locals {
   fml_domain = "fml.pulsifer.ca"
   fml_wlan   = "fml"
   clients    = yamldecode(file("./clients.yaml"))
-  one_day    = 86400
-  one_week   = local.one_day * 7
+  one_day    = "24h"
+  one_week   = "168h"
 }
 
 resource "unifi_network" "fml" {

--- a/terraform/unifi/versions.tf
+++ b/terraform/unifi/versions.tf
@@ -9,9 +9,8 @@ terraform {
       version = "~> 5.1"
     }
     unifi = {
-      # overridden in ~/.terraformrc
       source  = "ubiquiti-community/unifi"
-      version = "~> 0.41"
+      version = "~> 0.52"
     }
     onepassword = {
       source  = "1password/onepassword"


### PR DESCRIPTION
## Summary
Update the UniFi Terraform provider to the latest 0.52 series and remove the invalid Hackbook Pro client entry that used the placeholder MAC address.

## Changes
- fix(unifi): update provider and remove invalid client
- Convert UniFi DHCP lease durations to Go duration strings required by the current provider
- Remove obsolete provider override comment and lock the updated providers

## Test Plan
- [x] `terraform fmt -recursive terraform/unifi`
- [x] `terraform -chdir=terraform/unifi validate -no-color`
- [x] `terraform -chdir=terraform/unifi plan -no-color -out=/tmp/unifi.plan` — succeeds with 2 creates, 72 updates, 0 destroys

## Operational Notes
- State-only migrations were performed before this PR to unblock planning:
  - `unifi_client_group.*` removed from state and imported as `unifi_client_qos_rate.*`
  - `unifi_network.starlink` removed from state and imported as `unifi_wan.starlink`
  - Existing UniFi clients were imported by MAC to reduce create/adopt noise
