### PR TITLE
fix(ci): build native nix images

### DIFF
--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -21,9 +21,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
-    # radiopi0 (armv6l) cross-compiles from aarch64-linux (nix/hardware/pi0.nix
-    # sets nixpkgs.buildPlatform/hostPlatform) same as the native aarch64 pi4
-    # builds -- both want the arm64 runner, just for different reasons.
+    # Build Raspberry Pi images on the native ARM runner. The other image
+    # targets are x86_64 NixOS configurations and use the standard runner.
     runs-on: ${{ (contains(inputs.image, 'pi4') || inputs.image == 'radiopi0') && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     permissions:
       contents: read
@@ -40,7 +39,13 @@ jobs:
           name: jonpulsifer
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           skipPush: ${{ github.ref != 'refs/heads/main' }}
-      - run: nix build .#${{ inputs.image }}
+      - name: Build image
+        run: |
+          if [[ "${{ contains(inputs.image, 'pi4') || inputs.image == 'radiopi0' }}" == "true" ]]; then
+            nix build ".#nixosConfigurations.${{ inputs.image }}.config.system.build.sdImage"
+          else
+            nix build ".#packages.x86_64-linux.${{ inputs.image }}"
+          fi
 
       - name: Build WSL tarball
         if: ${{ inputs.image == 'wsl' }}
@@ -70,7 +75,7 @@ jobs:
         with:
           name: ${{ inputs.image }}-sd-image
           path: result/sd-image/nixos-image-sd-card-*
-          retention-days: 1
+          retention-days: 30
           compression-level: 0
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -75,7 +75,7 @@ jobs:
         with:
           name: ${{ inputs.image }}-sd-image
           path: result/sd-image/nixos-image-sd-card-*
-          retention-days: 30
+          retention-days: 1
           compression-level: 0
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/README.md
+++ b/README.md
@@ -53,9 +53,21 @@ nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel
 # Build installation media
 nix build .#iso         # x86_64 NixOS ISO
 nix build .#wsl         # WSL tarball
-nix build .#cloudpi4    # Raspberry Pi 4 SD image (cross-built via qemu emulation)
-nix build .#dns         # Raspberry Pi 5 SD image (cross-built via qemu emulation)
+nix build .#cloudpi4    # Raspberry Pi 4 SD image (local x86_64 build)
+nix build .#dns         # Raspberry Pi 5 SD image (local x86_64 build)
 ```
+
+For native Raspberry Pi image builds, run the host configuration on an
+`aarch64-linux` machine:
+
+```bash
+nix build .#nixosConfigurations.cloudpi4.config.system.build.sdImage
+```
+
+The manual `nix-image-builder` GitHub Actions workflow builds Pi images on a
+native ARM runner. Select an image from the workflow dispatch menu, then
+download the image from the run's artifact named `<image>-sd-image`; artifacts
+are retained for one day.
 
 See [`nix/README.md`](./nix/README.md) for detailed NixOS documentation.
 

--- a/docs/pages/Architecture___GitOps.md
+++ b/docs/pages/Architecture___GitOps.md
@@ -16,7 +16,7 @@ tags:: architecture
 	- `trivy.yml` — scans `.tf` and `clusters/**` for CRITICAL/HIGH IaC vulnerabilities
 	- `wiki.yml` — builds this wiki from `docs/` and deploys it to Cloudflare Pages
 	- `pulsifer-ca.yml` — builds and deploys the Hugo site to GitHub Pages
-	- `nixos-deploy.yaml`, `nix-ci.yaml`, `nix-image-builder.yaml` — NixOS build/deploy pipelines
+	- `nixos-deploy.yaml`, `nix-ci.yaml`, `nix-image-builder.yaml` — NixOS build/deploy pipelines; the manual image builder produces downloadable Pi SD-image artifacts from native ARM runners, retained for one day
 	- **Renovate** opens PRs for Helm charts, container images, Terraform providers, and GitHub Actions
 - ## The bootstrap exceptions
 	- Two places where a layer reaches into another: the Flux bootstrap (`clusters/<site>/bootstrap/` Terraform installs `flux-operator`/`flux-instance`), and the Atlantis ↔ ArgoCD auth wiring (see [[Runbooks/Kubernetes GitOps Change]] for token rotation).

--- a/docs/pages/Architecture___NixOS.md
+++ b/docs/pages/Architecture___NixOS.md
@@ -19,6 +19,10 @@ tags:: architecture
 	- ```bash
 	  nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel
 	  ```
+	- Build a Raspberry Pi SD image natively on ARM:
+	- ```bash
+	  nix build .#nixosConfigurations.<hostname>.config.system.build.sdImage
+	  ```
 	- Deploy immediately:
 	- ```bash
 	  nixos-rebuild switch --flake .#<hostname> --target-host <hostname> --sudo
@@ -31,6 +35,10 @@ tags:: architecture
 	- ```bash
 	  sudo nixos-rebuild switch --rollback
 	  ```
+- ## Downloadable Pi images
+	- Run the manual `nix-image-builder` workflow from GitHub Actions and select a Raspberry Pi image.
+	- Pi images build on a native `ubuntu-24.04-arm` runner and are uploaded as `<image>-sd-image` artifacts.
+	- Artifacts are retained for one day, so download them from the workflow run promptly.
 - ## Auto-upgrades keep git honest
 	- Hosts auto-rebuild from GitHub `main`. A config deployed from a branch **silently reverts** on the next upgrade cycle unless the branch merges promptly. Treat `nixos-rebuild` from a branch as a test, not a deploy.
 - ## Disk layout

--- a/nix/README.md
+++ b/nix/README.md
@@ -66,8 +66,16 @@ nix build .#wsl         # WSL tarball
 nix build .#gce         # Google Compute Engine image
 
 # Build Raspberry Pi images
-nix build .#cloudpi4    # SD card image
+nix build .#cloudpi4    # SD card image from an x86_64 build host
+
+# Build natively on an ARM host
+nix build .#nixosConfigurations.cloudpi4.config.system.build.sdImage
 ```
+
+The `nix-image-builder` GitHub Actions workflow builds Raspberry Pi images on
+native `ubuntu-24.04-arm` runners. Run it manually from the Actions tab, choose
+an image, and download the resulting `<image>-sd-image` artifact. GitHub keeps
+these image artifacts for one day.
 
 ### Deploying Updates
 


### PR DESCRIPTION
## Summary
Fix the Nix image builder so Raspberry Pi SD images build natively on ARM runners and are available as downloadable GitHub artifacts.

## Changes
- fix(ci): build native nix images

## Test Plan
- [x] git diff --check
- [x] Reviewer pass completed
- [ ] Dispatch the workflow with cloudpi4 and verify the uploaded sd-image artifact
