### PR TITLE
unifi: fix site-to-site BGP stuck in Active (update-source)

### DIFF
--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -26,6 +26,9 @@ spec:
       ATLANTIS_FAIL_ON_PRE_WORKFLOW_HOOK_ERROR: "true"
       ATLANTIS_WRITE_GIT_CREDS: "true"
       ATLANTIS_AUTOPLAN_MODULES: "true"
+      # Default is "**/*.tf*"; also autoplan when sidecar files referenced by
+      # file() change (e.g. terraform/unifi/bgp-*.conf for the unifi_bgp config).
+      ATLANTIS_AUTOPLAN_FILE_LIST: "**/*.tf*,**/*.conf"
       # ATLANTIS_SILENCE_FORK_PR_ERRORS: "true"
       GOOGLE_APPLICATION_CREDENTIALS: "/run/secrets/terraform.json"
       GOOGLEWORKSPACE_CREDENTIALS: "/run/secrets/terraform.json"

--- a/terraform/unifi/bgp-folly.conf
+++ b/terraform/unifi/bgp-folly.conf
@@ -22,6 +22,9 @@ router bgp 64512
   ! Site-to-site BGP peer (offsite ucg-max, iBGP ASN 64512)
   neighbor OFFSITE peer-group
   neighbor OFFSITE remote-as 64512
+  ! Source the session from the LAN router-id, not the WAN/tunnel egress IP,
+  ! so packets traverse the SD-WAN and offsite recognizes us as neighbor 10.3.0.1
+  neighbor OFFSITE update-source 10.3.0.1
   neighbor 10.89.0.1 peer-group OFFSITE
 
   ! Apply Policies

--- a/terraform/unifi/bgp-offsite.conf
+++ b/terraform/unifi/bgp-offsite.conf
@@ -21,6 +21,9 @@ router bgp 64512
   ! Site-to-site BGP peer (folly udm-pro, iBGP ASN 64512)
   neighbor FOLLY peer-group
   neighbor FOLLY remote-as 64512
+  ! Source the session from the LAN router-id, not the WAN/tunnel egress IP,
+  ! so packets traverse the SD-WAN and folly recognizes us as neighbor 10.89.0.1
+  neighbor FOLLY update-source 10.89.0.1
   neighbor 10.3.0.1 peer-group FOLLY
 
   ! Apply Policies

--- a/terraform/unifi/bgp.tf
+++ b/terraform/unifi/bgp.tf
@@ -14,6 +14,10 @@
 # unifi_bgp is a per-site singleton (v2/api/site/<site>/bgp/config) where the
 # provider's Create and Update are the same POST upsert, so the first apply
 # adopts the already-running config in place — it does not destroy/recreate.
+#
+# NOTE: the bgp-*.conf files are pulled in via file() below. Atlantis only
+# autoplans on its autoplan-file-list (ATLANTIS_AUTOPLAN_FILE_LIST in the
+# atlantis HelmRelease), which includes **/*.conf so .conf-only edits plan too.
 resource "unifi_bgp" "folly" {
   enabled     = true
   description = "Homelab BGP (Cilium <-> folly udm-pro)"


### PR DESCRIPTION
Follow-up to #898. Both gateways were stuck in **Active** (never reaching
Established) on the new site-to-site neighbor.

## Cause

The cluster→gateway peers establish fine because they're directly attached
on the LAN. The site-to-site peer is multi-hop across the SD-WAN tunnel, and
FRR sources a BGP session from the *egress* interface IP — for a multi-hop
peer that's the WAN/tunnel IP, **not** the LAN router-id. So each side
received a SYN from an address it has no `neighbor` statement for and dropped
it; both ends parked in Active.

## Fix

Pin `update-source` to the LAN router-id on both ends:
- folly: `neighbor OFFSITE update-source 10.3.0.1`
- offsite: `neighbor FOLLY update-source 10.89.0.1`

## Prerequisite (not Terraform)

`update-source` only works if the return path exists — the SD-WAN must route
`10.3.0.0/26` <-> `10.89.0.0/28` so the LAN source IPs are reachable across
the tunnel. If `ping 10.89.0.1` / `ping 10.3.0.1` fails from the far gateway,
add those subnets to the SiteManager site-to-site shared networks first, then
`atlantis apply` this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)