### PR TITLE
chore(nix): bump mise flake input to v2026.7.5+

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,11 +125,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783457023,
-        "narHash": "sha256-iyg+JkGFGE8Fq4NFrOWLdvW9W6zOCBpYTfStZY/du88=",
+        "lastModified": 1783816595,
+        "narHash": "sha256-UTzNzTVFEyBiaPme4rifGq045wkqSpEWIG/GqUYKURw=",
         "owner": "jdx",
         "repo": "mise",
-        "rev": "e40f4a142acc3a1ce95dab0ea2702667e54bb352",
+        "rev": "b574e15e6bbd475b564ca444aeef18c6f41e01a5",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Bumps the `mise` flake input (only) from `e40f4a1` (2026-07-07, mise v2026.7.2) to `b574e15` (2026-07-12, mise v2026.7.5+33), via `nix flake update mise`.
- Prerequisite for an upcoming chezmoi -> mise dotfiles migration: v2026.7.4 is the release where mise's `[dotfiles]` config / `mise bootstrap` features graduated out of requiring `MISE_EXPERIMENTAL=1`. The new lock is past that point (confirmed via `git describe --tags` against jdx/mise: `v2026.7.5-33-gb574e15e6`).
- Pure `flake.lock` diff — no other inputs, `flake.nix`, dotfiles, or other files touched.

## Test plan
- [x] `nix flake metadata` succeeds
- [x] `nix flake check --no-build` passes for all `nixosConfigurations`/packages/apps (aarch64-linux systems skipped per the tool's own "incompatible systems" note, consistent with running on an x86_64-linux sandbox)
- [x] Confirmed the diff touches only the `mise` node in `flake.lock` (rev/narHash/lastModified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)