### PR TITLE
fix(hermes): configure dashboard basic auth

### DIFF
--- a/clusters/folly/apps/hermes/hermes.yaml
+++ b/clusters/folly/apps/hermes/hermes.yaml
@@ -6,6 +6,14 @@
 # referenced 1Password fields are intentionally the existing item fields:
 # Password items use property "password"; the service-account token uses
 # property "credential".
+#
+# IMPORTANT: hermes-agent now refuses to bind its dashboard (port 9119) to
+# 0.0.0.0 unless a DashboardAuthProvider is registered (the bundled "nous"
+# OAuth plugin only auto-registers when HERMES_DASHBOARD_OAUTH_CLIENT_ID is
+# set, which requires an external Nous Portal account). This HelmRelease
+# uses the bundled dashboard_auth/basic plugin instead. Before deploying,
+# create a "hermes dashboard basic auth" Login item in the Homelab
+# 1Password vault with "username" and "password" fields.
 # =============================================================================
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -50,6 +58,14 @@ spec:
       - name: elevenlabs-api-key
         envVar: ELEVENLABS_API_KEY
         onePasswordItem: "rowbutt elevenlabs api key"
+        property: password
+      - name: dashboard-auth-username
+        envVar: HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+        onePasswordItem: "hermes dashboard basic auth"
+        property: username
+      - name: dashboard-auth-password
+        envVar: HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
+        onePasswordItem: "hermes dashboard basic auth"
         property: password
     hermes:
       enabled: true


### PR DESCRIPTION
## Summary
- hermes-agent's `:latest` image now refuses to bind its dashboard (port 9119) to `0.0.0.0` unless a `DashboardAuthProvider` plugin is registered — the bundled `nous` OAuth plugin only self-registers with an external Nous Portal client ID, which isn't appropriate here.
- Wire up the bundled `dashboard_auth/basic` plugin via `HERMES_DASHBOARD_BASIC_AUTH_USERNAME`/`_PASSWORD`, sourced from a new 1Password item ("hermes dashboard basic auth", already created), rather than passing `--insecure` — `hermes.${SECRET_DOMAIN}` is served through a real Gateway + cert-manager TLS cert, not a loopback-only endpoint.

## Test plan
- [x] `helm template` against the ai-agent chart with the new `envSecrets` entries — confirms the ExternalSecrets render and the container gets `HERMES_DASHBOARD_BASIC_AUTH_USERNAME`/`_PASSWORD` env vars from `secretKeyRef`.
- [x] `kustomize build clusters/folly/apps/hermes` — confirms the kustomization still builds cleanly.
- [ ] After merge, confirm the hermes pod stops crash-looping and the dashboard serves a login page at `https://hermes.<domain>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)