### PR TITLE
feat(pki): add disk-based root key storage mode, fix ceremony script bugs

### DIFF
--- a/pki/README.md
+++ b/pki/README.md
@@ -1,21 +1,24 @@
 # pki/ — Offline Root CA Ceremony
 
-An air-gap-friendly ceremony that mints a hardware-anchored Ed25519 root CA
-+ signed intermediate, designed to feed HashiCorp Vault's PKI mount so Vault
-becomes the active issuer of leaf certs for the homelab (k8s cert-manager,
-NixOS host identity, etc.).
+An air-gap-friendly ceremony that mints an Ed25519 root CA + signed
+intermediate, designed to feed HashiCorp Vault's PKI mount so Vault becomes
+the active issuer of leaf certs for the homelab (k8s cert-manager, NixOS host
+identity, etc.). The root can be anchored either to a YubiKey (default) or to
+an age-encrypted file on disk — see [Storage mode](#storage-mode-yubikey-vs-disk).
 
 ## Hybrid architecture (offline root → Vault intermediate → Terraform plumbs)
 
 This is deliberately split across the trust boundary:
 
-1. **Offline (this script, air-gapped host + YubiKey):**
+1. **Offline (this script, air-gapped host):**
    - mints the Ed25519 **root** keypair
    - shards the root seed via SLIP-0039 (2-of-3) for offline recovery
-   - imports the root private key onto a YubiKey PIV slot — the hardware anchor
+   - anchors the root private key — onto a YubiKey PIV slot (hardware anchor,
+     default) or as an age-encrypted file on disk (`STORAGE_MODE=disk`)
    - issues the **intermediate** signed by the root
-   - scrubs the root key from disk; the root private key lives **only** on the
-     YubiKey + in the shards
+   - scrubs the plaintext root key from disk; the root private key lives
+     **only** on the YubiKey + in the shards (or, in disk mode, only in the
+     age-encrypted `root.key.age` + shards file)
 
    The intermediate leaves with you in `pki/export/intermediate.pem`
    (key+cert concatenated). Its private key is *the* trust you carry into
@@ -54,8 +57,9 @@ This is deliberately split across the trust boundary:
 ## Why a script + Terraform, not one or the other?
 
 - **Terraform alone can't** drive the offline ceremony: USB passthrough to a
-  YubiKey, human transcription of SLIP-0039 shards, and Sigstore provenance
-  verification of `step` are all out-of-band operations no provider supports.
+  YubiKey (or age encryption to disk), human transcription of SLIP-0039
+  shards, and Sigstore provenance verification of `step` are all out-of-band
+  operations no provider supports.
 - **The offline script alone can't** own the *plumbing* — Vault mount + roles +
   URL config + AppRole issuance policies are exactly what Terraform is for.
   The script handshake-rolls the certs; Terraform owns everything that's
@@ -75,37 +79,81 @@ pki/
     root.crt                  # public root cert (kept)
     intermediate.crt          # signed intermediate (→ Vault)
     intermediate.key          # intermediate private key (→ Vault, secret)
+    root.key.age              # disk mode only — age-encrypted root key
+    root_seed_shards.txt.age  # disk mode only — age-encrypted SLIP-0039 shards
 ```
 
 ## What the ceremony does
 
 1. Builds a one-shot Ubuntu container with `step`, `cosign`, `ykman`,
-   `shamir-mnemonic[cli]`, `cryptography`, and `srm`.
+   `shamir-mnemonic[cli]`, `cryptography`, `secure-delete`, and `age`.
 2. Downloads Smallstep CLI from `dl.smallstep.com` and verifies its
    Sigstore bundle with cosign.
 3. Generates an Ed25519 root CA (`step certificate create --profile root-ca`).
 4. Extracts the 32-byte root seed from the PKCS8 PEM and shards it via
    SLIP-0039 **using `--master-secret=HEX`** — otherwise `shamir create`
    generates its own random secret and the shards would not recover the root.
-   The human is prompted to transcribe the shards before continuing.
-5. Imports the root private key and cert into PIV slot `9c` on a YubiKey.
+   In `STORAGE_MODE=yubikey` (default) the human transcribes the shards
+   before continuing; in `STORAGE_MODE=disk` they're encrypted straight to
+   `root_seed_shards.txt.age`.
+5. Anchors the root private key + cert: imports into PIV slot `9c` on a
+   YubiKey (`yubikey` mode), or encrypts `root.key` to `root.key.age` with
+   `age` (`disk` mode).
 6. Issues an Ed25519 intermediate CA signed by the root.
-7. Scrubs `root.key` and the raw seed from disk. The root private key now
-   exists **only** on the YubiKey + in the shards.
+7. Scrubs plaintext `root.key` and the raw seed from disk. The root private
+   key now exists **only** on the YubiKey + in the shards (or, in disk mode,
+   only in `root.key.age` + `root_seed_shards.txt.age`).
+
+## Storage mode: YubiKey vs. disk
+
+`STORAGE_MODE` picks how the root private key and SLIP-0039 shards are
+anchored after generation. Default is `yubikey`.
+
+| | `yubikey` (default) | `disk` |
+|---|---|---|
+| Root key | Imported to YubiKey PIV slot `9c` | Encrypted to `root.key.age` with `age` |
+| Shards | Printed for hand transcription, distributed to trusted parties | Encrypted to `root_seed_shards.txt.age`, kept together |
+| Hardware needed | YubiKey 5.7+, USB passthrough | None |
+| Recovery needs | 2-of-3 shards, or the YubiKey | The age identity file |
+
+Disk mode trades the hardware anchor and human-distributed shards for a
+single age identity file under your own custody — simpler to run, but a
+single point of compromise if that identity file and `export/` end up in the
+same place. Prefer `yubikey` for the real production root; `disk` is useful
+for lab/test roots or when a YubiKey isn't available.
+
+To use it, generate an age keypair **ahead of time**, on the air-gapped host,
+and keep `identity.txt` offline (a password manager, an encrypted USB stick —
+anywhere other than `pki/export/`, which this script treats as disposable):
+
+```bash
+age-keygen -o identity.txt
+# Public key: age1...   <- this is DISK_ENCRYPTION_RECIPIENT
+```
+
+```bash
+STORAGE_MODE=disk \
+DISK_ENCRYPTION_RECIPIENT="age1..." \
+./pki/offline-root-ceremony.sh
+```
 
 ## Requirements
 
-- Air-gapped host with Docker and a USB-attached YubiKey.
-- **YubiKey 5.7 or later** for PIV Ed25519 support. Verify with
-  `ykman info` (look for "Form factor" + firmware ≥ 5.7).
-- `sudo` to start/stop host `pcscd` (so the container can grab the card reader).
-- No host smart card daemon running (`pcscd` is stopped on the host, started
-  inside the container).
+- Air-gapped host with Docker.
+- `STORAGE_MODE=yubikey` (default) additionally needs:
+  - A USB-attached **YubiKey 5.7 or later** for PIV Ed25519 support. Verify
+    with `ykman info` (look for "Form factor" + firmware ≥ 5.7).
+  - `sudo` to start/stop host `pcscd` (so the container can grab the card
+    reader). No host smart card daemon running (`pcscd` is stopped on the
+    host, started inside the container).
+- `STORAGE_MODE=disk` additionally needs an age recipient key generated ahead
+  of time (see [Storage mode](#storage-mode-yubikey-vs-disk)) — no YubiKey,
+  USB passthrough, or `sudo` required.
 
 ## Running
 
 ```bash
-# from the repo root — defaults baked in; override env vars to taste
+# from the repo root — defaults baked in (STORAGE_MODE=yubikey); override env vars to taste
 ./pki/offline-root-ceremony.sh
 
 # overrides
@@ -113,11 +161,16 @@ STEP_VERSION=0.30.6 \
 ROOT_CA_NAME="My Homelab Root CA" \
 SHAMIR_THRESHOLD=2 SHAMIR_SHARES=3 \
 ./pki/offline-root-ceremony.sh
+
+# disk storage mode instead of a YubiKey
+STORAGE_MODE=disk DISK_ENCRYPTION_RECIPIENT="age1..." \
+./pki/offline-root-ceremony.sh
 ```
 
-You will be prompted to transcribe the SLIP-0039 shards before the YubiKey
-import step. Do not press Enter until every shard is recorded somewhere
-offline.
+In `yubikey` mode you will be prompted to transcribe the SLIP-0039 shards
+before the YubiKey import step. Do not press Enter until every shard is
+recorded somewhere offline. In `disk` mode the shards are encrypted
+automatically — nothing to transcribe.
 
 ## After the ceremony
 
@@ -144,10 +197,13 @@ offline.
    it where relying parties will pick it up (k8s ConfigMap, a NixOS module
    writing to `/etc/ssl/certs/`, etc.).
 
-4. **Shards**: store each of the three shards with a different trusted party.
-   Any two re-derive the root seed (`shamir recover`), which can be re-imported
-   to a replacement YubiKey if the original is lost. One shard alone leaks
-   nothing about the root.
+4. **Shards**: in `yubikey` mode, store each of the three shards with a
+   different trusted party. Any two re-derive the root seed (`shamir
+   recover`), which can be re-imported to a replacement YubiKey if the
+   original is lost. One shard alone leaks nothing about the root. In `disk`
+   mode the shards live together, encrypted, in `export/root_seed_shards.txt.age`
+   — back that file (and `root.key.age`) up somewhere durable, e.g. alongside
+   the age identity in a password manager.
 
 5. **Scrub the bundle from the laptop** once Vault owns the CA:
    ```bash
@@ -156,7 +212,9 @@ offline.
    ```
    (Keep `intermediate.crt` + `root.crt` for chain bundling.)
 
-## Recovery (re-key a YubiKey from shards)
+## Recovery
+
+### From shards, re-key a YubiKey (`yubikey` mode)
 
 ```bash
 shamir recover        # enter 2 of the 3 shards → master secret hex
@@ -177,6 +235,25 @@ ykman piv keys import 9c root.key
 ykman piv certificates import 9c root.crt
 ```
 
+### From the age-encrypted files (`disk` mode)
+
+The root key doesn't need reconstructing from shards in this mode — it's
+already on disk, just encrypted:
+
+```bash
+age -d -i identity.txt -o root.key pki/export/root.key.age
+age -d -i identity.txt -o root_seed_shards.txt pki/export/root_seed_shards.txt.age
+```
+
+`root.key` is ready to use directly (e.g. as `--ca-key` for a follow-up
+intermediate ceremony). The decrypted shards are a redundant recovery path if
+`root.key.age` itself is ever lost or corrupted while the age identity
+survives — feed 2 of the 3 into `shamir recover` as above. Note both files
+are encrypted to the *same* age identity, so losing the identity itself takes
+out both paths at once; back it up as carefully as you would a root key.
+Shred the plaintext `root.key` / `root_seed_shards.txt` again once you're
+done with them.
+
 ## Operational notes
 
 - The script deliberately **does not** rotate the PIV management key. The
@@ -189,4 +266,10 @@ ykman piv certificates import 9c root.crt
   configure touch policy via `ykman piv keys set-touch` (YubiKey 5.7+).
 - Intermediate expiry is 2 years; root expiry is ~15 years. Re-issuance of
   an intermediate can be done in a follow-up ceremony using the root on the
-  YubiKey.
+  YubiKey (or `root.key.age` in disk mode).
+- `STORAGE_MODE=disk` is a deliberately weaker trust model than `yubikey`:
+  the root key and shards both collapse to "whoever holds the age identity
+  file," rather than requiring physical possession of a hardware token or
+  collusion between separate shard holders. Fine for a lab/test root; think
+  twice before using it for the root that Vault's production PKI mount
+  ultimately chains to.

--- a/pki/offline-root-ceremony.sh
+++ b/pki/offline-root-ceremony.sh
@@ -4,17 +4,24 @@
 #   2. Verify the Smallstep CLI artifact via cosign (Sigstore provenance)
 #   3. Generate an Ed25519 root CA (cert + key) with step
 #   4. Extract the 32-byte root seed and split it into SLIP-0039 shards (2-of-3)
-#   5. Import the root key + cert onto a YubiKey PIV slot (hardware anchor)
-#   6. Issue an Ed25519 intermediate CA signed by the (now hardware-backed) root
+#   5. Anchor the root key, per STORAGE_MODE:
+#        yubikey (default) — import onto a YubiKey PIV slot (hardware anchor)
+#        disk              — encrypt root.key + the shards to disk with age,
+#                             for a recipient key you generated ahead of time
+#   6. Issue an Ed25519 intermediate CA signed by the (now anchored) root
 #   7. Bundle the intermediate key + cert into ./export/intermediate.pem — the
 #      form vault_pki_secret_backend_config_ca.pem_bundle consumes to make the
 #      offline-generated intermediate the active CA on a Vault PKI mount.
-#   8. Scrub the root private key + raw seed from disk — shards + YubiKey are the
-#      only recovery paths. Intermediate key/cert land in ./export/ for transit
-#      into Vault (terraform/vault/pki-fml.tf via TF_VAR_pki_intermediate_pem_bundle).
+#   8. Scrub the plaintext root private key + raw seed from disk — the shards
+#      plus the YubiKey (or the age-encrypted files, in disk mode) are the only
+#      recovery paths. Intermediate key/cert land in ./export/ for transit into
+#      Vault (terraform/vault/pki-fml.tf via TF_VAR_pki_intermediate_pem_bundle).
 #
-# Run on an air-gapped host with a YubiKey 5.7+ (PIV Ed25519 support) plugged
-# into a USB port. Never on a networked machine that has live cluster/Vault
+# Run on an air-gapped host. STORAGE_MODE=yubikey (default) needs a YubiKey
+# 5.7+ (PIV Ed25519 support) plugged into a USB port. STORAGE_MODE=disk needs
+# an age recipient key instead (see README.md) and skips the YubiKey/USB steps
+# entirely — it trades the hardware anchor for operator-held disk custody.
+# Never run either mode on a networked machine that has live cluster/Vault
 # credentials. See ./README.md.
 
 set -euo pipefail
@@ -32,11 +39,35 @@ set -euo pipefail
 : "${PIV_SLOT:=9c}"                      # 9c = PIV Digital Signature slot
 : "${SHAMIR_THRESHOLD:=2}"
 : "${SHAMIR_SHARES:=3}"
+: "${STORAGE_MODE:=yubikey}"       # yubikey | disk
+: "${DISK_ENCRYPTION_RECIPIENT:=}" # age1... — required when STORAGE_MODE=disk
 : "${DOCKER_IMAGE:=pki-offline-ceremony:latest}"
 
 export STEP_VERSION ROOT_CA_NAME INTERMEDIATE_CA_NAME KEY_TYPE CURVE
 export ROOT_EXPIRY_HOURS INTERMEDIATE_EXPIRY_HOURS PIV_SLOT
 export SHAMIR_THRESHOLD SHAMIR_SHARES
+export STORAGE_MODE DISK_ENCRYPTION_RECIPIENT
+
+case "${STORAGE_MODE}" in
+  yubikey | disk) ;;
+  *)
+    echo "[!] STORAGE_MODE must be 'yubikey' or 'disk' (got '${STORAGE_MODE}')" >&2
+    exit 1
+    ;;
+esac
+if [[ "${STORAGE_MODE}" == disk ]]; then
+  if [[ -z "${DISK_ENCRYPTION_RECIPIENT}" ]]; then
+    echo "[!] STORAGE_MODE=disk requires DISK_ENCRYPTION_RECIPIENT=age1... " >&2
+    echo "    Generate one ahead of time with: age-keygen -o identity.txt" >&2
+    echo "    (the 'Public key:' line it prints is DISK_ENCRYPTION_RECIPIENT;" >&2
+    echo "    keep identity.txt itself offline — it's the only way to decrypt)." >&2
+    exit 1
+  fi
+  if [[ "${DISK_ENCRYPTION_RECIPIENT}" != age1* ]]; then
+    echo "[!] DISK_ENCRYPTION_RECIPIENT doesn't look like an age recipient (expected 'age1...', got '${DISK_ENCRYPTION_RECIPIENT}')" >&2
+    exit 1
+  fi
+fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 EXPORT_DIR="${REPO_ROOT}/pki/export"
@@ -45,9 +76,11 @@ EXPORT_DIR="${REPO_ROOT}/pki/export"
 # HOST PREP
 # ==============================================================================
 sanitize_host_environment() {
-  echo "[*] Stopping host pcscd so the container can grab the smart card reader..."
-  sudo systemctl stop pcscd pcscd.socket 2>/dev/null || true
   mkdir -p "${EXPORT_DIR}"
+  if [[ "${STORAGE_MODE}" == yubikey ]]; then
+    echo "[*] Stopping host pcscd so the container can grab the smart card reader..."
+    sudo systemctl stop pcscd pcscd.socket 2>/dev/null || true
+  fi
 }
 
 # ==============================================================================
@@ -63,7 +96,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
       curl ca-certificates gnupg pcscd pcsc-tools \
       yubikey-manager python3 python3-pip python3-venv \
-      srm \
+      secure-delete age \
     && rm -rf /var/lib/apt/lists/*
 
 # Cosign (Sigstore) — pinned to a release that ships a static linux-amd64 binary
@@ -104,14 +137,18 @@ set -euo pipefail
 : "${PIV_SLOT:?}"
 : "${SHAMIR_THRESHOLD:?}"
 : "${SHAMIR_SHARES:?}"
+: "${STORAGE_MODE:?}"
+: "${DISK_ENCRYPTION_RECIPIENT:=}"
 
 EXPORT_DIR="/pki/export"
 mkdir -p "${EXPORT_DIR}"
 
-echo "[*] Starting pcscd inside the container..."
-mkdir -p /var/run/pcscd
-pcscd --disable-polkit >/dev/null 2>&1 &
-sleep 1
+if [[ "${STORAGE_MODE}" == yubikey ]]; then
+  echo "[*] Starting pcscd inside the container..."
+  mkdir -p /var/run/pcscd
+  pcscd --disable-polkit >/dev/null 2>&1 &
+  sleep 1
+fi
 
 # --------------------------------------------------------------
 verify_step_cli() {
@@ -164,26 +201,43 @@ with open("/pki/export/root.key", "rb") as f:
     priv = serialization.load_pem_private_key(f.read(), password=None)
 if not isinstance(priv, ed25519.Ed25519PrivateKey):
     raise SystemExit("root.key is not Ed25519 — refuse to shard")
-# OpenSSH + Raw encoding yields the raw 32-byte seed for Ed25519.
+# Raw encoding + Raw format is the only combination cryptography accepts for
+# Ed25519 and yields the raw 32-byte seed (OpenSSH format returns a PEM blob).
 seed = priv.private_bytes(
     encoding=serialization.Encoding.Raw,
-    format=serialization.PrivateFormat.OpenSSH,
+    format=serialization.PrivateFormat.Raw,
     encryption_algorithm=serialization.NoEncryption(),
 )
 print(seed.hex())
 PY
 )"
+  if [[ ${#seed_hex} -ne 64 ]]; then
+    echo "[!] Extracted seed is ${#seed_hex} hex chars, expected 64 (32 bytes) — refusing to shard." >&2
+    exit 1
+  fi
   printf '%s' "${seed_hex}" > "${EXPORT_DIR}/root_seed.hex"
 
-  echo
-  echo "[!] CAUTION — transcribe the following SLIP-0039 shards now."
-  echo "[!] Store each shard with a different trusted party."
-  echo "------------------------------------------------------------"
-  shamir create "${SHAMIR_THRESHOLD}of${SHAMIR_SHARES}" \
-    --master-secret="${seed_hex}"
-  echo "------------------------------------------------------------"
-  echo "[*] After confirming all shards are recorded, press Enter to continue."
-  read -r _
+  local shards
+  shards="$(shamir create "${SHAMIR_THRESHOLD}of${SHAMIR_SHARES}" --master-secret="${seed_hex}")"
+
+  if [[ "${STORAGE_MODE}" == disk ]]; then
+    # Never printed to the terminal in this mode — the point of disk mode is
+    # to keep the shards off tty/scrollback entirely, encrypted straight to disk.
+    echo "[*] Encrypting shards to ${EXPORT_DIR}/root_seed_shards.txt.age..."
+    printf '%s\n' "${shards}" \
+      | age -r "${DISK_ENCRYPTION_RECIPIENT}" -o "${EXPORT_DIR}/root_seed_shards.txt.age"
+    chmod 0600 "${EXPORT_DIR}/root_seed_shards.txt.age"
+    echo "[+] Shards encrypted to disk under ${DISK_ENCRYPTION_RECIPIENT}."
+  else
+    echo
+    echo "------------------------------------------------------------"
+    echo "${shards}"
+    echo "------------------------------------------------------------"
+    echo "[!] CAUTION — transcribe the shards above now."
+    echo "[!] Store each shard with a different trusted party."
+    echo "[*] After confirming all shards are recorded, press Enter to continue."
+    read -r _
+  fi
 }
 
 # --------------------------------------------------------------
@@ -204,6 +258,17 @@ import_to_yubikey() {
 
   echo "[*] Importing root cert into PIV slot ${PIV_SLOT}..."
   ykman piv certificates import "${PIV_SLOT}" "${EXPORT_DIR}/root.crt"
+}
+
+# --------------------------------------------------------------
+# Alternative to import_to_yubikey: encrypt the root private key to disk with
+# age instead of anchoring it to hardware. root.key stays in plaintext until
+# issue_intermediate signs with it; scrub_root_key removes the plaintext after.
+store_root_key_to_disk() {
+  echo "[*] Encrypting root private key to ${EXPORT_DIR}/root.key.age..."
+  age -r "${DISK_ENCRYPTION_RECIPIENT}" -o "${EXPORT_DIR}/root.key.age" "${EXPORT_DIR}/root.key"
+  chmod 0600 "${EXPORT_DIR}/root.key.age"
+  echo "[+] Root key encrypted under ${DISK_ENCRYPTION_RECIPIENT}."
 }
 
 # --------------------------------------------------------------
@@ -232,8 +297,9 @@ bundle_intermediate() {
 }
 
 # --------------------------------------------------------------
-# The root private key now lives ONLY on the YubiKey + in the shards.
-# Scrub every disk copy. Use srm when available, fall back to shred/rm.
+# The root private key now lives ONLY on the YubiKey + in the shards (or, in
+# STORAGE_MODE=disk, only in the age-encrypted root.key.age + shards file).
+# Scrub every plaintext disk copy. Use srm when available, fall back to shred/rm.
 scrub_root_key() {
   if command -v srm >/dev/null 2>&1; then
     srm -f "${EXPORT_DIR}/root.key" "${EXPORT_DIR}/root_seed.hex" 2>/dev/null || true
@@ -241,7 +307,7 @@ scrub_root_key() {
     shred -u "${EXPORT_DIR}/root.key" "${EXPORT_DIR}/root_seed.hex" 2>/dev/null \
       || rm -f "${EXPORT_DIR}/root.key" "${EXPORT_DIR}/root_seed.hex"
   fi
-  echo "[+] Scrubbed root.key + raw seed from disk."
+  echo "[+] Scrubbed plaintext root.key + raw seed from disk."
   echo "[+] Outputs in ${EXPORT_DIR}:"
   ls -l "${EXPORT_DIR}"
 }
@@ -249,7 +315,11 @@ scrub_root_key() {
 verify_step_cli
 generate_root_ca
 shard_root_seed
-import_to_yubikey
+if [[ "${STORAGE_MODE}" == yubikey ]]; then
+  import_to_yubikey
+else
+  store_root_key_to_disk
+fi
 issue_intermediate
 bundle_intermediate
 scrub_root_key
@@ -261,15 +331,20 @@ INNER
 # RUN THE CEREMONY IN THE CONTAINER
 # ==============================================================================
 run_ceremony() {
-  echo "[*] Launching container with USB passthrough..."
-  docker run -it --rm \
-    --device /dev/bus/usb \
-    --privileged \
+  local -a docker_args=(-it --rm)
+  if [[ "${STORAGE_MODE}" == yubikey ]]; then
+    echo "[*] Launching container with USB passthrough..."
+    docker_args+=(--device /dev/bus/usb --privileged)
+  else
+    echo "[*] Launching container (STORAGE_MODE=disk, no USB passthrough needed)..."
+  fi
+  docker run "${docker_args[@]}" \
     -v "${EXPORT_DIR}:/pki/export" \
     -e STEP_VERSION -e ROOT_CA_NAME -e INTERMEDIATE_CA_NAME \
     -e KEY_TYPE -e CURVE \
     -e ROOT_EXPIRY_HOURS -e INTERMEDIATE_EXPIRY_HOURS \
     -e PIV_SLOT -e SHAMIR_THRESHOLD -e SHAMIR_SHARES \
+    -e STORAGE_MODE -e DISK_ENCRYPTION_RECIPIENT \
     --name pki-ceremony \
     "${DOCKER_IMAGE}" \
     /pki/export/inner_ceremony.sh
@@ -280,13 +355,22 @@ run_ceremony() {
 # ==============================================================================
 cleanup_host() {
   rm -f "${EXPORT_DIR}/inner_ceremony.sh"
-  sudo systemctl start pcscd 2>/dev/null || true
+  if [[ "${STORAGE_MODE}" == yubikey ]]; then
+    sudo systemctl start pcscd 2>/dev/null || true
+  fi
   echo
   echo "[+] Ceremony complete. Operational artifacts in: ${EXPORT_DIR}/"
   echo "[+] Intermediate .key/.crt are ready to import into Vault's PKI mount"
   echo "    (terraform/vault/pki-fml.tf). Keep root.crt for chain bundling."
-  echo "[+] REMINDER: the root private key lives ONLY on the YubiKey + in your"
-  echo "    SLIP-0039 shards. Lose both and the root is unrecoverable."
+  if [[ "${STORAGE_MODE}" == yubikey ]]; then
+    echo "[+] REMINDER: the root private key lives ONLY on the YubiKey + in your"
+    echo "    SLIP-0039 shards. Lose both and the root is unrecoverable."
+  else
+    echo "[+] REMINDER: the root private key lives ONLY in ${EXPORT_DIR}/root.key.age"
+    echo "    and ${EXPORT_DIR}/root_seed_shards.txt.age, both encrypted to"
+    echo "    ${DISK_ENCRYPTION_RECIPIENT}. Back up the matching age identity"
+    echo "    file separately and offline — lose it and the root is unrecoverable."
+  fi
 }
 
 # ==============================================================================


### PR DESCRIPTION
## Summary
Fixes two bugs in the offline PKI root CA ceremony script (wrong apt package name, invalid crypto encoding/format pairing that broke SLIP-0039 sharding) and adds `STORAGE_MODE=disk` as an alternative to the default YubiKey hardware anchor — root key and shards get encrypted to disk with `age` instead.

## Changes
- fix: `srm` → `secure-delete` apt package (the actual package that provides the `srm` binary)
- fix: root-seed extraction now uses `Encoding.Raw` + `PrivateFormat.Raw` (the only valid pairing `cryptography` accepts for Ed25519); previously `PrivateFormat.OpenSSH` raised a `ValueError`, and the resulting garbage seed was rejected by `shamir create` with "Secret bytes must be hex encoded"
- feat: `STORAGE_MODE=disk` — encrypts root key + SLIP-0039 shards to an operator-supplied age recipient (`DISK_ENCRYPTION_RECIPIENT`) instead of importing to a YubiKey PIV slot; skips USB/pcscd/`--privileged` entirely in that mode
- shards are only ever printed to the terminal in `yubikey` mode — `disk` mode encrypts them straight to disk without hitting stdout/scrollback
- docs: README covers the new storage mode, requirements, running examples, and both recovery paths

## Test Plan
- [x] `bash -n pki/offline-root-ceremony.sh` — syntax check
- [x] `shellcheck pki/offline-root-ceremony.sh` — 0 findings
- [x] `shfmt -d -i 2 -ci -bn pki/offline-root-ceremony.sh` — clean
- [x] Verified the `cryptography`/`shamir-mnemonic` fix locally in an isolated venv (Raw+Raw encoding produces a valid 32-byte seed that `shamir create --master-secret` accepts; the old Raw+OpenSSH combo reproduces the exact reported error)
- [ ] Full ceremony dry run on the real air-gapped host (Docker unavailable in this dev environment) — in particular confirm the new `age` apt package installs cleanly in the `ubuntu:24.04` container
