### PR TITLE
fix(dump): use nfs volume claim

### DIFF
--- a/clusters/folly/apps/dump/dump.yaml
+++ b/clusters/folly/apps/dump/dump.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: dump
+  name: dump-nfs
   namespace: dump
   labels:
     app.kubernetes.io/name: dump
@@ -67,8 +67,8 @@ spec:
   - metadata:
       name: dump-data
     spec:
-      accessModes: [ "ReadWriteOnce" ]
-      storageClassName: local-path
+      accessModes: [ "ReadWriteMany" ]
+      storageClassName: nfs
       resources:
         requests:
           storage: 1Gi


### PR DESCRIPTION
## Summary
Wire the folly dump app to the existing NFS-backed storage path while keeping it as a StatefulSet.

## Changes
- Rename the dump StatefulSet to recreate it cleanly with a new volume claim template
- Switch the dump data claim template from local-path/RWO to nfs/RWX

## Test Plan
- [x] kustomize build /tmp/dump-kustomize
- [x] kubectl kustomize clusters/folly/apps

## Notes
The generated PVC will bind by class/access/request to the static spore NFS PV if it is available in the live cluster. No explicit volumeName is set.
