### PR TITLE
feat(nix): bootstrap sops-nix + harmonia signing keypair for oldschool

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -5,3 +5,13 @@ creation_rules:
     key_groups:
       - age:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+  # Bare NixOS host secrets (nix/secrets/<host>.sops.yaml), decrypted by
+  # sops-nix on the host itself. Each host's own SSH-host-key-derived age
+  # recipient is added alongside the fleet admin key as new hosts onboard --
+  # see nix/system/sops.nix.
+  - path_regex: nix/secrets/.*\.sops\.ya?ml
+    key_groups:
+      - age:
+          - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          # oldschool (ssh-to-age of its ed25519 host key)
+          - age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c

--- a/flake.lock
+++ b/flake.lock
@@ -282,6 +282,7 @@
         "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_3",
         "rowbuttkeys": "rowbuttkeys",
+        "sops-nix": "sops-nix",
         "unstable": "unstable",
         "wannabekeys": "wannabekeys"
       }
@@ -296,6 +297,26 @@
       "original": {
         "type": "file",
         "url": "https://github.com/rowbutt.keys"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     hosts = {
       url = "github:StevenBlack/hosts";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -126,12 +131,18 @@
           imports = [
             ./nix/system/quiker.nix
             ./nix/system/tailscale-disable.nix
+            ./nix/system/sops.nix
             ./nix/services/github-runner.nix
             ./nix/services/yarr.nix
           ];
           extraConfig = {
             virtualisation.docker.enable = true;
             homelab.disko.device = "/dev/sda";
+            sops.defaultSopsFile = ./nix/secrets/oldschool.sops.yaml;
+            # harmonia's binary-cache signing key (public half committed at
+            # nix/secrets/oldschool-harmonia-cache.pub); wired into
+            # services.harmonia in the deploy-harmonia ticket.
+            sops.secrets."harmonia-cache-key" = { };
           };
         };
         retrofit = mkHost "retrofit" {

--- a/nix/secrets/oldschool-harmonia-cache.pub
+++ b/nix/secrets/oldschool-harmonia-cache.pub
@@ -1,0 +1,1 @@
+oldschool.lolwtf.ca-1:Xrxrx4wJaGYiEmGWFLdeY9T0R8rmhcXbDpmc2gFllW8=

--- a/nix/secrets/oldschool.sops.yaml
+++ b/nix/secrets/oldschool.sops.yaml
@@ -1,0 +1,25 @@
+harmonia-cache-key: ENC[AES256_GCM,data:+tSoPRtR+7V3tdDuP4xYX2xppWDPxT/+hL9l+YtG8owBY6T+lhJxV2jitGA1P9RR9jYZ6hsitm0HHWm1XhImjLD3j9AGfZubWlFc+3GUvSsCbCVwkqHaSHZAX4lp6gW9GvSjBGyNVFcYH1chBKRb,iv:ZK7E/4iGwC+OSC01b5VvUctV1uwX4WUtQAasaU6NR1k=,tag:+jb6ho37HAPRs5SxVNLfDA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBa0RyeGYyUU11YUJFQzR4
+            dnZaZ3k1d1l3cDluZmxXNmhzS08wUUlWWVJnCnR1L1l4NEYyYmdTa1psNTNWSVl6
+            ZDV6WFREM21GRlduekdQaVBwMGd1M2sKLS0tIEZOb0lnU3lyYUNhTXovRFN6Zzg5
+            bmRSYStxUzN6VHA1T0VvQnZYSmMyZkEKLK0Jg9xn7tImHeQsakpihQRHUdZZqvFU
+            mSXPCn7HWcpyhlKh5hXoDIGoO9TjHOJEiB17FmPFSFjH5WDFkOnZ1g==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLblkvMkY1T25DMG9zVzZj
+            U2g3cjF5Y0IyZ1hjeGlKUHV3RkJGVGxPa1dVCnBzTktpWVduSGlLY1RKSmJTanE3
+            ZjNHSTBVNjgwNlpRd3c2VUFGcDIzVG8KLS0tIDdJdmNpNjBkNy84K2FHbkJiSHZz
+            UmUxZk5sKythWXRFTFJ2bzdocnh0aW8Ko6hKpkhnsMz9blw2aSpH0JrWLXgXY9Y3
+            R9aic1eFiEHPRodNFxrD7z5C0gI3NhoNbKlkG3rVYDFcqUrkMAU49A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c
+    lastmodified: "2026-07-12T01:05:48Z"
+    mac: ENC[AES256_GCM,data:U69fm8DhVHGbTzLChm/XiMVbSjw2zi/Go4qaH7V+uFjlIKeaxv3DV8iXzIvipRWyFBuTix/L1U0+nyyVabnoUMhJnXmHqktC4iFfRnYCrju4or/MMDQnLVsfnYtQYfYZZuM51lPfLU668vFg4E5Lofo9SbAYacF5dQscYnx7epo=,iv:+A8Lom3jKN0vaHoR/AbNCgISL9kcxcPXGeHyZE0dTBc=,tag:SlBi77ffjMDo91/QSWu9ow==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.2

--- a/nix/system/sops.nix
+++ b/nix/system/sops.nix
@@ -1,0 +1,10 @@
+{ inputs, ... }:
+{
+  imports = [ inputs.sops-nix.nixosModules.sops ];
+
+  # Decrypts with the host's own SSH host key (sops-nix's default
+  # age.sshKeyPaths) rather than distributing the fleet's shared cluster-secrets
+  # age key onto bare hosts -- a compromised host only exposes secrets scoped
+  # to that host, not every cluster secret in the repo.
+  sops.age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+}


### PR DESCRIPTION
## Summary
Bootstraps the harmonia binary-cache signing keypair for `oldschool` (part of the [self-hosted nix cache + remote builder effort](https://github.com/jonpulsifer/infra)), and introduces `sops-nix` as this repo's first SOPS-managed bare-host secret pattern.

## Changes
- `flake.nix`: add `sops-nix` input (follows `nixpkgs`); `oldschool` imports `nix/system/sops.nix` and declares `sops.secrets."harmonia-cache-key"`
- `nix/system/sops.nix` (new): sops-nix bootstrap module — decrypts with the host's own SSH host key (`ssh-to-age`), not the fleet's shared cluster-secrets age key, so a compromised bare host can't decrypt cluster/Flux secrets
- `.sops.yaml`: new creation rule for `nix/secrets/*.sops.yaml` (full-file encryption), recipients = fleet admin age key + oldschool's host-derived age key
- `nix/secrets/oldschool.sops.yaml` (new): the harmonia private signing key, SOPS-encrypted
- `nix/secrets/oldschool-harmonia-cache.pub` (new, plaintext): the public key `oldschool.lolwtf.ca-1:Xrxrx4wJaGYiEmGWFLdeY9T0R8rmhcXbDpmc2gFllW8=`, to be added to `trusted-public-keys` fleet-wide in a follow-up PR once harmonia is actually deployed

None of ddnsd/Tailscale/GitHub-runner/kiosk/nix-serve's existing `/var/secrets/...` paths were actually SOPS-managed — they're plain files placed on hosts out-of-band. This PR doesn't touch that existing pattern; it adds sops-nix alongside it for secrets that do need to live in git.

## Test Plan
- [x] `nix build .#nixosConfigurations.oldschool.config.system.build.toplevel` succeeds
- [x] `nix flake check` passes fleet-wide, no other host affected
- [x] `flake.lock` diff is `sops-nix`-only (no incidental input bumps)
- [x] `sops -d nix/secrets/oldschool.sops.yaml` lists both intended recipients (fleet admin key + oldschool's host key)
- [ ] Not deployed to the live host in this PR — no `nixos-rebuild` run against oldschool; the secret only gets consumed once `services.harmonia` is wired up in a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
