### PR TITLE
fix(ssh): remove pre-login warning banners

### DIFF
--- a/nix/system/ssh.nix
+++ b/nix/system/ssh.nix
@@ -6,42 +6,14 @@
   ...
 }:
 let
-  # Old-school unauthorized-access warning shown BEFORE login, on both the
-  # console (/etc/issue via getty) and SSH (pre-auth banner). Keep the stars
-  # aligned, eh.
-  warning = ''
-    ********************************************************************
-    *                          W A R N I N G                           *
-    *                                                                  *
-    * This is a PRIVATE computer system operated by the                *
-    * pulsifer.ca homelab AUTHORITY, eh.                               *
-    *                                                                  *
-    * Unauthorized access is prohibited under Section 342.1 of         *
-    * the Criminal Code of Canada and will be dealt with               *
-    * sternly, politely, and then reported to the RCMP.                *
-    *                                                                  *
-    * By accessing this system you consent to monitoring and           *
-    * recording. There is NO expectation of privacy, sorry.            *
-    *                                                                  *
-    * Evidence of unauthorized activity may be handed over to          *
-    * the authorities and/or your mother.                              *
-    *                                                                  *
-    * AUTHORIZED PERSONNEL: PROCEED.   EVERYONE ELSE: SORRY, BUD.      *
-    ********************************************************************
-  '';
-
   hostName = config.networking.hostName;
   date = inputs.self.lastModifiedDate or "19700101";
   buildDate = "${builtins.substring 0 4 date}-${builtins.substring 4 2 date}-${builtins.substring 6 2 date}";
   rev = inputs.self.shortRev or "dirty";
 in
 {
-  # Pre-login console banner (/etc/issue).
-  services.getty.greetingLine = warning;
   services.getty.helpLine = "";
 
-  # Post-auth, SSH-only login banner: hostname · build date · rev, with a live
-  # load average coloured green (chill) -> yellow (busy) -> red (cooking).
   environment.loginShellInit = ''
     if [ -n "$SSH_CONNECTION" ]; then
       read -r _l1 _l5 _l15 _rest < /proc/loadavg
@@ -70,8 +42,6 @@ in
       KbdInteractiveAuthentication = false;
       PasswordAuthentication = false;
       PermitRootLogin = "no";
-      # Pre-auth SSH banner (mirrors the console warning).
-      Banner = "${pkgs.writeText "ssh-banner" warning}";
     };
 
     hostKeys = [


### PR DESCRIPTION
## Summary
Remove pre-login warning banners from SSH and console login. The big ASCII warning burned tokens on every agent SSH session with no value. Kept the post-login load average banner.

## Changes
- fix(ssh): remove pre-login warning banners

## Test Plan
- [ ] Rebuild a NixOS host and verify clean SSH login (no banner, post-login load info still shows)
