### PR TITLE
docs(wiki): per-host pages with live-surveyed hardware facts

### DIFF
--- a/docs/pages/Fleet.md
+++ b/docs/pages/Fleet.md
@@ -1,31 +1,32 @@
 icon:: 🖥️
 
-- Every physical (and one virtual) host, from `flake.nix`. Hardware details from the [[Runbooks/TPM Audit]]; deploy mechanics in [[Architecture/NixOS]].
+- Every physical (and one virtual) host, from `flake.nix`. Each has a dedicated page under [[Hosts]] with serials, hardware, and quirks (surveyed live 2026-07-08); deploy mechanics in [[Architecture/NixOS]].
 - ## folly — primary k8s cluster
 	- | Host | Role | Hardware | Notes |
 	  | ---- | ---- | -------- | ----- |
-	  | optiplex | control-plane | Dell OptiPlex 3050 | disko on `/dev/sda` |
-	  | riptide | worker | HP EliteDesk 800 G5 Mini | disko on `/dev/nvme0n1`, working TPM 2.0 |
-	  | shale | worker | HP EliteDesk 800 G2 DM 35W | disko on `/dev/sda` |
+	  | [[Hosts/optiplex]] | control-plane | Dell OptiPlex 3050, i7-7700T | disko on `/dev/sda` |
+	  | [[Hosts/riptide]] | worker | HP EliteDesk 800 G5 Mini, i5-9500T | NVMe, working TPM 2.0 |
+	  | [[Hosts/shale]] | worker | HP EliteDesk 800 G2 DM 35W, i7-6700T | no `shale.lolwtf.ca` record — jump via optiplex |
 - ## offsite — backup k8s cluster
 	- | Host | Role | Hardware | Notes |
 	  | ---- | ---- | -------- | ----- |
-	  | retrofit | control-plane | HP EliteDesk 800 G2 DM 65W | |
-	  | oldschool | worker | HP EliteDesk 800 G3 DM 35W | also: docker, GitHub runner, yarr |
+	  | [[Hosts/retrofit]] | control-plane | HP EliteDesk 800 G2 DM 65W, i7-6700T | |
+	  | [[Hosts/oldschool]] | worker | HP EliteDesk 800 G3 DM 35W, i5-6500 | also: docker, GitHub runner, yarr |
 - ## Raspberry Pis
-	- | Host | Purpose | Notes |
-	  | ---- | ------- | ----- |
-	  | cloudpi4 | utility Pi | |
-	  | homepi4 | kiosk | [[Runbooks/Kiosk]] |
-	  | weatherpi4 | kiosk | reach over Tailscale; [[Runbooks/Kiosk]] |
-	  | dns | DNS | |
-	  | rackpi5 | rack status | **diskless** — boots a RAM image from spore ([[ADR/0008 Diskless netboot for rackpi5]]) |
-	  | spore | NFS/PXE boot server | boot-critical for rackpi5; monitored by folly |
+	- | Host | Purpose | Hardware | Notes |
+	  | ---- | ------- | -------- | ----- |
+	  | [[Hosts/cloudpi4]] | utility Pi | Pi 4B 4 GB | still Ubuntu 22.04, not NixOS |
+	  | [[Hosts/homepi4]] | kiosk | Pi 4B 8 GB | [[Runbooks/Kiosk]]; use `homepi4-wifi.lolwtf.ca` |
+	  | [[Hosts/weatherpi4]] | kiosk | Pi 4B 8 GB | reach over Tailscale; [[Runbooks/Kiosk]] |
+	  | [[Hosts/dns]] | DNS | Pi 5 8 GB | |
+	  | [[Hosts/rackpi5]] | rack status | Pi 5 8 GB | **diskless** — RAM image from spore ([[ADR/0008 Diskless netboot for rackpi5]]) |
+	  | [[Hosts/spore]] | NFS/PXE boot server | Pi 5 8 GB, NVMe | boot-critical for rackpi5; monitored by folly |
+	  | [[Hosts/radiopi0]] | radio | Pi Zero W | **unmanaged** — Raspbian buster, not in the flake |
 - ## Cloud
 	- | Host | Where | Notes |
 	  | ---- | ----- | ----- |
-	  | oldboy | GCE | tagged `gcp` |
+	  | [[Hosts/oldboy]] | GCE e2-micro (free tier) | tagged `gcp` |
 - ## Images (not hosts)
 	- `wsl`, `iso`, `gce`, `container`, `netboot`, and `rackpi5-ram` (the pi5 RAM image) are buildable images defined alongside the hosts in `flake.nix`.
 - ## Reaching things
