### PR TITLE
feat(spindrift): scaffold the app, manifest, and extraction test

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "apps/hub/**"
       - "apps/slingshot/**"
+      - "apps/spindrift/**"
       - "packages/k6/**"
       - "packages/typescript-config/**"
       - "package.json"
@@ -18,6 +19,7 @@ on:
     paths:
       - "apps/hub/**"
       - "apps/slingshot/**"
+      - "apps/spindrift/**"
       - "packages/k6/**"
       - "packages/typescript-config/**"
       - "package.json"
@@ -41,6 +43,22 @@ jobs:
     env:
       NEXT_TELEMETRY_DISABLED: 1
       TURBO_TELEMETRY_DISABLED: 1
+      # spindrift's tests fake the far side of an adapter, never the database.
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/spindrift
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: spindrift
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -1,0 +1,58 @@
+# spindrift
+
+Connect a repo, press Deploy, get a URL.
+
+Spindrift is a deploy layer, not a platform: it owns the UI and the feel, and
+adapts to whatever builds and delivers underneath — a Kubernetes cluster, Cloud
+Run, or static hosting. The design lives in `.agent/plans/spindrift/spec.md`
+(private) and is referenced from the source as `§N`.
+
+**This is a scaffold.** What exists is the workspace package, the installation
+manifest, the extraction test that polices it, and a placeholder screen. No App,
+Component, Build, Deploy, or Datastore yet.
+
+## Shape
+
+One image, two processes (§19):
+
+| Path | What it is |
+| --- | --- |
+| `src/web/` | the `web` process — UI, webhooks, log WebSockets |
+| `src/config/` | the installation manifest and its schema |
+| `build.ts` | `Bun.build` over the client HTML entry → `dist/` |
+
+There is no framework, no bundler beyond Bun, and no test runner beyond
+`bun test`.
+
+## The installation manifest
+
+Every value that names a particular installation lives in one document —
+`src/config/manifest.schema.ts` defines it, `test/fixtures/installation.example.yaml`
+is a complete one for an installation that does not exist. A literal outside
+that document is a bug, and `test/extraction/no-literals.test.ts` is what
+notices.
+
+Point the process at one:
+
+```bash
+export SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml
+# or, inline:
+export SPINDRIFT_MANIFEST="$(cat test/fixtures/installation.example.yaml)"
+```
+
+Boot fails loudly, naming every offending key, if it is missing or incomplete.
+Nothing has a default, because a default here would name someone's homelab.
+
+## Usage
+
+```bash
+bun install                       # once, at repo root (workspace member)
+bun run --cwd apps/spindrift build      # client → dist/
+bun run --cwd apps/spindrift test       # bun test
+bun run --cwd apps/spindrift typecheck  # tsc --noEmit
+SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml \
+  bun run --cwd apps/spindrift dev      # http://localhost:3000
+```
+
+`mise run ts:check` typechecks and lints the whole workspace, this package
+included.

--- a/apps/spindrift/build.ts
+++ b/apps/spindrift/build.ts
@@ -1,0 +1,39 @@
+/**
+ * Bundle the client — `bun run build`.
+ *
+ * The HTML entry is the graph root: `Bun.build` follows its script and style
+ * tags, so this file never grows an entry list. `src/web/server.ts` serves the
+ * same HTML directly in development.
+ */
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const OUT = join(import.meta.dir, 'dist');
+
+await rm(OUT, { recursive: true, force: true });
+
+const production = Bun.env.NODE_ENV === 'production';
+
+const result = await Bun.build({
+  entrypoints: [join(import.meta.dir, 'src/web/client/index.html')],
+  outdir: OUT,
+  target: 'browser',
+  minify: production,
+  sourcemap: 'linked',
+  // React ships a development build unless this is set.
+  define: {
+    'process.env.NODE_ENV': JSON.stringify(
+      production ? 'production' : 'development',
+    ),
+  },
+});
+
+if (!result.success) {
+  for (const log of result.logs) console.error(log);
+  process.exit(1);
+}
+
+const bytes = result.outputs.reduce((total, output) => total + output.size, 0);
+console.log(
+  `spindrift client → dist/ (${result.outputs.length} files, ${(bytes / 1024).toFixed(1)} KiB)`,
+);

