### PR TITLE
fix(spindrift): pin the web image by digest

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -24,7 +24,7 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    image: ghcr.io/jonpulsifer/spindrift:latest
+    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:613eb3be2955952e6082f1d451ee34ad854e14fc2376f43eb8e621bc129a3dc7
     # Substituted by the apps Kustomization from the cluster-secrets Secret, so
     # the zone is read rather than restated. external-dns publishes the record
     # from the HTTPRoute and cert-manager issues the certificate, so this line


### PR DESCRIPTION
## Summary
Pin the offsite Spindrift web image by digest (`sha256:613eb3be…`), the digest the running pod already serves, matching the pattern `hub`, `dave`, and `atlantis` use. Renovate maintains it from here — spindrift is in `.github/containers.json`'s `build` list and the `helm-values`/`docker` managers run over `clusters/**/*.yaml`.

## Changes
- fix(spindrift): pin the web image by digest

## Test Plan
- [ ] `mise run k8s:render-apps` renders cleanly (offsite spindrift overlay)
- [ ] `kubectl kustomize clusters/offsite/apps/spindrift` carries the digest in the Deployment image
- [ ] Flux reconcile rolls the pod to the pinned image (no-op if already at that digest)
- [ ] Next Renovate run opens `chore(container): update image ghcr.io/jonpulsifer/spindrift` digest PRs as it does for hub

## Context
The Spindrift control-plane DB had zero migrations applied (the chart's migration Job is disabled by design — `src/db/migrate.ts` has no runner), which crashed the web pod's auth flow on `relation "credentials" does not exist`. The schema was applied out-of-band to the live `spindrift-db` so the installation is now claimable; this PR pins the image so a Flux reconcile can't silently pull a different image while the migration-runner gap is still open.
