### PR TITLE
feat(folly): restore vault deployment

### DIFF
--- a/clusters/folly/apps/kustomization.yaml
+++ b/clusters/folly/apps/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   # - satisfactory
   - hermes
   - tronbyt
+  - vault
 patches:
   - target:
       group: helm.toolkit.fluxcd.io

--- a/clusters/folly/apps/vault/helm-release.yaml
+++ b/clusters/folly/apps/vault/helm-release.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vault
+  namespace: vault
+spec:
+  chart:
+    spec:
+      chart: vault
+      version: 0.32.0
+      sourceRef:
+        kind: HelmRepository
+        name: hashicorp
+  values:
+    server:
+      enabled: true
+      ingress:
+        enabled: true
+        annotations:
+          cert-manager.io/cluster-issuer: ${CERT_CLUSTER_ISSUER}
+          hajimari.io/icon: safe
+        hosts:
+          - host: &host "vault.${SECRET_DOMAIN}"
+        tls:
+          - hosts:
+              - *host
+            secretName: *host
+      extraEnvironmentVars:
+        GOOGLE_APPLICATION_CREDENTIALS: /var/run/secrets/vault/credentials.json
+        VAULT_LOG_LEVEL: debug
+      dataStorage:
+        enabled: false
+      standalone:
+        enabled: true
+        config: |
+          api_addr     = "https://0.0.0.0:8200"
+          cluster_addr = "https://0.0.0.0:8201"
+          ui = true
+
+          seal "gcpckms" {
+            project     = "homelab-ng"
+            region      = "northamerica-northeast1"
+            key_ring    = "vault"
+            crypto_key  = "vault"
+          }
+
+          storage "gcs" {
+            bucket     = "homelab-ng-vault"
+            ha_enabled = "false"
+          }
+
+          listener "tcp" {
+            address                  = "0.0.0.0:8200"
+            tls_disable              = true
+            tls_disable_client_certs = true
+          }
+      volumeMounts:
+        - name: secrets
+          mountPath: /var/run/secrets/vault
+          readOnly: true
+      volumes:
+        - name: secrets
+          secret:
+            secretName: vault
+    ui:
+      enabled: true

--- a/clusters/folly/apps/vault/helm-repository.yaml
+++ b/clusters/folly/apps/vault/helm-repository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: hashicorp
+spec:
+  interval: 24h
+  url: https://helm.releases.hashicorp.com

--- a/clusters/folly/apps/vault/kustomization.yaml
+++ b/clusters/folly/apps/vault/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - helm-release.yaml
+  - secret.sops.yaml
+namespace: vault

