### PR TITLE
feat(auth): prepare oauth2-proxy Flux wiring

### DIFF
--- a/clusters/folly/apps/oauth2-proxy/httproute.yaml
+++ b/clusters/folly/apps/oauth2-proxy/httproute.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: oauth2-proxy
+  namespace: oauth2-proxy
+spec:
+  parentRefs:
+    - name: cluster-gateway
+      namespace: default
+      sectionName: https-wildcard
+  hostnames:
+    - "oauth2.${SECRET_DOMAIN}"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /oauth2
+      backendRefs:
+        - name: oauth2-proxy
+          port: 80

--- a/clusters/folly/apps/oauth2-proxy/kustomization.yaml
+++ b/clusters/folly/apps/oauth2-proxy/kustomization.yaml
@@ -3,3 +3,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../base/apps/oauth2-proxy
+  - httproute.yaml

--- a/clusters/folly/flux-system/oauth2-proxy.yaml
+++ b/clusters/folly/flux-system/oauth2-proxy.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oauth2-proxy
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/folly/apps/oauth2-proxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  dependsOn:
+    - name: config
+    - name: networking
+    - name: onepassword-connect
+  healthChecks:
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      name: oauth2-proxy
+      namespace: oauth2-proxy
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: oauth2-proxy
+      namespace: oauth2-proxy
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: ConfigMap
+        name: cluster-topology
+      - kind: Secret
+        name: cluster-secrets

--- a/clusters/offsite/flux-system/oauth2-proxy.yaml
+++ b/clusters/offsite/flux-system/oauth2-proxy.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: oauth2-proxy
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/offsite/apps/oauth2-proxy
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  dependsOn:
+    - name: config
+    - name: networking
+    - name: onepassword-connect
+  healthChecks:
+    - apiVersion: external-secrets.io/v1
+      kind: ExternalSecret
+      name: oauth2-proxy
+      namespace: oauth2-proxy
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: oauth2-proxy
+      namespace: oauth2-proxy
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-settings
+      - kind: ConfigMap
+        name: cluster-topology
+      - kind: Secret
+        name: cluster-secrets


### PR DESCRIPTION
## Summary

Prepare the ordered Flux reconcilers for oauth2-proxy in both clusters and the folly OAuth callback route. The reconcilers remain intentionally excluded from each cluster root, so this PR has no live effect before the OAuth credential exists.

## Changes

- add an HTTPS-only folly callback route for `oauth2.${SECRET_DOMAIN}/oauth2*`
- make the callback route target the shared oauth2-proxy Service
- define per-cluster Flux Kustomizations that depend on config, networking, and 1Password
- health-check both the ExternalSecret and HelmRelease before reconciliation succeeds

## Test Plan

- [x] `kubectl kustomize clusters/folly/apps/oauth2-proxy`
- [x] `kubectl kustomize clusters/offsite/apps/oauth2-proxy`
- [x] `kubectl kustomize clusters/folly/flux-system`
- [x] `kubectl kustomize clusters/offsite/flux-system`
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`
