### PR TITLE
docs: prune editorial prose from wiki and ADRs

### DIFF
--- a/docs/pages/ADR___0002 Monorepo layout.md
+++ b/docs/pages/ADR___0002 Monorepo layout.md
@@ -4,14 +4,14 @@ deciders:: [[jawn]]
 tags:: adr
 
 - # Context
-	- Infrastructure, applications, images, and dotfiles were spread across multiple repos and an aging `systems/` layout. Cross-cutting changes needed coordinated PRs in several places, Renovate coverage was fragmented, and app → image → deployment wiring crossed repo boundaries.
+	- Infrastructure, applications, images, and dotfiles live in separate repos with an aging `systems/` layout. Cross-cutting changes require coordinated PRs, Renovate coverage is fragmented, and app → image → deployment wiring crosses repo boundaries.
 - # Decision
 	- One monorepo with a layer-per-directory layout:
 		- `nix/` — bare metal, `clusters/` — Kubernetes, `terraform/` — cloud & network, `apps/` + `packages/` + `images/` — first-party code and OCI images, `dotfiles/` — chezmoi source.
 	- External `jonpulsifer/*` repos get vendored **with history** (`git filter-repo`; the `onboard-repo` skill codifies it) rather than submoduled.
 	- TypeScript packages form a root Bun workspace; `containers.yml` builds images from any of the three code directories.
 - # Consequences
-	- A change can move an app, its chart, and its deployment in one reviewable PR.
+	- A change can move an app, its chart, and its deployment in one PR.
 	- One Renovate config and one CI surface; workflows must be path-scoped to stay fast.
 	- The repo is public, so everything in it — including this wiki — is written as public content.
 	- Repo size and CI matrix grow over time; path filters and dynamic discovery (e.g. `terraform.yml`) keep it manageable.

--- a/docs/pages/ADR___0004 Disko with GPT partlabels.md
+++ b/docs/pages/ADR___0004 Disko with GPT partlabels.md
@@ -9,7 +9,7 @@ tags:: adr
 	- Use **disko** for declarative partitioning on the x86 hosts, with mounts keyed on **GPT partlabels** (`disk-main-*`). Each host declares only its target device (`homelab.disko.device` in `flake.nix`).
 - # Consequences
 	- Installs and reinstalls are reproducible from the flake; device naming no longer matters.
