### PR TITLE
feat(nix): use prebuilt mise release binary via overlay

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -56,6 +56,22 @@
   },
   customManagers: [
     {
+      // mise prebuilt binary version in nix/overlays/mise.nix. The
+      // jdx/mise GitHub release tags are `v<ver>`; extractVersionTemplate
+      // strips the leading `v` so currentValue (`2026.7.5`) matches.
+      // Renovate bumps the version string only; the two fetchurl hashes are
+      // not covered and must be refreshed manually (see overlay comment).
+      customType: 'regex',
+      description: 'mise prebuilt binary (nix overlay)',
+      managerFilePatterns: ['/nix/overlays/mise\\.nix$/'],
+      matchStrings: [
+        '# renovate: datasource=github-releases depName=jdx/mise\\n\\s*version = "(?<currentValue>[^"]+)";',
+      ],
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'jdx/mise',
+      extractVersionTemplate: '^v(?<version>.*)$',
+    },
+    {
       customType: 'regex',
       description: 'Process annotated dependencies',
       managerFilePatterns: [
@@ -345,6 +361,18 @@
       matchManagers: ['nix'],
       matchPackageNames: ['dotfiles'],
       automerge: true,
+    },
+    {
+      // Renovate bumps only the version string in nix/overlays/mise.nix;
+      // the two fetchurl hashes (x64/arm64 tarballs) go stale and must be
+      // refreshed by hand before the build passes — so never automerge.
+      // nix-ci builds optiplex (x86_64) + rackpi5 (aarch64), which exercise
+      // both hashes and flag a mismatch quoting the correct replacement.
+      description: 'mise prebuilt binary — manual hash refresh, no automerge',
+      matchDepNames: ['jdx/mise'],
+      matchDatasources: ['github-releases'],
+      automerge: false,
+      addLabels: ['renovate/nix-mise'],
     },
     // ============================================================
     // Blocked

--- a/flake.lock
+++ b/flake.lock
@@ -67,24 +67,6 @@
         "type": "github"
       }
     },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "hosts": {
       "inputs": {
         "nixpkgs": [
@@ -115,27 +97,6 @@
       "original": {
         "type": "file",
         "url": "https://github.com/jonpulsifer.keys"
-      }
-    },
-    "mise": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1783816595,
-        "narHash": "sha256-UTzNzTVFEyBiaPme4rifGq045wkqSpEWIG/GqUYKURw=",
-        "owner": "jdx",
-        "repo": "mise",
-        "rev": "b574e15e6bbd475b564ca444aeef18c6f41e01a5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jdx",
-        "repo": "mise",
-        "type": "github"
       }
     },
     "nixos-hardware": {
@@ -276,7 +237,6 @@
         "disko": "disko",
         "hosts": "hosts",
         "keys": "keys",
-        "mise": "mise",
         "nixos-hardware": "nixos-hardware",
         "nixos-raspberrypi": "nixos-raspberrypi",
         "nixos-wsl": "nixos-wsl",
@@ -316,21 +276,6 @@
       "original": {
         "owner": "Mic92",
         "repo": "sops-nix",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -38,11 +38,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    mise = {
-      url = "github:jdx/mise";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
     keys = {
       url = "https://github.com/jonpulsifer.keys";
       flake = false;
@@ -99,6 +94,9 @@
         import nixpkgs {
           inherit system;
           config.allowUnfree = true;
+          overlays = [
+            (import ./nix/overlays/mise.nix)
+          ];
         }
       );
 

--- a/nix/overlays/mise.nix
+++ b/nix/overlays/mise.nix
@@ -1,0 +1,78 @@
+# Overlay that replaces the from-source `mise` (built by the jdx/mise flake
+# input, which compiles Rust on every host) with a derivation that just
+# fetches the matching prebuilt binary from the GitHub release tarball and
+# patchelfs it for NixOS' glibc.
+#
+# Only x86_64-linux and aarch64-linux have upstream release assets. armv6l
+# (radiopi0 / blinkypi0) is intentionally left to throw -- those hosts drop
+# mise from the user package set entirely (see nix/hosts/{radiopi0,blinkypi0}.nix)
+# so pkgs.mise is never instantiated there and this throw never fires.
+final: _prev:
+let
+  # When Renovate bumps `version`, the two fetchurl hashes below go stale and
+  # `nix-ci` (builds optiplex=x86_64 + rackpi5=aarch64) fails with a hash
+  # mismatch quoting the correct replacement. Paste each in, or refresh
+  # ahead of time:
+  #   nix-prefetch-url --type sha256 \
+  #     https://github.com/jdx/mise/releases/download/v<ver>/mise-v<ver>-linux-arm64.tar.gz
+  #   nix-prefetch-url --type sha256 \
+  #     https://github.com/jdx/mise/releases/download/v<ver>/mise-v<ver>-linux-x64.tar.gz
+  # (nix hash to-sri --type sha256 <h> gives the `sha256-...` SRI form.)
+  # renovate: datasource=github-releases depName=jdx/mise
+  version = "2026.7.5";
+  arch =
+    if final.stdenv.hostPlatform.isAarch64 then
+      "arm64"
+    else if final.stdenv.hostPlatform.isx86_64 then
+      "x64"
+    else
+      throw "mise prebuilt binary: upstream has no release for ${final.stdenv.hostPlatform.system}";
+in
+{
+  mise = final.stdenv.mkDerivation {
+    pname = "mise";
+    inherit version;
+
+    src = final.fetchurl {
+      url = "https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-linux-${arch}.tar.gz";
+      hash =
+        if final.stdenv.hostPlatform.isAarch64 then
+          "sha256-kCD3RTkxpoc9YM8gTVk169CGM7JfZ1sIIM0GhitLZFA="
+        else
+          "sha256-vpLaOvsYDccbPOb8qq8vOTgSycUOmmTJy2cGzyjttIY=";
+    };
+
+    # The tarball unpacks into ./mise/{bin,man,...}; set sourceRoot so the
+    # install phase can address it directly.
+    sourceRoot = ".";
+
+    nativeBuildInputs = [ final.autoPatchelfHook ];
+    # The prebuilt binary is dynamically linked against glibc + libgcc_s.
+    buildInputs = [
+      final.glibc
+      final.gcc-unwrapped.lib
+    ];
+
+    installPhase = ''
+      runHook preInstall
+      install -Dm555 mise/bin/mise      $out/bin/mise
+      install -Dm444 mise/man/man1/mise.1 $out/share/man/man1/mise.1
+      runHook postInstall
+    '';
+
+    # The downloaded binary is already stripped; keep autoPatchelf from
+    # re-running strip with mismatched toolchain expectations.
+    dontStrip = true;
+
+    meta = with final.lib; {
+      description = "Polyglot runtime manager (prebuilt upstream binary)";
+      homepage = "https://github.com/jdx/mise";
+      license = licenses.mit;
+      mainProgram = "mise";
+      platforms = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+    };
+  };
+}

--- a/nix/system/user.nix
+++ b/nix/system/user.nix
@@ -6,12 +6,22 @@
   ...
 }:
 let
+  # Use the prebuilt upstream mise binary instead of building the jdx/mise
+  # flake input from source on every host. See nix/overlays/mise.nix.
+  miseOverlay = import ../overlays/mise.nix;
+
   sshKeys = lib.splitString "\n" (builtins.readFile inputs.keys);
   rowbuttKeys = lib.splitString "\n" (builtins.readFile inputs.rowbuttkeys);
   consolePasswordHash = "$6$MyfHzd0UhaiNWR2.$e3CjotacfdkRzNBs/AyIGLkneJCeIZcIVd2zLm5cEoJbSCpKB2ilEAIBtqZQl6xiNgngoFH6dyqyabhwjYVQU/";
 in
 {
   programs.zsh.enable = true;
+
+  # Applied at the host level so every host's pkgs.mise resolves to the
+  # prebuilt binary. (radiopi0/blinkypi0 don't pull mise into their user
+  # package sets at all, so the overlay is inert there.)
+  nixpkgs.overlays = [ miseOverlay ];
+
   users.mutableUsers = false;
   users.users.root.hashedPassword = consolePasswordHash;
 
@@ -30,7 +40,7 @@ in
       git
       unzip
       gnupg
-      (inputs.mise.packages.${pkgs.stdenv.hostPlatform.system}.mise.overrideAttrs (_: { doCheck = false; }))
+      mise
     ];
   };
 
@@ -48,7 +58,7 @@ in
       git
       unzip
       gnupg
-      (inputs.mise.packages.${pkgs.stdenv.hostPlatform.system}.mise.overrideAttrs (_: { doCheck = false; }))
+      mise
     ];
   };
 }


