### PR TITLE
feat(monitoring): Grafana monitoring for spore's NFS/PXE stack and the pi5 fleet

### DIFF
--- a/clusters/folly/monitoring/grafana-dashboards/kustomization.yaml
+++ b/clusters/folly/monitoring/grafana-dashboards/kustomization.yaml
@@ -7,6 +7,7 @@ configMapGenerator:
     files:
       - dht22.json
       - pihole.json
+      - spore.json
 generatorOptions:
   disableNameSuffixHash: true
   annotations:

--- a/clusters/folly/monitoring/grafana-dashboards/spore.json
+++ b/clusters/folly/monitoring/grafana-dashboards/spore.json
@@ -1,0 +1,1204 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": true,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "NFS",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "NFS Server",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 1
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "noValue": "DOWN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_systemd_unit_state{instance=\"spore\", name=\"nfs-server.service\", state=\"active\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "NFS mountd",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 1
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "noValue": "DOWN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_systemd_unit_state{instance=\"spore\", name=\"nfs-mountd.service\", state=\"active\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "NFS Threads",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_nfsd_server_threads{instance=\"spore\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "NFS Connections",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(node_nfsd_connections_total{instance=\"spore\"}[$__rate_interval])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "gauge",
+      "title": "/nfs/data Used",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "unit": "percent",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 85
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - node_filesystem_avail_bytes{instance=\"spore\", mountpoint=\"/nfs/data\"} / node_filesystem_size_bytes{instance=\"spore\", mountpoint=\"/nfs/data\"})",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "stat",
+      "title": "/nfs/data Free",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_filesystem_avail_bytes{instance=\"spore\", mountpoint=\"/nfs/data\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "NFS Operations",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (method) (rate(node_nfsd_requests_total{instance=\"spore\"}[$__rate_interval])) > 0",
+          "refId": "A",
+          "legendFormat": "{{method}}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "NFS Disk Throughput",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(node_nfsd_disk_bytes_read_total{instance=\"spore\"}[$__rate_interval])",
+          "refId": "A",
+          "legendFormat": "read"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(node_nfsd_disk_bytes_written_total{instance=\"spore\"}[$__rate_interval])",
+          "refId": "A",
+          "legendFormat": "written"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "row",
+      "title": "PXE",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      },
+      "panels": []
+    },
+    {
+      "id": 11,
+      "type": "stat",
+      "title": "TFTP (dnsmasq)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 1
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "noValue": "DOWN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "node_systemd_unit_state{instance=\"spore\", name=\"dnsmasq.service\", state=\"active\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "stat",
+      "title": "HTTP (nginx)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN",
+                  "color": "red",
+                  "index": 1
+                },
+                "1": {
+                  "text": "UP",
+                  "color": "green",
+                  "index": 0
+                }
+              }
+            }
+          ],
+          "noValue": "DOWN",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "nginx_up{instance=\"spore\"}",
+          "refId": "A",
+          "instant": true
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "stat",
+      "title": "HTTP Requests",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(nginx_http_requests_total{instance=\"spore\"}[$__rate_interval])",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "stat",
+      "title": "Active Connections",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "nginx_connections_active{instance=\"spore\"}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 15,
+      "type": "timeseries",
+      "title": "PXE HTTP Requests",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(nginx_http_requests_total{instance=\"spore\"}[$__rate_interval])",
+          "refId": "A",
+          "legendFormat": "requests/s"
+        }
+      ]
+    },
+    {
+      "id": 16,
+      "type": "row",
+      "title": "Host",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "panels": []
+    },
+    {
+      "id": 17,
+      "type": "timeseries",
+      "title": "CPU Usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 19
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent",
+          "max": 100,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - avg(rate(node_cpu_seconds_total{instance=\"spore\", mode=\"idle\"}[$__rate_interval])))",
+          "refId": "A",
+          "legendFormat": "cpu"
+        }
+      ]
+    },
+    {
+      "id": 18,
+      "type": "timeseries",
+      "title": "Memory Usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 19
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent",
+          "max": 100,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - node_memory_MemAvailable_bytes{instance=\"spore\"} / node_memory_MemTotal_bytes{instance=\"spore\"})",
+          "refId": "A",
+          "legendFormat": "used"
+        }
+      ]
+    },
+    {
+      "id": 19,
+      "type": "timeseries",
+      "title": "Network Throughput",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(node_network_receive_bytes_total{instance=\"spore\", device!~\"lo|tailscale.*|veth.*\"}[$__rate_interval])",
+          "refId": "A",
+          "legendFormat": "rx {{device}}"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(node_network_transmit_bytes_total{instance=\"spore\", device!~\"lo|tailscale.*|veth.*\"}[$__rate_interval])",
+          "refId": "A",
+          "legendFormat": "tx {{device}}"
+        }
+      ]
+    },
+    {
+      "id": 20,
+      "type": "timeseries",
+      "title": "Filesystem Usage",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent",
+          "max": 100,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "100 * (1 - node_filesystem_avail_bytes{instance=\"spore\", fstype=\"ext4\"} / node_filesystem_size_bytes{instance=\"spore\", fstype=\"ext4\"})",
+          "refId": "A",
+          "legendFormat": "{{mountpoint}}"
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": [
+    "spore",
+    "nfs",
+    "pxe"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Spore (NFS + PXE)",
+  "uid": "spore-nfs-pxe",
+  "version": 1,
+  "weekStart": ""
+}

--- a/clusters/folly/monitoring/kustomization.yaml
+++ b/clusters/folly/monitoring/kustomization.yaml
@@ -6,8 +6,9 @@ resources:
   - helm-repository-prometheus.yaml
   - kube-prometheus.yaml
   - grafana-dashboards
- # - local-node-exporters.yaml
+  - local-node-exporters.yaml
   - dns.yaml
+  - spore.yaml
   - git-repository-loki.yaml
   - loki.yaml
  # - picow.yaml

--- a/clusters/folly/monitoring/local-node-exporters.yaml
+++ b/clusters/folly/monitoring/local-node-exporters.yaml
@@ -18,10 +18,10 @@ endpoints:
     nodeName: dns
   - addresses: ["10.2.0.24"]
     nodeName: radiopi0
-  - addresses: ["10.2.0.25"]
-    nodeName: blinkypi0
   - addresses: ["10.2.0.11"]
     nodeName: spore
+  - addresses: ["10.2.0.12"]
+    nodeName: rackpi5
 --- # trivy:ignore:avd-ksv-0108
 apiVersion: v1
 kind: Service

--- a/clusters/folly/monitoring/spore.yaml
+++ b/clusters/folly/monitoring/spore.yaml
@@ -1,0 +1,123 @@
+# Service-level monitoring for spore, the NFS + PXE (TFTP/HTTP) server
+# (nix/hosts/spore.nix). Node-level metrics (node_nfsd_*, /nfs/data
+# filesystem, systemd unit states) arrive via local-node-exporters.yaml;
+# this file scrapes the nginx exporter for the PXE HTTP endpoint and
+# carries the NFS/PXE alert rules.
+apiVersion: discovery.k8s.io/v1
+kind: EndpointSlice
+metadata:
+  name: spore
+  namespace: monitoring
+  labels:
+    kubernetes.io/service-name: spore
+    lolwtf.ca/service: spore-pxe
+addressType: IPv4
+ports:
+  - name: http-metrics
+    port: 9113
+    protocol: TCP
+endpoints:
+  - addresses: ["10.2.0.11"]
+    nodeName: spore
+--- # trivy:ignore:avd-ksv-0108
+apiVersion: v1
+kind: Service
+metadata:
+  name: spore
+  namespace: monitoring
+  labels:
+    lolwtf.ca/service: spore-pxe
+    jobLabel: spore-pxe
+spec:
+  ports:
+    - name: http-metrics
+      port: 9113
+      protocol: TCP
+      targetPort: 9113
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: spore
+  namespace: monitoring
+  labels:
+    lolwtf.ca/service: spore-pxe
+    release: prom-stack
+spec:
+  jobLabel: jobLabel
+  endpoints:
+    - port: http-metrics
+      interval: 30s
+      relabelings:
+        - action: replace
+          sourceLabels: [__meta_kubernetes_endpoint_node_name]
+          targetLabel: instance
+  selector:
+    matchLabels:
+      lolwtf.ca/service: spore-pxe
+  namespaceSelector:
+    matchNames:
+      - monitoring
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: spore
+  namespace: monitoring
+  labels:
+    lolwtf.ca/service: spore-pxe
+    release: prom-stack
+spec:
+  groups:
+    - name: spore
+      rules:
+        - alert: PrometheusTargetMissing
+          expr: up {endpoint="http-metrics",  namespace="monitoring", service="spore"} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            message: Prometheus target missing (instance {{ $labels.instance }})
+            description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        # The `or absent(...)` arms also catch the unit dropping out of the
+        # node exporter's --collector.systemd.unit-include regex.
+        - alert: SporeNfsServerDown
+          expr: (node_systemd_unit_state{instance="spore", name="nfs-server.service", state="active"} == 0) or absent(node_systemd_unit_state{instance="spore", name="nfs-server.service", state="active"})
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            message: NFS server on spore is down
+            description: "nfs-server.service is not active on spore. k8s PVs (spore-pv, nfs-provisioner) are unavailable."
+        - alert: SporeTftpDown
+          expr: (node_systemd_unit_state{instance="spore", name="dnsmasq.service", state="active"} == 0) or absent(node_systemd_unit_state{instance="spore", name="dnsmasq.service", state="active"})
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            message: PXE TFTP (dnsmasq) on spore is down
+            description: "dnsmasq.service is not active on spore. Bare-metal k8s nodes cannot netboot (ipxe.efi via terraform/network/unifi/folly/k8s.tf)."
+        - alert: SporePxeHttpDown
+          expr: nginx_up{instance="spore"} == 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            message: PXE HTTP (nginx) on spore is down
+            description: "nginx on spore is not serving. Netboot menus chain to bzImage/initrd over HTTP, so PXE boots will hang after ipxe.efi."
+        - alert: SporeNfsDataNotMounted
+          expr: absent(node_filesystem_size_bytes{instance="spore", mountpoint="/nfs/data"})
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            message: /nfs/data is not mounted on spore
+            description: "The nfs-data partition is not mounted (it is nofail, so boot continues without it). nfs-server refuses to start via RequiresMountsFor."
+        - alert: SporeNfsDataLowSpace
+          expr: 100 * (1 - node_filesystem_avail_bytes{instance="spore", mountpoint="/nfs/data"} / node_filesystem_size_bytes{instance="spore", mountpoint="/nfs/data"}) > 85
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: /nfs/data on spore is over 85% full
+            description: "VALUE = {{ $value }}% used. k8s PVCs provision from this filesystem; expand or prune before it fills."

--- a/nix/services/common.nix
+++ b/nix/services/common.nix
@@ -49,6 +49,14 @@
   services.prometheus.exporters.node = {
     enable = lib.mkDefault true;
     openFirewall = true;
+    # Unit-state metrics so Prometheus can alert on the services these hosts
+    # exist to run (nfsd/dnsmasq/nginx on spore, pihole-ftl on dns, ...).
+    # Scoped with an include regex: the full systemd collector emits ~5
+    # series per unit and these are small Pis.
+    enabledCollectors = [ "systemd" ];
+    extraFlags = [
+      "--collector.systemd.unit-include=(nfs-server|nfs-mountd|rpc-statd|dnsmasq|nginx|pihole-ftl|tailscaled|ddnsd|sshd)\\.service"
+    ];
   };
 
   programs.zsh.enable = lib.mkDefault true;

--- a/nix/services/pxe-netboot.nix
+++ b/nix/services/pxe-netboot.nix
@@ -43,6 +43,15 @@
     };
   };
 
+  # Metrics for the PXE HTTP endpoint: the stub_status page stays
+  # localhost-only, the exporter republishes it on :9113 for Prometheus
+  # (scraped via clusters/folly/monitoring/spore.yaml).
+  services.nginx.statusPage = true;
+  services.prometheus.exporters.nginx = {
+    enable = true;
+    openFirewall = true;
+  };
+
   networking.firewall = {
     allowedTCPPorts = [ 80 ];
     allowedUDPPorts = [ 69 ]; # tftp


### PR DESCRIPTION
## Summary
Wire up proper Grafana monitoring for spore (NFS + PXE/TFTP server) and the other pi5s. The bare-metal node exporter scrape (`local-node-exporters.yaml`) had been commented out since the `k8s/` → `clusters/` rename (fe6bcc68), so none of the existing node metrics were reaching Prometheus; this re-enables it and adds service-level metrics, alerts, and a dashboard on top.

## Changes
- feat(nix): export systemd unit and nginx metrics from the Pis
  - node exporter systemd collector on all `common.nix` hosts, scoped to the units the Pis exist to run (nfsd, dnsmasq, nginx, pihole-ftl, …)
  - nginx exporter (:9113) in `pxe-netboot.nix` for the PXE HTTP endpoint
- feat(monitoring): scrape and alert on spore's NFS/PXE stack
  - re-enable `local-node-exporters.yaml`; add rackpi5 (10.2.0.12), drop blinkypi0 (unreachable on :9100)
  - `spore.yaml`: nginx-exporter scrape + alerts (nfs-server/dnsmasq/nginx down, `/nfs/data` unmounted, `/nfs/data` >85% full)
  - "Spore (NFS + PXE)" Grafana dashboard: service state, NFS ops/throughput, PXE HTTP traffic, host vitals

## Deploy note
The `SporeNfsServerDown`/`SporeTftpDown` alerts have an `absent(...)` arm, so they fire until spore is rebuilt with the new systemd collector. Rebuild the pi5s around merge time:

```
nixos-rebuild switch --flake .#spore --target-host spore --sudo   # then dns, rackpi5
```

## Test Plan
- [x] `nix eval` of toplevel drvPaths for spore, dns, rackpi5, cloudpi4, optiplex
- [x] `kustomize build clusters/folly/monitoring`
- [x] dashboard JSON validated; live-probed :9100 on all scrape targets (node_nfsd_* and /nfs/data metrics confirmed on spore)
- [ ] after merge + rebuild: Grafana "Spore (NFS + PXE)" dashboard populates; `up{service=~"local-node-exporters|spore"}` all 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
