### PR TITLE
feat(tailscale): restore k8s subnet connectors

### DIFF
--- a/clusters/base/networking/tailscale/helm-release.yaml
+++ b/clusters/base/networking/tailscale/helm-release.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale
+  namespace: tailscale
+spec:
+  interval: 1m0s
+  maxHistory: 2
+  chart:
+    spec:
+      chart: tailscale-operator
+      version: 1.98.4
+      sourceRef:
+        kind: HelmRepository
+        name: tailscale
+        namespace: flux-system
+      interval: 5m0s
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  dependsOn:
+    - name: cilium
+      namespace: kube-system
+  values: {}

--- a/clusters/base/networking/tailscale/kustomization.yaml
+++ b/clusters/base/networking/tailscale/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml

--- a/clusters/base/sources/helm/kustomization.yaml
+++ b/clusters/base/sources/helm/kustomization.yaml
@@ -23,6 +23,7 @@ resources:
   - prometheus.yaml
   - stakater.yaml
   - stefanprodan.yaml
+  - tailscale.yaml
   - vector.yaml
 patches:
   - target:

--- a/clusters/base/sources/helm/tailscale.yaml
+++ b/clusters/base/sources/helm/tailscale.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: tailscale
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://pkgs.tailscale.com/helmcharts

--- a/clusters/folly/networking/kustomization.yaml
+++ b/clusters/folly/networking/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - cilium
   - cloudflare
   - external-dns.yaml
+  - tailscale
 patches:
   - target:
       group: helm.toolkit.fluxcd.io

--- a/clusters/folly/networking/tailscale/connector.yaml
+++ b/clusters/folly/networking/tailscale/connector.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: folly-k8s-lan-router
+spec:
+  replicas: 1
+  hostnamePrefix: folly-k8s-lan-router
+  subnetRouter:
+    advertiseRoutes:
+      - 10.1.0.0/24
+      - 10.2.0.0/24
+      - ${K8S_NODE_CIDR}
+      - ${LB_RANGE}
+  tags:
+    - tag:k8s
+    - tag:folly
+    - tag:k8s-folly

--- a/clusters/folly/networking/tailscale/kustomization.yaml
+++ b/clusters/folly/networking/tailscale/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - ../../../base/networking/tailscale
+  - secret.sops.yaml
+  - connector.yaml

