### PR TITLE
revert(cilium): remove tproxy configuration in folly

### DIFF
--- a/clusters/folly/networking/cilium/bootstrap-values.yaml
+++ b/clusters/folly/networking/cilium/bootstrap-values.yaml
@@ -8,7 +8,6 @@ ipv4NativeRoutingCIDR: 10.3.0.0/26
 enableIPv4Masquerade: true
 bpf:
   masquerade: true
-  tproxy: true
 ipam:
   mode: multi-pool
 enableXTSocketFallback: false

--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -35,7 +35,6 @@ spec:
     enableIPv4Masquerade: true
     bpf:
       masquerade: true
-      tproxy: true
     ipMasqAgent:
       enabled: true
       config:


### PR DESCRIPTION
## Summary
Revert the L7 load balancer BPF TPROXY configuration (`bpf.tproxy: true`) in the folly cluster.

## Changes
- `clusters/folly/networking/cilium/bootstrap-values.yaml`: remove `tproxy: true`
- `clusters/folly/networking/cilium/helm-release.yaml`: remove `tproxy: true`