### PR DESCRIPTION
## Summary
Replace the `jdx/mise` flake input — which compiled Rust from source on every host rebuild — with an overlay that fetches the matching prebuilt GitHub release tarball and `autoPatchelf`s it for NixOS' glibc. Drops the flake input (and its transitive `flake-utils`/`systems`) from `flake.lock`, and wires Renovate to open version-bump PRs for the upstream release.

## Changes
- `feat(nix): use prebuilt mise release binary instead of building the flake input`
  - New `nix/overlays/mise.nix`: `fetchurl` the `linux-{x64,arm64}` tarball from `github.com/jdx/mise/releases`, patch interpreter to nix-store glibc, install `mise` + manpage. Throws on arches with no upstream asset (armv6l — but `radiopi0`/`blinkypi0` already drop mise from their user package set, so it never fires).
  - `nix/system/user.nix`: apply the overlay at the host level; `pkgs.mise` replaces `inputs.mise.packages.…mise.overrideAttrs`.
  - `flake.nix`: drop the `mise` input; apply the overlay to `legacyPackages` so `shell.nix`'s devShell uses the binary too.
  - `flake.lock`: only `mise` + transitive `flake-utils`/`systems` removed.
- `chore(renovate): track jdx/mise releases for the prebuilt overlay`
  - Custom regex manager bumps the `version` in the overlay from the `github-releases` feed (`extractVersionTemplate` strips the leading `v`).
  - Package rule pins `jdx/mise` to `automerge:false` + `renovate/nix-mise` label: Renovate can only bump the version literal, not the two `fetchurl` SRI hashes, so each bump needs a quick `nix-prefetch-url` refresh (documented inline in the overlay; `nix-ci` quotes the correct hashes on mismatch).

## Test Plan
- [x] `nix build .#legacyPackages.x86_64-linux.mise` → builds, `mise --version` → `2026.7.5 linux-x64 (2026-07-09)`, interpreter patched to nix-store glibc.
- [x] `legacyPackages.aarch64-linux.mise.src.url` resolves to the arm64 tarball; `nixosConfigurations.optiplex` + `rackpi5` eval clean.
- [x] `nix flake check` passes.
- [x] Renovate custom-manager regex validated against the overlay content (extracts `currentValue=2026.7.5`); `.github/renovate.json5` parses.
- [ ] CI (`nix-ci`) — optiplex build + rackpi5 sdImage exercise both per-arch hashes.
