### PR TITLE
feat(folly): enable Gateway API ExternalAuth schema

### DIFF
--- a/clusters/folly/networking/gateway-api.yaml
+++ b/clusters/folly/networking/gateway-api.yaml
@@ -6,20 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h0m0s
-  path: ./config/crd/standard
-  patches:
-    - patch: |-
-        $patch: delete
-        apiVersion: admissionregistration.k8s.io/v1
-        kind: ValidatingAdmissionPolicy
-        metadata:
-          name: safe-upgrades.gateway.networking.k8s.io
-    - patch: |-
-        $patch: delete
-        apiVersion: admissionregistration.k8s.io/v1
-        kind: ValidatingAdmissionPolicyBinding
-        metadata:
-          name: safe-upgrades.gateway.networking.k8s.io
+  path: ./config/crd/experimental
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/folly/networking/git-repository-gateway-api.yaml
+++ b/clusters/folly/networking/git-repository-gateway-api.yaml
@@ -12,5 +12,5 @@ spec:
   ignore: |
     # exclude all
     /*
-    # include standard bundle for the channel-transition cleanup
-    !/config/crd/standard
+    # include experimental bundle (standard resources plus experimental fields)
+    !/config/crd/experimental


### PR DESCRIPTION
## Summary
Complete the staged Gateway API channel transition on folly by enabling the pinned 1.6.1 experimental bundle now that the channel-swap guard has been safely removed.

This makes the native HTTPRoute external authorization schema available while retaining the existing Gateway API version and Cilium controller.

## Changes
- fetch the Gateway API experimental CRD directory from the existing pinned source
- reconcile the experimental bundle
- remove the temporary transition delete patches

## Test Plan
- [x] `kubectl kustomize clusters/folly/networking`
- [x] render the pinned experimental bundle
- [x] verify the bundle contains 12 CRDs, the experimental channel annotation, and `externalAuth` schema
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`
- [ ] reconcile folly through Flux after merge
- [ ] verify `kubectl explain httproute.spec.rules.filters.externalAuth` succeeds
- [ ] verify existing Gateways and HTTPRoutes remain Accepted, Programmed, and ResolvedRefs