### PR TITLE
chore(folly): prepare Gateway API channel transition

### DIFF
--- a/clusters/folly/networking/gateway-api.yaml
+++ b/clusters/folly/networking/gateway-api.yaml
@@ -6,7 +6,20 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h0m0s
-  path: ./config/crd/experimental
+  path: ./config/crd/standard
+  patches:
+    - patch: |-
+        $patch: delete
+        apiVersion: admissionregistration.k8s.io/v1
+        kind: ValidatingAdmissionPolicy
+        metadata:
+          name: safe-upgrades.gateway.networking.k8s.io
+    - patch: |-
+        $patch: delete
+        apiVersion: admissionregistration.k8s.io/v1
+        kind: ValidatingAdmissionPolicyBinding
+        metadata:
+          name: safe-upgrades.gateway.networking.k8s.io
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/folly/networking/git-repository-gateway-api.yaml
+++ b/clusters/folly/networking/git-repository-gateway-api.yaml
@@ -12,5 +12,5 @@ spec:
   ignore: |
     # exclude all
     /*
-    # include experimental bundle (standard resources plus experimental fields)
-    !/config/crd/experimental
+    # include standard bundle for the channel-transition cleanup
+    !/config/crd/standard


### PR DESCRIPTION
## Summary
Prepare folly for a safe Gateway API standard-to-experimental channel transition by removing the installed channel-swap admission guard through Flux pruning.

This stage keeps all current CRDs on the standard 1.6.1 channel. The experimental bundle will be enabled in a follow-up after the guard is confirmed absent.

## Changes
- temporarily reconcile the pinned standard Gateway API bundle
- omit the safe-upgrade admission policy and binding with Kustomize delete patches
- retain Flux pruning so only those two guard objects are removed

## Test Plan
- [x] `kubectl kustomize clusters/folly/networking`
- [x] reconstruct the pinned standard bundle with the same delete patches
- [x] verify the transition render contains all 10 standard CRDs and neither admission guard
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`
- [ ] reconcile folly through Flux after merge
- [ ] verify the Gateway API Kustomization is Ready
- [ ] verify both safe-upgrade admission objects are absent
- [ ] verify existing Gateways and HTTPRoutes remain healthy