### PR TITLE
fix(containers): invoke Turbo through Bun

### DIFF
--- a/apps/hub/Dockerfile
+++ b/apps/hub/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="/root/.bun/bin:${PATH}" \
 FROM base AS pruner
 WORKDIR /app
 COPY . .
-RUN bunx turbo@2.10.3 prune hub --docker
+RUN bun x turbo@2.10.3 prune hub --docker
 
 FROM base AS builder
 WORKDIR /app

--- a/apps/slingshot/Dockerfile
+++ b/apps/slingshot/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH="/root/.bun/bin:${PATH}" \
 FROM base AS pruner
 WORKDIR /app
 COPY . .
-RUN bunx turbo@2.10.3 prune slingshot --docker
+RUN bun x turbo@2.10.3 prune slingshot --docker
 
 FROM base AS builder
 ENV STANDALONE=1

--- a/apps/spore/Dockerfile
+++ b/apps/spore/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH="/root/.bun/bin:${PATH}" \
 FROM base AS pruner
 WORKDIR /app
 COPY . .
-RUN bunx turbo@2.10.3 prune spore --docker
+RUN bun x turbo@2.10.3 prune spore --docker
 
 FROM base AS builder
 ENV STANDALONE=1


### PR DESCRIPTION
## Summary

Restore container pruning after Bun 1.3.10 stopped installing the `bunx` shim.

## Changes

- fix(containers): invoke Turbo through Bun

## Test Plan

- [x] Build the `pruner` target for hub, slingshot, and spore with `wslc.exe build --no-cache`
- [ ] Confirm the containers workflow passes its full amd64/arm64 build matrix

## Context

- `.agent/context/context.md`
- `.agent/context/plan.md`
