### PR TITLE
refactor(terraform): extract Flux bootstrap module

### DIFF
--- a/.github/scripts/validation-impact.sh
+++ b/.github/scripts/validation-impact.sh
@@ -57,7 +57,7 @@ targets() {
 terraform_roots() {
   # A backend declaration distinguishes independently validated roots from
   # reusable modules beneath terraform/modules.
-  rg -l --glob '*.tf' 'backend "' terraform clusters/*/bootstrap | xargs -r -n1 dirname | sort -u
+  grep -rl --include='*.tf' 'backend "' terraform clusters/*/bootstrap | xargs -r -n1 dirname | sort -u
 }
 
 case "${1:-}" in

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - '**/*.tf'
+      - '**/*.tftest.hcl'
       - '**/.terraform.lock.hcl'
       - terraform/network/unifi/folly/lab.tf.json
       - .github/scripts/validation-impact.sh
@@ -13,6 +14,7 @@ on:
   pull_request:
     paths:
       - '**/*.tf'
+      - '**/*.tftest.hcl'
       - '**/.terraform.lock.hcl'
       - terraform/network/unifi/folly/lab.tf.json
       - .github/scripts/validation-impact.sh
@@ -45,6 +47,7 @@ jobs:
           separator: "\n"
           files: |
             **/*.tf
+            **/*.tftest.hcl
             **/.terraform.lock.hcl
             terraform/network/unifi/folly/lab.tf.json
             .github/scripts/validation-impact.sh
@@ -94,6 +97,8 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate
+      - name: Terraform Test
+        run: terraform test
 
   # Formatting is enforced on the PR (a check), not auto-committed to main —
   # branch protection rejects bot pushes, and a PR check also avoids the

--- a/clusters/folly/bootstrap/bootstrap.tf
+++ b/clusters/folly/bootstrap/bootstrap.tf
@@ -40,50 +40,46 @@ locals {
   }
 }
 
