### PR TITLE
feat(auth): add shared oauth2-proxy component

### DIFF
--- a/clusters/base/apps/oauth2-proxy/external-secret.yaml
+++ b/clusters/base/apps/oauth2-proxy/external-secret.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: oauth2-proxy
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: oauth2-proxy
+    creationPolicy: Owner
+  data:
+    - secretKey: client-id
+      remoteRef:
+        key: oauth2-proxy
+        property: client-id
+    - secretKey: client-secret
+      remoteRef:
+        key: oauth2-proxy
+        property: client-secret
+    - secretKey: cookie-secret
+      remoteRef:
+        key: oauth2-proxy
+        property: cookie-secret

--- a/clusters/base/apps/oauth2-proxy/helm-release.yaml
+++ b/clusters/base/apps/oauth2-proxy/helm-release.yaml
@@ -1,0 +1,115 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+spec:
+  interval: 1h
+  chart:
+    spec:
+      chart: oauth2-proxy
+      version: 10.7.0
+      sourceRef:
+        kind: HelmRepository
+        name: oauth2-proxy
+      interval: 10m
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    config:
+      existingSecret: oauth2-proxy
+      cookieName: __Secure-oauth2_proxy
+      emailDomains:
+        - "*"
+      upstreams:
+        - static://200
+
+    extraArgs:
+      provider: github
+      github-user: jonpulsifer
+      scope: user:email
+      reverse-proxy: "true"
+      trusted-proxy-ip: ${K8S_NODE_CIDR}
+      redirect-url: https://oauth2.${SECRET_DOMAIN}/oauth2/callback
+      whitelist-domain: .${SECRET_DOMAIN}
+      cookie-domain: .${SECRET_DOMAIN}
+      cookie-httponly: "true"
+      cookie-secure: "true"
+      cookie-samesite: lax
+      set-xauthrequest: "true"
+      skip-provider-button: "true"
+      ping-path: ""
+      ready-path: ""
+
+    replicaCount: 2
+    enableServiceLinks: false
+
+    podAnnotations:
+      secret.reloader.stakater.com/reload: oauth2-proxy
+
+    serviceAccount:
+      enabled: true
+      automountServiceAccountToken: false
+
+    livenessProbe:
+      enabled: false
+
+    readinessProbe:
+      enabled: false
+
+    podDisruptionBudget:
+      enabled: true
+      minAvailable: 1
+      maxUnavailable: null
+
+    resources:
+      requests:
+        cpu: 25m
+        memory: 64Mi
+      limits:
+        memory: 128Mi
+
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/instance: oauth2-proxy
+                  app.kubernetes.io/name: oauth2-proxy
+
+  postRenderers:
+    - kustomize:
+        patches:
+          - target:
+              version: v1
+              kind: Deployment
+              name: oauth2-proxy
+            patch: |-
+              - op: add
+                path: /spec/template/spec/containers/0/livenessProbe
+                value:
+                  tcpSocket:
+                    port: http
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 5
+              - op: add
+                path: /spec/template/spec/containers/0/readinessProbe
+                value:
+                  tcpSocket:
+                    port: http
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3

--- a/clusters/base/apps/oauth2-proxy/helm-repository.yaml
+++ b/clusters/base/apps/oauth2-proxy/helm-repository.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: oauth2-proxy
+spec:
+  interval: 24h
+  url: https://oauth2-proxy.github.io/manifests

--- a/clusters/base/apps/oauth2-proxy/kustomization.yaml
+++ b/clusters/base/apps/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helm-repository.yaml
+  - external-secret.yaml
+  - helm-release.yaml
+namespace: oauth2-proxy

--- a/clusters/base/apps/oauth2-proxy/namespace.yaml
+++ b/clusters/base/apps/oauth2-proxy/namespace.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oauth2-proxy
+  labels:
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/folly/apps/oauth2-proxy/kustomization.yaml
+++ b/clusters/folly/apps/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/apps/oauth2-proxy

--- a/clusters/offsite/apps/oauth2-proxy/kustomization.yaml
+++ b/clusters/offsite/apps/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base/apps/oauth2-proxy


### PR DESCRIPTION
## Summary

Add a shared oauth2-proxy component for Cilium Gateway API ExternalAuth, with identical folly and offsite overlays. This preparation is intentionally not registered with either Flux root, so merging it does not create workloads or failed desired state before the OAuth credential exists.

## Changes

- pin the official oauth2-proxy chart at `10.7.0` and app `7.15.3`
- project `client-id`, `client-secret`, and `cookie-secret` from the `oauth2-proxy` 1Password item
- restrict GitHub authorization to `jonpulsifer` and trust only the site node CIDR
- disable unauthenticated HTTP health handlers and replace chart probes with TCP probes
- run two hardened replicas with a disruption budget and no ServiceAccount token
- add identical, inactive site overlays for folly and offsite

## Test Plan

- [x] `kubectl kustomize clusters/base/apps/oauth2-proxy`
- [x] `kubectl kustomize clusters/folly/apps/oauth2-proxy`
- [x] `kubectl kustomize clusters/offsite/apps/oauth2-proxy`
- [x] `mise run k8s:render-apps`
- [x] render official chart `10.7.0` with the exact values
- [x] locally apply the Flux TCP probe patches to the rendered Deployment
- [x] `git diff --check`
