### PR TITLE
feat(nix): netboot rackpi5 disklessly from spore

### DIFF
--- a/nix/hosts/rackpi5.nix
+++ b/nix/hosts/rackpi5.nix
@@ -1,4 +1,27 @@
-{ lib, name, ... }:
+# rackpi5 is diskless: the Pi 5 bootloader netboots from spore (10.2.0.11,
+# nix/hosts/spore.nix). The EEPROM TFTP-loads firmware/kernel/initrd from
+# spore's dnsmasq (/var/lib/tftpboot/rackpi5/, which is this host's
+# /boot/firmware mounted over NFS -- so every nixos-rebuild here lands
+# kernels straight in the netboot tree), and stage-1 mounts / over NFS from
+# spore:/nfs/data/rackpi5. The SD card keeps the last standalone image as a
+# rescue system; the EEPROM only falls back to it when netboot fails.
+#
+# Like nvme-hat.nix's settings, the netboot side of the EEPROM lives outside
+# the closure and is applied by hand with `sudo rpi-eeprom-config --edit`:
+#   BOOT_ORDER=0xf12          # right-to-left: NET first, SD rescue, retry
+#   TFTP_IP=10.2.0.11         # spore; Lab Net DHCP has no boot options
+#   TFTP_PREFIX=1             # prefix TFTP paths with TFTP_PREFIX_STR
+#                             # (0=serial dir, 1=TFTP_PREFIX_STR, 2=MAC dir)
+#   TFTP_PREFIX_STR=rackpi5/
+{
+  lib,
+  name,
+  pkgs,
+  ...
+}:
+let
+  spore = "10.2.0.11";
+in
 {
   imports = [
     ../hardware/pi5
@@ -10,4 +33,52 @@
     hostName = name;
     wireless.enable = lib.mkForce false;
   };
+
+  # The sd-image module pins these to the SD partition labels with
+  # mkImageMediaOverride (and mkForce for the firmware mount options), so
+  # out-prioritizing it needs mkForce / mkOverride 45.
+  fileSystems."/" = {
+    device = lib.mkForce "${spore}:/nfs/data/rackpi5";
+    fsType = lib.mkForce "nfs";
+    options = [ "nfsvers=4.2" ];
+  };
+  fileSystems."/boot/firmware" = {
+    device = lib.mkForce "${spore}:/var/lib/tftpboot/rackpi5";
+    fsType = lib.mkForce "nfs";
+    options = lib.mkOverride 45 [
+      "nfsvers=4.2"
+      "noatime"
+      "noauto"
+      "x-systemd.automount"
+      "x-systemd.idle-timeout=1min"
+    ];
+  };
+
+  # This platform uses systemd stage-1, where NFS root needs explicit wiring:
+  # nixpkgs' nfs module only ships the kernel module into the initrd, not the
+  # mount.nfs helper, and initrd networking is systemd-networkd, not the
+  # scripted stage-1's boot.initrd.network/ipconfig (those options build fine
+  # but wire nothing here -- learned the hard way, the first netboot hung in
+  # stage-1 with no NIC config and no way to mount /sysroot).
+  boot.initrd = {
+    supportedFilesystems.nfs = true;
+    # nfs.ko comes via supportedFilesystems; v4 is a separate module the
+    # sysroot mount needs. macb is the Pi 5 NIC (Cadence GEM in the RP1).
+    kernelModules = [ "nfsv4" ];
+    availableKernelModules = [ "macb" ];
+    systemd = {
+      extraBin."mount.nfs" = "${pkgs.nfs-utils}/bin/mount.nfs";
+      network = {
+        enable = true;
+        networks."10-end0" = {
+          matchConfig.Name = "end0";
+          networkConfig.DHCP = "ipv4";
+        };
+      };
+    };
+  };
+  # Belt and braces: systemd-network-generator also honours ip=dhcp, and
+  # UniFi pins this MAC to 10.2.0.12 so stage 2's dhcpcd re-acquires the
+  # same address without disturbing the NFS mounts.
+  boot.kernelParams = [ "ip=dhcp" ];
 }

--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -46,6 +46,27 @@
 
   homelab.nfsServer.dataDevice = "/dev/disk/by-label/nfs-data";
 
