### PR TITLE
fix(hub): install bun system-wide so non-root user can run it

### DIFF
--- a/apps/hub/Dockerfile
+++ b/apps/hub/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 FROM node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS base
 ARG BUN_VERSION=1.3.10
+ENV BUN_INSTALL=/usr/local \
+  TURBO_TELEMETRY_DISABLED=1
 RUN apk add --no-cache bash curl libc6-compat \
   && curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
-ENV PATH="/root/.bun/bin:${PATH}" \
-  TURBO_TELEMETRY_DISABLED=1
 
 FROM base AS pruner
 WORKDIR /app


### PR DESCRIPTION
## Summary
Fix the hub container `bun: Permission denied` crash by installing bun system-wide (`/usr/local/bin`) instead of into root's home directory, and run the container as a non-root user.

## Changes
- `apps/hub/Dockerfile`: set `BUN_INSTALL=/usr/local` so the bun binary is world-readable and on the default PATH; add `USER 1000:1000` + `--chown` on COPYs so the runner stage doesn't run as root

## Test Plan
- [ ] `docker build -t hub-test -f apps/hub/Dockerfile .` succeeds
- [ ] `docker run --rm hub-test bun --version` prints the version (confirm bun is reachable)
- [ ] Deploy to offsite cluster, verify pod starts without `Permission denied`
