### PR TITLE
feat(spindrift): detect source scopes

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -17,7 +17,9 @@ output records an artifact without a builder; creating a Deploy writes an intent
 under a locking read; the reconciler claims that intent, applies it through the
 Kubernetes adapter, and records what the platform said. The operator claims the
 installation with a passkey and reaches every command through an opaque
-session.
+session. Source detection classifies one named repo or archive scope, honours an
+authoritative `spindrift.yaml`, derives workspace watch paths, and keeps
+Dockerfile selection separate from Component-kind inference.
 
 What has no implementation is the Cloud Run and static deploy adapters, every
 real build route, config delivery, and datastores. **The three screens still
@@ -45,7 +47,7 @@ One image, two processes (§19); only `web` exists so far.
 | `src/config/` | the installation manifest and its schema |
 | `src/db/` | the Drizzle schema, the connection, and the committed migrations |
 | `src/commands/` | the application command layer and its registry |
-| `src/domain/` | `DesiredState`, the attempt log, Targets, capabilities, placement, sources, naming, diagnosis |
+| `src/domain/` | backend-neutral product rules and value types |
 | `src/adapters/` | the adapter contracts, Kubernetes delivery, DNS records, and the two stores |
 | `src/reconciler/` | two loops — Target health and capabilities, and deploy convergence |
 | `src/web/` | the `web` process — the server, the dispatch surface, and the client |

