### PR TITLE
chore(offsite): prepare Gateway API channel transition

### DIFF
--- a/clusters/offsite/networking/gateway-api.yaml
+++ b/clusters/offsite/networking/gateway-api.yaml
@@ -7,6 +7,19 @@ metadata:
 spec:
   interval: 1h0m0s
   path: ./config/crd/standard
+  patches:
+    - patch: |-
+        $patch: delete
+        apiVersion: admissionregistration.k8s.io/v1
+        kind: ValidatingAdmissionPolicy
+        metadata:
+          name: safe-upgrades.gateway.networking.k8s.io
+    - patch: |-
+        $patch: delete
+        apiVersion: admissionregistration.k8s.io/v1
+        kind: ValidatingAdmissionPolicyBinding
+        metadata:
+          name: safe-upgrades.gateway.networking.k8s.io
   prune: true
   sourceRef:
     kind: GitRepository


### PR DESCRIPTION
## Summary
Prepare offsite for a safe Gateway API standard-to-experimental channel transition by removing the installed channel-swap admission guard through Flux pruning.

This stage keeps all current CRDs on the standard 1.6.1 channel. The experimental bundle will be enabled in a follow-up after the guard is confirmed absent.

## Changes
- omit the safe-upgrade admission policy and binding with Kustomize delete patches
- retain the pinned standard Gateway API bundle
- retain Flux pruning so only those two guard objects are removed

## Test Plan
- [x] `kubectl kustomize clusters/offsite/networking`
- [x] reuse the delete-patch shape proven by the folly transition
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`
- [ ] reconcile offsite through Flux after merge
- [ ] verify the Gateway API Kustomization is Ready
- [ ] verify both safe-upgrade admission objects are absent
- [ ] verify existing Gateways and HTTPRoutes remain healthy