### PR TITLE
feat(spindrift): deploy an uploaded bundle to a cluster and get a URL

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -7,21 +7,22 @@ adapts to whatever builds and delivers underneath — a Kubernetes cluster, Clou
 Run, or static hosting. The design lives in `.agent/plans/spindrift/spec.md`
 (private) and is referenced from the source as `§N`.
 
-**Targets are real, the screens are drawn, and Kubernetes delivery works at the
-adapter seam.** The five nouns have tables, the three adapter contracts are
-written, and commands are the only way anything is acted on. Targets can be
-connected, inspected on a loop, and resolved against — asking where a Component
-can go returns an answer with a reason for every Target it cannot. The two
-secret stores and the Kubernetes deploy adapter are implemented.
+**An uploaded bundle reaches a Kubernetes cluster and comes back with a URL.**
+The five nouns have tables, the three adapter contracts are written, and
+commands are the only way anything is acted on. Targets can be connected,
+inspected on a loop, and resolved against — asking where a Component can go
+returns an answer with a reason for every Target it cannot. Uploading finished
+output records an artifact without a builder; creating a Deploy writes an intent
+under a locking read; the reconciler claims that intent, applies it through the
+Kubernetes adapter, and records what the platform said.
 
-What has no implementation is the command that creates a Deploy, the Cloud Run
-and static deploy adapters, and every build route, so a Deploy row is still
-something nothing writes. **The three screens therefore render placeholder
-data** from `src/web/demo/`, which is scaffolding meant to be deleted: the views
-are typed against `src/web/model.ts`, so the query commands that replace it have
-a contract to meet rather than a shape to guess.
+What has no implementation is the Cloud Run and static deploy adapters, every
+real build route, config delivery, and datastores. **The three screens still
+render placeholder data** from `src/web/demo/`, which is scaffolding meant to be
+deleted: the views are typed against `src/web/model.ts`, so the query commands
+that replace it have a contract to meet rather than a shape to guess.
 
-Two named gaps behind the screens, both deliberate:
+Three named gaps, all deliberate:
 
 - **Nobody can sign in.** Passkey enrolment and sessions are unbuilt, so every
   command route answers 401. The boundary is complete and rejects everything,
@@ -29,6 +30,10 @@ Two named gaps behind the screens, both deliberate:
 - **The creation draft is client state**, so a refresh mid-flow loses it. It
   wants a table and a pair of commands, which belong with the App and Component
   commands rather than in front of them.
+- **The status page is not served yet.** §9 wants a URL that resolves from the
+  moment an App exists, on a lowest-precedence wildcard route. Naming and the
+  DNS records are here; the route and the page it points at are not, so an App's
+  address only resolves once something has actually been deployed to it.
 
 ## Shape
 
@@ -39,9 +44,9 @@ One image, two processes (§19); only `web` exists so far.
 | `src/config/` | the installation manifest and its schema |
 | `src/db/` | the Drizzle schema, the connection, and the committed migrations |
 | `src/commands/` | the application command layer and its registry |
-| `src/domain/` | `DesiredState`, the attempt log, Targets, capabilities, placement |
-| `src/adapters/` | the adapter contracts, Kubernetes delivery, and the two stores |
-| `src/reconciler/` | the loop that refreshes Target health and capabilities |
+| `src/domain/` | `DesiredState`, the attempt log, Targets, capabilities, placement, sources, naming, diagnosis |
+| `src/adapters/` | the adapter contracts, Kubernetes delivery, DNS records, and the two stores |
+| `src/reconciler/` | two loops — Target health and capabilities, and deploy convergence |
 | `src/web/` | the `web` process — the server, the dispatch surface, and the client |
 | `src/web/ui/` | shadcn primitives, in this installation's palette |
 | `src/web/views/` | the three screens (§18) |
@@ -127,22 +132,82 @@ highest-ranked one is suggested, and **non-candidates are returned listed and
 annotated with why**, so "nowhere fits" is an answer rather than a deploy that
 fails later.
 
+## Build, Deploy, and the loop
+
+A **Build** records an artifact; it never deploys one. Uploading an archive of
+finished output produces a `SUCCEEDED` Build with the bundle digest naming the
+artifact and **no build route consulted at all** — there is nothing to run, and
+running one would produce a second digest over the same bytes. Everything else
+goes through a route, and the route's name and log fidelity land on the Build so
+a thin log reads as the runner it is rather than as a bug.
+
+A **Deploy** is an intent, written under `SELECT ... FOR UPDATE` on the one
+`(Component, Target)` desired row. That locking read is the whole of the
+concurrency design: two intents for one pair serialize, and the second reads what
+the first committed rather than what preceded both. **Rollback is an ordinary
+deploy** — a newer intent naming an older Build — and it asks only one extra
+question, under the same lock, so it cannot become a way to place what a forward
+deploy refused.
+
+`src/reconciler/deploy-loop.ts` is what turns an intent into a workload. It
+**claims with `FOR UPDATE SKIP LOCKED` and then lets the lock go**, because the
+claim is the `APPLYING` phase rather than a held transaction — a lock does not
+survive a reconciler restart and a phase does. Phases after that come from the
+adapter and never from core's own idea of readiness, and on red the verdict's
+reason, detail, and raw payload are written to the Deploy row, because cluster
+events expire in about an hour and core's copy is the one that will still exist
+tomorrow. **Exposure is never touched by a failure** — the previous release is
+still serving. Drift is reported and never corrected: the re-converge is an
+ordinary Deploy a person presses.
+
+**The interval is adaptive and the poll is the correctness path.** Seconds while
+an attempt is in flight, minutes once converged — which is also the drift
+cadence, since drift is information rather than an alarm. `LISTEN/NOTIFY` can
+shorten a sleep and can never be required to: a notification is lost when no
+listener is connected, so every test here runs with no wake-up wired.
+
+## Naming and DNS
+
+Two layers (§9), with different rules for a reason. **Canonical names nest**
+(`web.shop.<apex>`) because they are unproxied; **vanity names are one flat
+label** because a single apex's free certificate covers one subdomain level, and
+that is where §9's ceiling of roughly twenty of them comes from. Core mints a
+canonical name only for a cluster — Cloud Run and static hosting name their own
+workloads, and there the adapter reports the address back across the deploy seam.
+
+Records are written as `DNSEndpoint` objects for the DNS controller to publish,
+so **Spindrift holds no zone credential** and gets garbage collection free: a
+record lives in the App's namespace and dies with it.
+`test/extraction/no-dns-credential.test.ts` is the grep that keeps the first half
+of that true.
+
 ## Testing
 
 Tests run against a real Postgres — the concurrency design is a claim about
-transactions, and a fake cannot falsify it. Use `wslc.exe` for service
-containers on WSL and `docker` on macOS:
+transactions, and a fake cannot falsify it.
+
+**On WSL, `wslc.exe` containers are not reachable from this distro.** They run in
+their own WSL VM, so `--publish` binds a port in *that* VM's namespace: the
+container is healthy (`wslc.exe exec <name> pg_isready -U postgres` succeeds) and
+nothing in this distro can connect to it. The symptom is every database test
+failing on a `beforeEach` hook timeout, which reads like a code bug and is not
+one. Run Postgres natively instead:
 
 ```bash
-## WSL
-wslc.exe run --detach --name spindrift-postgres \
-  --env POSTGRES_USER=postgres \
-  --env POSTGRES_PASSWORD=postgres \
-  --env POSTGRES_DB=spindrift \
-  --publish 127.0.0.1:5432:5432 \
-  postgres:18-alpine
+## WSL — native, because a published container port does not reach this distro
+nix shell nixpkgs#postgresql_16 -c bash -c '
+  initdb -D /tmp/spg-data -U postgres --auth=trust &&
+  pg_ctl -D /tmp/spg-data -l /tmp/spg-data/log \
+    -o "-p 15432 -c listen_addresses=127.0.0.1 -c fsync=off" start &&
+  createdb -h 127.0.0.1 -p 15432 -U postgres spindrift'
 
-## macOS
+DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test
+```
+
+On macOS, and anywhere a container's published port is genuinely reachable, a
+container is fine:
+
+```bash
 docker run --detach --name spindrift-postgres \
   --env POSTGRES_USER=postgres \
   --env POSTGRES_PASSWORD=postgres \
@@ -151,7 +216,7 @@ docker run --detach --name spindrift-postgres \
   postgres:18-alpine
 ```
 
