### PR TITLE
feat(typescript)!: migrate to TypeScript 7 (native compiler)

### DIFF
--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -36,7 +36,7 @@
     "@types/ws": "8.18.1",
     "tailwindcss": "4.3.2",
     "tw-animate-css": "1.4.0",
-    "typescript": "5.9.3",
+    "typescript": "7.0.2",
     "vite": "8.1.5",
     "vite-plugin-devtools-json": "1.0.0",
     "vite-tsconfig-paths": "6.1.1"

--- a/apps/hub/tsconfig.json
+++ b/apps/hub/tsconfig.json
@@ -13,7 +13,6 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "rootDirs": [".", "./.react-router/types"],
-    "baseUrl": ".",
     "paths": {
       "~/*": ["./app/*"]
     },

--- a/apps/slingshot/next.config.ts
+++ b/apps/slingshot/next.config.ts
@@ -9,6 +9,11 @@ const nextConfig: NextConfig = {
     },
   },
   output: process.env.STANDALONE ? 'standalone' : undefined,
+  // Next 16.2 typechecks via the TS JS API, which TS 7 omits until 7.1.
+  // Type safety is enforced by the standalone `tsc --noEmit` (bun run typecheck).
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 export default nextConfig;

--- a/apps/slingshot/package.json
+++ b/apps/slingshot/package.json
@@ -66,7 +66,6 @@
     "sonner": "2.0.7",
     "swr": "2.4.2",
     "tailwind-merge": "3.6.0",
-    "typescript": "5.9.3",
     "vaul": "1.1.2",
     "zod": "4.4.3"
   },
@@ -79,6 +78,6 @@
     "postcss": "8.5.17",
     "tailwindcss": "4.3.2",
     "tw-animate-css": "1.4.0",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   }
 }

--- a/apps/spore/next.config.ts
+++ b/apps/spore/next.config.ts
@@ -4,6 +4,11 @@ const nextConfig: NextConfig = {
   cacheComponents: true,
   output: 'standalone',
   serverExternalPackages: ['better-sqlite3'],
+  // Next 16.2 typechecks via the TS JS API, which TS 7 omits until 7.1.
+  // Type safety is enforced by the standalone `tsc --noEmit` (bun run typecheck).
+  typescript: {
+    ignoreBuildErrors: true,
+  },
 };
 
 export default nextConfig;

--- a/apps/spore/package.json
+++ b/apps/spore/package.json
@@ -42,6 +42,6 @@
     "drizzle-kit": "0.31.10",
     "postcss": "8.5.17",
     "tailwindcss": "4.3.2",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
         "@types/ws": "8.18.1",
         "tailwindcss": "4.3.2",
         "tw-animate-css": "1.4.0",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
         "vite": "8.1.5",
         "vite-plugin-devtools-json": "1.0.0",
         "vite-tsconfig-paths": "6.1.1",
@@ -102,7 +102,6 @@
         "sonner": "2.0.7",
         "swr": "2.4.2",
         "tailwind-merge": "3.6.0",
-        "typescript": "5.9.3",
         "vaul": "1.1.2",
         "zod": "4.4.3",
       },
@@ -115,7 +114,7 @@
         "postcss": "8.5.17",
         "tailwindcss": "4.3.2",
         "tw-animate-css": "1.4.0",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
     },
     "apps/spore": {
@@ -151,7 +150,7 @@
         "drizzle-kit": "0.31.10",
         "postcss": "8.5.17",
         "tailwindcss": "4.3.2",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
     },
     "apps/wiki": {
@@ -179,7 +178,7 @@
         "@types/k6": "2.0.1",
         "@types/node": "26.1.1",
         "ts-node": "10.9.2",
-        "typescript": "5.9.3",
+        "typescript": "7.0.2",
       },
     },
     "packages/typescript-config": {
@@ -1684,10 +1683,6 @@
 
     "google-gax/google-auth-library": ["google-auth-library@10.5.0", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.0.0", "gcp-metadata": "^8.0.0", "google-logging-utils": "^1.0.0", "gtoken": "^8.0.0", "jws": "^4.0.0" } }, "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w=="],
 
-    "hub/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "k6-scripts/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
     "lightningcss/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -1707,10 +1702,6 @@
     "react-router-dom/react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
 
     "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
-    "slingshot/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "spore/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 

--- a/packages/k6/package.json
+++ b/packages/k6/package.json
@@ -9,7 +9,7 @@
     "@types/node": "26.1.1",
     "ts-node": "10.9.2",
     "@repo/typescript-config": "workspace:*",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   },
   "scripts": {
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Migrates the Bun/Turborepo workspace from TypeScript **5.9.3 → 7.0.2** (the native Go `tsc`). Scope is **type-check-only** — the fast native compiler now backs `bun run typecheck` in CI. TS 7.0 went GA on 2026-07-08 and ships on the normal `latest` tag.

## Changes

- **Bump `typescript` → `7.0.2`** in `apps/hub`, `apps/spore`, `apps/slingshot`, `packages/k6` (`packages/agent-web-ui`'s peer range already allowed `^7`).
- **`apps/hub/tsconfig.json`**: remove `baseUrl` — a **hard error** in TS7. The relative `paths` (`~/* → ./app/*`) still resolve without it.
- **`apps/spore` + `apps/slingshot` `next.config.ts`**: set `typescript.ignoreBuildErrors: true`. Next `16.2.10` type-checks during `next build` via the TS **JS programmatic API**, which TS7 intentionally omits until 7.1. Type safety is still enforced by the standalone `tsc --noEmit`.
- **`apps/slingshot/package.json`**: drop stray `typescript` from `dependencies` (it belongs in devDependencies only).

## Verification

```
bun run typecheck  →  4 successful, 4 total (~800ms)
tsc --version      →  7.0.2 (native)
```

hub (`react-router typegen && tsc`), spore/slingshot/k6 (`tsc --noEmit`) all pass.

## Follow-up (tracked, not in this PR)

When **Next 16.3+** stabilizes, bump spore/slingshot, switch to `experimental.useTypeScriptCli: true`, and **remove `ignoreBuildErrors`** so `next build` type-checks again. Until then, build-time typecheck for those two apps is intentionally off (covered by the separate `tsc --noEmit`).

Dead shared presets `packages/typescript-config/{nextjs,remix}.json` contain TS7-dropped options (`target: es5`, `baseUrl`) but nothing extends them; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Lfqh6GsScN9C9x7HN1inT