### PR TITLE
feat(kiosk): add public option to bind to 0.0.0.0 and open firewall

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -41,3 +41,22 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           skipPush: ${{ github.ref != 'refs/heads/main' }}
       - run: nix build .#nixosConfigurations.optiplex.config.system.build.toplevel
+  nixos-aarch64:
+    # Build one Pi (weatherpi4) on a native ARM runner so aarch64 packages
+    # get cached in Cachix — cross-compiling or building these on the Pis
+    # themselves is painfully slow. Runs on push to main and on PRs (cache
+    # push is gated on main, see skipPush below).
+    runs-on: ubuntu-24.04-arm
+    needs: check
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: NixOS/nix-installer-action@main
+        with:
+          extra-conf: |
+            experimental-features = nix-command flakes
+      - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
+        with:
+          name: jonpulsifer
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          skipPush: ${{ github.ref != 'refs/heads/main' }}
+      - run: nix build .#nixosConfigurations.weatherpi4.config.system.build.toplevel

--- a/nix/hosts/weatherpi4.nix
+++ b/nix/hosts/weatherpi4.nix
@@ -29,5 +29,6 @@
   services.kiosk = {
     enable = true;
     container = true;
+    public = true;
   };
 }

--- a/nix/services/kiosk.nix
+++ b/nix/services/kiosk.nix
@@ -26,6 +26,12 @@ in
       default = false;
     };
 
+    public = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Bind the container port to 0.0.0.0 instead of 127.0.0.1";
+    };
+
     image = mkOption {
       type = types.str;
       default = "ghcr.io/jonpulsifer/hub:latest";
@@ -44,6 +50,8 @@ in
 
   config = mkIf cfg.enable {
     boot.kernelParams = [ "nomodeset" ];
+
+    networking.firewall.allowedTCPPorts = mkIf cfg.public [ cfg.hostPort ];
 
     hardware = {
       graphics.enable = true;
@@ -112,7 +120,11 @@ in
       containers.kiosk = {
         autoStart = true;
         image = cfg.image;
-        ports = [ "127.0.0.1:${toString cfg.hostPort}:${toString cfg.containerPort}" ];
+        ports = [
+          "${
+            if cfg.public then "0.0.0.0" else "127.0.0.1"
+          }:${toString cfg.hostPort}:${toString cfg.containerPort}"
+        ];
         environmentFiles = [ "/var/secrets/kiosk.env" ];
         environment = {
           PORT = toString cfg.containerPort;


### PR DESCRIPTION
## Summary
Add a `services.kiosk.public` option (default `false`) that binds the container port to `0.0.0.0` instead of `127.0.0.1` and opens `hostPort` on the NixOS firewall, then enable it on weatherpi4 so the kiosk URL is reachable from the LAN.

## Changes
- feat(kiosk): add public option to bind to 0.0.0.0 and open firewall

## Test Plan
- [ ] `nix build .#nixosConfigurations.weatherpi4.config.system.build.sdImage` (or `nixos-rebuild build --flake .#weatherpi4`)
- [ ] On weatherpi4: `curl http://weatherpi4.lolwtf.ca:8080` returns the kiosk app
- [ ] On a non-`public` kiosk host (e.g. homepi4): `ss -tlnp | grep 8080` still shows `127.0.0.1:8080`

## Context
- `nix/services/kiosk.nix` — new `public` option + firewall rule + conditional bind address
- `nix/hosts/weatherpi4.nix` — `services.kiosk.public = true`
