### PR TITLE
docs: remove active vault references

### DIFF
--- a/.agents/skills/terraform/SKILL.md
+++ b/.agents/skills/terraform/SKILL.md
@@ -2,7 +2,7 @@
 name: terraform
 description: >-
   Work with Terraform modules in this infra repo (everything under terraform/:
-  gcp, cloudflare, vault, argo, unifi, tailscale, google-workspace, k8s).
+  gcp, cloudflare, argo, unifi, tailscale, google-workspace, k8s).
   Covers workflow, CI behaviour, and module layout.
 ---
 
@@ -14,7 +14,6 @@ All Terraform lives under `terraform/`. Each subdirectory below is an independen
 terraform/gcp/organization/       # org-level IAM, folders, billing
 terraform/gcp/projects/<name>/    # per-project resources
 terraform/cloudflare/             # DNS, tunnels, security rules
-terraform/vault/                  # auth backends, PKI, policies
 terraform/argo/                   # ArgoCD application definitions
 terraform/unifi/                  # VLANs, BGP, clients
 terraform/tailscale/              # devices, routes, ACL policy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Prefer `mise` for portable repo tooling:
 mise install
 ```
 
-This provides common Kubernetes, Terraform, SOPS, Vault, and cloud CLIs without
+This provides common Kubernetes, Terraform, SOPS, 1Password, and cloud CLIs without
 requiring a Nix-capable host. Use the Nix flake for NixOS-specific builds,
 formatting, and deploy workflows:
 
@@ -27,7 +27,7 @@ nix develop
 
 This repo is GitOps-first: author desired state in git and let the operators apply it. Do not mutate live infra directly.
 
-- **Terraform** (everything under `terraform/`: `gcp/`, `cloudflare/`, `vault/`, `argo/`, `unifi/`, `tailscale/`, `google-workspace/`, `k8s/`; reusable modules in `terraform/modules/`): applies run through **Atlantis** on the PR. Open a PR — Atlantis autoplans the changed module(s); comment `atlantis apply` to apply (a successful apply automerges). Locally, `terraform init`/`plan` and `init -backend=false && validate` are for inspection only. **Never run `terraform apply` against remote state** — it races Atlantis and causes lock contention / drift. CI (`terraform.yml`) only validates. See the `kubernetes-gitops` skill for the Atlantis ↔ ArgoCD auth + token-rotation details.
+- **Terraform** (everything under `terraform/`: `gcp/`, `cloudflare/`, `argo/`, `unifi/`, `tailscale/`, `google-workspace/`, `k8s/`; reusable modules in `terraform/modules/`): applies run through **Atlantis** on the PR. Open a PR — Atlantis autoplans the changed module(s); comment `atlantis apply` to apply (a successful apply automerges). Locally, `terraform init`/`plan` and `init -backend=false && validate` are for inspection only. **Never run `terraform apply` against remote state** — it races Atlantis and causes lock contention / drift. CI (`terraform.yml`) only validates. See the `kubernetes-gitops` skill for the Atlantis ↔ ArgoCD auth + token-rotation details.
 - **Kubernetes** (`clusters/**`): changes deploy via **Flux** (and **ArgoCD** for apps sourced from external repos) on merge to `main`. Commit manifests; **never `kubectl apply`** to author state. `kubectl`, `flux get`, and `flux reconcile` are for inspection or forcing a sync. Use explicit contexts (`--context folly` / `--context offsite`) and namespaces.
 - **NixOS** (`nix/**`): `nixos-rebuild` is the apply path (see Key Commands). State changes that may mutate live hosts should be called out before running.
 
@@ -61,7 +61,7 @@ sudo nixos-rebuild switch --rollback
 ### Terraform
 
 ```bash
-cd terraform/<module-dir>   # e.g. terraform/gcp/projects/homelab-ng, terraform/cloudflare, terraform/vault
+cd terraform/<module-dir>   # e.g. terraform/gcp/projects/homelab-ng, terraform/cloudflare, terraform/tailscale
 terraform init
 terraform plan    # local inspection only — applies go through Atlantis on the PR (see "How Changes Ship")
 
@@ -134,7 +134,6 @@ Every Terraform root module lives under `terraform/`; each is a standalone modul
 - `terraform/gcp/organization/` – org-level IAM, folders, projects, billing
 - `terraform/gcp/projects/<name>/` – per-project resources (homelab-ng, firebees, lolcorp, etc.)
 - `terraform/cloudflare/` – DNS zones (pulsifer.ca, wishin.app, lolwtf.ca), Cloudflare Tunnels, security rules
-- `terraform/vault/` – AppRole/GCP/JWT auth backends, PKI, policies
 - `terraform/argo/` – ArgoCD application definitions (Terraform-managed)
 - `terraform/unifi/` – VLANs, BGP config, client management
 - `terraform/tailscale/` – devices, routes, ACL policy

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Infrastructure-as-code for a multi-cloud homelab environment. This repository ma
 .
 ├── nix/           # NixOS configurations for bare metal hosts
 ├── clusters/      # Kubernetes GitOps manifests (folly, offsite, base) — FluxCD
-├── terraform/     # All Terraform: gcp, cloudflare, tailscale, argo, vault,
+├── terraform/     # All Terraform: gcp, cloudflare, tailscale, argo,
 │                  #   unifi, google-workspace, k8s (Flux bootstrap), modules/
 ├── apps/          # Deployable first-party services (agent-web, hermes, tidbyt, …)
 ├── packages/      # Shared building blocks (agent-web-ui, charts/)
@@ -109,7 +109,7 @@ Managed with:
 - **Infrastructure as Code**: Terraform, NixOS
 - **Orchestration**: Kubernetes (NixOS)
 - **GitOps**: ArgoCD, FluxCD
-- **Secrets**: SOPS, HashiCorp Vault
+- **Secrets**: SOPS, 1Password
 - **Networking**: Cilium, Tailscale, UniFi
 - **Monitoring**: Prometheus, Grafana, Loki
 - **CI/CD**: GitHub Actions (self-hosted)
@@ -123,7 +123,7 @@ Flake-based NixOS configurations for all physical and virtual machines. Modular 
 FluxCD GitOps manifests for the `folly` and `offsite` clusters, with shared resources in `clusters/base/`. The Flux bootstrap itself is Terraform (`terraform/k8s/`).
 
 ### `terraform/` - Cloud, Network & Bootstrap
-All Terraform root modules: `gcp/` (resources by project), `cloudflare/` (DNS & security), `tailscale/`, `argo/` (ArgoCD apps), `vault/` (policies), `unifi/` (network controller), `google-workspace/`, and `k8s/` (Flux bootstrap). Reusable modules live in `terraform/modules/`.
+All Terraform root modules: `gcp/` (resources by project), `cloudflare/` (DNS & security), `tailscale/`, `argo/` (ArgoCD apps), `unifi/` (network controller), `google-workspace/`, and `k8s/` (Flux bootstrap). Reusable modules live in `terraform/modules/`.
 
 ### `apps/`, `packages/`, `images/` - Code & Builds
 First-party services (`apps/`), shared libraries and Helm charts (`packages/`), and base/tool container + VM images (`images/`).
@@ -131,7 +131,7 @@ First-party services (`apps/`), shared libraries and Helm charts (`packages/`), 
 ## 🔐 Security
 
 - **Immutable infrastructure** - NixOS ensures declarative system state
-- **Secrets management** - SOPS encryption + Vault
+- **Secrets management** - SOPS encryption + 1Password
 - **Network segmentation** - VLANs and firewall rules via UniFi
 - **Zero-trust networking** - Tailscale mesh VPN
 - **SSH hardening** - Key-based auth only, automated key rotation
@@ -189,6 +189,6 @@ git push
 - **NixOS configs** - Version controlled in this repo
 - **Kubernetes state** - GitOps repo is source of truth
 - **Persistent data** - Automated backups to NAS + cloud storage
-- **Secrets** - Encrypted SOPS files in repo + Vault backups
+- **Secrets** - Encrypted SOPS files in repo + source values in 1Password
 
 **Built with**: NixOS 25.05 • Kubernetes • Terraform • ArgoCD • Love ❤️

--- a/nix/README.md
+++ b/nix/README.md
@@ -50,7 +50,7 @@ Enter the development shell with all required tools:
 nix develop
 ```
 
-This provides: `kubectl`, `helm`, `terraform`, `vault`, `sops`, `fluxcd`, `cilium-cli`, and more.
+This provides: `kubectl`, `helm`, `terraform`, `sops`, `fluxcd`, `cilium-cli`, and more.
 
 ### Building Systems
 


### PR DESCRIPTION
## Summary
Remove active documentation references to HashiCorp Vault and point current secrets documentation at SOPS + 1Password instead.

## Changes
- docs: remove active vault references

## Test Plan
- [x] `git diff --check`
- [x] `rg -n -i 'hashicorp vault|\bvault\b' --glob '*.md' --glob '!terraform/**/README.md' --glob '!**/.terraform/**' --glob '!**/.claude/**' .`

## Context
- `.agent/context/plan.md`