+  # rackpi5 netboots from this host (see nix/hosts/rackpi5.nix): its / is the
+  # NFS export below and its /boot/firmware is a directory inside the TFTP
+  # root, exported rw so nixos-rebuilds on rackpi5 drop kernels straight into
+  # the netboot tree dnsmasq already serves. no_root_squash because rackpi5's
+  # root writes both as uid 0.
+  systemd.tmpfiles.rules = [
+    "d /nfs/data/rackpi5 0755 root root -"
+    "d /var/lib/tftpboot/rackpi5 0755 root root -"
+  ];
+  services.nfs.server.exports = ''
+    /nfs/data/rackpi5           10.2.0.12(rw,sync,no_subtree_check,insecure,no_root_squash)
+    /var/lib/tftpboot/rackpi5   10.2.0.12(rw,sync,no_subtree_check,insecure,no_root_squash)
+  '';
+  # No file leases means nfsd grants no delegations. Nix hard-links files
+  # inside rackpi5's NFS root, and a LINK against a file whose write
+  # delegation the *same* client holds deadlocks in the server's recall
+  # (observed: nix-env stuck in nfs4_proc_link indefinitely while populating
+  # the netboot root). Delegations are a read-caching nicety; the k8s NFS
+  # workloads don't miss them.
+  boot.kernel.sysctl."fs.leases-enable" = 0;
+
   sdImage.expandOnBoot = false;
 
   systemd.services.grow-root-and-partition-storage = {

--- a/terraform/network/unifi/folly/clients.yaml
+++ b/terraform/network/unifi/folly/clients.yaml
@@ -65,10 +65,10 @@ rpis:
     hostname: pikvm
     dev-id: 4134
   dns:
-    mac: 2c:cf:67:dc:7e:9b
+    mac: 2c:cf:67:dc:7e:ce
     ip: 10
   rackpi5:
-    mac: 2c:cf:67:dc:7e:ce
+    mac: 2c:cf:67:dc:7e:9b
     ip: 12
     dev-id: 4133
   spore:


### PR DESCRIPTION
## Summary
rackpi5 is now diskless: the Pi 5 EEPROM netboots it over TFTP from spore, with `/` on NFSv4.2 from `spore:/nfs/data/rackpi5` and `/boot/firmware` mounted from spore's TFTP tree so `nixos-rebuild` on rackpi5 lands kernels directly in the netboot payload. Also fixes dns/rackpi5 having each other's MACs in clients.yaml.

**Already deployed and verified live** (rackpi5 booted SD-less, `/` = `nfs4 10.2.0.11:/nfs/data/rackpi5`, no block devices attached). Merging this is what makes it stick: the nightly `nixos-upgrade` from `main` (or any manual main-built rebuild) reverts spore's exports and rackpi5's netboot config until then.

## Changes
- feat(nix): netboot rackpi5 disklessly from spore — NFS exports + `fs.leases-enable=0` on spore (nfsd write delegations deadlock nix's hard-links from the same client); systemd stage-1 NFS-root wiring on rackpi5 (`mount.nfs` via `boot.initrd.systemd.extraBin`, initrd networkd DHCP on `end0`, `nfsv4` module). EEPROM settings (`BOOT_ORDER=0xf12`, `TFTP_IP=10.2.0.11`, `TFTP_PREFIX=1`, `TFTP_PREFIX_STR=rackpi5/`) documented in `nix/hosts/rackpi5.nix`, applied by hand.
- fix(unifi): dns and rackpi5 had each other's MACs — live boxes are rackpi5=`2c:cf:67:dc:7e:9b`@.12, dns=`…:7e:ce`@.10; UniFi live state already matches, so the Atlantis plan should read as drift alignment.

## Test Plan
- [x] rackpi5 netboots with no SD card; `findmnt /` shows `nfs4 10.2.0.11:/nfs/data/rackpi5`
- [x] `/boot/firmware` automounts spore's `/var/lib/tftpboot/rackpi5`; bootloader generations install into it
- [x] spore: `exportfs -s` shows both rackpi5 exports; dnsmasq TFTP serves `rackpi5/config.txt` → `nixos/default/{kernel.img,initrd,cmdline.txt}`
- [ ] `atlantis apply` for the clients.yaml swap (expect near-no-op vs live UniFi)
- [ ] After merge: re-enable/verify `nixos-upgrade` runs cleanly on spore + rackpi5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
