### PR TITLE
feat(storage): dynamic nfs subdir provisioner on spore, agent data on nfs

### DIFF
--- a/clusters/base/sources/helm/kustomization.yaml
+++ b/clusters/base/sources/helm/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - jetstack.yaml
   - jonpulsifer.yaml
   - metrics-server.yaml
+  - nfs-subdir-external-provisioner.yaml
   - node-feature-discovery.yaml
   - onepassword.yaml
   - open-webui.yaml

--- a/clusters/base/sources/helm/nfs-subdir-external-provisioner.yaml
+++ b/clusters/base/sources/helm/nfs-subdir-external-provisioner.yaml
@@ -1,0 +1,11 @@
+---
+# Source: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/tree/master/charts/nfs-subdir-external-provisioner
+# Chart values: https://github.com/kubernetes-sigs/nfs-subdir-external-provisioner/blob/master/charts/nfs-subdir-external-provisioner/values.yaml
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: nfs-subdir-external-provisioner
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://kubernetes-sigs.github.io/nfs-subdir-external-provisioner

--- a/clusters/folly/apps/hermes/hermes.yaml
+++ b/clusters/folly/apps/hermes/hermes.yaml
@@ -72,6 +72,13 @@ spec:
       dataVolume:
         enabled: true
         storageSize: 5Gi
+        # Backed by the dynamic `nfs` StorageClass (provisioned by
+        # clusters/folly/storage/nfs-provisioner) on spore (10.2.0.11).
+        # RWX so the agent could be scaled or migrated to another node
+        # without losing /opt/data; data survives a node loss.
+        storageClassName: nfs
+        accessModes:
+          - ReadWriteMany
       env:
         - name: API_SERVER_ENABLED
           value: "true"

--- a/clusters/folly/storage/nfs-provisioner/helm-release.yaml
+++ b/clusters/folly/storage/nfs-provisioner/helm-release.yaml
@@ -1,0 +1,100 @@
+---
+# nfs-subdir-external-provisioner
+#
+# Adds a real `nfs` StorageClass to the cluster, backed by spore (10.2.0.11).
+# The static `spore` PV (clusters/folly/storage/spore-pv.yaml) keeps working
+# unchanged; this provisioner is for new dynamic PVCs that ask for the `nfs`
+# StorageClass by name. The provisioner creates per-PVC subdirectories under
+# the configured `nfs.path` (default: /nfs/data/k8s-provisioned/ on spore),
+# so dynamic and static volumes are isolated.
+#
+# Required setup on the NFS server (one-time, manual on spore):
+#   1. mkdir -p /nfs/data/k8s-provisioned
+#      chown nobody:nogroup /nfs/data/k8s-provisioned
+#   2. Append to /etc/exports:
+#        /nfs/data/k8s-provisioned/  10.3.0.0/28(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
+#   3. exportfs -arv
+#
+# After this PR merges and Flux reconciles, any PVC like:
+#   kind: PersistentVolumeClaim
+#   spec:
+#     storageClassName: nfs
+#     accessModes: ["ReadWriteMany"]
+#     resources: { requests: { storage: 10Gi } }
+# will be bound and have a subdir auto-created under
+# /nfs/data/k8s-provisioned/<namespace>-<pvc-name>-<pv-hash>/.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nfs-provisioner
+  namespace: nfs-provisioner
+spec:
+  interval: 5m0s
+  maxHistory: 2
+  chart:
+    spec:
+      chart: nfs-subdir-external-provisioner
+      version: 4.0.18
+      sourceRef:
+        kind: HelmRepository
+        name: nfs-subdir-external-provisioner
+        namespace: flux-system
+      interval: 10m0s
+  values:
+    # Provisioner identity. The leader-election lease name must be unique per
+    # provisioner if you ever run more than one (e.g. per cluster).
+    replicaCount: 1
+    leaderElection:
+      enabled: true
+    # NFS target. The IP is hardcoded (mirrors clusters/folly/storage/spore-pv.yaml)
+    # so kubelet's NFS mounter doesn't depend on DNS during kernel mount option
+    # construction. Keep in sync with the spore.lolwtf.ca Lab Net address.
+    nfs:
+      server: 10.2.0.11
+      path: /nfs/data/k8s-provisioned
+      # Match the static PV's mount options so both paths behave consistently
+      # for pods that mount either.
+      mountOptions:
+        - hard
+        - nfsvers=3
+        - timeo=600
+        - retrans=2
+        - noatime
+    # StorageClass. defaultClass=false so we do NOT displace `local-path` as
+    # the cluster default — dump, hermes-config, and many other workloads are
+    # happy on local-path and would break if the default flipped.
+    storageClass:
+      create: true
+      name: nfs
+      defaultClass: false
+      # Retain keeps the subdir around if the PVC is deleted. archiveOnDelete
+      # additionally renames it to archived-<n> so a recreate-with-same-name
+      # doesn't lose data. Set reclaimPolicy: Delete + archiveOnDelete: false
+      # to wipe on PVC delete (NOT recommended for shared/agent data).
+      reclaimPolicy: Retain
+      archiveOnDelete: true
+      allowVolumeExpansion: true
+    # RBAC. The chart creates a ServiceAccount named after the release; bind
+    # the cluster role the chart ships (nfs-provisioner-runner).
+    rbac:
+      create: true
+    serviceAccount:
+      create: true
+    # Restrict to a single namespace, not the whole cluster-wide default.
+    podSecurityContext:
+      fsGroup: 65534
+      runAsUser: 65534
+      runAsGroup: 65534
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop:
+          - ALL
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        memory: 128Mi

