### PR TITLE
fix(nixos): stop Tailscale from breaking DNS on the dns host

### DIFF
--- a/nix/hosts/capsule.nix
+++ b/nix/hosts/capsule.nix
@@ -1,4 +1,12 @@
 { lib, name, ... }:
+let
+  # Public upstreams for pihole, and this host's own fallback resolver. Shared
+  # so the two can't drift apart.
+  upstreams = [
+    "1.1.1.2"
+    "1.0.0.2"
+  ];
+in
 {
   imports = [
     ../hardware/pi5
@@ -10,7 +18,24 @@
   networking = {
     hostName = name;
     wireless.enable = lib.mkForce false;
+
+    # Resolve through the local pihole, falling back to its own upstreams so a
+    # pihole-FTL outage doesn't also cost this host name resolution (which is
+    # what a `nixos-rebuild` needs to fetch a fix).
+    nameservers = [ "127.0.0.1" ] ++ upstreams;
   };
+
+  # Everywhere else, ../../nix/system/tailscale.nix leaves systemd-resolved
+  # enabled and tailscaled parks the real upstream resolvers there, so
+  # /etc/resolv.conf pointing at MagicDNS (100.100.100.100) still resolves.
+  # This host force-disables resolved below -- pihole-FTL binds 0.0.0.0:53 and
+  # would collide with resolved's stub listener -- which leaves the
+  # coordination server supplying no resolvers and MagicDNS falling back to
+  # "system default". That default is the resolv.conf tailscaled itself just
+  # rewrote to 100.100.100.100, so every public lookup loops back into
+  # tailscaled and SERVFAILs. Keep Tailscale out of DNS on this host; the
+  # nameservers above are the whole story.
+  services.tailscale.extraSetFlags = [ "--accept-dns=false" ];
 
   # Keep the labels already installed on the NVMe. The Pi 5 hardware module
   # normally derives these from `name`, but changing them during a hostname
@@ -32,10 +57,7 @@
     ];
     settings = {
       dns = {
-        upstreams = [
-          "1.1.1.2"
-          "1.0.0.2"
-        ];
+        inherit upstreams;
         listeningMode = "ALL";
         # Every query otherwise gets a line appended to pihole.log; skip that
         # write stream entirely since Grafana (via the exporter below) is the


### PR DESCRIPTION
## Problem

The `dns` host (capsule, 10.2.0.10) cannot resolve any public name. `api.github.com` and `cache.nixos.org` both fail, so it reaches no substituter — a `nix build` on it dies with `Could not resolve host`.

pihole-FTL is healthy throughout. Querying it directly works fine:

| resolver | result |
| --- | --- |
| `@127.0.0.1` (pihole) | `google.com has address 64.233.178.102` |
| `@10.2.0.10` (pihole) | `google.com has address 64.233.178.138` |
| `@10.2.0.1` (UDM) | `google.com has address 74.125.197.102` |
| `@1.1.1.2` | `google.com has address 142.250.69.142` |
| `@100.100.100.100` (MagicDNS) | **SERVFAIL** |

`/etc/resolv.conf` points at `100.100.100.100`.

## Root cause

`tailscale dns status` on the host reports:

```
Resolvers (in preference order):
  (no resolvers configured, system default will be used)
```

Everywhere else `nix/system/tailscale.nix` leaves systemd-resolved enabled, so tailscaled hands the real upstream resolvers to resolved and MagicDNS has somewhere to forward. This host force-disables resolved — correctly, since pihole-FTL uses `listeningMode = "ALL"` and binds `0.0.0.0:53`, which collides with resolved's stub listener.

With resolved gone and the coordination server supplying no resolvers, MagicDNS falls back to "system default" — and the system default is the `resolv.conf` tailscaled itself just rewrote to `100.100.100.100`. Every public lookup loops back into tailscaled and SERVFAILs.

## Fix

Keep Tailscale out of DNS on this host and declare the resolvers explicitly:

- `services.tailscale.extraSetFlags = [ "--accept-dns=false" ]` — merges with the module's `--accept-routes=false` rather than replacing it.
- `networking.nameservers = [ "127.0.0.1" ] ++ upstreams` — local pihole first, then pihole's own upstreams, so a pihole-FTL outage doesn't also cost this host the name resolution a `nixos-rebuild` needs to pull a fix.

The upstream pair is now one `let` binding feeding both pihole and the resolver list, so the two can't drift apart.

Trade-off: this host no longer resolves `*.ts.net` MagicDNS names. Nothing on it depends on that, and tailnet connectivity itself is unaffected (`--accept-routes=false` is unchanged).

## Verified

Eval against the changed config:

- `services.tailscale.extraSetFlags` → `["--accept-routes=false","--accept-dns=false"]`
- `networking.nameservers` → `["127.0.0.1","1.1.1.2","1.0.0.2"]`
- `services.pihole-ftl.settings.dns.upstreams` → `["1.1.1.2","1.0.0.2"]` (unchanged)
- `services.resolved.enable` → `false` (unchanged)
- `nix flake check --all-systems --no-build` → `all checks passed!`
- `mise run nix:fmt` → no diff

Post-merge: needs a `nixos-rebuild` on the host to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)