### PR TITLE
feat(spindrift): schema, commands, contracts, and the test harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ build/
 dist/
 out/
 *.tgz
+# Source that happens to be named after one: spindrift's build adapter is the
+# contract for build backends, not a build output.
+!apps/spindrift/src/adapters/build/
 
 # ─── Logseq (docs/ wiki graph) ───────────────────────────────────────────────
 # Track pages/journals + logseq/{config.edn,custom.css}; ignore app state.

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -7,22 +7,52 @@ adapts to whatever builds and delivers underneath — a Kubernetes cluster, Clou
 Run, or static hosting. The design lives in `.agent/plans/spindrift/spec.md`
 (private) and is referenced from the source as `§N`.
 
-**This is a scaffold.** What exists is the workspace package, the installation
-manifest, the extraction test that polices it, and a placeholder screen. No App,
-Component, Build, Deploy, or Datastore yet.
+**The foundations exist; nothing deploys yet.** The five nouns have tables, the
+three adapter contracts are written, and commands are the only way anything is
+acted on. What has no implementation is every adapter — no real cluster, cloud
+runtime, static host, build route, or secret store is spoken to. The UI is a
+placeholder.
 
 ## Shape
 
-One image, two processes (§19):
+One image, two processes (§19); only `web` exists so far.
 
 | Path | What it is |
 | --- | --- |
-| `src/web/` | the `web` process — UI, webhooks, log WebSockets |
 | `src/config/` | the installation manifest and its schema |
+| `src/db/` | the Drizzle schema, the connection, and the committed migrations |
+| `src/commands/` | the application command layer and its registry |
+| `src/domain/` | `DesiredState` and the attempt event log |
+| `src/adapters/` | the deploy, build, and store contracts |
+| `src/web/` | the `web` process — UI, webhooks, log WebSockets |
 | `build.ts` | `Bun.build` over the client HTML entry → `dist/` |
 
 There is no framework, no bundler beyond Bun, and no test runner beyond
 `bun test`.
+
+## The command layer
+
+Every user act is a command taking an explicit input and a request context, and
+the registry maps name → `{ input schema, handler }`. **A route may never hold
+domain logic**: `dispatch()` validates through the registry before a handler
+runs, so the browser endpoint is a mechanical wrap of the registry rather than a
+place decisions can accumulate. A command exported but not registered is a
+compile error, and so is a registry key that is not a command.
+
+## Testing
+
+Tests run against a real Postgres — the concurrency design is a claim about
+transactions, and a fake cannot falsify it. `DATABASE_URL` must point at one:
+
+```bash
+DATABASE_URL=postgres://postgres@127.0.0.1:5432/spindrift bun test
+```
+
+`test/harness/db.ts` gives every test its own migrated Postgres schema, so tests
+never see each other's rows. Adapters are faked only at the contract —
+**fake the far side, never our side** — and `test/conformance/adapter-suite.ts`
+is one suite every adapter implementation must pass. Adding an adapter without
+enrolling it in that suite fails a test that names it.
 
 ## The installation manifest
 

--- a/apps/spindrift/drizzle.config.ts
+++ b/apps/spindrift/drizzle.config.ts
@@ -1,0 +1,22 @@
+/**
+ * drizzle-kit configuration: reads `src/db/schema.ts`, writes migrations to
+ * `src/db/migrations/`. Only `drizzle-kit generate` is expected to run
+ * against this file directly — the app itself never imports it.
+ */
+import { defineConfig } from 'drizzle-kit';
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error(
+    'DATABASE_URL is not set: drizzle-kit needs it to introspect the target database',
+  );
+}
+
+export default defineConfig({
+  dialect: 'postgresql',
+  schema: './src/db/schema.ts',
+  out: './src/db/migrations',
+  dbCredentials: {
+    url: databaseUrl,
+  },
+});

--- a/apps/spindrift/package.json
+++ b/apps/spindrift/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "drizzle-orm": "0.45.2",
     "react": "19.2.7",
     "react-dom": "19.2.7",
     "zod": "4.4.3"
@@ -20,6 +21,7 @@
     "@types/bun": "1.3.14",
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
+    "drizzle-kit": "0.31.10",
     "typescript": "5.9.3"
   }
 }

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -1,0 +1,239 @@
+/**
+ * The build adapter contract (§4).
+ *
+ * ```
+ * build(source, spec) -> { artifact { type, digest, refs[] },
+ *                          status, logs, provenance, baseDigest }
+ * ```
+ *
+ * **Build is always separate from Deploy.** A platform's own build-from-source
+ * path is never used, because fusing the two would force a rollback to rebuild
+ * (§4). What comes back is a recorded artifact, not a deployed one — which is
+ * also why there is no ordinal and no `SUPERSEDED`: builds run concurrently up
+ * to a per-App limit, and a late-finishing older build moves nothing (§4).
+ *
+ * The two supply-chain terms this contract carries (§16):
+ *
+ * - **The bundle digest is a parameter on every route.** Without it the source
+ *   receipt and the provenance document have no join, and correlation joins on
+ *   digest. It is a required field of {@link BuildSource} and it comes back on
+ *   {@link BuildProvenance}, so no route can quietly not take one.
+ * - **The adapter never signs.** It returns artifact and digest exactly as
+ *   specified and core signs that digest, so no backend is disqualifiable and
+ *   the claim made is the honest one.
+ */
+import type {
+  Artifact,
+  ArtifactType,
+  ComponentKind,
+  Platform,
+} from '../../domain/desired-state.ts';
+import type { FailureReason } from '../deploy/contract.ts';
+
+/**
+ * Where the source came from. Repo and archive share **one pipeline** — unpack,
+ * detect, build — so this is an origin, not a second contract (§4, §5).
+ */
+export type BuildOrigin =
+  | {
+      type: 'repo';
+      /** The repository fetched. */
+      repository: string;
+      /** The exact commit. Triggers fire on default-branch HEAD (§5). */
+      commit: string;
+      /** An App is repo plus subpath; the scope is named, never searched (§5). */
+      subpath: string;
+    }
+  | {
+      type: 'archive';
+      /** Where the builder fetches the staged upload from. */
+      location: string;
+      /** Applied after unwrapping a lone top-level directory (§5). */
+      subpath: string;
+    };
+
+/**
+ * What to build.
+ *
+ * `bundleDigest` sits at the top rather than inside {@link BuildOrigin} because
+ * §16 states it as a parameter of every *route*, not a property of one kind of
+ * source: a git fetch and a ZIP upload are one predicate with different
+ * principals, and both are digested over the bundle that was staged.
+ */
+export interface BuildSource {
+  /**
+   * Digest over the staged bundle. Required — it is the join between the source
+   * receipt Spindrift signs and the provenance document the backend produces
+   * (§16).
+   */
+  bundleDigest: string;
+  origin: BuildOrigin;
+}
+
+/**
+ * What shape to build it in.
+ *
+ * Resolution runs **before** the build and outputs placement plus artifact
+ * shape, which is why the build key includes the target shape and why changing
+ * placement across shapes forces a rebuild (§3).
+ *
+ * The frontend is not here: BuildKit takes the repo's Dockerfile if present and
+ * a zero-config builder otherwise, and that ladder runs inside the pipeline,
+ * because a Dockerfile settles how to build and never what the thing is (§4,
+ * §5).
+ */
+export interface BuildSpec {
+  /** The shape placement chose, not one the kind implies (§3, §6). */
+  artifactType: ArtifactType;
+  /** What was detected, carried so the zero-config builder can plan (§5). */
+  kind: ComponentKind;
+  /** What the artifact must run on (§3). */
+  platform: Platform;
+  /**
+   * Where the artifact is published. Core picks it from the Target's
+   * `reachableRegistries` (§3); an adapter never chooses its own destination.
+   */
+  destination: string;
+  /**
+   * Build arguments as ordinary rows, never fetched from a store: whatever a
+   * website bakes becomes public anyway, so no builder ever holds a store
+   * credential (§4, §10).
+   */
+  buildArgs: Readonly<Record<string, string>>;
+}
+
+/**
+ * How faithfully a route's logs can be read while the build runs (§4).
+ *
+ * Logs are **read, not pushed**. Reading is outbound only, needs no public
+ * ingest endpoint, and surfaces the failures that happen *before* the
+ * instrumented step would have reported anything.
+ *
+ * - `LIVE_TEXT` — log events arrive as the backend emits them.
+ * - `LIVE_STATUS` — only step events arrive live; text lands at the end.
+ * - `ON_COMPLETION` — nothing arrives until the build is over.
+ */
+export const LOG_FIDELITIES = [
+  'LIVE_TEXT',
+  'LIVE_STATUS',
+  'ON_COMPLETION',
+] as const;
+
+export type LogFidelity = (typeof LOG_FIDELITIES)[number];
+
+/**
+ * What a build step, and therefore a Build row, can be. `PENDING` is core's
+ * alone — a Build exists before a route has been handed it — so it is not part
+ * of the adapter-facing `BuildEvent` state.
+ */
+export const BUILD_STATES = ['RUNNING', 'SUCCEEDED', 'FAILED'] as const;
+
+export type BuildState = (typeof BUILD_STATES)[number];
+
+/** What a route yields while it runs, at whatever fidelity it declared. */
+export type BuildEvent =
+  | { type: 'log'; at: Date; line: string; step?: string }
+  | { type: 'step'; at: Date; step: string; state: BuildState };
+
+/**
+ * SLSA Build Level. A Target has a minimum defaulting to L2 and an ordered list
+ * of build routes: **the level is a threshold, then admin rank wins** (§16).
+ * The in-cluster route is L1, which is why a Target cannot be both
+ * offline-capable and require L2 or above (§4).
+ */
+export type BuildLevel = 1 | 2 | 3;
+
+/**
+ * The backend's provenance — the isolation claim core verifies against the
+ * Target's minimum level **before** signing, which closes the custody-only gap
+ * while preserving one signature and one deploy-time check (§16).
+ *
+ * The builder's *own* provenance is a second, unsigned document carrying
+ * materials; it is where {@link BuildResult.baseDigest} comes from, so it adds
+ * no term here (§16).
+ */
+export interface BuildProvenance {
+  /**
+   * The bundle digest this build was given, echoed. Required: a route that
+   * cannot report the digest it was handed cannot produce a joinable
+   * provenance, and no-provenance modes are ineligible (§16).
+   */
+  bundleDigest: string;
+  /** The level this run claims. Core verifies it; it is not taken on trust. */
+  claimedLevel: BuildLevel;
+  /** The document itself, opaque to the adapter and read by core (§16). */
+  statement: unknown;
+}
+
+/**
+ * The route that ran and how well it could be watched. §4: **the build backend
+ * and its fidelity are visible on the Build**, because fidelity varies by runner
+ * and an invisible runner makes that look like a bug.
+ */
+export interface BuildLogs {
+  /** The route's own name, as the installation configured it. */
+  backend: string;
+  fidelity: LogFidelity;
+}
+
+/**
+ * §4's return record. Both arms carry all five names; the discriminant is
+ * `status`, so a green build is the only shape that can carry an artifact and a
+ * provenance, and a red one cannot pretend to.
+ *
+ * The failure `reason` is drawn from the **shared** vocabulary (§6): the user
+ * sees one timeline and must not meet two vocabularies along it.
+ */
+export type BuildResult =
+  | {
+      status: 'SUCCEEDED';
+      artifact: Artifact;
+      logs: BuildLogs;
+      provenance: BuildProvenance;
+      /**
+       * The base image this artifact was built on, from the builder's own
+       * materials. `null` where there is no base — a files artifact has none.
+       * Stale bases are **surfaced, never auto-corrected**: a base is fresh only
+       * at build time, and a repo's Dockerfile stays sovereign (§16).
+       */
+      baseDigest: string | null;
+    }
+  | {
+      status: 'FAILED';
+      artifact: null;
+      logs: BuildLogs;
+      provenance: null;
+      baseDigest: null;
+      reason: FailureReason;
+      detail?: string;
+      debug?: unknown;
+    };
+
+/**
+ * One build route.
+ *
+ * §4 names three: hosted CI on the fast-pipe side, a cloud build service, and
+ * the in-cluster one. The route's name is a string rather than a union because
+ * which routes exist is an installation's configuration, not this contract's
+ * vocabulary (§20).
+ *
+ * `build` is written as a generator for the same reason `apply` is: the yielded
+ * values are the timeline at whatever fidelity the route declared, and the
+ * return value is §4's record.
+ */
+export interface BuildAdapter {
+  readonly name: string;
+  /** Declared, not measured: it is a property of the runner (§4). */
+  readonly logFidelity: LogFidelity;
+  /**
+   * The level this route's profile guarantees. Guarantees belong to code-defined
+   * backend profiles; the achieved level belongs to the concrete verified Build
+   * (§16).
+   */
+  readonly buildLevel: BuildLevel;
+
+  build(
+    source: BuildSource,
+    spec: BuildSpec,
+  ): AsyncGenerator<BuildEvent, BuildResult, void>;
+}

