### PR TITLE
feat(unifi): import firewall policies

### DIFF
--- a/terraform/unifi/firewall.tf
+++ b/terraform/unifi/firewall.tf
@@ -1,0 +1,386 @@
+data "unifi_firewall_zone" "internal" {
+  name = "Internal"
+}
+
+data "unifi_firewall_zone" "external" {
+  name = "External"
+}
+
+data "unifi_firewall_zone" "hotspot" {
+  name = "Hotspot"
+}
+
+data "unifi_firewall_zone" "vpn" {
+  name = "Vpn"
+}
+
+data "unifi_network" "nest" {
+  name = "nest.pulsifer.ca"
+}
+
+resource "unifi_firewall_zone" "lab" {
+  name = "Lab"
+
+  network_ids = [
+    unifi_network.lab.id,
+    unifi_network.k8s.id,
+  ]
+}
+
+resource "unifi_firewall_group" "teleport_cidr" {
+  name    = "Teleport CIDR"
+  type    = "address-group"
+  members = ["192.168.2.0/24"]
+}
+
+resource "unifi_firewall_policy" "allow_established_related_internal" {
+  name                 = "Allow Established/Related Internal"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10000
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+}
+
+resource "unifi_firewall_policy" "allow_established_related_hotspot" {
+  name                 = "Allow Established/Related Hotspot"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10000
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.hotspot.id
+  }
+}
+
+resource "unifi_firewall_policy" "allow_established_related_external" {
+  name                 = "Allow Established/Related External"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10000
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.external.id
+  }
+}
+
+resource "unifi_firewall_policy" "allow_established_related_vpn" {
+  name                 = "Allow Established/Related VPN"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10000
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.vpn.id
+  }
+}
+
+resource "unifi_firewall_policy" "drop_invalid_internal" {
+  name                 = "Drop Invalid Internal"
+  action               = "BLOCK"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10001
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+}
+
+resource "unifi_firewall_policy" "drop_invalid_hotspot" {
+  name                 = "Drop Invalid Hotspot"
+  action               = "BLOCK"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10001
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.hotspot.id
+  }
+}
+
+resource "unifi_firewall_policy" "drop_invalid_external" {
+  name                 = "Drop Invalid External"
+  action               = "BLOCK"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10001
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.external.id
+  }
+}
+
+resource "unifi_firewall_policy" "drop_invalid_vpn" {
+  name                 = "Drop Invalid VPN"
+  action               = "BLOCK"
+  protocol             = "all"
+  ip_version           = "IPV4"
+  index                = 10001
+  create_allow_respond = false
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.vpn.id
+  }
+}
+
+resource "unifi_firewall_policy" "internal_to_lab" {
+  name                 = "Allow Internal to Lab"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "BOTH"
+  index                = 10000
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+}
+
+resource "unifi_firewall_policy" "lab_to_lab" {
+  name                 = "Allow Lab to Lab"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "BOTH"
+  index                = 10000
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+}
+
+resource "unifi_firewall_policy" "prometheus_windows_exporters" {
+  name                 = "Allow Prometheus Windows Exporters"
+  action               = "ALLOW"
+  protocol             = "tcp"
+  ip_version           = "BOTH"
+  index                = 10000
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port               = "9182"
+    port_matching_type = "SPECIFIC"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+}
+
+resource "unifi_firewall_policy" "nest_k8s_to_folly_k8s" {
+  name                 = "Allow Nest k8s to Folly k8s"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "BOTH"
+  index                = 10000
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "NETWORK"
+    network_ids        = [data.unifi_network.nest.id]
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.vpn.id
+  }
+
+  destination = {
+    matching_target    = "NETWORK"
+    network_ids        = [unifi_network.k8s.id]
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+}
+
+resource "unifi_firewall_policy" "folly_k8s_to_nest_k8s" {
+  name                 = "Allow Folly k8s to Nest k8s"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "BOTH"
+  index                = 10000
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "NETWORK"
+    network_ids        = [unifi_network.k8s.id]
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+
+  destination = {
+    matching_target    = "NETWORK"
+    network_ids        = [data.unifi_network.nest.id]
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.vpn.id
+  }
+}
+
+resource "unifi_firewall_policy" "internal_to_nest_k8s" {
+  name                 = "Allow Internal to Nest k8s"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "BOTH"
+  index                = 10002
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.internal.id
+  }
+
+  destination = {
+    matching_target    = "NETWORK"
+    network_ids        = [data.unifi_network.nest.id]
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.vpn.id
+  }
+}
+
+resource "unifi_firewall_policy" "teleport_cidr_to_lab" {
+  name                 = "Allow Teleport CIDR to Lab"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "BOTH"
+  index                = 10001
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    ip_group_id        = unifi_firewall_group.teleport_cidr.id
+    matching_target    = "IP"
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.vpn.id
+  }
+
+  destination = {
+    matching_target    = "ANY"
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+}

