### PR TITLE
feat(pki): export cluster CA keys for NixOS

### DIFF
--- a/scripts/pki/post-rotate.sh
+++ b/scripts/pki/post-rotate.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
-# Post-apply glue for terraform/pki signer (re)issuance.
+# Post-apply glue for terraform/pki cluster CA and signer (re)issuance.
 #
-# After `atlantis apply` (or a local tofu apply) creates/rotates the per-cluster
-# SA token signers, this script:
+# After `atlantis apply` creates/rotates the per-cluster CAs or SA token
+# signers, this script:
 #   1. writes the public cert material to terraform/pki/certs/ (committed);
-#      a replaced signer's previous cert is kept as *-prev.pem so the JWKS
-#      retains the old key while tokens signed by it are still live,
-#   2. sops-encrypts each signer private key into the control-plane host's
-#      nix/secrets/<host>.sops.yaml (key: k8s-sa-signing-key) — plaintext never
+#      replaced CA and signer certs are kept as *-prev.pem for trust overlap,
+#      and each cluster CA gets a current-plus-previous *-ca-bundle.pem,
+#   2. sops-encrypts each cluster CA and signer private key into the matching
+#      control-plane host's nix/secrets/<host>.sops.yaml — plaintext never
 #      touches disk,
 #   3. regenerates terraform/pki/oidc/<cluster>/{jwks.json,openid-configuration.json}
 #      via scripts/pki/jwks_from_certs.py.
@@ -36,13 +36,63 @@ mkdir -p "$certs_dir"
 jq -er '.fml_root_cert.value' <<<"$outputs" >"$certs_dir/fml-root.pem"
 jq -er '.fml_intermediate_cert.value' <<<"$outputs" >"$certs_dir/fml-intermediate.pem"
 
+sops_set_key() {
+  secret_file=$1
+  secret_name=$2
+  output_name=$3
+  cluster=$4
+
+  jq -cer ".${output_name}.value.\"$cluster\"" <<<"$outputs" \
+    | sops set --value-stdin "$secret_file" "[\"$secret_name\"]"
+}
+
+verify_key_pair() {
+  cert_output=$1
+  key_output=$2
+  cluster=$3
+
+  cert_spki="$(
+    jq -er ".${cert_output}.value.\"$cluster\"" <<<"$outputs" \
+      | openssl x509 -pubkey -noout \
+      | openssl pkey -pubin -outform DER \
+      | openssl sha256
+  )"
+  key_spki="$(
+    jq -er ".${key_output}.value.\"$cluster\"" <<<"$outputs" \
+      | openssl pkey -pubout -outform DER \
+      | openssl sha256
+  )"
+  if [[ $cert_spki != "$key_spki" ]]; then
+    echo "error: $cluster $cert_output does not match $key_output" >&2
+    return 1
+  fi
+}
+
 for cluster in folly offsite; do
   host="${control_plane[$cluster]}"
   issuer="$(jq -er ".issuers.value.\"$cluster\"" <<<"$outputs")"
+  ca_pem="$certs_dir/$cluster-ca.pem"
+  ca_prev_pem="$certs_dir/$cluster-ca-prev.pem"
+  ca_bundle_pem="$certs_dir/$cluster-ca-bundle.pem"
   signer_pem="$certs_dir/$cluster-sa-signer.pem"
   prev_pem="$certs_dir/$cluster-sa-signer-prev.pem"
 
-  jq -er ".cluster_ca_certs.value.\"$cluster\"" <<<"$outputs" >"$certs_dir/$cluster-ca.pem"
+  verify_key_pair cluster_ca_certs cluster_ca_private_keys "$cluster"
+  verify_key_pair sa_signer_certs sa_signer_private_keys "$cluster"
+
+  # Preserve the old CA before replacement. Consumers stage ca-bundle.pem,
+  # rotate every leaf, and only then retire ca-prev.pem in a later commit.
+  new_ca="$(jq -er ".cluster_ca_certs.value.\"$cluster\"" <<<"$outputs")"
+  if [[ -s $ca_pem ]] && ! diff -q <(printf '%s' "$new_ca") "$ca_pem" >/dev/null 2>&1; then
+    echo "==> $cluster: previous CA kept for overlap ($ca_prev_pem)" >&2
+    cp "$ca_pem" "$ca_prev_pem"
+  fi
+  printf '%s' "$new_ca" >"$ca_pem"
+  cp "$ca_pem" "$ca_bundle_pem"
+  if [[ -s $ca_prev_pem ]]; then
+    printf '\n' >>"$ca_bundle_pem"
+    cat "$ca_prev_pem" >>"$ca_bundle_pem"
+  fi
 
   # Preserve a replaced signer cert for JWKS overlap during rotation.
   new_signer="$(jq -er ".sa_signer_certs.value.\"$cluster\"" <<<"$outputs")"
