### PR TITLE
fix(spore): give the native-boot publisher openssl and its shell deps

### DIFF
--- a/nix/services/spore-native-boot.nix
+++ b/nix/services/spore-native-boot.nix
@@ -70,9 +70,15 @@ in
           wantedBy = [ "multi-user.target" ];
           before = [ "nginx.service" ];
           restartTriggers = [ target.package ];
+          # rpi-eeprom-digest is a shell script that shells out to openssl and
+          # xxd (and greps/awks its output); coreutils covers sha256sum/mktemp.
           path = with pkgs; [
             coreutils
+            gawk
+            gnugrep
+            openssl
             raspberrypi-eeprom
+            xxd
           ];
           serviceConfig = {
             Type = "oneshot";


### PR DESCRIPTION
Follow-up to #1169.

The static publisher's systemd unit had its `PATH` trimmed to `coreutils + raspberrypi-eeprom`, but `rpi-eeprom-digest` is a shell script that shells out to `openssl`, `xxd`, `awk`, and `grep` to sign `boot.img`. Deploy failed with:

```
spore-native-boot-rackpi5-start[...]: openssl not found. Try installing the openssl package.
```

Confirmed against the tool itself — `rpi-eeprom-digest` references `awk cut grep mktemp openssl sha256sum xxd`. This restores `openssl`, `xxd`, `gawk`, `gnugrep` (coreutils already covers `cut`/`mktemp`/`sha256sum`).

After merge + spore rebuild, the publisher should sign successfully; then `curl -sI http://10.2.0.11/rackpi5-ram/boot.sig` should return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)