### PR TITLE
docs(kube): remove Tailscale from cluster docs and kubeconfig script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ Two clusters managed with FluxCD kustomizations:
 - `clusters/offsite/` – backup cluster
 - `clusters/base/` – resources shared by both clusters (referenced by path from each)
 
-Each cluster directory has `flux-system/` (FluxCD source-of-truth kustomizations), `networking/` (Cilium, cert-manager, Cloudflare tunnel, Tailscale, Gateway API, external-dns), `monitoring/` (kube-prometheus-stack, Loki, Grafana, promtail), `nodes/` (Intel device plugins, node-feature-discovery), and `storage/`.
+Each cluster directory has `flux-system/` (FluxCD source-of-truth kustomizations), `networking/` (Cilium, cert-manager, Cloudflare tunnel, Gateway API, external-dns), `monitoring/` (kube-prometheus-stack, Loki, Grafana, promtail), `nodes/` (Intel device plugins, node-feature-discovery), and `storage/`.
 
 Cilium provides CNI + BGP load balancer (pools defined in `networking/cilium/ip-pools.yaml`). The Gateway API (`networking/gateway-api/`) handles ingress via a `cluster-gateway` with Cloudflare Tunnel as the external entry point.
 

--- a/dotfiles/dot_local/bin/executable_update-kubeconfigs
+++ b/dotfiles/dot_local/bin/executable_update-kubeconfigs
@@ -2,26 +2,13 @@
 
 set -u
 
