### PR TITLE
docs(runbooks): move ops procedures into logseq

### DIFF
--- a/.agents/skills/kubernetes-gitops/SKILL.md
+++ b/.agents/skills/kubernetes-gitops/SKILL.md
@@ -1,101 +1,30 @@
 ---
 name: kubernetes-gitops
 description: Work with Kubernetes manifests and GitOps workflows for the folly and offsite clusters. Covers FluxCD reconciliation, networking architecture, and SOPS secrets.
+metadata:
+  runbook: docs/pages/Runbooks___Kubernetes GitOps Change.md
+  wiki: https://wiki.lolwtf.ca/runbooks/kubernetes-gitops-change/
 ---
 
-## Cluster Structure
+# Kubernetes GitOps
 
-```
-clusters/
-  base/      # Shared resources referenced by both clusters
-  folly/     # Primary on-site (nuc, optiplex, riptide, 800g2)
-  offsite/   # Backup cluster (oldschool, retrofit)
-```
+Canonical human runbook: `docs/pages/Runbooks___Kubernetes GitOps Change.md`.
+Reference bridge: `references/runbook.md`.
 
-Each cluster contains: `flux-system/`, `networking/`, `monitoring/`, `nodes/`, `storage/`.
+## Agent Notes
 
-`base/` holds shared helm-releases (cert-manager, tailscale, external-dns, vector) used by both clusters via kustomize directory references. Cluster-specific values use Flux `postBuild` substitution with variables like `${CLUSTER_NAME}` from each cluster's `cluster-settings` ConfigMap.
-
-Shared platform components live under `base/platform/` (`arc-system`, `external-secrets-operator`, `onepassword-connect`, `agent-sandbox`) and `base/storage/`; each cluster's `flux-system/` Kustomization points at those base paths directly. HelmRepository/GitRepository sources are **not** centralized — each source is colocated in the same directory (and same Flux Kustomization) as the HelmRelease/manifests that consume it.
-
-## Making Changes
-
-Changes to `clusters/` deploy automatically via FluxCD when merged to `main`.
-
-```bash
-# Check reconciliation status
-flux get kustomizations -A
-flux get helmreleases -A
-
-# Force reconcile
-flux reconcile kustomization <name> -n flux-system --with-source
-```
-
-## Networking Architecture
-
-| Component     | Resource                                       | Purpose                          |
-|---------------|------------------------------------------------|----------------------------------|
-| CNI           | `networking/cilium/`                           | Pod networking + BGP LB          |
-| Ingress       | `networking/gateway-api/cluster-gateway.yaml`  | Kubernetes Gateway API           |
-| External      | `networking/cloudflare/cloudflared.yaml`        | Cloudflare Tunnel (no open ports)|
-| Internal VPN  | `networking/tailscale/`                        | Tailscale operator               |
-| TLS           | `networking/cert-manager/`                     | Let's Encrypt via Cloudflare DNS |
-| DNS           | `networking/external-dns/`                     | Cloudflare records from Gateway  |
-
-BGP IP pools are in `networking/cilium/ip-pools.yaml`.
-
-## SOPS Secrets
-
-Files matching `*.sops.yaml` are encrypted at rest. FluxCD decrypts via the cluster's age key.
-
-```bash
-# View/edit
-sops clusters/folly/networking/tailscale/secret.sops.yaml
-
-# Encrypt new file (must match path regex in .sops.yaml)
-sops -e -i clusters/<cluster>/<path>.sops.yaml
-```
-
-Encrypted fields: `data` and `stringData` only (per `.sops.yaml`).
-
-## Atlantis / ArgoCD Cross-Cluster Auth
-
-Atlantis (offsite) connects to ArgoCD (folly) to verify Terraform plans against live application state.
-
-| Component | Location | Account |
-|-----------|----------|---------|
-| Atlantis HelmRelease | `clusters/offsite/apps/atlantis/helm-release.yaml` | Connects via `ARGOCD_AUTH_TOKEN` |
-| Atlantis secret | `clusters/offsite/apps/atlantis/secret.sops.yaml` | Stores `argocd_token` |
-| ArgoCD config | `clusters/folly/apps/argo/helm-release.yaml` | Defines `accounts.atlantis: apiKey` + RBAC |
-
-**When the ArgoCD token expires**, `atlantis/plan` checks fail with signature errors (JWT signed with a rotated key). Symptoms:
-- GitHub PR status: `atlantis/plan: terraform/argo/default` → FAILURE
-- Atlantis logs show gRPC/auth errors against `argo.${SECRET_DOMAIN}:443`
-
-### Rotating the Token
-
-```bash
-# 1. Port-forward to ArgoCD server
-kubectl port-forward -n argo svc/argo-argocd-server 9090:80
-
-# 2. Get admin password and login
-ARGOCD_PASS=$(kubectl get secrets -n argo argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
-TOKEN=$(curl -s -X POST "http://localhost:9090/api/v1/session" \
-  -H "Content-Type: application/json" \
-  -d "{\"username\":\"admin\",\"password\":\"$ARGOCD_PASS\"}" | jq -r '.token')
-
-# 3. Generate new token for the atlantis account
-RESULT=$(curl -s -X POST "http://localhost:9090/api/v1/account/atlantis/token" \
-  -H "Authorization: Bearer $TOKEN" \
-  -H "Content-Type: application/json" \
-  -d "{}")
-NEW_TOKEN=$(echo "$RESULT" | jq -r '.token')
-
-# 4. Update SOPS secret (decrypt → edit → re-encrypt)
-sops clusters/offsite/apps/atlantis/secret.sops.yaml
-# Replace the argocd_token value with base64-encoded NEW_TOKEN
-```
-
-## Helm Releases
-
-Apps use `HelmRelease` resources pointing to a `HelmRepository`/`GitRepository`/`OCIRepository` source colocated in the same directory (named `helm-repository.yaml`, `git-repository.yaml`, or `oci-repository.yaml`, suffixed with the app name when a directory holds more than one). Renovate opens automatic update PRs for chart bumps.
+- Changes under `clusters/` deploy automatically via Flux after merge to `main`.
+- Do not use `kubectl apply` to author desired state.
+- Use explicit contexts: `--context folly` and `--context offsite`.
+- Inspect reconciliation:
+  ```bash
+  flux --context <cluster> get kustomizations -A
+  flux --context <cluster> get helmreleases -A
+  ```
+- Force reconcile only for inspection or merged changes:
+  ```bash
+  flux --context <cluster> reconcile kustomization <name> -n flux-system --with-source
+  ```
+- SOPS files are encrypted at rest; never expose decrypted values in docs, PR comments, or logs.
+- HelmRepository/GitRepository/OCIRepository sources are colocated with the resources that consume them unless the local pattern says otherwise.
+- For shared `clusters/base/` changes, also use the `multi-cluster` skill.

--- a/.agents/skills/kubernetes-gitops/references/runbook.md
+++ b/.agents/skills/kubernetes-gitops/references/runbook.md
@@ -1,0 +1,6 @@
+# Runbook Reference
+
+- Source: `../../../docs/pages/Runbooks___Kubernetes GitOps Change.md`
+- Published: https://wiki.lolwtf.ca/runbooks/kubernetes-gitops-change/
+
+Use the Logseq page as the canonical human procedure. Keep this reference file as a bridge only; do not duplicate the runbook here.

