### PR TITLE
feat(k8s): add valkey operator

### DIFF
--- a/clusters/base/platform/valkey-operator/helm-release.yaml
+++ b/clusters/base/platform/valkey-operator/helm-release.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: valkey-operator
+  namespace: valkey-operator-system
+spec:
+  interval: 1m0s
+  maxHistory: 2
+  chart:
+    spec:
+      chart: valkey-operator
+      version: 0.3.0
+      sourceRef:
+        kind: HelmRepository
+        name: valkey
+        namespace: flux-system
+      interval: 5m0s
+  install:
+    crds: CreateReplace
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    crds: CreateReplace
+    remediation:
+      retries: 5
+  values: {}

--- a/clusters/base/platform/valkey-operator/helm-repository.yaml
+++ b/clusters/base/platform/valkey-operator/helm-repository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: valkey
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://valkey.io/valkey-helm/

--- a/clusters/base/platform/valkey-operator/kustomization.yaml
+++ b/clusters/base/platform/valkey-operator/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - helm-release.yaml

--- a/clusters/base/platform/valkey-operator/namespace.yaml
+++ b/clusters/base/platform/valkey-operator/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: valkey-operator-system
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/folly/flux-system/valkey-operator.yaml
+++ b/clusters/folly/flux-system/valkey-operator.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: valkey-operator
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/base/platform/valkey-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: valkey-operator
+      namespace: valkey-operator-system

--- a/clusters/offsite/flux-system/valkey-operator.yaml
+++ b/clusters/offsite/flux-system/valkey-operator.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: valkey-operator
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/base/platform/valkey-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: valkey-operator
+      namespace: valkey-operator-system


### PR DESCRIPTION
## Summary
Install the Valkey operator in both the folly and offsite clusters so future Redis-compatible Valkey resources can be managed through GitOps.

## Changes
- feat(k8s): add valkey operator

## Test Plan
- [x] `kubectl kustomize clusters/base/platform/valkey-operator`
- [x] `kubectl apply --dry-run=client --validate=false -f clusters/folly/flux-system/valkey-operator.yaml`
- [x] `kubectl apply --dry-run=client --validate=false -f clusters/offsite/flux-system/valkey-operator.yaml`
- [x] `helm template valkey-operator valkey-operator --repo https://valkey.io/valkey-helm/ --version 0.3.0 -n valkey-operator-system`

## Context
- `.agent/context/context.md`
