### PR TITLE
fix(storage): use spore IP for NFS PV

### DIFF
--- a/clusters/folly/storage/spore-pv.yaml
+++ b/clusters/folly/storage/spore-pv.yaml
@@ -14,5 +14,8 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   storageClassName: nfs
   nfs:
-    server: spore.lolwtf.ca
+    # spore.lolwtf.ca is Terraform-managed to this static Lab Net address.
+    # Use the IP directly so kubelet's NFS mounter does not depend on DNS
+    # resolution while constructing the kernel mount options.
+    server: 10.2.0.11
     path: /nfs/data/k8s/


### PR DESCRIPTION
## Summary
Fixes the folly `spore` NFS PersistentVolume by using the Terraform-managed static Lab Net IP directly instead of relying on DNS during kubelet NFS mount setup.

## Changes
- fix(storage): use spore IP for NFS PV

## Test Plan
- [x] `kustomize build clusters/folly/storage`
- [x] `kustomize build clusters/folly`

## Context
- `clusters/folly/storage/spore-pv.yaml`
