### PR TITLE
fix(unifi): allow lab clients to reach offsite k8s

### DIFF
--- a/terraform/network/unifi/folly/firewall.tf
+++ b/terraform/network/unifi/folly/firewall.tf
@@ -350,6 +350,30 @@ resource "unifi_firewall_policy" "folly_k8s_to_nest_k8s" {
   }
 }
 
+resource "unifi_firewall_policy" "lab_clients_to_nest_k8s" {
+  name                 = "Allow Lab clients to Nest k8s"
+  action               = "ALLOW"
+  protocol             = "all"
+  ip_version           = "BOTH"
+  create_allow_respond = true
+  enabled              = true
+  logging              = false
+
+  source = {
+    matching_target    = "IP"
+    ips                = [local.lab.cidr]
+    port_matching_type = "ANY"
+    zone_id            = unifi_firewall_zone.lab.id
+  }
+
+  destination = {
+    matching_target    = "IP"
+    ips                = local.nest_k8s_cidrs
+    port_matching_type = "ANY"
+    zone_id            = data.unifi_firewall_zone.vpn.id
+  }
+}
+
 resource "unifi_firewall_policy" "internal_to_nest_k8s" {
   name                 = "Allow Internal to Nest k8s"
   action               = "ALLOW"


### PR DESCRIPTION
## Summary
Allow clients on the `10.2.0.0/24` Lab network to reach the offsite Kubernetes address space, restoring `homepi4` access to `hub.lolwtf.ca` at `10.89.0.66`.

## Changes
- Add an SSOT-backed `Lab` to `Vpn` UniFi firewall policy for offsite Kubernetes CIDRs.
- Preserve return traffic with `create_allow_respond` and keep the rule scoped to the Lab client CIDR.

## Test Plan
- [x] `tofu -chdir=terraform/network/unifi/folly fmt -check`
- [x] `tofu -chdir=terraform/network/unifi/folly validate`
- [x] `git diff --check`
- [ ] Review the Atlantis plan for one new UniFi firewall policy.
- [ ] After apply, verify `curl -fsSIL https://hub.lolwtf.ca` from `homepi4` and restart `cage-tty1.service`.
