### PR TITLE
feat(wiki): first-party Bun SSG replaces publish-spa

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -6,10 +6,12 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'apps/wiki/**'
       - '.github/workflows/wiki.yml'
   pull_request:
     paths:
       - 'docs/**'
+      - 'apps/wiki/**'
       - '.github/workflows/wiki.yml'
 
 concurrency:
@@ -25,19 +27,20 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - name: Build Logseq SPA
-        uses: logseq/publish-spa@3fa40f2288e96b5927037610e2445f892a438d79 # v0.3.1
-        with:
-          graph-directory: docs
-          output-directory: www
-          theme-mode: dark
-          accent-color: purple
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install
+        run: bun install --frozen-lockfile
+
+      - name: Build
+        working-directory: apps/wiki
+        run: bun run build
 
       - name: Deploy to Cloudflare Pages
         if: github.ref == 'refs/heads/main'
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        working-directory: apps/wiki
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           # fml account (terraform/network/cloudflare/account.tf)
-          accountId: d7f641bb9f4b9de593f721ad06989dbe
-          command: pages deploy www --project-name=infra-wiki --branch=main
+          CLOUDFLARE_ACCOUNT_ID: d7f641bb9f4b9de593f721ad06989dbe
+        run: bun x wrangler pages deploy dist --project-name=infra-wiki --branch=main

--- a/.gitignore
+++ b/.gitignore
@@ -41,10 +41,8 @@ docs/.trash/
 .agents/
 
 # ─── Node / Bun ──────────────────────────────────────────────────────────────
-# Only tracked in sub-packages that need them; root is not a node project
-# node_modules/
-# package-lock.json
-# bun.lockb
+# Root is a Bun workspace (apps/*, packages/*); bun.lock is tracked.
+node_modules/
 
 # ─── IDE / Editor ────────────────────────────────────────────────────────────
 .vscode/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,19 +193,23 @@ First-party code and container/image builds, separate from the infra layers:
 - **`terraform.yml`**: validates changed `.tf` files (discovered dynamically), then auto-formats and regenerates terraform-docs on merge to `main`
 - **`trivy.yml`**: scans `.tf` and `clusters/**` for CRITICAL/HIGH IaC vulnerabilities
 - **`containers.yml`**: builds container images from `apps/`, `packages/`, `images/`
-- **`wiki.yml`**: builds the `docs/` Logseq graph with `logseq/publish-spa` and deploys it to Cloudflare Pages on merge (see Documentation Wiki)
+- **`wiki.yml`**: builds the `docs/` Logseq graph with the first-party Bun SSG (`apps/wiki`) and deploys it to Cloudflare Pages on merge (see Documentation Wiki)
 - **Renovate**: opens PRs for Helm chart, container image, and Terraform provider updates automatically
 
 ## Documentation Wiki
 
 `docs/` is a **Logseq graph** (pages in `docs/pages/`, journals in `docs/journals/`, config in
-`docs/logseq/`) published publicly at **wiki.lolwtf.ca**. `.github/workflows/wiki.yml` builds it
-with the official `logseq/publish-spa` action and deploys via `wrangler pages deploy` to the
+`docs/logseq/`) published publicly at **wiki.lolwtf.ca**. `.github/workflows/wiki.yml` renders it
+with the first-party Bun SSG in **`apps/wiki`** (~400-line `build.ts`, shiki-only dep; `bun run
+build` → `dist/`, `bun run dev` to preview) and deploys via `bun x wrangler pages deploy` to the
 Cloudflare Pages project `infra-wiki` (project/domain/DNS are Terraform-managed in
 `terraform/network/cloudflare/wiki.tf`; deploys need the `CLOUDFLARE_API_TOKEN` Actions secret).
 
 - Pages are Logseq outline markdown: blocks start with `- `, nesting is tabs, page properties are
   `key:: value` lines at the top of the file, and a `/` in a page name is `___` in the filename.
+- The renderer supports outline text, `[[wikilinks]]`/backlinks, properties, `#tags`, tables, and
+  code fences — **not** block refs `((…))`, embeds, or `{{query}}`; extend `apps/wiki/build.ts`
+  before using those in `docs/`.
 - ADRs live in the `ADR/` namespace (`docs/pages/ADR___NNNN <title>.md`) with `status::`/`date::`
   properties; copy `ADR/Template` for new ones. Architecture docs are under `Architecture/`,
   runbooks under `Runbooks/`.

