### PR TITLE
unifi: document firewall-gated cross-site reachability; drop BGP distance no-op

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ Network fabric — `network/`:
 
 - `network/unifi/folly/` – primary-site UniFi: VLANs, BGP config, client management (state prefix `terraform/unifi`, kept for continuity)
 - `network/unifi/offsite/` – offsite UniFi: networks, WANs, WLANs, BGP (state prefix `terraform/unifi/offsite`)
+  - **Cross-site k8s reachability** (folly ⇄ offsite over the single Site Magic tunnel) is gated by the **gateway firewall**, not the routing protocol: iBGP between the gateways carries the pod CIDRs + LB VIP pools, but a gateway only forwards them if its firewall allows the **full k8s address space** (pod CIDRs + VIP pools, not just node subnets). folly enforces this in `firewall.tf` (custom `Lab` zone); offsite uses the permissive default `Internal` zone. See `network/unifi/folly/README.md`.
 - `network/cloudflare/` – DNS zones (pulsifer.ca, wishin.app, lolwtf.ca), Cloudflare Tunnels, security rules
 - `network/tailscale/` – devices, routes, ACL policy
 

--- a/network/unifi/folly/README.md
+++ b/network/unifi/folly/README.md
@@ -11,20 +11,29 @@ The offsite UniFi console is managed separately under `network/unifi/offsite/`.
 Each site runs Cilium (ASN 64513) on its k8s nodes, peering **eBGP** with the
 local UniFi gateway (ASN 64512) to announce its pod and LoadBalancer IP pools.
 
-Cross-site there are **two planes over the same Site Magic WireGuard tunnel
-(`wgsts1000`)**:
+There is a **single inter-site data plane**: the Site Magic WireGuard tunnel
+(`wgsts1000`). Two control-plane protocols run over it, but both next-hops
+resolve *through that same tunnel*, so they are not separate paths:
 
-- **iBGP between the gateways**, sourced from the LAN router-ids
-  (`update-source`), carries everything cross-site: the Cilium LoadBalancer
-  `/32` VIPs (from the `*.64/26` pools), the pod CIDRs (`10.100.0.0/20` /
-  `10.101.0.0/20`), and the node subnets (`10.3.0.0/26` ⇄ `10.89.0.0/28`). The
-  iBGP administrative distance is lowered to **105** (`distance bgp 20 105 105`)
-  so it wins over OSPF for the node subnets. This matters because the iBGP plane
-  forwards **pod-sourced** packets, while the OSPF/Site Magic plane only carries
-  the configured site LAN subnets — so pod → remote-node traffic must ride iBGP.
-- **OSPF (Site Magic, distance 110)** also auto-carries the node subnets
-  (`10.3.0.0/26` ⇄ `10.89.0.0/28`), but now sits **behind** iBGP as an automatic
-  backup for node-sourced traffic if the iBGP session drops.
+- **iBGP between the gateways** (sourced from the LAN router-ids via
+  `update-source`) is the **only** way the Cilium LoadBalancer `/32` VIPs (from
+  the `*.64/26` pools) and the pod CIDRs (`10.100.0.0/20` / `10.101.0.0/20`)
+  cross the sites — OSPF/Site Magic does not carry them.
+- **OSPF (Site Magic)** auto-shares the LAN/node subnets
+  (`10.3.0.0/26` ⇄ `10.89.0.0/28`) and wins the RIB for them; the iBGP copy of
+  the node subnet is an inactive (recursive-next-hop) backup.
+
+Because there is only one tunnel, cross-site **reachability does not depend on
+which protocol wins the RIB** — it depends on the **gateway firewall** allowing
+the full k8s address space across the tunnel. The folly gateway isolates its
+k8s network in a custom **`Lab`** zone (`firewall.tf`), so the cross-site allow
+policies must list the **pod CIDRs and LB VIP pools**, not just the node
+subnets — otherwise pod-sourced packets are dropped on the `Lab → Vpn` forward.
+(That gap was the cause of the "folly pods can't reach offsite nodes" outage;
+node↔node kept working because the node subnets *were* allowed.) The offsite
+console has **no custom firewall policies** — its k8s network sits in the
+default `Internal` zone, whose predefined `Internal ⇄ Vpn` rules already permit
+the traffic.
 
 ```mermaid
 flowchart LR
@@ -42,7 +51,7 @@ flowchart LR
         onodes -->|eBGP| ucg
     end
 
-    udm <-->|"Site Magic WireGuard tunnel (wgsts1000)<br/>— iBGP (d105, preferred): node subnets /26 ⇄ /28 + LB VIP /32s + pod CIDRs<br/>— OSPF (d110, backup): node subnets /26 ⇄ /28"| ucg
+    udm <-->|"Site Magic WireGuard tunnel (wgsts1000) — one data plane<br/>iBGP: LB VIP /32s + pod CIDRs (BGP-only) + node subnets<br/>OSPF: node subnets /26 ⇄ /28 (wins RIB)<br/>cross-site reachability gated by the gateway firewall, not protocol choice"| ucg
 ```
 
 <!-- BEGIN_TF_DOCS -->

