### PR TITLE
chore(containers): pin first-party image references to digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -38,6 +38,7 @@
   'helm-values': {
     managerFilePatterns: [
       '/clusters/.+\\.ya?ml$/',
+      '/packages/charts/.+\\.ya?ml$/',
     ],
   },
   kubernetes: {

--- a/clusters/base/apps/iperf3/iperf3-daemonset.yaml
+++ b/clusters/base/apps/iperf3/iperf3-daemonset.yaml
@@ -34,7 +34,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: iperf3
-          image: docker.io/jonpulsifer/netbench:latest
+          image: docker.io/jonpulsifer/netbench:latest@sha256:297a2b717c6818900861e51d8d50fa46695619f57e4b6f13c09bb40520ab26fd
           imagePullPolicy: IfNotPresent
           command: ["iperf3", "--server", "--port", "5201"]
           ports:

--- a/clusters/folly/apps/arc/infra.yaml
+++ b/clusters/folly/apps/arc/infra.yaml
@@ -38,7 +38,7 @@ spec:
       spec:
         containers:
           - name: runner
-            image: jonpulsifer/actions-runner:latest
+            image: jonpulsifer/actions-runner:latest@sha256:1d998da13bb6d6dcce7f1869920d6a7049696d6e6ff049c4472939c185660298
             command: ["/home/runner/run.sh"]
             env:
               - name: ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT

--- a/clusters/folly/apps/arc/ts.yaml
+++ b/clusters/folly/apps/arc/ts.yaml
@@ -38,7 +38,7 @@ spec:
       spec:
         containers:
           - name: runner
-            image: jonpulsifer/actions-runner:latest
+            image: jonpulsifer/actions-runner:latest@sha256:1d998da13bb6d6dcce7f1869920d6a7049696d6e6ff049c4472939c185660298
             command: ["/home/runner/run.sh"]
             env:
               - name: ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT

--- a/clusters/folly/apps/netbench/03-deployment.yaml
+++ b/clusters/folly/apps/netbench/03-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: netbench
-          image: docker.io/jonpulsifer/netbench:latest
+          image: docker.io/jonpulsifer/netbench:latest@sha256:297a2b717c6818900861e51d8d50fa46695619f57e4b6f13c09bb40520ab26fd
           imagePullPolicy: IfNotPresent
           ports:
             - name: http

--- a/clusters/folly/apps/walter.yaml
+++ b/clusters/folly/apps/walter.yaml
@@ -15,7 +15,7 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    image: docker.io/jonpulsifer/ai-agents:latest
+    image: docker.io/jonpulsifer/ai-agents:latest@sha256:4d3d5b10b68b9b81b68bae24ab70982ba5853bd858893f676ead8b2ed5685756
     port: 18789
     hostname: walter.lolwtf.ca
     storageSize: 10Gi

--- a/clusters/offsite/apps/arc/infra.yaml
+++ b/clusters/offsite/apps/arc/infra.yaml
@@ -38,7 +38,7 @@ spec:
       spec:
         containers:
           - name: runner
-            image: jonpulsifer/actions-runner:latest
+            image: jonpulsifer/actions-runner:latest@sha256:1d998da13bb6d6dcce7f1869920d6a7049696d6e6ff049c4472939c185660298
             command: ["/home/runner/run.sh"]
             env:
               - name: ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT

--- a/clusters/offsite/apps/arc/ts.yaml
+++ b/clusters/offsite/apps/arc/ts.yaml
@@ -38,7 +38,7 @@ spec:
       spec:
         containers:
           - name: runner
-            image: jonpulsifer/actions-runner:latest
+            image: jonpulsifer/actions-runner:latest@sha256:1d998da13bb6d6dcce7f1869920d6a7049696d6e6ff049c4472939c185660298
             command: ["/home/runner/run.sh"]
             env:
               - name: ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT

--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
   values:
     image:
       repository: jonpulsifer/atlantis
-      tag: latest
+      tag: latest@sha256:cd45c70637a51f9befa2a4dbd0bcf623a06a01860f36c53d87f4131753e443e9
     orgAllowlist: github.com/jonpulsifer/*
     environment:
       ATLANTIS_AUTOMERGE: "true"

--- a/clusters/offsite/apps/dave.yaml
+++ b/clusters/offsite/apps/dave.yaml
@@ -15,7 +15,7 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    image: docker.io/jonpulsifer/ai-agents:latest
+    image: docker.io/jonpulsifer/ai-agents:latest@sha256:4d3d5b10b68b9b81b68bae24ab70982ba5853bd858893f676ead8b2ed5685756
     port: 18789
     hostname: dave.lolwtf.ca
     storageSize: 2Gi

--- a/packages/charts/ai-agent/values.yaml
+++ b/packages/charts/ai-agent/values.yaml
@@ -1,4 +1,4 @@
-image: docker.io/jonpulsifer/ai-agents:latest
+image: docker.io/jonpulsifer/ai-agents:latest@sha256:4d3d5b10b68b9b81b68bae24ab70982ba5853bd858893f676ead8b2ed5685756
 port: 8080
 hostname: ""
 storageSize: 2Gi


### PR DESCRIPTION
## Summary
Pin all first-party DockerHub image references to immutable digests (`:latest@sha256:<digest>`) instead of floating `:latest`, so GitOps deployments run a traceable, deterministic image while Renovate keeps the digests current automatically.

## Changes
- Pin `ai-agents` consumers (`walter.yaml`, `dave.yaml`, `packages/charts/ai-agent/values.yaml`) to digest
- Pin `actions-runner` consumers (`arc/{infra,ts}.yaml` on folly + offsite) to digest
- Pin `netbench` consumers (`folly/apps/netbench`, `base/apps/iperf3`) to digest
- Pin `atlantis` HelmRelease image (split `tag: latest@sha256:…`) to digest
- Extend Renovate `helm-values` manager to `packages/charts/**` so the chart default digest stays maintained

The build pipeline is unchanged: `:latest` stays published as the anchor Renovate follows; the deployed reference is always a pinned digest. Existing `digest`/`pinDigest` auto-merge rules roll the digests forward on each new image build.

## Test Plan
- [ ] `kustomize build` passes for `clusters/folly/apps/netbench` and `clusters/base/apps/iperf3` (verified locally; rendered image shows the digest)
- [ ] `helm template packages/charts/ai-agent` renders with the pinned default (verified locally)
- [ ] No floating `:latest` remains for any published image (`ai-agents`, `actions-runner`, `netbench`, `atlantis`)
- [ ] After merge: Flux/ARC reconcile and pods resolve to the pinned `@sha256:` digest; next image build triggers a Renovate digest-bump PR that auto-merges

## Notes
Extending Renovate to `packages/charts/**` means it will also see other image refs in charts (e.g. `node:24-bookworm`, the `app` chart) and may propose pinning them — consistent with the repo's pinning philosophy. Scope can be narrowed if undesired.