@@ -58,16 +108,22 @@ for cluster in folly offsite; do
     rm "$prev_pem"
   fi
 
-  echo "==> $cluster: sops-encrypting signer key for $host" >&2
+  echo "==> $cluster: sops-encrypting cluster CA and signer keys for $host" >&2
   secret_file="$repo_root/nix/secrets/$host.sops.yaml"
-  key_json="$(jq -c ".sa_signer_private_keys.value.\"$cluster\"" <<<"$outputs")"
   if [[ -s $secret_file ]]; then
-    # NB: sops set takes the value on argv — briefly visible in process listings
-    # on the operator machine; acceptable for a single-user laptop.
-    sops set "$secret_file" '["k8s-sa-signing-key"]' "$key_json"
+    sops_set_key "$secret_file" "k8s-cluster-ca-key" cluster_ca_private_keys "$cluster"
+    sops_set_key "$secret_file" "k8s-sa-signing-key" sa_signer_private_keys "$cluster"
   else
-    encrypted="$(jq -n --argjson key "$key_json" '{"k8s-sa-signing-key": $key}' \
-      | sops encrypt --filename-override "$secret_file" --input-type json --output-type yaml /dev/stdin)"
+    encrypted="$(
+      jq -n \
+        --argjson cluster_ca_key "$(jq -c ".cluster_ca_private_keys.value.\"$cluster\"" <<<"$outputs")" \
+        --argjson signer_key "$(jq -c ".sa_signer_private_keys.value.\"$cluster\"" <<<"$outputs")" \
+        '{
+          "k8s-cluster-ca-key": $cluster_ca_key,
+          "k8s-sa-signing-key": $signer_key
+        }' \
+        | sops encrypt --filename-override "$secret_file" --input-type json --output-type yaml /dev/stdin
+    )"
     printf '%s\n' "$encrypted" >"$secret_file"
   fi
 
@@ -78,6 +134,13 @@ for cluster in folly offsite; do
     --issuer "$issuer" \
     --out "$pki_dir/oidc/$cluster" \
     "${jwks_args[@]}"
+
+  echo "==> $cluster: certificate inventory" >&2
+  for cert in "$ca_pem" "$ca_prev_pem" "$signer_pem" "$prev_pem"; do
+    [[ -s $cert ]] || continue
+    openssl x509 -noout -subject -serial -dates -in "$cert" \
+      | sed "s|^|    $(basename "$cert"): |" >&2
+  done
 done
 
 cat >&2 <<'EOF'
@@ -85,6 +148,8 @@ cat >&2 <<'EOF'
 Done. Next steps:
   1. git add terraform/pki/certs terraform/pki/oidc nix/secrets && commit + PR
      (the next atlantis apply uploads the refreshed OIDC documents)
-  2. deploy the control planes (optiplex, retrofit) per the runbook
-  3. after old tokens age out, remove *-sa-signer-prev.pem and rerun this script
+  2. deploy the control planes only after the matching NixOS configuration
+     consumes the refreshed keys
+  3. after every TLS leaf uses the new CA, remove *-ca-prev.pem and rerun this
+     script; after old tokens age out, do the same for *-sa-signer-prev.pem
 EOF

--- a/terraform/pki/README.md
+++ b/terraform/pki/README.md
@@ -16,14 +16,31 @@ Auth: the `onepassword` provider needs `OP_SERVICE_ACCOUNT_TOKEN` (Atlantis) or
 a locally signed-in `op` CLI (`OP_ACCOUNT`). The service account must be able to
 read the FML CA items in the `homelab` vault (UUIDs pinned in `pki.tf`).
 
