### PR TITLE
feat(kubernetes): deploy cnpg offsite

### DIFF
--- a/clusters/offsite/apps/cloudnative-pg/helm-release.yaml
+++ b/clusters/offsite/apps/cloudnative-pg/helm-release.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cloudnative-pg
+  namespace: cloudnative-pg
+spec:
+  chart:
+    spec:
+      chart: cloudnative-pg
+      version: 0.28.2
+      sourceRef:
+        kind: HelmRepository
+        name: cloudnative-pg

--- a/clusters/offsite/apps/cloudnative-pg/helm-repository.yaml
+++ b/clusters/offsite/apps/cloudnative-pg/helm-repository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: cloudnative-pg
+spec:
+  interval: 24h
+  url: https://cloudnative-pg.github.io/charts

--- a/clusters/offsite/apps/cloudnative-pg/kustomization.yaml
+++ b/clusters/offsite/apps/cloudnative-pg/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - helm-release.yaml
+namespace: cloudnative-pg

--- a/clusters/offsite/apps/cloudnative-pg/namespace.yaml
+++ b/clusters/offsite/apps/cloudnative-pg/namespace.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cloudnative-pg
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    pod-security.kubernetes.io/audit: baseline
+    pod-security.kubernetes.io/audit-version: latest
+    # pod-security.kubernetes.io/enforce: privileged
+    # pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/offsite/apps/kustomization.yaml
+++ b/clusters/offsite/apps/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - ../../base/apps/iperf3
   - atlantis
+  - cloudnative-pg
   - descheduler
   - hub
   - dave.yaml


### PR DESCRIPTION
## Summary
Add CloudNativePG to the offsite cluster through Flux-managed desired state, matching the operator deployment already used by folly.

## Changes
- feat(kubernetes): deploy cnpg offsite

## Test Plan
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`
- [x] Confirm the rendered offsite apps include `HelmRelease/cloudnative-pg` at chart version `0.28.2`

## Context
Local planning artifacts: `.agent/context/context.md`, `.agent/context/plan.md`
