### PR TITLE
unifi/folly: allow k8s pod CIDRs + LB VIPs across Site Magic

### DIFF
--- a/network/unifi/folly/firewall.tf
+++ b/network/unifi/folly/firewall.tf
@@ -33,29 +33,23 @@ resource "unifi_firewall_group" "teleport_cidr" {
   members = ["192.168.2.0/24"]
 }
 
-# Cross-site (Site Magic) k8s reachability address-groups.
+# Cross-site (Site Magic) k8s reachability CIDRs.
 #
 # The Site Magic firewall must allow the *full* Kubernetes address space across
 # the tunnel, not just the node subnets. The cross-site allow policies below
 # originally matched on the k8s/nest NETWORKs (node subnets 10.3.0.0/26 and
 # 10.89.0.0/28 only), so node<->node traffic worked but pod-sourced packets
 # (10.100.0.0/20) were dropped at the gateway on the Lab->Vpn forward — pods
-# could not reach the offsite nodes/VIPs and vice-versa. Match on these
-# address-groups instead so the pod CIDRs and Cilium LB VIP pools are permitted.
-resource "unifi_firewall_group" "folly_k8s_cidrs" {
-  name = "Folly k8s CIDRs"
-  type = "address-group"
-  members = [
+# could not reach the offsite nodes/VIPs and vice-versa. Match these CIDR lists
+# inline (matching_target = "IP") so the pod CIDRs and Cilium LB VIP pools are
+# permitted too.
+locals {
+  folly_k8s_cidrs = [
     "10.3.0.0/26",   # nodes (Kubernetes network, VLAN 8)
     "10.3.0.64/26",  # Cilium LB VIP pool
     "10.100.0.0/20", # pod CIDR
   ]
-}
-
-resource "unifi_firewall_group" "nest_k8s_cidrs" {
-  name = "Nest k8s CIDRs"
-  type = "address-group"
-  members = [
+  nest_k8s_cidrs = [
     "10.89.0.0/28",  # offsite nodes
     "10.89.0.64/26", # offsite Cilium LB VIP pool
     "10.101.0.0/20", # offsite pod CIDR
@@ -328,14 +322,14 @@ resource "unifi_firewall_policy" "nest_k8s_to_folly_k8s" {
 
   source = {
     matching_target    = "IP"
-    ip_group_id        = unifi_firewall_group.nest_k8s_cidrs.id
+    ips                = local.nest_k8s_cidrs
     port_matching_type = "ANY"
     zone_id            = data.unifi_firewall_zone.vpn.id
   }
 
   destination = {
     matching_target    = "IP"
-    ip_group_id        = unifi_firewall_group.folly_k8s_cidrs.id
+    ips                = local.folly_k8s_cidrs
     port_matching_type = "ANY"
     zone_id            = unifi_firewall_zone.lab.id
   }
@@ -353,14 +347,14 @@ resource "unifi_firewall_policy" "folly_k8s_to_nest_k8s" {
 
   source = {
     matching_target    = "IP"
-    ip_group_id        = unifi_firewall_group.folly_k8s_cidrs.id
+    ips                = local.folly_k8s_cidrs
     port_matching_type = "ANY"
     zone_id            = unifi_firewall_zone.lab.id
   }
 
   destination = {
     matching_target    = "IP"
-    ip_group_id        = unifi_firewall_group.nest_k8s_cidrs.id
+    ips                = local.nest_k8s_cidrs
     port_matching_type = "ANY"
     zone_id            = data.unifi_firewall_zone.vpn.id
   }

--- a/network/unifi/folly/firewall.tf
+++ b/network/unifi/folly/firewall.tf
@@ -33,6 +33,35 @@ resource "unifi_firewall_group" "teleport_cidr" {
   members = ["192.168.2.0/24"]
 }
 
+# Cross-site (Site Magic) k8s reachability address-groups.
+#
+# The Site Magic firewall must allow the *full* Kubernetes address space across
+# the tunnel, not just the node subnets. The cross-site allow policies below
+# originally matched on the k8s/nest NETWORKs (node subnets 10.3.0.0/26 and
+# 10.89.0.0/28 only), so node<->node traffic worked but pod-sourced packets
+# (10.100.0.0/20) were dropped at the gateway on the Lab->Vpn forward — pods
+# could not reach the offsite nodes/VIPs and vice-versa. Match on these
+# address-groups instead so the pod CIDRs and Cilium LB VIP pools are permitted.
+resource "unifi_firewall_group" "folly_k8s_cidrs" {
+  name = "Folly k8s CIDRs"
+  type = "address-group"
+  members = [
+    "10.3.0.0/26",   # nodes (Kubernetes network, VLAN 8)
+    "10.3.0.64/26",  # Cilium LB VIP pool
+    "10.100.0.0/20", # pod CIDR
+  ]
+}
+
+resource "unifi_firewall_group" "nest_k8s_cidrs" {
+  name = "Nest k8s CIDRs"
+  type = "address-group"
+  members = [
+    "10.89.0.0/28",  # offsite nodes
+    "10.89.0.64/26", # offsite Cilium LB VIP pool
+    "10.101.0.0/20", # offsite pod CIDR
+  ]
+}
+
 resource "unifi_firewall_policy" "allow_established_related_internal" {
   name                 = "Allow Established/Related Internal"
   action               = "ALLOW"
@@ -298,15 +327,15 @@ resource "unifi_firewall_policy" "nest_k8s_to_folly_k8s" {
   logging              = false
 
   source = {
-    matching_target    = "NETWORK"
-    network_ids        = [data.unifi_network.nest.id]
+    matching_target    = "IP"
+    ip_group_id        = unifi_firewall_group.nest_k8s_cidrs.id
     port_matching_type = "ANY"
     zone_id            = data.unifi_firewall_zone.vpn.id
   }
 
   destination = {
-    matching_target    = "NETWORK"
-    network_ids        = [unifi_network.k8s.id]
+    matching_target    = "IP"
+    ip_group_id        = unifi_firewall_group.folly_k8s_cidrs.id
     port_matching_type = "ANY"
     zone_id            = unifi_firewall_zone.lab.id
   }
@@ -323,15 +352,15 @@ resource "unifi_firewall_policy" "folly_k8s_to_nest_k8s" {
   logging              = false
 
   source = {
-    matching_target    = "NETWORK"
-    network_ids        = [unifi_network.k8s.id]
+    matching_target    = "IP"
+    ip_group_id        = unifi_firewall_group.folly_k8s_cidrs.id
     port_matching_type = "ANY"
     zone_id            = unifi_firewall_zone.lab.id
   }
 
   destination = {
-    matching_target    = "NETWORK"
-    network_ids        = [data.unifi_network.nest.id]
+    matching_target    = "IP"
+    ip_group_id        = unifi_firewall_group.nest_k8s_cidrs.id
     port_matching_type = "ANY"
     zone_id            = data.unifi_firewall_zone.vpn.id
   }


### PR DESCRIPTION
## Root cause

\"Folly k8s pods can't reach the offsite nodes/gateway (`10.89.0.0/28`)\" is a **UniFi zone-firewall** drop on the folly UDM, **not** a routing/BGP problem.

The cross-site Site Magic allow policies (`folly_k8s_to_nest_k8s`, `nest_k8s_to_folly_k8s`) matched `matching_target = "NETWORK"` on the node subnets only:
- folly `unifi_network.k8s` = `10.3.0.0/26`
- offsite `data.unifi_network.nest` = `10.89.0.0/28`

The **pod CIDRs** (`10.100.0.0/20`, `10.101.0.0/20`) and **Cilium LB VIP pools** (`10.3.0.64/26`, `10.89.0.64/26`) were in no rule, so pod-sourced packets fell through to the zone default drop on the `Lab -> Vpn` forward.

### Evidence (live captures on the folly UDM `10.3.0.1`)

| Flow | Result |
|---|---|
| retrofit `10.89.0.10` → folly node `10.3.0.12` | works |
| retrofit → live folly pod `10.100.1.27` | request reaches pod, **pod's reply dropped at the UDM** (`br8 In`, never `wgsts1000 Out`) |
| Walter pod `10.100.1.252` → offsite `10.89.0.10:6443` | SYN arrives `br8 In`, **never egresses `wgsts1000`** |

`rp_filter` passes (route back to the pod is via `br8`), confirming a firewall drop rather than RPF/routing.

### Why the prior `distance bgp` change couldn't help

There is a single inter-site data plane — the Site Magic WireGuard tunnel `wgsts1000` (allowed-ips `0.0.0.0/0`). Both the iBGP next-hop (`10.89.0.1`) and the OSPF next-hop resolve recursively *through* that same tunnel, so preferring "the iBGP plane" changed nothing. Both UDM route tables are otherwise correct.

## Change

Add `folly_k8s_cidrs` / `nest_k8s_cidrs` address-groups (node subnet + LB VIP pool + pod CIDR per side) and switch the two cross-site policies to match those groups. Same zones (pod traffic still ingresses the UDM on the Lab-zoned `br8`); only the L3 match is widened.

## Verification after `atlantis apply`

- Walter / a folly pod → `10.89.0.10`, `10.89.0.11`, `10.89.0.1`, and an offsite LB VIP all reachable.
- retrofit → a live folly pod IP reachable.
- node↔node still works (no regression).

## Follow-ups (not in this PR)

- **Offsite UDM** has no `firewall.tf` under `network/unifi/offsite/` — its firewall posture needs confirming for full pod↔pod and offsite-pod→folly. Folly-only should fix the reported folly-pod→offsite-node flow (offsite replies are node-sourced).
- The now-misleading "prefer iBGP plane" comments / `distance bgp` lines in `bgp-folly.conf` / `bgp.conf` can be cleaned up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)