### PR TITLE
feat(spindrift): deploy apps through Kubernetes operators

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -7,6 +7,7 @@ on:
       - "apps/hub/**"
       - "apps/slingshot/**"
       - "apps/spindrift/**"
+      - "packages/charts/**"
       - "packages/k6/**"
       - "packages/typescript-config/**"
       - "package.json"
@@ -20,6 +21,7 @@ on:
       - "apps/hub/**"
       - "apps/slingshot/**"
       - "apps/spindrift/**"
+      - "packages/charts/**"
       - "packages/k6/**"
       - "packages/typescript-config/**"
       - "package.json"
@@ -72,6 +74,12 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
+      # The App chart's goldens run `helm template` under `bun test`, where the
+      # chart lives (packages/charts).
+      - name: Set up Helm
+        uses: jdx/mise-action@f10502fc09dadecfefb962fff68ce77213930204 # v4.2.2
+        with:
+          install_args: helm
       - name: Install dependencies
         run: bun install --frozen-lockfile
       - name: Lint

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -129,10 +129,31 @@ fails later.
 ## Testing
 
 Tests run against a real Postgres — the concurrency design is a claim about
-transactions, and a fake cannot falsify it. `DATABASE_URL` must point at one:
+transactions, and a fake cannot falsify it. Use `wslc.exe` for service
+containers on WSL and `docker` on macOS:
 
 ```bash
-DATABASE_URL=postgres://postgres@127.0.0.1:5432/spindrift bun test
+## WSL
+wslc.exe run --detach --name spindrift-postgres \
+  --env POSTGRES_USER=postgres \
+  --env POSTGRES_PASSWORD=postgres \
+  --env POSTGRES_DB=spindrift \
+  --publish 127.0.0.1:5432:5432 \
+  postgres:18-alpine
+
+## macOS
+docker run --detach --name spindrift-postgres \
+  --env POSTGRES_USER=postgres \
+  --env POSTGRES_PASSWORD=postgres \
+  --env POSTGRES_DB=spindrift \
+  --publish 127.0.0.1:5432:5432 \
+  postgres:18-alpine
+```
+
+Point `DATABASE_URL` at that container:
+
+```bash
+DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/spindrift bun test
 ```
 
 `test/harness/db.ts` gives every test its own migrated Postgres schema, so tests

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -7,14 +7,15 @@ adapts to whatever builds and delivers underneath — a Kubernetes cluster, Clou
 Run, or static hosting. The design lives in `.agent/plans/spindrift/spec.md`
 (private) and is referenced from the source as `§N`.
 
-**Targets are real, the screens are drawn, nothing deploys yet.** The five nouns
-have tables, the three adapter contracts are written, and commands are the only
-way anything is acted on. Targets can be connected, inspected on a loop, and
-resolved against — asking where a Component can go returns an answer with a
-reason for every Target it cannot. The two secret stores are implemented.
+**Targets are real, the screens are drawn, and Kubernetes delivery works at the
+adapter seam.** The five nouns have tables, the three adapter contracts are
+written, and commands are the only way anything is acted on. Targets can be
+connected, inspected on a loop, and resolved against — asking where a Component
+can go returns an answer with a reason for every Target it cannot. The two
+secret stores and the Kubernetes deploy adapter are implemented.
 
-What has no implementation is every *deploy* adapter — no real cluster, cloud
-runtime, static host, or build route is spoken to — so a Deploy row is still
+What has no implementation is the command that creates a Deploy, the Cloud Run
+and static deploy adapters, and every build route, so a Deploy row is still
 something nothing writes. **The three screens therefore render placeholder
 data** from `src/web/demo/`, which is scaffolding meant to be deleted: the views
 are typed against `src/web/model.ts`, so the query commands that replace it have
@@ -39,7 +40,7 @@ One image, two processes (§19); only `web` exists so far.
 | `src/db/` | the Drizzle schema, the connection, and the committed migrations |
 | `src/commands/` | the application command layer and its registry |
 | `src/domain/` | `DesiredState`, the attempt log, Targets, capabilities, placement |
-| `src/adapters/` | the deploy, build, and store contracts, plus the two stores |
+| `src/adapters/` | the adapter contracts, Kubernetes delivery, and the two stores |
 | `src/reconciler/` | the loop that refreshes Target health and capabilities |
 | `src/web/` | the `web` process — the server, the dispatch surface, and the client |
 | `src/web/ui/` | shadcn primitives, in this installation's palette |

--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -21,6 +21,7 @@
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import type { TargetInspection } from '../../domain/capabilities.ts';
 import type { ArtifactType, DesiredState } from '../../domain/desired-state.ts';
+import type { TargetConnection } from '../../domain/target.ts';
 
 /**
  * What the verbs need to name a Target. The Target model (§13) carries
@@ -33,6 +34,20 @@ export interface DeployTarget {
   readonly name: string;
   /** Exactly one adapter type per Target (§13). */
   readonly adapter: TargetAdapter;