-Point `DATABASE_URL` at that container:
+and `DATABASE_URL` points at it:
 
 ```bash
 DATABASE_URL=postgres://postgres:postgres@127.0.0.1:5432/spindrift bun test

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -31,9 +31,10 @@ Three named gaps, all deliberate:
   wants a table and a pair of commands, which belong with the App and Component
   commands rather than in front of them.
 - **The status page is not served yet.** §9 wants a URL that resolves from the
-  moment an App exists, on a lowest-precedence wildcard route. Naming and the
-  DNS records are here; the route and the page it points at are not, so an App's
-  address only resolves once something has actually been deployed to it.
+  moment an App exists, on a lowest-precedence wildcard route. Naming is here and
+  a deployed Component's names resolve through its route; the wildcard route and
+  the page it points at are not, so an App's address stays dark until something
+  has actually been deployed to it.
 
 ## Shape
 
@@ -175,11 +176,26 @@ that is where §9's ceiling of roughly twenty of them comes from. Core mints a
 canonical name only for a cluster — Cloud Run and static hosting name their own
 workloads, and there the adapter reports the address back across the deploy seam.
 
-Records are written as `DNSEndpoint` objects for the DNS controller to publish,
-so **Spindrift holds no zone credential** and gets garbage collection free: a
-record lives in the App's namespace and dies with it.
-`test/extraction/no-dns-credential.test.ts` is the grep that keeps the first half
-of that true.
+**Spindrift publishes no record itself, and holds no zone credential.** On a
+cluster the names travel on the `HTTPRoute` the App chart renders — the
+installation's external-dns runs with `gateway-httproute` among its sources, so
+a route carrying a hostname *is* the record, and it is garbage collected with
+the release that owns it.
+
+`src/adapters/dns/cr.ts` builds `DNSEndpoint` objects for the names that have no
+route to hang on — the live-from-creation status name, and the vanity leg on a
+non-metal Target. **Neither of those is built, so nothing calls it yet**; it is
+here because external-dns's `crd` source is configured for exactly that gap.
+`test/extraction/no-dns-credential.test.ts` is the grep that keeps "no zone
+credential" true, and it also asserts DNS is still being described somewhere, so
+the negative claim cannot be satisfied by there being no DNS at all.
+
+One name is contended and one is not. The canonical is per Component, so it
+never collides. The **vanity name is per App**, so an App with two
+network-serving Components has one name and two claimants — it goes to a sole
+serving Component and otherwise to none, because putting one hostname on two
+routes lets the platform pick a winner arbitrarily. Which Component is the front
+door is the developer's to say, and there is nowhere to say it yet.
 
 ## Testing
 

--- a/apps/spindrift/src/adapters/dns/cr.ts
+++ b/apps/spindrift/src/adapters/dns/cr.ts
@@ -1,0 +1,127 @@
+/**
+ * DNS, written as custom resources (§9).
+ *
+ * §9: "**Spindrift writes DNS as CRs the DNS controller publishes**, so it holds
+ * **no Cloudflare credential** and gets garbage collection free."
+ *
+ * Both halves of that are the design:
+ *
+ * - **No provider credential anywhere.** There is no API client in this file and
+ *   no token in the manifest to build one with. What Spindrift can do to DNS is
+ *   exactly what its cluster identity can do to one namespaced kind, which is a
+ *   much smaller blast radius than an account-scoped zone token, and it is why
+ *   `test/extraction/no-dns-credential.test.ts` asserts by grep that no such
+ *   client exists.
+ * - **Garbage collection for free.** A record is an object in the App's own
+ *   namespace, so deleting the namespace deletes the record. Core never has to
+ *   remember which names it minted in order to clean them up later — the
+ *   cleanest kind of bookkeeping is the kind nobody does.
+ *
+ * The trade §9 accepts in exchange: **a Target must run a DNS controller that
+ * serves this kind**, which is a prerequisite on §13's checklist rather than
+ * something core can discover its way around.
+ */
+import type { KubernetesObject } from '../deploy/kubernetes/api.ts';
+
+/**
+ * The CRD this writes, as the DNS controller defines it.
+ *
+ * Pinned as constants rather than assembled from configuration: the group and
+ * version are a fact about the controller's API, not about an installation, and
+ * a version that varied per installation would mean core could not tell a
+ * missing controller from a mismatched one.
+ */
+export const DNS_ENDPOINT_API_VERSION = 'externaldns.k8s.io/v1alpha1';
+export const DNS_ENDPOINT_KIND = 'DNSEndpoint';
+/** The lowercase plural, as the API path uses it. */
+export const DNS_ENDPOINT_PLURAL = 'dnsendpoints';
+
+/** The record types core ever writes. */
+export type DnsRecordType = 'A' | 'CNAME';
+
+/** How long a record is cached. Short, because an App's address can move. */
+export const DEFAULT_TTL_SECONDS = 300;
+
+/** One record, in the controller's own vocabulary. */
+export interface DnsRecord {
+  /** The fully qualified name being published. */
+  readonly dnsName: string;
+  readonly recordType: DnsRecordType;
+  /** Addresses, or the single name a `CNAME` points at. */
+  readonly targets: readonly string[];
+  readonly ttlSeconds?: number;
+}
+
+/** What {@link dnsEndpointFor} needs to place one object. */
+export interface DnsEndpointRequest {
+  /** Object name. Namespaced, so it need only be unique within the App. */
+  readonly name: string;
+  readonly namespace: string;
+  readonly records: readonly DnsRecord[];
+  /**
+   * Labels the object carries, so a human reading the cluster can tell which
+   * Deploy put a record there. Never a selector — nothing selects these.
+   */
+  readonly labels?: Readonly<Record<string, string>>;
+}
+
+/**
+ * One `DNSEndpoint` object, ready for server-side apply.
+ *
+ * A pure function returning a plain object, deliberately: applying it is the
+ * Kubernetes API client's job (`adapters/deploy/kubernetes/api.ts`), and keeping
+ * the two apart is what lets a test assert the exact document core would write
+ * without standing up a fake API to catch it.
+ */
+export function dnsEndpointFor(request: DnsEndpointRequest): KubernetesObject {
+  return {
+    apiVersion: DNS_ENDPOINT_API_VERSION,
+    kind: DNS_ENDPOINT_KIND,
+    metadata: {
+      name: request.name,
+      namespace: request.namespace,
+      ...(request.labels === undefined ? {} : { labels: request.labels }),
+    },
+    spec: {
+      endpoints: request.records.map((record) => ({
+        dnsName: record.dnsName,
+        recordType: record.recordType,
+        targets: [...record.targets],
+        recordTTL: record.ttlSeconds ?? DEFAULT_TTL_SECONDS,
+      })),
+    },
+  };
+}
+
+/**
+ * The records one Component's canonical and vanity names need (§9).
+ *
+ * Both are `CNAME`s at the address the Target serves rather than `A` records at
+ * an IP, because §9's forcing fact is that the metal cluster's load-balancer
+ * range is RFC1918: an `A` record would publish an address the internet cannot
+ * route to, and the reachable address is the tunnel's, which core does not own
+ * and must not restate.
+ *
+ * **Core writes no vanity record where there is no vanity name**, rather than
+ * writing one that points at the canonical: §9 layers vanity on "where a
+ * mechanism exists", and an installation without one should have an App that
+ * simply has no second name.
+ */
+export function recordsFor(args: {
+  readonly canonical: string;
+  readonly vanity?: string | undefined;
+  /** The name the Target's ingress answers to — a tunnel or gateway address. */
+  readonly servedBy: string;
+}): readonly DnsRecord[] {
+  const records: DnsRecord[] = [
+    { dnsName: args.canonical, recordType: 'CNAME', targets: [args.servedBy] },
+  ];
+  if (args.vanity !== undefined && args.vanity !== '') {
+    records.push({
+      dnsName: args.vanity,
+      recordType: 'CNAME',
+      targets: [args.servedBy],
+    });
+  }
+  return records;
+}

--- a/apps/spindrift/src/commands/apps/resolve-placement.ts
+++ b/apps/spindrift/src/commands/apps/resolve-placement.ts
@@ -24,9 +24,7 @@ import {
   targets,
 } from '../../db/schema.ts';
 import {
-  deployPathReferences,
-  noCapabilities,
-  resolveCapabilities,
+  capabilitiesOfRow,
   type TargetCapabilities,
 } from '../../domain/capabilities.ts';
 import type { ArtifactType, Exposure } from '../../domain/desired-state.ts';
@@ -74,26 +72,20 @@ export interface ResolveComponentPlacementResult {
 /**
  * A Target's capabilities as of its last inspection.
  *
- * The two provenances that are not stored are supplied here: from-the-adapter-
- * type comes off the adapter itself, and the derived values are recomputed. A
- * Target whose adapter this installation does not ship, or that has never been
- * inspected, resolves to no capabilities — which excludes it, with a reason,
- * rather than dropping it silently from the list.
+ * The fold itself lives in `domain/capabilities.ts` because build dispatch and
+ * deploy creation now ask the same question, and a Target that looked capable to
+ * one of them and incapable to another would be a bug with no single place to
+ * fix it.
  */
 function capabilitiesOf(
   context: CommandContext,
   target: Target,
 ): TargetCapabilities {
-  const adapter = context.adapters.deploy(target.adapter);
-  const capabilityContext = {
-    adapter: target.adapter,
-    artifactTypes: adapter?.artifactTypes ?? [],
-    publicExposure: target.publicExposure,
-    deployPath: deployPathReferences(context.manifest),
-  };
-  return target.discovery === null || adapter === null
-    ? noCapabilities(capabilityContext)
-    : resolveCapabilities(target.discovery, capabilityContext);
+  return capabilitiesOfRow(target, {
+    artifactTypes:
+      context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+    manifest: context.manifest,
+  });
 }
 
 export const resolveComponentPlacement: Command<

--- a/apps/spindrift/src/commands/apps/resolve-placement.ts
+++ b/apps/spindrift/src/commands/apps/resolve-placement.ts
@@ -16,23 +16,13 @@
  */
 import { and, eq, isNotNull } from 'drizzle-orm';
 import { z } from 'zod';
-import {
-  apps,
-  components,
-  datastores,
-  type Target,
-  targets,
-} from '../../db/schema.ts';
-import {
-  capabilitiesOfRow,
-  type TargetCapabilities,
-} from '../../domain/capabilities.ts';
+import { apps, components, datastores, targets } from '../../db/schema.ts';
 import type { ArtifactType, Exposure } from '../../domain/desired-state.ts';
 import {
   DEFAULT_PLATFORM,
   type DerivedRequirements,
   type Exclusion,
-  type PlacementTarget,
+  placementTargetOf,
   type RequiredDatastore,
   resolvePlacement,
 } from '../../domain/placement.ts';
@@ -67,25 +57,6 @@ export interface ResolveComponentPlacementResult {
   readonly suggestedTargetId: string | null;
   /** Every Target, in rank order, candidates and non-candidates alike. */
   readonly options: readonly PlacementOption[];
-}
-
-/**
- * A Target's capabilities as of its last inspection.
- *
- * The fold itself lives in `domain/capabilities.ts` because build dispatch and
- * deploy creation now ask the same question, and a Target that looked capable to
- * one of them and incapable to another would be a bug with no single place to
- * fix it.
- */
-function capabilitiesOf(
-  context: CommandContext,
-  target: Target,
-): TargetCapabilities {
-  return capabilitiesOfRow(target, {
-    artifactTypes:
-      context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
-    manifest: context.manifest,
-  });
 }
 
 export const resolveComponentPlacement: Command<
@@ -137,14 +108,11 @@ export const resolveComponentPlacement: Command<
   ]);
 
   const placement = resolvePlacement(
-    connected.map(
-      (target): PlacementTarget => ({
-        id: target.id,
-        name: target.name,
-        adapter: target.adapter,
-        rank: target.rank,
-        healthy: target.health === 'healthy',
-        capabilities: capabilitiesOf(context, target),
+    connected.map((target) =>
+      placementTargetOf(target, {
+        artifactTypes:
+          context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+        manifest: context.manifest,
       }),
     ),
     requirements,

--- a/apps/spindrift/src/commands/apps/upload-archive.ts
+++ b/apps/spindrift/src/commands/apps/upload-archive.ts
@@ -25,18 +25,18 @@
  * the bytes that were staged, and the only thing that saw those is the thing
  * that staged them.
  */
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { builds, components, targets } from '../../db/schema.ts';
-import { capabilitiesOfRow } from '../../domain/capabilities.ts';
 import type { ArtifactType } from '../../domain/desired-state.ts';
-import { artifactTypeFor } from '../../domain/placement.ts';
+import { artifactTypeFor, placementTargetOf } from '../../domain/placement.ts';
 import {
   type ArchiveSource,
   commitOf,
+  isSuppliedArtifact,
   SUPPLIED_ARTIFACT_TYPE,
 } from '../../domain/source.ts';
-import { type Command, failed, ok } from '../types.ts';
+import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
 /** A content digest over the staged bundle (§16). */
 const bundleDigest = z
@@ -110,26 +110,20 @@ export const uploadArchive: Command<
     subpath: input.subpath,
   };
 
-  // §3: shape follows the Target, not the kind. A website lands as `files` on a
-  // static Target and as a server image anywhere else, and the Build's key
-  // carries whichever it was.
-  const shape =
-    input.contents === 'artifact'
-      ? SUPPLIED_ARTIFACT_TYPE
-      : artifactTypeFor(component.kind, {
-          id: target.id,
-          name: target.name,
-          adapter: target.adapter,
-          rank: target.rank,
-          healthy: target.health === 'healthy',
-          capabilities: capabilitiesOfRow(target, {
-            artifactTypes:
-              context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
-            manifest: context.manifest,
-          }),
-        });
+  const supplied = isSuppliedArtifact(source);
 
-  const supplied = input.contents === 'artifact';
+  // §3: shape follows the Target, not the kind.
+  const shape = supplied
+    ? SUPPLIED_ARTIFACT_TYPE
+    : artifactTypeFor(
+        component.kind,
+        placementTargetOf(target, {
+          artifactTypes:
+            context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+          manifest: context.manifest,
+        }),
+      );
+
   const now = context.clock.now();
 
   // §2 keys a Build on (component, commit, target-shape), and for an upload the
@@ -148,6 +142,13 @@ export const uploadArchive: Command<
       artifactDigest: supplied ? input.bundleDigest : null,
       artifactRefs: supplied ? [input.location] : null,
       bundleDigest: input.bundleDigest,
+      // Recorded on **both** arms, unlike `artifactRefs`. A source bundle has no
+      // artifact to be addressed by, and if its location only survived on the
+      // supplied arm then `dispatchBuild` would hand every source upload's
+      // builder an empty location — a build that cannot fetch what it is
+      // building.
+      bundleLocation: input.location,
+      bundleSubpath: input.subpath,
       status: supplied ? 'SUCCEEDED' : 'PENDING',
       // §4 makes the backend and its fidelity visible on the Build. A supplied
       // artifact has neither, and saying so is more useful than naming a runner
@@ -156,16 +157,50 @@ export const uploadArchive: Command<
       logFidelity: null,
       createdAt: now,
     })
-    .onConflictDoUpdate({
-      target: [builds.componentId, builds.commit, builds.targetShape],
-      set: { artifactRefs: supplied ? [input.location] : null },
-    })
+    // Nothing is overwritten on conflict. The key is (component, commit,
+    // target-shape) and the commit *is* the bundle digest, so a conflict means
+    // byte-identical input for the same shape — there is nothing new to write,
+    // and writing anyway is how a re-upload blanks the artifact refs of a Build
+    // that had already succeeded.
+    .onConflictDoNothing()
     .returning();
 
+  // `DO NOTHING` returns no row when it did nothing, so the existing one is
+  // read back: the caller asked which Build describes these bytes, and the
+  // answer is the same either way.
+  const build =
+    row ?? (await existingBuild(context, component.id, source, shape));
+  if (build === undefined) {
+    return failed(
+      'NOT_FOUND',
+      'the Build for this bundle could not be read back after writing it',
+    );
+  }
+
   return ok({
-    buildId: row!.id,
+    buildId: build.id,
     artifactType: shape,
-    status: supplied ? 'SUCCEEDED' : 'PENDING',
+    status: build.status === 'SUCCEEDED' ? 'SUCCEEDED' : 'PENDING',
     bundleDigest: input.bundleDigest,
   });
 };
+
+/** The Build this upload's key already names, when the insert conflicted. */
+async function existingBuild(
+  context: CommandContext,
+  componentId: string,
+  source: ArchiveSource,
+  shape: ArtifactType,
+) {
+  const [row] = await context.db
+    .select()
+    .from(builds)
+    .where(
+      and(
+        eq(builds.componentId, componentId),
+        eq(builds.commit, commitOf(source)),
+        eq(builds.targetShape, shape),
+      ),
+    );
+  return row;
+}

--- a/apps/spindrift/src/commands/apps/upload-archive.ts
+++ b/apps/spindrift/src/commands/apps/upload-archive.ts
@@ -1,0 +1,171 @@
+/**
+ * `uploadArchive` — an App whose source arrived as bytes rather than a repo
+ * (§4, §5, §15).
+ *
+ * §4: "Repo and archive share **one pipeline** — unpack, detect, build. An
+ * archive of *finished output* is a supplied artifact, digested over the
+ * uploaded bundle; an archive of *source* builds normally."
+ *
+ * Both arms end at the same place — **a Build row carrying a digest** — and that
+ * is the point of this command. What differs is only whether a builder is
+ * involved on the way there:
+ *
+ * - **Finished output** is recorded, not built. The Build is born `SUCCEEDED`
+ *   with the bundle digest standing as the artifact digest, and no build adapter
+ *   is looked up, let alone invoked. There is nothing for a builder to do: the
+ *   artifact already exists and core digested it.
+ * - **Source** is staged and left `PENDING` for `dispatchBuild` to run through
+ *   the identical ladder a repo takes. This command does not run it, because
+ *   §4's pipeline is one pipeline and a second entry point into it would be a
+ *   second pipeline wearing its name.
+ *
+ * **This command never reads the bundle.** It is handed a digest and a location
+ * by whatever received the upload, because the digest is §16's join between the
+ * source receipt and the provenance document — it must be computed over exactly
+ * the bytes that were staged, and the only thing that saw those is the thing
+ * that staged them.
+ */
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { builds, components, targets } from '../../db/schema.ts';
+import { capabilitiesOfRow } from '../../domain/capabilities.ts';
+import type { ArtifactType } from '../../domain/desired-state.ts';
+import { artifactTypeFor } from '../../domain/placement.ts';
+import {
+  type ArchiveSource,
+  commitOf,
+  SUPPLIED_ARTIFACT_TYPE,
+} from '../../domain/source.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+/** A content digest over the staged bundle (§16). */
+const bundleDigest = z
+  .string()
+  .trim()
+  .regex(/^sha256:[0-9a-f]{64}$/, 'must be a sha256 digest');
+
+export const uploadArchiveInput = z
+  .object({
+    componentId: z.uuid(),
+    /**
+     * Which Target this upload is destined for. Required because §3 puts
+     * resolution **before** the build and has it output "placement plus artifact
+     * shape" — a Build's key includes the shape, so there is no shape-agnostic
+     * Build row to write first and decide about later.
+     */
+    targetId: z.uuid(),
+    bundleDigest,
+    /** Where the staged bundle is fetched from. */
+    location: z.string().trim().min(1),
+    /** §4's two arms. See {@link ArchiveContents}. */
+    contents: z.enum(['artifact', 'source']),
+    /** §5's scope, after a lone top-level directory has been unwrapped. */
+    subpath: z.string().trim().min(1).default('.'),
+  })
+  .strict();
+
+export type UploadArchiveInput = z.infer<typeof uploadArchiveInput>;
+
+export interface UploadArchiveResult {
+  readonly buildId: number;
+  /** What this upload produced, or will produce (§3). */
+  readonly artifactType: ArtifactType;
+  /**
+   * `SUCCEEDED` for finished output — there was nothing to run. `PENDING` for
+   * source, which `dispatchBuild` picks up.
+   */
+  readonly status: 'SUCCEEDED' | 'PENDING';
+  /** §16's join, echoed so a caller can correlate without re-reading the row. */
+  readonly bundleDigest: string;
+}
+
+export const uploadArchive: Command<
+  UploadArchiveInput,
+  UploadArchiveResult
+> = async (input, context) => {
+  const [component] = await context.db
+    .select()
+    .from(components)
+    .where(eq(components.id, input.componentId));
+  if (component === undefined) {
+    return failed(
+      'NOT_FOUND',
+      `there is no Component with id ${input.componentId}`,
+    );
+  }
+
+  const [target] = await context.db
+    .select()
+    .from(targets)
+    .where(eq(targets.id, input.targetId));
+  if (target === undefined) {
+    return failed('NOT_FOUND', `there is no Target with id ${input.targetId}`);
+  }
+
+  const source: ArchiveSource = {
+    kind: 'archive',
+    digest: input.bundleDigest,
+    location: input.location,
+    contents: input.contents,
+    subpath: input.subpath,
+  };
+
+  // §3: shape follows the Target, not the kind. A website lands as `files` on a
+  // static Target and as a server image anywhere else, and the Build's key
+  // carries whichever it was.
+  const shape =
+    input.contents === 'artifact'
+      ? SUPPLIED_ARTIFACT_TYPE
+      : artifactTypeFor(component.kind, {
+          id: target.id,
+          name: target.name,
+          adapter: target.adapter,
+          rank: target.rank,
+          healthy: target.health === 'healthy',
+          capabilities: capabilitiesOfRow(target, {
+            artifactTypes:
+              context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+            manifest: context.manifest,
+          }),
+        });
+
+  const supplied = input.contents === 'artifact';
+  const now = context.clock.now();
+
+  // §2 keys a Build on (component, commit, target-shape), and for an upload the
+  // bundle digest *is* the commit. Re-uploading identical bytes for the same
+  // shape therefore lands on the row that already describes them rather than
+  // minting a second one that means the same thing.
+  const [row] = await context.db
+    .insert(builds)
+    .values({
+      componentId: component.id,
+      commit: commitOf(source),
+      targetShape: shape,
+      artifactType: shape,
+      // The digest is over the uploaded bundle on **both** arms (§16). What
+      // differs is only whether it also names a finished artifact.
+      artifactDigest: supplied ? input.bundleDigest : null,
+      artifactRefs: supplied ? [input.location] : null,
+      bundleDigest: input.bundleDigest,
+      status: supplied ? 'SUCCEEDED' : 'PENDING',
+      // §4 makes the backend and its fidelity visible on the Build. A supplied
+      // artifact has neither, and saying so is more useful than naming a runner
+      // that never ran.
+      runner: null,
+      logFidelity: null,
+      createdAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [builds.componentId, builds.commit, builds.targetShape],
+      set: { artifactRefs: supplied ? [input.location] : null },
+    })
+    .returning();
+
+  return ok({
+    buildId: row!.id,
+    artifactType: shape,
+    status: supplied ? 'SUCCEEDED' : 'PENDING',
+    bundleDigest: input.bundleDigest,
+  });
+};

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -120,20 +120,33 @@ export const dispatchBuild: Command<
     );
   }
 
+  // The staged bundle's own columns, not the artifact's. §15 stages a bundle for
+  // either builder, and a Build that has not run has no artifact refs to borrow
+  // an address from — reading them here is how a source upload reaches its
+  // builder with an empty location.
+  if (app.sourceKind === 'archive' && build.bundleLocation === null) {
+    return failed(
+      'NOT_BUILDABLE',
+      `Build ${build.id} has no staged bundle location, so no route can fetch it`,
+    );
+  }
+
   const source: Source =
     app.sourceKind === 'repo'
       ? {
           kind: 'repo',
           url: app.sourceRepoUrl ?? '',
           commit: build.commit,
+          // §5: an App is repo plus subpath, and the developer named it there.
           subpath: app.sourceRepoSubpath ?? '.',
         }
       : {
           kind: 'archive',
           digest: build.bundleDigest,
-          location: build.artifactRefs?.[0] ?? '',
+          location: build.bundleLocation ?? '',
           contents: 'source',
-          subpath: app.sourceRepoSubpath ?? '.',
+          // Per Build: the unwrap is a fact about the bytes that were uploaded.
+          subpath: build.bundleSubpath ?? '.',
         };
 
   const buildSource: BuildSource = {

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -1,0 +1,236 @@
+/**
+ * `dispatchBuild` — run one source through one build route (§4).
+ *
+ * §4: "**Build is always separate from Deploy**... a build records an artifact
+ * rather than deploying one, so a late-finishing older build moves nothing.
+ * There is no `SUPERSEDED` verdict to explain."
+ *
+ * That sentence is the design of this file. What it does when a build succeeds is
+ * write a digest onto a Build row — and nothing else. It does not touch the
+ * desired row, it does not create a Deploy, and it does not compare itself
+ * against any other Build. **A build that finishes last is a build that finishes
+ * last**, and the reason that costs nothing is that finishing has no effect on
+ * what is live. Making a Deploy is a separate act somebody takes deliberately.
+ *
+ * Two more §4 terms are structural here rather than documented:
+ *
+ * - **The bundle digest is a parameter on every route.** It comes off the Build
+ *   row and goes into {@link BuildSource}, which requires it, so a route cannot
+ *   be handed a source without one (§16's join).
+ * - **Logs are read, not pushed.** The adapter yields events and this loop writes
+ *   them to the attempt log; nothing is exposed for a builder to post back to.
+ *   Whatever fidelity the route declared is what lands, and the route's name and
+ *   fidelity are recorded on the Build so an operator can see why a log is thin
+ *   rather than reading it as a bug.
+ */
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { BuildSource, BuildSpec } from '../../adapters/build/contract.ts';
+import { apps, builds, components } from '../../db/schema.ts';
+import { recordBuildEvent } from '../../domain/attempt-log.ts';
+import { DEFAULT_PLATFORM } from '../../domain/placement.ts';
+import { buildOriginOf, type Source } from '../../domain/source.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const dispatchBuildInput = z
+  .object({
+    /** The Build row to run. It already carries the source and the shape. */
+    buildId: z.number().int().positive(),
+    /**
+     * Which route to run it on. §4 makes the set of routes an installation's
+     * configuration rather than a closed vocabulary, so this is a name core does
+     * not interpret — it hands it to the registry and reports what comes back.
+     */
+    route: z.string().trim().min(1),
+  })
+  .strict();
+
+export type DispatchBuildInput = z.infer<typeof dispatchBuildInput>;
+
+export interface DispatchBuildResult {
+  readonly buildId: number;
+  readonly status: 'SUCCEEDED' | 'FAILED';
+  /** Set when the build succeeded. */
+  readonly artifactDigest: string | null;
+  /** The route that ran, as recorded on the Build (§4). */
+  readonly runner: string;
+}
+
+export const dispatchBuild: Command<
+  DispatchBuildInput,
+  DispatchBuildResult
+> = async (input, context) => {
+  const [build] = await context.db
+    .select()
+    .from(builds)
+    .where(eq(builds.id, input.buildId));
+  if (build === undefined) {
+    return failed('NOT_FOUND', `there is no Build with id ${input.buildId}`);
+  }
+
+  const [component] = await context.db
+    .select()
+    .from(components)
+    .where(eq(components.id, build.componentId));
+  if (component === undefined) {
+    return failed(
+      'NOT_FOUND',
+      `Build ${build.id} names a Component that no longer exists`,
+    );
+  }
+
+  const [app] = await context.db
+    .select()
+    .from(apps)
+    .where(eq(apps.id, component.appId));
+  if (app === undefined) {
+    return failed(
+      'NOT_FOUND',
+      `Component ${component.id} names an App that no longer exists`,
+    );
+  }
+
+  // §4's supplied artifact: an archive of finished output already *is* the
+  // artifact, digested over the bundle core staged. There is no route to run and
+  // running one would produce a second digest over the same bytes.
+  if (build.status === 'SUCCEEDED' && build.artifactDigest !== null) {
+    return ok({
+      buildId: build.id,
+      status: 'SUCCEEDED' as const,
+      artifactDigest: build.artifactDigest,
+      runner: build.runner ?? 'supplied',
+    });
+  }
+
+  if (build.bundleDigest === null) {
+    // §16: "the bundle digest must be a build parameter on every route, or the
+    // correlation between a source receipt and a provenance document has no
+    // join." A Build without one cannot be dispatched at all.
+    return failed(
+      'NOT_BUILDABLE',
+      `Build ${build.id} has no staged bundle, so no route can be given one`,
+    );
+  }
+
+  const adapter = context.adapters.build(input.route);
+  if (adapter === null) {
+    return failed(
+      'NOT_FOUND',
+      `this installation has no build route named ${input.route}`,
+    );
+  }
+
+  const source: Source =
+    app.sourceKind === 'repo'
+      ? {
+          kind: 'repo',
+          url: app.sourceRepoUrl ?? '',
+          commit: build.commit,
+          subpath: app.sourceRepoSubpath ?? '.',
+        }
+      : {
+          kind: 'archive',
+          digest: build.bundleDigest,
+          location: build.artifactRefs?.[0] ?? '',
+          contents: 'source',
+          subpath: app.sourceRepoSubpath ?? '.',
+        };
+
+  const buildSource: BuildSource = {
+    bundleDigest: build.bundleDigest,
+    origin: buildOriginOf(source),
+  };
+
+  const spec: BuildSpec = {
+    artifactType: build.artifactType,
+    kind: component.kind,
+    platform: DEFAULT_PLATFORM,
+    /**
+     * §16 names one registry per installation — "every artifact is pushed to and
+     * pulled from" it — and a Build is keyed on a *shape*, not on a Target (§2),
+     * so there is no Target here to read a reachable registry off. That is the
+     * right way round: whether a Target can reach the registry is a placement
+     * filter (§3's `reachableRegistries`), applied before the build, not a
+     * choice the build makes. An adapter never picks its own destination (§4).
+     */
+    destination: context.manifest.supplyChain.registry,
+    buildArgs: {},
+  };
+
+  const attempt = {
+    appId: app.id,
+    componentId: component.id,
+    buildId: build.id,
+  };
+
+  await context.db
+    .update(builds)
+    .set({
+      status: 'RUNNING',
+      runner: adapter.name,
+      logFidelity: adapter.logFidelity,
+    })
+    .where(eq(builds.id, build.id));
+
+  const stream = adapter.build(buildSource, spec);
+  let next = await stream.next();
+  while (!next.done) {
+    const event = next.value;
+    // §6's one attempt-scoped log: build events and deploy events land on the
+    // same stream for the same attempt, so the UI subscribes once.
+    await recordBuildEvent(
+      context.db,
+      attempt,
+      event.type === 'log'
+        ? {
+            type: 'log',
+            line: event.line,
+            ...(event.step ? { resource: event.step } : {}),
+          }
+        : { type: 'status', phase: event.state, resource: event.step },
+    );
+    next = await stream.next();
+  }
+  const result = next.value;
+
+  if (result.status === 'FAILED') {
+    await recordBuildEvent(context.db, attempt, {
+      type: 'status',
+      phase: 'FAILED',
+      reason: result.reason,
+    });
+    await context.db
+      .update(builds)
+      .set({ status: 'FAILED' })
+      .where(eq(builds.id, build.id));
+    return ok({
+      buildId: build.id,
+      status: 'FAILED' as const,
+      artifactDigest: null,
+      runner: adapter.name,
+    });
+  }
+
+  await recordBuildEvent(context.db, attempt, {
+    type: 'status',
+    phase: 'SUCCEEDED',
+  });
+
+  await context.db
+    .update(builds)
+    .set({
+      status: 'SUCCEEDED',
+      artifactDigest: result.artifact.digest,
+      artifactRefs: [...result.artifact.refs],
+      baseDigest: result.baseDigest,
+      provenance: result.provenance,
+    })
+    .where(eq(builds.id, build.id));
+
+  return ok({
+    buildId: build.id,
+    status: 'SUCCEEDED' as const,
+    artifactDigest: result.artifact.digest,
+    runner: adapter.name,
+  });
+};

--- a/apps/spindrift/src/commands/components/create.ts
+++ b/apps/spindrift/src/commands/components/create.ts
@@ -1,0 +1,150 @@
+/**
+ * `createComponent` — the second half of §2's authored surface.
+ *
+ * §2: "one App to many Components", and the two fields that look like they want
+ * to be kinds are not:
+ *
+ * > `schedule` is a field on a job, not a kind. `expose` is a field on a
+ * > service.
+ *
+ * So this command takes one flat input with two conditional fields, and the
+ * schema — not the handler — is what refuses `schedule` on a service. A field
+ * that belongs to one kind arriving on another is malformed input, not a domain
+ * decision, and putting the refusal in the schema is what keeps it out of both
+ * the handler and every caller.
+ *
+ * **`website` is not a chart branch** (§7 renders it as a service with `expose`
+ * forced) but it *is* a kind here, because §3 lets placement choose its artifact
+ * shape and a website is the one kind that can land on either.
+ */
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { apps, components } from '../../db/schema.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+/** A DNS-safe label: a Component's name appears in canonical hostnames (§9). */
+const componentName = z
+  .string()
+  .trim()
+  .min(1)
+  .max(63)
+  .regex(
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
+    'must be lowercase letters, digits and hyphens',
+  );
+
+/**
+ * A five-field cron expression.
+ *
+ * Validated for shape and nothing more. Core never evaluates a schedule — §7's
+ * chart renders a `CronJob` and the platform's own cron does the rest — so a
+ * parser here would be a second implementation of something core does not run,
+ * and the two would eventually disagree about a Sunday.
+ */
+const cronExpression = z
+  .string()
+  .trim()
+  .regex(
+    /^(\S+\s+){4}\S+$/,
+    'must be a five-field cron expression, e.g. "0 3 * * *"',
+  );
+
+const common = {
+  appId: z.uuid(),
+  name: componentName,
+  /**
+   * §9: "`Private` is the default." Stated as a schema default rather than a
+   * column default so a caller reading the input type sees which state they get
+   * by saying nothing.
+   */
+  exposure: z.enum(['internal', 'private', 'public']).default('private'),
+};
+
+export const createComponentInput = z.discriminatedUnion('kind', [
+  z
+    .object({
+      ...common,
+      kind: z.literal('service'),
+      /** §2: "an unexposed service is a queue worker." */
+      expose: z.boolean().default(true),
+    })
+    .strict(),
+  z
+    .object({
+      ...common,
+      kind: z.literal('website'),
+    })
+    .strict(),
+  z
+    .object({
+      ...common,
+      kind: z.literal('job'),
+      /** Absent means unscheduled — §7 renders that as a suspended CronJob. */
+      schedule: cronExpression.optional(),
+    })
+    .strict(),
+]);
+
+export type CreateComponentInput = z.infer<typeof createComponentInput>;
+
+export interface CreateComponentResult {
+  readonly componentId: string;
+  readonly appId: string;
+  readonly name: string;
+  readonly kind: 'service' | 'website' | 'job';
+}
+
+export const createComponent: Command<
+  CreateComponentInput,
+  CreateComponentResult
+> = async (input, context) => {
+  const [app] = await context.db
+    .select()
+    .from(apps)
+    .where(eq(apps.id, input.appId));
+  if (app === undefined) {
+    return failed('NOT_FOUND', `there is no App with id ${input.appId}`);
+  }
+
+  const now = context.clock.now();
+
+  const [row] = await context.db
+    .insert(components)
+    .values({
+      appId: app.id,
+      name: input.name,
+      kind: input.kind,
+      // §7: a website is "a service with `expose` forced and a fixed port", so
+      // the value is not the developer's to set — it is what the kind means.
+      expose: exposeFor(input),
+      schedule: input.kind === 'job' ? (input.schedule ?? null) : null,
+      exposure: input.exposure,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .returning();
+
+  return ok({
+    componentId: row!.id,
+    appId: app.id,
+    name: row!.name,
+    kind: row!.kind,
+  });
+};
+
+/**
+ * `expose` per kind (§2, §7).
+ *
+ * Null for a job rather than false: a job does not serve, so it has no answer to
+ * the question, and `false` would say it chose not to.
+ */
+function exposeFor(input: CreateComponentInput): boolean | null {
+  switch (input.kind) {
+    case 'service':
+      return input.expose;
+    case 'website':
+      return true;
+    case 'job':
+      return null;
+  }
+}

--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -1,0 +1,335 @@
+/**
+ * `createDeploy` — an intent to change what is live at one Component@Target
+ * (§2, §6).
+ *
+ * §6 states the whole mechanism, and it is three rows rather than a protocol:
+ *
+ * ```
+ * Component@Target.desired   one row: which artifact should be live here
+ * Build                      a row; its id IS the total order
+ * Deploy                     a row; an intent to change `desired`, plus the attempt
+ * ```
+ *
+ * > A **locking read** on the desired row makes two concurrent deploys an atomic
+ * > check-and-set. **Rollback is an ordinary deploy** — a newer intent row
+ * > pointing at an older Build — so no adapter has a special path. **Cost,
+ * > accepted: correctness depends on a transactional store.**
+ *
+ * Hence the shape below: everything that decides is inside one transaction that
+ * opens with `SELECT ... FOR UPDATE` on the desired row. Two concurrent calls for
+ * the same pair do not race — the second blocks until the first commits, then
+ * reads what the first wrote. That is why this command cannot be tested against
+ * a fake database, and why the harness insists on real Postgres.
+ *
+ * **This command applies nothing.** It writes an intent and returns; the deploy
+ * loop (§6: "reconciliation lives in core") is what picks the row up and calls
+ * the adapter. Two reasons that split is not bureaucracy: an intent that applied
+ * inline would hold the desired row's lock across a call to somebody else's
+ * control plane, and a crash mid-apply would lose the intent entirely rather than
+ * leaving a row the loop finds again.
+ *
+ * **It also dispatches no build**, which is §4's "a build records an artifact
+ * rather than deploying one" read from the other end. A Deploy names a Build that
+ * already succeeded, so there is nothing here to run and — structurally — no
+ * `adapters.build` lookup to run it with.
+ */
+import { and, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import {
+  builds,
+  components,
+  componentTargetDesired,
+  deploys,
+  targets,
+} from '../../db/schema.ts';
+import { capabilitiesOfRow } from '../../domain/capabilities.ts';
+import { artifactTypeFor } from '../../domain/placement.ts';
+import {
+  type Command,
+  type CommandContext,
+  type CommandFailure,
+  type CommandFailureCode,
+  type CommandResult,
+  failed,
+  ok,
+} from '../types.ts';
+
+export const createDeployInput = z
+  .object({
+    componentId: z.uuid(),
+    targetId: z.uuid(),
+    /** The Build whose artifact should become live here. */
+    buildId: z.number().int().positive(),
+  })
+  .strict();
+
+export type CreateDeployInput = z.infer<typeof createDeployInput>;
+
+export interface CreateDeployResult {
+  readonly deployId: number;
+  readonly componentId: string;
+  readonly targetId: string;
+  readonly buildId: number;
+  /** Always `PENDING`: the loop owns every phase after this one (§6). */
+  readonly phase: 'PENDING';
+  /**
+   * The Build that was desired here before this intent, if any.
+   *
+   * Returned because it is what makes this intent legible as a rollback, a
+   * roll-forward, or a first deploy — and because the caller read it under the
+   * same lock this write took, so it is the one answer that cannot be stale.
+   */
+  readonly supersededBuildId: number | null;
+}
+
+/**
+ * Everything that must hold before an intent is worth writing, checked once.
+ *
+ * Returned as a value rather than thrown so the two commands that share it —
+ * this one and `rollback` — refuse identically. A rollback that refused with a
+ * different sentence for the same reason would be the "special path" §6 says
+ * rollback does not get.
+ */
+export interface DeployPreconditions {
+  readonly componentId: string;
+  readonly targetId: string;
+  readonly buildId: number;
+  readonly exposure: 'internal' | 'private' | 'public';
+}
+
+/**
+ * What {@link checkDeployable} answers.
+ *
+ * Its own two-arm type rather than a `CommandResult<DeployPreconditions>`: the
+ * success arm carries preconditions, the caller's success arm carries a deploy,
+ * and folding both through one generic makes the two indistinguishable to
+ * narrowing exactly where it matters.
+ */
+export type DeployCheck =
+  | { readonly ok: true; readonly value: DeployPreconditions }
+  | { readonly ok: false; readonly failure: CommandFailure };
+
+/** Refuse a check, in the envelope a command returns unchanged. */
+function refuse(code: CommandFailureCode, message: string): DeployCheck {
+  return { ok: false, failure: { code, message } };
+}
+
+export const createDeploy: Command<
+  CreateDeployInput,
+  CreateDeployResult
+> = async (input, context) => {
+  const checked = await checkDeployable(input, context);
+  if (!checked.ok) return { ok: false, failure: checked.failure };
+  return placeIntent(context, checked.value);
+};
+
+/**
+ * Write the intent under a locking read on the desired row (§6).
+ *
+ * The order inside the transaction is the whole correctness argument:
+ *
+ * 1. **Ensure the desired row exists**, conflict-tolerant. Two first-ever
+ *    deploys of the same pair would otherwise both try to insert it and one
+ *    would fail on the unique key rather than serializing. With
+ *    `ON CONFLICT DO NOTHING` the loser blocks on the index until the winner
+ *    commits and then finds the row, which is the serialization we want.
+ * 2. **Lock it.** From here to `COMMIT` no other transaction can read this pair's
+ *    desired row for update, so what step 3 reads is what step 5 overwrites.
+ * 3. **Read what was desired** — under the lock, so it is current.
+ * 4. **Insert the Deploy**, which is the intent itself.
+ * 5. **Point the desired row at it.** A newer `desiredDeployId` naming an older
+ *    `desiredBuildId` is exactly what a rollback is; nothing here needs to know
+ *    which of the two happened.
+ */
+export async function placeIntent(
+  context: CommandContext,
+  checked: DeployPreconditions,
+  /**
+   * A veto evaluated **under the lock**, against what is desired right now.
+   *
+   * Rollback is the caller that needs one: "is this Build older than what is
+   * live" is a question about the desired row, and asking it before the lock
+   * would let a concurrent deploy change the answer between the read and the
+   * write. Returning a sentence refuses; returning `null` proceeds.
+   *
+   * Allowed to be async because a guard is free to ask the database something
+   * before deciding, and because it is the one point inside the transaction a
+   * test can hold open — which is what makes the check-and-set falsifiable
+   * rather than merely stated (see `test/commands/deploys.test.ts`).
+   */
+  guard?: (
+    desiredBuildId: number | null,
+  ) => string | null | Promise<string | null>,
+): Promise<CommandResult<CreateDeployResult>> {
+  const now = context.clock.now();
+
+  const placed = await context.db.transaction(async (tx) => {
+    await tx
+      .insert(componentTargetDesired)
+      .values({
+        componentId: checked.componentId,
+        targetId: checked.targetId,
+        updatedAt: now,
+      })
+      .onConflictDoNothing();
+
+    const [desired] = await tx
+      .select()
+      .from(componentTargetDesired)
+      .where(
+        and(
+          eq(componentTargetDesired.componentId, checked.componentId),
+          eq(componentTargetDesired.targetId, checked.targetId),
+        ),
+      )
+      .for('update');
+
+    const supersededBuildId = desired?.desiredBuildId ?? null;
+
+    const vetoed = (await guard?.(supersededBuildId)) ?? null;
+    if (vetoed !== null) {
+      return { vetoed, deployId: null, supersededBuildId: null };
+    }
+
+    const [deploy] = await tx
+      .insert(deploys)
+      .values({
+        componentId: checked.componentId,
+        targetId: checked.targetId,
+        buildId: checked.buildId,
+        phase: 'PENDING',
+        // §9: exposure is the Component's setting, captured at intent time so a
+        // later change to the Component does not retroactively describe what
+        // this attempt asked for.
+        exposure: checked.exposure,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    await tx
+      .update(componentTargetDesired)
+      .set({
+        desiredBuildId: checked.buildId,
+        desiredDeployId: deploy!.id,
+        updatedAt: now,
+      })
+      .where(eq(componentTargetDesired.id, desired!.id));
+
+    return { vetoed: null, deployId: deploy!.id, supersededBuildId };
+  });
+
+  if (placed.vetoed !== null) {
+    return failed('NOT_DEPLOYABLE', placed.vetoed);
+  }
+
+  return ok({
+    deployId: placed.deployId,
+    componentId: checked.componentId,
+    targetId: checked.targetId,
+    buildId: checked.buildId,
+    phase: 'PENDING' as const,
+    supersededBuildId: placed.supersededBuildId,
+  });
+}
+
+/**
+ * Everything that is true before a lock is worth taking.
+ *
+ * Deliberately **outside** the transaction. None of these can change in a way
+ * that makes a committed intent wrong — a Build does not un-succeed, a
+ * Component's kind does not change — so holding the desired row's lock across
+ * them would serialize deploys of *different* pairs behind reads that prove
+ * nothing about contention.
+ */
+export async function checkDeployable(
+  input: CreateDeployInput,
+  context: CommandContext,
+): Promise<DeployCheck> {
+  const [component] = await context.db
+    .select()
+    .from(components)
+    .where(eq(components.id, input.componentId));
+  if (component === undefined) {
+    return refuse(
+      'NOT_FOUND',
+      `there is no Component with id ${input.componentId}`,
+    );
+  }
+
+  const [target] = await context.db
+    .select()
+    .from(targets)
+    .where(eq(targets.id, input.targetId));
+  if (target === undefined) {
+    return failed('NOT_FOUND', `there is no Target with id ${input.targetId}`);
+  }
+
+  const [build] = await context.db
+    .select()
+    .from(builds)
+    .where(eq(builds.id, input.buildId));
+  if (build === undefined) {
+    return failed('NOT_FOUND', `there is no Build with id ${input.buildId}`);
+  }
+
+  if (build.componentId !== component.id) {
+    return refuse(
+      'NOT_DEPLOYABLE',
+      'that Build belongs to a different Component',
+    );
+  }
+
+  // §13: a disconnected Target strands what is on it and takes nothing new. An
+  // intent written against one would sit PENDING forever, because the loop skips
+  // disconnected Targets for the same reason the Target loop does.
+  if (target.status !== 'connected') {
+    return refuse(
+      'NOT_DEPLOYABLE',
+      `${target.name} is disconnected, so nothing new can be placed on it`,
+    );
+  }
+
+  // §4: "a build records an artifact rather than deploying one." A Build that has
+  // not succeeded has no artifact, so there is nothing for this intent to name —
+  // and a Deploy that waited for one would be the fencing token §4 removed.
+  if (build.status !== 'SUCCEEDED' || build.artifactDigest === null) {
+    return refuse(
+      'NOT_DEPLOYABLE',
+      `Build ${build.id} has no artifact — it is ${build.status.toLowerCase()}`,
+    );
+  }
+
+  // §3: "changing placement across shapes forces a rebuild." The Build's key
+  // carries the shape it was built for, so a `files` artifact reaching a Target
+  // that runs images is not a deploy that fails later — it is one that never
+  // starts, which is the whole reason resolution runs before the build.
+  const shape = artifactTypeFor(component.kind, {
+    id: target.id,
+    name: target.name,
+    adapter: target.adapter,
+    rank: target.rank,
+    healthy: target.health === 'healthy',
+    capabilities: capabilitiesOfRow(target, {
+      artifactTypes:
+        context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+      manifest: context.manifest,
+    }),
+  });
+  if (build.targetShape !== shape) {
+    return refuse(
+      'NOT_DEPLOYABLE',
+      `Build ${build.id} produced ${build.targetShape}, and ${target.name} takes ${shape} — this placement needs a rebuild`,
+    );
+  }
+
+  return {
+    ok: true,
+    value: {
+      componentId: component.id,
+      targetId: target.id,
+      buildId: build.id,
+      exposure: component.exposure,
+    },
+  };
+}

--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -42,8 +42,7 @@ import {
   deploys,
   targets,
 } from '../../db/schema.ts';
-import { capabilitiesOfRow } from '../../domain/capabilities.ts';
-import { artifactTypeFor } from '../../domain/placement.ts';
+import { artifactTypeFor, placementTargetOf } from '../../domain/placement.ts';
 import {
   type Command,
   type CommandContext,
@@ -304,18 +303,14 @@ export async function checkDeployable(
   // carries the shape it was built for, so a `files` artifact reaching a Target
   // that runs images is not a deploy that fails later — it is one that never
   // starts, which is the whole reason resolution runs before the build.
-  const shape = artifactTypeFor(component.kind, {
-    id: target.id,
-    name: target.name,
-    adapter: target.adapter,
-    rank: target.rank,
-    healthy: target.health === 'healthy',
-    capabilities: capabilitiesOfRow(target, {
+  const shape = artifactTypeFor(
+    component.kind,
+    placementTargetOf(target, {
       artifactTypes:
         context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
       manifest: context.manifest,
     }),
-  });
+  );
   if (build.targetShape !== shape) {
     return refuse(
       'NOT_DEPLOYABLE',

--- a/apps/spindrift/src/commands/deploys/rollback.ts
+++ b/apps/spindrift/src/commands/deploys/rollback.ts
@@ -1,0 +1,66 @@
+/**
+ * `rollbackDeploy` — go back to an older Build (§6).
+ *
+ * §6: "**Rollback is an ordinary deploy** — a newer intent row pointing at an
+ * older Build — so no adapter has a special path."
+ *
+ * This command is therefore almost entirely a name. It runs the same
+ * preconditions and takes the same lock as `createDeploy`, because a rollback
+ * that checked less would be a way to place a Build that an ordinary deploy had
+ * refused. What it adds is one check the forward direction does not want: that
+ * the Build named really is **older** than what is desired now.
+ *
+ * That check is not ceremony. `Build.id` is a `bigserial` precisely so it carries
+ * a total order (§6: "its id IS the total order"), and a "rollback" to a *newer*
+ * Build is a roll-forward that a developer typed the wrong word for. Refusing it
+ * costs one sentence and saves the case where someone reaches for rollback during
+ * an incident and silently ships something newer instead.
+ *
+ * **A rollback dispatches no build.** Structurally, not by convention: the whole
+ * point of one Build to many Deploys (§2) is that the artifact already exists, and
+ * nothing on this path looks up a build adapter to run one with.
+ */
+import { z } from 'zod';
+import type { Command } from '../types.ts';
+import {
+  type CreateDeployResult,
+  checkDeployable,
+  placeIntent,
+} from './create.ts';
+
+export const rollbackDeployInput = z
+  .object({
+    componentId: z.uuid(),
+    targetId: z.uuid(),
+    /** The older Build to make live again. */
+    buildId: z.number().int().positive(),
+  })
+  .strict();
+
+export type RollbackDeployInput = z.infer<typeof rollbackDeployInput>;
+
+/** The same result an ordinary deploy returns, because that is what this is. */
+export type RollbackDeployResult = CreateDeployResult;
+
+export const rollbackDeploy: Command<
+  RollbackDeployInput,
+  RollbackDeployResult
+> = async (input, context) => {
+  const checked = await checkDeployable(input, context);
+  if (!checked.ok) return { ok: false, failure: checked.failure };
+
+  // The "is this actually older" question is asked **under the lock**, against
+  // the desired row as it is at the moment the intent is written. Asking it
+  // beforehand would let a concurrent deploy change the answer in the gap, and
+  // the gap is exactly when a rollback happens — during an incident, with
+  // somebody else also pressing buttons.
+  return placeIntent(context, checked.value, (desiredBuildId) => {
+    if (desiredBuildId === null) {
+      return 'nothing has been deployed here yet, so there is nothing to roll back to';
+    }
+    if (input.buildId >= desiredBuildId) {
+      return `Build ${input.buildId} is not older than the Build that is desired here (${desiredBuildId}) — deploy it forward instead`;
+    }
+    return null;
+  });
+};

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -16,6 +16,11 @@
  * named commands and arrive with the milestones that implement them.
  */
 export { resolveComponentPlacement } from './apps/resolve-placement.ts';
+export { uploadArchive } from './apps/upload-archive.ts';
+export { dispatchBuild } from './builds/dispatch.ts';
+export { createComponent } from './components/create.ts';
 export { createApp } from './create-app.ts';
+export { createDeploy } from './deploys/create.ts';
+export { rollbackDeploy } from './deploys/rollback.ts';
 export { connectTarget } from './targets/connect.ts';
 export { disconnectTarget } from './targets/disconnect.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -33,7 +33,12 @@ import {
   resolveComponentPlacement,
   resolveComponentPlacementInput,
 } from './apps/resolve-placement.ts';
+import { uploadArchive, uploadArchiveInput } from './apps/upload-archive.ts';
+import { dispatchBuild, dispatchBuildInput } from './builds/dispatch.ts';
+import { createComponent, createComponentInput } from './components/create.ts';
 import { createApp, createAppInput } from './create-app.ts';
+import { createDeploy, createDeployInput } from './deploys/create.ts';
+import { rollbackDeploy, rollbackDeployInput } from './deploys/rollback.ts';
 import type * as commands from './index.ts';
 import { connectTarget, connectTargetInput } from './targets/connect.ts';
 import {
@@ -61,6 +66,11 @@ export type AnyCommandDescriptor = CommandDescriptor<any, any>;
 /** Every command, by the name it is dispatched under. */
 export const commandRegistry = {
   createApp: { input: createAppInput, handler: createApp },
+  createComponent: { input: createComponentInput, handler: createComponent },
+  uploadArchive: { input: uploadArchiveInput, handler: uploadArchive },
+  dispatchBuild: { input: dispatchBuildInput, handler: dispatchBuild },
+  createDeploy: { input: createDeployInput, handler: createDeploy },
+  rollbackDeploy: { input: rollbackDeployInput, handler: rollbackDeploy },
   connectTarget: { input: connectTargetInput, handler: connectTarget },
   disconnectTarget: {
     input: disconnectTargetInput,

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -110,7 +110,22 @@ export type CommandFailureCode =
   | 'UNKNOWN_COMMAND'
   | 'INVALID_INPUT'
   /** A named thing the input refers to does not exist. */
-  | 'NOT_FOUND';
+  | 'NOT_FOUND'
+  /**
+   * Everything named exists, but this artifact cannot go on this Target — a
+   * Build that has not succeeded, a shape the Target does not take (§3), a
+   * disconnected Target (§13), a rollback that is not backwards (§6).
+   *
+   * Distinct from `INVALID_INPUT` because the input was well formed and the
+   * caller is not being told to fix a field: they are being told a fact about
+   * the world, which is the disabled-with-reasons grammar §3 uses everywhere.
+   */
+  | 'NOT_DEPLOYABLE'
+  /**
+   * A Build exists but no route can be handed it — §16's bundle digest is
+   * missing, so a provenance document would have nothing to join against.
+   */
+  | 'NOT_BUILDABLE';
 
 /** The assertable identity of a failure, plus the sentence a user reads. */
 export interface CommandFailure {

--- a/apps/spindrift/src/db/migrations/0002_bundle_staging.sql
+++ b/apps/spindrift/src/db/migrations/0002_bundle_staging.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "builds" ADD COLUMN "bundle_location" text;--> statement-breakpoint
+ALTER TABLE "builds" ADD COLUMN "bundle_subpath" text;

--- a/apps/spindrift/src/db/migrations/0003_drift_state.sql
+++ b/apps/spindrift/src/db/migrations/0003_drift_state.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "deploys" ADD COLUMN "drifted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "deploys" ADD COLUMN "observed_digest" text;

--- a/apps/spindrift/src/db/migrations/meta/0002_snapshot.json
+++ b/apps/spindrift/src/db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,1281 @@
+{
+  "id": "790c940f-4573-4719-a77e-d0dfc3913e00",
+  "prevId": "8e57ff9e-39eb-4b0b-bbe2-df271060caaa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "app_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repo_url": {
+          "name": "source_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repo_subpath": {
+          "name": "source_repo_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_archive_digest": {
+          "name": "source_archive_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vessel_ref": {
+          "name": "vessel_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vanity_domain": {
+          "name": "vanity_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempt_events": {
+      "name": "attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_kind": {
+          "name": "attempt_kind",
+          "type": "attempt_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_id": {
+          "name": "deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "attempt_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attempt_events_app_id_apps_id_fk": {
+          "name": "attempt_events_app_id_apps_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_component_id_components_id_fk": {
+          "name": "attempt_events_component_id_components_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_build_id_builds_id_fk": {
+          "name": "attempt_events_build_id_builds_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_deploy_id_deploys_id_fk": {
+          "name": "attempt_events_deploy_id_deploys_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempt_events_exactly_one_attempt": {
+          "name": "attempt_events_exactly_one_attempt",
+          "value": "(\"attempt_events\".\"build_id\" is not null) <> (\"attempt_events\".\"deploy_id\" is not null)"
+        },
+        "attempt_events_kind_matches_reference": {
+          "name": "attempt_events_kind_matches_reference",
+          "value": "(\"attempt_events\".\"attempt_kind\" = 'build' and \"attempt_events\".\"build_id\" is not null) or (\"attempt_events\".\"attempt_kind\" = 'deploy' and \"attempt_events\".\"deploy_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_shape": {
+          "name": "target_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "artifact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_digest": {
+          "name": "artifact_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_refs": {
+          "name": "artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "build_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "base_digest": {
+          "name": "base_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_fidelity": {
+          "name": "log_fidelity",
+          "type": "log_fidelity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_location": {
+          "name": "bundle_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_subpath": {
+          "name": "bundle_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_component_id_components_id_fk": {
+          "name": "builds_component_id_components_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "builds_component_commit_shape_unique": {
+          "name": "builds_component_commit_shape_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "commit",
+            "target_shape"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_target_desired": {
+      "name": "component_target_desired",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_build_id": {
+          "name": "desired_build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_deploy_id": {
+          "name": "desired_deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "component_target_desired_component_id_components_id_fk": {
+          "name": "component_target_desired_component_id_components_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_target_id_targets_id_fk": {
+          "name": "component_target_desired_target_id_targets_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_build_id_builds_id_fk": {
+          "name": "component_target_desired_desired_build_id_builds_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "desired_build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_deploy_id_deploys_id_fk": {
+          "name": "component_target_desired_desired_deploy_id_deploys_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "desired_deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "component_target_desired_pair_unique": {
+          "name": "component_target_desired_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.components": {
+      "name": "components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "component_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expose": {
+          "name": "expose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "components_app_id_apps_id_fk": {
+          "name": "components_app_id_apps_id_fk",
+          "tableFrom": "components",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "components_app_id_name_unique": {
+          "name": "components_app_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_items": {
+      "name": "config_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "config_item_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret_ref'"
+        },
+        "store_ref": {
+          "name": "store_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_value": {
+          "name": "plain_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_items_component_id_components_id_fk": {
+          "name": "config_items_component_id_components_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_items_target_id_targets_id_fk": {
+          "name": "config_items_target_id_targets_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_items_scope_key_unique": {
+          "name": "config_items_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id",
+            "environment",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "config_items_environment_pinned": {
+          "name": "config_items_environment_pinned",
+          "value": "\"config_items\".\"environment\" = 'default'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.datastores": {
+      "name": "datastores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "datastore_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "datastore_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_ref": {
+          "name": "connection_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datastores_app_id_apps_id_fk": {
+          "name": "datastores_app_id_apps_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "datastores_target_id_targets_id_fk": {
+          "name": "datastores_target_id_targets_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deploys": {
+      "name": "deploys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "deploy_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deploys_component_id_components_id_fk": {
+          "name": "deploys_component_id_components_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deploys_target_id_targets_id_fk": {
+          "name": "deploys_target_id_targets_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "deploys_build_id_builds_id_fk": {
+          "name": "deploys_build_id_builds_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "target_adapter",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "target_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "target_health",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery": {
+          "name": "discovery",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_exposure": {
+          "name": "public_exposure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_build_level": {
+          "name": "min_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "targets_name_unique": {
+          "name": "targets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway_identity": {
+          "name": "gateway_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.app_source_kind": {
+      "name": "app_source_kind",
+      "schema": "public",
+      "values": [
+        "repo",
+        "archive"
+      ]
+    },
+    "public.artifact_type": {
+      "name": "artifact_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "files"
+      ]
+    },
+    "public.attempt_event_type": {
+      "name": "attempt_event_type",
+      "schema": "public",
+      "values": [
+        "log",
+        "status"
+      ]
+    },
+    "public.attempt_kind": {
+      "name": "attempt_kind",
+      "schema": "public",
+      "values": [
+        "build",
+        "deploy"
+      ]
+    },
+    "public.blame": {
+      "name": "blame",
+      "schema": "public",
+      "values": [
+        "developer",
+        "platform"
+      ]
+    },
+    "public.build_status": {
+      "name": "build_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.component_kind": {
+      "name": "component_kind",
+      "schema": "public",
+      "values": [
+        "service",
+        "website",
+        "job"
+      ]
+    },
+    "public.config_item_kind": {
+      "name": "config_item_kind",
+      "schema": "public",
+      "values": [
+        "secret_ref",
+        "plain"
+      ]
+    },
+    "public.datastore_engine": {
+      "name": "datastore_engine",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "redis"
+      ]
+    },
+    "public.datastore_provenance": {
+      "name": "datastore_provenance",
+      "schema": "public",
+      "values": [
+        "managed",
+        "external"
+      ]
+    },
+    "public.deploy_phase": {
+      "name": "deploy_phase",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPLYING",
+        "WAITING",
+        "LIVE",
+        "FAILED"
+      ]
+    },
+    "public.deploy_reason": {
+      "name": "deploy_reason",
+      "schema": "public",
+      "values": [
+        "BUILD_FAILED",
+        "ARTIFACT_UNAVAILABLE",
+        "REJECTED",
+        "STARTUP_FAILED",
+        "UNHEALTHY",
+        "TIMEOUT",
+        "TARGET_UNREACHABLE",
+        "INTERNAL"
+      ]
+    },
+    "public.exposure_state": {
+      "name": "exposure_state",
+      "schema": "public",
+      "values": [
+        "internal",
+        "private",
+        "public"
+      ]
+    },
+    "public.log_fidelity": {
+      "name": "log_fidelity",
+      "schema": "public",
+      "values": [
+        "LIVE_TEXT",
+        "LIVE_STATUS",
+        "ON_COMPLETION"
+      ]
+    },
+    "public.target_adapter": {
+      "name": "target_adapter",
+      "schema": "public",
+      "values": [
+        "kubernetes",
+        "cloudrun",
+        "static"
+      ]
+    },
+    "public.target_health": {
+      "name": "target_health",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy"
+      ]
+    },
+    "public.target_status": {
+      "name": "target_status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "disconnected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/spindrift/src/db/migrations/meta/0003_snapshot.json
+++ b/apps/spindrift/src/db/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1293 @@
+{
+  "id": "bc4dc6c7-bbf6-4fa8-ad95-5f86345ae14d",
+  "prevId": "790c940f-4573-4719-a77e-d0dfc3913e00",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "app_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repo_url": {
+          "name": "source_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repo_subpath": {
+          "name": "source_repo_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_archive_digest": {
+          "name": "source_archive_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vessel_ref": {
+          "name": "vessel_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vanity_domain": {
+          "name": "vanity_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempt_events": {
+      "name": "attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_kind": {
+          "name": "attempt_kind",
+          "type": "attempt_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_id": {
+          "name": "deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "attempt_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attempt_events_app_id_apps_id_fk": {
+          "name": "attempt_events_app_id_apps_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_component_id_components_id_fk": {
+          "name": "attempt_events_component_id_components_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_build_id_builds_id_fk": {
+          "name": "attempt_events_build_id_builds_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_deploy_id_deploys_id_fk": {
+          "name": "attempt_events_deploy_id_deploys_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempt_events_exactly_one_attempt": {
+          "name": "attempt_events_exactly_one_attempt",
+          "value": "(\"attempt_events\".\"build_id\" is not null) <> (\"attempt_events\".\"deploy_id\" is not null)"
+        },
+        "attempt_events_kind_matches_reference": {
+          "name": "attempt_events_kind_matches_reference",
+          "value": "(\"attempt_events\".\"attempt_kind\" = 'build' and \"attempt_events\".\"build_id\" is not null) or (\"attempt_events\".\"attempt_kind\" = 'deploy' and \"attempt_events\".\"deploy_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_shape": {
+          "name": "target_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "artifact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_digest": {
+          "name": "artifact_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_refs": {
+          "name": "artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "build_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "base_digest": {
+          "name": "base_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_fidelity": {
+          "name": "log_fidelity",
+          "type": "log_fidelity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_location": {
+          "name": "bundle_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_subpath": {
+          "name": "bundle_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_component_id_components_id_fk": {
+          "name": "builds_component_id_components_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "builds_component_commit_shape_unique": {
+          "name": "builds_component_commit_shape_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "commit",
+            "target_shape"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_target_desired": {
+      "name": "component_target_desired",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_build_id": {
+          "name": "desired_build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_deploy_id": {
+          "name": "desired_deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "component_target_desired_component_id_components_id_fk": {
+          "name": "component_target_desired_component_id_components_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_target_id_targets_id_fk": {
+          "name": "component_target_desired_target_id_targets_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_build_id_builds_id_fk": {
+          "name": "component_target_desired_desired_build_id_builds_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "desired_build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_deploy_id_deploys_id_fk": {
+          "name": "component_target_desired_desired_deploy_id_deploys_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "desired_deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "component_target_desired_pair_unique": {
+          "name": "component_target_desired_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.components": {
+      "name": "components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "component_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expose": {
+          "name": "expose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "components_app_id_apps_id_fk": {
+          "name": "components_app_id_apps_id_fk",
+          "tableFrom": "components",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "components_app_id_name_unique": {
+          "name": "components_app_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_items": {
+      "name": "config_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "config_item_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret_ref'"
+        },
+        "store_ref": {
+          "name": "store_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_value": {
+          "name": "plain_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_items_component_id_components_id_fk": {
+          "name": "config_items_component_id_components_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_items_target_id_targets_id_fk": {
+          "name": "config_items_target_id_targets_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_items_scope_key_unique": {
+          "name": "config_items_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id",
+            "environment",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "config_items_environment_pinned": {
+          "name": "config_items_environment_pinned",
+          "value": "\"config_items\".\"environment\" = 'default'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.datastores": {
+      "name": "datastores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "datastore_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "datastore_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_ref": {
+          "name": "connection_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datastores_app_id_apps_id_fk": {
+          "name": "datastores_app_id_apps_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "datastores_target_id_targets_id_fk": {
+          "name": "datastores_target_id_targets_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deploys": {
+      "name": "deploys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "deploy_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drifted_at": {
+          "name": "drifted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_digest": {
+          "name": "observed_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deploys_component_id_components_id_fk": {
+          "name": "deploys_component_id_components_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deploys_target_id_targets_id_fk": {
+          "name": "deploys_target_id_targets_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "deploys_build_id_builds_id_fk": {
+          "name": "deploys_build_id_builds_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "target_adapter",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "target_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "target_health",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery": {
+          "name": "discovery",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_exposure": {
+          "name": "public_exposure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_build_level": {
+          "name": "min_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "targets_name_unique": {
+          "name": "targets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway_identity": {
+          "name": "gateway_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.app_source_kind": {
+      "name": "app_source_kind",
+      "schema": "public",
+      "values": [
+        "repo",
+        "archive"
+      ]
+    },
+    "public.artifact_type": {
+      "name": "artifact_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "files"
+      ]
+    },
+    "public.attempt_event_type": {
+      "name": "attempt_event_type",
+      "schema": "public",
+      "values": [
+        "log",
+        "status"
+      ]
+    },
+    "public.attempt_kind": {
+      "name": "attempt_kind",
+      "schema": "public",
+      "values": [
+        "build",
+        "deploy"
+      ]
+    },
+    "public.blame": {
+      "name": "blame",
+      "schema": "public",
+      "values": [
+        "developer",
+        "platform"
+      ]
+    },
+    "public.build_status": {
+      "name": "build_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.component_kind": {
+      "name": "component_kind",
+      "schema": "public",
+      "values": [
+        "service",
+        "website",
+        "job"
+      ]
+    },
+    "public.config_item_kind": {
+      "name": "config_item_kind",
+      "schema": "public",
+      "values": [
+        "secret_ref",
+        "plain"
+      ]
+    },
+    "public.datastore_engine": {
+      "name": "datastore_engine",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "redis"
+      ]
+    },
+    "public.datastore_provenance": {
+      "name": "datastore_provenance",
+      "schema": "public",
+      "values": [
+        "managed",
+        "external"
+      ]
+    },
+    "public.deploy_phase": {
+      "name": "deploy_phase",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPLYING",
+        "WAITING",
+        "LIVE",
+        "FAILED"
+      ]
+    },
+    "public.deploy_reason": {
+      "name": "deploy_reason",
+      "schema": "public",
+      "values": [
+        "BUILD_FAILED",
+        "ARTIFACT_UNAVAILABLE",
+        "REJECTED",
+        "STARTUP_FAILED",
+        "UNHEALTHY",
+        "TIMEOUT",
+        "TARGET_UNREACHABLE",
+        "INTERNAL"
+      ]
+    },
+    "public.exposure_state": {
+      "name": "exposure_state",
+      "schema": "public",
+      "values": [
+        "internal",
+        "private",
+        "public"
+      ]
+    },
+    "public.log_fidelity": {
+      "name": "log_fidelity",
+      "schema": "public",
+      "values": [
+        "LIVE_TEXT",
+        "LIVE_STATUS",
+        "ON_COMPLETION"
+      ]
+    },
+    "public.target_adapter": {
+      "name": "target_adapter",
+      "schema": "public",
+      "values": [
+        "kubernetes",
+        "cloudrun",
+        "static"
+      ]
+    },
+    "public.target_health": {
+      "name": "target_health",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy"
+      ]
+    },
+    "public.target_status": {
+      "name": "target_status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "disconnected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1785153497731,
       "tag": "0001_targets",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785187708931,
+      "tag": "0002_bundle_staging",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785188201016,
+      "tag": "0003_drift_state",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -272,6 +272,25 @@ export const builds = pgTable(
      * the join between a source receipt and its provenance document.
      */
     bundleDigest: text('bundle_digest'),
+    /**
+     * Where the staged bundle is fetched from (§15: "fetches the exact commit
+     * once and stages an immutable source bundle for either builder").
+     *
+     * Beside the digest rather than folded into `artifactRefs`: those are
+     * addresses the *artifact* can be pulled by, and a bundle that has not been
+     * built yet has no artifact. Conflating them makes a source upload's
+     * location vanish the moment it is not a supplied artifact.
+     */
+    bundleLocation: text('bundle_location'),
+    /**
+     * §5's named scope for this bundle, after a lone top-level directory has
+     * been unwrapped.
+     *
+     * Per Build rather than per App because the unwrap is a fact about the bytes
+     * that were uploaded, and two uploads to one App may wrap differently. A
+     * repo App keeps its scope on the App, where the developer named it.
+     */
+    bundleSubpath: text('bundle_subpath'),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -333,6 +352,25 @@ export const deploys = pgTable('deploys', {
    * reads the two together.
    */
   orphanedAt: timestamp('orphaned_at', { withTimezone: true }),
+  /**
+   * §6: "**Drift is detected and surfaced, never silently corrected** — a
+   * visible state with a one-click re-converge."
+   *
+   * *Visible* is what makes this a column. A loop that noticed drift and only
+   * returned it would surface it to nobody: the UI reads rows, and a fact that
+   * lives for the length of one pass is a fact the screen can never show.
+   * Cleared when what is running matches again, so a drift that somebody fixed
+   * out of band stops being reported without anyone having to dismiss it.
+   */
+  driftedAt: timestamp('drifted_at', { withTimezone: true }),
+  /**
+   * The digest `observe` last reported as actually serving.
+   *
+   * Stored beside the drift flag rather than derived from it because "what is
+   * running instead" is the first question anyone asks, and by the time they
+   * ask, the answer is one poll interval old at best.
+   */
+  observedDigest: text('observed_digest'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -328,6 +328,48 @@ export function noCapabilities(context: CapabilityContext): TargetCapabilities {
   );
 }
 
+/**
+ * One stored Target row, as capabilities.
+ *
+ * §3 gives capabilities four provenances and this is where the two that are not
+ * stored get supplied: from-the-adapter-type comes off the adapter instance, and
+ * the derived values are recomputed from the manifest every read (see
+ * `target-loop.ts` — "a stored derivation can never be stale in a way nothing
+ * notices").
+ *
+ * It lives here rather than in whichever command needed it first because three
+ * of them now do — placement, build dispatch, and deploy creation — and a Target
+ * that looks capable to one and incapable to another is a bug with no single
+ * place to fix it. A Target whose adapter this installation does not ship, or
+ * that has never been inspected, resolves to no capabilities: excluded with a
+ * reason, never silently dropped.
+ */
+export function capabilitiesOfRow(
+  target: Pick<TargetRow, 'adapter' | 'discovery' | 'publicExposure'>,
+  options: {
+    /** The adapter instance, or `null` when this installation ships none. */
+    readonly artifactTypes: readonly ArtifactType[] | null;
+    readonly manifest: InstallationManifest;
+  },
+): TargetCapabilities {
+  const context: CapabilityContext = {
+    adapter: target.adapter,
+    artifactTypes: options.artifactTypes ?? [],
+    publicExposure: target.publicExposure,
+    deployPath: deployPathReferences(options.manifest),
+  };
+  return target.discovery === null || options.artifactTypes === null
+    ? noCapabilities(context)
+    : resolveCapabilities(target.discovery, context);
+}
+
+/** The columns {@link capabilitiesOfRow} reads, without importing the schema. */
+interface TargetRow {
+  adapter: TargetAdapter;
+  discovery: TargetDiscovery | null;
+  publicExposure: boolean | null;
+}
+
 /** Healthy is every item met. §13 makes an unmet item a non-candidate. */
 export function deriveHealth(
   prerequisites: readonly PrerequisiteResult[],

--- a/apps/spindrift/src/domain/diagnosis.ts
+++ b/apps/spindrift/src/domain/diagnosis.ts
@@ -24,6 +24,7 @@
 import {
   type Blame,
   blameFor,
+  type DeployPhase,
   type DeployVerdict,
   type FailureReason,
 } from '../adapters/deploy/contract.ts';
@@ -94,7 +95,7 @@ export function failureColumns(diagnosis: Diagnosis): {
  * converging has not drifted; it has not arrived.
  */
 export function hasDrifted(args: {
-  readonly phase: string;
+  readonly phase: DeployPhase;
   /** The digest the Deploy's Build named. */
   readonly desiredDigest: string;
   /** The digest `observe` says is actually serving, or `null` when nothing is. */

--- a/apps/spindrift/src/domain/diagnosis.ts
+++ b/apps/spindrift/src/domain/diagnosis.ts
@@ -1,0 +1,106 @@
+/**
+ * What a red Deploy remembers (§6, §12).
+ *
+ * §6: "**Spindrift diagnoses on red**: on failure or stall it reads pods and
+ * events (or the cloud log) **once** and fills in the detail."
+ *
+ * The adapter does that read — it is the only thing that knows what a pod is —
+ * and this module is what makes the answer outlive it. §12 states the reason
+ * plainly: **the platform will not keep it.** Cluster events expire in about an
+ * hour, a Cloud Run revision's logs roll, and a developer who opens the deploy
+ * screen the next morning would otherwise find a red Deploy with no explanation
+ * and no way to get one back. So the diagnosis is denormalized onto the Deploy
+ * row at the moment it is drawn, and every read after that is a read of core's
+ * own storage rather than a second trip to a backend that has forgotten.
+ *
+ * That is also the reason `debug` is stored verbatim. The closed `reason` is
+ * what the UI keys on and what a test asserts; the raw payload is for the
+ * operator who needs to know which admission webhook, and it is precisely the
+ * thing that no longer exists an hour later.
+ *
+ * **Blame is derived, never taken.** §6: an adapter "reports a reason and never
+ * a blame... so two adapters cannot disagree about who a failure indicts."
+ */
+import {
+  type Blame,
+  blameFor,
+  type DeployVerdict,
+  type FailureReason,
+} from '../adapters/deploy/contract.ts';
+
+/** The columns a red Deploy carries, as one value. */
+export interface Diagnosis {
+  readonly reason: FailureReason;
+  /** Derived from the reason via §6's table. `null` only for `TIMEOUT`. */
+  readonly blame: Blame | null;
+  /** The sentence the developer reads, in the platform's own words. */
+  readonly detail: string | null;
+  /** The raw platform payload, kept for the operator (§6, §12). */
+  readonly debug: unknown;
+}
+
+/**
+ * Draw the diagnosis from a terminal verdict.
+ *
+ * `null` for a green verdict, which is not the same as an empty diagnosis: a
+ * Deploy that succeeded has nothing to explain, and writing a row of nulls would
+ * make "was this ever diagnosed" unanswerable.
+ */
+export function diagnosisOf(verdict: DeployVerdict): Diagnosis | null {
+  if (verdict.phase === 'LIVE') return null;
+  return {
+    reason: verdict.reason,
+    blame: blameFor(verdict.reason),
+    detail: verdict.detail ?? null,
+    debug: verdict.debug ?? null,
+  };
+}
+
+/**
+ * The columns a failed attempt writes, and **nothing else**.
+ *
+ * Named as its own function because of what it must not contain. §9: "**exposure
+ * never mutates on red**" — a failed deploy leaves the App exactly as reachable
+ * as it was, because the previous release is still serving and quietly making it
+ * unreachable would turn one failed deploy into an outage. There is no `exposure`
+ * key here, and there is no code path that adds one: a red Deploy updates its own
+ * verdict columns and stops.
+ */
+export function failureColumns(diagnosis: Diagnosis): {
+  phase: 'FAILED';
+  reason: FailureReason;
+  blame: Blame | null;
+  detail: string | null;
+  debug: unknown;
+} {
+  return {
+    phase: 'FAILED',
+    reason: diagnosis.reason,
+    blame: diagnosis.blame,
+    detail: diagnosis.detail,
+    debug: diagnosis.debug,
+  };
+}
+
+/**
+ * Whether what is running is what was asked for (§6).
+ *
+ * "**Drift is detected and surfaced, never silently corrected** — a visible state
+ * with a one-click re-converge." So this returns an answer and takes no action,
+ * and nothing downstream of it applies anything: the re-converge is an ordinary
+ * Deploy that a person presses, which is the same path every other change takes.
+ *
+ * Drift is only meaningful for a Deploy that reached `LIVE`. A Deploy still
+ * converging has not drifted; it has not arrived.
+ */
+export function hasDrifted(args: {
+  readonly phase: string;
+  /** The digest the Deploy's Build named. */
+  readonly desiredDigest: string;
+  /** The digest `observe` says is actually serving, or `null` when nothing is. */
+  readonly observedDigest: string | null;
+}): boolean {
+  if (args.phase !== 'LIVE') return false;
+  if (args.observedDigest === null) return true;
+  return args.observedDigest !== args.desiredDigest;
+}

--- a/apps/spindrift/src/domain/naming.ts
+++ b/apps/spindrift/src/domain/naming.ts
@@ -1,0 +1,142 @@
+/**
+ * Naming (§9).
+ *
+ * §9 is two layers, and the reason there are two is that they answer different
+ * questions:
+ *
+ * > A **canonical** name that always resolves. Where the platform gives one of
+ * > its own, that *is* the canonical; Spindrift mints one in its own zone only
+ * > where the platform gives none — which is the metal cluster alone. A
+ * > **vanity** flat single-label name layered on where a mechanism exists, so
+ * > the name a developer shares is backend-agnostic and moving an App between
+ * > backends is one record re-point.
+ *
+ * The asymmetry between them is not cosmetic and it is enforced here:
+ *
+ * - **Canonical names nest freely.** `web.shop.apps.example` is legal because
+ *   free universal certificates only bind *proxied* records to one subdomain
+ *   level, and a canonical name is not proxied.
+ * - **Vanity names are flat, single-label, and rationed.** One apex, one
+ *   certificate, and §9's "hard ceiling: roughly 20 vanity names" is a property
+ *   of that certificate rather than a policy anyone chose.
+ *
+ * **Core mints only what the platform will not.** {@link canonicalFor} returns
+ * `null` for a Target whose backend names its own workloads, and on those the
+ * adapter reports the address back across the deploy seam (§6's
+ * `DeployVerdict.url`). A core that minted a name there would be inventing a
+ * second address for something that already had one.
+ */
+import type { TargetAdapter } from '../config/manifest.schema.ts';
+import type { Hostname } from './desired-state.ts';
+
+/**
+ * A single DNS label: what a vanity name is allowed to be, and what each
+ * segment of a canonical name is built from.
+ */
+const LABEL = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
+
+/** Whether a string is one legal DNS label. */
+export function isLabel(value: string): boolean {
+  return value.length > 0 && value.length <= 63 && LABEL.test(value);
+}
+
+/**
+ * The backends that name their own workloads (§6's table, §9).
+ *
+ * Cloud Run mints a service URL and the hosting product mints a site address, so
+ * on both of those the platform's name *is* the canonical one. A cluster mints
+ * nothing an outsider can resolve — §9's "forcing fact" is that the metal
+ * cluster's load-balancer range is RFC1918 — which is why it is the one place
+ * core has to supply a name.
+ */
+const PLATFORM_NAMES_ITS_OWN: readonly TargetAdapter[] = ['cloudrun', 'static'];
+
+/** Whether core mints the canonical name for a Target of this adapter type. */
+export function coreMintsCanonical(adapter: TargetAdapter): boolean {
+  return !PLATFORM_NAMES_ITS_OWN.includes(adapter);
+}
+
+/** What a canonical name is assembled from. */
+export interface CanonicalName {
+  readonly app: string;
+  readonly component: string;
+  /** The installation's dedicated apex, disjoint from any hand-managed space. */
+  readonly apexZone: string;
+}
+
+/**
+ * The name core mints for one Component on a Target that has none (§9).
+ *
+ * `<component>.<app>.<apex>` — nested rather than flattened to
+ * `<component>-<app>`, because nesting is free here (canonical names are
+ * unproxied) and a hyphen-joined name is ambiguous the moment either half
+ * contains a hyphen, which both are allowed to.
+ */
+export function componentCanonical(name: CanonicalName): string {
+  return `${name.component}.${name.app}.${name.apexZone}`;
+}
+
+/**
+ * The App's own name (§9: "the URL is live from App creation").
+ *
+ * An App has an address before any Component is deployed — a lowest-precedence
+ * route serving a status page hangs off this — so it is a name in its own right
+ * rather than something derived from whichever Component happened to be first.
+ */
+export function appCanonical(app: string, apexZone: string): string {
+  return `${app}.${apexZone}`;
+}
+
+/** §9's flat single-label vanity name, in the installation's vanity zone. */
+export function vanity(label: string, vanityZone: string): string {
+  return `${label}.${vanityZone}`;
+}
+
+/** What {@link hostnameFor} needs to answer §6's `hostname` field. */
+export interface HostnameContext {
+  readonly app: string;
+  readonly component: string;
+  readonly adapter: TargetAdapter;
+  readonly apexZone: string;
+  readonly vanityZone: string;
+  /** The flat label the developer chose, if any. */
+  readonly vanityLabel: string | null;
+}
+
+/**
+ * The `hostname` core hands the adapter (§6).
+ *
+ * `canonical` is empty exactly when the platform names its own — the adapter
+ * fills that gap from its own API and reports the result back on the verdict,
+ * which is why {@link Hostname} carries a string rather than a nullable one:
+ * every deploy ends with a canonical name, but not every deploy starts with one.
+ */
+export function hostnameFor(context: HostnameContext): Hostname {
+  const canonical = coreMintsCanonical(context.adapter)
+    ? componentCanonical({
+        app: context.app,
+        component: context.component,
+        apexZone: context.apexZone,
+      })
+    : '';
+
+  return {
+    canonical,
+    ...(context.vanityLabel === null
+      ? {}
+      : { vanity: vanity(context.vanityLabel, context.vanityZone) }),
+  };
+}
+
+/**
+ * The address a developer is shown for one Deploy.
+ *
+ * Vanity first where there is one, because that is the name §9 says a developer
+ * shares; the canonical is what always resolves underneath it. `null` when
+ * neither exists yet — a Deploy that has not reached a Target has no address,
+ * and inventing one for the UI would make a pending deploy look live.
+ */
+export function displayUrl(hostname: Hostname): string | null {
+  const host = hostname.vanity ?? hostname.canonical;
+  return host === '' ? null : `https://${host}`;
+}

