### PR TITLE
fix(iam): allow ts repo to authenticate via shared github WIF provider

### DIFF
--- a/terraform/gcp/projects/homelab-ng/.terraform.lock.hcl
+++ b/terraform/gcp/projects/homelab-ng/.terraform.lock.hcl
@@ -106,3 +106,24 @@ provider "registry.terraform.io/hashicorp/google-beta" {
     "zh:ff93e1841b6b3876c95ee40a4e3889a0efb4347a24067f53c18ffaa0503de4f0",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.13"
+  hashes = [
+    "h1:4EThC3ocCFiFPMZQSUvSGSxoJqBcGWxMcFYmL67uS7Y=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}

--- a/terraform/gcp/projects/homelab-ng/policy.tf
+++ b/terraform/gcp/projects/homelab-ng/policy.tf
@@ -140,7 +140,7 @@ resource "google_org_policy_policy" "allowed_workload_identity_providers" {
       values {
         allowed_values = [
           "is:https://token.actions.githubusercontent.com",
-          "is:https://oidc.vercel.com/jonpulsifers-projects"
+          "is:https://oidc.vercel.com/jonpulsifer"
         ]
       }
     }

--- a/terraform/gcp/projects/homelab-ng/slingshot.tf
+++ b/terraform/gcp/projects/homelab-ng/slingshot.tf
@@ -1,6 +1,6 @@
 locals {
-  slingshot_subject      = "owner:jonpulsifers-projects:project:slingshot:environment:production"
+  slingshot_subject      = "owner:jonpulsifer:project:slingshot:environment:production"
   slingshot_environments = ["production", "development"]
-  slingshot_subjects     = [for environment in local.slingshot_environments : "owner:jonpulsifers-projects:project:slingshot:environment:${environment}"]
+  slingshot_subjects     = [for environment in local.slingshot_environments : "owner:jonpulsifer:project:slingshot:environment:${environment}"]
   slingshot_principals   = [for subject in local.slingshot_subjects : "principal://iam.googleapis.com/${google_iam_workload_identity_pool.homelab.name}/subject/${subject}"]
 }

--- a/terraform/gcp/projects/homelab-ng/versions.tf
+++ b/terraform/gcp/projects/homelab-ng/versions.tf
@@ -73,6 +73,10 @@ terraform {
       source  = "1password/onepassword"
       version = "~> 3.0"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.13"
+    }
   }
   required_version = ">= 1.2.6"
 }

--- a/terraform/gcp/projects/homelab-ng/workload-identity.tf
+++ b/terraform/gcp/projects/homelab-ng/workload-identity.tf
@@ -12,6 +12,20 @@ resource "google_iam_workload_identity_pool" "homelab" {
   workload_identity_pool_id = "homelab"
 }
 
+# Org policy changes to iam.workloadIdentityPoolProviders are eventually
+# consistent — GCP can reject a provider create/update against the *old*
+# allowed_values for a minute or two even after the policy update has been
+# applied. Force a delay here, and re-trigger it whenever allowed_values
+# changes, so provider resources don't race the policy's propagation.
+resource "time_sleep" "workload_identity_org_policy_propagation" {
+  depends_on      = [google_org_policy_policy.allowed_workload_identity_providers]
+  create_duration = "120s"
+
+  triggers = {
+    allowed_values = jsonencode(google_org_policy_policy.allowed_workload_identity_providers.spec[0].rules[0].values[0].allowed_values)
+  }
+}
+
 resource "google_iam_workload_identity_pool_provider" "github" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.homelab.workload_identity_pool_id
   workload_identity_pool_provider_id = "github"
@@ -30,7 +44,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
   attribute_condition = "assertion.repository_owner_id == '5461940' && assertion.repository_id in ${jsonencode(local.github_actions_allowed_repository_ids)}"
-  depends_on          = [google_org_policy_policy.allowed_workload_identity_providers]
+  depends_on          = [time_sleep.workload_identity_org_policy_propagation]
 }
 
 resource "google_iam_workload_identity_pool_provider" "vercel" {
@@ -48,5 +62,5 @@ resource "google_iam_workload_identity_pool_provider" "vercel" {
     issuer_uri        = "https://oidc.vercel.com/jonpulsifer"
   }
 
-  depends_on = [google_org_policy_policy.allowed_workload_identity_providers]
+  depends_on = [time_sleep.workload_identity_org_policy_propagation]
 }

--- a/terraform/gcp/projects/homelab-ng/workload-identity.tf
+++ b/terraform/gcp/projects/homelab-ng/workload-identity.tf
@@ -42,10 +42,10 @@ resource "google_iam_workload_identity_pool_provider" "vercel" {
     "attribute.environment" = "assertion.environment"
   }
 