--- a/clusters/folly/storage/nfs-provisioner/kustomization.yaml
+++ b/clusters/folly/storage/nfs-provisioner/kustomization.yaml
@@ -2,7 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base/storage
-  - nfs-provisioner
-  - spore-pv.yaml
-
+  - namespace.yaml
+  - helm-release.yaml

--- a/clusters/folly/storage/nfs-provisioner/namespace.yaml
+++ b/clusters/folly/storage/nfs-provisioner/namespace.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nfs-provisioner
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    # The provisioner pod needs to talk to the API server (leader election,
+    # PV/PVC watches), and the nfs-client container runs as root to chown
+    # newly created subdirs. Allow privileged but cap it at baseline.
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn-version: latest

--- a/packages/charts/ai-agent/templates/hermes-deployment.yaml
+++ b/packages/charts/ai-agent/templates/hermes-deployment.yaml
@@ -33,8 +33,14 @@ metadata:
   labels:
     {{- include "ai-agent.labels" . | nindent 4 }}
 spec:
-  accessModes: ["ReadWriteOnce"]
-  storageClassName: local-path
+  # storageClassName defaults to "local-path" (single-node, RWO). Override via
+  # .Values.hermes.dataVolume.storageClassName to use a different backend, e.g.
+  # "nfs" (RWX, multi-node, persistent across node loss).
+  {{- with .Values.hermes.dataVolume.storageClassName }}
+  storageClassName: {{ . }}
+  {{- end }}
+  accessModes:
+    {{- toYaml .Values.hermes.dataVolume.accessModes | nindent 4 }}
   resources:
     requests:
       storage: {{ .Values.hermes.dataVolume.storageSize | default "5Gi" }}

--- a/packages/charts/ai-agent/values.yaml
+++ b/packages/charts/ai-agent/values.yaml
@@ -77,6 +77,12 @@ hermes:
   dataVolume:
     enabled: true
     storageSize: 5Gi
+    # storageClassName: defaults to local-path (RWO, single-node). Set to
+    # "nfs" (or another RWX-capable class) for multi-node / durable storage.
+    # When nil, the rendered PVC omits the field and uses the cluster default.
+    storageClassName: null
+    accessModes:
+      - ReadWriteOnce
   shmSizeLimit: 1Gi
   # Web dashboard (HERMES_DASHBOARD=1) listens on its own port, separate from
   # the gateway's OpenAI-compatible API/health port (.Values.port). Set to ""


### PR DESCRIPTION
The existing 'spore' PV (clusters/folly/storage/spore-pv.yaml) is a one-off hand-stitched PersistentVolume for the dump workload. There is no 'nfs' StorageClass, so new PVCs cannot dynamically claim NFS storage. Meanwhile the hermes agent (clusters/folly/apps/hermes/hermes.yaml) uses local-path (RWO, single-node hostPath) for its /opt/data volume, so a node loss takes the agent's data with it.

Add nfs-subdir-external-provisioner to folly:

  * clusters/base/sources/helm/nfs-subdir-external-provisioner.yaml (new): HelmRepository for the kubernetes-sigs chart.
  * clusters/folly/storage/nfs-provisioner/{namespace,helm-release,kustomization}.yaml (new): HelmRelease for the provisioner, pinned to 4.0.18. Wires the 'nfs' StorageClass with reclaimPolicy: Retain, archiveOnDelete: true, defaultClass: false (do NOT displace local-path as the cluster default).
  * clusters/base/sources/helm/kustomization.yaml: register the new HelmRepository.
  * clusters/folly/storage/kustomization.yaml: include the new subdir in the folly storage kustomize tree.

Make the hermes agent's data PVC configurable:

  * packages/charts/ai-agent/values.yaml: hermes.dataVolume gains storageClassName (nullable) and accessModes (default RWO). Renders identical PVC when neither is set, so existing deployments (walter) are unaffected.
  * packages/charts/ai-agent/templates/hermes-deployment.yaml: render storageClassName only when set, template accessModes from values.
  * clusters/folly/apps/hermes/hermes.yaml: opt the running hermes workload into storageClassName: nfs + accessModes: [ReadWriteMany], so its /opt/data lives on spore (10.2.0.11) instead of a single node's hostPath. Data is durable across node loss.

One-time manual step on spore (documented in the provisioner HelmRelease header) before any dynamic PVC will bind: add an export line for /nfs/data/k8s-provisioned/ to /etc/exports with the 10.3.0.0/28 and 10.100.0.0/20 CIDRs, mkdir the path, then exportfs -arv. The provisioner and StorageClass will reconcile from the cluster side; spore just needs to know about the new export.