-# Configuration
-# Tailscale addresses (SSH access)
-HOSTS=("optiplex.pirate-musical.ts.net" "retrofit.pirate-musical.ts.net")
-declare -A CLUSTER_NAMES=(
-  ["optiplex.pirate-musical.ts.net"]="folly"
-  ["retrofit.pirate-musical.ts.net"]="offsite"
+# Cluster name → direct IP address (SSH + kubeconfig server)
+CLUSTERS=("folly" "offsite")
+declare -A CLUSTER_IPS=(
+  ["folly"]="10.3.0.10"
+  ["offsite"]="10.89.0.10"
 )
 
-# Direct access (IP and DNS)
-declare -A CLUSTER_DIRECT_IPS=(
-  ["optiplex.pirate-musical.ts.net"]="10.3.0.10"
-  ["retrofit.pirate-musical.ts.net"]="10.89.0.10"
-)
-declare -A CLUSTER_DIRECT_DNS=(
-  ["optiplex.pirate-musical.ts.net"]="folly.lolwtf.ca"
-  ["retrofit.pirate-musical.ts.net"]="offsite.lolwtf.ca"
-)
-
-# Default method: tailscale or direct
-CONNECT_METHOD="direct"
 KUBECONFIG_PATH="$HOME/.kube/config"
 TEMP_DIR=$(mktemp -d)
 BACKUP_PATH="$HOME/.kube/config.backup.$(date +%Y%m%d-%H%M%S)"
@@ -65,80 +52,61 @@ cleanup() {
 
 trap cleanup EXIT
 
-# Function to get short hostname from FQDN
-get_short_hostname() {
-  local hostname="$1"
-  echo "${hostname%%.*}"
-}
-
-# Function to fetch and process kubeconfig from a host
+# Function to fetch and process kubeconfig from a cluster
 fetch_and_process_kubeconfig() {
-  local host="$1"
-  local cluster_name="${CLUSTER_NAMES[$host]}"
+  local cluster_name="$1"
+  local ip="${CLUSTER_IPS[$cluster_name]}"
   local temp_config="$TEMP_DIR/kubeconfig-$cluster_name"
-  local connect_ip="${CLUSTER_DIRECT_IPS[$host]}"
-  local connect_dns="${CLUSTER_DIRECT_DNS[$host]}"
 
-  # Determine server address based on method
-  local server_addr
-  case "$CONNECT_METHOD" in
-    tailscale)
-      server_addr="$host"
-      ;;
-    direct)
-      server_addr="$connect_ip"
-      ;;
-  esac
-
-  log "Fetching kubeconfig from $host (SSH via Tailscale)..."
+  log "Fetching kubeconfig from $cluster_name ($ip)..."
 
   # Fetch the kubeconfig in JSON format for easier processing. Bound both the
   # SSH connection attempt and the whole remote command so unavailable clusters
   # do not stall the entire update.
   if command -v timeout &>/dev/null; then
-    if ! timeout "${SSH_COMMAND_TIMEOUT}s" ssh "${SSH_OPTS[@]}" "$host" -- sudo kubectl config view --minify --flatten --output=json >"$TEMP_DIR/$cluster_name-original.json"; then
-      error "Failed to fetch kubeconfig from $host within ${SSH_COMMAND_TIMEOUT}s"
+    if ! timeout "${SSH_COMMAND_TIMEOUT}s" ssh "${SSH_OPTS[@]}" "$ip" -- sudo kubectl config view --minify --flatten --output=json >"$TEMP_DIR/$cluster_name-original.json"; then
+      error "Failed to fetch kubeconfig from $cluster_name ($ip) within ${SSH_COMMAND_TIMEOUT}s"
       return 1
     fi
-  elif ! ssh "${SSH_OPTS[@]}" "$host" -- sudo kubectl config view --minify --flatten --output=json >"$TEMP_DIR/$cluster_name-original.json"; then
-    error "Failed to fetch kubeconfig from $host"
+  elif ! ssh "${SSH_OPTS[@]}" "$ip" -- sudo kubectl config view --minify --flatten --output=json >"$TEMP_DIR/$cluster_name-original.json"; then
+    error "Failed to fetch kubeconfig from $cluster_name ($ip)"
     return 1
   fi
 
   # Check if the file is empty or invalid
   if [[ ! -s "$TEMP_DIR/$cluster_name-original.json" ]]; then
-    error "Received empty kubeconfig from $host"
+    error "Received empty kubeconfig from $cluster_name ($ip)"
     return 1
   fi
 
-  log "Processing kubeconfig for $host..."
+  log "Processing kubeconfig for $cluster_name..."
 
   # Process the JSON kubeconfig using jq
-  if ! jq --arg cluster_name "$cluster_name" --arg server_addr "$server_addr" '
+  if ! jq --arg cluster_name "$cluster_name" --arg ip "$ip" '
         .clusters[0].name = $cluster_name |
-        .clusters[0].cluster.server = "https://\($server_addr):6443" |
+        .clusters[0].cluster.server = "https://\($ip):6443" |
         .contexts[0].name = $cluster_name |
         .contexts[0].context.cluster = $cluster_name |
         .contexts[0].context.user = "\($cluster_name)-admin" |
         .users[0].name = "\($cluster_name)-admin" |
         .["current-context"] = $cluster_name
     ' "$TEMP_DIR/$cluster_name-original.json" >"$TEMP_DIR/$cluster_name-processed.json"; then
-    error "Failed to process JSON for $host"
+    error "Failed to process JSON for $cluster_name"
     return 1
   fi
 
   # Convert back to YAML for kubectl compatibility
   if ! kubectl config view --kubeconfig="$TEMP_DIR/$cluster_name-processed.json" --minify --flatten >"$temp_config"; then
-    error "Failed to convert to YAML for $host"
+    error "Failed to convert to YAML for $cluster_name"
     return 1
   fi
 
   if [[ ! -s "$temp_config" ]]; then
-    error "Failed to process kubeconfig for $host"
+    error "Failed to process kubeconfig for $cluster_name"
     return 1
   fi
 
-  success "Processed kubeconfig for $host (cluster: $cluster_name, method: $CONNECT_METHOD, server: https://$server_addr:6443)"
+  success "Processed kubeconfig for $cluster_name (server: https://$ip:6443)"
   return 0
 }
 