--- a/.agents/skills/multi-cluster/SKILL.md
+++ b/.agents/skills/multi-cluster/SKILL.md
@@ -1,74 +1,25 @@
 ---
 name: multi-cluster
 description: Add or modify shared resources across folly and offsite k8s clusters using the base/ pattern.
+metadata:
+  runbook: docs/pages/Runbooks___Add Shared Kubernetes Resource.md
+  wiki: https://wiki.lolwtf.ca/runbooks/add-shared-kubernetes-resource/
 ---
 
-## Shared Base Pattern
+# Multi-Cluster
 
-`clusters/base/` holds resources shared by both clusters. Each shared component is a directory with its own `kustomization.yaml`.
+Canonical human runbook: `docs/pages/Runbooks___Add Shared Kubernetes Resource.md`.
+Reference bridge: `references/runbook.md`.
 
-```
-clusters/base/
-├── kustomization.yaml              # cluster-runtimeclass
-├── monitoring/
-│   ├── kustomization.yaml
-│   └── vector.yaml                 # ${CLUSTER_NAME} templated
-└── networking/
-    ├── cert-manager/
-    │   ├── kustomization.yaml
-    │   └── helm-release.yaml
-    ├── external-dns/
-    │   ├── kustomization.yaml
-    │   └── helm-release.yaml       # ${CLUSTER_NAME}, ${SECRET_DOMAIN} templated
-    └── tailscale/
-        ├── kustomization.yaml
-        └── helm-release.yaml
-```
+## Agent Notes
 
-## Adding a New Shared Resource
-
-1. Create `clusters/base/<category>/<component>/kustomization.yaml` listing the resource files
-2. Templatize cluster-specific values with `${CLUSTER_NAME}`, `${SECRET_DOMAIN}`, or other vars from `cluster-settings`/`cluster-secrets`
-3. In each cluster's kustomization, reference the base directory:
-   ```yaml
-   resources:
-     - ../../../base/networking/<component>
-   ```
-4. Add cluster-specific patches in the overlay kustomization if needed
-5. Validate both clusters:
-   ```bash
-   kubectl kustomize clusters/folly/<category>/
-   kubectl kustomize clusters/offsite/<category>/
-   ```
-
-## Key Constraints
-
-- **Never reference individual files** outside the kustomization root — kustomize blocks this. Always reference directories.
-- **Flux postBuild substitution** handles variable replacement at deploy time. Variables come from:
-  - `cluster-settings` ConfigMap (CLUSTER_NAME, TIMEZONE, network CIDRs, etc.)
-  - `cluster-secrets` Secret (SECRET_DOMAIN, CLOUDFLARE_ZONE, GATEWAY_ZONE, etc.)
-- The Flux Kustomization must have `postBuild.substituteFrom` configured to use templated vars.
-
-## Shared via Flux Path References
-
-Shared platform components live under `base/` and **both** clusters' `flux-system/` Kustomizations point at the same base path:
-
-| Resource                  | Flux Kustomization path                          |
-|---------------------------|--------------------------------------------------|
-| ARC (runner controller)   | `./clusters/base/platform/arc-system`            |
-| External Secrets Operator | `./clusters/base/platform/external-secrets-operator` |
-| 1Password Connect         | `./clusters/base/platform/onepassword-connect`   |
-| Sandbox apps              | `./clusters/base/platform/agent-sandbox`         |
-| Storage (offsite)         | `./clusters/base/storage`                        |
-
-This works because Flux resolves paths relative to the git repo root, not the kustomization file.
-
-HelmRepository/GitRepository/OCIRepository **sources are not shared centrally** — each is colocated in the same directory as the HelmRelease that consumes it (`helm-repository.yaml` / `git-repository.yaml` / `oci-repository.yaml`). Sources needed by both clusters (e.g. `descheduler`, `gateway-api`) are duplicated into each cluster's directory, matching how those apps are already duplicated.
-
-## What Stays Cluster-Specific
-
-- `cilium/` — different BGP peers, IP pools, hubble config
-- `gateway-api/` — different listeners and routes
-- `tailscale/connector.yaml` — different names, routes, tags
-- `cloudflare/` SOPS secrets — different tunnel credentials
-- `cert-manager/issuers/` and `certificates/` — may have domain-specific diffs
+- Shared resources live under `clusters/base/`.
+- Each shared component should be a directory with its own `kustomization.yaml`.
+- Cluster overlays reference shared directories, not individual files outside the kustomization root.
+- Templatize cluster-specific values with Flux substitutions such as `${CLUSTER_NAME}` and `${SECRET_DOMAIN}` when the parent Flux Kustomization provides them.
+- Validate every consuming cluster:
+  ```bash
+  kubectl kustomize clusters/folly/<category>
+  kubectl kustomize clusters/offsite/<category>
+  ```
+- Keep genuinely cluster-specific resources in cluster overlays.

--- a/.agents/skills/multi-cluster/references/runbook.md
+++ b/.agents/skills/multi-cluster/references/runbook.md
@@ -1,0 +1,6 @@
+# Runbook Reference
+
+- Source: `../../../docs/pages/Runbooks___Add Shared Kubernetes Resource.md`
+- Published: https://wiki.lolwtf.ca/runbooks/add-shared-kubernetes-resource/
+
+Use the Logseq page as the canonical human procedure. Keep this reference file as a bridge only; do not duplicate the runbook here.

--- a/.agents/skills/nixos-deploy/SKILL.md
+++ b/.agents/skills/nixos-deploy/SKILL.md
@@ -1,76 +1,22 @@
 ---
 name: nixos-deploy
 description: Build, validate, and deploy NixOS host configurations in this infra repo. Use when rebuilding hosts, adding new systems, or rolling back.
+metadata:
+  runbook: docs/pages/Runbooks___Deploy a NixOS Host.md
+  wiki: https://wiki.lolwtf.ca/runbooks/deploy-a-nixos-host/
 ---
 
-## Workflow
+# NixOS Deploy
 
-1. **Validate** before touching hosts:
-   ```bash
-   nix flake check
-   ```
+Canonical human runbook: `docs/pages/Runbooks___Deploy a NixOS Host.md`.
+Reference bridge: `references/runbook.md`.
 
-2. **Build** (no side effects):
-   ```bash
-   nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel
-   ```
+## Agent Notes
 
