### PR TITLE
fix(atlantis): load bootstrap credentials ephemerally

### DIFF
--- a/clusters/folly/bootstrap/.terraform.lock.hcl
+++ b/clusters/folly/bootstrap/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/1password/onepassword" {
+  version     = "3.3.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:35PCpSNLVubReT1imwfC+FpIP5gQWx+rvG4njkXkZKM=",
+    "h1:GqvBYImDNYNPMi9o3kJTSIJDeEnNO7om46RWA0wjeso=",
+    "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
+    "h1:a8DHdeyXt8YaEngXGEWZC75W27OG742wtw5BmRnhrpI=",
+    "h1:bPFt8A+PWGwEj3wQ3D0GxyrTMmr1piNrwEuPJu7AZTo=",
+    "h1:nThx/0XctUKlAa6aAsSEHZvx/mD1tSxCE6pacSnotxU=",
+    "h1:syh+iS5VPBQTLszL503BOi5rLpL1wGl1IjyYqgpKYIg=",
+    "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
+    "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
+    "zh:161bc55c466214a5d425ba85753d74ed5078212db965f726e6650d2e1524d633",
+    "zh:3de4a9f212e1046016a3ace8816e2cb15cfb7b9579161e468a08b9034d6a5f51",
+    "zh:730105346065ea3d2bd6acc6f5fe36f7b8a2b54c513d20a46bcd51d656e82bb4",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c29f6025d099bc8f1f96e7bb4cd66c5d07209b4141d2fd7720228cf20c9c8efd",
+    "zh:d8ea431d396986ca6baf033fa9aaccb73d6a9f9b7d42bea7af8dc73b9ef20297",
+  ]
+}
+
 provider "registry.opentofu.org/fluxcd/flux" {
   version = "1.9.2"
   hashes = [

--- a/clusters/folly/bootstrap/bootstrap.tf
+++ b/clusters/folly/bootstrap/bootstrap.tf
@@ -16,6 +16,10 @@ terraform {
     github = {
       source = "integrations/github"
     }
+    onepassword = {
+      source  = "1password/onepassword"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -33,13 +37,27 @@ provider "kubernetes" {
 
 provider "github" {
   owner = local.github.org
+
+  app_auth {
+    id              = jsondecode(ephemeral.onepassword_item.github_app.note_value).app_id
+    installation_id = jsondecode(ephemeral.onepassword_item.github_app.note_value).installation_id
+    pem_file        = jsondecode(ephemeral.onepassword_item.github_app.note_value).private_key
+  }
 }
 
+provider "onepassword" {}
+
 locals {
+  vault_id = "ib23znjeikv74p37f6mbfk7uya"
   github = {
     org  = "jonpulsifer"
     repo = "infra"
   }
+}
+
+ephemeral "onepassword_item" "github_app" {
+  vault = local.vault_id
+  uuid  = "gppbidlscm4tb5k5wpjhen7zhu"
 }
 
 module "topology" {

--- a/clusters/folly/bootstrap/bootstrap.tftest.hcl
+++ b/clusters/folly/bootstrap/bootstrap.tftest.hcl
@@ -1,6 +1,7 @@
 mock_provider "github" {}
 mock_provider "helm" {}
 mock_provider "kubernetes" {}
+mock_provider "onepassword" {}
 mock_provider "tls" {}
 
 run "exposes_folly_bootstrap_resources" {

--- a/clusters/offsite/bootstrap/.terraform.lock.hcl
+++ b/clusters/offsite/bootstrap/.terraform.lock.hcl
@@ -1,6 +1,28 @@
 # This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
+provider "registry.opentofu.org/1password/onepassword" {
+  version     = "3.3.1"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:35PCpSNLVubReT1imwfC+FpIP5gQWx+rvG4njkXkZKM=",
+    "h1:GqvBYImDNYNPMi9o3kJTSIJDeEnNO7om46RWA0wjeso=",
+    "h1:Tg8bJ+ATy5pla6ZTn87lb3nIyiTJTgQHJdxOWQjFF9k=",
+    "h1:a8DHdeyXt8YaEngXGEWZC75W27OG742wtw5BmRnhrpI=",
+    "h1:bPFt8A+PWGwEj3wQ3D0GxyrTMmr1piNrwEuPJu7AZTo=",
+    "h1:nThx/0XctUKlAa6aAsSEHZvx/mD1tSxCE6pacSnotxU=",
+    "h1:syh+iS5VPBQTLszL503BOi5rLpL1wGl1IjyYqgpKYIg=",
+    "zh:02d93a7f520ec69ad8944a68dcbf512e2f9920a6696628b8d05e6ad408309f35",
+    "zh:0f91a902da84470af95f0da4dc21127b84e23c856a431ff9ecfe45d9c6775ef0",
+    "zh:161bc55c466214a5d425ba85753d74ed5078212db965f726e6650d2e1524d633",
+    "zh:3de4a9f212e1046016a3ace8816e2cb15cfb7b9579161e468a08b9034d6a5f51",
+    "zh:730105346065ea3d2bd6acc6f5fe36f7b8a2b54c513d20a46bcd51d656e82bb4",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c29f6025d099bc8f1f96e7bb4cd66c5d07209b4141d2fd7720228cf20c9c8efd",
+    "zh:d8ea431d396986ca6baf033fa9aaccb73d6a9f9b7d42bea7af8dc73b9ef20297",
+  ]
+}
+
 provider "registry.opentofu.org/fluxcd/flux" {
   version = "1.9.2"
   hashes = [

--- a/clusters/offsite/bootstrap/bootstrap.tf
+++ b/clusters/offsite/bootstrap/bootstrap.tf
@@ -16,6 +16,10 @@ terraform {
     github = {
       source = "integrations/github"
     }
+    onepassword = {
+      source  = "1password/onepassword"
+      version = "~> 3.0"
+    }
   }
 }
 
@@ -33,13 +37,27 @@ provider "kubernetes" {
 
 provider "github" {
   owner = local.github.org
+
+  app_auth {
+    id              = jsondecode(ephemeral.onepassword_item.github_app.note_value).app_id
+    installation_id = jsondecode(ephemeral.onepassword_item.github_app.note_value).installation_id
+    pem_file        = jsondecode(ephemeral.onepassword_item.github_app.note_value).private_key
+  }
 }
 
+provider "onepassword" {}
+
 locals {
+  vault_id = "ib23znjeikv74p37f6mbfk7uya"
   github = {
     org  = "jonpulsifer"
     repo = "infra"
   }
+}
+
+ephemeral "onepassword_item" "github_app" {
+  vault = local.vault_id
+  uuid  = "gppbidlscm4tb5k5wpjhen7zhu"
 }
 
 module "topology" {

--- a/clusters/offsite/bootstrap/bootstrap.tftest.hcl
+++ b/clusters/offsite/bootstrap/bootstrap.tftest.hcl
@@ -1,6 +1,7 @@
 mock_provider "github" {}
 mock_provider "helm" {}
 mock_provider "kubernetes" {}
+mock_provider "onepassword" {}
 mock_provider "tls" {}
 
 run "exposes_offsite_bootstrap_resources" {


### PR DESCRIPTION
## Summary

- configure both cluster bootstrap roots to authenticate the GitHub provider as the Atlantis GitHub App
- read the app credentials ephemerally from the pinned 1Password item
- keep the credentials out of Terraform state, Kubernetes Secrets, and Atlantis environment variables

This is the end-to-end follow-up to #1230 and #1231. Atlantis planning both roots proves the projected service-account kubeconfig works across both clusters and the ephemeral GitHub App credentials can refresh the Flux deploy keys.

## Validation

- `mise run tf:fmt`
- `tofu init -backend=false -input=false && tofu validate` in both bootstrap roots
- both roots previously produced read-only local plans with no changes using the same ephemeral item
- acceptance: Atlantis plans for both roots must complete successfully