### PR TITLE
fix(rackstat): update monitored host targets

### DIFF
--- a/apps/rackstat/README.md
+++ b/apps/rackstat/README.md
@@ -27,7 +27,7 @@ Serves `/api/rackstat` and `/healthz` on `:8080`, caching snapshots for 15s.
 Sources, each degrading independently:
 
 - **Prometheus** — node up/temp/CPU/mem from the `node-exporter` job (k8s
-  nodes and the bare Pis), firing alerts (excluding the always-firing
+  nodes and bare hosts), firing alerts (excluding the always-firing
   Watchdog/InfoInhibitor), k8s readiness from kube-state-metrics, and a 24h
   cluster CPU history. Fleet membership comes from Prometheus targets, so
   hosts never need to be hardcoded.

--- a/apps/rackstat/main.go
+++ b/apps/rackstat/main.go
@@ -2,7 +2,7 @@
 // rack-top Tidbyt/Tronbyt display (apps/rackstat/rackstat.star). It fans out
 // to three sources and degrades gracefully when any of them is unavailable:
 //
-//   - Prometheus: node up/temp/cpu/mem (node-exporter, incl. the bare Pis),
+//   - Prometheus: node up/temp/cpu/mem (node-exporter, incl. bare hosts),
 //     firing alerts (minus the always-firing Watchdog/InfoInhibitor), k8s
 //     node readiness, and a 24h cluster CPU history for the sparkline page.
 //   - Kubernetes API: Flux Kustomization/HelmRelease readiness and the last
@@ -54,7 +54,7 @@ type Snapshot struct {
 }
 
 // Node is one machine known to Prometheus' node-exporter job. K8s nodes also
