### PR TITLE
fix(spore): allow LAN access to management vhost

### DIFF
--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -53,6 +53,20 @@ in
 
   homelab.nfsServer.dataDevice = "/dev/disk/by-label/nfs-data";
 
+  services.spore.managementCidrs = [
+    "127.0.0.0/8"
+    "::1/128"
+    "100.64.0.0/10"
+    "10.1.0.0/24" # fml / management LAN
+    lab.cidr # 10.2.0.0/24 — lab LAN
+    "10.3.0.0/26" # k8s node subnet
+    "10.13.37.0/28" # future VLAN
+  ];
+  services.spore.managementAliases = [
+    "spore.pirate-musical.ts.net"
+    lab.hosts.spore # 10.2.0.11 — reachable by LAN IP
+  ];
+
   # Desired boot state is built into an immutable catalog. MAC addresses are
   # derived from clients.yaml in the package closure, keeping UniFi's client
   # inventory as the single source of truth instead of transcribing it here.


### PR DESCRIPTION
## Summary
Open spore's management vhost (`spore.lolwtf.ca`) to LAN access, not just loopback and Tailscale. Previously the nginx allow-list restricted access to `127.0.0.0/8`, `::1/128`, and `100.64.0.0/10` (Tailscale) only.

## Changes
- fix(spore): allow LAN access to management vhost

## Test Plan
- [ ] Rebuild spore: `nixos-rebuild switch --flake .#spore --target-host spore --sudo`
- [ ] Verify `http://spore.lolwtf.ca/` is reachable from the future VLAN (`10.13.37.0/28`)
- [ ] Verify it's also reachable from the lab LAN (`10.2.0.0/24`) and management LAN (`10.1.0.0/24`)

## Context
- `nix/hosts/spore.nix`