-3. **Run commands on a host**:
-   ```bash
-   nix run .#<hostname> -- date
-   nix run .#<hostname> -- <command> [args...]
-   ```
-
-4. **Deploy** — prefer `boot` for remote/headless hosts (activates on next reboot):
-   ```bash
-   # Safe (next reboot)
-   nixos-rebuild boot --sudo --target-host <hostname> --flake .#<hostname>
-
-   # Immediate
-   nixos-rebuild switch --flake .#<hostname> --target-host <hostname> --sudo
-   ```
-
-5. **Rollback**:
-   ```bash
-   sudo nixos-rebuild switch --rollback
-   ```
-
-## Host Inventory
-
-| Hostname   | Cluster | Role          | Arch        |
-|------------|---------|---------------|-------------|
-| optiplex   | folly   | control-plane | x86_64      |
-| riptide    | folly   | worker        | x86_64      |
-| oldschool  | offsite | worker        | x86_64      |
-| retrofit   | offsite | control-plane | x86_64      |
-| cloudpi4   | –       | cloud svc     | aarch64     |
-| homepi4    | –       | home auto     | aarch64     |
-| weatherpi4 | –       | kiosk         | aarch64     |
-| oldboy     | –       | GCE VM        | x86_64      |
-
-## Adding a New Host
-
-**Kubernetes node** — add to `flake.nix` `baseHostsSpec` only (hostname is the attr name; cluster comes from tags):
-
-```nix
-newnode = { tags = [ "folly" ]; role = "control-plane"; }; # role defaults to worker
-```
-
-**Host with unique config** — add a file under `nix/hosts/` and reference it:
-
-```nix
-newpi = {
-  system = "aarch64-linux";
-  modules = [ ./nix/hosts/newpi.nix ];
-};
-```
-
-K8s nodes with extra services can use `imports` and `extraConfig` in the spec (see `oldschool` in `flake.nix`).
-
-Run `nix flake check` after changes.
-
-## Dotfiles Integration
-
-Home-manager user config comes from the dotfiles flake via `inputs.dotfiles.homeModules.{basic,full}`.
-- `basic` — used for all standard hosts (`nix/system/user.nix`)
-- `full` — used for WSL image (`nix/images/wsl.nix`)
+- Validate before touching hosts when feasible: `nix flake check`.
+- Build without side effects: `nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel --no-link`.
+- Run harmless remote commands through the host app: `nix run .#<hostname> -- date`.
+- Prefer `nixos-rebuild boot --sudo --target-host <hostname> --flake .#<hostname>` for remote/headless hosts.
+- Use `switch` only when immediate activation is intended.
+- Roll back with `nix run .#<hostname> -- sudo nixos-rebuild switch --rollback` when the host is reachable.
+- Dotfiles are chezmoi-managed from in-repo `dotfiles/` via `nix/system/chezmoi.nix`; there is no dotfiles flake input or home-manager integration.

--- a/.agents/skills/nixos-deploy/references/runbook.md
+++ b/.agents/skills/nixos-deploy/references/runbook.md
@@ -1,0 +1,6 @@
+# Runbook Reference
+
+- Source: `../../../docs/pages/Runbooks___Deploy a NixOS Host.md`
+- Published: https://wiki.lolwtf.ca/runbooks/deploy-a-nixos-host/
+
+Use the Logseq page as the canonical human procedure. Keep this reference file as a bridge only; do not duplicate the runbook here.

--- a/.agents/skills/onboard-repo/SKILL.md
+++ b/.agents/skills/onboard-repo/SKILL.md
@@ -5,109 +5,22 @@ description: >-
   history, then rewire its in-repo consumers. Use when asked to "onboard",
   "merge in", "vendor", or "absorb" a standalone repo into apps/, packages/, or
   images/.
+metadata:
+  guide: docs/pages/Contributing___Onboard Repo.md
+  wiki: https://wiki.lolwtf.ca/contributing/onboard-repo/
 ---
 
-## Overview
+# Onboard Repo
 
-Onboarding = (1) merge the external repo's source into the monorepo with full
-history, then (2) rewire whatever the monorepo already used from the external
-repo so it points at the vendored copy. Most repos worth onboarding are *already
-consumed* (a flake input, an ArgoCD/Flux ref, a terraform-managed SA). Grep
-first — the rewiring is usually the bigger half of the job.
+Canonical contributor guide: `docs/pages/Contributing___Onboard Repo.md`.
+Reference bridge: `references/runbook.md`.
 
-```bash
-grep -rln "<repo-name>" . | grep -v '\.git/'
-```
+## Agent Notes
 
-## 1. Pick the destination
-
-| Kind | Goes in | Examples |
-|------|---------|----------|
-| Deployable first-party service (has a Dockerfile / deploys somewhere) | `apps/<name>/` | hermes, minecraft, ddnsd, view-counter, tidbyt |
-| Reusable lib / chart consumed by other code | `packages/<name>/` | agent-web-ui, charts |
-| Base or tool OCI image | `images/<name>/` | base, kubectl, atlantis, cloudlab-linux |
-
-## 2. Merge with history
-
-There's a zsh helper, `monorepo-merge` (in `dotfiles/dot_config/zsh/dot_zshrc.tmpl`),
-that clones the repo, runs `git filter-repo --to-subdirectory-filter`, and merges
-with `--allow-unrelated-histories`. It defaults to a **top-level** `<repo>/` dir.
-
-To land directly under `apps/` (etc.), run the same mechanism retargeted. Work on
-a branch, never `main`:
-
-```bash
-git checkout -b onboard/<name>
-repo=<name>; dest=apps/$repo      # or packages/$repo, images/$repo
-rm -rf "/tmp/$repo"
-gh repo clone "jonpulsifer/$repo" "/tmp/$repo" -- -q
-branch="$(git -C /tmp/$repo branch --show-current)"
-# git-filter-repo isn't on PATH here; run it via nix
-( cd "/tmp/$repo" && nix run nixpkgs#git-filter-repo -- --to-subdirectory-filter "$dest" )
-git remote add "temp-$repo" "/tmp/$repo"
-git fetch -q "temp-$repo"
-git merge "temp-$repo/$branch" --allow-unrelated-histories -m "Merge $repo into $dest"
-git remote remove "temp-$repo"; rm -rf "/tmp/$repo"
-```
-
-**Merge the PR as a merge commit, not squash** — squashing flattens the
-preserved subtree history, defeating the point.
-
-## 3. Strip dead vendored config
-
-GitHub only runs workflows in the repo-root `.github/workflows`, and Renovate
-only reads the root config. So inside the vendored dir these are dead and should
-be removed (port anything still needed to the root — see step 4):
-
-```bash
-git rm -rq apps/<name>/.github
-git rm -q  apps/<name>/renovate.json        # if present
-```
-
-For a Go app whose Nix build moves into the monorepo flake, also drop its nested
-flake: `git rm apps/<name>/flake.nix apps/<name>/flake.lock`.
-
-## 4. Rewire consumers
-
-- **CI / container image**: add the app to the matrix in
-  `.github/workflows/containers.yml` (`image`, `context`, `watch`) if it ships a
-  container.
-- **Deploy workflow** (e.g. a GCP Cloud Function): recreate it as a root
-  workflow `.github/workflows/<name>.yml`, path-filtered to `apps/<name>/**`,
-  with `source_dir`/`working-directory` pointing at the vendored path. Pin
-  actions to SHAs (`gh api repos/<owner>/<repo>/git/refs/tags/<tag>`); bump any
-  node16-era actions so they actually run.
-- **Nix-consumed Go program** (the ddnsd pattern): the repo shipped a flake the
-  monorepo imported as an input. Replace it:
-  1. Remove the `inputs.<name>` block from the root `flake.nix`; `nix flake lock`.
-  2. Add `apps/<name>/package.nix` (a `callPackage`-style `buildGoModule`) and an
-     overlay `nix/overlays/<name>.nix` →
-     `final: prev: { <name> = final.callPackage ../../apps/<name>/package.nix {}; }`.
-  3. In the host module that used the input (e.g. `nix/system/<name>.nix`):
-     `imports = [ ../../apps/<name>/module.nix ];`
-     `nixpkgs.overlays = [ (import ../overlays/<name>.nix) ];`
-  4. **vendorHash gotcha**: the upstream flake's `vendorHash` is often stale
-     (go.sum drifted via renovate). Build it, let Nix print the real hash, paste
-     it in.
-
-## 5. Validate
-
-```bash
-# Nix package builds + correct vendorHash (use the flake's nixpkgs):
-nix build --impure --no-link --expr \
-  'let p = (builtins.getFlake (toString ./.)).inputs.nixpkgs.legacyPackages.x86_64-linux; in p.callPackage ./apps/<name>/package.nix { }'
-# A host that imports the module still evaluates:
-nix eval --raw .#nixosConfigurations.<host>.config.system.build.toplevel.drvPath
-grep -rn "inputs.<name>\|github:jonpulsifer/<name>" --include='*.nix' .   # expect none
-# Go apps compile (pure shell has no cgo compiler):
-nix shell nixpkgs#go -c bash -c 'CGO_ENABLED=0 go -C apps/<name> build ./...'
-```
-
-See `validate-build` for the broader pre-commit checks.
-
-## 6. After merge
-
-Offer to archive the now-vendored source repos
-(`gh repo archive jonpulsifer/<name>`). Call out any deploy-time behavior change
-(e.g. a Cloud Function gen1→gen2 migration changes the URL) so nothing surprises
-on the first merge to `main`.
+- Work on a branch, never `main`.
+- Pick the destination first: `apps/`, `packages/`, or `images/`.
+- Grep for existing consumers before merging history.
+- Preserve history with `git filter-repo --to-subdirectory-filter <dest>` and merge with `--allow-unrelated-histories`.
+- Remove dead vendored `.github/` and Renovate config unless content needs to be ported to root-level config.
+- Rewire CI, deploy workflows, Nix flake inputs, overlays, and host modules as needed.
+- The PR should merge as a merge commit, not squash, so preserved subtree history remains useful.

