### PR TITLE
fix(clusters): resolve colocated HelmRepository sources in their app namespace

### DIFF
--- a/clusters/base/platform/onepassword-connect/helm-release-connect.yaml
+++ b/clusters/base/platform/onepassword-connect/helm-release-connect.yaml
@@ -15,7 +15,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: onepassword
-        namespace: flux-system
       interval: 5m0s
   dependsOn:
     - name: external-secrets

--- a/clusters/base/platform/onepassword-connect/helm-repository.yaml
+++ b/clusters/base/platform/onepassword-connect/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: onepassword
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://1password.github.io/connect-helm-charts

--- a/clusters/folly/apps/cloudnative-pg/helm-release.yaml
+++ b/clusters/folly/apps/cloudnative-pg/helm-release.yaml
@@ -12,4 +12,3 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: cloudnative-pg
-        namespace: flux-system

--- a/clusters/folly/apps/cloudnative-pg/helm-repository.yaml
+++ b/clusters/folly/apps/cloudnative-pg/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: cloudnative-pg
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://cloudnative-pg.github.io/charts

--- a/clusters/folly/apps/descheduler/helm-release.yaml
+++ b/clusters/folly/apps/descheduler/helm-release.yaml
@@ -12,7 +12,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: descheduler
-        namespace: flux-system
   maxHistory: 2
   install:
     remediation:

--- a/clusters/folly/apps/descheduler/helm-repository.yaml
+++ b/clusters/folly/apps/descheduler/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: descheduler
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://kubernetes-sigs.github.io/descheduler

--- a/clusters/folly/apps/falco/helm-release.yaml
+++ b/clusters/folly/apps/falco/helm-release.yaml
@@ -12,7 +12,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: falco
-        namespace: flux-system
   values:
     driver:
       kind: modern-bpf

--- a/clusters/folly/apps/falco/helm-repository.yaml
+++ b/clusters/folly/apps/falco/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: falco
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://falcosecurity.github.io/charts

--- a/clusters/folly/apps/k6/helm-release.yaml
+++ b/clusters/folly/apps/k6/helm-release.yaml
@@ -13,4 +13,3 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: grafana
-        namespace: flux-system

--- a/clusters/folly/apps/k6/helm-repository.yaml
+++ b/clusters/folly/apps/k6/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://grafana.github.io/helm-charts

--- a/clusters/folly/apps/open-webui/helm-release.yaml
+++ b/clusters/folly/apps/open-webui/helm-release.yaml
@@ -13,7 +13,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: open-webui
-        namespace: flux-system
   values:
     ingress:
       enabled: true

--- a/clusters/folly/apps/open-webui/helm-repository.yaml
+++ b/clusters/folly/apps/open-webui/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: open-webui
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://helm.openwebui.com/

--- a/clusters/folly/nodes/helm-repository-intel.yaml
+++ b/clusters/folly/nodes/helm-repository-intel.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: intel
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://intel.github.io/helm-charts

--- a/clusters/folly/nodes/helm-repository-node-feature-discovery.yaml
+++ b/clusters/folly/nodes/helm-repository-node-feature-discovery.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: node-feature-discovery
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://kubernetes-sigs.github.io/node-feature-discovery/charts

--- a/clusters/folly/nodes/intel-device-plugin-gpu.yaml
+++ b/clusters/folly/nodes/intel-device-plugin-gpu.yaml
@@ -13,7 +13,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: intel
-        namespace: flux-system
   dependsOn:
     - name: node-feature-discovery
   install:

--- a/clusters/folly/nodes/intel-device-plugin-operator.yaml
+++ b/clusters/folly/nodes/intel-device-plugin-operator.yaml
@@ -13,7 +13,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: intel
-        namespace: flux-system
   dependsOn:
     - name: node-feature-discovery
   values:

--- a/clusters/folly/nodes/node-feature-discovery.yaml
+++ b/clusters/folly/nodes/node-feature-discovery.yaml
@@ -13,6 +13,5 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: node-feature-discovery
-        namespace: flux-system
   values:
     fullnameOverride: node-feature-discovery

--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -12,7 +12,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: atlantis
-        namespace: flux-system
   values:
     image:
       repository: jonpulsifer/atlantis

--- a/clusters/offsite/apps/atlantis/helm-repository.yaml
+++ b/clusters/offsite/apps/atlantis/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: atlantis
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://runatlantis.github.io/helm-charts

--- a/clusters/offsite/apps/descheduler/helm-release.yaml
+++ b/clusters/offsite/apps/descheduler/helm-release.yaml
@@ -12,7 +12,6 @@ spec:
       sourceRef:
         kind: HelmRepository
         name: descheduler
-        namespace: flux-system
   maxHistory: 2
   install:
     remediation:

--- a/clusters/offsite/apps/descheduler/helm-repository.yaml
+++ b/clusters/offsite/apps/descheduler/helm-repository.yaml
@@ -3,7 +3,6 @@ apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: descheduler
-  namespace: flux-system
 spec:
   interval: 24h
   url: https://kubernetes-sigs.github.io/descheduler


### PR DESCRIPTION
## Summary
Fixes the `failed to get source: HelmRepository "<name>" not found` errors on folly (and latent ones on both clusters) introduced by the sources-colocation reorg (#942).

## Root cause
Several app `kustomization.yaml`s carry a `namespace: <app>` directive. When a HelmRepository was colocated into such a directory, kustomize's namespace transformer rewrote the **HelmRepository's** `metadata.namespace` to the app namespace — but it does **not** rewrite the **HelmRelease's** `sourceRef.namespace`, which still pinned `flux-system`. So Flux created the HelmChart in `flux-system` and couldn't find the source there.

## Impact
- **Actively failing on folly:** `cloudnative-pg`, `descheduler`, `falco`, `k6` (grafana repo), `open-webui`, `onepassword-connect`.
- **Latently broken:** `intel` + `node-feature-discovery` (nodes) — masked only by 107-day-stale "Ready" status; they'd fail on their next reconcile / chart bump.
- **Offsite:** `atlantis`, `descheduler` (same mechanism).

## Fix
Drop the `namespace: flux-system` pin from each affected HelmRelease's `sourceRef` so it defaults to the release's own namespace — the exact namespace the directive places the source in — and remove the now-inaccurate `metadata.namespace: flux-system` from the colocated source files (the directive sets it). Each app-specific source is now fully colocated with its consumer in the app namespace, matching the existing `reloader` app. Shared sources under `base/` (no namespace directive) stay in `flux-system` as before.

## Verification
- [x] `kustomize build` on every affected dir succeeds
- [x] Repo-wide check (built 31 leaf kustomizations): every HelmRelease `sourceRef` resolves to an existing source object **in the same namespace** — the only prior mismatches are gone (the lone remaining flag, `truffle`→`infra`, is the root GitRepository correctly in `flux-system`)
- [ ] After merge: `flux -n flux-system get helmreleases -A` and `get helmcharts -A` all Ready on folly and offsite

## Note
The remote branch `fix/repositories-dependson-cleanup` (from the now-merged #943) got recreated by an errant push and I wasn't able to delete it (guardrail on deleting a merged-PR branch). Safe to delete manually if you like.
