### PR TITLE
fix(nix): move pi sd-image outputs to packages.x86_64-linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel
 # Build installation media
 nix build .#iso         # x86_64 NixOS ISO
 nix build .#wsl         # WSL tarball
-nix build .#cloudpi4    # Raspberry Pi 4 SD image
+nix build .#cloudpi4    # Raspberry Pi 4 SD image (cross-built via qemu emulation)
+nix build .#rackpi5     # Raspberry Pi 5 SD image (cross-built via qemu emulation)
 ```
 
 See [`nix/README.md`](./nix/README.md) for detailed NixOS documentation.

--- a/flake.nix
+++ b/flake.nix
@@ -89,8 +89,7 @@
           config.allowUnfree = true;
         }
       );
-    in
-    rec {
+
       nixosConfigurations = {
         optiplex = mkHost "optiplex" {
           role = "control-plane";
@@ -165,9 +164,24 @@
         container = mkImage ./nix/images/container.nix;
         netboot = mkImage ./nix/images/netboot.nix;
       };
+    in
+    {
+      inherit nixosConfigurations;
 
       packages = {
+        # sdImage derivations are pinned to aarch64-linux internally (each
+        # Pi's nixosSystem is called with system = "aarch64-linux" above),
+        # but they're only ever built by cross-compiling from the x86_64
+        # WSL/laptop dev box via the qemu binfmt emulation in
+        # nix/images/wsl.nix -- nobody builds these while logged into the Pi
+        # itself. So they live under x86_64-linux, matching how `nix build
+        # .#<host>` actually gets invoked, not under aarch64-linux.
         x86_64-linux = {
+          cloudpi4 = nixosConfigurations.cloudpi4.config.system.build.sdImage;
+          homepi4 = nixosConfigurations.homepi4.config.system.build.sdImage;
+          weatherpi4 = nixosConfigurations.weatherpi4.config.system.build.sdImage;
+          rackpi5 = nixosConfigurations.rackpi5.config.system.build.sdImage;
+
           iso = nixosConfigurations.iso.config.system.build.isoImage;
           wsl = nixosConfigurations.wsl.config.system.build.tarballBuilder;
           container = nixosConfigurations.container.config.system.build.tarball;
@@ -182,12 +196,6 @@
             ];
             preferLocalBuild = true;
           };
-        };
-        aarch64-linux = {
-          cloudpi4 = nixosConfigurations.cloudpi4.config.system.build.sdImage;
-          homepi4 = nixosConfigurations.homepi4.config.system.build.sdImage;
-          weatherpi4 = nixosConfigurations.weatherpi4.config.system.build.sdImage;
-          rackpi5 = nixosConfigurations.rackpi5.config.system.build.sdImage;
         };
       };
 


### PR DESCRIPTION
## Summary
`nix build .#rackpi5` / `.#weatherpi4` silently failed to resolve on the x86_64 WSL/laptop dev box because the sd-image outputs lived under `packages.aarch64-linux`, not the current build system. Moves them to `packages.x86_64-linux` where they're actually built (via qemu binfmt emulation), and drops the now-pointless `aarch64-linux` package set along with the unnecessary `rec` on the flake outputs.

## Changes
- fix(nix): move pi sd-image outputs to packages.x86_64-linux

## Test Plan
- [x] `nix build .#rackpi5 --dry-run` resolves and evaluates correctly (previously errored: "does not provide attribute 'packages.x86_64-linux.rackpi5'")
- [x] `nix build .#weatherpi4 --dry-run` resolves and evaluates correctly
- [x] `nix flake check --no-build` passes with no new warnings (previously emitted `warning: unknown flake output 'piImages'` during iteration, now gone)
- [x] `nix fmt` on `flake.nix` reports 0 changes needed
