### PR TITLE
fix(cloudflare): remove offsite tunnel, add A records for folly and offsite

### DIFF
--- a/terraform/cloudflare/lolwtf.ca.tf
+++ b/terraform/cloudflare/lolwtf.ca.tf
@@ -24,6 +24,24 @@ module "tunnel_folly" {
   }
 }
 
+module "tunnel_offsite" {
+  source     = "./modules/tunnel"
+  account_id = local.fml_account_id
+  zone_id    = cloudflare_zone.lolwtf_ca.id
+  name       = "offsite"
+  config = {
+    ingress = [
+      {
+        hostname = "tf.${cloudflare_zone.lolwtf_ca.name}"
+        service  = "http://atlantis.atlantis"
+      },
+      {
+        service = "http_status:418"
+      }
+    ]
+  }
+}
+
 resource "cloudflare_dns_record" "folly_lolwtf_ca" {
   zone_id = cloudflare_zone.lolwtf_ca.id
   name    = "folly.lolwtf.ca"
@@ -45,4 +63,9 @@ resource "cloudflare_dns_record" "offsite_lolwtf_ca" {
 output "cloudflare_tunnel_token_folly" {
   sensitive = true
   value     = module.tunnel_folly.cloudflare_tunnel_token
+}
+
+output "cloudflare_tunnel_token_offsite" {
+  sensitive = true
+  value     = module.tunnel_offsite.cloudflare_tunnel_token
 }

--- a/terraform/cloudflare/lolwtf.ca.tf
+++ b/terraform/cloudflare/lolwtf.ca.tf
@@ -24,34 +24,25 @@ module "tunnel_folly" {
   }
 }
 
-module "tunnel_offsite" {
-  source     = "./modules/tunnel"
-  account_id = local.fml_account_id
-  zone_id    = cloudflare_zone.lolwtf_ca.id
-  name       = "offsite"
-  config = {
-    ingress = [
-      {
-        hostname = "offsite.${cloudflare_zone.lolwtf_ca.name}"
-        service  = "http_status:418"
-      },
-      {
-        hostname = "tf.${cloudflare_zone.lolwtf_ca.name}"
-        service  = "http://atlantis.atlantis"
-      },
-      {
-        service = "http_status:418"
-      }
-    ]
-  }
+resource "cloudflare_dns_record" "folly_lolwtf_ca" {
+  zone_id = cloudflare_zone.lolwtf_ca.id
+  name    = "folly.lolwtf.ca"
+  type    = "A"
+  content = "10.3.0.10"
+  proxied = false
+  ttl     = 1
+}
+
+resource "cloudflare_dns_record" "offsite_lolwtf_ca" {
+  zone_id = cloudflare_zone.lolwtf_ca.id
+  name    = "offsite.lolwtf.ca"
+  type    = "A"
+  content = "10.89.0.10"
+  proxied = false
+  ttl     = 1
 }
 
 output "cloudflare_tunnel_token_folly" {
   sensitive = true
   value     = module.tunnel_folly.cloudflare_tunnel_token
-}
-
-output "cloudflare_tunnel_token_offsite" {
-  sensitive = true
-  value     = module.tunnel_offsite.cloudflare_tunnel_token
 }


### PR DESCRIPTION
Replace the tunnel_offsite Cloudflare module with a simple DNS A record
pointing offsite.lolwtf.ca to 10.89.0.10. Also adds folly.lolwtf.ca → 10.3.0.10.
Removes the offsite tunnel token output since the tunnel no longer exists.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NUtzqDHkNtCF16f9v7vkkA