### PR TITLE
fix(atlantis): restart when hook config changes

### DIFF
--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -110,6 +110,9 @@ spec:
     defaultTFDistribution: opentofu
     hidePrevPlanComments: true
     hideUnchangedPlanComments: true
+    podTemplate:
+      annotations:
+        configmap.reloader.stakater.com/reload: kubeconfig-hook,plan-hook,policies
     ingress:
       enabled: true
       annotations:


### PR DESCRIPTION
## Summary

- subscribe the Atlantis pod template to its generated ConfigMaps through the deployed Reloader controller
- restart Atlantis when kubeconfig, plan hook, or policy content changes

This activates the corrected Kubernetes CA hook from #1231 and prevents stale subPath-mounted hook scripts in future.

## Validation

- `mise run k8s:render-apps`
- `git diff --check`