### PR TITLE
feat(nix): stateless HTTP-booted RAM image as rackpi5's default boot

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,13 @@
           system = "aarch64-linux";
           modules = [ ./nix/hosts/rackpi5.nix ];
         };
+        # rackpi5's default boot: stateless RAM image served over HTTP from
+        # spore (nix/images/pi5-ram.nix); the rackpi5 config above is its
+        # NFS-root fallback tier.
+        rackpi5-ram = mkHost "rackpi5-ram" {
+          system = "aarch64-linux";
+          modules = [ ./nix/images/pi5-ram.nix ];
+        };
         spore = mkHost "spore" {
           system = "aarch64-linux";
           modules = [ ./nix/hosts/spore.nix ];
@@ -192,6 +199,7 @@
           weatherpi4 = nixosConfigurations.weatherpi4.config.system.build.sdImage;
           dns = nixosConfigurations.dns.config.system.build.sdImage;
           rackpi5 = nixosConfigurations.rackpi5.config.system.build.sdImage;
+          rackpi5-ram = nixosConfigurations.rackpi5-ram.config.system.build.piBootImg;
           spore = nixosConfigurations.spore.config.system.build.sdImage;
 
           iso = nixosConfigurations.iso.config.system.build.isoImage;

--- a/nix/hardware/pi5/base.nix
+++ b/nix/hardware/pi5/base.nix
@@ -1,0 +1,30 @@
+# Raspberry Pi 5 platform without the sd-image machinery: board support,
+# caches, and overlays only. Image-style configs whose root doesn't live on
+# an sd-image-partitioned disk (e.g. nix/images/pi5-ram.nix's RAM-booted
+# squashfs) import this; regular hosts import ./default.nix, which layers
+# the sd-image module and per-host volume labels on top.
+{
+  lib,
+  nixos-raspberrypi,
+  ...
+}:
+{
+  imports = [
+    nixos-raspberrypi.nixosModules.trusted-nix-caches
+    nixos-raspberrypi.nixosModules.raspberry-pi-5.base
+    nixos-raspberrypi.lib.inject-overlays
+  ];
+
+  # save some space
+  documentation.enable = false;
+
+  nixpkgs.hostPlatform = "aarch64-linux";
+
+  # The installer profiles (nixpkgs' profiles/base.nix, pulled in by both
+  # sd-image and netboot) default zfs support on whenever it's available on
+  # the platform, but our kernel comes from nixos-raspberrypi's own pinned
+  # nixpkgs while userland zfs comes from ours -- mismatched versions trip
+  # the "kernel module and userspace tooling not matching" assertion. We
+  # don't need zfs on these hosts anyway.
+  boot.supportedFilesystems.zfs = lib.mkForce false;
+}

--- a/nix/hardware/pi5/default.nix
+++ b/nix/hardware/pi5/default.nix
@@ -6,23 +6,9 @@
 }:
 {
   imports = [
-    nixos-raspberrypi.nixosModules.trusted-nix-caches
+    ./base.nix
     nixos-raspberrypi.nixosModules.sd-image
-    nixos-raspberrypi.nixosModules.raspberry-pi-5.base
-    nixos-raspberrypi.lib.inject-overlays
   ];
-
-  # save some space
-  documentation.enable = false;
-
-  nixpkgs.hostPlatform = "aarch64-linux";
-
-  # The sd-image installer profile (nixpkgs' profiles/base.nix) defaults zfs
-  # support on whenever it's available on the platform, but our kernel comes
-  # from nixos-raspberrypi's own pinned nixpkgs while userland zfs comes from
-  # ours -- mismatched versions trip the "kernel module and userspace tooling
-  # not matching" assertion. We don't need zfs on this host anyway.
-  boot.supportedFilesystems.zfs = lib.mkForce false;
 
   sdImage = {
     compressImage = true;

--- a/nix/hosts/rackpi5.nix
+++ b/nix/hosts/rackpi5.nix
@@ -1,18 +1,32 @@
-# rackpi5 is diskless: the Pi 5 bootloader netboots from spore (10.2.0.11,
-# nix/hosts/spore.nix). The EEPROM TFTP-loads firmware/kernel/initrd from
-# spore's dnsmasq (/var/lib/tftpboot/rackpi5/, which is this host's
-# /boot/firmware mounted over NFS -- so every nixos-rebuild here lands
-# kernels straight in the netboot tree), and stage-1 mounts / over NFS from
-# spore:/nfs/data/rackpi5. The SD card keeps the last standalone image as a
-# rescue system; the EEPROM only falls back to it when netboot fails.
+# rackpi5 is diskless, with a three-tier boot ladder off spore (10.2.0.11,
+# nix/hosts/spore.nix):
+#
+#   1. HTTP (default): the stateless RAM image (nix/images/pi5-ram.nix,
+#      the rackpi5-ram flake config) -- boot.img pulled from spore's nginx
+#      at wire speed, runs entirely from RAM.
+#   2. NET (fallback): THIS config. The EEPROM TFTP-loads firmware/kernel/
+#      initrd from spore's dnsmasq (/var/lib/tftpboot/rackpi5/, which is
+#      this host's /boot/firmware mounted over NFS -- so every
+#      nixos-rebuild here lands kernels straight in the netboot tree), and
+#      stage-1 mounts / over NFS from spore:/nfs/data/rackpi5.
+#   3. SD (last resort): the pre-netboot standalone image, if a card is
+#      inserted.
 #
 # Like nvme-hat.nix's settings, the netboot side of the EEPROM lives outside
 # the closure and is applied by hand with `sudo rpi-eeprom-config --edit`:
-#   BOOT_ORDER=0xf12          # right-to-left: NET first, SD rescue, retry
+#   BOOT_ORDER=0xf127         # right-to-left: HTTP, NET, SD, retry
+#   HTTP_HOST=10.2.0.11       # spore's nginx (plain http is allowed only
+#   HTTP_PATH=rackpi5-ram     #   because HTTP_HOST is explicitly set)
 #   TFTP_IP=10.2.0.11         # spore; Lab Net DHCP has no boot options
 #   TFTP_PREFIX=1             # prefix TFTP paths with TFTP_PREFIX_STR
 #                             # (0=serial dir, 1=TFTP_PREFIX_STR, 2=MAC dir)
 #   TFTP_PREFIX_STR=rackpi5/
+#
+# The EEPROM additionally embeds the public half of spore's
+# /var/lib/pi-boot-sign/private.pem (rpi-eeprom-config -p): the bootloader
+# refuses any HTTP-downloaded boot.img whose boot.sig isn't RSA-signed.
+# Reflashing a stock EEPROM image wipes the key, which silently demotes
+# rackpi5 to the NFS tier until the key is re-added.
 {
   lib,
   name,

--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -54,6 +54,14 @@
   systemd.tmpfiles.rules = [
     "d /nfs/data/rackpi5 0755 root root -"
     "d /var/lib/tftpboot/rackpi5 0755 root root -"
+    # rackpi5's default boot is the stateless RAM image, HTTP-booted from
+    # nginx's tftpboot root: `nix build .#nixosConfigurations.rackpi5-ram
+    # .config.system.build.piBootImg`, copy boot.img + nix-store.squashfs
+    # here, then sign (the bootloader rejects unsigned HTTP downloads;
+    # rackpi5's EEPROM holds the matching public key):
+    #   rpi-eeprom-digest -i boot.img -o boot.sig \
+    #     -k /var/lib/pi-boot-sign/private.pem
+    "d /var/lib/tftpboot/rackpi5-ram 0755 root root -"
   ];
   services.nfs.server.exports = ''
     /nfs/data/rackpi5           10.2.0.12(rw,sync,no_subtree_check,insecure,no_root_squash)

--- a/nix/images/pi5-ram.nix
+++ b/nix/images/pi5-ram.nix
@@ -1,0 +1,191 @@
+# Stateless RAM-booted Pi 5 image, delivered in two stages because the
+# bootloader's native HTTP boot (BOOT_ORDER digit 7) is small and slow: it
+# loads boot.img into a fixed ~180MiB RAM window at ~2.6MB/s (measured --
+# a 764MB all-in-one image aborted at exactly 189MB), so the bootloader
+# only pulls a small boot.img (firmware + kernel + stock initrd, ~80MB),
+# and stage-1 then curls the ~700MB squashfs nix store at real wire speed
+# and loop-mounts it from RAM. Nothing persists across reboots, including
+# host keys.
+#
+# This is the aarch64 sibling of nix/images/netboot.nix: same
+# netboot-minimal squashfs profile, but instead of an iPXE script the
+# payload is `system.build.piBootImg` (boot.img + nix-store.squashfs),
+# copied to /var/lib/tftpboot/rackpi5-ram on spore (whose nginx serves it)
+# and RSA-signed there -- see the note at the bottom of this file.
+#
+# rackpi5 boots this by default; its EEPROM settings are documented in
+# nix/hosts/rackpi5.nix.
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  name,
+  ...
+}:
+let
+  spore = "10.2.0.11";
+  storeUrl = "http://${spore}/rackpi5-ram/nix-store.squashfs";
+  # systemd-escape -p /sysroot/nix/.ro-store
+  roStoreMount = "sysroot-nix-.ro\\x2dstore.mount";
+  # Deliberately world-readable (it lives in the store and inside the
+  # unencrypted boot.img anyway): this key only authenticates the stage-1
+  # debug sshd of a stateless image on the lab VLAN, not a real host
+  # identity. The usual boot.initrd.secrets append doesn't run here -- the
+  # nixos-raspberrypi bootloader copies the initrd verbatim.
+  initrdSshHostKey =
+    pkgs.runCommand "initrd-ssh-hostkey" { nativeBuildInputs = [ pkgs.openssh ]; }
+      ''
+        mkdir $out
+        ssh-keygen -q -t ed25519 -N "" -C rackpi5-ram-initrd -f $out/key
+      '';
+in
+{
+  imports = [
+    (modulesPath + "/installer/netboot/netboot-minimal.nix")
+    ../hardware/pi5/base.nix
+  ];
+
+  networking = {
+    hostName = name;
+    wireless.enable = lib.mkForce false;
+    useDHCP = lib.mkForce true;
+  };
+
+  # Remove initialHashedPassword for root and nixos (installer profile)
+  users.users = {
+    root.initialHashedPassword = lib.mkForce null;
+    nixos.initialHashedPassword = lib.mkForce null;
+  };
+
+  # why is this a thing that exists
+  services.openssh.settings.PermitRootLogin = lib.mkForce "no";
+
+  # auto log me in
+  services.getty.autologinUser = lib.mkForce config.users.users.jawn.name;
+
+  # The generational "kernel" bootloader normally comes as a default from
+  # the sd-image module, which this image doesn't import; its populate
+  # command is what lays out config.txt/kernel/initrd/DTBs for boot.img.
+  boot.loader.raspberry-pi.bootloader = "kernel";
+
+  # The netboot profile expects the squashfs inside the initrd
+  # ("../nix-store.squashfs"); ours is downloaded by the fetch service
+  # below into the initrd rootfs instead.
+  fileSystems."/nix/.ro-store".device = lib.mkForce "/nix-store.squashfs";
+
+  # Same systemd stage-1 networking recipe as the NFS tier in
+  # nix/hosts/rackpi5.nix, plus curl to pull the store.
+  boot.initrd.systemd = {
+    extraBin.curl = "${pkgs.curl}/bin/curl";
+    network = {
+      enable = true;
+      networks."10-end0" = {
+        matchConfig.Name = "end0";
+        networkConfig.DHCP = "ipv4";
+      };
+    };
+    services.fetch-nix-store = {
+      description = "Fetch the squashfs nix store from spore over HTTP";
+      requiredBy = [ roStoreMount ];
+      before = [ roStoreMount ];
+      wants = [ "systemd-networkd-wait-online.service" ];
+      after = [ "systemd-networkd-wait-online.service" ];
+      unitConfig.DefaultDependencies = false;
+      serviceConfig = {
+        Type = "oneshot";
+        # Without this, any later re-trigger of the .ro-store mount
+        # re-runs the unit and re-downloads the whole store.
+        RemainAfterExit = true;
+      };
+      script = ''
+        [ -s /nix-store.squashfs ] && exit 0
+        curl --fail --retry 10 --retry-connrefused --retry-delay 2 \
+          -o /nix-store.squashfs ${storeUrl}
+      '';
+    };
+
+    # Stage-1 debug shell: `ssh -p 2222 root@10.2.0.12` while the initrd is
+    # up, since this Pi has no reachable console.
+    services.initrd-ssh-hostkey = {
+      description = "Install the initrd sshd host key with the perms sshd demands";
+      before = [ "sshd.service" ];
+      requiredBy = [ "sshd.service" ];
+      unitConfig.DefaultDependencies = false;
+      serviceConfig.Type = "oneshot";
+      script = "install -m 600 /etc/ssh/initrd_host_key_ro /etc/ssh/initrd_host_key";
+    };
+    contents."/etc/ssh/initrd_host_key_ro".source = "${initrdSshHostKey}/key";
+    emergencyAccess = true;
+  };
+  boot.initrd.network.ssh = {
+    enable = true;
+    port = 2222;
+    ignoreEmptyHostKeys = true;
+    authorizedKeys = config.users.users.jawn.openssh.authorizedKeys.keys;
+    extraConfig = "HostKey /etc/ssh/initrd_host_key";
+  };
+  boot.kernelParams = [ "ip=dhcp" ];
+
+  system.build.piBootImg =
+    pkgs.runCommand "pi5-ram-boot-img"
+      {
+        nativeBuildInputs = with pkgs; [
+          dosfstools
+          mtools
+          openssl
+          raspberrypi-eeprom
+          util-linux
+        ];
+      }
+      ''
+        # Lay out the firmware tree exactly as the TFTP/sd-image path would:
+        # config.txt with os_prefix=nixos/default/, kernel.img, cmdline.txt
+        # (kernel-params + init=<toplevel>), DTBs, overlays. The stock
+        # initrd is all we need -- the squashfs is fetched at boot, not
+        # embedded -- which is what keeps boot.img inside the bootloader's
+        # ~180MiB HTTP-boot window.
+        mkdir staging
+        ${config.boot.loader.raspberry-pi.firmwarePopulateCmd} \
+          -c ${config.system.build.toplevel} -f ./staging
+
+        # The populate script also copies Pi 4-era GPU boot code
+        # (bootcode.bin/start*.elf/fixup*.dat) that the Pi 5's EEPROM never
+        # reads; the bootloader caps ramdisks at 96MB, so every megabyte
+        # counts.
+        chmod -R u+w staging
+        rm -f staging/bootcode.bin staging/start*.elf staging/fixup*.dat
+
+        # Match the layout of the official boot.img (usbboot's
+        # mass-storage-gadget64 / the network-install image): everything at
+        # the FAT root with no os_prefix indirection -- the ramdisk boot
+        # path rejected our generational os_prefix=nixos/default/ layout.
+        mv staging/nixos/default/* staging/
+        rm -rf staging/nixos
+        sed -i "/^os_prefix=/d" staging/config.txt
+
+        # ... and the official container format: an MBR (single bootable
+        # FAT32-LBA partition starting at sector 1) around the filesystem,
+        # not a bare "superfloppy" FAT -- the other observed difference vs
+        # the boot.img the bootloader accepts.
+        size_kib=$(du -s --apparent-size --block-size=1024 staging | cut -f1)
+        size_kib=$(( size_kib + size_kib / 10 + 8192 ))
+        mkdir -p $out
+        truncate -s "''${size_kib}K" $out/boot.img
+        echo "start=1, type=c, bootable" | sfdisk --no-reread --no-tell-kernel $out/boot.img
+        mkfs.vfat --offset 1 -F 32 -n BOOT $out/boot.img
+        (cd staging && mcopy -psvm -i "$out/boot.img@@512" ./* ::/ > /dev/null)
+
+        # No boot.sig here: ALL bootloader HTTP downloads must be
+        # RSA-signed with a key whose public half is programmed into the
+        # EEPROM (a bare sha256 sig is rejected -- learned by watching four
+        # perfectly good downloads get discarded). The private key must
+        # stay out of the store, so signing happens at deploy time on
+        # spore:
+        #   rpi-eeprom-digest -i boot.img -o boot.sig \
+        #     -k /var/lib/pi-boot-sign/private.pem
+
+        # Served next to boot.img; stage-1 curls it (see fetch-nix-store).
+        ln -s ${config.system.build.squashfsStore} $out/nix-store.squashfs
+      '';
+}


### PR DESCRIPTION
## Summary
rackpi5 is now **stateless**: the Pi 5 EEPROM HTTP-boots a signed ~76MB `boot.img` from spore's nginx, stage-1 curls the ~550MB squashfs store at wire speed (~5s), and the whole system runs from RAM (`/` = tmpfs, only "block device" is the squashfs loop). The NFS-root config from #1022 remains as the automatic fallback tier (`BOOT_ORDER=0xf127`: HTTP → NET/NFS → SD), which caught every failed iteration during bring-up.

**Already deployed and verified live**: `rackpi5-ram root=tmpfs`, zero failed units, 6.2GB RAM free.

## Changes
- `nix/images/pi5-ram.nix` — netboot-minimal squashfs image + `system.build.piBootImg` (MBR-wrapped FAT32 boot.img matching the official network-install layout), stage-1 networkd + curl fetch of the store, debug sshd on port 2222 (no console on this Pi)
- `nix/hardware/pi5/base.nix` — Pi 5 platform without the sd-image module (its label-pinned mounts conflict with the netboot tmpfs root); `default.nix` now layers sd-image on top
- `nix/hosts/rackpi5.nix` / `nix/hosts/spore.nix` — three-tier boot ladder + deploy/signing docs
- `flake.nix` — `rackpi5-ram` config + package output

## Bootloader facts learned the hard way (all encoded in comments)
- boot.img is capped at **96MB** (764MB all-in-one aborted at exactly 189MB downloaded; 99MB was rejected post-download)
- the bootloader's own HTTP is ~14MB/s — the kernel must fetch the bulk payload
- ramdisk boot rejects `os_prefix=` layouts; files live at the FAT root, MBR-wrapped, like the official image
- **all bootloader HTTP downloads must be RSA-signed** (`rpi-eeprom-digest -k`) with the public key programmed into the EEPROM — sha256-only sigs are silently discarded; signing happens at deploy time on spore because the key can't live in the nix store
- nixpkgs' `rpi-eeprom-config` wrapper is missing `pycryptodomex` for the `-p` pubkey path (worked around with explicit PYTHONPATH; possible upstream fix)

## Test Plan
- [x] rackpi5 boots to `rackpi5-ram` with `/` on tmpfs, no SD card, no NVMe
- [x] nginx log shows sig+img fetch by `rpiboot/1.0` and squashfs fetch by stage-1 `curl` at wire speed
- [x] `nix eval` of `rackpi5-ram` piBootImg and spore toplevel
- [ ] After merge: spore rebuild picks up the `/var/lib/tftpboot/rackpi5-ram` tmpfiles rule (dir already exists live)

⚠️ Reflashing a stock EEPROM on rackpi5 wipes the embedded pubkey → HTTP tier silently fails → box lands on the NFS tier until the key is re-added (`rpi-eeprom-config -p`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