--- a/apps/spindrift/src/domain/detection/ladder.ts
+++ b/apps/spindrift/src/domain/detection/ladder.ts
@@ -1,0 +1,148 @@
+/**
+ * One Component proposal from one explicitly named directory (§5).
+ *
+ * The zero-config builder owns language/framework detection. Core consumes a
+ * normalized plan instead of duplicating those heuristics, then selects the
+ * build frontend independently: a Dockerfile changes how code is built, never
+ * what kind of Component it is.
+ */
+import { access } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { ComponentKind } from '../desired-state.ts';
+import type { DetectionSource } from './scope.ts';
+import { resolveDetectionScope } from './scope.ts';
+import { loadSpindriftFile } from './spindrift-file.ts';
+import { deriveWatchPaths } from './watch-paths.ts';
+
+export type { DetectionSource } from './scope.ts';
+
+export type InferredComponentKind = Exclude<ComponentKind, 'job'>;
+
+export type KindOption =
+  | {
+      readonly kind: ComponentKind;
+      readonly available: true;
+      readonly reason?: string;
+    }
+  | {
+      readonly kind: ComponentKind;
+      readonly available: false;
+      readonly reason: string;
+    };
+
+export type ZeroConfigPlan =
+  | {
+      readonly outcome: 'detected';
+      readonly kind: InferredComponentKind;
+      readonly kinds: readonly KindOption[];
+      readonly buildCommand: string | null;
+      readonly outputDirectory: string | null;
+    }
+  | {
+      readonly outcome: 'unsupported';
+      readonly detail: string;
+    };
+
+/**
+ * The Railpack-facing seam. A concrete process adapter belongs beside the build
+ * routes; the detection ladder depends only on the stable facts it needs.
+ */
+export interface ZeroConfigPlanner {
+  plan(directory: string): Promise<ZeroConfigPlan>;
+}
+
+export interface DetectionProposal {
+  readonly source: 'railpack' | 'spindrift-file';
+  readonly kind: ComponentKind;
+  readonly kinds: readonly KindOption[];
+  readonly build:
+    | { readonly frontend: 'dockerfile'; readonly dockerfile: string }
+    | {
+        readonly frontend: 'railpack';
+        readonly buildCommand: string | null;
+        readonly outputDirectory: string | null;
+      };
+  readonly watchPaths: readonly string[];
+}
+
+export type DetectionResult =
+  | {
+      readonly outcome: 'detected';
+      readonly scope: string;
+      readonly proposal: DetectionProposal;
+    }
+  | {
+      readonly outcome: 'unknown';
+      readonly scope: string;
+      readonly reason: 'unsupported';
+      readonly detail: string;
+      readonly watchPaths: readonly string[];
+    };
+
+export interface DetectScopeInput {
+  readonly repositoryRoot: string;
+  readonly source: DetectionSource;
+  readonly planner: ZeroConfigPlanner;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function detectScope(
+  input: DetectScopeInput,
+): Promise<DetectionResult> {
+  const { scope, directory } = await resolveDetectionScope(
+    input.repositoryRoot,
+    input.source,
+  );
+
+  const spindriftFile = join(directory, 'spindrift.yaml');
+  if (input.source.kind === 'repo' && (await exists(spindriftFile))) {
+    return {
+      outcome: 'detected',
+      scope,
+      proposal: await loadSpindriftFile(spindriftFile),
+    };
+  }
+
+  const watchPaths =
+    input.source.kind === 'repo'
+      ? await deriveWatchPaths(input.repositoryRoot, scope)
+      : [];
+  const plan = await input.planner.plan(directory);
+
+  if (plan.outcome === 'unsupported') {
+    return {
+      outcome: 'unknown',
+      scope,
+      reason: 'unsupported',
+      detail: plan.detail,
+      watchPaths,
+    };
+  }
+
+  const dockerfile = await exists(join(directory, 'Dockerfile'));
+  return {
+    outcome: 'detected',
+    scope,
+    proposal: {
+      source: 'railpack',
+      kind: plan.kind,
+      kinds: plan.kinds,
+      build: dockerfile
+        ? { frontend: 'dockerfile', dockerfile: 'Dockerfile' }
+        : {
+            frontend: 'railpack',
+            buildCommand: plan.buildCommand,
+            outputDirectory: plan.outputDirectory,
+          },
+      watchPaths,
+    },
+  };
+}

--- a/apps/spindrift/src/domain/detection/scope.ts
+++ b/apps/spindrift/src/domain/detection/scope.ts
@@ -1,0 +1,80 @@
+/**
+ * Resolve the one directory detection is allowed to inspect (§5).
+ *
+ * Repo scopes are caller-named and may not escape through either traversal or
+ * a symlink. Archives have no named scope and unwrap exactly one lone directory.
+ */
+import { readdir, realpath } from 'node:fs/promises';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+export type DetectionSource =
+  | { readonly kind: 'repo'; readonly subpath: string }
+  | { readonly kind: 'archive' };
+
+export interface ResolvedDetectionScope {
+  readonly scope: string;
+  readonly directory: string;
+}
+
+function isWithin(parent: string, child: string): boolean {
+  const path = relative(parent, child);
+  return path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path);
+}
+
+function assertWithin(parent: string, child: string): void {
+  if (!isWithin(parent, child)) {
+    throw new RangeError('scope must stay inside the repository root');
+  }
+}
+
+async function repoScope(
+  repositoryRoot: string,
+  requestedScope: string,
+): Promise<ResolvedDetectionScope> {
+  const requested = requestedScope.replaceAll('\\', '/');
+  if (
+    requested.length === 0 ||
+    isAbsolute(requested) ||
+    /^[A-Za-z]:\//.test(requested)
+  ) {
+    throw new RangeError('scope must stay inside the repository root');
+  }
+
+  const root = resolve(repositoryRoot);
+  const directory = resolve(root, requested);
+  assertWithin(root, directory);
+
+  const [realRoot, realDirectory] = await Promise.all([
+    realpath(root),
+    realpath(directory),
+  ]);
+  assertWithin(realRoot, realDirectory);
+
+  const scope = relative(root, directory);
+  return {
+    scope: scope.length === 0 ? '.' : scope.split(sep).join('/'),
+    directory: realDirectory,
+  };
+}
+
+async function archiveScope(
+  directory: string,
+): Promise<ResolvedDetectionScope> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  return {
+    scope: '.',
+    directory:
+      entries.length === 1 && entries[0]?.isDirectory()
+        ? join(directory, entries[0].name)
+        : directory,
+  };
+}
+
+export function resolveDetectionScope(
+  repositoryRoot: string,
+  source: DetectionSource,
+): Promise<ResolvedDetectionScope> {
+  return source.kind === 'repo'
+    ? repoScope(repositoryRoot, source.subpath)
+    : archiveScope(repositoryRoot);
+}

