### PR TITLE
fix(flux): stop apps/networking Kustomizations breaking on chartRef HelmReleases

### DIFF
--- a/clusters/folly/apps/kustomization.yaml
+++ b/clusters/folly/apps/kustomization.yaml
@@ -28,11 +28,19 @@ patches:
         path: /spec/interval
         value: 5m0s
       - op: replace
-        path: /spec/chart/spec/interval
-        value: 10m0s
-      - op: replace
         path: /spec/maxHistory
         value: 2
       - op: replace
         path: /spec/upgrade
         value: { cleanupOnFail: true, remediation: { retries: 5 } }
+  # chart.spec.interval only exists on HelmRepository-backed HelmReleases;
+  # OCIRepository-backed ones (chartRef) are labeled to skip it.
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      labelSelector: "!source.toolkit.fluxcd.io/kind"
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/interval
+        value: 10m0s

--- a/clusters/folly/apps/reloader/helm-release.yaml
+++ b/clusters/folly/apps/reloader/helm-release.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: reloader
   namespace: reloader
+  labels:
+    source.toolkit.fluxcd.io/kind: OCIRepository
 spec:
   interval: 24h
   chartRef:

--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: cilium
   namespace: kube-system
+  labels:
+    source.toolkit.fluxcd.io/kind: OCIRepository
 spec:
   interval: 24h
   maxHistory: 2

--- a/clusters/folly/networking/kustomization.yaml
+++ b/clusters/folly/networking/kustomization.yaml
@@ -19,8 +19,16 @@ patches:
         path: /spec/interval
         value: 1m0s
       - op: replace
-        path: /spec/chart/spec/interval
-        value: 5m0s
-      - op: replace
         path: /spec/maxHistory
         value: 2
+  # chart.spec.interval only exists on HelmRepository-backed HelmReleases;
+  # OCIRepository-backed ones (chartRef) are labeled to skip it.
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      labelSelector: "!source.toolkit.fluxcd.io/kind"
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/interval
+        value: 5m0s

--- a/clusters/offsite/apps/kustomization.yaml
+++ b/clusters/offsite/apps/kustomization.yaml
@@ -17,11 +17,19 @@ patches:
         path: /spec/interval
         value: 5m0s
       - op: replace
-        path: /spec/chart/spec/interval
-        value: 10m0s
-      - op: replace
         path: /spec/maxHistory
         value: 2
       - op: replace
         path: /spec/upgrade
         value: { cleanupOnFail: true, remediation: { retries: 5 } }
+  # chart.spec.interval only exists on HelmRepository-backed HelmReleases;
+  # OCIRepository-backed ones (chartRef) are labeled to skip it.
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      labelSelector: "!source.toolkit.fluxcd.io/kind"
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/interval
+        value: 10m0s

--- a/clusters/offsite/apps/reloader/helm-release.yaml
+++ b/clusters/offsite/apps/reloader/helm-release.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: reloader
   namespace: reloader
+  labels:
+    source.toolkit.fluxcd.io/kind: OCIRepository
 spec:
   interval: 24h
   chartRef:

--- a/clusters/offsite/networking/cilium/helm-release.yaml
+++ b/clusters/offsite/networking/cilium/helm-release.yaml
@@ -4,6 +4,8 @@ kind: HelmRelease
 metadata:
   name: cilium
   namespace: kube-system
+  labels:
+    source.toolkit.fluxcd.io/kind: OCIRepository
 spec:
   interval: 24h
   maxHistory: 2

--- a/clusters/offsite/networking/kustomization.yaml
+++ b/clusters/offsite/networking/kustomization.yaml
@@ -19,8 +19,16 @@ patches:
         path: /spec/interval
         value: 1m0s
       - op: replace
-        path: /spec/chart/spec/interval
-        value: 5m0s
-      - op: replace
         path: /spec/maxHistory
         value: 2
+  # chart.spec.interval only exists on HelmRepository-backed HelmReleases;
+  # OCIRepository-backed ones (chartRef) are labeled to skip it.
+  - target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      labelSelector: "!source.toolkit.fluxcd.io/kind"
+    patch: |-
+      - op: replace
+        path: /spec/chart/spec/interval
+        value: 5m0s


### PR DESCRIPTION
## Summary
Fixes two Flux Kustomizations (`networking` and `apps`, both clusters) that broke after #932 switched `cilium` and `reloader` to `chartRef`. Confirmed live via `flux get kustomizations --context folly`: both stuck on the pre-merge revision with `kustomize build failed: replace operation does not apply: doc is missing path: /spec/chart/spec/interval: missing value`.

## Changes
- Root cause: `clusters/{folly,offsite}/{apps,networking}/kustomization.yaml` each carry a JSON6902 patch that does `replace /spec/chart/spec/interval` on every `HelmRelease` in the tree. `replace` requires the parent object to exist — `chartRef`-based releases (cilium, reloader) have no `spec.chart` at all, so the op fails hard for the whole Kustomization. The other ops in the same patch (`spec.interval`, `spec.maxHistory`, `spec.upgrade`) are safe upserts under the always-present `spec` object, so only this one op needed to change.
- Label `cilium` and `reloader` HelmReleases with `source.toolkit.fluxcd.io/kind: OCIRepository`
- Split each affected patch: the `chart.spec.interval` op now targets only HelmReleases without that label via `labelSelector: "!source.toolkit.fluxcd.io/kind"`

## Test Plan
- [x] `kustomize build` passes on all 4 previously-failing paths (`folly/networking`, `offsite/networking`, `folly/apps`, `offsite/apps`)
- [x] Verified rendered output: chart.spec-based HelmReleases (cert-manager, argo, cloudnative-pg, hajimari, descheduler, falco, k6, open-webui, hermes, dave, atlantis) still get `chart.spec.interval` set; `cilium`/`reloader` correctly have no such field and no error
- [ ] Confirm `flux get kustomizations` shows `apps`/`networking` reconciling to this revision as `Ready: True` on both clusters after merge
