### PR TITLE
fix(ci): trust flake.nix's nixConfig substituters

### DIFF
--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -34,6 +34,7 @@ jobs:
         with:
           extra-conf: |
             experimental-features = nix-command flakes
+            accept-flake-config = true
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: jonpulsifer

--- a/.github/workflows/nixos-deploy.yaml
+++ b/.github/workflows/nixos-deploy.yaml
@@ -40,6 +40,7 @@ jobs:
         with:
           extra-conf: |
             experimental-features = nix-command flakes
+            accept-flake-config = true
 
       - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:


### PR DESCRIPTION
## Summary

- Adds `accept-flake-config = true` to the Nix install step in `nix-image-builder.yaml` and `nixos-deploy.yaml`.
- Without it, a fresh Nix install (every CI run) ignores `flake.nix`'s `nixConfig` (`extra-substituters`/`extra-trusted-public-keys` for `nixos-raspberrypi.cachix.org`), warning "ignoring untrusted flake configuration setting" and silently never using that cache.
- Split out of #1058 (radiopi0) — that commit landed on the branch after the PR was already merged, so it never made it into `main`.

## Test plan

- [ ] Trigger `nix-image-builder` or `nixos-deploy` on this branch and confirm no "ignoring untrusted flake configuration setting" warning, and that `nixos-raspberrypi.cachix.org` substitutions actually occur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXHMQMfawe7aBnbJCo9okF