--- a/apps/wiki/README.md
+++ b/apps/wiki/README.md
@@ -1,0 +1,32 @@
+# wiki
+
+A ~400-line Bun static site generator that renders the repo's `docs/` Logseq
+graph to [wiki.lolwtf.ca](https://wiki.lolwtf.ca). It replaced
+`logseq/publish-spa` (which cloned and compiled the entire Logseq frontend in
+CI, ~20 min cold) with a build that takes about a second.
+
+## What it understands
+
+Logseq outline markdown, as written by the Logseq desktop app:
+
+- `- ` blocks with tab nesting; continuation lines (code fences, tables)
+- `key:: value` page properties → chips (`status::` gets ADR colors)
+- `[[wikilinks]]` (+ backlinks collected into a "Linked references" panel)
+- `#tags` and `tags::` → generated tag pages
+- headings, tables, inline markdown, and shiki-highlighted code fences
+  (dual light/dark themes)
+
+It also emits a client-side search index (⌘K), a canvas force-directed
+graph view (`/graph/`), namespace sub-page listings, journals, and a 404.
+
+## Usage
+
+```bash
+bun install          # once, at repo root (workspace member)
+bun run build        # docs/ → dist/
+bun run dev          # build + preview on :8787
+```
+
+Deployed by `.github/workflows/wiki.yml`: build, then
+`bun x wrangler pages deploy dist` to the Cloudflare Pages project
+`infra-wiki` (Terraform: `terraform/network/cloudflare/wiki.tf`).

--- a/apps/wiki/assets/client.js
+++ b/apps/wiki/assets/client.js
@@ -1,0 +1,190 @@
+/* infra wiki client: theme toggle, ⌘K search, graph view. no deps. */
+(() => {
+  // ── theme ──
+  const root = document.documentElement;
+  document.querySelector("[data-theme-toggle]")?.addEventListener("click", () => {
+    const dark = !root.classList.contains("dark");
+    root.classList.toggle("dark", dark);
+    localStorage.theme = dark ? "dark" : "light";
+  });
+
+  // ── search ──
+  const modal = document.querySelector(".search-modal");
+  const input = modal?.querySelector("input");
+  const list = modal?.querySelector(".search-results");
+  let index = null;
+  let sel = 0;
+
+  const open = async () => {
+    modal.hidden = false;
+    input.value = "";
+    list.innerHTML = "";
+    input.focus();
+    index ??= await (await fetch("/search.json")).json();
+  };
+  const close = () => (modal.hidden = true);
+
+  const render = (results) => {
+    sel = 0;
+    list.innerHTML = results
+      .map(
+        (r, i) =>
+          `<li${i === 0 ? ' class="sel"' : ""}><a href="${r.u}">${r.t}<small>${r.snip}</small></a></li>`,
+      )
+      .join("");
+  };
+
+  const search = (q) => {
+    q = q.trim().toLowerCase();
+    if (!q || !index) return render([]);
+    const terms = q.split(/\s+/);
+    const scored = [];
+    for (const p of index) {
+      const title = p.t.toLowerCase();
+      const text = p.x.toLowerCase();
+      let score = 0;
+      let ok = true;
+      for (const t of terms) {
+        if (title.includes(t)) score += title.startsWith(t) ? 12 : 6;
+        else if (text.includes(t)) score += 1;
+        else { ok = false; break; }
+      }
+      if (!ok || !score) continue;
+      const at = text.indexOf(terms[0]);
+      const snip = at >= 0 ? p.x.slice(Math.max(0, at - 30), at + 90) : p.x.slice(0, 100);
+      scored.push({ ...p, score, snip: `…${snip}…` });
+    }
+    render(scored.sort((a, b) => b.score - a.score).slice(0, 9));
+  };
+
+  document.querySelectorAll("[data-search]").forEach((b) => b.addEventListener("click", open));
+  document.addEventListener("keydown", (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "k") { e.preventDefault(); modal.hidden ? open() : close(); }
+    else if (e.key === "/" && modal.hidden && !/input|textarea/i.test(e.target.tagName)) { e.preventDefault(); open(); }
+    else if (!modal.hidden) {
+      const items = [...list.querySelectorAll("li")];
+      if (e.key === "Escape") close();
+      else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        sel = (sel + (e.key === "ArrowDown" ? 1 : items.length - 1)) % Math.max(items.length, 1);
+        items.forEach((li, i) => li.classList.toggle("sel", i === sel));
+        items[sel]?.scrollIntoView({ block: "nearest" });
+      } else if (e.key === "Enter") items[sel]?.querySelector("a")?.click();
+    }
+  });
+  modal?.addEventListener("click", (e) => e.target === modal && close());
+  input?.addEventListener("input", () => search(input.value));
+
+  // ── graph ──
+  const canvas = document.getElementById("graph");
+  if (!canvas) return;
+
+  fetch("/graph.json").then((r) => r.json()).then(({ nodes, links }) => {
+    const ctx = canvas.getContext("2d");
+    const dpr = devicePixelRatio || 1;
+    let W, H;
+    const resize = () => {
+      W = canvas.clientWidth; H = canvas.clientHeight;
+      canvas.width = W * dpr; canvas.height = H * dpr;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+    addEventListener("resize", resize);
+
+    const N = nodes.map((n, i) => ({
+      ...n,
+      x: W / 2 + Math.cos((i / nodes.length) * 2 * Math.PI) * Math.min(W, H) * 0.32,
+      y: H / 2 + Math.sin((i / nodes.length) * 2 * Math.PI) * Math.min(W, H) * 0.32,
+      vx: 0, vy: 0, r: 4 + Math.sqrt(n.d) * 2.2,
+    }));
+    let zoom = 1, panX = 0, panY = 0, hover = -1, heat = 1;
+
+    const tick = () => {
+      // repulsion
+      for (let i = 0; i < N.length; i++)
+        for (let j = i + 1; j < N.length; j++) {
+          const a = N[i], b = N[j];
+          let dx = a.x - b.x, dy = a.y - b.y;
+          const d2 = dx * dx + dy * dy + 0.01, d = Math.sqrt(d2);
+          const f = Math.min(2200 / d2, 4);
+          dx /= d; dy /= d;
+          a.vx += dx * f; a.vy += dy * f;
+          b.vx -= dx * f; b.vy -= dy * f;
+        }
+      // springs
+      for (const [s, t] of links) {
+        const a = N[s], b = N[t];
+        const dx = b.x - a.x, dy = b.y - a.y;
+        const d = Math.hypot(dx, dy) || 1;
+        const f = (d - 110) * 0.004;
+        a.vx += (dx / d) * f; a.vy += (dy / d) * f;
+        b.vx -= (dx / d) * f; b.vy -= (dy / d) * f;
+      }
+      for (const n of N) {
+        n.vx += (W / 2 - n.x) * 0.0012; n.vy += (H / 2 - n.y) * 0.0012;
+        n.x += n.vx * heat; n.y += n.vy * heat;
+        n.vx *= 0.82; n.vy *= 0.82;
+      }
+      heat = Math.max(heat * 0.995, 0.25);
+    };
+
+    const violet = "#8b5cf6", blue = "#60a5fa";
+    const dark = () => document.documentElement.classList.contains("dark");
+    const draw = () => {
+      ctx.clearRect(0, 0, W, H);
+      ctx.save();
+      ctx.translate(panX, panY); ctx.scale(zoom, zoom);
+      ctx.lineWidth = 1 / zoom;
+      for (const [s, t] of links) {
+        const hi = hover === s || hover === t;
+        ctx.strokeStyle = hi ? blue : dark() ? "rgba(139,92,246,.22)" : "rgba(139,92,246,.3)";
+        ctx.beginPath(); ctx.moveTo(N[s].x, N[s].y); ctx.lineTo(N[t].x, N[t].y); ctx.stroke();
+      }
+      for (let i = 0; i < N.length; i++) {
+        const n = N[i];
+        const hi = i === hover;
+        ctx.beginPath();
+        ctx.arc(n.x, n.y, n.r, 0, 2 * Math.PI);
+        const g = ctx.createRadialGradient(n.x, n.y, 0, n.x, n.y, n.r);
+        g.addColorStop(0, hi ? blue : "#a78bfa");
+        g.addColorStop(1, violet);
+        ctx.fillStyle = g;
+        ctx.shadowColor = violet; ctx.shadowBlur = hi ? 26 : 10;
+        ctx.fill();
+        ctx.shadowBlur = 0;
+        if (zoom > 0.55 || hi || n.d > 4) {
+          ctx.font = `${hi ? 600 : 450} ${11 / zoom}px Inter, sans-serif`;
+          ctx.fillStyle = dark() ? (hi ? "#f4f5fb" : "rgba(217,219,232,.78)") : (hi ? "#191b28" : "rgba(42,45,61,.8)");
+          ctx.fillText(n.t, n.x + n.r + 4 / zoom, n.y + 3.5 / zoom);
+        }
+      }
+      ctx.restore();
+    };
+
+    const pos = (e) => {
+      const b = canvas.getBoundingClientRect();
+      return [(e.clientX - b.left - panX) / zoom, (e.clientY - b.top - panY) / zoom];
+    };
+    canvas.addEventListener("mousemove", (e) => {
+      if (drag) { panX += e.movementX; panY += e.movementY; return; }
+      const [x, y] = pos(e);
+      hover = N.findIndex((n) => Math.hypot(n.x - x, n.y - y) < n.r + 5);
+      canvas.style.cursor = hover >= 0 ? "pointer" : "grab";
+    });
+    canvas.addEventListener("click", () => { if (hover >= 0) location.href = N[hover].u; });
+    canvas.addEventListener("wheel", (e) => {
+      e.preventDefault();
+      const f = e.deltaY < 0 ? 1.1 : 0.9;
+      const b = canvas.getBoundingClientRect();
+      const mx = e.clientX - b.left, my = e.clientY - b.top;
+      panX = mx - (mx - panX) * f; panY = my - (my - panY) * f;
+      zoom *= f;
+    }, { passive: false });
+    let drag = false;
+    canvas.addEventListener("mousedown", () => (drag = true));
+    addEventListener("mouseup", () => (drag = false));
+
+    const loop = () => { tick(); draw(); requestAnimationFrame(loop); };
+    loop();
+  });
+})();

