### PR TITLE
feat(coredns): migrate CoreDNS from addonManager to Flux HelmRelease

### DIFF
--- a/clusters/base/networking/coredns/helm-release.yaml
+++ b/clusters/base/networking/coredns/helm-release.yaml
@@ -1,0 +1,57 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: coredns
+  namespace: kube-system
+spec:
+  interval: 1m0s
+  maxHistory: 2
+  chart:
+    spec:
+      chart: coredns
+      version: 1.46.2
+      sourceRef:
+        kind: HelmRepository
+        name: coredns
+        namespace: flux-system
+      interval: 5m0s
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    replicaCount: 1
+    k8sAppLabelOverride: kube-dns
+    service:
+      clusterIP: "${CLUSTER_DNS}"
+    servers:
+      - zones:
+          - zone: .
+        port: 53
+        plugins:
+          - name: errors
+          - name: health
+            configBlock: |-
+              lameduck 10s
+          - name: ready
+          - name: kubernetes
+            parameters: cluster.local in-addr.arpa ip6.arpa
+            configBlock: |-
+              pods insecure
+              fallthrough in-addr.arpa ip6.arpa
+              ttl 30
+          - name: prometheus
+            parameters: 0.0.0.0:9153
+          - name: forward
+            parameters: . ${ROUTER_IP}
+          - name: cache
+            parameters: "30"
+          - name: loop
+          - name: reload
+          - name: loadbalance
+    prometheus:
+      service:
+        enabled: true

--- a/clusters/base/networking/coredns/helm-repository.yaml
+++ b/clusters/base/networking/coredns/helm-repository.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: coredns
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://coredns.github.io/helm

--- a/clusters/base/networking/coredns/kustomization.yaml
+++ b/clusters/base/networking/coredns/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-repository.yaml
+  - helm-release.yaml

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -33,10 +33,6 @@ spec:
     kubeControllerManager.enabled: false
     kubeEtcd.enabled: false
     kubeScheduler.enabled: false
-    coreDns:
-      service:
-        port: 10055
-        targetPort: 10055
     cleanPrometheusOperatorObjectNames: true
     prometheus:
       ingress:

--- a/clusters/folly/networking/coredns.yaml
+++ b/clusters/folly/networking/coredns.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: coredns
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/folly/networking/coredns
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: ConfigMap
+        name: cluster-topology
+      - kind: Secret
+        name: cluster-secrets

--- a/clusters/folly/networking/coredns/kustomization.yaml
+++ b/clusters/folly/networking/coredns/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/networking/coredns

--- a/clusters/folly/networking/kustomization.yaml
+++ b/clusters/folly/networking/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cert-manager.yaml
+  - coredns.yaml
   - gateway-api.yaml
   - git-repository-gateway-api.yaml
   - cilium

--- a/clusters/offsite/networking/coredns.yaml
+++ b/clusters/offsite/networking/coredns.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: coredns
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/offsite/networking/coredns
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: ConfigMap
+        name: cluster-topology
+      - kind: Secret
+        name: cluster-secrets

--- a/clusters/offsite/networking/coredns/kustomization.yaml
+++ b/clusters/offsite/networking/coredns/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/networking/coredns

--- a/clusters/offsite/networking/kustomization.yaml
+++ b/clusters/offsite/networking/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - cert-manager.yaml
+  - coredns.yaml
   - gateway-api.yaml
   - git-repository-gateway-api.yaml
   - cilium

--- a/nix/services/k8s/default.nix
+++ b/nix/services/k8s/default.nix
@@ -153,22 +153,6 @@ in
 
         proxy.enable = false;
         easyCerts = true;
-        addons.dns.corefile = ''
-          .:10053 {
-            errors
-            health :10054
-            kubernetes cluster.local in-addr.arpa ip6.arpa {
-              pods insecure
-              fallthrough in-addr.arpa ip6.arpa
-            }
-            prometheus :10055
-            forward . ${networkConfig.upstreamDns}
-            cache 30
-            loop
-            reload
-            loadbalance
-          }
-        '';
       }
       (lib.mkIf (cfg.role == "control-plane") {
         apiserver = {
@@ -211,7 +195,7 @@ in
           ) config.sops.secrets."k8s-sa-signing-key".path;
         };
         scheduler.enable = true;
-        addonManager.enable = true;
+        addonManager.enable = false;
       })
     ];
 


### PR DESCRIPTION
## Summary
Migrate CoreDNS from the NixOS addonManager to a Flux-managed HelmRelease using the official coredns/helm chart. This is the only addon that was managed by the addonManager, so it is disabled entirely.

## Changes
- Add `clusters/base/networking/coredns/` with HelmRelease (chart v1.46.2) and HelmRepository
- Wire per-cluster Flux Kustomizations for folly and offsite
- Remove `addons.dns.corefile` and disable `addonManager.enable` in NixOS k8s module
- Update kube-prometheus-stack to use default CoreDNS metrics port (9153, was 10055)
- `${CLUSTER_DNS}` and `${ROUTER_IP}` substituted from cluster-topology ConfigMap

## Test Plan
- [ ] `kubectl kustomize clusters/folly/networking/coredns` renders without error
- [ ] `kubectl kustomize clusters/offsite/networking/coredns` renders without error
- [ ] Flux reconciles CoreDNS HelmRelease successfully
- [ ] CoreDNS pod is running in kube-system
- [ ] Cluster DNS resolution works (`nslookup kubernetes.default.svc.cluster.local`)
- [ ] Prometheus scrapes CoreDNS metrics on port 9153

## Notes
Flux controllers do not require cluster DNS for their own operation (they use node DNS for external lookups and talk to the API server directly), so there is no chicken-and-egg issue deploying CoreDNS as a Flux HelmRelease.