--- a/apps/spindrift/src/domain/naming.ts
+++ b/apps/spindrift/src/domain/naming.ts
@@ -76,17 +76,6 @@ export function componentCanonical(name: CanonicalName): string {
   return `${name.component}.${name.app}.${name.apexZone}`;
 }
 
-/**
- * The App's own name (§9: "the URL is live from App creation").
- *
- * An App has an address before any Component is deployed — a lowest-precedence
- * route serving a status page hangs off this — so it is a name in its own right
- * rather than something derived from whichever Component happened to be first.
- */
-export function appCanonical(app: string, apexZone: string): string {
-  return `${app}.${apexZone}`;
-}
-
 /** §9's flat single-label vanity name, in the installation's vanity zone. */
 export function vanity(label: string, vanityZone: string): string {
   return `${label}.${vanityZone}`;

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -25,8 +25,15 @@
  * shape* — which is why a Build's key includes the target shape and why moving
  * across shapes forces a rebuild while moving within one does not (§3).
  */
-import type { TargetAdapter } from '../config/manifest.schema.ts';
-import type { TargetCapabilities } from './capabilities.ts';
+import type {
+  InstallationManifest,
+  TargetAdapter,
+} from '../config/manifest.schema.ts';
+import {
+  capabilitiesOfRow,
+  type TargetCapabilities,
+  type TargetDiscovery,
+} from './capabilities.ts';
 import type {
   ArtifactType,
   ComponentKind,
@@ -143,6 +150,49 @@ export interface Placement {
   readonly suggested: Candidate | null;
   readonly candidates: readonly Candidate[];
   readonly nonCandidates: readonly NonCandidate[];
+}
+
+/**
+ * The `targets` columns {@link placementTargetOf} reads.
+ *
+ * Structural rather than an import of the row type: this file is domain, and a
+ * domain module that imports the schema is a domain module the schema can break.
+ */
+interface RankedTargetRow {
+  id: string;
+  name: string;
+  adapter: TargetAdapter;
+  rank: number;
+  health: 'healthy' | 'unhealthy';
+  discovery: TargetDiscovery | null;
+  publicExposure: boolean | null;
+}
+
+/**
+ * One stored Target row, as placement sees it.
+ *
+ * Three commands now need a `PlacementTarget` out of a `targets` row —
+ * resolution, upload, and deploy creation — and each was rebuilding the same
+ * six-field object around the same `capabilitiesOfRow` call. That is one shape,
+ * so it is one function: a Target that looked capable to the command that
+ * resolved it and incapable to the command that deployed to it is a bug with no
+ * single place to fix it.
+ */
+export function placementTargetOf(
+  target: RankedTargetRow,
+  options: {
+    readonly artifactTypes: readonly ArtifactType[] | null;
+    readonly manifest: InstallationManifest;
+  },
+): PlacementTarget {
+  return {
+    id: target.id,
+    name: target.name,
+    adapter: target.adapter,
+    rank: target.rank,
+    healthy: target.health === 'healthy',
+    capabilities: capabilitiesOfRow(target, options),
+  };
 }
 
 /**

--- a/apps/spindrift/src/domain/source.ts
+++ b/apps/spindrift/src/domain/source.ts
@@ -3,12 +3,9 @@
  *
  * §4 settles the shape this file exists to keep honest: **repo and archive share
  * one pipeline** — unpack, detect, build — so a source is an *origin*, not a
- * second contract. The one place the two genuinely diverge is retention (§15:
- * "repo bundles are ephemeral, archives durable"), and that divergence is a
- * property of where the bytes came from rather than a branch anything downstream
- * takes.
+ * second contract.
  *
- * The other distinction §4 draws is inside the archive, not between the two:
+ * The distinction §4 does draw is inside the archive, not between the two:
  *
  * > An archive of *finished output* is a supplied artifact, digested over the
  * > uploaded bundle; an archive of *source* builds normally.
@@ -19,8 +16,8 @@
  * receipt and the provenance document name one digest whether or not a build
  * happened between them.
  *
- * Nothing here writes. The commands own the rows; this owns the three questions
- * they both have to answer the same way.
+ * Nothing here writes. The commands own the rows; this owns the questions they
+ * both have to answer the same way.
  */
 import type { BuildOrigin } from '../adapters/build/contract.ts';
 import type { ArtifactType } from './desired-state.ts';
@@ -62,20 +59,6 @@ export interface ArchiveSource {
 }
 
 export type Source = RepoSource | ArchiveSource;
-
-/**
- * How long a staged bundle is kept (§15).
- *
- * "Repo bundles are ephemeral, archives durable." The asymmetry is not a policy
- * choice — a repo bundle can be fetched again from the commit that produced it,
- * and an upload cannot be fetched again from anywhere. Losing the second one
- * loses the only copy.
- */
-export type Retention = 'durable' | 'ephemeral';
-
-export function retentionOf(source: Source): Retention {
-  return source.kind === 'archive' ? 'durable' : 'ephemeral';
-}
 
 /**
  * Whether this source is finished output core records rather than builds (§4).
@@ -126,27 +109,4 @@ export function buildOriginOf(source: Source): BuildOrigin {
         location: source.location,
         subpath: source.subpath,
       };
-}
-
-/**
- * §5's unwrap: "archives use the identical ladder **after unwrapping a lone
- * top-level directory**."
- *
- * A ZIP made by right-clicking a folder contains that folder; one made by
- * selecting its contents does not. Both are the same upload as far as the person
- * doing it is concerned, so the ladder must see the same tree either way.
- *
- * **A lone top-level directory, and nothing else.** Two directories are a
- * monorepo whose scope is named rather than searched (§5), and one directory
- * beside a stray `README.md` is a project that happens to have a directory in
- * it. Unwrapping either would be the search §5 refuses to do.
- */
-export function unwrapSubpath(topLevelEntries: readonly string[]): string {
-  const entries = topLevelEntries.filter((entry) => entry.length > 0);
-  const [only] = entries;
-  if (entries.length !== 1 || only === undefined) return '.';
-  // Directory entries carry the trailing slash the archive format wrote; a lone
-  // top-level *file* is a one-file upload, not a wrapper to unwrap.
-  if (!only.endsWith('/')) return '.';
-  return only.slice(0, -1);
 }

--- a/apps/spindrift/src/domain/source.ts
+++ b/apps/spindrift/src/domain/source.ts
@@ -1,0 +1,152 @@
+/**
+ * Where an App's code comes from, and what staging it means (§4, §5, §15).
+ *
+ * §4 settles the shape this file exists to keep honest: **repo and archive share
+ * one pipeline** — unpack, detect, build — so a source is an *origin*, not a
+ * second contract. The one place the two genuinely diverge is retention (§15:
+ * "repo bundles are ephemeral, archives durable"), and that divergence is a
+ * property of where the bytes came from rather than a branch anything downstream
+ * takes.
+ *
+ * The other distinction §4 draws is inside the archive, not between the two:
+ *
+ * > An archive of *finished output* is a supplied artifact, digested over the
+ * > uploaded bundle; an archive of *source* builds normally.
+ *
+ * That is {@link ArchiveContents}, and it is the whole reason a `files` artifact
+ * can exist with no builder ever having run. **Both arms are still digested over
+ * the same uploaded bundle**, which is what keeps §16's join intact: the source
+ * receipt and the provenance document name one digest whether or not a build
+ * happened between them.
+ *
+ * Nothing here writes. The commands own the rows; this owns the three questions
+ * they both have to answer the same way.
+ */
+import type { BuildOrigin } from '../adapters/build/contract.ts';
+import type { ArtifactType } from './desired-state.ts';
+
+/**
+ * What is inside an uploaded archive (§4).
+ *
+ * `artifact` is finished output — a built site, a compiled bundle — which core
+ * records as-is. `source` is code, which goes through §5's identical ladder.
+ *
+ * **This is stated by the uploader today and detected tomorrow.** §5's ladder
+ * ("archives use the identical ladder after unwrapping a lone top-level
+ * directory") is what will fill it in, and that ladder arrives with detection.
+ * Until then the caller says which it uploaded, because the alternative — core
+ * guessing from a file listing — is the unbounded surface §5 declines to read.
+ */
+export type ArchiveContents = 'artifact' | 'source';
+
+/** An App sourced from a repository at one named scope (§5). */
+export interface RepoSource {
+  readonly kind: 'repo';
+  readonly url: string;
+  /** The exact commit fetched. Triggers fire on default-branch HEAD (§5, §15). */
+  readonly commit: string;
+  /** §5: "the scope is named, never searched." */
+  readonly subpath: string;
+}
+
+/** An App sourced from an upload (§4). */
+export interface ArchiveSource {
+  readonly kind: 'archive';
+  /** Digest over the staged bundle — §16's join, on both arms. */
+  readonly digest: string;
+  /** Where the staged bundle is fetched from. */
+  readonly location: string;
+  readonly contents: ArchiveContents;
+  /** Applied after unwrapping a lone top-level directory (§5). */
+  readonly subpath: string;
+}
+
+export type Source = RepoSource | ArchiveSource;
+
+/**
+ * How long a staged bundle is kept (§15).
+ *
+ * "Repo bundles are ephemeral, archives durable." The asymmetry is not a policy
+ * choice — a repo bundle can be fetched again from the commit that produced it,
+ * and an upload cannot be fetched again from anywhere. Losing the second one
+ * loses the only copy.
+ */
+export type Retention = 'durable' | 'ephemeral';
+
+export function retentionOf(source: Source): Retention {
+  return source.kind === 'archive' ? 'durable' : 'ephemeral';
+}
+
+/**
+ * Whether this source is finished output core records rather than builds (§4).
+ *
+ * A repo is never one: §4's supplied-artifact arm is about an *uploaded* bundle,
+ * and a repository is code by construction.
+ */
+export function isSuppliedArtifact(source: Source): boolean {
+  return source.kind === 'archive' && source.contents === 'artifact';
+}
+
+/**
+ * What a supplied artifact is, as an artifact type (§6's table).
+ *
+ * `files`, always. §6 gives exactly one backend that accepts `files` — `static`
+ * — and finished output uploaded as a bundle is what that backend serves. An
+ * uploaded *image* is not a shape v1 has: it would need a registry push core
+ * does not do and a digest core did not compute, which is the custody gap §16
+ * closes by digesting what was actually staged.
+ */
+export const SUPPLIED_ARTIFACT_TYPE: ArtifactType = 'files';
+
+/**
+ * The commit a Build row records for one source.
+ *
+ * A Build is keyed on `(component, commit, target-shape)` (§2), and an archive
+ * has no commit — so the bundle digest stands in for one. That is not a
+ * workaround: the key exists to make "this exact input, this exact shape" one
+ * row, and for an upload the bundle digest *is* the exact input. Using it here
+ * is what makes re-uploading identical bytes reuse the Build rather than mint a
+ * second one that means the same thing.
+ */
+export function commitOf(source: Source): string {
+  return source.kind === 'repo' ? source.commit : source.digest;
+}
+
+/** The build contract's view of one source (§4). */
+export function buildOriginOf(source: Source): BuildOrigin {
+  return source.kind === 'repo'
+    ? {
+        type: 'repo',
+        repository: source.url,
+        commit: source.commit,
+        subpath: source.subpath,
+      }
+    : {
+        type: 'archive',
+        location: source.location,
+        subpath: source.subpath,
+      };
+}
+
+/**
+ * §5's unwrap: "archives use the identical ladder **after unwrapping a lone
+ * top-level directory**."
+ *
+ * A ZIP made by right-clicking a folder contains that folder; one made by
+ * selecting its contents does not. Both are the same upload as far as the person
+ * doing it is concerned, so the ladder must see the same tree either way.
+ *
+ * **A lone top-level directory, and nothing else.** Two directories are a
+ * monorepo whose scope is named rather than searched (§5), and one directory
+ * beside a stray `README.md` is a project that happens to have a directory in
+ * it. Unwrapping either would be the search §5 refuses to do.
+ */
+export function unwrapSubpath(topLevelEntries: readonly string[]): string {
+  const entries = topLevelEntries.filter((entry) => entry.length > 0);
+  const [only] = entries;
+  if (entries.length !== 1 || only === undefined) return '.';
+  // Directory entries carry the trailing slash the archive format wrote; a lone
+  // top-level *file* is a one-file upload, not a wrapper to unwrap.
+  if (!only.endsWith('/')) return '.';
+  return only.slice(0, -1);
+}

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -1,0 +1,513 @@
+/**
+ * The deploy loop (§6, Task 20).
+ *
+ * §6 puts reconciliation in core, above the adapter seam: the verbs are one-shot
+ * and imperative, "every backend self-heals below the seam, so an adapter never
+ * holds a workload up". This file is that above — the thing that decides *when*
+ * to act and *when* to look.
+ *
+ * **Poll, not watch.** Three reasons, and only the first is about Kubernetes:
+ * one of the three backends has a watch and the other two do not, so an
+ * event-driven seam would have two shapes; a watch held across a satellite uplink
+ * dies while still looking connected, which is the one failure mode a
+ * convergence loop must not have; and hand-rolled watch bookkeeping in
+ * TypeScript with no informer is real work for no gain at this scale.
+ *
+ * **The interval is adaptive, not fixed** (see {@link intervalFor}). Fast while
+ * an attempt is in flight — a bounded window, not a standing watch — and slow
+ * once converged, where the slow cadence *is* the drift detection §6 asks for.
+ *
+ * **Claiming is `FOR UPDATE SKIP LOCKED`, and the claim is a phase, not a lock.**
+ * The lock is held only long enough to move a row `PENDING -> APPLYING`; it is not
+ * held across the apply. Holding a database transaction open for the length of a
+ * call to somebody else's control plane would put a rollout's duration inside a
+ * lock, and a `reconciler` that died mid-apply would leave the row locked until
+ * the connection timed out. A phase survives the process; a lock does not.
+ *
+ * **`LISTEN`/`NOTIFY` is an optimization and never the delivery path.** It is
+ * free with the Postgres already required and it cuts intent-to-pickup latency
+ * from one interval to nearly nothing — but `NOTIFY` is *lost* when no listener
+ * is connected, so a loop that depended on it would silently stop converging
+ * across a `reconciler` restart. Everything here is correct with every
+ * notification dropped: the wake-up only shortens a sleep, and
+ * `test/reconciler/deploy-loop.test.ts` runs the whole convergence with
+ * notifications disabled to keep that true.
+ */
+import { asc, eq } from 'drizzle-orm';
+import type {
+  DeployAdapter,
+  DeployEvent,
+  DeployPhase,
+  DeployVerdict,
+} from '../adapters/deploy/contract.ts';
+import type { AdapterRegistry, Clock } from '../commands/types.ts';
+import type { InstallationManifest } from '../config/manifest.schema.ts';
+import type { Database } from '../db/client.ts';
+import {
+  apps,
+  builds,
+  components,
+  type Deploy,
+  deploys,
+  targets,
+} from '../db/schema.ts';
+import { recordDeployEvent } from '../domain/attempt-log.ts';
+import type { DesiredState } from '../domain/desired-state.ts';
+import {
+  diagnosisOf,
+  failureColumns,
+  hasDrifted,
+} from '../domain/diagnosis.ts';
+import { hostnameFor } from '../domain/naming.ts';
+import { DEFAULT_PLATFORM } from '../domain/placement.ts';
+import { deployTargetOf } from '../domain/target.ts';
+
+/** What the loop needs. No principal: nobody asked for it to run. */
+export interface DeployLoopContext {
+  readonly db: Database;
+  readonly adapters: Pick<AdapterRegistry, 'deploy'>;
+  readonly clock: Clock;
+  readonly manifest: InstallationManifest;
+}
+
+/** The phases an attempt is still in flight in (§6). */
+const IN_FLIGHT: readonly DeployPhase[] = ['APPLYING', 'WAITING'];
+
+/** How often to look, given what the Deploy is doing (§6, plan Transport). */
+export interface LoopIntervals {
+  /** While an attempt is converging. Short, and bounded by the attempt. */
+  readonly fastMs: number;
+  /** Once converged. Also the drift-detection cadence — drift is information. */
+  readonly slowMs: number;
+}
+
+export const DEFAULT_INTERVALS: LoopIntervals = {
+  fastMs: 2_000,
+  slowMs: 5 * 60_000,
+};
+
+/**
+ * The interval to wait before looking again.
+ *
+ * Fast only while something is in flight. §6 is explicit that drift is
+ * "information, not an alarm", so the converged cadence is minutes: polling a
+ * settled workload every two seconds would be a watch built out of polls, which
+ * is the thing this design declined.
+ */
+export function intervalFor(
+  phases: readonly DeployPhase[],
+  intervals: LoopIntervals = DEFAULT_INTERVALS,
+): number {
+  return phases.some((phase) => IN_FLIGHT.includes(phase))
+    ? intervals.fastMs
+    : intervals.slowMs;
+}
+
+/**
+ * Take one `PENDING` Deploy and mark it `APPLYING`, or return `null`.
+ *
+ * `SKIP LOCKED` is what lets more than one `reconciler` run without either
+ * waiting on the other or both picking up the same row: a contended row is
+ * skipped rather than queued behind, so a second worker moves on to the next
+ * intent instead of stalling on the first.
+ */
+export async function claimNextDeploy(
+  context: DeployLoopContext,
+): Promise<Deploy | null> {
+  const now = context.clock.now();
+  return context.db.transaction(async (tx) => {
+    const [row] = await tx
+      .select()
+      .from(deploys)
+      .where(eq(deploys.phase, 'PENDING'))
+      // Oldest intent first: a queue that reordered itself would make two
+      // deploys of one Component@Target land in an order nobody asked for.
+      .orderBy(asc(deploys.id))
+      .limit(1)
+      .for('update', { skipLocked: true });
+
+    if (row === undefined) return null;
+
+    await tx
+      .update(deploys)
+      .set({ phase: 'APPLYING', updatedAt: now })
+      .where(eq(deploys.id, row.id));
+
+    return { ...row, phase: 'APPLYING' as const };
+  });
+}
+
+/** Everything one attempt needs, read once. */
+interface AttemptSubject {
+  readonly deploy: Deploy;
+  readonly app: typeof apps.$inferSelect;
+  readonly component: typeof components.$inferSelect;
+  readonly build: typeof builds.$inferSelect;
+  readonly target: typeof targets.$inferSelect;
+  readonly adapter: DeployAdapter;
+}
+
+/**
+ * Assemble the neutral `DesiredState` core hands the adapter (§6).
+ *
+ * "**Core describes; the adapter renders.**" Nothing here is a Kubernetes field,
+ * a Cloud Run field, or a hosting field — this is the vocabulary all three are
+ * rendered from, and a field this function cannot fill is a field core does not
+ * get to describe.
+ */
+export function desiredStateFor(
+  subject: AttemptSubject,
+  manifest: InstallationManifest,
+): DesiredState {
+  const { deploy, app, component, build, target } = subject;
+  return {
+    deploy: String(deploy.id),
+    app: app.name,
+    component: component.name,
+    target: target.name,
+    kind: component.kind,
+    artifact: {
+      type: build.artifactType,
+      digest: build.artifactDigest ?? '',
+      refs: build.artifactRefs ?? [],
+    },
+    ...(component.expose === null ? {} : { expose: component.expose }),
+    // The Deploy's own exposure, not the Component's current one: this attempt
+    // asked for what it asked for, and a Component edited since must not
+    // retroactively change what a running attempt is placing.
+    exposure: deploy.exposure ?? component.exposure,
+    ...(component.schedule === null ? {} : { schedule: component.schedule }),
+    // §10's config arrives with Milestone 6. Empty is honest: no config item has
+    // been written yet, so there is no pinned reference to deliver.
+    config: [],
+    requirements: { platform: DEFAULT_PLATFORM, resources: {} },
+    hostname: hostnameFor({
+      app: app.name,
+      component: component.name,
+      adapter: target.adapter,
+      apexZone: manifest.dns.apexZone,
+      vanityZone: manifest.dns.vanityZone,
+      vanityLabel: app.vanityDomain,
+    }),
+  };
+}
+
+/** What one attempt did. */
+export interface AttemptOutcome {
+  readonly deployId: number;
+  readonly phase: 'LIVE' | 'FAILED';
+  readonly url: string | null;
+}
+
+/**
+ * Run one claimed Deploy to a terminal verdict.
+ *
+ * **Phases come from the adapter, never from core's own opinion** (§6: "phase
+ * transitions come from the controller or platform API — never Spindrift
+ * reimplementing readiness"). Every status event the adapter yields is written to
+ * both the Deploy row and the attempt log, so what the UI reads is what the
+ * platform said, in the order it said it.
+ *
+ * `apply` does not throw by contract, but an adapter is code and code throws. A
+ * thrown error becomes `INTERNAL` — blamed on the platform by §6's table — rather
+ * than escaping into the loop, because an attempt that ends by crashing the
+ * reconciler is an attempt that stays `APPLYING` forever.
+ */
+export async function runAttempt(
+  context: DeployLoopContext,
+  deploy: Deploy,
+): Promise<AttemptOutcome | null> {
+  const subject = await subjectOf(context, deploy);
+  if (subject === null) return null;
+
+  const attempt = {
+    appId: subject.app.id,
+    componentId: subject.component.id,
+    deployId: deploy.id,
+  };
+  const desired = desiredStateFor(subject, context.manifest);
+  const targetRef = deployTargetOf(subject.target);
+
+  let verdict: DeployVerdict;
+  try {
+    const stream = subject.adapter.apply(targetRef, desired);
+    let next = await stream.next();
+    while (!next.done) {
+      await absorb(context, attempt, deploy.id, next.value);
+      next = await stream.next();
+    }
+    verdict = next.value;
+  } catch (cause) {
+    verdict = {
+      phase: 'FAILED',
+      reason: 'INTERNAL',
+      detail: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+
+  return settle(context, subject, verdict);
+}
+
+/** Write one adapter event to the log, and its phase to the row. */
+async function absorb(
+  context: DeployLoopContext,
+  attempt: { appId: string; componentId: string; deployId: number },
+  deployId: number,
+  event: DeployEvent,
+): Promise<void> {
+  if (event.type === 'log') {
+    await recordDeployEvent(context.db, attempt, {
+      type: 'log',
+      line: event.line,
+      ...(event.resource === undefined ? {} : { resource: event.resource }),
+    });
+    return;
+  }
+
+  await recordDeployEvent(context.db, attempt, {
+    type: 'status',
+    phase: event.phase,
+    ...(event.resource === undefined ? {} : { resource: event.resource }),
+    ...(event.reason === undefined ? {} : { reason: event.reason }),
+  });
+
+  // Only the non-terminal phases are taken from the stream. The terminal one is
+  // written once, with the verdict, so a stream that yields FAILED and then
+  // returns LIVE cannot leave the row disagreeing with the verdict.
+  if (event.phase === 'APPLYING' || event.phase === 'WAITING') {
+    await context.db
+      .update(deploys)
+      .set({ phase: event.phase, updatedAt: context.clock.now() })
+      .where(eq(deploys.id, deployId));
+  }
+}
+
+/** Persist the terminal verdict, and the diagnosis if there is one. */
+async function settle(
+  context: DeployLoopContext,
+  subject: AttemptSubject,
+  verdict: DeployVerdict,
+): Promise<AttemptOutcome> {
+  const now = context.clock.now();
+  const deployId = subject.deploy.id;
+  const attempt = {
+    appId: subject.app.id,
+    componentId: subject.component.id,
+    deployId,
+  };
+
+  if (verdict.phase === 'LIVE') {
+    // §9: where the platform names its own, the canonical comes back across the
+    // seam. Where core minted one, the adapter has nothing to add and core's
+    // name stands.
+    const url =
+      verdict.url ??
+      urlOf(desiredStateFor(subject, context.manifest).hostname.canonical);
+
+    await context.db
+      .update(deploys)
+      .set({
+        phase: 'LIVE',
+        ref: verdict.ref,
+        url,
+        reason: null,
+        blame: null,
+        detail: null,
+        debug: null,
+        updatedAt: now,
+      })
+      .where(eq(deploys.id, deployId));
+
+    await recordDeployEvent(context.db, attempt, {
+      type: 'status',
+      phase: 'LIVE',
+    });
+    return { deployId, phase: 'LIVE', url };
+  }
+
+  const diagnosis = diagnosisOf(verdict);
+  // §12: the platform will not keep this. Cluster events expire in about an
+  // hour, so what is written here is the only copy that will exist tomorrow.
+  await context.db
+    .update(deploys)
+    .set({
+      ...failureColumns(diagnosis!),
+      ...(verdict.ref === undefined ? {} : { ref: verdict.ref }),
+      updatedAt: now,
+    })
+    .where(eq(deploys.id, deployId));
+
+  await recordDeployEvent(context.db, attempt, {
+    type: 'status',
+    phase: 'FAILED',
+    reason: verdict.reason,
+  });
+
+  // Nothing here touches `exposure` — §9: "exposure never mutates on red." The
+  // previous release is still serving, and quietly making it unreachable would
+  // turn one failed deploy into an outage.
+  return { deployId, phase: 'FAILED', url: null };
+}
+
+function urlOf(canonical: string): string | null {
+  return canonical === '' ? null : `https://${canonical}`;
+}
+
+/** One pass of `observe` over what has converged, to notice drift (§6). */
+export interface DriftReport {
+  readonly deployId: number;
+  readonly drifted: boolean;
+  readonly observedDigest: string | null;
+}
+
+/**
+ * Look at what is actually running, and say so.
+ *
+ * **Never corrects anything.** §6: "drift is detected and surfaced, never
+ * silently corrected — a visible state with a one-click re-converge." The
+ * re-converge is an ordinary Deploy somebody presses, so this function returns a
+ * report and writes no desired state. A loop that healed drift on its own would
+ * also happily undo a deliberate manual change during an incident.
+ */
+export async function observeConverged(
+  context: DeployLoopContext,
+): Promise<readonly DriftReport[]> {
+  const live = await context.db
+    .select()
+    .from(deploys)
+    .where(eq(deploys.phase, 'LIVE'));
+
+  const reports: DriftReport[] = [];
+  for (const deploy of live) {
+    if (deploy.ref === null || deploy.orphanedAt !== null) continue;
+    const subject = await subjectOf(context, deploy);
+    if (subject === null) continue;
+
+    let observed: string | null = null;
+    try {
+      const state = await subject.adapter.observe(
+        deployTargetOf(subject.target),
+        deploy.ref,
+      );
+      observed = state?.artifactDigest ?? null;
+    } catch {
+      // A Target that cannot be reached is not a Target that has drifted. Saying
+      // "drifted" here would turn every uplink blip into a false alarm about
+      // something a developer did.
+      continue;
+    }
+
+    reports.push({
+      deployId: deploy.id,
+      drifted: hasDrifted({
+        phase: deploy.phase,
+        desiredDigest: subject.build.artifactDigest ?? '',
+        observedDigest: observed,
+      }),
+      observedDigest: observed,
+    });
+  }
+  return reports;
+}
+
+/** Read everything one Deploy refers to, or `null` if it is not runnable. */
+async function subjectOf(
+  context: DeployLoopContext,
+  deploy: Deploy,
+): Promise<AttemptSubject | null> {
+  const [row] = await context.db
+    .select({
+      component: components,
+      app: apps,
+      build: builds,
+      target: targets,
+    })
+    .from(deploys)
+    .innerJoin(components, eq(deploys.componentId, components.id))
+    .innerJoin(apps, eq(components.appId, apps.id))
+    .innerJoin(builds, eq(deploys.buildId, builds.id))
+    .innerJoin(targets, eq(deploys.targetId, targets.id))
+    .where(eq(deploys.id, deploy.id));
+
+  if (row === undefined) return null;
+  const adapter = context.adapters.deploy(row.target.adapter);
+  if (adapter === null) return null;
+
+  return { deploy, ...row, adapter };
+}
+
+/** How the loop runs, and how to stop it. */
+export interface DeployLoopOptions {
+  readonly intervals?: LoopIntervals;
+  readonly signal?: AbortSignal;
+  /**
+   * An optional early wake-up — the `LISTEN/NOTIFY` leg.
+   *
+   * Resolves when something says an intent was written. **Purely an
+   * optimization**: it can only shorten a sleep, never extend one, and a loop
+   * that never sees a notification still converges on the poll interval. Omit it
+   * and everything still works, only slower — which is exactly what the test
+   * with notifications disabled asserts.
+   */
+  readonly wakeup?: (signal: AbortSignal) => Promise<void>;
+  readonly onPass?: (pass: LoopPass) => void;
+}
+
+/** What one pass did, for whatever an installation wires to it. */
+export interface LoopPass {
+  readonly applied: readonly AttemptOutcome[];
+  readonly drift: readonly DriftReport[];
+}
+
+/**
+ * Drain every claimable intent, then look at what has converged.
+ *
+ * Draining rather than taking one per tick: a burst of intents should not take
+ * one poll interval each to start, and the drain is bounded by how many rows are
+ * actually `PENDING`.
+ */
+export async function runDeployPass(
+  context: DeployLoopContext,
+): Promise<LoopPass> {
+  const applied: AttemptOutcome[] = [];
+  for (;;) {
+    const claimed = await claimNextDeploy(context);
+    if (claimed === null) break;
+    const outcome = await runAttempt(context, claimed);
+    if (outcome !== null) applied.push(outcome);
+  }
+  return { applied, drift: await observeConverged(context) };
+}
+
+/** Run until aborted. */
+export async function runDeployLoop(
+  context: DeployLoopContext,
+  options: DeployLoopOptions = {},
+): Promise<void> {
+  const intervals = options.intervals ?? DEFAULT_INTERVALS;
+  while (!options.signal?.aborted) {
+    const pass = await runDeployPass(context);
+    options.onPass?.(pass);
+    if (options.signal?.aborted) return;
+
+    const phases = pass.applied.map((outcome) => outcome.phase);
+    await sleep(intervalFor(phases, intervals), options);
+  }
+}
+
+/** A sleep that wakes early on abort, or on a notification if one is wired. */
+function sleep(ms: number, options: DeployLoopOptions): Promise<void> {
+  return new Promise((resolve) => {
+    const controller = new AbortController();
+    const done = (): void => {
+      clearTimeout(timer);
+      controller.abort();
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    options.signal?.addEventListener('abort', done, { once: true });
+    // A rejected wake-up is a dropped notification, which the poll below already
+    // tolerates — so it is swallowed rather than allowed to fail a pass.
+    options.wakeup?.(controller.signal).then(done, () => {});
+  });
+}

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -33,7 +33,7 @@
  * `test/reconciler/deploy-loop.test.ts` runs the whole convergence with
  * notifications disabled to keep that true.
  */
-import { asc, eq } from 'drizzle-orm';
+import { asc, eq, inArray } from 'drizzle-orm';
 import type {
   DeployAdapter,
   DeployEvent,
@@ -58,7 +58,7 @@ import {
   failureColumns,
   hasDrifted,
 } from '../domain/diagnosis.ts';
-import { hostnameFor } from '../domain/naming.ts';
+import { displayUrl, hostnameFor } from '../domain/naming.ts';
 import { DEFAULT_PLATFORM } from '../domain/placement.ts';
 import { deployTargetOf } from '../domain/target.ts';
 
@@ -70,8 +70,17 @@ export interface DeployLoopContext {
   readonly manifest: InstallationManifest;
 }
 
-/** The phases an attempt is still in flight in (§6). */
-const IN_FLIGHT: readonly DeployPhase[] = ['APPLYING', 'WAITING'];
+/**
+ * The phases that mean something is still owed work (§6).
+ *
+ * `PENDING` is here alongside §6's two in-flight phases because an intent nobody
+ * has claimed is the most urgent thing there is — it is a developer waiting.
+ * `APPLYING` and `WAITING` appear *between* passes only when an attempt did not
+ * finish inside one: a reconciler that died mid-apply leaves exactly that, and
+ * the fast cadence is how it gets picked back up rather than sitting for the
+ * converged interval.
+ */
+const UNSETTLED: readonly DeployPhase[] = ['PENDING', 'APPLYING', 'WAITING'];
 
 /** How often to look, given what the Deploy is doing (§6, plan Transport). */
 export interface LoopIntervals {
@@ -89,18 +98,41 @@ export const DEFAULT_INTERVALS: LoopIntervals = {
 /**
  * The interval to wait before looking again.
  *
- * Fast only while something is in flight. §6 is explicit that drift is
+ * Fast only while something is unsettled. §6 is explicit that drift is
  * "information, not an alarm", so the converged cadence is minutes: polling a
  * settled workload every two seconds would be a watch built out of polls, which
  * is the thing this design declined.
+ *
+ * **The phases must come from the database, not from what the last pass
+ * returned.** A pass only ever returns terminal outcomes — an attempt runs to
+ * `LIVE` or `FAILED` inside it — so deciding from those would mean the fast
+ * cadence never once fired, and the adaptive interval would be a fixed one
+ * wearing a switch.
  */
 export function intervalFor(
   phases: readonly DeployPhase[],
   intervals: LoopIntervals = DEFAULT_INTERVALS,
 ): number {
-  return phases.some((phase) => IN_FLIGHT.includes(phase))
+  return phases.some((phase) => UNSETTLED.includes(phase))
     ? intervals.fastMs
     : intervals.slowMs;
+}
+
+/**
+ * The phases of everything still owed work, straight from the database.
+ *
+ * Read after a pass rather than derived from it, so an intent that arrived while
+ * the pass was running is picked up on the fast cadence instead of waiting out a
+ * converged interval.
+ */
+export async function unsettledPhases(
+  context: DeployLoopContext,
+): Promise<readonly DeployPhase[]> {
+  const rows = await context.db
+    .select({ phase: deploys.phase })
+    .from(deploys)
+    .where(inArray(deploys.phase, [...UNSETTLED]));
+  return rows.map((row) => row.phase);
 }
 
 /**
@@ -158,6 +190,20 @@ interface AttemptSubject {
 export function desiredStateFor(
   subject: AttemptSubject,
   manifest: InstallationManifest,
+  /**
+   * Whether this Component may carry the App's vanity name.
+   *
+   * §9 puts the vanity name on the **App** — "the name a developer shares" — and
+   * the canonical name on each Component. An App with two network-serving
+   * Components therefore has one vanity name and two claimants, and handing it to
+   * both puts the same hostname on two HTTPRoutes: a collision the platform
+   * resolves arbitrarily, which is worse than not having the name at all.
+   *
+   * So it goes to a sole network-serving Component and otherwise to none. Picking
+   * a winner among several would be a policy §9 does not state, and the developer
+   * is the one who knows which of their Components is the front door.
+   */
+  vanityIsUnambiguous: boolean,
 ): DesiredState {
   const { deploy, app, component, build, target } = subject;
   return {
@@ -187,7 +233,7 @@ export function desiredStateFor(
       adapter: target.adapter,
       apexZone: manifest.dns.apexZone,
       vanityZone: manifest.dns.vanityZone,
-      vanityLabel: app.vanityDomain,
+      vanityLabel: vanityIsUnambiguous ? app.vanityDomain : null,
     }),
   };
 }
@@ -225,7 +271,11 @@ export async function runAttempt(
     componentId: subject.component.id,
     deployId: deploy.id,
   };
-  const desired = desiredStateFor(subject, context.manifest);
+  const desired = desiredStateFor(
+    subject,
+    context.manifest,
+    await soleServingComponent(context, subject),
+  );
   const targetRef = deployTargetOf(subject.target);
 
   let verdict: DeployVerdict;
@@ -245,7 +295,32 @@ export async function runAttempt(
     };
   }
 
-  return settle(context, subject, verdict);
+  return settle(context, subject, desired, verdict);
+}
+
+/**
+ * Whether this Component is the only network-serving one its App has.
+ *
+ * A job serves nothing, and an unexposed service is a queue worker (§2), so
+ * neither can claim the App's front-door name.
+ */
+async function soleServingComponent(
+  context: DeployLoopContext,
+  subject: AttemptSubject,
+): Promise<boolean> {
+  const siblings = await context.db
+    .select({
+      id: components.id,
+      kind: components.kind,
+      expose: components.expose,
+    })
+    .from(components)
+    .where(eq(components.appId, subject.app.id));
+
+  const serving = siblings.filter(
+    (sibling) => sibling.kind === 'website' || sibling.expose === true,
+  );
+  return serving.length === 1 && serving[0]?.id === subject.component.id;
 }
 
 /** Write one adapter event to the log, and its phase to the row. */
@@ -286,6 +361,7 @@ async function absorb(
 async function settle(
   context: DeployLoopContext,
   subject: AttemptSubject,
+  desired: DesiredState,
   verdict: DeployVerdict,
 ): Promise<AttemptOutcome> {
   const now = context.clock.now();
@@ -301,8 +377,7 @@ async function settle(
     // seam. Where core minted one, the adapter has nothing to add and core's
     // name stands.
     const url =
-      verdict.url ??
-      urlOf(desiredStateFor(subject, context.manifest).hostname.canonical);
+      verdict.url ?? displayUrl({ canonical: desired.hostname.canonical });
 
     await context.db
       .update(deploys)
@@ -314,6 +389,10 @@ async function settle(
         blame: null,
         detail: null,
         debug: null,
+        // A deploy that just landed is by definition what was asked for. Left
+        // set, a previous attempt's drift would follow the new release around.
+        driftedAt: null,
+        observedDigest: desired.artifact.digest,
         updatedAt: now,
       })
       .where(eq(deploys.id, deployId));
@@ -349,10 +428,6 @@ async function settle(
   return { deployId, phase: 'FAILED', url: null };
 }
 
-function urlOf(canonical: string): string | null {
-  return canonical === '' ? null : `https://${canonical}`;
-}
-
 /** One pass of `observe` over what has converged, to notice drift (§6). */
 export interface DriftReport {
   readonly deployId: number;
@@ -372,6 +447,7 @@ export interface DriftReport {
 export async function observeConverged(
   context: DeployLoopContext,
 ): Promise<readonly DriftReport[]> {
+  const now = context.clock.now();
   const live = await context.db
     .select()
     .from(deploys)
@@ -397,15 +473,31 @@ export async function observeConverged(
       continue;
     }
 
-    reports.push({
-      deployId: deploy.id,
-      drifted: hasDrifted({
-        phase: deploy.phase,
-        desiredDigest: subject.build.artifactDigest ?? '',
-        observedDigest: observed,
-      }),
+    const drifted = hasDrifted({
+      phase: deploy.phase,
+      desiredDigest: subject.build.artifactDigest ?? '',
       observedDigest: observed,
     });
+
+    // §6 wants drift to be "a visible state", and visible means a row: the UI
+    // reads rows, so a finding that lived only for the length of this pass
+    // would be surfaced to nobody. Cleared when it matches again, so drift
+    // somebody fixed out of band stops being reported without a dismissal.
+    if (
+      drifted !== (deploy.driftedAt !== null) ||
+      observed !== deploy.observedDigest
+    ) {
+      await context.db
+        .update(deploys)
+        .set({
+          driftedAt: drifted ? now : null,
+          observedDigest: observed,
+          updatedAt: now,
+        })
+        .where(eq(deploys.id, deploy.id));
+    }
+
+    reports.push({ deployId: deploy.id, drifted, observedDigest: observed });
   }
   return reports;
 }
@@ -457,6 +549,14 @@ export interface DeployLoopOptions {
 export interface LoopPass {
   readonly applied: readonly AttemptOutcome[];
   readonly drift: readonly DriftReport[];
+  /**
+   * What is still owed work when the pass ended, read from the database.
+   *
+   * This — not {@link applied} — is what sets the next interval. A pass returns
+   * terminal outcomes only, so choosing from those could never select the fast
+   * cadence.
+   */
+  readonly unsettled: readonly DeployPhase[];
 }
 
 /**
@@ -476,7 +576,11 @@ export async function runDeployPass(
     const outcome = await runAttempt(context, claimed);
     if (outcome !== null) applied.push(outcome);
   }
-  return { applied, drift: await observeConverged(context) };
+  return {
+    applied,
+    drift: await observeConverged(context),
+    unsettled: await unsettledPhases(context),
+  };
 }
 
 /** Run until aborted. */
@@ -490,8 +594,7 @@ export async function runDeployLoop(
     options.onPass?.(pass);
     if (options.signal?.aborted) return;
 
-    const phases = pass.applied.map((outcome) => outcome.phase);
-    await sleep(intervalFor(phases, intervals), options);
+    await sleep(intervalFor(pass.unsettled, intervals), options);
   }
 }
 

--- a/apps/spindrift/src/web/dispatch.ts
+++ b/apps/spindrift/src/web/dispatch.ts
@@ -100,6 +100,13 @@ const STATUS = {
   UNKNOWN_COMMAND: 404,
   INVALID_INPUT: 422,
   NOT_FOUND: 404,
+  // 409, not 422: the request is well formed and the caller has nothing to fix
+  // in it. What they are being told is a fact about the world — this Build has
+  // no artifact, this Target takes a different shape — which is the
+  // disabled-with-reasons grammar §3 uses everywhere, and a conflict is the
+  // status that means "not in this state".
+  NOT_DEPLOYABLE: 409,
+  NOT_BUILDABLE: 409,
   UNAUTHENTICATED: 401,
   METHOD_NOT_ALLOWED: 405,
   MALFORMED_REQUEST: 400,

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -1,0 +1,684 @@
+/**
+ * Build and Deploy, and the three claims §6 makes about them (Task 19).
+ *
+ * Every test here targets a sentence that would still "work" if it were false,
+ * which is what makes them worth writing:
+ *
+ * - **Two concurrent deploys of the same Component@Target serialize.** Against a
+ *   fake database this passes by accident, because a fake has no concurrency to
+ *   get wrong. It is asserted here with **two real Postgres sessions contending
+ *   for one row**, which is the only arrangement that can fail.
+ * - **A late-finishing older build moves nothing** (§4: "a build records an
+ *   artifact rather than deploying one... there is no `SUPERSEDED` verdict to
+ *   explain"). Asserted by finishing an older Build *after* a newer one is live
+ *   and reading the desired row back.
+ * - **Rollback dispatches no build** (§6: "rollback is an ordinary deploy"). The
+ *   context's build registry throws if it is so much as consulted, so this is a
+ *   claim about what the code path does not contain rather than about what it
+ *   returned.
+ */
+import { describe, expect, test } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
+import { placeIntent } from '../../src/commands/deploys/create.ts';
+import {
+  createDeploy,
+  dispatchBuild,
+  rollbackDeploy,
+  uploadArchive,
+} from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  componentTargetDesired,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+/** A digest of the right shape, distinct per call. */
+function digest(seed: number): string {
+  return `sha256:${seed.toString(16).padStart(64, '0')}`;
+}
+
+/**
+ * A registry whose build side is a tripwire.
+ *
+ * "Rollback dispatches no build" and "creating a Deploy dispatches no build" are
+ * negative claims, and a negative claim needs something that fails when it is
+ * violated. A `build()` that throws is that something.
+ */
+function registryOf(
+  deployAdapter: DeployAdapter,
+  buildAdapter?: FakeBuildAdapter,
+): AdapterRegistry {
+  return {
+    deploy: (adapter) =>
+      adapter === deployAdapter.adapter ? deployAdapter : null,
+    build: (route) => {
+      if (buildAdapter === undefined) {
+        throw new Error(
+          `a command that must not build looked up the ${route} route`,
+        );
+      }
+      return route === buildAdapter.name ? buildAdapter : null;
+    },
+    store: () => {
+      throw new Error('a deploy command reached the secret store');
+    },
+  };
+}
+
+function context(adapters: AdapterRegistry): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** An App, a Component, and a connected Target that accepts images. */
+async function fixture(
+  options: { kind?: 'service' | 'website'; adapter?: 'kubernetes' } = {},
+) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'shop', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({
+      appId: app!.id,
+      name: 'web',
+      kind: options.kind ?? 'service',
+      expose: true,
+    })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: `cluster-${crypto.randomUUID()}`,
+        adapter: options.adapter ?? 'kubernetes',
+        discovery: null,
+      }),
+    )
+    .returning();
+  return { app: app!, component: component!, target: target! };
+}
+
+/** A Build that is ready to deploy: succeeded, with an artifact of one shape. */
+async function succeededBuild(
+  componentId: string,
+  seed: number,
+  shape: 'image' | 'files' = 'image',
+) {
+  const [build] = await database()
+    .db.insert(builds)
+    .values({
+      componentId,
+      commit: digest(seed),
+      targetShape: shape,
+      artifactType: shape,
+      artifactDigest: digest(seed),
+      bundleDigest: digest(seed),
+      status: 'SUCCEEDED',
+    })
+    .returning();
+  return build!;
+}
+
+/** A Target whose discovery makes it capable, so `artifactTypeFor` agrees. */
+function capableAdapter(): FakeDeployAdapter {
+  return new FakeDeployAdapter({ adapter: 'kubernetes' });
+}
+
+async function desiredRow(componentId: string, targetId: string) {
+  const [row] = await database()
+    .db.select()
+    .from(componentTargetDesired)
+    .where(
+      and(
+        eq(componentTargetDesired.componentId, componentId),
+        eq(componentTargetDesired.targetId, targetId),
+      ),
+    );
+  return row;
+}
+
+describe('createDeploy writes an intent, and only an intent', () => {
+  test('the Deploy is PENDING and the desired row points at it', async () => {
+    const { component, target } = await fixture();
+    const build = await succeededBuild(component.id, 1);
+
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('PENDING');
+    // Nothing was live here before, so there is nothing this superseded.
+    expect(result.value.supersededBuildId).toBeNull();
+
+    const [row] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, result.value.deployId));
+    expect(row?.phase).toBe('PENDING');
+    // §6: the loop owns every phase after PENDING, so an intent has placed
+    // nothing and carries no adapter handle yet.
+    expect(row?.ref).toBeNull();
+    expect(row?.url).toBeNull();
+
+    const desired = await desiredRow(component.id, target.id);
+    expect(desired?.desiredBuildId).toBe(build.id);
+    expect(desired?.desiredDeployId).toBe(result.value.deployId);
+  });
+
+  test('a Build that has not succeeded has no artifact to place', async () => {
+    const { component, target } = await fixture();
+    const [pending] = await database()
+      .db.insert(builds)
+      .values({
+        componentId: component.id,
+        commit: digest(9),
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'RUNNING',
+      })
+      .returning();
+
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: pending!.id },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    // No intent row was written, so the loop has nothing to find.
+    expect(await desiredRow(component.id, target.id)).toBeUndefined();
+  });
+
+  test('a shape the Target does not take needs a rebuild, and says so', async () => {
+    // §3: "changing placement across shapes forces a rebuild." A `files`
+    // artifact against a cluster is that case, caught here rather than as a
+    // deploy that fails on the far side.
+    const { component, target } = await fixture();
+    const build = await succeededBuild(component.id, 2, 'files');
+
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('rebuild');
+  });
+
+  test('a disconnected Target takes nothing new', async () => {
+    const { component, target } = await fixture();
+    await database()
+      .db.update(targets)
+      .set({ status: 'disconnected' })
+      .where(eq(targets.id, target.id));
+    const build = await succeededBuild(component.id, 3);
+
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+  });
+});
+
+describe('concurrency: the locking read (§6)', () => {
+  /**
+   * The load-bearing test, and the reason the harness hands out a second
+   * session.
+   *
+   * §6 rests correctness on "a **locking read** on the desired row", and the
+   * honest way to assert a lock is to **hold it from another session and watch
+   * the command stop**. Firing two commands with `Promise.all` does not do that:
+   * it passes whether or not the `FOR UPDATE` is there, because nothing forces
+   * the two transactions to overlap. This test forces it — the row is locked
+   * before `createDeploy` is called and released only after we have observed it
+   * blocked — so deleting the `FOR UPDATE` makes it fail.
+   */
+  test('an intent waits for whoever holds the desired row', async () => {
+    const { component, target } = await fixture();
+    const first = await succeededBuild(component.id, 60);
+    const second = await succeededBuild(component.id, 61);
+    const registry = registryOf(capableAdapter());
+
+    // The desired row has to exist before it can be locked.
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: first.id },
+      context(registry),
+    );
+
+    const other = database().connect();
+    let release = (): void => {};
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const holding = other.begin(async (tx: typeof other) => {
+      await tx.unsafe(
+        'select * from component_target_desired where component_id = $1 and target_id = $2 for update',
+        [component.id, target.id],
+      );
+      await held;
+    });
+
+    // Give the holder time to actually take the lock before contending.
+    await Bun.sleep(100);
+
+    let settled = false;
+    const contending = createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: second.id },
+      context(registry),
+    ).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await Bun.sleep(400);
+    // The claim: it is *stopped*, not merely slow-and-lucky. Without the
+    // locking read this command would have committed by now.
+    expect(settled).toBe(false);
+
+    release();
+    await holding;
+
+    const result = await contending;
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Having waited, it read the committed state rather than the stale one.
+    expect(result.value.supersededBuildId).toBe(first.id);
+
+    const desired = await desiredRow(component.id, target.id);
+    expect(desired?.desiredBuildId).toBe(second.id);
+    expect(desired?.desiredDeployId).toBe(result.value.deployId);
+  });
+
+  /**
+   * The check-and-set itself, with the interleaving pinned.
+   *
+   * The previous test proves a contending intent *waits*; it does not prove the
+   * `FOR UPDATE` is what makes it wait, because the closing `UPDATE` takes a row
+   * lock too and would block a second transaction anyway. What only the locking
+   * read gives is **what the second transaction reads**: without it, both read
+   * the desired row before either commits, both see the same stale value, and
+   * the second one's answer about what it superseded is a lie that the row it
+   * finally writes does not contradict.
+   *
+   * So this test holds the first transaction open *past its read* — using the
+   * guard, which runs under the lock — starts the second, and asserts the second
+   * saw the first's write. Deleting `.for('update')` fails it.
+   */
+  test('the second intent reads what the first wrote, not what preceded it', async () => {
+    const { component, target } = await fixture();
+    const existing = await succeededBuild(component.id, 69);
+    const first = await succeededBuild(component.id, 70);
+    const second = await succeededBuild(component.id, 71);
+    const registry = registryOf(capableAdapter());
+
+    // The desired row must already exist and be committed. If the two intents
+    // below were both its first writer they would serialize on its unique index
+    // instead — which is correct behaviour, but it is not the locking read, and
+    // a test that cannot tell them apart proves nothing about `FOR UPDATE`.
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: existing.id },
+      context(registry),
+    );
+
+    const preconditions = {
+      componentId: component.id,
+      targetId: target.id,
+      exposure: 'private' as const,
+    };
+
+    let announceRead = (): void => {};
+    const hasRead = new Promise<void>((resolve) => {
+      announceRead = resolve;
+    });
+    let release = (): void => {};
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    // First intent: enters the transaction, takes the lock, reads — and then
+    // stops inside the guard, still holding everything.
+    const holding = placeIntent(
+      context(registry),
+      { ...preconditions, buildId: first.id },
+      async () => {
+        announceRead();
+        await released;
+        return null;
+      },
+    );
+
+    await hasRead;
+
+    // Second intent, started while the first is provably mid-transaction.
+    const contending = createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: second.id },
+      context(registry),
+    );
+
+    // Long enough that an unlocked read would certainly have happened by now.
+    await Bun.sleep(300);
+    release();
+
+    const [a, b] = await Promise.all([holding, contending]);
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+
+    // The first superseded what was already there; the second superseded the
+    // first. That pair is only reachable if the second's read happened after the
+    // first's commit — without the locking read, both read `existing` and the
+    // second's answer is stale.
+    expect(a.value.supersededBuildId).toBe(existing.id);
+    expect(b.value.supersededBuildId).toBe(first.id);
+
+    const desired = await desiredRow(component.id, target.id);
+    expect(desired?.desiredBuildId).toBe(second.id);
+    expect(desired?.desiredDeployId).toBe(b.value.deployId);
+  });
+
+  test('two concurrent deploys of one Component@Target serialize', async () => {
+    // The claim under test is that the desired row ends up describing *one* of
+    // the two intents completely — same Build, same Deploy — rather than a torn
+    // pair where one command's Build is left beside the other's Deploy. Only
+    // two real sessions contending on one row can produce the torn state, which
+    // is why this test is worth its Postgres.
+    const { component, target } = await fixture();
+    const first = await succeededBuild(component.id, 10);
+    const second = await succeededBuild(component.id, 11);
+
+    const registry = registryOf(capableAdapter());
+    const [a, b] = await Promise.all([
+      createDeploy(
+        { componentId: component.id, targetId: target.id, buildId: first.id },
+        context(registry),
+      ),
+      createDeploy(
+        { componentId: component.id, targetId: target.id, buildId: second.id },
+        context(registry),
+      ),
+    ]);
+
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+
+    // Both intents exist — neither was lost, and neither was refused.
+    const rows = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, component.id));
+    expect(rows).toHaveLength(2);
+
+    const desired = await desiredRow(component.id, target.id);
+    const winner = [a.value, b.value].find(
+      (value) => value.deployId === desired?.desiredDeployId,
+    );
+    // The pair is consistent: the desired Build is the one that winning intent
+    // named. A lost update would leave the other command's Build here.
+    expect(winner).toBeDefined();
+    expect(desired?.desiredBuildId).toBe(winner!.buildId);
+
+    // Exactly one of them saw the other's write, which is what serialization
+    // means: the loser ran second and read the winner's row under the lock.
+    const superseded = [a.value, b.value].map((v) => v.supersededBuildId);
+    expect(superseded.filter((value) => value === null)).toHaveLength(1);
+    expect(superseded.filter((value) => value !== null)).toHaveLength(1);
+  });
+});
+
+describe('§4: a late-finishing older build moves nothing', () => {
+  test('finishing an older Build leaves the desired row alone', async () => {
+    const { app, component, target } = await fixture();
+    const older = await succeededBuild(component.id, 20);
+    const newer = await succeededBuild(component.id, 21);
+
+    // The newer artifact is what should be live here.
+    const deployed = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: newer.id },
+      context(registryOf(capableAdapter())),
+    );
+    expect(deployed.ok).toBe(true);
+
+    const before = await desiredRow(component.id, target.id);
+
+    // Now the older build finishes — late, as §4 allows. It records an artifact
+    // and that is the whole of its effect.
+    await database()
+      .db.update(builds)
+      .set({ status: 'PENDING', artifactDigest: null })
+      .where(eq(builds.id, older.id));
+    const builder = new FakeBuildAdapter({
+      script: [{ result: { status: 'SUCCEEDED', digest: digest(20) } }],
+    });
+    const finished = await dispatchBuild(
+      { buildId: older.id, route: builder.name },
+      context(registryOf(capableAdapter(), builder)),
+    );
+
+    expect(finished.ok).toBe(true);
+    if (!finished.ok) return;
+    expect(finished.value.status).toBe('SUCCEEDED');
+
+    const after = await desiredRow(component.id, target.id);
+    expect(after?.desiredBuildId).toBe(before!.desiredBuildId!);
+    expect(after?.desiredDeployId).toBe(before!.desiredDeployId!);
+
+    // And no second Deploy appeared for the App as a side effect.
+    const all = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, component.id));
+    expect(all).toHaveLength(1);
+    expect(app.id).toBeDefined();
+  });
+});
+
+describe('§6: rollback is an ordinary deploy', () => {
+  test('it places an older Build and dispatches nothing', async () => {
+    const { component, target } = await fixture();
+    const older = await succeededBuild(component.id, 30);
+    const newer = await succeededBuild(component.id, 31);
+
+    // The build registry throws if consulted — see `registryOf`.
+    const registry = registryOf(capableAdapter());
+
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: older.id },
+      context(registry),
+    );
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: newer.id },
+      context(registry),
+    );
+
+    const rolled = await rollbackDeploy(
+      { componentId: component.id, targetId: target.id, buildId: older.id },
+      context(registry),
+    );
+
+    expect(rolled.ok).toBe(true);
+    if (!rolled.ok) return;
+    // A newer intent row pointing at an older Build — §6's definition, verbatim.
+    expect(rolled.value.buildId).toBe(older.id);
+    expect(rolled.value.supersededBuildId).toBe(newer.id);
+    expect(rolled.value.phase).toBe('PENDING');
+
+    const desired = await desiredRow(component.id, target.id);
+    expect(desired?.desiredBuildId).toBe(older.id);
+    expect(desired?.desiredDeployId).toBe(rolled.value.deployId);
+
+    // Three intents, one per act. Rollback made a Deploy like any other.
+    const all = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, component.id));
+    expect(all).toHaveLength(3);
+  });
+
+  test('a "rollback" to a newer Build is refused as the typo it is', async () => {
+    const { component, target } = await fixture();
+    const older = await succeededBuild(component.id, 40);
+    const newer = await succeededBuild(component.id, 41);
+    const registry = registryOf(capableAdapter());
+
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: older.id },
+      context(registry),
+    );
+
+    const rolled = await rollbackDeploy(
+      { componentId: component.id, targetId: target.id, buildId: newer.id },
+      context(registry),
+    );
+
+    expect(rolled.ok).toBe(false);
+    if (rolled.ok) return;
+    expect(rolled.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(rolled.failure.message).toContain('older');
+
+    // The refusal wrote nothing: the desired row still names the first intent.
+    const desired = await desiredRow(component.id, target.id);
+    expect(desired?.desiredBuildId).toBe(older.id);
+  });
+
+  test('rolling back where nothing was ever deployed is refused', async () => {
+    const { component, target } = await fixture();
+    const build = await succeededBuild(component.id, 50);
+
+    const rolled = await rollbackDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(rolled.ok).toBe(false);
+    if (rolled.ok) return;
+    expect(rolled.failure.message).toContain('nothing has been deployed');
+  });
+});
+
+describe('§4: an uploaded artifact is recorded, never built', () => {
+  test('a finished bundle becomes a SUCCEEDED Build with no builder invoked', async () => {
+    const { component, target } = await fixture({ kind: 'website' });
+
+    // The registry's `build()` throws. If uploading finished output so much as
+    // looked for a route, this test fails rather than passing quietly.
+    const result = await uploadArchive(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        bundleDigest: digest(60),
+        location: 'bundles/shop-web/60.zip',
+        contents: 'artifact',
+        subpath: '.',
+      },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('SUCCEEDED');
+    expect(result.value.artifactType).toBe('files');
+
+    const [row] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    expect(row?.status).toBe('SUCCEEDED');
+    // §16: the digest is over the uploaded bundle, and it is what names the
+    // artifact — one digest, so the receipt and the provenance have a join.
+    expect(row?.artifactDigest).toBe(digest(60));
+    expect(row?.bundleDigest).toBe(digest(60));
+    // §4: the backend and its fidelity are visible on the Build. There was no
+    // backend, and saying so beats naming a runner that never ran.
+    expect(row?.runner).toBeNull();
+    expect(row?.logFidelity).toBeNull();
+  });
+
+  test('an uploaded source bundle waits for a route instead', async () => {
+    const { component, target } = await fixture();
+
+    const result = await uploadArchive(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        bundleDigest: digest(61),
+        location: 'bundles/shop-web/61.zip',
+        contents: 'source',
+        subpath: '.',
+      },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('PENDING');
+
+    const [row] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    // Staged, digested, and not yet an artifact — §4's other arm.
+    expect(row?.bundleDigest).toBe(digest(61));
+    expect(row?.artifactDigest).toBeNull();
+  });
+
+  test('re-uploading identical bytes lands on the same Build', async () => {
+    // §2 keys a Build on (component, commit, target-shape), and for an upload
+    // the bundle digest is the commit. Identical bytes are the same input, so
+    // they are the same row rather than two rows meaning one thing.
+    const { component, target } = await fixture({ kind: 'website' });
+    const input = {
+      componentId: component.id,
+      targetId: target.id,
+      bundleDigest: digest(62),
+      location: 'bundles/shop-web/62.zip',
+      contents: 'artifact' as const,
+      subpath: '.',
+    };
+    const registry = registryOf(capableAdapter());
+
+    const first = await uploadArchive(input, context(registry));
+    const second = await uploadArchive(input, context(registry));
+
+    expect(first.ok && second.ok).toBe(true);
+    if (!first.ok || !second.ok) return;
+    expect(second.value.buildId).toBe(first.value.buildId);
+  });
+});

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -140,6 +140,9 @@ async function succeededBuild(
       artifactType: shape,
       artifactDigest: digest(seed),
       bundleDigest: digest(seed),
+      // Where the bundle was staged. A Build without one cannot be dispatched
+      // at all — a route would have nothing to fetch.
+      bundleLocation: `bundles/${seed}.zip`,
       status: 'SUCCEEDED',
     })
     .returning();