--- a/terraform/unifi/imports.tf
+++ b/terraform/unifi/imports.tf
@@ -7,3 +7,88 @@ import {
   to = unifi_network.iot
   id = "694868ac431ebd3a4f203db3"
 }
+
+import {
+  to = unifi_firewall_zone.lab
+  id = "692b8b73eef6d318e4523136"
+}
+
+import {
+  to = unifi_firewall_group.teleport_cidr
+  id = "6a3f1d492205cf188208afcd"
+}
+
+import {
+  to = unifi_firewall_policy.allow_established_related_internal
+  id = "690f96d7b345851556ac974c"
+}
+
+import {
+  to = unifi_firewall_policy.allow_established_related_hotspot
+  id = "690f96d7b345851556ac974d"
+}
+
+import {
+  to = unifi_firewall_policy.allow_established_related_external
+  id = "690f96d7b345851556ac974e"
+}
+
+import {
+  to = unifi_firewall_policy.allow_established_related_vpn
+  id = "690f96d7b345851556ac974f"
+}
+
+import {
+  to = unifi_firewall_policy.drop_invalid_internal
+  id = "690f96d7b345851556ac9750"
+}
+
+import {
+  to = unifi_firewall_policy.drop_invalid_hotspot
+  id = "690f96d7b345851556ac9751"
+}
+
+import {
+  to = unifi_firewall_policy.drop_invalid_external
+  id = "690f96d7b345851556ac9752"
+}
+
+import {
+  to = unifi_firewall_policy.drop_invalid_vpn
+  id = "690f96d7b345851556ac9753"
+}
+
+import {
+  to = unifi_firewall_policy.internal_to_lab
+  id = "692b8bf1eef6d318e4523161"
+}
+
+import {
+  to = unifi_firewall_policy.lab_to_lab
+  id = "692b8fa4eef6d318e4523271"
+}
+
+import {
+  to = unifi_firewall_policy.prometheus_windows_exporters
+  id = "695ae5bf431ebd3a4f4ee7da"
+}
+
+import {
+  to = unifi_firewall_policy.nest_k8s_to_folly_k8s
+  id = "6a3b19d12205cf1882f7fcfc"
+}
+
+import {
+  to = unifi_firewall_policy.folly_k8s_to_nest_k8s
+  id = "6a3b1a062205cf1882f7fdfc"
+}
+
+import {
+  to = unifi_firewall_policy.internal_to_nest_k8s
+  id = "6a3d2ae32205cf1882014c54"
+}
+
+import {
+  to = unifi_firewall_policy.teleport_cidr_to_lab
+  id = "6a3ff8be2205cf18820b54da"
+}


### PR DESCRIPTION
## Summary
Import the live UniFi zone-based firewall configuration into `terraform/unifi` so Atlantis can adopt the existing controller state. The PR also renames ambiguous live rules like `wat` and `Allow folly to k8s Copy` to clearer policy names during adoption.

## Changes
- Add Terraform-managed firewall zones, groups, and policies for the live UniFi UDM firewall state
- Add import blocks for the Lab zone, Teleport CIDR group, and 15 custom firewall policies
- Keep UniFi-generated/predefined policies unmanaged

## Test Plan
- [x] `terraform fmt -check -recursive terraform/unifi`
- [x] `terraform validate`
- [x] `terraform plan -no-color` (17 to import, 0 to add, 15 to change, 0 to destroy)
- [x] Secret scan on changed Terraform files for password/secret/token/key/credential terms
