### PR TITLE
feat(ntp): add redundant LAN time servers

### DIFF
--- a/clusters/folly/monitoring/dns.yaml
+++ b/clusters/folly/monitoring/dns.yaml
@@ -74,3 +74,11 @@ spec:
           annotations:
             message: Prometheus target missing (instance {{ $labels.instance }})
             description: "A Prometheus target has disappeared. An exporter might be crashed.\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+        - alert: DnsChronyDown
+          expr: (node_systemd_unit_state{instance="dns", name="chronyd.service", state="active"} == 0) or absent(node_systemd_unit_state{instance="dns", name="chronyd.service", state="active"})
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            message: NTP server on dns is down
+            description: "chronyd.service is not active on dns. Clients configured to use dns as a time source have lost one half of the redundant NTP pair."

--- a/clusters/folly/monitoring/spore.yaml
+++ b/clusters/folly/monitoring/spore.yaml
@@ -90,6 +90,14 @@ spec:
           annotations:
             message: NFS server on spore is down
             description: "nfs-server.service is not active on spore. k8s PVs (spore-pv, nfs-provisioner) are unavailable."
+        - alert: SporeChronyDown
+          expr: (node_systemd_unit_state{instance="spore", name="chronyd.service", state="active"} == 0) or absent(node_systemd_unit_state{instance="spore", name="chronyd.service", state="active"})
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            message: NTP server on spore is down
+            description: "chronyd.service is not active on spore. Clients configured to use spore as a time source have lost one half of the redundant NTP pair."
         - alert: SporeTftpDown
           expr: (node_systemd_unit_state{instance="spore", name="dnsmasq.service", state="active"} == 0) or absent(node_systemd_unit_state{instance="spore", name="dnsmasq.service", state="active"})
           for: 5m

--- a/docs/pages/Hosts___dns.md
+++ b/docs/pages/Hosts___dns.md
@@ -12,5 +12,7 @@ storage:: 32 GB microSD (root 27 GB, 13% used)
 os:: NixOS 26.05 (Yarara)
 
 - LAN DNS server. Config: `nix/hosts/dns.nix`.
+- Redundant LAN NTP server paired with [[Hosts/spore]] (`nix/services/ntp-server.nix`). Chrony uses authenticated Cloudflare and Netnod NTS upstreams, polls Spore, and serves UDP/123 to routed `10.0.0.0/8` clients. If all upstream time disappears, orphan mode elects one Pi to preserve a common timebase at stratum 10.
+- Verify with `chronyc tracking`, `chronyc sources -v`, and `chronyc authdata`.
 - Reached as `dns.lolwtf.ca`.
 - See [[Fleet]] for the full inventory.

--- a/docs/pages/Hosts___spore.md
+++ b/docs/pages/Hosts___spore.md
@@ -14,6 +14,8 @@ os:: NixOS 26.05 (Yarara)
 - NFS/PXE and signed native-boot server — **boot-critical for [[Hosts/rackpi5]]** ([[ADR/0008 Diskless netboot for rackpi5]]); monitored by folly.
 - Only Pi with NVMe storage (128 GB Patriot P300). Config: `nix/hosts/spore.nix`.
 - Reached as `spore.lolwtf.ca`.
+- Redundant LAN NTP server paired with [[Hosts/dns]] (`nix/services/ntp-server.nix`). Chrony uses authenticated Cloudflare and Netnod NTS upstreams, polls DNS, and serves UDP/123 to routed `10.0.0.0/8` clients. Orphan fallback reports stratum 10; neither Pi is stratum 1 without a hardware reference clock.
+- Verify with `chronyc tracking`, `chronyc sources -v`, and `chronyc authdata`.
 - ## Netboot serving
 	- There is **no application, database, or dynamic boot decision** — the Nix-built image is the policy. Spore just serves files over HTTP (nginx) plus TFTP (dnsmasq). The old Next.js catalog/observation app was removed; boot integrity is enforced by the EEPROM signature and the initrd's cmdline-pinned squashfs digest, not by a server.
 	- **x86 k8s nodes** netboot off the static iPXE tree in `/var/lib/tftpboot` (`nix/services/pxe-netboot.nix`): DHCP → TFTP `boot/ipxe.efi` → `menu.ipxe` → per-target kernel/initrd over HTTP.

--- a/nix/README.md
+++ b/nix/README.md
@@ -116,6 +116,7 @@ Custom service modules in `services/`:
 - **`iperf3.nix`** – iperf3 server for netbench
 - **`kiosk.nix`** – kiosk-mode display (see wiki `Runbooks/Kiosk`)
 - **`nfs-server.nix`** – NFS exports (spore)
