### PR TITLE
feat(folly): activate oauth2-proxy

### DIFF
--- a/clusters/base/apps/oauth2-proxy/external-secret.yaml
+++ b/clusters/base/apps/oauth2-proxy/external-secret.yaml
@@ -14,13 +14,13 @@ spec:
   data:
     - secretKey: client-id
       remoteRef:
-        key: oauth2-proxy
+        key: 46xuydwpk5vbw2gld2pzn5o4pq
         property: client-id
     - secretKey: client-secret
       remoteRef:
-        key: oauth2-proxy
+        key: 46xuydwpk5vbw2gld2pzn5o4pq
         property: client-secret
     - secretKey: cookie-secret
       remoteRef:
-        key: oauth2-proxy
+        key: 46xuydwpk5vbw2gld2pzn5o4pq
         property: cookie-secret

--- a/clusters/folly/flux-system/kustomization.yaml
+++ b/clusters/folly/flux-system/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - monitoring.yaml
   - networking.yaml
   - nodes.yaml
+  - oauth2-proxy.yaml
   - storage.yaml


### PR DESCRIPTION
## Summary

Activate the prepared oauth2-proxy component on folly only. The shared ExternalSecret now uses the verified 1Password item UUID, while offsite remains inactive pending the folly rollout.

## Changes

- reference the stable 1Password item UUID for all three credential fields
- register the prepared oauth2-proxy Flux Kustomization in folly
- leave the offsite Flux root unchanged

## Test Plan

- [x] verify `client-id`, `client-secret`, and `cookie-secret` exist and are populated without exposing their values
- [x] `kubectl kustomize clusters/folly/apps/oauth2-proxy`
- [x] `kubectl kustomize clusters/offsite/apps/oauth2-proxy`
- [x] `kubectl kustomize clusters/folly/flux-system`
- [x] `kubectl kustomize clusters/offsite/flux-system`
- [x] `mise run k8s:render-apps`
- [x] `git diff --check`

## Post-merge

- reconcile folly’s Flux root and oauth2-proxy Kustomization
- verify the ExternalSecret, HelmRelease, Deployment, Service, and callback HTTPRoute
- verify the callback hostname serves only `/oauth2*`