--- a/.agents/skills/onboard-repo/references/runbook.md
+++ b/.agents/skills/onboard-repo/references/runbook.md
@@ -1,0 +1,6 @@
+# Contributor Guide Reference
+
+- Source: `../../../docs/pages/Contributing___Onboard Repo.md`
+- Published: https://wiki.lolwtf.ca/contributing/onboard-repo/
+
+Use the Logseq page as the canonical human procedure. Keep this reference file as a bridge only; do not duplicate the guide here.

--- a/.agents/skills/terraform/SKILL.md
+++ b/.agents/skills/terraform/SKILL.md
@@ -5,80 +5,25 @@ description: >-
   terraform/: cloud/identity (gcp, argo, google-workspace, vault) and network
   fabric under terraform/network/ (unifi/folly, unifi/offsite, cloudflare, tailscale).
   Covers workflow, CI behaviour, and module layout.
+metadata:
+  runbook: docs/pages/Runbooks___Terraform Change.md
+  wiki: https://wiki.lolwtf.ca/runbooks/terraform-change/
 ---
 
-## Module Layout
+# Terraform
 
-All Terraform roots live under `terraform/`, split by domain into network fabric
-(`terraform/network/`) and cloud/identity. Each subdirectory below is an independent
-root module with its own state:
+Canonical human runbook: `docs/pages/Runbooks___Terraform Change.md`.
+Reference bridge: `references/runbook.md`.
 
-```
-# network fabric — terraform/network/
-terraform/network/unifi/folly/    # primary-site UniFi: VLANs, BGP, clients
-terraform/network/unifi/offsite/  # offsite UniFi: networks, WANs, WLANs, BGP
-terraform/network/cloudflare/     # DNS, tunnels, security rules
-terraform/network/tailscale/      # devices, routes, ACL policy
+## Agent Notes
 
-# cloud & identity — terraform/
-terraform/gcp/organization/       # org-level IAM, folders, billing
-terraform/gcp/projects/<name>/    # per-project resources
-terraform/argo/                   # ArgoCD application definitions
-terraform/google-workspace/       # Workspace users, groups, domains
-terraform/vault/                  # Vault auth, mounts, policies
-terraform/modules/                # reusable modules consumed via relative paths
-
-# Flux bootstrap (Terraform, colocated with each cluster)
-clusters/folly/bootstrap/         # Flux bootstrap for the folly cluster
-clusters/offsite/bootstrap/       # Flux bootstrap for the offsite cluster
-```
-
-> The `terraform/network/` roots keep their original GCS state prefixes (`terraform/unifi`,
-> `terraform/unifi/offsite`, `terraform/cloudflare`, `terraform/tailscale`) so the
-> directory move needed no state migration — backend `prefix` intentionally differs
-> from the path.
-
-## Standard Workflow
-
-Applies run through **Atlantis on the PR**, not locally. Open a PR with your `.tf`
-changes; Atlantis autoplans on the changed module(s). Review the plan comment, then
-comment `atlantis apply` — a successful apply automerges the PR.
-
-```bash
-cd terraform/<module-dir>
-terraform init
-terraform plan     # local inspection only
-```
-
-Do **not** run `terraform apply` against remote state — it races Atlantis and causes
-state lock contention / drift. CI (`terraform.yml`) only validates; Atlantis is the
-only thing that applies. See `kubernetes-gitops` for the Atlantis ↔ ArgoCD auth and
-token-rotation details.
-
-## Validation (no backend)
-
-```bash
-terraform init -backend=false
-terraform validate
-```
-
-## Formatting
-
-CI auto-formats and commits on merge to `main`. Run locally before committing:
-
-```bash
-terraform fmt -recursive
-```
-
-## CI Behaviour
-
-- **On PR**: validates all changed `*.tf` directories in a matrix job.
-- **On merge to `main`**: auto-formats and commits (`style: format terraform files`), then regenerates terraform-docs (`docs: regenerate terraform documentation`).
-- Do not manually commit formatting fixes — CI handles it.
-
-## Notes
-
-- Terraform state is remote; `.tfstate` files are gitignored.
-- `terraform/gcp/organization/` manages the GCP org hierarchy — changes affect all projects.
-- `terraform/network/cloudflare/` Tunnel modules control external ingress for folly and offsite clusters.
-- `terraform/modules/` are reusable (no backend); root modules reference them via relative paths (e.g. homelab-ng → `../../../modules/gce-vpc`).
+- Applies run through Atlantis on the PR, never local `terraform apply` against remote state.
+- Root modules are standalone under `terraform/` plus `clusters/<site>/bootstrap/`.
+- For local validation, run from the changed root:
+  ```bash
+  terraform init -backend=false
+  terraform validate
+  ```
+- Formatting: `terraform fmt -recursive`.
+- Local `terraform plan` is inspection only.
+- If a change touches Kubernetes/Argo auth behavior, also use the `kubernetes-gitops` skill.

--- a/.agents/skills/terraform/references/runbook.md
+++ b/.agents/skills/terraform/references/runbook.md
@@ -1,0 +1,6 @@
+# Runbook Reference
+
+- Source: `../../../docs/pages/Runbooks___Terraform Change.md`
+- Published: https://wiki.lolwtf.ca/runbooks/terraform-change/
+
+Use the Logseq page as the canonical human procedure. Keep this reference file as a bridge only; do not duplicate the runbook here.

