### PR TITLE
feat(dotfiles): add neovim config with native LSP setup

### DIFF
--- a/dotfiles/dot_config/mise/config.toml.tmpl
+++ b/dotfiles/dot_config/mise/config.toml.tmpl
@@ -27,6 +27,7 @@ krew = "latest"
 {{- if eq .chezmoi.os "linux" }}
 btop = "latest"
 neovim = "latest"
+node = "latest" # runtime for npm-based LSP servers (yamlls, bashls, jsonls) installed by mason
 {{- if contains "microsoft" .chezmoi.kernel.osrelease }}
 gcloud = "latest"
 codex = "latest"

--- a/dotfiles/dot_config/nvim/init.lua
+++ b/dotfiles/dot_config/nvim/init.lua
@@ -1,0 +1,43 @@
+-- Leaders must be set before lazy.nvim (and any plugins) load
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
+require("config.options")
+require("config.keymaps")
+
+-- Bootstrap lazy.nvim
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.uv.fs_stat(lazypath) then
+  local out = vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "--branch=stable",
+    "https://github.com/folke/lazy.nvim.git",
+    lazypath,
+  })
+  if vim.v.shell_error ~= 0 then
+    vim.api.nvim_echo({
+      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+      { out, "WarningMsg" },
+      { "\nPress any key to exit..." },
+    }, true, {})
+    vim.fn.getchar()
+    os.exit(1)
+  end
+end
+vim.opt.rtp:prepend(lazypath)
+
+-- Plugin manager setup
+require("lazy").setup({
+  spec = {
+    { import = "plugins" },
+  },
+  install = { colorscheme = { "tokyonight" } },
+  checker = { enabled = true, notify = false },
+  change_detection = { notify = false },
+})
+
+-- Native LSP: enable the servers configured in <config>/lsp/
+-- (after lazy so mason's bin dir is on PATH and blink.cmp is requirable)
+require("config.lsp")

--- a/dotfiles/dot_config/nvim/lazy-lock.json
+++ b/dotfiles/dot_config/nvim/lazy-lock.json
@@ -1,0 +1,16 @@
+{
+  "alpha-nvim": { "branch": "main", "commit": "6c6a89d5b068b5251c8bdf0dd57bb921bcfeeb09" },
+  "blink.cmp": { "branch": "main", "commit": "78336bc89ee5365633bcf754d93df01678b5c08f" },
+  "bufferline.nvim": { "branch": "main", "commit": "655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3" },
+  "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "mason.nvim": { "branch": "main", "commit": "2a6940af80375532e5e9e7c1f2fc6319a1b7a69d" },
+  "mini.pick": { "branch": "main", "commit": "04e73ab07222508361095bb6e27621b315e6b9f1" },
+  "neo-tree.nvim": { "branch": "v3.x", "commit": "ebd66767191714e008ce73b769518a763ff31bdc" },
+  "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
+  "nvim-web-devicons": { "branch": "master", "commit": "dad71387de386a946b123079d0e53f23028f3abd" },
+  "oil.nvim": { "branch": "master", "commit": "b73018b75affd13fa38e2fc94ef753b465f770d7" },
+  "plenary.nvim": { "branch": "master", "commit": "74b06c6c75e4eeb3108ec01852001636d85a932b" },
+  "tokyonight.nvim": { "branch": "main", "commit": "cdc07ac78467a233fd62c493de29a17e0cf2b2b6" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
+}

--- a/dotfiles/dot_config/nvim/lsp/bashls.lua
+++ b/dotfiles/dot_config/nvim/lsp/bashls.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { "bash-language-server", "start" },
+  filetypes = { "bash", "sh" },
+  root_markers = { ".git" },
+}

--- a/dotfiles/dot_config/nvim/lsp/gopls.lua
+++ b/dotfiles/dot_config/nvim/lsp/gopls.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { "gopls" },
+  filetypes = { "go", "gomod", "gowork", "gotmpl" },
+  root_markers = { "go.work", "go.mod", ".git" },
+}

