### PR TITLE
fix(atlantis): establish cross-cluster bootstrap auth

### DIFF
--- a/clusters/base/atlantis-bootstrap-rbac.yaml
+++ b/clusters/base/atlantis-bootstrap-rbac.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: atlantis-bootstrap
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: system:serviceaccount:atlantis:atlantis
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: federated:system:serviceaccount:atlantis:atlantis

--- a/clusters/base/kustomization.yaml
+++ b/clusters/base/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - atlantis-bootstrap-rbac.yaml
   - cluster-runtimeclass.yaml
   - cluster-settings.yaml

--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -79,6 +79,9 @@ spec:
         allowed_overrides: []
         allow_custom_workflows: false
         pre_workflow_hooks:
+          - run: /home/atlantis/kubeconfig-hook.sh
+            description: Generate Kubernetes provider config
+            commands: plan, apply
           - run: /home/atlantis/plan-hook.sh
             description: Plan Hook
             commands: plan
@@ -130,6 +133,10 @@ spec:
         configMap:
           name: plan-hook
           defaultMode: 0777
+      - name: kubeconfig-hook
+        configMap:
+          name: kubeconfig-hook
+          defaultMode: 0555
       - name: terraform-gsa
         secret:
           secretName: atlantis-github
@@ -140,6 +147,10 @@ spec:
       - name: plan-hook
         mountPath: /home/atlantis/plan-hook.sh
         subPath: plan-hook.sh
+        readOnly: true
+      - name: kubeconfig-hook
+        mountPath: /home/atlantis/kubeconfig-hook.sh
+        subPath: kubeconfig-hook.sh
         readOnly: true
       - name: terraform-gsa
         mountPath: /run/secrets/terraform.json

--- a/clusters/offsite/apps/atlantis/kubeconfig-hook.sh
+++ b/clusters/offsite/apps/atlantis/kubeconfig-hook.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+token_file=${KUBECONFIG_TOKEN_FILE:-/var/run/secrets/kubernetes.io/serviceaccount/token}
+kubeconfig=${KUBECONFIG_OUTPUT:-/home/atlantis/.kube/config}
+kube_dir=$(dirname "${kubeconfig}")
+
+topology_value() {
+  key=$1
+  file=$2
+  sed -n "s/^[[:space:]]*\"${key}\": \"\\([^\"]*\\)\",*$/\\1/p" "${file}"
+}
+
+cluster_entry() {
+  cluster=$1
+  topology="${DIR}/clusters/${cluster}/config/cluster-topology.json"
+  ca="${DIR}/terraform/pki/certs/${cluster}-ca.pem"
+  host=$(topology_value API_SERVER_HOSTNAME "${topology}")
+  port=$(topology_value API_SERVER_PORT "${topology}")
+
+  test -n "${host}"
+  test -n "${port}"
+  test -r "${ca}"
+
+  cat <<EOF
+- cluster:
+    certificate-authority-data: $(base64 <"${ca}" | tr -d '\n')
+    server: https://${host}:${port}
+  name: ${cluster}
+EOF
+}
+
+test -n "${DIR:-}"
+test -r "${token_file}"
+mkdir -p "${kube_dir}"
+temporary=$(mktemp "${kubeconfig}.XXXXXX")
+trap 'rm -f "${temporary}"' EXIT
+
+{
+  cat <<EOF
+apiVersion: v1
+kind: Config
+clusters:
+EOF
+  cluster_entry folly
+  cluster_entry offsite
+  cat <<EOF
+contexts:
+- context:
+    cluster: folly
+    user: atlantis
+  name: folly
+- context:
+    cluster: offsite
+    user: atlantis
+  name: offsite
+current-context: offsite
+users:
+- name: atlantis
+  user:
+    tokenFile: ${token_file}
+EOF
+} >"${temporary}"
+
+chmod 0600 "${temporary}"
+mv "${temporary}" "${kubeconfig}"
+trap - EXIT

--- a/clusters/offsite/apps/atlantis/kustomization.yaml
+++ b/clusters/offsite/apps/atlantis/kustomization.yaml
@@ -15,6 +15,9 @@ configMapGenerator:
   - name: plan-hook
     files:
       - plan-hook.sh
