### PR TITLE
fix(monitoring): discover EndpointSlice targets

### DIFF
--- a/clusters/folly/monitoring/capsule.yaml
+++ b/clusters/folly/monitoring/capsule.yaml
@@ -45,7 +45,7 @@ spec:
       interval: 30s
       relabelings:
         - action: replace
-          sourceLabels: [__meta_kubernetes_endpoint_node_name]
+          sourceLabels: [__meta_kubernetes_endpointslice_endpoint_node_name]
           targetLabel: instance
   selector:
     matchLabels:

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -50,6 +50,7 @@ spec:
               - *prom
         pathType: Prefix
       prometheusSpec:
+        serviceDiscoveryRole: EndpointSlice
         retention: 30d
         retentionSize: 40GB
         additionalScrapeConfigs:
@@ -202,5 +203,5 @@ spec:
         monitor:
           relabelings:
             - action: replace
-              sourceLabels: [__meta_kubernetes_endpoint_node_name]
+              sourceLabels: [__meta_kubernetes_endpointslice_endpoint_node_name]
               targetLabel: instance

--- a/clusters/folly/monitoring/local-node-exporters.yaml
+++ b/clusters/folly/monitoring/local-node-exporters.yaml
@@ -53,7 +53,7 @@ spec:
       interval: 30s
       relabelings:
         - action: replace
-          sourceLabels: [__meta_kubernetes_endpoint_node_name]
+          sourceLabels: [__meta_kubernetes_endpointslice_endpoint_node_name]
           targetLabel: instance
   selector:
     matchLabels:

--- a/clusters/folly/monitoring/picow.yaml
+++ b/clusters/folly/monitoring/picow.yaml
@@ -45,7 +45,7 @@ spec:
       interval: 30s
       relabelings:
         - action: replace
-          sourceLabels: [__meta_kubernetes_endpoint_node_name]
+          sourceLabels: [__meta_kubernetes_endpointslice_endpoint_node_name]
           targetLabel: instance
   selector:
     matchLabels:

--- a/clusters/folly/monitoring/spore.yaml
+++ b/clusters/folly/monitoring/spore.yaml
@@ -58,13 +58,13 @@ spec:
       interval: 30s
       relabelings:
         - action: replace
-          sourceLabels: [__meta_kubernetes_endpoint_node_name]
+          sourceLabels: [__meta_kubernetes_endpointslice_endpoint_node_name]
           targetLabel: instance
     - port: dns-metrics
       interval: 30s
       relabelings:
         - action: replace
-          sourceLabels: [__meta_kubernetes_endpoint_node_name]
+          sourceLabels: [__meta_kubernetes_endpointslice_endpoint_node_name]
           targetLabel: instance
   selector:
     matchLabels:


### PR DESCRIPTION
## Summary

Restore Prometheus discovery for the manually managed EndpointSlice targets used by standalone hosts, including capsule and spore CoreDNS.

## Changes

- configure kube-prometheus-stack to use EndpointSlice service discovery
- update hostname relabeling to the EndpointSlice node-name metadata label

## Test Plan

- [x] `mise run k8s:render-apps`
- [x] `kubectl kustomize clusters/folly/monitoring`
- [x] `git diff --check`
- [x] standards and spec review
- [ ] after merge, reconcile the folly monitoring kustomization and confirm `up{endpoint="dns-metrics"}` for capsule and spore

## Context

`.agent/context/context.md`
