### PR TITLE
refactor(wsl): drop docker-desktop for wslc.exe + enable nix-ld systemwide

### DIFF
--- a/nix/images/wsl.nix
+++ b/nix/images/wsl.nix
@@ -21,7 +21,7 @@
   # NixOS's binfmt module takes over the whole binfmt_misc table on
   # activation; without this, adding the aarch64 registration above wipes
   # out WSL2's own .exe interop handler and breaks running Windows binaries
-  # (explorer.exe, code.exe, Docker Desktop, ...) from inside WSL.
+  # (explorer.exe, code.exe, wslc.exe, ...) from inside WSL.
   wsl.interop.register = true;
 
   wsl = {
@@ -29,13 +29,6 @@
     defaultUser = "jawn";
     useWindowsDriver = true;
     ssh-agent.enable = true;
-    # Enable integration with Docker Desktop (needs to be installed separately)
-    docker-desktop.enable = true;
-    # https://github.com/nix-community/NixOS-WSL/issues/1081 Docker Desktop v4.80.0+
-    extraBin = [
-      { src = "${pkgs.coreutils}/bin/install"; }
-      { src = "${pkgs.coreutils}/bin/mv"; }
-    ];
   };
 
   i18n.defaultLocale = "en_US.UTF-8";
@@ -49,8 +42,6 @@
     pkgs.bubblewrap
     # pkgs.pipx
   ];
-
-  programs.nix-ld.enable = true;
 
   programs.zsh.enable = true;
 }

--- a/nix/system/nixos.nix
+++ b/nix/system/nixos.nix
@@ -50,4 +50,11 @@
       randomizedDelaySec = "3600";
     };
   };
+
+  # Run pre-linked binaries (mise-managed tools, downloaded releases, vendor
+  # installers) on NixOS: `programs.nix-ld.enable` installs the dynamic loader
+  # such binaries expect and exports `NIX_LD` / `NIX_LD_LIBRARY_PATH` so they
+  # find it. Anything needing more than glibc gets its library closure surfaced
+  # by adding paths to `environment.variables.NIX_LD_LIBRARY_PATH` per host.
+  programs.nix-ld.enable = lib.mkDefault true;
 }


### PR DESCRIPTION
## Summary
Move the WSL dev host off Docker Desktop and onto Microsoft's `wslc.exe`
container CLI, and lift `nix-ld` from the WSL image to the shared NixOS
module so every host can run pre-linked binaries (mise-managed tools,
vendor installers).

The host's `~/.wslconfig` already runs `networkingMode=mirrored`, so
`wslc run --publish 127.0.0.1:5432:5432 …` is reachable from the distro's
loopback — verified live on WSL 2.9.4.0 with a throwaway `postgres:18-alpine`
container that responded to `pg_isready` from inside the distro and self-cleaned.

## Changes
- feat(nix): enable nix-ld systemwide so mise-managed linked binaries run
- refactor(wsl): drop docker-desktop integration in favour of wslc.exe

## Test Plan
- [ ] `nix build .#nixosConfigurations.wsl.config.system.build.toplevel`
      (already green at `/nix/store/g98v565gyrsjz0i4k4z8kjr1a1306izc-…`)
- [ ] `nix build .#nixosConfigurations.forge.config.system.build.toplevel`
      (already green at `/nix/store/vp143q258d5fh6psq668g5qgc4pabxml-…`)
- [ ] After deploy + `wsl --shutdown`: `wslc.exe run -d --rm --publish
      127.0.0.1:5432:5432 -e POSTGRES_PASSWORD=postgres postgres:18-alpine`
      and `pg_isready` from the distro → accept
- [ ] `mise <tool>` runs the linked binary without `NIX_LD` errors on any
      host (this is what the `nix-ld` move fixes)

## Context
- `.agent/context/context.md` — full findings: wslc probe results, mirrored-mode
  rationale, and the work that remains (add `spindrift:db:up/down` mise tasks
  and update the spindrift README in a follow-up).