+- **`ntp-server.nix`** – redundant Chrony LAN time servers (dns + spore)
 - **`pxe-netboot.nix`** – dnsmasq/nginx PXE netboot server (spore)
 - **`spore-native-boot.nix`** – signed Pi native-boot publisher (spore → rackpi5)
 - **`yarr.nix`** – RSS reader (oldschool)

--- a/nix/hosts/dns.nix
+++ b/nix/hosts/dns.nix
@@ -4,6 +4,7 @@
     ../hardware/pi5
     ../hardware/pi5/nvme-hat.nix
     ../services/common.nix
+    ../services/ntp-server.nix
   ];
 
   networking = {

--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -29,6 +29,7 @@
     ../hardware/pi5/nvme-hat.nix
     ../services/common.nix
     ../services/nfs-server.nix
+    ../services/ntp-server.nix
     ../services/pxe-netboot.nix
     ../services/spore-native-boot.nix
   ];

--- a/nix/services/common.nix
+++ b/nix/services/common.nix
@@ -55,7 +55,7 @@
     # series per unit and these are small Pis.
     enabledCollectors = [ "systemd" ];
     extraFlags = [
-      "--collector.systemd.unit-include=(nfs-server|nfs-mountd|rpc-statd|dnsmasq|nginx|spore-native-boot-rackpi5|pihole-ftl|tailscaled|ddnsd|sshd)\\.service"
+      "--collector.systemd.unit-include=(nfs-server|nfs-mountd|rpc-statd|dnsmasq|nginx|spore-native-boot-rackpi5|pihole-ftl|chronyd|tailscaled|ddnsd|sshd)\\.service"
     ];
   };
 

--- a/nix/services/ntp-server.nix
+++ b/nix/services/ntp-server.nix
@@ -20,8 +20,8 @@ in
     enable = true;
     enableNTS = true;
     servers = [
-      "time.cloudflare.com"
-      "nts.netnod.se"
+      "time.nrc.ca"
+      "time.chu.nrc.ca"
     ];
     extraConfig = ''
       # The two LAN servers poll one another so orphan mode can elect a leader

--- a/nix/services/ntp-server.nix
+++ b/nix/services/ntp-server.nix
@@ -1,0 +1,50 @@
+# Redundant LAN time service shared by dns and spore. Both hosts synchronise
+# from authenticated Internet sources and poll one another. Chrony's orphan
+# mode elects one local reference if every upstream is unavailable, keeping
+# the lab internally consistent while honestly reporting low-quality stratum
+# 10 time.
+{ lib, name, ... }:
+let
+  lab =
+    (builtins.fromJSON (builtins.readFile ../../terraform/network/unifi/folly/lab.tf.json)).locals.lab;
+  peer =
+    if name == "dns" then
+      lab.hosts.spore
+    else if name == "spore" then
+      lab.hosts.dns
+    else
+      throw "ntp-server.nix supports only dns and spore, not ${name}";
+in
+{
+  services.chrony = {
+    enable = true;
+    enableNTS = true;
+    servers = [
+      "time.cloudflare.com"
+      "nts.netnod.se"
+    ];
+    extraConfig = ''
+      # The two LAN servers poll one another so orphan mode can elect a leader
+      # and preserve a common timebase during a total upstream outage.
+      server ${peer} iburst
+      local stratum 10 orphan
+
+      # Serve routed homelab IPv4 networks, but never become a public NTP
+      # endpoint. The firewall separately limits ingress to UDP/123.
+      allow 10.0.0.0/8
+      ratelimit interval 1 burst 8
+    '';
+  };
+
+  networking.firewall.allowedUDPPorts = [ 123 ];
+
+  assertions = [
+    {
+      assertion = lib.elem name [
+        "dns"
+        "spore"
+      ];
+      message = "ntp-server.nix may only be imported by dns or spore";
+    }
+  ];
+}


### PR DESCRIPTION
## Summary
Run redundant, authenticated LAN NTP services on `dns` and `spore`. Each Pi synchronizes through NTS, polls its peer, and can preserve a common lab timebase with Chrony orphan mode during a total upstream outage.

## Changes
- add a shared Chrony NTP-server module for `dns` and `spore`
- expose `chronyd.service` through node exporter and alert when either server is unavailable
- document the NTP roles, failover behavior, and verification commands

## Test Plan
- [x] Build `nixosConfigurations.dns.config.system.build.toplevel`
- [x] Build `nixosConfigurations.spore.config.system.build.toplevel`
- [x] Render `clusters/folly/monitoring` with Kustomize
- [x] Build the documentation wiki
- [x] Run Nix formatting and `git diff --check`
- [ ] Full `nix flake check` (blocked by the unrelated stale hash for `https://github.com/wannabehero.keys` while evaluating `oldschool`)

## Deployment
No hosts or UniFi state were changed. UniFi DHCP option 42 remains deferred because the current provider cannot express the two NTP server addresses.
