### PR TITLE
fix(tailscale): apply offsite subnet-router autoApprovers (re-trigger ACL)

### DIFF
--- a/network/tailscale/main.tf
+++ b/network/tailscale/main.tf
@@ -2,7 +2,9 @@
 # Tailscale tailnet-wide resources
 # ---------------------------------------------------------------------------
 
-# Touch to trigger Atlantis plan on policy.hujson changes
+# Touch to trigger Atlantis plan on policy.hujson changes.
+# Re-applies the offsite k8s subnet-router autoApprovers that merged in #911
+# without an apply, leaving offsite-k8s-lan-router routes stuck pending.
 resource "tailscale_acl" "this" {
   acl = file("${path.module}/policy.hujson")
 }


### PR DESCRIPTION
## Summary

Offsite is unreachable over Tailscale while folly works. The offsite subnet router (`offsite-k8s-lan-router`) is deployed and registered in the tailnet, but its advertised routes (`192.168.1.0/24`, `10.89.0.0/28`, `10.89.0.64/26`) are stuck **pending** in the admin console, so no offsite traffic flows.

## Root cause

The offsite `autoApprovers` were added to `network/tailscale/policy.hujson` in **#911** (`9668930`) *alongside* the Flux `Connector` manifests. That PR merged ~3.5 minutes after opening with no `atlantis apply`:

- **Flux** applied the `Connector` on merge → the node registers in the tailnet (visible in the console).
- The **`tailscale_acl`** resource (`network/tailscale/main.tf`) only reaches the tailnet via `atlantis apply`, which never ran → the offsite `autoApprovers` were never pushed → routes stay pending.

folly's k8s `autoApprovers` (`10.3.0.0/26`, `10.3.0.64/26`) were applied in an earlier change, which is why folly works and offsite doesn't.

`policy.hujson` is **already correct on `main`** — it just was never applied.

## Changes

- No-op comment touch to `network/tailscale/main.tf` to re-trigger an Atlantis autoplan on the `network/tailscale` module. No resource definition changes.

## How to apply

1. Review the Atlantis plan — it should show `tailscale_acl.this` updating to add the offsite `autoApprovers` (`10.89.0.0/28`, `10.89.0.64/26`, `192.168.1.0/24` → `tag:k8s-offsite`) and the owner-grant `folly-lan`/`offsite-lan` additions.
2. Comment `atlantis apply`.

## Verification

- After apply, `offsite-k8s-lan-router`'s three routes flip to **Approved** (auto-approved by the now-live `autoApprovers`).
- From a tailnet client: `ping 192.168.1.1` (offsite LAN gw), reach `10.89.0.1` (offsite k8s gw), and an offsite LB VIP in `10.89.0.64/26`.
- The ACL `tests` block already asserts `10.89.0.1:443` and `192.168.1.1:443` are reachable for the owner.

### Fallback (only if routes stay pending after a successful apply)

Confirm the connector node actually carries `tag:k8s-offsite` in the console; if not, the offsite `operator-oauth` client's tag scope needs fixing in the Tailscale admin console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvRBNWvtu48teF8z37gMT4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvRBNWvtu48teF8z37gMT4)_