--- a/dotfiles/dot_config/nvim/lsp/jsonls.lua
+++ b/dotfiles/dot_config/nvim/lsp/jsonls.lua
@@ -1,0 +1,6 @@
+return {
+  cmd = { "vscode-json-language-server", "--stdio" },
+  filetypes = { "json", "jsonc" },
+  root_markers = { ".git" },
+  init_options = { provideFormatter = true },
+}

--- a/dotfiles/dot_config/nvim/lsp/lua_ls.lua
+++ b/dotfiles/dot_config/nvim/lsp/lua_ls.lua
@@ -1,0 +1,11 @@
+return {
+  cmd = { "lua-language-server" },
+  filetypes = { "lua" },
+  root_markers = { ".luarc.json", ".luarc.jsonc", ".git" },
+  settings = {
+    Lua = {
+      workspace = { checkThirdParty = false },
+      diagnostics = { globals = { "vim" } },
+    },
+  },
+}

--- a/dotfiles/dot_config/nvim/lsp/nil_ls.lua
+++ b/dotfiles/dot_config/nvim/lsp/nil_ls.lua
@@ -1,0 +1,6 @@
+-- not mason-managed: nix hosts provide `nil` themselves (see config/lsp.lua guard)
+return {
+  cmd = { "nil" },
+  filetypes = { "nix" },
+  root_markers = { "flake.nix", ".git" },
+}

--- a/dotfiles/dot_config/nvim/lsp/terraformls.lua
+++ b/dotfiles/dot_config/nvim/lsp/terraformls.lua
@@ -1,0 +1,5 @@
+return {
+  cmd = { "terraform-ls", "serve" },
+  filetypes = { "terraform", "terraform-vars" },
+  root_markers = { ".terraform", ".git" },
+}

--- a/dotfiles/dot_config/nvim/lsp/yamlls.lua
+++ b/dotfiles/dot_config/nvim/lsp/yamlls.lua
@@ -1,0 +1,9 @@
+return {
+  cmd = { "yaml-language-server", "--stdio" },
+  filetypes = { "yaml", "yaml.docker-compose", "yaml.gitlab" },
+  root_markers = { ".git" },
+  settings = {
+    redhat = { telemetry = { enabled = false } },
+    yaml = { keyOrdering = false },
+  },
+}

--- a/dotfiles/dot_config/nvim/lua/config/keymaps.lua
+++ b/dotfiles/dot_config/nvim/lua/config/keymaps.lua
@@ -1,0 +1,49 @@
+local map = vim.keymap.set
+
+-- Clear search highlight
+map("n", "<Esc>", "<cmd>nohlsearch<CR>", { desc = "Clear search highlight" })
+
+-- Window navigation
+map("n", "<C-h>", "<C-w>h", { desc = "Move to left window" })
+map("n", "<C-j>", "<C-w>j", { desc = "Move to lower window" })
+map("n", "<C-k>", "<C-w>k", { desc = "Move to upper window" })
+map("n", "<C-l>", "<C-w>l", { desc = "Move to right window" })
+
+-- Window resizing
+map("n", "<C-Up>", "<cmd>resize +2<CR>", { desc = "Increase window height" })
+map("n", "<C-Down>", "<cmd>resize -2<CR>", { desc = "Decrease window height" })
+map("n", "<C-Left>", "<cmd>vertical resize -2<CR>", { desc = "Decrease window width" })
+map("n", "<C-Right>", "<cmd>vertical resize +2<CR>", { desc = "Increase window width" })
+
+-- Move lines
+map("n", "<A-j>", "<cmd>m .+1<CR>==", { desc = "Move line down" })
+map("n", "<A-k>", "<cmd>m .-2<CR>==", { desc = "Move line up" })
+map("v", "<A-j>", ":m '>+1<CR>gv=gv", { desc = "Move selection down" })
+map("v", "<A-k>", ":m '<-2<CR>gv=gv", { desc = "Move selection up" })
+
+-- Stay in visual mode while indenting
+map("v", "<", "<gv", { desc = "Indent left" })
+map("v", ">", ">gv", { desc = "Indent right" })
+
+-- Centered scrolling / searching
+map("n", "<C-d>", "<C-d>zz", { desc = "Scroll down (centered)" })
+map("n", "<C-u>", "<C-u>zz", { desc = "Scroll up (centered)" })
+map("n", "n", "nzzzv", { desc = "Next search result (centered)" })
+map("n", "N", "Nzzzv", { desc = "Previous search result (centered)" })
+
+-- Save / quit
+map("n", "<leader>w", "<cmd>write<CR>", { desc = "Save file" })
+map("n", "<leader>q", "<cmd>quit<CR>", { desc = "Quit" })
+
+-- Buffers
+map("n", "<S-h>", "<cmd>bprevious<CR>", { desc = "Previous buffer" })
+map("n", "<S-l>", "<cmd>bnext<CR>", { desc = "Next buffer" })
+map("n", "<leader>bd", "<cmd>bdelete<CR>", { desc = "Delete buffer" })
+
+-- Paste without yanking replaced text
+map("v", "<leader>p", '"_dP', { desc = "Paste without yanking" })
+
+-- Diagnostics
+map("n", "<leader>d", vim.diagnostic.open_float, { desc = "Show line diagnostics" })
+map("n", "[d", function() vim.diagnostic.jump({ count = -1, float = true }) end, { desc = "Previous diagnostic" })
+map("n", "]d", function() vim.diagnostic.jump({ count = 1, float = true }) end, { desc = "Next diagnostic" })

