### PR TITLE
feat(unifi): backfill network drift

### DIFF
--- a/terraform/unifi/README.md
+++ b/terraform/unifi/README.md
@@ -2,18 +2,18 @@
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_cloudflare"></a> [cloudflare](#requirement\_cloudflare) | ~> 5.1 |
 | <a name="requirement_onepassword"></a> [onepassword](#requirement\_onepassword) | ~> 3.0 |
-| <a name="requirement_unifi"></a> [unifi](#requirement\_unifi) | ~> 0.41 |
+| <a name="requirement_unifi"></a> [unifi](#requirement\_unifi) | ~> 0.52 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
-| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.19.1 |
+| ---- | ------- |
+| <a name="provider_cloudflare"></a> [cloudflare](#provider\_cloudflare) | 5.21.0 |
 | <a name="provider_onepassword"></a> [onepassword](#provider\_onepassword) | 3.3.1 |
-| <a name="provider_unifi"></a> [unifi](#provider\_unifi) | 0.41.25 |
+| <a name="provider_unifi"></a> [unifi](#provider\_unifi) | 0.52.4 |
 
 ## Modules
 
@@ -22,18 +22,15 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [cloudflare_dns_record.k8s_remote_dns](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
 | [cloudflare_dns_record.lab_remote_dns](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/dns_record) | resource |
-| [unifi_client.cameras](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client) | resource |
-| [unifi_client.computers](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client) | resource |
-| [unifi_client.iot](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client) | resource |
-| [unifi_client.lab](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client) | resource |
-| [unifi_client.personal_devices](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client) | resource |
 | [unifi_client_qos_rate.iot](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client_qos_rate) | resource |
 | [unifi_client_qos_rate.streaming](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client_qos_rate) | resource |
 | [unifi_client_qos_rate.unmetered](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/client_qos_rate) | resource |
 | [unifi_network.fml](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/network) | resource |
+| [unifi_network.future](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/network) | resource |
+| [unifi_network.iot](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/network) | resource |
 | [unifi_network.k8s](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/network) | resource |
 | [unifi_network.lab](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/network) | resource |
 | [unifi_static_route.starlink](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/resources/static_route) | resource |
@@ -43,7 +40,6 @@ No modules.
 | [cloudflare_zone.lab](https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/zone) | data source |
 | [onepassword_item.wifi](https://registry.terraform.io/providers/1password/onepassword/latest/docs/data-sources/item) | data source |
 | [unifi_ap_group.all_aps](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/data-sources/ap_group) | data source |
-| [unifi_ap_group.lab](https://registry.terraform.io/providers/ubiquiti-community/unifi/latest/docs/data-sources/ap_group) | data source |
 
 ## Inputs
 

--- a/terraform/unifi/clients-removed.tf
+++ b/terraform/unifi/clients-removed.tf
@@ -1,0 +1,39 @@
+removed {
+  from = unifi_client.personal_devices
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = unifi_client.computers
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = unifi_client.iot
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = unifi_client.cameras
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = unifi_client.lab
+
+  lifecycle {
+    destroy = false
+  }
+}

--- a/terraform/unifi/extra-networks.tf
+++ b/terraform/unifi/extra-networks.tf
@@ -1,0 +1,47 @@
+resource "unifi_network" "future" {
+  name                          = "future"
+  subnet                        = local.future_cidr
+  vlan                          = 1337
+  setting_preference            = "manual"
+  auto_scale                    = true
+  lte_lan                       = true
+  multicast_dns                 = true
+  ipv6_interface_type           = "pd"
+  ipv6_pd_interface             = "wan"
+  ipv6_ra                       = true
+  ipv6_pd_auto_prefixid_enabled = true
+
+  dhcp_server = {
+    enabled     = true
+    leasetime   = local.one_day
+    start       = cidrhost(local.future_cidr, 2)
+    stop        = cidrhost(local.future_cidr, 14)
+    dns_enabled = true
+    dns_servers = ["10.2.0.20"]
+    boot = {
+      enabled = false
+    }
+  }
+}
+
+resource "unifi_network" "iot" {
+  name               = "iot"
+  subnet             = local.iot_cidr
+  vlan               = 666
+  domain_name        = local.iot_domain
+  setting_preference = "manual"
+  auto_scale         = false
+  lte_lan            = true
+  network_isolation  = true
+  multicast_dns      = true
+
+  dhcp_server = {
+    enabled   = true
+    leasetime = local.one_day
+    start     = cidrhost(local.iot_cidr, 2)
+    stop      = cidrhost(local.iot_cidr, 62)
+    boot = {
+      enabled = false
+    }
+  }
+}

--- a/terraform/unifi/groups.tf
+++ b/terraform/unifi/groups.tf
@@ -1,17 +1,11 @@
 resource "unifi_client_qos_rate" "unmetered" {
-  name              = "Unlimited Power"
-  qos_rate_max_down = 100000
-  qos_rate_max_up   = 100000
+  name = "Unlimited Power"
 }
 
 resource "unifi_client_qos_rate" "iot" {
-  name              = "IoT"
-  qos_rate_max_down = 100000
-  qos_rate_max_up   = 100000
+  name = "IoT"
 }
 
 resource "unifi_client_qos_rate" "streaming" {
-  name              = "Streaming Media"
-  qos_rate_max_down = 100000
-  qos_rate_max_up   = 100000
+  name = "Streaming Media"
 }

--- a/terraform/unifi/home.tf
+++ b/terraform/unifi/home.tf
@@ -1,15 +1,23 @@
 locals {
-  fml_cidr   = "10.1.0.1/24"
-  fml_domain = "fml.pulsifer.ca"
-  fml_wlan   = "fml"
-  clients    = yamldecode(file("./clients.yaml"))
-  one_day    = "24h"
-  one_week   = "168h"
+  fml_cidr    = "10.1.0.1/24"
+  fml_domain  = "fml.pulsifer.ca"
+  fml_wlan    = "fml"
+  future_cidr = "10.13.37.1/28"
+  iot_cidr    = "10.66.6.1/26"
+  iot_domain  = "iot.fml.pulsifer.ca"
+  clients     = yamldecode(file("./clients.yaml"))
+  one_day     = "24h0m0s"
+  one_week    = "168h0m0s"
 }
 
 resource "unifi_network" "fml" {
-  name   = "Management"
-  subnet = local.fml_cidr
+  name               = "Management"
+  subnet             = local.fml_cidr
+  domain_name        = local.fml_domain
+  setting_preference = "manual"
+  auto_scale         = false
+  lte_lan            = false
+  multicast_dns      = true
 
   dhcp_server = {
     enabled   = true
@@ -21,9 +29,6 @@ resource "unifi_network" "fml" {
     }
   }
 
-  dhcp_relay = {
-    enabled = false
-  }
 }
 
 
@@ -48,74 +53,16 @@ resource "unifi_wlan" "fml" {
   network_id    = unifi_network.fml.id
   user_group_id = unifi_client_qos_rate.unmetered.id
 
-  wlan_band            = "both"
-  bss_transition       = true
-  fast_roaming_enabled = false
-  multicast_enhance    = false
-  uapsd                = true
-  no2ghz_oui           = false
-}
-
-resource "unifi_client" "personal_devices" {
-  for_each               = local.clients.personal-devices
-  name                   = each.key
-  mac                    = each.value.mac
-  local_dns_record       = lookup(each.value, "ip", false) == false ? null : can(regex("^[a-zA-Z0-9]+[a-zA-Z0-9-]*[^-]$", lookup(each.value, "local_dns_record", each.key))) == false ? "" : format("%s.%s", lower(lookup(each.value, "local_dns_record", each.key)), local.fml_domain)
-  blocked                = lookup(each.value, "blocked", false)
-  fixed_ip               = lookup(each.value, "ip", false) == false ? null : cidrhost(local.fml_cidr, each.value.ip)
-  note                   = lookup(each.value, "note", "Managed by terraform")
-  allow_existing         = lookup(each.value, "allow_existing", true)
-  skip_forget_on_destroy = lookup(each.value, "skip_forget_on_destroy", true)
-  network_id             = unifi_network.fml.id
-  qos_rate = {
-    id = unifi_client_qos_rate.unmetered.id
-  }
-}
-
-resource "unifi_client" "computers" {
-  for_each               = merge(local.clients.desktops, local.clients.laptops)
-  name                   = each.key
-  mac                    = each.value.mac
-  local_dns_record       = lookup(each.value, "ip", false) == false ? null : can(regex("^[a-zA-Z0-9]+[a-zA-Z0-9-]*[^-]$", lookup(each.value, "local_dns_record", each.key))) == false ? "" : format("%s.%s", lower(lookup(each.value, "local_dns_record", each.key)), local.fml_domain)
-  blocked                = lookup(each.value, "blocked", false)
-  fixed_ip               = lookup(each.value, "ip", false) == false ? null : cidrhost(local.fml_cidr, each.value.ip)
-  note                   = lookup(each.value, "note", "Managed by terraform")
-  allow_existing         = lookup(each.value, "allow_existing", true)
-  skip_forget_on_destroy = lookup(each.value, "skip_forget_on_destroy", true)
-  network_id             = unifi_network.fml.id
-  qos_rate = {
-    id = unifi_client_qos_rate.unmetered.id
-  }
-}
-
-resource "unifi_client" "iot" {
-  for_each               = local.clients.iot
-  name                   = each.key
-  mac                    = each.value.mac
-  local_dns_record       = lookup(each.value, "ip", false) == false ? null : can(regex("^[a-zA-Z0-9]+[a-zA-Z0-9-]*[^-]$", lookup(each.value, "local_dns_record", each.key))) == false ? "" : format("%s.%s", lower(lookup(each.value, "local_dns_record", each.key)), local.fml_domain)
-  blocked                = lookup(each.value, "blocked", false)
-  fixed_ip               = lookup(each.value, "ip", false) == false ? null : cidrhost(local.fml_cidr, each.value.ip)
-  note                   = lookup(each.value, "note", "Managed by terraform")
-  allow_existing         = lookup(each.value, "allow_existing", true)
-  skip_forget_on_destroy = lookup(each.value, "skip_forget_on_destroy", true)
-  network_id             = unifi_network.fml.id
-  qos_rate = {
-    id = lookup(each.value, "streaming", false) == false ? unifi_client_qos_rate.iot.id : unifi_client_qos_rate.streaming.id
-  }
-}
-
-resource "unifi_client" "cameras" {
-  for_each               = local.clients.cameras
-  name                   = each.key
-  mac                    = each.value.mac
-  local_dns_record       = lookup(each.value, "ip", false) == false ? "" : can(regex("^[a-zA-Z0-9]+[a-zA-Z0-9-]*[^-]$", lookup(each.value, "local_dns_record", each.key))) == false ? "" : format("%s.%s", lower(lookup(each.value, "local_dns_record", each.key)), local.fml_domain)
-  fixed_ip               = lookup(each.value, "ip", false) == false ? null : cidrhost(local.fml_cidr, each.value.ip)
-  blocked                = lookup(each.value, "blocked", false)
-  note                   = lookup(each.value, "note", "Managed by terraform")
-  allow_existing         = lookup(each.value, "allow_existing", true)
-  skip_forget_on_destroy = lookup(each.value, "skip_forget_on_destroy", true)
-  network_id             = unifi_network.fml.id
-  qos_rate = {
-    id = unifi_client_qos_rate.unmetered.id
-  }
+  wlan_band                 = "both"
+  wlan_bands                = ["2g", "5g", "6g"]
+  wpa3_support              = true
+  wpa3_transition           = true
+  pmf_mode                  = "optional"
+  minimum_data_rate_2g_kbps = 1000
+  minimum_data_rate_5g_kbps = 6000
+  bss_transition            = true
+  fast_roaming_enabled      = false
+  multicast_enhance         = false
+  uapsd                     = true
+  no2ghz_oui                = false
 }

--- a/terraform/unifi/imports.tf
+++ b/terraform/unifi/imports.tf
@@ -1,0 +1,9 @@
+import {
+  to = unifi_network.future
+  id = "6796f004c07e89327fb048b6"
+}
+
+import {
+  to = unifi_network.iot
+  id = "694868ac431ebd3a4f203db3"
+}

--- a/terraform/unifi/k8s.tf
+++ b/terraform/unifi/k8s.tf
@@ -1,20 +1,25 @@
 locals {
   node_cidr = "10.3.0.1/26"
   static_records = {
-    "erx" : cidrhost(local.lab_cidr, 5)
-    "k8s" : cidrhost(local.node_cidr, 10)
-    "nuc" : cidrhost(local.node_cidr, 13)
-    "k8s" : cidrhost(local.node_cidr, 10)
-    "800g2" : cidrhost(local.node_cidr, 11)
-    "riptide" : cidrhost(local.node_cidr, 12)
-    "optiplex" : cidrhost(local.node_cidr, 10)
+    "erx"      = cidrhost(local.lab_cidr, 5)
+    "k8s"      = cidrhost(local.node_cidr, 10)
+    "nuc"      = cidrhost(local.node_cidr, 13)
+    "800g2"    = cidrhost(local.node_cidr, 11)
+    "riptide"  = cidrhost(local.node_cidr, 12)
+    "optiplex" = cidrhost(local.node_cidr, 10)
   }
 }
 
 resource "unifi_network" "k8s" {
-  name   = "Kubernetes"
-  subnet = local.node_cidr
-  vlan   = 8
+  name               = "Kubernetes"
+  subnet             = local.node_cidr
+  vlan               = 8
+  domain_name        = local.lab_domain
+  setting_preference = "manual"
+  auto_scale         = false
+  lte_lan            = false
+  network_isolation  = true
+  multicast_dns      = false
 
   dhcp_server = {
     enabled     = true
@@ -23,14 +28,14 @@ resource "unifi_network" "k8s" {
     stop        = cidrhost(local.node_cidr, 62)
     dns_enabled = true
     dns_servers = ["10.2.0.20"]
+    tftp_server = "10.2.0.11"
     boot = {
-      enabled = false
+      enabled  = true
+      server   = "10.2.0.11"
+      filename = "boot/ipxe.efi"
     }
   }
 
-  dhcp_relay = {
-    enabled = false
-  }
 }
 
 resource "cloudflare_dns_record" "k8s_remote_dns" {

--- a/terraform/unifi/lolwtf.ca.tf
+++ b/terraform/unifi/lolwtf.ca.tf
@@ -5,10 +5,6 @@ locals {
   lab_clients = merge(local.clients.lab, local.clients.rpis)
 }
 
-data "unifi_ap_group" "lab" {
-  name = "Lab"
-}
-
 data "cloudflare_zone" "lab" {
   filter = {
     name   = local.lab_domain
@@ -32,9 +28,15 @@ resource "cloudflare_dns_record" "lab_remote_dns" {
 }
 
 resource "unifi_network" "lab" {
-  name   = "Lab Net"
-  subnet = local.lab_cidr
-  vlan   = 2
+  name               = "Lab Net"
+  subnet             = local.lab_cidr
+  vlan               = 2
+  domain_name        = local.lab_domain
+  setting_preference = "manual"
+  auto_scale         = false
+  lte_lan            = false
+  network_isolation  = true
+  multicast_dns      = false
 
   dhcp_server = {
     enabled   = true
@@ -46,37 +48,26 @@ resource "unifi_network" "lab" {
     }
   }
 
-  dhcp_relay = {
-    enabled = false
-  }
 }
 
 resource "unifi_wlan" "lab" {
-  name              = local.lab_wlan
-  security          = "open"
-  hide_ssid         = true
-  ap_group_ids      = [data.unifi_ap_group.all_aps.id]
-  network_id        = unifi_network.lab.id
-  user_group_id     = unifi_client_qos_rate.unmetered.id
-  multicast_enhance = false
-  bss_transition    = false
-  no2ghz_oui        = false
-  uapsd             = true
-  wlan_band         = "both"
-}
+  name                      = local.lab_wlan
+  security                  = "open"
+  hide_ssid                 = true
+  ap_group_ids              = ["693c98563a6bcc1ba862e1ae"]
+  ap_group_mode             = "devices"
+  network_id                = unifi_network.lab.id
+  user_group_id             = unifi_client_qos_rate.unmetered.id
+  multicast_enhance         = false
+  bss_transition            = false
+  no2ghz_oui                = false
+  uapsd                     = true
+  wlan_band                 = "both"
+  wlan_bands                = ["2g", "5g"]
+  minimum_data_rate_2g_kbps = 1000
+  minimum_data_rate_5g_kbps = 6000
 
-resource "unifi_client" "lab" {
-  for_each               = local.lab_clients
-  name                   = each.key
-  mac                    = each.value.mac
-  local_dns_record       = lookup(each.value, "ip", false) == false ? null : can(regex("^[a-zA-Z0-9]+[a-zA-Z0-9-]*[^-]$", lookup(each.value, "local_dns_record", each.key))) == false ? "" : format("%s.%s", lower(lookup(each.value, "local_dns_record", each.key)), local.lab_domain)
-  fixed_ip               = lookup(each.value, "ip", false) == false ? null : cidrhost(local.lab_cidr, each.value.ip)
-  blocked                = lookup(each.value, "blocked", false)
-  note                   = lookup(each.value, "note", "Managed by terraform")
-  allow_existing         = lookup(each.value, "allow_existing", true)
-  skip_forget_on_destroy = lookup(each.value, "skip_forget_on_destroy", true)
-  network_id             = unifi_network.lab.id
-  qos_rate = {
-    id = unifi_client_qos_rate.unmetered.id
+  lifecycle {
+    ignore_changes = [passphrase]
   }
 }


### PR DESCRIPTION
## Summary
Backfill current UniFi controller state into Terraform and retire broad per-client UniFi management to reduce drift/noisy plans.

## Changes
- feat(unifi): backfill network drift

## Test Plan
- [x] `terraform -chdir=terraform/unifi fmt -check`
- [x] `terraform -chdir=terraform/unifi init -backend=false -input=false`
- [x] `terraform -chdir=terraform/unifi validate`
- [x] `terraform-docs markdown table --output-file README.md --output-mode inject terraform/unifi`
- [x] `terraform -chdir=terraform/unifi plan -input=false -no-color` (post-apply: only remaining changes are existing Cloudflare DNS records for `pihole`/`spore`)

## Context
- `.agent/context/context.md`
- `.agent/context/plan.md`
