### PR TITLE
fix(hermes): opencode-go base URL caused 404 on every LLM call

### DIFF
--- a/clusters/folly/apps/hermes/hermes.yaml
+++ b/clusters/folly/apps/hermes/hermes.yaml
@@ -87,8 +87,12 @@ spec:
           value: "opencode-go"
         - name: LLM_MODEL
           value: "minimax-m3"
+        # Must be the bare /v1 root: hermes derives the per-model endpoint
+        # itself (strips /v1 and appends /v1/messages for anthropic-style
+        # models like minimax, appends /chat/completions for openai-style).
+        # Pointing this at .../v1/messages produced .../v1/messages/v1/messages -> 404.
         - name: OPENCODE_GO_BASE_URL
-          value: "https://opencode.ai/zen/go/v1/messages"
+          value: "https://opencode.ai/zen/go/v1"
         - name: SLACK_CHANNEL_GENERAL
           value: "#general"
         - name: SLACK_CHANNEL_CHORES


### PR DESCRIPTION
## Summary
Every hermes LLM call was failing with `HTTP 404 — Not Found | opencode`, killing Discord responses. `OPENCODE_GO_BASE_URL` was set to the full Anthropic messages endpoint (`.../zen/go/v1/messages`), but hermes builds the per-model path from the base URL itself — strip trailing `/v1`, then the Anthropic SDK appends `/v1/messages` (or `/chat/completions` for OpenAI-style models). The old value produced `.../v1/messages/v1/messages` → 404 on every request.

## Changes
- fix(hermes): use bare `/v1` root for `OPENCODE_GO_BASE_URL` (`https://opencode.ai/zen/go/v1`, hermes' own default per `hermes_cli/auth.py`)

## Test Plan
- [x] Verified from inside the running pod: `POST https://opencode.ai/zen/go/v1/messages` with `model: minimax-m3` and the existing `OPENCODE_GO_API_KEY` returns 200 with a valid completion
- [ ] After merge + Flux reconcile, confirm hermes responds in Discord and logs show no `NotFoundError`

## Notes
The persisted `config.yaml` in the hermes data volume still has `model.default: minimax-m2.7` (overrides the `LLM_MODEL=minimax-m3` env). m2.7 is a valid opencode-go model so the bot works either way; switch to m3 via the dashboard `/model` command or a one-off pod edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
