### PR TITLE
fix(offsite): rotate Hubble TLS certificates

### DIFF
--- a/clusters/offsite/networking/cilium/helm-release.yaml
+++ b/clusters/offsite/networking/cilium/helm-release.yaml
@@ -71,6 +71,9 @@ spec:
         enabled: true
     hubble:
       enabled: true
+      tls:
+        auto:
+          method: cronJob
       relay:
         enabled: true
         prometheus:


### PR DESCRIPTION
## Summary
Restore offsite Hubble Relay readiness and prevent recurrence by switching Cilium Hubble TLS automation from Helm-only certificate generation to the chart’s scheduled certgen Job/CronJob.

The rc.1 rollout exposed expired Hubble server and relay leaf certificates (`notAfter=2026-07-19`). The shared Cilium CA remains valid until 2028 and node clocks are correct.

## Changes
- set `hubble.tls.auto.method: cronJob` for offsite
- generate replacement leaf certificates immediately during reconciliation
- rotate Hubble certificates every four months using the chart default schedule

## Test Plan
- [x] reproduce Hubble Relay not-Ready twice with `kubectl --context offsite -n kube-system wait --for=condition=Ready pod -l k8s-app=hubble-relay --timeout=1s`
- [x] confirm Relay TLS verification fails on the expired July 19 leaf
- [x] confirm both leaf certificates expired and the CA remains valid until 2028
- [x] confirm offsite node clocks are correct
- [x] render Cilium rc.1 and verify the immediate certgen Job plus recurring CronJob
- [x] `kubectl kustomize clusters/offsite/networking`
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`

## Post-merge verification
- [ ] certgen Job completes
- [ ] replacement leaf certificates have future expiry dates
- [ ] Hubble Relay becomes Ready
- [ ] Cilium HelmRelease reaches Ready on rc.1