### PR TITLE
chore(offsite): upgrade Gateway API to 1.6.1

### DIFF
--- a/clusters/offsite/networking/gateway-api.yaml
+++ b/clusters/offsite/networking/gateway-api.yaml
@@ -18,9 +18,11 @@ metadata:
   name: gateway-api-experimental-apis
   namespace: flux-system
 spec:
+  deletionPolicy: Orphan
   interval: 1h0m0s
   path: ./config/crd/experimental
   prune: true
+  suspend: true
   sourceRef:
     kind: GitRepository
     name: gateway-api
@@ -36,7 +38,6 @@ spec:
   prune: true
   dependsOn:
     - name: gateway-api
-    - name: gateway-api-experimental-apis
   sourceRef:
     kind: GitRepository
     name: infra

--- a/clusters/offsite/networking/git-repository-gateway-api.yaml
+++ b/clusters/offsite/networking/git-repository-gateway-api.yaml
@@ -8,10 +8,9 @@ spec:
   interval: 24h
   url: https://github.com/kubernetes-sigs/gateway-api
   ref:
-    tag: v1.4.1
+    tag: v1.6.1
   ignore: |
     # exclude all
     /*
     # include crds directory
     !/config/crd/standard
-    !/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml


### PR DESCRIPTION
## Summary
Prepare offsite for Cilium 1.20 by upgrading Gateway API from v1.4.1 to v1.6.1 and safely handing TLSRoute ownership to the standard CRD bundle. Offsite has no TLSRoute objects.

## Changes
- pin the offsite Gateway API source to `v1.6.1`
- stop including the obsolete experimental TLSRoute manifest
- suspend the experimental Flux Kustomization with `deletionPolicy: Orphan`
- remove the suspended owner from the cluster Gateway dependency list

The suspended Kustomization remains for one reconciliation so its orphan policy is live before deletion in the Cilium upgrade PR.

## Test Plan
- [x] confirm live offsite Gateway API is healthy at v1.4.1
- [x] confirm offsite has no TLSRoute or CiliumNodeConfig objects
- [x] `kubectl kustomize clusters/offsite/networking`
- [x] `mise run k8s:render-apps`
- [x] confirm the upstream `v1.6.1` tag resolves
- [x] `git diff --check`