@@ -659,6 +662,71 @@ describe('§4: an uploaded artifact is recorded, never built', () => {
     expect(row?.artifactDigest).toBeNull();
   });
 
+  test('a source bundle reaches its builder with the location it was staged at', async () => {
+    // The bug this pins: the staged location was only kept on the supplied arm,
+    // so every source upload handed its route an empty location — a build that
+    // cannot fetch what it is building, with nothing saying so.
+    const { component, target } = await fixture();
+    const builder = new FakeBuildAdapter();
+    const registry = registryOf(capableAdapter(), builder);
+
+    const uploaded = await uploadArchive(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        bundleDigest: digest(63),
+        location: 'bundles/shop-web/63.zip',
+        contents: 'source',
+        subpath: 'apps/web',
+      },
+      context(registry),
+    );
+    expect(uploaded.ok).toBe(true);
+    if (!uploaded.ok) return;
+
+    const dispatched = await dispatchBuild(
+      { buildId: uploaded.value.buildId, route: builder.name },
+      context(registry),
+    );
+    expect(dispatched.ok).toBe(true);
+
+    expect(builder.built).toHaveLength(1);
+    const origin = builder.built[0]!.source.origin;
+    expect(origin.type).toBe('archive');
+    if (origin.type !== 'archive') return;
+    expect(origin.location).toBe('bundles/shop-web/63.zip');
+    // §5's scope, per Build: the unwrap is a fact about the uploaded bytes.
+    expect(origin.subpath).toBe('apps/web');
+    // §16's join reaches the route on every path.
+    expect(builder.built[0]!.source.bundleDigest).toBe(digest(63));
+  });
+
+  test('a Build with no staged bundle is refused rather than dispatched empty', async () => {
+    const { component } = await fixture();
+    const [orphan] = await database()
+      .db.insert(builds)
+      .values({
+        componentId: component.id,
+        commit: digest(64),
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: digest(64),
+        status: 'PENDING',
+      })
+      .returning();
+
+    const builder = new FakeBuildAdapter();
+    const result = await dispatchBuild(
+      { buildId: orphan!.id, route: builder.name },
+      context(registryOf(capableAdapter(), builder)),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_BUILDABLE');
+    expect(builder.built).toHaveLength(0);
+  });
+
   test('re-uploading identical bytes lands on the same Build', async () => {
     // §2 keys a Build on (component, commit, target-shape), and for an upload
     // the bundle digest is the commit. Identical bytes are the same input, so
@@ -680,5 +748,50 @@ describe('§4: an uploaded artifact is recorded, never built', () => {
     expect(first.ok && second.ok).toBe(true);
     if (!first.ok || !second.ok) return;
     expect(second.value.buildId).toBe(first.value.buildId);
+
+    // And the second upload changed nothing. The bug this pins: an upsert that
+    // wrote on conflict blanked the artifact refs of a Build that had already
+    // succeeded — a finished artifact quietly losing the address it is pulled by.
+    const [row] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, first.value.buildId));
+    expect(row?.status).toBe('SUCCEEDED');
+    expect(row?.artifactDigest).toBe(digest(62));
+    expect(row?.artifactRefs).toEqual(['bundles/shop-web/62.zip']);
+  });
+
+  test('a source re-upload cannot blank a Build that already succeeded', async () => {
+    const { component, target } = await fixture({ kind: 'website' });
+    const registry = registryOf(capableAdapter());
+    const common = {
+      componentId: component.id,
+      targetId: target.id,
+      bundleDigest: digest(65),
+      location: 'bundles/shop-web/65.zip',
+      subpath: '.',
+    };
+
+    const supplied = await uploadArchive(
+      { ...common, contents: 'artifact' as const },
+      context(registry),
+    );
+    expect(supplied.ok).toBe(true);
+    if (!supplied.ok) return;
+
+    // Same bytes, now claimed to be source. The key is identical, so it lands on
+    // the same row — which must not be demoted out from under a live Deploy.
+    await uploadArchive(
+      { ...common, contents: 'source' as const },
+      context(registry),
+    );
+
+    const [row] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, supplied.value.buildId));
+    expect(row?.status).toBe('SUCCEEDED');
+    expect(row?.artifactDigest).toBe(digest(65));
+    expect(row?.artifactRefs).toEqual(['bundles/shop-web/65.zip']);
   });
 });

