### PR TITLE
fix(atlantis): use defaultTFDistribution chart value instead of env var

### DIFF
--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -37,11 +37,11 @@ spec:
       # for "**"; unifi/folly/bgp-folly.conf only has one) — "terraform/**/*.conf"
       # has enough segments before the target file to avoid that.
       ATLANTIS_AUTOPLAN_FILE_LIST: "**/*.tf*,terraform/**/*.conf"
+      # ATLANTIS_DEFAULT_TF_DISTRIBUTION is set via defaultTFDistribution below.
       # OpenTofu for every root: state-format compatible with Terraform, and
       # terraform/pki needs the opentofu/tls provider fork (max_path_length),
       # which only exists on the OpenTofu registry. Server-wide because the
       # server-side repos[] config has no per-project terraform_distribution.
-      ATLANTIS_DEFAULT_TF_DISTRIBUTION: "opentofu"
       # ATLANTIS_SILENCE_FORK_PR_ERRORS: "true"
       GOOGLE_APPLICATION_CREDENTIALS: "/run/secrets/terraform.json"
       GOOGLEWORKSPACE_CREDENTIALS: "/run/secrets/terraform.json"
@@ -102,6 +102,9 @@ spec:
           - name: Super Duper Policy Set
             path: /home/atlantis/policies/
             source: local
+    # Set via dedicated chart value to avoid duplicating ATLANTIS_DEFAULT_TF_DISTRIBUTION
+    # in the environment map (the chart auto-generates the env var from this value).
+    defaultTFDistribution: opentofu
     hidePrevPlanComments: true
     hideUnchangedPlanComments: true
     ingress:


### PR DESCRIPTION
## Summary
Fix duplicate `ATLANTIS_DEFAULT_TF_DISTRIBUTION` env var that caused the Atlantis Helm release to fail with a server-side apply error.

## Changes
- Use the chart's dedicated `defaultTFDistribution: opentofu` value instead of setting `ATLANTIS_DEFAULT_TF_DISTRIBUTION` in the user `environment` map (which the chart also auto-generates from `defaultTFDistribution`, creating a duplicate)

## Test Plan
- [ ] Verify the Atlantis HelmRelease reconciles successfully after merge

