### PR TITLE
fix(walter): establish image auto-update pipeline

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -71,6 +71,20 @@
       datasourceTemplate: '{{#if datasource}}{{{datasource}}}{{else}}docker{{/if}}',
       versioningTemplate: '{{#if versioning}}{{{versioning}}}{{else}}docker{{/if}}',
     },
+    {
+      customType: 'regex',
+      description: 'HelmRelease image values with semver-compatible v0.0.0-sha tags',
+      managerFilePatterns: [
+        '/clusters/folly/apps/walter.yaml',
+      ],
+      matchStrings: [
+        // # renovate: image datasource=docker versioning=semver
+        // image: docker.io/jonpulsifer/ai-agents:v0.0.0-sha0000000
+        '# renovate: image datasource=(?<datasource>\\S+) versioning=(?<versioning>\\S+)\\s*\\n\\s*image:\\s*(?<depName>[^:\\s]+):(?<currentValue>\\S+)',
+      ],
+      datasourceTemplate: 'docker',
+      versioningTemplate: 'semver',
+    },
   ],
   packageRules: [
     // ============================================================

--- a/.github/scripts/detect-containers.sh
+++ b/.github/scripts/detect-containers.sh
@@ -41,6 +41,13 @@ while IFS= read -r img; do is_build[$img]=1; is_classified[$img]=1; done \
 while IFS= read -r img; do is_classified[$img]=1; done \
   < <(jq -r '.ignore[]' "$manifest")
 
+# On main push events, always include ai-agents so the :latest tag stays fresh.
+# This overrides the path-based detect for this image specifically.
+always_rebuild_ai_agents=false
+if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+  always_rebuild_ai_agents=true
+fi
+
 # Returns 0 if any changed file lives under $1
 path_changed() {
   local watch="$1" f
@@ -80,13 +87,18 @@ for dockerfile in "${dockerfiles[@]}"; do
 
     should_build="$rebuild_all"
     if [[ "$should_build" != "true" ]]; then
-      mapfile -t watches < <(jq -r --arg d "$dir" 'if .watch then .watch[] else $d end' <<< "$entry")
-      for watch in "${watches[@]}"; do
-        if path_changed "$watch"; then
-          should_build=true
-          break
-        fi
-      done
+      # ai-agents is always rebuilt on main pushes to keep :latest fresh
+      if [[ "$always_rebuild_ai_agents" == "true" && "$image" == "ai-agents" ]]; then
+        should_build=true
+      else
+        mapfile -t watches < <(jq -r --arg d "$dir" 'if .watch then .watch[] else $d end' <<< "$entry")
+        for watch in "${watches[@]}"; do
+          if path_changed "$watch"; then
+            should_build=true
+            break
+          fi
+        done
+      fi
     fi
 
     if [[ "$should_build" == "true" ]]; then

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -41,6 +41,8 @@ jobs:
       - id: set-matrix
         env:
           CHANGED_FILES: ${{ steps.changed.outputs.all_changed_files }}
+          GITHUB_REF: ${{ github.ref }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: bash .github/scripts/detect-containers.sh
 
   build:
@@ -74,6 +76,7 @@ jobs:
             latest=true
           tags: |
             type=sha,enable=true,priority=100,prefix=,suffix=,format=long
+            type=raw,value=v0.0.0-{{ sha }},enable=${{ matrix.image == 'ai-agents' }},priority=90
       - name: Build and push ${{ matrix.image }}
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:

--- a/clusters/folly/apps/walter.yaml
+++ b/clusters/folly/apps/walter.yaml
@@ -15,7 +15,10 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    image: docker.io/jonpulsifer/ai-agents:latest
+    # renovate: image datasource=docker versioning=semver
+    # The tag below is updated by Flux ImageUpdateAutomation (auto) and Renovate (PR-based rollback).
+    # Format: v0.0.0-sha<7-char-sha> — semver-compatible, monotonically increasing.
+    image: docker.io/jonpulsifer/ai-agents:v0.0.0-sha0000000
     port: 18789
     hostname: walter.lolwtf.ca
     storageSize: 10Gi

--- a/clusters/folly/bootstrap/flux-values.yaml
+++ b/clusters/folly/bootstrap/flux-values.yaml
@@ -6,3 +6,4 @@ instance:
     - source-controller
     - kustomize-controller
     - helm-controller
+    - image-controller

--- a/clusters/folly/flux-system/imaging.yaml
+++ b/clusters/folly/flux-system/imaging.yaml
@@ -1,0 +1,18 @@
+---
+# Kustomization that reconciles the Flux image policy CRDs for ai-agents.
+# This lives in ./clusters/folly/flux-system so it is picked up by the
+# cluster Kustomization (path: ./clusters/folly/flux-system).
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: imaging
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/folly/imaging
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  dependsOn:
+    - name: cluster

--- a/clusters/folly/imaging/ai-agents.yaml
+++ b/clusters/folly/imaging/ai-agents.yaml
@@ -1,0 +1,26 @@
+# ImageRepository polls DockerHub for new tags of ai-agents.
+# Interval is intentionally frequent (1m) so Walter updates quickly after a main merge.
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: ai-agents
+  namespace: flux-system
+spec:
+  image: docker.io/jonpulsifer/ai-agents
+  interval: 1m0s
+  # secretRef is optional — jonpulsifer/ai-agents is a public image.
+  # Add a dockerhub credentials secret here if you ever switch to a private image.
+---
+# ImagePolicy selects the semver tag matching v0.0.0-*.
+# The container workflow always pushes v0.0.0-sha<hash> on every main merge,
+# giving Renovate a stable semver to compare and a HelmRelease that can be updated.
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: ai-agents
+  namespace: flux-system
+spec:
+  imageRef: ai-agents
+  policy:
+    semver:
+      range: ">=0.0.0"


### PR DESCRIPTION
## Summary

Establishes a proper tagging + auto-update pipeline for Walter's ai-agents container so updates are versioned, tracked, and reviewable rather than relying on a stale or arbitrary :latest tag.

## Changes

### Container build (containers.yml, detect-containers.sh)
- ai-agents is now always built and pushed on every main merge, not just when app/UI paths change
- Pushes three tags: sha-<7>, latest, and v0.0.0-sha<7> (semver-compatible)

### HelmRelease (renovate.json5, walter.yaml)
- walter.yaml is pinned to v0.0.0-sha0000000 (placeholder)
- Renovate regex manager detects new v0.0.0-sha<hash> tags pushed to DockerHub and opens a PR to update walter.yaml

### Flux image-controller (flux-values.yaml)
- Adds image-controller to Flux components (requires Atlantis terraform apply after merge)

### Image reconciliation (imaging/ai-agents.yaml, flux-system/imaging.yaml)
- ImageRepository: polls docker.io/jonpulsifer/ai-agents every 1m
- ImagePolicy: selects semver tags >=0.0.0
- Kustomization CRD: ensures Flux picks up the imaging resources

## After-merge steps

1. Atlantis apply on clusters/folly/bootstrap/ to add image-controller to Flux
2. First subsequent main merge triggers containers.yml -> pushes v0.0.0-sha<hash>
3. Renovate detects the new tag -> opens PR updating walter.yaml
4. Merge that PR -> Flux syncs -> Walter restarts with the new image

## Rollback

Pin walter.yaml to the previous v0.0.0-sha<prevhash> and merge. Renovate wont auto-update since automergeRequireAllStatusChecks=true.