-## Rotation
+## Export and rotation
 
-Signer certs live 1 year (`early_renewal_hours` makes plans flag them ~30 days
-out). To rotate: let Atlantis apply the replacement, then run
-`scripts/pki/post-rotate.sh` — it sops-encrypts the new signer keys for the
-control-plane hosts and regenerates `oidc/<cluster>/{jwks.json,openid-configuration.json}`
-(committed here; the oidc workflow deploys them to Pages on merge). Deploy the
-control planes per the Kubernetes GitOps runbook.
+Cluster CAs expire in July 2028. Their shorter lifetime is intentional: the
+fleet exercises overlapping CA rotation rather than treating its trust roots as
+permanent. Signer certs live 1 year (`early_renewal_hours` makes plans flag them
+about 30 days out).
+
+After Atlantis applies a CA or signer replacement, run
+`scripts/pki/post-rotate.sh`. It writes public certificates under `certs/`,
+SOPS-encrypts each cluster CA and signer private key for the matching
+control-plane host, and regenerates
+`oidc/<cluster>/{jwks.json,openid-configuration.json}`. Commit those outputs
+before deploying the control planes. The OIDC workflow publishes the discovery
+documents on merge. The helper verifies that each private key matches its
+certificate and prints the certificate expiry inventory.
+
+ServiceAccount signer overlap and Kubernetes TLS CA overlap are separate
+rotation concerns: JWKS retains the previous signer while its tokens remain
+valid. On CA replacement, the helper moves the current certificate to
+`certs/<cluster>-ca-prev.pem` and builds
+`certs/<cluster>-ca-bundle.pem` with new and previous CAs. Stage that bundle on
+every Kubernetes client and server, reissue all TLS leaves from the new CA, and
+verify the fleet before deleting `*-ca-prev.pem` and rerunning the helper.
+Rollback restores the prior git revision (including its SOPS ciphertext), then
+redeploys the overlap bundle and rebuilds the affected hosts.
 
 <!-- BEGIN_TF_DOCS -->
 <!-- END_TF_DOCS -->

--- a/terraform/pki/outputs.tf
+++ b/terraform/pki/outputs.tf
@@ -8,6 +8,12 @@ output "cluster_ca_certs" {
   value       = { for c in local.clusters : c => tls_locally_signed_cert.cluster_ca[c].cert_pem }
 }
 
+output "cluster_ca_private_keys" {
+  description = "Per-cluster FML K8s CA private keys (PEM). Consumed only by scripts/pki/post-rotate.sh, which sops-encrypts each key for its control-plane host."
+  sensitive   = true
+  value       = { for c in local.clusters : c => tls_private_key.cluster_ca[c].private_key_pem }
+}
+
 output "sa_signer_certs" {
   description = "Per-cluster ServiceAccount token signer certificates (PEM)."
   value       = { for c in local.clusters : c => tls_locally_signed_cert.sa_signer[c].cert_pem }


### PR DESCRIPTION
## Summary
Expose the existing per-cluster CA private keys as sensitive Atlantis outputs so they can be delivered to NixOS through SOPS, with rotation-safe public trust artifacts and integrity checks.

This is the foundation step for replacing NixOS-generated Kubernetes CAs. It does not change a running host or cluster.

## Changes
- add a sensitive `cluster_ca_private_keys` OpenTofu output
- deliver cluster CA and ServiceAccount signer keys to the matching control-plane SOPS file without argv exposure
- preserve prior CA/signer certificates, generate a CA overlap bundle, verify SPKI matches, and print expiry inventory
- document deliberate July 2028 CA expiry and separate TLS/JWKS rotation concerns

## Test Plan
- [x] `shfmt -d -i 2 -ci -bn scripts/pki/post-rotate.sh`
- [x] `shellcheck scripts/pki/post-rotate.sh`
- [x] `tofu -chdir=terraform/pki fmt -check`
- [x] `tofu -chdir=terraform/pki validate`
- [x] `git diff --check origin/main..HEAD`
- [ ] Atlantis plan shows output-only state change
- [ ] After Atlantis apply, run `scripts/pki/post-rotate.sh` and verify encrypted control-plane keys plus CA bundles
