### PR TITLE
fix(dotfiles): make update-kubeconfigs bash 3.2 compatible for macOS

### DIFF
--- a/dotfiles/dot_local/bin/executable_update-kubeconfigs
+++ b/dotfiles/dot_local/bin/executable_update-kubeconfigs
@@ -4,10 +4,14 @@ set -u
 
 # Cluster name → direct IP address (SSH + kubeconfig server)
 CLUSTERS=("folly" "offsite")
-declare -A CLUSTER_IPS=(
-  ["folly"]="10.3.0.10"
-  ["offsite"]="10.89.0.10"
-)
+
+get_cluster_ip() {
+  case "$1" in
+    folly)   echo "10.3.0.10" ;;
+    offsite) echo "10.89.0.10" ;;
+    *)       return 1 ;;
+  esac
+}
 
 KUBECONFIG_PATH="$HOME/.kube/config"
 TEMP_DIR=$(mktemp -d)
@@ -55,7 +59,8 @@ trap cleanup EXIT
 # Function to fetch and process kubeconfig from a cluster
 fetch_and_process_kubeconfig() {
   local cluster_name="$1"
-  local ip="${CLUSTER_IPS[$cluster_name]}"
+  local ip
+  ip=$(get_cluster_ip "$cluster_name") || { error "Unknown cluster: $cluster_name"; return 1; }
   local temp_config="$TEMP_DIR/kubeconfig-$cluster_name"
 
   log "Fetching kubeconfig from $cluster_name ($ip)..."
@@ -192,9 +197,9 @@ main() {
 
   # Process each cluster in parallel. Each job writes to its own log so output is
   # still readable while the slow/unavailable clusters are bounded by timeouts.
+  # PID→cluster mapping uses temp files to avoid bash 4+ associative arrays.
   local successful_clusters=0
   local pids=()
-  declare -A pid_clusters=()
 
   log "About to process ${#CLUSTERS[@]} clusters in parallel: ${CLUSTERS[*]}"
   for cluster_name in "${CLUSTERS[@]}"; do
@@ -204,15 +209,16 @@ main() {
     fetch_and_process_kubeconfig "$cluster_name" >"$job_log" 2>&1 &
     local pid=$!
     pids+=("$pid")
-    pid_clusters[$pid]="$cluster_name"
+    echo "$cluster_name" >"$TEMP_DIR/pid-$pid"
   done
 
   for pid in "${pids[@]}"; do
-    local cluster_name="${pid_clusters[$pid]}"
+    local cluster_name
+    cluster_name=$(cat "$TEMP_DIR/pid-$pid")
     local job_log="$TEMP_DIR/$cluster_name.log"
 
     if wait "$pid"; then
-      ((successful_clusters++))
+      successful_clusters=$((successful_clusters + 1))
       while IFS= read -r line; do
         echo "[$cluster_name] $line"
       done <"$job_log"
@@ -282,7 +288,7 @@ ENVIRONMENT:
 
 CONFIGURED CLUSTERS:
 $(for cluster_name in "${CLUSTERS[@]}"; do
-    echo "  $cluster_name: ${CLUSTER_IPS[$cluster_name]}"
+    echo "  $cluster_name: $(get_cluster_ip "$cluster_name")"
   done)
 
 The script will:
@@ -310,7 +316,7 @@ while [[ $# -gt 0 ]]; do
     -l | --list)
       echo "Configured clusters:"
       for cluster_name in "${CLUSTERS[@]}"; do
-        echo "  $cluster_name: ${CLUSTER_IPS[$cluster_name]}"
+        echo "  $cluster_name: $(get_cluster_ip "$cluster_name")"
       done
       exit 0
       ;;


### PR DESCRIPTION
Replace bash 4+ associative arrays with a get_cluster_ip() case function and file-based PID→cluster mapping for bash 3.2 / macOS compatibility.