### PR TITLE
chore(offsite): enable experimental Gateway API

### DIFF
--- a/clusters/offsite/networking/gateway-api.yaml
+++ b/clusters/offsite/networking/gateway-api.yaml
@@ -6,20 +6,7 @@ metadata:
   namespace: flux-system
 spec:
   interval: 1h0m0s
-  path: ./config/crd/standard
-  patches:
-    - patch: |-
-        $patch: delete
-        apiVersion: admissionregistration.k8s.io/v1
-        kind: ValidatingAdmissionPolicy
-        metadata:
-          name: safe-upgrades.gateway.networking.k8s.io
-    - patch: |-
-        $patch: delete
-        apiVersion: admissionregistration.k8s.io/v1
-        kind: ValidatingAdmissionPolicyBinding
-        metadata:
-          name: safe-upgrades.gateway.networking.k8s.io
+  path: ./config/crd/experimental
   prune: true
   sourceRef:
     kind: GitRepository

--- a/clusters/offsite/networking/git-repository-gateway-api.yaml
+++ b/clusters/offsite/networking/git-repository-gateway-api.yaml
@@ -12,5 +12,5 @@ spec:
   ignore: |
     # exclude all
     /*
-    # include crds directory
-    !/config/crd/standard
+    # include experimental crds directory
+    !/config/crd/experimental


### PR DESCRIPTION
## Summary

Move the offsite cluster from the Gateway API v1.6.1 standard CRD bundle to the experimental bundle now that the temporary safe-upgrade policy removal has reconciled.

## Changes

- include the experimental CRD directory in the pinned Gateway API source
- reconcile the experimental CRD bundle
- restore the upstream safe-upgrade admission policy by removing the transition-only deletion patches

## Test Plan

- [x] `kubectl kustomize clusters/offsite/networking`
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`
- [x] verify the offsite Gateway API Kustomization is healthy on v1.6.1 before the channel switch
- [x] verify existing offsite Gateways remain Programmed before the channel switch
