### PR TITLE
docs(pulsifer.ca): update role to Principal Infrastructure & Cloud Security Engineer

### DIFF
--- a/apps/pulsifer.ca/content/about.md
+++ b/apps/pulsifer.ca/content/about.md
@@ -8,14 +8,13 @@ draft: false
 
 Greetings. I'm **@jonpulsifer**, welcome to my cyber zen garden.
 
-I'm currently the Engineering Manager for [MoonPay's](https://moonpay.com) [Site Reliability Engineering][2] and [Cloud Security][3] teams.
+I'm currently the **Principal Infrastructure & Cloud Security Engineer** at [MoonPay](https://moonpay.com).
 
-Before that, I was a [Staff Security Engineer][1] working on Kubernetes :blue_heart: at [Shopify](https://shopify.ca).
+Previously, I was a [Staff Security Engineer][1] working on Kubernetes :blue_heart: at [Shopify](https://shopify.ca), and before that I was a [Cyber Operator][2] :anchor: in the Royal Canadian Navy.
 
 :raised_hand: I am **not** open for employment. You can still take a look at [my resume]({{< relref "/cv" >}}) and if you think I might be a good fit, email [jonathan@pulsifer.ca](mailto:jonathan@pulsifer.ca) or contact me using one of the social icons at the bottom... but don't get your hopes up :smile:
 
 **PGP:** `0x0472D3B3F5012430`
 
 [1]: https://staffeng.com/guides/what-do-staff-engineers-actually-do
-[2]: https://sre.google/sre-book/introduction/
-[3]: https://cloud.google.com/learn/what-is-cloud-security
+[2]: https://forces.ca/en/career/cyber-operator/

--- a/apps/pulsifer.ca/content/cv.md
+++ b/apps/pulsifer.ca/content/cv.md
@@ -9,15 +9,19 @@ toc: true
 
 ## Summary
 
-:wave: Hi, I'm Jonathan Pulsifer, an **engineering manager** who fits into the [Staff Engineer Tech Lead & Architect](https://staffeng.com/guides/staff-archetypes) archetypes. I enjoy working with [Open Source][github], **Google Cloud Platform**, **Kubernetes**, and **Containers**. Some might call me a **security engineer** or **sysadmin**, some might call me a **DevOps** engineer, but I just like computers :technologist:
+:wave: Hi, I'm Jonathan Pulsifer, a **principal engineer** who fits into the [Staff Engineer Tech Lead & Architect](https://staffeng.com/guides/staff-archetypes) archetypes. I enjoy working with [Open Source][github], **Google Cloud Platform**, **Kubernetes**, and **Containers**. Some might call me a **security engineer** or **sysadmin**, some might call me a **DevOps** engineer, but I just like computers :technologist:
 
 ## Employment History
 
 ### [MoonPay][moonpay], 2021-current
 
+#### Principal Infrastructure & Cloud Security Engineer, 2026-current
+
+I'm currently the Principal Infrastructure & Cloud Security Engineer at MoonPay, leading the technical implementation of MoonPay's infrastructure and cloud security.
+
 #### Engineering Manager
 
-I'm currently the Engineering Manager for MoonPay's **Site Reliability Engineering** and **Cloud Security** teams. I'm responsible for the hiring, onboarding, and development of the teams, as well as the day-to-day operations of the teams. I'm also responsible for the technical direction of the teams, and the overall security posture of MoonPay's infrastructure.
+I was the Engineering Manager for MoonPay's **Site Reliability Engineering** and **Cloud Security** teams. I was responsible for the hiring, onboarding, and development of the teams, as well as their day-to-day operations, technical direction, and the overall security posture of MoonPay's infrastructure.
 
 ### [Shopify][shop], 2016-2021
 


### PR DESCRIPTION
## Summary
Update my role at MoonPay to **Principal Infrastructure & Cloud Security Engineer** across the website bio and CV.

## Changes
- `about.md`: current role is now the Principal title; bio flows current role → Shopify (Staff Security Engineer) → Royal Canadian Navy (Cyber Operator); cleaned up now-unused footer link refs
- `cv.md`: summary now says "principal engineer"; MoonPay section split into "Principal Infrastructure & Cloud Security Engineer, 2026-current" and the prior "Engineering Manager" role (undated, past tense)

## Test Plan
- [ ] `pulsifer.ca` workflow (Hugo build) passes on this PR
- [ ] After merge, spot-check https://pulsifer.ca/about/ and https://pulsifer.ca/cv/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
