### PR TITLE
fix(hermes): expose dashboard UI, fix LLM provider config

### DIFF
--- a/clusters/folly/apps/hermes/gateway.yaml
+++ b/clusters/folly/apps/hermes/gateway.yaml
@@ -30,4 +30,4 @@ spec:
   rules:
     - backendRefs:
         - name: hermes-ai-agent
-          port: 8642
+          port: 9119

--- a/clusters/folly/apps/hermes/hermes.yaml
+++ b/clusters/folly/apps/hermes/hermes.yaml
@@ -39,8 +39,8 @@ spec:
         envVar: API_SERVER_KEY
         onePasswordItem: "hermes api server key"
         property: password
-      - name: openrouter-api-key
-        envVar: OPENROUTER_API_KEY
+      - name: opencode-go-api-key
+        envVar: OPENCODE_GO_API_KEY
         onePasswordItem: "opencode api key"
         property: password
       - name: discord-bot-token
@@ -65,12 +65,14 @@ spec:
           value: "8642"
         - name: API_SERVER_CORS_ORIGINS
           value: "https://hermes.${SECRET_DOMAIN}"
+        - name: HERMES_DASHBOARD
+          value: "1"
         - name: LLM_PROVIDER
-          value: "openrouter"
+          value: "opencode-go"
         - name: LLM_MODEL
-          value: "opencode-go/minimax-m2.7"
-        - name: OPENROUTER_BASE_URL
-          value: "https://openrouter.ai/api/v1"
+          value: "minimax-m3"
+        - name: OPENCODE_GO_BASE_URL
+          value: "https://opencode.ai/zen/go/v1/messages"
         - name: SLACK_CHANNEL_GENERAL
           value: "#general"
         - name: SLACK_CHANNEL_CHORES

--- a/packages/charts/ai-agent/Chart.yaml
+++ b/packages/charts/ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: ai-agent
 description: An opinionated Helm chart for deploying AI agents with sandbox isolation
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "latest"

--- a/packages/charts/ai-agent/templates/hermes-deployment.yaml
+++ b/packages/charts/ai-agent/templates/hermes-deployment.yaml
@@ -16,6 +16,12 @@ spec:
       protocol: TCP
       port: {{ .Values.port }}
       targetPort: {{ .Values.port }}
+    {{- if .Values.hermes.dashboardPort }}
+    - name: dashboard
+      protocol: TCP
+      port: {{ .Values.hermes.dashboardPort }}
+      targetPort: {{ .Values.hermes.dashboardPort }}
+    {{- end }}
 ---
 # PVC for /opt/data
 {{- if .Values.hermes.dataVolume.enabled }}
@@ -79,6 +85,10 @@ spec:
           ports:
             - containerPort: {{ .Values.port }}
               protocol: TCP
+            {{- if .Values.hermes.dashboardPort }}
+            - containerPort: {{ .Values.hermes.dashboardPort }}
+              protocol: TCP
+            {{- end }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.port }}

--- a/packages/charts/ai-agent/values.yaml
+++ b/packages/charts/ai-agent/values.yaml
@@ -78,6 +78,10 @@ hermes:
     enabled: true
     storageSize: 5Gi
   shmSizeLimit: 1Gi
+  # Web dashboard (HERMES_DASHBOARD=1) listens on its own port, separate from
+  # the gateway's OpenAI-compatible API/health port (.Values.port). Set to ""
+  # to disable exposing it (Service/HTTPRoute keep the single API port only).
+  dashboardPort: 9119
   env: []
   configFiles: []
 


### PR DESCRIPTION
## Summary
Hermes Agent's UI was unreachable (only the API/health port was routed) and its LLM provider config was broken. Also disables Discord on the `walter` openclaw agent so only `hermes` holds the Discord bot session.

## Changes
- `feat(ai-agent chart)`: add `hermes.dashboardPort` (9119) to the chart — Service + container now expose both the API port and the dashboard port
- `fix(hermes)`: HTTPRoute now backends to 9119 (dashboard) instead of 8642 (API/health only); switch `LLM_PROVIDER`/`LLM_MODEL` from a nonexistent OpenRouter slug (`openrouter` / `opencode-go/minimax-m2.7`) to a proper custom `opencode-go` provider (`OPENCODE_GO_API_KEY`, `OPENCODE_GO_BASE_URL`, `LLM_MODEL=minimax-m3`); adds `HERMES_DASHBOARD=1`

## Test Plan
- [x] `helm template`/`helm lint` on `packages/charts/ai-agent` with hermes values — Service/Deployment render both ports, env vars correct
- [x] `kustomize build clusters/folly/apps/hermes` and `clusters/folly/apps` — builds clean
- [ ] After merge/reconcile: confirm `https://hermes.pulsifer.ca` loads the dashboard, and hermes responds via Discord

## Context
Out-of-band, already applied live (not in this diff): ran `openclaw channels remove --channel discord` against the `walter` sandbox pod to disable (not delete) its Discord channel — `walter` and `hermes` were both configured against the same Discord guild/bot token, which is almost certainly what was causing hermes's Discord gateway reconnect/DNS churn in its logs (two clients fighting over one session). `hermes.yaml` already had matching `DISCORD_*` env vars for the same guild/channels, so hermes takes over cleanly. Re-enable via `openclaw channels add --channel discord` on `walter` if ever needed.
