### PR TITLE
unifi: extend site-to-site BGP for LB VIPs + pod CIDRs; fix diagram; scope autoplan

### DIFF
--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -26,9 +26,10 @@ spec:
       ATLANTIS_FAIL_ON_PRE_WORKFLOW_HOOK_ERROR: "true"
       ATLANTIS_WRITE_GIT_CREDS: "true"
       ATLANTIS_AUTOPLAN_MODULES: "true"
-      # Default is "**/*.tf*"; also autoplan when sidecar files referenced by
-      # file() change (e.g. terraform/unifi/bgp-*.conf for the unifi_bgp config).
-      ATLANTIS_AUTOPLAN_FILE_LIST: "**/*.tf*,**/*.conf"
+      # Default is "**/*.tf*"; also autoplan when the unifi_bgp sidecar configs
+      # pulled in via file() change. Scoped to terraform/unifi so a stray .conf
+      # elsewhere in the repo doesn't trigger plans.
+      ATLANTIS_AUTOPLAN_FILE_LIST: "**/*.tf*,terraform/unifi/*.conf"
       # ATLANTIS_SILENCE_FORK_PR_ERRORS: "true"
       GOOGLE_APPLICATION_CREDENTIALS: "/run/secrets/terraform.json"
       GOOGLEWORKSPACE_CREDENTIALS: "/run/secrets/terraform.json"

--- a/terraform/unifi/README.md
+++ b/terraform/unifi/README.md
@@ -1,3 +1,46 @@
+# UniFi network
+
+Terraform for the UniFi side of the homelab: networks/VLANs, WLANs, WAN,
+client QoS, DNS, and the gateways' BGP/FRR config (`unifi_bgp`, sourced from
+`bgp-folly.conf` / `bgp-offsite.conf`).
+
+## BGP topology
+
+Each site runs Cilium (ASN 64513) on its k8s nodes, peering **eBGP** with the
+local UniFi gateway (ASN 64512) to announce its pod and LoadBalancer IP pools.
+
+Cross-site there are **two planes over the same Site Magic WireGuard tunnel
+(`wgsts1000`)**:
+
+- **OSPF (Site Magic, distance 110)** auto-carries the node subnets
+  (`10.3.0.0/26` ⇄ `10.89.0.0/28`). This is the *active* path for node-to-node
+  traffic — it beats iBGP on administrative distance.
+- **iBGP between the gateways (distance 200)**, sourced from the LAN router-ids
+  (`update-source`), carries the things OSPF does *not* share: the Cilium
+  LoadBalancer `/32` VIPs (from the `*.64/26` pools) and the pod CIDRs
+  (`10.100.0.0/20` / `10.101.0.0/20`). The node-subnet prefixes are also
+  advertised here but stay inactive behind OSPF; the `/32` VIPs win on
+  longest-prefix match, so cross-site Service access rides BGP.
+
+```mermaid
+flowchart LR
+    subgraph folly["folly site (default)"]
+        direction TB
+        udm["UDM Pro<br/>ASN 64512<br/>router-id 10.3.0.1"]
+        fnodes["Cilium nodes (ASN 64513)<br/>10.3.0.10 / .11 / .12<br/>pods 10.100.0.0/20<br/>LB VIPs 10.3.0.64/26"]
+        fnodes -->|eBGP| udm
+    end
+
+    subgraph offsite["offsite site"]
+        direction TB
+        ucg["UCG Max<br/>ASN 64512<br/>router-id 10.89.0.1"]
+        onodes["Cilium nodes (ASN 64513)<br/>10.89.0.10 / .11<br/>pods 10.101.0.0/20<br/>LB VIPs 10.89.0.64/26"]
+        onodes -->|eBGP| ucg
+    end
+
+    udm <-->|"Site Magic WireGuard tunnel (wgsts1000)<br/>— OSPF (d110): node subnets /26 ⇄ /28 (active)<br/>— iBGP (d200): LB VIP /32s + pod CIDRs"| ucg
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/terraform/unifi/bgp-folly.conf
+++ b/terraform/unifi/bgp-folly.conf
@@ -64,15 +64,24 @@ route-map RM-HOMELAB-OUT permit 10
   match ip address prefix-list HOMELAB-OUT
 exit
 
-! Accept offsite k8s node subnet from offsite ucg-max
+! Accept offsite node subnet + LB VIP pool + pod CIDR from offsite ucg-max.
+! The node subnet (/28) also arrives via OSPF/Site Magic and loses the RIB
+! tie-break (OSPF distance 110 < iBGP 200); the LB VIP /32s and pod /24s are
+! BGP-only and install (the /32s win on longest-prefix match regardless).
 ip prefix-list OFFSITE-IN seq 10 permit 10.89.0.0/28 le 32
+ip prefix-list OFFSITE-IN seq 20 permit 10.89.0.64/26 le 32
+ip prefix-list OFFSITE-IN seq 30 permit 10.101.0.0/20 le 32
 
 route-map RM-OFFSITE-IN permit 10
   match ip address prefix-list OFFSITE-IN
 exit
 
-! Advertise folly k8s node subnet to offsite ucg-max
+! Advertise folly node subnet + LB VIP pool + pod CIDR to offsite ucg-max.
+! The /32 VIPs and pod /24s are learned from folly nodes via eBGP; re-advertised
+! here so offsite can reach folly Services/pods across the SD-WAN tunnel.
 ip prefix-list OFFSITE-OUT seq 10 permit 10.3.0.0/26 le 32
+ip prefix-list OFFSITE-OUT seq 20 permit 10.3.0.64/26 le 32
+ip prefix-list OFFSITE-OUT seq 30 permit 10.100.0.0/20 le 32
 
 route-map RM-OFFSITE-OUT permit 10
   match ip address prefix-list OFFSITE-OUT

--- a/terraform/unifi/bgp-offsite.conf
+++ b/terraform/unifi/bgp-offsite.conf
@@ -61,15 +61,24 @@ route-map RM-HOMELAB-OUT permit 10
   match ip address prefix-list HOMELAB-OUT
 exit
 
-! Accept folly k8s node subnet from folly udm-pro
+! Accept folly node subnet + LB VIP pool + pod CIDR from folly udm-pro.
+! The node subnet (/26) also arrives via OSPF/Site Magic and loses the RIB
+! tie-break (OSPF distance 110 < iBGP 200); the LB VIP /32s and pod /24s are
+! BGP-only and install (the /32s win on longest-prefix match regardless).
 ip prefix-list FOLLY-IN seq 10 permit 10.3.0.0/26 le 32
+ip prefix-list FOLLY-IN seq 20 permit 10.3.0.64/26 le 32
+ip prefix-list FOLLY-IN seq 30 permit 10.100.0.0/20 le 32
 
 route-map RM-FOLLY-IN permit 10
   match ip address prefix-list FOLLY-IN
 exit
 
-! Advertise offsite k8s node subnet to folly udm-pro
+! Advertise offsite node subnet + LB VIP pool + pod CIDR to folly udm-pro.
+! The /32 VIPs and pod /24s are learned from offsite nodes via eBGP; re-advertised
+! here so folly can reach offsite Services/pods across the SD-WAN tunnel.
 ip prefix-list FOLLY-OUT seq 10 permit 10.89.0.0/28 le 32
+ip prefix-list FOLLY-OUT seq 20 permit 10.89.0.64/26 le 32
+ip prefix-list FOLLY-OUT seq 30 permit 10.101.0.0/20 le 32
 
 route-map RM-FOLLY-OUT permit 10
   match ip address prefix-list FOLLY-OUT

--- a/terraform/unifi/bgp.tf
+++ b/terraform/unifi/bgp.tf
@@ -17,7 +17,8 @@
 #
 # NOTE: the bgp-*.conf files are pulled in via file() below. Atlantis only
 # autoplans on its autoplan-file-list (ATLANTIS_AUTOPLAN_FILE_LIST in the
-# atlantis HelmRelease), which includes **/*.conf so .conf-only edits plan too.
+# atlantis HelmRelease), which includes terraform/unifi/*.conf so .conf-only
+# edits plan too.
 resource "unifi_bgp" "folly" {
   enabled     = true
   description = "Homelab BGP (Cilium <-> folly udm-pro)"


### PR DESCRIPTION
Follow-up to #898 / #900, after debugging why cross-site routes weren't
installing.

## What we found

The gateway-to-gateway iBGP came up fine, but its routes were **inactive** —
there's a pre-existing **Site Magic WireGuard tunnel (`wgsts1000`) running
OSPF**, which already carries the node subnets (`10.3.0.0/26` ⇄
`10.89.0.0/28`) and beats iBGP on administrative distance (110 < 200). So
node-to-node already works (ping confirmed); the iBGP was redundant/inert.

```
# show ip route 10.89.0.0/28  (folly)
  Known via "bgp",  distance 200 ...  10.89.0.1 inactive
  Known via "ospf", distance 110 ...  * 192.168.0.0, wgsts1000   <- wins
