### PR TITLE
fix(nix): minimize radiopi0/blinkypi0 initrd, drop zfs from the closure

### DIFF
--- a/nix/hardware/pi0.nix
+++ b/nix/hardware/pi0.nix
@@ -46,7 +46,26 @@
   # Required for the Pi Zero W's wifi/bt firmware (bcm43438).
   hardware.enableRedistributableFirmware = true;
 
-  boot.zfs.forceImportRoot = false;
+  boot = {
+    # sd-image-raspberrypi pulls in the generic installer's filesystem set
+    # (zfs, btrfs, cifs, f2fs, ntfs, xfs) via profiles/base.nix -- all
+    # irrelevant here, and zfs in particular is a large, slow, from-source
+    # cross build with no armv6l cache. Only ext4 (root) and vfat (firmware
+    # partition) are actually used.
+    supportedFilesystems = lib.mkForce [
+      "ext4"
+      "vfat"
+    ];
+
+    # Same installer default pulls in drivers for SATA, NVMe, RAID, virtio,
+    # and USB HID devices that don't exist on this board. The Pi Zero W's SD
+    # host controller is built into the kernel; only the modular MMC block
+    # driver is needed to mount an ext4 root from the SD card.
+    initrd = {
+      availableKernelModules = lib.mkForce [ "mmc_block" ];
+      kernelModules = lib.mkForce [ ];
+    };
+  };
 
   sdImage.compressImage = true;
 }


### PR DESCRIPTION
## Summary

- To answer the question directly: no, we weren't avoiding zfs entirely — `boot.zfs.forceImportRoot = false` only affects import-root behavior, not whether zfs actually gets built. `radiopi0`'s `supportedFilesystems` had merged in the generic installer's full default set (`zfs`, `btrfs`, `cifs`, `f2fs`, `ntfs`, `xfs`) since nothing forced the list, and the initrd carried a large irrelevant driver set (SATA/NVMe/RAID/virtio/USB HID) via `all-hardware.nix`.
- Applies the same fix as the just-merged pi4 initrd minimization (#1066): `lib.mkForce` `supportedFilesystems` down to `ext4`+`vfat`, and initrd modules down to just `mmc_block`.
- Matters more here than on pi4: everything on this armv6l cross target builds from source with no binary cache, so zfs (a large, slow build) was pure waste.
- Shared `nix/hardware/pi0.nix`, so this covers both `radiopi0` and `blinkypi0`.

## Test plan

- [x] `nix eval` confirms `boot.supportedFilesystems` is now just `{ ext4 = true; vfat = true; }`
- [x] `nix eval` confirms `boot.initrd.availableKernelModules` is now just `["mmc_block"]`, `kernelModules` is `[]`
- [x] `nix-store -q --requisites` on the toplevel closure confirms no `zfs` package present anymore
- [x] `radiopi0` and `blinkypi0` toplevel configs both still evaluate cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FXHMQMfawe7aBnbJCo9okF