--- a/clusters/folly/networking/tailscale/namespace.yaml
+++ b/clusters/folly/networking/tailscale/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/folly/networking/tailscale/secret.sops.yaml
+++ b/clusters/folly/networking/tailscale/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: operator-oauth
+    namespace: tailscale
+stringData:
+    client_id: ENC[AES256_GCM,data:F8fFFD300xPzqEn9wjavpB4=,iv:azrErvt7o+TL1bSTrfHlRjSny1WNdFUK9908Rky3F7s=,tag:OSp26q/CvKMEB18dyohpSQ==,type:str]
+    client_secret: ENC[AES256_GCM,data:0tP29qaEyXFN64Vi3/H1HgkKHSZizdmPXrL76bYr4gTuD3Eq0RhkjGpUWn+3wPBBk0Y/+qLLl9P0yXrdpgth,iv:rHKmXNiEzTiHy5fM44gi/aOVk8OPDjjbZYocqts5t6o=,tag:iqKp5OOHWBzkJeALJGk+Sw==,type:str]
+sops:
+    age:
+        - recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSArMFNJcjg3VE5EVG1wRDdw
+            cE82Y1NTRkRJU09MczgwTnIrQnJLQkZwdFhRCjhlM09WSGxSOFdxOEFJanM0ckQ5
+            VUhQUTlOdHNxTDZCTytxdTVLa3hLMDAKLS0tIFNNKy84NHZScnRBYnh4RFBpNFR4
+            MDRzdWhXVnNYRWFWN1BuUXJkSjB3NEkKyJ8C3DSoRujFbCDP/8cJDzfrhWJ1zI7y
+            mqKPs4BllLK36GBpQ/oMt1zEZ0DqRqMBn297XBHQyxIl1YDTU0mKIg==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-11-09T22:21:07Z"
+    mac: ENC[AES256_GCM,data:1rP70/PkeM1jwH079zuLSJrO/Xw3G1qyme9hR++lFMOZxbKfa85GScAt/+GUJLM93U8+EoFfooJZhJcz9Tg+EEG/3OXWalDIO9LaHXDjbJjW7TNlFQpktFs2z+GXF5CnTRQW2SEnJJKRfOQSDGigSmUD9MtAIiviFHXDFciFVv8=,iv:rl+BKiaR6jv3nB0q+FLxKl05bs23V6SzIdDiUb85zOI=,tag:tEGQVuZOYE8lPQOHrMBr5g==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/clusters/offsite/networking/kustomization.yaml
+++ b/clusters/offsite/networking/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - cilium
   - cloudflare
   - external-dns.yaml
+  - tailscale
 patches:
   - target:
       group: helm.toolkit.fluxcd.io

--- a/clusters/offsite/networking/tailscale/connector.yaml
+++ b/clusters/offsite/networking/tailscale/connector.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: offsite-k8s-lan-router
+spec:
+  replicas: 1
+  hostnamePrefix: offsite-k8s-lan-router
+  subnetRouter:
+    advertiseRoutes:
+      - 192.168.1.0/24
+      - 10.89.0.0/28
+      - ${LB_RANGE}
+  tags:
+    - tag:k8s
+    - tag:k8s-offsite
+    - tag:offsite

--- a/clusters/offsite/networking/tailscale/kustomization.yaml
+++ b/clusters/offsite/networking/tailscale/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - ../../../base/networking/tailscale
+  - secret.sops.yaml
+  - connector.yaml

--- a/clusters/offsite/networking/tailscale/namespace.yaml
+++ b/clusters/offsite/networking/tailscale/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tailscale
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/offsite/networking/tailscale/secret.sops.yaml
+++ b/clusters/offsite/networking/tailscale/secret.sops.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: operator-oauth
+    namespace: tailscale
+stringData:
+    client_id: ENC[AES256_GCM,data:2/9LGJ8EnixYjEBBB0AVwzQ=,iv:fon1naqzTnrgrohydvMZYNIRt760St4OoA7IuVyPvUI=,tag:4ktp/8ALw7DmLl0WyHaA7A==,type:str]
+    client_secret: ENC[AES256_GCM,data:ne0UYeZ99esKEZmJjC63gF6uvudxmzmOZXqFTIW3hJJmf7MkLOWF4zaQ7cA1BIEypGu7dBIRqlh19N/ms4dx,iv:rndyoUaweCQLATiI3D0e9uWIn033ar1m+2ss1BuJEXM=,tag:JiH4KHuBF5RrymTkSj3WFg==,type:str]
+sops:
+    age:
+        - recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFeXUvV3FuY3NlcUU1bzR2
+            TTRhQ0J1L21HT2xQb2RVSmlmMEdLQkl5OGlFClBiU1dveHpXeCtWcHhaNi9XTnBY
+            anNJZHY3MVUxeVpEOWQ1dWliVm5veVEKLS0tIEFsTVZzeHNkMi9LRTMra3dUZWVF
+            QW16UHNTRGRQbXptZXA2WHB2S3pvVTAKjtZ6Rc9d6lA+khT38xXJi9FVg80iR4+S
+            BNJq8or1fZIy844pbGe8Z73orz2vKTwrzJpY7vcbv5BwwbzSurMT0A==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2025-11-09T22:21:35Z"
+    mac: ENC[AES256_GCM,data:M8ZslN7ZBu1uxv5BYjiRr1NmHQ+oExIPcXaZN1xLK4RhkNXVc0ecI3p+ikk9+zs6peYkupVt+ra8vHkKT8745AkI7H/1Izogdabr/IJd3RaltCLWPA76ljuUifLOZyMVaoIxP+TxPZ0vAKOWl8TxV4KyQe2g84LEVgq/0lIUZyc=,iv:N2kANLOiyB/ogWVMvXVAjw7eq7VH7I4s98jIQn7zDB4=,tag:6buZaVlxE89jTIu8A+cmzQ==,type:str]
+    encrypted_regex: ^(data|stringData)$
+    version: 3.11.0

--- a/network/tailscale/policy.hujson
+++ b/network/tailscale/policy.hujson
@@ -68,7 +68,7 @@
 		},
 		{
 			"src": ["autogroup:owner"],
-			"dst": ["ipset:offsite-bell"],
+			"dst": ["ipset:folly-lan", "ipset:offsite-lan", "ipset:offsite-bell"],
 			"ip":  ["*"],
 		},
 		{
@@ -90,13 +90,19 @@
 
 	"autoApprovers": {
 		"routes": {
+			"10.1.0.0/24":    ["tag:k8s-folly"],
+			"10.2.0.0/24":    ["tag:k8s-folly"],
 			"10.3.0.0/26":    ["tag:k8s-folly"],
 			"10.3.0.64/26":   ["tag:k8s-folly"],
+			"10.89.0.0/28":   ["tag:k8s-offsite"],
+			"10.89.0.64/26":  ["tag:k8s-offsite"],
+			"192.168.1.0/24": ["tag:k8s-offsite"],
 			"192.168.2.0/24": ["tag:k8s-operator"],
 		},
 	},
 
 	"ipsets": {
+		"ipset:folly-lan":                ["add 10.1.0.0/24", "add 10.2.0.0/24"],
 		"ipset:k8s-offsite-nodes-and-lb": ["add ipset:k8s-offsite-nodes", "add ipset:k8s-offsite-lb"],
 		"ipset:k8s-folly-nodes-and-lb":   ["add ipset:k8s-folly-nodes", "add ipset:k8s-folly-lb"],
 		"ipset:offsite-bell":             ["add 192.168.2.0/24"],
@@ -116,6 +122,11 @@
 		{
 			"src":    "jonathan@pulsifer.ca",
 			"accept": ["10.3.0.10:22", "10.3.0.70:443"],
+			"proto":  "tcp",
+		},
+		{
+			"src":    "jonathan@pulsifer.ca",
+			"accept": ["10.1.0.1:443", "10.2.0.20:53", "10.89.0.1:443", "192.168.1.1:443"],
 			"proto":  "tcp",
 		},
 	],


### PR DESCRIPTION
## Summary
Restore the Tailscale Kubernetes operator in both clusters and add constrained per-cluster subnet-router Connectors so VPN clients can reach LAN and service VIP ranges without advertising pod/native routing CIDRs.

## Changes
- feat(tailscale): restore k8s subnet connectors

## Test Plan
- [x] kubectl kustomize clusters/folly/networking
- [x] kubectl kustomize clusters/offsite/networking
- [x] kubectl kustomize clusters/base/sources
- [x] terraform fmt -check (network/tailscale)
- [x] git diff --check
- [ ] terraform validate (blocked locally by provider plugin handshake failure in sandbox)
