### PR TITLE
fix(folly): restart Cilium Gateway controller

### DIFF
--- a/clusters/folly/networking/cilium/helm-release.yaml
+++ b/clusters/folly/networking/cilium/helm-release.yaml
@@ -62,6 +62,8 @@ spec:
     k8sNetworkPolicy:
       enabled: true
     operator:
+      podAnnotations:
+        kubectl.kubernetes.io/restartedAt: "2026-07-27T02:40:27Z"
       dashboards:
         enabled: true
       prometheus:


### PR DESCRIPTION
## Summary
Recover folly’s Cilium Gateway API controllers after startup-time CRD discovery disabled them, allowing newly created HTTPRoutes to reconcile.

## Changes
- roll the folly Cilium operator pods through the Helm-managed pod template
- leave the Cilium agent dataplane and offsite cluster unchanged

## Test Plan
- [x] `mise run k8s:render-apps`
- [x] `kubectl kustomize clusters/folly/networking`
- [x] `git diff --check`
- [ ] after merge, reconcile Cilium and confirm fresh operator logs initialize Gateway API
- [ ] confirm `oauth2-proxy/oauth2-proxy` becomes Accepted and ResolvedRefs