### PR TITLE
refactor(network): derive firewall CIDRs from cluster-topology SSOT

### DIFF
--- a/nix/services/k8s/networks.nix
+++ b/nix/services/k8s/networks.nix
@@ -23,6 +23,9 @@ let
     serviceCidr = d.SERVICE_CIDR;
     dns = lib.splitString "," d.CLUSTER_DNS;
     upstreamDns = d.ROUTER_IP;
+    # NFS export and firewall require the node CIDR and the LB VIP pool.
+    nodeCidr = d.K8S_NODE_CIDR;
+    lbRange = d.LB_RANGE;
   };
 in
 {

--- a/nix/services/nfs-server.nix
+++ b/nix/services/nfs-server.nix
@@ -14,8 +14,8 @@
 # `homelab.nfsServer.dataDevice` to a by-label path instead.
 { config, lib, ... }:
 let
-  # folly cluster CIDRs come from the network SSOT (see nix/services/k8s/networks.nix).
-  folly = (builtins.fromJSON (builtins.readFile ../../clusters/folly/config/cluster-topology.json)).data;
+  networks = import ./k8s/networks.nix { inherit lib; };
+  folly = networks.folly;
 in
 {
   options.homelab.nfsServer.dataDevice = lib.mkOption {
@@ -46,13 +46,14 @@ in
       lockdPort = 4001;
       mountdPort = 4002;
       statdPort = 4000;
-      # K8S_NODE_CIDR is the single Kubernetes network (VLAN 8, 10.3.0.0/26);
-      # CILIUM_POD_CIDR covers the pods. 10.13.37.0/28 is the "future" network
+      # nodeCidr is the Kubernetes node subnet (VLAN 8, 10.3.0.0/26); lbRange is
+      # the Cilium LB VIP pool (10.3.0.64/26); podCidr covers the pods.
+      # 10.13.37.0/28 is the "future" network
       # (terraform/network/unifi/folly/extra-networks.tf).
       exports = ''
         /nfs/data/                 10.13.37.0/28(rw,sync,nohide,no_subtree_check,insecure,all_squash,anonuid=1000,anongid=1000)
-        /nfs/data/k8s/              ${folly.K8S_NODE_CIDR}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) ${folly.CILIUM_POD_CIDR}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
-        /nfs/data/k8s-provisioned/  ${folly.K8S_NODE_CIDR}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) ${folly.CILIUM_POD_CIDR}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
+        /nfs/data/k8s/              ${folly.nodeCidr}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) ${folly.podCidr}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) ${folly.lbRange}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
+        /nfs/data/k8s-provisioned/  ${folly.nodeCidr}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) ${folly.podCidr}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash) ${folly.lbRange}(rw,sync,nohide,no_subtree_check,insecure,no_root_squash)
       '';
     };
 