--- a/dotfiles/dot_config/nvim/lua/config/lsp.lua
+++ b/dotfiles/dot_config/nvim/lua/config/lsp.lua
@@ -1,0 +1,53 @@
+-- Native LSP wiring (nvim 0.11+): one config file per server in <config>/lsp/,
+-- binaries installed by mason (lua/plugins/lsp.lua), enabled by the scan below.
+
+-- Rounded floats, severity-sorted, nerd-font signs
+vim.diagnostic.config({
+  severity_sort = true,
+  float = { border = "rounded" },
+  signs = {
+    text = {
+      [vim.diagnostic.severity.ERROR] = "",
+      [vim.diagnostic.severity.WARN] = "",
+      [vim.diagnostic.severity.HINT] = "",
+      [vim.diagnostic.severity.INFO] = "",
+    },
+  },
+})
+
+-- Advertise blink.cmp completion capabilities to every server
+local has_blink, blink = pcall(require, "blink.cmp")
+if has_blink then
+  vim.lsp.config("*", { capabilities = blink.get_lsp_capabilities() })
+end
+
+-- Buffer-local keymaps once a server attaches
+vim.api.nvim_create_autocmd("LspAttach", {
+  callback = function(args)
+    local map = function(mode, lhs, rhs, desc)
+      vim.keymap.set(mode, lhs, rhs, { buffer = args.buf, desc = desc })
+    end
+
+    map("n", "gd", vim.lsp.buf.definition, "lsp: goto definition")
+    map("n", "gD", vim.lsp.buf.declaration, "lsp: goto declaration")
+    map("n", "gr", vim.lsp.buf.references, "lsp: references")
+    map("n", "gI", vim.lsp.buf.implementation, "lsp: goto implementation")
+    map("n", "K", vim.lsp.buf.hover, "lsp: hover")
+    map("n", "<leader>lr", vim.lsp.buf.rename, "lsp: rename")
+    map("n", "<leader>la", vim.lsp.buf.code_action, "lsp: code action")
+    map("n", "<leader>lf", function()
+      vim.lsp.buf.format({ async = true })
+    end, "lsp: format")
+  end,
+})
+
+-- Enable every server that has a config file on the runtimepath (lsp/*.lua)
+local servers = {}
+for _, f in ipairs(vim.api.nvim_get_runtime_file("lsp/*.lua", true)) do
+  local name = vim.fn.fnamemodify(f, ":t:r")
+  -- nil_ls isn't mason-managed; only enable it where nix put `nil` on PATH
+  if name ~= "nil_ls" or vim.fn.executable("nil") == 1 then
+    table.insert(servers, name)
+  end
+end
+vim.lsp.enable(servers)

--- a/dotfiles/dot_config/nvim/lua/config/options.lua
+++ b/dotfiles/dot_config/nvim/lua/config/options.lua
@@ -1,0 +1,65 @@
+local opt = vim.opt
+
+-- Indentation
+opt.tabstop = 2
+opt.shiftwidth = 2
+opt.expandtab = true
+opt.smartindent = true
+opt.autoindent = true
+opt.smarttab = true
+
+-- UI
+opt.number = true
+opt.relativenumber = true
+opt.cursorline = true
+opt.signcolumn = "yes"
+opt.termguicolors = true
+opt.showmode = false
+opt.wildmode = "longest:full,full"
+
+-- Search
+opt.ignorecase = true
+opt.smartcase = true
+opt.hlsearch = true
+opt.incsearch = true
+
+-- Scrolling
+opt.scrolloff = 8
+opt.sidescrolloff = 8
+
+-- Mouse / clipboard
+opt.mouse = "a"
+opt.clipboard = "unnamedplus"
+
+-- Whitespace display
+opt.list = true
+opt.listchars = { tab = "→ ", trail = "·", extends = ">", precedes = "<" }
+opt.fillchars = { vert = "│", fold = "─", eob = " " }
+
+-- Folding
+opt.foldenable = false
+opt.foldmethod = "indent"
+opt.foldlevel = 99
+
+-- Responsiveness
+opt.updatetime = 300
+opt.timeoutlen = 300 -- short so which-key pops quickly
+
+-- Splits
+opt.splitright = true
+opt.splitbelow = true
+
+-- Persistence
+opt.undofile = true
+opt.swapfile = false
+
+-- Messages
+opt.shortmess:append("c")
+
+-- Built-in treesitter (nvim 0.11+): highlight when a parser exists,
+-- silently fall back to regex syntax when it doesn't
+vim.api.nvim_create_autocmd("FileType", {
+  callback = function(args)
+    pcall(vim.treesitter.start, args.buf)
+  end,
+})

--- a/dotfiles/dot_config/nvim/lua/plugins/completion.lua
+++ b/dotfiles/dot_config/nvim/lua/plugins/completion.lua
@@ -1,0 +1,19 @@
+return {
+  "saghen/blink.cmp",
+  version = "1.*",
+  event = "InsertEnter",
+  dependencies = { "rafamadriz/friendly-snippets" },
+  opts = {
+    keymap = { preset = "enter" },
+    appearance = {
+      nerd_font_variant = "mono",
+    },
+    completion = {
+      documentation = { auto_show = true },
+    },
+    signature = { enabled = true },
+    sources = {
+      default = { "lsp", "path", "snippets", "buffer" },
+    },
+  },
+}

--- a/dotfiles/dot_config/nvim/lua/plugins/dashboard.lua
+++ b/dotfiles/dot_config/nvim/lua/plugins/dashboard.lua
@@ -1,0 +1,43 @@
+return {
+  "goolord/alpha-nvim",
+  event = "VimEnter",
+  dependencies = { "nvim-tree/nvim-web-devicons" },
+  config = function()
+    local dashboard = require("alpha.themes.dashboard")
+
+    dashboard.section.header.val = {
+      "                                                     ",
+      "  ███╗   ██╗███████╗ ██████╗ ██╗   ██╗██╗███╗   ███╗ ",
+      "  ████╗  ██║██╔════╝██╔═══██╗██║   ██║██║████╗ ████║ ",
+      "  ██╔██╗ ██║█████╗  ██║   ██║██║   ██║██║██╔████╔██║ ",
+      "  ██║╚██╗██║██╔══╝  ██║   ██║╚██╗ ██╔╝██║██║╚██╔╝██║ ",
+      "  ██║ ╚████║███████╗╚██████╔╝ ╚████╔╝ ██║██║ ╚═╝ ██║ ",
+      "  ╚═╝  ╚═══╝╚══════╝ ╚═════╝   ╚═══╝  ╚═╝╚═╝     ╚═╝ ",
+      "                                                     ",
+    }
+
+    dashboard.section.buttons.val = {
+      dashboard.button("f", "  Find file", ":lua require('mini.pick').builtin.files()<CR>"),
+      dashboard.button("g", "  Live grep", ":lua require('mini.pick').builtin.grep_live()<CR>"),
+      dashboard.button("e", "  New file", ":ene <BAR> startinsert<CR>"),
+      dashboard.button("c", "  Config", ":e ~/.config/nvim/init.lua<CR>"),
+      dashboard.button("l", "󰒲  Lazy", ":Lazy<CR>"),
+      dashboard.button("q", "  Quit", ":qa<CR>"),
+    }
+
+    dashboard.section.footer.val = ""
+
+    require("alpha").setup(dashboard.opts)
+
+    -- Swap in lazy.nvim's plugin count + startuptime once it reports them
+    vim.api.nvim_create_autocmd("User", {
+      pattern = "LazyVimStarted",
+      callback = function()
+        local stats = require("lazy").stats()
+        local ms = math.floor(stats.startuptime * 100 + 0.5) / 100
+        dashboard.section.footer.val = "⚡ " .. stats.count .. " plugins loaded in " .. ms .. "ms"
+        pcall(vim.cmd.AlphaRedraw)
+      end,
+    })
+  end,
+}

--- a/dotfiles/dot_config/nvim/lua/plugins/lsp.lua
+++ b/dotfiles/dot_config/nvim/lua/plugins/lsp.lua
@@ -1,0 +1,29 @@
+-- mason only installs server binaries; server configs live in <config>/lsp/
+-- and are enabled natively by lua/config/lsp.lua (nvim 0.11+ vim.lsp.enable)
+return {
+  "mason-org/mason.nvim",
+  lazy = false, -- must set up early so its bin dir is on PATH before servers start
+  opts = {},
+  config = function(_, opts)
+    require("mason").setup(opts)
+
+    local ensure_installed = {
+      "lua-language-server",
+      "gopls",
+      "terraform-ls",
+      "yaml-language-server",
+      "bash-language-server",
+      "json-lsp",
+    }
+
+    local registry = require("mason-registry")
+    registry.refresh(function()
+      for _, name in ipairs(ensure_installed) do
+        local pkg = registry.get_package(name)
+        if not pkg:is_installed() then
+          pkg:install()
+        end
+      end
+    end)
+  end,
+}

--- a/dotfiles/dot_config/nvim/lua/plugins/navigation.lua
+++ b/dotfiles/dot_config/nvim/lua/plugins/navigation.lua
@@ -1,0 +1,94 @@
+return {
+  -- Fuzzy finder
+  {
+    "echasnovski/mini.pick",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    keys = {
+      { "<leader>ff", function() require("mini.pick").builtin.files() end, desc = "find files" },
+      { "<leader>fg", function() require("mini.pick").builtin.grep_live() end, desc = "live grep" },
+      { "<leader>fb", function() require("mini.pick").builtin.buffers() end, desc = "find buffers" },
+      { "<leader>fh", function() require("mini.pick").builtin.help() end, desc = "find help" },
+      { "<leader>fr", function() require("mini.pick").builtin.resume() end, desc = "resume last picker" },
+      { "<leader><leader>", function() require("mini.pick").builtin.buffers() end, desc = "find buffers" },
+    },
+    opts = {},
+  },
+
+  -- File tree sidebar
+  {
+    "nvim-neo-tree/neo-tree.nvim",
+    branch = "v3.x",
+    dependencies = {
+      "nvim-lua/plenary.nvim",
+      "MunifTanjim/nui.nvim",
+      "nvim-tree/nvim-web-devicons",
+    },
+    keys = {
+      { "<leader>e", ":Neotree toggle<CR>", desc = "toggle file explorer" },
+    },
+    opts = {
+      close_if_last_window = true,
+      filesystem = {
+        follow_current_file = { enabled = true },
+        -- oil owns directory buffers (default_file_explorer below)
+        hijack_netrw_behavior = "disabled",
+      },
+      default_component_configs = {
+        git_status = {
+          symbols = {
+            added = "",
+            modified = "",
+            deleted = "",
+            renamed = "",
+            untracked = "",
+            ignored = "",
+            unstaged = "",
+            staged = "",
+            conflict = "",
+          },
+        },
+      },
+    },
+  },
+
+  -- Edit directories as buffers
+  {
+    "stevearc/oil.nvim",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    keys = {
+      { "-", "<CMD>Oil<CR>", desc = "open parent directory" },
+    },
+    opts = {
+      default_file_explorer = true,
+      view_options = {
+        show_hidden = true,
+      },
+    },
+  },
+
+  -- Buffer line / tabs
+  {
+    "akinsho/bufferline.nvim",
+    version = "*",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    event = "VeryLazy",
+    keys = {
+      { "[b", "<CMD>BufferLineCyclePrev<CR>", desc = "prev buffer" },
+      { "]b", "<CMD>BufferLineCycleNext<CR>", desc = "next buffer" },
+    },
+    opts = {
+      options = {
+        diagnostics = "nvim_lsp",
+        separator_style = "slant",
+        offsets = {
+          {
+            filetype = "neo-tree",
+            text = "File Explorer",
+            highlight = "Directory",
+            text_align = "left",
+          },
+        },
+      },
+    },
+  },
+}

--- a/dotfiles/dot_config/nvim/lua/plugins/ui.lua
+++ b/dotfiles/dot_config/nvim/lua/plugins/ui.lua
@@ -1,0 +1,37 @@
+return {
+  -- Colorscheme
+  {
+    "folke/tokyonight.nvim",
+    lazy = false,
+    priority = 1000,
+    opts = {
+      style = "night",
+    },
+    config = function(_, opts)
+      require("tokyonight").setup(opts)
+      vim.cmd.colorscheme("tokyonight")
+    end,
+  },
+
+  -- Nerd-font icons used by which-key, mini.pick, neo-tree, bufferline
+  {
+    "nvim-tree/nvim-web-devicons",
+    lazy = true,
+  },
+
+  -- Popup keymap hints/discovery
+  {
+    "folke/which-key.nvim",
+    event = "VeryLazy",
+    config = function()
+      local wk = require("which-key")
+      wk.setup({})
+      wk.add({
+        { "<leader>f", group = "find" },
+        { "<leader>b", group = "buffer" },
+        { "<leader>g", group = "git" },
+        { "<leader>l", group = "lsp" },
+      })
+    end,
+  },
+}


### PR DESCRIPTION
## Summary
Adds a chezmoi-managed Neovim config to dotfiles: lazy.nvim with a small curated plugin set, and LSP done the native nvim 0.11+ way — mason installs binaries only, per-server configs live in `lsp/*.lua`, and `config/lsp.lua` enables whatever it finds on the runtimepath (no nvim-lspconfig / mason-lspconfig plugins). Treesitter highlighting uses the nvim 0.12 built-in, so no parser compilation and no C compiler needed on NixOS hosts.

## Changes
- feat(dotfiles): add neovim config (lazy.nvim, native LSP)
  - `init.lua` + `lua/config/{options,keymaps,lsp}.lua`, plugins split per file under `lua/plugins/`
  - plugins: alpha-nvim, which-key, mini.pick, neo-tree, oil, bufferline, tokyonight, blink.cmp, mason (14 total, `lazy-lock.json` pinned)
  - `lsp/`: lua_ls, gopls, terraformls, yamlls, bashls, jsonls, nil_ls (nil_ls only enabled where nix provides `nil`)
- feat(dotfiles): add node to global mise tools — yamlls/bashls/jsonls are npm packages; mason can't install them without node/npm on PATH (root cause of the `failed to install` errors)

## Test Plan
- [x] headless boot in a sandboxed XDG env: zero startup errors, all plugins load
- [x] mason installed all 6 servers with mise node/go on PATH
- [x] `lua_ls` and `yamlls` attach to real buffers (config + a cluster manifest)
- [ ] after merge: `chezmoi apply && mise install`, open nvim, `:Mason` shows servers green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
