### PR TITLE
feat(hub): add TEMPESTWX_IGNORE_STATIONS to suppress entire stations

### DIFF
--- a/apps/hub/README.md
+++ b/apps/hub/README.md
@@ -34,6 +34,9 @@ A weather station dashboard designed for the Raspberry Pi 4 display, powered by 
 3. Create a `.env` file with your TempestWx token:
    ```env
    TEMPESTWX_TOKENS=your_token_here
+   # Optional: comma-separated station IDs to ignore (all devices belonging to
+   # an ignored station are dropped)
+   TEMPESTWX_IGNORE_STATIONS=85191
    ```
 
 ### Development

--- a/apps/hub/app/lib/weatherflow/config.ts
+++ b/apps/hub/app/lib/weatherflow/config.ts
@@ -20,6 +20,11 @@ export const WEATHERFLOW_CONFIG = {
   REST_API_URL: 'https://swd.weatherflow.com/swd/rest',
   API_TIMEOUT: 10000, // 10 seconds
 
+  // Station filtering
+  // Comma-separated list of station IDs to ignore (set via TEMPESTWX_IGNORE_STATIONS env var).
+  // All devices belonging to an ignored station are dropped.
+  IGNORE_STATIONS_ENV: 'TEMPESTWX_IGNORE_STATIONS',
+
   // Data processing thresholds
   PRESSURE_TREND_THRESHOLD: 1.0, // mb threshold for significant change
   PRESSURE_HISTORY_SIZE: 20, // Keep last 20 readings for trend calculation

--- a/apps/hub/app/services/weather.server.ts
+++ b/apps/hub/app/services/weather.server.ts
@@ -29,11 +29,37 @@ export class WeatherService extends EventEmitter {
   private connections = new Map<string, StationConnection>(); // token -> connection state
   private messageHandler = new WeatherMessageHandler();
   private deviceToStation = new Map<number, string>();
+  private ignoreStationIds: Set<number>;
+  // Derived set: device IDs belonging to ignored stations, populated
+  // in fetchAndListen and consulted in the message handler for defense
+  // in depth (drops messages that arrive before/during fetchAndListen).
+  private blockedDeviceIds = new Set<number>();
 
   private constructor() {
     super();
     // Increase max listeners for many SSE clients
     this.setMaxListeners(100);
+    this.ignoreStationIds = this.parseIgnoreStations();
+  }
+
+  /**
+   * Parse TEMPESTWX_IGNORE_STATIONS env var into a Set of station IDs to ignore.
+   * Comma-separated list, e.g. "85191,12345". All devices belonging to an
+   * ignored station are dropped.
+   */
+  private parseIgnoreStations(): Set<number> {
+    const raw = process.env[WEATHERFLOW_CONFIG.IGNORE_STATIONS_ENV];
+    if (!raw) return new Set();
+    const ids = raw
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number)
+      .filter((n) => !isNaN(n));
+    if (ids.length > 0) {
+      log.info(`Ignoring station IDs: ${ids.join(', ')}`);
+    }
+    return new Set(ids);
   }
 
   public static getInstance(): WeatherService {
@@ -111,6 +137,10 @@ export class WeatherService extends EventEmitter {
 
         // Process with handler to get clean WeatherData
         const deviceId = message.device_id || 0;
+
+        // Drop messages from devices belonging to ignored stations
+        if (this.blockedDeviceIds.has(deviceId)) return;
+
         const stationLabel = this.deviceToStation.get(deviceId) || '';
 
         const weatherData = this.messageHandler.processObservation(
@@ -257,12 +287,28 @@ export class WeatherService extends EventEmitter {
       if (!data.stations) return;
 
       for (const station of data.stations) {
+        // Skip entire station if its ID is in the ignore list
+        if (this.ignoreStationIds.has(station.station_id)) {
+          log.info(
+            `Ignoring station ${station.station_id} (${station.name}) — in TEMPESTWX_IGNORE_STATIONS`,
+          );
+          // Populate blockedDeviceIds so the message handler also drops
+          // any messages from these devices (defense in depth).
+          if (station.devices) {
+            for (const device of station.devices) {
+              this.blockedDeviceIds.add(device.device_id);
+            }
+          }
+          continue;
+        }
+
         if (!station.devices) continue;
         for (const device of station.devices) {
           // Only listen to Tempest (ST) or Air/Sky devices, not Hubs (HB)
           if (device.device_type === 'HB') continue;
 
           const deviceId = device.device_id;
+
           this.deviceToStation.set(deviceId, station.name);
 
           // Emit status update so client knows about this station immediately

--- a/clusters/offsite/apps/hub/helm-release.yaml
+++ b/clusters/offsite/apps/hub/helm-release.yaml
@@ -21,6 +21,9 @@ spec:
     port: 3000
     hostname: hub.lolwtf.ca
     sandbox: false
+    env:
+      - name: TEMPESTWX_IGNORE_STATIONS
+        value: "85191"
     envFromSecret: hub-env
     ingress:
       enabled: true


### PR DESCRIPTION
## Summary
Add `TEMPESTWX_IGNORE_STATIONS` env var so hub can suppress an entire WeatherFlow station (e.g. station 85191) — all its devices are dropped from the dashboard.

## Changes
- `apps/hub/app/lib/weatherflow/config.ts` — new `IGNORE_STATIONS_ENV` constant
- `apps/hub/app/services/weather.server.ts` — parse ignore list, skip in `fetchAndListen` (no `listen_start`, no map entry, no SSE emit), drop messages in the WS handler via derived `blockedDeviceIds` set
- `apps/hub/README.md` — document the new env var
- `clusters/offsite/apps/hub/helm-release.yaml` — set `TEMPESTWX_IGNORE_STATIONS=85191`

## Test Plan
- [ ] Deploy to offsite, confirm station 85191 (device 223967) no longer appears in dashboard
- [ ] Verify other stations still display correctly
