### PR TITLE
feat(skills): add unifi-network skill for live network discovery

### DIFF
--- a/.agents/skills/unifi-network/SKILL.md
+++ b/.agents/skills/unifi-network/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: unifi-network
+description: Discover, query, inspect, and reason about the live homelab UniFi network — controller, networks/VLANs, WLANs, adopted devices, and connected clients. Use when asked to look at, audit, debug, or reason about the UniFi network, find a client/device by name/IP/MAC, check what VLANs/subnets/DHCP exist, or reconcile live state against terraform/unifi/. Authenticates against the UDM Pro using creds from 1Password (op).
+---
+
+# unifi-network
+
+Read-only discovery for the homelab UniFi controller (a **UDM Pro**, Network
+app `10.4.57`, at `https://unifi.fml.pulsifer.ca` / `https://10.13.37.1`).
+This is the live counterpart to the desired state in `terraform/unifi/` — use it
+to see what the controller *actually* has before editing the Terraform.
+
+The driver is **`.agents/skills/unifi-network/unifi.sh`** (paths below are
+relative to the repo root). It pulls the `terraform` Super Admin creds from
+the **homelab 1Password vault** via `op`, opens a UniFi-OS cookie session, and
+wraps the legacy Network API (`/proxy/network/api/...`) behind named subcommands.
+It is **read-only** — every subcommand is a GET. Authoring network state still
+goes through `terraform/unifi/` + Atlantis (see CLAUDE.md "How Changes Ship").
+
+## Prerequisites
+
+- `op`, `curl`, `jq` — all provided by `mise install` in this repo.
+- `OP_SERVICE_ACCOUNT_TOKEN` exported with access to the homelab vault. `op whoami`
+  should print `User Type: SERVICE_ACCOUNT`. To set it:
+  ```bash
+  export OP_SERVICE_ACCOUNT_TOKEN=$(op item get 'Service Account Auth Token: Nixos' --fields=token --account=pulsifer --vault=ib23znjeikv74p37f6mbfk7uya --reveal)
+  ```
+  In this environment the token was already present in the shell.
+- LAN reachability to the controller. From WSL/LAN it resolves directly; from
+  off-tailnet you still reach it via `unifi.fml.pulsifer.ca` / `unifi.lolwtf.ca`.
+
+No build step — it's a shell script.
+
+## Run (agent path)
+
+```bash
+# from the repo root
+chmod +x .agents/skills/unifi-network/unifi.sh   # first time only
+D=.agents/skills/unifi-network/unifi.sh
+
+$D summary          # one-shot overview — START HERE
+```
+
+`summary` prints controller info, per-subsystem health, networks/VLANs, WLANs,
+and adopted devices in one go. Individual subcommands:
+
+```bash
+$D networks         # configured networks/VLANs/subnets/DHCP/domains
+$D devices          # adopted APs / switches / gateways (model, ip, version, #clients)
+$D wlans            # SSIDs + security
+$D clients          # live associations, grouped by network, sorted by IP
+$D clients-known    # controller-configured clients (fixed IPs, aliases, "Managed by terraform")
+$D health           # wan/lan/wlan/www/vpn status
+$D sysinfo          # controller version / device type / uptime
+$D routes           # static routes (rest/routing) — raw JSON
+$D firewall         # firewall rules (rest/firewallrule) — raw JSON
+$D portforward      # port-forward rules (rest/portforward) — raw JSON
+$D find <term>      # search active + known clients by name/ip/mac/ssid
+$D raw <api-path>   # GET any legacy path, e.g.  raw /s/default/stat/health
+$D bgp              # FRR/BGP summary over SSH — Cilium k8s peers (see SSH section)
+$D ssh <cmd>        # run a command on the UDM as root, e.g.  ssh "mca-dump"
+```
+
+Examples that work right now:
+
+```bash
+$D find nuc                       # locate a host across active + configured clients
+$D raw /s/default/stat/health     # any endpoint not yet wrapped; pipe to jq yourself
+```
+
+The cookie session is cached under `$TMPDIR/.unifi-cookies-$UID` for ~50 min, so
+repeated calls don't re-login. Override targets with env vars:
+`UNIFI_HOST`, `UNIFI_SITE`, `OP_VAULT`, `OP_UNIFI_ITEM`.
+
+### Integration API (developer.ui.com) — optional, needs a key
+
+The driver's `integ` subcommand targets the official Network **Integration API**
+(`/proxy/network/integration/v1/...`, the one documented at
+`developer.ui.com/network`). That API authenticates with an `X-API-KEY` header
+**only** — the cookie session is rejected (`401 api.authentication.missing-credentials`).
+No API key exists in the vault today, so this path is dormant:
+
+```bash
+$D integ            # -> error: UNIFI_API_KEY not set
+```
+
+To enable it: create a key in the UI (Control Plane → Admins → the user →
+Create API Key), store it in 1Password, then:
+
+```bash
+export UNIFI_API_KEY=$(op item get '<item>' --vault ib23znjeikv74p37f6mbfk7uya --fields credential --reveal)
+$D integ /sites
+```
+
+Until then, use the **legacy** subcommands above — they cover the same data
+(and more: live clients, health) and need no extra key.
+
+## Human path
+
+Browse `https://unifi.fml.pulsifer.ca` in a browser and log in as `terraform`
+(password in the `unifi-terraform` vault item). That's the GUI; it's useless from
+a headless agent, hence the driver.
+
+## SSH (on-box escape hatch — for things the API can't show)
+
+The UDM Pro accepts SSH as `root` (creds in the `unifi.fml.pulsifer.ca ssh` vault
+item). The controller **requires** these flags or auth fails:
+
+```
+ssh -o PasswordAuthentication=yes -o ChallengeResponseAuthentication=yes root@unifi.fml.pulsifer.ca
+```
+
+It's a password login. `sshpass` isn't preinstalled but is one `nix-shell` away,
+so you can drive it non-interactively. This exact command was verified this
+session — it prints live BGP state (the Cilium k8s peers that `bgp-folly.conf` /
+`bgp-offsite.conf` in this module configure):
+
+```bash
+PASS=$(op item get kdtm4q6suztovorkisukvctfme --vault ib23znjeikv74p37f6mbfk7uya --fields password --reveal)
+nix-shell -p sshpass --run "SSHPASS='$PASS' sshpass -e \
+  ssh -o PasswordAuthentication=yes -o ChallengeResponseAuthentication=yes \
+      -o StrictHostKeyChecking=accept-new root@unifi.fml.pulsifer.ca \
+  'vtysh -c \"show ip bgp summary\"'"
+```
+
+Or interactively, type in the session prompt: `! ssh -o PasswordAuthentication=yes -o ChallengeResponseAuthentication=yes root@unifi.fml.pulsifer.ca`
+
+Genuinely useful on-box (don't reach for these when an API subcommand exists):
+
+- `vtysh -c 'show ip bgp summary'` / `vtysh -c 'show ip route bgp'` — FRR/BGP
+  state. The UDM is AS `64512`; k8s nodes peer from AS `64513` (`10.3.0.10-13`).
+- `mca-dump` — entire controller state as one JSON blob (`/usr/bin/mca-dump`).
+- `ubnt-device-info summary` — model/firmware; `ip -4 addr` — per-VLAN bridge IPs
+  (`br0`=Management, `br2`=Lab, `br8`=k8s, `br666`=iot, `br1337`=future).
+
+Prefer the API driver for anything it already covers; SSH is for FRR/BGP, raw
+`mca-dump`, and OS-level inspection the Network API doesn't expose.
+
+## Gotchas
+
+- **Two different APIs, two different auths.** Legacy (`/proxy/network/api/...`)
+  uses the **cookie + `x-csrf-token`** from `POST /api/auth/login` — this is what
+  the driver and the Terraform provider use, and it works. Integration
+  (`/proxy/network/integration/v1/...`) uses **`X-API-KEY` only** and ignores the
+  cookie. Don't expect one credential to work for both.
+- **It's a UDM (UniFi OS), so paths are prefixed `/proxy/network`.** Login is
+  `/api/auth/login` (UniFi-OS level), *not* the old `/api/login`. The Network app
+  endpoints then live under `/proxy/network/api/s/<site>/...`.
+- **`allow_insecure` / `-k` is required** — the controller serves a self-signed
+  cert. The driver always passes `curl -k`.
+- **`health` reporting `lan: error` / `wlan: warning` is normal-ish** here — it
+  flags disconnected/pending/disabled devices, not an outage. Cross-check with
+  `devices` (look for `0`-uptime or missing rows) before assuming something's down.
+- **`raw` paths must be site-scoped** for most stats: `/s/default/stat/...` or
+  `/s/default/rest/...`. Non-site paths like `/self/sites` also work.
+- **The `terraform` user is Super Admin** — the session can read everything
+  (Protect, Access, etc.), but this driver deliberately only GETs Network data.
+  Don't add write verbs here; state changes belong in `terraform/unifi/`.
+
+## Troubleshooting
+
+- `error: could not read UniFi username from op (is OP_SERVICE_ACCOUNT_TOKEN set?)`
+  → export the service-account token (see Prerequisites); confirm with `op whoami`.
+- `login failed (no CSRF token returned)` → controller unreachable or creds
+  rotated. Test `curl -sk -o /dev/null -w '%{http_code}\n' https://unifi.fml.pulsifer.ca`
+  (expect `200`); verify the `unifi-terraform` item still has a valid password.
+- Subcommand prints nothing / empty table → that resource is genuinely empty
+  (e.g. `firewallrule` and `portforward` currently return 0 rows). Confirm with
+  `$D raw /s/default/rest/firewallrule`.
+- `integ` errors with `UNIFI_API_KEY not set` → expected; see "Integration API".
+- Stale results after a controller change → delete the cached session:
+  `rm -f ${TMPDIR:-/tmp}/.unifi-cookies-$(id -u) ${TMPDIR:-/tmp}/.unifi-csrf-$(id -u)`.

--- a/.agents/skills/unifi-network/unifi.sh
+++ b/.agents/skills/unifi-network/unifi.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# unifi.sh — read-only discovery driver for the homelab UniFi controller.
+#
+# Authenticates as the `terraform` Super Admin user (creds pulled from the
+# homelab 1Password vault via `op`), opens a UniFi-OS cookie session against
+# the UDM Pro, and exposes read-only subcommands over the legacy Network API
+# (/proxy/network/api/...). Cookie + CSRF token are cached under a temp file
+# so repeated calls in a session reuse one login.
+#
+# Usage:  ./unifi.sh <command> [args]
+# Run     ./unifi.sh help   for the command list.
+#
+# Env overrides:
+#   UNIFI_HOST       controller base URL (default https://unifi.fml.pulsifer.ca)
+#   OP_VAULT         1Password vault id  (default homelab)
+#   OP_UNIFI_ITEM    1Password item id   (default unifi-terraform login)
+#   UNIFI_API_KEY    if set, also enables the Integration API (`integ` cmd)
+#   OP_SSH_ITEM      1Password item id for the UDM root SSH login
+#   UNIFI_SSH_HOST   SSH target host (default unifi.fml.pulsifer.ca)
+set -euo pipefail
+
+HOST="${UNIFI_HOST:-https://unifi.fml.pulsifer.ca}"
+OP_VAULT="${OP_VAULT:-ib23znjeikv74p37f6mbfk7uya}"
+OP_UNIFI_ITEM="${OP_UNIFI_ITEM:-lb532zq5efzs3y3xlfbdk2kace}"
+OP_SSH_ITEM="${OP_SSH_ITEM:-kdtm4q6suztovorkisukvctfme}"
+SSH_HOST="${UNIFI_SSH_HOST:-unifi.fml.pulsifer.ca}"
+SITE="${UNIFI_SITE:-default}"
+JAR="${TMPDIR:-/tmp}/.unifi-cookies-$(id -u)"
+CSRF_FILE="${TMPDIR:-/tmp}/.unifi-csrf-$(id -u)"
+
+die() { echo "error: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing dependency: $1"; }
+need curl; need jq
+
+login() {
+  # Reuse a cached session if the cookie jar is < 50 min old (token TTL is ~2h).
+  if [[ -f "$JAR" && -f "$CSRF_FILE" ]]; then
+    local age; age=$(( $(date +%s) - $(stat -c %Y "$JAR" 2>/dev/null || echo 0) ))
+    [[ $age -lt 3000 ]] && return 0
+  fi
+  command -v op >/dev/null 2>&1 || die "op (1Password CLI) not found; needed to fetch UniFi creds"
+  local user pass
+  user=$(op item get "$OP_UNIFI_ITEM" --vault "$OP_VAULT" --fields username 2>/dev/null) \
+    || die "could not read UniFi username from op (is OP_SERVICE_ACCOUNT_TOKEN set?)"
+  pass=$(op item get "$OP_UNIFI_ITEM" --vault "$OP_VAULT" --fields password --reveal 2>/dev/null) \
+    || die "could not read UniFi password from op"
+  local csrf
+  csrf=$(curl -sk -c "$JAR" -D - -o /dev/null -X POST "$HOST/api/auth/login" \
+    -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$user\",\"password\":\"$pass\"}" \
+    | awk 'tolower($1)=="x-csrf-token:"{print $2}' | tr -d '\r')
+  [[ -n "$csrf" ]] || die "login failed (no CSRF token returned) — check host/creds"
+  printf '%s' "$csrf" > "$CSRF_FILE"
+  chmod 600 "$JAR" "$CSRF_FILE"
+}
+
+# GET an arbitrary legacy Network API path (path is appended to /proxy/network/api).
+get() {
+  login
+  curl -sk -b "$JAR" -H "x-csrf-token: $(cat "$CSRF_FILE")" -H 'Accept: application/json' \
+    "$HOST/proxy/network/api$1"
+}
+# GET a site-scoped path: $1 is appended after /s/<site>
+sget() { get "/s/$SITE$1"; }
+
+# Run a command on the UDM over SSH (root). Needs sshpass; auto-fetched via
+# nix-shell if not on PATH. The controller requires keyboard-interactive auth.
+udm_ssh() {
+  command -v op >/dev/null 2>&1 || die "op not found; needed for SSH password"
+  local pass; pass=$(op item get "$OP_SSH_ITEM" --vault "$OP_VAULT" --fields password --reveal 2>/dev/null) \
+    || die "could not read UDM SSH password from op"
+  local ssh_cmd="sshpass -e ssh -o PasswordAuthentication=yes -o ChallengeResponseAuthentication=yes \
+    -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 root@$SSH_HOST"
+  if command -v sshpass >/dev/null 2>&1; then
+    SSHPASS="$pass" bash -c "$ssh_cmd \"\$@\"" _ "$@"
+  elif command -v nix-shell >/dev/null 2>&1; then
+    SSHPASS="$pass" nix-shell -p sshpass --run "$ssh_cmd $(printf '%q ' "$@")" 2>/dev/null
+  else
+    die "need sshpass (or nix-shell to fetch it) for SSH"
+  fi
+}
+cmd_ssh() { udm_ssh "${@:?usage: ssh <remote command>}"; }
+cmd_bgp() { udm_ssh "vtysh -c 'show ip bgp summary'"; }
+
+cmd_raw()      { get "${1:?usage: raw <api-path, e.g. /s/default/stat/health>}" | jq .; }
+cmd_integ()    {
+  [[ -n "${UNIFI_API_KEY:-}" ]] || die "UNIFI_API_KEY not set (see SKILL.md: Integration API)"
+  curl -sk -H "X-API-KEY: $UNIFI_API_KEY" -H 'Accept: application/json' \
+    "$HOST/proxy/network/integration/v1${1:-/sites}" | jq .
+}
+
+cmd_networks() {
+  sget /rest/networkconf | jq -r '
+    ["NAME","SUBNET","PURPOSE","VLAN","DHCP","DOMAIN"], (.data[] |
+    [.name, (.ip_subnet // "-"), .purpose, (.vlan // "-"|tostring),
+     (if .dhcpd_enabled then "on" else "off" end), (.domain_name // "-")]) | @tsv' | column -t -s$'\t'
+}
+cmd_devices() {
+  sget /stat/device | jq -r '
+    ["MODEL","NAME","IP","MAC","VERSION","UPTIME_h","CLIENTS"], (.data[] |
+    [.model, (.name // "-"), (.ip // "-"), .mac, (.version // "-"),
+     ((.uptime // 0)/3600|floor|tostring), ((.num_sta // 0)|tostring)]) | @tsv' | column -t -s$'\t'
+}
+cmd_clients() {
+  { printf 'HOSTNAME\tIP\tMAC\tNETWORK\tWIFI/WIRED\tUPTIME_h\n'
+    sget /stat/sta | jq -r '.data[] |
+      [(.hostname // .name // "-"), (.ip // "-"), .mac, (.network // "-"),
+       (if .is_wired then "wired" else (.essid // "wifi") end),
+       ((.uptime // 0)/3600|floor|tostring)] | @tsv' | sort -t$'\t' -k4,4 -k2,2V
+  } | column -t -s$'\t'
+}
+cmd_clients_known() {
+  sget /rest/user | jq -r '
+    ["NAME","MAC","FIXED_IP","NETWORK_ID","NOTE"], (.data[] |
+    [(.name // .hostname // "-"), .mac, (.fixed_ip // "-"),
+     (.network_id // "-"), (.note // "-")]) | @tsv' | column -t -s$'\t'
+}
+cmd_wlans() {
+  sget /rest/wlanconf | jq -r '
+    ["SSID","SECURITY","ENABLED","BANDS","NETWORK_ID"], (.data[] |
+    [.name, .security, (.enabled|tostring), ((.wlan_bands // [])|join(",")),
+     (.networkconf_id // "-")]) | @tsv' | column -t -s$'\t'
+}
+cmd_routes()      { sget /rest/routing | jq '.data'; }
+cmd_firewall()    { sget /rest/firewallrule | jq '.data'; }
+cmd_portforward() { sget /rest/portforward | jq '.data'; }
+cmd_health() {
+  sget /stat/health | jq -r '["SUBSYSTEM","STATUS","CLIENTS"], (.data[] |
+    [.subsystem, .status, ((.num_user // .num_sta // 0)|tostring)]) | @tsv' | column -t -s$'\t'
+}
+cmd_sysinfo() {
+  sget /stat/sysinfo | jq -r '.data[0] | "Controller : \(.version)\nDevice     : \(.ubnt_device_type // "-")\nHostname   : \(.hostname // "-")\nUptime(h)  : \((.uptime // 0)/3600|floor)"'
+}
+
+cmd_find() {
+  local q="${1:?usage: find <name|mac|ip substring>}"
+  echo "## active clients matching '$q'"
+  sget /stat/sta | jq -r --arg q "$q" '.data[] |
+    select((.hostname//"")+(.name//"")+(.ip//"")+(.mac//"")+(.essid//"") | ascii_downcase | contains($q|ascii_downcase)) |
+    "\(.hostname // .name // "?")\t\(.ip // "-")\t\(.mac)\t\(if .is_wired then "wired" else (.essid // "wifi") end)"' \
+    | column -t -s$'\t'
+  echo "## known/configured clients matching '$q'"
+  sget /rest/user | jq -r --arg q "$q" '.data[] |
+    select((.name//"")+(.hostname//"")+(.mac//"")+(.fixed_ip//"")+(.note//"") | ascii_downcase | contains($q|ascii_downcase)) |
+    "\(.name // .hostname // "?")\t\(.fixed_ip // "-")\t\(.mac)\t\(.note // "-")"' \
+    | column -t -s$'\t'
+}
+
+cmd_summary() {
+  echo "# UniFi homelab — $HOST (site: $SITE)"; echo
+  echo "## controller";       cmd_sysinfo; echo
+  echo "## health";           cmd_health;  echo
+  echo "## networks (VLANs)"; cmd_networks; echo
+  echo "## wlans";            cmd_wlans;    echo
+  echo "## devices";          cmd_devices;  echo
+  echo "## active clients: $(sget /stat/sta | jq '.data|length')"
+}
+
+cmd_help() {
+  cat <<'EOF'
+unifi.sh — read-only UniFi homelab discovery
+
+  summary            one-shot overview: controller, health, networks, wlans, devices
+  sysinfo            controller version / device / uptime
+  health             per-subsystem status (wan/lan/wlan/www/vpn)
+  networks           configured networks / VLANs / subnets / DHCP
+  wlans              wireless SSIDs and security
+  devices            adopted UniFi devices (APs, switches, gateways)
+  clients            currently-connected clients (live association table)
+  clients-known      clients configured in the controller (fixed IPs, aliases)
+  routes             static routes (rest/routing)
+  firewall           firewall rules (rest/firewallrule)
+  portforward        port-forward rules (rest/portforward)
+  find <term>        search clients (active + known) by name/ip/mac/ssid
+  raw <api-path>     GET any legacy path, e.g.  raw /s/default/stat/health
+  integ [path]       Integration API GET (needs UNIFI_API_KEY); default /sites
+  bgp                FRR/BGP summary over SSH (Cilium k8s peers)
+  ssh <cmd>          run a command on the UDM over SSH as root (e.g. mca-dump)
+  help               this text
+
+Auth is automatic: creds come from 1Password (op) and a cookie session is cached.
+The bgp/ssh commands additionally SSH to the UDM (sshpass via nix-shell if needed).
+EOF
+}
+
+main() {
+  local c="${1:-help}"; shift || true
+  case "$c" in
+    summary)        cmd_summary "$@" ;;
+    sysinfo)        cmd_sysinfo "$@" ;;
+    health)         cmd_health "$@" ;;
+    networks)       cmd_networks "$@" ;;
+    wlans)          cmd_wlans "$@" ;;
+    devices)        cmd_devices "$@" ;;
+    clients)        cmd_clients "$@" ;;
+    clients-known)  cmd_clients_known "$@" ;;
+    routes)         cmd_routes "$@" ;;
+    firewall)       cmd_firewall "$@" ;;
+    portforward)    cmd_portforward "$@" ;;
+    find)           cmd_find "$@" ;;
+    raw)            cmd_raw "$@" ;;
+    integ)          cmd_integ "$@" ;;
+    bgp)            cmd_bgp "$@" ;;
+    ssh)            cmd_ssh "$@" ;;
+    help|-h|--help) cmd_help ;;
+    *) echo "unknown command: $c" >&2; cmd_help; exit 1 ;;
+  esac
+}
+main "$@"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,3 +179,4 @@ Available skills:
 - `kubernetes-gitops` — FluxCD reconciliation, networking, SOPS secrets
 - `multi-cluster` — Add or modify shared resources across folly and offsite clusters using the base/ pattern
 - `onboard-repo` — Vendor an external jonpulsifer repo into apps/packages/images with history, then rewire its consumers
+- `unifi-network` — Read-only discovery of the live UniFi homelab network (networks/VLANs, WLANs, devices, clients) via the UDM Pro API, creds from 1Password


### PR DESCRIPTION
## Summary
Adds a repo-local `unifi-network` skill that lets an agent discover and reason about the live homelab UniFi network (UDM Pro) read-only, without mutating state — the live counterpart to the desired state in `terraform/unifi/`.

## Changes
- `.agents/skills/unifi-network/unifi.sh` — driver: pulls the `terraform` Super Admin creds from 1Password (`op`), opens a UniFi-OS cookie session, and wraps the legacy Network API behind subcommands: `summary`, `networks`, `devices`, `wlans`, `clients`, `clients-known`, `health`, `sysinfo`, `routes`, `firewall`, `portforward`, `find`, `raw`.
- Integration API (`developer.ui.com`) support via `integ` (X-API-KEY; dormant until a key is stored in the vault — cookie auth is rejected there).
- SSH-backed `bgp` and `ssh` subcommands (sshpass via `nix-shell` if absent) for FRR/BGP state — the Cilium k8s peers configured by `bgp-{folly,offsite}.conf` — and on-box `mca-dump`.
- `.agents/skills/unifi-network/SKILL.md` — man page; every code block was run against the live controller this session.
- `AGENTS.md` — index entry under Skills.

## Test Plan
- [ ] `export OP_SERVICE_ACCOUNT_TOKEN=...` (homelab vault), then `.agents/skills/unifi-network/unifi.sh summary` prints controller/health/networks/wlans/devices.
- [ ] `unifi.sh find <host>` locates a client; `unifi.sh bgp` shows BGP peers; `unifi.sh integ` errors cleanly without a key.
- [ ] `shellcheck` clean on `unifi.sh`.

## Notes
Read-only by design — authoring network state still flows through `terraform/unifi/` + Atlantis per the repo's GitOps rules.