+  - name: kubeconfig-hook
+    files:
+      - kubeconfig-hook.sh
 generatorOptions:
   disableNameSuffixHash: true
   annotations:

--- a/nix/services/k8s/default.nix
+++ b/nix/services/k8s/default.nix
@@ -9,6 +9,8 @@ let
   networkConfig = networks.${config.services.k8s.network};
   cfg = config.services.k8s;
   fmlIssuer = "https://oidc.lolwtf.ca/${cfg.network}";
+  peerNetwork = if cfg.network == "folly" then "offsite" else "folly";
+  peerIssuer = "https://oidc.lolwtf.ca/${peerNetwork}";
   fmlSignerCert = ../../../terraform/pki/certs/${cfg.network}-sa-signer.pem;
 in
 {
@@ -60,6 +62,25 @@ in
 
     # cilium writes its own config to /etc/cni/net.d, so we need to make sure it's writable/empty/whatever
     environment.etc."cni/net.d".enable = false;
+    environment.etc."kubernetes/authentication-config.yaml".text = builtins.toJSON {
+      apiVersion = "apiserver.config.k8s.io/v1";
+      kind = "AuthenticationConfiguration";
+      jwt = [
+        {
+          issuer = {
+            url = peerIssuer;
+            audiences = [ "api" ];
+          };
+          claimValidationRules = [
+            {
+              expression = ''claims.sub == "system:serviceaccount:atlantis:atlantis"'';
+              message = "only the Atlantis service account may authenticate across clusters";
+            }
+          ];
+          claimMappings.username.expression = ''"federated:" + claims.sub'';
+        }
+      ];
+    };
 
     environment.systemPackages =
       with pkgs;
@@ -154,6 +175,7 @@ in
           serviceAccountKeyFile = fmlSignerCert;
           serviceAccountSigningKeyFile = config.sops.secrets."k8s-sa-signing-key".path;
           extraOpts = ''
+            --authentication-config=/etc/kubernetes/authentication-config.yaml \
             --enable-aggregator-routing=true \
             --requestheader-allowed-names=front-proxy-client \
             --requestheader-extra-headers-prefix=X-Remote-Extra- \

--- a/nix/system/nixos.nix
+++ b/nix/system/nixos.nix
@@ -44,7 +44,7 @@
   system = {
     autoUpgrade = {
       enable = lib.mkDefault true;
-      flake = "github:jonpulsifer/infra";
+      flake = "git+https://github.com/jonpulsifer/infra.git";
       flags = [ "-L" ];
       dates = "03:37";
       randomizedDelaySec = "3600";


### PR DESCRIPTION
## Summary

- trust the peer cluster service-account issuer on each Kubernetes API server, restricted to the Atlantis service account
- grant the native and federated Atlantis identities bootstrap privileges in the shared cluster base
- generate an ephemeral two-cluster kubeconfig from topology SSOT, public cluster CAs, and the projected service-account token before Atlantis plan/apply
- repair the NixOS auto-upgrade flake URL so control-plane hosts can follow `main`

## Rollout

This is the foundation PR and intentionally does not touch either bootstrap Terraform root. After merge:

1. deploy `optiplex` and `retrofit` from `main`
2. let Flux reconcile the shared RBAC and Atlantis hook
3. verify Atlantis can authenticate to both APIs
4. open the follow-up bootstrap Terraform PR using ephemeral 1Password GitHub App credentials; its Atlantis plans are the end-to-end proof

Keeping the Terraform changes out of this PR avoids requiring the new authentication path before it has been deployed.

## Validation

- `mise run nix:fmt`
- `shellcheck clusters/offsite/apps/atlantis/kubeconfig-hook.sh`
- `mise run k8s:render-apps`
- local hook regression: both contexts/endpoints generated, token referenced through `tokenFile`, mode `0600`
- evaluated both NixOS authentication configurations: each trusts the peer issuer and restricts the exact Atlantis subject
- evaluated both hosts with `system.autoUpgrade.flake = git+https://github.com/jonpulsifer/infra.git`
- `git diff --check`