-	- LAN hosts resolve as `<host>.lolwtf.ca`; offsite requires the tailnet. k8s nodes have Tailscale disabled — go through the LAN or the cluster.
+	- LAN hosts resolve as `<host>.lolwtf.ca`; offsite and weatherpi4 require the tailnet. k8s nodes have Tailscale disabled — go through the LAN or the cluster (shale currently needs `ssh -J optiplex.lolwtf.ca jawn@10.3.0.11`).

--- a/docs/pages/Hosts.md
+++ b/docs/pages/Hosts.md
@@ -1,0 +1,6 @@
+icon:: 🗄️
+
+- One page per machine with live-surveyed hardware facts (vendor, model, serial, CPU, RAM, storage, OS — collected over SSH on 2026-07-08). The cluster/role tables live in [[Fleet]].
+- x86: [[Hosts/optiplex]], [[Hosts/riptide]], [[Hosts/shale]], [[Hosts/retrofit]], [[Hosts/oldschool]]
+- Raspberry Pi: [[Hosts/cloudpi4]], [[Hosts/homepi4]], [[Hosts/weatherpi4]], [[Hosts/dns]], [[Hosts/rackpi5]], [[Hosts/spore]], [[Hosts/radiopi0]]
+- Cloud: [[Hosts/oldboy]]

