### PR TITLE
feat(nix): add rackpi5 host via nixos-raspberrypi + wsl binfmt

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "argononed": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1729566243,
+        "narHash": "sha256-DPNI0Dpk5aym3Baf5UbEe5GENDrSmmXVdriRSWE+rgk=",
+        "owner": "nvmd",
+        "repo": "argononed",
+        "rev": "16dbee54d49b66d5654d228d1061246b440ef7cf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvmd",
+        "repo": "argononed",
+        "type": "github"
+      }
+    },
     "disko": {
       "inputs": {
         "nixpkgs": [
@@ -21,6 +37,21 @@
       }
     },
     "flake-compat": {
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1767039857,
@@ -125,9 +156,57 @@
         "type": "github"
       }
     },
+    "nixos-images": {
+      "inputs": {
+        "nixos-stable": [
+          "nixos-raspberrypi",
+          "nixpkgs"
+        ],
+        "nixos-unstable": [
+          "nixos-raspberrypi",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747747741,
+        "narHash": "sha256-LUOH27unNWbGTvZFitHonraNx0JF/55h30r9WxqrznM=",
+        "owner": "nvmd",
+        "repo": "nixos-images",
+        "rev": "cbbd6db325775096680b65e2a32fb6187c09bbb4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvmd",
+        "ref": "sdimage-installer",
+        "repo": "nixos-images",
+        "type": "github"
+      }
+    },
+    "nixos-raspberrypi": {
+      "inputs": {
+        "argononed": "argononed",
+        "flake-compat": "flake-compat",
+        "nixos-images": "nixos-images",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1779023229,
+        "narHash": "sha256-MInilg7B/06c34SwOuGSBho4l0H1EZcmvxTkSWCs5pE=",
+        "owner": "nvmd",
+        "repo": "nixos-raspberrypi",
+        "rev": "06c6e3513e1ee64b651913193fc6ac38aa4963f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvmd",
+        "ref": "main",
+        "repo": "nixos-raspberrypi",
+        "type": "github"
+      }
+    },
     "nixos-wsl": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_2",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -162,6 +241,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1778737229,
+        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1782999065,
         "narHash": "sha256-5Dgj5+pIQYZKrXUGaLCk7CKfN3MmpwIhO94++WVxvng=",
         "owner": "nixos",
@@ -183,8 +278,9 @@
         "keys": "keys",
         "mise": "mise",
         "nixos-hardware": "nixos-hardware",
+        "nixos-raspberrypi": "nixos-raspberrypi",
         "nixos-wsl": "nixos-wsl",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "rowbuttkeys": "rowbuttkeys",
         "unstable": "unstable",
         "wannabekeys": "wannabekeys"

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,19 @@
 {
   description = "the homelab";
 
+  nixConfig = {
+    extra-substituters = [
+      "https://nixos-raspberrypi.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nixos-raspberrypi.cachix.org-1:4iMO9LXa8BqhU+Rpg6LQKiGa2lsNh/j2oiYLNOQ5sPI="
+    ];
+  };
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     nixos-hardware.url = "github:nixos/nixos-hardware";
+    nixos-raspberrypi.url = "github:nvmd/nixos-raspberrypi/main";
     nixos-wsl = {
       url = "github:nix-community/NixOS-WSL/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -68,6 +78,7 @@
         "cloudpi4"
         "homepi4"
         "weatherpi4"
+        "rackpi5"
         "oldboy"
       ];
 
@@ -138,6 +149,10 @@
           system = "aarch64-linux";
           modules = [ ./nix/hosts/weatherpi4.nix ];
         };
+        rackpi5 = mkHost "rackpi5" {
+          system = "aarch64-linux";
+          modules = [ ./nix/hosts/rackpi5.nix ];
+        };
 
         oldboy = mkHost "oldboy" {
           tags = [ "gcp" ];
@@ -172,6 +187,7 @@
           cloudpi4 = nixosConfigurations.cloudpi4.config.system.build.sdImage;
           homepi4 = nixosConfigurations.homepi4.config.system.build.sdImage;
           weatherpi4 = nixosConfigurations.weatherpi4.config.system.build.sdImage;
+          rackpi5 = nixosConfigurations.rackpi5.config.system.build.sdImage;
         };
       };
 

