### PR TITLE
fix(cilium): disable endpointRoutes to restore Envoy proxy IP routing

### DIFF
--- a/clusters/folly/networking/cilium/bootstrap-values.yaml
+++ b/clusters/folly/networking/cilium/bootstrap-values.yaml
@@ -13,7 +13,7 @@ ipam:
   mode: multi-pool
 enableXTSocketFallback: false
 endpointRoutes:
-  enabled: true
+  enabled: false
 bgpControlPlane:
   enabled: true
 gatewayAPI:

--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -48,7 +48,7 @@ spec:
       mode: multi-pool
     enableXTSocketFallback: false
     endpointRoutes:
-      enabled: true
+      enabled: false
     bgpControlPlane:
       enabled: true
     gatewayAPI:

--- a/clusters/offsite/networking/cilium/helm-release.yaml
+++ b/clusters/offsite/networking/cilium/helm-release.yaml
@@ -39,7 +39,7 @@ spec:
       mode: multi-pool
     enableXTSocketFallback: false
     endpointRoutes:
-      enabled: true
+      enabled: false
     bgpControlPlane:
       enabled: true
     gatewayAPI:


### PR DESCRIPTION
## Summary
Disable `endpointRoutes` in Cilium configuration for both folly and offsite clusters. This restores native subnet routing on the nodes for the Envoy proxy IPs (`reserved:ingress` identity), correcting the "Network is unreachable" error during L7 load balancer backend connection forwarding.

## Changes
- `clusters/folly/networking/cilium/bootstrap-values.yaml`: set `endpointRoutes.enabled` to `false`
- `clusters/folly/networking/cilium/helm-release.yaml`: set `endpointRoutes.enabled` to `false`
- `clusters/offsite/networking/cilium/helm-release.yaml`: set `endpointRoutes.enabled` to `false`

## Test Plan
- [x] Validate kustomize build for changed overlays.
- [x] Verify routing logic on nodes (host kernel now successfully routes proxy IP sources).