-	- **Migration hazard**: hosts installed before the disko change (PR #799) have differently-labeled GPT partitions and **fail to boot** on a new generation unless relabeled to `disk-main-*` first. Relabel scripts live in `nix/scripts/`.
-	- Rollback on an unmigrated host means booting the previous generation from the bootloader menu.
+	- Hosts labeled before the disko change fail to boot on a new generation unless relabeled to `disk-main-*`; relabel scripts live in `nix/scripts/`.
+	- Rollback on an unmigrated host is the bootloader's previous-generation menu.
 - # Links
 	- [[Architecture/NixOS]], [[Fleet]]

--- a/docs/pages/ADR___0005 Cilium BGP load balancing.md
+++ b/docs/pages/ADR___0005 Cilium BGP load balancing.md
@@ -10,7 +10,7 @@ tags:: adr
 	- Cross-site reachability is **gated by the gateway firewall, not the routing protocol**: each gateway must allow the full k8s address space (pod CIDRs + VIP pools, not just node subnets) to forward the routes it learns. folly enforces this with the custom `Lab` zone in `terraform/network/unifi/folly/firewall.tf`; offsite relies on the permissive default `Internal` zone.
 - # Consequences
 	- LB VIPs are plain routed IPs — no MetalLB, no ARP tricks, and the gateway's routing table shows exactly what's advertised.
-	- Debugging lesson learned the hard way: when VIPs are unreachable, check **whether the UDM actually programmed the BGP routes** and for Tailscale hairpin interference **before** suspecting Cilium — a past outage was misdiagnosed as a Cilium/kernel regression and it wasn't. Don't downgrade Cilium for this symptom.
+	- Unreachable VIPs most often point to the gateway not programming the advertised BGP routes, or Tailscale hairpin interference — not the Cilium/kernel. Check those first; do not downgrade Cilium for this symptom.
 	- Firewall changes are part of any address-space change; forgetting them breaks cross-site silently.
 - # Links
 	- [[Architecture/Networking]], [[ADR/0003 Cluster topology single source of truth]], `terraform/network/unifi/folly/README.md`

--- a/docs/pages/ADR___0009 Logseq wiki on Cloudflare Pages.md
+++ b/docs/pages/ADR___0009 Logseq wiki on Cloudflare Pages.md
@@ -15,5 +15,5 @@ tags:: adr
 	- One-time setup: the `CLOUDFLARE_API_TOKEN` Actions secret (Pages:Edit scope) and an Atlantis apply of the Pages project must precede the first deploy.
 	- Alternatives considered: in-cluster hosting (rejected — circular dependency with the infra it documents), GitHub Pages subpath under pulsifer.ca (rejected — two workflows sharing one `gh-pages` branch clobber each other), plain static renderers like Hugo/Quartz (rejected — Logseq outline syntax renders poorly outside Logseq).
 - # Links
-	- **Renderer superseded** the same day by [[ADR/0010 First-party Bun SSG for the wiki]] — `publish-spa` broke its first deploy (Node 18 leak) and cost ~20 min per cold build. Hosting, domain, and graph layout here still stand.
+	- Renderer superseded by [[ADR/0010 First-party Bun SSG for the wiki]] — `publish-spa` pins Node 18 on `PATH` (incompatible with wrangler 4) and takes ~20 min per cold build. Hosting, domain, and graph layout here still stand.
 	- [[Contributing]], [[Architecture/GitOps]]

--- a/docs/pages/ADR___0010 First-party Bun SSG for the wiki.md
+++ b/docs/pages/ADR___0010 First-party Bun SSG for the wiki.md
@@ -5,7 +5,7 @@ supersedes:: the renderer choice in [[ADR/0009 Logseq wiki on Cloudflare Pages]]
 tags:: adr
 
 - # Context
-	- [[ADR/0009 Logseq wiki on Cloudflare Pages]] chose the official `logseq/publish-spa` action as the renderer. In practice it clones and compiles the entire Logseq frontend (yarn + ClojureScript) in CI — ~20 minutes on a cold cache — and the pinned 2024-era release (`v0.3.1`) sets up **Node 18** and leaves it on `PATH`, which broke the very first production deploy: wrangler 4 requires Node ≥ 20. The published site was also a multi-megabyte SPA for what is fundamentally a documentation site.
+	- [[ADR/0009 Logseq wiki on Cloudflare Pages]] chose the official `logseq/publish-spa` action as the renderer. In practice it clones and compiles the entire Logseq frontend (yarn + ClojureScript) in CI — ~20 minutes on a cold cache — and the pinned 2024-era release (`v0.3.1`) sets up **Node 18** and leaves it on `PATH`; wrangler 4 requires Node ≥ 20. The published site was also a multi-megabyte SPA for what is fundamentally a documentation site.
 - # Decision
 	- Replace the renderer with a **first-party static site generator**: `apps/wiki` — ~400 lines of TypeScript run by **Bun**, with shiki as the only dependency.
 	- It renders the Logseq subset this wiki actually uses: outline blocks, `[[wikilinks]]` with a linked-references panel, namespaces with sub-page listings, `key:: value` properties (ADR `status::` gets colored chips), `#tags` with tag pages, tables, and dual-theme highlighted code — plus a ⌘K search index and a canvas force-directed **graph view**.

--- a/docs/pages/ADR___Template.md
+++ b/docs/pages/ADR___Template.md
@@ -6,7 +6,7 @@ tags:: adr
 - # Context
 	- What forces are at play? What problem does this decision address, and why does it need deciding now?
 - # Decision
-	- The change being made, stated actively: "We will …"
+	- The change being made, stated actively: "The decision is to …"
 - # Consequences
 	- What becomes easier, what becomes harder, and what new obligations exist. Include migration/rollback notes if relevant.
 - # Links

--- a/docs/pages/Fleet.md
+++ b/docs/pages/Fleet.md
@@ -21,7 +21,12 @@ icon:: 🖥️
 	  | [[Hosts/dns]] | DNS | Pi 5 8 GB | |
 	  | [[Hosts/rackpi5]] | rack status | Pi 5 8 GB | **diskless** — RAM image from spore ([[ADR/0008 Diskless netboot for rackpi5]]) |
 	  | [[Hosts/spore]] | NFS/PXE boot server | Pi 5 8 GB, NVMe | boot-critical for rackpi5; monitored by folly |
-	  | [[Hosts/radiopi0]] | radio | Pi Zero W | **unmanaged** — Raspbian buster, not in the flake |
+	  | [[Hosts/radiopi0]] | radio | Pi Zero W | **unmanaged** — Raspbian buster, Pirate Radio case + pHAT BEAT DAC |
+- ## Offline / unplugged Pis
+	- | Host | Purpose | Hardware | Notes |
+	  | ---- | ------- | -------- | ----- |
+	  | [[Hosts/blinkypi0]] | blinky + CloudEvents | Pi Zero W | offline — Blinkt! in a Flirc case; not in the flake |
+	  | [[Hosts/eviropico]] | enviro sensor | Pico W / Pico 2 W | unplugged but working — Enviro+ MicroPython, not in the flake |
 - ## Cloud
 	- | Host | Where | Notes |
 	  | ---- | ----- | ----- |

--- a/docs/pages/Hosts.md
+++ b/docs/pages/Hosts.md
@@ -1,6 +1,11 @@
 icon:: 🗄️
 
-- One page per machine with live-surveyed hardware facts (vendor, model, serial, CPU, RAM, storage, OS — collected over SSH on 2026-07-08). The cluster/role tables live in [[Fleet]].
+- One page per machine with live-surveyed hardware facts (vendor, model, serial, CPU, RAM, storage, OS — collected over SSH on 2026-07-08). blinkypi0 and eviropico are pulled forward from `systems/rpi/` history (the `df20515b` graveyard cleanup); [[Fleet]] holds the cluster/role tables. See [[Architecture/NixOS]] for deploy mechanics.
 - x86: [[Hosts/optiplex]], [[Hosts/riptide]], [[Hosts/shale]], [[Hosts/retrofit]], [[Hosts/oldschool]]
-- Raspberry Pi: [[Hosts/cloudpi4]], [[Hosts/homepi4]], [[Hosts/weatherpi4]], [[Hosts/dns]], [[Hosts/rackpi5]], [[Hosts/spore]], [[Hosts/radiopi0]]
-- Cloud: [[Hosts/oldboy]]
+## Raspberry Pis (active)
+- [[Hosts/cloudpi4]], [[Hosts/homepi4]], [[Hosts/weatherpi4]], [[Hosts/dns]], [[Hosts/rackpi5]], [[Hosts/spore]], [[Hosts/radiopi0]]
+## Raspberry Pis (offline / unplugged)
+- [[Hosts/blinkypi0]] — Pi Zero W + Blinkt!, [Flirc case](https://flirc.tv/more/flirc-raspberry-pi-zero-case); CloudEvents receiver on :3000
+- [[Hosts/eviropico]] — Pico W/Pico 2 W + Pimoroni Enviro+, still working well, just unplugged
+## Cloud
+- [[Hosts/oldboy]]

--- a/docs/pages/Hosts___blinkypi0.md
+++ b/docs/pages/Hosts___blinkypi0.md
@@ -1,0 +1,29 @@
+type:: host
+role:: blinky LED + CloudEvents
+vendor:: Raspberry Pi
+model:: Raspberry Pi Zero W
+year:: ~2017
+cpu:: BCM2835, ARM1176 (armv6l)
+ram:: 512 MB LPDDR2
+gpu:: Broadcom VideoCore IV
+os:: Raspberry Pi OS Lite (historical)
+status:: offline
+hat:: Pimoroni Blinkt! (8-pixel APA102 LED strip)
+case:: Flirc Raspberry Pi Zero Case
+
+- Pi Zero W with a [Blinkt!](https://github.com/pimoroni/blinkt) LED board in the [Flirc Raspberry Pi Zero Case](https://flirc.tv/more/flirc-raspberry-pi-zero-case) — the source of every `flirc` reference in the repo.
+- **Offline** (not retired — the hardware's still here, just unplugged). Never migrated into the flake; runs Raspberry Pi OS Lite with two hand-installed systemd services. The `systems/rpi/blinkypi0/` provisioning artifacts lived in git until the `df20515b` graveyard cleanup; everything below is from that history.
+- `cloudevents.service` runs a Flask + [cloudevents-python](https://github.com/cloudevents/sdk-python) server on `:3000` that turns incoming CloudEvents into Blinkt! animations, supporting `blink`, `brighten`, `clear`, `darken`, `rainbow`, `status`:
+	- ```sh
+	  curl -X POST \
+	      -H "content-type: application/json" \
+	      -H "ce-specversion: 1.0" \
+	      -H "ce-source: https://github.com/jonpulsifer/cloudlab/rpi/blinkypi0" \
+	      -H "ce-type: dev.pulsifer.blinky.request" \
+	      -H "ce-id: lolpotato-123" \
+	      -d '{"action":"rainbow"}' \
+	      http://blinkypi0:3000
+	  ```
+- `blinky.service` runs `/usr/local/bin/blinky` — an 8-pixel random-colour randomizer over the [Blinkt!](https://github.com/pimoroni/blinkt) python library (`blinkt.set_pixel`/`show` at 0.05 s cadence, brightness 0.1).
+- Same CloudEvents pattern as its sibling [[Hosts/radiopi0]].
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___eviropico.md
+++ b/docs/pages/Hosts___eviropico.md
@@ -1,0 +1,14 @@
+type:: host
+role:: enviro sensor
+vendor:: Raspberry Pi
+model:: Raspberry Pi Pico W / Pico 2 W
+cpu:: RP2040 / RP2350 (MicroPython, not Linux)
+ram:: 264 KB SRP6 / 8 MB flash
+os:: Pimoroni MicroPython firmware
+status:: unplugged
+hat:: Pimoroni Enviro+ (BME688, LTR559, mic/SPL, TFT + optional particulate)
+
+- A **Raspberry Pi Pico** (W or Pico 2 W), not a Pi proper — ran **MicroPython** flashed with [Pimoroni's pimoroni-pico / pimoroni-pico-rp2350](https://github.com/pimoroni/pimoroni-pico) firmware, driving a Pimoroni **Enviro+** board (BME688 gas/temp/hum/press, LTR559 light, an SPL/graphic-equalizer mic FFT, and a 240×240 `DISPLAY_ENVIRO_PLUS` TFT).
+- **Unplugged, not retired — still here and working well** when powered and re-chained over USB. Never in the flake (MicroPython on a microcontroller, nothing to declaratively manage); flashed via Thonny, shared into WSL with [usbipd-win](https://github.com/dorssel/usbipd-win). The `systems/rpi/eviropico/` dir (`default.nix` shell + 315-line `main.py`) was cleared in the `df20515b` graveyard cleanup; everything below is from that history.
+- `main.py` read all Enviro+ sensors (BME688 via `breakout_bme68x`, LTR559 light, `ADCFFT` mic graphic equaliser), rendered to the TFT, and lit the onboard RGBLED red when the gas resistance dropped below 50%. Buttons A/B toggled backlight; X/Y switched between sensor readout and graphic-equaliser modes.
+- See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___homepi4.md
+++ b/docs/pages/Hosts___homepi4.md
@@ -2,6 +2,8 @@ type:: host
 role:: kiosk
 vendor:: Raspberry Pi
 model:: Raspberry Pi 4 Model B Rev 1.4 (8 GB)
+hat:: Raspberry Pi 7" Touch Display
+case:: SmartiPi Touch 2
 year:: ~2020
 serial:: 100000001e657842
 revision:: d03114
@@ -11,6 +13,7 @@ gpu:: Broadcom VideoCore VI
 storage:: 32 GB microSD (root 29 GB, 72% used)
 os:: NixOS 26.05 (Yarara)
 
-- Kiosk Pi ([[Runbooks/Kiosk]]). Config: `nix/hosts/homepi4.nix`.
+- Kiosk Pi in a [SmartiPi Touch 2](https://smarticase.com/collections/smartipi-touch-2/products/smartipi-touch-2) case with the [Raspberry Pi 7" Touch Display](https://www.buyapi.ca/product/smartipi-touch-2-case-for-7-official-display/) — a physical twin of [[Hosts/weatherpi4]] (same Pi 4B 8 GB, same `pi4 + common + iperf3 + kiosk` NixOS modules; only Wi-Fi SSIDs differ). [[Runbooks/Kiosk]].
+- Config: `nix/hosts/homepi4.nix` (the homepi4/weatherpi4 pair are the two NixOS kiosk Pis).
 - The wired `homepi4.lolwtf.ca` record can be unreachable; `homepi4-wifi.lolwtf.ca` works.
 - See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___radiopi0.md
+++ b/docs/pages/Hosts___radiopi0.md
@@ -2,6 +2,8 @@ type:: host
 role:: radio
 vendor:: Raspberry Pi
 model:: Raspberry Pi Zero W Rev 1.1
+hat:: Pimoroni pHAT BEAT (mono 2×7 VU LED + audio DAC)
+case:: Pimoroni Pirate Radio case
 year:: ~2017
 serial:: 0000000056f8a6ff
 revision:: 9000c1
@@ -11,6 +13,8 @@ gpu:: Broadcom VideoCore IV
 storage:: 32 GB microSD (root 30 GB, 8% used)
 os:: Raspbian 10 (buster)
 
-- Pi Zero W radio box. **Unmanaged**: not in `flake.nix`, runs EOL Raspbian buster, login is `pi@radiopi0.lolwtf.ca`.
+- Pi Zero W radio box in a Pimoroni [Pirate Radio](https://shop.pimoroni.com/products/pirate-radio-pi-zero-w-project-kit) case with a [pHAT BEAT](https://shop.pimoroni.com/products/phat-beat) DAC + mono VU LED bar. **Unmanaged**: not in `flake.nix`, runs EOL Raspbian buster, login is `pi@radiopi0.lolwtf.ca`.
+- `radio.service` runs `/usr/local/bin/radio`, an HSV rainbow chase across the pHAT BEAT's two 7-pixel channels (`phatbeat.set_pixel`/`show` at 1 ms cadence). Its CloudEvents sibling lives at [[Hosts/blinkypi0]] (`ce-type: dev.pulsifer.radio.request`, also on `:3000`).
+- Scrape target for folly's node-exporter job (`clusters/folly/monitoring/...`; `instance: radiopi0` → `radiopi0.lolwtf.ca:9100`).
 - Candidate for adoption into the flake (armv6l makes NixOS awkward — cross-compiled or stay Raspbian).
 - See [[Fleet]] for the full inventory.


### PR DESCRIPTION
## Summary
Prune anecdotal, past-tense, and editorial phrasing from the wiki and ADRs. The docs should be matter-of-fact reference material; narrative and war-story prose belongs in the journal, not in ADRs or architecture pages.

## Changes
- docs: prune editorial prose from wiki and ADRs

## Test Plan
- [ ] `bun run --cwd apps/wiki build` — site renders cleanly with no broken links
- [ ] Inspect changed pages for remaining past-tense narrative

## Context
- Related: journal `docs/journals/2026_07_08.md` (where the narrative lives)