--- a/nix/hardware/pi5/default.nix
+++ b/nix/hardware/pi5/default.nix
@@ -1,89 +1,23 @@
-{
-  config,
-  lib,
-  pkgs,
-  inputs,
-  modulesPath,
-  ...
-}:
+{ lib, nixos-raspberrypi, ... }:
 {
   imports = [
-    inputs.nixos-hardware.nixosModules.raspberry-pi-5
-    (modulesPath + "/installer/sd-card/sd-image-aarch64.nix")
+    nixos-raspberrypi.nixosModules.trusted-nix-caches
+    nixos-raspberrypi.nixosModules.sd-image
+    nixos-raspberrypi.nixosModules.raspberry-pi-5.base
+    nixos-raspberrypi.lib.inject-overlays
   ];
 
   # save some space
   documentation.enable = false;
 
-  nixpkgs = {
-    # Cross compile the system from x86_64-linux to aarch64-linux if you want
-    # buildPlatform.system = "x86_64-linux";
-    hostPlatform.system = "aarch64-linux";
+  nixpkgs.hostPlatform = "aarch64-linux";
 
-    overlays = [
-      # https://github.com/NixOS/nixpkgs/issues/154163
-      (final: super: {
-        makeModulesClosure = x: super.makeModulesClosure (x // { allowMissing = true; });
-      })
-    ];
-  };
-
-  boot =
-    let
-      linux_rpi5 = pkgs.unstable.linux_rpi4.override {
-        rpiVersion = 5;
-        argsOverride.defconfig = "bcm2712_defconfig";
-      };
-    in
-    {
-      kernelPackages = lib.mkForce linux_rpi5;
-      # kernelParams = [
-      #   "console=tty0"
-      #   "cma=256M"
-      #   "cgroup_enable=cpuset"
-      #   "cgroup_enable=memory"
-      # ];
-      supportedFilesystems = [
-        "ext4"
-        "vfat"
-      ];
-
-      # this runs out of space sometimes
-      tmp = {
-        useTmpfs = false;
-      };
-
-      consoleLogLevel = 7;
-
-      loader = {
-        # we legacy boot
-        systemd-boot.enable = false;
-        efi.canTouchEfiVariables = false;
-        timeout = lib.mkForce 1;
-      };
-    };
-
-  # Required for the Wireless firmware
-  hardware.enableRedistributableFirmware = true;
-
-  powerManagement.cpuFreqGovernor = lib.mkDefault "ondemand";
+  # The sd-image installer profile (nixpkgs' profiles/base.nix) defaults zfs
+  # support on whenever it's available on the platform, but our kernel comes
+  # from nixos-raspberrypi's own pinned nixpkgs while userland zfs comes from
+  # ours -- mismatched versions trip the "kernel module and userspace tooling
+  # not matching" assertion. We don't need zfs on this host anyway.
+  boot.supportedFilesystems.zfs = lib.mkForce false;
 
   sdImage.compressImage = true;
-  sdImage.firmwareSize = 512;
-
-  fileSystems = lib.mkForce {
-    "/" = {
-      device = "/dev/disk/by-label/NIXOS_SD";
-      fsType = "ext4";
-      options = [ "noatime" ];
-    };
-    "/boot/firmware" = {
-      device = "/dev/disk/by-label/FIRMWARE";
-      fsType = "vfat";
-      options = [
-        "noauto"
-        "nofail"
-      ];
-    };
-  };
 }

--- a/nix/hosts/rackpi5.nix
+++ b/nix/hosts/rackpi5.nix
@@ -1,4 +1,4 @@
-{ config, name, ... }:
+{ lib, name, ... }:
 {
   imports = [
     ../hardware/pi5
@@ -7,13 +7,6 @@
 
   networking = {
     hostName = name;
-    wireless = {
-      enable = true;
-      networks = {
-        lab = {
-          hidden = true;
-        };
-      };
-    };
+    wireless.enable = lib.mkForce false;
   };
 }

--- a/nix/images/wsl.nix
+++ b/nix/images/wsl.nix
@@ -14,6 +14,16 @@
 
   nixpkgs.config.allowUnfree = true;
 
+  # Emulate aarch64 via qemu-user/binfmt so we can build the Pi (pi4/pi5)
+  # sdImage outputs on this x86_64 host instead of needing a native aarch64
+  # builder or a remote builder.
+  boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+  # NixOS's binfmt module takes over the whole binfmt_misc table on
+  # activation; without this, adding the aarch64 registration above wipes
+  # out WSL2's own .exe interop handler and breaks running Windows binaries
+  # (explorer.exe, code.exe, Docker Desktop, ...) from inside WSL.
+  wsl.interop.register = true;
+
   wsl = {
     enable = true;
     defaultUser = "jawn";

--- a/nix/lib/mkHost.nix
+++ b/nix/lib/mkHost.nix
@@ -49,7 +49,13 @@ in
     nixosSystem {
       inherit system;
       modules = baseModules ++ modules;
-      specialArgs = { inherit inputs name tags; };
+      specialArgs = {
+        inherit inputs name tags;
+        # nixos-raspberrypi's board modules expect this as a top-level
+        # specialArg (not inputs.nixos-raspberrypi) so they can resolve their
+        # own packages/overlays.
+        nixos-raspberrypi = inputs.nixos-raspberrypi;
+      };
     };
 
   mkImage =


### PR DESCRIPTION
## Summary
Adds `rackpi5` (a Pi5) to the flake using the `nvmd/nixos-raspberrypi` flake instead of `nixos-hardware`, and enables aarch64 binfmt emulation on the WSL dev host so its sdImage output (and the other Pi images) can be cross-built on x86_64.

## Changes
- feat(nix): add rackpi5 host on the nixos-raspberrypi flake
- feat(nix): enable aarch64 binfmt emulation on the wsl image

## Test Plan
- [x] `nix flake lock` resolves the new `nixos-raspberrypi` input cleanly
- [x] `nix eval .#nixosConfigurations.rackpi5.config.system.build.toplevel.drvPath` evaluates without error
- [x] `nix eval .#packages.aarch64-linux.rackpi5.drvPath` (sdImage) evaluates without error
- [x] `nix eval .#nixosConfigurations.wsl.config.system.build.toplevel.drvPath` evaluates without the WSL interop warning
- [x] `nix flake check` passes
- [ ] Actual sdImage build + first boot on real rackpi5 hardware (not done in this session)