--- a/clusters/folly/apps/vault/namespace.yaml
+++ b/clusters/folly/apps/vault/namespace.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: vault
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/part-of: vault
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/folly/apps/vault/secret.sops.yaml
+++ b/clusters/folly/apps/vault/secret.sops.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: vault
+    namespace: vault
+stringData:
+    credentials.json: ENC[AES256_GCM,data:HBjX4QHXtR2V023JtjT7MAZ9mpOkR6RWm6b5bBV838c1mxOessF+M3uzuvS4FpGxGJtx5R7xRwoAUwyTNyLGuDX5Kv141UGkatkbw7tuNIlRAVDKyezhzQ3zeVyR80L4NLYSUg3ebZCbbnBW4T/rK4JwHNRzMZd0+fMUIKAi+cWESIGDVTcuCF8f31SimjkjF3E6xWTk26Sxfy5fhF79lkOzi1ZSF/H/p63OsUQDyAmBneCTjMYm6ckxnEfYHRyoPgurDahhQbdDq9UXvNdBKEXbGC2trCJjJUU7AkQVS0GYWtrTLuazfBX22vdJsTez0I+Z8J2HFkO5AKlTvXxkt71K90Xzdl5viyNuWFF6rdNMXOrQTH1PijMaf62k6CLkjFu/optpLhCjgZjoDyEBUMh2s1+U2nVht0jXQArvTNnICg/pY4q04V4k7FSci0xvW6GmaYy782xI4jofxY7xcobFF2EUkZ14JRaL8xhXsIkxLjJ9SXA+1yrL3rTbmfUT9d0YlmuJbhvpTvYaGsHwbv21ds9NPwJDcsV8hQPLgsM2wxFuZJLD1kCrUKLb6/ikokhLJoSUr5fldqX3sFsJhzzksdRsXK2GqhC/xWFGsOL9AAK6DaxP9irzZekK+G5jDGR2Rs0v5xYTINOrBWnKgVo8MSHXgZsmqpp/4mW+v0oba2P9l/7FZAB7wI/rFkugG9cKzW1NGWgZo991Nxxa2QqLmXW5F7VjiPnlDDOr+Ea3yUkzzWB9yJ5rcgV516tse9Bsr71X/2kds2LjJelea+iiqQ28NLc/uhrTCWzej4dabptywlu16yQJ60lrmh6pEKgEr2UmKJhq7AidKahqUPlpHnfHshpjsMQqcvl3vmCnMglSoksLh7RS5gmZxkGCT7P6nH/ec6kofZxhHp5RPRqP/IJ3BdrJorAN3hGkOSiKihgSmrub5rg2/zE/l3ZguZg/oY79kKs7bAZzWpZlDoEfRZuFzbWNC7SwcD1iKvb7KpRPg16KZgxhsvXnMWAEwStzGhaACOWdWNXz/2EdH0O8Z164IOJwZn97k0YHPImmk/nOMn7rlef2l4WwvJXaPHD3MyrwYG1zesymca9Eh6coQwI3/T2C5W/w4HDnCSotmPGaUMi5QQU3gbJXUIpX+zquCo9eFVCTQRDc8NCTMKA/O/s9PllziElaRvBYzt4giyaJula9Z8swp67c4ntgJm8yZaFhAbTduEMrjKhImNZ4OUrLPtCdEFURY9d+LM1jW9fhAPU4TOlEFBhY7BhoqyWXOoQF0H/fux1KlxJpFRGnF984iHarh/9M4sys53OhLmdrCtGI1qlhUc/81+aqeiiWF8dCHlCh+DoSRwbf1MmFOKiyHgZOqMElhbRaQRhuR/QrYv/ieJa2QTWMx3J0u+9DUZziyq9qNwI8Yxn2GbQeBU0wqD/ekG/2onep1pDQcTS0/Q/jCUbJyJqOV6S9LXzde4qewQudvxW4PWhx1oVdAVXTEQZrduhQG/ydUlO92R8dBrSFHVO4wC4cQOR0lEvh1hac6r7vtS2Mewf5eQAaCzYg7OXG5RkfVXkwf1X3GAusrUjck0fdfADY+4mfoqbRj/vlOUhLxlHslGhq76GcMv94DLCA+LkVEib1tUIb3gcQ82yPoIHJyUUTWXkkgNJ379OQji3To6dK0qjxJUqgb7rSY4cAXwYTNmyb4qk6q7Gd4bWlVn1++Yhiz/FDuOve0qdvz1slsMQ+0YlmoGUndJM/t2ZZdAhTdar9112WqHBa/B44Vtj1FNfqfoOjyzGKEZEmnpHofe50IAD45QadOEsOm0nbEHYrzR6qEpQT5BptGIIQP07X4AOdVOaaXhZx7sftQ/+TZVCGvGOPe6SPaAIVspcY9gkAvoduSYW2+74r0x8EezOyx+WWHMY09lcl402wpMi2ISvG/kRAistepLQ73HS8tnqxx6bqP2HYEW8R7Lj1PBH17RZTrgYI50Xikbn28BPc+67pFN9ketJ6jqEFO9KSL0OE0xL3dJpL87B83ty+RVaVMi9xSykNj/WPp4DDgYF4poM/tkVglyCtoyuqIPk89quVmFl0c2X0ceqiauxZoghtvxCBBBINkUmtYJIdFyueW+e0AsoR9UAGJjR8MTUh+bzolR7/DtDXX8znEl91vOd2r3upz6sxUQAfW5OTnnKBI3Qr+df5HZBpFMuRdaqEuH5QHSga8visY9H4OIGSbE0NZKYSlMkawaMU59bdqez7s8PrJNbECPu+vbxHaq6v+jnm+5ZpP+DDytZz/g40oQLoGgccDlstSGSYLtipz4LaHQ+GevV102eRjU22sucrCanBsDNqL4RGenstUqVhWZ9eacFu/Two4Zpks3cJcCO8n6lGo6mb7nOV6YmtFKTuzviHXoOKr7AY7JSF3veFILyrjT4c6PFKVR8ENA9Tc/MMwPPISQ9zgB42iV2OgzifPMSCh/GXMVHGypUr/ujLXKh8aTaA4Buhtr2dSEUAZA9YGkvlRoBz7doNmDiYlbo74YnfZs4Rc6ALCk6vU6Sth3t9dk3U6urmNmkAHqd41AxBI0Q7WdXQ4naOZlTVYju1istouHQ7TzsavnGJKiENX+FW2so0+iJ4s0qrbWRJwz32mrTgisY3QCxxe4+jRl35yzLvLRUsNCgJAvWSlDxI4+dyhV1IL9YOvAkao7pTFc6K6At5OrFFZYABOVdV74GFGMasl0XL480elcq2B8DNj/QXhoTw1DFNgpEpAV1iHc7RSsqkzPpG2ndR7VDMtBcB7KhwzrHwsqrquby1EGDTd3+lUai6wK1h0dsGxjemy6hKx1gOY2tQUG6IUELrP9jOXnFgVB5p/iufwmTXy2anRKbUyoKx9O1uZizLuf/sjHNWXhiG3q9WCLOo/AkjDakK3LzdayF1aDS4E1b2OhP/u4BGVoSnm0KnLrrHN0KJrMqojDJuQzZtnZggff/A3tzbaUBmiNKgSdVNbuRnkBKr526F0YhC2SMeOWfZ,iv:sbllOfAO7Vq5zcTgbJX9Schgx+3V8vEKmn21z7rg6p8=,tag:bOmHPuDCdp8SpiPSkxgD6A==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBIeUNZdkdnTFAxaU1pS1ZQ
+            WDZyUFNSUmJvM3E3NDdOVWx5STA5eit1OGljCnh6SGw0NzQxdGVNQXRYNGNWNW5T
+            cUtOZHVlRmJUOUdlY05ua0czczF1S1kKLS0tIC93ZGVDMW5xNnhLQWlNSy9weTZv
+            MUZQQ2VwbUxzUCs0aW5DRUpuV2syUWsKWFiO73whdqtlobZTgzJGC5kdk4qePYmL
+            oKuToa4HF21qRyyjnkRpx+WQWptKlRrdETOYIXDOrmaQ+wBPUaxbaw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2022-08-05T20:30:09Z"
+    mac: ENC[AES256_GCM,data:85rDOKfJchmty/8QwJFQ2MWlbi4W4hlP3yk9vMnDXkonYPpbXGOSlU4RR/s8nQ0kWf7+K0HFdlguTM78ZPH0oqPlkWyydQR30PUYOzfg981cVT0ZY1QeqFyWZOvKA2VUbY2borw3vLPf8uKInqkSF0YeXI7bFE2LwGzDiYMsSUc=,iv:YvHPK9RbnHWoZpgwxjXdu7lUFP+Zv4UTW66cQxOt4JY=,tag:z9pUi4u7AAFTxOMXkeO2ZA==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3


### PR DESCRIPTION
## Summary

Restore the HashiCorp Vault deployment in the folly cluster through Flux-managed Kubernetes manifests.

## Changes
- feat(folly): restore vault deployment

## Test Plan
- [x] kubectl kustomize clusters/folly/apps
- [x] kubectl kustomize clusters/folly