--- a/apps/spindrift/test/domain/naming.test.ts
+++ b/apps/spindrift/test/domain/naming.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Naming and DNS (Task 21, §9).
+ *
+ * §9's two layers differ in a way that is easy to collapse by accident, so both
+ * halves are asserted: canonical names **nest freely** because they are not
+ * proxied, and vanity names are **flat single-label** because one apex's free
+ * certificate covers exactly one subdomain level. A canonical name that had been
+ * flattened to fit the vanity rule would work fine and quietly spend the ration.
+ *
+ * The other claim here is negative and therefore needs a test that can fail:
+ * **Spindrift holds no Cloudflare credential** (§9 — "Spindrift writes DNS as CRs
+ * the DNS controller publishes"). `test/extraction/no-dns-credential.test.ts` is
+ * the grep that notices if one ever arrives.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_TTL_SECONDS,
+  DNS_ENDPOINT_API_VERSION,
+  DNS_ENDPOINT_KIND,
+  dnsEndpointFor,
+  recordsFor,
+} from '../../src/adapters/dns/cr.ts';
+import {
+  appCanonical,
+  componentCanonical,
+  coreMintsCanonical,
+  displayUrl,
+  hostnameFor,
+  isLabel,
+  vanity,
+} from '../../src/domain/naming.ts';
+
+const APEX = 'apps.example.test';
+const VANITY_ZONE = 'sh.example.test';
+
+describe('§9: two layers, two different rules', () => {
+  test('canonical names nest, because they are not proxied', () => {
+    expect(
+      componentCanonical({ app: 'shop', component: 'web', apexZone: APEX }),
+    ).toBe('web.shop.apps.example.test');
+    expect(appCanonical('shop', APEX)).toBe('shop.apps.example.test');
+  });
+
+  test('a vanity name is one flat label in the vanity zone', () => {
+    expect(vanity('shop', VANITY_ZONE)).toBe('shop.sh.example.test');
+    // The ration §9 names — "roughly 20" — is a property of one apex's
+    // certificate, and a dotted vanity name would silently need a second one.
+    expect(isLabel('shop')).toBe(true);
+    expect(isLabel('my-shop')).toBe(true);
+    expect(isLabel('shop.web')).toBe(false);
+    expect(isLabel('-shop')).toBe(false);
+    expect(isLabel('')).toBe(false);
+  });
+});
+
+describe('§9: core mints a name only where the platform gives none', () => {
+  test('a cluster gets a minted canonical', () => {
+    expect(coreMintsCanonical('kubernetes')).toBe(true);
+    const hostname = hostnameFor({
+      app: 'shop',
+      component: 'web',
+      adapter: 'kubernetes',
+      apexZone: APEX,
+      vanityZone: VANITY_ZONE,
+      vanityLabel: null,
+    });
+    expect(hostname.canonical).toBe('web.shop.apps.example.test');
+    expect(hostname.vanity).toBeUndefined();
+  });
+
+  test('the backends that name their own workloads get none from core', () => {
+    // §9: "where the platform gives one of its own, that *is* the canonical."
+    // Minting a second address for something that already has one is how an App
+    // ends up with two URLs and no answer about which is real.
+    for (const adapter of ['cloudrun', 'static'] as const) {
+      expect(coreMintsCanonical(adapter)).toBe(false);
+      const hostname = hostnameFor({
+        app: 'shop',
+        component: 'web',
+        adapter,
+        apexZone: APEX,
+        vanityZone: VANITY_ZONE,
+        vanityLabel: null,
+      });
+      expect(hostname.canonical).toBe('');
+    }
+  });
+
+  test('a vanity label is layered on wherever one was chosen', () => {
+    const hostname = hostnameFor({
+      app: 'shop',
+      component: 'web',
+      adapter: 'cloudrun',
+      apexZone: APEX,
+      vanityZone: VANITY_ZONE,
+      vanityLabel: 'shop',
+    });
+    // Vanity is backend-agnostic on purpose: moving an App between backends is
+    // one record re-point, so the name a developer shares does not change.
+    expect(hostname.vanity).toBe('shop.sh.example.test');
+  });
+
+  test('the address shown prefers the vanity name, and is null when there is none', () => {
+    expect(displayUrl({ canonical: 'web.shop.apps.example.test' })).toBe(
+      'https://web.shop.apps.example.test',
+    );
+    expect(
+      displayUrl({
+        canonical: 'web.shop.apps.example.test',
+        vanity: 'shop.sh.example.test',
+      }),
+    ).toBe('https://shop.sh.example.test');
+    // A Deploy that has not reached a Target has no address, and inventing one
+    // would make a pending deploy look live.
+    expect(displayUrl({ canonical: '' })).toBeNull();
+  });
+});
+
+describe('§9: DNS is a custom resource, not an API call', () => {
+  test('a DNSEndpoint carries the records and nothing else', () => {
+    const object = dnsEndpointFor({
+      name: 'shop-web',
+      namespace: 'app-shop',
+      records: recordsFor({
+        canonical: 'web.shop.apps.example.test',
+        vanity: 'shop.sh.example.test',
+        servedBy: 'tunnel.example.test',
+      }),
+      labels: { 'app.spindrift/app': 'shop' },
+    });
+
+    expect(object.apiVersion).toBe(DNS_ENDPOINT_API_VERSION);
+    expect(object.kind).toBe(DNS_ENDPOINT_KIND);
+    // Namespaced, which is what buys §9's "garbage collection free": deleting
+    // the App's namespace deletes its records, so core keeps no list of names
+    // it once minted.
+    expect(object.metadata.namespace).toBe('app-shop');
+    expect(object.spec).toEqual({
+      endpoints: [
+        {
+          dnsName: 'web.shop.apps.example.test',
+          recordType: 'CNAME',
+          targets: ['tunnel.example.test'],
+          recordTTL: DEFAULT_TTL_SECONDS,
+        },
+        {
+          dnsName: 'shop.sh.example.test',
+          recordType: 'CNAME',
+          targets: ['tunnel.example.test'],
+          recordTTL: DEFAULT_TTL_SECONDS,
+        },
+      ],
+    });
+  });
+
+  test('no vanity name means no vanity record', () => {
+    // Not a record pointing at the canonical: §9 layers vanity on "where a
+    // mechanism exists", so an installation without one has an App with one
+    // name rather than two names that mean the same thing.
+    const records = recordsFor({
+      canonical: 'web.shop.apps.example.test',
+      servedBy: 'tunnel.example.test',
+    });
+    expect(records).toHaveLength(1);
+    expect(records[0]?.dnsName).toBe('web.shop.apps.example.test');
+  });
+
+  test('records are CNAMEs, never A records at an address core does not own', () => {
+    // §9's forcing fact: the metal cluster's load-balancer range is RFC1918, so
+    // an A record here would publish an address the internet cannot route to.
+    const records = recordsFor({
+      canonical: 'web.shop.apps.example.test',
+      servedBy: 'tunnel.example.test',
+    });
+    expect(records.every((record) => record.recordType === 'CNAME')).toBe(true);
+  });
+});

