### PR TITLE
fix(cilium): disable useOriginalSourceAddress to resolve ingress timeout

### DIFF
--- a/clusters/folly/networking/cilium/bootstrap-values.yaml
+++ b/clusters/folly/networking/cilium/bootstrap-values.yaml
@@ -19,6 +19,7 @@ gatewayAPI:
   enabled: true
 envoy:
   enabled: true
+  useOriginalSourceAddress: false
   prometheus:
     enabled: true
     serviceMonitor:

--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -54,6 +54,7 @@ spec:
       enabled: true
     envoy:
       enabled: true
+      useOriginalSourceAddress: false
       prometheus:
         enabled: true
         serviceMonitor:

--- a/clusters/offsite/networking/cilium/helm-release.yaml
+++ b/clusters/offsite/networking/cilium/helm-release.yaml
@@ -46,6 +46,7 @@ spec:
       enabled: true
     envoy:
       enabled: true
+      useOriginalSourceAddress: false
     ingressController:
       enabled: true
       default: true


### PR DESCRIPTION
## Summary
Disable `useOriginalSourceAddress` in Cilium's Envoy configuration. In native routing mode, Envoy attempting to bind its upstream sockets to the nonlocal Ingress/proxy IP (`10.100.0.249`) causes the host kernel to reject the routing lookup with `Network is unreachable`, leading to 503 gateway timeouts. Disabling this flag allows Envoy to connect upstream using the host's primary routable IP.

## Changes
- fix(cilium): disable useOriginalSourceAddress to resolve ingress timeout in native routing

## Test Plan
- Verified that Kustomize builds cleanly on both folly and offsite.
- Tested locally on `optiplex` that routing succeeds using the host's primary IP source.
