### PR TITLE
unifi: prefer iBGP over OSPF for cross-site node subnets

### DIFF
--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -27,9 +27,13 @@ spec:
       ATLANTIS_WRITE_GIT_CREDS: "true"
       ATLANTIS_AUTOPLAN_MODULES: "true"
       # Default is "**/*.tf*"; also autoplan when the unifi_bgp sidecar configs
-      # pulled in via file() change. Scoped to network/unifi so a stray .conf
-      # elsewhere in the repo doesn't trigger plans.
-      ATLANTIS_AUTOPLAN_FILE_LIST: "**/*.tf*,network/unifi/**/*.conf"
+      # pulled in via file() change. Use an unanchored "**/*.conf" glob: the
+      # previous "network/unifi/**/*.conf" globstar failed to match the .conf
+      # files and they never autoplanned. This stays safe because Atlantis only
+      # creates a project for a dir that contains .tf — and the only .conf files
+      # in tf roots are network/unifi/{folly,offsite}; other .conf files live in
+      # non-tf dirs (apps/, dotfiles/) so they never trigger a plan.
+      ATLANTIS_AUTOPLAN_FILE_LIST: "**/*.tf*,**/*.conf"
       # ATLANTIS_SILENCE_FORK_PR_ERRORS: "true"
       GOOGLE_APPLICATION_CREDENTIALS: "/run/secrets/terraform.json"
       GOOGLEWORKSPACE_CREDENTIALS: "/run/secrets/terraform.json"

--- a/network/unifi/folly/README.md
+++ b/network/unifi/folly/README.md
@@ -14,15 +14,17 @@ local UniFi gateway (ASN 64512) to announce its pod and LoadBalancer IP pools.
 Cross-site there are **two planes over the same Site Magic WireGuard tunnel
 (`wgsts1000`)**:
 
-- **OSPF (Site Magic, distance 110)** auto-carries the node subnets
-  (`10.3.0.0/26` ⇄ `10.89.0.0/28`). This is the *active* path for node-to-node
-  traffic — it beats iBGP on administrative distance.
-- **iBGP between the gateways (distance 200)**, sourced from the LAN router-ids
-  (`update-source`), carries the things OSPF does *not* share: the Cilium
-  LoadBalancer `/32` VIPs (from the `*.64/26` pools) and the pod CIDRs
-  (`10.100.0.0/20` / `10.101.0.0/20`). The node-subnet prefixes are also
-  advertised here but stay inactive behind OSPF; the `/32` VIPs win on
-  longest-prefix match, so cross-site Service access rides BGP.
+- **iBGP between the gateways**, sourced from the LAN router-ids
+  (`update-source`), carries everything cross-site: the Cilium LoadBalancer
+  `/32` VIPs (from the `*.64/26` pools), the pod CIDRs (`10.100.0.0/20` /
+  `10.101.0.0/20`), and the node subnets (`10.3.0.0/26` ⇄ `10.89.0.0/28`). The
+  iBGP administrative distance is lowered to **105** (`distance bgp 20 105 105`)
+  so it wins over OSPF for the node subnets. This matters because the iBGP plane
+  forwards **pod-sourced** packets, while the OSPF/Site Magic plane only carries
+  the configured site LAN subnets — so pod → remote-node traffic must ride iBGP.
+- **OSPF (Site Magic, distance 110)** also auto-carries the node subnets
+  (`10.3.0.0/26` ⇄ `10.89.0.0/28`), but now sits **behind** iBGP as an automatic
+  backup for node-sourced traffic if the iBGP session drops.
 
 ```mermaid
 flowchart LR
@@ -40,7 +42,7 @@ flowchart LR
         onodes -->|eBGP| ucg
     end
 
-    udm <-->|"Site Magic WireGuard tunnel (wgsts1000)<br/>— OSPF (d110): node subnets /26 ⇄ /28 (active)<br/>— iBGP (d200): LB VIP /32s + pod CIDRs"| ucg
+    udm <-->|"Site Magic WireGuard tunnel (wgsts1000)<br/>— iBGP (d105, preferred): node subnets /26 ⇄ /28 + LB VIP /32s + pod CIDRs<br/>— OSPF (d110, backup): node subnets /26 ⇄ /28"| ucg
 ```
 
 <!-- BEGIN_TF_DOCS -->

--- a/network/unifi/folly/bgp-folly.conf
+++ b/network/unifi/folly/bgp-folly.conf
@@ -30,6 +30,11 @@ router bgp 64512
   ! Apply Policies
   address-family ipv4 unicast
     redistribute connected
+    ! Prefer iBGP (offsite) over OSPF/Site Magic for cross-site prefixes so the
+    ! offsite node subnet (10.89.0.0/28) rides the same iBGP plane as the LB VIP
+    ! /32s and pod CIDRs — that plane forwards folly pod-sourced traffic, the
+    ! OSPF plane does not. iBGP=105 < OSPF 110 (OSPF stays as node-path backup).
+    distance bgp 20 105 105
     neighbor HOMELAB activate
     neighbor HOMELAB next-hop-self
     neighbor HOMELAB soft-reconfiguration inbound
