### PR TITLE
feat(hermes): upgrade to 0.18.0 (v2026.7.1), pin image for Renovate

### DIFF
--- a/clusters/folly/apps/hermes/hermes.yaml
+++ b/clusters/folly/apps/hermes/hermes.yaml
@@ -33,7 +33,7 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    image: nousresearch/hermes-agent:latest
+    image: docker.io/nousresearch/hermes-agent:v2026.7.1
     port: 8642
     ingress:
       enabled: false


### PR DESCRIPTION
## Summary
Upgrade hermes to the just-released **0.18.0 "Judgment" release** (Docker tag `v2026.7.1` — upstream tags images with CalVer, the 0.18.0 marketing version only appears in the release name) and pin the image instead of tracking `:latest`.

## Why Renovate wasn't doing this
Renovate's helm-values manager already watches `clusters/**` and updates the other chart images (e.g. walter's `ai-agents:latest@sha256:...` digest bumps), but hermes was a bare `nousresearch/hermes-agent:latest` — no version and no digest, so there was nothing for Renovate to bump. With a pinned CalVer tag, future releases (`v2026.7.x` patches auto-merge, `v2026.x` minors get a PR) show up automatically.

## Changes
- feat(hermes): pin image to `docker.io/nousresearch/hermes-agent:v2026.7.1` (hermes-agent 0.18.0)

## Test Plan
- [x] `kubectl apply --dry-run=client` parses the HelmRelease
- [ ] After merge + Flux reconcile, confirm the pod runs `v2026.7.1` and hermes still responds in Discord (the opencode-go base-URL fix from #928 must keep working on 0.18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