--- a/apps/wiki/assets/style.css
+++ b/apps/wiki/assets/style.css
@@ -1,0 +1,304 @@
+/* infra wiki — violet/blue, dark-first */
+* { box-sizing: border-box; }
+
+:root {
+  --violet: #8b5cf6;
+  --violet-soft: #a78bfa;
+  --blue: #60a5fa;
+  --grad: linear-gradient(120deg, #a78bfa 0%, #818cf8 45%, #60a5fa 100%);
+
+  --bg: #fbfbfe;
+  --bg2: #f4f4fb;
+  --bg3: #ecedf8;
+  --fg: #2a2d3d;
+  --fg2: #5b5f79;
+  --title: #191b28;
+  --line: #e2e3f0;
+  --link: #7c3aed;
+  --code-bg: #eeeefa;
+  --code-fg: #6d28d9;
+  --glow: rgba(139, 92, 246, 0.10);
+}
+
+html.dark {
+  --bg: #0b0d16;
+  --bg2: #10131f;
+  --bg3: #171b2c;
+  --fg: #d9dbe8;
+  --fg2: #9aa1bc;
+  --title: #f4f5fb;
+  --line: #232842;
+  --link: #a78bfa;
+  --code-bg: #1a1e33;
+  --code-fg: #c4b5fd;
+  --glow: rgba(139, 92, 246, 0.16);
+}
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+  font-size: 15.5px;
+  line-height: 1.65;
+  color: var(--fg);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+}
+
+html.dark body {
+  background:
+    radial-gradient(1100px 520px at 85% -5%, var(--glow), transparent 60%),
+    radial-gradient(900px 460px at -10% 25%, rgba(96, 165, 250, 0.07), transparent 55%),
+    var(--bg);
+  background-attachment: fixed;
+}
+
+.layout { display: flex; min-height: 100vh; }
+
+/* ── sidebar ── */
+.sidebar {
+  position: sticky; top: 0; align-self: flex-start;
+  width: 250px; flex-shrink: 0; height: 100vh; overflow-y: auto;
+  padding: 1.4rem 1.1rem;
+  border-right: 1px solid var(--line);
+  background: color-mix(in srgb, var(--bg2) 72%, transparent);
+  backdrop-filter: blur(10px);
+  display: flex; flex-direction: column; gap: 1rem;
+}
+
+.logo {
+  display: flex; align-items: center; gap: 0.55rem;
+  font-size: 1.12rem; font-weight: 800; letter-spacing: -0.02em;
+  color: var(--title); text-decoration: none;
+}
+.logo-text b {
+  background: var(--grad);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.searchbtn {
+  display: flex; justify-content: space-between; align-items: center;
+  width: 100%; padding: 0.45rem 0.7rem;
+  font: inherit; font-size: 0.85rem; color: var(--fg2);
+  background: var(--bg3); border: 1px solid var(--line); border-radius: 9px;
+  cursor: pointer;
+}
+.searchbtn:hover { border-color: var(--violet); color: var(--fg); }
+kbd {
+  font-family: "JetBrains Mono", monospace; font-size: 0.7rem;
+  padding: 0.05rem 0.35rem; border: 1px solid var(--line);
+  border-radius: 5px; background: var(--bg);
+}
+
+.nav { list-style: none; margin: 0; padding: 0; font-size: 0.92rem; }
+.nav > li { margin: 0.15rem 0; }
+.nav a {
+  display: block; padding: 0.28rem 0.6rem; border-radius: 7px;
+  color: var(--fg); text-decoration: none; font-weight: 600;
+}
+.nav ul { list-style: none; margin: 0; padding-left: 0.9rem; border-left: 1px solid var(--line); margin-left: 0.7rem; }
+.nav ul a { font-weight: 400; color: var(--fg2); font-size: 0.87rem; padding: 0.2rem 0.55rem; }
+.nav a:hover { background: var(--bg3); color: var(--link); }
+.nav a[aria-current] {
+  background: linear-gradient(120deg, rgba(139,92,246,.16), rgba(96,165,250,.12));
+  color: var(--link);
+}
+
+.side-foot {
+  margin-top: auto; display: flex; align-items: center; gap: 0.7rem;
+  font-size: 0.85rem;
+}
+.side-foot a { color: var(--fg2); }
+.themebtn {
+  font-size: 1rem; line-height: 1; padding: 0.3rem 0.5rem;
+  background: var(--bg3); color: var(--fg); border: 1px solid var(--line);
+  border-radius: 8px; cursor: pointer;
+}
+.themebtn:hover { border-color: var(--violet); }
+
+/* ── main ── */
+main { flex: 1; min-width: 0; padding: 2.6rem 3rem 3rem; }
+article { max-width: 46rem; margin: 0 auto; }
+.hamburger { display: none; }
+
+.crumbs { max-width: 46rem; margin: 0 auto 0.4rem; font-size: 0.85rem; color: var(--fg2); }
+.crumbs a { color: var(--fg2); text-decoration: none; }
+.crumbs a:hover { color: var(--link); }
+.crumbs .sep { margin: 0 0.4rem; opacity: 0.5; }
+
+.ptitle {
+  margin: 0.1rem 0 0.6rem; font-size: 2.1rem; font-weight: 800;
+  letter-spacing: -0.03em; line-height: 1.15;
+  background: var(--grad);
+  -webkit-background-clip: text; background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+.picon { margin-right: 0.5rem; -webkit-text-fill-color: initial; }
+
+.props { display: flex; flex-wrap: wrap; gap: 0.4rem; margin: 0 0 1.3rem; }
+.chip, .tag {
+  display: inline-block; padding: 0.1rem 0.65rem;
+  font-size: 0.74rem; font-weight: 600; border-radius: 999px;
+  border: 1px solid var(--line); background: var(--bg3);
+  color: var(--fg2); text-decoration: none;
+}
+.chip b { color: var(--blue); font-weight: 600; margin-right: 0.25rem; }
+.tag {
+  background: rgba(139,92,246,.1); border-color: rgba(139,92,246,.35);
+  color: var(--violet-soft); text-transform: uppercase; letter-spacing: 0.02em;
+}
+html:not(.dark) .tag { color: #7c3aed; }
+.tag:hover { background: rgba(139,92,246,.2); }
+.chip.status-accepted { background: rgba(52,211,153,.12); border-color: rgba(52,211,153,.4); color: #34d399; }
+html:not(.dark) .chip.status-accepted { color: #059669; }
+.chip.status-proposed { background: rgba(251,191,36,.12); border-color: rgba(251,191,36,.4); color: #fbbf24; }
+html:not(.dark) .chip.status-proposed { color: #b45309; }
+.chip.status-superseded { opacity: 0.65; text-decoration: line-through; }
+
+/* ── outline ── */
+.outline { list-style: none; margin: 0; padding: 0; }
+.outline .outline {
+  padding-left: 1.15rem; margin-left: 0.32rem;
+  border-left: 1px solid var(--line);
+}
+.block { position: relative; margin: 0.28rem 0; }
+.outline .outline > .block:not(.hblock) > .bc { padding-left: 0.95rem; }
+.outline .outline > .block:not(.hblock)::before {
+  content: ""; position: absolute; left: 0; top: 0.62em;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--violet); opacity: 0.55;
+  box-shadow: 0 0 0 3px var(--glow);
+}
+.bc > p { margin: 0.15rem 0; }
+
+h2, h3, h4, h5 { color: var(--title); letter-spacing: -0.02em; line-height: 1.3; }
+h2 { font-size: 1.35rem; margin: 1.6rem 0 0.4rem; padding-bottom: 0.3rem; border-bottom: 1px solid var(--line); }
+h3 { font-size: 1.12rem; margin: 1.1rem 0 0.25rem; }
+h4 { font-size: 1rem; margin: 0.9rem 0 0.2rem; }
+h2 .count { font-size: 0.8rem; color: var(--fg2); font-weight: 500; margin-left: 0.4rem; }
+
+a { color: var(--link); }
+.wl { font-weight: 550; text-decoration: none; border-bottom: 1px solid rgba(139,92,246,.4); }
+.wl:hover { border-bottom-color: var(--link); background: var(--glow); border-radius: 3px; }
+.wl.broken { color: var(--fg2); border-bottom: 1px dashed var(--line); cursor: help; }
+
+strong { color: var(--title); }
+mark { background: rgba(251,191,36,.3); color: inherit; border-radius: 3px; padding: 0 0.15em; }
+img { max-width: 100%; border-radius: 10px; }
+.dim { color: var(--fg2); }
+
+/* ── code ── */
+code, pre, .shiki {
+  font-family: "JetBrains Mono", ui-monospace, monospace;
+  font-size: 0.84em;
+}
+:not(pre) > code {
+  background: var(--code-bg); color: var(--code-fg);
+  padding: 0.1em 0.38em; border-radius: 5px;
+}
+pre.shiki {
+  margin: 0.45rem 0; padding: 0.85rem 1rem;
+  border: 1px solid var(--line); border-radius: 11px;
+  overflow-x: auto; line-height: 1.55;
+}
+.shiki, .shiki span { color: var(--shiki-light); background-color: transparent !important; }
+pre.shiki { background-color: var(--bg2) !important; }
+html.dark .shiki, html.dark .shiki span { color: var(--shiki-dark); }
+html.dark pre.shiki { background-color: #0d0f1c !important; }
+
+/* ── tables ── */
+.tablewrap { overflow-x: auto; margin: 0.5rem 0; border: 1px solid var(--line); border-radius: 11px; }
+table { border-collapse: collapse; width: 100%; font-size: 0.88rem; }
+th {
+  text-align: left; background: var(--bg3);
+  border-bottom: 2px solid var(--violet); font-weight: 700;
+}
+th, td { padding: 0.45rem 0.8rem; border-bottom: 1px solid var(--line); white-space: nowrap; }
+td { white-space: normal; }
+tr:last-child td { border-bottom: 0; }
+tbody tr:nth-child(even) { background: var(--glow); }
+
+/* ── panels: backlinks, sub-pages ── */
+.panel {
+  margin-top: 2.2rem; padding: 1rem 1.2rem;
+  border: 1px solid var(--line); border-radius: 13px;
+  background: color-mix(in srgb, var(--bg2) 65%, transparent);
+}
+.panel h2 { margin: 0 0 0.6rem; font-size: 1.05rem; border: 0; padding: 0; }
+.reflist { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.3rem; }
+.ref { padding: 0.55rem 0; border-top: 1px solid var(--line); }
+.ref:first-of-type { border-top: 0; }
+.ref-src { font-size: 0.78rem; font-weight: 700; color: var(--blue); text-decoration: none; text-transform: uppercase; letter-spacing: 0.04em; }
+.ref-body { font-size: 0.9rem; color: var(--fg2); }
+.ref-body p { margin: 0.15rem 0 0; }
+
+.editlink { margin-top: 2rem; font-size: 0.83rem; }
+.editlink a { color: var(--fg2); }
+.editlink a:hover { color: var(--link); }
+
+.journal { margin-bottom: 1.6rem; }
+.journal h2 { border: 0; }
+
+.foot {
+  max-width: 46rem; margin: 3.5rem auto 0; padding-top: 1rem;
+  border-top: 1px solid var(--line);
+  font-size: 0.8rem; color: var(--fg2);
+}
+.foot a { color: var(--fg2); }
+
+/* ── graph ── */
+.grapharticle { max-width: none; }
+#graph {
+  width: 100%; height: 72vh; display: block;
+  border: 1px solid var(--line); border-radius: 14px;
+  background: color-mix(in srgb, var(--bg2) 60%, transparent);
+  cursor: grab;
+}
+
+/* ── search modal ── */
+.search-modal {
+  position: fixed; inset: 0; z-index: 50;
+  background: rgba(5, 6, 12, 0.55); backdrop-filter: blur(3px);
+  display: flex; align-items: flex-start; justify-content: center;
+  padding-top: 12vh;
+}
+.search-modal[hidden] { display: none; }
+.search-box {
+  width: min(620px, 92vw); border-radius: 14px; overflow: hidden;
+  background: var(--bg2); border: 1px solid var(--line);
+  box-shadow: 0 24px 70px rgba(0,0,0,0.45), 0 0 0 1px var(--glow);
+}
+.search-box input {
+  width: 100%; padding: 0.9rem 1.1rem; font: inherit; font-size: 1rem;
+  color: var(--fg); background: transparent; border: 0; outline: 0;
+  border-bottom: 1px solid var(--line);
+}
+.search-results { list-style: none; margin: 0; padding: 0.35rem; max-height: 46vh; overflow-y: auto; }
+.search-results li a {
+  display: block; padding: 0.5rem 0.75rem; border-radius: 8px;
+  color: var(--fg); text-decoration: none;
+}
+.search-results li a small { display: block; color: var(--fg2); font-size: 0.78rem; }
+.search-results li.sel a, .search-results li a:hover {
+  background: linear-gradient(120deg, rgba(139,92,246,.18), rgba(96,165,250,.14));
+}
+
+/* ── mobile ── */
+@media (max-width: 860px) {
+  .layout { display: block; }
+  .sidebar {
+    position: fixed; z-index: 40; height: 100vh; width: 260px;
+    transform: translateX(-100%); transition: transform 0.2s ease;
+    background: var(--bg2);
+  }
+  #menu:checked ~ .sidebar { transform: none; box-shadow: 0 0 60px rgba(0,0,0,0.5); }
+  .hamburger {
+    display: inline-block; font-size: 1.3rem; cursor: pointer;
+    color: var(--fg); margin-bottom: 0.6rem; user-select: none;
+  }
+  main { padding: 1.2rem 1.1rem 2rem; }
+  .ptitle { font-size: 1.6rem; }
+  th, td { white-space: normal; }
+}

--- a/apps/wiki/build.ts
+++ b/apps/wiki/build.ts
@@ -1,0 +1,517 @@
+/**
+ * wiki — a tiny static site generator for the docs/ Logseq graph.
+ *
+ * Reads docs/pages/*.md + docs/journals/*.md (Logseq outline markdown:
+ * `- ` blocks, tab nesting, `key:: value` page properties, [[wikilinks]])
+ * and renders a static site to dist/: pages, backlinks, namespace listings,
+ * tag pages, a client-side search index, and a force-directed graph view.
+ */
+import { codeToHtml } from "shiki";
+import { readdir, mkdir, rm, cp } from "node:fs/promises";
+import { join, dirname } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const DOCS = join(ROOT, "docs");
+const OUT = join(import.meta.dir, "dist");
+const SITE = "wiki.lolwtf.ca";
+const REPO = "https://github.com/jonpulsifer/infra";
+
+// ── model ────────────────────────────────────────────────────────────────────
+
+interface Block {
+  depth: number;
+  lines: string[];
+  children: Block[];
+}
+
+interface Page {
+  name: string; // "ADR/0001 GitOps apply model"
+  file: string; // path relative to repo root, for edit links
+  kind: "page" | "journal";
+  props: Record<string, string>;
+  blocks: Block[];
+  url: string; // "/adr/0001-gitops-apply-model/"
+}
+
+interface Ref {
+  page: Page;
+  html: string;
+}
+
+const pages = new Map<string, Page>(); // lowercased name -> page
+const backlinks = new Map<string, Ref[]>(); // lowercased target name -> refs
+const tagged = new Map<string, Page[]>(); // tag -> pages
+
+// ── parsing ──────────────────────────────────────────────────────────────────
+
+function parse(src: string): { props: Record<string, string>; blocks: Block[] } {
+  const lines = src.split("\n");
+  const props: Record<string, string> = {};
+  let i = 0;
+  while (i < lines.length && /^[A-Za-z][\w-]*:: /.test(lines[i])) {
+    const at = lines[i].indexOf(":: ");
+    props[lines[i].slice(0, at).toLowerCase()] = lines[i].slice(at + 3).trim();
+    i++;
+  }
+  const blocks: Block[] = [];
+  const stack: Block[] = [];
+  for (; i < lines.length; i++) {
+    const m = lines[i].match(/^(\t*)- (.*)$/);
+    if (m) {
+      const b: Block = { depth: m[1].length, lines: [m[2]], children: [] };
+      while (stack.length && stack[stack.length - 1].depth >= b.depth) stack.pop();
+      (stack.length ? stack[stack.length - 1].children : blocks).push(b);
+      stack.push(b);
+    } else if (stack.length && lines[i].trim() !== "") {
+      // continuation line: strip the block's tab indent + two-space alignment
+      stack[stack.length - 1].lines.push(lines[i].replace(/^\t*(?: {2})?/, ""));
+    }
+  }
+  return { props, blocks };
+}
+
+function slug(name: string): string {
+  return name
+    .split("/")
+    .map((s) =>
+      s
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, ""),
+    )
+    .join("/");
+}
+
+function pageUrl(name: string, kind: Page["kind"]): string {
+  if (kind === "journal") return `/journals/${slug(name)}/`;
+  if (name.toLowerCase() === "home") return "/";
+  return `/${slug(name)}/`;
+}
+
+// ── inline rendering ─────────────────────────────────────────────────────────
+
+const esc = (s: string) =>
+  s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+function wikilink(name: string, current: Page): string {
+  const target = pages.get(name.toLowerCase());
+  if (target) return `<a class="wl" href="${target.url}">${esc(target.name)}</a>`;
+  return `<span class="wl broken" title="no such page (yet)">${esc(name)}</span>`;
+}
+
+function inline(s: string, page: Page, refs?: Set<string>): string {
+  s = esc(s);
+  const codes: string[] = [];
+  s = s.replace(/`([^`]+)`/g, (_, c) => `\u0000${codes.push(c) - 1}\u0000`);
+  s = s.replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, `<img alt="$1" src="$2" loading="lazy">`);
+  s = s.replace(/\[([^\]]+)\]\((https?:[^)\s]+)\)/g, `<a href="$2" rel="noopener">$1</a>`);
+  s = s.replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, `<a href="$2">$1</a>`);
+  s = s.replace(/\[\[([^\]]+)\]\]/g, (_, n) => {
+    refs?.add(n.toLowerCase());
+    return wikilink(n, page);
+  });
+  s = s.replace(
+    /(^|[\s(])#([A-Za-z][\w/-]*)/g,
+    (_, sp, t) => `${sp}<a class="tag" href="/tags/${slug(t)}/">#${t}</a>`,
+  );
+  s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  s = s.replace(/(^|[\s(>])\*([^*\n]+)\*(?=[\s).,;:!?]|$)/g, "$1<em>$2</em>");
+  s = s.replace(/==([^=]+)==/g, "<mark>$1</mark>");
+  s = s.replace(/\u0000(\d+)\u0000/g, (_, i) => `<code>${esc(codes[+i])}</code>`);
+  return s;
+}
+
+// ── block rendering ──────────────────────────────────────────────────────────
+
+async function highlight(code: string, lang: string): Promise<string> {
+  const opts = {
+    themes: { light: "catppuccin-latte", dark: "tokyo-night" },
+    defaultColor: false,
+  } as const;
+  try {
+    return await codeToHtml(code, { lang: lang || "text", ...opts });
+  } catch {
+    return await codeToHtml(code, { lang: "text", ...opts });
+  }
+}
+
+async function renderBlockContent(
+  b: Block,
+  page: Page,
+  refs: Set<string>,
+): Promise<{ html: string; heading: boolean }> {
+  const text = b.lines.join("\n").trim();
+
+  const fence = text.match(/^```(\S*)\n?([\s\S]*?)\n?```$/);
+  if (fence) return { html: await highlight(fence[2], fence[1]), heading: false };
+
+  const rows = text.split("\n");
+  if (rows.length > 1 && rows.every((r) => r.trim().startsWith("|"))) {
+    const cells = (r: string) =>
+      r
+        .trim()
+        .replace(/^\||\|$/g, "")
+        .split("|")
+        .map((c) => inline(c.trim(), page, refs));
+    const head = cells(rows[0]);
+    const body = rows.slice(2).map(cells);
+    return {
+      html:
+        `<div class="tablewrap"><table><thead><tr>` +
+        head.map((h) => `<th>${h}</th>`).join("") +
+        `</tr></thead><tbody>` +
+        body.map((r) => `<tr>${r.map((c) => `<td>${c}</td>`).join("")}</tr>`).join("") +
+        `</tbody></table></div>`,
+      heading: false,
+    };
+  }
+
+  const h = text.match(/^(#{1,4}) (.*)$/s);
+  if (h) {
+    const level = h[1].length + 1; // # -> h2
+    return { html: `<h${level}>${inline(h[2], page, refs)}</h${level}>`, heading: true };
+  }
+
+  const html = text
+    .split("\n")
+    .map((l) => inline(l, page, refs))
+    .join("<br>");
+  return { html: `<p>${html}</p>`, heading: false };
+}
+
+async function renderBlocks(blocks: Block[], page: Page, refs: Set<string>): Promise<string> {
+  let out = `<ul class="outline">`;
+  for (const b of blocks) {
+    const { html, heading } = await renderBlockContent(b, page, refs);
+    const kids = b.children.length ? await renderBlocks(b.children, page, refs) : "";
+    out += `<li class="block${heading ? " hblock" : ""}"><div class="bc">${html}</div>${kids}</li>`;
+  }
+  return out + `</ul>`;
+}
+
+// collect backlink refs: flat render of a single block (without children) for the refs panel
+async function blockSnippet(b: Block, page: Page): Promise<string> {
+  const { html } = await renderBlockContent(b, page, new Set());
+  return html;
+}
+
+// ── chrome ───────────────────────────────────────────────────────────────────
+
+const NAV_ORDER = ["Home", "Architecture", "ADR", "Runbooks", "Fleet", "Contributing"];
+
+function nav(current: Page | null): string {
+  const item = (name: string) => {
+    const p = pages.get(name.toLowerCase());
+    if (!p) return "";
+    const here = current && p.name === current.name ? ` aria-current="page"` : "";
+    const kids = [...pages.values()]
+      .filter((c) => c.name.startsWith(name + "/") && !c.name.endsWith("/Template"))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    return (
+      `<li><a href="${p.url}"${here}>${esc(name)}</a>` +
+      (kids.length
+        ? `<ul>` +
+          kids
+            .map((c) => {
+              const cur = current && c.name === current.name ? ` aria-current="page"` : "";
+              return `<li><a href="${c.url}"${cur}>${esc(c.name.slice(name.length + 1))}</a></li>`;
+            })
+            .join("") +
+          `</ul>`
+        : "") +
+      `</li>`
+    );
+  };
+  return (
+    `<ul class="nav">` +
+    NAV_ORDER.map(item).join("") +
+    `<li><a href="/graph/"${current?.name === "__graph" ? ` aria-current="page"` : ""}>Graph</a></li>` +
+    `<li><a href="/journals/"${current?.kind === "journal" ? ` aria-current="page"` : ""}>Journals</a></li>` +
+    `</ul>`
+  );
+}
+
+function chip(k: string, v: string, page: Page): string {
+  if (k === "tags")
+    return v
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean)
+      .map((t) => `<a class="tag" href="/tags/${slug(t)}/">#${esc(t)}</a>`)
+      .join(" ");
+  if (k === "status") return `<span class="chip status-${esc(v.split(" ")[0])}">${esc(v)}</span>`;
+  return `<span class="chip"><b>${esc(k)}</b> ${inline(v, page)}</span>`;
+}
+
+function layout(title: string, current: Page | null, body: string, desc = ""): string {
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${esc(title)} · infra wiki</title>
+<meta name="description" content="${esc(desc || `${title} — jonpulsifer/infra wiki`)}">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🛰️</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/style.css">
+<script>document.documentElement.classList.toggle("dark",(localStorage.theme??"dark")==="dark")</script>
+</head>
+<body>
+<div class="layout">
+<input type="checkbox" id="menu" hidden>
+<aside class="sidebar">
+  <a class="logo" href="/"><span class="logo-mark">🛰️</span> <span class="logo-text">infra<b>wiki</b></span></a>
+  <button class="searchbtn" data-search>Search… <kbd>⌘K</kbd></button>
+  ${nav(current)}
+  <div class="side-foot">
+    <button class="themebtn" data-theme-toggle title="toggle theme">◐</button>
+    <a href="${REPO}" rel="noopener">GitHub</a>
+  </div>
+</aside>
+<main>
+<label for="menu" class="hamburger" aria-label="menu">☰</label>
+${body}
+<footer class="foot">Built from <a href="${REPO}/tree/main/docs" rel="noopener">docs/</a> with <a href="${REPO}/tree/main/apps/wiki" rel="noopener">bun + ~400 lines of TypeScript</a> · deployed on Cloudflare Pages</footer>
+</main>
+</div>
+<div class="search-modal" hidden><div class="search-box"><input type="search" placeholder="Search the wiki…" aria-label="search"><ul class="search-results"></ul></div></div>
+<script src="/client.js" defer></script>
+</body>
+</html>`;
+}
+
+function breadcrumbs(p: Page): string {
+  const parts = p.name.split("/");
+  if (parts.length === 1 && p.kind === "page") return "";
+  let acc = "";
+  const crumbs = parts.slice(0, -1).map((part) => {
+    acc = acc ? `${acc}/${part}` : part;
+    const t = pages.get(acc.toLowerCase());
+    return t ? `<a href="${t.url}">${esc(part)}</a>` : `<span>${esc(part)}</span>`;
+  });
+  if (p.kind === "journal") crumbs.unshift(`<a href="/journals/">Journals</a>`);
+  return crumbs.length ? `<nav class="crumbs">${crumbs.join(`<span class="sep">/</span>`)}</nav>` : "";
+}
+
+// ── build ────────────────────────────────────────────────────────────────────
+
+async function loadPages() {
+  for (const kind of ["pages", "journals"] as const) {
+    const dir = join(DOCS, kind);
+    const files = ((await readdir(dir).catch(() => [])) as string[]).filter((f) => f.endsWith(".md"));
+    for (const f of files) {
+      const raw = await Bun.file(join(dir, f)).text();
+      const { props, blocks } = parse(raw);
+      const name =
+        kind === "journals"
+          ? f.replace(/\.md$/, "").replace(/_/g, "-")
+          : f.replace(/\.md$/, "").replace(/___/g, "/");
+      const page: Page = {
+        name,
+        file: `docs/${kind}/${f}`,
+        kind: kind === "journals" ? "journal" : "page",
+        props,
+        blocks,
+        url: pageUrl(name, kind === "journals" ? "journal" : "page"),
+      };
+      pages.set(name.toLowerCase(), page);
+    }
+  }
+}
+
+function plainText(blocks: Block[], acc: string[] = []): string[] {
+  for (const b of blocks) {
+    acc.push(
+      b.lines
+        .join(" ")
+        .replace(/```\S*/g, "")
+        .replace(/\[\[([^\]]+)\]\]/g, "$1")
+        .replace(/[*`#|]+/g, " ")
+        .replace(/\s+/g, " ")
+        .trim(),
+    );
+    plainText(b.children, acc);
+  }
+  return acc;
+}
+
+async function collectRefs() {
+  // walk every block of every page; record outgoing wikilinks with a snippet
+  for (const page of pages.values()) {
+    if (page.name.toLowerCase() === "contents") continue;
+    const walk = async (bs: Block[]) => {
+      for (const b of bs) {
+        const refs = new Set<string>();
+        const text = b.lines.join("\n");
+        for (const m of text.matchAll(/\[\[([^\]]+)\]\]/g)) refs.add(m[1].toLowerCase());
+        if (refs.size) {
+          const html = await blockSnippet(b, page);
+          for (const r of refs) {
+            if (!backlinks.has(r)) backlinks.set(r, []);
+            backlinks.get(r)!.push({ page, html });
+          }
+        }
+        await walk(b.children);
+      }
+    };
+    await walk(page.blocks);
+  }
+  for (const page of pages.values()) {
+    for (const t of (page.props["tags"] ?? "").split(",").map((s) => s.trim()).filter(Boolean)) {
+      if (!tagged.has(t)) tagged.set(t, []);
+      tagged.get(t)!.push(page);
+    }
+  }
+}
+
+async function emit(path: string, html: string) {
+  const file = join(OUT, path.replace(/^\//, ""), "index.html");
+  await mkdir(dirname(file), { recursive: true });
+  await Bun.write(file, html);
+}
+
+async function renderPage(p: Page): Promise<string> {
+  const refs = new Set<string>();
+  const content = await renderBlocks(p.blocks, p, refs);
+  const icon = p.props["icon"] ? `<span class="picon">${p.props["icon"]}</span>` : "";
+  const meta = Object.entries(p.props)
+    .filter(([k]) => k !== "icon")
+    .map(([k, v]) => chip(k, v, p))
+    .join(" ");
+  const kids = [...pages.values()]
+    .filter((c) => c.name.startsWith(p.name + "/"))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const bl = (backlinks.get(p.name.toLowerCase()) ?? []).filter((r) => r.page.name !== p.name);
+  const title = p.kind === "journal" ? p.name : p.name.split("/").pop()!;
+
+  return layout(
+    p.name,
+    p,
+    `${breadcrumbs(p)}
+<article>
+<h1 class="ptitle">${icon}${esc(title)}</h1>
+${meta ? `<div class="props">${meta}</div>` : ""}
+${content}
+${
+  kids.length
+    ? `<section class="panel"><h2>Sub-pages</h2><ul class="reflist">` +
+      kids.map((k) => `<li><a class="wl" href="${k.url}">${esc(k.name)}</a></li>`).join("") +
+      `</ul></section>`
+    : ""
+}
+${
+  bl.length
+    ? `<section class="panel"><h2>Linked references <span class="count">${bl.length}</span></h2>` +
+      bl
+        .map(
+          (r) =>
+            `<div class="ref"><a class="ref-src" href="${r.page.url}">${esc(r.page.name)}</a><div class="ref-body">${r.html}</div></div>`,
+        )
+        .join("") +
+      `</section>`
+    : ""
+}
+<p class="editlink"><a href="${REPO}/edit/main/${encodeURI(p.file)}" rel="noopener">Edit this page on GitHub</a></p>
+</article>`,
+    plainText(p.blocks).join(" ").slice(0, 155),
+  );
+}
+
+async function build() {
+  await rm(OUT, { recursive: true, force: true });
+  await mkdir(OUT, { recursive: true });
+
+  await loadPages();
+  await collectRefs();
+
+  // pages
+  for (const p of pages.values()) {
+    if (p.name.toLowerCase() === "contents") continue;
+    await emit(p.url, await renderPage(p));
+  }
+
+  // journals index
+  const journals = [...pages.values()]
+    .filter((p) => p.kind === "journal")
+    .sort((a, b) => b.name.localeCompare(a.name));
+  let jbody = `<article><h1 class="ptitle">Journals</h1>`;
+  for (const j of journals) {
+    jbody += `<section class="journal"><h2><a class="wl" href="${j.url}">${esc(j.name)}</a></h2>${await renderBlocks(j.blocks, j, new Set())}</section>`;
+  }
+  await emit("/journals/", layout("Journals", null, jbody + `</article>`));
+
+  // tag pages
+  for (const [tag, tps] of tagged) {
+    await emit(
+      `/tags/${slug(tag)}/`,
+      layout(
+        `#${tag}`,
+        null,
+        `<article><h1 class="ptitle"><span class="picon">#</span>${esc(tag)}</h1><ul class="reflist">` +
+          tps
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((p) => `<li><a class="wl" href="${p.url}">${esc(p.name)}</a></li>`)
+            .join("") +
+          `</ul></article>`,
+      ),
+    );
+  }
+
+  // graph page + data
+  const ids = [...pages.values()].filter((p) => p.name.toLowerCase() !== "contents");
+  const index = new Map(ids.map((p, i) => [p.name.toLowerCase(), i]));
+  const links: [number, number][] = [];
+  for (const [target, refs] of backlinks) {
+    const t = index.get(target);
+    if (t === undefined) continue;
+    for (const r of refs) {
+      const s = index.get(r.page.name.toLowerCase());
+      if (s !== undefined && s !== t) links.push([s, t]);
+    }
+  }
+  const deg = new Array(ids.length).fill(1);
+  for (const [s, t] of links) (deg[s] += 1), (deg[t] += 1);
+  await Bun.write(
+    join(OUT, "graph.json"),
+    JSON.stringify({
+      nodes: ids.map((p, i) => ({ t: p.name, u: p.url, d: deg[i] })),
+      links,
+    }),
+  );
+  await emit(
+    "/graph/",
+    layout(
+      "Graph",
+      { name: "__graph" } as Page,
+      `<article class="grapharticle"><h1 class="ptitle">Graph</h1><p class="dim">Every page, every link. Drag to pan, scroll to zoom, click to visit.</p><canvas id="graph"></canvas></article>`,
+    ),
+  );
+
+  // search index
+  await Bun.write(
+    join(OUT, "search.json"),
+    JSON.stringify(
+      ids.map((p) => ({ t: p.name, u: p.url, x: plainText(p.blocks).join(" ").slice(0, 2000) })),
+    ),
+  );
+
+  // 404
+  await Bun.write(
+    join(OUT, "404.html"),
+    layout(
+      "404",
+      null,
+      `<article><h1 class="ptitle">404</h1><p>No such page. It would render as a <span class="wl broken">broken link</span> — maybe it's waiting to be written. <a class="wl" href="/">Go home</a>.</p></article>`,
+    ),
+  );
+
+  // static assets
+  await cp(join(import.meta.dir, "assets", "style.css"), join(OUT, "style.css"));
+  await cp(join(import.meta.dir, "assets", "client.js"), join(OUT, "client.js"));
+
+  console.log(`built ${ids.length} pages, ${links.length} graph edges → ${OUT}`);
+}
+
+await build();

--- a/apps/wiki/package.json
+++ b/apps/wiki/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wiki",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "bun run build.ts",
+    "dev": "bun run build.ts && bun run serve.ts"
+  },
+  "dependencies": {
+    "shiki": "^3.13.0"
+  }
+}

