### PR TITLE
chore(renovate): limit concurrent PRs and rebase only when conflicted

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,11 +29,11 @@
     'prEditedNotification',
     'prIgnoreNotification',
   ],
-  // Recreate dependency branches only when they conflict with main. This
-  // avoids regenerating shared lockfiles and rerunning CI after every merge.
-  // Terraform provider PRs opt into behind-base-branch below so Atlantis
-  // always applies a current plan.
-  rebaseWhen: 'conflicted',
+  // 'auto' rebases automerging PRs (most of this repo) whenever they fall
+  // behind main — Atlantis plans stay fresh and GitHub native auto-merge can
+  // satisfy require-up-to-date rules — while manual-review PRs only rebase on
+  // conflict. Terraform PRs are forced to behind-base-branch below.
+  rebaseWhen: 'auto',
   // Use GitHub's native auto-merge so PRs merge as soon as required checks
   // pass, instead of waiting for the next Renovate run.
   platformAutomerge: true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,11 @@
   ],
   dependencyDashboardTitle: 'Renovate Dashboard',
   dependencyDashboard: true,
+  // Keep the repository-wide dependency queue small. This also limits
+  // concurrent branches, so workspace updates do not pile up against shared
+  // lockfiles. Vulnerability alerts bypass these limits by design.
+  prConcurrentLimit: 3,
+  branchConcurrentLimit: 3,
   lockFileMaintenance: {
     enabled: true,
     automerge: true,
@@ -24,11 +29,11 @@
     'prEditedNotification',
     'prIgnoreNotification',
   ],
-  // 'auto' rebases automerging PRs (most of this repo) whenever they fall
-  // behind main — Atlantis plans stay fresh and GitHub native auto-merge can
-  // satisfy require-up-to-date rules — while manual-review PRs only rebase on
-  // conflict. Terraform PRs are forced to behind-base-branch below.
-  rebaseWhen: 'auto',
+  // Recreate dependency branches only when they conflict with main. This
+  // avoids regenerating shared lockfiles and rerunning CI after every merge.
+  // Terraform provider PRs opt into behind-base-branch below so Atlantis
+  // always applies a current plan.
+  rebaseWhen: 'conflicted',
   // Use GitHub's native auto-merge so PRs merge as soon as required checks
   // pass, instead of waiting for the next Renovate run.
   platformAutomerge: true,


### PR DESCRIPTION
## Summary

Limits Renovate's concurrent PR and branch creation to reduce lockfile churn and CI noise. Switches from automatic rebasing to conflict-only rebasing, which prevents unnecessary regeneration of shared lockfiles after each merge.

## Changes

- Add `prConcurrentLimit: 3` and `branchConcurrentLimit: 3` to cap the dependency update queue
- Change `rebaseWhen` from `'auto'` to `'conflicted'` so branches only recreate when they conflict with `main`