--- a/apps/spindrift/test/domain/naming.test.ts
+++ b/apps/spindrift/test/domain/naming.test.ts
@@ -21,7 +21,6 @@ import {
   recordsFor,
 } from '../../src/adapters/dns/cr.ts';
 import {
-  appCanonical,
   componentCanonical,
   coreMintsCanonical,
   displayUrl,
@@ -38,7 +37,6 @@ describe('§9: two layers, two different rules', () => {
     expect(
       componentCanonical({ app: 'shop', component: 'web', apexZone: APEX }),
     ).toBe('web.shop.apps.example.test');
-    expect(appCanonical('shop', APEX)).toBe('shop.apps.example.test');
   });
 
   test('a vanity name is one flat label in the vanity zone', () => {

--- a/apps/spindrift/test/extraction/no-dns-credential.test.ts
+++ b/apps/spindrift/test/extraction/no-dns-credential.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Spindrift holds no DNS provider credential (§9).
+ *
+ * §9: "**Spindrift writes DNS as CRs the DNS controller publishes**, so it holds
+ * **no Cloudflare credential** and gets garbage collection free."
+ *
+ * That is a claim about what the code *does not contain*, and the only way to
+ * keep one of those true is to have something fail when it stops being true. A
+ * provider SDK is a plausible thing to reach for — it is one import and one
+ * token away, and it would work — so this is the grep that notices.
+ *
+ * It is deliberately separate from `no-literals.test.ts`. That test polices §20's
+ * extraction contract: nothing may *name this installation*. This one polices a
+ * §9 architecture decision: nothing may *hold a zone credential*, in any
+ * installation. A Cloudflare token belonging to somebody else's account would
+ * pass the extraction grep and still be exactly the thing §9 ruled out.
+ *
+ * What it does not claim: that no DNS is written. Plenty is — as `DNSEndpoint`
+ * objects, through the cluster API, with the controller doing the publishing.
+ * The line is between describing a record and holding the key to a zone.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readdir } from 'node:fs/promises';
+import { join, relative } from 'node:path';
+
+const APP = join(import.meta.dir, '../..');
+
+/**
+ * Ways a DNS provider credential shows up.
+ *
+ * Two groups, for two different mistakes:
+ *
+ * - **A provider SDK or API host.** Importing one is the direct route to holding
+ *   a credential, and there is no legitimate reason for core to talk to a zone
+ *   API when the controller already does.
+ * - **A credential-shaped name.** An installation can hold a token without ever
+ *   importing an SDK — a raw `fetch` and an environment variable is enough — so
+ *   the names such a value would travel under are matched too.
+ */
+const FORBIDDEN: readonly { pattern: RegExp; why: string }[] = [
+  {
+    pattern: /\bcloudflare\b/i,
+    why: '§9 writes DNS as CRs; core never talks to the zone provider',
+  },
+  {
+    pattern: /api\.cloudflare\.com|\bcloudflare-sdk\b|\bcloudflare4?\b/i,
+    why: 'a zone API client is the credential §9 removed',
+  },
+  {
+    pattern: /\broute53\b|\bgoogle-?clouddns\b/i,
+    why: 'any zone provider client, not only the one this installation uses',
+  },
+  {
+    pattern: /\b(dns|zone)_?(api)?_?token\b/i,
+    why: 'a zone credential, however it is spelled',
+  },
+];
+
+/**
+ * The one file allowed to say the word.
+ *
+ * `cr.ts` documents *why* there is no Cloudflare client, and a rule that
+ * forbids explaining itself is a rule whose reason gets lost. Its exemption is
+ * narrow — one file, and the test below proves the scanner still has teeth
+ * everywhere else.
+ */
+const EXPLAINS_ITSELF = new Set(['src/adapters/dns/cr.ts']);
+
+const BINARY = /\.(png|jpe?g|gif|ico|webp|avif|woff2?|ttf|otf|pdf|zip|gz)$/i;
+
+interface SourceFile {
+  path: string;
+  source: string;
+}
+
+async function readSource(dir: string): Promise<SourceFile[]> {
+  const root = join(APP, dir);
+  const entries = await readdir(root, { recursive: true, withFileTypes: true });
+  const files: SourceFile[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || BINARY.test(entry.name)) continue;
+    const absolute = join(entry.parentPath, entry.name);
+    files.push({
+      path: relative(APP, absolute),
+      source: await Bun.file(absolute).text(),
+    });
+  }
+  return files;
+}
+
+/** Files reaching for a zone provider. */
+function findCredentials(files: readonly SourceFile[]): string[] {
+  const offenders: string[] = [];
+  for (const file of files) {
+    if (EXPLAINS_ITSELF.has(file.path)) continue;
+    for (const { pattern, why } of FORBIDDEN) {
+      if (pattern.test(file.source)) {
+        offenders.push(`${file.path}: ${pattern} — ${why}`);
+      }
+    }
+  }
+  return offenders;
+}
+
+const source = await readSource('src');
+
+describe('§9: no DNS provider credential lives in src/', () => {
+  test('nothing reaches for a zone API', () => {
+    expect(findCredentials(source)).toEqual([]);
+  });
+
+  test('the package declares no DNS provider dependency', async () => {
+    const manifest = (await Bun.file(join(APP, 'package.json')).json()) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
+    const declared = [
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.devDependencies ?? {}),
+    ];
+    // An SDK in `devDependencies` is still an SDK somebody will import.
+    expect(
+      declared.filter((name) => /cloudflare|route53|clouddns/i.test(name)),
+    ).toEqual([]);
+  });
+
+  test('DNS is still written — as objects, through the cluster API', async () => {
+    // The negative claim must not be satisfied by there being no DNS at all.
+    const cr = await Bun.file(join(APP, 'src/adapters/dns/cr.ts')).text();
+    expect(cr).toContain('externaldns.k8s.io/v1alpha1');
+    expect(cr).toContain('DNSEndpoint');
+  });
+});
+
+describe('the scanner catches a deliberately dirty file', () => {
+  test('an SDK import is found', () => {
+    // A detector nobody has seen fail is not a detector.
+    const dirty: SourceFile[] = [
+      {
+        path: 'src/adapters/dns/zone.ts',
+        source: "import Cloudflare from 'cloudflare';\n",
+      },
+    ];
+    expect(findCredentials(dirty)).not.toEqual([]);
+  });
+
+  test('a bare token, with no SDK anywhere, is found', () => {
+    const dirty: SourceFile[] = [
+      {
+        path: 'src/config/manifest.schema.ts',
+        source: 'const dnsApiToken = process.env.DNS_API_TOKEN;\n',
+      },
+    ];
+    expect(findCredentials(dirty)).not.toEqual([]);
+  });
+
+  test('the exemption is one file, not a directory', () => {
+    const dirty: SourceFile[] = [
+      {
+        path: 'src/adapters/dns/other.ts',
+        source: "import Cloudflare from 'cloudflare';\n",
+      },
+    ];
+    expect(findCredentials(dirty)).not.toEqual([]);
+  });
+});