-  attribute_condition = "assertion.sub.startsWith('owner:jonpulsifers-projects:project:')"
+  attribute_condition = "assertion.sub.startsWith('owner:jonpulsifer:project:')"
   oidc {
-    allowed_audiences = ["https://vercel.com/jonpulsifers-projects"]
-    issuer_uri        = "https://oidc.vercel.com/jonpulsifers-projects"
+    allowed_audiences = ["https://vercel.com/jonpulsifer"]
+    issuer_uri        = "https://oidc.vercel.com/jonpulsifer"
   }
 
   depends_on = [google_org_policy_policy.allowed_workload_identity_providers]

--- a/terraform/gcp/projects/homelab-ng/workload-identity.tf
+++ b/terraform/gcp/projects/homelab-ng/workload-identity.tf
@@ -1,5 +1,11 @@
 locals {
-  github_actions_subject_prefix = "repo:jonpulsifer@5461940/infra@952814997"
+  # Repos allowed to mint tokens from the shared "homelab" GitHub OIDC provider.
+  # This only gates who can authenticate at all; what each repo can then do is
+  # scoped separately by per-resource IAM bindings (see iam.tf, datastore.tf).
+  github_actions_allowed_repository_ids = [
+    "952814997", # jonpulsifer/infra
+    "554977933", # jonpulsifer/ts
+  ]
 }
 
 resource "google_iam_workload_identity_pool" "homelab" {
@@ -23,7 +29,7 @@ resource "google_iam_workload_identity_pool_provider" "github" {
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"
   }
-  attribute_condition = "assertion.sub.startsWith('${local.github_actions_subject_prefix}') && assertion.repository_owner_id == '5461940' && assertion.repository_id == '952814997'"
+  attribute_condition = "assertion.repository_owner_id == '5461940' && assertion.repository_id in ${jsonencode(local.github_actions_allowed_repository_ids)}"
   depends_on          = [google_org_policy_policy.allowed_workload_identity_providers]
 }
 


### PR DESCRIPTION
## Summary
Three related fixes in the shared `homelab` WIF pool, surfaced by `ts` CI and Vercel deployment failures, plus an apply-time failure from GCP org-policy propagation delay:

1. `ts`'s CI has been failing on every `pull_request` run (and would fail on push too) because the `homelab`/`github` provider's `attribute_condition` only accepted tokens from the `infra` repo. `ts`'s build already depends on this same provider to read Firestore at build time (see `datastore.tf`'s `datastore.viewer` binding scoped to `attribute.repository/jonpulsifer/ts`), so that binding was live but unreachable.
2. Vercel's production build for `slingshot` was separately failing with `invalid_grant: The issuer in ID Token https://oidc.vercel.com/jonpulsifer does not match the expected ones: https://oidc.vercel.com/jonpulsifers-projects` — Vercel's OIDC issuer/owner slug for this account is now `jonpulsifer`, not the old `jonpulsifers-projects`.
3. Applying (1)+(2) hit `Error 400: Precondition check failed. Org Policy violated for value: 'https://oidc.vercel.com/jonpulsifer'` — the `iam.workloadIdentityPoolProviders` org policy update is eventually consistent, so the provider resources (which already `depends_on` the policy) can still race its propagation. Added a `time_sleep` between the policy and both provider resources, re-triggered whenever `allowed_values` changes.

## Changes
- fix(iam): allow ts repo to authenticate via shared github WIF provider — explicit `repository_id` allow-list (infra + ts) instead of an infra-specific subject-string match
- fix(iam): update vercel oidc issuer slug from jonpulsifers-projects to jonpulsifer across the `vercel` WIF provider, the `slingshot` subject locals, and the org policy allowlisting valid WIF issuers
- fix(iam): guard org-policy propagation delay before WIF provider apply — `time_sleep` resource + `hashicorp/time` provider

## Test Plan
- [x] `terraform validate` passes
- [x] `terraform fmt -check` passes
- [ ] Apply succeeds cleanly (propagation delay resolved)
- [ ] After apply, confirm `jonpulsifer/ts` PR #3560 (https://github.com/jonpulsifer/ts/pull/3560) CI goes green
- [ ] After apply, confirm the `slingshot` Vercel deployment succeeds
- [ ] Confirm `infra`'s own CI/deploy auth still works post-apply (no regression for the existing repo)

## Context
Per-repo/per-owner permissions are unaffected by change (1) — it only changes which repos can authenticate against the provider at all; downstream access stays scoped by each resource's own IAM bindings in `iam.tf` and `datastore.tf`.
