### PR TITLE
fix(offsite): unblock Hubble certificate rotation

### DIFF
--- a/clusters/offsite/networking/cilium/helm-release.yaml
+++ b/clusters/offsite/networking/cilium/helm-release.yaml
@@ -20,6 +20,7 @@ spec:
     remediation:
       retries: 5
   upgrade:
+    disableWait: true
     timeout: 10m
     remediation:
       retries: 5


### PR DESCRIPTION
## Summary
Allow the queued Cilium release to apply the Hubble certificate-generation resources without deadlocking on the currently unready Hubble Relay.

This is a temporary bootstrap flag. It will be removed with the Cilium preflight release after certificate rotation restores readiness.

## Changes
- disable Helm upgrade readiness waiting for the offsite Cilium release

## Test Plan
- [x] `mise run k8s:render-apps`
- [x] `kubectl kustomize clusters/offsite/networking`
- [x] `git diff --check`
- [ ] merge and reconcile the offsite networking Flux kustomization
- [ ] verify the Hubble certificate job completes and both leaf certificates have future expiration dates
- [ ] verify Hubble Relay, Cilium, Gateway API resources, and front-door routes are healthy