### PR TITLE
fix(spindrift): bump image digest

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -24,7 +24,7 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:613eb3be2955952e6082f1d451ee34ad854e14fc2376f43eb8e621bc129a3dc7
+    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:318eeb3c90bf491f81fc2f7577c595af6eb36765983e409b37f1985a33625e33
     # Substituted by the apps Kustomization from the cluster-secrets Secret, so
     # the zone is read rather than restated. external-dns publishes the record
     # from the HTTPRoute and cert-manager issues the certificate, so this line


### PR DESCRIPTION
## Summary
Bump the spindrift web image digest to the latest published `:latest` (built from `cf0fa58d`, PR #1282 — "detect source scopes"). Renovate's existing digest rules own future bumps; this one is manual because Renovate's pin (#1281) landed against PR #1280's image, before #1282 published a new one.

## Changes
- fix(spindrift): bump image digest ( 613eb3be → 318eeb3c )

## Test Plan
- [ ] `kustomize render` passes (ran locally via `mise run k8s:render-apps`)
- [ ] After merge, `flux --context offsite reconcile helmrelease spindrift -n spindrift --with-source` picks up the new digest
- [ ] New spindrift pod rolls out successfully on offsite
