### PR TITLE
fix(ci): prune test fixture dirs from container detection

### DIFF
--- a/.github/scripts/detect-containers.sh
+++ b/.github/scripts/detect-containers.sh
@@ -57,7 +57,10 @@ path_changed() {
 includes='[]'
 declare -A unclassified
 
-mapfile -t dockerfiles < <(find apps images -name "Dockerfile" | sort)
+# Prune `fixtures` directories: test fixtures (e.g. apps/<x>/test/fixtures/...)
+# contain Dockerfiles that are inputs to a project's own tests, not buildable
+# images owned by this workflow.
+mapfile -t dockerfiles < <(find apps images -path '*/fixtures' -prune -o -name "Dockerfile" -print | sort)
 
 for dockerfile in "${dockerfiles[@]}"; do
   dir=$(dirname "$dockerfile")


### PR DESCRIPTION
## Summary
Prune `fixtures` directories from the container-detection `find`, so test-fixture Dockerfiles don't get classified as images that must be listed in `.github/containers.json`.

## Changes
- fix(ci): prune test fixture dirs from container detection

## Background
`detect-containers.sh` ran `find apps images -name "Dockerfile"`, which descended into `apps/spindrift/test/fixtures/detection/dockerfile-website/` — a fixture for spindrift's own source-detection tests. The fixture dir's basename (`dockerfile-website`) was treated as an image name and failed the allowlist check:

```
error: Dockerfile image(s) missing from .github/containers.json — add each to "build" or "ignore":
  - dockerfile-website
```

These are not buildable images owned by the containers workflow — adding them to `ignore` would be wrong ("intentionally not published" mischaracterizes test inputs) and would grow with every future fixture.

## Test Plan
- [ ] `containers` workflow job (the failing one) re-runs green: https://github.com/jonpulsifer/infra/actions/runs/30317868748/job/90148591675
- [ ] All nine real images still detected: `actions-runner, ai-agents, atlantis, ddnsd, hub, netbench, rackstat, slingshot, spindrift`
- [ ] With a `*/fixtures/*/` Dockerfile present, detection produces no unclassified-image error