--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -1,0 +1,271 @@
+/**
+ * The deploy adapter contract (§6).
+ *
+ * ```
+ * apply(target, DesiredState) -> stream<DeployEvent> -> terminal verdict
+ * observe(target, ref)        -> current state
+ * destroy(target, ref)
+ * ```
+ *
+ * The verbs are one shot and imperative: **reconciliation lives in core, above
+ * this seam.** Every backend self-heals below it, so an adapter never holds a
+ * workload up — it puts it there and reports honestly. That is also why
+ * `observe` is poll shaped rather than a watch: core decides when to look.
+ *
+ * Status is the platform's verdict and Spindrift's explanation. Phase
+ * transitions come from the controller or platform API, never from Spindrift
+ * reimplementing readiness — but on red the adapter reads pods and events (or
+ * the cloud log) **once** and fills in the detail. A read on red, not a
+ * continuous watch (§6).
+ */
+import type { TargetAdapter } from '../../config/manifest.schema.ts';
+import type { ArtifactType, DesiredState } from '../../domain/desired-state.ts';
+
+/**
+ * What the verbs need to name a Target. The Target model (§13) carries
+ * capabilities and connection material as well; this is the narrow view the
+ * contract takes, because a Target has exactly one adapter type and the adapter
+ * is constructed against the connection.
+ */
+export interface DeployTarget {
+  /** Stable identifier, unique within the installation. */
+  readonly name: string;
+  /** Exactly one adapter type per Target (§13). */
+  readonly adapter: TargetAdapter;
+}
+
+/**
+ * The adapter's own handle on what `apply` placed. Opaque to core, which stores
+ * it and hands it back to `observe` and `destroy` — the seam would leak a
+ * backend's naming scheme if core ever parsed it.
+ */
+export type DeployRef = string;
+
+/**
+ * §6's phase progression:
+ *
+ * ```
+ * PENDING -> APPLYING -> WAITING -> LIVE | FAILED
+ * ```
+ */
+export const DEPLOY_PHASES = [
+  'PENDING',
+  'APPLYING',
+  'WAITING',
+  'LIVE',
+  'FAILED',
+] as const;
+
+export type DeployPhase = (typeof DEPLOY_PHASES)[number];
+
+/** The two phases a stream may end on. */
+export type TerminalPhase = Extract<DeployPhase, 'LIVE' | 'FAILED'>;
+
+/**
+ * The closed reason set a `FAILED` carries (§6).
+ *
+ * **One shared vocabulary**, not one per contract: the user sees a single
+ * timeline and must not meet two vocabularies along it. `BUILD_FAILED` is on
+ * this list for exactly that reason — a reason that cannot apply to a phase
+ * simply never occurs there (§6, folding in §10's eighth reason).
+ *
+ * The union is closed on purpose. Free text lives in `detail`, and the raw
+ * platform payload in `debug`; neither is ever an identity a test or the UI can
+ * key on.
+ */
+export const FAILURE_REASONS = [
+  'BUILD_FAILED',
+  'ARTIFACT_UNAVAILABLE',
+  'REJECTED',
+  'STARTUP_FAILED',
+  'UNHEALTHY',
+  'TIMEOUT',
+  'TARGET_UNREACHABLE',
+  'INTERNAL',
+] as const;
+
+export type FailureReason = (typeof FAILURE_REASONS)[number];
+
+/**
+ * Who a failure indicts. §6: **blame is the most useful thing the UI knows** —
+ * justified hardest by `ARTIFACT_UNAVAILABLE`, where the build is green and
+ * every instinct wrongly says "look at my app".
+ */
+export const BLAMES = ['developer', 'platform'] as const;
+
+export type Blame = (typeof BLAMES)[number];
+
+/**
+ * §6's blame column, verbatim. `TIMEOUT` is a dash there and `null` here: a
+ * deploy that never reached a terminal state within budget indicts nobody, and
+ * saying so is more useful than guessing.
+ *
+ * | Reason | Blame | Covers |
+ * | --- | --- | --- |
+ * | `BUILD_FAILED` | developer | compile error, failed build step |
+ * | `ARTIFACT_UNAVAILABLE` | platform | image pull failure, registry auth, missing object |
+ * | `REJECTED` | developer | admission webhook, invalid spec, quota, org policy |
+ * | `STARTUP_FAILED` | developer | crash loop, exits non-zero, revision will not start |
+ * | `UNHEALTHY` | developer | readiness never passed |
+ * | `TIMEOUT` | — | no terminal state within budget |
+ * | `TARGET_UNREACHABLE` | platform | credentials expired, cluster down, API unreachable |
+ * | `INTERNAL` | platform | adapter bug |
+ *
+ * An adapter reports a reason and never a blame: blame is derived here so that
+ * two adapters cannot disagree about who a failure indicts.
+ */
+export const BLAME = {
+  BUILD_FAILED: 'developer',
+  ARTIFACT_UNAVAILABLE: 'platform',
+  REJECTED: 'developer',
+  STARTUP_FAILED: 'developer',
+  UNHEALTHY: 'developer',
+  TIMEOUT: null,
+  TARGET_UNREACHABLE: 'platform',
+  INTERNAL: 'platform',
+} as const satisfies Record<FailureReason, Blame | null>;
+
+/** The blame §6's table assigns a reason, or `null` where the table is a dash. */
+export function blameFor(reason: FailureReason): Blame | null {
+  return BLAME[reason];
+}
+
+/** The union is closed; a value outside it is a compile error, not a branch. */
+function unreachable(value: never): never {
+  throw new Error(`unhandled failure reason: ${String(value)}`);
+}
+
+/**
+ * The Covers column of §6's table, verbatim.
+ *
+ * This is the one switch over the reason union, and it is exhaustive: the
+ * `unreachable` call fails to type-check the moment a ninth reason is added
+ * without a case here, which is what keeps the vocabulary closed in practice
+ * rather than only in the type.
+ */
+export function reasonCovers(reason: FailureReason): string {
+  switch (reason) {
+    case 'BUILD_FAILED':
+      return 'compile error, failed build step';
+    case 'ARTIFACT_UNAVAILABLE':
+      return 'image pull failure, registry auth, missing object';
+    case 'REJECTED':
+      return 'admission webhook, invalid spec, quota, org policy';
+    case 'STARTUP_FAILED':
+      return 'crash loop, exits non-zero, revision will not start';
+    case 'UNHEALTHY':
+      return 'readiness never passed';
+    case 'TIMEOUT':
+      return 'no terminal state within budget';
+    case 'TARGET_UNREACHABLE':
+      return 'credentials expired, cluster down, API unreachable';
+    case 'INTERNAL':
+      return 'adapter bug';
+    default:
+      return unreachable(reason);
+  }
+}
+
+/**
+ * What travels on the attempt-scoped event log while `apply` runs (§6): log
+ * lines and status events `{phase, resource?, reason?, blame?}`. The UI
+ * subscribes once and Build writes to the same stream.
+ *
+ * **A running app's stdout is not on this log** — it is unbounded, and an
+ * unbounded log would mean the attempt never ends (§6). Runtime output is the
+ * second pipe (§17).
+ */
+export type DeployEvent =
+  | {
+      type: 'log';
+      at: Date;
+      line: string;
+      /** Which resource produced the line, where the backend says. */
+      resource?: string;
+    }
+  | {
+      type: 'status';
+      at: Date;
+      phase: DeployPhase;
+      /** What buys the per-resource feel at three fidelities (§6). */
+      resource?: string;
+      reason?: FailureReason;
+      /**
+       * Derived from {@link BLAME}. An adapter may leave it unset; core stamps
+       * it so the log and the verdict cannot disagree.
+       */
+      blame?: Blame | null;
+      detail?: string;
+    };
+
+/**
+ * What a stream ends on. `apply` does not throw: an adapter that cannot place
+ * the workload says so as a `FAILED` verdict, because a thrown error has no
+ * reason and therefore no blame.
+ */
+export type DeployVerdict =
+  | {
+      phase: 'LIVE';
+      ref: DeployRef;
+      /**
+       * The canonical address, where the platform gives one of its own — on
+       * those Targets the platform's name *is* the canonical, so it comes back
+       * across this seam rather than being handed in (§9).
+       */
+      url?: string;
+    }
+  | {
+      phase: 'FAILED';
+      /** Present when something was placed before the failure. */
+      ref?: DeployRef;
+      reason: FailureReason;
+      /** Free text: the sentence the developer reads. */
+      detail?: string;
+      /** The raw platform payload, kept for the operator (§6). */
+      debug?: unknown;
+    };
+
+/** What `observe` reports: the platform's current answer, not core's memory. */
+export interface ObservedState {
+  ref: DeployRef;
+  phase: DeployPhase;
+  /**
+   * The digest actually serving. Core compares it against the desired row to
+   * detect drift, which is **surfaced, never silently corrected** (§6).
+   */
+  artifactDigest: string;
+  reason?: FailureReason;
+  detail?: string;
+}
+
+/**
+ * One backend, one artifact shape family, three verbs.
+ *
+ * `apply` is written as a generator because §6's contract is literally a stream
+ * that resolves to a terminal verdict: the yielded values are the timeline, the
+ * return value is the verdict.
+ */
+export interface DeployAdapter {
+  /** Which adapter type this is — the same vocabulary Targets are seeded with. */
+  readonly adapter: TargetAdapter;
+
+  /**
+   * The artifact types this backend accepts (§6's table: `kubernetes` and
+   * `cloudrun` take an image, `static` takes files). Declaring it is what makes
+   * "each backend declares which artifact types it accepts" mean something —
+   * placement filters on it, and an artifact outside it reaching `apply` is a
+   * core bug, reported as `INTERNAL` rather than rendered.
+   */
+  readonly artifactTypes: readonly ArtifactType[];
+
+  apply(
+    target: DeployTarget,
+    desired: DesiredState,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void>;
+
+  /** The current state, or `null` when nothing is there. */
+  observe(target: DeployTarget, ref: DeployRef): Promise<ObservedState | null>;
+
+  /** Idempotent: destroying what is already gone succeeds. */
+  destroy(target: DeployTarget, ref: DeployRef): Promise<void>;
+}

--- a/apps/spindrift/src/adapters/store/contract.ts
+++ b/apps/spindrift/src/adapters/store/contract.ts
@@ -1,0 +1,106 @@
+/**
+ * The secret store contract (§10).
+ *
+ * One store per Target, **per-key, pinned, and delivered by the platform's own
+ * secret operator**. Spindrift writes; the operator on the far side reads. That
+ * shape is what the three rules below defend:
+ *
+ * - **Values are write-only.** There is deliberately no verb here that returns a
+ *   value. Plaintext is confined to transient request memory and the store,
+ *   auditing is metadata only, and redaction is structural rather than a promise
+ *   to scrub what an App prints (§10). The consequence is stated and accepted:
+ *   core cannot migrate config between stores, so Place names the keys that will
+ *   not follow and demands them before the move commits.
+ * - **One secret per variable, not a blob.** The blob is elegant on Kubernetes
+ *   and has no cloud-runtime equivalent, so the contract is per key (§10).
+ * - **Pinned, never a floating latest.** A put returns the reference to the
+ *   version it just wrote, and that reference is what a Deploy carries.
+ *   `configVersion` is a hash over a document of those references, scoped to
+ *   (Component, Target) — so a config change produces a new Deploy rather than
+ *   silently not applying on Kubernetes (§10).
+ */
+import type { StoreAdapter } from '../../config/manifest.schema.ts';
+import type { SecretReference } from '../../domain/desired-state.ts';
+
+/**
+ * Which (Component, Target) pair a config item belongs to — the scope
+ * `configVersion` is defined over (§10). The App is carried too because
+ * deleting an App deletes its own config items (§2).
+ *
+ * The scope is Spindrift's, not the store's: how it becomes an item name is the
+ * adapter's business, which is what lets one vault back several Targets.
+ */
+export interface ConfigScope {
+  app: string;
+  component: string;
+  target: string;
+}
+
+/**
+ * How a store pins.
+ *
+ * - `NATIVE` — the store versions items itself and a version is addressable.
+ * - `IMMUTABLE_ITEM_PER_VERSION` — it does not, so the adapter writes a fresh
+ *   immutable item per version under a Spindrift-side name and reports it as a
+ *   version. §10 records this as making the contract *more* portable, not less:
+ *   the reference {@link SecretStore.put} returns has the same shape either way,
+ *   and nothing above this seam can tell which strategy produced it.
+ */
+export type PinningStrategy = 'NATIVE' | 'IMMUTABLE_ITEM_PER_VERSION';
+
+/** Metadata about one pinned version. Never the value (§10). */
+export interface SecretVersion {
+  reference: SecretReference;
+  /** The variable this version fills, as {@link SecretStore.put} was given it. */
+  key: string;
+  createdAt: Date;
+}
+
+/**
+ * One store of record, reached over one access path.
+ *
+ * §10: a store is its store of record plus one or more access paths, which is
+ * why two clusters running their own connect service in front of the same vault
+ * are one store and cluster-to-cluster re-placement is free. The reach rule
+ * binds the store to **the Target the Component is placed on**, not to every
+ * Target — reachability is a Target capability (§3), so it is not asked here.
+ */
+export interface SecretStore {
+  /** Which store adapter this is, in the vocabulary the manifest seeds. */
+  readonly adapter: StoreAdapter;
+  /** Declared so the conformance suite can assert both strategies pin. */
+  readonly pinning: PinningStrategy;
+
+  /**
+   * Write a value and return the pinned reference to the version just written.
+   *
+   * The value is the only plaintext that crosses this seam, and it crosses in
+   * one direction. Uploads are replace-with-diff above this verb (§10): a put is
+   * always a new version, never an edit of one.
+   */
+  put(scope: ConfigScope, key: string, value: string): Promise<SecretReference>;
+
+  /**
+   * Metadata for a pinned reference, or `null` when it is gone.
+   *
+   * This is the read-back: what a store round-trips is the reference, never the
+   * value. Core uses it to prove a Deploy's pinned document still resolves
+   * before it deploys against it.
+   */
+  describe(reference: SecretReference): Promise<SecretVersion | null>;
+
+  /**
+   * Every version Spindrift has written for one key, newest first.
+   *
+   * Config lifecycle is a core responsibility — no store offers an escape to
+   * delegate it — and retention is N = 10, the same depth as artifacts, since
+   * shallower config makes a rollback come up green and unconfigured. Core reaps
+   * on a loop, and this is what it reaps from (§10).
+   */
+  versions(scope: ConfigScope, key: string): Promise<SecretVersion[]>;
+
+  /** Idempotent: destroying a version that is already gone succeeds. */
+  destroy(reference: SecretReference): Promise<void>;
+}
+
+export type { SecretReference } from '../../domain/desired-state.ts';

--- a/apps/spindrift/src/commands/create-app.ts
+++ b/apps/spindrift/src/commands/create-app.ts
@@ -1,0 +1,127 @@
+/**
+ * `createApp` — the first of §2's two human-authored nouns.
+ *
+ * §2: "App <- authored, source = repo(url, subpath) | archive(upload),
+ * immutable vessel reference, domain, config." The source is a discriminated
+ * union in the input schema for the same reason it is two nullable column
+ * pairs in the schema: an App has exactly one source, and a repo App with an
+ * archive digest is not a state the domain has a name for.
+ *
+ * What this command deliberately does **not** do: create Components, detect a
+ * kind, or place anything. §2's cardinality is one App to many Components, and
+ * every one of those acts is its own command in a later milestone. Creating an
+ * App writes one row and nothing else.
+ */
+import { z } from 'zod';
+import { apps } from '../db/schema.ts';
+import { type Command, ok } from './types.ts';
+
+/** A DNS-safe label: the name appears in canonical hostnames (§9). */
+const appName = z
+  .string()
+  .trim()
+  .min(1)
+  .max(63)
+  .regex(
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
+    'must be lowercase letters, digits and hyphens',
+  );
+
+/** §9: "the flat single-label vanity name" — one label, never dotted. */
+const vanityLabel = z
+  .string()
+  .trim()
+  .min(1)
+  .max(63)
+  .regex(
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
+    'must be a single lowercase DNS label',
+  );
+
+/**
+ * §14: the project this App's own resources live in. There is no default
+ * here: §20 puts every installation-naming value in the manifest, so the act
+ * of defaulting an unset vessel belongs to whatever reads the manifest, never
+ * to a literal in this file.
+ */
+const vesselRef = z.string().trim().min(1);
+
+/** A content digest of the uploaded bundle (§4: the bundle digest joins the receipt to its provenance). */
+const archiveDigest = z
+  .string()
+  .trim()
+  .regex(/^sha256:[0-9a-f]{64}$/, 'must be a sha256 digest');
+
+const common = {
+  name: appName,
+  vesselRef: vesselRef.optional(),
+  vanityDomain: vanityLabel.optional(),
+};
+
+export const createAppInput = z.discriminatedUnion('sourceKind', [
+  z
+    .object({
+      ...common,
+      sourceKind: z.literal('repo'),
+      repoUrl: z.url(),
+      /** §5: "the scope is named, never searched" — a subpath, not a scan. */
+      subpath: z.string().trim().min(1).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ...common,
+      sourceKind: z.literal('archive'),
+      archiveDigest,
+    })
+    .strict(),
+]);
+
+export type CreateAppInput = z.infer<typeof createAppInput>;
+
+/**
+ * What the caller learns. Narrow on purpose: the App row's shape is the data
+ * layer's business, and a result that mirrored it would make every column a
+ * promise to the UI.
+ */
+export interface CreateAppResult {
+  readonly appId: string;
+  readonly name: string;
+  /** Stamped from the context clock, never from the database's `now()`. */
+  readonly createdAt: Date;
+}
+
+/**
+ * There is no duplicate-name refusal here, because there is no unique key on
+ * `apps.name` to enforce one — inventing the rule in this handler alone would
+ * put it exactly one concurrent request away from being false.
+ */
+export const createApp: Command<CreateAppInput, CreateAppResult> = async (
+  input,
+  context,
+) => {
+  const now = context.clock.now();
+
+  const [row] = await context.db
+    .insert(apps)
+    .values({
+      name: input.name,
+      sourceKind: input.sourceKind,
+      sourceRepoUrl: input.sourceKind === 'repo' ? input.repoUrl : null,
+      sourceRepoSubpath:
+        input.sourceKind === 'repo' ? (input.subpath ?? null) : null,
+      sourceArchiveDigest:
+        input.sourceKind === 'archive' ? input.archiveDigest : null,
+      vesselRef: input.vesselRef ?? null,
+      vanityDomain: input.vanityDomain ?? null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return ok({
+    appId: row!.id,
+    name: row!.name,
+    createdAt: row!.createdAt,
+  });
+};

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -1,0 +1,19 @@
+/**
+ * The commands. One export per user act (§21), and nothing else.
+ *
+ * The rule this file exists to make checkable: **every value exported here is
+ * a `Command`, and every one of them is registered in `registry.ts`.** Both
+ * halves are enforced — at compile time by the exhaustiveness assertions in
+ * `registry.ts`, and at run time by `test/commands/registry.test.ts` — because
+ * the browser dispatch surface is generated from the registry, so a command
+ * that is exported but unregistered is a command nobody can call.
+ *
+ * Input schemas, input types, and result types stay in each command's own
+ * module. Keeping this file to values of one type is what lets the check above
+ * be "every export", with no allowlist to fall out of date.
+ *
+ * v1 has exactly one act: creating an App (§2). Building, deploying,
+ * rollback, placement, and desired-state changes are §21's other named
+ * commands and arrive with the milestones that implement them.
+ */
+export { createApp } from './create-app.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -1,0 +1,133 @@
+/**
+ * The command registry: every command that exists, by name, with the schema
+ * its input must satisfy.
+ *
+ * This object is the **single source the browser dispatch endpoint is
+ * generated from**. §21 declines to declare an external API, and a React
+ * client still needs a boundary to call across, so the boundary is one
+ * generated dispatch point rather than hand-authored routes: a command added
+ * without a route is a compile error, and a route that is not a command cannot
+ * be written at all, because there is no place to write one. That is the whole
+ * reason the registry exists rather than each page importing the command it
+ * wants.
+ *
+ * Two invariants, both mechanical:
+ *
+ * 1. **No command escapes the registry.** `MissingFromRegistry` below is the
+ *    set of commands `./index.ts` exports that are absent here; the assertion
+ *    constrains it to `never`, so forgetting an entry fails `tsc`.
+ * 2. **No registry entry is not a command.** `ExtraInRegistry` is the mirror
+ *    of it, which keeps the dispatch surface from growing a name the command
+ *    layer does not back.
+ *
+ * `test/commands/registry.test.ts` asserts the same two things at run time,
+ * because a type-level guarantee that nobody has watched fail is not one.
+ *
+ * The HTTP endpoint is not here — Task 38 owns it, and it is deliberately a
+ * thin wrapper: read a name and a JSON body, call {@link dispatch}, render the
+ * result. §21's "no route may contain domain logic" is met by there being
+ * nothing left for a route to decide.
+ */
+import type { z } from 'zod';
+import { createApp, createAppInput } from './create-app.ts';
+import type * as commands from './index.ts';
+import {
+  type Command,
+  type CommandContext,
+  type CommandIssue,
+  type CommandResult,
+  failed,
+} from './types.ts';
+
+/** What the dispatch surface needs to know about one command. */
+export interface CommandDescriptor<Input, Output> {
+  /** Validates untrusted input before the handler ever sees it. */
+  readonly input: z.ZodType<Input>;
+  readonly handler: Command<Input, Output>;
+}
+
+/** A descriptor of unknown input and output — what the registry holds. */
+export type AnyCommandDescriptor = CommandDescriptor<any, any>;
+
+/** Every command, by the name it is dispatched under. */
+export const commandRegistry = {
+  createApp: { input: createAppInput, handler: createApp },
+} as const satisfies Readonly<Record<string, AnyCommandDescriptor>>;
+
+/** The closed set of dispatchable names. */
+export type CommandName = keyof typeof commandRegistry;
+
+/** The names, in a form route generation can iterate. */
+export const commandNames: readonly CommandName[] = Object.keys(
+  commandRegistry,
+) as CommandName[];
+
+/** Whether an untrusted string names a command. */
+export function isCommandName(name: string): name is CommandName {
+  return Object.hasOwn(commandRegistry, name);
+}
+
+/**
+ * Run a named command against untrusted input.
+ *
+ * This is the entirety of what dispatch does, kept transport-free on purpose:
+ * validate, then hand the parsed input to the handler. Anything a transport
+ * adds — sessions, JSON decoding, status codes — sits above it and adds no
+ * decision of its own.
+ */
+export async function dispatch(
+  name: string,
+  input: unknown,
+  context: CommandContext,
+): Promise<CommandResult<unknown>> {
+  if (!isCommandName(name)) {
+    return failed('UNKNOWN_COMMAND', `there is no command named ${name}`);
+  }
+
+  const descriptor: AnyCommandDescriptor = commandRegistry[name];
+  const parsed = descriptor.input.safeParse(input);
+  if (!parsed.success) {
+    return failed(
+      'INVALID_INPUT',
+      `the input given to ${name} is not valid`,
+      issuesOf(parsed.error),
+    );
+  }
+
+  return descriptor.handler(parsed.data, context);
+}
+
+/** Zod's issues, flattened to the field-level detail a UI renders. */
+function issuesOf(error: z.ZodError): readonly CommandIssue[] {
+  return error.issues.map((issue) => ({
+    path: issue.path.map(String).join('.'),
+    message: issue.message,
+  }));
+}
+
+// --- The two invariants, at compile time -----------------------------------
+
+/** The module shape of `./index.ts`, as a type — no runtime import. */
+type CommandModule = typeof commands;
+
+/** Names `./index.ts` exports whose value is a command. */
+type ExportedCommandName = {
+  [Name in keyof CommandModule]: CommandModule[Name] extends Command<any, any>
+    ? Name
+    : never;
+}[keyof CommandModule];
+
+/** Commands that exist but cannot be dispatched — must be empty. */
+export type MissingFromRegistry = Exclude<ExportedCommandName, CommandName>;
+
+/** Dispatchable names the command layer does not back — must be empty. */
+export type ExtraInRegistry = Exclude<CommandName, ExportedCommandName>;
+
+/**
+ * The assertions themselves. Both aliases resolve only while their argument is
+ * `never`; a command exported without an entry above stops type-checking here,
+ * naming itself in the error.
+ */
+type Empty<Difference extends never> = Difference;
+export type NoUnregisteredCommand = Empty<MissingFromRegistry>;
+export type NoUnbackedRoute = Empty<ExtraInRegistry>;

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -1,0 +1,156 @@
+/**
+ * The application command layer (§21 Boundaries).
+ *
+ * §21: "v1 exposes neither a supported external API nor a CLI... The boundary
+ * is nevertheless explicit inside the application. Creation, building,
+ * deployment, rollback, and desired-state changes are application commands,
+ * not logic embedded in pages, so a later thin API or CLI can wrap them
+ * without reconstructing the domain from UI handlers. This is the primary
+ * test seam."
+ *
+ * Hence the shape here: **one exported function per user act**, taking an
+ * explicit input object and a request context, returning a typed result.
+ * Nothing in this layer knows it is reached over HTTP, from a page, or from a
+ * test — `registry.ts` is the only thing that knows a command can be named,
+ * and a route above it may hold no domain logic whatsoever.
+ *
+ * The context is the whole of what a command may reach for. Anything absent
+ * from it — the wall clock, a connection string, an ambient adapter — is a
+ * dependency a test cannot replace, and the seam is only primary if every one
+ * of them can be replaced.
+ */
+import type { BuildAdapter } from '../adapters/build/contract.ts';
+import type { DeployAdapter } from '../adapters/deploy/contract.ts';
+import type { SecretStore } from '../adapters/store/contract.ts';
+import type { TargetAdapter } from '../config/manifest.schema.ts';
+import type { Database } from '../db/client.ts';
+
+/**
+ * Who is acting.
+ *
+ * §"First run and identity": every enrolled user is one fully privileged
+ * kind, so there is no role here to branch on — a command knows *who*, and v1
+ * never asks *whether*.
+ */
+export interface Principal {
+  /** The `users` row this act is attributed to. */
+  readonly id: string;
+  readonly displayName: string;
+}
+
+/**
+ * Time, injected.
+ *
+ * A handler calling `Date.now()` is a handler whose result cannot be asserted,
+ * and every row this layer writes carries a timestamp. The clock is therefore
+ * part of the context rather than a global.
+ */
+export interface Clock {
+  now(): Date;
+}
+
+/** The clock every non-test caller passes. */
+export const systemClock: Clock = {
+  now: () => new Date(),
+};
+
+/**
+ * The adapters a command may reach the outside world through (§6, §20).
+ *
+ * Lookups return `null` rather than throwing: an installation that has no
+ * adapter for a Target's declared type is a configuration fact a command must
+ * report, not an exception it should propagate. Tests substitute fakes here —
+ * "fake the far side, not our side" (§ Testing) — and this is the only
+ * far side there is.
+ */
+export interface AdapterRegistry {
+  /** The delivery adapter for a Target's one adapter type (§13). */
+  deploy(adapter: TargetAdapter): DeployAdapter | null;
+  /**
+   * A build route by name. §4: which routes exist is an installation's
+   * configuration, not a closed vocabulary.
+   */
+  build(route: string): BuildAdapter | null;
+  /** §10: one store of record per installation, selected by the manifest. */
+  store(): SecretStore;
+}
+
+/**
+ * Everything a command is allowed to reach: who, when, the database, and the
+ * far side. A command takes exactly this and its own input — never a module
+ * singleton, never `Bun.env`.
+ */
+export interface CommandContext {
+  readonly principal: Principal;
+  readonly clock: Clock;
+  readonly db: Database;
+  readonly adapters: AdapterRegistry;
+}
+
+/**
+ * Why a command did not do what was asked.
+ *
+ * Closed on purpose, in the spirit of §6's failure reasons: "a failure test
+ * asserts the sentence the user reads", which requires the failure to have an
+ * identity a test can key on. Only the two codes the layer can actually
+ * produce today are listed — a command that grows a domain failure adds its
+ * code here alongside it, rather than the set being guessed at in advance.
+ */
+export type CommandFailureCode = 'UNKNOWN_COMMAND' | 'INVALID_INPUT';
+
+/** The assertable identity of a failure, plus the sentence a user reads. */
+export interface CommandFailure {
+  readonly code: CommandFailureCode;
+  /** The sentence the user reads. */
+  readonly message: string;
+  /** Field-level detail, where the failure has any. */
+  readonly issues?: readonly CommandIssue[];
+}
+
+/** One thing wrong with one part of the input. */
+export interface CommandIssue {
+  /** Dotted path into the input object, empty for the object itself. */
+  readonly path: string;
+  readonly message: string;
+}
+
+/**
+ * What every command returns.
+ *
+ * A refusal is a value, not an exception: the dispatch surface above this
+ * layer has to turn a refusal into something a browser can render, and a
+ * thrown error carries no code to render. Genuine faults — a database that is
+ * gone — still throw, because they are not answers to the user's act.
+ */
+export type CommandResult<Output> =
+  | { readonly ok: true; readonly value: Output }
+  | { readonly ok: false; readonly failure: CommandFailure };
+
+/** Succeed with a value. */
+export function ok<Output>(value: Output): CommandResult<Output> {
+  return { ok: true, value };
+}
+
+/** Refuse, with an identity and a sentence. */
+export function failed<Output>(
+  code: CommandFailureCode,
+  message: string,
+  issues?: readonly CommandIssue[],
+): CommandResult<Output> {
+  return {
+    ok: false,
+    failure: issues ? { code, message, issues } : { code, message },
+  };
+}
+
+/**
+ * One user act.
+ *
+ * Every export of `./index.ts` has this type, and `registry.ts` asserts that
+ * at compile time — which is what makes "no route may contain domain logic"
+ * enforceable rather than aspirational.
+ */
+export type Command<Input, Output> = (
+  input: Input,
+  context: CommandContext,
+) => Promise<CommandResult<Output>>;

--- a/apps/spindrift/src/db/client.ts
+++ b/apps/spindrift/src/db/client.ts
@@ -1,0 +1,50 @@
+/**
+ * The database connection (§12 State: "One Postgres, Spindrift's own
+ * cluster of the in-cluster operator's kind").
+ *
+ * Reached over Bun's native SQL client, wrapped by Drizzle's `bun-sql`
+ * driver — there is no `pg` or `postgres.js` dependency here on purpose
+ * (the driver decision this task follows, not one it makes).
+ *
+ * There is no default connection string. A missing `DATABASE_URL` is a boot
+ * failure, never a fallback to a guessed host — the same discipline
+ * `src/config/manifest.ts` applies to the installation manifest.
+ */
+import { SQL } from 'bun';
+import { drizzle } from 'drizzle-orm/bun-sql';
+import * as schema from './schema.ts';
+
+type Env = Record<string, string | undefined>;
+
+/** Raised when `DATABASE_URL` is absent or blank. */
+export class DatabaseConfigError extends Error {
+  override readonly name = 'DatabaseConfigError';
+}
+
+/** Read and validate the connection string. Never guesses at a default. */
+export function databaseUrl(env: Env = Bun.env): string {
+  const url = env.DATABASE_URL?.trim();
+  if (!url) {
+    throw new DatabaseConfigError(
+      'DATABASE_URL is not set: Spindrift has no database to connect to',
+    );
+  }
+  return url;
+}
+
+/**
+ * A native Bun SQL client against `DATABASE_URL`. Callers that need a
+ * second, independent connection (a locking read held open while another
+ * transaction is attempted, for instance) construct their own with `new
+ * SQL(...)` rather than sharing this one's pool.
+ */
+export function createClient(env: Env = Bun.env): SQL {
+  return new SQL(databaseUrl(env));
+}
+
+export type Database = ReturnType<typeof drizzle<typeof schema>>;
+
+/** Wrap a client — or a fresh one built from `DATABASE_URL` — in Drizzle. */
+export function createDb(client: SQL = createClient()): Database {
+  return drizzle({ client, schema });
+}

--- a/apps/spindrift/src/db/migrate.ts
+++ b/apps/spindrift/src/db/migrate.ts
@@ -1,0 +1,23 @@
+/**
+ * Applies the committed migrations in `db/migrations/` to a database.
+ *
+ * Production never calls this at runtime: this repo is GitOps-first, and a
+ * running process mutating its own schema on boot is the same shape of
+ * mistake as a process mutating live infrastructure. Migrations are applied
+ * as an out-of-band operator act. This runner exists so
+ * `test/db/schema.test.ts` can stand up a clean, migrated schema before
+ * asserting against it.
+ */
+import { join } from 'node:path';
+import type { SQL } from 'bun';
+import { migrate as runMigrations } from 'drizzle-orm/bun-sql/migrator';
+import { createDb } from './client.ts';
+
+const MIGRATIONS_FOLDER = join(import.meta.dir, 'migrations');
+
+/** Apply every committed migration to `client`'s database, in order. */
+export async function applyMigrations(client: SQL): Promise<void> {
+  await runMigrations(createDb(client), {
+    migrationsFolder: MIGRATIONS_FOLDER,
+  });
+}

--- a/apps/spindrift/src/db/migrations/0000_init.sql
+++ b/apps/spindrift/src/db/migrations/0000_init.sql
@@ -1,0 +1,168 @@
+CREATE TYPE "public"."app_source_kind" AS ENUM('repo', 'archive');--> statement-breakpoint
+CREATE TYPE "public"."artifact_type" AS ENUM('image', 'files');--> statement-breakpoint
+CREATE TYPE "public"."attempt_event_type" AS ENUM('log', 'status');--> statement-breakpoint
+CREATE TYPE "public"."attempt_kind" AS ENUM('build', 'deploy');--> statement-breakpoint
+CREATE TYPE "public"."blame" AS ENUM('developer', 'platform');--> statement-breakpoint
+CREATE TYPE "public"."build_status" AS ENUM('PENDING', 'RUNNING', 'SUCCEEDED', 'FAILED');--> statement-breakpoint
+CREATE TYPE "public"."component_kind" AS ENUM('service', 'website', 'job');--> statement-breakpoint
+CREATE TYPE "public"."config_item_kind" AS ENUM('secret_ref', 'plain');--> statement-breakpoint
+CREATE TYPE "public"."datastore_engine" AS ENUM('postgres', 'redis');--> statement-breakpoint
+CREATE TYPE "public"."datastore_provenance" AS ENUM('managed', 'external');--> statement-breakpoint
+CREATE TYPE "public"."deploy_phase" AS ENUM('PENDING', 'APPLYING', 'WAITING', 'LIVE', 'FAILED');--> statement-breakpoint
+CREATE TYPE "public"."deploy_reason" AS ENUM('BUILD_FAILED', 'ARTIFACT_UNAVAILABLE', 'REJECTED', 'STARTUP_FAILED', 'UNHEALTHY', 'TIMEOUT', 'TARGET_UNREACHABLE', 'INTERNAL');--> statement-breakpoint
+CREATE TYPE "public"."exposure_state" AS ENUM('internal', 'private', 'public');--> statement-breakpoint
+CREATE TYPE "public"."log_fidelity" AS ENUM('LIVE_TEXT', 'LIVE_STATUS', 'ON_COMPLETION');--> statement-breakpoint
+CREATE TYPE "public"."target_adapter" AS ENUM('kubernetes', 'cloudrun', 'static');--> statement-breakpoint
+CREATE TYPE "public"."target_status" AS ENUM('connected', 'disconnected');--> statement-breakpoint
+CREATE TABLE "apps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"source_kind" "app_source_kind" NOT NULL,
+	"source_repo_url" text,
+	"source_repo_subpath" text,
+	"source_archive_digest" text,
+	"vessel_ref" text,
+	"vanity_domain" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "attempt_events" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"app_id" uuid NOT NULL,
+	"component_id" uuid NOT NULL,
+	"attempt_kind" "attempt_kind" NOT NULL,
+	"build_id" bigint,
+	"deploy_id" bigint,
+	"event_type" "attempt_event_type" NOT NULL,
+	"line" text,
+	"phase" text,
+	"resource" text,
+	"reason" "deploy_reason",
+	"blame" "blame",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "attempt_events_exactly_one_attempt" CHECK (("attempt_events"."build_id" is not null) <> ("attempt_events"."deploy_id" is not null)),
+	CONSTRAINT "attempt_events_kind_matches_reference" CHECK (("attempt_events"."attempt_kind" = 'build' and "attempt_events"."build_id" is not null) or ("attempt_events"."attempt_kind" = 'deploy' and "attempt_events"."deploy_id" is not null))
+);
+--> statement-breakpoint
+CREATE TABLE "builds" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"component_id" uuid NOT NULL,
+	"commit" text NOT NULL,
+	"target_shape" text NOT NULL,
+	"artifact_type" "artifact_type" NOT NULL,
+	"artifact_digest" text,
+	"artifact_refs" jsonb,
+	"status" "build_status" DEFAULT 'PENDING' NOT NULL,
+	"base_digest" text,
+	"runner" text,
+	"log_fidelity" "log_fidelity",
+	"provenance" jsonb,
+	"bundle_digest" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "builds_component_commit_shape_unique" UNIQUE("component_id","commit","target_shape")
+);
+--> statement-breakpoint
+CREATE TABLE "component_target_desired" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"component_id" uuid NOT NULL,
+	"target_id" uuid NOT NULL,
+	"desired_build_id" bigint,
+	"desired_deploy_id" bigint,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "component_target_desired_pair_unique" UNIQUE("component_id","target_id")
+);
+--> statement-breakpoint
+CREATE TABLE "components" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"app_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"kind" "component_kind" NOT NULL,
+	"expose" boolean,
+	"schedule" text,
+	"exposure" "exposure_state" DEFAULT 'private' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "components_app_id_name_unique" UNIQUE("app_id","name")
+);
+--> statement-breakpoint
+CREATE TABLE "config_items" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"component_id" uuid NOT NULL,
+	"target_id" uuid NOT NULL,
+	"environment" text DEFAULT 'default' NOT NULL,
+	"key" text NOT NULL,
+	"kind" "config_item_kind" DEFAULT 'secret_ref' NOT NULL,
+	"store_ref" text,
+	"plain_value" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "config_items_scope_key_unique" UNIQUE("component_id","target_id","environment","key"),
+	CONSTRAINT "config_items_environment_pinned" CHECK ("config_items"."environment" = 'default')
+);
+--> statement-breakpoint
+CREATE TABLE "datastores" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"engine" "datastore_engine" NOT NULL,
+	"provenance" "datastore_provenance" NOT NULL,
+	"app_id" uuid,
+	"target_id" uuid NOT NULL,
+	"connection_ref" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "deploys" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"component_id" uuid NOT NULL,
+	"target_id" uuid NOT NULL,
+	"build_id" bigint NOT NULL,
+	"phase" "deploy_phase" DEFAULT 'PENDING' NOT NULL,
+	"reason" "deploy_reason",
+	"blame" "blame",
+	"detail" text,
+	"debug" jsonb,
+	"url" text,
+	"config_version" text,
+	"exposure" "exposure_state",
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "targets" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"adapter" "target_adapter" NOT NULL,
+	"status" "target_status" DEFAULT 'connected' NOT NULL,
+	"rank" integer NOT NULL,
+	"public_exposure" boolean,
+	"min_build_level" integer,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"display_name" text NOT NULL,
+	"gateway_identity" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "attempt_events" ADD CONSTRAINT "attempt_events_app_id_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."apps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attempt_events" ADD CONSTRAINT "attempt_events_component_id_components_id_fk" FOREIGN KEY ("component_id") REFERENCES "public"."components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attempt_events" ADD CONSTRAINT "attempt_events_build_id_builds_id_fk" FOREIGN KEY ("build_id") REFERENCES "public"."builds"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "attempt_events" ADD CONSTRAINT "attempt_events_deploy_id_deploys_id_fk" FOREIGN KEY ("deploy_id") REFERENCES "public"."deploys"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "builds" ADD CONSTRAINT "builds_component_id_components_id_fk" FOREIGN KEY ("component_id") REFERENCES "public"."components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "component_target_desired" ADD CONSTRAINT "component_target_desired_component_id_components_id_fk" FOREIGN KEY ("component_id") REFERENCES "public"."components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "component_target_desired" ADD CONSTRAINT "component_target_desired_target_id_targets_id_fk" FOREIGN KEY ("target_id") REFERENCES "public"."targets"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "component_target_desired" ADD CONSTRAINT "component_target_desired_desired_build_id_builds_id_fk" FOREIGN KEY ("desired_build_id") REFERENCES "public"."builds"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "component_target_desired" ADD CONSTRAINT "component_target_desired_desired_deploy_id_deploys_id_fk" FOREIGN KEY ("desired_deploy_id") REFERENCES "public"."deploys"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "components" ADD CONSTRAINT "components_app_id_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."apps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "config_items" ADD CONSTRAINT "config_items_component_id_components_id_fk" FOREIGN KEY ("component_id") REFERENCES "public"."components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "config_items" ADD CONSTRAINT "config_items_target_id_targets_id_fk" FOREIGN KEY ("target_id") REFERENCES "public"."targets"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "datastores" ADD CONSTRAINT "datastores_app_id_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."apps"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "datastores" ADD CONSTRAINT "datastores_target_id_targets_id_fk" FOREIGN KEY ("target_id") REFERENCES "public"."targets"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "deploys" ADD CONSTRAINT "deploys_component_id_components_id_fk" FOREIGN KEY ("component_id") REFERENCES "public"."components"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "deploys" ADD CONSTRAINT "deploys_target_id_targets_id_fk" FOREIGN KEY ("target_id") REFERENCES "public"."targets"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "deploys" ADD CONSTRAINT "deploys_build_id_builds_id_fk" FOREIGN KEY ("build_id") REFERENCES "public"."builds"("id") ON DELETE restrict ON UPDATE no action;

