### PR TITLE
feat: comprehensive repo-level gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,50 @@
-.terraform
-*.tfstate
-*.tfplan
+# ─── Nix / NixOS ──────────────────────────────────────────────────────────────
 result
+result*
+*.nixexpr
+*.nixpkgs
 *.iso
 *.img
 *.backup
 *.wsl
 *.zstd
-.claude
+
+# ─── Terraform ───────────────────────────────────────────────────────────────
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.tfvars
+
+# ─── Build Artifacts ─────────────────────────────────────────────────────────
+build/
+dist/
+out/
+*.tgz
+
+# ─── Agent / AI Tooling ──────────────────────────────────────────────────────
+.claude/
+.agents/
+
+# ─── Node / Bun ──────────────────────────────────────────────────────────────
+# Only tracked in sub-packages that need them; root is not a node project
+# node_modules/
+# package-lock.json
+# bun.lockb
+
+# ─── IDE / Editor ────────────────────────────────────────────────────────────
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# ─── OS ──────────────────────────────────────────────────────────────────────
+.DS_Store
+Thumbs.db
+
+# ─── Logs & Reports ───────────────────────────────────────────────────────────
+*.log
+logs/
+coverage/
+*.lcov


### PR DESCRIPTION
## Summary

Replace the minimal `.gitignore` with a comprehensive one covering NixOS builds, Terraform state, build artifacts, IDE files, agent tooling, and common log patterns.

## Changes

- feat: comprehensive repo-level gitignore

## Test Plan

- [ ] Verify no tracked files become untracked
- [ ] Confirm `result`, `.terraform/`, etc. are ignored

## Context

Replaces the previous 10-line `.gitignore`