--- a/apps/spindrift/test/harness/fakes/deploy-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/deploy-adapter.ts
@@ -61,6 +61,15 @@ export interface FakeDeployAdapterOptions {
   unmet?: Readonly<Partial<Record<(typeof PREREQUISITES)[number], string>>>;
   /** When set, `inspect` throws — the Target that cannot be reached at all. */
   unreachable?: string;
+  /**
+   * When set, `apply` throws instead of returning a verdict.
+   *
+   * §6 contracts `apply` not to throw — "an adapter that cannot place the
+   * workload says so as a `FAILED` verdict, because a thrown error has no reason
+   * and therefore no blame" — but an adapter is code, and code has bugs. Core
+   * has to survive one, so the fake has to be able to be one.
+   */
+  applyThrows?: string;
 }
 
 /**
@@ -138,6 +147,10 @@ export class FakeDeployAdapter implements DeployAdapter {
     desired: DesiredState,
   ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
     this.applied.push({ target, desired });
+
+    if (this.options.applyThrows !== undefined) {
+      throw new Error(this.options.applyThrows);
+    }
 
     // An artifact type this backend never declared is a core bug, and §6 says
     // so in the adapter's own vocabulary rather than by throwing.

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -80,6 +80,12 @@ export function connectionFor(adapter: TargetAdapter): TargetConnection {
         apiServer: input.apiServer,
         namespace: input.namespace,
         delivery: input.delivery,
+        // Mirrors what the connect act stores, field for field: a helper that
+        // drops one of them makes every "the row holds what was connected"
+        // assertion pass for the wrong reason.
+        ...(input.chartContract === undefined
+          ? {}
+          : { chartContract: input.chartContract }),
       };
     }
     case 'cloudrun':

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -1,0 +1,436 @@
+/**
+ * The deploy loop (Task 20, §6).
+ *
+ * Four claims, each of which would look fine while being false:
+ *
+ * - **Every reason arrives with the blame §6's table assigns**, and the blame is
+ *   core's derivation rather than the adapter's opinion — so the fake never
+ *   supplies one and the row is read back to see what core wrote.
+ * - **The diagnosis survives the platform forgetting.** §12 stores it precisely
+ *   because cluster events expire in about an hour; the test makes the far side
+ *   forget and reads the explanation back anyway.
+ * - **Exposure never mutates on red** (§9). A failed attempt leaves the App as
+ *   reachable as it was, because the previous release is still serving.
+ * - **The loop converges with `NOTIFY` dropped.** Notifications are lost when no
+ *   listener is connected, so the poll has to be the correctness path. Every
+ *   test here runs with no wake-up wired at all.
+ */
+import { describe, expect, test } from 'bun:test';
+import { asc, eq } from 'drizzle-orm';
+import {
+  BLAME,
+  type DeployVerdict,
+  FAILURE_REASONS,
+} from '../../src/adapters/deploy/contract.ts';
+import type { AdapterRegistry, Clock } from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import {
+  claimNextDeploy,
+  DEFAULT_INTERVALS,
+  type DeployLoopContext,
+  intervalFor,
+  runAttempt,
+  runDeployPass,
+} from '../../src/reconciler/deploy-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import {
+  FakeDeployAdapter,
+  type ScriptedAttempt,
+} from '../harness/fakes/deploy-adapter.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+const DIGEST = `sha256:${'a'.repeat(64)}`;
+
+function context(adapter: FakeDeployAdapter): DeployLoopContext {
+  const adapters: Pick<AdapterRegistry, 'deploy'> = {
+    deploy: (name) => (name === adapter.adapter ? adapter : null),
+  };
+  return { db: database().db, adapters, clock, manifest };
+}
+
+/** An App, Component, Target, Build, and one PENDING Deploy intent. */
+async function pendingDeploy(
+  options: { exposure?: 'internal' | 'private' | 'public' } = {},
+) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'shop', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({
+      appId: app!.id,
+      name: 'web',
+      kind: 'service',
+      expose: true,
+      exposure: options.exposure ?? 'private',
+    })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: `cluster-${crypto.randomUUID()}`,
+        adapter: 'kubernetes',
+      }),
+    )
+    .returning();
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'abcdef0',
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: DIGEST,
+      status: 'SUCCEEDED',
+    })
+    .returning();
+  const [deploy] = await db
+    .insert(deploys)
+    .values({
+      componentId: component!.id,
+      targetId: target!.id,
+      buildId: build!.id,
+      phase: 'PENDING',
+      exposure: options.exposure ?? 'private',
+    })
+    .returning();
+
+  return {
+    app: app!,
+    component: component!,
+    target: target!,
+    build: build!,
+    deploy: deploy!,
+  };
+}
+
+async function deployRow(id: number) {
+  const [row] = await database()
+    .db.select()
+    .from(deploys)
+    .where(eq(deploys.id, id));
+  return row;
+}
+
+describe('claiming (§6, SKIP LOCKED)', () => {
+  test('a claim moves PENDING to APPLYING and is taken once', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter();
+
+    const first = await claimNextDeploy(context(adapter));
+    expect(first?.id).toBe(deploy.id);
+    expect(first?.phase).toBe('APPLYING');
+
+    // The claim is the phase, not a held lock: a second worker looking now sees
+    // nothing to take, which is what stops two reconcilers applying one intent.
+    const second = await claimNextDeploy(context(adapter));
+    expect(second).toBeNull();
+  });
+
+  test('intents are claimed oldest first', async () => {
+    const first = await pendingDeploy();
+    const [later] = await database()
+      .db.insert(deploys)
+      .values({
+        componentId: first.component.id,
+        targetId: first.target.id,
+        buildId: first.build.id,
+        phase: 'PENDING',
+      })
+      .returning();
+
+    const adapter = new FakeDeployAdapter();
+    const claimed = await claimNextDeploy(context(adapter));
+    expect(claimed?.id).toBe(first.deploy.id);
+    expect(claimed?.id).not.toBe(later!.id);
+  });
+});
+
+describe('phases come from the platform, not from core (§6)', () => {
+  test('the adapter’s status events drive the row through to LIVE', async () => {
+    const { deploy } = await pendingDeploy();
+    const at = FROZEN;
+    const adapter = new FakeDeployAdapter({
+      script: [
+        {
+          events: [
+            { type: 'status', at, phase: 'APPLYING' },
+            {
+              type: 'log',
+              at,
+              line: 'creating HelmRelease',
+              resource: 'hr/web',
+            },
+            { type: 'status', at, phase: 'WAITING', resource: 'hr/web' },
+          ],
+          verdict: { phase: 'LIVE', ref: 'hr/apps/web' },
+        },
+      ],
+    });
+
+    const claimed = await claimNextDeploy(context(adapter));
+    const outcome = await runAttempt(context(adapter), claimed!);
+
+    expect(outcome?.phase).toBe('LIVE');
+    const row = await deployRow(deploy.id);
+    expect(row?.phase).toBe('LIVE');
+    // §6: the adapter's handle is opaque to core, stored and handed back.
+    expect(row?.ref).toBe('hr/apps/web');
+    // §9: core minted the canonical name, so the URL is core's and the adapter
+    // had nothing to add.
+    expect(row?.url).toBe(`https://web.shop.${manifest.dns.apexZone}`);
+
+    // The whole timeline landed on the one attempt log the UI subscribes to.
+    const events = await database()
+      .db.select()
+      .from(attemptEvents)
+      .where(eq(attemptEvents.deployId, deploy.id))
+      .orderBy(asc(attemptEvents.id));
+    expect(events.map((event) => event.phase ?? event.line)).toEqual([
+      'APPLYING',
+      'creating HelmRelease',
+      'WAITING',
+      'LIVE',
+    ]);
+  });
+
+  test('core describes the neutral DesiredState the adapter renders', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter();
+
+    const claimed = await claimNextDeploy(context(adapter));
+    await runAttempt(context(adapter), claimed!);
+
+    expect(adapter.applied).toHaveLength(1);
+    const desired = adapter.applied[0]!.desired;
+    expect(desired.app).toBe('shop');
+    expect(desired.component).toBe('web');
+    expect(desired.kind).toBe('service');
+    expect(desired.artifact.digest).toBe(DIGEST);
+    expect(desired.deploy).toBe(String(deploy.id));
+    expect(desired.hostname.canonical).toBe(
+      `web.shop.${manifest.dns.apexZone}`,
+    );
+  });
+});
+
+describe('§6: every reason, with the blame the table assigns', () => {
+  // BUILD_FAILED is in the shared vocabulary but cannot arrive from `apply` —
+  // §6: "a reason that cannot apply to a phase simply never occurs there."
+  const fromApply = FAILURE_REASONS.filter(
+    (reason) => reason !== 'BUILD_FAILED',
+  );
+
+  for (const reason of fromApply) {
+    test(`${reason} is recorded with blame ${String(BLAME[reason])}`, async () => {
+      const { deploy } = await pendingDeploy();
+      // The fake supplies a reason and never a blame — §6 makes blame core's
+      // derivation so two adapters cannot indict different people.
+      const verdict: DeployVerdict = {
+        phase: 'FAILED',
+        reason,
+        detail: `the platform said ${reason}`,
+      };
+      const adapter = new FakeDeployAdapter({ script: [{ verdict }] });
+
+      const claimed = await claimNextDeploy(context(adapter));
+      const outcome = await runAttempt(context(adapter), claimed!);
+
+      expect(outcome?.phase).toBe('FAILED');
+      const row = await deployRow(deploy.id);
+      expect(row?.phase).toBe('FAILED');
+      expect(row?.reason).toBe(reason);
+      expect(row?.blame).toBe(BLAME[reason]);
+      expect(row?.detail).toBe(`the platform said ${reason}`);
+    });
+  }
+
+  test('an adapter that throws is INTERNAL and blamed on the platform', async () => {
+    const { deploy } = await pendingDeploy();
+    // `apply` is contracted not to throw, but an adapter is code. An attempt
+    // that ended by crashing the loop would stay APPLYING forever.
+    const adapter = new FakeDeployAdapter({
+      applyThrows: 'the adapter has a bug',
+    });
+
+    const claimed = await claimNextDeploy(context(adapter));
+    const outcome = await runAttempt(context(adapter), claimed!);
+
+    expect(outcome?.phase).toBe('FAILED');
+    const row = await deployRow(deploy.id);
+    expect(row?.reason).toBe('INTERNAL');
+    expect(row?.blame).toBe('platform');
+    expect(row?.detail).toBe('the adapter has a bug');
+  });
+});
+
+describe('§12: the diagnosis outlives the platform', () => {
+  test('it is readable after the far side has forgotten everything', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [
+        {
+          verdict: {
+            phase: 'FAILED',
+            reason: 'REJECTED',
+            detail: 'admission webhook "policy.example" denied the request',
+            debug: { events: [{ reason: 'FailedCreate' }] },
+          },
+        },
+      ],
+    });
+
+    const claimed = await claimNextDeploy(context(adapter));
+    await runAttempt(context(adapter), claimed!);
+
+    // Simulate the hour passing: cluster events expire and the backend can no
+    // longer answer the question at all. §12 is the whole reason this is
+    // survivable — "the platform will not keep it", so core did.
+    const expired = new FakeDeployAdapter({
+      applyThrows: 'the events are gone',
+    });
+    expired.observe = async () => null;
+
+    // Keep running against that amnesiac backend. Nothing may overwrite or
+    // clear what was already explained — a later pass that blanked the row
+    // because the platform no longer remembers would lose the only copy.
+    await runDeployPass(context(expired));
+
+    const row = await deployRow(deploy.id);
+    expect(row?.reason).toBe('REJECTED');
+    expect(row?.blame).toBe('developer');
+    expect(row?.detail).toContain('admission webhook');
+    expect(row?.debug).toEqual({ events: [{ reason: 'FailedCreate' }] });
+  });
+});
+
+describe('§9: exposure never mutates on red', () => {
+  test('a failed attempt leaves the Component and the Deploy as they were', async () => {
+    const { deploy, component } = await pendingDeploy({ exposure: 'public' });
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'FAILED', reason: 'STARTUP_FAILED' } }],
+    });
+
+    const claimed = await claimNextDeploy(context(adapter));
+    await runAttempt(context(adapter), claimed!);
+
+    const row = await deployRow(deploy.id);
+    expect(row?.phase).toBe('FAILED');
+    // The App is exactly as reachable as it was: the previous release is still
+    // serving, and quietly tightening this would turn one red deploy into an
+    // outage nobody asked for.
+    expect(row?.exposure).toBe('public');
+
+    const [after] = await database()
+      .db.select()
+      .from(components)
+      .where(eq(components.id, component.id));
+    expect(after?.exposure).toBe('public');
+  });
+});
+
+describe('drift is surfaced, never corrected (§6)', () => {
+  test('a digest that is not the desired one is reported and left alone', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'hr/apps/web' } }],
+    });
+
+    await runDeployPass(context(adapter));
+
+    // Somebody changed what is running underneath us.
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'LIVE',
+      artifactDigest: `sha256:${'b'.repeat(64)}`,
+    });
+
+    const pass = await runDeployPass(context(adapter));
+    const report = pass.drift.find((entry) => entry.deployId === deploy.id);
+    expect(report?.drifted).toBe(true);
+
+    // Reported, and nothing else: no second apply went out to put it back.
+    // §6 — the re-converge is one click a human takes, not something a loop does
+    // to a cluster somebody may have changed on purpose during an incident.
+    expect(adapter.applied).toHaveLength(1);
+    const row = await deployRow(deploy.id);
+    expect(row?.phase).toBe('LIVE');
+  });
+
+  test('a Target that cannot be reached has not drifted', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'hr/apps/web' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    adapter.observe = async () => {
+      throw new Error('dial tcp: no route to host');
+    };
+
+    const pass = await runDeployPass(context(adapter));
+    // An uplink blip is not a developer changing something, and reporting it as
+    // drift would make every satellite hiccup look like a person.
+    expect(
+      pass.drift.find((entry) => entry.deployId === deploy.id),
+    ).toBeUndefined();
+  });
+});
+
+describe('the poll is the correctness path (plan, Transport shape)', () => {
+  test('a pass converges every pending intent with no notification wired', async () => {
+    // Nothing in this file ever wires a wake-up. If `NOTIFY` were load-bearing
+    // rather than an optimization, none of these tests would converge at all —
+    // which is the point: notifications are lost when no listener is connected.
+    const first = await pendingDeploy();
+    const scripted: ScriptedAttempt = {
+      verdict: { phase: 'LIVE', ref: `hr/${crypto.randomUUID()}` },
+    };
+    await database().db.insert(deploys).values({
+      componentId: first.component.id,
+      targetId: first.target.id,
+      buildId: first.build.id,
+      phase: 'PENDING',
+    });
+
+    const adapter = new FakeDeployAdapter({ script: [scripted] });
+    const pass = await runDeployPass(context(adapter));
+
+    // Both intents were drained in one pass rather than one per interval.
+    expect(pass.applied).toHaveLength(2);
+    expect(pass.applied.every((outcome) => outcome.phase === 'LIVE')).toBe(
+      true,
+    );
+
+    const rows = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, first.component.id));
+    expect(rows.every((row) => row.phase === 'LIVE')).toBe(true);
+  });
+
+  test('the interval is fast only while something is in flight', async () => {
+    expect(intervalFor(['LIVE'])).toBe(DEFAULT_INTERVALS.slowMs);
+    expect(intervalFor(['FAILED'])).toBe(DEFAULT_INTERVALS.slowMs);
+    // The converged cadence is also the drift cadence — drift is information,
+    // not an alarm, so it is checked in minutes rather than seconds.
+    expect(intervalFor([])).toBe(DEFAULT_INTERVALS.slowMs);
+    expect(intervalFor(['LIVE', 'APPLYING'])).toBe(DEFAULT_INTERVALS.fastMs);
+    expect(intervalFor(['WAITING'])).toBe(DEFAULT_INTERVALS.fastMs);
+  });
+});

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -319,6 +319,80 @@ describe('§12: the diagnosis outlives the platform', () => {
   });
 });
 
