### PR TITLE
feat(cloudflare): add A records for folly and offsite in lolwtf.ca

### DIFF
--- a/terraform/cloudflare/lolwtf.ca.tf
+++ b/terraform/cloudflare/lolwtf.ca.tf
@@ -46,6 +46,24 @@ module "tunnel_offsite" {
   }
 }
 
+resource "cloudflare_dns_record" "folly_lolwtf_ca" {
+  zone_id = cloudflare_zone.lolwtf_ca.id
+  name    = "folly.lolwtf.ca"
+  type    = "A"
+  content = "10.3.0.10"
+  proxied = false
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "offsite_lolwtf_ca" {
+  zone_id = cloudflare_zone.lolwtf_ca.id
+  name    = "offsite.lolwtf.ca"
+  type    = "A"
+  content = "10.89.0.10"
+  proxied = false
+  ttl     = 1
+}
+
 output "cloudflare_tunnel_token_folly" {
   sensitive = true
   value     = module.tunnel_folly.cloudflare_tunnel_token


### PR DESCRIPTION
## Summary

- Adds `folly.lolwtf.ca` A record pointing to `10.3.0.10` (folly cluster)
- Adds `offsite.lolwtf.ca` A record pointing to `10.89.0.10` (offsite cluster)
- Both records are unproxied (private IP addresses, no Cloudflare proxy)

## Test plan

- [ ] Atlantis autoplan passes on this PR
- [ ] Comment `atlantis apply` to apply; verify records resolve after apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpQQFyL2WHFeZK7fVSDhyK

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpQQFyL2WHFeZK7fVSDhyK)_