### PR TITLE
feat(homepi4): point kiosk at tronbyt tv/next

### DIFF
--- a/nix/hosts/homepi4.nix
+++ b/nix/hosts/homepi4.nix
@@ -22,5 +22,6 @@
   services.kiosk = {
     enable = true;
     container = true;
+    url = "https://tronbyt.lolwtf.ca/tv/next";
   };
 }


### PR DESCRIPTION
## Summary
Set the homepi4 kiosk URL to `https://tronbyt.lolwtf.ca/tv/next` so the device boots into the Tronbyt "next-up" TV view.

## Changes
- feat(homepi4): point kiosk at tronbyt tv/next

## Test Plan
- [ ] `nix build .#nixosConfigurations.homepi4.config.system.build.toplevel` succeeds
- [ ] After deploy, the kiosk Firefox opens `https://tronbyt.lolwtf.ca/tv/next`
