### PR TITLE
ci: publish first-party images to GHCR

### DIFF
--- a/.github/containers.json
+++ b/.github/containers.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Allowlist for the containers workflow. Every image produced by a Dockerfile under apps/ or images/ must appear in exactly one of these lists. detect-containers.sh fails CI if a Dockerfile is left unclassified, so a new app can't be silently published or silently dropped. 'build' = published to DockerHub; 'ignore' = has a Dockerfile but is intentionally not published here.",
+  "_comment": "Allowlist for the containers workflow. Every image produced by a Dockerfile under apps/ or images/ must appear in exactly one of these lists. detect-containers.sh fails CI if a Dockerfile is left unclassified, so a new app can't be silently published or silently dropped. 'build' = published to GHCR; 'ignore' = has a Dockerfile but is intentionally not published here.",
   "build": [
     "ai-agents",
     "ddnsd",

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -26,6 +26,10 @@ concurrency:
   group: containers-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   detect:
     runs-on: ubuntu-latest
@@ -57,19 +61,20 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         # Only needed for the push (on main); PRs build to validate without pushing,
         # so they don't require — or have access to, from forks — the registry creds.
         if: github.event_name != 'pull_request'
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate Docker Meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         id: meta
         with:
-          images: ${{ vars.DOCKERHUB_USERNAME }}/${{ matrix.image }}
+          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
           flavor: |
             latest=true
           tags: |

--- a/apps/agent-web/Dockerfile
+++ b/apps/agent-web/Dockerfile
@@ -2,8 +2,8 @@
 #
 # Build context is the REPO ROOT (the frontend lives in packages/agent-web-ui).
 # Two images are produced from this one Dockerfile via --build-arg AGENT_SET:
-#   AGENT_SET=full  -> docker.io/jonpulsifer/ai-agents (claude-code, opencode, pi, openclaw)
-#   AGENT_SET=pi    -> docker.io/jonpulsifer/pi         (openclaw only)
+#   AGENT_SET=full  -> ghcr.io/jonpulsifer/ai-agents (claude-code, opencode, pi, openclaw)
+#   AGENT_SET=pi    -> local validation only (openclaw only)
 #
 #   docker build -f apps/agent-web/Dockerfile --build-arg AGENT_SET=full .
 


### PR DESCRIPTION
## Summary
Migrate the generic first-party container publisher from Docker Hub to GitHub Container Registry using the repository's `GITHUB_TOKEN`. This is phase 1 of the registry rollout: consumers remain on their current, verified Docker Hub digests until the GHCR packages have been published and their digests can be resolved.

## Changes
- grant the containers workflow read-content and write-package permissions
- authenticate to `ghcr.io` with `GITHUB_TOKEN` for main-branch pushes
- publish all six allowlisted images as `ghcr.io/jonpulsifer/<image>`
- retain build-only pull request validation with no registry push
- update first-party publishing comments from Docker Hub to GHCR

## Test Plan
- [x] Run the container detector for a workflow change and verify all six images are in the generated matrix
- [x] Verify the allowlist contains exactly the six expected published images
- [x] Run `git diff --check`
- [ ] Merge and verify the main-branch containers run publishes all six GHCR packages
- [ ] Resolve GHCR digests and cut consumers over in a follow-up PR