-// carry cluster readiness; the bare Pis just have exporter reachability.
+// carry cluster readiness; bare hosts just have exporter reachability.
 type Node struct {
 	Name   string   `json:"name"`
 	Up     bool     `json:"up"`
@@ -385,8 +385,8 @@ func severityRank(s string) int {
 }
 
 // nodeName normalizes a node-exporter series to a short host name: prefer
-// the k8s node label, else the host part of instance ("homepi4.lolwtf.ca:9100"
-// -> "homepi4").
+// the k8s node label, else the host part of instance ("dns.lolwtf.ca:9100"
+// -> "dns").
 func nodeName(metric map[string]string) string {
 	if n := metric["node"]; n != "" {
 		return n

--- a/apps/rackstat/main_test.go
+++ b/apps/rackstat/main_test.go
@@ -36,7 +36,7 @@ func TestNodeName(t *testing.T) {
 		want   string
 	}{
 		{map[string]string{"node": "optiplex"}, "optiplex"},
-		{map[string]string{"instance": "homepi4-wifi.lolwtf.ca:9100"}, "homepi4-wifi"},
+		{map[string]string{"instance": "dns.lolwtf.ca:9100"}, "dns"},
 		{map[string]string{"instance": "cloudpi4:9100"}, "cloudpi4"},
 		{map[string]string{"instance": "radiopi0"}, "radiopi0"},
 		{map[string]string{}, ""},
@@ -79,7 +79,8 @@ func fakeProm(t *testing.T) *httptest.Server {
 			w.Write([]byte(promVec(
 				map[string]any{"node": "optiplex", "_value": "1"},
 				map[string]any{"node": "riptide", "_value": "1"},
-				map[string]any{"instance": "tallboy.lolwtf.ca:9100", "_value": "0"},
+				map[string]any{"instance": "dns.lolwtf.ca:9100", "_value": "1"},
+				map[string]any{"instance": "spore.lolwtf.ca:9100", "_value": "0"},
 				map[string]any{"instance": "cloudpi4:9100", "_value": "1"},
 			)))
 		case strings.HasPrefix(q, `max by (node, instance) (node_hwmon_temp_celsius)`):
@@ -113,8 +114,8 @@ func TestCollectProm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(snap.Nodes) != 4 {
-		t.Fatalf("want 4 nodes, got %+v", snap.Nodes)
+	if len(snap.Nodes) != 5 {
+		t.Fatalf("want 5 nodes, got %+v", snap.Nodes)
 	}
 	// k8s nodes sort first
 	if !snap.Nodes[0].K8s || snap.Nodes[0].Name != "optiplex" {
@@ -124,8 +125,8 @@ func TestCollectProm(t *testing.T) {
 		t.Errorf("riptide should be k8s and not ready, got %+v", snap.Nodes[1])
 	}
 	for _, n := range snap.Nodes {
-		if n.Name == "tallboy" && n.Up {
-			t.Errorf("tallboy should be down")
+		if n.Name == "spore" && n.Up {
+			t.Errorf("spore should be down")
 		}
 	}
 	if snap.Nodes[0].TempC == nil || *snap.Nodes[0].TempC != 54.3 {
@@ -168,7 +169,7 @@ func TestSnapshotCachesAndServes(t *testing.T) {
 	if decoded.Cluster != "" && decoded.Cluster != "folly" {
 		t.Errorf("unexpected cluster: %q", decoded.Cluster)
 	}
-	if len(decoded.Nodes) != 4 {
-		t.Errorf("want 4 nodes over HTTP, got %d", len(decoded.Nodes))
+	if len(decoded.Nodes) != 5 {
+		t.Errorf("want 5 nodes over HTTP, got %d", len(decoded.Nodes))
 	}
 }

--- a/apps/rackstat/sample_results.json
+++ b/apps/rackstat/sample_results.json
@@ -38,8 +38,8 @@
    "mem_pct": 17.9
   },
   {
-   "name": "homepi4-wifi",
-   "up": false,
+   "name": "dns",
+   "up": true,
    "k8s": false
   },
   {
@@ -51,7 +51,7 @@
    "mem_pct": 34.2
   },
   {
-   "name": "tallboy",
+   "name": "spore",
    "up": false,
    "k8s": false
   }

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -65,10 +65,10 @@ spec:
             static_configs:
               - targets:
                 - cloudpi4.${SECRET_DOMAIN}:9100
-                - homepi4-wifi.${SECRET_DOMAIN}:9100
+                - dns.${SECRET_DOMAIN}:9100
                 - radiopi0.${SECRET_DOMAIN}:9100
+                - spore.${SECRET_DOMAIN}:9100
                 # - blinkypi0.${SECRET_DOMAIN}:9100
-                - tallboy.${SECRET_DOMAIN}:9182
             relabel_configs:
               - source_labels: [__address__]
                 regex: '(\w+)\.(.+):(\d+)'

--- a/clusters/folly/monitoring/local-node-exporters.yaml
+++ b/clusters/folly/monitoring/local-node-exporters.yaml
@@ -14,70 +14,14 @@ ports:
 endpoints:
   - addresses: ["10.2.0.20"]
     nodeName: cloudpi4
-  - addresses: ["10.2.0.23"]
-    nodeName: homepi4-wifi
+  - addresses: ["10.2.0.10"]
+    nodeName: dns
   - addresses: ["10.2.0.24"]
     nodeName: radiopi0
   - addresses: ["10.2.0.25"]
     nodeName: blinkypi0
   - addresses: ["10.2.0.11"]
     nodeName: spore
----
-apiVersion: discovery.k8s.io/v1
-kind: EndpointSlice
-metadata:
-  name: windows-exporters
-  namespace: monitoring
-  labels:
-    kubernetes.io/service-name: windows-exporters
-    lolwtf.ca/service: windows-exporter
-addressType: IPv4
-ports:
-  - name: http-metrics
-    port: 9182
-    protocol: TCP
-endpoints:
-  - addresses: ["10.13.37.2"]
-    nodeName: tallboy
---- # trivy:ignore:avd-ksv-0108
-apiVersion: v1
-kind: Service
-metadata:
-  name: windows-exporters
-  namespace: monitoring
-  labels:
-    lolwtf.ca/service: windows-exporter
-    jobLabel: windows-exporter
-spec:
-  ports:
-    - name: http-metrics
-      port: 9182
-      protocol: TCP
-      targetPort: 9182
----
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: windows-exporters
-  namespace: monitoring
-  labels:
-    lolwtf.ca/service: windows-exporter
-    release: prom-stack
-spec:
-  jobLabel: jobLabel
-  endpoints:
-    - port: http-metrics
-      interval: 30s
-      relabelings:
-        - action: replace
-          sourceLabels: [__meta_kubernetes_endpoint_node_name]
-          targetLabel: instance
-  selector:
-    matchLabels:
-      lolwtf.ca/service: windows-exporter
-  namespaceSelector:
-    matchNames:
-      - monitoring
 --- # trivy:ignore:avd-ksv-0108
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary
Update rackstat monitoring to remove the retired homepi4/tallboy targets and add dns.lolwtf.ca plus spore.lolwtf.ca as node-exporter targets.

## Changes
- fix(rackstat): update monitored host targets

## Test Plan
- [x] go test ./...
- [x] kubectl kustomize clusters/folly/monitoring
- [x] git diff --check
