### PR TITLE
fix(walter): bump ai-agents image to dated tag

### DIFF
--- a/apps/agent-web/AGENTS.md
+++ b/apps/agent-web/AGENTS.md
@@ -23,4 +23,4 @@ Coding/automation agent with a ghostty-web terminal UI. Full tool stack for agen
 - Ports: 8080 (web terminal), 18789 (openclaw)
 - Runs as uid 1337 (agent)
 - /home/agent is a VOLUME
-- ghostty-web assets at /opt/ghostty-web/
+- ghostty-web assets at /opt/ghostty-web/<!-- ai-agents container build trigger: 20260623-011158 UTC -->

--- a/clusters/folly/apps/walter.yaml
+++ b/clusters/folly/apps/walter.yaml
@@ -15,7 +15,7 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    image: docker.io/jonpulsifer/ai-agents:latest
+    image: docker.io/jonpulsifer/ai-agents:20260623
     port: 18789
     hostname: walter.lolwtf.ca
     storageSize: 10Gi


### PR DESCRIPTION
Bumps walter's container image from `docker.io/jonpulsifer/ai-agents:latest` to `docker.io/jonpulsifer/ai-agents:20260623`. The `apps/agent-web/AGENTS.md` touch ensures the `containers.yml` workflow runs and publishes the dated tag.

On merge: CI builds and pushes the `:20260623` tag → Flux picks it up on next reconcile.