--- a/terraform/network/unifi/folly/firewall.tf
+++ b/terraform/network/unifi/folly/firewall.tf
@@ -44,10 +44,13 @@ resource "unifi_firewall_group" "teleport_cidr" {
 # inline (matching_target = "IP") so the pod CIDRs and Cilium LB VIP pools are
 # permitted too.
 locals {
+  # Cross-site k8s CIDRs derived from the network SSOT (topology.tf).
+  # folly_k8s_cidrs covers the folly cluster's node subnet, Cilium LB VIP pool,
+  # and pod CIDR.  nest_k8s_cidrs covers the offsite cluster's equivalent.
   folly_k8s_cidrs = [
-    "10.3.0.0/26",   # nodes (Kubernetes network, VLAN 8)
-    "10.3.0.64/26",  # Cilium LB VIP pool
-    "10.100.0.0/20", # pod CIDR
+    local.topology.K8S_NODE_CIDR,    # nodes (Kubernetes network, VLAN 8)
+    local.lb_range,                    # Cilium LB VIP pool
+    local.topology.CILIUM_POD_CIDR,   # pod CIDR
   ]
   nest_k8s_cidrs = [
     "10.89.0.0/28",  # offsite nodes

--- a/terraform/network/unifi/offsite/.terraform.lock.hcl
+++ b/terraform/network/unifi/offsite/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/1password/onepassword" {
   version     = "3.3.1"
   constraints = "~> 3.0"
   hashes = [
+    "h1:35PCpSNLVubReT1imwfC+FpIP5gQWx+rvG4njkXkZKM=",
     "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
     "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
     "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",

--- a/terraform/network/unifi/offsite/networks.tf
+++ b/terraform/network/unifi/offsite/networks.tf
@@ -1,6 +1,9 @@
+# k8s_cidr is the /28 network, not the full CIDR prefix. The cluster-topology
+# holds the /28 (K8S_NODE_CIDR = "10.89.0.0/28"), but unifi_network.subnet
+# requires the full CIDR notation with mask (e.g. "10.89.0.0/28"), so we take the
+# node CIDR as-is. The DHCP range is derived from it.
 locals {
   lan_cidr = "192.168.1.1/24"
-  k8s_cidr = "10.89.0.1/28"
 }
 
 resource "unifi_network" "default" {
@@ -25,7 +28,7 @@ resource "unifi_network" "default" {
 
 resource "unifi_network" "k8s" {
   name               = "Kubernetes"
-  subnet             = local.k8s_cidr
+  subnet             = local.topology.K8S_NODE_CIDR
   vlan               = 2
   setting_preference = "auto"
   auto_scale         = false
@@ -35,8 +38,8 @@ resource "unifi_network" "k8s" {
   dhcp_server = {
     enabled   = true
     leasetime = local.one_day
-    start     = cidrhost(local.k8s_cidr, 2)
-    stop      = cidrhost(local.k8s_cidr, 14)
+    start     = cidrhost(local.topology.K8S_NODE_CIDR, 2)
+    stop      = cidrhost(local.topology.K8S_NODE_CIDR, 14)
     boot = {
       enabled = false
     }

--- a/terraform/network/unifi/offsite/networks.tf
+++ b/terraform/network/unifi/offsite/networks.tf
@@ -1,9 +1,8 @@
-# k8s_cidr is the /28 network, not the full CIDR prefix. The cluster-topology
-# holds the /28 (K8S_NODE_CIDR = "10.89.0.0/28"), but unifi_network.subnet
-# requires the full CIDR notation with mask (e.g. "10.89.0.0/28"), so we take the
-# node CIDR as-is. The DHCP range is derived from it.
 locals {
   lan_cidr = "192.168.1.1/24"
+  # node_cidr keeps the gateway-host (.1) form the UniFi network subnet expects;
+  # cidrhost() masks host bits so the static_records/dhcp ranges below are unchanged.
+  node_cidr = "${cidrhost(local.topology.K8S_NODE_CIDR, 1)}/${split("/", local.topology.K8S_NODE_CIDR)[1]}"
 }
 
 resource "unifi_network" "default" {
@@ -28,7 +27,7 @@ resource "unifi_network" "default" {
 
 resource "unifi_network" "k8s" {
   name               = "Kubernetes"
-  subnet             = local.topology.K8S_NODE_CIDR
+  subnet             = local.node_cidr
   vlan               = 2
   setting_preference = "auto"
   auto_scale         = false

--- a/terraform/network/unifi/offsite/topology.tf
+++ b/terraform/network/unifi/offsite/topology.tf
@@ -1,11 +1,11 @@
 # Network single source of truth. Edit the cluster-topology ConfigMap at
-# clusters/folly/config/cluster-topology.json (that JSON file IS the Flux
+# clusters/offsite/config/cluster-topology.json (that JSON file IS the Flux
 # ConfigMap and the shared facts), not the values that reference local.topology
 # here. Keys are the flat ConfigMap data, e.g. local.topology.K8S_NODE_CIDR.
 locals {
-  topology = jsondecode(file("${path.module}/../../../../clusters/folly/config/cluster-topology.json")).data
+  topology = jsondecode(file("${path.module}/../../../../clusters/offsite/config/cluster-topology.json")).data
   # Derived: LB_RANGE is split off K8S_NODE_CIDR by UniFi; it's not a separate
   # ConfigMap key, so we compute it here from the SSOT's node CIDR.
-  # K8S_NODE_CIDR = "10.3.0.0/26" → LB_RANGE = "10.3.0.64/26"
+  # K8S_NODE_CIDR = "10.89.0.0/28" → LB_RANGE = "10.89.0.64/26"
   lb_range = cidrsubnet(local.topology.K8S_NODE_CIDR, 2, 1)
 }


### PR DESCRIPTION
## Summary

Collapse three cross-layer DRY violations in the network topology wiring: the folly UniFi firewall hardcoded folly CIDRs that were already in `cluster-topology.json`; the offsite Terraform root had its own literal for the k8s CIDR; and `nfs-server.nix` read the folly topology JSON directly instead of going through `networks.nix`. All three now derive their values from the SSOT.

## Changes

- `terraform/network/unifi/folly/topology.tf` — add `lb_range` derived via `cidrsubnet(K8S_NODE_CIDR, 2, 1)`
- `terraform/network/unifi/folly/firewall.tf` — `folly_k8s_cidrs` now reads `local.topology.K8S_NODE_CIDR`, `local.lb_range`, `local.topology.CILIUM_POD_CIDR`
- `terraform/network/unifi/offsite/topology.tf` — new file, mirrors the folly topology.tf pattern
- `terraform/network/unifi/offsite/networks.tf` — drops `k8s_cidr` literal; `unifi_network.k8s` reads `local.topology.K8S_NODE_CIDR`
- `nix/services/k8s/networks.nix` — `mkCluster` now exports `nodeCidr` and `lbRange`
- `nix/services/nfs-server.nix` — imports `networks.nix` instead of reading the topology JSON directly; uses new field names; adds `lbRange` to k8s export paths

## Test Plan

- [ ] `terraform init -backend=false && terraform validate` passes on both `terraform/network/unifi/folly/` and `terraform/network/unifi/offsite/`
- [ ] `nix flake check` passes (Nix layer)
- [ ] After merge, Atlantis autoplans both changed Terraform roots; no drift expected
