### PR TITLE
fix(k8s): limit external-dns automatic sources

### DIFF
--- a/clusters/base/networking/external-dns/helm-release.yaml
+++ b/clusters/base/networking/external-dns/helm-release.yaml
@@ -41,11 +41,8 @@ spec:
     policy: sync
     sources:
       - crd
-      - node
       - ingress
-      - service
       - gateway-httproute
-      - gateway-tlsroute
       # - gateway-tcproute
       # - gateway-udproute
     txtPrefix: "k8s."


### PR DESCRIPTION
## Summary
Limit external-dns automatic DNS discovery to Ingress and Gateway HTTPRoute resources while keeping CRD support for explicit DNSEndpoint records.

## Changes
- fix(k8s): limit external-dns automatic sources

## Test Plan
- [x] kustomize build clusters/folly/networking/external-dns
- [x] kustomize build clusters/offsite/networking/external-dns
- [x] kustomize build clusters/folly/networking
- [x] kustomize build clusters/offsite/networking
