### PR TITLE
fix(tailscale): health check operator release only

### DIFF
--- a/clusters/folly/networking/tailscale.yaml
+++ b/clusters/folly/networking/tailscale.yaml
@@ -8,11 +8,15 @@ spec:
   interval: 1h0m0s
   path: ./clusters/folly/networking/tailscale
   prune: true
-  wait: true
-  timeout: 5m0s
   sourceRef:
     kind: GitRepository
     name: infra
+  # CRDs exist only after the operator HelmRelease is ready; connectors need them.
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: tailscale
+      namespace: tailscale
   decryption:
     provider: sops
     secretRef:

--- a/clusters/offsite/networking/tailscale.yaml
+++ b/clusters/offsite/networking/tailscale.yaml
@@ -8,11 +8,15 @@ spec:
   interval: 1h0m0s
   path: ./clusters/offsite/networking/tailscale
   prune: true
-  wait: true
-  timeout: 5m0s
   sourceRef:
     kind: GitRepository
     name: infra
+  # CRDs exist only after the operator HelmRelease is ready; connectors need them.
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: tailscale
+      namespace: tailscale
   decryption:
     provider: sops
     secretRef:


### PR DESCRIPTION
## Summary
Fix the Tailscale Flux Kustomization health wait so it waits only for the operator HelmRelease instead of trying to health-check every applied resource, including the namespace.

## Changes
- Replace wait: true on per-cluster tailscale Kustomizations with explicit HelmRelease healthChecks
- Keep tailscale-connectors dependent on the tailscale Kustomization so Connector CRs wait for operator/CRD readiness

## Test Plan
- [x] kubectl kustomize clusters/folly/networking
- [x] kubectl kustomize clusters/offsite/networking
- [x] kubectl kustomize clusters/folly/networking/tailscale
- [x] kubectl kustomize clusters/offsite/networking/tailscale
- [x] kubectl kustomize clusters/folly/networking/tailscale-connectors
- [x] kubectl kustomize clusters/offsite/networking/tailscale-connectors
- [x] git diff --check

## Context
The previous fix used wait: true, but Flux reported timeout waiting for Namespace/tailscale status NotFound. This follows the existing ARC pattern and health-checks the HelmRelease that owns the CRDs.
