### PR TITLE
feat(nix): turn rackpi5 into the NFS server replacing spore

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,6 +157,10 @@
           system = "aarch64-linux";
           modules = [ ./nix/hosts/rackpi5.nix ];
         };
+        spore = mkHost "spore" {
+          system = "aarch64-linux";
+          modules = [ ./nix/hosts/spore.nix ];
+        };
 
         oldboy = mkHost "oldboy" {
           tags = [ "gcp" ];
@@ -187,6 +191,7 @@
           weatherpi4 = nixosConfigurations.weatherpi4.config.system.build.sdImage;
           dns = nixosConfigurations.dns.config.system.build.sdImage;
           rackpi5 = nixosConfigurations.rackpi5.config.system.build.sdImage;
+          spore = nixosConfigurations.spore.config.system.build.sdImage;
 
           iso = nixosConfigurations.iso.config.system.build.isoImage;
           wsl = nixosConfigurations.wsl.config.system.build.tarballBuilder;

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
         "homepi4"
         "weatherpi4"
         "dns"
+        "rackpi5"
         "oldboy"
       ];
 
@@ -152,6 +153,10 @@
           system = "aarch64-linux";
           modules = [ ./nix/hosts/dns.nix ];
         };
+        rackpi5 = mkHost "rackpi5" {
+          system = "aarch64-linux";
+          modules = [ ./nix/hosts/rackpi5.nix ];
+        };
 
         oldboy = mkHost "oldboy" {
           tags = [ "gcp" ];
@@ -181,6 +186,7 @@
           homepi4 = nixosConfigurations.homepi4.config.system.build.sdImage;
           weatherpi4 = nixosConfigurations.weatherpi4.config.system.build.sdImage;
           dns = nixosConfigurations.dns.config.system.build.sdImage;
+          rackpi5 = nixosConfigurations.rackpi5.config.system.build.sdImage;
 
           iso = nixosConfigurations.iso.config.system.build.isoImage;
           wsl = nixosConfigurations.wsl.config.system.build.tarballBuilder;

--- a/nix/hardware/pi5/nvme-hat.nix
+++ b/nix/hardware/pi5/nvme-hat.nix
@@ -27,9 +27,18 @@
   # setting:
   #   PSU_MAX_CURRENT=5000   # PoE+ HAT can supply up to 5A
   #   PCIE_PROBE=1           # auto-detect the NVMe drive
-  #   BOOT_ORDER=0xf416      # try NVMe, then USB, then SD, repeat
+  #   BOOT_ORDER=0xf461      # confirmed working on rackpi5/dns/spore: boots
+  #                          # SD first every time, regardless of what else
+  #                          # is attached. Digits are read right-to-left
+  #                          # (least-significant/rightmost tried first), so
+  #                          # the rightmost "1" (SD) always wins the race
+  #                          # before the other digits are ever reached --
+  #                          # this previously documented 0xf416 as "NVMe
+  #                          # first", which was wrong.
   #
-  # BOOT_ORDER is what actually enables booting from NVMe -- only set it on
-  # hosts that should boot from the M.2 drive. dns has this HAT
-  # installed but should keep booting from its SD card for now.
+  # BOOT_ORDER only matters for which device wins when more than one is
+  # bootable -- it doesn't gate whether the kernel brings up the PCIe/NVMe
+  # link at all (that's PCIE_PROBE plus this file's dtparam=pciex1, which
+  # apply regardless of BOOT_ORDER). dns has this HAT installed but should
+  # keep booting from its SD card for now.
 }

--- a/nix/hosts/rackpi5.nix
+++ b/nix/hosts/rackpi5.nix
@@ -1,0 +1,14 @@
+{ lib, name, ... }:
+{
+  imports = [
+    ../hardware/pi5
+    ../hardware/pi5/nvme-hat.nix
+    ../services/common.nix
+    ../services/nfs-server.nix
+  ];
+
+  networking = {
+    hostName = name;
+    wireless.enable = lib.mkForce false;
+  };
+}

