### PR TITLE
fix(dotfiles): backport local chezmoi drift and fix stale host alias

### DIFF
--- a/dotfiles/dot_pi/agent/settings.json
+++ b/dotfiles/dot_pi/agent/settings.json
@@ -1,7 +1,7 @@
 {
-  "lastChangelogVersion": "0.78.0",
-  "defaultProvider": "openai-codex",
-  "defaultModel": "gpt-5.5",
+  "lastChangelogVersion": "0.80.3",
+  "defaultProvider": "opencode-go",
+  "defaultModel": "minimax-m2.7",
   "defaultThinkingLevel": "high",
   "hideThinkingBlock": false,
   "theme": "hipster-night",

--- a/dotfiles/private_dot_ssh/config.tmpl
+++ b/dotfiles/private_dot_ssh/config.tmpl
@@ -1,22 +1,16 @@
 # Managed by chezmoi
 
-Host *.fml.pulsifer.ca
-  Port 22
-  ForwardAgent yes
-
-Host *.lolwtf.ca
-  Port 22
+Host *.fml.pulsifer.ca *.lolwtf.ca
   ForwardAgent yes
 
 Host *.pirate-musical.ts.net
-  Port 22
   ForwardAgent yes
   StrictHostKeyChecking accept-new
 
 Host github.com
   User git
 
-Host *pi0* *pi4* *pi5*
+Host *pi0*
   User pi
   ForwardAgent yes
   PasswordAuthentication yes
@@ -40,12 +34,12 @@ Host compute.*
   ForwardAgent yes
   ChallengeResponseAuthentication yes
 
-Host optiplex riptide nuc 800g2
+Host optiplex riptide nuc shale
   CanonicalizeHostname yes
-  CanonicalDomains pirate-musical.ts.net lolwtf.ca
+  CanonicalDomains lolwtf.ca pirate-musical.ts.net
   CanonicalizeMaxDots 0
 
-Host retrofit offsite shale oldschool oldboy
+Host retrofit offsite oldschool oldboy
   CanonicalizeHostname yes
   CanonicalDomains pirate-musical.ts.net
   CanonicalizeMaxDots 0
@@ -53,6 +47,7 @@ Host retrofit offsite shale oldschool oldboy
 Host *
   AddKeysToAgent yes
   AddressFamily inet
+  Port 22
   ChallengeResponseAuthentication no
   ForwardX11 no
   ForwardX11Trusted no


### PR DESCRIPTION
## Summary
Backports local chezmoi drift (`chezmoi diff`) into the dotfiles source, and fixes a stale host alias in the SSH config that predates a hardware rename.

## Changes
- chore(dotfiles): sync agent settings from local chezmoi state
- fix(dotfiles): sync ssh config and fix stale 800g2/shale host alias

## Test Plan
- [x] `chezmoi diff` shows no pending changes for `.ssh/config` after this backport
- [x] Confirmed via `terraform/network/unifi/folly/k8s.tf` that `shale.lolwtf.ca` is the current DNS record for the box formerly known as `800g2`
