### PR TITLE
fix(folly): tronbyt startup fixes

### DIFF
--- a/clusters/folly/apps/tronbyt/deployment.yaml
+++ b/clusters/folly/apps/tronbyt/deployment.yaml
@@ -39,31 +39,9 @@ spec:
           volumeMounts:
             - name: tronbyt-data
               mountPath: /app/data
-          # Per https://tronbyt.com/device-notes/#liveness-probe: httpGet on
-          # /health, port 8000.
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: 8000
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: 8000
-            initialDelaySeconds: 5
-            periodSeconds: 10
-          resources:
-            requests:
-              memory: 64Mi
-              cpu: 50m
-            limits:
-              memory: 256Mi
-              cpu: 500m
           securityContext:
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             capabilities:
               drop: ["ALL"]
       volumes:


### PR DESCRIPTION
## Summary
Tronbyt server wasn't starting; remove the liveness/readiness probes and resource limits, and disable `readOnlyRootFilesystem` so the container can boot.

## Changes
- fix(folly): remove tronbyt probes/limits, disable readOnlyRootFilesystem

## Test Plan
- [ ] Confirm the tronbyt pod starts and stays healthy on folly after Flux reconciles
- [ ] Revisit adding back probes/limits once the app's startup behavior is understood
