### PR TITLE
fix(clusters): drop dangling deps + sweep stale references after sources reorg

### DIFF
--- a/.agents/skills/kubernetes-gitops/SKILL.md
+++ b/.agents/skills/kubernetes-gitops/SKILL.md
@@ -16,7 +16,7 @@ Each cluster contains: `flux-system/`, `networking/`, `monitoring/`, `nodes/`, `
 
 `base/` holds shared helm-releases (cert-manager, tailscale, external-dns, vector) used by both clusters via kustomize directory references. Cluster-specific values use Flux `postBuild` substitution with variables like `${CLUSTER_NAME}` from each cluster's `cluster-settings` ConfigMap.
 
-Both clusters share `sources/` (HelmRepository definitions) and `sandbox/` from folly's directories via Flux Kustomization path references. Offsite also shares `external-secrets-operator/` and `external-secrets/` from folly.
+Shared platform components live under `base/platform/` (`arc-system`, `external-secrets-operator`, `onepassword-connect`, `agent-sandbox`) and `base/storage/`; each cluster's `flux-system/` Kustomization points at those base paths directly. HelmRepository/GitRepository sources are **not** centralized — each source is colocated in the same directory (and same Flux Kustomization) as the HelmRelease/manifests that consume it.
 
 ## Making Changes
 
@@ -98,4 +98,4 @@ sops clusters/offsite/apps/atlantis/secret.sops.yaml
 
 ## Helm Releases
 
-Apps use `HelmRelease` resources pointing to `HelmRepository` sources in `sources/helm/`. Renovate opens automatic update PRs for chart bumps.
+Apps use `HelmRelease` resources pointing to a `HelmRepository`/`GitRepository`/`OCIRepository` source colocated in the same directory (named `helm-repository.yaml`, `git-repository.yaml`, or `oci-repository.yaml`, suffixed with the app name when a directory holds more than one). Renovate opens automatic update PRs for chart bumps.

--- a/.agents/skills/multi-cluster/SKILL.md
+++ b/.agents/skills/multi-cluster/SKILL.md
@@ -51,16 +51,19 @@ clusters/base/
 
 ## Shared via Flux Path References
 
-Some resources are shared by pointing offsite's Flux Kustomization at folly's directory:
+Shared platform components live under `base/` and **both** clusters' `flux-system/` Kustomizations point at the same base path:
 
-| Resource                  | Flux Kustomization path              |
-|---------------------------|--------------------------------------|
-| HelmRepository sources    | `./clusters/folly/sources`       |
-| Sandbox apps              | `./clusters/folly/sandbox`       |
-| External Secrets Operator | `./clusters/folly/external-secrets-operator` |
-| External Secrets          | `./clusters/folly/external-secrets` |
+| Resource                  | Flux Kustomization path                          |
+|---------------------------|--------------------------------------------------|
+| ARC (runner controller)   | `./clusters/base/platform/arc-system`            |
+| External Secrets Operator | `./clusters/base/platform/external-secrets-operator` |
+| 1Password Connect         | `./clusters/base/platform/onepassword-connect`   |
+| Sandbox apps              | `./clusters/base/platform/agent-sandbox`         |
+| Storage (offsite)         | `./clusters/base/storage`                        |
 
 This works because Flux resolves paths relative to the git repo root, not the kustomization file.
+
+HelmRepository/GitRepository/OCIRepository **sources are not shared centrally** — each is colocated in the same directory as the HelmRelease that consumes it (`helm-repository.yaml` / `git-repository.yaml` / `oci-repository.yaml`). Sources needed by both clusters (e.g. `descheduler`, `gateway-api`) are duplicated into each cluster's directory, matching how those apps are already duplicated.
 
 ## What Stays Cluster-Specific
 

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -307,8 +307,10 @@
     // Blocked
     // ============================================================
     {
+      // gateway-api CRD version is coupled to each cluster's cluster-gateway
+      // config; bump it manually, not via Renovate. Colocated per-cluster.
       matchManagers: ['flux'],
-      matchFileNames: ['clusters/folly/sources/git/gateway-api.yaml'],
+      matchFileNames: ['clusters/*/networking/git-repository-gateway-api.yaml'],
       enabled: false,
     },
   ],

--- a/clusters/folly/flux-system/arc-system.yaml
+++ b/clusters/folly/flux-system/arc-system.yaml
@@ -11,8 +11,6 @@ spec:
   sourceRef:
     kind: GitRepository
     name: infra
-  dependsOn:
-    - name: repositories
   # CRDs exist only after this HelmRelease is ready; runners need them.
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/clusters/folly/flux-system/external-secrets-operator.yaml
+++ b/clusters/folly/flux-system/external-secrets-operator.yaml
@@ -11,5 +11,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: infra
-  dependsOn:
-    - name: repositories

--- a/clusters/folly/flux-system/onepassword-connect.yaml
+++ b/clusters/folly/flux-system/onepassword-connect.yaml
@@ -16,5 +16,4 @@ spec:
     secretRef:
       name: sops-age
   dependsOn:
-    - name: repositories
     - name: external-secrets-operator

--- a/clusters/folly/flux-system/sandbox.yaml
+++ b/clusters/folly/flux-system/sandbox.yaml
@@ -11,5 +11,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: infra
-  dependsOn:
-    - name: repositories

--- a/clusters/offsite/flux-system/arc-system.yaml
+++ b/clusters/offsite/flux-system/arc-system.yaml
@@ -11,8 +11,6 @@ spec:
   sourceRef:
     kind: GitRepository
     name: infra
-  dependsOn:
-    - name: repositories
   # CRDs exist only after this HelmRelease is ready; runners need them.
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2

--- a/clusters/offsite/flux-system/external-secrets-operator.yaml
+++ b/clusters/offsite/flux-system/external-secrets-operator.yaml
@@ -11,5 +11,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: infra
-  dependsOn:
-    - name: repositories

--- a/clusters/offsite/flux-system/onepassword-connect.yaml
+++ b/clusters/offsite/flux-system/onepassword-connect.yaml
@@ -16,5 +16,4 @@ spec:
     secretRef:
       name: sops-age
   dependsOn:
-    - name: repositories
     - name: external-secrets-operator

--- a/clusters/offsite/flux-system/sandbox.yaml
+++ b/clusters/offsite/flux-system/sandbox.yaml
@@ -11,5 +11,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: infra
-  dependsOn:
-    - name: repositories

--- a/clusters/offsite/kustomization.yaml
+++ b/clusters/offsite/kustomization.yaml
@@ -6,4 +6,4 @@ metadata:
   name: flux-bootstrap
 resources:
   - cluster.yaml
-  - flux/flux-self-managed.yaml
+  - flux-system/flux-self-managed.yaml


### PR DESCRIPTION
## Summary
Follow-up cleanup after the sources colocation (#942). Removes the dangling `dependsOn` that broke reconciliation, then sweeps the repo for every other stale reference the reorg (and an older rename) left behind, verified with a full dependency-graph check.

## Changes
- **fix: drop dangling `dependsOn: repositories`** — #942 deleted the `repositories` Kustomization but 8 Kustomizations (`arc-system`, `external-secrets-operator`, `onepassword-connect`, `sandbox` in both clusters) still depended on it. Flux leaves a Kustomization `NotReady` forever when a `dependsOn` target doesn't exist, which is what broke a bunch of apps. Each of those sources is now colocated in the same Kustomization, so the dep is redundant.
- **fix: correct two stale file-path references**
  - `renovate.json5` — the flux "blocked" rule for the gateway-api CRD source pointed at `clusters/folly/sources/git/gateway-api.yaml`, a path that **never existed** (so the auto-bump block was silently a no-op). Repointed at `clusters/*/networking/git-repository-gateway-api.yaml`.
  - `clusters/offsite/kustomization.yaml` — this manual bootstrap helper referenced `flux/flux-self-managed.yaml`, broken since the `k8s/`→`clusters/` rename (file is at `flux-system/…`). Now `kustomize build clusters/offsite` succeeds. References an already-deployed file, so no live-cluster change.
- **docs: update `kubernetes-gitops` + `multi-cluster` skills** to describe the colocated-sources layout and the `base/platform`/`base/storage` sharing pattern (both were still describing the deleted `sources/` structure and a "shared from folly's directory" pattern that no longer exists).

## Verification
- [x] `grep -rn "name: repositories" clusters/` → nothing
- [x] Full dependency-graph check: **every** `Kustomization→Kustomization` and `HelmRelease→HelmRelease` `dependsOn` target resolves to a defined resource (27 Kustomizations, 31 HelmReleases)
- [x] `kustomize build clusters/folly` **and** `clusters/offsite` both succeed (offsite previously failed on the stale bootstrap path)
- [x] Repo-wide sweep: no remaining references to `base/sources`, `sources/helm`, `sources/git`, or `clusters/*/sources`
- [ ] Flux reconciles `arc-system`, `external-secrets-operator`, `onepassword-connect`, `sandbox` to Ready on both clusters after merge
