### PR TITLE
fix(folly): complete Gateway API 1.6 ownership handoff

### DIFF
--- a/clusters/folly/networking/gateway-api.yaml
+++ b/clusters/folly/networking/gateway-api.yaml
@@ -18,9 +18,11 @@ metadata:
   name: gateway-api-experimental-apis
   namespace: flux-system
 spec:
+  deletionPolicy: Orphan
   interval: 1h0m0s
   path: ./config/crd/experimental
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: gateway-api
@@ -36,7 +38,6 @@ spec:
   prune: true
   dependsOn:
     - name: gateway-api
-    - name: gateway-api-experimental-apis
   sourceRef:
     kind: GitRepository
     name: infra

--- a/clusters/folly/networking/git-repository-gateway-api.yaml
+++ b/clusters/folly/networking/git-repository-gateway-api.yaml
@@ -14,4 +14,3 @@ spec:
     /*
     # include crds directory
     !/config/crd/standard
-    !/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml


### PR DESCRIPTION
## Summary
Complete folly’s Gateway API v1.6.1 ownership handoff after the new safe-upgrades policy rejected the obsolete experimental TLSRoute overlay on top of the standard v1 TLSRoute CRD. Folly has no TLSRoute objects, so the standard channel is the correct prerequisite for Cilium 1.20.

## Changes
- stop including the obsolete experimental TLSRoute manifest
- suspend the old experimental Flux Kustomization with `deletionPolicy: Orphan`
- remove the suspended Kustomization from the cluster Gateway dependency list

The old Kustomization remains in this PR so Flux first observes the orphan deletion policy. The Cilium upgrade PR can safely delete it after this change reconciles.

## Test Plan
- [x] `kubectl --context folly explain kustomization.spec.deletionPolicy --api-version=kustomize.toolkit.fluxcd.io/v1`
- [x] `kubectl kustomize clusters/folly/networking`
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`