+describe('§9: one vanity name, and never two claimants', () => {
+  test('a sole serving Component carries the App’s vanity name', async () => {
+    const { app } = await pendingDeploy();
+    await database()
+      .db.update(apps)
+      .set({ vanityDomain: 'shop' })
+      .where(eq(apps.id, app.id));
+
+    const adapter = new FakeDeployAdapter();
+    await runDeployPass(context(adapter));
+
+    expect(adapter.applied[0]?.desired.hostname.vanity).toBe(
+      `shop.${manifest.dns.vanityZone}`,
+    );
+  });
+
+  test('a second serving Component means neither gets it', async () => {
+    // §9 puts the vanity name on the App and the canonical on each Component.
+    // Handing one name to two Components puts the same hostname on two routes,
+    // and the platform resolves that collision arbitrarily — which is worse
+    // than the App simply not having a front-door name yet.
+    const { app, component, target, build } = await pendingDeploy();
+    await database()
+      .db.update(apps)
+      .set({ vanityDomain: 'shop' })
+      .where(eq(apps.id, app.id));
+    await database().db.insert(components).values({
+      appId: app.id,
+      name: 'admin',
+      kind: 'service',
+      expose: true,
+    });
+
+    const adapter = new FakeDeployAdapter();
+    await runDeployPass(context(adapter));
+
+    const desired = adapter.applied[0]?.desired;
+    expect(desired?.hostname.vanity).toBeUndefined();
+    // The canonical still resolves — it is per Component and never contended.
+    expect(desired?.hostname.canonical).toBe(
+      `web.shop.${manifest.dns.apexZone}`,
+    );
+    expect(component.id).toBeDefined();
+    expect(target.id).toBeDefined();
+    expect(build.id).toBeDefined();
+  });
+
+  test('an unexposed sibling is not a claimant', async () => {
+    // §2: an unexposed service is a queue worker, and a job serves nothing.
+    // Neither can contend for the App's front door.
+    const { app } = await pendingDeploy();
+    await database()
+      .db.update(apps)
+      .set({ vanityDomain: 'shop' })
+      .where(eq(apps.id, app.id));
+    await database().db.insert(components).values({
+      appId: app.id,
+      name: 'worker',
+      kind: 'service',
+      expose: false,
+    });
+    await database()
+      .db.insert(components)
+      .values({ appId: app.id, name: 'nightly', kind: 'job' });
+
+    const adapter = new FakeDeployAdapter();
+    await runDeployPass(context(adapter));
+
+    expect(adapter.applied[0]?.desired.hostname.vanity).toBe(
+      `shop.${manifest.dns.vanityZone}`,
+    );
+  });
+});
+
 describe('§9: exposure never mutates on red', () => {
   test('a failed attempt leaves the Component and the Deploy as they were', async () => {
     const { deploy, component } = await pendingDeploy({ exposure: 'public' });
@@ -368,8 +442,46 @@ describe('drift is surfaced, never corrected (§6)', () => {
     // §6 — the re-converge is one click a human takes, not something a loop does
     // to a cluster somebody may have changed on purpose during an incident.
     expect(adapter.applied).toHaveLength(1);
+
+    // And it is a *state*, not just a return value. §6 asks for drift to be
+    // visible, and the UI reads rows — a finding that lived for the length of
+    // one pass would be surfaced to nobody.
     const row = await deployRow(deploy.id);
     expect(row?.phase).toBe('LIVE');
+    expect(row?.driftedAt).toEqual(FROZEN);
+    expect(row?.observedDigest).toBe(`sha256:${'b'.repeat(64)}`);
+  });
+
+  test('drift fixed out of band stops being reported, with no dismissal', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'hr/apps/web' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'LIVE',
+      artifactDigest: `sha256:${'b'.repeat(64)}`,
+    });
+    await runDeployPass(context(adapter));
+    expect((await deployRow(deploy.id))?.driftedAt).toEqual(FROZEN);
+
+    // Somebody put it back by hand. Nothing should have to be clicked for the
+    // state to clear — it is an observation, not an acknowledgement.
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'LIVE',
+      artifactDigest: DIGEST,
+    });
+    const pass = await runDeployPass(context(adapter));
+
+    expect(
+      pass.drift.find((entry) => entry.deployId === deploy.id)?.drifted,
+    ).toBe(false);
+    const row = await deployRow(deploy.id);
+    expect(row?.driftedAt).toBeNull();
+    expect(row?.observedDigest).toBe(DIGEST);
   });
 
   test('a Target that cannot be reached has not drifted', async () => {


### PR DESCRIPTION
Milestone 3 of the Spindrift plan — Tasks 18–21. An uploaded bundle now reaches
a Kubernetes cluster and comes back with a URL, which is the first thing that
works end to end.

## Summary

A Deploy row was previously something nothing wrote. Now: uploading finished
output records an artifact without invoking a builder, creating a Deploy writes
an intent under a locking read on the desired row, and the reconciler claims
that intent, applies it through the Kubernetes adapter, and records what the
platform said.

## Changes

- **Task 18 — archive source.** An archive of finished output is *recorded*, not
  built: the Build is born `SUCCEEDED` with the bundle digest naming the
  artifact, and no build route is looked up at all.
- **Task 19 — the commands.** `createComponent`, `dispatchBuild`, `createDeploy`,
  `rollbackDeploy`. §6's transactional row is the whole concurrency design;
  rollback is an ordinary deploy with one extra question asked under the same
  lock.
- **Task 20 — the deploy loop.** Claims with `FOR UPDATE SKIP LOCKED` and then
  releases the lock — the claim is the `APPLYING` phase, because a phase
  survives a reconciler restart and a lock does not. Phases come from the
  adapter; the diagnosis is persisted because cluster events expire in about an
  hour; exposure is never touched on red; drift is surfaced and never corrected.
- **Task 21 — naming.** Canonical names nest (unproxied), vanity names are one
  flat label (one apex, one certificate), and core mints nothing where the
  platform names its own.

## The concurrency test earns its Postgres

The first two versions of it **passed with `.for('update')` deleted** — the
transactions were serializing on the desired row's unique index, and then on the
closing `UPDATE`. Only after pre-creating the desired row and pinning the
interleaving through the guard hook does removing the lock fail the test. That
was mutation-checked rather than assumed.

## Reviewed, and four bugs fixed

A two-axis review found four defects that passed every test:

- The **adaptive interval was never adaptive** — the cadence was chosen from
  terminal outcomes, so the fast branch could not fire.
- A **source archive could never be built** — the staged bundle's location was
  written to `artifactRefs` and only on the supplied arm.
- **Re-uploading blanked a finished Build**, possibly one a live Deploy pointed
  at.
- **One vanity name, two claimants** — an App with two serving Components put one
  hostname on two HTTPRoutes.

Each is fixed with a test pinning it. The review also caught the README claiming
Spindrift writes DNS records; it does not — on a cluster the names ride the
chart's `HTTPRoute`, and this installation's external-dns already runs
`gateway-httproute` as a source.

## Not done, and stated in the README

§9's live-from-creation status page on a lowest-precedence wildcard route. An
App's address stays dark until something has been deployed to it.

## Test Plan

- [ ] `mise run ts:check` — clean
- [ ] `DATABASE_URL=... bun test` in `apps/spindrift` — 376 pass
- [ ] `bun test packages/charts` — chart goldens unaffected
- [ ] `mise run k8s:render-apps` — renders clean
- [ ] Migrations `0002_bundle_staging` and `0003_drift_state` replay on a clean
      schema (every test does this via the harness)

**Note on running the tests under WSL:** `wslc.exe` containers are not reachable
from the distro this repo is checked out in — they run in their own WSL VM, so a
published port binds in that VM's namespace. The container is healthy and every
database test times out against it. The README now documents running Postgres
natively instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
