### PR TITLE
fix: cilium 1.19.5 + tailscale LB range fix

### DIFF
--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 1.19.4
+      version: 1.19.5
       sourceRef:
         kind: HelmRepository
         name: cilium

--- a/clusters/folly/networking/tailscale/connector.yaml
+++ b/clusters/folly/networking/tailscale/connector.yaml
@@ -7,7 +7,6 @@ spec:
   hostnamePrefix: folly-k8s-lan-router
   subnetRouter:
     advertiseRoutes:
-      - ${CILIUM_NATIVE_ROUTING_CIDR}
       - ${LB_RANGE}
   tags:
     - tag:k8s

--- a/terraform/tailscale/policy.hujson
+++ b/terraform/tailscale/policy.hujson
@@ -83,7 +83,12 @@
 		},
 	],
 
-	"autoApprovers": {"routes": {"192.168.2.0/24": ["tag:k8s-operator"]}},
+	"autoApprovers": {
+		"routes": {
+			"10.3.0.64/26":   ["tag:k8s-folly"],
+			"192.168.2.0/24": ["tag:k8s-operator"],
+		},
+	},
 
 	"ipsets": {
 		"ipset:k8s-offsite-nodes-and-lb": ["add ipset:k8s-offsite-nodes", "add ipset:k8s-offsite-lb"],


### PR DESCRIPTION
## Summary

Fixes LB/Ingress 503 errors on NixOS 26.05 nodes running kernel 7.0.12. Cilium 1.19.5 contains `bpf: fix host proxy packet routing to pods` which directly addresses the regression where Envoy (host L7 proxy) could not establish upstream connections to pods on kernel 7.0.12, while kernel 7.0.10 (shale) worked fine.

Also tightens the Tailscale connector to only advertise the folly LB range instead of the broad `10.0.0.0/9`.

## Root Cause

All three nodes (optiplex, riptide, shale) had BGP sessions up and were advertising LB VIPs. UniFi FRR had ECMP next-hops correctly installed for all three. But on nodes running kernel 7.0.12 (optiplex, riptide), Envoy returned `503: upstream connect error` when proxying Ingress/Gateway traffic to pods. Shale (kernel 7.0.10) returned 200. The fix is in Cilium 1.19.5's BPF datapath: `bpf: fix host proxy packet routing to pods` (#45916) and related `local_delivery` CB flag changes (#46291).

## Changes

- `fix(cilium)`: upgrade folly HelmRelease from 1.19.4 → 1.19.5
- `fix(tailscale)`: connector advertises only `${LB_RANGE}` (10.3.0.64/26), not `${CILIUM_NATIVE_ROUTING_CIDR}` (10.0.0.0/9); add auto-approver for 10.3.0.64/26 via `tag:k8s-folly`

## Test Plan

- [ ] Flux reconciles `cilium` HelmRelease on folly cluster
- [ ] `curl -skI https://argo.lolwtf.ca` returns `200` consistently (not just on shale-bound ECMP flows)
- [ ] All three nodes return `200` when curling the LB VIP directly from the node
- [ ] BGP sessions remain established on all three nodes post-upgrade