@@ -147,15 +115,14 @@ merge_kubeconfigs() {
   log "Merging kubeconfigs..." >&2
 
   local temp_kubeconfigs=()
-  for host in "${HOSTS[@]}"; do
-    local cluster_name="${CLUSTER_NAMES[$host]}"
+  for cluster_name in "${CLUSTERS[@]}"; do
     local temp_config="$TEMP_DIR/kubeconfig-$cluster_name"
 
     if [[ -f "$temp_config" ]]; then
       temp_kubeconfigs+=("$temp_config")
       log "Will merge: $temp_config" >&2
     else
-      warn "Skipping $host - kubeconfig not available"
+      warn "Skipping $cluster_name - kubeconfig not available"
     fi
   done
 
@@ -223,51 +190,49 @@ main() {
     cp "$KUBECONFIG_PATH" "$BACKUP_PATH"
   fi
 
-  # Process each host in parallel. Each job writes to its own log so output is
-  # still readable while the slow/unavailable hosts are bounded by timeouts.
-  local successful_hosts=0
+  # Process each cluster in parallel. Each job writes to its own log so output is
+  # still readable while the slow/unavailable clusters are bounded by timeouts.
+  local successful_clusters=0
   local pids=()
-  declare -A pid_hosts=()
+  declare -A pid_clusters=()
 
-  log "About to process ${#HOSTS[@]} hosts in parallel: ${HOSTS[*]}"
-  for host in "${HOSTS[@]}"; do
-    local cluster_name="${CLUSTER_NAMES[$host]}"
+  log "About to process ${#CLUSTERS[@]} clusters in parallel: ${CLUSTERS[*]}"
+  for cluster_name in "${CLUSTERS[@]}"; do
     local job_log="$TEMP_DIR/$cluster_name.log"
 
-    log "Starting processing for host: $host"
-    fetch_and_process_kubeconfig "$host" >"$job_log" 2>&1 &
+    log "Starting processing for cluster: $cluster_name"
+    fetch_and_process_kubeconfig "$cluster_name" >"$job_log" 2>&1 &
     local pid=$!
     pids+=("$pid")
-    pid_hosts[$pid]="$host"
+    pid_clusters[$pid]="$cluster_name"
   done
 
   for pid in "${pids[@]}"; do
-    local host="${pid_hosts[$pid]}"
-    local cluster_name="${CLUSTER_NAMES[$host]}"
+    local cluster_name="${pid_clusters[$pid]}"
     local job_log="$TEMP_DIR/$cluster_name.log"
 
     if wait "$pid"; then
-      ((successful_hosts++))
+      ((successful_clusters++))
       while IFS= read -r line; do
         echo "[$cluster_name] $line"
       done <"$job_log"
-      log "SUCCESS: Host $host processed successfully"
+      log "SUCCESS: Cluster $cluster_name processed successfully"
     else
       while IFS= read -r line; do
         echo "[$cluster_name] $line"
       done <"$job_log"
-      warn "Failed to process kubeconfig from $host"
+      warn "Failed to process kubeconfig from $cluster_name"
     fi
   done
 
-  log "Completed host processing (successful: $successful_hosts/${#HOSTS[@]})"
+  log "Completed cluster processing (successful: $successful_clusters/${#CLUSTERS[@]})"
 
-  if [[ $successful_hosts -eq 0 ]]; then
+  if [[ $successful_clusters -eq 0 ]]; then
     error "No kubeconfigs were successfully fetched"
     exit 1
   fi
 
-  log "Successfully processed $successful_hosts kubeconfig(s)"
+  log "Successfully processed $successful_clusters kubeconfig(s)"
 
   # Merge all kubeconfigs
   local merged_config
@@ -287,8 +252,7 @@ main() {
 
     # Show cluster info
     log "Cluster information:"
-    for host in "${HOSTS[@]}"; do
-      local cluster_name="${CLUSTER_NAMES[$host]}"
+    for cluster_name in "${CLUSTERS[@]}"; do
       if kubectl config get-contexts -o name | grep -q "^${cluster_name}$"; then
         local server
         server=$(kubectl config view -o jsonpath="{.clusters[?(@.name=='$cluster_name')].cluster.server}" 2>/dev/null || echo "unknown")
@@ -306,35 +270,25 @@ show_help() {
   cat <<EOF
 Usage: $0 [OPTIONS]
 
-Update kubeconfig by fetching and merging configs from multiple Kubernetes clusters.
+Update kubeconfig by fetching and merging configs from multiple Kubernetes clusters via direct IP.
 
 OPTIONS:
-    -h, --help          Show this help message
-    -l, --list          List configured hosts
-    -m, --method METHOD  Connection method: tailscale or direct (default: direct)
-    --dry-run           Show what would be done without making changes
+    -h, --help     Show this help message
+    -l, --list     List configured clusters
 
 ENVIRONMENT:
     SSH_CONNECT_TIMEOUT   SSH connection timeout in seconds (default: 5)
     SSH_COMMAND_TIMEOUT   Whole remote fetch timeout in seconds (default: 20)
 
-CONFIGURED HOSTS:
-$(printf '  %s\n' "${HOSTS[@]}")
-
-CLUSTER DIRECT ACCESS:
-$(for host in "${HOSTS[@]}"; do
-    echo "  ${CLUSTER_NAMES[$host]}: IP=${CLUSTER_DIRECT_IPS[$host]}, DNS=${CLUSTER_DIRECT_DNS[$host]}"
+CONFIGURED CLUSTERS:
+$(for cluster_name in "${CLUSTERS[@]}"; do
+    echo "  $cluster_name: ${CLUSTER_IPS[$cluster_name]}"
   done)
 
-METHODS:
-  tailscale   Use Tailscale hostnames (e.g., optiplex.pirate-musical.ts.net)
-  direct      Use direct IPs for server endpoints (default)
-              DNS names: folly.lolwtf.ca, offsite.lolwtf.ca
-
 The script will:
-1. Fetch kubeconfig from each host via SSH over Tailscale
+1. Fetch kubeconfig from each cluster node via SSH (direct IP)
 2. Rename clusters/contexts/users to avoid conflicts
-3. Update server URLs based on --method
+3. Update server URLs to use direct IP addresses
 4. Merge all configs into ~/.kube/config using kubectl
 5. Create a backup of the existing config
 
@@ -354,26 +308,11 @@ while [[ $# -gt 0 ]]; do
       exit 0
       ;;
     -l | --list)
-      echo "Configured hosts:"
-      printf '  %s\n' "${HOSTS[@]}"
-      echo ""
-      echo "Direct access:"
-      for host in "${HOSTS[@]}"; do
-        echo "  ${CLUSTER_NAMES[$host]}: IP=${CLUSTER_DIRECT_IPS[$host]}, DNS=${CLUSTER_DIRECT_DNS[$host]}"
+      echo "Configured clusters:"
+      for cluster_name in "${CLUSTERS[@]}"; do
+        echo "  $cluster_name: ${CLUSTER_IPS[$cluster_name]}"
       done
       exit 0
-      ;;
-    -m | --method)
-      case "$2" in
-        tailscale | direct)
-          CONNECT_METHOD="$2"
-          shift 2
-          ;;
-        *)
-          error "Invalid method: $2. Use 'tailscale' or 'direct'"
-          exit 1
-          ;;
-      esac
       ;;
     --dry-run)
       log "DRY RUN MODE - No changes will be made"
@@ -388,5 +327,4 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-log "Using connection method: $CONNECT_METHOD"
 main


### PR DESCRIPTION
Clusters now use direct IP connections instead of Tailscale. Update
update-kubeconfigs to SSH and set server addresses via direct IP only,
dropping the Tailscale hostname config and --method flag entirely.
Remove Tailscale from the AGENTS.md cluster networking description.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0149cL2MtktumGf5VtycXNjV