### PR TITLE
fix(nix): correct spore's storage partitioning and add to deployHosts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,7 @@
         "dns"
         "rackpi5"
         "oldboy"
+        "spore"
       ];
 
       legacyPackages = forAllSystems (

--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -83,8 +83,8 @@
       fi
 
       rootPart=$(findmnt -n -o SOURCE /)
-      diskDev=$(lsblk -npo PKNAME "$rootPart")
-      partNum=$(lsblk -npo MAJ:MIN "$rootPart" | awk -F: '{print $2}')
+      diskDev=$(lsblk -rnpo PKNAME "$rootPart")
+      partNum=$(lsblk -rno PARTN "$rootPart")
 
       echo "root=$rootPart disk=$diskDev partNum=$partNum"
 
@@ -95,10 +95,18 @@
       resize2fs "$rootPart"
 
       # Give everything after that to a new partition for /nfs/data.
-      echo ",+,L" | sfdisk --append --no-reread "$diskDev"
+      # NOT "echo ,+,L | sfdisk --append" -- with an unspecified start,
+      # sfdisk fills the first free gap it finds in disk order, which on
+      # this layout is a few reserved sectors *before* partition 1, not
+      # the real free space after root. Compute the real start explicitly
+      # from partition 2's own current geometry instead.
+      rootStart=$(cat "/sys/class/block/$(basename "$rootPart")/start")
+      rootSize=$(cat "/sys/class/block/$(basename "$rootPart")/size")
+      dataStart=$(( rootStart + rootSize ))
+      echo "start=$dataStart,type=L" | sfdisk --append --no-reread "$diskDev"
       partprobe "$diskDev"
 
-      dataPart=$(lsblk -npo NAME "$diskDev" | tail -n1)
+      dataPart=$(lsblk -rnpo NAME "$diskDev" | tail -n1)
       echo "data partition: $dataPart"
       mkfs.ext4 -F -L nfs-data "$dataPart"
 


### PR DESCRIPTION
## Summary
Finishes spore's Alpine-to-NixOS reinstall: the NVMe is now flashed, booting, and preferred over the recovery SD card, with a real bug fix to the storage-partitioning script found along the way.

## Changes
- `sfdisk --append` with an unspecified start fills the *first* free gap it finds in disk order — on spore's disk that's a few reserved sectors before partition 1, not the real free space after root, so `/nfs/data` came out as a stray 7MiB partition instead of the ~86GB actually available. Fixed by computing the append's start explicitly from root's own sysfs geometry (`rootStart + rootSize`).
- Swapped the `awk`-based partition-number lookup for `lsblk`'s `PARTN` column (awk isn't in the unit's `PATH`, and this also sidesteps `lsblk`'s column padding).
- Added `spore` to `flake.nix`'s `deployHosts`.

## Test Plan
- [x] `nix build .#nixosConfigurations.{spore,rackpi5,dns}.config.system.build.toplevel` succeeds
- [x] Flashed spore's NVMe over the network from its SD-booted session, relabeled the SD card to avoid a label collision, flipped `BOOT_ORDER` to prefer NVMe, and confirmed a full cold reboot lands on `/dev/nvme0n1p2`
- [x] Verified final on-disk layout: 1G firmware, 32G root, 86.2G `/nfs/data` at the correct offset
- [x] Restored the pre-migration NFS + TFTP backups onto the fresh disk; confirmed `exportfs -v` and the PXE (dnsmasq/nginx) stack are serving correctly
