### PR TITLE
Add SessionStart hook to bootstrap toolchain for Claude Code on the web

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# SessionStart hook for Claude Code on the web.
+#
+# Bootstraps the curated validation toolchain (via mise) so linters, terraform
+# validate, and tests work out of the box in a freshly-cloned web container.
+# Web-only, synchronous, idempotent — safe to re-run.
+set -euo pipefail
+
+# Only run in the remote (Claude Code on the web) environment.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+export MISE_YES=1
+
+# 1. Install mise if it isn't already on PATH.
+if ! command -v mise >/dev/null 2>&1; then
+  export PATH="$HOME/.local/bin:$PATH"
+  if ! command -v mise >/dev/null 2>&1; then
+    echo "==> installing mise"
+    curl -fsSL https://mise.run | sh
+  fi
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# 2. Install the curated set of validation tools. These are pinned unversioned
+#    in mise.toml, so 'latest' matches the repo defaults. (go/bun/node already
+#    ship in the container; nix and the heavier CLIs are intentionally skipped.)
+echo "==> installing curated tools via mise"
+mise install \
+  terraform \
+  terraform-docs \
+  shellcheck \
+  shfmt \
+  kustomize \
+  helm
+
+# 3. Install the 1Password CLI (op) straight from 1Password's CDN.
+#    mise's op backends don't work in the scoped web env (the vfox plugin needs
+#    an out-of-scope GitHub clone; aqua can't resolve versions for it), so we
+#    pull the official zip instead. Skipped if op is already present.
+if ! command -v op >/dev/null 2>&1; then
+  echo "==> installing 1Password CLI (op)"
+  case "$(uname -m)" in
+    x86_64 | amd64) op_arch=amd64 ;;
+    aarch64 | arm64) op_arch=arm64 ;;
+    *) op_arch="" ;;
+  esac
+  if [ -n "$op_arch" ]; then
+    op_ver="$(curl -fsS -m 20 'https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N' \
+      | tr ',' '\n' | sed -n 's/.*"version":"\([0-9.]*\)".*/\1/p')"
+    if [ -n "$op_ver" ]; then
+      op_tmp="$(mktemp -d)"
+      if curl -fsSL -m 60 -o "$op_tmp/op.zip" \
+        "https://cache.agilebits.com/dist/1P/op2/pkg/v${op_ver}/op_linux_${op_arch}_v${op_ver}.zip" \
+        && (cd "$op_tmp" && unzip -oq op.zip op); then
+        install -m 0755 "$op_tmp/op" "$HOME/.local/bin/op"
+      else
+        echo "WARN: 1Password CLI download failed; skipping op" >&2
+      fi
+      rm -rf "$op_tmp"
+    else
+      echo "WARN: could not resolve latest op version; skipping op" >&2
+    fi
+  fi
+fi
+
+# 4. Persist PATH + mise settings into the session.
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  {
+    # shellcheck disable=SC2016  # written literally so it expands in the session shell, not here
+    echo 'export PATH="$HOME/.local/bin:$HOME/.local/share/mise/shims:$PATH"'
+    echo 'export MISE_YES=1'
+    # Don't let `mise run <task>` auto-install the full mise.toml toolchain
+    # (gcloud, k9s, the out-of-scope 1password vfox plugin, …). Tasks use the
+    # curated tools installed above; anything else is installed on demand.
+    echo 'export MISE_TASK_RUN_AUTO_INSTALL=0'
+  } >>"$CLAUDE_ENV_FILE"
+fi
+
+echo "==> session-start hook complete"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,12 @@ out/
 *.tgz
 
 # ─── Agent / AI Tooling ──────────────────────────────────────────────────────
-.claude/
+# Ignore local/personal Claude config, but track the shared session-start hook
+# + settings so Claude Code on the web bootstraps the toolchain.
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
+.claude/settings.local.json
 .agents/
 
 # ─── Node / Bun ──────────────────────────────────────────────────────────────

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,34 @@ nix develop
 # Provides: nixos-rebuild and the full Nix development shell
 ```
 
+### Claude Code on the web
+
+[Claude Code on the web](https://code.claude.com/docs/en/claude-code-on-the-web) runs in a
+freshly-cloned, ephemeral container that ships only `bun`, `go`, and `node`/`npm`. A
+**SessionStart hook** (`.claude/hooks/session-start.sh`, registered in `.claude/settings.json`)
+bootstraps the validation toolchain on session start so linters, `terraform validate`, and tests
+work out of the box. It runs **only** in the web env, **synchronously**, and is idempotent.
+
+It installs `mise` plus a curated set of validation tools — `terraform`, `terraform-docs`,
+`shellcheck`, `shfmt`, `kustomize`, `helm` — and the 1Password CLI (`op`) straight from
+1Password's CDN (mise's `op` backends need an out-of-scope GitHub clone that the web env's
+network policy blocks). The heavier CLIs (`gcloud`, `k9s`, `cilium-cli`, …) and Nix are
+intentionally skipped; run the full `mise install` on demand if you need them.
+
+Environment variables relevant to web sessions:
+
+- `CLAUDE_CODE_REMOTE` — set to `true` by the harness in the web env; the hook keys off it to stay web-only.
+- `CLAUDE_ENV_FILE` — file the hook appends to in order to persist vars into the session (`PATH`, the two below).
+- `CLAUDE_PROJECT_DIR` — repo root, used for the hook path in `.claude/settings.json`.
+- `MISE_YES=1` — non-interactive `mise`.
+- `MISE_TASK_RUN_AUTO_INSTALL=0` — stops `mise run <task>` from auto-installing the *entire*
+  `mise.toml` toolchain (which would fail on the out-of-scope `op` plugin); tasks use the curated tools instead.
+- `OP_SERVICE_ACCOUNT_TOKEN` (optional) — if set, `op` can fetch creds non-interactively; otherwise `op` is present but unauthenticated.
+
+Cluster/state secrets are intentionally **not** provisioned in web sessions: Terraform applies go
+through Atlantis on the PR and `kubectl` is inspection-only with no cluster creds, so validation is
+limited to `init -backend=false && validate`, lint, build, and unit tests.
+
 ## How Changes Ship (GitOps + Atlantis)
 
 This repo is GitOps-first: author desired state in git and let the operators apply it. Do not mutate live infra directly.


### PR DESCRIPTION
Fresh web containers ship only bun/go/node, so terraform, shellcheck,
shfmt, kustomize, helm and the 1Password CLI are missing and validation
can't run. Add a web-only, synchronous, idempotent SessionStart hook that
installs mise + a curated validation toolset and pulls op directly from
1Password's CDN (mise's op backends require an out-of-scope GitHub clone
the web network policy blocks). Persist PATH and disable mise task
auto-install so `mise run` uses the curated tools instead of pulling the
full mise.toml toolchain.

Un-ignore .claude/settings.json and .claude/hooks/ so the hook ships, and
document the relevant env vars in AGENTS.md.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017uwHn5ed44tDwvYMb4wWFr