### PR TITLE
fix(cilium): enable tproxy for folly l7 load balancers

### DIFF
--- a/clusters/folly/networking/cilium/bootstrap-values.yaml
+++ b/clusters/folly/networking/cilium/bootstrap-values.yaml
@@ -8,6 +8,7 @@ ipv4NativeRoutingCIDR: 10.3.0.0/26
 enableIPv4Masquerade: true
 bpf:
   masquerade: true
+  tproxy: true
 ipam:
   mode: multi-pool
 enableXTSocketFallback: false

--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -35,6 +35,7 @@ spec:
     enableIPv4Masquerade: true
     bpf:
       masquerade: true
+      tproxy: true
     ipMasqAgent:
       enabled: true
       config:


### PR DESCRIPTION
## Summary
Enable Cilium BPF TPROXY for folly so Envoy-backed L7 LoadBalancer/NodePort services can handle externally-routed traffic.

## Changes
- Set `bpf.tproxy: true` in the folly Cilium HelmRelease.
- Keep folly Cilium bootstrap values aligned for future/bootstrap installs.

## Test Plan
- [x] `kustomize build clusters/folly/networking`
- [x] `git diff --check`

## Context
After the previous BGP/native-routing fix, BGP, Tailscale routes, and node SSH work, but LB HTTP/S still times out. Live Cilium logs show `--enable-bpf-tproxy='false'` while L7 LB services are using Envoy proxy ports; enabling BPF TPROXY should allow those external flows to be redirected correctly.
