### PR TITLE
fix(spore): satisfy any for management vhost auth

### DIFF
--- a/apps/spore/module.nix
+++ b/apps/spore/module.nix
@@ -347,7 +347,11 @@ in
       locations."/" = {
         proxyPass = upstream;
         proxyWebsockets = false;
-        extraConfig = lib.concatMapStringsSep "\n" (cidr: "allow ${cidr};") cfg.managementCidrs + ''
+        extraConfig = ''
+          satisfy any;
+        ''
+        + lib.concatMapStringsSep "\n" (cidr: "allow ${cidr};") cfg.managementCidrs
+        + ''
 
           deny all;
           proxy_set_header Host $host;


### PR DESCRIPTION
## Summary
Open spore's management vhost to LAN access — the host-level CIDR allow-lists are already on main via #1155, but `satisfy any` was missing, causing nginx to require BOTH IP allow AND Tailscale auth. LAN clients passed the IP check but failed Tailscale auth → HTTP 401.

## Changes
- Add `satisfy any;` to the management vhost location so either IP allow OR tailscaleAuth passes

## Test Plan
- [ ] Rebuild spore: `nixos-rebuild switch --flake .#spore --target-host spore --sudo`
- [ ] Verify `http://spore.lolwtf.ca/` is reachable from `10.13.37.0/28` without Tailscale

## Context
- See #1155 for the host-level CIDR additions (`nix/hosts/spore.nix`)
