### PR TITLE
docs: describe offsite as a full cluster

### DIFF
--- a/.agents/skills/unifi-network/SKILL.md
+++ b/.agents/skills/unifi-network/SKILL.md
@@ -11,7 +11,7 @@ metadata:
 Read-only discovery for the homelab UniFi controller (a **UDM Pro**, Network
 app `10.4.57`, at `https://unifi.fml.pulsifer.ca` / `https://10.13.37.1`).
 This is the live counterpart to the desired state in `terraform/network/unifi/folly/`
-(the primary site; the offsite gateway is `terraform/network/unifi/offsite/`) — use
+(the on-site controller; the remote-site gateway is `terraform/network/unifi/offsite/`) — use
 it to see what the controller *actually* has before editing the Terraform.
 
 Canonical public runbook: `docs/pages/Runbooks___Inspect UniFi Network.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,7 +73,7 @@ file does not list contents.
 | Path | What lives here |
 | --- | --- |
 | `nix/` | NixOS configuration for every host, plus image builds. Hosts are declared in `flake.nix`. |
-| `clusters/` | Kubernetes manifests for `folly` (primary) and `offsite` (backup), with `base/` shared between them. |
+| `clusters/` | Kubernetes manifests for the fully capable `folly` (on-site) and `offsite` (remote-site) clusters, with `base/` shared between them. |
 | `terraform/` | All Terraform root modules — network fabric under `network/`, cloud and identity alongside it, reusable modules in `modules/`. |
 | `apps/` | Deployable first-party services. |
 | `packages/` | Reusable building blocks, including the Helm charts Flux consumes. |

--- a/docs/pages/Architecture.md
+++ b/docs/pages/Architecture.md
@@ -6,7 +6,7 @@ tags:: architecture
 	- ### Layer 1 — Bare metal ([[Architecture/NixOS]])
 		- NixOS configuration under `nix/` for every host. Declared in `flake.nix`, deployed with `nixos-rebuild`, self-healing via auto-upgrades that track `main`.
 	- ### Layer 2 — Kubernetes ([[Architecture/Kubernetes]])
-		- Two clusters under `clusters/`: `folly` (primary, on-site) and `offsite` (backup), with `clusters/base/` shared between them. FluxCD reconciles every manifest on merge. ArgoCD is installed as a Flux HelmRelease and currently owns no applications.
+		- Two fully capable clusters under `clusters/`: `folly` on-site and `offsite` at the remote site, with `clusters/base/` shared between them. FluxCD reconciles every manifest on merge. ArgoCD is installed as a Flux HelmRelease and currently owns no applications.
 	- ### Layer 3 — Cloud and network ([[Architecture/Terraform]])
 		- OpenTofu root modules under `terraform/`, covering the network fabric and the cloud and identity estate. Applies run through Atlantis on the PR.
 	- ### Layer 4 — Applications ([[Architecture/Applications]])

--- a/docs/pages/Architecture___Kubernetes.md
+++ b/docs/pages/Architecture___Kubernetes.md
@@ -3,8 +3,8 @@ tags:: architecture
 
 - **Layer 2** of [[Architecture]]: two Kubernetes clusters under `clusters/`, reconciled by FluxCD on every merge to `main`. The Terraform bootstrap roots own CoreDNS and Flux itself; Flux owns post-bootstrap cluster state. ArgoCD is installed as a Flux HelmRelease and owns no applications; `terraform/argo/` wires the provider and declares no resources. Reconciliation mechanics and the apply model live on [[Architecture/GitOps]].
 - ## Clusters
-	- `clusters/folly/` — primary, on-site. Nodes: `optiplex` (control-plane), `riptide`, `shale` (workers).
-	- `clusters/offsite/` — backup. Nodes: `retrofit` (control-plane), `oldschool` (worker).
+	- `clusters/folly/` — independent, fully capable on-site cluster. Nodes: `optiplex` (control-plane), `riptide`, `shale` (workers).
+	- `clusters/offsite/` — independent, fully capable remote-site cluster. Nodes: `retrofit` (control-plane), `oldschool` (worker).
 	- `clusters/base/` — resources shared by both clusters, referenced by relative path from each cluster's manifests.
 	- Hardware, serials, and per-host quirks for all five nodes: [[Fleet]].
 - ## The base/ sharing pattern

--- a/docs/pages/Architecture___Networking.md
+++ b/docs/pages/Architecture___Networking.md
@@ -3,7 +3,7 @@ tags:: architecture
 
 - Networking spans all four layers: UniFi VLANs and BGP at Layer 1/3 (`terraform/network/`), Cilium and the Gateway API inside each cluster at Layer 2 (`clusters/*/networking/`), Cloudflare and Tailscale gluing sites together at Layer 3. This page is the single place the whole story lives. Cluster composition is on [[Architecture/Kubernetes]]; host hardware is on [[Fleet]]; live discovery of the running UniFi controller is the `unifi-network` skill ([[Runbooks/Inspect UniFi Network]]).
 - ## Sites and fabric
-	- Two UniFi consoles, each its own Terraform root: `terraform/network/unifi/folly/` (primary, on-site) and `terraform/network/unifi/offsite/` (backup). They're joined by exactly **one** inter-site data plane: a UniFi Site Magic WireGuard tunnel (`wgsts1000`).
+	- Two UniFi consoles, each its own Terraform root: `terraform/network/unifi/folly/` on-site and `terraform/network/unifi/offsite/` at the remote site. They're joined by exactly **one** inter-site data plane: a UniFi Site Magic WireGuard tunnel (`wgsts1000`).
 	- Each site's k8s nodes run Cilium with a BGP control plane (ASN 64513) peering **eBGP** with that site's own UniFi gateway (ASN 64512) — folly's UDM Pro, offsite's UCG Max.
 - ## LAN / VLANs
 	- folly (`terraform/network/unifi/folly/`), all networks domain `lolwtf.ca` unless noted:

--- a/docs/pages/Home.md
+++ b/docs/pages/Home.md
@@ -8,7 +8,7 @@ icon:: 🏡
 	- [[Fleet]] — every host, its hardware, and its quirks
 - ## The stack in one breath
 	- **Bare metal** — [[Architecture/NixOS]] configuration for every host, deployed with `nixos-rebuild` and kept honest by auto-upgrades from `main`.
-	- **Kubernetes** — two clusters, `folly` on-site and `offsite` for backup, reconciled by FluxCD. See [[Architecture/Kubernetes]].
+	- **Kubernetes** — two fully capable clusters, `folly` on-site and `offsite` at the remote site, reconciled by FluxCD. See [[Architecture/Kubernetes]].
 	- **Cloud and network** — UniFi, Cloudflare, Tailscale, GCP and Google Workspace under [[Architecture/Terraform]], with applies gated through Atlantis. The network fabric itself is [[Architecture/Networking]].
 	- **Applications** — first-party services, packages and OCI images, described in [[Architecture/Applications]].
 	- Everything ships the same way: open a PR and let the operators apply it. See [[Architecture/GitOps]].


### PR DESCRIPTION
## Summary
Describe folly and offsite as independent, fully capable site clusters without primary/backup hierarchy.

## Changes
- update the repo router and architecture pages to describe both cluster roles consistently
- align the UniFi inspection skill with on-site/remote-site terminology

## Test Plan
- [x] `mise run docs:build`
- [x] `mise run docs:check`
- [x] `git diff --check`
- [x] verify no folly/offsite primary, backup, or secondary pairings remain under `AGENTS.md`, `docs/`, or `.agents/`