--- a/network/unifi/folly/bgp-folly.conf
+++ b/network/unifi/folly/bgp-folly.conf
@@ -30,11 +30,6 @@ router bgp 64512
   ! Apply Policies
   address-family ipv4 unicast
     redistribute connected
-    ! Prefer iBGP (offsite) over OSPF/Site Magic for cross-site prefixes so the
-    ! offsite node subnet (10.89.0.0/28) rides the same iBGP plane as the LB VIP
-    ! /32s and pod CIDRs — that plane forwards folly pod-sourced traffic, the
-    ! OSPF plane does not. iBGP=105 < OSPF 110 (OSPF stays as node-path backup).
-    distance bgp 20 105 105
     neighbor HOMELAB activate
     neighbor HOMELAB next-hop-self
     neighbor HOMELAB soft-reconfiguration inbound
@@ -70,10 +65,15 @@ route-map RM-HOMELAB-OUT permit 10
 exit
 
 ! Accept offsite node subnet + LB VIP pool + pod CIDR from offsite ucg-max.
-! The node subnet (/28) also arrives via OSPF/Site Magic, but iBGP now wins the
-! RIB tie-break (distance 105 < OSPF 110, see `distance bgp` above) so it rides
-! the pod-capable iBGP plane; OSPF stays as a backup for node-sourced traffic.
-! The LB VIP /32s and pod /24s are BGP-only and install regardless.
+! The LB VIP /32s and pod /24s cross the sites ONLY via this iBGP session —
+! OSPF/Site Magic auto-shares just the LAN/node subnets (10.3.0.0/26 ⇄
+! 10.89.0.0/28), so the node /28 is learned via both (OSPF wins the RIB; the
+! iBGP copy is an inactive recursive-next-hop backup). There is a single
+! inter-site data plane (the Site Magic tunnel `wgsts1000`); both the iBGP and
+! OSPF next-hops resolve through it, so reachability does NOT depend on which
+! protocol wins — it depends on the gateway firewall allowing the full k8s
+! address space across the tunnel (see firewall.tf: the cross-site allow
+! policies must include the pod CIDRs + VIP pools, not just the node subnets).
 ip prefix-list OFFSITE-IN seq 10 permit 10.89.0.0/28 le 32
 ip prefix-list OFFSITE-IN seq 20 permit 10.89.0.64/26 le 32
 ip prefix-list OFFSITE-IN seq 30 permit 10.101.0.0/20 le 32

--- a/network/unifi/offsite/README.md
+++ b/network/unifi/offsite/README.md
@@ -7,6 +7,24 @@ State: `gs://homelab-ng/terraform/unifi/offsite`
 This root owns the offsite gateway networks, WANs, WLANs, and BGP/FRR config.
 Applies run through Atlantis on PRs; do not run `terraform apply` locally.
 
+## Cross-site BGP + firewall
+
+The offsite UCG peers **iBGP** (ASN 64512) with the folly UDM (`10.3.0.1`) over
+the Site Magic WireGuard tunnel — see `bgp.conf` and the folly side's
+`network/unifi/folly/README.md` for the full topology. That iBGP session is the
+only thing that carries the LB VIP `/32`s and pod CIDRs between the sites;
+OSPF/Site Magic only auto-shares the LAN/node subnets.
+
+Unlike folly, the offsite console has **no Terraform-managed firewall** and **no
+custom firewall policies** — the Kubernetes network (VLAN 2, `10.89.0.1/28`)
+lives in the default **`Internal`** zone, whose predefined `Internal ⇄ Vpn`
+rules already permit cross-site k8s traffic (pods included). So
+offsite-pod → folly works without extra rules. (Folly needs explicit policies
+only because it isolates its k8s network in a custom `Lab` zone; see
+`network/unifi/folly/firewall.tf`.) If the offsite k8s network is ever moved into
+a custom/isolated zone, mirror folly's cross-site allow policies here — matching
+the **pod CIDRs + VIP pools**, not just the node subnets.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/network/unifi/offsite/bgp.conf
+++ b/network/unifi/offsite/bgp.conf
@@ -29,11 +29,6 @@ router bgp 64512
   ! Apply Policies
   address-family ipv4 unicast
     redistribute connected
