### PR TITLE
chore(dotfiles): symlink gemini config skills to agents skills

### DIFF
--- a/dotfiles/dot_gemini/config/symlink_skills.tmpl
+++ b/dotfiles/dot_gemini/config/symlink_skills.tmpl
@@ -1,0 +1,1 @@
+{{ .chezmoi.homeDir }}/.agents/skills


### PR DESCRIPTION
## Summary
Configure chezmoi to symlink the global Gemini customization directory (~/.gemini/config/skills) to the shared agent skills directory (~/.agents/skills), allowing Antigravity to discover and use the global agent skills.

## Changes
- Added `dotfiles/dot_gemini/config/symlink_skills.tmpl` pointing to `{{ .chezmoi.homeDir }}/.agents/skills`.

## Test Plan
- Ran `chezmoi apply` which correctly generated the `~/.gemini/config/skills` symlink pointing to `~/.agents/skills`.