+  /**
+   * How this Target is reached, in its adapter's own terms (§13).
+   *
+   * One adapter instance serves every Target of its type, so the connection
+   * travels with the call rather than with the construction. The alternative —
+   * an adapter per Target held in the registry — would make the registry a
+   * factory over live connection state, and would still have to be rebuilt
+   * whenever an operator reconnected one.
+   *
+   * **Never a credential** (§13: "one auth mode — native OIDC federation,
+   * nothing stored"). What authorizes a call is minted per request by whatever
+   * federates, and is injected when the adapter is constructed.
+   */
+  readonly connection: TargetConnection;
 }
 
 /**

--- a/apps/spindrift/src/adapters/deploy/kubernetes/api.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/api.ts
@@ -1,0 +1,235 @@
+/**
+ * The Kubernetes API, as thin as the adapter needs it.
+ *
+ * § Seam 2 names the pattern: "a fake of the far-side HTTP API behind the real
+ * client, with the test asserting the requests that were made". That only works
+ * if the client takes its transport, so `fetch` is injected and nothing here
+ * reaches for a global.
+ *
+ * There is no client library. §19 already rules out the machinery a library
+ * brings — "no CRD, no informer, no controller-runtime" — and what is left is
+ * four verbs over REST paths. A dependency for that would be a dependency whose
+ * types drift from the four objects this adapter actually writes.
+ *
+ * **Writes are server-side apply.** A `PATCH` with the apply content type makes
+ * Spindrift a named field manager, so a field an operator sets on the same
+ * object is not silently reverted by the next deploy — and re-applying an
+ * unchanged object is a no-op rather than a new generation.
+ */
+
+/** The transport, in the shape `fetch` already has. */
+export type Fetcher = (request: Request) => Promise<Response>;
+
+/** Mints a bearer token per request. Never a stored credential (§13). */
+export type TokenProvider = () => string | Promise<string>;
+
+/** Where a cluster is reached and how a request to it is authorized. */
+export interface KubernetesEndpoint {
+  /** The API server, without a trailing slash. */
+  readonly apiServer: string;
+  readonly token: TokenProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+}
+
+/**
+ * The field manager every write is attributed to.
+ *
+ * A constant rather than a value: two installations sharing a cluster still
+ * want their writes attributed to Spindrift, and a per-installation manager
+ * would make the same object look contended between them.
+ */
+export const FIELD_MANAGER = 'spindrift';
+
+/** A cluster that answered, but not with success. */
+export class KubernetesRequestError extends Error {
+  override readonly name = 'KubernetesRequestError';
+
+  constructor(
+    readonly method: string,
+    readonly url: string,
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`${method} ${url} failed with ${status}: ${body}`);
+  }
+}
+
+/** Any Kubernetes object, as loosely typed as the API's own JSON. */
+export interface KubernetesObject {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/** Where one object lives, in the API's own path vocabulary. */
+export interface ResourceRef {
+  /** `apps/v1`, or `v1` for the core group. */
+  apiVersion: string;
+  /** The lowercase plural, as the path uses it — `helmreleases`, `pods`. */
+  plural: string;
+  namespace?: string;
+  name?: string;
+}
+
+/** The path a ref addresses. Exported because the tests assert on paths. */
+export function resourcePath(ref: ResourceRef): string {
+  const prefix = ref.apiVersion.includes('/')
+    ? `/apis/${ref.apiVersion}`
+    : `/api/${ref.apiVersion}`;
+  const scope =
+    ref.namespace === undefined ? '' : `/namespaces/${ref.namespace}`;
+  const name = ref.name === undefined ? '' : `/${ref.name}`;
+  return `${prefix}${scope}/${ref.plural}${name}`;
+}
+
+/** What a list call returns, of whatever kind was listed. */
+export interface KubernetesList<Item = KubernetesObject> {
+  items: Item[];
+}
+
+export class KubernetesApi {
+  constructor(private readonly endpoint: KubernetesEndpoint) {}
+
+  /** One object, or `null` when the API says it is not there. */
+  async get(ref: ResourceRef): Promise<KubernetesObject | null> {
+    return this.json<KubernetesObject>('GET', resourcePath(ref));
+  }
+
+  /**
+   * Every object matching a ref, or `null` when the *kind* is not served.
+   *
+   * The distinction is the whole reason this returns `null` rather than an
+   * empty list: "no `HelmRelease`s exist" and "this cluster does not know what
+   * a `HelmRelease` is" are different answers, and §13's checklist turns on the
+   * second one.
+   */
+  async list(
+    ref: ResourceRef,
+    query?: Record<string, string>,
+  ): Promise<KubernetesObject[] | null> {
+    const search = query ? `?${new URLSearchParams(query)}` : '';
+    const list = await this.json<KubernetesList>(
+      'GET',
+      `${resourcePath(ref)}${search}`,
+    );
+    return list === null ? null : (list.items ?? []);
+  }
+
+  /**
+   * Server-side apply one object.
+   *
+   * `force` resolves a conflict in Spindrift's favour for the fields Spindrift
+   * owns. Without it a field another manager once set — a replica count edited
+   * by hand, say — would make every subsequent deploy fail with a conflict
+   * instead of converging.
+   */
+  async apply(object: KubernetesObject, plural: string): Promise<void> {
+    const path = resourcePath({
+      apiVersion: object.apiVersion,
+      plural,
+      namespace: object.metadata.namespace,
+      name: object.metadata.name,
+    });
+    await this.send(
+      'PATCH',
+      `${path}?fieldManager=${FIELD_MANAGER}&force=true`,
+      {
+        body: object,
+        contentType: 'application/apply-patch+yaml',
+      },
+    );
+  }
+
+  /**
+   * `POST` one object, for the APIs that answer rather than store.
+   *
+   * `SelfSubjectAccessReview` is the only such call this adapter makes: the
+   * API server replies with what the request's own identity may do, which is
+   * how §13's "OIDC both ways" is checked without holding a credential.
+   */
+  async create(
+    ref: ResourceRef,
+    object: KubernetesObject,
+  ): Promise<KubernetesObject | null> {
+    return this.json<KubernetesObject>('POST', resourcePath(ref), object);
+  }
+
+  /** Idempotent: deleting what is already gone succeeds (§6). */
+  async delete(ref: ResourceRef): Promise<void> {
+    await this.send('DELETE', resourcePath(ref));
+  }
+
+  /** Whether the API serves a kind at all — §13's checklist, one call. */
+  async servesKind(apiVersion: string, kind: string): Promise<boolean> {
+    const path = apiVersion.includes('/')
+      ? `/apis/${apiVersion}`
+      : `/api/${apiVersion}`;
+    const resources = await this.json<{ resources?: { kind: string }[] }>(
+      'GET',
+      path,
+    );
+    return (resources?.resources ?? []).some(
+      (resource) => resource.kind === kind,
+    );
+  }
+
+  private async json<Result>(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<Result | null> {
+    const response = await this.send(
+      method,
+      path,
+      body === undefined ? {} : { body },
+    );
+    if (response === null) return null;
+    return (await response.json()) as Result;
+  }
+
+  private async send(
+    method: string,
+    path: string,
+    options: { body?: unknown; contentType?: string } = {},
+  ): Promise<Response | null> {
+    const url = `${this.endpoint.apiServer}${path}`;
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      Authorization: `Bearer ${await this.endpoint.token()}`,
+    };
+    if (options.body !== undefined) {
+      headers['Content-Type'] = options.contentType ?? 'application/json';
+    }
+
+    const request = new Request(url, {
+      method,
+      headers,
+      body:
+        options.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+
+    const send = this.endpoint.fetch ?? ((input: Request) => fetch(input));
+    const response = await send(request);
+
+    // Absence is an answer every caller here has a value for, so it comes back
+    // rather than being raised.
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new KubernetesRequestError(
+        method,
+        url,
+        response.status,
+        await response.text(),
+      );
+    }
+    return response;
+  }
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/argo-application.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/argo-application.ts
@@ -1,0 +1,166 @@
+/**
+ * The Argo delivery flavour: an `Application`, applied through the API (§6).
+ *
+ * The same shape as the Flux flavour and for the same reason — the Target
+ * declares which operator drives it, and Spindrift writes that operator's own
+ * object rather than manifests to a repository. What differs is only how the
+ * object is spelled and where its verdict is written, which is why both
+ * flavours end at {@link DeliveryStatus} and nothing above them branches.
+ */
+import type { FailureReason } from '../contract.ts';
+import type { KubernetesObject } from './api.ts';
+import type { DeliveryStatus } from './status.ts';
+
+/** The API this flavour writes. */
+export const APPLICATION = {
+  apiVersion: 'argoproj.io/v1alpha1',
+  kind: 'Application',
+  plural: 'applications',
+} as const;
+
+/** What rendering one `Application` needs beyond the values themselves. */
+export interface ApplicationSpec {
+  name: string;
+  /** Namespace the `Application` object lives in — Argo's own. */
+  namespace: string;
+  /** Namespace the release's workloads land in. */
+  destinationNamespace: string;
+  /** The cluster, in Argo's vocabulary. */
+  server: string;
+  project: string;
+  repoUrl: string;
+  revision: string;
+  /** The chart's path inside the repository (§20's manifest value). */
+  path: string;
+  labels: Record<string, string>;
+  values: Record<string, unknown>;
+}
+
+/**
+ * Render the object.
+ *
+ * `syncPolicy.automated.selfHeal` is on because §6 requires every backend to
+ * self-heal *below* the seam — "an adapter never holds a workload up". `prune`
+ * is on for the same reason a `HelmRelease` upgrade removes what it no longer
+ * renders: an object the chart stopped producing is not something a later
+ * deploy should have to know about.
+ *
+ * `CreateNamespace` is deliberately **not** set: the namespace is vessel (§7),
+ * and a sync that created it would make `destroy()` able to remove it.
+ */
+export function argoApplication(spec: ApplicationSpec): KubernetesObject {
+  return {
+    apiVersion: APPLICATION.apiVersion,
+    kind: APPLICATION.kind,
+    metadata: {
+      name: spec.name,
+      namespace: spec.namespace,
+      labels: spec.labels,
+    },
+    spec: {
+      project: spec.project,
+      destination: {
+        server: spec.server,
+        namespace: spec.destinationNamespace,
+      },
+      source: {
+        repoURL: spec.repoUrl,
+        targetRevision: spec.revision,
+        path: spec.path,
+        helm: {
+          releaseName: spec.name,
+          // Argo's inline values, which is the same single blob §7 requires:
+          // a values ConfigMap has no Argo equivalent at all.
+          valuesObject: spec.values,
+        },
+      },
+      syncPolicy: {
+        automated: { prune: true, selfHeal: true },
+      },
+    },
+  };
+}
+
+interface ApplicationStatus {
+  sync?: { status?: string };
+  health?: { status?: string; message?: string };
+  operationState?: { phase?: string; message?: string };
+  conditions?: { type?: string; message?: string }[];
+}
+
+/**
+ * Argo's condition types that are decidable without looking at pods.
+ *
+ * A `Degraded` health is not among them — it says a workload is unhealthy and
+ * not why — so it maps to no reason and the adapter goes and reads (§6).
+ */
+const CONDITION_REASONS: Record<string, FailureReason> = {
+  ComparisonError: 'REJECTED',
+  InvalidSpecError: 'REJECTED',
+  SyncError: 'REJECTED',
+  UnknownError: 'INTERNAL',
+};
+
+/** What the object says is happening, in §6's vocabulary. */
+export function applicationStatus(object: KubernetesObject): DeliveryStatus {
+  const status = object.status as ApplicationStatus | undefined;
+
+  // Nothing has been written yet: Argo has the object but has not synced it.
+  if (status === undefined || status.health?.status === undefined) {
+    return { phase: 'APPLYING' };
+  }
+
+  const failing = (status.conditions ?? []).find(
+    (condition) =>
+      condition.type !== undefined &&
+      CONDITION_REASONS[condition.type] !== undefined,
+  );
+  if (failing !== undefined) {
+    return {
+      phase: 'FAILED',
+      reason: CONDITION_REASONS[failing.type as string],
+      detail: failing.message,
+      debug: { conditions: status.conditions },
+    };
+  }
+
+  const operation = status.operationState?.phase;
+  if (operation === 'Failed' || operation === 'Error') {
+    return {
+      phase: 'FAILED',
+      detail: status.operationState?.message,
+      debug: { operationState: status.operationState },
+    };
+  }
+
+  switch (status.health.status) {
+    case 'Healthy':
+      return status.sync?.status === 'Synced'
+        ? { phase: 'LIVE', detail: status.health.message }
+        : { phase: 'WAITING', detail: status.health.message };
+    case 'Degraded':
+      // Degraded is terminal for the attempt and silent about the cause, which
+      // is precisely the read-on-red case.
+      return {
+        phase: 'FAILED',
+        detail: status.health.message,
+        debug: { health: status.health },
+      };
+    case 'Missing':
+    case 'Progressing':
+    case 'Suspended':
+      return { phase: 'WAITING', detail: status.health.message };
+    default:
+      return { phase: 'WAITING', detail: status.health.message };
+  }
+}
+
+/** The values the Application was applied with, as it still carries them. */
+export function applicationValues(
+  object: KubernetesObject,
+): Record<string, unknown> {
+  const spec = object.spec as
+    | { source?: { helm?: { valuesObject?: Record<string, unknown> } } }
+    | undefined;
+  return spec?.source?.helm?.valuesObject ?? {};
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/diagnose.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/diagnose.ts
@@ -1,0 +1,171 @@
+/**
+ * The read on red (§6).
+ *
+ * "**Spindrift diagnoses on red**: on failure or stall it reads pods and events
+ * (or the cloud log) **once** and fills in the detail. A read on red, not a
+ * continuous watch." Two facts make that read worth doing at all: the delivery
+ * object says a release failed without saying why, and **cluster events expire
+ * in about an hour** — §12 stores the diagnosis precisely because the platform
+ * will not keep it.
+ *
+ * Everything here is one pass over what two API calls returned. There is no
+ * retry, no second look, and no branch that waits: a diagnosis that took time
+ * to gather would be a watch wearing a different name.
+ */
+import type { Blame, FailureReason } from '../contract.ts';
+import { blameFor } from '../contract.ts';
+import type { KubernetesObject } from './api.ts';
+
+/** What one read on red concluded. */
+export interface Diagnosis {
+  readonly reason: FailureReason;
+  readonly blame: Blame | null;
+  /** The sentence the developer reads, in the platform's own words. */
+  readonly detail: string;
+  /** The raw payload, kept for the operator (§6, §12). */
+  readonly debug: unknown;
+}
+
+/** Container-status reasons that mean the artifact never arrived. */
+const ARTIFACT_WAITING = new Set([
+  'ImagePullBackOff',
+  'ErrImagePull',
+  'InvalidImageName',
+  'ImageInspectError',
+  'RegistryUnavailable',
+]);
+
+/** Container-status reasons that mean the artifact arrived and would not run. */
+const STARTUP_WAITING = new Set([
+  'CrashLoopBackOff',
+  'RunContainerError',
+  'CreateContainerConfigError',
+  'CreateContainerError',
+  'StartError',
+]);
+
+/** Event reasons that mean something refused to admit the workload. */
+const REJECTION_EVENTS = new Set([
+  'FailedCreate',
+  'Forbidden',
+  'FailedScheduling',
+  'PolicyViolation',
+  'ExceededQuota',
+]);
+
+interface ContainerStatus {
+  name?: string;
+  ready?: boolean;
+  state?: {
+    waiting?: { reason?: string; message?: string };
+    terminated?: { reason?: string; exitCode?: number; message?: string };
+  };
+}
+
+interface PodEvent {
+  reason?: string;
+  message?: string;
+  type?: string;
+  involvedObject?: { kind?: string; name?: string };
+}
+
+/**
+ * Decide the reason from pods and events.
+ *
+ * The order is the order the evidence is trustworthy in. A container that could
+ * not pull its image is the least ambiguous thing in the list, and it is also
+ * the one where every instinct is wrong — §6 calls `ARTIFACT_UNAVAILABLE` the
+ * hardest justification for `blame` existing, because the build is green and
+ * the developer is about to go and read their own code.
+ */
+export function diagnose(
+  pods: readonly KubernetesObject[],
+  events: readonly KubernetesObject[],
+  fallbackDetail?: string,
+): Diagnosis {
+  const statuses = pods.flatMap((pod) => containerStatuses(pod));
+
+  for (const status of statuses) {
+    const waiting = status.state?.waiting;
+    if (waiting?.reason !== undefined && ARTIFACT_WAITING.has(waiting.reason)) {
+      return conclude(
+        'ARTIFACT_UNAVAILABLE',
+        waiting.message ?? waiting.reason,
+        { pods, events },
+      );
+    }
+  }
+
+  for (const status of statuses) {
+    const waiting = status.state?.waiting;
+    if (waiting?.reason !== undefined && STARTUP_WAITING.has(waiting.reason)) {
+      return conclude('STARTUP_FAILED', waiting.message ?? waiting.reason, {
+        pods,
+        events,
+      });
+    }
+    const terminated = status.state?.terminated;
+    if (terminated !== undefined && (terminated.exitCode ?? 0) !== 0) {
+      return conclude(
+        'STARTUP_FAILED',
+        terminated.message ??
+          `container ${status.name ?? 'app'} exited with ${terminated.exitCode}`,
+        { pods, events },
+      );
+    }
+  }
+
+  const rejection = (events as readonly PodEvent[]).find(
+    (event) => event.reason !== undefined && REJECTION_EVENTS.has(event.reason),
+  );
+  if (rejection !== undefined) {
+    return conclude(
+      'REJECTED',
+      rejection.message ?? (rejection.reason as string),
+      { pods, events },
+    );
+  }
+
+  // Pods exist, none of them is ready, and nothing said why: the workload came
+  // up and never passed readiness, which is exactly `UNHEALTHY` (§6).
+  if (
+    statuses.length > 0 &&
+    statuses.every((status) => status.ready !== true)
+  ) {
+    return conclude(
+      'UNHEALTHY',
+      fallbackDetail ?? 'the workload started but never became ready',
+      { pods, events },
+    );
+  }
+
+  // No pod was ever created. Something between the release and the scheduler
+  // refused it — an admission webhook, a quota, an invalid spec — and §6 puts
+  // all three under one reason.
+  return conclude(
+    'REJECTED',
+    fallbackDetail ?? 'the release produced no pods',
+    { pods, events },
+  );
+}
+
+function conclude(
+  reason: FailureReason,
+  detail: string,
+  debug: unknown,
+): Diagnosis {
+  return { reason, blame: blameFor(reason), detail, debug };
+}
+
+function containerStatuses(pod: KubernetesObject): ContainerStatus[] {
+  const status = pod.status as
+    | {
+        containerStatuses?: ContainerStatus[];
+        initContainerStatuses?: ContainerStatus[];
+      }
+    | undefined;
+  return [
+    ...(status?.initContainerStatuses ?? []),
+    ...(status?.containerStatuses ?? []),
+  ];
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/flux-helmrelease.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/flux-helmrelease.ts
@@ -1,0 +1,180 @@
+/**
+ * The Flux delivery flavour: a `HelmRelease`, applied through the API (§6).
+ *
+ * "The GitOps operator *is* the pluggable machinery, so Spindrift applies a
+ * `HelmRelease` or an Argo `Application` **through the API** — using Flux or
+ * Argo is not the same as writing manifests to git, and only the chart source
+ * lives in a repo." Nothing here writes to a repository, and nothing here
+ * reimplements what the controller does: this module renders one object and
+ * reads one status.
+ *
+ * **The chart is sourced from the Target's own repository**, not from OCI. That
+ * is the plan's deliberate deviation from §7 for v1, and its whole cost is
+ * stated where the prerequisite is checked: a Target without that repository is
+ * a non-candidate, and it is the first thing that breaks on extraction.
+ */
+import type { FailureReason } from '../contract.ts';
+import type { KubernetesObject } from './api.ts';
+import type { DeliveryStatus } from './status.ts';
+
+/** The API this flavour writes. */
+export const HELM_RELEASE = {
+  apiVersion: 'helm.toolkit.fluxcd.io/v2',
+  kind: 'HelmRelease',
+  plural: 'helmreleases',
+} as const;
+
+/** The source object a `HelmRelease` fetches its chart from. */
+export const GIT_REPOSITORY = {
+  apiVersion: 'source.toolkit.fluxcd.io/v1',
+  kind: 'GitRepository',
+  plural: 'gitrepositories',
+} as const;
+
+/** What rendering one `HelmRelease` needs beyond the values themselves. */
+export interface HelmReleaseSpec {
+  /** Object name — one per (Component, Target), so a re-deploy is an upgrade. */
+  name: string;
+  /** Namespace the `HelmRelease` object lives in. */
+  namespace: string;
+  /** Namespace the release's workloads land in. */
+  targetNamespace: string;
+  /** The chart's path inside the source repository (§20's manifest value). */
+  chart: string;
+  sourceRef: { name: string; namespace: string };
+  /** Labels every object this adapter writes carries. */
+  labels: Record<string, string>;
+  /** §7: "Spindrift writes one inline values blob." */
+  values: Record<string, unknown>;
+}
+
+/**
+ * Render the object.
+ *
+ * `remediation.retries: 0` is the load-bearing setting: §6 puts reconciliation
+ * in core, and a controller that retried an install on its own would produce
+ * phase transitions no Deploy row asked for — the timeline would then be
+ * telling the developer about attempts nobody made.
+ */
+export function helmRelease(spec: HelmReleaseSpec): KubernetesObject {
+  return {
+    apiVersion: HELM_RELEASE.apiVersion,
+    kind: HELM_RELEASE.kind,
+    metadata: {
+      name: spec.name,
+      namespace: spec.namespace,
+      labels: spec.labels,
+    },
+    spec: {
+      interval: '10m',
+      releaseName: spec.name,
+      targetNamespace: spec.targetNamespace,
+      // The release namespace is vessel (§7), so the controller must not be
+      // the thing that creates it — a `destroy()` that removed a namespace
+      // would take every other Component in it along.
+      storageNamespace: spec.targetNamespace,
+      chart: {
+        spec: {
+          chart: spec.chart,
+          reconcileStrategy: 'Revision',
+          sourceRef: {
+            kind: GIT_REPOSITORY.kind,
+            name: spec.sourceRef.name,
+            namespace: spec.sourceRef.namespace,
+          },
+        },
+      },
+      install: { remediation: { retries: 0 } },
+      upgrade: { remediation: { retries: 0 } },
+      values: spec.values,
+    },
+  };
+}
+
+/** One condition, as Flux writes it. */
+interface Condition {
+  type: string;
+  status: 'True' | 'False' | 'Unknown';
+  reason?: string;
+  message?: string;
+}
+
+function conditions(object: KubernetesObject): Condition[] {
+  const status = object.status as { conditions?: Condition[] } | undefined;
+  return status?.conditions ?? [];
+}
+
+function condition(object: KubernetesObject, type: string): Condition | null {
+  return conditions(object).find((entry) => entry.type === type) ?? null;
+}
+
+/**
+ * Flux's own reasons, mapped onto §6's shared vocabulary.
+ *
+ * Only the reasons that are *decidable from the HelmRelease alone* are here.
+ * An install that failed because the workload never became ready is not one of
+ * them: the object says `InstallFailed` either way, and telling a crash loop
+ * from an image that will not pull needs the read on red (§6) — so those map to
+ * `null` and the adapter goes and looks.
+ */
+const REASONS: Record<string, FailureReason> = {
+  ArtifactFailed: 'ARTIFACT_UNAVAILABLE',
+  ChartPullFailed: 'ARTIFACT_UNAVAILABLE',
+  SourceNotReady: 'ARTIFACT_UNAVAILABLE',
+  DependencyNotReady: 'ARTIFACT_UNAVAILABLE',
+  InvalidChartReference: 'ARTIFACT_UNAVAILABLE',
+  ValuesError: 'REJECTED',
+  InvalidSpec: 'REJECTED',
+  ReconciliationFailed: 'REJECTED',
+};
+
+/**
+ * What the object says is happening.
+ *
+ * Phase transitions come from the controller, never from Spindrift
+ * reimplementing readiness (§6). This function is that rule as code: every
+ * branch reads a condition Flux wrote.
+ */
+export function helmReleaseStatus(object: KubernetesObject): DeliveryStatus {
+  const ready = condition(object, 'Ready');
+  const generation = (object.metadata as { generation?: number }).generation;
+  const observed = (
+    object.status as { observedGeneration?: number } | undefined
+  )?.observedGeneration;
+
+  // The controller has not looked at this generation yet, whatever the last
+  // one said. Reporting the stale condition here is how a re-deploy of a
+  // broken release would come back green before anything was tried.
+  if (ready === null || (generation !== undefined && observed !== generation)) {
+    return { phase: 'APPLYING', detail: ready?.message };
+  }
+
+  if (ready.status === 'True') {
+    return { phase: 'LIVE', detail: ready.message };
+  }
+
+  const stalled = condition(object, 'Stalled');
+  const terminal =
+    stalled?.status === 'True' || ready.reason === 'RetriesExceeded';
+  if (!terminal) {
+    return { phase: 'WAITING', detail: ready.message };
+  }
+
+  const reason = ready.reason === undefined ? undefined : REASONS[ready.reason];
+  return {
+    phase: 'FAILED',
+    // An absent reason is the signal to read pods and events once (§6), not a
+    // reason to guess: the adapter fills it in from what it finds.
+    reason,
+    detail: ready.message,
+    debug: { conditions: conditions(object) },
+  };
+}
+
+/** The values the release was applied with, as the object still carries them. */
+export function helmReleaseValues(
+  object: KubernetesObject,
+): Record<string, unknown> {
+  const spec = object.spec as { values?: Record<string, unknown> } | undefined;
+  return spec?.values ?? {};
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -1,0 +1,863 @@
+/**
+ * The Kubernetes deploy adapter (§6).
+ *
+ * Accepts an `image`. **The Target declares the delivery flavour**, and
+ * Spindrift applies a `HelmRelease` or an Argo `Application` **through the
+ * API** — using Flux or Argo is not the same as writing manifests to git, and
+ * only the chart source lives in a repository. Status is read from those
+ * objects' own conditions.
+ *
+ * **Nothing here watches.** `apply` polls the object it just wrote on a fast
+ * cadence for a bounded window — an attempt, not a standing watch — and
+ * `observe` is one read. The plan's transport shape says why: only one of the
+ * three backends has a watch at all, a watch dies across the satellite uplink
+ * while still looking connected, and any correct watch design needs a resync
+ * poll underneath it anyway. So the poll is not the fallback; it is the design.
+ *
+ * The three verbs are one-shot and imperative. Reconciliation lives in core,
+ * above this seam, and both delivery operators self-heal below it — which is
+ * why `install.remediation.retries` is zero on the Flux side and why
+ * `selfHeal` is on on the Argo side. Neither is a contradiction: the operator
+ * keeps what is running running; it does not retry an attempt core did not ask
+ * for.
+ */
+import type {
+  StoreAdapter,
+  TargetAdapter,
+} from '../../../config/manifest.schema.ts';
+import {
+  type PolicyEngineState,
+  PREREQUISITES,
+  type PrerequisiteResult,
+  type TargetDiscovery,
+  type TargetInspection,
+} from '../../../domain/capabilities.ts';
+import type {
+  ArtifactType,
+  DesiredState,
+} from '../../../domain/desired-state.ts';
+import type {
+  KubernetesConnection,
+  KubernetesDelivery,
+} from '../../../domain/target.ts';
+import type {
+  DeployAdapter,
+  DeployEvent,
+  DeployPhase,
+  DeployRef,
+  DeployTarget,
+  DeployVerdict,
+  FailureReason,
+  ObservedState,
+} from '../contract.ts';
+import {
+  type Fetcher,
+  KubernetesApi,
+  type KubernetesObject,
+  KubernetesRequestError,
+  type TokenProvider,
+} from './api.ts';
+import {
+  APPLICATION,
+  applicationStatus,
+  applicationValues,
+  argoApplication,
+} from './argo-application.ts';
+import { diagnose } from './diagnose.ts';
+import {
+  GIT_REPOSITORY,
+  HELM_RELEASE,
+  helmRelease,
+  helmReleaseStatus,
+  helmReleaseValues,
+} from './flux-helmrelease.ts';
+import type { DeliveryStatus } from './status.ts';
+import { chartValues, imageReference, VALUES_CONTRACT } from './values.ts';
+
+/** What the adapter needs that a Target's connection does not carry. */
+export interface KubernetesAdapterOptions {
+  /**
+   * The chart, as this installation names it (§20's `charts.app`). A path
+   * inside the Target's configured repository until the OCI swap.
+   */
+  readonly chart: string;
+  /** Mints a bearer token per request. Never a stored credential (§13). */
+  readonly token: TokenProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+  /**
+   * The fast cadence, while an attempt is in flight. A bounded window, not a
+   * standing watch (plan, Transport shape).
+   */
+  readonly pollIntervalMs?: number;
+  /** How long an attempt may run before it is `TIMEOUT` (§6). */
+  readonly timeoutMs?: number;
+  /** Injected so a test does not spend the cadence it is asserting about. */
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+}
+
+const DEFAULT_POLL_MS = 2_000;
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
+
+/** Which store a `ClusterSecretStore`'s provider key names (§10). */
+const STORE_PROVIDERS: Record<string, StoreAdapter> = {
+  onepassword: 'onepassword',
+  gcpsm: 'gcp-secret-manager',
+};
+
+/** The CRDs a datastore engine is discovered by (§3, §11). */
+const ENGINE_KINDS = {
+  postgres: { apiVersion: 'postgresql.cnpg.io/v1', kind: 'Cluster' },
+  redis: { apiVersion: 'redis.redis.opstreelabs.in/v1beta2', kind: 'Redis' },
+} as const;
+
+/** The policy engine `verifiedDeploy` is derived from (§32). */
+const POLICY = {
+  apiVersion: 'kyverno.io/v1',
+  kind: 'ClusterPolicy',
+  plural: 'clusterpolicies',
+} as const;
+
+/** The CNI object that means egress can be filtered by name (§8). */
+const EGRESS_POLICY = {
+  apiVersion: 'cilium.io/v2',
+  kind: 'CiliumNetworkPolicy',
+} as const;
+
+const SECRET_STORE = {
+  apiVersion: 'external-secrets.io/v1',
+  kind: 'ClusterSecretStore',
+  plural: 'clustersecretstores',
+} as const;
+
+export class KubernetesDeployAdapter implements DeployAdapter {
+  readonly adapter: TargetAdapter = 'kubernetes';
+  /** §6's table: `kubernetes` takes an image. */
+  readonly artifactTypes: readonly ArtifactType[] = ['image'];
+
+  constructor(private readonly options: KubernetesAdapterOptions) {}
+
+  async *apply(
+    target: DeployTarget,
+    desired: DesiredState,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      return this.internal('this Target is not a Kubernetes Target');
+    }
+    if (!this.artifactTypes.includes(desired.artifact.type)) {
+      // A foreign artifact reaching `apply` is a core bug, and §6 says so in
+      // the adapter's own vocabulary rather than by throwing.
+      yield this.status('FAILED', { reason: 'INTERNAL' });
+      return this.internal(
+        `kubernetes does not accept a ${desired.artifact.type} artifact`,
+      );
+    }
+    const image = imageReference(desired);
+    if (image === null) {
+      yield this.status('FAILED', { reason: 'INTERNAL' });
+      return this.internal('the artifact carries no address to pull it by');
+    }
+
+    const object = this.deliveryObject(connection, desired, image);
+    const ref = refOf(connection.delivery.flavour, object);
+    const api = this.api(connection);
+
+    yield this.status('APPLYING', { resource: resourceLabel(object) });
+    try {
+      await api.apply(object, pluralOf(connection.delivery.flavour));
+    } catch (cause) {
+      const verdict = writeFailure(cause, ref);
+      yield this.status('FAILED', { reason: verdict.reason });
+      return verdict;
+    }
+    yield this.log(`applied ${resourceLabel(object)}`, resourceLabel(object));
+
+    return yield* this.awaitVerdict(api, connection, desired, object, ref);
+  }
+
+  async observe(
+    target: DeployTarget,
+    ref: DeployRef,
+  ): Promise<ObservedState | null> {
+    const connection = this.connectionOf(target);
+    if (connection === null) return null;
+    const parsed = parseRef(ref);
+    if (parsed === null) return null;
+
+    const object = await this.api(connection).get({
+      apiVersion: apiVersionOf(parsed.flavour),
+      plural: pluralOf(parsed.flavour),
+      namespace: parsed.namespace,
+      name: parsed.name,
+    });
+    if (object === null) return null;
+
+    const status = statusOf(parsed.flavour, object);
+    return {
+      ref,
+      phase: status.phase,
+      // The digest actually serving, as the delivery object still carries it.
+      // Core compares it against the desired row to detect drift, which is
+      // surfaced and never silently corrected (§6).
+      artifactDigest: appliedDigest(parsed.flavour, object),
+      ...(status.reason === undefined ? {} : { reason: status.reason }),
+      ...(status.detail === undefined ? {} : { detail: status.detail }),
+    };
+  }
+
+  async destroy(target: DeployTarget, ref: DeployRef): Promise<void> {
+    const connection = this.connectionOf(target);
+    if (connection === null) return;
+    const parsed = parseRef(ref);
+    if (parsed === null) return;
+    // `delete` treats a 404 as success, which is the whole of §6's idempotence
+    // requirement: destroying what is already gone succeeds.
+    await this.api(connection).delete({
+      apiVersion: apiVersionOf(parsed.flavour),
+      plural: pluralOf(parsed.flavour),
+      namespace: parsed.namespace,
+      name: parsed.name,
+    });
+  }
+
+  /**
+   * One pass of §13's checklist and §3's discovery, in one call (§13's one
+   * loop).
+   *
+   * It reports **observations, never judgements**: `verifiedDeploy` and
+   * `offlineDeploy` are core's conclusions, so what comes back is what was
+   * seen — a policy engine's mode, the hosts an operator says this Target
+   * serves — and never what either of them implies.
+   */
+  async inspect(target: DeployTarget): Promise<TargetInspection> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      throw new Error(`${target.name} is not a Kubernetes Target`);
+    }
+    const api = this.api(connection);
+
+    const [prerequisites, discovery] = await Promise.all([
+      this.checklist(api, connection),
+      this.discover(api, connection),
+    ]);
+    return { prerequisites, discovery };
+  }
+
+  // --- apply's second half -------------------------------------------------
+
+  /**
+   * Poll the object just written until it reaches a verdict.
+   *
+   * The cadence is fast because the window is bounded: §6's phases come from
+   * the controller, and this is the only period in which they change quickly.
+   * Once the attempt ends, nothing here keeps looking — the slow cadence that
+   * detects drift belongs to core's loop, and lives on `observe`.
+   */
+  private async *awaitVerdict(
+    api: KubernetesApi,
+    connection: KubernetesConnection,
+    desired: DesiredState,
+    object: KubernetesObject,
+    ref: DeployRef,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    const resource = resourceLabel(object);
+    const deadline =
+      this.clock() + (this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    // `apply` emitted APPLYING before the write. Treat that as the first
+    // reported controller phase too, so an object whose status has not caught
+    // up to its generation does not duplicate the event on the timeline.
+    let reported: DeployPhase = 'APPLYING';
+
+    for (;;) {
+      const current = await api.get({
+        apiVersion: object.apiVersion,
+        plural: pluralOf(connection.delivery.flavour),
+        namespace: object.metadata.namespace,
+        name: object.metadata.name,
+      });
+      const status: DeliveryStatus =
+        current === null
+          ? { phase: 'APPLYING' }
+          : statusOf(connection.delivery.flavour, current);
+
+      if (status.phase !== reported) {
+        reported = status.phase;
+        yield this.status(status.phase, {
+          resource,
+          ...(status.reason === undefined ? {} : { reason: status.reason }),
+          ...(status.detail === undefined ? {} : { detail: status.detail }),
+        });
+      }
+
+      if (status.phase === 'LIVE') {
+        // No `url`: §9 gives a metal cluster no name of its own, so the
+        // canonical name is core's to mint and never comes back across here.
+        return { phase: 'LIVE', ref };
+      }
+
+      if (status.phase === 'FAILED') {
+        return yield* this.failed(api, connection, desired, status, ref);
+      }
+
+      if (this.clock() >= deadline) {
+        yield this.status('FAILED', { resource, reason: 'TIMEOUT' });
+        return {
+          phase: 'FAILED',
+          ref,
+          reason: 'TIMEOUT',
+          detail: status.detail ?? 'the release did not settle in time',
+          debug: status.debug,
+        };
+      }
+
+      await this.wait();
+    }
+  }
+
+  /** The read on red, once (§6), and the verdict it produces. */
+  private async *failed(
+    api: KubernetesApi,
+    connection: KubernetesConnection,
+    desired: DesiredState,
+    status: DeliveryStatus,
+    ref: DeployRef,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    if (status.reason !== undefined) {
+      // The delivery object already said why, in terms §6 has a reason for.
+      // Reading pods would add nothing a developer can act on.
+      return {
+        phase: 'FAILED',
+        ref,
+        reason: status.reason,
+        ...(status.detail === undefined ? {} : { detail: status.detail }),
+        debug: status.debug,
+      };
+    }
+
+    const namespace = connection.namespace;
+    const selector = `app.kubernetes.io/name=${desired.component},app.kubernetes.io/part-of=${desired.app}`;
+    const [pods, events] = await Promise.all([
+      api
+        .list(
+          { apiVersion: 'v1', plural: 'pods', namespace },
+          { labelSelector: selector },
+        )
+        .catch(() => null),
+      api
+        .list({ apiVersion: 'v1', plural: 'events', namespace })
+        .catch(() => null),
+    ]);
+
+    const diagnosis = diagnose(pods ?? [], events ?? [], status.detail);
+    yield this.log(diagnosis.detail);
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: diagnosis.reason,
+      detail: diagnosis.detail,
+      // §12: the diagnosis is stored because the platform will not keep it —
+      // cluster events expire in about an hour.
+      debug: { delivery: status.debug, diagnosis: diagnosis.debug },
+    };
+  }
+
+  // --- inspect's two halves ------------------------------------------------
+
+  private async checklist(
+    api: KubernetesApi,
+    connection: KubernetesConnection,
+  ): Promise<readonly PrerequisiteResult[]> {
+    const delivery = connection.delivery;
+    const results = new Map<string, PrerequisiteResult>();
+    const set = (
+      name: (typeof PREREQUISITES)[number],
+      met: boolean,
+      detail?: string,
+    ): void => {
+      results.set(name, met ? { name, met } : { name, met: false, detail });
+    };
+
+    const kind = deliveryKind(delivery.flavour);
+    const operator = await api.servesKind(kind.apiVersion, kind.kind);
+    set(
+      'DELIVERY_OPERATOR',
+      operator,
+      `this cluster does not serve ${kind.kind}: a Kubernetes Target must run Flux or Argo (§6)`,
+    );
+
+    set('CHART_SOURCE', ...(await this.chartSource(api, delivery)));
+
+    const stores = await this.reachableSecretStores(api);
+    set(
+      'WRITABLE_STORE',
+      stores.length > 0,
+      'this cluster has no ClusterSecretStore, so config cannot be delivered',
+    );
+
+    const allowed = await this.canWriteDelivery(api, delivery);
+    set(
+      'OIDC_FEDERATION',
+      allowed,
+      `the federated identity may not create ${kind.kind}s in ${delivery.namespace}`,
+    );
+
+    const namespace = await api.get({
+      apiVersion: 'v1',
+      plural: 'namespaces',
+      name: connection.namespace,
+    });
+    set(
+      'VESSEL',
+      namespace !== null,
+      `namespace ${connection.namespace} does not exist, and Spindrift does not create it (§7)`,
+    );
+
+    // §7: the chart declares its own value contract, read at pin time. Until
+    // the OCI swap the pin is a branch, so skew is **detected** here rather
+    // than prevented — the operator states what the pinned chart declares, and
+    // a mismatch becomes a prerequisite failure in the existing grammar.
+    const pinned = connection.chartContract;
+    set(
+      'CHART_CONTRACT',
+      pinned === undefined || pinned === VALUES_CONTRACT,
+      `the App chart at this Target declares value contract ${pinned}; this Spindrift renders ${VALUES_CONTRACT}`,
+    );
+
+    return PREREQUISITES.map(
+      (name) =>
+        results.get(name) ?? {
+          name,
+          met: false,
+          detail: 'not assessed',
+        },
+    );
+  }
+
+  /** Whether the chart's source exists where the Target says it does. */
+  private async chartSource(
+    api: KubernetesApi,
+    delivery: KubernetesDelivery,
+  ): Promise<[boolean, string?]> {
+    if (delivery.flavour === 'argo-application') {
+      // Argo resolves the repository itself, with credentials Spindrift never
+      // sees, so there is nothing here to read. The honest check is that a
+      // repository was named at all; a wrong one surfaces as a sync error on
+      // the first deploy.
+      return [
+        delivery.repoUrl.length > 0,
+        'this Target names no repository to fetch the App chart from',
+      ];
+    }
+    const source = await api.get({
+      apiVersion: GIT_REPOSITORY.apiVersion,
+      plural: GIT_REPOSITORY.plural,
+      namespace: delivery.sourceRef.namespace,
+      name: delivery.sourceRef.name,
+    });
+    return [
+      source !== null,
+      `this cluster has no ${GIT_REPOSITORY.kind} ${delivery.sourceRef.namespace}/${delivery.sourceRef.name} to fetch the App chart from`,
+    ];
+  }
+
+  /**
+   * Whether the federated identity may write the delivery object.
+   *
+   * A `SelfSubjectAccessReview` is the one call that answers §13's "OIDC both
+   * ways" without holding a credential: the API server answers about whoever
+   * the request authenticated as, which is exactly what federation produced.
+   */
+  private async canWriteDelivery(
+    api: KubernetesApi,
+    delivery: KubernetesDelivery,
+  ): Promise<boolean> {
+    const kind = deliveryKind(delivery.flavour);
+    const [group] = kind.apiVersion.split('/');
+    try {
+      const review = await api.create(
+        {
+          apiVersion: 'authorization.k8s.io/v1',
+          plural: 'selfsubjectaccessreviews',
+        },
+        {
+          apiVersion: 'authorization.k8s.io/v1',
+          kind: 'SelfSubjectAccessReview',
+          metadata: { name: '' },
+          spec: {
+            resourceAttributes: {
+              namespace: delivery.namespace,
+              verb: 'create',
+              group,
+              resource: pluralOf(delivery.flavour),
+            },
+          },
+        },
+      );
+      const status = review?.status as { allowed?: boolean } | undefined;
+      return status?.allowed === true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async reachableSecretStores(
+    api: KubernetesApi,
+  ): Promise<readonly StoreAdapter[]> {
+    const stores = await api
+      .list({
+        apiVersion: SECRET_STORE.apiVersion,
+        plural: SECRET_STORE.plural,
+      })
+      .catch(() => null);
+    if (stores === null) return [];
+
+    const found = new Set<StoreAdapter>();
+    for (const store of stores) {
+      const spec = store.spec as
+        | { provider?: Record<string, unknown> }
+        | undefined;
+      for (const provider of Object.keys(spec?.provider ?? {})) {
+        const adapter = STORE_PROVIDERS[provider];
+        if (adapter !== undefined) found.add(adapter);
+      }
+    }
+    return [...found];
+  }
+
+  private async discover(
+    api: KubernetesApi,
+    connection: KubernetesConnection,
+  ): Promise<TargetDiscovery> {
+    const [nodes, storageClasses, postgres, redis, egress, policy, stores] =
+      await Promise.all([
+        api.list({ apiVersion: 'v1', plural: 'nodes' }).catch(() => null),
+        api
+          .list({ apiVersion: 'storage.k8s.io/v1', plural: 'storageclasses' })
+          .catch(() => null),
+        api.servesKind(
+          ENGINE_KINDS.postgres.apiVersion,
+          ENGINE_KINDS.postgres.kind,
+        ),
+        api.servesKind(ENGINE_KINDS.redis.apiVersion, ENGINE_KINDS.redis.kind),
+        api.servesKind(EGRESS_POLICY.apiVersion, EGRESS_POLICY.kind),
+        this.policyEngine(api),
+        this.reachableSecretStores(api),
+      ]);
+
+    const capacity = nodeCapacity(nodes ?? []);
+    return {
+      arch: capacity.arch,
+      gpu: capacity.gpu,
+      resourceCeiling: capacity.ceiling,
+      persistence: (storageClasses ?? []).length > 0,
+      postgres,
+      redis,
+      egressFiltering: egress,
+      policyEngine: policy,
+      // §18: how far back a tail can honestly reach. The log store sits beside
+      // the cluster rather than in it, so this is the operator's statement and
+      // an unstated one is zero rather than a guess.
+      logHistorySeconds: connection.logHistorySeconds ?? 0,
+      servedHosts: connection.servedHosts ?? [],
+      reachableRegistries: connection.reachableRegistries ?? [],
+      reachableSecretStores: stores,
+    };
+  }
+
+  /**
+   * What the policy engine was found doing — installed, and in which mode.
+   *
+   * §32: `verifiedDeploy` "must discover **enforcing** mode, not merely
+   * installed — under an audit-only policy a green deploy proves nothing". The
+   * conclusion is core's to draw, so this reports both fields and neither
+   * implication.
+   */
+  private async policyEngine(api: KubernetesApi): Promise<PolicyEngineState> {
+    const installed = await api.servesKind(POLICY.apiVersion, POLICY.kind);
+    if (!installed) return { installed: false, mode: null };
+
+    const policies = await api
+      .list({ apiVersion: POLICY.apiVersion, plural: POLICY.plural })
+      .catch(() => null);
+    const enforcing = (policies ?? []).some((policy) => {
+      const spec = policy.spec as
+        | {
+            validationFailureAction?: string;
+            rules?: { validate?: { failureAction?: string } }[];
+          }
+        | undefined;
+      if (spec?.validationFailureAction === 'Enforce') return true;
+      return (spec?.rules ?? []).some(
+        (rule) => rule.validate?.failureAction === 'Enforce',
+      );
+    });
+    return { installed: true, mode: enforcing ? 'ENFORCE' : 'AUDIT' };
+  }
+
+  // --- plumbing ------------------------------------------------------------
+
+  private api(connection: KubernetesConnection): KubernetesApi {
+    return new KubernetesApi({
+      apiServer: connection.apiServer,
+      token: this.options.token,
+      ...(this.options.fetch === undefined
+        ? {}
+        : { fetch: this.options.fetch }),
+    });
+  }
+
+  private connectionOf(target: DeployTarget): KubernetesConnection | null {
+    return target.connection.adapter === 'kubernetes'
+      ? target.connection
+      : null;
+  }
+
+  private deliveryObject(
+    connection: KubernetesConnection,
+    desired: DesiredState,
+    image: string,
+  ): KubernetesObject {
+    const name = releaseName(desired);
+    const values = chartValues(desired, connection, image);
+    const labels = {
+      'app.kubernetes.io/managed-by': 'spindrift',
+      'app.kubernetes.io/part-of': desired.app,
+      'app.kubernetes.io/name': desired.component,
+    };
+
+    if (connection.delivery.flavour === 'argo-application') {
+      return argoApplication({
+        name,
+        namespace: connection.delivery.namespace,
+        destinationNamespace: connection.namespace,
+        server: connection.delivery.server,
+        project: connection.delivery.project,
+        repoUrl: connection.delivery.repoUrl,
+        revision: connection.delivery.revision,
+        path: this.options.chart,
+        labels,
+        values,
+      });
+    }
+
+    return helmRelease({
+      name,
+      namespace: connection.delivery.namespace,
+      targetNamespace: connection.namespace,
+      chart: this.options.chart,
+      sourceRef: connection.delivery.sourceRef,
+      labels,
+      values,
+    });
+  }
+
+  private internal(detail: string): DeployVerdict {
+    return { phase: 'FAILED', reason: 'INTERNAL', detail };
+  }
+
+  private status(
+    phase: DeployPhase,
+    extra: { resource?: string; reason?: FailureReason; detail?: string } = {},
+  ): DeployEvent {
+    return { type: 'status', at: new Date(this.clock()), phase, ...extra };
+  }
+
+  private log(line: string, resource?: string): DeployEvent {
+    return {
+      type: 'log',
+      at: new Date(this.clock()),
+      line,
+      ...(resource === undefined ? {} : { resource }),
+    };
+  }
+
+  private clock(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+
+  private async wait(): Promise<void> {
+    const interval = this.options.pollIntervalMs ?? DEFAULT_POLL_MS;
+    if (this.options.sleep !== undefined) {
+      await this.options.sleep(interval);
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+// --- flavour-shaped helpers ------------------------------------------------
+
+type Flavour = KubernetesDelivery['flavour'];
+
+function deliveryKind(flavour: Flavour): {
+  apiVersion: string;
+  kind: string;
+} {
+  return flavour === 'argo-application'
+    ? { apiVersion: APPLICATION.apiVersion, kind: APPLICATION.kind }
+    : { apiVersion: HELM_RELEASE.apiVersion, kind: HELM_RELEASE.kind };
+}
+
+function apiVersionOf(flavour: Flavour): string {
+  return deliveryKind(flavour).apiVersion;
+}
+
+function pluralOf(flavour: Flavour): string {
+  return flavour === 'argo-application'
+    ? APPLICATION.plural
+    : HELM_RELEASE.plural;
+}
+
+function statusOf(flavour: Flavour, object: KubernetesObject): DeliveryStatus {
+  return flavour === 'argo-application'
+    ? applicationStatus(object)
+    : helmReleaseStatus(object);
+}
+
+/** The digest the delivery object was applied with — what is serving. */
+function appliedDigest(flavour: Flavour, object: KubernetesObject): string {
+  const values =
+    flavour === 'argo-application'
+      ? applicationValues(object)
+      : helmReleaseValues(object);
+  const app = values.app as { artifactDigest?: string } | undefined;
+  return app?.artifactDigest ?? '';
+}
+
+/** One release per (Component, Target), so a re-deploy is an upgrade. */
+function releaseName(desired: DesiredState): string {
+  return `${desired.app}-${desired.component}`.slice(0, 63);
+}
+
+function resourceLabel(object: KubernetesObject): string {
+  return `${object.kind}/${object.metadata.namespace}/${object.metadata.name}`;
+}
+
+/**
+ * The adapter's own handle on what `apply` placed — opaque to core (§6).
+ *
+ * The flavour is part of it because an operator may change a Target's flavour,
+ * and a ref that did not say which object it named would then be read against
+ * the wrong kind.
+ */
+function refOf(flavour: Flavour, object: KubernetesObject): DeployRef {
+  return `${flavour}:${object.metadata.namespace}/${object.metadata.name}`;
+}
+
+interface ParsedRef {
+  flavour: Flavour;
+  namespace: string;
+  name: string;
+}
+
+function parseRef(ref: DeployRef): ParsedRef | null {
+  const [flavour, path] = ref.split(':', 2);
+  if (path === undefined) return null;
+  if (flavour !== 'argo-application' && flavour !== 'flux-helmrelease') {
+    return null;
+  }
+  const [namespace, name] = path.split('/', 2);
+  if (namespace === undefined || name === undefined) return null;
+  return { flavour, namespace, name };
+}
+
+/** A write that never landed, in §6's vocabulary. */
+function writeFailure(
+  cause: unknown,
+  ref: DeployRef,
+): Extract<DeployVerdict, { phase: 'FAILED' }> {
+  if (cause instanceof KubernetesRequestError) {
+    // A 4xx is the cluster refusing this object — an admission webhook, a
+    // quota, an invalid spec — which §6 puts under one reason. A 5xx or an
+    // auth failure is the cluster being unavailable to Spindrift, which is a
+    // different blame entirely.
+    const rejected = cause.status >= 400 && cause.status < 500;
+    const authFailure = cause.status === 401 || cause.status === 403;
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: rejected && !authFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
+      detail: cause.body || cause.message,
+      debug: { status: cause.status, url: cause.url },
+    };
+  }
+  return {
+    phase: 'FAILED',
+    ref,
+    reason: 'TARGET_UNREACHABLE',
+    detail: cause instanceof Error ? cause.message : String(cause),
+  };
+}
+
+/** What the nodes say this Target can run (§3's discovered half). */
+function nodeCapacity(nodes: readonly KubernetesObject[]): {
+  arch: readonly string[];
+  gpu: boolean;
+  ceiling: { cpu?: string; memory?: string };
+} {
+  const arch = new Set<string>();
+  let gpu = false;
+  let cpu: number | null = null;
+  let memory: number | null = null;
+
+  for (const node of nodes) {
+    const labels = node.metadata.labels ?? {};
+    const architecture = labels['kubernetes.io/arch'];
+    if (architecture !== undefined) arch.add(architecture);
+
+    const status = node.status as
+      | { allocatable?: Record<string, string> }
+      | undefined;
+    const allocatable = status?.allocatable ?? {};
+    if (Number(allocatable['nvidia.com/gpu'] ?? '0') > 0) gpu = true;
+
+    const nodeCpu = cores(allocatable.cpu);
+    if (nodeCpu !== null) cpu = Math.max(cpu ?? 0, nodeCpu);
+    const nodeMemory = bytes(allocatable.memory);
+    if (nodeMemory !== null) memory = Math.max(memory ?? 0, nodeMemory);
+  }
+
+  return {
+    arch: [...arch].sort(),
+    gpu,
+    // The ceiling is the largest single workload the Target will admit (§3),
+    // which is one node's allocatable — never the sum, because nothing here
+    // schedules across nodes.
+    ceiling: {
+      ...(cpu === null ? {} : { cpu: String(cpu) }),
+      ...(memory === null
+        ? {}
+        : { memory: `${Math.floor(memory / 1024 ** 2)}Mi` }),
+    },
+  };
+}
+
+function cores(quantity: string | undefined): number | null {
+  if (quantity === undefined) return null;
+  const millis = quantity.endsWith('m');
+  const value = Number(millis ? quantity.slice(0, -1) : quantity);
+  if (Number.isNaN(value)) return null;
+  return millis ? value / 1000 : value;
+}
+
+const SUFFIXES: Record<string, number> = {
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  K: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+};
+
+function bytes(quantity: string | undefined): number | null {
+  if (quantity === undefined) return null;
+  const match = quantity.match(/^(\d+(?:\.\d+)?)([A-Za-z]*)$/);
+  if (!match) return null;
+  const scale = match[2] === '' ? 1 : SUFFIXES[match[2] as string];
+  if (scale === undefined) return null;
+  return Number(match[1]) * scale;
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -421,7 +421,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
     const pinned = connection.chartContract;
     set(
       'CHART_CONTRACT',
-      pinned === undefined || pinned === VALUES_CONTRACT,
+      pinned === VALUES_CONTRACT,
       `the App chart at this Target declares value contract ${pinned}; this Spindrift renders ${VALUES_CONTRACT}`,
     );
 

--- a/apps/spindrift/src/adapters/deploy/kubernetes/status.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/status.ts
@@ -1,0 +1,22 @@
+/**
+ * What a delivery object says, in §6's vocabulary rather than its own.
+ *
+ * The two flavours report differently — Flux writes conditions, Argo writes a
+ * health and a sync status — and neither vocabulary may reach core: §6 gives
+ * the user **one shared vocabulary** along one timeline. So each flavour
+ * translates into this shape, and everything above it reads only this.
+ *
+ * A `reason` left unset on a `FAILED` is not an omission. It is the signal that
+ * the delivery object knows the release failed but not why, which is exactly
+ * when §6 says to read pods and events **once** and fill in the detail.
+ */
+import type { DeployPhase, FailureReason } from '../contract.ts';
+
+export interface DeliveryStatus {
+  phase: DeployPhase;
+  reason?: FailureReason;
+  /** The sentence the developer reads, in the platform's own words. */
+  detail?: string;
+  /** The raw payload, kept for the operator (§6). */
+  debug?: unknown;
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
@@ -96,6 +96,7 @@ export interface AppValues {
   expose: boolean;
   exposure: DesiredState['exposure'];
   schedule: string;
+  deployId: string;
   artifactDigest: string;
   hostnames: string[];
   secretEnv: SecretEnvValue[];
@@ -137,14 +138,9 @@ export function imageReference(desired: DesiredState): string | null {
 /**
  * Render Spindrift's class from the neutral description (§6).
  *
- * The one value that needs explaining is `artifactDigest`. §7 puts a per-deploy
- * label on the pod template — never in the selector — because both delivery
- * flavours enumerate applied objects and neither covers pods, so a pod needs
- * something on it that says what placed it. **Core's description names no
- * Deploy**: §6's `DesiredState` has no such field, and adding one would put a
- * row identity across a seam whose whole point is that the adapter knows
- * nothing about core's tables. The digest does the job and is already there —
- * it is the identity §16 correlates on everywhere in the supply chain.
+ * Deploy identity and artifact identity remain separate. The Deploy label lets
+ * diagnosis select only the pods created by this rollout (§7); the digest lets
+ * core compare what the delivery object still carries with desired state (§6).
  */
 export function appValues(desired: DesiredState, image: string): AppValues {
   return {
@@ -158,6 +154,7 @@ export function appValues(desired: DesiredState, image: string): AppValues {
     // An absent schedule is a suspended CronJob, which is why this is '' and
     // not omitted: the chart branches on emptiness, not on presence.
     schedule: desired.schedule ?? '',
+    deployId: desired.deploy,
     artifactDigest: desired.artifact.digest,
     hostnames: [
       desired.hostname.canonical,

--- a/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
@@ -93,6 +93,7 @@ export interface AppValues {
   component: string;
   kind: DesiredState['kind'];
   image: string;
+  port: number;
   expose: boolean;
   exposure: DesiredState['exposure'];
   schedule: string;
@@ -148,8 +149,11 @@ export function appValues(desired: DesiredState, image: string): AppValues {
     component: desired.component,
     kind: desired.kind,
     image,
-    // A website's `expose` is forced by the chart; a job never serves.
-    expose: desired.expose ?? false,
+    // `website` is not a chart branch: normalize it to service values here.
+    port: 8080,
+    expose:
+      desired.kind === 'website' ||
+      (desired.kind === 'service' && desired.expose === true),
     exposure: desired.exposure,
     // An absent schedule is a suspended CronJob, which is why this is '' and
     // not omitted: the chart branches on emptiness, not on presence.

--- a/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
@@ -1,0 +1,224 @@
+/**
+ * The App chart's values, and the boundary between who may write which (§7).
+ *
+ * **Three value classes, not two.** "Some keys are written by both operator and
+ * Spindrift, so a disjointness rule would reject a correct config. The boundary
+ * is enforced at save time, giving each Target a chart-values field." So this
+ * module does two things: it renders Spindrift's class from a
+ * {@link DesiredState}, and it is where an operator's chart-values are checked
+ * before they are stored on a Target — not when a deploy happens to run, by
+ * which point the operator who typed them is gone.
+ *
+ * **Spindrift writes one inline values blob** (§7). A values ConfigMap is dead
+ * as a portable mechanism: Flux merges `valuesFrom` and then overwrites it
+ * inline, and Argo has no equivalent at all.
+ */
+import type { DesiredState } from '../../../domain/desired-state.ts';
+import type { KubernetesConnection } from '../../../domain/target.ts';
+
+/**
+ * The value-contract version this adapter renders for.
+ *
+ * §7: "The chart declares its own value contract and version, read at pin
+ * time. Skew is guaranteed and Helm ignores unknown values silently, so an
+ * unrepinned Target would apply cleanly, report green, and run without config."
+ * This constant is the other half of that comparison — what the code writing
+ * the values believes the contract to be — and `packages/charts/spindrift-app`
+ * declares the same number in its own `Chart.yaml`.
+ */
+export const VALUES_CONTRACT = '1';
+
+/** The three classes §7 names, as the chart's three top-level keys. */
+export const VALUE_CLASSES = {
+  /** Spindrift writes; an operator may not. */
+  app: 'spindrift',
+  /** The operator writes, per Target; Spindrift never renders into it. */
+  platform: 'operator',
+  /** Either may write. Spindrift's value wins where both do. */
+  shared: 'both',
+} as const;
+
+export type ValueClass = keyof typeof VALUE_CLASSES;
+
+/** One thing wrong with an operator's chart-values, in their own terms. */
+export interface ValuesIssue {
+  /** Dotted path into the values object. */
+  readonly path: string;
+  readonly message: string;
+}
+
+/**
+ * Check an operator's chart-values before they are saved to a Target.
+ *
+ * Two refusals, and no others: a key in Spindrift's own class, and a key the
+ * chart has no class for. The second matters as much as the first — Helm
+ * ignores an unknown value silently, so a typo an operator makes here would
+ * otherwise be discovered as a workload running without the setting they
+ * thought they had applied.
+ */
+export function operatorValuesIssues(
+  values: Record<string, unknown> | undefined,
+): readonly ValuesIssue[] {
+  if (values === undefined) return [];
+  const issues: ValuesIssue[] = [];
+  for (const key of Object.keys(values)) {
+    if (!Object.hasOwn(VALUE_CLASSES, key)) {
+      issues.push({
+        path: key,
+        message: `the App chart has no ${key} values`,
+      });
+      continue;
+    }
+    if (VALUE_CLASSES[key as ValueClass] === 'spindrift') {
+      issues.push({
+        path: key,
+        message: `${key} values are Spindrift's to write, not an operator's`,
+      });
+    }
+  }
+  return issues;
+}
+
+/** One environment variable, as the chart names a pinned reference (§10). */
+interface SecretEnvValue {
+  name: string;
+  /** The Secret the platform's own machinery materializes the value into. */
+  secretName: string;
+  key: string;
+}
+
+/** Spindrift's class, rendered from what core described. */
+export interface AppValues {
+  name: string;
+  component: string;
+  kind: DesiredState['kind'];
+  image: string;
+  expose: boolean;
+  exposure: DesiredState['exposure'];
+  schedule: string;
+  artifactDigest: string;
+  hostnames: string[];
+  secretEnv: SecretEnvValue[];
+}
+
+/** The whole inline blob one release is applied with. */
+export interface ChartValues {
+  app: AppValues;
+  shared: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * The Secret one Component's config is delivered through.
+ *
+ * §10 is per-key, not per-blob — one secret *per variable* — which is about how
+ * a value is stored and pinned in the store of record, not about how many
+ * Kubernetes objects it lands in. What materializes this Secret from the pinned
+ * references arrives with §10's config work; the name is derived here so both
+ * halves agree on it without either importing the other.
+ */
+export function configSecretName(desired: DesiredState): string {
+  return `${desired.app}-${desired.component}`;
+}
+
+/**
+ * A pullable address for what was built.
+ *
+ * §6's `artifact` carries a digest and the addresses it can be pulled by; a
+ * Kubernetes Target needs an address, and the digest is what makes it
+ * immutable. An artifact with no address is a core bug — the adapter says so as
+ * `INTERNAL` rather than rendering a release that cannot pull.
+ */
+export function imageReference(desired: DesiredState): string | null {
+  const [reference] = desired.artifact.refs;
+  return reference ?? null;
+}
+
+/**
+ * Render Spindrift's class from the neutral description (§6).
+ *
+ * The one value that needs explaining is `artifactDigest`. §7 puts a per-deploy
+ * label on the pod template — never in the selector — because both delivery
+ * flavours enumerate applied objects and neither covers pods, so a pod needs
+ * something on it that says what placed it. **Core's description names no
+ * Deploy**: §6's `DesiredState` has no such field, and adding one would put a
+ * row identity across a seam whose whole point is that the adapter knows
+ * nothing about core's tables. The digest does the job and is already there —
+ * it is the identity §16 correlates on everywhere in the supply chain.
+ */
+export function appValues(desired: DesiredState, image: string): AppValues {
+  return {
+    name: desired.app,
+    component: desired.component,
+    kind: desired.kind,
+    image,
+    // A website's `expose` is forced by the chart; a job never serves.
+    expose: desired.expose ?? false,
+    exposure: desired.exposure,
+    // An absent schedule is a suspended CronJob, which is why this is '' and
+    // not omitted: the chart branches on emptiness, not on presence.
+    schedule: desired.schedule ?? '',
+    artifactDigest: desired.artifact.digest,
+    hostnames: [
+      desired.hostname.canonical,
+      ...(desired.hostname.vanity === undefined
+        ? []
+        : [desired.hostname.vanity]),
+    ],
+    secretEnv: desired.config.map((entry) => ({
+      name: entry.name,
+      secretName: configSecretName(desired),
+      key: entry.secret.key,
+    })),
+  };
+}
+
+/**
+ * The whole blob: the operator's class as saved on the Target, plus
+ * Spindrift's, plus the shared keys Spindrift has an opinion about.
+ *
+ * The merge is one level deep and Spindrift wins, which is the shared class's
+ * whole definition. It is not deeper than that on purpose: a recursive merge
+ * would let an operator set `shared.resources.limits.cpu` and leave Spindrift's
+ * `requests` beside it, and the result would be a value neither of them wrote.
+ */
+export function chartValues(
+  desired: DesiredState,
+  connection: KubernetesConnection,
+  image: string,
+): ChartValues {
+  const operator = connection.chartValues ?? {};
+  const shared = {
+    ...((operator.shared as Record<string, unknown> | undefined) ?? {}),
+    ...(hasResources(desired) ? { resources: resources(desired) } : {}),
+  };
+
+  return {
+    ...operator,
+    app: appValues(desired, image),
+    shared,
+  };
+}
+
+function hasResources(desired: DesiredState): boolean {
+  const { cpu, memory } = desired.requirements.resources;
+  return cpu !== undefined || memory !== undefined;
+}
+
+/**
+ * What the workload asked for, as the chart takes it.
+ *
+ * Requests only. §3 keeps core out of scheduling — "resolution is a filter, not
+ * a scheduler" — and a limit is the Target's ceiling to set (§8: limits and
+ * quotas are per-Target numbers rendered outside the App's release), so the
+ * operator's `shared.resources.limits` stands wherever they set one.
+ */
+function resources(desired: DesiredState): Record<string, unknown> {
+  const { cpu, memory } = desired.requirements.resources;
+  return {
+    requests: {
+      ...(cpu === undefined ? {} : { cpu }),
+      ...(memory === undefined ? {} : { memory }),
+    },
+  };
+}

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -26,6 +26,7 @@
  */
 import { and, eq, isNotNull, sql } from 'drizzle-orm';
 import { z } from 'zod';
+import { operatorValuesIssues } from '../../adapters/deploy/kubernetes/values.ts';
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import { deploys, targets } from '../../db/schema.ts';
 import {
@@ -33,12 +34,13 @@ import {
   type PrerequisiteResult,
 } from '../../domain/capabilities.ts';
 import {
+  type DeployTargetRef,
   type TargetConnection,
   type TargetHealth,
   targetNames,
 } from '../../domain/target.ts';
 import { inspectTarget } from '../../reconciler/target-loop.ts';
-import { type Command, type CommandContext, ok } from '../types.ts';
+import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
 /** A stable identifier, unique within the installation (§13). */
 const targetName = z
@@ -51,6 +53,39 @@ const targetName = z
     'must be lowercase letters, digits and hyphens',
   );
 
+/**
+ * The delivery flavour a Kubernetes Target declares (§6).
+ *
+ * Required, with no default: an installation-wide default would be a guess
+ * about somebody else's cluster, and §20 puts every such value in the manifest
+ * or in the operator's hands rather than in a literal.
+ */
+const kubernetesDelivery = z.discriminatedUnion('flavour', [
+  z
+    .object({
+      flavour: z.literal('flux-helmrelease'),
+      namespace: z.string().trim().min(1),
+      /** The `GitRepository` the App chart is fetched from (Milestone 3). */
+      sourceRef: z
+        .object({
+          name: z.string().trim().min(1),
+          namespace: z.string().trim().min(1),
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      flavour: z.literal('argo-application'),
+      namespace: z.string().trim().min(1),
+      project: z.string().trim().min(1),
+      repoUrl: z.string().trim().min(1),
+      revision: z.string().trim().min(1),
+      server: z.string().trim().min(1),
+    })
+    .strict(),
+]);
+
 export const connectTargetInput = z.discriminatedUnion('kind', [
   z
     .object({
@@ -58,6 +93,16 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
       name: targetName,
       /** §13's prerequisite is OIDC against this, not a credential for it. */
       apiServer: z.url(),
+      /** Where an App's workloads land. Never created by Spindrift (§7). */
+      namespace: z.string().trim().min(1),
+      delivery: kubernetesDelivery,
+      /** §33's static reachability input, and §3's stated capabilities. */
+      servedHosts: z.array(z.string().trim().min(1)).optional(),
+      reachableRegistries: z.array(z.string().trim().min(1)).optional(),
+      logHistorySeconds: z.number().int().nonnegative().optional(),
+      /** §7's per-Target chart-values field, and what the pin declares. */
+      chartValues: z.record(z.string(), z.unknown()).optional(),
+      chartContract: z.string().trim().min(1).optional(),
     })
     .strict(),
   z
@@ -100,7 +145,27 @@ function connectionFor(
     if (input.kind !== 'kubernetes') {
       throw new Error('a cloud project does not register a cluster Target');
     }
-    return { adapter, apiServer: input.apiServer };
+    return {
+      adapter,
+      apiServer: input.apiServer,
+      namespace: input.namespace,
+      delivery: input.delivery,
+      ...(input.servedHosts === undefined
+        ? {}
+        : { servedHosts: input.servedHosts }),
+      ...(input.reachableRegistries === undefined
+        ? {}
+        : { reachableRegistries: input.reachableRegistries }),
+      ...(input.logHistorySeconds === undefined
+        ? {}
+        : { logHistorySeconds: input.logHistorySeconds }),
+      ...(input.chartValues === undefined
+        ? {}
+        : { chartValues: input.chartValues }),
+      ...(input.chartContract === undefined
+        ? {}
+        : { chartContract: input.chartContract }),
+    };
   }
   if (input.kind !== 'cloud') {
     throw new Error('a cluster does not register a cloud Target');
@@ -114,6 +179,24 @@ export const connectTarget: Command<
   ConnectTargetInput,
   ConnectTargetResult
 > = async (input, context) => {
+  // §7: the boundary between the value classes is "enforced at save time".
+  // This is that time — the operator who typed these is still here to be told
+  // which key was not theirs, which is not true of the deploy that would
+  // otherwise discover it.
+  if (input.kind === 'kubernetes') {
+    const issues = operatorValuesIssues(input.chartValues);
+    if (issues.length > 0) {
+      return failed(
+        'INVALID_INPUT',
+        'these chart values are not an operator’s to set',
+        issues.map((issue) => ({
+          path: `chartValues.${issue.path}`,
+          message: issue.message,
+        })),
+      );
+    }
+  }
+
   const now = context.clock.now();
   const registered: ConnectedTarget[] = [];
   const readopted: string[] = [];
@@ -123,15 +206,15 @@ export const connectTarget: Command<
       await context.db.select().from(targets).where(eq(targets.name, name))
     )[0];
 
+    const connection = connectionFor(input, adapter);
     // One pass of the same loop §13 runs on a schedule — not a second notion of
     // what "healthy" means that happens to run at connect time.
-    const { prerequisites, discovery } = await inspectTarget(
-      context,
+    const { prerequisites, discovery } = await inspectTarget(context, {
       name,
       adapter,
-    );
+      connection,
+    });
     const health = deriveHealth(prerequisites);
-    const connection = connectionFor(input, adapter);
 
     if (existing === undefined) {
       // §13: "Rank is one global ordered list." A new Target joins the end of
@@ -182,7 +265,12 @@ export const connectTarget: Command<
 
     if (existing.status === 'disconnected') {
       readopted.push(
-        ...(await readopt(context, existing.id, name, adapter, now)),
+        ...(await readopt(
+          context,
+          existing.id,
+          { name, adapter, connection },
+          now,
+        )),
       );
     }
 
@@ -210,11 +298,10 @@ export const connectTarget: Command<
 async function readopt(
   context: CommandContext,
   targetId: string,
-  name: string,
-  adapter: TargetAdapter,
+  target: DeployTargetRef,
   now: Date,
 ): Promise<string[]> {
-  const deployAdapter = context.adapters.deploy(adapter);
+  const deployAdapter = context.adapters.deploy(target.adapter);
   if (deployAdapter === null) return [];
 
   const stranded = await context.db
@@ -232,7 +319,7 @@ async function readopt(
   for (const deploy of stranded) {
     let observed: Awaited<ReturnType<typeof deployAdapter.observe>>;
     try {
-      observed = await deployAdapter.observe({ name, adapter }, deploy.ref!);
+      observed = await deployAdapter.observe(target, deploy.ref!);
     } catch {
       // Connect still succeeds. An adapter that cannot answer leaves the
       // Deploy stranded, which is the honest state — not an error to raise.

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -55,9 +55,17 @@ import type {
  * `OIDC_FEDERATION` is one item rather than two because §13 states it as "both
  * ways": half of a federation is not a state a Target can usefully be in, and
  * splitting it would put two rows in the UI that always agree.
+ *
+ * `CHART_SOURCE` is separate from `DELIVERY_OPERATOR` because the two fail
+ * apart: a cluster can run Flux perfectly and still not carry the repository
+ * the App chart is fetched from. It exists at all because v1 sources the chart
+ * from a repository rather than from OCI (plan, Milestone 3) — **it is the
+ * first thing that breaks on extraction**, and naming it here is what makes
+ * that visible as a stated reason rather than as a deploy that fails late.
  */
 export const PREREQUISITES = [
   'DELIVERY_OPERATOR',
+  'CHART_SOURCE',
   'WRITABLE_STORE',
   'OIDC_FEDERATION',
   'VESSEL',

--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -125,6 +125,8 @@ export interface Hostname {
  * §7's chart takes the same flat values.
  */
 export interface DesiredState {
+  /** The Deploy placing this state, used to trace controller-created pods (§7). */
+  deploy: string;
   /** The App this Component belongs to. */
   app: string;
   /** The Component being deployed. */

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -37,11 +37,7 @@ import type { TargetAdapter } from '../config/manifest.schema.ts';
  * eventually put a token in.
  */
 export type TargetConnection =
-  | {
-      adapter: 'kubernetes';
-      /** The API server endpoint (§13's prerequisite is OIDC against it). */
-      apiServer: string;
-    }
+  | KubernetesConnection
   | {
       adapter: 'cloudrun';
       /** The vessel project this Target deploys into (§14). */
@@ -53,6 +49,120 @@ export type TargetConnection =
       /** The vessel project this Target's sites live in (§14). */
       project: string;
     };
+
+/**
+ * How a Kubernetes Target is reached, and by which GitOps operator.
+ *
+ * §6: **the Target declares the delivery flavour.** "The GitOps operator *is*
+ * the pluggable machinery, so Spindrift applies a `HelmRelease` or an Argo
+ * `Application` **through the API**" — which is why the flavour is connection
+ * material rather than an installation-wide setting: two clusters may run
+ * different operators and neither is more correct.
+ *
+ * Everything below the flavour is an operator's statement about their own
+ * cluster. None of it is a credential (§13), and none of it is interpreted
+ * here: core stores it and hands it to the adapter, which is the only thing
+ * that knows what a `GitRepository` is.
+ */
+export interface KubernetesConnection {
+  adapter: 'kubernetes';
+  /** The API server endpoint (§13's prerequisite is OIDC against it). */
+  apiServer: string;
+  /** The namespace an App's workloads land in. Never created by Spindrift (§7). */
+  namespace: string;
+  delivery: KubernetesDelivery;
+  /**
+   * §33: hosts this Target serves itself, the input to the static reachability
+   * check `offlineDeploy` is derived from. An operator's statement, because no
+   * cluster API reports what it can reach.
+   */
+  servedHosts?: readonly string[];
+  /** Registries reachable from this Target, likewise stated (§3). */
+  reachableRegistries?: readonly string[];
+  /**
+   * §18: "how far back a tail can honestly reach", in seconds. Stated rather
+   * than discovered, because the log store is beside the cluster and not in it.
+   */
+  logHistorySeconds?: number;
+  /**
+   * §7's per-Target chart-values field: the operator's half of the value
+   * contract. Untyped here on purpose — the chart's classes are the adapter's
+   * knowledge, and the boundary between what an operator may write and what
+   * Spindrift writes is enforced where this is saved, not where it is stored.
+   */
+  chartValues?: Record<string, unknown>;
+  /**
+   * The value-contract version the App chart pinned for this Target declares
+   * (§7, read at pin time).
+   *
+   * Stated rather than read, because v1 sources the chart from a branch rather
+   * than from a pinned OCI artifact — so skew is **detected** here rather than
+   * prevented, and detection needs the operator to say what they pinned.
+   */
+  chartContract?: string;
+}
+
+/**
+ * The two delivery flavours §6 names, each carrying what its operator needs.
+ *
+ * A direct apply and a Flux Kustomization are designed-for and deferred — note
+ * the inversion §6 records: applying manifests directly is the *expensive*
+ * flavour, being the only one with no controller to report status.
+ *
+ * **Both carry the chart's source**, because until the OCI swap the App chart
+ * is fetched from a repository the Target already trusts (plan, Milestone 3).
+ * That makes "a `GitRepository` in this cluster" a Target prerequisite, and the
+ * prerequisite is checkable exactly because the reference is here.
+ */
+export const KUBERNETES_DELIVERY_FLAVOURS = [
+  'flux-helmrelease',
+  'argo-application',
+] as const;
+
+/** Which GitOps operator drives one Target. Vocabulary, never an identity. */
+export type KubernetesDeliveryFlavour =
+  (typeof KUBERNETES_DELIVERY_FLAVOURS)[number];
+
+export type KubernetesDelivery =
+  | {
+      flavour: 'flux-helmrelease';
+      /** Namespace the `HelmRelease` object itself is created in. */
+      namespace: string;
+      /** The `GitRepository` the App chart is fetched from. */
+      sourceRef: { name: string; namespace: string };
+    }
+  | {
+      flavour: 'argo-application';
+      /** Namespace the Argo `Application` object is created in. */
+      namespace: string;
+      /** The Argo project the Application belongs to. */
+      project: string;
+      /** The repository the App chart is fetched from, and at which revision. */
+      repoUrl: string;
+      revision: string;
+      /** The cluster Argo deploys to, in Argo's own vocabulary. */
+      server: string;
+    };
+
+/** What the deploy contract's verbs need to name one Target (§6). */
+export interface DeployTargetRef {
+  readonly name: string;
+  readonly adapter: TargetAdapter;
+  readonly connection: TargetConnection;
+}
+
+/** The narrow view of a Target row the adapter contract takes. */
+export function deployTargetOf(target: {
+  name: string;
+  adapter: TargetAdapter;
+  connection: TargetConnection;
+}): DeployTargetRef {
+  return {
+    name: target.name,
+    adapter: target.adapter,
+    connection: target.connection,
+  };
+}
 
 /**
  * Whether the Target passes §13's standing checklist.

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -22,7 +22,6 @@
  */
 import { eq } from 'drizzle-orm';
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
-import type { TargetAdapter } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
 import { type Target, targets } from '../db/schema.ts';
 import {
@@ -31,7 +30,11 @@ import {
   type TargetDiscovery,
   unreachablePrerequisites,
 } from '../domain/capabilities.ts';
-import type { TargetHealth } from '../domain/target.ts';
+import {
+  type DeployTargetRef,
+  deployTargetOf,
+  type TargetHealth,
+} from '../domain/target.ts';
 
 /**
  * What the loop needs. Narrower than a `CommandContext` on purpose — the loop
@@ -59,23 +62,22 @@ export interface TargetInspectionResult {
  */
 export async function inspectTarget(
   context: TargetLoopContext,
-  name: string,
-  adapter: TargetAdapter,
+  target: DeployTargetRef,
 ): Promise<TargetInspectionResult> {
-  const deployAdapter = context.adapters.deploy(adapter);
+  const deployAdapter = context.adapters.deploy(target.adapter);
   if (deployAdapter === null) {
     // Not a fault: an installation is allowed to have a Target whose adapter it
     // does not ship. It is simply a Target nothing can be placed on, and saying
     // so is more useful than refusing to record it.
     return {
       prerequisites: unreachablePrerequisites(
-        `this installation has no ${adapter} adapter`,
+        `this installation has no ${target.adapter} adapter`,
       ),
       discovery: null,
     };
   }
   try {
-    const inspection = await deployAdapter.inspect({ name, adapter });
+    const inspection = await deployAdapter.inspect(target);
     return {
       prerequisites: inspection.prerequisites,
       discovery: inspection.discovery,
@@ -109,13 +111,12 @@ export interface TargetRefresh {
  */
 export async function refreshTarget(
   context: TargetLoopContext,
-  target: Pick<Target, 'id' | 'name' | 'adapter' | 'health'>,
+  target: Pick<Target, 'id' | 'name' | 'adapter' | 'health' | 'connection'>,
 ): Promise<TargetRefresh> {
   const now = context.clock.now();
   const { prerequisites, discovery } = await inspectTarget(
     context,
-    target.name,
-    target.adapter,
+    deployTargetOf(target),
   );
   const health = deriveHealth(prerequisites);
 

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -20,6 +20,7 @@ import {
 import { PREREQUISITES } from '../../src/domain/capabilities.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
+import { connectionFor } from '../harness/installation.ts';
 
 /**
  * §6's table, transcribed. A reviewer can check this against the spec without
@@ -104,7 +105,11 @@ describe("§6's failure vocabulary", () => {
   });
 });
 
-const target = { name: 'somewhere', adapter: 'kubernetes' } as const;
+const target = {
+  name: 'somewhere',
+  adapter: 'kubernetes',
+  connection: connectionFor('kubernetes'),
+} as const;
 
 const desired: DesiredState = {
   app: 'app',

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -112,6 +112,7 @@ const target = {
 } as const;
 
 const desired: DesiredState = {
+  deploy: 'deploy-1',
   app: 'app',
   component: 'web',
   target: target.name,

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -137,8 +137,10 @@ interface RenderedValues {
   shared: { resources?: unknown; podLabels?: unknown };
   app: {
     artifactDigest?: string;
+    expose?: boolean;
     hostnames?: readonly string[];
     kind?: string;
+    port?: number;
   };
 }
 
@@ -305,6 +307,8 @@ describe('the delivery object', () => {
     );
     const values = renderedValues(cluster);
     expect(values.app.kind).toBe('website');
+    expect(values.app.expose).toBe(true);
+    expect(values.app.port).toBe(8080);
     expect(values.app.hostnames).toEqual([
       'blog-web.apps.example.test',
       'blog.example.test',

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -75,6 +75,7 @@ function connection(
     apiServer: 'https://cluster.example.test',
     namespace: 'apps',
     delivery: FLUX,
+    chartContract: VALUES_CONTRACT,
     ...overrides,
   };
 }
@@ -91,6 +92,7 @@ function target(
 
 function desiredState(overrides: Partial<DesiredState> = {}): DesiredState {
   return {
+    deploy: 'deploy-1',
     app: 'blog',
     component: 'web',
     target: 'cluster',
@@ -648,6 +650,17 @@ describe('the checklist', () => {
     );
     expect(contract?.met).toBe(false);
     expect(contract?.detail).toContain(VALUES_CONTRACT);
+  });
+
+  test('an unread chart contract is a prerequisite failure', async () => {
+    const { adapter } = adapterFor();
+    const { prerequisites } = await adapter.inspect(
+      target({ chartContract: undefined }),
+    );
+    const contract = prerequisites.find(
+      (item) => item.name === 'CHART_CONTRACT',
+    );
+    expect(contract?.met).toBe(false);
   });
 });
 

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -1,0 +1,778 @@
+/**
+ * The Kubernetes deploy adapter (Task 17, §6, §7).
+ *
+ * Every test drives the real adapter against a fake of the cluster's HTTP API
+ * (§ Seam 2) and asserts what a cluster would have been sent, or what the
+ * adapter concluded from what it was told. Nothing here reaches core: the
+ * command layer is Seam 1 and has its own tests.
+ *
+ * The claims worth stating up front, because each is a rule §6 or §7 makes
+ * that a plausible implementation would break:
+ *
+ * - Spindrift applies a delivery object **through the API**, with **one inline
+ *   values blob** — never a values ConfigMap, which Flux overwrites and Argo
+ *   has no equivalent for.
+ * - **The Target declares the flavour**, so the same `DesiredState` produces a
+ *   `HelmRelease` on one Target and an Argo `Application` on another.
+ * - Phase transitions come from the controller. The adapter polls; it never
+ *   decides that something is ready.
+ * - **On red it reads pods and events once** and fills in the reason — which is
+ *   what turns "InstallFailed" into `ARTIFACT_UNAVAILABLE` with the blame on
+ *   the platform rather than on the developer's code.
+ */
+import { describe, expect, test } from 'bun:test';
+import type {
+  DeployEvent,
+  DeployTarget,
+  DeployVerdict,
+} from '../../src/adapters/deploy/contract.ts';
+import { blameFor } from '../../src/adapters/deploy/contract.ts';
+import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
+import { VALUES_CONTRACT } from '../../src/adapters/deploy/kubernetes/values.ts';
+import type { DesiredState } from '../../src/domain/desired-state.ts';
+import type {
+  KubernetesConnection,
+  KubernetesDelivery,
+} from '../../src/domain/target.ts';
+import {
+  FakeKubernetes,
+  type FakeKubernetesOptions,
+  type FakeObject,
+  type StatusScript,
+} from '../harness/fakes/kubernetes-api.ts';
+
+const CHART = 'example/spindrift-app';
+
+const FLUX: KubernetesDelivery = {
+  flavour: 'flux-helmrelease',
+  namespace: 'delivery',
+  sourceRef: { name: 'charts', namespace: 'delivery' },
+};
+
+const ARGO: KubernetesDelivery = {
+  flavour: 'argo-application',
+  namespace: 'delivery',
+  project: 'default',
+  repoUrl: 'https://git.example.test/infra',
+  revision: 'main',
+  server: 'https://kubernetes.default.svc',
+};
+
+/** A cluster that serves everything the checklist looks for. */
+const SERVED = {
+  'helm.toolkit.fluxcd.io/v2': ['HelmRelease'],
+  'argoproj.io/v1alpha1': ['Application'],
+  'postgresql.cnpg.io/v1': ['Cluster'],
+  'cilium.io/v2': ['CiliumNetworkPolicy'],
+  'kyverno.io/v1': ['ClusterPolicy'],
+};
+
+function connection(
+  overrides: Partial<KubernetesConnection> = {},
+): KubernetesConnection {
+  return {
+    adapter: 'kubernetes',
+    apiServer: 'https://cluster.example.test',
+    namespace: 'apps',
+    delivery: FLUX,
+    ...overrides,
+  };
+}
+
+function target(
+  connectionOverrides: Partial<KubernetesConnection> = {},
+): DeployTarget {
+  return {
+    name: 'cluster',
+    adapter: 'kubernetes',
+    connection: connection(connectionOverrides),
+  };
+}
+
+function desiredState(overrides: Partial<DesiredState> = {}): DesiredState {
+  return {
+    app: 'blog',
+    component: 'web',
+    target: 'cluster',
+    kind: 'service',
+    artifact: {
+      type: 'image',
+      digest: 'sha256:feed',
+      refs: ['registry.example.test/blog/web@sha256:feed'],
+    },
+    expose: true,
+    exposure: 'private',
+    config: [],
+    requirements: {
+      platform: { os: 'linux', arch: 'amd64' },
+      resources: { cpu: '250m', memory: '256Mi' },
+    },
+    hostname: { canonical: 'blog-web.apps.example.test' },
+    ...overrides,
+  };
+}
+
+/** The adapter, wired to one fake cluster, with the cadence spent instantly. */
+function adapterFor(options: FakeKubernetesOptions = {}): {
+  adapter: KubernetesDeployAdapter;
+  cluster: FakeKubernetes;
+} {
+  const cluster = new FakeKubernetes({ servedKinds: SERVED, ...options });
+  const adapter = new KubernetesDeployAdapter({
+    chart: CHART,
+    token: cluster.token,
+    fetch: cluster.fetch,
+    pollIntervalMs: 1,
+    // A test must not spend the cadence it is asserting about, and a fake
+    // clock is also what makes the timeout case finite.
+    sleep: async () => {},
+  });
+  return { adapter, cluster };
+}
+
+interface RenderedValues {
+  platform: { runtimeClassName?: string };
+  shared: { resources?: unknown; podLabels?: unknown };
+  app: {
+    artifactDigest?: string;
+    hostnames?: readonly string[];
+    kind?: string;
+  };
+}
+
+/** The inline values on the Flux object, failing clearly if apply wrote none. */
+function renderedValues(cluster: FakeKubernetes): RenderedValues {
+  const release = cluster.get('helmreleases/delivery/blog-web');
+  const spec = release?.spec as { values?: RenderedValues } | undefined;
+  if (spec?.values === undefined) {
+    throw new Error('expected the HelmRelease to carry inline values');
+  }
+  return spec.values;
+}
+
+/** Drive a stream to its verdict, collecting the timeline. */
+async function drain(
+  stream: AsyncGenerator<DeployEvent, DeployVerdict, void>,
+): Promise<{ events: DeployEvent[]; verdict: DeployVerdict }> {
+  const events: DeployEvent[] = [];
+  let step = await stream.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return { events, verdict: step.value };
+}
+
+/** A pod in one waiting state, as the API reports it. */
+function pod(reason: string, message: string): FakeObject {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: { name: 'blog-web-abc', namespace: 'apps' },
+    status: {
+      containerStatuses: [
+        { name: 'app', ready: false, state: { waiting: { reason, message } } },
+      ],
+    },
+  };
+}
+
+/** A `HelmRelease` that failed without saying why — the read-on-red case. */
+const INSTALL_FAILED: StatusScript = () => ({
+  observedGeneration: 1,
+  conditions: [
+    {
+      type: 'Ready',
+      status: 'False',
+      reason: 'InstallFailed',
+      message: 'install retries exhausted',
+    },
+    { type: 'Stalled', status: 'True', reason: 'InstallFailed' },
+  ],
+});
+
+describe('the delivery object', () => {
+  test('a HelmRelease is applied through the API, with inline values', async () => {
+    const { adapter, cluster } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+
+    expect(verdict.phase).toBe('LIVE');
+    const applied = cluster.get('helmreleases/delivery/blog-web');
+    expect(applied?.kind).toBe('HelmRelease');
+
+    const spec = applied?.spec as any;
+    // §7: one inline values blob. A values ConfigMap is dead as a portable
+    // mechanism — Flux merges `valuesFrom` and then overwrites it inline.
+    expect(spec.values.app.image).toBe(
+      'registry.example.test/blog/web@sha256:feed',
+    );
+    expect(spec.valuesFrom).toBeUndefined();
+    expect(cluster.all('configmaps')).toEqual([]);
+
+    // The chart comes from the Target's own repository until the OCI swap.
+    expect(spec.chart.spec.chart).toBe(CHART);
+    expect(spec.chart.spec.sourceRef).toEqual({
+      kind: 'GitRepository',
+      name: 'charts',
+      namespace: 'delivery',
+    });
+    // Reconciliation lives in core: the controller must not retry an attempt
+    // nobody asked for (§6).
+    expect(spec.install.remediation.retries).toBe(0);
+  });
+
+  test('the write is a server-side apply, attributed to Spindrift', async () => {
+    const { adapter, cluster } = adapterFor();
+    await drain(adapter.apply(target(), desiredState()));
+
+    const write = cluster.requests.find(
+      (request) => request.method === 'PATCH',
+    );
+    expect(write?.contentType).toBe('application/apply-patch+yaml');
+    expect(write?.path).toBe(
+      '/apis/helm.toolkit.fluxcd.io/v2/namespaces/delivery/helmreleases/blog-web',
+    );
+  });
+
+  test('the Target declares the flavour: the same state, an Argo Application', async () => {
+    const { adapter, cluster } = adapterFor({
+      status: () => ({
+        health: { status: 'Healthy' },
+        sync: { status: 'Synced' },
+      }),
+    });
+    const { verdict } = await drain(
+      adapter.apply(target({ delivery: ARGO }), desiredState()),
+    );
+
+    expect(verdict.phase).toBe('LIVE');
+    const applied = cluster.get('applications/delivery/blog-web');
+    expect(applied?.kind).toBe('Application');
+    const spec = applied?.spec as any;
+    expect(spec.source.helm.valuesObject.app.component).toBe('web');
+    expect(spec.destination.namespace).toBe('apps');
+    // The namespace is vessel (§7): a sync that created it would let a
+    // `destroy()` remove it.
+    expect(spec.syncPolicy.syncOptions).toBeUndefined();
+  });
+
+  test('the values carry the three classes, with Spindrift winning the shared one', async () => {
+    const { adapter, cluster } = adapterFor();
+    await drain(
+      adapter.apply(
+        target({
+          chartValues: {
+            platform: { runtimeClassName: 'gvisor' },
+            shared: {
+              resources: { limits: { cpu: '2' } },
+              podLabels: { tier: 'web' },
+            },
+          },
+        }),
+        desiredState(),
+      ),
+    );
+
+    const values = renderedValues(cluster);
+    // The operator's class, untouched.
+    expect(values.platform.runtimeClassName).toBe('gvisor');
+    // The shared class: Spindrift's requests replace the operator's key,
+    // and the keys Spindrift has no opinion about survive.
+    expect(values.shared.resources).toEqual({
+      requests: { cpu: '250m', memory: '256Mi' },
+    });
+    expect(values.shared.podLabels).toEqual({ tier: 'web' });
+    // Spindrift's own class, rendered from what core described.
+    expect(values.app.artifactDigest).toBe('sha256:feed');
+    expect(values.app.hostnames).toEqual(['blog-web.apps.example.test']);
+  });
+
+  test('a website on a cluster is a service with a hostname, not files', async () => {
+    const { adapter, cluster } = adapterFor();
+    await drain(
+      adapter.apply(
+        target(),
+        desiredState({
+          kind: 'website',
+          hostname: {
+            canonical: 'blog-web.apps.example.test',
+            vanity: 'blog.example.test',
+          },
+        }),
+      ),
+    );
+    const values = renderedValues(cluster);
+    expect(values.app.kind).toBe('website');
+    expect(values.app.hostnames).toEqual([
+      'blog-web.apps.example.test',
+      'blog.example.test',
+    ]);
+  });
+});
+
+describe('phases come from the controller', () => {
+  test('the timeline reports each phase the object moved through, once', async () => {
+    const { adapter } = adapterFor({
+      status: (reads) =>
+        reads < 3
+          ? {
+              observedGeneration: 1,
+              conditions: [
+                {
+                  type: 'Ready',
+                  status: 'False',
+                  reason: 'Progressing',
+                  message: 'installing',
+                },
+              ],
+            }
+          : {
+              observedGeneration: 1,
+              conditions: [{ type: 'Ready', status: 'True', message: 'ok' }],
+            },
+    });
+
+    const { events, verdict } = await drain(
+      adapter.apply(target(), desiredState()),
+    );
+    expect(verdict.phase).toBe('LIVE');
+
+    const phases = events
+      .filter((event) => event.type === 'status')
+      .map((event) => (event.type === 'status' ? event.phase : ''));
+    // APPLYING once, WAITING once however many times it was polled, LIVE once.
+    expect(phases).toEqual(['APPLYING', 'WAITING', 'LIVE']);
+  });
+
+  test('a LIVE verdict carries no url — the cluster gives no name of its own', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    // §9: Spindrift mints the canonical name where the platform gives none,
+    // which is the metal cluster alone. A url coming back here would be a
+    // second naming authority.
+    expect(verdict).toEqual({
+      phase: 'LIVE',
+      ref: 'flux-helmrelease:delivery/blog-web',
+    });
+  });
+
+  test('a stale status is not read as a verdict', async () => {
+    // The object still carries the last generation's Ready=True. An adapter
+    // that trusted it would report a re-deploy green before anything was
+    // tried.
+    let observed = 0;
+    const { adapter } = adapterFor({
+      status: (reads) => {
+        observed = reads;
+        return reads < 2
+          ? {
+              observedGeneration: 0,
+              conditions: [{ type: 'Ready', status: 'True', message: 'stale' }],
+            }
+          : {
+              observedGeneration: 1,
+              conditions: [{ type: 'Ready', status: 'True', message: 'fresh' }],
+            };
+      },
+    });
+
+    const { events } = await drain(adapter.apply(target(), desiredState()));
+    expect(observed).toBeGreaterThan(1);
+    const phases = events
+      .filter((event) => event.type === 'status')
+      .map((event) => (event.type === 'status' ? event.phase : ''));
+    expect(phases).toEqual(['APPLYING', 'LIVE']);
+  });
+
+  test('an attempt that never settles is TIMEOUT, blaming nobody', async () => {
+    const cluster = new FakeKubernetes({
+      servedKinds: SERVED,
+      status: () => ({
+        observedGeneration: 1,
+        conditions: [{ type: 'Ready', status: 'False', reason: 'Progressing' }],
+      }),
+    });
+    let clock = 0;
+    const adapter = new KubernetesDeployAdapter({
+      chart: CHART,
+      token: cluster.token,
+      fetch: cluster.fetch,
+      pollIntervalMs: 1_000,
+      timeoutMs: 5_000,
+      sleep: async () => {
+        clock += 1_000;
+      },
+      now: () => clock,
+    });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('TIMEOUT');
+    // §6's table gives TIMEOUT a dash: a deploy that never reached a terminal
+    // state indicts nobody.
+    expect(blameFor(verdict.reason)).toBeNull();
+  });
+});
+
+describe('the read on red', () => {
+  test('an image that will not pull is the platform’s fault, not the code’s', async () => {
+    const { adapter, cluster } = adapterFor({
+      status: INSTALL_FAILED,
+      lists: {
+        pods: [pod('ImagePullBackOff', 'Back-off pulling image')],
+        events: [],
+      },
+    });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+    expect(blameFor(verdict.reason)).toBe('platform');
+    expect(verdict.detail).toBe('Back-off pulling image');
+
+    // Read **once** (§6): one pass over pods and one over events, not a watch.
+    expect(
+      cluster.pathsOf('GET').filter((path) => path.endsWith('/pods')),
+    ).toHaveLength(1);
+  });
+
+  test('a crash loop is the developer’s', async () => {
+    const { adapter } = adapterFor({
+      status: INSTALL_FAILED,
+      lists: {
+        pods: [pod('CrashLoopBackOff', 'back-off restarting failed container')],
+        events: [],
+      },
+    });
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('STARTUP_FAILED');
+    expect(blameFor(verdict.reason)).toBe('developer');
+  });
+
+  test('an admission refusal is REJECTED, and the diagnosis is kept', async () => {
+    const { adapter } = adapterFor({
+      status: INSTALL_FAILED,
+      lists: {
+        pods: [],
+        events: [
+          {
+            apiVersion: 'v1',
+            kind: 'Event',
+            metadata: { name: 'e1', namespace: 'apps' },
+            reason: 'FailedCreate',
+            message: 'admission webhook denied the request',
+          },
+        ],
+      },
+    });
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('REJECTED');
+    expect(verdict.detail).toBe('admission webhook denied the request');
+    // §12: the platform will not keep this — cluster events expire in about an
+    // hour — so the raw payload comes back for core to store.
+    expect(verdict.debug).toBeDefined();
+  });
+
+  test('a reason the object already carries needs no read at all', async () => {
+    const { adapter, cluster } = adapterFor({
+      status: () => ({
+        observedGeneration: 1,
+        conditions: [
+          {
+            type: 'Ready',
+            status: 'False',
+            reason: 'ChartPullFailed',
+            message: 'chart not found',
+          },
+          { type: 'Stalled', status: 'True' },
+        ],
+      }),
+    });
+
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+    expect(
+      cluster.pathsOf('GET').filter((path) => path.endsWith('/pods')),
+    ).toEqual([]);
+  });
+});
+
+describe('a write that never landed', () => {
+  test('a refused apply is REJECTED, carrying the cluster’s own sentence', async () => {
+    const { adapter } = adapterFor({
+      refuse: { status: 422, body: 'admission webhook denied the request' },
+    });
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('REJECTED');
+    expect(verdict.detail).toBe('admission webhook denied the request');
+  });
+
+  test('a cluster that is down is TARGET_UNREACHABLE, blaming the platform', async () => {
+    const { adapter } = adapterFor({
+      refuse: { status: 503, body: 'the server is currently unable' },
+    });
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('TARGET_UNREACHABLE');
+    expect(blameFor(verdict.reason)).toBe('platform');
+  });
+
+  test('an expired credential is unreachable, not a rejection', async () => {
+    const { adapter } = adapterFor({ token: 'a-different-token' });
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    // §6 puts "credentials expired" under TARGET_UNREACHABLE explicitly: the
+    // developer's app has nothing to do with it.
+    expect(verdict.reason).toBe('TARGET_UNREACHABLE');
+  });
+});
+
+describe('observe is the authority on what is running', () => {
+  test('it reports the digest the delivery object carries', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'LIVE') throw new Error('expected a live deploy');
+
+    const observed = await adapter.observe(target(), verdict.ref);
+    expect(observed?.artifactDigest).toBe('sha256:feed');
+    expect(observed?.phase).toBe('LIVE');
+  });
+
+  test('a workload nobody placed through Spindrift is still observable', async () => {
+    // Drift is detected by comparing what is serving against the desired row
+    // (§6), which only works if `observe` reads the cluster rather than core's
+    // memory of what it applied.
+    const { adapter, cluster } = adapterFor();
+    cluster.place('helmreleases/delivery/other-web', {
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      kind: 'HelmRelease',
+      metadata: { name: 'other-web', namespace: 'delivery', generation: 1 },
+      spec: { values: { app: { artifactDigest: 'sha256:elsewhere' } } },
+    });
+
+    const observed = await adapter.observe(
+      target(),
+      'flux-helmrelease:delivery/other-web',
+    );
+    expect(observed?.artifactDigest).toBe('sha256:elsewhere');
+  });
+});
+
+describe('the checklist', () => {
+  test('a healthy cluster meets every item', async () => {
+    const { adapter } = adapterFor({
+      objects: {
+        'gitrepositories/delivery/charts': {
+          apiVersion: 'source.toolkit.fluxcd.io/v1',
+          kind: 'GitRepository',
+          metadata: { name: 'charts', namespace: 'delivery' },
+        },
+        'namespaces//apps': {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'apps' },
+        },
+      },
+      lists: {
+        clustersecretstores: [
+          {
+            apiVersion: 'external-secrets.io/v1',
+            kind: 'ClusterSecretStore',
+            metadata: { name: 'vault' },
+            spec: { provider: { gcpsm: {} } },
+          },
+        ],
+      },
+    });
+
+    const { prerequisites } = await adapter.inspect(target());
+    expect(prerequisites.filter((item) => !item.met)).toEqual([]);
+  });
+
+  test('a Target without the GitRepository is unhealthy, and says so', async () => {
+    // The plan's named cost: sourcing the chart from a repository makes "a
+    // GitRepository in this cluster" a Target prerequisite, and it is the
+    // first thing that breaks on extraction.
+    const { adapter } = adapterFor({
+      objects: {
+        'namespaces//apps': {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'apps' },
+        },
+      },
+    });
+
+    const { prerequisites } = await adapter.inspect(target());
+    const chartSource = prerequisites.find(
+      (item) => item.name === 'CHART_SOURCE',
+    );
+    expect(chartSource?.met).toBe(false);
+    expect(chartSource?.detail).toContain('GitRepository');
+    expect(chartSource?.detail).toContain('charts');
+  });
+
+  test('a cluster running neither operator cannot deliver anything', async () => {
+    const { adapter } = adapterFor({ servedKinds: {} });
+    const { prerequisites } = await adapter.inspect(target());
+    const operator = prerequisites.find(
+      (item) => item.name === 'DELIVERY_OPERATOR',
+    );
+    expect(operator?.met).toBe(false);
+    expect(operator?.detail).toContain('HelmRelease');
+  });
+
+  test('an identity that may not write the delivery object fails OIDC', async () => {
+    const { adapter } = adapterFor({ allowed: false });
+    const { prerequisites } = await adapter.inspect(target());
+    const federation = prerequisites.find(
+      (item) => item.name === 'OIDC_FEDERATION',
+    );
+    expect(federation?.met).toBe(false);
+    expect(federation?.detail).toContain('delivery');
+  });
+
+  test('chart-contract skew is a prerequisite failure, not a silent green', async () => {
+    // §7: Helm ignores unknown values silently, so an unrepinned Target would
+    // apply cleanly, report green, and run without config.
+    const { adapter } = adapterFor();
+    const { prerequisites } = await adapter.inspect(
+      target({ chartContract: '99' }),
+    );
+    const contract = prerequisites.find(
+      (item) => item.name === 'CHART_CONTRACT',
+    );
+    expect(contract?.met).toBe(false);
+    expect(contract?.detail).toContain(VALUES_CONTRACT);
+  });
+});
+
+describe('discovery reports observations, never judgements', () => {
+  test('it reads the nodes for arch, GPU, and the ceiling', async () => {
+    const { adapter } = adapterFor({
+      lists: {
+        nodes: [
+          node('amd64', { cpu: '8', memory: '32Gi' }),
+          node('arm64', { cpu: '4', memory: '8Gi', 'nvidia.com/gpu': '1' }),
+        ],
+        storageclasses: [
+          {
+            apiVersion: 'storage.k8s.io/v1',
+            kind: 'StorageClass',
+            metadata: { name: 'local' },
+          },
+        ],
+      },
+    });
+
+    const { discovery } = await adapter.inspect(target());
+    expect(discovery.arch).toEqual(['amd64', 'arm64']);
+    expect(discovery.gpu).toBe(true);
+    // The ceiling is the largest single workload the Target admits — one
+    // node's allocatable, never the sum, because nothing here schedules.
+    expect(discovery.resourceCeiling).toEqual({ cpu: '8', memory: '32768Mi' });
+    expect(discovery.persistence).toBe(true);
+  });
+
+  test('an audit-mode policy engine is reported as auditing, not as verified', async () => {
+    // §32: core decides what enforcing means. An adapter that answered
+    // `verifiedDeploy` would let two adapters disagree about it.
+    const { adapter } = adapterFor({
+      lists: {
+        clusterpolicies: [
+          {
+            apiVersion: 'kyverno.io/v1',
+            kind: 'ClusterPolicy',
+            metadata: { name: 'verify-images' },
+            spec: { validationFailureAction: 'Audit' },
+          },
+        ],
+      },
+    });
+
+    const { discovery } = await adapter.inspect(target());
+    expect(discovery.policyEngine).toEqual({ installed: true, mode: 'AUDIT' });
+    expect(discovery).not.toHaveProperty('verifiedDeploy');
+  });
+
+  test('an enforcing rule is enough, wherever the field lives', async () => {
+    const { adapter } = adapterFor({
+      lists: {
+        clusterpolicies: [
+          {
+            apiVersion: 'kyverno.io/v1',
+            kind: 'ClusterPolicy',
+            metadata: { name: 'verify-images' },
+            spec: { rules: [{ validate: { failureAction: 'Enforce' } }] },
+          },
+        ],
+      },
+    });
+    const { discovery } = await adapter.inspect(target());
+    expect(discovery.policyEngine.mode).toBe('ENFORCE');
+  });
+
+  test('the stated facts are reported as stated, never inferred', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(
+      target({
+        servedHosts: ['registry.example.test'],
+        reachableRegistries: ['registry.example.test'],
+        logHistorySeconds: 3_600,
+      }),
+    );
+    // §33's static check is over hosts nobody can discover from inside a
+    // cluster, and §18's reach is a property of a log store beside it.
+    expect(discovery.servedHosts).toEqual(['registry.example.test']);
+    expect(discovery.logHistorySeconds).toBe(3_600);
+    expect(discovery).not.toHaveProperty('offlineDeploy');
+  });
+
+  test('an unstated log reach is zero, not a guess', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(target());
+    expect(discovery.logHistorySeconds).toBe(0);
+  });
+
+  test('the stores it can reach come from what the cluster carries', async () => {
+    const { adapter } = adapterFor({
+      lists: {
+        clustersecretstores: [
+          {
+            apiVersion: 'external-secrets.io/v1',
+            kind: 'ClusterSecretStore',
+            metadata: { name: 'one' },
+            spec: { provider: { onepassword: {} } },
+          },
+          {
+            apiVersion: 'external-secrets.io/v1',
+            kind: 'ClusterSecretStore',
+            metadata: { name: 'two' },
+            spec: { provider: { gcpsm: {} } },
+          },
+        ],
+      },
+    });
+    const { discovery } = await adapter.inspect(target());
+    expect([...discovery.reachableSecretStores].sort()).toEqual([
+      'gcp-secret-manager',
+      'onepassword',
+    ]);
+  });
+});
+
+function node(arch: string, allocatable: Record<string, string>): FakeObject {
+  return {
+    apiVersion: 'v1',
+    kind: 'Node',
+    metadata: {
+      name: `node-${arch}`,
+      labels: { 'kubernetes.io/arch': arch },
+    },
+    status: { allocatable },
+  };
+}

--- a/apps/spindrift/test/commands/placement.test.ts
+++ b/apps/spindrift/test/commands/placement.test.ts
@@ -33,7 +33,7 @@ import {
 import type { ComponentKind } from '../../src/domain/desired-state.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest } from '../harness/installation.ts';
+import { clusterInput, fixtureManifest } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -74,14 +74,7 @@ function context(registry: AdapterRegistry): CommandContext {
 
 /** The cluster and the two cloud Targets, in rank order, all healthy. */
 async function connectEverything(registry: AdapterRegistry) {
-  await connectTarget(
-    {
-      kind: 'kubernetes',
-      name: 'cluster',
-      apiServer: 'https://cluster.example.test',
-    },
-    context(registry),
-  );
+  await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
   await connectTarget(
     {
       kind: 'cloud',

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -39,7 +39,11 @@ import {
   FakeDeployAdapter,
   type FakeDeployAdapterOptions,
 } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest } from '../harness/installation.ts';
+import {
+  clusterInput,
+  connectionFor,
+  fixtureManifest,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -136,11 +140,7 @@ describe('connect always succeeds', () => {
   test('a reachable cluster is registered healthy, at the end of the rank', async () => {
     const { registry, of } = fakes();
     const result = await connectTarget(
-      {
-        kind: 'kubernetes',
-        name: 'cluster',
-        apiServer: 'https://cluster.example.test',
-      },
+      clusterInput({ name: 'cluster' }),
       context(registry),
     );
 
@@ -150,10 +150,7 @@ describe('connect always succeeds', () => {
     expect(row?.rank).toBe(0);
     expect(row?.status).toBe('connected');
     expect(row?.inspectedAt).toEqual(FROZEN);
-    expect(row?.connection).toEqual({
-      adapter: 'kubernetes',
-      apiServer: 'https://cluster.example.test',
-    });
+    expect(row?.connection).toEqual(connectionFor('kubernetes'));
     expect(of('kubernetes').inspected).toHaveLength(1);
   });
 
@@ -162,11 +159,7 @@ describe('connect always succeeds', () => {
       kubernetes: { unreachable: 'dial tcp: no route to host' },
     });
     const result = await connectTarget(
-      {
-        kind: 'kubernetes',
-        name: 'cluster',
-        apiServer: 'https://cluster.example.test',
-      },
+      clusterInput({ name: 'cluster' }),
       context(registry),
     );
 
@@ -183,11 +176,7 @@ describe('connect always succeeds', () => {
   test('a Target whose adapter this installation does not ship', async () => {
     const { registry } = fakes({ kubernetes: null });
     const result = await connectTarget(
-      {
-        kind: 'kubernetes',
-        name: 'cluster',
-        apiServer: 'https://cluster.example.test',
-      },
+      clusterInput({ name: 'cluster' }),
       context(registry),
     );
 
@@ -233,11 +222,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
 
   test('connect is idempotent by name and keeps the rank', async () => {
     const { registry } = fakes();
-    const input = {
-      kind: 'kubernetes',
-      name: 'cluster',
-      apiServer: 'https://cluster.example.test',
-    } as const;
+    const input = clusterInput({ name: 'cluster' });
 
     await connectTarget(
       { kind: 'cloud', name: 'vessel', project: 'p', region: 'r' },
@@ -259,14 +244,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
 describe('disconnect strands rather than stops', () => {
   test('live Deploys go orphaned and are named, and nothing is destroyed', async () => {
     const { registry, of } = fakes();
-    await connectTarget(
-      {
-        kind: 'kubernetes',
-        name: 'cluster',
-        apiServer: 'https://cluster.example.test',
-      },
-      context(registry),
-    );
+    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
     const target = (await targetRow('cluster'))!;
     const { app, component } = await seedLiveDeploy(target.id, 'ref-1');
 
@@ -305,14 +283,7 @@ describe('disconnect strands rather than stops', () => {
 
   test('disconnecting a Target with nothing on it strands nothing', async () => {
     const { registry } = fakes();
-    await connectTarget(
-      {
-        kind: 'kubernetes',
-        name: 'cluster',
-        apiServer: 'https://cluster.example.test',
-      },
-      context(registry),
-    );
+    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
     const result = await disconnectTarget(
       { name: 'cluster' },
       context(registry),
@@ -336,11 +307,7 @@ describe('disconnect strands rather than stops', () => {
 describe('reconnect re-adopts via observe', () => {
   test('a workload the adapter still sees is adopted back', async () => {
     const { registry, of } = fakes();
-    const input = {
-      kind: 'kubernetes',
-      name: 'cluster',
-      apiServer: 'https://cluster.example.test',
-    } as const;
+    const input = clusterInput({ name: 'cluster' });
 
     await connectTarget(input, context(registry));
     const target = (await targetRow('cluster'))!;
@@ -372,11 +339,7 @@ describe('reconnect re-adopts via observe', () => {
 
   test('a workload that is gone stays orphaned rather than resurrected', async () => {
     const { registry } = fakes();
-    const input = {
-      kind: 'kubernetes',
-      name: 'cluster',
-      apiServer: 'https://cluster.example.test',
-    } as const;
+    const input = clusterInput({ name: 'cluster' });
 
     await connectTarget(input, context(registry));
     const target = (await targetRow('cluster'))!;

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -46,6 +46,7 @@ export function desiredState(
   digest = 'sha256:conformance',
 ): DesiredState {
   return {
+    deploy: 'conformance-deploy',
     app: 'conformance',
     component: 'web',
     target: 'target',

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -31,6 +31,7 @@ import type {
   ArtifactType,
   DesiredState,
 } from '../../src/domain/desired-state.ts';
+import { connectionFor } from '../harness/installation.ts';
 
 /** Names the suite has been run over, collected as the suites declare them. */
 const enrolled = {
@@ -49,7 +50,14 @@ export function desiredState(
     component: 'web',
     target: 'target',
     kind: artifactType === 'files' ? 'website' : 'service',
-    artifact: { type: artifactType, digest, refs: [] },
+    // A real address, because an adapter that has to pull one cannot place
+    // anything without it — and "the artifact carries no address" is a core
+    // bug, not a shape the contract's own suite should exercise.
+    artifact: {
+      type: artifactType,
+      digest,
+      refs: [`registry.example.test/conformance@${digest}`],
+    },
     exposure: 'private',
     config: [],
     requirements: {
@@ -88,7 +96,12 @@ export function deployAdapterSuite(
   enrolled.deploy.add(label);
 
   describe(`deploy contract: ${label}`, () => {
-    const target: DeployTarget = { name: 'target', adapter: make().adapter };
+    const adapter = make().adapter;
+    const target: DeployTarget = {
+      name: 'target',
+      adapter,
+      connection: connectionFor(adapter),
+    };
 
     test('declares at least one artifact type it accepts', () => {
       expect(make().artifactTypes.length).toBeGreaterThan(0);
@@ -296,7 +309,7 @@ export function storeAdapterSuite(
  * inferred from a directory listing that would silently agree with itself.
  */
 export const ADAPTERS = {
-  deploy: ['fake'],
+  deploy: ['fake', 'kubernetes'],
   build: ['fake'],
   store: [
     'fake native',

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -13,10 +13,12 @@
  * tell `NATIVE` from `IMMUTABLE_ITEM_PER_VERSION` — a tested claim rather than a
  * stated one.
  */
+import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
 import { SecretManagerStore } from '../../src/adapters/store/gcp-secret-manager.ts';
 import { OnePasswordStore } from '../../src/adapters/store/onepassword.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { FakeKubernetes } from '../harness/fakes/kubernetes-api.ts';
 import { FakeOnePasswordConnect } from '../harness/fakes/onepassword-connect.ts';
 import { FakeSecretManager } from '../harness/fakes/secret-manager-api.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
@@ -28,6 +30,54 @@ import {
 } from './adapter-suite.ts';
 
 deployAdapterSuite('fake', () => new FakeDeployAdapter(), 'files');
+
+deployAdapterSuite(
+  'kubernetes',
+  () => {
+    const cluster = new FakeKubernetes({
+      servedKinds: {
+        'helm.toolkit.fluxcd.io/v2': ['HelmRelease'],
+        'postgresql.cnpg.io/v1': ['Cluster'],
+        'redis.redis.opstreelabs.in/v1beta2': ['Redis'],
+        'cilium.io/v2': ['CiliumNetworkPolicy'],
+        'kyverno.io/v1': ['ClusterPolicy'],
+      },
+      objects: {
+        'gitrepositories/delivery/charts': {
+          apiVersion: 'source.toolkit.fluxcd.io/v1',
+          kind: 'GitRepository',
+          metadata: { name: 'charts', namespace: 'delivery' },
+        },
+        'namespaces//apps': {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: { name: 'apps' },
+        },
+      },
+      lists: {
+        clustersecretstores: [
+          {
+            apiVersion: 'external-secrets.io/v1',
+            kind: 'ClusterSecretStore',
+            metadata: { name: 'secrets' },
+            spec: { provider: { onepassword: {} } },
+          },
+        ],
+        nodes: [],
+        storageclasses: [],
+        clusterpolicies: [],
+      },
+    });
+    return new KubernetesDeployAdapter({
+      chart: 'example/spindrift-app',
+      token: cluster.token,
+      fetch: cluster.fetch,
+      pollIntervalMs: 1,
+      sleep: async () => {},
+    });
+  },
+  'files',
+);
 
 buildAdapterSuite('fake', () => new FakeBuildAdapter());
 

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -21,6 +21,7 @@ import {
   storeAdapterSchema,
   targetAdapterSchema,
 } from '../../src/config/manifest.schema.ts';
+import { KUBERNETES_DELIVERY_FLAVOURS } from '../../src/domain/target.ts';
 
 const APP = join(import.meta.dir, '../..');
 
@@ -62,6 +63,9 @@ const NOT_A_WORD = /[-\d]/;
 const PROJECT_ID_ALLOWLIST = new Set<string>([
   ...targetAdapterSchema.options,
   ...storeAdapterSchema.options,
+  // Delivery flavours wear the same shape and are the same kind of thing: the
+  // name of a mechanism this software knows, identical in every installation.
+  ...KUBERNETES_DELIVERY_FLAVOURS,
 ]);
 
 /**
@@ -189,9 +193,19 @@ function findProjectIds(files: SourceFile[]): string[] {
   return offenders;
 }
 
-const FROM_IMPORT =
-  /(?:^|\s)(?:import|export)[\s\S]*?from\s*['"]([^'"]+)['"]/gm;
-const BARE_IMPORT = /(?:^|\s)import\s*['"]([^'"]+)['"]/gm;
+/**
+ * An import statement, and nothing that merely reads like one.
+ *
+ * Three narrowings, each closing a false positive this scanner produced when it
+ * was looser: the statement starts a line, because that is the only place an
+ * `import` may appear; the `from` clause is in the same statement, so a `;`
+ * between the two ends the match; and a specifier holds no newline, because
+ * none ever does. Without them, `export class Foo {` followed a hundred lines
+ * later by a sentence ending in the word `from` is reported as an import of
+ * everything in between.
+ */
+const FROM_IMPORT = /^(?:import|export)\b[^;]*?from\s*['"]([^'"\n]+)['"]/gm;
+const BARE_IMPORT = /^import\s*['"]([^'"\n]+)['"]/gm;
 
 /** Every module specifier a source imports, in either form. */
 function importSpecifiers(source: string): string[] {
@@ -423,6 +437,19 @@ describe('the scanners catch a deliberately dirty file', () => {
     expect(findForeignImports(dirty("import express from 'express';"))).toEqual(
       ["src/dirty.ts: 'express' is not a declared dependency"],
     );
+  });
+
+  test('but not an export followed by prose ending in the word from', () => {
+    // The shape that broke the looser scanner: a declaration at column zero,
+    // and further down a sentence whose last word is followed by a quote.
+    const source = [
+      'export class Adapter {',
+      '  detail() {',
+      "    return 'the repository this chart is fetched from';",
+      '  }',
+      '}',
+    ].join('\n');
+    expect(findForeignImports(dirty(source))).toEqual([]);
   });
 
   test('a side-effect import of an undeclared dependency', () => {

--- a/apps/spindrift/test/harness/fakes/kubernetes-api.ts
+++ b/apps/spindrift/test/harness/fakes/kubernetes-api.ts
@@ -1,0 +1,253 @@
+/**
+ * A fake Kubernetes API (Task 17, § Seam 2).
+ *
+ * "A fake of the far-side HTTP API behind the real client, with the test
+ * asserting the requests that were made" — so the adapter's real paths, its
+ * real server-side apply, and its real status reading all run. Nothing inside
+ * core is faked; this is the cluster that is not there.
+ *
+ * Three behaviours are modelled because the adapter has to survive them:
+ *
+ * - **A kind the cluster does not serve answers `404`**, which is how §13's
+ *   checklist tells "no `HelmRelease`s exist" from "this cluster has never
+ *   heard of one".
+ * - **The controller writes status after the object is applied.** A fake that
+ *   returned a ready object immediately would let an adapter that never polled
+ *   pass, which is the whole of `apply`'s second half.
+ * - **A rejected write answers `4xx` with a body**, because §6 wants the
+ *   sentence the developer reads and a fake that returned a bare status code
+ *   would leave nothing to read.
+ */
+import type { Fetcher } from '../../../src/adapters/deploy/kubernetes/api.ts';
+
+export interface RecordedRequest {
+  method: string;
+  path: string;
+  contentType: string | null;
+  body: unknown;
+}
+
+/** Any object the fake holds, as loosely typed as the API's own JSON. */
+export interface FakeObject {
+  apiVersion: string;
+  kind: string;
+  metadata: { name: string; namespace?: string; [key: string]: unknown };
+  [key: string]: unknown;
+}
+
+/** What one applied object's status becomes, read by read. */
+export type StatusScript = (reads: number) => Record<string, unknown> | null;
+
+export interface FakeKubernetesOptions {
+  /** Kinds this cluster serves, as `group/version` → kind names. */
+  servedKinds?: Record<string, string[]>;
+  /** Objects that already exist, keyed by `plural/namespace/name`. */
+  objects?: Record<string, FakeObject>;
+  /** Collections a list call returns, keyed by plural. */
+  lists?: Record<string, FakeObject[]>;
+  /** What an applied delivery object's status becomes over successive reads. */
+  status?: StatusScript;
+  /** When set, every apply is refused with this status and body. */
+  refuse?: { status: number; body: string };
+  /** What a `SelfSubjectAccessReview` answers. */
+  allowed?: boolean;
+  token?: string;
+}
+
+const HOST = 'https://cluster.invalid';
+
+/** The default: the controller reports ready on the first read after apply. */
+const READY: StatusScript = () => ({
+  observedGeneration: 1,
+  conditions: [
+    {
+      type: 'Ready',
+      status: 'True',
+      reason: 'InstallSucceeded',
+      message: 'ok',
+    },
+  ],
+});
+
+export class FakeKubernetes {
+  readonly apiServer = HOST;
+  readonly requests: RecordedRequest[] = [];
+
+  private readonly objects = new Map<string, FakeObject>();
+  private readonly reads = new Map<string, number>();
+  private readonly options: FakeKubernetesOptions;
+
+  constructor(options: FakeKubernetesOptions = {}) {
+    this.options = options;
+    for (const [key, object] of Object.entries(options.objects ?? {})) {
+      this.objects.set(key, object);
+    }
+  }
+
+  /** Mint the token provider the adapter is constructed with. */
+  token = (): string => this.options.token ?? 'federated-token';
+
+  /** Put an object where the adapter will find it. */
+  place(key: string, object: FakeObject): void {
+    this.objects.set(key, object);
+  }
+
+  /** What the cluster holds now — the assertion surface for a write. */
+  get(key: string): FakeObject | undefined {
+    return this.objects.get(key);
+  }
+
+  /** Every object of one plural, in insertion order. */
+  all(plural: string): FakeObject[] {
+    return [...this.objects.entries()]
+      .filter(([key]) => key.startsWith(`${plural}/`))
+      .map(([, object]) => object);
+  }
+
+  /** Requests the adapter made, in order — what § Seam 2 asserts on. */
+  pathsOf(method: string): string[] {
+    return this.requests
+      .filter((request) => request.method === method)
+      .map((request) => request.path);
+  }
+
+  fetch: Fetcher = async (request) => {
+    const url = new URL(request.url);
+    const body =
+      request.method === 'GET' || request.method === 'DELETE'
+        ? null
+        : await request.clone().json();
+    this.requests.push({
+      method: request.method,
+      path: url.pathname,
+      contentType: request.headers.get('content-type'),
+      body,
+    });
+
+    // The cluster trusts one federated credential. `token()` is the adapter's
+    // injected provider, so overriding it must be able to model an expired or
+    // otherwise invalid credential rather than silently teaching the fake to
+    // trust the bad value too.
+    if (request.headers.get('authorization') !== 'Bearer federated-token') {
+      return json(401, { message: 'unauthenticated' });
+    }
+
+    const discovery = this.discovery(url.pathname);
+    if (discovery !== null) return discovery;
+
+    const parsed = parsePath(url.pathname);
+    if (parsed === null) return json(404, { message: 'no such path' });
+
+    // The one API that answers rather than stores.
+    if (parsed.plural === 'selfsubjectaccessreviews') {
+      return json(201, {
+        apiVersion: 'authorization.k8s.io/v1',
+        kind: 'SelfSubjectAccessReview',
+        status: { allowed: this.options.allowed ?? true },
+      });
+    }
+
+    if (parsed.name === undefined) return this.listResponse(parsed.plural);
+
+    const key = `${parsed.plural}/${parsed.namespace ?? ''}/${parsed.name}`;
+    switch (request.method) {
+      case 'GET':
+        return this.getResponse(key);
+      case 'PATCH':
+        return this.applyResponse(key, body as FakeObject);
+      case 'DELETE':
+        this.objects.delete(key);
+        this.reads.delete(key);
+        return json(200, { status: 'Success' });
+      default:
+        return json(405, { message: `${request.method} is not supported` });
+    }
+  };
+
+  private discovery(path: string): Response | null {
+    const match = path.match(/^\/apis\/([^/]+\/[^/]+)$/);
+    if (match === null) return null;
+    const served = this.options.servedKinds ?? {};
+    const kinds = served[match[1] as string];
+    if (kinds === undefined) return json(404, { message: 'no such group' });
+    return json(200, {
+      resources: kinds.map((kind) => ({ kind, name: kind.toLowerCase() })),
+    });
+  }
+
+  private listResponse(plural: string): Response {
+    const seeded = this.options.lists?.[plural];
+    if (seeded === undefined && this.all(plural).length === 0) {
+      // A kind nothing was seeded for is a kind this cluster does not serve.
+      return json(404, { message: `no ${plural}` });
+    }
+    return json(200, { items: seeded ?? this.all(plural) });
+  }
+
+  private getResponse(key: string): Response {
+    const object = this.objects.get(key);
+    if (object === undefined) return json(404, { message: 'not found' });
+
+    // The controller writes status *after* the object exists, which is what
+    // makes `apply` poll rather than assume.
+    const script = this.options.status ?? READY;
+    const reads = (this.reads.get(key) ?? 0) + 1;
+    this.reads.set(key, reads);
+    const status = script(reads);
+    return json(200, status === null ? object : { ...object, status });
+  }
+
+  private applyResponse(key: string, object: FakeObject): Response {
+    if (this.options.refuse !== undefined) {
+      return new Response(this.options.refuse.body, {
+        status: this.options.refuse.status,
+      });
+    }
+    const stored = {
+      ...object,
+      metadata: { ...object.metadata, generation: 1 },
+    };
+    this.objects.set(key, stored);
+    this.reads.set(key, 0);
+    return json(200, stored);
+  }
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+interface ParsedPath {
+  plural: string;
+  namespace?: string;
+  name?: string;
+}
+
+/** The inverse of `resourcePath` — what the adapter addressed. */
+function parsePath(path: string): ParsedPath | null {
+  const parts = path.split('/').filter((part) => part.length > 0);
+  // /api/v1/... or /apis/group/version/...
+  const rest =
+    parts[0] === 'api'
+      ? parts.slice(2)
+      : parts[0] === 'apis'
+        ? parts.slice(3)
+        : null;
+  if (rest === null) return null;
+
+  if (rest[0] === 'namespaces' && rest.length >= 3) {
+    return {
+      namespace: rest[1] as string,
+      plural: rest[2] as string,
+      ...(rest[3] === undefined ? {} : { name: rest[3] }),
+    };
+  }
+  if (rest.length === 0) return null;
+  return {
+    plural: rest[0] as string,
+    ...(rest[1] === undefined ? {} : { name: rest[1] }),
+  };
+}

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -14,6 +14,7 @@
  * ranks silently deciding what a healthy Target looks like.
  */
 import { join } from 'node:path';
+import { VALUES_CONTRACT } from '../../src/adapters/deploy/kubernetes/values.ts';
 import type { ConnectTargetInput } from '../../src/commands/targets/connect.ts';
 import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
 import {
@@ -58,6 +59,7 @@ export function clusterInput(
       namespace: 'apps',
       sourceRef: { name: 'charts', namespace: 'delivery' },
     },
+    chartContract: VALUES_CONTRACT,
     ...overrides,
   };
 }

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -14,6 +14,7 @@
  * ranks silently deciding what a healthy Target looks like.
  */
 import { join } from 'node:path';
+import type { ConnectTargetInput } from '../../src/commands/targets/connect.ts';
 import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
 import {
   type InstallationManifest,
@@ -34,11 +35,51 @@ export async function fixtureManifest(): Promise<InstallationManifest> {
   return cached;
 }
 
+/**
+ * The connect input a cluster takes, with anything a test cares about
+ * overridden.
+ *
+ * A Kubernetes Target carries more than an endpoint — §6 makes the delivery
+ * flavour a Target's own declaration, and the App chart's source is a
+ * prerequisite until the OCI swap — and none of it has a default (§20). So the
+ * shape lives here once rather than in every test that connects a cluster and
+ * does not care which operator it runs.
+ */
+export function clusterInput(
+  overrides: Partial<KubernetesConnectInput> = {},
+): KubernetesConnectInput {
+  return {
+    kind: 'kubernetes',
+    name: 'cluster',
+    apiServer: 'https://cluster.example.test',
+    namespace: 'apps',
+    delivery: {
+      flavour: 'flux-helmrelease',
+      namespace: 'apps',
+      sourceRef: { name: 'charts', namespace: 'delivery' },
+    },
+    ...overrides,
+  };
+}
+
+/** The kubernetes arm of `connectTargetInput`. */
+export type KubernetesConnectInput = Extract<
+  ConnectTargetInput,
+  { kind: 'kubernetes' }
+>;
+
 /** A connection of the shape one adapter type needs. */
 export function connectionFor(adapter: TargetAdapter): TargetConnection {
   switch (adapter) {
-    case 'kubernetes':
-      return { adapter, apiServer: 'https://cluster.example.test' };
+    case 'kubernetes': {
+      const input = clusterInput();
+      return {
+        adapter,
+        apiServer: input.apiServer,
+        namespace: input.namespace,
+        delivery: input.delivery,
+      };
+    }
     case 'cloudrun':
       return { adapter, project: 'example-vessel', region: 'somewhere' };
     case 'static':

--- a/apps/spindrift/test/reconciler/target-loop.test.ts
+++ b/apps/spindrift/test/reconciler/target-loop.test.ts
@@ -21,6 +21,7 @@ import type {
 } from '../../src/commands/types.ts';
 import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
 import { apps, components, targets } from '../../src/db/schema.ts';
+import { PREREQUISITES } from '../../src/domain/capabilities.ts';
 import {
   refreshAllTargets,
   refreshTarget,
@@ -28,7 +29,11 @@ import {
 } from '../../src/reconciler/target-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  clusterInput,
+  fixtureManifest,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -99,7 +104,7 @@ describe('one pass over every connected Target', () => {
     expect(refresh?.health).toBe('healthy');
     const row = await targetRow('cluster');
     expect(row.discovery?.arch).toEqual(['amd64', 'arm64']);
-    expect(row.prerequisites).toHaveLength(5);
+    expect(row.prerequisites).toHaveLength(PREREQUISITES.length);
     expect(row.inspectedAt).toEqual(clock.now());
     expect(of('kubernetes').inspected.map((t) => t.name)).toEqual(['cluster']);
   });
@@ -175,14 +180,7 @@ describe('a capability flip changes candidacy on the next pass', () => {
     const clock = ticking();
     const ctx = () => context(registry, clock);
 
-    await connectTarget(
-      {
-        kind: 'kubernetes',
-        name: 'cluster',
-        apiServer: 'https://cluster.example.test',
-      },
-      ctx(),
-    );
+    await connectTarget(clusterInput({ name: 'cluster' }), ctx());
 
     const [app] = await database()
       .db.insert(apps)

--- a/bun.lock
+++ b/bun.lock
@@ -150,6 +150,14 @@
         "typescript": "^5 || ^6.0.0 || ^7.0.0",
       },
     },
+    "packages/charts": {
+      "name": "@repo/charts",
+      "devDependencies": {
+        "@repo/typescript-config": "workspace:*",
+        "@types/bun": "1.3.14",
+        "typescript": "5.9.3",
+      },
+    },
     "packages/k6": {
       "name": "k6-scripts",
       "version": "0.0.1",
@@ -614,6 +622,8 @@
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.12.0", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw=="],
 
     "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.3", "", {}, "sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA=="],
+
+    "@repo/charts": ["@repo/charts@workspace:packages/charts"],
 
     "@repo/typescript-config": ["@repo/typescript-config@workspace:packages/typescript-config"],
 

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@repo/charts",
+  "private": true,
+  "type": "module",
+  "//": "The Helm charts Flux consumes. This package.json exists so chart correctness is asserted where the chart lives (Spindrift spec, § Not a seam) — `helm template` goldens run by `bun test`, in the workspace's own runner, rather than a second test harness bolted on beside it.",
+  "scripts": {
+    "lint": "biome check .",
+    "lint:fix": "biome check . --write",
+    "test": "bun test",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/bun": "1.3.14",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/charts/spindrift-app/Chart.yaml
+++ b/packages/charts/spindrift-app/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: spindrift-app
+description: The one chart every Component Spindrift deploys to a Kubernetes Target renders through
+type: application
+version: 0.1.0
+appVersion: "1"
+annotations:
+  # The chart declares its own value contract and version, read at pin time
+  # (§7). Helm ignores unknown values silently, so a Target pinned to a chart
+  # whose contract has moved would apply cleanly, report green, and run without
+  # the config it was handed. Core reads this annotation when a Target is
+  # pinned and turns skew into a prerequisite failure rather than a mystery.
+  spindrift.dev/values-contract: "1"

--- a/packages/charts/spindrift-app/templates/_helpers.tpl
+++ b/packages/charts/spindrift-app/templates/_helpers.tpl
@@ -38,12 +38,14 @@ Pod template labels: the common set plus the one label that moves per deploy.
 
 §7: "a deploy label goes on the pod template and **never** in the selector",
 because both delivery flavours enumerate applied objects and neither covers
-pods — the label is how a pod is traced back to the Deploy that placed it.
+pods — the label is how a pod is traced back to what placed it. What travels
+across the seam is the artifact's digest: §6's neutral description names no
+Deploy, and the digest is the identity §16 correlates on everywhere.
 */}}
 {{- define "spindrift-app.podLabels" -}}
 {{ include "spindrift-app.labels" . }}
-{{- with .Values.app.deployId }}
-spindrift.dev/deploy: {{ . | quote }}
+{{- with .Values.app.artifactDigest }}
+spindrift.dev/artifact: {{ . | quote }}
 {{- end }}
 {{- with .Values.shared.podLabels }}
 {{ toYaml . }}

--- a/packages/charts/spindrift-app/templates/_helpers.tpl
+++ b/packages/charts/spindrift-app/templates/_helpers.tpl
@@ -64,21 +64,21 @@ spindrift.dev/values-contract: {{ index .Chart.Annotations "spindrift.dev/values
 {{/*
 The port this Component serves on.
 
-A website is a service with a fixed port (§7) — the difference is a value, not
-a template branch, so nothing downstream of here knows which kind it rendered.
+A website is already normalized to a service with a fixed port in values (§7),
+so this helper never needs to know which non-job kind it rendered.
 */}}
 {{- define "spindrift-app.port" -}}
-{{- if eq .Values.app.kind "website" }}{{ .Values.app.websitePort }}{{ else }}{{ .Values.app.port }}{{ end }}
+{{- .Values.app.port }}
 {{- end }}
 
 {{/*
 Whether this Component serves traffic at all.
 
-`expose` is a field on a service; a website has it forced on (§2, §7). A job
-never serves.
+`expose` is a field on a service; website normalization has already forced it
+on (§2, §7). A job is the only workload branch and never serves.
 */}}
 {{- define "spindrift-app.serving" -}}
-{{- if eq .Values.app.kind "website" }}true{{ else if and (eq .Values.app.kind "service") .Values.app.expose }}true{{ end }}
+{{- if and (ne .Values.app.kind "job") .Values.app.expose }}true{{ end }}
 {{- end }}
 
 {{/*

--- a/packages/charts/spindrift-app/templates/_helpers.tpl
+++ b/packages/charts/spindrift-app/templates/_helpers.tpl
@@ -38,14 +38,12 @@ Pod template labels: the common set plus the one label that moves per deploy.
 
 §7: "a deploy label goes on the pod template and **never** in the selector",
 because both delivery flavours enumerate applied objects and neither covers
-pods — the label is how a pod is traced back to what placed it. What travels
-across the seam is the artifact's digest: §6's neutral description names no
-Deploy, and the digest is the identity §16 correlates on everywhere.
+pods — the label is how a pod is traced back to the Deploy that placed it.
 */}}
 {{- define "spindrift-app.podLabels" -}}
 {{ include "spindrift-app.labels" . }}
-{{- with .Values.app.artifactDigest }}
-spindrift.dev/artifact: {{ . | quote }}
+{{- with .Values.app.deployId }}
+spindrift.dev/deploy: {{ . | quote }}
 {{- end }}
 {{- with .Values.shared.podLabels }}
 {{ toYaml . }}

--- a/packages/charts/spindrift-app/templates/_helpers.tpl
+++ b/packages/charts/spindrift-app/templates/_helpers.tpl
@@ -1,0 +1,170 @@
+{{/*
+The release's object name: one App's one Component.
+
+Names are already DNS labels by the time Spindrift writes them (§9 mints the
+canonical hostname from the same two), so this composes rather than sanitizes —
+a value that needed sanitizing here would be a value that could not be a
+hostname either.
+*/}}
+{{- define "spindrift-app.fullname" -}}
+{{- printf "%s-%s" .Values.app.name .Values.app.component | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Selector labels: what a Deployment's selector and a Service's selector match on.
+
+**Immutable by construction.** Nothing that changes deploy to deploy is here —
+the deploy label lives on the pod template only (§7), because a selector cannot
+be edited on an existing Deployment and putting a per-deploy value in one would
+brick every upgrade after the first.
+*/}}
+{{- define "spindrift-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Values.app.component }}
+app.kubernetes.io/part-of: {{ .Values.app.name }}
+{{- end }}
+
+{{/*
+Common labels, on every object this chart renders.
+*/}}
+{{- define "spindrift-app.labels" -}}
+{{ include "spindrift-app.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: {{ .Values.app.kind }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}
+
+{{/*
+Pod template labels: the common set plus the one label that moves per deploy.
+
+§7: "a deploy label goes on the pod template and **never** in the selector",
+because both delivery flavours enumerate applied objects and neither covers
+pods — the label is how a pod is traced back to the Deploy that placed it.
+*/}}
+{{- define "spindrift-app.podLabels" -}}
+{{ include "spindrift-app.labels" . }}
+{{- with .Values.app.deployId }}
+spindrift.dev/deploy: {{ . | quote }}
+{{- end }}
+{{- with .Values.shared.podLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+The value-contract version the chart declares, read back onto every object.
+
+The pin-time read is of `Chart.yaml`; this puts the same number on what was
+rendered, so an object in a cluster can be traced to the contract it was
+rendered under without holding the chart that did it.
+*/}}
+{{- define "spindrift-app.contractAnnotations" -}}
+spindrift.dev/values-contract: {{ index .Chart.Annotations "spindrift.dev/values-contract" | quote }}
+{{- end }}
+
+{{/*
+The port this Component serves on.
+
+A website is a service with a fixed port (§7) — the difference is a value, not
+a template branch, so nothing downstream of here knows which kind it rendered.
+*/}}
+{{- define "spindrift-app.port" -}}
+{{- if eq .Values.app.kind "website" }}{{ .Values.app.websitePort }}{{ else }}{{ .Values.app.port }}{{ end }}
+{{- end }}
+
+{{/*
+Whether this Component serves traffic at all.
+
+`expose` is a field on a service; a website has it forced on (§2, §7). A job
+never serves.
+*/}}
+{{- define "spindrift-app.serving" -}}
+{{- if eq .Values.app.kind "website" }}true{{ else if and (eq .Values.app.kind "service") .Values.app.expose }}true{{ end }}
+{{- end }}
+
+{{/*
+The container: identical between the Deployment and the CronJob.
+
+Hardening is fixed with no per-App opt-out (§7), which is why every security
+field here is a literal rather than a value. The readiness probe is the other
+half of that rule — **readiness on the port, no liveness probe** — and it is
+absent for a job, which has no port to probe.
+*/}}
+{{- define "spindrift-app.container" -}}
+- name: app
+  image: {{ .Values.app.image | quote }}
+  imagePullPolicy: IfNotPresent
+  {{- with .Values.app.command }}
+  command:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.app.args }}
+  args:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if ne .Values.app.kind "job" }}
+  ports:
+    - name: http
+      containerPort: {{ include "spindrift-app.port" . }}
+      protocol: TCP
+  readinessProbe:
+    tcpSocket:
+      port: {{ include "spindrift-app.port" . }}
+  {{- end }}
+  env:
+    # readOnlyRootFilesystem below leaves /tmp as the only writable path, so
+    # the two variables every runtime reaches for point at it.
+    - name: TMPDIR
+      value: /tmp
+    - name: HOME
+      value: /tmp
+    {{- range .Values.app.env }}
+    - name: {{ .name }}
+      value: {{ .value | quote }}
+    {{- end }}
+    {{- range .Values.app.secretEnv }}
+    - name: {{ .name }}
+      valueFrom:
+        secretKeyRef:
+          name: {{ .secretName }}
+          key: {{ .key }}
+    {{- end }}
+  volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+  resources:
+    {{- toYaml .Values.shared.resources | nindent 4 }}
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    runAsGroup: 65532
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
+{{- end }}
+
+{{/*
+The pod spec around that container, likewise shared by both workload objects.
+*/}}
+{{- define "spindrift-app.podSpec" -}}
+automountServiceAccountToken: false
+securityContext:
+  runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+{{- with .Values.platform.runtimeClassName }}
+runtimeClassName: {{ . }}
+{{- end }}
+{{- with .Values.platform.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+containers:
+  {{- include "spindrift-app.container" . | nindent 2 }}
+volumes:
+  - name: tmp
+    emptyDir: {}
+{{- end }}

--- a/packages/charts/spindrift-app/templates/cronjob.yaml
+++ b/packages/charts/spindrift-app/templates/cronjob.yaml
@@ -1,0 +1,48 @@
+{{/*
+A job **always** renders a CronJob, suspended when unscheduled (§7).
+
+Two facts force it: a Job's template is immutable, so a chart rendering one
+cannot be upgraded — and Helm then prunes the old Job on the next upgrade,
+which would silently cut an N-deep execution history to one. A CronJob owns its
+executions, so a scheduled run and a manual run are the same object with a
+field flipped, and `apply` for a job becomes two acts rather than two objects.
+*/}}
+{{- if eq .Values.app.kind "job" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "spindrift-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spindrift-app.labels" . | nindent 4 }}
+  annotations:
+    {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
+spec:
+  # An unscheduled job is a suspended CronJob, not an absent one — the object
+  # has to exist for a manual run to have something to trigger.
+  suspend: {{ not .Values.app.schedule }}
+  # A date that never occurs, so an unscheduled job cannot fire even if
+  # something un-suspends it. Suspension is the mechanism; this is the belt.
+  schedule: {{ default "0 0 31 2 *" .Values.app.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 10
+  failedJobsHistoryLimit: 10
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "spindrift-app.labels" . | nindent 8 }}
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          labels:
+            {{- include "spindrift-app.podLabels" . | nindent 12 }}
+          annotations:
+            {{- include "spindrift-app.contractAnnotations" . | nindent 12 }}
+            {{- with .Values.shared.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+        spec:
+          restartPolicy: Never
+          {{- include "spindrift-app.podSpec" . | nindent 10 }}
+{{- end }}

--- a/packages/charts/spindrift-app/templates/deployment.yaml
+++ b/packages/charts/spindrift-app/templates/deployment.yaml
@@ -1,0 +1,32 @@
+{{/*
+A service and a website are one object. §7: "`kind` branches; **`website` is
+not a branch**" — every difference between the two is a value, so this template
+never asks which of the two it is rendering.
+*/}}
+{{- if ne .Values.app.kind "job" }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spindrift-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spindrift-app.labels" . | nindent 4 }}
+  annotations:
+    {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "spindrift-app.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "spindrift-app.podLabels" . | nindent 8 }}
+      annotations:
+        {{- include "spindrift-app.contractAnnotations" . | nindent 8 }}
+        {{- with .Values.shared.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- include "spindrift-app.podSpec" . | nindent 6 }}
+{{- end }}

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -1,0 +1,35 @@
+{{/*
+The route onto the shared gateway's **existing HTTP listener** (§9).
+
+Three things this deliberately is not: it is not a Gateway, not a certificate,
+and not a cross-namespace grant — all three are vessel, and §7 excludes them
+from the release because a `destroy()` that could take the gateway with it is
+not a `destroy()` anybody can run.
+
+An `internal` Component has no route at all. §9 makes internal Target-private,
+authenticated at the workload boundary, and a route onto the shared gateway is
+exactly the alternate origin a non-public state may not leave open.
+*/}}
+{{- if and (include "spindrift-app.serving" .) (ne .Values.app.exposure "internal") }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "spindrift-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spindrift-app.labels" . | nindent 4 }}
+  annotations:
+    {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
+spec:
+  parentRefs:
+    - name: {{ .Values.platform.gateway.name }}
+      namespace: {{ .Values.platform.gateway.namespace }}
+  hostnames:
+    {{- range .Values.app.hostnames }}
+    - {{ . | quote }}
+    {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "spindrift-app.fullname" . }}
+          port: {{ include "spindrift-app.port" . }}
+{{- end }}

--- a/packages/charts/spindrift-app/templates/networkpolicy.yaml
+++ b/packages/charts/spindrift-app/templates/networkpolicy.yaml
@@ -1,0 +1,47 @@
+{{/*
+Ingress is default-deny with a fixed exception list (§8).
+
+"**Internal is a workload boundary, not a network location.**" Without this,
+any pod in any namespace could reach an Internal Component directly and skip
+the authenticated gateway — so the policy is on for every Component, whatever
+its exposure, and there is no per-App opt-out.
+
+**The shape is fixed; the names are Target configuration.** Same-namespace
+siblings are always allowed because a release's own pods are the one caller
+that cannot be named ahead of time; everything else arrives as a namespace name
+an operator set on the Target.
+
+Egress is not here. §8 wants an FQDN allowlist rather than an IP blocklist, and
+a portable NetworkPolicy cannot express one — which is why egress filtering is
+a *discovered capability* rather than a prerequisite (§8), and why the ingress
+half is the half that ships in a portable chart.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "spindrift-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spindrift-app.labels" . | nindent 4 }}
+  annotations:
+    {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "spindrift-app.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        # Same-namespace siblings.
+        - podSelector: {}
+        {{- range .Values.platform.networkPolicy.allowedNamespaces }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ . | quote }}
+        {{- end }}
+{{- if include "spindrift-app.serving" . }}
+      ports:
+        - port: {{ include "spindrift-app.port" . }}
+          protocol: TCP
+{{- end }}

--- a/packages/charts/spindrift-app/templates/service.yaml
+++ b/packages/charts/spindrift-app/templates/service.yaml
@@ -1,0 +1,20 @@
+{{- if include "spindrift-app.serving" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spindrift-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spindrift-app.labels" . | nindent 4 }}
+  annotations:
+    {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "spindrift-app.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      protocol: TCP
+      port: {{ include "spindrift-app.port" . }}
+      targetPort: http
+{{- end }}

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -1,0 +1,341 @@
+/**
+ * The App chart's rendering goldens (§7).
+ *
+ * § Not a seam: "Chart correctness is asserted where the chart lives, as
+ * `helm template` goldens over representative value sets... This is a rendering
+ * assertion, not a Spindrift test, and it must not be reached through the
+ * command layer." Nothing in this file imports Spindrift.
+ *
+ * Each `describe` below is one of the claims §7 makes about the chart, and each
+ * is a claim a wrong rendering would silently satisfy in a cluster — a missing
+ * NetworkPolicy, a Job that cannot be upgraded, a per-deploy label in an
+ * immutable selector — which is why they are asserted here rather than trusted.
+ */
+import { describe, expect, test } from 'bun:test';
+import { chartMetadata, kinds, one, render } from './render.ts';
+
+describe('kind branches', () => {
+  test('a service renders a Deployment, a Service, and a route', async () => {
+    const objects = await render();
+    expect(kinds(objects).sort()).toEqual([
+      'Deployment',
+      'HTTPRoute',
+      'NetworkPolicy',
+      'Service',
+    ]);
+    const deployment = one(objects, 'Deployment');
+    expect(deployment.spec.template.spec.containers[0].image).toBe(
+      'registry.example.test/blog/web@sha256:feed',
+    );
+  });
+
+  test('an unexposed service is a queue worker: no Service, no route', async () => {
+    // §2: "`expose` is a field on a service; an unexposed service is a queue
+    // worker." Nothing routes to it and nothing needs to.
+    const objects = await render({ app: { expose: false } });
+    expect(kinds(objects).sort()).toEqual(['Deployment', 'NetworkPolicy']);
+  });
+
+  test('a job always renders a CronJob and never a Deployment', async () => {
+    const objects = await render({ app: { kind: 'job' } });
+    expect(kinds(objects).sort()).toEqual(['CronJob', 'NetworkPolicy']);
+  });
+});
+
+describe('website is not a branch', () => {
+  test('it renders a Deployment and a Service, exactly like a service', async () => {
+    const website = await render({ app: { kind: 'website' } });
+    expect(kinds(website).sort()).toEqual([
+      'Deployment',
+      'HTTPRoute',
+      'NetworkPolicy',
+      'Service',
+    ]);
+  });
+
+  test('expose is forced: `expose: false` does not un-expose a website', async () => {
+    // §7: a website is "a service with `expose` forced and a fixed port, every
+    // difference a value rather than a template". A value that could turn a
+    // website into a queue worker would make it a branch after all.
+    const objects = await render({
+      app: { kind: 'website', expose: false },
+    });
+    expect(kinds(objects)).toContain('Service');
+  });
+
+  test('the port is the fixed one, not the service port', async () => {
+    const objects = await render({
+      app: { kind: 'website', port: 9999, websitePort: 3000 },
+    });
+    expect(one(objects, 'Service').spec.ports[0].port).toBe(3000);
+    const container = one(objects, 'Deployment').spec.template.spec
+      .containers[0];
+    expect(container.ports[0].containerPort).toBe(3000);
+  });
+});
+
+describe('the suspended CronJob', () => {
+  test('an unscheduled job is suspended, on a date that never occurs', async () => {
+    const cronJob = one(await render({ app: { kind: 'job' } }), 'CronJob');
+    expect(cronJob.spec.suspend).toBe(true);
+    // 31 February: the schedule field is required, so the belt is a date the
+    // clock cannot reach even if something un-suspends the object.
+    expect(cronJob.spec.schedule).toBe('0 0 31 2 *');
+  });
+
+  test('a scheduled job carries its schedule and is not suspended', async () => {
+    const cronJob = one(
+      await render({ app: { kind: 'job', schedule: '17 4 * * *' } }),
+      'CronJob',
+    );
+    expect(cronJob.spec.suspend).toBe(false);
+    expect(cronJob.spec.schedule).toBe('17 4 * * *');
+  });
+
+  test('it keeps an execution history a Job could not', async () => {
+    // The reason a job is a CronJob at all: Helm prunes the old Job on upgrade,
+    // which would cut an N-deep history to one, silently (§7).
+    const cronJob = one(await render({ app: { kind: 'job' } }), 'CronJob');
+    expect(cronJob.spec.successfulJobsHistoryLimit).toBeGreaterThan(1);
+    expect(cronJob.spec.failedJobsHistoryLimit).toBeGreaterThan(1);
+  });
+});
+
+describe('the three exclusions', () => {
+  const excluded = ['Cluster', 'Gateway', 'Certificate', 'Namespace'];
+
+  test('no Datastore, no Gateway or certificate, no Namespace', async () => {
+    // All three are vessel (§7). A release-scoped datastore would be destroyed
+    // by `destroy()`; a release-scoped gateway would take every other App's
+    // routes with it.
+    for (const values of [
+      {},
+      { app: { kind: 'job' } },
+      { app: { kind: 'website' } },
+      { app: { exposure: 'public' } },
+    ]) {
+      const rendered = kinds(await render(values));
+      for (const kind of excluded) expect(rendered).not.toContain(kind);
+    }
+  });
+
+  test('objects land in the release namespace without declaring it', async () => {
+    const objects = await render();
+    for (const object of objects) {
+      expect(object.metadata.namespace).toBe('apps');
+    }
+  });
+});
+
+describe('the deploy label', () => {
+  test('it is on the pod template', async () => {
+    const deployment = one(await render(), 'Deployment');
+    expect(
+      deployment.spec.template.metadata.labels['spindrift.dev/deploy'],
+    ).toBe('7');
+  });
+
+  test('it is never in a selector', async () => {
+    // §7: the selector is immutable, so a per-deploy value in one would brick
+    // every upgrade after the first.
+    const objects = await render();
+    const deployment = one(objects, 'Deployment');
+    const service = one(objects, 'Service');
+    const policy = one(objects, 'NetworkPolicy');
+
+    expect(Object.keys(deployment.spec.selector.matchLabels)).not.toContain(
+      'spindrift.dev/deploy',
+    );
+    expect(Object.keys(service.spec.selector)).not.toContain(
+      'spindrift.dev/deploy',
+    );
+    expect(Object.keys(policy.spec.podSelector.matchLabels)).not.toContain(
+      'spindrift.dev/deploy',
+    );
+  });
+
+  test('a job carries it on the pod template too', async () => {
+    const cronJob = one(await render({ app: { kind: 'job' } }), 'CronJob');
+    expect(
+      cronJob.spec.jobTemplate.spec.template.metadata.labels[
+        'spindrift.dev/deploy'
+      ],
+    ).toBe('7');
+  });
+
+  test('two deploys of the same Component keep one selector', async () => {
+    const first = one(await render({ app: { deployId: '7' } }), 'Deployment');
+    const second = one(await render({ app: { deployId: '8' } }), 'Deployment');
+    expect(second.spec.selector).toEqual(first.spec.selector);
+    expect(second.spec.template.metadata.labels).not.toEqual(
+      first.spec.template.metadata.labels,
+    );
+  });
+});
+
+describe('the value contract', () => {
+  test('the chart declares its version where pin time reads it', async () => {
+    const chart = await chartMetadata();
+    expect(chart.name).toBe('spindrift-app');
+    expect(chart.annotations?.['spindrift.dev/values-contract']).toBe('1');
+  });
+
+  test('every rendered object carries the version it was rendered under', async () => {
+    // Helm ignores unknown values silently (§7), so a cluster object has to be
+    // traceable to the contract that produced it without holding the chart.
+    const chart = await chartMetadata();
+    const declared = chart.annotations?.['spindrift.dev/values-contract'];
+    for (const values of [{}, { app: { kind: 'job' } }]) {
+      for (const object of await render(values)) {
+        expect(
+          object.metadata.annotations?.['spindrift.dev/values-contract'],
+        ).toBe(declared);
+      }
+    }
+  });
+});
+
+describe('fixed defaults', () => {
+  test('readiness on the port, and no liveness probe', async () => {
+    const container = one(await render(), 'Deployment').spec.template.spec
+      .containers[0];
+    expect(container.readinessProbe.tcpSocket.port).toBe(8080);
+    expect(container.livenessProbe).toBeUndefined();
+  });
+
+  test('hardening has no per-App opt-out', async () => {
+    // §7 fixes these, which is what constrains the zero-config base image to a
+    // non-root, read-only-rootfs shape. A value that could relax one would make
+    // the constraint advisory.
+    const pod = one(
+      await render({ app: { securityContext: { runAsUser: 0 } } }),
+      'Deployment',
+    ).spec.template.spec;
+    expect(pod.automountServiceAccountToken).toBe(false);
+    expect(pod.securityContext.runAsNonRoot).toBe(true);
+    const security = pod.containers[0].securityContext;
+    expect(security.runAsNonRoot).toBe(true);
+    expect(security.readOnlyRootFilesystem).toBe(true);
+    expect(security.allowPrivilegeEscalation).toBe(false);
+    expect(security.capabilities.drop).toEqual(['ALL']);
+    expect(security.seccompProfile.type).toBe('RuntimeDefault');
+  });
+
+  test('the sandbox runtime class is an operator value, unset by default', async () => {
+    const bare = one(await render(), 'Deployment');
+    expect(bare.spec.template.spec.runtimeClassName).toBeUndefined();
+    const sandboxed = one(
+      await render({ platform: { runtimeClassName: 'gvisor' } }),
+      'Deployment',
+    );
+    expect(sandboxed.spec.template.spec.runtimeClassName).toBe('gvisor');
+  });
+
+  test('NetworkPolicy is on and PodDisruptionBudget is off', async () => {
+    // §7: `minAvailable: 1` at one replica blocks node drain forever on hosts
+    // that reboot to auto-upgrade, so there is no PDB to render.
+    for (const values of [{}, { app: { kind: 'job' } }]) {
+      const rendered = kinds(await render(values));
+      expect(rendered).toContain('NetworkPolicy');
+      expect(rendered).not.toContain('PodDisruptionBudget');
+    }
+  });
+
+  test('ingress is default-deny with the operator’s named exceptions', async () => {
+    // §8: "the shape is fixed while the names are Target configuration".
+    const policy = one(await render(), 'NetworkPolicy');
+    expect(policy.spec.policyTypes).toEqual(['Ingress']);
+    const from = policy.spec.ingress[0].from;
+    expect(from[0]).toEqual({ podSelector: {} });
+    expect(from.slice(1)).toEqual([
+      {
+        namespaceSelector: {
+          matchLabels: { 'kubernetes.io/metadata.name': 'gateway' },
+        },
+      },
+      {
+        namespaceSelector: {
+          matchLabels: { 'kubernetes.io/metadata.name': 'monitoring' },
+        },
+      },
+    ]);
+  });
+});
+
+describe('the route', () => {
+  test('it attaches to the shared gateway, and renders neither', async () => {
+    const route = one(await render(), 'HTTPRoute');
+    expect(route.spec.parentRefs).toEqual([
+      { name: 'cluster-gateway', namespace: 'gateway' },
+    ]);
+    expect(route.spec.hostnames).toEqual(['blog-web.apps.example.test']);
+  });
+
+  test('the vanity name rides the same route as the canonical one', async () => {
+    const route = one(
+      await render({
+        app: {
+          hostnames: ['blog-web.apps.example.test', 'blog.vanity.example.test'],
+        },
+      }),
+      'HTTPRoute',
+    );
+    expect(route.spec.hostnames).toHaveLength(2);
+  });
+
+  test('an internal Component has no route at all', async () => {
+    // §9: no non-public state may leave a bypassable origin, and a route onto
+    // the shared gateway is exactly that for a Target-private workload.
+    const objects = await render({ app: { exposure: 'internal' } });
+    expect(kinds(objects)).not.toContain('HTTPRoute');
+    expect(kinds(objects)).toContain('Service');
+  });
+
+  test('public and private route identically — the edge is the difference', async () => {
+    const asPrivate = one(
+      await render({ app: { exposure: 'private' } }),
+      'HTTPRoute',
+    );
+    const asPublic = one(
+      await render({ app: { exposure: 'public' } }),
+      'HTTPRoute',
+    );
+    expect(asPublic.spec).toEqual(asPrivate.spec);
+  });
+});
+
+describe('config delivery', () => {
+  test('one secret per variable, never a blob', async () => {
+    // §10: per-key, not per-blob. An `envFrom` here would be the blob.
+    const container = one(
+      await render({
+        app: {
+          secretEnv: [
+            { name: 'TOKEN', secretName: 'blog-web-token', key: 'value' },
+            { name: 'DSN', secretName: 'blog-web-dsn', key: 'value' },
+          ],
+        },
+      }),
+      'Deployment',
+    ).spec.template.spec.containers[0];
+
+    expect(container.envFrom).toBeUndefined();
+    const names = container.env.map((entry: { name: string }) => entry.name);
+    expect(names).toContain('TOKEN');
+    expect(names).toContain('DSN');
+    const token = container.env.find(
+      (entry: { name: string }) => entry.name === 'TOKEN',
+    );
+    expect(token.valueFrom.secretKeyRef).toEqual({
+      name: 'blog-web-token',
+      key: 'value',
+    });
+  });
+
+  test('no Component-declared volumes beyond the writable /tmp', async () => {
+    // §7 deletes PVC lifecycle, orphan tracking, and the silent recreate
+    // strategy by having no volume a Component can declare.
+    const pod = one(await render(), 'Deployment').spec.template.spec;
+    expect(pod.volumes).toEqual([{ name: 'tmp', emptyDir: {} }]);
+  });
+});

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -131,8 +131,8 @@ describe('the deploy label', () => {
   test('it is on the pod template', async () => {
     const deployment = one(await render(), 'Deployment');
     expect(
-      deployment.spec.template.metadata.labels['spindrift.dev/artifact'],
-    ).toBe('sha256:feed');
+      deployment.spec.template.metadata.labels['spindrift.dev/deploy'],
+    ).toBe('deploy-1');
   });
 
   test('it is never in a selector', async () => {
@@ -144,13 +144,13 @@ describe('the deploy label', () => {
     const policy = one(objects, 'NetworkPolicy');
 
     expect(Object.keys(deployment.spec.selector.matchLabels)).not.toContain(
-      'spindrift.dev/artifact',
+      'spindrift.dev/deploy',
     );
     expect(Object.keys(service.spec.selector)).not.toContain(
-      'spindrift.dev/artifact',
+      'spindrift.dev/deploy',
     );
     expect(Object.keys(policy.spec.podSelector.matchLabels)).not.toContain(
-      'spindrift.dev/artifact',
+      'spindrift.dev/deploy',
     );
   });
 
@@ -158,18 +158,18 @@ describe('the deploy label', () => {
     const cronJob = one(await render({ app: { kind: 'job' } }), 'CronJob');
     expect(
       cronJob.spec.jobTemplate.spec.template.metadata.labels[
-        'spindrift.dev/artifact'
+        'spindrift.dev/deploy'
       ],
-    ).toBe('sha256:feed');
+    ).toBe('deploy-1');
   });
 
   test('two deploys of the same Component keep one selector', async () => {
     const first = one(
-      await render({ app: { artifactDigest: 'sha256:feed' } }),
+      await render({ app: { deployId: 'deploy-1' } }),
       'Deployment',
     );
     const second = one(
-      await render({ app: { artifactDigest: 'sha256:two' } }),
+      await render({ app: { deployId: 'deploy-2' } }),
       'Deployment',
     );
     expect(second.spec.selector).toEqual(first.spec.selector);

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -44,7 +44,9 @@ describe('kind branches', () => {
 
 describe('website is not a branch', () => {
   test('it renders a Deployment and a Service, exactly like a service', async () => {
-    const website = await render({ app: { kind: 'website' } });
+    const website = await render({
+      app: { kind: 'website', expose: true, port: 8080 },
+    });
     expect(kinds(website).sort()).toEqual([
       'Deployment',
       'HTTPRoute',
@@ -53,24 +55,14 @@ describe('website is not a branch', () => {
     ]);
   });
 
-  test('expose is forced: `expose: false` does not un-expose a website', async () => {
-    // §7: a website is "a service with `expose` forced and a fixed port, every
-    // difference a value rather than a template". A value that could turn a
-    // website into a queue worker would make it a branch after all.
+  test('the fixed website port arrives as the ordinary service value', async () => {
     const objects = await render({
-      app: { kind: 'website', expose: false },
+      app: { kind: 'website', expose: true, port: 8080 },
     });
-    expect(kinds(objects)).toContain('Service');
-  });
-
-  test('the port is the fixed one, not the service port', async () => {
-    const objects = await render({
-      app: { kind: 'website', port: 9999, websitePort: 3000 },
-    });
-    expect(one(objects, 'Service').spec.ports[0].port).toBe(3000);
+    expect(one(objects, 'Service').spec.ports[0].port).toBe(8080);
     const container = one(objects, 'Deployment').spec.template.spec
       .containers[0];
-    expect(container.ports[0].containerPort).toBe(3000);
+    expect(container.ports[0].containerPort).toBe(8080);
   });
 });
 

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -131,8 +131,8 @@ describe('the deploy label', () => {
   test('it is on the pod template', async () => {
     const deployment = one(await render(), 'Deployment');
     expect(
-      deployment.spec.template.metadata.labels['spindrift.dev/deploy'],
-    ).toBe('7');
+      deployment.spec.template.metadata.labels['spindrift.dev/artifact'],
+    ).toBe('sha256:feed');
   });
 
   test('it is never in a selector', async () => {
@@ -144,13 +144,13 @@ describe('the deploy label', () => {
     const policy = one(objects, 'NetworkPolicy');
 
     expect(Object.keys(deployment.spec.selector.matchLabels)).not.toContain(
-      'spindrift.dev/deploy',
+      'spindrift.dev/artifact',
     );
     expect(Object.keys(service.spec.selector)).not.toContain(
-      'spindrift.dev/deploy',
+      'spindrift.dev/artifact',
     );
     expect(Object.keys(policy.spec.podSelector.matchLabels)).not.toContain(
-      'spindrift.dev/deploy',
+      'spindrift.dev/artifact',
     );
   });
 
@@ -158,14 +158,20 @@ describe('the deploy label', () => {
     const cronJob = one(await render({ app: { kind: 'job' } }), 'CronJob');
     expect(
       cronJob.spec.jobTemplate.spec.template.metadata.labels[
-        'spindrift.dev/deploy'
+        'spindrift.dev/artifact'
       ],
-    ).toBe('7');
+    ).toBe('sha256:feed');
   });
 
   test('two deploys of the same Component keep one selector', async () => {
-    const first = one(await render({ app: { deployId: '7' } }), 'Deployment');
-    const second = one(await render({ app: { deployId: '8' } }), 'Deployment');
+    const first = one(
+      await render({ app: { artifactDigest: 'sha256:feed' } }),
+      'Deployment',
+    );
+    const second = one(
+      await render({ app: { artifactDigest: 'sha256:two' } }),
+      'Deployment',
+    );
     expect(second.spec.selector).toEqual(first.spec.selector);
     expect(second.spec.template.metadata.labels).not.toEqual(
       first.spec.template.metadata.labels,

--- a/packages/charts/spindrift-app/tests/render.ts
+++ b/packages/charts/spindrift-app/tests/render.ts
@@ -38,6 +38,7 @@ const BASELINE: Values = {
     name: 'blog',
     component: 'web',
     image: 'registry.example.test/blog/web@sha256:feed',
+    deployId: 'deploy-1',
     artifactDigest: 'sha256:feed',
     hostnames: ['blog-web.apps.example.test'],
   },

--- a/packages/charts/spindrift-app/tests/render.ts
+++ b/packages/charts/spindrift-app/tests/render.ts
@@ -1,0 +1,148 @@
+/**
+ * `helm template` over the App chart, parsed.
+ *
+ * Chart correctness is asserted **where the chart lives**, as a rendering
+ * assertion — never through Spindrift's command layer (Spindrift spec, § Not a
+ * seam). So this helper knows about Helm and YAML and nothing else: no adapter,
+ * no `DesiredState`, no database. What it renders is what a cluster would get.
+ */
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/** The chart under test — this file's own parent, not a configured path. */
+const CHART = dirname(import.meta.dir);
+
+/** One rendered Kubernetes object, as loosely typed as YAML actually is. */
+export interface RenderedObject {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    labels?: Record<string, string>;
+    annotations?: Record<string, string>;
+  };
+  spec?: any;
+  [key: string]: unknown;
+}
+
+/** The values a test sets. Everything else comes from `values.yaml`. */
+export type Values = Record<string, unknown>;
+
+/**
+ * The minimum a Deploy always carries: Spindrift never renders a release
+ * without an App, a Component, and a digest-pinned image.
+ */
+const BASELINE: Values = {
+  app: {
+    name: 'blog',
+    component: 'web',
+    image: 'registry.example.test/blog/web@sha256:feed',
+    deployId: '7',
+    hostnames: ['blog-web.apps.example.test'],
+  },
+  platform: {
+    gateway: { name: 'cluster-gateway', namespace: 'gateway' },
+    networkPolicy: { allowedNamespaces: ['gateway', 'monitoring'] },
+  },
+};
+
+/** Merge one level deeper than `{...a, ...b}`, which is all these values nest. */
+function merge(base: Values, overrides: Values): Values {
+  const merged: Values = { ...base };
+  for (const [key, value] of Object.entries(overrides)) {
+    const existing = merged[key];
+    merged[key] =
+      isRecord(existing) && isRecord(value)
+        ? merge(existing, value)
+        : (value as unknown);
+  }
+  return merged;
+}
+
+function isRecord(value: unknown): value is Values {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Render the chart with `overrides` on top of a realistic baseline.
+ *
+ * Values go through a file rather than `--set` because `--set` has its own
+ * escaping grammar, and a test that fails on a comma inside a hostname would be
+ * testing Helm's argument parser instead of the chart.
+ */
+export async function render(
+  overrides: Values = {},
+): Promise<RenderedObject[]> {
+  const values = merge(BASELINE, overrides);
+  const file = join(
+    tmpdir(),
+    `spindrift-app-values-${crypto.randomUUID()}.json`,
+  );
+  await Bun.write(file, JSON.stringify(values));
+
+  try {
+    const helm = Bun.spawn(
+      [
+        'helm',
+        'template',
+        'release',
+        CHART,
+        '--namespace',
+        'apps',
+        '--values',
+        file,
+      ],
+      { stdout: 'pipe', stderr: 'pipe' },
+    );
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(helm.stdout).text(),
+      new Response(helm.stderr).text(),
+      helm.exited,
+    ]);
+    if (code !== 0) {
+      throw new Error(`helm template failed (${code}): ${stderr}`);
+    }
+    const documents = Bun.YAML.parse(stdout) as unknown;
+    const list = Array.isArray(documents) ? documents : [documents];
+    return list.filter(
+      (document): document is RenderedObject =>
+        isRecord(document) && typeof document.kind === 'string',
+    );
+  } finally {
+    await Bun.file(file)
+      .delete()
+      .catch(() => {});
+  }
+}
+
+/** The one object of a kind, or a failure naming what was rendered instead. */
+export function one(objects: RenderedObject[], kind: string): RenderedObject {
+  const matches = objects.filter((object) => object.kind === kind);
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one ${kind}, got ${matches.length} ` +
+        `(rendered: ${objects.map((o) => o.kind).join(', ') || 'nothing'})`,
+    );
+  }
+  return matches[0] as RenderedObject;
+}
+
+/** Every kind rendered, for the assertions about what is *absent*. */
+export function kinds(objects: RenderedObject[]): string[] {
+  return objects.map((object) => object.kind);
+}
+
+/** The chart's own metadata, as `helm show chart` reads it at pin time. */
+export async function chartMetadata(): Promise<{
+  name: string;
+  version: string;
+  annotations?: Record<string, string>;
+}> {
+  const text = await Bun.file(join(CHART, 'Chart.yaml')).text();
+  return Bun.YAML.parse(text) as {
+    name: string;
+    version: string;
+    annotations?: Record<string, string>;
+  };
+}

--- a/packages/charts/spindrift-app/tests/render.ts
+++ b/packages/charts/spindrift-app/tests/render.ts
@@ -38,7 +38,7 @@ const BASELINE: Values = {
     name: 'blog',
     component: 'web',
     image: 'registry.example.test/blog/web@sha256:feed',
-    deployId: '7',
+    artifactDigest: 'sha256:feed',
     hostnames: ['blog-web.apps.example.test'],
   },
   platform: {

--- a/packages/charts/spindrift-app/values.yaml
+++ b/packages/charts/spindrift-app/values.yaml
@@ -46,10 +46,13 @@ app:
   # a manual run and a scheduled run are one object with a field flipped (§7).
   schedule: ""
 
-  # What is running here, as a digest. Rendered onto the pod template and
+  # The Deploy this release came from. Rendered onto the pod template and
   # **never** into a selector, which is immutable and would brick every
-  # upgrade (§7). §6's description names no Deploy, so the identity that
-  # travels is the artifact's — which is what §16 correlates on anyway.
+  # upgrade (§7).
+  deployId: ""
+
+  # What is running here, as a digest. Kept on the delivery object so observe
+  # can report drift against core's desired state (§6).
   artifactDigest: ""
 
   # Hostnames the route answers on: the canonical name first, the vanity name

--- a/packages/charts/spindrift-app/values.yaml
+++ b/packages/charts/spindrift-app/values.yaml
@@ -46,10 +46,11 @@ app:
   # a manual run and a scheduled run are one object with a field flipped (§7).
   schedule: ""
 
-  # The Deploy this release came from. Rendered onto the pod template and
+  # What is running here, as a digest. Rendered onto the pod template and
   # **never** into a selector, which is immutable and would brick every
-  # upgrade (§7).
-  deployId: ""
+  # upgrade (§7). §6's description names no Deploy, so the identity that
+  # travels is the artifact's — which is what §16 correlates on anyway.
+  artifactDigest: ""
 
   # Hostnames the route answers on: the canonical name first, the vanity name
   # after it where one exists (§9).

--- a/packages/charts/spindrift-app/values.yaml
+++ b/packages/charts/spindrift-app/values.yaml
@@ -28,13 +28,12 @@ app:
   # tag here would break the join between what was signed and what runs.
   image: ""
 
-  # The port a service listens on. Ignored for `website`, which serves on
-  # `websitePort` — the fixed port its rendering always uses.
+  # The port this non-job Component listens on. Spindrift supplies the fixed
+  # website port as this value, leaving `job` as the only chart branch.
   port: 8080
-  websitePort: 8080
 
-  # Service only, and forced on for a website. An unexposed service is a queue
-  # worker (§2).
+  # Whether this non-job Component serves traffic. Spindrift forces this on
+  # when it normalizes a website; an unexposed service is a queue worker (§2).
   expose: true
 
   # internal | private | public (§9). The chart renders a route for a Component

--- a/packages/charts/spindrift-app/values.yaml
+++ b/packages/charts/spindrift-app/values.yaml
@@ -1,0 +1,102 @@
+# The App chart's values (§7).
+#
+# Three value classes, not two: some keys are written by both the operator and
+# Spindrift, so a disjointness rule would reject a correct config. The classes
+# are the three top-level keys below, and the boundary between them is enforced
+# where a Target's chart-values are saved — not here, because a chart cannot
+# know who set a value.
+#
+#   app.*       Spindrift writes. Never an operator's to set.
+#   platform.*  The operator writes, per Target. Spindrift never renders into it.
+#   shared.*    Either may write. Spindrift's value wins where both do.
+#
+# Everything a Component is, is a value. `website` is not a template branch —
+# it is a service with `expose` forced and a fixed port (§7).
+
+# --- Spindrift's class ------------------------------------------------------
+app:
+  # The App and Component this release runs. Both appear in selector labels, so
+  # neither is changeable in place — a rename is a new release.
+  name: ""
+  component: ""
+
+  # service | website | job. `job` is the one branch: it renders a CronJob
+  # rather than a Deployment (§7).
+  kind: service
+
+  # Digest-pinned image reference. §16 correlates on digest everywhere, so a
+  # tag here would break the join between what was signed and what runs.
+  image: ""
+
+  # The port a service listens on. Ignored for `website`, which serves on
+  # `websitePort` — the fixed port its rendering always uses.
+  port: 8080
+  websitePort: 8080
+
+  # Service only, and forced on for a website. An unexposed service is a queue
+  # worker (§2).
+  expose: true
+
+  # internal | private | public (§9). The chart renders a route for a Component
+  # that is exposed and not `internal`; the authenticated edge in front of that
+  # route is the Target's, never this chart's.
+  exposure: private
+
+  # Job only. Empty renders a suspended CronJob — a job always renders one, so
+  # a manual run and a scheduled run are one object with a field flipped (§7).
+  schedule: ""
+
+  # The Deploy this release came from. Rendered onto the pod template and
+  # **never** into a selector, which is immutable and would brick every
+  # upgrade (§7).
+  deployId: ""
+
+  # Hostnames the route answers on: the canonical name first, the vanity name
+  # after it where one exists (§9).
+  hostnames: []
+
+  # Plain environment. §10 keeps no secret/non-secret classification; a value
+  # that is a secret arrives through `secretEnv` as a reference, never here.
+  env: []
+  # [{ name, secretName, key }] — one secret per variable, not a blob (§10).
+  # Delivered by the platform's own secret machinery; the chart only names it.
+  secretEnv: []
+
+  # Entrypoint overrides. Empty means the image's own.
+  command: []
+  args: []
+
+# --- The operator's class ---------------------------------------------------
+platform:
+  # Sandbox runtime class, defaulting to unset (§7).
+  runtimeClassName: ""
+
+  imagePullSecrets: []
+
+  # The shared gateway routes attach to. No Gateway and no certificate are
+  # rendered here — routes attach to the existing HTTP listener (§7, §9).
+  gateway:
+    name: ""
+    namespace: ""
+
+  networkPolicy:
+    # Ingress is default-deny with a fixed exception list whose **names are
+    # Target configuration while the shape is fixed** (§8). Same-namespace
+    # siblings are always allowed; these are the namespaces outside it.
+    allowedNamespaces: []
+
+# --- Written by both --------------------------------------------------------
+shared:
+  # The operator sets a Target's defaults; Spindrift overrides them per
+  # Component. Both are legitimate authors of the same key, which is the whole
+  # reason this class exists.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: "1"
+      memory: 512Mi
+
+  podAnnotations: {}
+  podLabels: {}

--- a/packages/charts/tsconfig.json
+++ b/packages/charts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@repo/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "Preserve",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["bun"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["**/tests/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary

Add Spindrift's App chart and Kubernetes deploy adapter, giving the first vertical delivery slice a Flux or Argo object applied directly through the Kubernetes API.

## Changes

- add the hardened `spindrift-app` chart and rendering contract
- deploy digest-pinned images through Flux `HelmRelease` or Argo `Application`
- poll controller-owned status and diagnose pods/events on failure
- connect Kubernetes Targets with delivery, chart-contract, and operator-value configuration
- discover Target prerequisites and capabilities through the real API client
- enroll Kubernetes in the shared deploy-adapter conformance suite
- preserve Deploy identity on pod templates and artifact identity on delivery objects
- normalize websites to ordinary service chart values
- document WSL `wslc.exe` and macOS Docker test-container commands

## Test Plan

- [x] `mise run ts:check`
- [x] `mise run k8s:render-apps`
- [x] `bun test apps/spindrift/test/adapters/kubernetes.test.ts`
- [x] `bun test apps/spindrift/test/conformance/adapters.test.ts apps/spindrift/test/adapters/deploy-contract.test.ts`
- [x] `bun test packages/charts/spindrift-app/tests/render.test.ts`
- [x] database-backed Target, capability-loop, and placement tests (26 passing)

## Notes

The complete workspace run reached the Postgres locking test but exceeded Bun's five-second timeout through the local WSL container bridge. The changed database-backed suites pass when run directly.