```

## What this PR does

**Repurpose the iBGP to carry what OSPF does *not* share** — the Cilium
LoadBalancer `/32` VIPs (from the `*.64/26` pools) and the pod CIDRs
(`10.100.0.0/20` / `10.101.0.0/20`):

- folly `OFFSITE-IN/OUT` and offsite `FOLLY-IN/OUT` prefix-lists extended with
  the LB pool + pod CIDR (`le 32`). These are BGP-only, so they install
  cleanly; the `/32` VIPs win on longest-prefix match regardless of distance.
  Net effect: cross-site Service and pod reachability.
- Node-subnet prefixes stay in the lists but remain inactive behind OSPF
  (harmless backup intent).

**Redraw the README diagram** to show the real dual-plane topology (OSPF for
node subnets, iBGP for VIPs/pods) over the shared WireGuard tunnel — placed
above the `BEGIN_TF_DOCS` markers so terraform-docs preserves it.

**Scope the autoplan file list** from `**/*.conf` to `terraform/unifi/*.conf`
so only the `unifi_bgp` sidecar configs trigger a plan (effective once Flux
reconciles it post-merge).

## Verify after apply

```bash
# offsite: should now show folly VIPs/pods as active BGP routes
vtysh -c "show ip route 10.3.0.64/26"
vtysh -c "show ip route 10.100.0.0/20"
# and reach a folly Service VIP from offsite
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)