### PR TITLE
fix(oidc): always deploy Pages output

### DIFF
--- a/.github/workflows/oidc.yml
+++ b/.github/workflows/oidc.yml
@@ -34,9 +34,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Assemble site
-        id: assemble
         run: |
           set -euo pipefail
+          mkdir -p dist
           for cluster in folly offsite; do
             src="terraform/pki/oidc/$cluster"
             [ -d "$src" ] || continue
@@ -46,23 +46,21 @@ jobs:
             cp "$src/openid-configuration.json" "dist/$cluster/.well-known/openid-configuration"
             cp "$src/jwks.json" "dist/$cluster/openid/v1/jwks"
           done
-          if [ ! -d dist ]; then
-            echo "no issuer documents committed yet; skipping deploy"
-            echo "have_docs=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           # Extensionless JSON needs explicit headers; keep max-age short so
           # signer rotation propagates to verifiers quickly.
           cat > dist/_headers <<'EOF'
-          /*
+          /:cluster/.well-known/openid-configuration
+            Content-Type: application/json; charset=utf-8
+            Cache-Control: public, max-age=300
+
+          /:cluster/openid/v1/jwks
             Content-Type: application/json; charset=utf-8
             Cache-Control: public, max-age=300
           EOF
           find dist -type f | sort
-          echo "have_docs=true" >> "$GITHUB_OUTPUT"
 
       - name: Deploy to Cloudflare Pages
-        if: github.ref == 'refs/heads/main' && steps.assemble.outputs.have_docs == 'true'
+        if: github.ref == 'refs/heads/main'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           # fml account (terraform/network/cloudflare/account.tf)


### PR DESCRIPTION
## Summary

Ensure the Terraform-managed `fml-oidc` Cloudflare Pages project receives a production deployment even before cluster issuer documents have been generated.

## Changes

- Always create the Pages output directory and deploy it from `main`.
- Use the generated `_headers` configuration as the initial deployment artifact.
- Scope JSON content and cache headers to the OIDC discovery and JWKS routes.

## Test Plan

- [x] `mise exec actionlint -- actionlint .github/workflows/oidc.yml`
- [x] `mise exec yq -- yq eval '.' .github/workflows/oidc.yml`
- [x] `git diff --check`
- [x] Assemble the no-document output locally and confirm `dist/_headers` is produced.