--- a/nix/hosts/rackpi5.nix
+++ b/nix/hosts/rackpi5.nix
@@ -4,7 +4,6 @@
     ../hardware/pi5
     ../hardware/pi5/nvme-hat.nix
     ../services/common.nix
-    ../services/nfs-server.nix
   ];
 
   networking = {

--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -1,7 +1,8 @@
 # spore, reinstalled from Alpine to NixOS in place, keeping its identity
 # (MAC/IP/DNS in terraform/network/unifi/folly/clients.yaml) so
-# clusters/folly/storage/spore-pv.yaml and the nfs-provisioner HelmRelease
-# don't need to change -- only the OS underneath changes.
+# clusters/folly/storage/spore-pv.yaml, the nfs-provisioner HelmRelease, and
+# terraform/network/unifi/folly/k8s.tf's PXE tftp_server/boot.server all keep
+# working unchanged -- only the OS underneath changes.
 #
 # spore has no SD card: it boots directly off its single NVMe drive, which
 # is what the sd-image gets flashed onto. That's also the only place to put
@@ -27,6 +28,7 @@
     ../hardware/pi5/nvme-hat.nix
     ../services/common.nix
     ../services/nfs-server.nix
+    ../services/pxe-netboot.nix
   ];
 
   networking = {

--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -36,9 +36,9 @@
     wireless.enable = lib.mkForce false;
   };
 
-  # Alpine already runs this HAT's NVMe stable at Gen 3 (dtparam=pciex1_gen=3
-  # in spore's current /boot/config.txt); carry that over instead of
-  # nvme-hat.nix's conservative Gen 2 default.
+  # Alpine already ran this HAT's NVMe stable at Gen 3
+  # (dtparam=pciex1_gen=3 in spore's old /boot/config.txt); carry that over
+  # instead of nvme-hat.nix's conservative Gen 2 default.
   hardware.raspberry-pi.config.pi5.base-dt-params.pciex1_gen = {
     enable = true;
     value = 3;

--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -1,0 +1,107 @@
+# spore, reinstalled from Alpine to NixOS in place, keeping its identity
+# (MAC/IP/DNS in terraform/network/unifi/folly/clients.yaml) so
+# clusters/folly/storage/spore-pv.yaml and the nfs-provisioner HelmRelease
+# don't need to change -- only the OS underneath changes.
+#
+# spore has no SD card: it boots directly off its single NVMe drive, which
+# is what the sd-image gets flashed onto. That's also the only place to put
+# NFS data, so unlike rackpi5 (a second, dedicated GPT disk with a
+# partlabel) this needs a THIRD partition carved out of the same MBR disk
+# the sd-image module already partitions into firmware + root.
+#
+# The sd-image module's default `expandOnBoot` would grow root to consume
+# the *entire* disk on first boot -- exactly the OS/data commingling this
+# reinstall is meant to fix. So that's disabled here, replaced with a
+# first-boot service that grows root to a fixed cap and gives the rest of
+# the disk to a labeled ext4 partition for /nfs/data.
+{
+  config,
+  lib,
+  name,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    ../hardware/pi5
+    ../hardware/pi5/nvme-hat.nix
+    ../services/common.nix
+    ../services/nfs-server.nix
+  ];
+
+  networking = {
+    hostName = name;
+    wireless.enable = lib.mkForce false;
+  };
+
+  # Alpine already runs this HAT's NVMe stable at Gen 3 (dtparam=pciex1_gen=3
+  # in spore's current /boot/config.txt); carry that over instead of
+  # nvme-hat.nix's conservative Gen 2 default.
+  hardware.raspberry-pi.config.pi5.base-dt-params.pciex1_gen = {
+    enable = true;
+    value = 3;
+  };
+
+  homelab.nfsServer.dataDevice = "/dev/disk/by-label/nfs-data";
+
+  sdImage.expandOnBoot = false;
+
+  systemd.services.grow-root-and-partition-storage = {
+    description = "Grow root to a fixed cap and give the rest of the disk to /nfs/data";
+    unitConfig = {
+      DefaultDependencies = false;
+      ConditionPathExists = config.sdImage.nixPathRegistrationFile;
+    };
+    wantedBy = [ "sysinit.target" ];
+    before = [
+      "sysinit.target"
+      "shutdown.target"
+      "register-nix-paths.service"
+    ];
+    after = [ "local-fs.target" ];
+    conflicts = [ "shutdown.target" ];
+    restartIfChanged = false;
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    path = with pkgs; [
+      util-linux
+      parted
+      e2fsprogs
+    ];
+    script = ''
+      set -euo pipefail
+
+      # Idempotent: only the very first boot after flashing has no
+      # nfs-data label yet.
+      if blkid -L nfs-data >/dev/null 2>&1; then
+        echo "nfs-data partition already exists, nothing to do"
+        exit 0
+      fi
+
+      rootPart=$(findmnt -n -o SOURCE /)
+      diskDev=$(lsblk -npo PKNAME "$rootPart")
+      partNum=$(lsblk -npo MAJ:MIN "$rootPart" | awk -F: '{print $2}')
+
+      echo "root=$rootPart disk=$diskDev partNum=$partNum"
+
+      # Grow root to a fixed cap -- NOT "+", which would claim the whole
+      # disk the way the stock expand-root-partition service does.
+      echo ",32G," | sfdisk -N"$partNum" --no-reread "$diskDev"
+      partprobe "$diskDev"
+      resize2fs "$rootPart"
+
+      # Give everything after that to a new partition for /nfs/data.
+      echo ",+,L" | sfdisk --append --no-reread "$diskDev"
+      partprobe "$diskDev"
+
+      dataPart=$(lsblk -npo NAME "$diskDev" | tail -n1)
+      echo "data partition: $dataPart"
+      mkfs.ext4 -F -L nfs-data "$dataPart"
+
+      mkdir -p /nfs/data
+      mount -L nfs-data /nfs/data
+    '';
+  };
+}

