### PR TITLE
feat(nix): add config.txt PCIe options for 52Pi P33 NVMe HAT on rackpi5

### DIFF
--- a/nix/hardware/pi5/nvme-hat.nix
+++ b/nix/hardware/pi5/nvme-hat.nix
@@ -1,0 +1,35 @@
+# 52Pi P33 M.2 NVMe M-Key & PoE+ HAT for Raspberry Pi 5
+# https://wiki.52pi.com/index.php?title=EP-0241
+{ pkgs, ... }:
+{
+  hardware.raspberry-pi.config.pi5.base-dt-params = {
+    # Enables the PCIe port the HAT's M.2 slot is wired to.
+    pciex1 = {
+      enable = true;
+    };
+
+    # The HAT's PCIe link is certified for Gen 2.0 (5 GT/s). Gen 3.0
+    # (10 GT/s) can be forced, but only once a given board+drive is tested
+    # stable at that speed:
+    # pciex1_gen = {
+    #   enable = true;
+    #   value = 3;
+    # };
+  };
+
+  # rpi-eeprom-config/-update, for the bootloader step below.
+  environment.systemPackages = [ pkgs.raspberrypi-eeprom ];
+
+  # config.txt is all that's declarative here -- the bootloader config below
+  # lives in the Pi's SPI EEPROM, outside the NixOS closure, so it has to be
+  # applied by hand per-device with:
+  #   sudo rpi-eeprom-config --edit
+  # setting:
+  #   PSU_MAX_CURRENT=5000   # PoE+ HAT can supply up to 5A
+  #   PCIE_PROBE=1           # auto-detect the NVMe drive
+  #   BOOT_ORDER=0xf416      # try NVMe, then USB, then SD, repeat
+  #
+  # BOOT_ORDER is what actually enables booting from NVMe -- only set it on
+  # hosts that should boot from the M.2 drive. rackpi5 has this HAT
+  # installed but should keep booting from its SD card for now.
+}

--- a/nix/hosts/rackpi5.nix
+++ b/nix/hosts/rackpi5.nix
@@ -2,6 +2,7 @@
 {
   imports = [
     ../hardware/pi5
+    ../hardware/pi5/nvme-hat.nix
     ../services/common.nix
   ];
 


### PR DESCRIPTION
## Summary
Adds declarative config.txt PCIe options for the 52Pi P33 M.2 NVMe M-Key & PoE+ HAT ([EP-0241](https://wiki.52pi.com/index.php?title=EP-0241)) and wires them into rackpi5, which has the HAT installed.

## Changes
- `nix/hardware/pi5/nvme-hat.nix` (new): opt-in hardware module setting `dtparam=pciex1` via `hardware.raspberry-pi.config.pi5.base-dt-params`, with Gen3 (`pciex1_gen=3`) documented but left commented/opt-in until tested stable on a given board+drive. Adds `pkgs.raspberrypi-eeprom` for the manual EEPROM step below.
- `nix/hosts/rackpi5.nix`: imports the new module.

EEPROM bootloader settings (`PSU_MAX_CURRENT=5000`, `PCIE_PROBE=1`, `BOOT_ORDER=0xf416`) aren't declarative in this flake's version of `nixos-raspberrypi` — they live in the Pi's SPI flash, outside the Nix closure — so they're documented in the module as manual `sudo rpi-eeprom-config --edit` steps rather than applied automatically. `BOOT_ORDER` (which enables NVMe boot) is intentionally **not** set on rackpi5 — it should only be applied per-host once a specific device is ready to boot from NVMe.

## Test Plan
- [x] `nix flake check` passes
- [x] Verified generated config.txt for rackpi5 contains `dtparam=pciex1` under the `[pi5]` section (built `nixosConfigurations.rackpi5.config.hardware.raspberry-pi.config-generated`)
- [x] `nix fmt` clean on changed files
- [ ] Deploy to rackpi5 and confirm NVMe drive is detected via `lspci`/`nvme list` (no boot behavior change expected)