-resource "tls_private_key" "flux" {
-  algorithm   = "ECDSA"
-  ecdsa_curve = "P256"
-}
+module "flux_bootstrap" {
+  source = "../../../terraform/modules/flux-bootstrap"
 
-resource "github_repository_deploy_key" "this" {
-  title      = "Flux (folly)"
-  repository = local.github.repo
-  key        = tls_private_key.flux.public_key_openssh
-  read_only  = "true"
-}
+  cluster_name = "folly"
+  github_repo  = local.github.repo
+  flux_values  = file("${path.module}/flux-values.yaml")
 
-resource "helm_release" "flux_operator" {
-  name             = "flux-operator"
-  namespace        = "flux-system"
-  repository       = "oci://ghcr.io/controlplaneio-fluxcd/charts"
-  chart            = "flux-operator"
-  create_namespace = true
-}
-
-resource "helm_release" "flux" {
-  depends_on = [helm_release.flux_operator]
-
-  name       = "flux"
-  namespace  = "flux-system"
-  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
-  chart      = "flux-instance"
-
-  values = [
-    file("${path.module}/flux-values.yaml")
-  ]
-}
-
-resource "kubernetes_secret" "main" {
-  metadata {
-    name      = "flux-github-app-credentials"
-    namespace = "flux-system"
+  providers = {
+    github     = github
+    helm       = helm
+    kubernetes = kubernetes
   }
+}
 
-  data = {
-    identity       = tls_private_key.flux.private_key_pem
-    "identity.pub" = tls_private_key.flux.public_key_pem
-    known_hosts    = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
-  }
+moved {
+  from = tls_private_key.flux
+  to   = module.flux_bootstrap.tls_private_key.flux
+}
 
-  depends_on = [helm_release.flux]
+moved {
+  from = github_repository_deploy_key.this
+  to   = module.flux_bootstrap.github_repository_deploy_key.this
+}
+
+moved {
+  from = helm_release.flux_operator
+  to   = module.flux_bootstrap.helm_release.flux_operator
+}
+
+moved {
+  from = helm_release.flux
+  to   = module.flux_bootstrap.helm_release.flux
+}
+
+moved {
+  from = kubernetes_secret.main
+  to   = module.flux_bootstrap.kubernetes_secret.main
+}
+
+output "bootstrap_resources" {
+  description = "Stable identities of resources created for Flux bootstrap."
+  value       = module.flux_bootstrap.bootstrap_resources
 }

--- a/clusters/folly/bootstrap/bootstrap.tftest.hcl
+++ b/clusters/folly/bootstrap/bootstrap.tftest.hcl
@@ -1,0 +1,30 @@
+mock_provider "github" {}
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+mock_provider "tls" {}
+
+run "exposes_folly_bootstrap_resources" {
+  command = plan
+
+  assert {
+    condition = output.bootstrap_resources == {
+      deploy_key = {
+        repository = "infra"
+        title      = "Flux (folly)"
+      }
+      flux = {
+        name      = "flux"
+        namespace = "flux-system"
+      }
+      flux_operator = {
+        name      = "flux-operator"
+        namespace = "flux-system"
+      }
+      github_credentials_secret = {
+        name      = "flux-github-app-credentials"
+        namespace = "flux-system"
+      }
+    }
+    error_message = "folly bootstrap must expose its Flux deploy key, releases, and credentials secret"
+  }
+}

--- a/clusters/offsite/bootstrap/bootstrap.tf
+++ b/clusters/offsite/bootstrap/bootstrap.tf
@@ -42,50 +42,46 @@ locals {
   }
 }
 
-resource "tls_private_key" "flux" {
-  algorithm   = "ECDSA"
-  ecdsa_curve = "P256"
-}
+module "flux_bootstrap" {
+  source = "../../../terraform/modules/flux-bootstrap"
 
-resource "github_repository_deploy_key" "this" {
-  title      = "Flux (offsite)"
-  repository = local.github.repo
-  key        = tls_private_key.flux.public_key_openssh
-  read_only  = "true"
-}
+  cluster_name = "offsite"
+  github_repo  = local.github.repo
+  flux_values  = file("${path.module}/flux-values.yaml")
 
-resource "helm_release" "flux_operator" {
-  name             = "flux-operator"
-  namespace        = "flux-system"
-  repository       = "oci://ghcr.io/controlplaneio-fluxcd/charts"
-  chart            = "flux-operator"
-  create_namespace = true
-}
-
-resource "helm_release" "flux" {
-  depends_on = [helm_release.flux_operator]
-
-  name       = "flux"
-  namespace  = "flux-system"
-  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
-  chart      = "flux-instance"
-
-  values = [
-    file("${path.module}/flux-values.yaml")
-  ]
-}
-
-resource "kubernetes_secret" "main" {
-  metadata {
-    name      = "flux-github-app-credentials"
-    namespace = "flux-system"
+  providers = {
+    github     = github
+    helm       = helm
+    kubernetes = kubernetes
   }
+}
 
-  data = {
-    identity       = tls_private_key.flux.private_key_pem
-    "identity.pub" = tls_private_key.flux.public_key_pem
-    known_hosts    = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
-  }
+moved {
+  from = tls_private_key.flux
+  to   = module.flux_bootstrap.tls_private_key.flux
+}
 
-  depends_on = [helm_release.flux]
+moved {
+  from = github_repository_deploy_key.this
+  to   = module.flux_bootstrap.github_repository_deploy_key.this
+}
+
+moved {
+  from = helm_release.flux_operator
+  to   = module.flux_bootstrap.helm_release.flux_operator
+}
+
+moved {
+  from = helm_release.flux
+  to   = module.flux_bootstrap.helm_release.flux
+}
+
+moved {
+  from = kubernetes_secret.main
+  to   = module.flux_bootstrap.kubernetes_secret.main
+}
+
+output "bootstrap_resources" {
+  description = "Stable identities of resources created for Flux bootstrap."
+  value       = module.flux_bootstrap.bootstrap_resources
 }

--- a/clusters/offsite/bootstrap/bootstrap.tftest.hcl
+++ b/clusters/offsite/bootstrap/bootstrap.tftest.hcl
@@ -1,0 +1,30 @@
+mock_provider "github" {}
+mock_provider "helm" {}
+mock_provider "kubernetes" {}
+mock_provider "tls" {}
+
+run "exposes_offsite_bootstrap_resources" {
+  command = plan
+
+  assert {
+    condition = output.bootstrap_resources == {
+      deploy_key = {
+        repository = "infra"
+        title      = "Flux (offsite)"
+      }
+      flux = {
+        name      = "flux"
+        namespace = "flux-system"
+      }
+      flux_operator = {
+        name      = "flux-operator"
+        namespace = "flux-system"
+      }
+      github_credentials_secret = {
+        name      = "flux-github-app-credentials"
+        namespace = "flux-system"
+      }
+    }
+    error_message = "offsite bootstrap must expose its Flux deploy key, releases, and credentials secret"
+  }
+}

--- a/terraform/modules/flux-bootstrap/main.tf
+++ b/terraform/modules/flux-bootstrap/main.tf
@@ -1,0 +1,45 @@
+resource "tls_private_key" "flux" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
+}
+
+resource "github_repository_deploy_key" "this" {
+  title      = "Flux (${var.cluster_name})"
+  repository = var.github_repo
+  key        = tls_private_key.flux.public_key_openssh
+  read_only  = "true"
+}
+
+resource "helm_release" "flux_operator" {
+  name             = "flux-operator"
+  namespace        = "flux-system"
+  repository       = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart            = "flux-operator"
+  create_namespace = true
+}
+
+resource "helm_release" "flux" {
+  depends_on = [helm_release.flux_operator]
+
+  name       = "flux"
+  namespace  = "flux-system"
+  repository = "oci://ghcr.io/controlplaneio-fluxcd/charts"
+  chart      = "flux-instance"
+
+  values = [var.flux_values]
+}
+
+resource "kubernetes_secret" "main" {
+  metadata {
+    name      = "flux-github-app-credentials"
+    namespace = "flux-system"
+  }
+
+  data = {
+    identity       = tls_private_key.flux.private_key_pem
+    "identity.pub" = tls_private_key.flux.public_key_pem
+    known_hosts    = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
+  }
+
+  depends_on = [helm_release.flux]
+}

--- a/terraform/modules/flux-bootstrap/outputs.tf
+++ b/terraform/modules/flux-bootstrap/outputs.tf
@@ -1,0 +1,22 @@
+output "bootstrap_resources" {
+  description = "Stable identities of resources created for Flux bootstrap."
+
+  value = {
+    deploy_key = {
+      repository = github_repository_deploy_key.this.repository
+      title      = github_repository_deploy_key.this.title
+    }
+    flux = {
+      name      = helm_release.flux.name
+      namespace = helm_release.flux.namespace
+    }
+    flux_operator = {
+      name      = helm_release.flux_operator.name
+      namespace = helm_release.flux_operator.namespace
+    }
+    github_credentials_secret = {
+      name      = kubernetes_secret.main.metadata[0].name
+      namespace = kubernetes_secret.main.metadata[0].namespace
+    }
+  }
+}

--- a/terraform/modules/flux-bootstrap/variables.tf
+++ b/terraform/modules/flux-bootstrap/variables.tf
@@ -1,0 +1,14 @@
+variable "cluster_name" {
+  type        = string
+  description = "Cluster identity used in the Flux deploy-key title."
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository that Flux reads."
+}
+
+variable "flux_values" {
+  type        = string
+  description = "Rendered values for the flux-instance Helm release."
+}

--- a/terraform/modules/flux-bootstrap/versions.tf
+++ b/terraform/modules/flux-bootstrap/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    github = {
+      source = "integrations/github"
+    }
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+    tls = {
+      source = "hashicorp/tls"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Extract the shared Flux bootstrap implementation into a reusable Terraform module while keeping separate folly and offsite root state.

## Changes

- Add a shared Flux bootstrap Terraform module.
- Preserve existing resource addresses with moved declarations.
- Add and run bootstrap root contract tests in CI.

## Test Plan

- [x] Terraform formatting checks
- [x] Backend-free initialization for both bootstrap roots
- [ ] Terraform validate/test in CI (sandbox provider handshake blocked locally)