--- a/.agents/skills/unifi-network/SKILL.md
+++ b/.agents/skills/unifi-network/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: unifi-network
 description: Discover, query, inspect, and reason about the live homelab UniFi network — controller, networks/VLANs, WLANs, adopted devices, and connected clients. Use when asked to look at, audit, debug, or reason about the UniFi network, find a client/device by name/IP/MAC, check what VLANs/subnets/DHCP exist, or reconcile live state against terraform/network/unifi/. Authenticates against the UDM Pro using creds from 1Password (op).
+metadata:
+  runbook: docs/pages/Runbooks___Inspect UniFi Network.md
+  wiki: https://wiki.lolwtf.ca/runbooks/inspect-unifi-network/
 ---
 
 # unifi-network
@@ -10,6 +13,9 @@ app `10.4.57`, at `https://unifi.fml.pulsifer.ca` / `https://10.13.37.1`).
 This is the live counterpart to the desired state in `terraform/network/unifi/folly/`
 (the primary site; the offsite gateway is `terraform/network/unifi/offsite/`) — use
 it to see what the controller *actually* has before editing the Terraform.
+
+Canonical public runbook: `docs/pages/Runbooks___Inspect UniFi Network.md`.
+Reference bridge: `references/runbook.md`.
 
 The driver is **`.agents/skills/unifi-network/unifi.sh`** (paths below are
 relative to the repo root). It pulls the `terraform` Super Admin creds from

--- a/.agents/skills/unifi-network/references/runbook.md
+++ b/.agents/skills/unifi-network/references/runbook.md
@@ -1,0 +1,6 @@
+# Runbook Reference
+
+- Source: `../../../docs/pages/Runbooks___Inspect UniFi Network.md`
+- Published: https://wiki.lolwtf.ca/runbooks/inspect-unifi-network/
+
+Use the Logseq page as the canonical public read-only procedure. Keep credential lookup and headless/private mechanics in the skill body, not in the public runbook.

--- a/.agents/skills/validate-build/SKILL.md
+++ b/.agents/skills/validate-build/SKILL.md
@@ -3,39 +3,21 @@ name: validate-build
 description: >-
   Verify this repo builds and validates cleanly before commit: Kustomize
   overlays. Use after editing clusters/
+metadata:
+  runbook: docs/pages/Runbooks___Validate Infra Changes.md
+  wiki: https://wiki.lolwtf.ca/runbooks/validate-infra-changes/
 ---
 
-## Environment
+# Validate Build
 
-Prefer `mise` for portable repo tooling. Use the Nix dev shell only for Nix-specific builds or formatters.
+Canonical human runbook: `docs/pages/Runbooks___Validate Infra Changes.md`.
+Reference bridge: `references/runbook.md`.
 
-```bash
-mise install
-```
+## Agent Notes
 
-## Kubernetes / Kustomize
-
-Build the **kustomization root that includes your change** (the directory with `kustomization.yaml` that lists your file, or a parent Flux kustomization).
-
-Use either `kubectl kustomize` or the mise-managed standalone `kustomize`:
-
-```bash
-kubectl kustomize clusters/folly/sandbox
-kubectl kustomize clusters/offsite/monitoring
-```
-
-When validating shared base changes, build **both** clusters since both reference `clusters/base/`:
-
-```bash
-for cluster in folly offsite; do
-  kubectl kustomize "clusters/$cluster/networking/cert-manager/" && echo "OK: $cluster"
-done
-```
-
-If `kubectl kustomize` fails with YAML errors, check for unquoted `:` inside plain scalars.
-
-**Important:** Kustomize cannot reference individual files outside the kustomization root. Shared resources in `base/` must be directories with their own `kustomization.yaml`, referenced as directory paths (not file paths).
-
-For GitOps behaviour, SOPS, and Flux, see the `kubernetes-gitops` skill.
-
-CI also runs Terraform validation on changed modules and Trivy on `clusters/**` and `.tf`; local commands above catch most merge-blocking issues faster.
+- Prefer `mise` for portable validation tooling; use Nix for NixOS-specific builds and formatters.
+- For Kubernetes changes, build the kustomization root that includes the changed file.
+- For shared `clusters/base/` changes, validate every consuming cluster.
+- For Terraform changes, validate from the changed root with `terraform init -backend=false && terraform validate`.
+- For docs changes, build the wiki with `bun run --cwd apps/wiki build`.
+- Do not recommend unrelated follow-up skills at the end of validation output; report what ran and what remains.

--- a/.agents/skills/validate-build/references/runbook.md
+++ b/.agents/skills/validate-build/references/runbook.md
@@ -1,0 +1,6 @@
+# Runbook Reference
+
+- Source: `../../../docs/pages/Runbooks___Validate Infra Changes.md`
+- Published: https://wiki.lolwtf.ca/runbooks/validate-infra-changes/
+
+Use the Logseq page as the canonical human procedure. Keep this reference file as a bridge only; do not duplicate the runbook here.

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,9 @@ docs/.trash/
 !.claude/settings.json
 !.claude/hooks/
 .claude/settings.local.json