-    ! Prefer iBGP (folly) over OSPF/Site Magic for cross-site prefixes so the
-    ! folly node subnet (10.3.0.0/26) rides the same iBGP plane as the LB VIP
-    ! /32s and pod CIDRs — that plane forwards offsite pod-sourced traffic, the
-    ! OSPF plane does not. iBGP=105 < OSPF 110 (OSPF stays as node-path backup).
-    distance bgp 20 105 105
     neighbor HOMELAB activate
     neighbor HOMELAB next-hop-self
     neighbor HOMELAB soft-reconfiguration inbound
@@ -67,10 +62,17 @@ route-map RM-HOMELAB-OUT permit 10
 exit
 
 ! Accept folly node subnet + LB VIP pool + pod CIDR from folly udm-pro.
-! The node subnet (/26) also arrives via OSPF/Site Magic, but iBGP now wins the
-! RIB tie-break (distance 105 < OSPF 110, see `distance bgp` above) so it rides
-! the pod-capable iBGP plane; OSPF stays as a backup for node-sourced traffic.
-! The LB VIP /32s and pod /24s are BGP-only and install regardless.
+! The LB VIP /32s and pod /24s cross the sites ONLY via this iBGP session —
+! OSPF/Site Magic auto-shares just the LAN/node subnets (10.3.0.0/26 ⇄
+! 10.89.0.0/28), so the node /26 is learned via both (OSPF wins the RIB; the
+! iBGP copy is an inactive recursive-next-hop backup). There is a single
+! inter-site data plane (the Site Magic tunnel `wgsts1000`); both the iBGP and
+! OSPF next-hops resolve through it, so reachability does NOT depend on which
+! protocol wins — it depends on the gateway firewall allowing the full k8s
+! address space across the tunnel. NOTE: the offsite console has no custom
+! firewall policies (k8s sits in the default Internal zone, whose predefined
+! Internal⇄Vpn rules already permit this); folly enforces the same via its
+! custom Lab zone in firewall.tf.
 ip prefix-list FOLLY-IN seq 10 permit 10.3.0.0/26 le 32
 ip prefix-list FOLLY-IN seq 20 permit 10.3.0.64/26 le 32
 ip prefix-list FOLLY-IN seq 30 permit 10.100.0.0/20 le 32


### PR DESCRIPTION
Followup to #909 (which fixed folly pods reaching offsite by allowing the pod CIDRs + LB VIP pools across Site Magic in `firewall.tf`).

## What this does

Corrects the docs/comments that framed cross-site k8s reachability as a **routing-plane** property, and removes the `distance bgp 20 105 105` override that encoded that wrong model.

**The real model:** there is a *single* inter-site data plane — the Site Magic WireGuard tunnel `wgsts1000`. Both the iBGP and OSPF next-hops resolve recursively *through that same tunnel*, so reachability is gated by the **gateway firewall**, not by which protocol wins the RIB. iBGP between the gateways is the only thing that carries the pod CIDRs + LB VIP pools cross-site; OSPF/Site Magic only auto-shares the node subnets.

The `distance bgp` override never changed forwarding: pod/VIP prefixes are iBGP-only (install regardless of distance), and the iBGP copy of the node subnet is an inactive recursive-next-hop route that loses to OSPF either way. Verified live on both UDMs.

## Changes (no Terraform resources change)

- **`bgp-folly.conf` / `bgp.conf`**: remove `distance bgp 20 105 105` + the misleading "iBGP plane forwards pod traffic, OSPF plane doesn't" comments; replace with the accurate single-tunnel + firewall-gate explanation.
- **`folly/README.md`**: rewrite the BGP topology section + mermaid — one data plane, the firewall as the gate, and the pod-CIDR allow requirement that caused the "folly pods can't reach offsite nodes" outage.
- **`offsite/README.md`**: document that the offsite console has **no custom firewall policies** (k8s sits in the default `Internal` zone, whose predefined `Internal ⇄ Vpn` rules already permit cross-site pod traffic) — so offsite-pod → folly already works.
- **`AGENTS.md`**: one-line cross-site note pointing at the firewall mechanism.

## Offsite "import"

Inspected the offsite controller: **64 predefined firewall policies, 0 custom**, k8s in the default `Internal` zone. There is nothing to import and no broken rule to fix — adding a restrictive custom zone there would only risk breaking working connectivity, so it's intentionally left as-is (documented in `offsite/README.md`).

## Verification

Confirmed live after #909 applied: folly pod → offsite nodes/gateway/VIPs and offsite pod → folly all reachable; node↔node unaffected. The `distance` removal is forwarding-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)