--- a/apps/wiki/serve.ts
+++ b/apps/wiki/serve.ts
@@ -1,0 +1,18 @@
+/** Preview server for dist/ — `bun run dev`. */
+import { join } from "node:path";
+
+const DIST = join(import.meta.dir, "dist");
+
+Bun.serve({
+  port: 8787,
+  async fetch(req) {
+    const path = new URL(req.url).pathname;
+    for (const candidate of [path, join(path, "index.html")]) {
+      const f = Bun.file(join(DIST, candidate));
+      if (await f.exists()) return new Response(f);
+    }
+    return new Response(Bun.file(join(DIST, "404.html")), { status: 404 });
+  },
+});
+
+console.log("wiki preview → http://localhost:8787");

--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,273 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "infra",
+    },
+    "apps/wiki": {
+      "name": "wiki",
+      "dependencies": {
+        "shiki": "^3.13.0",
+      },
+    },
+    "packages/agent-web-ui": {
+      "name": "ai-agents",
+      "devDependencies": {
+        "@tailwindcss/cli": "^4.2.1",
+        "@types/bun": "latest",
+        "tailwindcss": "^4.2.1",
+      },
+      "peerDependencies": {
+        "typescript": "^5 || ^6.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@parcel/watcher": ["@parcel/watcher@2.5.1", "", { "dependencies": { "detect-libc": "^1.0.3", "is-glob": "^4.0.3", "micromatch": "^4.0.5", "node-addon-api": "^7.0.0" }, "optionalDependencies": { "@parcel/watcher-android-arm64": "2.5.1", "@parcel/watcher-darwin-arm64": "2.5.1", "@parcel/watcher-darwin-x64": "2.5.1", "@parcel/watcher-freebsd-x64": "2.5.1", "@parcel/watcher-linux-arm-glibc": "2.5.1", "@parcel/watcher-linux-arm-musl": "2.5.1", "@parcel/watcher-linux-arm64-glibc": "2.5.1", "@parcel/watcher-linux-arm64-musl": "2.5.1", "@parcel/watcher-linux-x64-glibc": "2.5.1", "@parcel/watcher-linux-x64-musl": "2.5.1", "@parcel/watcher-win32-arm64": "2.5.1", "@parcel/watcher-win32-ia32": "2.5.1", "@parcel/watcher-win32-x64": "2.5.1" } }, "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg=="],
+
+    "@parcel/watcher-android-arm64": ["@parcel/watcher-android-arm64@2.5.1", "", { "os": "android", "cpu": "arm64" }, "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA=="],
+
+    "@parcel/watcher-darwin-arm64": ["@parcel/watcher-darwin-arm64@2.5.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw=="],
+
+    "@parcel/watcher-darwin-x64": ["@parcel/watcher-darwin-x64@2.5.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg=="],
+
+    "@parcel/watcher-freebsd-x64": ["@parcel/watcher-freebsd-x64@2.5.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ=="],
+
+    "@parcel/watcher-linux-arm-glibc": ["@parcel/watcher-linux-arm-glibc@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA=="],
+
+    "@parcel/watcher-linux-arm-musl": ["@parcel/watcher-linux-arm-musl@2.5.1", "", { "os": "linux", "cpu": "arm" }, "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q=="],
+
+    "@parcel/watcher-linux-arm64-glibc": ["@parcel/watcher-linux-arm64-glibc@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w=="],
+
+    "@parcel/watcher-linux-arm64-musl": ["@parcel/watcher-linux-arm64-musl@2.5.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg=="],
+
+    "@parcel/watcher-linux-x64-glibc": ["@parcel/watcher-linux-x64-glibc@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A=="],
+
+    "@parcel/watcher-linux-x64-musl": ["@parcel/watcher-linux-x64-musl@2.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg=="],
+
+    "@parcel/watcher-win32-arm64": ["@parcel/watcher-win32-arm64@2.5.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw=="],
+
+    "@parcel/watcher-win32-ia32": ["@parcel/watcher-win32-ia32@2.5.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ=="],
+
+    "@parcel/watcher-win32-x64": ["@parcel/watcher-win32-x64@2.5.1", "", { "os": "win32", "cpu": "x64" }, "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA=="],
+
+    "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g=="],
+
+    "@shikijs/langs": ["@shikijs/langs@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg=="],
+
+    "@shikijs/themes": ["@shikijs/themes@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0" } }, "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA=="],
+
+    "@shikijs/types": ["@shikijs/types@3.23.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@tailwindcss/cli": ["@tailwindcss/cli@4.3.2", "", { "dependencies": { "@parcel/watcher": "2.5.1", "@tailwindcss/node": "4.3.2", "@tailwindcss/oxide": "4.3.2", "enhanced-resolve": "5.21.6", "mri": "^1.2.0", "picocolors": "^1.1.1", "tailwindcss": "4.3.2" }, "bin": { "tailwindcss": "./dist/index.mjs" } }, "sha512-Fzt+HrIZHDlkRYKdLMBeufaroaPvwCBG70sMLdmurdeadNMO/LxbmT8Sbb+P83ep0iAlAImettb7Y+rO+37rXw=="],
+
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.2", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "5.21.6", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.2" } }, "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg=="],
+
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.2", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.2", "@tailwindcss/oxide-darwin-arm64": "4.3.2", "@tailwindcss/oxide-darwin-x64": "4.3.2", "@tailwindcss/oxide-freebsd-x64": "4.3.2", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2", "@tailwindcss/oxide-linux-arm64-musl": "4.3.2", "@tailwindcss/oxide-linux-x64-gnu": "4.3.2", "@tailwindcss/oxide-linux-x64-musl": "4.3.2", "@tailwindcss/oxide-wasm32-wasi": "4.3.2", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2", "@tailwindcss/oxide-win32-x64-msvc": "4.3.2" } }, "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag=="],
+
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.2", "", { "os": "android", "cpu": "arm64" }, "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA=="],
+
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w=="],
+
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ=="],
+
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA=="],
+
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w=="],
+
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw=="],
+
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA=="],
+
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w=="],
+
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw=="],
+
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.2", "", { "dependencies": { "@emnapi/core": "^1.11.1", "@emnapi/runtime": "^1.11.1", "@emnapi/wasi-threads": "^1.2.2", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.2", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw=="],
+
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ=="],
+
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.2", "", { "os": "win32", "cpu": "x64" }, "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
+
+    "ai-agents": ["ai-agents@workspace:packages/agent-web-ui"],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@1.0.3", "", { "bin": { "detect-libc": "./bin/detect-libc.js" } }, "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+
+    "enhanced-resolve": ["enhanced-resolve@5.21.6", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mri": ["mri@1.2.0", "", {}, "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA=="],
+
+    "node-addon-api": ["node-addon-api@7.1.1", "", {}, "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ=="],
+
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "property-information": ["property-information@7.2.0", "", {}, "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg=="],
+
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "shiki": ["shiki@3.23.0", "", { "dependencies": { "@shikijs/core": "3.23.0", "@shikijs/engine-javascript": "3.23.0", "@shikijs/engine-oniguruma": "3.23.0", "@shikijs/langs": "3.23.0", "@shikijs/themes": "3.23.0", "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
+    "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
+
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "wiki": ["wiki@workspace:apps/wiki"],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+  }
+}

--- a/docs/journals/2026_07_08.md
+++ b/docs/journals/2026_07_08.md
@@ -1,2 +1,3 @@
 - 🎉 **Wiki launched.** [[ADR/0009 Logseq wiki on Cloudflare Pages]] accepted: `docs/` is now a Logseq graph published to [wiki.lolwtf.ca](https://wiki.lolwtf.ca) on every merge.
 	- Seeded [[Architecture]] (all four layers plus networking, secrets, and GitOps), [[Fleet]], [[Runbooks]] (migrated from loose files in `docs/`), and backfilled [[ADR]]s 0001–0008.
+	- The first deploy promptly broke — `publish-spa` leaked Node 18 onto `PATH` and wrangler 4 refused. Replaced the renderer with a first-party Bun SSG (`apps/wiki`) the same day: [[ADR/0010 First-party Bun SSG for the wiki]]. Builds went from ~20 minutes to ~1 second.

--- a/docs/pages/ADR.md
+++ b/docs/pages/ADR.md
@@ -16,3 +16,4 @@ icon:: 📜
 	- [[ADR/0007 Offline root CA with YubiKey and SLIP-0039]] — root stays offline; Vault runs the intermediate
 	- [[ADR/0008 Diskless netboot for rackpi5]] — stateless RAM image served from spore
 	- [[ADR/0009 Logseq wiki on Cloudflare Pages]] — this wiki
+	- [[ADR/0010 First-party Bun SSG for the wiki]] — the renderer that actually builds it

--- a/docs/pages/ADR___0009 Logseq wiki on Cloudflare Pages.md
+++ b/docs/pages/ADR___0009 Logseq wiki on Cloudflare Pages.md
@@ -15,4 +15,5 @@ tags:: adr
 	- One-time setup: the `CLOUDFLARE_API_TOKEN` Actions secret (Pages:Edit scope) and an Atlantis apply of the Pages project must precede the first deploy.
 	- Alternatives considered: in-cluster hosting (rejected — circular dependency with the infra it documents), GitHub Pages subpath under pulsifer.ca (rejected — two workflows sharing one `gh-pages` branch clobber each other), plain static renderers like Hugo/Quartz (rejected — Logseq outline syntax renders poorly outside Logseq).
 - # Links
+	- **Renderer superseded** the same day by [[ADR/0010 First-party Bun SSG for the wiki]] — `publish-spa` broke its first deploy (Node 18 leak) and cost ~20 min per cold build. Hosting, domain, and graph layout here still stand.
 	- [[Contributing]], [[Architecture/GitOps]]

--- a/docs/pages/ADR___0010 First-party Bun SSG for the wiki.md
+++ b/docs/pages/ADR___0010 First-party Bun SSG for the wiki.md
@@ -1,0 +1,19 @@
+status:: accepted
+date:: 2026-07-08
+deciders:: [[jawn]]
+supersedes:: the renderer choice in [[ADR/0009 Logseq wiki on Cloudflare Pages]]
+tags:: adr
+
+- # Context
+	- [[ADR/0009 Logseq wiki on Cloudflare Pages]] chose the official `logseq/publish-spa` action as the renderer. In practice it clones and compiles the entire Logseq frontend (yarn + ClojureScript) in CI — ~20 minutes on a cold cache — and the pinned 2024-era release (`v0.3.1`) sets up **Node 18** and leaves it on `PATH`, which broke the very first production deploy: wrangler 4 requires Node ≥ 20. The published site was also a multi-megabyte SPA for what is fundamentally a documentation site.
+- # Decision
+	- Replace the renderer with a **first-party static site generator**: `apps/wiki` — ~400 lines of TypeScript run by **Bun**, with shiki as the only dependency.
+	- It renders the Logseq subset this wiki actually uses: outline blocks, `[[wikilinks]]` with a linked-references panel, namespaces with sub-page listings, `key:: value` properties (ADR `status::` gets colored chips), `#tags` with tag pages, tables, and dual-theme highlighted code — plus a ⌘K search index and a canvas force-directed **graph view**.
+	- Deploys run `bun x wrangler pages deploy` — bun brings its own runtime, so the Node-version dance disappears. The hosting decision (Cloudflare Pages, wiki.lolwtf.ca, public) from ADR/0009 is unchanged, and `docs/` remains a normal Logseq graph — the editing workflow is untouched.
+- # Consequences
+	- Builds take about **a second** instead of ~20 minutes; CI is checkout + `bun install` + one script.
+	- Full control over markup, theme, and payload — the site is a few hundred KB of static HTML.
+	- We own a parser: it covers the constructs used today, but Logseq features we don't use (block refs `((…))`, embeds, `{{query}}`) are **unsupported** — avoid them in `docs/`, or extend `apps/wiki/build.ts` first.
+	- The authentic Logseq SPA (and its native graph UI) is gone; the custom graph view at `/graph/` fills that niche.
+- # Links
+	- [[ADR/0009 Logseq wiki on Cloudflare Pages]], [[Contributing]], `apps/wiki/README.md`

--- a/docs/pages/Contributing.md
+++ b/docs/pages/Contributing.md
@@ -1,6 +1,7 @@
 icon:: ✍️
 
-- This wiki is the `docs/` directory of [jonpulsifer/infra](https://github.com/jonpulsifer/infra) — a Logseq graph. Editing it is a normal PR; merging to `main` publishes it to [wiki.lolwtf.ca](https://wiki.lolwtf.ca) via `.github/workflows/wiki.yml` ([[ADR/0009 Logseq wiki on Cloudflare Pages]]).
+- This wiki is the `docs/` directory of [jonpulsifer/infra](https://github.com/jonpulsifer/infra) — a Logseq graph. Editing it is a normal PR; merging to `main` publishes it to [wiki.lolwtf.ca](https://wiki.lolwtf.ca) via `.github/workflows/wiki.yml` ([[ADR/0009 Logseq wiki on Cloudflare Pages]]), rendered by the first-party Bun SSG in `apps/wiki` ([[ADR/0010 First-party Bun SSG for the wiki]]).
+- One renderer caveat: block refs `((…))`, embeds, and `{{query}}` are not supported — stick to outline text, wikilinks, properties, tables, and code fences, or extend `apps/wiki/build.ts` first.
 - ## Editing with Logseq (recommended)
 	- Open the Logseq desktop app → *Add new graph* → choose the repo's `docs/` directory.
 	- Logseq's working files (`logseq/bak/`, `logseq/.recycle/`, metadata) are gitignored; `logseq/config.edn` and `logseq/custom.css` are tracked — changes to them are deliberate.


### PR DESCRIPTION
## Summary
Replaces the `logseq/publish-spa` wiki renderer with a first-party Bun static site generator (`apps/wiki`, ~400 lines, shiki-only dep). The pinned publish-spa release leaks Node 18 onto `PATH`, which broke the first wrangler 4 deploy on `main`, and its cold builds compile the whole Logseq frontend (~20 min). The new build takes ~1 second and deploys with `bun x wrangler pages deploy` (bun brings its own runtime — no Node version dance). Recorded as `ADR/0010`; hosting/domain from ADR/0009 unchanged.

## What the SSG renders
Outline blocks, `[[wikilinks]]` + linked-references panels, namespaces with sub-page listings, `key::value` property chips (ADR statuses colored), `#tags` + tag pages, tables, dual-theme shiki code, ⌘K client-side search, a canvas force-directed graph view at `/graph/`, journals, and a 404. `docs/` stays a normal Logseq graph — editing is unchanged.

## Changes
- feat(wiki): replace publish-spa with a first-party Bun SSG (apps/wiki + workflow + ADR/0010 + docs updates + root bun.lock)

## Test Plan
- [x] `bun run build` locally: 27 pages, 94 graph edges, ~1s
- [x] `bun run dev` smoke test: `/`, `/adr/`, `/graph/`, `/search.json` all 200; unknown path 404
- [x] Rendering spot-checks: 15 shiki blocks in the kiosk runbook, tables in Fleet/TPM audit, backlink counts, ADR status chips, no leftover raw fences or NULs
- [x] `bun x wrangler --version` under bun → 4.108.0 (deploy path proven)
- [x] `actionlint` on the workflow
- [ ] `wiki` build job green on this PR
- [ ] After merge (+ `CLOUDFLARE_API_TOKEN` secret): wiki.lolwtf.ca live

🤖 Generated with [Claude Code](https://claude.com/claude-code)