@@ -65,9 +70,10 @@ route-map RM-HOMELAB-OUT permit 10
 exit
 
 ! Accept offsite node subnet + LB VIP pool + pod CIDR from offsite ucg-max.
-! The node subnet (/28) also arrives via OSPF/Site Magic and loses the RIB
-! tie-break (OSPF distance 110 < iBGP 200); the LB VIP /32s and pod /24s are
-! BGP-only and install (the /32s win on longest-prefix match regardless).
+! The node subnet (/28) also arrives via OSPF/Site Magic, but iBGP now wins the
+! RIB tie-break (distance 105 < OSPF 110, see `distance bgp` above) so it rides
+! the pod-capable iBGP plane; OSPF stays as a backup for node-sourced traffic.
+! The LB VIP /32s and pod /24s are BGP-only and install regardless.
 ip prefix-list OFFSITE-IN seq 10 permit 10.89.0.0/28 le 32
 ip prefix-list OFFSITE-IN seq 20 permit 10.89.0.64/26 le 32
 ip prefix-list OFFSITE-IN seq 30 permit 10.101.0.0/20 le 32

--- a/network/unifi/folly/bgp.tf
+++ b/network/unifi/folly/bgp.tf
@@ -17,8 +17,9 @@
 #
 # NOTE: the bgp-*.conf files are pulled in via file() below. Atlantis only
 # autoplans on its autoplan-file-list (ATLANTIS_AUTOPLAN_FILE_LIST in the
-# atlantis HelmRelease), which includes network/unifi/**/*.conf so .conf-only
-# edits in this root and network/unifi/offsite plan too.
+# atlantis HelmRelease), which includes "**/*.conf" so .conf-only edits in this
+# root and network/unifi/offsite plan too. (The earlier anchored
+# "network/unifi/**/*.conf" glob failed to match and never autoplanned.)
 resource "unifi_bgp" "folly" {
   enabled     = true
   description = "Homelab BGP (Cilium <-> folly udm-pro)"

--- a/network/unifi/offsite/bgp.conf
+++ b/network/unifi/offsite/bgp.conf
@@ -29,6 +29,11 @@ router bgp 64512
   ! Apply Policies
   address-family ipv4 unicast
     redistribute connected
+    ! Prefer iBGP (folly) over OSPF/Site Magic for cross-site prefixes so the
+    ! folly node subnet (10.3.0.0/26) rides the same iBGP plane as the LB VIP
+    ! /32s and pod CIDRs — that plane forwards offsite pod-sourced traffic, the
+    ! OSPF plane does not. iBGP=105 < OSPF 110 (OSPF stays as node-path backup).
+    distance bgp 20 105 105
     neighbor HOMELAB activate
     neighbor HOMELAB next-hop-self
     neighbor HOMELAB soft-reconfiguration inbound
@@ -62,9 +67,10 @@ route-map RM-HOMELAB-OUT permit 10
 exit
 
 ! Accept folly node subnet + LB VIP pool + pod CIDR from folly udm-pro.
-! The node subnet (/26) also arrives via OSPF/Site Magic and loses the RIB
-! tie-break (OSPF distance 110 < iBGP 200); the LB VIP /32s and pod /24s are
-! BGP-only and install (the /32s win on longest-prefix match regardless).
+! The node subnet (/26) also arrives via OSPF/Site Magic, but iBGP now wins the
+! RIB tie-break (distance 105 < OSPF 110, see `distance bgp` above) so it rides
+! the pod-capable iBGP plane; OSPF stays as a backup for node-sourced traffic.
+! The LB VIP /32s and pod /24s are BGP-only and install regardless.
 ip prefix-list FOLLY-IN seq 10 permit 10.3.0.0/26 le 32
 ip prefix-list FOLLY-IN seq 20 permit 10.3.0.64/26 le 32
 ip prefix-list FOLLY-IN seq 30 permit 10.100.0.0/20 le 32

--- a/network/unifi/offsite/bgp.tf
+++ b/network/unifi/offsite/bgp.tf
@@ -1,3 +1,5 @@
+# bgp.conf is pulled in via file() below. Atlantis autoplans .conf-only edits
+# via ATLANTIS_AUTOPLAN_FILE_LIST ("**/*.conf") in the atlantis HelmRelease.
 resource "unifi_bgp" "offsite" {
   enabled     = true
   description = "Homelab BGP (Cilium <-> offsite ucg-max)"


### PR DESCRIPTION
Folly pods (10.100.0.0/20) could reach offsite LB VIPs (10.89.0.64/26)
but not the offsite node/gateway subnet (10.89.0.0/28). The node subnet
arrives via both OSPF (distance 110) and iBGP (distance 200), and OSPF
won the RIB tie-break. The OSPF/Site Magic plane only forwards the
configured site LAN subnets, so it dropped pod-sourced packets; the iBGP
plane forwards them (proven by LB VIPs, which are iBGP-only, working).

Lower the iBGP administrative distance to 105 (distance bgp 20 105 105)
on both gateways so the node subnets ride the pod-capable iBGP plane.
OSPF (110) remains as an automatic backup for node-sourced traffic.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LqnVujNS2MBYtSZKkvWAQe