### PR TITLE
feat(wsl): add bubblewrap to system packages

### DIFF
--- a/nix/images/wsl.nix
+++ b/nix/images/wsl.nix
@@ -46,6 +46,7 @@
   environment.systemPackages = [
     pkgs.wget
     pkgs.python3
+    pkgs.bubblewrap
     # pkgs.pipx
   ];
 


### PR DESCRIPTION
## Summary
Add `bubblewrap` to the WSL image's system packages so sandboxed/containerized tooling that depends on it works out of the box.

## Changes
- feat(wsl): add bubblewrap to system packages

## Test Plan
- [ ] Build the WSL image and confirm `bwrap --version` runs for the `jawn` user
