### PR TITLE
fix(nixos): enable nfs on k8s nodes

### DIFF
--- a/nix/profiles/k8s-node.nix
+++ b/nix/profiles/k8s-node.nix
@@ -1,5 +1,7 @@
 {
+  lib,
   name,
+  pkgs,
   ...
 }:
 {
@@ -11,7 +13,18 @@
   ];
 
   boot.initrd.availableKernelModules = [ "nvme" ];
+  boot.initrd.kernelModules = [ "nfs" ];
+  boot.initrd.supportedFilesystems = [ "nfs" ];
+  boot.supportedFilesystems = lib.mkOverride 40 [
+    "ext4"
+    "vfat"
+    "nfs"
+  ];
   boot.kernelModules = [ "kvm-intel" ];
+
+  environment.systemPackages = with pkgs; [
+    nfs-utils
+  ];
 
   services.k8s.enable = true;
   networking.hostName = name;


### PR DESCRIPTION
## Summary
Enable NFS support on shared NixOS Kubernetes nodes so kubelet can mount the existing spore NFS persistent volume.

## Changes
- fix(nixos): enable nfs on k8s nodes

## Test Plan
- [x] nix fmt nix/profiles/k8s-node.nix
- [x] git diff --check
- [x] nix eval .#nixosConfigurations.optiplex.config.boot.supportedFilesystems --json
- [x] nix eval .#nixosConfigurations.optiplex.config.boot.initrd.supportedFilesystems --json
- [x] nix flake check
