### PR TITLE
fix(sops): add forge host recipient

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -25,12 +25,9 @@ creation_rules:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
           # retrofit (ssh-to-age of its ed25519 host key)
           - age1lsh940ctw2v0lmyeqnk3qgh0p57rp0ffh84vc3hg609v84mqfq2sudzcgz
-  # forge: only the operator's age key for now. The host's own
-  # ssh-to-age recipient is added on first boot, mirroring how
-  # oldschool/optiplex/retrofit got theirs -- `ssh forge.lolwtf.ca cat
-  # /etc/ssh/ssh_host_ed25519_key.pub | ssh-to-age` then
-  # `sops -r --add-age <pub> nix/secrets/forge.sops.yaml`.
   - path_regex: nix/secrets/forge\.sops\.ya?ml
     key_groups:
       - age:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          # forge (ssh-to-age of its ed25519 host key)
+          - age1x2zrt0atyzhc05eg6sdq7ce06y24g5tz8keqzy658jtz9n93x92qj4h0ns

--- a/nix/secrets/forge.sops.yaml
+++ b/nix/secrets/forge.sops.yaml
@@ -1,16 +1,25 @@
-harmonia-cache-key: ENC[AES256_GCM,data:hui6JY6n5bdSHnQxCEdb9kSvtng4MhG0Da+Amy1O251ukPKTXH2yqTMfpR5SVZQEy12ev2lr7g/XLP63TJu2R+5O71XG4mTRCpi9iWTNrxdjmTDoqEo0l6dBTHriYeVnesOR7rqZOtpD8ig=,iv:6PWX1FT2KjvUfbSouSfLl/jU2/pTt/SVw183c+jwuO4=,tag:aqKDhDiiWsFh32osux/Bgg==,type:str]
+harmonia-cache-key: ENC[AES256_GCM,data:3iaDbjEkmK58VFMmYzk0EMZ0ZRLQRZ3Yy92I2FJTaw2oLzswk+yzGZiVYxd3r738ogi2GBadBWHvuie/hZ7n6fchaNunHUp48rE15MxbZ2NsmEDmNLtOMuSu/mI99xWbAF4BJdpQ1mhhUAY=,iv:6PWX1FT2KjvUfbSouSfLl/jU2/pTt/SVw183c+jwuO4=,tag:zJuv0xQgsgNbMb/sTC4SMg==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBid2Z3MVlaeW03QVUvc1VD
-            RmdEZjVaRWp5L0dSUkl1ajFsWUt5V2NMMnhzCkNnTGxrbUQyZHdYZ3A3VzJvV2Uv
-            Z3lsSTFWaEQxMm9RMFdONGs0Z3lodG8KLS0tIGNpNkFBMFZzTjRPWUNwcTRwMHl6
-            bXhPamZOZ1F3M0dndjhlN0JYTXJWZk0Kj6+O2HPoxRHaDP515ULKGbkQdlWKicX/
-            G8rY35WF29DfAJTI0kjGuBikUOunX/NkIhN6aH/EhIfaUl7r1EEKhQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBrcTFJdytDdW9STjIrT2pE
+            eDAzY2pVL0dNZU4vMHdjL1d3RFZBNHhZbmpFCmYxNnd0RDNiRWRKMjRlSGFyT0RZ
+            cnhtTXNzMVJ5THJGc3Q1LzdSQllwUVEKLS0tIDVWTmVIRm9SVnlHbWxPU0V4QnN3
+            UE90Z1RqaWdlR2hZNmdQWTlSdzMxWmsKUc5axne6f4zjZTelh9KFzsl3VEmO8Bx6
+            stGbygBUBXIfNeihM+oCSMWTyLSgyo4U52CTHEzdj1C5ESzEjBgK8g==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
-    lastmodified: "2026-07-26T15:56:10Z"
-    mac: ENC[AES256_GCM,data:Mbs79wXkrCYzovlch5qIN45ZmaZ27LNy3e+3VOlCmz0xzCf6JQ1fy5Nrm+Y8P8bkxDa0seSbMETJziU41qtPePkNSrQJEHySJ0l3LUyu6asWvHHj7J9Wf5pqDMV9EcdV6p1PVI9GPyyGLW1KR15GudVr5BiRi9feaRAqUDbJZec=,iv:9TEFl4tmoxQnm3gv6MJqgvxv+AsFakJpEou6/yIHP4w=,tag:KhzX+1oBGqguxMHApncsEA==,type:str]
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBWT2gybWxSeFFPbW8ySFpt
+            WEtoaDJGZUEweEFXeW1tVWwvR3FRODdKaDFjCjJycDVRdjFuYXYycVhpNzdGaHRF
+            NHVNVVlTNmx0RDBtVmNpbjk1SG5YZ3cKLS0tIFZ6N0JROEFKVXNlZVQ0dzk0bkJp
+            bWJCZGZnNlVFQWc1Qk8wTjZKQldiM0UKIqj5RSEMfiKVb/jImsvsypkXcpAmBXuH
+            q+a/UVt/VTCOATQ4a97MfpCmgWXPHPwHM/i64X2F9DajdzV9Pc7+ug==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1x2zrt0atyzhc05eg6sdq7ce06y24g5tz8keqzy658jtz9n93x92qj4h0ns
+    lastmodified: "2026-07-26T19:17:07Z"
+    mac: ENC[AES256_GCM,data:x4gOoGG6zEy/LPvDCu5zg9ZOiewhK4OWqWoQNk9Bgo2II/qup3hSRfoaLuPrjIJ4Lqf7rMDwhPbh8q5WpzOXolxvF2wSt1vrZOqlWd5d9ivUZJxD4IjtLalTXuFs+tEQtTzVz/y/Tid1QzHadoh3xC0IKE3IVdeVDIrfdLFV+rM=,iv:aQf1R7OfwMUC3krlbGH0IrMVsMh7L9Him0Vp2WHGXGg=,tag:LJsDrwQ8t76oFJRQeJyrHw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
## Summary
Complete Forge's two-stage SOPS enrollment after its first successful NVMe boot by adding the host's SSH-derived age recipient.

## Changes
- add Forge's `ssh-to-age` recipient to the per-host SOPS creation rule
- rotate `nix/secrets/forge.sops.yaml` to retain the operator recipient and add the host recipient
- preserve the decrypted Harmonia cache key unchanged

## Test Plan
- [x] Confirm Forge boots from `/dev/nvme0n1p2` with expanded root
- [x] Confirm live EEPROM `BOOT_ORDER=0xf1276`
- [x] Derive the age recipient from Forge's live ed25519 SSH host key
- [x] Verify the encrypted file retains both operator and host recipients
- [x] Verify the decrypted plaintext SHA-256 is unchanged
- [x] `mise run nix:check`
- [x] `HOST=forge mise run nix:build`
