### PR TITLE
fix(nix): give each pi5 host a unique sd-image volume label

### DIFF
--- a/nix/hardware/pi5/default.nix
+++ b/nix/hardware/pi5/default.nix
@@ -1,4 +1,9 @@
-{ lib, nixos-raspberrypi, ... }:
+{
+  lib,
+  name,
+  nixos-raspberrypi,
+  ...
+}:
 {
   imports = [
     nixos-raspberrypi.nixosModules.trusted-nix-caches
@@ -19,5 +24,16 @@
   # not matching" assertion. We don't need zfs on this host anyway.
   boot.supportedFilesystems.zfs = lib.mkForce false;
 
-  sdImage.compressImage = true;
+  sdImage = {
+    compressImage = true;
+
+    # Every sd-image build defaults to the exact same "NIXOS_SD"/"FIRMWARE"
+    # labels, so any two sd-image-flashed devices attached to the same
+    # running kernel at once (e.g. a recovery SD card next to a
+    # sd-image-flashed NVMe drive) race for /dev/disk/by-label/NIXOS_SD --
+    # this is exactly what hung spore's boot with its NVMe attached.
+    # Per-host labels make that impossible.
+    rootVolumeLabel = "NIXOS_${lib.toUpper name}";
+    firmwarePartitionName = "FW_${lib.toUpper name}";
+  };
 }


### PR DESCRIPTION
## Summary
Fixes the boot hang on spore when its NVMe drive is physically attached — root-caused to a filesystem-label collision, not a hardware/kernel issue.

## Changes
- Every sd-image build in this repo defaults to nixpkgs' identical `NIXOS_SD`/`FIRMWARE` labels. When spore's sd-image-flashed NVMe and a recovery SD card were attached to the same running kernel at once, both claimed `/dev/disk/by-label/NIXOS_SD`, and the initrd's root-mount-by-label resolution raced/looped between them — the actual cause of the fan-max hang previously suspected to be a PCIe/kernel driver issue.
- `nix/hardware/pi5/default.nix` now derives a unique `sdImage.rootVolumeLabel` / `firmwarePartitionName` per host from its hostname (e.g. spore → `NIXOS_SPORE`/`FW_SPORE`), so this can't recur fleet-wide across dns, rackpi5, and spore.

## Test Plan
- [x] `nix build .#nixosConfigurations.{spore,rackpi5,dns}.config.system.build.toplevel` succeeds
- [x] Confirmed spore's generated `/etc/fstab` references `NIXOS_SPORE`/`FW_SPORE` instead of the shared default labels
- [ ] Relabel (or reflash) spore's physical NVMe with the new labels and confirm it boots cleanly with the drive attached
