### PR TITLE
docs(agents): route engineering skills to a private local-markdown tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,20 @@ read by `nix/hosts/rackpi5.nix`.
 Inside `docs/`, pages link each other with Logseq `[[wikilinks]]`. This file is
 not part of the graph, so it uses paths.
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs live as **private** local markdown under `.agent/plans/` (gitignored) — the planning surface stays off the public repo; code and PRs stay public. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles, written as `Status:` values on each ticket file (local tracker, not GitHub labels). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `AGENTS.md` router + the `docs/pages/` wiki graph (no `CONTEXT.md`/ADR). See `docs/agents/domain.md`.
+
 ## Writing rule for these docs
 
 The previous docs rotted because they restated what the tree already says. When

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,45 +1,60 @@
-# Issue tracker: GitHub
+# Issue tracker: Local Markdown (private)
 
-Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+Issues and specs (you may know a spec as a PRD) for this repo live as markdown
+files under **`.agent/plans/`**. This directory is gitignored (via the global
+`~/.config/git/ignore` `.agent/` rule), so PRDs, tickets, triage state, and
+iteration **never reach the public `jonpulsifer/infra` repo**. Keeping the
+planning surface private is the whole point — code and PRs stay public with full
+CI; the messy decision-making does not.
 
 ## Conventions
 
-- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
-- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
-- **Comment on an issue**: `gh issue comment <number> --body "..."`
-- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
-- **Close**: `gh issue close <number> --comment "..."`
-
-Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
-
-## Pull requests as a triage surface
-
-**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
-
-When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
-
-- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
-- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
-
-GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+- One feature per directory: `.agent/plans/<feature-slug>/`
+- The spec is `.agent/plans/<feature-slug>/spec.md`
+- Implementation issues are one file per ticket at
+  `.agent/plans/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` —
+  never a single combined tickets file
+- Triage state is recorded as a `Status:` line near the top of each issue file
+  (see `triage-labels.md` for the role strings — for a local tracker they are
+  `Status:` values, not GitHub labels)
+- Comments and conversation history append to the bottom of the file under a
+  `## Comments` heading
 
 ## When a skill says "publish to the issue tracker"
 
-Create a GitHub issue.
+Create a new file under `.agent/plans/<feature-slug>/` (creating the directory
+if needed). Do **not** `gh issue create` — that would leak it to the public repo.
 
 ## When a skill says "fetch the relevant ticket"
 
-Run `gh issue view <number> --comments`.
+Read the file at the referenced path. The user will normally pass the path or
+the ticket number directly.
+
+## Shipping to the public repo
+
+When work is ready, the PR goes to the public `jonpulsifer/infra` as normal
+(`gh pr create`, Atlantis/Flux/Nix CI). Reference the private spec in the PR body
+by its role or a one-line summary, not by pasting the raw iteration — the private
+files stay private. A public PR linking to a local `.agent/plans/` path is fine;
+the path simply isn't resolvable by outsiders, which is intended.
 
 ## Wayfinding operations
 
-Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+Used by `/wayfinder`. Efforts keep their established home under
+`.agent/wayfinder/<effort>/` (also gitignored). The **map** is a file with one
+**child** file per ticket.
 
-- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
-- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
-- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
-- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
-- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
-- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+- **Map**: `.agent/wayfinder/<effort>/map.md` — the Notes / Decisions-so-far /
+  Fog body.
+- **Child ticket**: `.agent/wayfinder/<effort>/issues/NN-<slug>.md`, numbered
+  from `01`, with the question in the body. A `Type:` line records the ticket
+  type (`research`/`prototype`/`grilling`/`task`); a `Status:` line records
+  `claimed`/`resolved`.
+- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked
+  when every file it lists is `resolved`.
+- **Frontier**: scan `.agent/wayfinder/<effort>/issues/` for files that are open,
+  unblocked, and unclaimed; first by number wins.
+- **Claim**: set `Status: claimed` and save before any work.
+- **Resolve**: append the answer under an `## Answer` heading, set
+  `Status: resolved`, then append a context pointer to the map's
+  Decisions-so-far in `map.md`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual strings used in this repo's issue tracker.
+
+This repo tracks issues as local markdown under `.agent/plans/` (see `issue-tracker.md`), so these are the values written on the `Status:` line of a ticket file — **not** GitHub labels.
+
+| Label in mattpocock/skills | Status: value in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary
Scaffold the Matt Pocock engineering-skills config and point it at a **private** planning surface: PRDs, tickets, and triage live as local markdown under `.agent/plans/` (gitignored), so the decision-making stays off this public repo while code and PRs stay public with full CI.

## Changes
- Add an `## Agent skills` section to the `AGENTS.md` router (issue tracker, triage labels, domain docs)
- `docs/agents/issue-tracker.md`: local-markdown tracker under `.agent/plans/` (was GitHub Issues)
- `docs/agents/triage-labels.md`: five canonical roles as `Status:` values, not GitHub labels

## Test Plan
- [ ] `mise run docs:check` passes (wikilinks, referenced paths, no archaeology)
- [ ] `/to-tickets` and `/triage` write to `.agent/plans/` and never `gh issue create`
- [ ] Config files contain no private content — only pointers to the gitignored dir

## Notes
Planning content is gitignored and never committed; the config files under `docs/agents/` are public but only describe *where* issues live.
