### PR TITLE
fix(kiosk): wait for app before launching firefox

### DIFF
--- a/docs/kiosk-runbook.md
+++ b/docs/kiosk-runbook.md
@@ -1,0 +1,130 @@
+# Kiosk Runbook
+
+This runbook covers the Raspberry Pi kiosk hosts:
+
+- `homepi4`
+- `weatherpi4`
+
+Both use `nix/services/kiosk.nix`. The display stack is Cage on Wayland. Firefox runs in kiosk/private-window mode against the configured kiosk URL. For container-backed kiosks, the default URL is `http://localhost:8080`.
+
+## Quick Checks
+
+Check Cage and Firefox:
+
+```bash
+nix run .#<host> -- systemctl --no-pager --full status cage-tty1.service
+nix run .#<host> -- pgrep -a firefox
+```
+
+Expected:
+
+- `cage-tty1.service` is `active (running)`.
+- Cage runs `/nix/store/...-kiosk-firefox`.
+- Firefox runs with `--kiosk --private-window http://localhost:8080`.
+
+Check the container-backed app:
+
+```bash
+nix run .#<host> -- systemctl --no-pager --full status docker-kiosk.service
+nix run .#<host> -- docker ps
+nix run .#<host> -- journalctl -u docker-kiosk.service -n 50 --no-pager
+```
+
+Expected:
+
+- `docker-kiosk.service` is active.
+- Container `kiosk` is running `ghcr.io/jonpulsifer/hub:latest`.
+- Port mapping includes `0.0.0.0:8080->8080/tcp`.
+- Recent logs include `GET / 200` and, for the weather app, `GET /api/weather 200`.
+
+## If The Screen Shows Firefox "Oops"
+
+This is usually Firefox loading before the local container is ready. The module now uses a wrapper that waits for the kiosk URL before launching Firefox, but after manual switches or service restarts it is still worth checking the order of events.
+
+1. Check whether the app is serving:
+
+   ```bash
+   nix run .#<host> -- journalctl -u docker-kiosk.service -n 80 --no-pager
+   ```
+
+2. If the app is healthy and logging `GET / 200`, refresh the display by restarting Cage:
+
+   ```bash
+   nix run .#<host> -- sudo systemctl restart cage-tty1.service
+   ```
+
+3. Verify Firefox relaunched:
+
+   ```bash
+   nix run .#<host> -- pgrep -a firefox
+   nix run .#<host> -- journalctl -u docker-kiosk.service -n 20 --no-pager
+   ```
+
+## If Cage Is Inactive
+
+Check whether it is enabled and part of the graphical target:
+
+```bash
+nix run .#<host> -- systemctl is-enabled cage-tty1.service
+nix run .#<host> -- readlink -f /etc/systemd/system/default.target
+nix run .#<host> -- systemctl --no-pager list-dependencies graphical.target
+```
+
+Start it manually if needed:
+
+```bash
+nix run .#<host> -- sudo systemctl start cage-tty1.service
+```
+
+If this happens immediately after `nixos-rebuild switch`, note that NixOS may report:
+
+```text
+NOT restarting the following changed units: cage-tty1.service
+```
+
+In that case, restart Cage once:
+
+```bash
+nix run .#<host> -- sudo systemctl restart cage-tty1.service
+```
+
+## If The Container Is Down
+
+Restart the container service:
+
+```bash
+nix run .#<host> -- sudo systemctl restart docker-kiosk.service
+nix run .#<host> -- systemctl --no-pager --full status docker-kiosk.service
+```
+
+Then restart Cage so Firefox reconnects to the now-running app:
+
+```bash
+nix run .#<host> -- sudo systemctl restart cage-tty1.service
+```
+
+## Deploying Changes
+
+Build before switching:
+
+```bash
+nix build .#nixosConfigurations.<host>.config.system.build.toplevel --no-link
+```
+
+Switch a kiosk host:
+
+```bash
+nixos-rebuild switch --flake .#<host> --target-host <host> --sudo
+```
+
+For `weatherpi4` over Tailscale:
+
+```bash
+nixos-rebuild switch --flake .#weatherpi4 --target-host weatherpi4.pirate-musical.ts.net --sudo
+```
+
+After a switch, check whether Cage was restarted. If the switch output says it was not restarted, run:
+
+```bash
+nix run .#<host> -- sudo systemctl restart cage-tty1.service
+```

--- a/nix/README.md
+++ b/nix/README.md
@@ -121,7 +121,7 @@ Custom service modules in `services/`:
 - **`common.nix`** - Base server configuration with SSH, Tailscale, monitoring
 - **`jellyfin.nix`** - Media server
 - **`github-runner.nix`** - Self-hosted GitHub Actions runners
-- **`kiosk.nix`** - Kiosk mode display
+- **`kiosk.nix`** - Kiosk mode display. See the [kiosk runbook](../docs/kiosk-runbook.md).
 - **`nas.nix`** - Network attached storage
 - **`nix-serve.nix`** - Binary cache server
 - **`yarr.nix`** - RSS reader
@@ -292,4 +292,3 @@ When making changes:
 2. Format code with `nix fmt`
 3. Build affected systems to verify
 4. Document any new options or services
-

--- a/nix/services/kiosk.nix
+++ b/nix/services/kiosk.nix
@@ -7,6 +7,15 @@
 with lib;
 let
   cfg = config.services.kiosk;
+  kioskProgram = pkgs.writeShellScript "kiosk-firefox" ''
+    ${optionalString cfg.container ''
+      until ${pkgs.curl}/bin/curl --fail --silent --show-error --max-time 2 --output /dev/null ${escapeShellArg cfg.url}; do
+        ${pkgs.coreutils}/bin/sleep 2
+      done
+    ''}
+
+    exec ${pkgs.firefox}/bin/firefox --kiosk --private-window ${escapeShellArg cfg.url}
+  '';
 in
 {
   options.services.kiosk = {
@@ -83,9 +92,14 @@ in
         environment = {
           MOZ_ENABLE_WAYLAND = "1";
         };
-        program = "${pkgs.firefox}/bin/firefox --kiosk --private-window ${escapeShellArg cfg.url}";
+        program = "${kioskProgram}";
       };
       xserver.enable = mkForce false;
+    };
+
+    systemd.services.cage-tty1 = mkIf cfg.container {
+      after = [ "docker-kiosk.service" ];
+      wants = [ "docker-kiosk.service" ];
     };
 
     virtualisation.docker.enable = mkIf cfg.container true;


### PR DESCRIPTION
## Summary
Update the NixOS kiosk module so Cage waits for the local container-backed app before launching Firefox, preventing Firefox from getting stuck on its startup error page.

## Changes
- fix(kiosk): wait for app before launching firefox

## Test Plan
- [x] nix fmt nix/services/kiosk.nix
- [x] nix build .#nixosConfigurations.homepi4.config.system.build.toplevel --no-link
- [x] nix build .#nixosConfigurations.weatherpi4.config.system.build.toplevel --no-link
- [x] switched and verified homepi4 cage/firefox/container
- [x] switched and verified weatherpi4 cage/firefox/container