--- a/apps/spindrift/package.json
+++ b/apps/spindrift/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "spindrift",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "bun run build.ts",
+    "dev": "bun run --hot src/web/server.ts",
+    "lint": "biome check .",
+    "lint:fix": "biome check . --write",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/bun": "1.3.14",
+    "@types/react": "19.2.17",
+    "@types/react-dom": "19.2.3",
+    "typescript": "5.9.3"
+  }
+}

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -1,0 +1,141 @@
+/**
+ * The installation manifest: every value that names a particular installation
+ * of Spindrift.
+ *
+ * Spec §20, line 3 — "everything naming this installation is a value in the
+ * installation manifest; a literal outside it is a bug". That rule is
+ * mechanical: `test/extraction/no-literals.test.ts` greps `src/` for
+ * installation-specific literals, so nothing in this file may carry an example
+ * value from the installation that happens to run it.
+ *
+ * There are no defaults. A missing key fails the boot rather than falling back
+ * to whatever the first operator happened to use.
+ */
+import { z } from 'zod';
+
+/** A non-empty string with no surrounding whitespace. */
+const nonEmptyString = z.string().trim().min(1);
+
+/** A DNS zone apex, e.g. `apps.example.test`. */
+const zone = nonEmptyString.regex(
+  /^(?!-)[a-z0-9-]+(\.[a-z0-9-]+)+$/,
+  'must be a lowercase dotted DNS name',
+);
+
+/**
+ * The delivery adapter a Target speaks (§6). One Target has exactly one
+ * adapter type, because placement determines artifact shape (§13).
+ */
+export const targetAdapterSchema = z.enum(['kubernetes', 'cloudrun', 'static']);
+
+/**
+ * The secret store this installation resolves the reach rule with (§10, §20).
+ * v1 ships two so the pluggability claim is falsifiable.
+ */
+export const storeAdapterSchema = z.enum(['onepassword', 'gcp-secret-manager']);
+
+/**
+ * A Target as the manifest seeds it. The connect act (Task 13) owns the rest of
+ * the model; this is only what must exist before the first boot can place
+ * anything.
+ */
+export const targetSeedSchema = z
+  .object({
+    /** Stable identifier, unique within the installation. */
+    name: nonEmptyString,
+    /** Which delivery adapter drives it. */
+    adapter: targetAdapterSchema,
+  })
+  .strict();
+
+export const installationManifestSchema = z
+  .object({
+    /**
+     * Opaque label for this installation. Appears in the UI and in logs; it
+     * carries no behaviour.
+     */
+    installation: nonEmptyString,
+
+    dns: z
+      .object({
+        /**
+         * Dedicated apex Spindrift mints canonical names under, disjoint from
+         * any hand-managed flat space (§9).
+         */
+        apexZone: zone,
+        /**
+         * Zone the flat single-label vanity names are layered on (§9). May be
+         * the same zone as the apex; it is named separately because the two are
+         * allowed to diverge.
+         */
+        vanityZone: zone,
+      })
+      .strict(),
+
+    cloud: z
+      .object({
+        /**
+         * Project holding immutable build artifacts and signing material. Shared
+         * across every vessel (§14).
+         */
+        artifactsProject: nonEmptyString,
+        /**
+         * Spindrift's own project, and the default shared vessel for Apps that
+         * do not choose one (§14).
+         */
+        homeVesselProject: nonEmptyString,
+      })
+      .strict(),
+
+    charts: z
+      .object({
+        /**
+         * Reference to the App chart (§7) — the chart every deployed Component
+         * renders through.
+         */
+        app: nonEmptyString,
+        /**
+         * Reference to the installer chart (§19) — the chart this installation
+         * itself was installed from.
+         */
+        installer: nonEmptyString,
+      })
+      .strict(),
+
+    github: z
+      .object({
+        /** Numeric id of the GitHub App used for repository integration (§15). */
+        appId: nonEmptyString.regex(
+          /^[0-9]+$/,
+          'must be a numeric GitHub App id',
+        ),
+      })
+      .strict(),
+
+    secretStore: z
+      .object({
+        /** Which store adapter this installation delivers config through. */
+        adapter: storeAdapterSchema,
+      })
+      .strict(),
+
+    /**
+     * Targets that exist before anyone connects one, in rank order — rank is one
+     * global ordered list (§13), so the order of this array is the order
+     * placement considers them in.
+     */
+    targets: z
+      .array(targetSeedSchema)
+      .min(1)
+      .refine(
+        (targets) =>
+          new Set(targets.map((t) => t.name)).size === targets.length,
+        'target names must be unique',
+      ),
+  })
+  .strict();
+
+export type TargetAdapter = z.infer<typeof targetAdapterSchema>;
+export type StoreAdapter = z.infer<typeof storeAdapterSchema>;
+export type TargetSeed = z.infer<typeof targetSeedSchema>;
+export type InstallationManifest = z.infer<typeof installationManifestSchema>;

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -1,0 +1,89 @@
+/**
+ * Loading and validating the installation manifest.
+ *
+ * The manifest is read once at boot from a mounted file (the chart renders it
+ * from values into a ConfigMap) or, for tests and local runs, from an inline
+ * document in the environment. Validation failures are fatal and name every
+ * offending key at once — a half-configured installation must not reach the
+ * point where it can place a workload.
+ */
+import {
+  type InstallationManifest,
+  installationManifestSchema,
+} from './manifest.schema.ts';
+
+/** Path to a YAML or JSON manifest document. */
+export const MANIFEST_PATH_VAR = 'SPINDRIFT_MANIFEST_PATH';
+/** An inline YAML or JSON manifest document, used in place of a file. */
+export const MANIFEST_INLINE_VAR = 'SPINDRIFT_MANIFEST';
+
+/** Raised when the manifest is absent, unparseable, or invalid. */
+export class ManifestError extends Error {
+  override readonly name = 'ManifestError';
+}
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Parse and validate a manifest document. Accepts YAML, and therefore JSON.
+ *
+ * @param document the raw manifest text
+ * @param source where it came from, for error messages
+ */
+export function parseManifest(
+  document: string,
+  source: string,
+): InstallationManifest {
+  let parsed: unknown;
+  try {
+    parsed = Bun.YAML.parse(document);
+  } catch (cause) {
+    throw new ManifestError(
+      `${source}: not valid YAML: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  const result = installationManifestSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => {
+        const path = issue.path.join('.');
+        return `  ${path === '' ? '(root)' : path}: ${issue.message}`;
+      })
+      .join('\n');
+    throw new ManifestError(
+      `${source}: invalid installation manifest\n${issues}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Read the manifest the environment points at.
+ *
+ * `SPINDRIFT_MANIFEST_PATH` wins over `SPINDRIFT_MANIFEST`; neither being set is
+ * an error, because there is no manifest this code could invent.
+ */
+export async function loadManifest(
+  env: Env = Bun.env,
+): Promise<InstallationManifest> {
+  const path = env[MANIFEST_PATH_VAR]?.trim();
+  if (path) {
+    const file = Bun.file(path);
+    if (!(await file.exists())) {
+      throw new ManifestError(`${MANIFEST_PATH_VAR}=${path}: no such file`);
+    }
+    return parseManifest(await file.text(), path);
+  }
+
+  const inline = env[MANIFEST_INLINE_VAR];
+  if (inline?.trim()) {
+    return parseManifest(inline, `$${MANIFEST_INLINE_VAR}`);
+  }
+
+  throw new ManifestError(
+    `no installation manifest: set ${MANIFEST_PATH_VAR} to a manifest file or ${MANIFEST_INLINE_VAR} to its contents`,
+  );
+}
+
+export type { InstallationManifest } from './manifest.schema.ts';

--- a/apps/spindrift/src/web/client/index.html
+++ b/apps/spindrift/src/web/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Spindrift</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/apps/spindrift/src/web/client/main.tsx
+++ b/apps/spindrift/src/web/client/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { Placeholder } from './placeholder.tsx';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('no #root element to mount on');
+
+createRoot(root).render(
+  <StrictMode>
+    <Placeholder />
+  </StrictMode>,
+);

--- a/apps/spindrift/src/web/client/placeholder.tsx
+++ b/apps/spindrift/src/web/client/placeholder.tsx
@@ -1,0 +1,15 @@
+/**
+ * The scaffold's placeholder screen. It exists to prove the client bundle
+ * builds and mounts; every real surface (§18) replaces it.
+ *
+ * It talks to no endpoint on purpose — the browser's only server surface will
+ * be the dispatch endpoint generated from the command registry.
+ */
+export function Placeholder() {
+  return (
+    <main>
+      <h1>Spindrift</h1>
+      <p>Connect a repo, press Deploy, get a URL. None of that is built yet.</p>
+    </main>
+  );
+}

--- a/apps/spindrift/src/web/server.ts
+++ b/apps/spindrift/src/web/server.ts
@@ -1,0 +1,27 @@
+/**
+ * The `web` process (§19) — UI, webhooks, and log WebSockets. Today it is a
+ * scaffold: it validates the installation manifest at boot and serves the
+ * client bundle.
+ *
+ * It deliberately serves no route but the UI and a health probe. Every act the
+ * browser performs will reach one dispatch endpoint generated from the command
+ * registry; the first hand-authored route is the drift that turns an internal
+ * protocol into the API §21 declined to declare.
+ *
+ * `reconciler`, the second Deployment off the same image, does not exist yet.
+ */
+import { loadManifest } from '../config/manifest.ts';
+import index from './client/index.html';
+
+const manifest = await loadManifest();
+
+const server = Bun.serve({
+  port: Number(Bun.env.PORT ?? 3000),
+  development: Bun.env.NODE_ENV !== 'production',
+  routes: {
+    '/': index,
+    '/healthz': new Response('ok\n'),
+  },
+});
+
+console.log(`spindrift web → ${server.url} (${manifest.installation})`);

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  loadManifest,
+  MANIFEST_INLINE_VAR,
+  MANIFEST_PATH_VAR,
+  ManifestError,
+  parseManifest,
+} from '../../src/config/manifest.ts';
+
+const FIXTURE = join(import.meta.dir, '../fixtures/installation.example.yaml');
+
+const fixtureText = await Bun.file(FIXTURE).text();
+
+describe('the fixture installation', () => {
+  test('boots clean from a file', async () => {
+    const manifest = await loadManifest({ [MANIFEST_PATH_VAR]: FIXTURE });
+    expect(manifest.installation).toBe('example');
+    expect(manifest.dns.apexZone).toBe('apps.example.test');
+    expect(manifest.secretStore.adapter).toBe('gcp-secret-manager');
+    expect(manifest.targets.map((t) => t.adapter)).toEqual([
+      'kubernetes',
+      'cloudrun',
+      'static',
+    ]);
+  });
+
+  test('boots clean from an inline document', async () => {
+    const manifest = await loadManifest({ [MANIFEST_INLINE_VAR]: fixtureText });
+    expect(manifest.installation).toBe('example');
+  });
+
+  test('is read from the path when both are set', async () => {
+    const manifest = await loadManifest({
+      [MANIFEST_PATH_VAR]: FIXTURE,
+      [MANIFEST_INLINE_VAR]: 'installation: inline',
+    });
+    expect(manifest.installation).toBe('example');
+  });
+});
+
+describe('boot fails loudly', () => {
+  test('when no manifest is pointed at', async () => {
+    await expect(loadManifest({})).rejects.toThrow(ManifestError);
+  });
+
+  test('when the file does not exist', async () => {
+    await expect(
+      loadManifest({
+        [MANIFEST_PATH_VAR]: join(import.meta.dir, 'absent.yaml'),
+      }),
+    ).rejects.toThrow(/no such file/);
+  });
+
+  test('when the document is not YAML', () => {
+    expect(() => parseManifest('installation: [unclosed', 'test')).toThrow(
+      ManifestError,
+    );
+  });
+
+  test('naming every missing key at once', () => {
+    let message = '';
+    try {
+      parseManifest('installation: example\n', 'test');
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain('dns');
+    expect(message).toContain('cloud');
+    expect(message).toContain('charts');
+    expect(message).toContain('github');
+    expect(message).toContain('secretStore');
+    expect(message).toContain('targets');
+  });
+
+  test('on a required key that is present but empty', () => {
+    const document = fixtureText.replace(
+      'installation: example',
+      "installation: ''",
+    );
+    expect(() => parseManifest(document, 'test')).toThrow(/installation/);
+  });
+
+  test('on an unknown key, which is a typo or a stale manifest', () => {
+    expect(() =>
+      parseManifest(`${fixtureText}\nvessel: mistake\n`, 'test'),
+    ).toThrow(/vessel/);
+  });
+
+  test('on an unknown target adapter', () => {
+    const document = fixtureText.replace(
+      'adapter: kubernetes',
+      'adapter: nomad',
+    );
+    expect(() => parseManifest(document, 'test')).toThrow(
+      /targets\.0\.adapter/,
+    );
+  });
+
+  test('on duplicate target names', () => {
+    const document = fixtureText.replace('name: cloud\n', 'name: cluster\n');
+    expect(() => parseManifest(document, 'test')).toThrow(/unique/);
+  });
+
+  test('with no targets at all', () => {
+    const document = fixtureText.split('targets:')[0] ?? '';
+    expect(() => parseManifest(`${document}targets: []\n`, 'test')).toThrow(
+      /targets/,
+    );
+  });
+});

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -1,0 +1,316 @@
+/**
+ * The extraction contract, mechanically (spec §20).
+ *
+ * Line 3 of the contract — "everything naming this installation is a value in
+ * the installation manifest; a literal outside it is a bug" — is a grep, and
+ * this is the grep. It exists before the feature code it polices, because a
+ * rule like this is never made to pass retroactively.
+ *
+ * The second half is the source-level discipline: no import from outside
+ * `apps/spindrift/` except declared workspace dependencies, which is what makes
+ * workspace pruning produce a self-contained package.
+ *
+ * Both scanners run twice: over the real package, where they must find nothing,
+ * and over deliberately dirty synthetic files, where they must find it. A
+ * detector nobody has seen fail is not a detector.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+import {
+  storeAdapterSchema,
+  targetAdapterSchema,
+} from '../../src/config/manifest.schema.ts';
+
+const APP = join(import.meta.dir, '../..');
+
+/** The one file allowed to describe installation-shaped values in prose. */
+const SCHEMA = 'src/config/manifest.schema.ts';
+
+/**
+ * Literals that name the installation this repository happens to run. Matched
+ * case-insensitively on word boundaries, so a hyphenated derivative such as a
+ * `homelab-…` project id is caught by the bare word. Adding a value here is
+ * cheap; the point is that any one of them appearing under `src/` is a bug.
+ */
+const INSTALLATION_LITERALS = [
+  'lolwtf\\.ca',
+  'pulsifer\\.ca',
+  'jonpulsifer',
+  'folly',
+  'offsite',
+  'homelab',
+  'oldschool',
+  'harmonia',
+];
+
+/**
+ * A cloud project id: 6–30 characters, lowercase letter first, letters, digits
+ * and hyphens after, and carrying at least one hyphen or digit — which is what
+ * separates `sunlit-vector-4021` from an English word of the same shape. Only
+ * checked inside quoted runs, because even so the shape is too common to grep
+ * for in free text.
+ */
+const PROJECT_ID = /^[a-z][a-z0-9-]{4,28}[a-z0-9]$/;
+const NOT_A_WORD = /[-\d]/;
+
+/**
+ * Strings that match the project-id shape but are vocabulary, not identity.
+ * The adapter names come from the schema itself so that adding an adapter does
+ * not break a test in another directory.
+ */
+const PROJECT_ID_ALLOWLIST = new Set<string>([
+  ...targetAdapterSchema.options,
+  ...storeAdapterSchema.options,
+]);
+
+/** Files that are not text, and would only produce noise. */
+const BINARY = /\.(png|jpe?g|gif|ico|webp|avif|woff2?|ttf|otf|pdf|zip|gz)$/i;
+
+type SourceFile = { path: string; source: string };
+
+const packageJson = (await Bun.file(join(APP, 'package.json')).json()) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+const DECLARED_DEPENDENCIES = new Set([
+  ...Object.keys(packageJson.dependencies ?? {}),
+  ...Object.keys(packageJson.devDependencies ?? {}),
+]);
+
+/** Strip comments, so a file's prose can be scanned separately from its code. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/**
+ * What of a file gets scanned. Only the manifest schema is scanned with its
+ * comments stripped: it is where installation-shaped values are described, so
+ * its prose may say what a value is for. Every other file is scanned whole,
+ * comments included, because a hostname in a comment is still a hostname.
+ */
+function scannable(file: SourceFile): string {
+  return file.path === SCHEMA ? stripComments(file.source) : file.source;
+}
+
+/** Files carrying an installation-specific literal. */
+function findLiterals(files: SourceFile[]): string[] {
+  const offenders: string[] = [];
+  for (const literal of INSTALLATION_LITERALS) {
+    const pattern = new RegExp(`\\b${literal}\\b`, 'i');
+    for (const file of files) {
+      if (pattern.test(scannable(file))) {
+        offenders.push(`${file.path}: /${literal}/`);
+      }
+    }
+  }
+  return offenders;
+}
+
+/**
+ * Every quoted run in a file: single, double, backtick, and the bare form a JSX
+ * or HTML attribute takes. Quote style is a formatter setting, so the scanner
+ * must not depend on one.
+ */
+const QUOTED = /['"`]([^'"`\n]{6,30})['"`]/g;
+
+/** Strings shaped like a cloud project id. */
+function findProjectIds(files: SourceFile[]): string[] {
+  const offenders: string[] = [];
+  for (const file of files) {
+    for (const [, value] of scannable(file).matchAll(QUOTED)) {
+      if (!value || PROJECT_ID_ALLOWLIST.has(value)) continue;
+      if (value.includes('/') || value.includes('.')) continue;
+      if (PROJECT_ID.test(value) && NOT_A_WORD.test(value)) {
+        offenders.push(`${file.path}: '${value}'`);
+      }
+    }
+  }
+  return offenders;
+}
+
+const FROM_IMPORT =
+  /(?:^|\s)(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/gm;
+const BARE_IMPORT = /(?:^|\s)import\s*['"]([^'"]+)['"]/gm;
+
+/** Imports that reach outside the package or outside its declared dependencies. */
+function findForeignImports(files: SourceFile[]): string[] {
+  const offenders: string[] = [];
+  for (const file of files) {
+    if (!/\.[jt]sx?$/.test(file.path)) continue;
+    const source = stripComments(file.source);
+    const specifiers = [
+      ...[...source.matchAll(FROM_IMPORT)].map((m) => m[1]),
+      ...[...source.matchAll(BARE_IMPORT)].map((m) => m[1]),
+    ].filter((s): s is string => s !== undefined);
+
+    for (const specifier of specifiers) {
+      const where = `${file.path}: '${specifier}'`;
+      if (specifier.startsWith('.')) {
+        const resolved = join(APP, file.path, '..', specifier);
+        if (relative(APP, resolved).startsWith('..')) {
+          offenders.push(`${where} escapes apps/spindrift/`);
+        }
+        continue;
+      }
+      if (specifier.startsWith('node:') || specifier.startsWith('bun:')) {
+        continue;
+      }
+      if (specifier === 'bun') continue;
+      // A subpath import such as `react-dom/client` is declared as `react-dom`.
+      const packageName = specifier.startsWith('@')
+        ? specifier.split('/').slice(0, 2).join('/')
+        : (specifier.split('/')[0] ?? specifier);
+      if (!DECLARED_DEPENDENCIES.has(packageName)) {
+        offenders.push(`${where} is not a declared dependency`);
+      }
+    }
+  }
+  return offenders;
+}
+
+/**
+ * Every text file under a directory — deliberately not an extension allowlist,
+ * because the file type nobody thought to list is exactly where a literal
+ * survives.
+ */
+async function readSource(dir: string): Promise<SourceFile[]> {
+  const entries = await readdir(join(APP, dir), {
+    withFileTypes: true,
+    recursive: true,
+  });
+  const paths = entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => join(entry.parentPath, entry.name))
+    .filter((path) => !BINARY.test(path))
+    .sort();
+  return Promise.all(
+    paths.map(async (path) => ({
+      path: relative(APP, path),
+      source: await Bun.file(path).text(),
+    })),
+  );
+}
+
+async function readFiles(...paths: string[]): Promise<SourceFile[]> {
+  return Promise.all(
+    paths.map(async (path) => ({
+      path,
+      source: await Bun.file(join(APP, path)).text(),
+    })),
+  );
+}
+
+/** The literal rule polices `src/`; the import rule polices the package. */
+const src = await readSource('src');
+const everything = [
+  ...src,
+  ...(await readSource('test')),
+  ...(await readFiles('build.ts')),
+];
+
+describe('the real src/', () => {
+  test('has source to scan', () => {
+    expect(src.length).toBeGreaterThan(0);
+  });
+
+  test('names no installation', () => {
+    expect(findLiterals(src)).toEqual([]);
+  });
+
+  test('holds no string shaped like a cloud project id', () => {
+    expect(findProjectIds(src)).toEqual([]);
+  });
+
+  test('leaves the installation-specific values to the fixture manifest', async () => {
+    const fixture = await Bun.file(
+      join(APP, 'test/fixtures/installation.example.yaml'),
+    ).text();
+    expect(fixture).toContain('apexZone');
+    expect(fixture).toContain('artifactsProject');
+  });
+});
+
+describe('the whole package', () => {
+  test('imports only relatives, builtins, and declared dependencies', () => {
+    expect(findForeignImports(everything)).toEqual([]);
+  });
+
+  test('scans more than the source tree', () => {
+    expect(everything.length).toBeGreaterThan(src.length);
+  });
+});
+
+describe('the scanners catch a deliberately dirty file', () => {
+  const dirty = (source: string, path = 'src/dirty.ts'): SourceFile[] => [
+    { path, source },
+  ];
+
+  test('a hostname literal', () => {
+    expect(findLiterals(dirty("const url = 'https://app.lolwtf.ca';"))).toEqual(
+      ['src/dirty.ts: /lolwtf\\.ca/'],
+    );
+  });
+
+  test('a cluster name, even in a comment', () => {
+    expect(findLiterals(dirty('// defaults to folly\n')).length).toBe(1);
+  });
+
+  test('a hyphenated derivative of a banned word', () => {
+    expect(findLiterals(dirty("const project = 'homelab-ng';")).length).toBe(1);
+  });
+
+  test('a literal in a file type nobody thought to list', () => {
+    expect(
+      findLiterals(dirty('# notes about folly\n', 'src/notes.md')).length,
+    ).toBe(1);
+  });
+
+  test('a project id, whichever quote it wears', () => {
+    for (const source of [
+      "const project = 'sunlit-vector-4021';",
+      'const project = "sunlit-vector-4021";',
+      'const project = `sunlit-vector-4021`;',
+      '<div data-project="sunlit-vector-4021" />',
+    ]) {
+      expect(findProjectIds(dirty(source, 'src/dirty.tsx')).length).toBe(1);
+    }
+  });
+
+  test('a project id in a comment', () => {
+    expect(
+      findProjectIds(dirty("// defaults to 'sunlit-vector-4021'")).length,
+    ).toBe(1);
+  });
+
+  test('a doc comment in a file that is not the manifest schema', () => {
+    expect(findLiterals(dirty('/** the offsite cluster */')).length).toBe(1);
+  });
+
+  test('but not a doc comment in the manifest schema itself', () => {
+    expect(findLiterals(dirty('/** the folly zone */', SCHEMA))).toEqual([]);
+  });
+
+  test('and not a schema-shaped filename somewhere else', () => {
+    expect(
+      findLiterals(dirty('/** the folly zone */', 'src/other.schema.ts'))
+        .length,
+    ).toBe(1);
+  });
+
+  test('an import reaching out of the package', () => {
+    expect(
+      findForeignImports(dirty("import { x } from '../../hub/app/x.ts';")),
+    ).toEqual(["src/dirty.ts: '../../hub/app/x.ts' escapes apps/spindrift/"]);
+  });
+
+  test('an undeclared dependency', () => {
+    expect(findForeignImports(dirty("import express from 'express';"))).toEqual(
+      ["src/dirty.ts: 'express' is not a declared dependency"],
+    );
+  });
+
+  test('a side-effect import of an undeclared dependency', () => {
+    expect(findForeignImports(dirty("import 'dotenv/config';")).length).toBe(1);
+  });
+});

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -1,0 +1,34 @@
+# A complete installation manifest for an installation that does not exist.
+#
+# This is the fixture install of spec §20: everything naming a particular
+# Spindrift installation appears here and nowhere in src/. If a new
+# installation-specific value is added to the schema, this file is where it
+# gets a value, and the extraction test is what notices when it does not.
+installation: example
+
+dns:
+  apexZone: apps.example.test
+  vanityZone: example.test
+
+cloud:
+  artifactsProject: example-artifacts
+  homeVesselProject: example-home
+
+charts:
+  app: example/spindrift-app
+  installer: example/spindrift
+
+github:
+  appId: '1234567'
+
+secretStore:
+  adapter: gcp-secret-manager
+
+# Rank order: placement considers these top to bottom.
+targets:
+  - name: cluster
+    adapter: kubernetes
+  - name: cloud
+    adapter: cloudrun
+  - name: hosting
+    adapter: static

--- a/apps/spindrift/tsconfig.json
+++ b/apps/spindrift/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "types": ["bun"],
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*", "test/**/*", "build.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -107,6 +107,21 @@
         "typescript": "5.9.3",
       },
     },
+    "apps/spindrift": {
+      "name": "spindrift",
+      "dependencies": {
+        "react": "19.2.7",
+        "react-dom": "19.2.7",
+        "zod": "4.4.3",
+      },
+      "devDependencies": {
+        "@repo/typescript-config": "workspace:*",
+        "@types/bun": "1.3.14",
+        "@types/react": "19.2.17",
+        "@types/react-dom": "19.2.3",
+        "typescript": "5.9.3",
+      },
+    },
     "apps/wiki": {
       "name": "wiki",
       "dependencies": {
@@ -1272,6 +1287,8 @@
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "spindrift": ["spindrift@workspace:apps/spindrift"],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 

--- a/turbo.json
+++ b/turbo.json
@@ -37,12 +37,7 @@
     },
     "test": {
       "dependsOn": ["build"],
-      "inputs": [
-        "src/**/*.tsx",
-        "src/**/*.ts",
-        "test/**/*.ts",
-        "test/**/*.tsx"
-      ],
+      "inputs": ["src/**", "test/**", "package.json"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "typecheck": {


### PR DESCRIPTION
First PR of the Spindrift build — Milestone 0, tasks 1–4 of the plan, plus the placeholder screen.

`apps/spindrift/` exists as a Bun workspace package with no framework: `Bun.serve` for the `web` process, `Bun.build` over an HTML client entry, `bun test` as the runner. No App, Component, Build, Deploy, or Datastore yet.

## What's here

| Task | What landed |
| --- | --- |
| 1 — package | `package.json`, `tsconfig.json` (extends `@repo/typescript-config/base.json`), `build.ts`, `README.md`, and a placeholder client + server under `src/web/` |
| 2 — CI | `apps/spindrift/**` on both the `pull_request` and `push` path filters; a Postgres service container with `DATABASE_URL` on the `validate` job |
| 3 — manifest | `src/config/manifest.schema.ts` + `manifest.ts`, and `test/fixtures/installation.example.yaml` — a complete manifest for an installation that does not exist |
| 4 — extraction grep | `test/extraction/no-literals.test.ts` |

### The installation manifest

Every value naming a particular installation lives in one validated document — apex and vanity zones, artifacts and home-vessel projects, chart refs, GitHub App id, store adapter, and the Target seed in rank order. There are no defaults, because a default here would name someone's homelab, and boot fails naming every offending key at once.

### The extraction grep test

The mechanical half of the extraction contract, landed **before** the feature code it polices — a rule like this is never made to pass retroactively. It asserts no installation-specific literal appears under `src/`, and that nothing imports from outside `apps/spindrift/` except a declared dependency.

Its scanners are proven against deliberately dirty synthetic files, so the detector has been seen to fail. Planting `lolwtf.ca`, `homelab-ng`, and a `folly` reference in a `.md` under `src/` turns it red; removing them turns it green.

## Notes for review

- **`zod` 4.4.3** is a dependency the plan's task 1 doesn't list. It pins to the version `apps/slingshot` already uses, it isn't a framework/bundler/test-runner, and the command registry needs input schemas anyway. Easy to swap for a hand-rolled validator.
- **The Postgres service runs on every `hub`/`slingshot`/`k6` PR** even though nothing consumes it until the schema task. The plan puts it in task 2; it's here, and it's cheap to defer.
- **The placeholder talks to no endpoint on purpose.** An earlier draft served `/internal/installation`; that is exactly the drift the plan warns about, so it's gone. The manifest is still proven at boot and in tests.
- **Chart refs are opaque strings.** Under the plan's deliberate GitRepository deviation there is nothing yet to pin, so they carry no shape.

## Validation

`bun run lint`, `bun run typecheck`, `bun test` (30 pass), `bun run build` (989 KiB production bundle), and the server serving the placeholder with `/healthz` green and boot failing loudly when no manifest is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7JVtobykFNruQyDBCkQ6M