### PR TITLE
chore(offsite): upgrade Cilium to 1.20.0-rc.1

### DIFF
--- a/clusters/offsite/networking/cilium/helm-release.yaml
+++ b/clusters/offsite/networking/cilium/helm-release.yaml
@@ -9,6 +9,8 @@ metadata:
 spec:
   interval: 24h
   maxHistory: 2
+  dependsOn:
+    - name: cilium-preflight
   chartRef:
     kind: OCIRepository
     name: cilium
@@ -22,6 +24,7 @@ spec:
     remediation:
       retries: 5
   values:
+    upgradeCompatibility: "1.17"
     autoDirectNodeRoutes: true
     devices: eno+ enp+ tailscale0
     kubeProxyReplacement: true

--- a/clusters/offsite/networking/cilium/kustomization.yaml
+++ b/clusters/offsite/networking/cilium/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - oci-repository.yaml
+  - preflight-helm-release.yaml
   - helm-release.yaml
   - ip-pools.yaml
   - bgp.yaml

--- a/clusters/offsite/networking/cilium/oci-repository.yaml
+++ b/clusters/offsite/networking/cilium/oci-repository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 1.19.6
+    tag: 1.20.0-rc.1
   url: oci://quay.io/cilium/charts/cilium

--- a/clusters/offsite/networking/cilium/preflight-helm-release.yaml
+++ b/clusters/offsite/networking/cilium/preflight-helm-release.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cilium-preflight
+  namespace: kube-system
+  labels:
+    source.toolkit.fluxcd.io/kind: OCIRepository
+spec:
+  interval: 24h
+  maxHistory: 2
+  chartRef:
+    kind: OCIRepository
+    name: cilium
+    namespace: flux-system
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    timeout: 10m
+    remediation:
+      retries: 5
+  values:
+    agent: false
+    config:
+      enabled: false
+    operator:
+      enabled: false
+    preflight:
+      enabled: true

--- a/clusters/offsite/networking/gateway-api.yaml
+++ b/clusters/offsite/networking/gateway-api.yaml
@@ -15,21 +15,6 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: gateway-api-experimental-apis
-  namespace: flux-system
-spec:
-  deletionPolicy: Orphan
-  interval: 1h0m0s
-  path: ./config/crd/experimental
-  prune: true
-  suspend: true
-  sourceRef:
-    kind: GitRepository
-    name: gateway-api
----
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
   name: gateway-api-cluster-gateway
   namespace: flux-system
 spec:


### PR DESCRIPTION
## Summary
Upgrade offsite from Cilium 1.19.6 to 1.20.0-rc.1 after Gateway API v1.6.1 reconciled successfully. Flux installs and validates the target Cilium preflight release first; the main Cilium HelmRelease cannot reconcile until preflight is Ready.

Cilium release: https://github.com/cilium/cilium/releases/tag/v1.20.0-rc.1
Upgrade guidance: https://docs.cilium.io/en/latest/operations/upgrade/

## Changes
- pin the offsite Cilium OCI chart to `1.20.0-rc.1`
- add a temporary GitOps-managed `cilium-preflight` HelmRelease
- make the main Cilium release depend on preflight readiness
- preserve offsite’s original install defaults with `upgradeCompatibility: "1.17"`
- delete the obsolete Gateway API experimental owner after its orphan policy reconciled

## Test Plan
- [x] confirm live Gateway API standard CRDs are healthy at v1.6.1
- [x] confirm the obsolete Gateway API owner is suspended with `deletionPolicy: Orphan`
- [x] confirm no TLSRoute, CiliumNodeConfig, or removed proxylib policy fields are present
- [x] render Cilium 1.20.0-rc.1 with offsite’s live Helm values and compatibility mode
- [x] render the target preflight chart and verify only preflight workloads are enabled
- [x] `kubectl kustomize clusters/offsite/networking`
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`

## Rollout note
Cilium documents that Gateway/Ingress/L7 connections reset while the agents roll. After merge, verify Cilium, Gateway, and HTTPRoute status before removing the temporary preflight release.