--- a/apps/spindrift/src/db/migrations/meta/0000_snapshot.json
+++ b/apps/spindrift/src/db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,1210 @@
+{
+  "id": "e03367c3-55b7-4491-9ee7-33d1c2e035a7",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "app_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repo_url": {
+          "name": "source_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repo_subpath": {
+          "name": "source_repo_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_archive_digest": {
+          "name": "source_archive_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vessel_ref": {
+          "name": "vessel_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vanity_domain": {
+          "name": "vanity_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempt_events": {
+      "name": "attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_kind": {
+          "name": "attempt_kind",
+          "type": "attempt_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_id": {
+          "name": "deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "attempt_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attempt_events_app_id_apps_id_fk": {
+          "name": "attempt_events_app_id_apps_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_component_id_components_id_fk": {
+          "name": "attempt_events_component_id_components_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_build_id_builds_id_fk": {
+          "name": "attempt_events_build_id_builds_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_deploy_id_deploys_id_fk": {
+          "name": "attempt_events_deploy_id_deploys_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempt_events_exactly_one_attempt": {
+          "name": "attempt_events_exactly_one_attempt",
+          "value": "(\"attempt_events\".\"build_id\" is not null) <> (\"attempt_events\".\"deploy_id\" is not null)"
+        },
+        "attempt_events_kind_matches_reference": {
+          "name": "attempt_events_kind_matches_reference",
+          "value": "(\"attempt_events\".\"attempt_kind\" = 'build' and \"attempt_events\".\"build_id\" is not null) or (\"attempt_events\".\"attempt_kind\" = 'deploy' and \"attempt_events\".\"deploy_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_shape": {
+          "name": "target_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "artifact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_digest": {
+          "name": "artifact_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_refs": {
+          "name": "artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "build_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "base_digest": {
+          "name": "base_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_fidelity": {
+          "name": "log_fidelity",
+          "type": "log_fidelity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_component_id_components_id_fk": {
+          "name": "builds_component_id_components_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "builds_component_commit_shape_unique": {
+          "name": "builds_component_commit_shape_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "commit",
+            "target_shape"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_target_desired": {
+      "name": "component_target_desired",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_build_id": {
+          "name": "desired_build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_deploy_id": {
+          "name": "desired_deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "component_target_desired_component_id_components_id_fk": {
+          "name": "component_target_desired_component_id_components_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_target_id_targets_id_fk": {
+          "name": "component_target_desired_target_id_targets_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_build_id_builds_id_fk": {
+          "name": "component_target_desired_desired_build_id_builds_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "desired_build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_deploy_id_deploys_id_fk": {
+          "name": "component_target_desired_desired_deploy_id_deploys_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "desired_deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "component_target_desired_pair_unique": {
+          "name": "component_target_desired_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.components": {
+      "name": "components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "component_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expose": {
+          "name": "expose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "components_app_id_apps_id_fk": {
+          "name": "components_app_id_apps_id_fk",
+          "tableFrom": "components",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "components_app_id_name_unique": {
+          "name": "components_app_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_items": {
+      "name": "config_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "config_item_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret_ref'"
+        },
+        "store_ref": {
+          "name": "store_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_value": {
+          "name": "plain_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_items_component_id_components_id_fk": {
+          "name": "config_items_component_id_components_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_items_target_id_targets_id_fk": {
+          "name": "config_items_target_id_targets_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_items_scope_key_unique": {
+          "name": "config_items_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id",
+            "environment",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "config_items_environment_pinned": {
+          "name": "config_items_environment_pinned",
+          "value": "\"config_items\".\"environment\" = 'default'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.datastores": {
+      "name": "datastores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "datastore_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "datastore_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_ref": {
+          "name": "connection_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datastores_app_id_apps_id_fk": {
+          "name": "datastores_app_id_apps_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "datastores_target_id_targets_id_fk": {
+          "name": "datastores_target_id_targets_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deploys": {
+      "name": "deploys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "deploy_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deploys_component_id_components_id_fk": {
+          "name": "deploys_component_id_components_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deploys_target_id_targets_id_fk": {
+          "name": "deploys_target_id_targets_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "deploys_build_id_builds_id_fk": {
+          "name": "deploys_build_id_builds_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "target_adapter",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "target_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_exposure": {
+          "name": "public_exposure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_build_level": {
+          "name": "min_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway_identity": {
+          "name": "gateway_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.app_source_kind": {
+      "name": "app_source_kind",
+      "schema": "public",
+      "values": [
+        "repo",
+        "archive"
+      ]
+    },
+    "public.artifact_type": {
+      "name": "artifact_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "files"
+      ]
+    },
+    "public.attempt_event_type": {
+      "name": "attempt_event_type",
+      "schema": "public",
+      "values": [
+        "log",
+        "status"
+      ]
+    },
+    "public.attempt_kind": {
+      "name": "attempt_kind",
+      "schema": "public",
+      "values": [
+        "build",
+        "deploy"
+      ]
+    },
+    "public.blame": {
+      "name": "blame",
+      "schema": "public",
+      "values": [
+        "developer",
+        "platform"
+      ]
+    },
+    "public.build_status": {
+      "name": "build_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.component_kind": {
+      "name": "component_kind",
+      "schema": "public",
+      "values": [
+        "service",
+        "website",
+        "job"
+      ]
+    },
+    "public.config_item_kind": {
+      "name": "config_item_kind",
+      "schema": "public",
+      "values": [
+        "secret_ref",
+        "plain"
+      ]
+    },
+    "public.datastore_engine": {
+      "name": "datastore_engine",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "redis"
+      ]
+    },
+    "public.datastore_provenance": {
+      "name": "datastore_provenance",
+      "schema": "public",
+      "values": [
+        "managed",
+        "external"
+      ]
+    },
+    "public.deploy_phase": {
+      "name": "deploy_phase",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPLYING",
+        "WAITING",
+        "LIVE",
+        "FAILED"
+      ]
+    },
+    "public.deploy_reason": {
+      "name": "deploy_reason",
+      "schema": "public",
+      "values": [
+        "BUILD_FAILED",
+        "ARTIFACT_UNAVAILABLE",
+        "REJECTED",
+        "STARTUP_FAILED",
+        "UNHEALTHY",
+        "TIMEOUT",
+        "TARGET_UNREACHABLE",
+        "INTERNAL"
+      ]
+    },
+    "public.exposure_state": {
+      "name": "exposure_state",
+      "schema": "public",
+      "values": [
+        "internal",
+        "private",
+        "public"
+      ]
+    },
+    "public.log_fidelity": {
+      "name": "log_fidelity",
+      "schema": "public",
+      "values": [
+        "LIVE_TEXT",
+        "LIVE_STATUS",
+        "ON_COMPLETION"
+      ]
+    },
+    "public.target_adapter": {
+      "name": "target_adapter",
+      "schema": "public",
+      "values": [
+        "kubernetes",
+        "cloudrun",
+        "static"
+      ]
+    },
+    "public.target_status": {
+      "name": "target_status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "disconnected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1785150495994,
+      "tag": "0000_init",
+      "breakpoints": true
+    }
+  ]
+}

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -1,0 +1,671 @@
+/**
+ * Spindrift's own store (§12 State: "One Postgres... Kubernetes-objects-as-
+ * database, git, and split stores are rejected; the transactional
+ * requirement rules out JSON files and anything eventually consistent").
+ *
+ * This file is the whole schema; `drizzle-kit generate` reads it to produce
+ * `db/migrations/0000_init.sql`, which is what actually ships.
+ *
+ * Object model (§2): five nouns, two authored by a human (`App`, `Datastore`).
+ * `Target` and `User` are admin-surface nouns a developer never creates.
+ * `Build` and `Component` round out the five. The names `service`, `unit`,
+ * and `deployment` are forbidden as table or type names here — they are
+ * lost to collisions elsewhere in this repo's world (§2) — so the noun for
+ * "one artifact on one Target" is `deploys`, not `deployments`, and a
+ * Component's `kind` may hold the *value* `'service'` (the spec's own
+ * vocabulary) without the table or enum being named after it.
+ *
+ * Concurrency and rollback (§6, §12) rest on a transactional row, not a
+ * token: `componentTargetDesired` is that row, one per (Component, Target),
+ * locked with `SELECT ... FOR UPDATE` to make two concurrent deploys an
+ * atomic check-and-set. `Build.id` is a `bigserial` on purpose — its total
+ * order is the mechanism rollback compares against ("a newer intent row
+ * pointing at an older Build"), which an unordered id could not give it.
+ */
+import { relations, sql } from 'drizzle-orm';
+import {
+  bigint,
+  bigserial,
+  boolean,
+  check,
+  integer,
+  jsonb,
+  pgEnum,
+  pgTable,
+  text,
+  timestamp,
+  unique,
+  uuid,
+} from 'drizzle-orm/pg-core';
+import { BUILD_STATES, LOG_FIDELITIES } from '../adapters/build/contract.ts';
+import {
+  BLAMES,
+  DEPLOY_PHASES,
+  FAILURE_REASONS,
+} from '../adapters/deploy/contract.ts';
+
+// --- Enums -----------------------------------------------------------------
+//
+// Where an enum's values are also a contract vocabulary, the enum is built
+// from the contract's own tuple rather than restating it. §6 asks for **one
+// shared vocabulary**, and two spellings of one closed set is what a
+// translation table between them is made of.
+
+/** §2: "source = repo(url, subpath) | archive(upload)". */
+export const appSourceKind = pgEnum('app_source_kind', ['repo', 'archive']);
+
+/** §2: "kind = service | website | job". */
+export const componentKind = pgEnum('component_kind', [
+  'service',
+  'website',
+  'job',
+]);
+
+/**
+ * §9: "Exposure is three states with `Private` as the default." Shared by a
+ * Component's authored setting and a Deploy's rendered `DesiredState.exposure`
+ * (§6) — one vocabulary, not two.
+ */
+export const exposureState = pgEnum('exposure_state', [
+  'internal',
+  'private',
+  'public',
+]);
+
+/** §6 `DesiredState.artifact.type`: "image | files". */
+export const artifactType = pgEnum('artifact_type', ['image', 'files']);
+
+/**
+ * §4: "Concurrency: no ordinal... a build records an artifact rather than
+ * deploying one." Build has no `SUPERSEDED` verdict; this is the plain
+ * lifecycle of a single build attempt.
+ */
+export const buildStatus = pgEnum('build_status', ['PENDING', ...BUILD_STATES]);
+
+/** §4: "a declared `logFidelity` of `LIVE_TEXT | LIVE_STATUS | ON_COMPLETION`." */
+export const logFidelity = pgEnum('log_fidelity', LOG_FIDELITIES);
+
+/** §6: "PENDING -> APPLYING -> WAITING -> LIVE | FAILED". */
+export const deployPhase = pgEnum('deploy_phase', DEPLOY_PHASES);
+
+/**
+ * §6: the closed reason set a `FAILED` Deploy carries. "One shared
+ * vocabulary": Build and Deploy attempts both write reasons from this set
+ * into `attemptEvents`, so a reason never needs a second table to mean the
+ * same thing twice.
+ */
+export const deployReason = pgEnum('deploy_reason', FAILURE_REASONS);
+
+/**
+ * §6: "`blame` is the most useful thing the UI knows." `TIMEOUT` carries no
+ * blame, hence nullable everywhere this is used.
+ */
+export const blame = pgEnum('blame', BLAMES);
+
+/** §11: "for two wire protocols: `postgres` and `redis`." */
+export const datastoreEngine = pgEnum('datastore_engine', [
+  'postgres',
+  'redis',
+]);
+
+/** §11: "Two provenances, differing only in who authors the URL." */
+export const datastoreProvenance = pgEnum('datastore_provenance', [
+  'managed',
+  'external',
+]);
+
+/**
+ * §6/§13: "`Target`... has exactly one adapter type." Values mirror
+ * `targetAdapterSchema` in `src/config/manifest.schema.ts`; kept as an
+ * independent enum here so the data layer does not import the config layer
+ * for a handful of string literals.
+ */
+export const targetAdapter = pgEnum('target_adapter', [
+  'kubernetes',
+  'cloudrun',
+  'static',
+]);
+
+/**
+ * §13: "Disconnect always works: live Deploys go `orphaned`... reconnect
+ * re-adopts via `observe`." The Target row itself just remembers which of
+ * those two states it is in.
+ */
+export const targetStatus = pgEnum('target_status', [
+  'connected',
+  'disconnected',
+]);
+
+/**
+ * §10: "One mechanism, no secret/non-secret classification... Narrow
+ * exception: a website's build-time config... lives as ordinary rows." A
+ * `secret_ref` row is write-only (a pointer into the connected store); a
+ * `plain` row is the narrow exception, holding a real value because it was
+ * always going to be public once baked into the site.
+ */
+export const configItemKind = pgEnum('config_item_kind', [
+  'secret_ref',
+  'plain',
+]);
+
+/**
+ * §6: "One attempt-scoped event log... Build and Deploy both write to it."
+ * `attemptKind` says which of the two subjects an event belongs to.
+ */
+export const attemptKind = pgEnum('attempt_kind', ['build', 'deploy']);
+
+/**
+ * §6: "carrying log lines and status events `{phase, resource?, reason?,
+ * blame?}`." A row is one or the other.
+ */
+export const attemptEventType = pgEnum('attempt_event_type', ['log', 'status']);
+
+// --- App and Component -------------------------------------------------
+
+/**
+ * §2: "App <- authored... immutable vessel reference, domain, config." One
+ * App owns many Components. Deleting an App detaches its Datastores and
+ * never cascades to them (§2, §11) but does cascade to its own Components,
+ * Builds, Deploys, and config items — none of those are reattachable.
+ */
+export const apps = pgTable('apps', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  sourceKind: appSourceKind('source_kind').notNull(),
+  /** Set when `sourceKind = 'repo'`. */
+  sourceRepoUrl: text('source_repo_url'),
+  /** Set when `sourceKind = 'repo'`; the scope is named, never searched (§5). */
+  sourceRepoSubpath: text('source_repo_subpath'),
+  /** Set when `sourceKind = 'archive'`: the uploaded bundle's digest. */
+  sourceArchiveDigest: text('source_archive_digest'),
+  /** §14: the cloud project this App's own resources live in, if any. */
+  vesselRef: text('vessel_ref'),
+  /** §9: the flat single-label vanity name, if the developer chose one. */
+  vanityDomain: text('vanity_domain'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * §2: "`schedule` is a field on a job, not a kind. `expose` is a field on a
+ * service." Both stay nullable columns on the one Component table rather
+ * than becoming separate nouns.
+ */
+export const components = pgTable(
+  'components',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    appId: uuid('app_id')
+      .notNull()
+      .references(() => apps.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    kind: componentKind('kind').notNull(),
+    /** Service only: an unexposed service is a queue worker (§2). */
+    expose: boolean('expose'),
+    /** Job only: a cron expression. */
+    schedule: text('schedule'),
+    /** §9: network-serving Components carry an exposure state; default Private. */
+    exposure: exposureState('exposure').notNull().default('private'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('components_app_id_name_unique').on(table.appId, table.name),
+  ],
+);
+
+// --- Build and Deploy ----------------------------------------------------
+
+/**
+ * §2: "one per (Component, commit, target-shape)". §6: "Build's id IS the
+ * total order" — a `bigserial`, not a `uuid`, is what makes an id
+ * comparable at all, which rollback depends on ("a newer intent row
+ * pointing at an older Build").
+ */
+export const builds = pgTable(
+  'builds',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    componentId: uuid('component_id')
+      .notNull()
+      .references(() => components.id, { onDelete: 'cascade' }),
+    commit: text('commit').notNull(),
+    /**
+     * §3: "Resolution runs before the build and outputs placement plus
+     * artifact shape, which is why Build's key includes target-shape."
+     */
+    targetShape: text('target_shape').notNull(),
+    artifactType: artifactType('artifact_type').notNull(),
+    /** Set once the build produces a digestible artifact. */
+    artifactDigest: text('artifact_digest'),
+    artifactRefs: jsonb('artifact_refs').$type<string[]>(),
+    status: buildStatus('status').notNull().default('PENDING'),
+    /** §4: the base image digest this build started from, for provenance. */
+    baseDigest: text('base_digest'),
+    /** §4: "The build backend and its fidelity are visible on the Build." */
+    runner: text('runner'),
+    logFidelity: logFidelity('log_fidelity'),
+    /** §16: the normalized provenance envelope Core derived, if assessed. */
+    provenance: jsonb('provenance'),
+    /**
+     * §4/§32: "The bundle digest must be a build parameter on every route,"
+     * the join between a source receipt and its provenance document.
+     */
+    bundleDigest: text('bundle_digest'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('builds_component_commit_shape_unique').on(
+      table.componentId,
+      table.commit,
+      table.targetShape,
+    ),
+  ],
+);
+
+/**
+ * §2: "one Build → many Deploys — this is what makes two runtimes cost no
+ * new concept and what makes rollback-without-rebuild possible." §10:
+ * `configVersion` lives here as a field, "scoped to (Component, Target)",
+ * which is what makes a Deploy "exactly Heroku's Release."
+ */
+export const deploys = pgTable('deploys', {
+  id: bigserial('id', { mode: 'number' }).primaryKey(),
+  componentId: uuid('component_id')
+    .notNull()
+    .references(() => components.id, { onDelete: 'cascade' }),
+  targetId: uuid('target_id')
+    .notNull()
+    .references(() => targets.id, { onDelete: 'restrict' }),
+  buildId: bigint('build_id', { mode: 'number' })
+    .notNull()
+    .references(() => builds.id, { onDelete: 'restrict' }),
+  phase: deployPhase('phase').notNull().default('PENDING'),
+  /** Set only when `phase = 'failed'`. */
+  reason: deployReason('reason'),
+  /** Set only when `phase = 'failed'`; null exactly when `reason = 'timeout'`. */
+  blame: blame('blame'),
+  /** §6: "`FAILED` carries a closed reason set plus free-text `detail`." */
+  detail: text('detail'),
+  /** §6: "and a raw `debug` payload." */
+  debug: jsonb('debug'),
+  url: text('url'),
+  /** §10: "a hash over a document of pinned version references." */
+  configVersion: text('config_version'),
+  exposure: exposureState('exposure'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * §6/§12: "Concurrency and rollback rest on a transactional row, not a
+ * token": `Component@Target.desired`, "one row: which artifact should be
+ * live here." A locking read (`SELECT ... FOR UPDATE`) on this row is the
+ * atomic check-and-set that makes two concurrent deploys resolve safely,
+ * and "rollback is an ordinary deploy" — a newer `desiredDeployId` pointing
+ * at an older `desiredBuildId`.
+ */
+export const componentTargetDesired = pgTable(
+  'component_target_desired',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    componentId: uuid('component_id')
+      .notNull()
+      .references(() => components.id, { onDelete: 'cascade' }),
+    targetId: uuid('target_id')
+      .notNull()
+      .references(() => targets.id, { onDelete: 'cascade' }),
+    /** Null until the first Deploy for this pair completes placement. */
+    desiredBuildId: bigint('desired_build_id', { mode: 'number' }).references(
+      () => builds.id,
+      { onDelete: 'restrict' },
+    ),
+    /** The Deploy row whose intent last set `desiredBuildId`. */
+    desiredDeployId: bigint('desired_deploy_id', {
+      mode: 'number',
+    }).references(() => deploys.id, { onDelete: 'restrict' }),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // The task's hard requirement: a UNIQUE key on (component_id, target_id),
+    // kept as its own named constraint rather than folded into a composite
+    // primary key so a catalog query for a UNIQUE constraint finds exactly
+    // that.
+    unique('component_target_desired_pair_unique').on(
+      table.componentId,
+      table.targetId,
+    ),
+  ],
+);
+
+// --- Datastore -------------------------------------------------------------
+
+/**
+ * §11: "Top-level and attached, not a field, forced by reattachment to a
+ * different App." `appId` is nullable because "deleting an App detaches its
+ * Datastores and never cascades" (§2) — detachment is `appId = null`, the
+ * row survives.
+ */
+export const datastores = pgTable('datastores', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  engine: datastoreEngine('engine').notNull(),
+  provenance: datastoreProvenance('provenance').notNull(),
+  appId: uuid('app_id').references(() => apps.id, { onDelete: 'set null' }),
+  /** §11: "Delivery follows the Datastore's placement." */
+  targetId: uuid('target_id')
+    .notNull()
+    .references(() => targets.id, { onDelete: 'restrict' }),
+  /**
+   * §11: "an in-cluster secret reference in-cluster... a pinned store
+   * reference everywhere else." Never a copy of the credential itself.
+   */
+  connectionRef: text('connection_ref'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+// --- Target and User ---------------------------------------------------
+
+/**
+ * §13: "`Target` keeps its name, stays flat, and has exactly one adapter
+ * type." §3: capabilities (discovered, asserted, derived) belong to the
+ * connect/discovery act (a later task); this table holds only what must
+ * exist before anything can be placed.
+ */
+export const targets = pgTable('targets', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  name: text('name').notNull(),
+  adapter: targetAdapter('adapter').notNull(),
+  status: targetStatus('status').notNull().default('connected'),
+  /** §13: "set a global ordered rank across Targets." */
+  rank: integer('rank').notNull(),
+  /**
+   * §3: "`publicExposure` is the single genuine assertion: no cluster API
+   * reports whether a tunnel exists." Null until an operator states it.
+   */
+  publicExposure: boolean('public_exposure'),
+  /** §4/§13: "a Target to declare a minimum SLSA Build Level." */
+  minBuildLevel: integer('min_build_level'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+/**
+ * §"First run and identity": an operator enrolls a passkey and gets a fully
+ * privileged account; there is no role table in v1 because every enrolled
+ * user is that one privileged kind. `gatewayIdentity` is the optional
+ * linked identity from the front-door Gateway, kept distinct from
+ * Spindrift's own user model on purpose.
+ */
+export const users = pgTable('users', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  displayName: text('display_name').notNull(),
+  gatewayIdentity: text('gateway_identity'),
+  createdAt: timestamp('created_at', { withTimezone: true })
+    .notNull()
+    .defaultNow(),
+});
+
+// --- Config -----------------------------------------------------------------
+
+/**
+ * §10: "One store per Target, per-key, pinned... One secret per variable,
+ * not a blob." §2: "config is stored scoped by an environment key pinned to
+ * one value, so environments and previews can arrive later without a
+ * migration." The column exists now; the check constraint pins it to the
+ * one value v1 ever writes, so a later migration only has to relax the
+ * constraint, not add the column.
+ */
+export const PINNED_ENVIRONMENT = 'default';
+
+export const configItems = pgTable(
+  'config_items',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    componentId: uuid('component_id')
+      .notNull()
+      .references(() => components.id, { onDelete: 'cascade' }),
+    targetId: uuid('target_id')
+      .notNull()
+      .references(() => targets.id, { onDelete: 'cascade' }),
+    environment: text('environment').notNull().default(PINNED_ENVIRONMENT),
+    key: text('key').notNull(),
+    kind: configItemKind('kind').notNull().default('secret_ref'),
+    /**
+     * §10: "Values are write-only." Set only when `kind = 'secret_ref'`: a
+     * pointer (path/version) into the connected store, never a value.
+     */
+    storeRef: text('store_ref'),
+    /**
+     * §10: the narrow website exception — set only when `kind = 'plain'`,
+     * because a website's build-time config "becomes public either way."
+     */
+    plainValue: text('plain_value'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    unique('config_items_scope_key_unique').on(
+      table.componentId,
+      table.targetId,
+      table.environment,
+      table.key,
+    ),
+    // A bound parameter is not legal inside a CHECK constraint's DDL, hence
+    // `sql.raw` rather than the usual interpolation — this must be a SQL
+    // literal, not a query argument.
+    check(
+      'config_items_environment_pinned',
+      sql`${table.environment} = ${sql.raw(`'${PINNED_ENVIRONMENT}'`)}`,
+    ),
+  ],
+);
+
+// --- Attempt log -------------------------------------------------------
+
+/**
+ * §6: "One attempt-scoped event log keyed by (App, Component, attempt),
+ * carrying log lines and status events `{phase, resource?, reason?,
+ * blame?}`. Build and Deploy both write to it; the UI subscribes once."
+ *
+ * This task owns the table only. Task 11 owns the domain code that writes
+ * to it and may extend it with a follow-up migration; the columns below are
+ * the shared shape the spec names, not the final word on it.
+ *
+ * Exactly one of `buildId` / `deployId` is set per row — which attempt this
+ * event belongs to — enforced by the check constraint below rather than by
+ * two separate tables, because the log itself is one stream (§6: "the UI
+ * subscribes once").
+ */
+export const attemptEvents = pgTable(
+  'attempt_events',
+  {
+    id: bigserial('id', { mode: 'number' }).primaryKey(),
+    appId: uuid('app_id')
+      .notNull()
+      .references(() => apps.id, { onDelete: 'cascade' }),
+    componentId: uuid('component_id')
+      .notNull()
+      .references(() => components.id, { onDelete: 'cascade' }),
+    attemptKind: attemptKind('attempt_kind').notNull(),
+    buildId: bigint('build_id', { mode: 'number' }).references(
+      () => builds.id,
+      { onDelete: 'cascade' },
+    ),
+    deployId: bigint('deploy_id', { mode: 'number' }).references(
+      () => deploys.id,
+      { onDelete: 'cascade' },
+    ),
+    eventType: attemptEventType('event_type').notNull(),
+    /** Set when `eventType = 'log'`: one line of build or deploy output. */
+    line: text('line'),
+    /** Set when `eventType = 'status'`. Free text: Build and Deploy phases differ. */
+    phase: text('phase'),
+    /** §6: "`resource?` is what buys the per-resource feel at three fidelities." */
+    resource: text('resource'),
+    reason: deployReason('reason'),
+    blame: blame('blame'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    check(
+      'attempt_events_exactly_one_attempt',
+      sql`(${table.buildId} is not null) <> (${table.deployId} is not null)`,
+    ),
+    check(
+      'attempt_events_kind_matches_reference',
+      sql`(${table.attemptKind} = 'build' and ${table.buildId} is not null) or (${table.attemptKind} = 'deploy' and ${table.deployId} is not null)`,
+    ),
+  ],
+);
+
+// --- Relations (query-builder convenience; no schema effect) ---------------
+
+export const appsRelations = relations(apps, ({ many }) => ({
+  components: many(components),
+  datastores: many(datastores),
+}));
+
+export const componentsRelations = relations(components, ({ one, many }) => ({
+  app: one(apps, { fields: [components.appId], references: [apps.id] }),
+  builds: many(builds),
+  deploys: many(deploys),
+  configItems: many(configItems),
+}));
+
+export const buildsRelations = relations(builds, ({ one, many }) => ({
+  component: one(components, {
+    fields: [builds.componentId],
+    references: [components.id],
+  }),
+  deploys: many(deploys),
+}));
+
+export const deploysRelations = relations(deploys, ({ one }) => ({
+  component: one(components, {
+    fields: [deploys.componentId],
+    references: [components.id],
+  }),
+  target: one(targets, {
+    fields: [deploys.targetId],
+    references: [targets.id],
+  }),
+  build: one(builds, { fields: [deploys.buildId], references: [builds.id] }),
+}));
+
+export const componentTargetDesiredRelations = relations(
+  componentTargetDesired,
+  ({ one }) => ({
+    component: one(components, {
+      fields: [componentTargetDesired.componentId],
+      references: [components.id],
+    }),
+    target: one(targets, {
+      fields: [componentTargetDesired.targetId],
+      references: [targets.id],
+    }),
+    desiredBuild: one(builds, {
+      fields: [componentTargetDesired.desiredBuildId],
+      references: [builds.id],
+    }),
+    desiredDeploy: one(deploys, {
+      fields: [componentTargetDesired.desiredDeployId],
+      references: [deploys.id],
+    }),
+  }),
+);
+
+export const datastoresRelations = relations(datastores, ({ one }) => ({
+  app: one(apps, { fields: [datastores.appId], references: [apps.id] }),
+  target: one(targets, {
+    fields: [datastores.targetId],
+    references: [targets.id],
+  }),
+}));
+
+export const targetsRelations = relations(targets, ({ many }) => ({
+  deploys: many(deploys),
+  datastores: many(datastores),
+}));
+
+export const configItemsRelations = relations(configItems, ({ one }) => ({
+  component: one(components, {
+    fields: [configItems.componentId],
+    references: [components.id],
+  }),
+  target: one(targets, {
+    fields: [configItems.targetId],
+    references: [targets.id],
+  }),
+}));
+
+export const attemptEventsRelations = relations(attemptEvents, ({ one }) => ({
+  app: one(apps, { fields: [attemptEvents.appId], references: [apps.id] }),
+  component: one(components, {
+    fields: [attemptEvents.componentId],
+    references: [components.id],
+  }),
+  build: one(builds, {
+    fields: [attemptEvents.buildId],
+    references: [builds.id],
+  }),
+  deploy: one(deploys, {
+    fields: [attemptEvents.deployId],
+    references: [deploys.id],
+  }),
+}));
+
+// --- Row types ---------------------------------------------------------
+
+export type App = typeof apps.$inferSelect;
+export type NewApp = typeof apps.$inferInsert;
+export type Component = typeof components.$inferSelect;
+export type NewComponent = typeof components.$inferInsert;
+export type Build = typeof builds.$inferSelect;
+export type NewBuild = typeof builds.$inferInsert;
+export type Deploy = typeof deploys.$inferSelect;
+export type NewDeploy = typeof deploys.$inferInsert;
+export type ComponentTargetDesired = typeof componentTargetDesired.$inferSelect;
+export type NewComponentTargetDesired =
+  typeof componentTargetDesired.$inferInsert;
+export type Datastore = typeof datastores.$inferSelect;
+export type NewDatastore = typeof datastores.$inferInsert;
+export type Target = typeof targets.$inferSelect;
+export type NewTarget = typeof targets.$inferInsert;
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+export type ConfigItem = typeof configItems.$inferSelect;
+export type NewConfigItem = typeof configItems.$inferInsert;
+export type AttemptEvent = typeof attemptEvents.$inferSelect;
+export type NewAttemptEvent = typeof attemptEvents.$inferInsert;

--- a/apps/spindrift/src/domain/attempt-log.ts
+++ b/apps/spindrift/src/domain/attempt-log.ts
@@ -1,0 +1,278 @@
+/**
+ * The attempt event log (§6, Task 11).
+ *
+ * "One attempt-scoped event log keyed by (App, Component, attempt), carrying
+ * log lines and status events `{phase, resource?, reason?, blame?}`. Build
+ * and Deploy both write to it; the UI subscribes once." (§6)
+ *
+ * `src/db/schema.ts` already carries the `attemptEvents` table this module
+ * writes and reads — one row is either a build-attempt event or a
+ * deploy-attempt event (a CHECK enforces exactly one of `buildId`/`deployId`),
+ * reusing `deployReason`/`blame` so a reason means the same thing on either
+ * side (§6: "one shared vocabulary"). This module is the domain code over
+ * that table; it adds no column, because the table already carries
+ * everything this task needs.
+ *
+ * **A running app's stdout never reaches this log** (§6: "it is unbounded and
+ * would mean the attempt never ends"; §17 is the second pipe that carries
+ * it). That is structural here, not a convention: every write goes through
+ * {@link recordBuildEvent} or {@link recordDeployEvent}, and both require an
+ * attempt reference — a `buildId` or a `deployId` that already exists as a
+ * row. A live app has neither; it is placed on a Target, not attempted. There
+ * is no third write function and no variant that accepts a bare
+ * component/target pair, so there is no call shape a runtime-log tailer could
+ * use to reach this table even by mistake.
+ *
+ * **Ordering.** `attemptEvents.id` is a `bigserial` — one sequence, one
+ * table, so every row gets a distinct, strictly increasing value. Reads order
+ * on `id`, never on `createdAt`: two events can legitimately share a
+ * millisecond (a status event and the log line that explains it, written back
+ * to back), and a timestamp column cannot break that tie in insertion order.
+ * `id` can. Each write here is one `INSERT ... RETURNING`, never batched
+ * inside a longer-lived transaction, so a row's sequence value is assigned
+ * and committed together — there is no open transaction holding a low `id`
+ * back while a later write with a higher `id` commits first. That is what
+ * lets `ORDER BY id` stand in for "the order they happened" for this table.
+ */
+import { and, asc, eq, gt, or } from 'drizzle-orm';
+import {
+  type Blame,
+  blameFor,
+  type FailureReason,
+} from '../adapters/deploy/contract.ts';
+import type { Database } from '../db/client.ts';
+import { attemptEvents } from '../db/schema.ts';
+
+/** The cursor a resumed read starts after — an `attemptEvents.id` value. */
+export type AttemptLogCursor = number;
+
+/**
+ * What a caller writes. Deliberately narrower than either adapter's own event
+ * union — `DeployEvent` carries a `DeployPhase`, `BuildEvent` carries a
+ * `step`/`state` pair — because the table's `phase` column is free text on
+ * purpose (schema.ts: "Build and Deploy phases differ"). Both adapters'
+ * events reduce to this shape at the write call site.
+ *
+ * `blame` is never a field here: §6 says an adapter "reports a reason and
+ * never a blame... blame is derived... so two adapters cannot disagree about
+ * who a failure indicts." This type makes that the only option, not merely
+ * the documented one.
+ */
+export type AttemptLogEvent =
+  | {
+      readonly type: 'log';
+      readonly line: string;
+      /** Which resource produced the line, where the backend says (§6). */
+      readonly resource?: string;
+    }
+  | {
+      readonly type: 'status';
+      /** Free text: a Build step name or a `DeployPhase` value. */
+      readonly phase: string;
+      readonly resource?: string;
+      /** Present only on a failure; `blame` is derived from this, not taken. */
+      readonly reason?: FailureReason;
+    };
+
+/** Identifies the App/Component a write belongs to (denormalized on the row). */
+interface AttemptScope {
+  readonly appId: string;
+  readonly componentId: string;
+}
+
+/** A build attempt to write to: the Build row must already exist. */
+export interface BuildAttemptRef extends AttemptScope {
+  readonly buildId: number;
+}
+
+/** A deploy attempt to write to: the Deploy row must already exist. */
+export interface DeployAttemptRef extends AttemptScope {
+  readonly deployId: number;
+}
+
+/**
+ * Identifies one attempt's *read* stream: the Build that fed it and, once a
+ * Deploy exists for it, the Deploy too. §6's acceptance shape — "a build
+ * failure and a deploy failure land on one ordered stream for the same
+ * attempt" — is exactly this union: a Deploy is an intent over a Build
+ * (schema.ts, `deploys.buildId`), and the attempt a developer watches spans
+ * both. `deployId` is omitted while only the build leg has happened yet.
+ */
+export interface AttemptStreamRef {
+  readonly componentId: string;
+  readonly buildId: number;
+  readonly deployId?: number;
+}
+
+/** One row of the merged stream, as the UI would render it. */
+export type AttemptLogEntry = {
+  readonly cursor: AttemptLogCursor;
+  readonly at: Date;
+  readonly attemptKind: 'build' | 'deploy';
+} & (
+  | {
+      readonly type: 'log';
+      readonly line: string;
+      readonly resource: string | null;
+    }
+  | {
+      readonly type: 'status';
+      readonly phase: string;
+      readonly resource: string | null;
+      readonly reason: FailureReason | null;
+      readonly blame: Blame | null;
+    }
+);
+
+/** Options for {@link readAttemptStream}. */
+export interface ReadAttemptStreamOptions {
+  /** Resume after this cursor rather than reading from the start (§17). */
+  readonly after?: AttemptLogCursor;
+  /** Caps how many rows come back in one read. */
+  readonly limit?: number;
+}
+
+/** What {@link readAttemptStream} returns. */
+export interface AttemptStreamPage {
+  readonly entries: readonly AttemptLogEntry[];
+  /**
+   * Where the next read should resume from. Unchanged from `after` when this
+   * page is empty, so a caller can always pass `cursor` straight back in
+   * without special-casing "nothing new yet".
+   */
+  readonly cursor: AttemptLogCursor | null;
+}
+
+const DEFAULT_LIMIT = 500;
+
+/** Append one event to a build attempt's leg of the log. */
+export async function recordBuildEvent(
+  db: Database,
+  ref: BuildAttemptRef,
+  event: AttemptLogEvent,
+): Promise<void> {
+  await insertEvent(db, {
+    appId: ref.appId,
+    componentId: ref.componentId,
+    attemptKind: 'build',
+    buildId: ref.buildId,
+    deployId: null,
+    event,
+  });
+}
+
+/** Append one event to a deploy attempt's leg of the log. */
+export async function recordDeployEvent(
+  db: Database,
+  ref: DeployAttemptRef,
+  event: AttemptLogEvent,
+): Promise<void> {
+  await insertEvent(db, {
+    appId: ref.appId,
+    componentId: ref.componentId,
+    attemptKind: 'deploy',
+    buildId: null,
+    deployId: ref.deployId,
+    event,
+  });
+}
+
+async function insertEvent(
+  db: Database,
+  args: {
+    appId: string;
+    componentId: string;
+    attemptKind: 'build' | 'deploy';
+    buildId: number | null;
+    deployId: number | null;
+    event: AttemptLogEvent;
+  },
+): Promise<void> {
+  const { event } = args;
+  // §6: blame is derived here, from the shared BLAME table — never accepted
+  // as a caller-supplied field (see AttemptLogEvent's doc comment).
+  const reason = event.type === 'status' ? (event.reason ?? null) : null;
+  await db.insert(attemptEvents).values({
+    appId: args.appId,
+    componentId: args.componentId,
+    attemptKind: args.attemptKind,
+    buildId: args.buildId,
+    deployId: args.deployId,
+    eventType: event.type,
+    line: event.type === 'log' ? event.line : null,
+    phase: event.type === 'status' ? event.phase : null,
+    resource: event.resource ?? null,
+    reason: reason ?? null,
+    blame: reason ? blameFor(reason) : null,
+  });
+}
+
+/**
+ * Read one attempt's merged stream, ordered from the beginning or resumed
+ * after a prior cursor (§17: "a resume cursor and bounded buffering" is what
+ * the browser stream needs from whatever it reads).
+ */
+export async function readAttemptStream(
+  db: Database,
+  ref: AttemptStreamRef,
+  options: ReadAttemptStreamOptions = {},
+): Promise<AttemptStreamPage> {
+  const legs = [
+    and(
+      eq(attemptEvents.attemptKind, 'build'),
+      eq(attemptEvents.buildId, ref.buildId),
+    ),
+    ref.deployId === undefined
+      ? undefined
+      : and(
+          eq(attemptEvents.attemptKind, 'deploy'),
+          eq(attemptEvents.deployId, ref.deployId),
+        ),
+  ];
+
+  const rows = await db
+    .select()
+    .from(attemptEvents)
+    .where(
+      and(
+        eq(attemptEvents.componentId, ref.componentId),
+        or(...legs),
+        options.after === undefined
+          ? undefined
+          : gt(attemptEvents.id, options.after),
+      ),
+    )
+    .orderBy(asc(attemptEvents.id))
+    .limit(options.limit ?? DEFAULT_LIMIT);
+
+  const entries: AttemptLogEntry[] = rows.map((row) => {
+    const base = {
+      cursor: row.id,
+      at: row.createdAt,
+      attemptKind: row.attemptKind,
+    };
+    if (row.eventType === 'log') {
+      return {
+        ...base,
+        type: 'log' as const,
+        line: row.line ?? '',
+        resource: row.resource,
+      };
+    }
+    return {
+      ...base,
+      type: 'status' as const,
+      phase: row.phase ?? '',
+      resource: row.resource,
+      reason: row.reason,
+      blame: row.blame,
+    };
+  });
+
+  const cursor =
+    entries.length > 0
+      ? entries[entries.length - 1]!.cursor
+      : (options.after ?? null);
+
+  return { entries, cursor };
+}

--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -1,0 +1,149 @@
+/**
+ * The neutral `DesiredState` core hands a deploy adapter (§6).
+ *
+ * §6 settles the direction of the seam: **core describes, the adapter renders.**
+ * Core-renders-native was rejected because it puts every backend's schema in
+ * core, which is the coupling this seam exists to break. So nothing here is a
+ * Kubernetes field, a Cloud Run field, or a hosting field — it is the vocabulary
+ * all three can be rendered from, and a file sync is not a special case bolted
+ * onto core.
+ *
+ * The shape is §6's, field for field. A field this file does not name is a field
+ * core does not get to describe.
+ */
+
+/**
+ * What a Component is (§3, §5). `website` is not a chart branch — §7 renders it
+ * as a service with `expose` forced — but it is a distinct kind here because
+ * placement, not kind, chooses the artifact type, and a `website` is the one
+ * kind that can land on either.
+ */
+export type ComponentKind = 'service' | 'website' | 'job';
+
+/**
+ * What a Build produced (§4). A deploy adapter declares which of these it
+ * accepts; the placement, not the kind, decides which one is built (§6).
+ */
+export type ArtifactType = 'image' | 'files';
+
+/** The thing being deployed, exactly as Build returns it (§4, §6). */
+export interface Artifact {
+  type: ArtifactType;
+  /**
+   * The identity. Correlation joins on digest everywhere in the supply chain
+   * (§16), so this is what a signature and a provenance document both name.
+   */
+  digest: string;
+  /** The addresses the same digest can be pulled by. */
+  refs: readonly string[];
+}
+
+/**
+ * The three exposure states, with `private` the default (§9).
+ *
+ * - `internal` — Target-private, authenticated at the workload boundary.
+ * - `private` — internet reachable, behind the Target-native authenticated edge.
+ * - `public` — intentionally unauthenticated.
+ *
+ * No non-public state may leave a bypassable origin, which is why exposure both
+ * filters Targets and selects the artifact shape (§3, §9).
+ */
+export type Exposure = 'internal' | 'private' | 'public';
+
+/**
+ * A pinned reference to one config value in the Target's store (§10).
+ *
+ * Values are write-only: this is a reference core can render into a delivery
+ * document, never a value core has read. Pinned means a concrete version, never
+ * a floating latest — a config change must produce a new Deploy rather than
+ * silently not applying (§10).
+ *
+ * The store is not named here because a Target has exactly one (§10).
+ */
+export interface SecretReference {
+  /** The store's own name for the item, as the store adapter minted it. */
+  key: string;
+  /** The version pinned. */
+  version: string;
+}
+
+/**
+ * One environment variable and the pinned reference that fills it.
+ *
+ * §10 is per-key, not per-blob: the blob is elegant on Kubernetes and has no
+ * cloud-runtime equivalent. There is no secret / non-secret classification
+ * either, so every row is delivered the same way — the exception §10 carves out
+ * is a website's build-time config, which is a Build input (§4), not this.
+ */
+export interface ConfigEntry {
+  /** The variable name the workload reads. */
+  name: string;
+  secret: SecretReference;
+}
+
+/** Where the artifact can run (§3's `arch` capability). */
+export interface Platform {
+  os: string;
+  arch: string;
+}
+
+/**
+ * What the workload asks for. Quantities are opaque strings the adapter maps to
+ * its backend's own units; core compares them against a Target's discovered
+ * `resourceCeiling` (§3) and never invents a scheduler (§3: resolution is a
+ * filter, not a scheduler).
+ */
+export interface Resources {
+  cpu?: string;
+  memory?: string;
+}
+
+/** §6's `requirements: platform/arch, resources`. */
+export interface Requirements {
+  platform: Platform;
+  resources: Resources;
+}
+
+/**
+ * §9's two layers. The canonical name always resolves — where the platform gives
+ * one of its own, that *is* the canonical, so on those Targets the adapter
+ * reports it back rather than being told it. The vanity name is the flat
+ * single-label one a developer shares, and exists only where a mechanism for it
+ * does.
+ */
+export interface Hostname {
+  canonical: string;
+  vanity?: string;
+}
+
+/**
+ * Everything core knows about what should be running, in backend-neutral terms.
+ *
+ * `expose` and `schedule` are the two fields §6 marks as belonging to one kind:
+ * `expose` to `service`, `schedule` to `job`. They are optional rather than
+ * modelled as a union per kind because §6 states one flat shape, and because
+ * §7's chart takes the same flat values.
+ */
+export interface DesiredState {
+  /** The App this Component belongs to. */
+  app: string;
+  /** The Component being deployed. */
+  component: string;
+  /** The Target it is being placed on. */
+  target: string;
+
+  kind: ComponentKind;
+  artifact: Artifact;
+
+  /** Service only. Forced on for a `website` (§7). */
+  expose?: boolean;
+
+  exposure: Exposure;
+
+  /** Job only. A cron expression; absent means the CronJob is suspended (§7). */
+  schedule?: string;
+
+  config: readonly ConfigEntry[];
+  requirements: Requirements;
+  hostname: Hostname;
+}

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The build contract's one non-negotiable term.
+ *
+ * §16: correlation joins on digest with no signer over-vouching, which forces
+ * the bundle digest to be a build parameter on **every** route — otherwise the
+ * source receipt Spindrift signs and the provenance document the backend
+ * produces have no join. This file makes that a compile-time fact rather than a
+ * convention: a route cannot be called without one, and cannot report a build
+ * without echoing it.
+ */
+import { describe, expect, test } from 'bun:test';
+import type {
+  BuildAdapter,
+  BuildEvent,
+  BuildProvenance,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+  LogFidelity,
+} from '../../src/adapters/build/contract.ts';
+
+/** A type-level claim that fails to compile if `T` is not exactly `true`. */
+type Assert<T extends true> = T;
+
+const spec: BuildSpec = {
+  artifactType: 'image',
+  kind: 'service',
+  platform: { os: 'linux', arch: 'arm64' },
+  destination: 'registry.example.test/apps',
+  buildArgs: {},
+};
+
+const source: BuildSource = {
+  bundleDigest: 'sha256:bundle',
+  origin: {
+    type: 'repo',
+    repository: 'https://git.example.test/app',
+    commit: 'c0ffee',
+    subpath: '.',
+  },
+};
+
+/** A route that does the one thing every route must: echo what it was given. */
+const route: BuildAdapter = {
+  name: 'example',
+  logFidelity: 'LIVE_TEXT',
+  buildLevel: 2,
+  async *build(
+    given: BuildSource,
+  ): AsyncGenerator<BuildEvent, BuildResult, void> {
+    yield { type: 'step', at: new Date(), step: 'unpack', state: 'RUNNING' };
+    return {
+      status: 'SUCCEEDED',
+      artifact: { type: 'image', digest: 'sha256:built', refs: [] },
+      logs: { backend: 'example', fidelity: 'LIVE_TEXT' },
+      provenance: {
+        bundleDigest: given.bundleDigest,
+        claimedLevel: 2,
+        statement: null,
+      },
+      baseDigest: 'sha256:base',
+    };
+  },
+};
+
+describe('the bundle digest', () => {
+  test('is a required field of every build source', () => {
+    const required: Assert<
+      Omit<BuildSource, 'bundleDigest'> extends BuildSource ? false : true
+    > = true;
+    expect(required).toBe(true);
+  });
+
+  test('is a parameter no adapter can decline to accept', () => {
+    type RouteTakes = Parameters<BuildAdapter['build']>[0];
+    const accepted: Assert<
+      RouteTakes extends { bundleDigest: string } ? true : false
+    > = true;
+    expect(accepted).toBe(true);
+  });
+
+  test('cannot be omitted at the call site', () => {
+    const withoutIt = {
+      origin: source.origin,
+    };
+    // @ts-expect-error — a source without a bundle digest is not a BuildSource
+    const built = route.build(withoutIt, spec);
+    expect(built).toBeDefined();
+  });
+
+  test('cannot be omitted from a provenance', () => {
+    // @ts-expect-error — §16: the document must carry the digest it was given
+    const incomplete: BuildProvenance = { claimedLevel: 2, statement: null };
+    expect(incomplete.claimedLevel).toBe(2);
+  });
+
+  test('comes back on the provenance the route returns', async () => {
+    const stream = route.build(source, spec);
+    let step = await stream.next();
+    const events: BuildEvent[] = [];
+    while (!step.done) {
+      events.push(step.value);
+      step = await stream.next();
+    }
+    const result = step.value;
+
+    expect(events).toHaveLength(1);
+    expect(result.status).toBe('SUCCEEDED');
+    if (result.status !== 'SUCCEEDED') throw new Error('unreachable');
+    expect(result.provenance.bundleDigest).toBe(source.bundleDigest);
+    expect(result.artifact.digest).toBe('sha256:built');
+    expect(result.baseDigest).toBe('sha256:base');
+  });
+});
+
+describe('a red build', () => {
+  test('carries a reason from the shared vocabulary and no provenance', () => {
+    const failed: BuildResult = {
+      status: 'FAILED',
+      artifact: null,
+      logs: { backend: 'example', fidelity: 'ON_COMPLETION' },
+      provenance: null,
+      baseDigest: null,
+      reason: 'BUILD_FAILED',
+      detail: 'step 3 exited 1',
+    };
+    expect(failed.status).toBe('FAILED');
+    if (failed.status !== 'FAILED') throw new Error('unreachable');
+    expect(failed.reason).toBe('BUILD_FAILED');
+  });
+});
+
+describe('log fidelity', () => {
+  test('is declared by the route, because it varies by runner', () => {
+    const fidelities: LogFidelity[] = [
+      'LIVE_TEXT',
+      'LIVE_STATUS',
+      'ON_COMPLETION',
+    ];
+    expect(fidelities).toContain(route.logFidelity);
+  });
+});

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -1,0 +1,169 @@
+/**
+ * The deploy contract's closed vocabulary.
+ *
+ * A failure test asserts the sentence the user reads, not that an error was
+ * thrown — the closed reason set and `blame` exist precisely so a failure has an
+ * assertable identity (§ Testing). This file asserts that identity: the eight
+ * reasons, their blame, and that a stream ends on a verdict carrying one.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  BLAME,
+  type Blame,
+  blameFor,
+  type DeployAdapter,
+  type DeployEvent,
+  type DeployVerdict,
+  type FailureReason,
+  reasonCovers,
+} from '../../src/adapters/deploy/contract.ts';
+import type { DesiredState } from '../../src/domain/desired-state.ts';
+
+/**
+ * §6's table, transcribed. A reviewer can check this against the spec without
+ * reading it, because the whole table is here:
+ *
+ * | Reason | Blame | Covers |
+ * | --- | --- | --- |
+ * | `BUILD_FAILED` | developer | compile error, failed build step |
+ * | `ARTIFACT_UNAVAILABLE` | platform | image pull failure, registry auth, missing object |
+ * | `REJECTED` | developer | admission webhook, invalid spec, quota, org policy |
+ * | `STARTUP_FAILED` | developer | crash loop, exits non-zero, revision will not start |
+ * | `UNHEALTHY` | developer | readiness never passed |
+ * | `TIMEOUT` | — | no terminal state within budget |
+ * | `TARGET_UNREACHABLE` | platform | credentials expired, cluster down, API unreachable |
+ * | `INTERNAL` | platform | adapter bug |
+ */
+const TABLE = [
+  ['BUILD_FAILED', 'developer', 'compile error, failed build step'],
+  [
+    'ARTIFACT_UNAVAILABLE',
+    'platform',
+    'image pull failure, registry auth, missing object',
+  ],
+  [
+    'REJECTED',
+    'developer',
+    'admission webhook, invalid spec, quota, org policy',
+  ],
+  [
+    'STARTUP_FAILED',
+    'developer',
+    'crash loop, exits non-zero, revision will not start',
+  ],
+  ['UNHEALTHY', 'developer', 'readiness never passed'],
+  ['TIMEOUT', null, 'no terminal state within budget'],
+  [
+    'TARGET_UNREACHABLE',
+    'platform',
+    'credentials expired, cluster down, API unreachable',
+  ],
+  ['INTERNAL', 'platform', 'adapter bug'],
+] as const satisfies readonly (readonly [
+  FailureReason,
+  Blame | null,
+  string,
+])[];
+
+/** A type-level claim that fails to compile if `T` is not exactly `true`. */
+type Assert<T extends true> = T;
+
+describe("§6's failure vocabulary", () => {
+  test('is the eight reasons the table names, and no others', () => {
+    expect(Object.keys(BLAME).sort()).toEqual(
+      TABLE.map(([reason]) => reason).sort(),
+    );
+  });
+
+  test('is closed — no ninth reason is left uncovered', () => {
+    const covered: Assert<
+      Exclude<FailureReason, (typeof TABLE)[number][0]> extends never
+        ? true
+        : false
+    > = true;
+    expect(covered).toBe(true);
+  });
+
+  for (const [reason, blame, covers] of TABLE) {
+    test(`${reason} blames ${blame ?? 'nobody'}`, () => {
+      expect(blameFor(reason)).toBe(blame);
+      expect(BLAME[reason]).toBe(blame);
+    });
+
+    test(`${reason} covers ${covers}`, () => {
+      expect(reasonCovers(reason)).toBe(covers);
+    });
+  }
+
+  test('a reason outside the union is not a reason', () => {
+    // @ts-expect-error — the union is closed; free text lives in `detail`
+    const invented: FailureReason = 'ROBOT_UPRISING';
+    expect(Object.keys(BLAME)).not.toContain(invented);
+  });
+});
+
+const target = { name: 'somewhere', adapter: 'kubernetes' } as const;
+
+const desired: DesiredState = {
+  app: 'app',
+  component: 'web',
+  target: target.name,
+  kind: 'service',
+  artifact: { type: 'image', digest: 'sha256:beef', refs: [] },
+  expose: true,
+  exposure: 'private',
+  config: [],
+  requirements: { platform: { os: 'linux', arch: 'arm64' }, resources: {} },
+  hostname: { canonical: 'web.example.test' },
+};
+
+/**
+ * A red adapter, written here rather than reached for from the harness, because
+ * what is under test is the contract's own shape: that a stream of events
+ * resolves to a verdict, and that the verdict is what carries the reason.
+ */
+const refuses: DeployAdapter = {
+  adapter: 'kubernetes',
+  artifactTypes: ['image'],
+  async *apply(): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    yield { type: 'status', at: new Date(), phase: 'APPLYING' };
+    yield { type: 'log', at: new Date(), line: 'pulling', resource: 'web' };
+    return {
+      phase: 'FAILED',
+      reason: 'ARTIFACT_UNAVAILABLE',
+      detail: 'the registry refused the pull',
+    };
+  },
+  async observe() {
+    return null;
+  },
+  async destroy() {},
+};
+
+describe('apply', () => {
+  test('streams events and ends on a terminal verdict', async () => {
+    const stream = refuses.apply(target, desired);
+    const events: DeployEvent[] = [];
+    let step = await stream.next();
+    while (!step.done) {
+      events.push(step.value);
+      step = await stream.next();
+    }
+    const verdict = step.value;
+
+    expect(events.map((event) => event.type)).toEqual(['status', 'log']);
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase !== 'FAILED') throw new Error('unreachable');
+    expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+    // The green build with the red deploy: the case blame exists for (§6).
+    expect(blameFor(verdict.reason)).toBe('platform');
+  });
+});
+
+describe('destroy', () => {
+  test('is idempotent', async () => {
+    await refuses.destroy(target, 'anything');
+    await refuses.destroy(target, 'anything');
+    expect(await refuses.observe(target, 'anything')).toBeNull();
+  });
+});

--- a/apps/spindrift/test/commands/registry.test.ts
+++ b/apps/spindrift/test/commands/registry.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The registry is the dispatch surface, so this file asserts the two things
+ * that make it one (§21, and the plan's "one dispatch endpoint generated from
+ * the command registry"):
+ *
+ * 1. **Every exported command is registered.** An export absent from the
+ *    registry is a command the browser could never call, and the generated
+ *    endpoint would silently not have it. `registry.ts` also refuses to
+ *    type-check in that case; this test is the version that fails loudly
+ *    without reading the compiler's output.
+ * 2. **Every registered name is an exported command.** A route that is not a
+ *    command is exactly what §21 refuses to grow, and the only way one could
+ *    appear is an entry here pointing at something else.
+ *
+ * Neither assertion needs a database: the failure paths under test refuse
+ * before a handler runs, and the context below proves it by throwing if
+ * anything reaches for the connection.
+ */
+import { describe, expect, test } from 'bun:test';
+import * as commandModule from '../../src/commands/index.ts';
+import {
+  commandNames,
+  commandRegistry,
+  dispatch,
+  isCommandName,
+} from '../../src/commands/registry.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import type { Database } from '../../src/db/client.ts';
+
+/** Reaching for any of these is the failure this file is watching for. */
+function unreachable(what: string): never {
+  throw new Error(`a refused command reached the ${what}`);
+}
+
+const noDatabase = new Proxy(
+  {},
+  {
+    get: () => unreachable('database'),
+  },
+) as Database;
+
+const noAdapters: AdapterRegistry = {
+  deploy: () => unreachable('deploy adapter'),
+  build: () => unreachable('build adapter'),
+  store: () => unreachable('secret store'),
+};
+
+const context: CommandContext = {
+  principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+  clock: { now: () => unreachable('clock') },
+  db: noDatabase,
+  adapters: noAdapters,
+};
+
+/**
+ * Every value `src/commands/index.ts` exports. That file's contract is that
+ * each of them is a command — which is why this needs no allowlist, and why a
+ * newly exported command cannot slip past by not being mentioned here.
+ */
+const exported = Object.entries(commandModule);
+
+describe('the command surface and the registry are the same set', () => {
+  test('index.ts exports commands and nothing else', () => {
+    expect(exported.length).toBeGreaterThan(0);
+    for (const [name, value] of exported) {
+      expect(typeof value).toBe('function');
+      expect(name).not.toBe('');
+    }
+  });
+
+  test('every exported command is registered under its own name', () => {
+    const exportedNames = exported.map(([name]) => name).sort();
+    const registeredNames = Object.keys(commandRegistry).sort();
+    expect(registeredNames).toEqual(exportedNames);
+  });
+
+  test('each registry entry points at the command it names', () => {
+    for (const [name, value] of exported) {
+      const descriptor = (
+        commandRegistry as Record<string, { handler: unknown } | undefined>
+      )[name];
+      expect(descriptor).toBeDefined();
+      expect(descriptor?.handler).toBe(value);
+    }
+  });
+
+  test('each registry entry carries an input schema', () => {
+    for (const descriptor of Object.values(commandRegistry)) {
+      expect(typeof descriptor.input.safeParse).toBe('function');
+    }
+  });
+
+  test('the generated name list is the registry keys', () => {
+    expect(Object.keys(commandRegistry).sort()).toEqual(
+      [...commandNames].sort(),
+    );
+    for (const name of commandNames) {
+      expect(isCommandName(name)).toBe(true);
+    }
+  });
+});
+
+describe('dispatch refuses what the registry does not back', () => {
+  test('an unknown name is a refusal, not a thrown error', async () => {
+    const result = await dispatch('deployTheWholeFleet', {}, context);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('UNKNOWN_COMMAND');
+    expect(result.failure.message).toContain('deployTheWholeFleet');
+  });
+
+  test('isCommandName rejects a name that is only a property of Object', () => {
+    expect(isCommandName('toString')).toBe(false);
+    expect(isCommandName('constructor')).toBe(false);
+  });
+
+  test('invalid input is refused with the field that was wrong', async () => {
+    const result = await dispatch(
+      'createApp',
+      { name: 'UPPERCASE', sourceKind: 'repo', repoUrl: 'nonsense' },
+      context,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+    const paths = (result.failure.issues ?? []).map((issue) => issue.path);
+    expect(paths).toContain('name');
+    expect(paths).toContain('repoUrl');
+  });
+
+  test('an input naming no known source kind is refused', async () => {
+    const result = await dispatch(
+      'createApp',
+      { name: 'thing', sourceKind: 'ftp' },
+      context,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+  });
+});

--- a/apps/spindrift/test/commands/smoke.test.ts
+++ b/apps/spindrift/test/commands/smoke.test.ts
@@ -1,0 +1,191 @@
+/**
+ * The command layer, driven end to end against a real Postgres (§ Testing,
+ * Seam 1: "Tests drive commands against a real Postgres and fake adapters,
+ * asserting rows, timeline events, and the `DesiredState` each adapter was
+ * handed").
+ *
+ * What is asserted here is the row, not the return value: a command that
+ * reported an id it never wrote would pass a test of its own output and fail
+ * this one. The clock is fixed and the timestamps are checked against it,
+ * which is the assertable proof that the handler took time from the context
+ * rather than from the process.
+ *
+ * Each test runs in its own migrated Postgres schema, handed out by the
+ * harness (`test/harness/db.ts`), so nothing here depends on what any other
+ * test left behind.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { createApp } from '../../src/commands/index.ts';
+import { dispatch } from '../../src/commands/registry.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { apps } from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+
+/** A clock that does not move: every timestamp is checkable against it. */
+const FROZEN = new Date('2024-03-05T11:22:33.000Z');
+const frozenClock: Clock = { now: () => FROZEN };
+
+/**
+ * No command under test reaches an adapter yet, so every lookup refuses
+ * rather than returning a hand-written stand-in — a fake nobody exercises is
+ * a fake nobody has checked. Task 7 owns the recording fakes.
+ */
+const noAdapters: AdapterRegistry = {
+  deploy: () => null,
+  build: () => null,
+  store: () => {
+    throw new Error('no store adapter is configured for this test');
+  },
+};
+
+function context(clock: Clock = frozenClock): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters: noAdapters,
+  };
+}
+
+/** The App row as the database holds it, or `undefined`. */
+async function appRow(id: string) {
+  const rows = await database().db.select().from(apps).where(eq(apps.id, id));
+  return rows[0];
+}
+
+describe('createApp: an App sourced from a repository', () => {
+  test('writes the App row the caller described', async () => {
+    const name = `web-${crypto.randomUUID().slice(0, 8)}`;
+    const result = await createApp(
+      {
+        name,
+        sourceKind: 'repo',
+        repoUrl: 'https://git.example.test/acme/website.git',
+        subpath: 'services/api',
+      },
+      context(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const row = await appRow(result.value.appId);
+    expect(row).toBeDefined();
+    expect(row?.name).toBe(name);
+    expect(row?.sourceKind).toBe('repo');
+    expect(row?.sourceRepoUrl).toBe(
+      'https://git.example.test/acme/website.git',
+    );
+    expect(row?.sourceRepoSubpath).toBe('services/api');
+    // §2: an App has one source. The archive column stays empty.
+    expect(row?.sourceArchiveDigest).toBeNull();
+  });
+
+  test('stamps both timestamps from the injected clock', async () => {
+    const result = await createApp(
+      {
+        name: `api-${crypto.randomUUID().slice(0, 8)}`,
+        sourceKind: 'repo',
+        repoUrl: 'https://git.example.test/acme/api.git',
+      },
+      context(),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const row = await appRow(result.value.appId);
+    expect(row?.createdAt.toISOString()).toBe(FROZEN.toISOString());
+    expect(row?.updatedAt.toISOString()).toBe(FROZEN.toISOString());
+    expect(result.value.createdAt.toISOString()).toBe(FROZEN.toISOString());
+  });
+
+  test('leaves an unnamed subpath, vessel, and vanity name unset', async () => {
+    const result = await createApp(
+      {
+        name: `plain-${crypto.randomUUID().slice(0, 8)}`,
+        sourceKind: 'repo',
+        repoUrl: 'https://git.example.test/acme/plain.git',
+      },
+      context(),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const row = await appRow(result.value.appId);
+    expect(row?.sourceRepoSubpath).toBeNull();
+    expect(row?.vesselRef).toBeNull();
+    expect(row?.vanityDomain).toBeNull();
+  });
+});
+
+describe('createApp: an App sourced from an uploaded archive', () => {
+  test('records the bundle digest and no repository', async () => {
+    const digest = `sha256:${'a1b2c3d4'.repeat(8)}`;
+    const result = await createApp(
+      {
+        name: `bundle-${crypto.randomUUID().slice(0, 8)}`,
+        sourceKind: 'archive',
+        archiveDigest: digest,
+        vesselRef: 'vessel-of-record',
+        vanityDomain: 'notes',
+      },
+      context(),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const row = await appRow(result.value.appId);
+    expect(row?.sourceKind).toBe('archive');
+    expect(row?.sourceArchiveDigest).toBe(digest);
+    expect(row?.sourceRepoUrl).toBeNull();
+    expect(row?.vesselRef).toBe('vessel-of-record');
+    expect(row?.vanityDomain).toBe('notes');
+  });
+});
+
+describe('dispatch: the same act, reached by name', () => {
+  test('writes the same row the direct call would have', async () => {
+    const name = `dispatched-${crypto.randomUUID().slice(0, 8)}`;
+    const result = await dispatch(
+      'createApp',
+      {
+        name,
+        sourceKind: 'repo',
+        repoUrl: 'https://git.example.test/acme/dispatched.git',
+      },
+      context(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const value = result.value as { appId: string };
+    const row = await appRow(value.appId);
+    expect(row?.name).toBe(name);
+    expect(row?.createdAt.toISOString()).toBe(FROZEN.toISOString());
+  });
+
+  test('writes nothing when the input does not satisfy the schema', async () => {
+    const before = await database().db.select().from(apps);
+
+    const result = await dispatch(
+      'createApp',
+      { name: 'Not A Label', sourceKind: 'repo', repoUrl: 'not a url' },
+      context(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+
+    const after = await database().db.select().from(apps);
+    expect(after.length).toBe(before.length);
+  });
+});

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -1,0 +1,300 @@
+/**
+ * The adapter conformance suite (Task 12, § Seam 2).
+ *
+ * One suite, run against **every** implementation of each contract, so the
+ * deploy adapters, the build routes, and the stores cannot drift apart in what
+ * they mean. It asserts contract behaviour and nothing else: no backend's own
+ * semantics appear here, because a suite that knew one backend's rendering
+ * would be the coupling §6's seam exists to break.
+ *
+ * What it asserts, per the task:
+ *
+ * - `apply` reaches a terminal verdict
+ * - `observe` reports what `apply` placed
+ * - `destroy` is idempotent
+ * - declared artifact types are honoured, and a foreign one is refused
+ * - a store round-trips a pinned version reference
+ *
+ * **Enrolment is the other half.** A suite you can forget to run is not a
+ * contract, so {@link assertEveryAdapterEnrolled} compares what the suite was
+ * run over against the registry of adapters that exist, and names the gap.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { BuildAdapter } from '../../src/adapters/build/contract.ts';
+import type {
+  DeployAdapter,
+  DeployTarget,
+} from '../../src/adapters/deploy/contract.ts';
+import type { SecretStore } from '../../src/adapters/store/contract.ts';
+import type {
+  ArtifactType,
+  DesiredState,
+} from '../../src/domain/desired-state.ts';
+
+/** Names the suite has been run over, collected as the suites declare them. */
+const enrolled = {
+  deploy: new Set<string>(),
+  build: new Set<string>(),
+  store: new Set<string>(),
+};
+
+/** A `DesiredState` of the given artifact type — the neutral one, not a mock. */
+export function desiredState(
+  artifactType: ArtifactType,
+  digest = 'sha256:conformance',
+): DesiredState {
+  return {
+    app: 'conformance',
+    component: 'web',
+    target: 'target',
+    kind: artifactType === 'files' ? 'website' : 'service',
+    artifact: { type: artifactType, digest, refs: [] },
+    exposure: 'private',
+    config: [],
+    requirements: {
+      platform: { os: 'linux', arch: 'amd64' },
+      resources: {},
+    },
+    hostname: { canonical: 'app.example.test' },
+  };
+}
+
+/** Drive a generator to its return value, collecting what it yielded. */
+async function drain<Event, Verdict>(
+  stream: AsyncGenerator<Event, Verdict, void>,
+): Promise<{ events: Event[]; verdict: Verdict }> {
+  const events: Event[] = [];
+  let step = await stream.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return { events, verdict: step.value };
+}
+
+/**
+ * Run the deploy contract's suite against one adapter.
+ *
+ * The artifact type it does not accept is required rather than guessed: a
+ * `static` adapter's foreign type is an image, a `kubernetes` adapter's is
+ * files, and the suite must not decide that for a backend it does not know.
+ */
+export function deployAdapterSuite(
+  label: string,
+  make: () => DeployAdapter,
+  foreign: ArtifactType,
+): void {
+  enrolled.deploy.add(label);
+
+  describe(`deploy contract: ${label}`, () => {
+    const target: DeployTarget = { name: 'target', adapter: make().adapter };
+
+    test('declares at least one artifact type it accepts', () => {
+      expect(make().artifactTypes.length).toBeGreaterThan(0);
+    });
+
+    test('apply reaches a terminal verdict', async () => {
+      const adapter = make();
+      const accepted = adapter.artifactTypes[0];
+      expect(accepted).toBeDefined();
+      const { verdict } = await drain(
+        adapter.apply(target, desiredState(accepted as ArtifactType)),
+      );
+      expect(['LIVE', 'FAILED']).toContain(verdict.phase);
+    });
+
+    test('observe reports what apply placed', async () => {
+      const adapter = make();
+      const digest = 'sha256:observed';
+      const { verdict } = await drain(
+        adapter.apply(
+          target,
+          desiredState(adapter.artifactTypes[0] as ArtifactType, digest),
+        ),
+      );
+      if (verdict.phase !== 'LIVE') {
+        throw new Error('adapter did not place anything to observe');
+      }
+      const observed = await adapter.observe(target, verdict.ref);
+      expect(observed).not.toBeNull();
+      expect(observed?.ref).toBe(verdict.ref);
+      expect(observed?.artifactDigest).toBe(digest);
+    });
+
+    test('observe reports null for a ref it never placed', async () => {
+      expect(await make().observe(target, 'never-placed')).toBeNull();
+    });
+
+    test('destroy is idempotent', async () => {
+      const adapter = make();
+      const { verdict } = await drain(
+        adapter.apply(
+          target,
+          desiredState(adapter.artifactTypes[0] as ArtifactType),
+        ),
+      );
+      const ref = verdict.phase === 'LIVE' ? verdict.ref : 'absent';
+      await adapter.destroy(target, ref);
+      // The second destroy is the assertion: destroying what is already gone
+      // succeeds (§6), so this must not throw and must leave nothing behind.
+      await adapter.destroy(target, ref);
+      expect(await adapter.observe(target, ref)).toBeNull();
+    });
+
+    test('refuses an artifact type it did not declare', async () => {
+      const adapter = make();
+      expect(adapter.artifactTypes).not.toContain(foreign);
+      const { verdict } = await drain(
+        adapter.apply(target, desiredState(foreign)),
+      );
+      // Refusal is a verdict, not an exception: a thrown error has no reason
+      // and therefore no blame (§6).
+      expect(verdict.phase).toBe('FAILED');
+      if (verdict.phase === 'FAILED') expect(verdict.reason).toBe('INTERNAL');
+    });
+  });
+}
+
+/** Run the build contract's suite against one route. */
+export function buildAdapterSuite(
+  label: string,
+  make: () => BuildAdapter,
+): void {
+  enrolled.build.add(label);
+
+  describe(`build contract: ${label}`, () => {
+    const source = {
+      bundleDigest: 'sha256:bundle',
+      origin: {
+        type: 'archive',
+        location: 'staged://bundle',
+        subpath: '.',
+      },
+    } as const;
+    const spec = {
+      artifactType: 'image',
+      kind: 'service',
+      platform: { os: 'linux', arch: 'amd64' },
+      destination: 'registry.example.test/app',
+      buildArgs: {},
+    } as const;
+
+    test('declares a fidelity and a level', () => {
+      const adapter = make();
+      expect(['LIVE_TEXT', 'LIVE_STATUS', 'ON_COMPLETION']).toContain(
+        adapter.logFidelity,
+      );
+      expect([1, 2, 3]).toContain(adapter.buildLevel);
+    });
+
+    test('build reaches a terminal result', async () => {
+      const { verdict } = await drain(make().build(source, spec));
+      expect(['SUCCEEDED', 'FAILED']).toContain(verdict.status);
+    });
+
+    test('a green build echoes the bundle digest it was handed', async () => {
+      const { verdict } = await drain(make().build(source, spec));
+      if (verdict.status !== 'SUCCEEDED') {
+        throw new Error('adapter did not produce a green build');
+      }
+      // §16's join: a route that cannot report the digest it was given cannot
+      // produce a provenance anything can be correlated against.
+      expect(verdict.provenance.bundleDigest).toBe(source.bundleDigest);
+      expect(verdict.artifact.type).toBe(spec.artifactType);
+    });
+
+    test('reports the route that ran and at what fidelity', async () => {
+      const adapter = make();
+      const { verdict } = await drain(adapter.build(source, spec));
+      expect(verdict.logs.backend).toBe(adapter.name);
+      expect(verdict.logs.fidelity).toBe(adapter.logFidelity);
+    });
+  });
+}
+
+/** Run the store contract's suite against one store. */
+export function storeAdapterSuite(
+  label: string,
+  make: () => SecretStore,
+): void {
+  enrolled.store.add(label);
+
+  describe(`store contract: ${label}`, () => {
+    const scope = { app: 'app', component: 'web', target: 'target' };
+
+    test('round-trips a pinned version reference', async () => {
+      const store = make();
+      const reference = await store.put(scope, 'TOKEN', 'value');
+      const described = await store.describe(reference);
+      expect(described).not.toBeNull();
+      expect(described?.reference).toEqual(reference);
+      expect(described?.key).toBe('TOKEN');
+    });
+
+    test('a put is a new version, never an edit of one', async () => {
+      const store = make();
+      const first = await store.put(scope, 'TOKEN', 'one');
+      const second = await store.put(scope, 'TOKEN', 'two');
+      expect(second).not.toEqual(first);
+      // The older pin still resolves — that is what makes a Deploy pinned to it
+      // still deployable (§10).
+      expect(await store.describe(first)).not.toBeNull();
+    });
+
+    test('lists every version of a key, newest first', async () => {
+      const store = make();
+      const first = await store.put(scope, 'TOKEN', 'one');
+      const second = await store.put(scope, 'TOKEN', 'two');
+      const versions = await store.versions(scope, 'TOKEN');
+      expect(versions.map((v) => v.reference)).toEqual([second, first]);
+    });
+
+    test('describe reports null for a reference that is gone', async () => {
+      const store = make();
+      const reference = await store.put(scope, 'TOKEN', 'value');
+      await store.destroy(reference);
+      expect(await store.describe(reference)).toBeNull();
+    });
+
+    test('destroy is idempotent', async () => {
+      const store = make();
+      const reference = await store.put(scope, 'TOKEN', 'value');
+      await store.destroy(reference);
+      await store.destroy(reference);
+      expect(await store.describe(reference)).toBeNull();
+    });
+  });
+}
+
+/**
+ * Every adapter that exists, by contract. **This is the enrolment registry**:
+ * an implementation added here without a suite call above fails the check
+ * below, and an implementation added *nowhere* is the case a human review has
+ * to catch — which is why this list lives next to the suite rather than being
+ * inferred from a directory listing that would silently agree with itself.
+ */
+export const ADAPTERS = {
+  deploy: ['fake'],
+  build: ['fake'],
+  store: ['fake native', 'fake immutable item per version'],
+} as const;
+
+/**
+ * Fail if any registered adapter was never run through the suite.
+ *
+ * Called from the file that runs the suites, after they are declared. The
+ * failure names the gap rather than only counting it, so the fix is obvious
+ * from the output alone.
+ */
+export function assertEveryAdapterEnrolled(): void {
+  describe('every adapter is enrolled in the conformance suite', () => {
+    for (const contract of ['deploy', 'build', 'store'] as const) {
+      test(`${contract} adapters`, () => {
+        const missing = ADAPTERS[contract].filter(
+          (name) => !enrolled[contract].has(name),
+        );
+        expect(missing).toEqual([]);
+      });
+    }
+  });
+}

--- a/apps/spindrift/test/conformance/fakes.test.ts
+++ b/apps/spindrift/test/conformance/fakes.test.ts
@@ -1,0 +1,36 @@
+/**
+ * The conformance suite, run against every adapter that exists (Task 12).
+ *
+ * Today that is the three fakes: the two store implementations are deliberately
+ * deferred, so no real backend is enrolled yet. The point of running it now is
+ * that the enrolment check is live before the first real adapter arrives —
+ * `ADAPTERS` in the suite is what it will have to be added to, and the check
+ * fails until it is also run.
+ */
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import {
+  assertEveryAdapterEnrolled,
+  buildAdapterSuite,
+  deployAdapterSuite,
+  storeAdapterSuite,
+} from './adapter-suite.ts';
+
+deployAdapterSuite('fake', () => new FakeDeployAdapter(), 'files');
+
+buildAdapterSuite('fake', () => new FakeBuildAdapter());
+
+// Both pinning strategies run the same suite, because §10's claim is that
+// nothing above the seam can tell them apart. One of them passing would not
+// establish that.
+storeAdapterSuite(
+  'fake native',
+  () => new FakeSecretStore({ pinning: 'NATIVE' }),
+);
+storeAdapterSuite(
+  'fake immutable item per version',
+  () => new FakeSecretStore({ pinning: 'IMMUTABLE_ITEM_PER_VERSION' }),
+);
+
+assertEveryAdapterEnrolled();

--- a/apps/spindrift/test/db/schema.test.ts
+++ b/apps/spindrift/test/db/schema.test.ts
@@ -1,0 +1,186 @@
+/**
+ * The schema acceptance test (Task 5). Two things are load-bearing here and
+ * must be proven against a real Postgres, not merely trusted from the DDL:
+ *
+ * 1. The desired-state row (`component_target_desired`, §6/§12) actually
+ *    carries a UNIQUE constraint on `(component_id, target_id)` — checked
+ *    against the catalog, and then by trying to violate it.
+ * 2. `SELECT ... FOR UPDATE` on that row genuinely blocks a second
+ *    transaction. This is proven with two independent connections and a
+ *    timeout race — a test that would pass even if the lock did nothing is
+ *    not a test of the lock.
+ *
+ * Each test runs in its own migrated Postgres schema, handed out by the
+ * harness (`test/harness/db.ts`), so this file can run beside any other
+ * without either seeing the other's rows.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  apps,
+  components,
+  componentTargetDesired,
+  configItems,
+  PINNED_ENVIRONMENT,
+  targets,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+
+/** Insert the App -> Component -> Target chain a desired-state row needs. */
+async function seedPlacement() {
+  const [app] = await database()
+    .db.insert(apps)
+    .values({ name: `app-${crypto.randomUUID()}`, sourceKind: 'repo' })
+    .returning();
+  const [target] = await database()
+    .db.insert(targets)
+    .values({
+      name: `target-${crypto.randomUUID()}`,
+      adapter: 'kubernetes',
+      rank: 0,
+    })
+    .returning();
+  const [component] = await database()
+    .db.insert(components)
+    .values({ appId: app!.id, name: 'web', kind: 'service' })
+    .returning();
+  return { app: app!, component: component!, target: target! };
+}
+
+describe('component_target_desired: the unique key', () => {
+  test('exists in the catalog as a UNIQUE constraint on (component_id, target_id)', async () => {
+    // One row per (constraint, column) — grouped in JS rather than with
+    // `array_agg`, whose Postgres array-literal result (`{a,b}`) is not a JS
+    // array and would make the shape assertion below lie.
+    const isolated = database();
+    const rows = await isolated.client<
+      { constraintName: string; columnName: string }[]
+    >`
+      SELECT tc.constraint_name AS "constraintName",
+             kcu.column_name AS "columnName"
+      FROM information_schema.table_constraints tc
+      JOIN information_schema.key_column_usage kcu
+        ON tc.constraint_name = kcu.constraint_name
+       AND tc.table_schema = kcu.table_schema
+      WHERE tc.table_schema = ${isolated.schema}
+        AND tc.table_name = 'component_target_desired'
+        AND tc.constraint_type = 'UNIQUE'
+    `;
+
+    const byConstraint = new Map<string, string[]>();
+    for (const row of rows) {
+      const columns = byConstraint.get(row.constraintName) ?? [];
+      columns.push(row.columnName);
+      byConstraint.set(row.constraintName, columns);
+    }
+
+    const pairConstraint = [...byConstraint.values()].find(
+      (columns) => columns.sort().join(',') === 'component_id,target_id',
+    );
+    expect(pairConstraint).toBeDefined();
+  });
+
+  test('rejects a second row for the same (component_id, target_id)', async () => {
+    const { component, target } = await seedPlacement();
+
+    await database()
+      .db.insert(componentTargetDesired)
+      .values({ componentId: component.id, targetId: target.id });
+
+    // Drizzle's query builder is thenable but not a real `Promise`
+    // instance; `expect(...).rejects` needs the latter.
+    await expect(
+      Promise.resolve(
+        database()
+          .db.insert(componentTargetDesired)
+          .values({ componentId: component.id, targetId: target.id }),
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+describe('component_target_desired: the locking read', () => {
+  test('SELECT ... FOR UPDATE blocks a second concurrent transaction', async () => {
+    const { component, target } = await seedPlacement();
+    const [desired] = await database()
+      .db.insert(componentTargetDesired)
+      .values({ componentId: component.id, targetId: target.id })
+      .returning();
+
+    // Two independent connections, not two checkouts sharing a pool's
+    // notion of "the same" transaction — each one is its own real session.
+    const holder = database().connect();
+    const contender = database().connect();
+
+    let lockAcquired: () => void;
+    const lockAcquiredPromise = new Promise<void>((resolve) => {
+      lockAcquired = resolve;
+    });
+    let releaseHold: () => void;
+    const releaseHoldPromise = new Promise<void>((resolve) => {
+      releaseHold = resolve;
+    });
+
+    const holderTx = holder.begin(async (tx) => {
+      await tx`
+        SELECT * FROM component_target_desired WHERE id = ${desired!.id} FOR UPDATE
+      `;
+      lockAcquired();
+      await releaseHoldPromise;
+    });
+
+    await lockAcquiredPromise;
+
+    const contenderAttempt = contender.begin(async (tx) => {
+      await tx`
+        SELECT * FROM component_target_desired WHERE id = ${desired!.id} FOR UPDATE
+      `;
+      return 'acquired' as const;
+    });
+
+    const raceResult = await Promise.race([
+      contenderAttempt.then(() => 'acquired' as const),
+      new Promise<'timeout'>((resolve) =>
+        setTimeout(() => resolve('timeout'), 1000),
+      ),
+    ]);
+
+    // The assertion that matters: the second transaction did NOT get the
+    // row inside the timeout window, because the first still holds it.
+    expect(raceResult).toBe('timeout');
+
+    releaseHold!();
+    await holderTx;
+    // Now that the lock is released, the contender's own attempt resolves.
+    await expect(contenderAttempt).resolves.toBe('acquired');
+
+    await holder.close();
+    await contender.close();
+  });
+});
+
+describe('config_items: the pinned environment', () => {
+  test('defaults new rows to the pinned environment', async () => {
+    const { component, target } = await seedPlacement();
+    const [item] = await database()
+      .db.insert(configItems)
+      .values({ componentId: component.id, targetId: target.id, key: 'PORT' })
+      .returning();
+    expect(item!.environment).toBe(PINNED_ENVIRONMENT);
+  });
+
+  test('the pin is a database constraint, not just an app default', async () => {
+    const { component, target } = await seedPlacement();
+    await expect(
+      Promise.resolve(
+        database().db.insert(configItems).values({
+          componentId: component.id,
+          targetId: target.id,
+          key: 'PORT',
+          environment: 'staging',
+        }),
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/spindrift/test/domain/attempt-log.test.ts
+++ b/apps/spindrift/test/domain/attempt-log.test.ts
@@ -1,0 +1,295 @@
+/**
+ * The attempt log acceptance test (Task 11, §6).
+ *
+ * Three things load-bearing here, proven against a real Postgres:
+ *
+ * 1. A Build's failure and the Deploy that followed it land on **one**
+ *    ordered stream, in the order they actually happened — the shape of
+ *    §6's own worked example: a build failure vs. `ARTIFACT_UNAVAILABLE`
+ *    on a green build, told on one timeline.
+ * 2. Every status event's `blame` is exactly what the deploy contract's
+ *    `BLAME` table assigns its `reason` — never independently supplied.
+ * 3. The resume cursor is gap-free and duplicate-free: reading, then
+ *    resuming from the returned cursor, yields exactly the events written
+ *    after it.
+ *
+ * Each test runs in its own migrated Postgres schema, handed out by the
+ * harness (`test/harness/db.ts`).
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  BLAME,
+  type FailureReason,
+} from '../../src/adapters/deploy/contract.ts';
+import {
+  apps,
+  builds,
+  components,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import {
+  type AttemptLogCursor,
+  readAttemptStream,
+  recordBuildEvent,
+  recordDeployEvent,
+} from '../../src/domain/attempt-log.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+
+/** Seed an App -> Component -> Target -> Build -> Deploy chain. */
+async function seedAttempt() {
+  const [app] = await database()
+    .db.insert(apps)
+    .values({ name: `app-${crypto.randomUUID()}`, sourceKind: 'repo' })
+    .returning();
+  const [target] = await database()
+    .db.insert(targets)
+    .values({
+      name: `target-${crypto.randomUUID()}`,
+      adapter: 'kubernetes',
+      rank: 0,
+    })
+    .returning();
+  const [component] = await database()
+    .db.insert(components)
+    .values({
+      appId: app!.id,
+      name: `web-${crypto.randomUUID()}`,
+      kind: 'service',
+    })
+    .returning();
+  const [build] = await database()
+    .db.insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'deadbeef',
+      targetShape: 'kubernetes:image',
+      artifactType: 'image',
+    })
+    .returning();
+  const [deploy] = await database()
+    .db.insert(deploys)
+    .values({
+      componentId: component!.id,
+      targetId: target!.id,
+      buildId: build!.id,
+    })
+    .returning();
+
+  return {
+    app: app!,
+    component: component!,
+    target: target!,
+    build: build!,
+    deploy: deploy!,
+  };
+}
+
+describe('attempt log: one stream across build and deploy', () => {
+  test('a build failure and a deploy failure land on one ordered stream, in order', async () => {
+    const { app, component, build, deploy } = await seedAttempt();
+
+    // Build leg: a log line, then the failing status.
+    await recordBuildEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, buildId: build.id },
+      { type: 'log', line: 'Step 3/5: RUN bun test' },
+    );
+    await recordBuildEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, buildId: build.id },
+      { type: 'status', phase: 'FAILED', reason: 'BUILD_FAILED' },
+    );
+
+    // Deploy leg for the *same* attempt: a later status event.
+    await recordDeployEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, deployId: deploy.id },
+      { type: 'status', phase: 'PENDING' },
+    );
+    await recordDeployEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, deployId: deploy.id },
+      {
+        type: 'status',
+        phase: 'FAILED',
+        resource: 'helmrelease/web',
+        reason: 'ARTIFACT_UNAVAILABLE',
+      },
+    );
+
+    const page = await readAttemptStream(database().db, {
+      componentId: component.id,
+      buildId: build.id,
+      deployId: deploy.id,
+    });
+
+    expect(page.entries).toHaveLength(4);
+    // Ordered exactly as written: build log, build status, deploy status,
+    // deploy status — one stream, not two concatenated after the fact.
+    expect(page.entries.map((e) => e.attemptKind)).toEqual([
+      'build',
+      'build',
+      'deploy',
+      'deploy',
+    ]);
+    expect(page.entries[0]).toMatchObject({
+      type: 'log',
+      line: 'Step 3/5: RUN bun test',
+    });
+    expect(page.entries[1]).toMatchObject({
+      type: 'status',
+      phase: 'FAILED',
+      reason: 'BUILD_FAILED',
+    });
+    expect(page.entries[2]).toMatchObject({ type: 'status', phase: 'PENDING' });
+    expect(page.entries[3]).toMatchObject({
+      type: 'status',
+      phase: 'FAILED',
+      reason: 'ARTIFACT_UNAVAILABLE',
+      resource: 'helmrelease/web',
+    });
+
+    // Cursors strictly increase — the total order the read side promises.
+    const cursors = page.entries.map((e) => e.cursor);
+    expect(cursors).toEqual([...cursors].sort((a, b) => a - b));
+    expect(new Set(cursors).size).toBe(4);
+  });
+
+  test('a build-only attempt (no deploy yet) reads just the build leg', async () => {
+    const { app, component, build } = await seedAttempt();
+
+    await recordBuildEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, buildId: build.id },
+      { type: 'log', line: 'building...' },
+    );
+
+    const page = await readAttemptStream(database().db, {
+      componentId: component.id,
+      buildId: build.id,
+    });
+
+    expect(page.entries).toHaveLength(1);
+    expect(page.entries[0]).toMatchObject({
+      attemptKind: 'build',
+      type: 'log',
+      line: 'building...',
+    });
+  });
+});
+
+describe('attempt log: blame is derived, never independently supplied', () => {
+  test('every FailureReason in the shared table produces exactly its stamped blame', async () => {
+    const { app, component, deploy } = await seedAttempt();
+
+    const reasons = Object.keys(BLAME) as FailureReason[];
+    for (const reason of reasons) {
+      await recordDeployEvent(
+        database().db,
+        { appId: app.id, componentId: component.id, deployId: deploy.id },
+        { type: 'status', phase: 'FAILED', reason },
+      );
+    }
+
+    const page = await readAttemptStream(database().db, {
+      componentId: component.id,
+      buildId: deploy.buildId,
+      deployId: deploy.id,
+    });
+
+    const byReason = new Map(
+      page.entries
+        .filter(
+          (e): e is Extract<typeof e, { type: 'status' }> =>
+            e.type === 'status',
+        )
+        .map((e) => [e.reason, e.blame]),
+    );
+
+    for (const reason of reasons) {
+      expect(byReason.get(reason)).toBe(BLAME[reason]);
+    }
+  });
+
+  test('the write API never accepts a caller-supplied blame (closed at the type level)', () => {
+    // AttemptLogEvent's status arm has no `blame` field; this is a
+    // compile-time property, asserted here by construction rather than by
+    // reflection, since TypeScript has nothing to introspect at runtime.
+    const event: import('../../src/domain/attempt-log.ts').AttemptLogEvent = {
+      type: 'status',
+      phase: 'FAILED',
+      reason: 'TIMEOUT',
+    };
+    expect('blame' in event).toBe(false);
+  });
+});
+
+describe('attempt log: resume cursor', () => {
+  test('resuming from a cursor yields exactly the events written after it — no gap, no duplicate', async () => {
+    const { app, component, build } = await seedAttempt();
+
+    await recordBuildEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, buildId: build.id },
+      { type: 'log', line: 'line 1' },
+    );
+    await recordBuildEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, buildId: build.id },
+      { type: 'log', line: 'line 2' },
+    );
+
+    const first = await readAttemptStream(database().db, {
+      componentId: component.id,
+      buildId: build.id,
+    });
+    expect(first.entries.map((e) => (e as { line: string }).line)).toEqual([
+      'line 1',
+      'line 2',
+    ]);
+    const cursor = first.cursor as AttemptLogCursor;
+
+    // Nothing new yet: resuming from the tip cursor is an empty, gap-free page.
+    const empty = await readAttemptStream(
+      database().db,
+      { componentId: component.id, buildId: build.id },
+      { after: cursor },
+    );
+    expect(empty.entries).toHaveLength(0);
+    expect(empty.cursor).toBe(cursor);
+
+    await recordBuildEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, buildId: build.id },
+      { type: 'log', line: 'line 3' },
+    );
+    await recordBuildEvent(
+      database().db,
+      { appId: app.id, componentId: component.id, buildId: build.id },
+      { type: 'log', line: 'line 4' },
+    );
+
+    const resumed = await readAttemptStream(
+      database().db,
+      { componentId: component.id, buildId: build.id },
+      { after: cursor },
+    );
+    expect(resumed.entries.map((e) => (e as { line: string }).line)).toEqual([
+      'line 3',
+      'line 4',
+    ]);
+
+    // The union of the two resumed reads equals a from-scratch read: no gap
+    // (line 3/4 missing) and no duplicate (line 1/2 repeated).
+    const fullReplay = await readAttemptStream(database().db, {
+      componentId: component.id,
+      buildId: build.id,
+    });
+    expect(fullReplay.entries.map((e) => (e as { line: string }).line)).toEqual(
+      ['line 1', 'line 2', 'line 3', 'line 4'],
+    );
+  });
+});

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -118,8 +118,17 @@ const QUOTED = /['"`]([^'"`\n]{6,30})['"`]/g;
 function findProjectIds(files: SourceFile[]): string[] {
   const offenders: string[] = [];
   for (const file of files) {
-    for (const [, value] of scannable(file).matchAll(QUOTED)) {
+    const source = scannable(file);
+    // A package name is not an identity. `drizzle-orm` and `bun-sql` wear the
+    // same shape as a project id, so the file's own import specifiers are
+    // exempt — and an import that names something it should not is the other
+    // scanner's finding, not this one's.
+    const imported = new Set(
+      importSpecifiers(source).flatMap((specifier) => specifier.split('/')),
+    );
+    for (const [, value] of source.matchAll(QUOTED)) {
       if (!value || PROJECT_ID_ALLOWLIST.has(value)) continue;
+      if (imported.has(value)) continue;
       if (value.includes('/') || value.includes('.')) continue;
       if (PROJECT_ID.test(value) && NOT_A_WORD.test(value)) {
         offenders.push(`${file.path}: '${value}'`);
@@ -133,18 +142,21 @@ const FROM_IMPORT =
   /(?:^|\s)(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/gm;
 const BARE_IMPORT = /(?:^|\s)import\s*['"]([^'"]+)['"]/gm;
 
+/** Every module specifier a source imports, in either form. */
+function importSpecifiers(source: string): string[] {
+  return [
+    ...[...source.matchAll(FROM_IMPORT)].map((m) => m[1]),
+    ...[...source.matchAll(BARE_IMPORT)].map((m) => m[1]),
+  ].filter((s): s is string => s !== undefined);
+}
+
 /** Imports that reach outside the package or outside its declared dependencies. */
 function findForeignImports(files: SourceFile[]): string[] {
   const offenders: string[] = [];
   for (const file of files) {
     if (!/\.[jt]sx?$/.test(file.path)) continue;
     const source = stripComments(file.source);
-    const specifiers = [
-      ...[...source.matchAll(FROM_IMPORT)].map((m) => m[1]),
-      ...[...source.matchAll(BARE_IMPORT)].map((m) => m[1]),
-    ].filter((s): s is string => s !== undefined);
-
-    for (const specifier of specifiers) {
+    for (const specifier of importSpecifiers(source)) {
       const where = `${file.path}: '${specifier}'`;
       if (specifier.startsWith('.')) {
         const resolved = join(APP, file.path, '..', specifier);
@@ -275,6 +287,12 @@ describe('the scanners catch a deliberately dirty file', () => {
     ]) {
       expect(findProjectIds(dirty(source, 'src/dirty.tsx')).length).toBe(1);
     }
+  });
+
+  test('but not a package name wearing the same shape', () => {
+    expect(
+      findProjectIds(dirty("import { drizzle } from 'drizzle-orm/bun-sql';")),
+    ).toEqual([]);
   });
 
   test('a project id in a comment', () => {

--- a/apps/spindrift/test/harness/db.ts
+++ b/apps/spindrift/test/harness/db.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-test database isolation (Task 7).
+ *
+ * § Testing: "Tests must be deterministic and offline — no cluster, no cloud
+ * project, no network. **The only external process is Postgres**, because the
+ * concurrency design is a claim about transactions and a fake store cannot
+ * falsify it." Real Postgres is therefore not negotiable, which makes isolation
+ * the harness's whole job: a suite that resets a shared schema at file scope
+ * cannot be run beside anything, and the claims §6 makes about locking reads and
+ * serialized deploys are exactly the claims two tests racing each other would
+ * corrupt.
+ *
+ * The lever is a **Postgres schema per test**, created, migrated, and dropped
+ * around each one, reached over a connection whose `search_path` names only that
+ * schema. Nothing is qualified in application code — `src/db/schema.ts` declares
+ * bare `pgTable`s — so the same Drizzle queries land in whichever schema the
+ * session points at, and a row written by one test is not on any path the next
+ * one searches.
+ *
+ * **What drizzle-kit's DDL forced.** The generated migration schema-qualifies
+ * every `CREATE TYPE` and every foreign-key `REFERENCES` to `"public"`, e.g.
+ * `CREATE TYPE "public"."app_source_kind" AS ENUM(...)`. A qualified name ignores
+ * `search_path` entirely, so replaying the file as written would put all sixteen
+ * enums in `public` — colliding on the second test — while the tables landed in
+ * the isolated schema. Hence {@link migrationStatements}: the committed SQL is
+ * read and its `"public".` qualifier — and only that qualifier, never the bare
+ * word, which also appears as an `exposure_state` value and in the
+ * `public_exposure` column — is rewritten to the test schema. That is a
+ * mechanical rewrite of one token, so what runs is still the committed DDL.
+ *
+ * This is also why `src/db/migrate.ts` is not used here: `drizzle-orm`'s migrator
+ * reads a folder and applies it verbatim, with no seam to rewrite through.
+ */
+
+import { afterEach, beforeEach } from 'bun:test';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { SQL } from 'bun';
+import {
+  createClient,
+  createDb,
+  type Database,
+  databaseUrl,
+} from '../../src/db/client.ts';
+
+const MIGRATIONS = join(import.meta.dir, '../../src/db/migrations');
+
+/** drizzle-kit writes one statement per breakpoint, not per semicolon. */
+const BREAKPOINT = '--> statement-breakpoint';
+
+/**
+ * The qualifier drizzle-kit bakes into `CREATE TYPE` and `REFERENCES`. Matched
+ * with its quotes and trailing dot so the bare word `public` — a legitimate
+ * `exposure_state` value and part of the `public_exposure` column name — is
+ * untouched.
+ */
+const QUALIFIER = '"public".';
+
+/** The committed migrations, in filename order, rewritten to target `schema`. */
+async function migrationStatements(schema: string): Promise<string[]> {
+  const files = (await readdir(MIGRATIONS))
+    .filter((name) => name.endsWith('.sql'))
+    .sort();
+  const statements: string[] = [];
+  for (const file of files) {
+    const sql = await Bun.file(join(MIGRATIONS, file)).text();
+    for (const statement of sql.split(BREAKPOINT)) {
+      const trimmed = statement.replaceAll(QUALIFIER, `"${schema}".`).trim();
+      if (trimmed.length > 0) statements.push(trimmed);
+    }
+  }
+  return statements;
+}
+
+/**
+ * A schema name that is a legal bare identifier and cannot collide with another
+ * test's — the isolation claim rests on the name being unguessable, not on a
+ * counter that resets when a second process starts.
+ */
+function schemaName(): string {
+  return `spindrift_test_${crypto.randomUUID().replaceAll('-', '')}`;
+}
+
+/**
+ * A connection string pointing every session in the pool at one schema.
+ *
+ * The `options` startup parameter travels in the connection handshake, so it
+ * applies to every connection the pool opens — a bare `SET search_path` would
+ * only bind whichever connection happened to run it. `public` is deliberately
+ * *not* on the path: leaving it there would let a query for a table this schema
+ * is missing silently find one next door, which is the failure the isolation
+ * exists to make impossible.
+ */
+function schemaUrl(schema: string): string {
+  const url = new URL(databaseUrl());
+  url.searchParams.set('options', `-c search_path=${schema}`);
+  return url.toString();
+}
+
+/** One test's private, migrated schema. */
+export interface IsolatedDatabase {
+  /** The Postgres schema every session below is pinned to. */
+  readonly schema: string;
+  /** Drizzle over the primary connection — what a command context takes. */
+  readonly db: Database;
+  /** The primary connection, for catalog queries and raw SQL. */
+  readonly client: SQL;
+  /**
+   * A second, independent session into the same schema. §6's locking read can
+   * only be proven by two real sessions contending, so the harness hands them
+   * out rather than leaving a test to rebuild the connection string.
+   */
+  connect(): SQL;
+  /** Close every session handed out and drop the schema. */
+  close(): Promise<void>;
+}
+
+/**
+ * Create, migrate, and hand back one private schema.
+ *
+ * Callers that want it around every test should use {@link withIsolatedDatabase};
+ * this is the form for a test that wants two of them at once, which is what the
+ * isolation proof itself needs.
+ */
+export async function createIsolatedDatabase(): Promise<IsolatedDatabase> {
+  const schema = schemaName();
+
+  const admin = createClient();
+  await admin.unsafe(`CREATE SCHEMA "${schema}"`);
+  await admin.close();
+
+  const url = schemaUrl(schema);
+  const opened: SQL[] = [];
+  const connect = (): SQL => {
+    const client = createClient({ DATABASE_URL: url });
+    opened.push(client);
+    return client;
+  };
+
+  const client = connect();
+  for (const statement of await migrationStatements(schema)) {
+    await client.unsafe(statement);
+  }
+
+  return {
+    schema,
+    client,
+    db: createDb(client),
+    connect,
+    async close() {
+      for (const open of opened) await open.close();
+      const dropper = createClient();
+      await dropper.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
+      await dropper.close();
+    },
+  };
+}
+
+/**
+ * A fresh migrated schema before every test in the enclosing scope, dropped
+ * after it.
+ *
+ * Returns an accessor rather than a value because the value does not exist yet
+ * when the file is read: `const database = withIsolatedDatabase()` at the top of a
+ * file, `database().db` inside a test.
+ */
+export function withIsolatedDatabase(): () => IsolatedDatabase {
+  let current: IsolatedDatabase | null = null;
+
+  beforeEach(async () => {
+    current = await createIsolatedDatabase();
+  });
+
+  afterEach(async () => {
+    const finished = current;
+    current = null;
+    await finished?.close();
+  });
+
+  return () => {
+    if (!current) {
+      throw new Error(
+        'withIsolatedDatabase() was read outside a test — call the accessor ' +
+          'inside a test body, not at file scope',
+      );
+    }
+    return current;
+  };
+}

--- a/apps/spindrift/test/harness/fakes/build-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/build-adapter.ts
@@ -1,0 +1,120 @@
+/**
+ * A fake build route (Task 7).
+ *
+ * § Testing: **"Fake the far side, not our side."** This is the builder that is
+ * not there. It records the {@link BuildSource} and {@link BuildSpec} it was
+ * handed — so a test can assert that the bundle digest reached the route, which
+ * is §16's whole join — and replays a scripted result.
+ */
+import type {
+  BuildAdapter,
+  BuildEvent,
+  BuildLevel,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+  LogFidelity,
+} from '../../../src/adapters/build/contract.ts';
+
+/** What the fake was asked to build, in order. */
+export interface RecordedBuild {
+  source: BuildSource;
+  spec: BuildSpec;
+}
+
+/** One scripted build: what to yield along the way, and how it ends. */
+export interface ScriptedBuild {
+  events?: readonly BuildEvent[];
+  /**
+   * The result, minus the bookkeeping the fake fills in itself: `logs` names
+   * this route, and a green build echoes the bundle digest it was given, since
+   * a route that cannot do that cannot produce a joinable provenance (§16).
+   */
+  result:
+    | { status: 'SUCCEEDED'; digest?: string; baseDigest?: string | null }
+    | {
+        status: 'FAILED';
+        reason: BuildResultFailure['reason'];
+        detail?: string;
+      };
+}
+
+type BuildResultFailure = Extract<BuildResult, { status: 'FAILED' }>;
+
+export interface FakeBuildAdapterOptions {
+  name?: string;
+  logFidelity?: LogFidelity;
+  buildLevel?: BuildLevel;
+  script?: readonly ScriptedBuild[];
+}
+
+const DEFAULT_BUILD: ScriptedBuild = { result: { status: 'SUCCEEDED' } };
+
+export class FakeBuildAdapter implements BuildAdapter {
+  readonly name: string;
+  readonly logFidelity: LogFidelity;
+  readonly buildLevel: BuildLevel;
+
+  /** Every `build`, in call order. */
+  readonly built: RecordedBuild[] = [];
+
+  private readonly script: readonly ScriptedBuild[];
+  private builds = 0;
+
+  constructor(options: FakeBuildAdapterOptions = {}) {
+    this.name = options.name ?? 'fake';
+    this.logFidelity = options.logFidelity ?? 'LIVE_TEXT';
+    this.buildLevel = options.buildLevel ?? 2;
+    this.script = options.script?.length ? options.script : [DEFAULT_BUILD];
+  }
+
+  async *build(
+    source: BuildSource,
+    spec: BuildSpec,
+  ): AsyncGenerator<BuildEvent, BuildResult, void> {
+    this.built.push({ source, spec });
+
+    const scripted = this.nextBuild();
+    for (const event of scripted.events ?? []) yield event;
+
+    const logs = { backend: this.name, fidelity: this.logFidelity } as const;
+
+    if (scripted.result.status === 'FAILED') {
+      return {
+        status: 'FAILED',
+        artifact: null,
+        logs,
+        provenance: null,
+        baseDigest: null,
+        reason: scripted.result.reason,
+        ...(scripted.result.detail === undefined
+          ? {}
+          : { detail: scripted.result.detail }),
+      };
+    }
+
+    return {
+      status: 'SUCCEEDED',
+      artifact: {
+        type: spec.artifactType,
+        digest: scripted.result.digest ?? `sha256:${this.name}-${this.builds}`,
+        refs: [`${spec.destination}@${scripted.result.digest ?? 'fake'}`],
+      },
+      logs,
+      provenance: {
+        // Echoed, never invented: this is the join §16 asks a route for.
+        bundleDigest: source.bundleDigest,
+        claimedLevel: this.buildLevel,
+        statement: { fake: true },
+      },
+      baseDigest: scripted.result.baseDigest ?? null,
+    };
+  }
+
+  /** The last scripted build repeats once the script is exhausted. */
+  private nextBuild(): ScriptedBuild {
+    const index = Math.min(this.builds, this.script.length - 1);
+    this.builds += 1;
+    return this.script[index] ?? DEFAULT_BUILD;
+  }
+}

--- a/apps/spindrift/test/harness/fakes/deploy-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/deploy-adapter.ts
@@ -1,0 +1,127 @@
+/**
+ * A fake deploy backend (Task 7).
+ *
+ * § Testing: **"Fake the far side, not our side."** This sits exactly at the
+ * adapter contract — it is the cluster that is not there, never a stand-in for
+ * anything inside core. Core runs for real against it.
+ *
+ * It does two things a real backend cannot be asked to do on demand: it
+ * **records** the {@link DesiredState} it was handed, so a test can assert what
+ * core described, and it **replays a scripted verdict sequence**, so a test can
+ * drive any phase progression or failure reason §6 names without arranging a
+ * real cluster to misbehave.
+ */
+import type {
+  DeployAdapter,
+  DeployEvent,
+  DeployRef,
+  DeployTarget,
+  DeployVerdict,
+  ObservedState,
+} from '../../../src/adapters/deploy/contract.ts';
+import type { TargetAdapter } from '../../../src/config/manifest.schema.ts';
+import type {
+  ArtifactType,
+  DesiredState,
+} from '../../../src/domain/desired-state.ts';
+
+/** One scripted attempt: what to yield along the way, and how it ends. */
+export interface ScriptedAttempt {
+  events?: readonly DeployEvent[];
+  verdict: DeployVerdict;
+}
+
+/** What the fake was asked to do, in order. */
+export interface RecordedApply {
+  target: DeployTarget;
+  desired: DesiredState;
+}
+
+export interface FakeDeployAdapterOptions {
+  adapter?: TargetAdapter;
+  artifactTypes?: readonly ArtifactType[];
+  /**
+   * One entry per `apply` call. When the script runs out the fake keeps
+   * replaying its last entry rather than throwing, so a test that only cares
+   * about the first attempt does not have to script the rest.
+   */
+  script?: readonly ScriptedAttempt[];
+}
+
+/** A clock the fake stamps events with, so a test's assertions stay stable. */
+const AT = new Date('2000-01-01T00:00:00.000Z');
+
+const DEFAULT_ATTEMPT: ScriptedAttempt = {
+  verdict: { phase: 'LIVE', ref: 'fake-deploy-1' },
+};
+
+export class FakeDeployAdapter implements DeployAdapter {
+  readonly adapter: TargetAdapter;
+  readonly artifactTypes: readonly ArtifactType[];
+
+  /** Every `apply`, in call order — the assertion surface §Testing asks for. */
+  readonly applied: RecordedApply[] = [];
+  /** Every `destroy`, including the repeats that prove idempotence. */
+  readonly destroyed: DeployRef[] = [];
+
+  private readonly script: readonly ScriptedAttempt[];
+  private attempts = 0;
+  /** What `apply` placed, so `observe` can report it back (§6). */
+  private readonly placed = new Map<DeployRef, ObservedState>();
+
+  constructor(options: FakeDeployAdapterOptions = {}) {
+    this.adapter = options.adapter ?? 'kubernetes';
+    this.artifactTypes = options.artifactTypes ?? ['image'];
+    this.script = options.script?.length ? options.script : [DEFAULT_ATTEMPT];
+  }
+
+  async *apply(
+    target: DeployTarget,
+    desired: DesiredState,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    this.applied.push({ target, desired });
+
+    // An artifact type this backend never declared is a core bug, and §6 says
+    // so in the adapter's own vocabulary rather than by throwing.
+    if (!this.artifactTypes.includes(desired.artifact.type)) {
+      const verdict: DeployVerdict = {
+        phase: 'FAILED',
+        reason: 'INTERNAL',
+        detail: `${this.adapter} does not accept a ${desired.artifact.type} artifact`,
+      };
+      yield { type: 'status', at: AT, phase: 'FAILED', reason: 'INTERNAL' };
+      return verdict;
+    }
+
+    const attempt = this.nextAttempt();
+    for (const event of attempt.events ?? []) yield event;
+
+    if (attempt.verdict.phase === 'LIVE') {
+      this.placed.set(attempt.verdict.ref, {
+        ref: attempt.verdict.ref,
+        phase: 'LIVE',
+        artifactDigest: desired.artifact.digest,
+      });
+    }
+    return attempt.verdict;
+  }
+
+  async observe(
+    _target: DeployTarget,
+    ref: DeployRef,
+  ): Promise<ObservedState | null> {
+    return this.placed.get(ref) ?? null;
+  }
+
+  async destroy(_target: DeployTarget, ref: DeployRef): Promise<void> {
+    this.destroyed.push(ref);
+    this.placed.delete(ref);
+  }
+
+  /** The last scripted attempt repeats once the script is exhausted. */
+  private nextAttempt(): ScriptedAttempt {
+    const index = Math.min(this.attempts, this.script.length - 1);
+    this.attempts += 1;
+    return this.script[index] ?? DEFAULT_ATTEMPT;
+  }
+}

--- a/apps/spindrift/test/harness/fakes/store-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/store-adapter.ts
@@ -1,0 +1,109 @@
+/**
+ * A fake secret store (Task 7).
+ *
+ * § Testing: **"Fake the far side, not our side."** This is the vault that is
+ * not there. It is constructible under either pinning strategy, because §10
+ * claims the reference `put` returns has the same shape either way and nothing
+ * above the seam can tell which produced it — a claim the conformance suite can
+ * only falsify if both are runnable.
+ *
+ * Values written are held so `put`/`describe` round-trips can be asserted, but
+ * they are never returned across the contract: §10's read-back is metadata, and
+ * the value crosses in one direction only.
+ */
+import type {
+  ConfigScope,
+  PinningStrategy,
+  SecretReference,
+  SecretStore,
+  SecretVersion,
+} from '../../../src/adapters/store/contract.ts';
+import type { StoreAdapter } from '../../../src/config/manifest.schema.ts';
+
+interface StoredVersion {
+  version: SecretVersion;
+  /** Held only so a test can prove what was written; never handed back. */
+  value: string;
+}
+
+export interface FakeSecretStoreOptions {
+  adapter?: StoreAdapter;
+  pinning?: PinningStrategy;
+}
+
+/** The store's own name for a scoped key — the adapter's business, per §10. */
+function itemName(scope: ConfigScope, key: string): string {
+  return `${scope.app}/${scope.component}/${scope.target}/${key}`;
+}
+
+export class FakeSecretStore implements SecretStore {
+  readonly adapter: StoreAdapter;
+  readonly pinning: PinningStrategy;
+
+  /** Every `put`, in call order. */
+  readonly puts: { scope: ConfigScope; key: string }[] = [];
+  /** Every `destroy`, including the repeats that prove idempotence. */
+  readonly destroyed: SecretReference[] = [];
+
+  /** Keyed by the reference's own identity, so a lookup is what a read is. */
+  private readonly stored = new Map<string, StoredVersion>();
+  private counter = 0;
+
+  constructor(options: FakeSecretStoreOptions = {}) {
+    this.adapter = options.adapter ?? 'gcp-secret-manager';
+    this.pinning = options.pinning ?? 'NATIVE';
+  }
+
+  async put(
+    scope: ConfigScope,
+    key: string,
+    value: string,
+  ): Promise<SecretReference> {
+    this.puts.push({ scope, key });
+    this.counter += 1;
+    const sequence = String(this.counter);
+    const item = itemName(scope, key);
+
+    // The two strategies differ in where the version lives, and in nothing
+    // else a caller can observe: NATIVE addresses a version of one item, and
+    // IMMUTABLE_ITEM_PER_VERSION mints a fresh item and reports it as one.
+    const reference: SecretReference =
+      this.pinning === 'NATIVE'
+        ? { key: item, version: sequence }
+        : { key: `${item}@${sequence}`, version: sequence };
+
+    this.stored.set(referenceId(reference), {
+      value,
+      version: { reference, key, createdAt: new Date(this.counter) },
+    });
+    return reference;
+  }
+
+  async describe(reference: SecretReference): Promise<SecretVersion | null> {
+    return this.stored.get(referenceId(reference))?.version ?? null;
+  }
+
+  async versions(scope: ConfigScope, key: string): Promise<SecretVersion[]> {
+    const item = itemName(scope, key);
+    return [...this.stored.values()]
+      .filter(({ version }) => version.reference.key.split('@')[0] === item)
+      .map(({ version }) => version)
+      .sort(
+        (a, b) => Number(b.reference.version) - Number(a.reference.version),
+      );
+  }
+
+  async destroy(reference: SecretReference): Promise<void> {
+    this.destroyed.push(reference);
+    this.stored.delete(referenceId(reference));
+  }
+
+  /** What was written, for a test to assert against. Never a contract verb. */
+  written(reference: SecretReference): string | null {
+    return this.stored.get(referenceId(reference))?.value ?? null;
+  }
+}
+
+function referenceId(reference: SecretReference): string {
+  return `${reference.key}#${reference.version}`;
+}

--- a/apps/spindrift/test/harness/isolation.test.ts
+++ b/apps/spindrift/test/harness/isolation.test.ts
@@ -1,0 +1,79 @@
+/**
+ * The harness's own acceptance test (Task 7): two tests running concurrently
+ * against the same database do not see each other's rows.
+ *
+ * This is the claim the whole harness exists to make, so it is proven the only
+ * way it can be — two isolated schemas alive at once, writing interleaved, each
+ * reading back only its own. A sequential version would pass just as happily
+ * against a harness that reset one shared schema between tests, which is
+ * exactly the design this replaces.
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import { apps } from '../../src/db/schema.ts';
+import { createIsolatedDatabase, type IsolatedDatabase } from './db.ts';
+
+const opened: IsolatedDatabase[] = [];
+
+async function isolated(): Promise<IsolatedDatabase> {
+  const database = await createIsolatedDatabase();
+  opened.push(database);
+  return database;
+}
+
+afterAll(async () => {
+  for (const database of opened) await database.close();
+});
+
+describe('two isolated databases', () => {
+  test('do not see each other’s rows', async () => {
+    const [left, right] = await Promise.all([isolated(), isolated()]);
+
+    expect(left.schema).not.toBe(right.schema);
+
+    // Interleaved on purpose: both schemas are live for the whole exchange, so
+    // nothing here would pass on a harness that merely truncates between tests.
+    await left.db.insert(apps).values({ name: 'left', sourceKind: 'archive' });
+    await right.db
+      .insert(apps)
+      .values({ name: 'right', sourceKind: 'archive' });
+    await left.db
+      .insert(apps)
+      .values({ name: 'left-two', sourceKind: 'archive' });
+
+    const leftRows = await left.db.select({ name: apps.name }).from(apps);
+    const rightRows = await right.db.select({ name: apps.name }).from(apps);
+
+    expect(leftRows.map((row) => row.name).sort()).toEqual([
+      'left',
+      'left-two',
+    ]);
+    expect(rightRows.map((row) => row.name)).toEqual(['right']);
+  });
+
+  test('each carries its own migrated tables, not the ones next door', async () => {
+    const database = await isolated();
+    const [row] = await database.client`
+      SELECT count(*)::int AS tables
+      FROM information_schema.tables
+      WHERE table_schema = ${database.schema}
+    `;
+    // Every table the migration creates, in this schema alone.
+    expect(row.tables).toBeGreaterThan(5);
+  });
+
+  test('a dropped schema takes its rows with it', async () => {
+    const database = await createIsolatedDatabase();
+    await database.db
+      .insert(apps)
+      .values({ name: 'gone', sourceKind: 'archive' });
+    const schema = database.schema;
+    await database.close();
+
+    const [row] = await opened[0]!.client`
+      SELECT count(*)::int AS present
+      FROM information_schema.schemata
+      WHERE schema_name = ${schema}
+    `;
+    expect(row.present).toBe(0);
+  });
+});

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "files": {
+    "includes": ["**", "!**/db/migrations/**"]
+  },
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,7 @@
     "apps/spindrift": {
       "name": "spindrift",
       "dependencies": {
+        "drizzle-orm": "0.45.2",
         "react": "19.2.7",
         "react-dom": "19.2.7",
         "zod": "4.4.3",
@@ -119,6 +120,7 @@
         "@types/bun": "1.3.14",
         "@types/react": "19.2.17",
         "@types/react-dom": "19.2.3",
+        "drizzle-kit": "0.31.10",
         "typescript": "5.9.3",
       },
     },
@@ -238,11 +240,69 @@
 
     "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
 
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.10.2", "", {}, "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w=="],
+
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@esbuild-kit/core-utils": ["@esbuild-kit/core-utils@3.3.2", "", { "dependencies": { "esbuild": "~0.18.20", "source-map-support": "^0.5.21" } }, "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ=="],
+
+    "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 
@@ -824,6 +884,10 @@
 
     "diff": ["diff@4.0.4", "", {}, "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ=="],
 
+    "drizzle-kit": ["drizzle-kit@0.31.10", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "tsx": "^4.21.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw=="],
+
+    "drizzle-orm": ["drizzle-orm@0.45.2", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "prisma": "*", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "prisma", "sql.js", "sqlite3"] }, "sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
@@ -859,6 +923,8 @@
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "es-toolkit": ["es-toolkit@1.49.0", "", {}, "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -923,6 +989,8 @@
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
@@ -1236,6 +1304,8 @@
 
     "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
 
+    "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
+
     "retry-request": ["retry-request@8.0.3", "", { "dependencies": { "extend": "^3.0.2", "teeny-request": "^10.0.0" } }, "sha512-qqoc4kkGgP9cmQDWELlOpAmfgJOg0Yi7MT82ZjiPWu451ayju4itwomjM4/dBEliify8C1b3tSaeCOldugtwPQ=="],
 
     "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
@@ -1338,6 +1408,8 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "tsx": ["tsx@4.23.1", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ=="],
+
     "turbo": ["turbo@2.10.5", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.5", "@turbo/darwin-arm64": "2.10.5", "@turbo/linux-64": "2.10.5", "@turbo/linux-arm64": "2.10.5", "@turbo/windows-64": "2.10.5", "@turbo/windows-arm64": "2.10.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ=="],
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
@@ -1424,6 +1496,8 @@
 
     "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
+    "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
+
     "@img/sharp-wasm32/@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
     "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
@@ -1484,11 +1558,57 @@
 
     "sharp/detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "vaul/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.19", "", { "dependencies": { "@radix-ui/primitive": "1.1.5", "@radix-ui/react-compose-refs": "1.1.3", "@radix-ui/react-context": "1.2.0", "@radix-ui/react-dismissable-layer": "1.1.15", "@radix-ui/react-focus-guards": "1.1.4", "@radix-ui/react-focus-scope": "1.1.12", "@radix-ui/react-id": "1.1.2", "@radix-ui/react-portal": "1.1.13", "@radix-ui/react-presence": "1.1.7", "@radix-ui/react-primitive": "2.1.7", "@radix-ui/react-slot": "1.3.0", "@radix-ui/react-use-controllable-state": "1.2.3", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.7.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg=="],
 
     "vite/postcss": ["postcss@8.5.17", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.18.20", "", { "os": "android", "cpu": "arm64" }, "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.18.20", "", { "os": "android", "cpu": "x64" }, "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.18.20", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.18.20", "", { "os": "darwin", "cpu": "x64" }, "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.18.20", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.18.20", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.18.20", "", { "os": "linux", "cpu": "arm" }, "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.18.20", "", { "os": "linux", "cpu": "arm64" }, "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.18.20", "", { "os": "linux", "cpu": "ia32" }, "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.18.20", "", { "os": "linux", "cpu": "ppc64" }, "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.18.20", "", { "os": "linux", "cpu": "none" }, "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.18.20", "", { "os": "linux", "cpu": "s390x" }, "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.18.20", "", { "os": "linux", "cpu": "x64" }, "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.18.20", "", { "os": "none", "cpu": "x64" }, "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.18.20", "", { "os": "openbsd", "cpu": "x64" }, "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.18.20", "", { "os": "sunos", "cpu": "x64" }, "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.18.20", "", { "os": "win32", "cpu": "arm64" }, "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.18.20", "", { "os": "win32", "cpu": "ia32" }, "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g=="],
+
+    "@esbuild-kit/core-utils/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1513,6 +1633,58 @@
     "morgan/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "next/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "vaul/@radix-ui/react-dialog/@radix-ui/primitive": ["@radix-ui/primitive@1.1.5", "", {}, "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg=="],
 

--- a/turbo.json
+++ b/turbo.json
@@ -38,6 +38,7 @@
     "test": {
       "dependsOn": ["build"],
       "inputs": ["src/**", "test/**", "package.json"],
+      "env": ["DATABASE_URL"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "typecheck": {


### PR DESCRIPTION
Milestone 0 tasks 5–7 and Milestone 1 tasks 8–12. **No adapter has an implementation, so nothing here deploys anything** — this is the foundation every later milestone is written against.

110 tests, all against a real Postgres.

## What's here

| Task | What landed |
| --- | --- |
| 5 | Drizzle schema, committed `0000_init.sql`, connection, and the schema test |
| 6 | The command layer and its registry |
| 7 | The test harness: schema-per-test isolation and the adapter fakes |
| 8 | Deploy contract and the neutral `DesiredState` |
| 9 | Build contract |
| 10 | Store contract (implementations deferred — see below) |
| 11 | The attempt event log |
| 12 | The adapter conformance suite |

## The load-bearing bits

**The desired-state row.** Unique on `(component_id, target_id)`, and the lock is proven rather than assumed: two independent sessions, the holder takes `SELECT … FOR UPDATE`, the contender loses a one-second race and then acquires once released. A test that would pass with the lock removed is not a test of the lock.

**The command registry** is enforced in both directions at compile time — a command exported without being registered fails `tsc`, and so does a registry key that is not a command. `dispatch()` validates through the registry before any handler runs, so the later browser endpoint is a mechanical wrap with nowhere to put domain logic.

**The conformance suite** fails by name when an adapter is registered without being enrolled in it. Verified by registering a fourth adapter and watching it go red.

**Schema-per-test isolation.** Every test gets its own migrated Postgres schema. drizzle-kit qualifies `CREATE TYPE` and `REFERENCES` to `"public"`, which ignores `search_path`, so the harness rewrites that one token in the committed DDL — what runs is still the committed migration.

## Decisions worth reviewing

- **Database enums are built from the contracts' own vocabularies.** The first draft had `BUILD_FAILED` in the contract and `build_failed` in Postgres, bridged by a hand-maintained map — and `deploy_phase`, `log_fidelity`, and `build_status` had the same split waiting to be discovered. §6 asks for one shared vocabulary, so the contracts now export const tuples and `schema.ts` builds the pg enums from them. A second spelling is a type error.
- **`builds.id` is `bigserial`, not `uuid`** — §6 says a Build's id *is* the total order, which an unordered id cannot carry.
- **`apply` is an `AsyncGenerator<DeployEvent, DeployVerdict>` and never throws.** A thrown error has no reason and therefore no blame, so a refusal is a `FAILED` verdict.
- **Adapters report a reason, never a blame** — blame is derived in core from the const table, so two adapters cannot disagree about who a failure indicts.
- **`createApp` has no duplicate-name refusal.** `apps` has no unique key on `name`, and a check in the handler alone would be one concurrent request from being false. Better nothing than a check that lies.

## Deviations from the plan

- **Task 11's `0001_attempt_events.sql` does not exist and should not.** Task 5 landed `attempt_events` complete; the plan was written before that was knowable. No migration was manufactured to match the document.
- **Task 10's two store implementations are deferred.** The plan's own dependency note says to build the contract first and the implementations after the suite exists. The suite now exists; they are the next PR, and they are the least-verified assumption in the plan.
- **`.gitignore`'s `build/` rule was silently swallowing `src/adapters/build/contract.ts`.** Caught while staging — the file would have been missing from this PR with everything still green locally. Negated for that one path.

## Validation

`bun run lint`, `bun run typecheck`, `bun test` (110 pass), `bun run build`. Tests need `DATABASE_URL`; CI has the Postgres service from the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7JVtobykFNruQyDBCkQ6M