### PR TITLE
fix(nix): minimize pi4 initrd

### DIFF
--- a/nix/hardware/pi4/default.nix
+++ b/nix/hardware/pi4/default.nix
@@ -29,13 +29,26 @@
 
   boot = {
     zfs.forceImportRoot = false;
+
+    # The generic aarch64 installer image pulls in all-hardware.nix, which
+    # otherwise adds drivers for SATA, NVMe, RAID, virtio, displays, and other
+    # boards to the initrd.  The Pi 4 kernel has its SD host controller and
+    # ext4 support built in; only the modular MMC block driver is needed to
+    # mount an ext4 root from the SD card.
+    initrd = {
+      availableKernelModules = lib.mkForce [ "mmc_block" ];
+      kernelModules = lib.mkForce [ ];
+    };
+
     kernelParams = [
       "console=tty0"
       "cma=256M"
       "cgroup_enable=cpuset"
       "cgroup_enable=memory"
     ];
-    supportedFilesystems = [
+    # sd-image-aarch64 enables the installer filesystem set by default.  These
+    # hosts only need ext4 for root and vfat for the firmware partition.
+    supportedFilesystems = lib.mkForce [
       "ext4"
       "vfat"
     ];


### PR DESCRIPTION
## Summary
Minimize the SD-card initrd shared by the Pi 4 hosts so the native ARM image build carries only the boot support these systems need.

## Changes
- Force the initrd module set to the modular `mmc_block` driver; the SD host controller and ext4 are built into the Pi kernel.
- Limit supported filesystems to ext4 root and vfat firmware partitions, removing installer defaults such as ZFS.

## Test Plan
- [x] Format `nix/hardware/pi4/default.nix` with the flake formatter.
- [x] Evaluate cloudpi4, homepi4, and weatherpi4 boot module/filesystem settings.
- [ ] Build the cloudpi4 SD image on the native ARM GitHub Actions runner.