--- a/apps/spindrift/src/domain/detection/spindrift-file.ts
+++ b/apps/spindrift/src/domain/detection/spindrift-file.ts
@@ -1,0 +1,104 @@
+/**
+ * The authoritative, in-repo projection of one scope's detection config (§5).
+ *
+ * This boundary is intentionally strict. Once `spindrift.yaml` exists the repo
+ * is the source of truth, so malformed or unknown input must stop
+ * reconciliation rather than quietly falling through to a fresh guess.
+ */
+import { z } from 'zod';
+import type { DetectionProposal } from './ladder.ts';
+
+const scopedPathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (value) =>
+      !value.startsWith('/') &&
+      !/^[A-Za-z]:[\\/]/.test(value) &&
+      !value.split(/[\\/]/).includes('..'),
+    'path must stay inside its scope',
+  );
+
+const componentSchema = z.strictObject({
+  kind: z.enum(['service', 'website', 'job']),
+});
+
+const buildSchema = z.discriminatedUnion('frontend', [
+  z.strictObject({
+    frontend: z.literal('dockerfile'),
+    file: scopedPathSchema,
+  }),
+  z.strictObject({
+    frontend: z.literal('railpack'),
+    command: z.string().min(1).nullable(),
+    outputDirectory: z.string().min(1).nullable(),
+  }),
+]);
+
+const spindriftFileSchema = z.strictObject({
+  version: z.literal(1),
+  component: componentSchema,
+  build: buildSchema,
+  watchPaths: z.array(scopedPathSchema).min(1),
+});
+
+function formatIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : 'document';
+      return `${path}: ${issue.message}`;
+    })
+    .join('; ');
+}
+
+export function parseSpindriftFile(
+  document: string,
+  source = 'spindrift.yaml',
+): DetectionProposal {
+  let decoded: unknown;
+  try {
+    decoded = Bun.YAML.parse(document);
+  } catch (cause) {
+    throw new Error(
+      `${source}: not valid YAML: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+      { cause },
+    );
+  }
+
+  const parsed = spindriftFileSchema.safeParse(decoded);
+  if (!parsed.success) {
+    throw new Error(
+      `${source}: invalid Spindrift file: ${formatIssues(parsed.error)}`,
+    );
+  }
+
+  const { component, build, watchPaths } = parsed.data;
+  return {
+    source: 'spindrift-file',
+    kind: component.kind,
+    kinds: [
+      {
+        kind: component.kind,
+        available: true,
+        reason: 'asserted by spindrift.yaml',
+      },
+    ],
+    build:
+      build.frontend === 'dockerfile'
+        ? { frontend: 'dockerfile', dockerfile: build.file }
+        : {
+            frontend: 'railpack',
+            buildCommand: build.command,
+            outputDirectory: build.outputDirectory,
+          },
+    watchPaths,
+  };
+}
+
+export async function loadSpindriftFile(
+  path: string,
+): Promise<DetectionProposal> {
+  return parseSpindriftFile(await Bun.file(path).text(), path);
+}

--- a/apps/spindrift/src/domain/detection/watch-paths.ts
+++ b/apps/spindrift/src/domain/detection/watch-paths.ts
@@ -1,0 +1,180 @@
+/**
+ * Derive rebuild triggers for one repo scope (§5).
+ *
+ * Package workspaces contribute their internal dependency graph transitively.
+ * Other ecosystems degrade honestly to the named scope plus the root manifests
+ * and lockfiles that exist, which is still conservative: it can overbuild but
+ * cannot silently miss a root toolchain change.
+ */
+import { access } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+const ROOT_WATCH_FILES = [
+  'package.json',
+  'bun.lock',
+  'bun.lockb',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'yarn.lock',
+  'go.mod',
+  'go.sum',
+  'go.work',
+  'go.work.sum',
+  'pyproject.toml',
+  'uv.lock',
+  'poetry.lock',
+  'Cargo.toml',
+  'Cargo.lock',
+] as const;
+
+interface PackageManifest {
+  readonly name?: string;
+  readonly workspaces?:
+    | readonly string[]
+    | { readonly packages?: readonly string[] };
+  readonly dependencies?: Readonly<Record<string, string>>;
+  readonly devDependencies?: Readonly<Record<string, string>>;
+  readonly optionalDependencies?: Readonly<Record<string, string>>;
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+}
+
+interface WorkspacePackage {
+  readonly directory: string;
+  readonly manifest: PackageManifest;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPackageManifest(
+  path: string,
+): Promise<PackageManifest | null> {
+  if (!(await exists(path))) return null;
+  try {
+    return (await Bun.file(path).json()) as PackageManifest;
+  } catch {
+    return null;
+  }
+}
+
+function packageWorkspacePatterns(
+  manifest: PackageManifest,
+): readonly string[] {
+  const workspaces = manifest.workspaces;
+  if (!workspaces) return [];
+  if (Array.isArray(workspaces)) return workspaces;
+  return (
+    (workspaces as { readonly packages?: readonly string[] }).packages ?? []
+  );
+}
+
+async function pnpmWorkspacePatterns(
+  repositoryRoot: string,
+): Promise<readonly string[]> {
+  const path = join(repositoryRoot, 'pnpm-workspace.yaml');
+  if (!(await exists(path))) return [];
+
+  try {
+    const document = Bun.YAML.parse(await Bun.file(path).text()) as {
+      packages?: unknown;
+    };
+    return Array.isArray(document?.packages) &&
+      document.packages.every((entry) => typeof entry === 'string')
+      ? document.packages
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function dependencyNames(manifest: PackageManifest): string[] {
+  return [
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.devDependencies ?? {}),
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}),
+  ];
+}
+
+async function workspacePackages(
+  repositoryRoot: string,
+  rootManifest: PackageManifest,
+): Promise<Map<string, WorkspacePackage>> {
+  const packages = new Map<string, WorkspacePackage>();
+  const patterns = new Set([
+    ...packageWorkspacePatterns(rootManifest),
+    ...(await pnpmWorkspacePatterns(repositoryRoot)),
+  ]);
+  for (const pattern of patterns) {
+    const manifests = new Bun.Glob(
+      `${pattern.replace(/\/+$/, '')}/package.json`,
+    );
+    for await (const path of manifests.scan({
+      cwd: repositoryRoot,
+      onlyFiles: true,
+    })) {
+      const manifest = await readPackageManifest(join(repositoryRoot, path));
+      if (manifest?.name) {
+        packages.set(manifest.name, {
+          directory: dirname(path),
+          manifest,
+        });
+      }
+    }
+  }
+  return packages;
+}
+
+async function workspaceDependencyPaths(
+  repositoryRoot: string,
+  scope: string,
+): Promise<string[]> {
+  if (scope === '.') return [];
+
+  const rootManifest = await readPackageManifest(
+    join(repositoryRoot, 'package.json'),
+  );
+  const scopeManifest = await readPackageManifest(
+    join(repositoryRoot, scope, 'package.json'),
+  );
+  if (!rootManifest || !scopeManifest) return [];
+
+  const packages = await workspacePackages(repositoryRoot, rootManifest);
+  const paths: string[] = [];
+  const queued = dependencyNames(scopeManifest);
+  const seen = new Set<string>();
+
+  while (queued.length > 0) {
+    const name = queued.shift();
+    if (!name || seen.has(name)) continue;
+    seen.add(name);
+
+    const dependency = packages.get(name);
+    if (!dependency) continue;
+    if (dependency.directory !== scope) paths.push(dependency.directory);
+    queued.push(...dependencyNames(dependency.manifest));
+  }
+
+  return paths;
+}
+
+export async function deriveWatchPaths(
+  repositoryRoot: string,
+  scope: string,
+): Promise<string[]> {
+  const paths = [
+    scope,
+    ...(await workspaceDependencyPaths(repositoryRoot, scope)),
+  ];
+  for (const path of ROOT_WATCH_FILES) {
+    if (await exists(join(repositoryRoot, path))) paths.push(path);
+  }
+  return paths;
+}

--- a/apps/spindrift/test/domain/detection.test.ts
+++ b/apps/spindrift/test/domain/detection.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Detection is one algorithm over one named directory (§5).
+ *
+ * The public seam is `detectScope`: a caller supplies the directory and the
+ * zero-config builder's normalized plan, then receives either one Component
+ * proposal or an honest unknown outcome. Tests stay above the filesystem and
+ * planner boundaries; none reaches into the ladder's helpers.
+ */
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  detectScope,
+  type InferredComponentKind,
+  type ZeroConfigPlanner,
+} from '../../src/domain/detection/ladder.ts';
+
+const FIXTURES = join(import.meta.dir, '../fixtures/detection');
+
+type Assert<T extends true> = T;
+
+function planner(
+  plan: Awaited<ReturnType<ZeroConfigPlanner['plan']>>,
+): ZeroConfigPlanner {
+  return {
+    async plan() {
+      return plan;
+    },
+  };
+}
+
+describe('the detection ladder', () => {
+  test('job is asserted and cannot be inferred', () => {
+    const excluded: Assert<'job' extends InferredComponentKind ? false : true> =
+      true;
+    expect(excluded).toBe(true);
+  });
+
+  test('a Dockerfile-wrapped static site is still a website', async () => {
+    const result = await detectScope({
+      repositoryRoot: join(FIXTURES, 'dockerfile-website'),
+      source: { kind: 'repo', subpath: '.' },
+      planner: planner({
+        outcome: 'detected',
+        kind: 'website',
+        kinds: [
+          { kind: 'website', available: true },
+          {
+            kind: 'service',
+            available: false,
+            reason: 'the build produces static files and has no start command',
+          },
+          {
+            kind: 'job',
+            available: false,
+            reason: 'jobs are asserted, never inferred',
+          },
+        ],
+        buildCommand: 'bun run build',
+        outputDirectory: 'dist',
+      }),
+    });
+
+    expect(result.outcome).toBe('detected');
+    if (result.outcome !== 'detected') return;
+
+    expect(result.proposal.kind).toBe('website');
+    expect(result.proposal.build).toEqual({
+      frontend: 'dockerfile',
+      dockerfile: 'Dockerfile',
+    });
+    expect(result.proposal.watchPaths).toEqual([
+      '.',
+      'package.json',
+      'bun.lock',
+    ]);
+  });
+
+  test('spindrift.yaml is authoritative and stops the ladder', async () => {
+    let plannerCalls = 0;
+    const result = await detectScope({
+      repositoryRoot: join(FIXTURES, 'authoritative-file'),
+      source: { kind: 'repo', subpath: '.' },
+      planner: {
+        async plan() {
+          plannerCalls += 1;
+          return {
+            outcome: 'detected',
+            kind: 'website',
+            kinds: [{ kind: 'website', available: true }],
+            buildCommand: 'bun run build',
+            outputDirectory: 'dist',
+          };
+        },
+      },
+    });
+
+    expect(plannerCalls).toBe(0);
+    expect(result).toEqual({
+      outcome: 'detected',
+      scope: '.',
+      proposal: {
+        source: 'spindrift-file',
+        kind: 'job',
+        kinds: [
+          {
+            kind: 'job',
+            available: true,
+            reason: 'asserted by spindrift.yaml',
+          },
+        ],
+        build: {
+          frontend: 'railpack',
+          buildCommand: 'bun run report',
+          outputDirectory: null,
+        },
+        watchPaths: ['.', 'shared/reporting'],
+      },
+    });
+  });
+
+  test('classifies only the named monorepo scope', async () => {
+    const plannedDirectories: string[] = [];
+    const result = await detectScope({
+      repositoryRoot: join(FIXTURES, 'named-scope'),
+      source: { kind: 'repo', subpath: 'apps/unknown' },
+      planner: {
+        async plan(directory) {
+          plannedDirectories.push(directory);
+          return {
+            outcome: 'unsupported',
+            detail:
+              'I do not know how to build this; add a Dockerfile or supply a build command.',
+          };
+        },
+      },
+    });
+
+    expect(plannedDirectories).toEqual([
+      join(FIXTURES, 'named-scope/apps/unknown'),
+    ]);
+    expect(result).toEqual({
+      outcome: 'unknown',
+      scope: 'apps/unknown',
+      reason: 'unsupported',
+      detail:
+        'I do not know how to build this; add a Dockerfile or supply a build command.',
+      watchPaths: ['apps/unknown', 'package.json', 'bun.lock'],
+    });
+  });
+
+  test('derives transitive workspace watch paths from manifests', async () => {
+    const result = await detectScope({
+      repositoryRoot: join(FIXTURES, 'workspace-watch'),
+      source: { kind: 'repo', subpath: 'apps/web' },
+      planner: planner({
+        outcome: 'detected',
+        kind: 'service',
+        kinds: [
+          { kind: 'service', available: true },
+          {
+            kind: 'website',
+            available: false,
+            reason: 'the plan has a start command and no static output',
+          },
+        ],
+        buildCommand: 'bun run build',
+        outputDirectory: null,
+      }),
+    });
+
+    expect(result.outcome).toBe('detected');
+    if (result.outcome !== 'detected') return;
+    expect(result.proposal.watchPaths).toEqual([
+      'apps/web',
+      'packages/ui',
+      'packages/tokens',
+      'package.json',
+      'bun.lock',
+      'pnpm-workspace.yaml',
+    ]);
+  });
+
+  test('unwraps an archive once and runs the same classifier without repo state', async () => {
+    const plannedDirectories: string[] = [];
+    const result = await detectScope({
+      repositoryRoot: join(FIXTURES, 'wrapped-archive'),
+      source: { kind: 'archive' },
+      planner: {
+        async plan(directory) {
+          plannedDirectories.push(directory);
+          return {
+            outcome: 'detected',
+            kind: 'website',
+            kinds: [{ kind: 'website', available: true }],
+            buildCommand: null,
+            outputDirectory: '.',
+          };
+        },
+      },
+    });
+
+    expect(plannedDirectories).toEqual([
+      join(FIXTURES, 'wrapped-archive/site'),
+    ]);
+    expect(result).toEqual({
+      outcome: 'detected',
+      scope: '.',
+      proposal: {
+        source: 'railpack',
+        kind: 'website',
+        kinds: [{ kind: 'website', available: true }],
+        build: {
+          frontend: 'railpack',
+          buildCommand: null,
+          outputDirectory: '.',
+        },
+        watchPaths: [],
+      },
+    });
+  });
+
+  test('returns unknown instead of reading foreign build configuration', async () => {
+    const result = await detectScope({
+      repositoryRoot: join(FIXTURES, 'foreign-config'),
+      source: { kind: 'repo', subpath: '.' },
+      planner: planner({
+        outcome: 'unsupported',
+        detail: 'I do not know how to build this.',
+      }),
+    });
+
+    expect(result).toEqual({
+      outcome: 'unknown',
+      scope: '.',
+      reason: 'unsupported',
+      detail: 'I do not know how to build this.',
+      watchPaths: ['.'],
+    });
+  });
+
+  test('rejects a named scope outside the repository root', async () => {
+    let plannerCalls = 0;
+    const detection = detectScope({
+      repositoryRoot: join(FIXTURES, 'named-scope'),
+      source: { kind: 'repo', subpath: '../outside' },
+      planner: {
+        async plan() {
+          plannerCalls += 1;
+          return {
+            outcome: 'unsupported',
+            detail: 'must not run',
+          };
+        },
+      },
+    });
+
+    await expect(detection).rejects.toThrow(
+      'scope must stay inside the repository root',
+    );
+    expect(plannerCalls).toBe(0);
+  });
+
+  test('an invalid authoritative file fails instead of falling through', async () => {
+    let plannerCalls = 0;
+    const detection = detectScope({
+      repositoryRoot: join(FIXTURES, 'invalid-authority'),
+      source: { kind: 'repo', subpath: '.' },
+      planner: {
+        async plan() {
+          plannerCalls += 1;
+          return {
+            outcome: 'unsupported',
+            detail: 'must not run',
+          };
+        },
+      },
+    });
+
+    await expect(detection).rejects.toThrow(
+      'build.file: path must stay inside its scope',
+    );
+    expect(plannerCalls).toBe(0);
+  });
+});

--- a/apps/spindrift/test/fixtures/detection/authoritative-file/package.json
+++ b/apps/spindrift/test/fixtures/detection/authoritative-file/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixture-authoritative-file",
+  "private": true,
+  "scripts": {
+    "report": "bun run report.ts"
+  }
+}

--- a/apps/spindrift/test/fixtures/detection/authoritative-file/spindrift.yaml
+++ b/apps/spindrift/test/fixtures/detection/authoritative-file/spindrift.yaml
@@ -1,0 +1,10 @@
+version: 1
+component:
+  kind: job
+build:
+  frontend: railpack
+  command: bun run report
+  outputDirectory: null
+watchPaths:
+  - .
+  - shared/reporting

--- a/apps/spindrift/test/fixtures/detection/dockerfile-website/Dockerfile
+++ b/apps/spindrift/test/fixtures/detection/dockerfile-website/Dockerfile
@@ -1,0 +1,2 @@
+FROM caddy:alpine
+COPY dist /usr/share/caddy

--- a/apps/spindrift/test/fixtures/detection/dockerfile-website/bun.lock
+++ b/apps/spindrift/test/fixtures/detection/dockerfile-website/bun.lock
@@ -1,0 +1,1 @@
+# Fixture lockfile: its contents do not matter to watch-path derivation.

--- a/apps/spindrift/test/fixtures/detection/dockerfile-website/package.json
+++ b/apps/spindrift/test/fixtures/detection/dockerfile-website/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "fixture-website",
+  "private": true,
+  "scripts": {
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "vite": "latest"
+  }
+}

--- a/apps/spindrift/test/fixtures/detection/foreign-config/build.json
+++ b/apps/spindrift/test/fixtures/detection/foreign-config/build.json
@@ -1,0 +1,4 @@
+{
+  "kind": "website",
+  "build": "this file must never be read"
+}

--- a/apps/spindrift/test/fixtures/detection/invalid-authority/spindrift.yaml
+++ b/apps/spindrift/test/fixtures/detection/invalid-authority/spindrift.yaml
@@ -1,0 +1,8 @@
+version: 1
+component:
+  kind: service
+build:
+  frontend: dockerfile
+  file: ../Dockerfile
+watchPaths:
+  - .

--- a/apps/spindrift/test/fixtures/detection/named-scope/apps/known/spindrift.yaml
+++ b/apps/spindrift/test/fixtures/detection/named-scope/apps/known/spindrift.yaml
@@ -1,0 +1,8 @@
+version: 1
+component:
+  kind: service
+build:
+  frontend: dockerfile
+  file: Dockerfile
+watchPaths:
+  - apps/known

--- a/apps/spindrift/test/fixtures/detection/named-scope/apps/unknown/main.xyz
+++ b/apps/spindrift/test/fixtures/detection/named-scope/apps/unknown/main.xyz
@@ -1,0 +1,1 @@
+This deliberately unsupported source proves the sibling is never classified.

--- a/apps/spindrift/test/fixtures/detection/named-scope/bun.lock
+++ b/apps/spindrift/test/fixtures/detection/named-scope/bun.lock
@@ -1,0 +1,1 @@
+# Fixture lockfile.

--- a/apps/spindrift/test/fixtures/detection/named-scope/package.json
+++ b/apps/spindrift/test/fixtures/detection/named-scope/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "fixture-monorepo",
+  "private": true,
+  "workspaces": [
+    "apps/*"
+  ]
+}

--- a/apps/spindrift/test/fixtures/detection/workspace-watch/apps/web/package.json
+++ b/apps/spindrift/test/fixtures/detection/workspace-watch/apps/web/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/web",
+  "private": true,
+  "dependencies": {
+    "@fixture/ui": "workspace:*"
+  }
+}

--- a/apps/spindrift/test/fixtures/detection/workspace-watch/bun.lock
+++ b/apps/spindrift/test/fixtures/detection/workspace-watch/bun.lock
@@ -1,0 +1,1 @@
+# Fixture lockfile.

--- a/apps/spindrift/test/fixtures/detection/workspace-watch/package.json
+++ b/apps/spindrift/test/fixtures/detection/workspace-watch/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "fixture-workspace",
+  "private": true
+}

--- a/apps/spindrift/test/fixtures/detection/workspace-watch/packages/tokens/package.json
+++ b/apps/spindrift/test/fixtures/detection/workspace-watch/packages/tokens/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixture/tokens",
+  "private": true
+}

--- a/apps/spindrift/test/fixtures/detection/workspace-watch/packages/ui/package.json
+++ b/apps/spindrift/test/fixtures/detection/workspace-watch/packages/ui/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/ui",
+  "private": true,
+  "dependencies": {
+    "@fixture/tokens": "workspace:*"
+  }
+}

--- a/apps/spindrift/test/fixtures/detection/workspace-watch/packages/unrelated/package.json
+++ b/apps/spindrift/test/fixtures/detection/workspace-watch/packages/unrelated/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@fixture/unrelated",
+  "private": true
+}

--- a/apps/spindrift/test/fixtures/detection/workspace-watch/pnpm-workspace.yaml
+++ b/apps/spindrift/test/fixtures/detection/workspace-watch/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - packages/*

--- a/apps/spindrift/test/fixtures/detection/wrapped-archive/site/index.html
+++ b/apps/spindrift/test/fixtures/detection/wrapped-archive/site/index.html
@@ -1,0 +1,2 @@
+<!doctype html>
+<title>Finished artifact</title>

--- a/apps/spindrift/test/fixtures/detection/wrapped-archive/site/spindrift.yaml
+++ b/apps/spindrift/test/fixtures/detection/wrapped-archive/site/spindrift.yaml
@@ -1,0 +1,1 @@
+This file is deliberately invalid: archive inputs do not carry repo authority.


### PR DESCRIPTION
## Summary

Implement Spindrift Task 22 as one bounded build-pipeline slice: classify one
named repository or archive scope into an honest Component proposal.

## Changes

- add the Railpack-facing detection ladder and authoritative `spindrift.yaml`
  boundary
- keep Component-kind inference independent from Dockerfile frontend selection
- derive transitive package and pnpm workspace watch paths
- safely contain named scopes, unwrap archives once, and return unsupported
  stacks as data
- cover the behavior with repository and archive fixtures

## Test Plan

- [x] `mise run ts:check`
- [x] `bun test apps/spindrift/test/domain/detection.test.ts apps/spindrift/test/extraction/no-literals.test.ts`
- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test` (509 passed)
- [x] standards and Task 22 spec reviews have no material findings