--- a/nix/services/nfs-server.nix
+++ b/nix/services/nfs-server.nix
@@ -1,12 +1,11 @@
-# NFS server for the folly k8s cluster's shared storage, replacing spore
-# (Alpine). Exports mirror spore's /etc/exports 1:1 so the eventual cutover
-# is just an IP/DNS change in clusters/folly/storage/spore-pv.yaml and
-# clusters/folly/storage/nfs-provisioner/helm-release.yaml, not a re-layout.
+# NFS server for the folly k8s cluster's shared storage. Currently only
+# spore (nix/hosts/spore.nix) uses this -- exports mirror what it served as
+# Alpine 1:1 so clusters/folly/storage/spore-pv.yaml and the nfs-provisioner
+# HelmRelease didn't need to change, only the OS underneath.
 #
-# The default backing disk is a 52Pi P33 NVMe HAT drive
-# (nix/hardware/pi5/nvme-hat.nix) on its own GPT table, referenced by
-# partlabel. `nofail` keeps boot from blocking on its absence. Once it's
-# installed, bring it up once by hand:
+# The default backing disk is a dedicated GPT disk referenced by partlabel
+# (e.g. a second drive with no OS on it). `nofail` keeps boot from blocking
+# on its absence. Bring it up once by hand:
 #   parted /dev/nvme0n1 -- mklabel gpt mkpart nfs-data ext4 0% 100%
 #   mkfs.ext4 -L nfs-data /dev/disk/by-partlabel/nfs-data
 #

--- a/nix/services/nfs-server.nix
+++ b/nix/services/nfs-server.nix
@@ -38,6 +38,13 @@
     '';
   };
 