--- a/docs/pages/Hosts___cloudpi4.md
+++ b/docs/pages/Hosts___cloudpi4.md
@@ -1,0 +1,15 @@
+type:: host
+role:: utility Pi
+vendor:: Raspberry Pi
+model:: Raspberry Pi 4 Model B Rev 1.1 (4 GB)
+year:: ~2019
+serial:: 100000009c1080f8
+revision:: c03111
+cpu:: BCM2711, Cortex-A72 (4c)
+ram:: 4 GB
+storage:: 64 GB microSD
+os:: Ubuntu 22.04.5 LTS
+
+- Utility Pi. The odd one out: still runs **Ubuntu**, not NixOS (config exists as `nix/hosts/cloudpi4.nix` but the deployed OS is Ubuntu 22.04, kernel 5.15-raspi).
+- Reached as `cloudpi4.lolwtf.ca`.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___dns.md
+++ b/docs/pages/Hosts___dns.md
@@ -1,0 +1,15 @@
+type:: host
+role:: DNS
+vendor:: Raspberry Pi
+model:: Raspberry Pi 5 Model B Rev 1.1 (8 GB)
+year:: ~2023
+serial:: d9c81ac9b4823886
+revision:: d04171
+cpu:: BCM2712, Cortex-A76 (4c)
+ram:: 8 GB
+storage:: 32 GB microSD
+os:: NixOS 26.05 (Yarara)
+
+- LAN DNS server. Config: `nix/hosts/dns.nix`.
+- Reached as `dns.lolwtf.ca`.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___homepi4.md
+++ b/docs/pages/Hosts___homepi4.md
@@ -1,0 +1,15 @@
+type:: host
+role:: kiosk
+vendor:: Raspberry Pi
+model:: Raspberry Pi 4 Model B Rev 1.4 (8 GB)
+year:: ~2020
+serial:: 100000001e657842
+revision:: d03114
+cpu:: BCM2711, Cortex-A72 (4c)
+ram:: 8 GB
+storage:: 32 GB microSD
+os:: NixOS 26.05 (Yarara)
+
+- Kiosk Pi ([[Runbooks/Kiosk]]). Config: `nix/hosts/homepi4.nix`.
+- The wired `homepi4.lolwtf.ca` record can be unreachable; `homepi4-wifi.lolwtf.ca` works.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___oldboy.md
+++ b/docs/pages/Hosts___oldboy.md
@@ -1,0 +1,13 @@
+type:: host
+role:: cloud VM
+vendor:: Google Cloud
+model:: GCE e2-micro (free tier)
+serial:: n/a (virtual)
+cpu:: 2 shared vCPU
+ram:: 1 GB
+storage:: 16 GB pd-standard
+os:: NixOS
+
+- Free-tier GCE VM in the `homelab-ng` project, built from the repo's NixOS GCE image (`terraform/gcp/projects/homelab-ng/compute.tf`).
+- Not reachable from the LAN by name; no `oldboy.lolwtf.ca` or tailnet record as of 2026-07 — specs above are from Terraform, not a live login.
+- Config: `nix/hosts/oldboy.nix`, tagged `gcp`. See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___oldschool.md
+++ b/docs/pages/Hosts___oldschool.md
@@ -1,0 +1,17 @@
+type:: host
+cluster:: [[Architecture/Kubernetes]] offsite
+role:: worker
+vendor:: HP
+model:: EliteDesk 800 G3 DM 35W
+year:: ~2017
+serial:: 8CG74769HJ
+sku:: 1VR53UC#ABA
+cpu:: Intel Core i5-6500 @ 3.20GHz (4c/4t)
+ram:: 16 GB
+storage:: 512 GB KingFast SATA SSD
+os:: NixOS 26.05 (Yarara)
+firmware:: P21 Ver. 02.15 (2018-01-31)
+
+- offsite worker; also runs docker, a GitHub Actions runner, and yarr.
+- Offsite — reach over the tailnet.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___optiplex.md
+++ b/docs/pages/Hosts___optiplex.md
@@ -1,0 +1,17 @@
+type:: host
+cluster:: [[Architecture/Kubernetes]] folly
+role:: control-plane
+vendor:: Dell
+model:: OptiPlex 3050 (micro)
+year:: ~2017
+serial:: 66BT7M2
+sku:: 07A3
+cpu:: Intel Core i7-7700T @ 2.90GHz (4c/8t)
+ram:: 16 GB
+storage:: 256 GB SK hynix SC311 SATA SSD
+os:: NixOS 26.05 (Yarara)
+firmware:: BIOS 1.27.0 (2023-09-19)
+
+- folly control-plane node, node IP `10.3.0.10`. Config in `flake.nix` (`mkHost "optiplex"`); disko on `/dev/sda`.
+- Reached as `optiplex.lolwtf.ca`; also the handy jump host for other folly nodes.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___rackpi5.md
+++ b/docs/pages/Hosts___rackpi5.md
@@ -1,0 +1,15 @@
+type:: host
+role:: rack status display
+vendor:: Raspberry Pi
+model:: Raspberry Pi 5 Model B Rev 1.1 (8 GB)
+year:: ~2023
+serial:: aed421e548c12e74
+revision:: d04171
+cpu:: BCM2712, Cortex-A76 (4c)
+ram:: 8 GB
+storage:: none — diskless
+os:: NixOS 26.05 (Yarara), RAM image
+
+- **Diskless**: PXE-netboots the `rackpi5-ram` image from [[Hosts/spore]] and runs entirely from RAM (`lsblk` shows no disks; static hostname is `rackpi5-ram`). See [[ADR/0008 Diskless netboot for rackpi5]].
+- Reached as `rackpi5.lolwtf.ca`. Config: `nix/hosts/rackpi5.nix`.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___radiopi0.md
+++ b/docs/pages/Hosts___radiopi0.md
@@ -1,0 +1,15 @@
+type:: host
+role:: radio
+vendor:: Raspberry Pi
+model:: Raspberry Pi Zero W Rev 1.1
+year:: ~2017
+serial:: 0000000056f8a6ff
+revision:: 9000c1
+cpu:: BCM2835, ARM1176 (1c, armv6l)
+ram:: 512 MB
+storage:: 32 GB microSD
+os:: Raspbian 10 (buster)
+
+- Pi Zero W radio box. **Unmanaged**: not in `flake.nix`, runs EOL Raspbian buster, login is `pi@radiopi0.lolwtf.ca`.
+- Candidate for adoption into the flake (armv6l makes NixOS awkward — cross-compiled or stay Raspbian).
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___retrofit.md
+++ b/docs/pages/Hosts___retrofit.md
@@ -1,0 +1,17 @@
+type:: host
+cluster:: [[Architecture/Kubernetes]] offsite
+role:: control-plane
+vendor:: HP
+model:: EliteDesk 800 G2 DM 65W
+year:: ~2016
+serial:: MXL7211HNN
+sku:: W3X40UC#ABA
+cpu:: Intel Core i7-6700T @ 2.80GHz (4c/8t)
+ram:: 16 GB
+storage:: 512 GB Timetec SD08 SATA SSD
+os:: NixOS 26.05 (Yarara)
+firmware:: N21 Ver. 02.21 (2016-11-01)
+
+- offsite control-plane. Chassis asset tag matches the serial (MXL7211HNN).
+- Offsite — reach over the tailnet.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___riptide.md
+++ b/docs/pages/Hosts___riptide.md
@@ -1,0 +1,17 @@
+type:: host
+cluster:: [[Architecture/Kubernetes]] folly
+role:: worker
+vendor:: HP
+model:: EliteDesk 800 G5 Desktop Mini
+year:: ~2019
+serial:: MXL0172Q6L
+sku:: 9GB06UC#ABA
+cpu:: Intel Core i5-9500T @ 2.20GHz (6c/6t)
+ram:: 16 GB
+storage:: 256 GB KIOXIA KXG60ZNV256G NVMe
+os:: NixOS 26.05 (Yarara)
+firmware:: R21 Ver. 02.20.00 (2023-12-15)
+
+- folly worker, node IP `10.3.0.12`. Disko on `/dev/nvme0n1`.
+- Newest x86 box in the fleet; has a working TPM 2.0 ([[Runbooks/TPM Audit]]).
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___shale.md
+++ b/docs/pages/Hosts___shale.md
@@ -1,0 +1,17 @@
+type:: host
+cluster:: [[Architecture/Kubernetes]] folly
+role:: worker
+vendor:: HP
+model:: EliteDesk 800 G2 DM 35W
+year:: ~2016
+serial:: MXL6372537
+sku:: V0B22UP#ABA
+cpu:: Intel Core i7-6700T @ 2.80GHz (4c/8t)
+ram:: 16 GB
+storage:: 512 GB KingFast SATA SSD
+os:: NixOS 26.05 (Yarara)
+firmware:: N21 Ver. 02.37 (2019-01-02)
+
+- folly worker, node IP `10.3.0.11`. Disko on `/dev/sda`.
+- No `shale.lolwtf.ca` DNS record as of 2026-07 — reach it via `ssh -J optiplex.lolwtf.ca jawn@10.3.0.11` (or fix the record).
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___spore.md
+++ b/docs/pages/Hosts___spore.md
@@ -1,0 +1,16 @@
+type:: host
+role:: NFS / PXE boot server
+vendor:: Raspberry Pi
+model:: Raspberry Pi 5 Model B Rev 1.1 (8 GB)
+year:: ~2023
+serial:: d860ec5f943fe335
+revision:: d04171
+cpu:: BCM2712, Cortex-A76 (4c)
+ram:: 8 GB
+storage:: 128 GB Patriot P300 NVMe
+os:: NixOS 26.05 (Yarara)
+
+- NFS/PXE boot server — **boot-critical for [[Hosts/rackpi5]]** ([[ADR/0008 Diskless netboot for rackpi5]]); monitored by folly.
+- Only Pi with NVMe storage (128 GB Patriot P300). Config: `nix/hosts/spore.nix`.
+- Reached as `spore.lolwtf.ca`.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___weatherpi4.md
+++ b/docs/pages/Hosts___weatherpi4.md
@@ -1,0 +1,15 @@
+type:: host
+role:: kiosk
+vendor:: Raspberry Pi
+model:: Raspberry Pi 4 Model B Rev 1.4 (8 GB)
+year:: ~2020
+serial:: 10000000cfbd3890
+revision:: d03114
+cpu:: BCM2711, Cortex-A72 (4c)
+ram:: 8 GB
+storage:: 32 GB microSD
+os:: NixOS 26.05 (Yarara)
+
+- Weather kiosk ([[Runbooks/Kiosk]]). Config: `nix/hosts/weatherpi4.nix`.
+- Not on the LAN — reach it over the tailnet (`weatherpi4.pirate-musical.ts.net`).
+- See [[Fleet]] for the full inventory.


### PR DESCRIPTION
Adds a `Hosts/` namespace to the Logseq wiki: one page per machine (13 hosts + a `Hosts` index) with properties for vendor, model, ~year, serial, SKU, CPU, RAM, storage, OS, and firmware — surveyed live over SSH on 2026-07-08. `Fleet.md` now links every host to its page and gains the previously undocumented `radiopi0` (Pi Zero W, Raspbian buster, unmanaged).

Notable findings baked into the pages:
- **shale** has no `shale.lolwtf.ca` DNS record — reachable only via `ssh -J optiplex.lolwtf.ca jawn@10.3.0.11`
- **cloudpi4** still runs Ubuntu 22.04, not its NixOS config
- **rackpi5** confirmed fully diskless (no block devices; hostname `rackpi5-ram`)
- **oldboy** specs are from Terraform only (no LAN/tailnet route to it)

`apps/wiki` build verified: 41 pages, 141 graph edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)