### PR TITLE
chore(folly): upgrade Gateway API to 1.6.1

### DIFF
--- a/clusters/folly/networking/git-repository-gateway-api.yaml
+++ b/clusters/folly/networking/git-repository-gateway-api.yaml
@@ -8,7 +8,7 @@ spec:
   interval: 24h
   url: https://github.com/kubernetes-sigs/gateway-api
   ref:
-    tag: v1.4.1
+    tag: v1.6.1
   ignore: |
     # exclude all
     /*


### PR DESCRIPTION
## Summary
Upgrade folly Gateway API CRDs to v1.6.1 as the required first stage of the Cilium 1.20 upgrade. This keeps the existing experimental TLSRoute source so both `v1` and `v1alpha2` remain served, and does not change Cilium or offsite.

Cilium requires Gateway API v1.6.1 to be installed before upgrading to 1.20: https://docs.cilium.io/en/latest/operations/upgrade/#id4

## Changes
- pin folly Gateway API to v1.6.1
- retain the experimental TLSRoute CRD compatibility path

## Test Plan
- [x] `kubectl kustomize clusters/folly/networking`
- [x] `mise run k8s:render-apps`
- [x] confirm the upstream `v1.6.1` tag resolves
- [x] confirm the v1.6.1 experimental TLSRoute CRD serves `v1` and `v1alpha2`
- [x] `git diff --check`