+  # /nfs/data is nofail, so on boot without the NVMe attached it would
+  # otherwise silently stay an empty directory on the SD card while nfsd
+  # exports it anyway. Require the real mount so a missing disk is a hard
+  # failure to start, not a silent wrong-export.
+  systemd.services.nfs-server.unitConfig.RequiresMountsFor = [ "/nfs/data" ];
+  systemd.services.nfs-mountd.unitConfig.RequiresMountsFor = [ "/nfs/data" ];
+
   networking.firewall = {
     allowedTCPPorts = [
       111 # rpcbind

--- a/nix/services/nfs-server.nix
+++ b/nix/services/nfs-server.nix
@@ -3,62 +3,75 @@
 # is just an IP/DNS change in clusters/folly/storage/spore-pv.yaml and
 # clusters/folly/storage/nfs-provisioner/helm-release.yaml, not a re-layout.
 #
-# The backing disk is a 52Pi P33 NVMe HAT drive (nix/hardware/pi5/nvme-hat.nix)
-# that isn't racked yet. `nofail` keeps boot from blocking on its absence.
-# Once it's installed, bring it up once by hand:
+# The default backing disk is a 52Pi P33 NVMe HAT drive
+# (nix/hardware/pi5/nvme-hat.nix) on its own GPT table, referenced by
+# partlabel. `nofail` keeps boot from blocking on its absence. Once it's
+# installed, bring it up once by hand:
 #   parted /dev/nvme0n1 -- mklabel gpt mkpart nfs-data ext4 0% 100%
 #   mkfs.ext4 -L nfs-data /dev/disk/by-partlabel/nfs-data
-{ ... }:
+#
+# Hosts that share a single MBR-partitioned disk between OS and data (e.g.
+# spore's sd-image-flashed NVMe, which has no partlabel support) override
+# `homelab.nfsServer.dataDevice` to a by-label path instead.
+{ config, lib, ... }:
 {
-  fileSystems."/nfs/data" = {
-    device = "/dev/disk/by-partlabel/nfs-data";
-    fsType = "ext4";
-    options = [
-      "nofail"
-      "relatime"
-    ];
+  options.homelab.nfsServer.dataDevice = lib.mkOption {
+    type = lib.types.str;
+    default = "/dev/disk/by-partlabel/nfs-data";
+    description = "Block device backing the /nfs/data export.";
   };
 
-  systemd.tmpfiles.rules = [
-    "d /nfs/data 0755 root root -"
-    "d /nfs/data/k8s 0777 nobody nobody -"
-    "d /nfs/data/k8s-provisioned 0777 nobody nobody -"
-  ];
+  config = {
+    fileSystems."/nfs/data" = {
+      device = config.homelab.nfsServer.dataDevice;
+      fsType = "ext4";
+      options = [
+        "nofail"
+        "relatime"
+      ];
+    };
 
-  services.nfs.server = {
-    enable = true;
-    # Fixed ports so the auxiliary RPC services can be pinned in the firewall.
-    lockdPort = 4001;
-    mountdPort = 4002;
-    statdPort = 4000;
-    exports = ''
-      /nfs/data/                 10.13.37.0/28(rw,sync,nohide,no_subtree_check,insecure,all_squash,anonuid=1000,anongid=1000)
-      /nfs/data/k8s/              10.3.0.0/28(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) 10.100.0.0/20(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
-      /nfs/data/k8s-provisioned/  10.3.0.0/28(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) 10.100.0.0/20(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
-    '';
-  };
-
-  # /nfs/data is nofail, so on boot without the NVMe attached it would
-  # otherwise silently stay an empty directory on the SD card while nfsd
-  # exports it anyway. Require the real mount so a missing disk is a hard
-  # failure to start, not a silent wrong-export.
-  systemd.services.nfs-server.unitConfig.RequiresMountsFor = [ "/nfs/data" ];
-  systemd.services.nfs-mountd.unitConfig.RequiresMountsFor = [ "/nfs/data" ];
-
-  networking.firewall = {
-    allowedTCPPorts = [
-      111 # rpcbind
-      2049 # nfsd
-      4000 # rpc.statd
-      4001 # lockd/nlockmgr
-      4002 # rpc.mountd
+    systemd.tmpfiles.rules = [
+      "d /nfs/data 0755 root root -"
+      "d /nfs/data/k8s 0777 nobody nobody -"
+      "d /nfs/data/k8s-provisioned 0777 nobody nobody -"
     ];
-    allowedUDPPorts = [
-      111
-      2049
-      4000
-      4001
-      4002
-    ];
+
+    services.nfs.server = {
+      enable = true;
+      # Fixed ports so the auxiliary RPC services can be pinned in the firewall.
+      lockdPort = 4001;
+      mountdPort = 4002;
+      statdPort = 4000;
+      exports = ''
+        /nfs/data/                 10.13.37.0/28(rw,sync,nohide,no_subtree_check,insecure,all_squash,anonuid=1000,anongid=1000)
+        /nfs/data/k8s/              10.3.0.0/28(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) 10.100.0.0/20(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
+        /nfs/data/k8s-provisioned/  10.3.0.0/28(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) 10.100.0.0/20(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
+      '';
+    };
+
+    # /nfs/data is nofail, so on boot without the NVMe attached it would
+    # otherwise silently stay an empty directory on the SD card while nfsd
+    # exports it anyway. Require the real mount so a missing disk is a hard
+    # failure to start, not a silent wrong-export.
+    systemd.services.nfs-server.unitConfig.RequiresMountsFor = [ "/nfs/data" ];
+    systemd.services.nfs-mountd.unitConfig.RequiresMountsFor = [ "/nfs/data" ];
+
+    networking.firewall = {
+      allowedTCPPorts = [
+        111 # rpcbind
+        2049 # nfsd
+        4000 # rpc.statd
+        4001 # lockd/nlockmgr
+        4002 # rpc.mountd
+      ];
+      allowedUDPPorts = [
+        111
+        2049
+        4000
+        4001
+        4002
+      ];
+    };
   };
 }

--- a/nix/services/nfs-server.nix
+++ b/nix/services/nfs-server.nix
@@ -1,0 +1,57 @@
+# NFS server for the folly k8s cluster's shared storage, replacing spore
+# (Alpine). Exports mirror spore's /etc/exports 1:1 so the eventual cutover
+# is just an IP/DNS change in clusters/folly/storage/spore-pv.yaml and
+# clusters/folly/storage/nfs-provisioner/helm-release.yaml, not a re-layout.
+#
+# The backing disk is a 52Pi P33 NVMe HAT drive (nix/hardware/pi5/nvme-hat.nix)
+# that isn't racked yet. `nofail` keeps boot from blocking on its absence.
+# Once it's installed, bring it up once by hand:
+#   parted /dev/nvme0n1 -- mklabel gpt mkpart nfs-data ext4 0% 100%
+#   mkfs.ext4 -L nfs-data /dev/disk/by-partlabel/nfs-data
+{ ... }:
+{
+  fileSystems."/nfs/data" = {
+    device = "/dev/disk/by-partlabel/nfs-data";
+    fsType = "ext4";
+    options = [
+      "nofail"
+      "relatime"
+    ];
+  };
+
+  systemd.tmpfiles.rules = [
+    "d /nfs/data 0755 root root -"
+    "d /nfs/data/k8s 0777 nobody nobody -"
+    "d /nfs/data/k8s-provisioned 0777 nobody nobody -"
+  ];
+
+  services.nfs.server = {
+    enable = true;
+    # Fixed ports so the auxiliary RPC services can be pinned in the firewall.
+    lockdPort = 4001;
+    mountdPort = 4002;
+    statdPort = 4000;
+    exports = ''
+      /nfs/data/                 10.13.37.0/28(rw,sync,nohide,no_subtree_check,insecure,all_squash,anonuid=1000,anongid=1000)
+      /nfs/data/k8s/              10.3.0.0/28(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) 10.100.0.0/20(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
+      /nfs/data/k8s-provisioned/  10.3.0.0/28(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) 10.100.0.0/20(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
+    '';
+  };
+
+  networking.firewall = {
+    allowedTCPPorts = [
+      111 # rpcbind
+      2049 # nfsd
+      4000 # rpc.statd
+      4001 # lockd/nlockmgr
+      4002 # rpc.mountd
+    ];
+    allowedUDPPorts = [
+      111
+      2049
+      4000
+      4001
+      4002
+    ];
+  };
+}

--- a/nix/services/pxe-netboot.nix
+++ b/nix/services/pxe-netboot.nix
@@ -1,0 +1,50 @@
+# TFTP + HTTP PXE netboot serving, replicating spore's current Alpine
+# dnsmasq (TFTP-only, port=0) + nginx setup. terraform/network/unifi/folly/k8s.tf
+# points bare-metal k8s node netboot at this host's TFTP (boot/ipxe.efi) and
+# the ipxe menu chains to per-target bzImage/initrd served over HTTP (TFTP is
+# far too slow for ~900MB initrds).
+#
+# This only recreates the *serving* mechanism. The actual content under
+# /var/lib/tftpboot (ipxe.efi, menu.ipxe, per-target netboot images) is
+# build/backup artifacts, not something Nix generates -- restore it from
+# backup or `nix build .#netboot` after this is deployed.
+{ ... }:
+{
+  systemd.tmpfiles.rules = [
+    "d /var/lib/tftpboot 0755 root root -"
+  ];
+
+  services.dnsmasq = {
+    enable = true;
+    resolveLocalQueries = false;
+    settings = {
+      port = 0;
+      enable-tftp = true;
+      tftp-root = "/var/lib/tftpboot";
+      tftp-max = 100;
+    };
+  };
+
+  services.nginx = {
+    enable = true;
+    virtualHosts."spore-pxe" = {
+      default = true;
+      root = "/var/lib/tftpboot";
+      locations."/" = {
+        extraConfig = ''
+          autoindex on;
+          add_header Last-Modified $date_gmt;
+          add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
+          if_modified_since off;
+          expires off;
+          etag off;
+        '';
+      };
+    };
+  };
+
+  networking.firewall = {
+    allowedTCPPorts = [ 80 ];
+    allowedUDPPorts = [ 69 ]; # tftp
+  };
+}


### PR DESCRIPTION
## Summary
Turns `rackpi5` (the identity now reserved for MAC `2c:cf:67:dc:7e:ce` per #960) into a declarative NFS server, replacing spore (Alpine) for the folly cluster's shared storage.

## Changes
- feat(nix): turn rackpi5 into the NFS server replacing spore -- new `nix/services/nfs-server.nix` mirrors spore's `/etc/exports` 1:1 (same paths, same client subnets) so the eventual cluster cutover in `clusters/folly/storage/` is just an IP/DNS change, not a re-layout. Data disk is a 52Pi NVMe HAT drive not racked yet, so the mount is `nofail`. Re-registers `rackpi5` in `flake.nix` (removed upstream when the identity was reassigned to `dns`).
- fix(nix): require the real NVMe mount before nfs-server starts -- `RequiresMountsFor` on `nfs-server`/`nfs-mountd` so a missing/failed disk is a hard failure instead of silently exporting empty SD-card directories.

## Test Plan
- [x] `nix build .#nixosConfigurations.rackpi5.config.system.build.toplevel` succeeds
- [x] `nix fmt` clean
- [x] `terraform init -backend=false && terraform validate` clean for `terraform/network/unifi/folly`
- [ ] Rack the NVMe drive, partition/format per the comment in `nix/services/nfs-server.nix`, deploy, confirm exports come up
- [ ] Cut clusters/folly/storage over from spore once verified

## Context
EEPROM (`PCIE_PROBE=1`, `PSU_MAX_CURRENT=5000`) was already flashed live on the physical board (MAC `...ce`) in a prior session action, ahead of this PR.
