### PR TITLE
feat(folly): enable experimental Gateway API fields

### DIFF
--- a/clusters/folly/networking/gateway-api.yaml
+++ b/clusters/folly/networking/gateway-api.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h0m0s
-  path: ./config/crd/standard
+  path: ./config/crd/experimental
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/folly/networking/git-repository-gateway-api.yaml
+++ b/clusters/folly/networking/git-repository-gateway-api.yaml
@@ -12,5 +12,5 @@ spec:
   ignore: |
     # exclude all
     /*
-    # include crds directory
-    !/config/crd/standard
+    # include experimental bundle (standard resources plus experimental fields)
+    !/config/crd/experimental


### PR DESCRIPTION
## Summary
Enable the pinned Gateway API 1.6.1 experimental schema on folly so HTTPRoutes can declare native external authorization filters.

This changes only the CRD bundle channel. Existing Gateway and route resources retain the same API versions and controller.

## Changes
- fetch the Gateway API experimental CRD directory from the existing pinned source
- reconcile the experimental bundle instead of the standard bundle on folly

## Test Plan
- [x] `kubectl kustomize clusters/folly/networking`
- [x] render the pinned upstream experimental bundle
- [x] verify the bundle contains the experimental channel annotation and `externalAuth` schema
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`
- [ ] reconcile folly through Flux after merge
- [ ] verify `kubectl explain httproute.spec.rules.filters.externalAuth` succeeds
- [ ] verify existing Gateways and HTTPRoutes remain Accepted, Programmed, and ResolvedRefs