### PR TITLE
Add radiopi0 (Pi Zero W, armv6l) as a managed NixOS host

### DIFF
--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -14,13 +14,17 @@ on:
           - cloudpi4
           - homepi4
           - weatherpi4
+          - radiopi0
           - wsl
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   build:
-    runs-on: ${{ contains(inputs.image, 'pi4') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    # radiopi0 (armv6l) cross-compiles from aarch64-linux (nix/hardware/pi0.nix
+    # sets nixpkgs.buildPlatform/hostPlatform) same as the native aarch64 pi4
+    # builds -- both want the arm64 runner, just for different reasons.
+    runs-on: ${{ (contains(inputs.image, 'pi4') || inputs.image == 'radiopi0') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
       id-token: write
@@ -61,7 +65,7 @@ jobs:
           process_gcloudignore: false
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        if: ${{ contains(inputs.image, 'pi4') }}
+        if: ${{ contains(inputs.image, 'pi4') || inputs.image == 'radiopi0' }}
         with:
           name: ${{ inputs.image }}-sd-image
           path: result/sd-image/nixos-image-sd-card-*

--- a/.github/workflows/nixos-deploy.yaml
+++ b/.github/workflows/nixos-deploy.yaml
@@ -3,13 +3,14 @@ on:
   workflow_dispatch:
     inputs:
       host:
-        description: "Pi4 host to build + deploy"
+        description: "Host to build + deploy"
         required: true
         type: choice
         options:
           - cloudpi4
           - homepi4
           - weatherpi4
+          - radiopi0
       mode:
         description: "nixos-rebuild action (boot activates on next reboot; switch activates immediately)"
         required: true
@@ -23,8 +24,11 @@ concurrency:
   cancel-in-progress: false
 jobs:
   deploy:
-    # Native aarch64 runner: cloudpi4/homepi4/weatherpi4 are aarch64-linux,
-    # same as nixos-aarch64 in nix-ci.yaml — avoids slow qemu cross-compilation.
+    # Native aarch64 runner: cloudpi4/homepi4/weatherpi4 build natively as
+    # aarch64-linux (same as nixos-aarch64 in nix-ci.yaml); radiopi0 (armv6l)
+    # cross-compiles from aarch64-linux (nix/hardware/pi0.nix sets
+    # nixpkgs.buildPlatform/hostPlatform). Both want this runner, avoiding
+    # slow qemu emulation either way.
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
@@ -63,8 +67,8 @@ jobs:
 
       - name: Deploy ${{ inputs.host }}
         env:
-          # Pi4s are only ever reached over the tailnet; accept the host key
-          # on first contact instead of prompting.
+          # These hosts are only ever reached over the tailnet; accept the
+          # host key on first contact instead of prompting.
           NIX_SSHOPTS: -o StrictHostKeyChecking=accept-new
         run: |
           nix shell --inputs-from . nixpkgs#nixos-rebuild-ng -c \

--- a/docs/pages/Hosts___radiopi0.md
+++ b/docs/pages/Hosts___radiopi0.md
@@ -13,8 +13,8 @@ gpu:: Broadcom VideoCore IV
 storage:: 32 GB microSD (root 30 GB, 8% used)
 os:: Raspbian 10 (buster)
 
-- Pi Zero W radio box in a Pimoroni [Pirate Radio](https://shop.pimoroni.com/products/pirate-radio-pi-zero-w-project-kit) case with a [pHAT BEAT](https://shop.pimoroni.com/products/phat-beat) DAC + mono VU LED bar. **Unmanaged**: not in `flake.nix`, runs EOL Raspbian buster, login is `pi@radiopi0.lolwtf.ca`.
-- `radio.service` runs `/usr/local/bin/radio`, an HSV rainbow chase across the pHAT BEAT's two 7-pixel channels (`phatbeat.set_pixel`/`show` at 1 ms cadence). Its CloudEvents sibling lives at [[Hosts/blinkypi0]] (`ce-type: dev.pulsifer.radio.request`, also on `:3000`).
-- Scrape target for folly's node-exporter job (`clusters/folly/monitoring/...`; `instance: radiopi0` → `radiopi0.lolwtf.ca:9100`).
-- Candidate for adoption into the flake (armv6l makes NixOS awkward — cross-compiled or stay Raspbian).
+- Pi Zero W radio box in a Pimoroni [Pirate Radio](https://shop.pimoroni.com/products/pirate-radio-pi-zero-w-project-kit) case with a [pHAT BEAT](https://shop.pimoroni.com/products/phat-beat) DAC + mono VU LED bar.
+- **In the flake** as `nixosConfigurations.radiopi0` (`nix/hosts/radiopi0.nix` + `nix/hardware/pi0.nix`). armv6l has no upstream binary cache and no board-support module (nixos-hardware/nixos-raspberrypi both bottom out at Pi 2 / Zero 2 W), so this cross-compiles from spore's aarch64 CPU via `nixpkgs.buildPlatform`/`hostPlatform` — no board module to lean on, no QEMU emulation, but the whole closure builds from source. Deliberately minimal: tailscale + ssh only, no chezmoi/ddnsd (mise also has no armv6l release, so it's dropped from the default user package set).
+- `system.autoUpgrade` is disabled — there's no armv6l builder on the device itself, so generations are always built on spore and pushed via `nixos-rebuild --target-host`, never attempted on-device.
+- **Not yet migrated**: still running Raspbian buster with `radio.service` (`/usr/local/bin/radio`, an HSV rainbow chase across the pHAT BEAT's two 7-pixel channels via `phatbeat.set_pixel`/`show` at 1 ms cadence) and the folly node-exporter scrape target (`clusters/folly/monitoring/...`; `instance: radiopi0` → `radiopi0.lolwtf.ca:9100`). Both need to be ported to the NixOS config before cutover. CloudEvents sibling lives at [[Hosts/blinkypi0]] (`ce-type: dev.pulsifer.radio.request`, also on `:3000`).
 - See [[Fleet]] for the full inventory.

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
         "rackpi5"
         "oldboy"
         "spore"
+        "radiopi0"
       ];
 
       legacyPackages = forAllSystems (
@@ -170,6 +171,15 @@
           modules = [ ./nix/hosts/spore.nix ];
         };
 
+        # armv6l Pi Zero W: no native builder/cache exists for this arch, so
+        # this is cross-compiled (nix/hardware/pi0.nix sets nixpkgs.crossSystem)
+        # from whatever machine builds it -- in practice spore, hence the
+        # aarch64-linux system below matching spore's native arch.
+        radiopi0 = mkHost "radiopi0" {
+          system = "aarch64-linux";
+          modules = [ ./nix/hosts/radiopi0.nix ];
+        };
+
         oldboy = mkHost "oldboy" {
           tags = [ "gcp" ];
           modules = [ ./nix/hosts/oldboy.nix ];
@@ -216,6 +226,14 @@
             ];
             preferLocalBuild = true;
           };
+        };
+
+        # radiopi0's armv6l target is cross-compiled, not natively built, so
+        # its build platform (aarch64-linux, matching spore) actually needs to
+        # be the system running `nix build`, unlike the x86_64-linux aliases
+        # above.
+        aarch64-linux = {
+          radiopi0 = nixosConfigurations.radiopi0.config.system.build.sdImage;
         };
       };
 

--- a/nix/hardware/pi0.nix
+++ b/nix/hardware/pi0.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  modulesPath,
+  ...
+}:
+{
+  imports = [
+    (modulesPath + "/installer/sd-card/sd-image-raspberrypi.nix")
+  ];
+
+  # save some space
+  documentation.enable = false;
+
+  # Original Pi Zero W: BCM2835, single-core ARM1176JZF-S (armv6l). No
+  # nixos-hardware/nixos-raspberrypi board module targets this chip (those
+  # bottom out at Pi 2 / Zero 2 W), and there's no armv6l binary cache
+  # anywhere -- everything in this closure compiles from source.
+  # nixpkgs.buildPlatform keeps the *build* machine on its own native arch
+  # (aarch64-linux on spore) while hostPlatform cross-compiles the armv6l
+  # target, no QEMU emulation. Must use the modern hostPlatform/buildPlatform
+  # options (matching nix/system/nixos.nix's own hostPlatform default) rather
+  # than the legacy localSystem/crossSystem pair -- nixpkgs asserts against
+  # mixing the two.
+  nixpkgs.buildPlatform.system = "aarch64-linux";
+  nixpkgs.hostPlatform = lib.systems.examples.raspberryPi;
+
+  # efivar/efibootmgr are EFI-specific (irrelevant on this non-EFI board) --
+  # systemd/dbus pull them in transitively regardless, and efivar is marked
+  # broken for this cross target upstream. Stub both out entirely rather than
+  # letting the real (likely genuinely broken, not just meta-flagged) cross
+  # build run.
+  nixpkgs.overlays = [
+    (
+      final: prev: {
+        efivar = prev.runCommand "empty-efivar" { } "mkdir $out";
+        efibootmgr = prev.runCommand "empty-efibootmgr" { } "mkdir $out";
+      }
+    )
+  ];
+
+  # Required for the Pi Zero W's wifi/bt firmware (bcm43438).
+  hardware.enableRedistributableFirmware = true;
+
+  boot.zfs.forceImportRoot = false;
+
+  sdImage.compressImage = true;
+}

--- a/nix/hosts/radiopi0.nix
+++ b/nix/hosts/radiopi0.nix
@@ -1,0 +1,45 @@
+{
+  lib,
+  pkgs,
+  name,
+  ...
+}:
+{
+  imports = [
+    ../hardware/pi0.nix
+    ../system/nixos.nix
+    ../system/tailscale.nix
+  ];
+
+  networking = {
+    hostName = name;
+    wireless = {
+      enable = true;
+      networks.lab.hidden = true;
+    };
+  };
+
+  # No armv6l builder or cache exists anywhere -- generations are always
+  # cross-built elsewhere (spore) and pushed via `nixos-rebuild --target-host`,
+  # never attempted on-device.
+  system.autoUpgrade.enable = false;
+
+  # mise (from system/user.nix) has no armv6l-linux release; keep the rest of
+  # the default user package set, drop just that.
+  users.users.jawn.packages = lib.mkForce (
+    with pkgs;
+    [
+      git
+      unzip
+      gnupg
+    ]
+  );
+  users.users.rowbutt.packages = lib.mkForce (
+    with pkgs;
+    [
+      git
+      unzip
+      gnupg
+    ]
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `radiopi0` (original Raspberry Pi Zero W — BCM2835, single-core ARM1176JZF-S, armv6l) as a managed NixOS host: `nix/hardware/pi0.nix` + `nix/hosts/radiopi0.nix`, wired into `flake.nix` (`nixosConfigurations.radiopi0`, `packages.aarch64-linux.radiopi0` sd-image output, `deployHosts`).
- No board-support module exists upstream for the original Pi Zero W (nixos-hardware/nixos-raspberrypi both bottom out at Pi 2 / Zero 2 W) and there's no armv6l binary cache, so this cross-compiles from aarch64-linux via `nixpkgs.buildPlatform`/`hostPlatform`, no QEMU emulation.
- Deliberately minimal config: tailscale + ssh only, no chezmoi/ddnsd. `mise` is dropped from the default user package set since it has no armv6l release.
- `efivar`/`efibootmgr` are stubbed out via overlay — `efivar`'s build hardcodes `gcc -march=native` for a build-time codegen helper, which breaks under cross-compilation (confirmed via an actual build attempt, not just nixpkgs' `meta.broken` flag).
- `system.autoUpgrade` is disabled — there's no armv6l builder on-device, so generations are always built elsewhere (currently spore, over aarch64→armv6l cross-compilation) and pushed via `nixos-rebuild --target-host`.
- Wires `radiopi0` into `nix-image-builder.yaml` and `nixos-deploy.yaml` alongside the existing pi4 hosts, on the same arm64 GitHub-hosted runner (`ubuntu-24.04-arm`) — genuine cross-compilation there too, same reasoning as the pi4 native builds just for a different underlying reason.
- Updates the wiki doc (`docs/pages/Hosts___radiopi0.md`) from "unmanaged" to reflect the new flake-managed status, and flags that `radio.service`/node-exporter still need to be ported from the existing Raspbian install before cutover.

## Test plan

- [x] `nix eval .#nixosConfigurations.radiopi0.config.nixpkgs.hostPlatform.system` → `armv6l-linux`, `.config.nixpkgs.buildPlatform.system` → `aarch64-linux`
- [x] `nix eval .#nixosConfigurations.radiopi0.config.system.build.toplevel.drvPath` and `.#packages.aarch64-linux.radiopi0.drvPath` both evaluate cleanly
- [x] `nix build .#packages.aarch64-linux.radiopi0 -L` run manually on spore (aarch64) — in progress, cross-compiling successfully after the efivar/efibootmgr overlay fix (initial attempts hit the `-march=native` build failure and disk space on `/`, both resolved)
- [ ] Flash the resulting sd-image, confirm first boot + tailscale join
- [ ] Trigger `nix-image-builder` (image: `radiopi0`) and `nixos-deploy` (host: `radiopi0`) workflows on this branch to confirm they build in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXHMQMfawe7aBnbJCo9okF