-.agents/
+.agents/*
+!.agents/skills/
+!.agents/skills/**
 
 # ─── Node / Bun ──────────────────────────────────────────────────────────────
 # Root is a Bun workspace (apps/*, packages/*); bun.lock is tracked.

--- a/docs/pages/Architecture___GitOps.md
+++ b/docs/pages/Architecture___GitOps.md
@@ -19,4 +19,4 @@ tags:: architecture
 	- `nixos-deploy.yaml`, `nix-ci.yaml`, `nix-image-builder.yaml` — NixOS build/deploy pipelines
 	- **Renovate** opens PRs for Helm charts, container images, Terraform providers, and GitHub Actions
 - ## The bootstrap exceptions
-	- Two places where a layer reaches into another: the Flux bootstrap (`clusters/<site>/bootstrap/` Terraform installs `flux-operator`/`flux-instance`), and the Atlantis ↔ ArgoCD auth wiring (see the `kubernetes-gitops` skill for token rotation).
+	- Two places where a layer reaches into another: the Flux bootstrap (`clusters/<site>/bootstrap/` Terraform installs `flux-operator`/`flux-instance`), and the Atlantis ↔ ArgoCD auth wiring (see [[Runbooks/Kubernetes GitOps Change]] for token rotation).

--- a/docs/pages/Contributing.md
+++ b/docs/pages/Contributing.md
@@ -13,6 +13,8 @@ icon:: ✍️
 	- Link generously: `[[Page Name]]`. A link to a page that doesn't exist yet is fine — it marks something worth writing.
 - ## Writing an ADR
 	- Copy [[ADR/Template]] to `ADR/NNNN <short title>` (next free number), fill in Context / Decision / Consequences, set `status:: proposed`, PR it. Process details on [[ADR]].
+- ## Repository changes
+	- [[Contributing/Onboard Repo]] — vendor an external `jonpulsifer` repo into this monorepo while preserving history.
 - ## House rules
 	- **This site is public.** Never paste decrypted SOPS content, tokens, or private keys — if `sops -d` touched it, it doesn't go here.
 	- Facts that have a single source of truth (network topology, versions) should be referenced, not copied — link to the file instead of restating values that will drift.

--- a/docs/pages/Contributing___Onboard Repo.md
+++ b/docs/pages/Contributing___Onboard Repo.md
@@ -1,0 +1,61 @@
+tags:: contributing
+
+- Use this when vendoring an external `jonpulsifer` repo into this monorepo while preserving history.
+- # Pick the destination
+	- Deployable first-party service: `apps/<name>/`
+	- Reusable library or chart: `packages/<name>/`
+	- Base or tool OCI image: `images/<name>/`
+- # Find existing consumers
+	- Grep first. Rewiring consumers is often the larger part of the work:
+	- ```bash
+	  rg -n "<repo-name>|github:jonpulsifer/<repo-name>|jonpulsifer/<repo-name>"
+	  ```
+- # Merge with history
+	- Work on a branch:
+	- ```bash
+	  git switch -c onboard/<name>
+	  ```
+	- Clone the source repo and rewrite its history into the destination directory:
+	- ```bash
+	  repo=<name>
+	  dest=apps/$repo
+	  rm -rf "/tmp/$repo"
+	  gh repo clone "jonpulsifer/$repo" "/tmp/$repo" -- -q
+	  branch="$(git -C /tmp/$repo branch --show-current)"
+	  ( cd "/tmp/$repo" && nix run nixpkgs#git-filter-repo -- --to-subdirectory-filter "$dest" )
+	  git remote add "temp-$repo" "/tmp/$repo"
+	  git fetch -q "temp-$repo"
+	  git merge "temp-$repo/$branch" --allow-unrelated-histories -m "Merge $repo into $dest"
+	  git remote remove "temp-$repo"
+	  rm -rf "/tmp/$repo"
+	  ```
+	- Merge the PR as a merge commit, not squash, so the preserved subtree history remains useful.
+- # Remove dead vendored config
+	- GitHub workflows and Renovate config inside the vendored directory are inert in this monorepo. Remove them unless there is content to port to root-level config:
+	- ```bash
+	  git rm -r apps/<name>/.github
+	  git rm apps/<name>/renovate.json
+	  ```
+	- For Go apps now built by the monorepo flake, remove nested `flake.nix` and `flake.lock` after replacing their behavior at the root.
+- # Rewire consumers
+	- Container images: update `.github/workflows/containers.yml` matrix entries and watch paths.
+	- Deploy workflows: recreate root workflows under `.github/workflows/<name>.yml` with paths and working directories pointed at the vendored location.
+	- Nix-consumed Go programs:
+		- Remove the old flake input.
+		- Add `apps/<name>/package.nix`.
+		- Add an overlay under `nix/overlays/`.
+		- Update host modules to import the vendored module or package.
+		- Build once to confirm the correct `vendorHash`.
+- # Validate
+	- Build the Nix package or host that consumes it.
+	- Compile Go apps where relevant:
+	- ```bash
+	  CGO_ENABLED=0 go -C apps/<name> build ./...
+	  ```
+	- Confirm no old external references remain:
+	- ```bash
+	  rg -n "inputs\\.<name>|github:jonpulsifer/<name>|jonpulsifer/<name>"
+	  ```
+- # After merge
+	- Offer to archive the now-vendored source repo after the monorepo PR lands.
+	- Call out any deploy-time behavior changes in the PR, especially URL or runtime generation changes.

--- a/docs/pages/Runbooks.md
+++ b/docs/pages/Runbooks.md
@@ -2,9 +2,17 @@ icon:: 🚒
 
 - Operational procedures for when things misbehave. Runbooks live here — on Cloudflare, off the infrastructure they describe — precisely so they stay readable during an outage ([[ADR/0009 Logseq wiki on Cloudflare Pages]]).
 - ## The runbooks
+	- [[Runbooks/Deploy a NixOS Host]] — build, deploy, verify, and roll back NixOS hosts
+	- [[Runbooks/Terraform Change]] — Atlantis-first Terraform workflow and local validation
+	- [[Runbooks/Kubernetes GitOps Change]] — inspect Flux, reconcile resources, and handle SOPS safely
+	- [[Runbooks/Add Shared Kubernetes Resource]] — use the `clusters/base/` pattern for both clusters
+	- [[Runbooks/Validate Infra Changes]] — validation commands by change area
+	- [[Runbooks/Inspect UniFi Network]] — read-only UniFi discovery before Terraform changes
 	- [[Runbooks/Kiosk]] — the Raspberry Pi kiosk hosts (`homepi4`, `weatherpi4`): Cage/Wayland, Firefox, container-backed apps
 	- [[Runbooks/TPM Audit]] — TPM inventory of the k8s fleet and how it was gathered
 - ## Conventions
 	- Tag runbook pages `#runbook`, lead with quick checks, then symptom-shaped sections ("If X…"), each with copy-pasteable commands and expected output.
 	- Commands should assume the reader is on the tailnet or LAN; note when a host needs a special path (e.g. `weatherpi4` over Tailscale).
 	- When a runbook procedure changes the fleet's desired state, the change still ships via git — see [[Architecture/GitOps]].
+	- If an Agent Skill covers the same workflow, the public runbook is the durable human source. The skill should backlink to the runbook with Agent Skills `metadata` and, when useful, a one-level `references/runbook.md` bridge.
+	- Do not symlink raw `SKILL.md` files into `docs/pages`: skills are agent instructions, not Logseq outline pages, and may include private mechanics that should not be published.

--- a/docs/pages/Runbooks___Add Shared Kubernetes Resource.md
+++ b/docs/pages/Runbooks___Add Shared Kubernetes Resource.md
@@ -1,0 +1,43 @@
+tags:: runbook, kubernetes, gitops
+
+- Use this when adding or changing resources shared by both clusters through `clusters/base/`. General GitOps flow is in [[Runbooks/Kubernetes GitOps Change]].
+- # Pattern
+	- Shared resources live under `clusters/base/`.
+	- Each shared component should be a directory with its own `kustomization.yaml`.
+	- Cluster overlays reference the shared directory, not individual files.
+- # Add a shared component
+	- Create a directory:
+	- ```text
+	  clusters/base/<category>/<component>/
+	  ```
+	- Add a `kustomization.yaml` that lists the component's resource files:
+	- ```yaml
+	  apiVersion: kustomize.config.k8s.io/v1beta1
+	  kind: Kustomization
+	  resources:
+	    - resource.yaml
+	  ```
+	- Templatize cluster-specific values with Flux substitutions such as `${CLUSTER_NAME}` or `${SECRET_DOMAIN}` when the parent Flux Kustomization provides them.
+	- Reference the shared directory from each cluster overlay:
+	- ```yaml
+	  resources:
+	    - ../../../base/<category>/<component>
+	  ```
+	- Add cluster-specific patches in the overlay only when the clusters genuinely differ.
+- # Constraints
+	- Kustomize cannot reference individual files outside the kustomization root. Always reference a directory with its own `kustomization.yaml`.
+	- Flux `postBuild.substituteFrom` performs variable replacement at deploy time.
+	- Variables generally come from the cluster topology/config ConfigMaps and SOPS-encrypted cluster secrets.
+- # Usually cluster-specific
+	- `cilium/` BGP peers, IP pools, and Hubble settings.
+	- Gateway listeners and routes.
+	- Tailscale connector names, routes, and tags.
+	- Cloudflare tunnel credentials.
+	- Some cert-manager issuers and certificates.
+- # Validate
+	- Build each consuming cluster overlay:
+	- ```bash
+	  kubectl kustomize clusters/folly/<category>
+	  kubectl kustomize clusters/offsite/<category>
+	  ```
+	- If only one cluster consumes the base path today, validate that cluster and note the asymmetry in the PR.

--- a/docs/pages/Runbooks___Deploy a NixOS Host.md
+++ b/docs/pages/Runbooks___Deploy a NixOS Host.md
@@ -1,0 +1,59 @@
+tags:: runbook, nixos
+
+- Use this when building, deploying, or rolling back a NixOS host from this repo. Host inventory lives in [[Fleet]]; architecture background lives in [[Architecture/NixOS]].
+- # Quick checks
+	- Confirm the host exists in the flake:
+	- ```bash
+	  nix eval --json .#nixosConfigurations --apply builtins.attrNames
+	  ```
+	- Build the system closure without deploying:
+	- ```bash
+	  nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel --no-link
+	  ```
+	- Run a harmless remote command through the host app:
+	- ```bash
+	  nix run .#<hostname> -- date
+	  ```
+- # Deploy safely
+	- Prefer `boot` for remote or headless hosts. It builds and installs the new generation, but activation waits until the next reboot:
+	- ```bash
+	  nixos-rebuild boot --sudo --target-host <hostname> --flake .#<hostname>
+	  ```
+	- Use `switch` when immediate activation is intended:
+	- ```bash
+	  nixos-rebuild switch --flake .#<hostname> --target-host <hostname> --sudo
+	  ```
+	- For offsite or Tailscale-only paths, use the reachable target host name:
+	- ```bash
+	  nixos-rebuild boot --sudo --target-host <hostname>.<tailnet-name> --flake .#<hostname>
+	  ```
+- # After deploying
+	- Verify the host answers:
+	- ```bash
+	  nix run .#<hostname> -- hostname
+	  nix run .#<hostname> -- systemctl --failed --no-pager
+	  ```
+	- If the change touched a service, check that unit explicitly:
+	- ```bash
+	  nix run .#<hostname> -- systemctl --no-pager --full status <unit>.service
+	  nix run .#<hostname> -- journalctl -u <unit>.service -n 80 --no-pager
+	  ```
+- # Roll back
+	- If the host is reachable and the current generation is bad:
+	- ```bash
+	  nix run .#<hostname> -- sudo nixos-rebuild switch --rollback
+	  ```
+	- If remote access is risky, use the bootloader console or local access and select the previous generation.
+- # Adding a host
+	- Kubernetes nodes normally belong in `baseHostsSpec` in `flake.nix`; the hostname is the attr name and cluster membership comes from tags.
+	- Standalone hosts with unique config get a file under `nix/hosts/<hostname>.nix` and a `flake.nix` host entry pointing at it.
+	- Validate after adding a host:
+	- ```bash
+	  nix flake check
+	  nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel --no-link
+	  ```
+- # Dotfiles
+	- Dotfiles are chezmoi-managed from the in-repo `dotfiles/` tree. `nix/system/chezmoi.nix` carries that subtree into the system closure and runs `chezmoi apply --source <store-path>` during activation. See [[ADR/0006 Dotfiles vendored in-repo with chezmoi]].
+	- There is no dotfiles flake input and no home-manager integration.
+- # Auto-upgrade caveat
+	- Hosts auto-rebuild from GitHub `main`. A config deployed from a branch can be reverted by the next auto-upgrade unless the branch merges promptly. Treat a branch deploy as a test unless it has merged.

--- a/docs/pages/Runbooks___Inspect UniFi Network.md
+++ b/docs/pages/Runbooks___Inspect UniFi Network.md
@@ -1,0 +1,63 @@
+tags:: runbook, unifi, network
+
+- Use this for read-only inspection of the live UniFi network before changing Terraform desired state. Desired state still lives under `terraform/network/unifi/`; changes apply through Atlantis. See [[Runbooks/Terraform Change]].
+- # Rule
+	- Inspect live state only. Do not add write operations to the inspection helper and do not mutate the controller manually.
+- # Start with a summary
+	- From the repo root:
+	- ```bash
+	  D=.agents/skills/unifi-network/unifi.sh
+	  $D summary
+	  ```
+	- The summary should show controller info, subsystem health, networks/VLANs, WLANs, and adopted devices.
+- # Common reads
+	- Networks and VLANs:
+	- ```bash
+	  $D networks
+	  ```
+	- Adopted devices:
+	- ```bash
+	  $D devices
+	  ```
+	- WLANs:
+	- ```bash
+	  $D wlans
+	  ```
+	- Active and known clients:
+	- ```bash
+	  $D clients
+	  $D clients-known
+	  ```
+	- Find a device, IP, MAC, hostname, or SSID:
+	- ```bash
+	  $D find <term>
+	  ```
+- # If the helper cannot authenticate
+	- Confirm the expected CLI tools are available:
+	- ```bash
+	  command -v op curl jq
+	  ```
+	- Confirm the environment has access to the required 1Password service account. Do not paste or commit credential lookup commands or revealed values.
+	- Confirm controller reachability:
+	- ```bash
+	  curl -sk -o /dev/null -w '%{http_code}\n' https://unifi.fml.pulsifer.ca
+	  ```
+	- Expected HTTP status is `200`.
+- # If results look stale
+	- The helper caches the controller session in the local temp directory. Remove the cache and retry:
+	- ```bash
+	  rm -f "${TMPDIR:-/tmp}/.unifi-cookies-$(id -u)" "${TMPDIR:-/tmp}/.unifi-csrf-$(id -u)"
+	  $D summary
+	  ```
+- # For BGP and routes
+	- Prefer helper subcommands first:
+	- ```bash
+	  $D routes
+	  $D bgp
+	  ```
+	- Use on-box SSH only for data the API cannot expose, and keep any credential handling out of public docs.
+- # Reconcile with Terraform
+	- Compare observed live state to:
+		- `terraform/network/unifi/folly/`
+		- `terraform/network/unifi/offsite/`
+	- Author the desired change in Terraform and use [[Runbooks/Terraform Change]].

--- a/docs/pages/Runbooks___Kubernetes GitOps Change.md
+++ b/docs/pages/Runbooks___Kubernetes GitOps Change.md
@@ -1,0 +1,62 @@
+tags:: runbook, kubernetes, gitops
+
+- Use this when changing manifests under `clusters/` or inspecting Flux deployment state. Architecture lives in [[Architecture/Kubernetes]] and the apply model is [[ADR/0001 GitOps apply model]].
+- # Rule
+	- Author desired state in git and let Flux reconcile it after merge. Do not use `kubectl apply` to author state.
+	- Use explicit contexts:
+	- ```bash
+	  kubectl --context folly get nodes
+	  kubectl --context offsite get nodes
+	  ```
+- # Inspect reconciliation
+	- ```bash
+	  flux --context folly get kustomizations -A
+	  flux --context folly get helmreleases -A
+	  flux --context offsite get kustomizations -A
+	  flux --context offsite get helmreleases -A
+	  ```
+	- For a specific object:
+	- ```bash
+	  kubectl --context <cluster> -n <namespace> describe <kind> <name>
+	  kubectl --context <cluster> -n <namespace> get events --sort-by=.lastTimestamp
+	  ```
+- # Force a reconcile
+	- Use this for inspection or to speed up a merged change:
+	- ```bash
+	  flux --context <cluster> reconcile kustomization <name> -n flux-system --with-source
+	  ```
+	- If a HelmRelease is stuck after its source reconciles:
+	- ```bash
+	  flux --context <cluster> reconcile helmrelease <name> -n <namespace>
+	  ```
+- # SOPS secrets
+	- SOPS-encrypted files match `clusters/**/*.sops.yaml`; only encrypted `data` and `stringData` belong there.
+	- Edit with SOPS:
+	- ```bash
+	  sops clusters/<cluster>/<path>/<secret>.sops.yaml
+	  ```
+	- Encrypt a new matching file:
+	- ```bash
+	  sops -e -i clusters/<cluster>/<path>/<secret>.sops.yaml
+	  ```
+	- Never paste decrypted values into this wiki, issues, PR comments, or logs.
+- # HelmRelease source pattern
+	- Keep `HelmRepository`, `GitRepository`, or `OCIRepository` sources colocated with the resource that consumes them.
+	- Do not centralize sources unless the local pattern changes across the repo.
+- # Atlantis and ArgoCD auth
+	- Atlantis runs in offsite and may need to authenticate to ArgoCD in folly for Terraform/Argo checks.
+	- Symptom of an expired or rotated ArgoCD token:
+		- GitHub PR status for Atlantis plan fails.
+		- Atlantis logs show authentication or signature errors talking to ArgoCD.
+	- Rotation shape:
+		- Generate a fresh token for the Atlantis ArgoCD account using an authenticated ArgoCD admin path.
+		- Store it only in the SOPS-encrypted Atlantis secret.
+		- Reconcile or wait for Flux to deploy the updated secret.
+		- Re-run the Atlantis plan.
+	- Do not record generated tokens or admin credentials in plaintext.
+- # Validate before PR
+	- Build the kustomization root that includes the change:
+	- ```bash
+	  kubectl kustomize clusters/<cluster>/<category>
+	  ```
+	- For shared `clusters/base/` changes, validate both clusters. See [[Runbooks/Add Shared Kubernetes Resource]].

--- a/docs/pages/Runbooks___Terraform Change.md
+++ b/docs/pages/Runbooks___Terraform Change.md
@@ -1,0 +1,46 @@
+tags:: runbook, terraform
+
+- Use this when changing Terraform under `terraform/` or cluster bootstrap Terraform under `clusters/<site>/bootstrap/`. Background lives in [[Architecture/Terraform]] and the apply model is [[ADR/0001 GitOps apply model]].
+- # Rule
+	- Terraform applies run through Atlantis on the PR. Do not run `terraform apply` against remote state locally; it can race Atlantis, lock state, and create drift.
+- # Find the root module
+	- Each Terraform root has its own state and backend. Common roots:
+		- `terraform/network/unifi/folly`
+		- `terraform/network/unifi/offsite`
+		- `terraform/network/cloudflare`
+		- `terraform/network/tailscale`
+		- `terraform/gcp/organization`
+		- `terraform/gcp/projects/<name>`
+		- `terraform/argo`
+		- `terraform/google-workspace`
+		- `terraform/vault`
+		- `clusters/folly/bootstrap`
+		- `clusters/offsite/bootstrap`
+- # Local validation
+	- From the changed root:
+	- ```bash
+	  terraform init -backend=false
+	  terraform validate
+	  ```
+	- Format before review when practical:
+	- ```bash
+	  terraform fmt -recursive
+	  ```
+	- Local plans are inspection only:
+	- ```bash
+	  terraform init
+	  terraform plan
+	  ```
+- # PR flow
+	- Open a PR with the `.tf` change.
+	- Atlantis autoplans the changed root modules.
+	- Review the Atlantis plan comment.
+	- Comment `atlantis apply` only after the plan is reviewed and expected.
+	- A successful Atlantis apply automerges according to the repo workflow.
+- # If validation fails
+	- For backend errors during local validation, retry with `-backend=false`.
+	- For provider/schema errors, run from the exact root that owns the changed files.
+	- For plans that include unexpected replacement or deletion, stop and inspect state/import history before applying.
+- # Notes
+	- The `terraform/network/` roots keep historical GCS state prefixes that do not always match the current directory name.
+	- Network facts should come from the cluster topology single source of truth where a root already has a `topology.tf`; see [[ADR/0003 Cluster topology single source of truth]].

--- a/docs/pages/Runbooks___Validate Infra Changes.md
+++ b/docs/pages/Runbooks___Validate Infra Changes.md
@@ -1,0 +1,53 @@
+tags:: runbook, validation
+
+- Use this as the pre-PR validation index. Deeper workflows live in the linked runbooks.
+- # Docs and wiki
+	- Build the wiki:
+	- ```bash
+	  bun run --cwd apps/wiki build
+	  ```
+	- Check Logseq page links manually in the generated site when adding or renaming pages.
+- # Nix and NixOS
+	- Full flake check:
+	- ```bash
+	  nix flake check
+	  ```
+	- Host build:
+	- ```bash
+	  nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel --no-link
+	  ```
+	- See [[Runbooks/Deploy a NixOS Host]].
+- # Kubernetes
+	- Build the kustomization root that includes the changed file:
+	- ```bash
+	  kubectl kustomize clusters/<cluster>/<category>
+	  ```
+	- For shared base changes, validate every consuming cluster:
+	- ```bash
+	  kubectl kustomize clusters/folly/<category>
+	  kubectl kustomize clusters/offsite/<category>
+	  ```
+	- See [[Runbooks/Kubernetes GitOps Change]] and [[Runbooks/Add Shared Kubernetes Resource]].
+- # Terraform
+	- From the changed root:
+	- ```bash
+	  terraform init -backend=false
+	  terraform validate
+	  ```
+	- Format:
+	- ```bash
+	  terraform fmt -recursive
+	  ```
+	- See [[Runbooks/Terraform Change]].
+- # Secrets safety
+	- Do not put decrypted SOPS values, API tokens, passwords, private keys, or one-time tokens in docs, PR comments, logs, or screenshots.
+	- A crude docs scan before publishing sensitive-adjacent runbooks:
+	- ```bash
+	  rg -n "op item|--reveal|password|token|private key|BEGIN .*KEY" docs/pages
+	  ```
+- # Tooling
+	- Prefer `mise` for portable validation tooling:
+	- ```bash
+	  mise install
+	  ```
+	- Use the Nix dev shell for NixOS-specific builds and formatters.


### PR DESCRIPTION
## Summary
Move operational procedures from repo-local skills into the public Logseq wiki runbooks, while keeping skills as concise agent-facing entry points with Agent Skills metadata and references back to the canonical docs.

## Changes
- docs(runbooks): move ops procedures into logseq

## Test Plan
- [x] nix run nixpkgs#bun -- run --cwd apps/wiki build
- [x] git diff --check
- [x] rg -n "home-manager|dotfiles flake|inputs\\.dotfiles|homeModules" .agents/skills docs/pages flake.nix
- [x] rg -n "op item|--reveal|password|token|kdtm|ib23|private key|BEGIN .*KEY" docs/pages
- [x] reviewer pass: ship

## Context
- .agent/context/context.md
- .agent/context/plan.md
