### PR TITLE
feat(spindrift): stage source bundles with signed receipts

### DIFF
--- a/apps/spindrift/src/domain/source-bundle.ts
+++ b/apps/spindrift/src/domain/source-bundle.ts
@@ -1,0 +1,233 @@
+/**
+ * Stage one immutable source bundle before any build route sees it (§15).
+ *
+ * Repository and archive sources converge here. Core fetches an exact commit
+ * once or accepts uploaded bytes, digests those bytes, stores them through a
+ * content-addressed immutable depot, and signs the same source-receipt
+ * predicate for both. The only deliberate storage difference is retention:
+ * repository bundles are ephemeral and uploaded archives are durable.
+ *
+ * The Git credential is scoped to {@link ExactCommitFetcher.fetchExactCommit}.
+ * It appears in no staged or signed type, which makes "store no token" a
+ * structural property instead of a cleanup step.
+ */
+
+import type { Principal } from '../commands/types.ts';
+import {
+  type ReceiptSigner,
+  type SignedSourceReceipt,
+  type SourcePrincipal,
+  type SourceReceiptStore,
+  signSourceReceipt,
+  sourceReceiptStatement,
+} from '../supply-chain/receipt.ts';
+
+export type BundleRetention = 'ephemeral' | 'durable';
+
+/** A content-addressed bundle that every builder can fetch. */
+export interface StagedSourceBundle {
+  readonly digest: string;
+  readonly location: string;
+  readonly retention: BundleRetention;
+}
+
+/** The only result this seam exposes; credentials cannot fit in it. */
+export interface StagedSource {
+  readonly bundle: StagedSourceBundle;
+  readonly receipt: SignedSourceReceipt;
+  /** Durable address of the signed evidence, keyed by the bundle digest. */
+  readonly receiptLocation: string;
+}
+
+/**
+ * What the Git integration returns from one exact-revision fetch.
+ *
+ * Feature flags are facts learned while producing the archive. Core refuses
+ * them before storage because v1 cannot reproduce a submodule or LFS checkout
+ * from the single immutable bundle it promises builders.
+ */
+export interface FetchedCommit {
+  readonly bytes: Uint8Array;
+  readonly resolvedCommit: string;
+  readonly hasSubmodules: boolean;
+  readonly hasGitLfs: boolean;
+  /**
+   * Identity authenticated by the repository client that performed the fetch.
+   * It comes back from the trusted integration instead of being asserted by the
+   * caller asking core to stage a commit.
+   */
+  readonly principal: Extract<SourcePrincipal, { kind: 'githubApp' }>;
+}
+
+/** Far-side repository client. `Credential` remains opaque to core. */
+export interface ExactCommitFetcher<Credential> {
+  fetchExactCommit(input: {
+    readonly repository: string;
+    readonly commit: string;
+    readonly credential: Credential;
+  }): Promise<FetchedCommit>;
+}
+
+/**
+ * Immutable object storage behind source staging.
+ *
+ * The digest is computed by core and handed to the depot with the bytes. A
+ * production depot may reuse an object already present at that digest, but it
+ * must never replace its bytes.
+ */
+export interface BundleDepot {
+  putImmutable(input: {
+    readonly bytes: Uint8Array;
+    readonly digest: string;
+    readonly retention: BundleRetention;
+  }): Promise<{ readonly location: string }>;
+}
+
+export type SourceBundleInput<Credential> =
+  | {
+      readonly kind: 'git';
+      readonly repository: string;
+      readonly commit: string;
+      readonly credential: Credential;
+    }
+  | {
+      readonly kind: 'upload';
+      readonly bytes: Uint8Array;
+      readonly name: string;
+      /**
+       * The application principal established by the session boundary, not a
+       * receipt-shaped identity a caller may fill with an arbitrary subject.
+       */
+      readonly principal: Principal;
+    };
+
+export type SourceBundleErrorCode =
+  | 'FETCHED_COMMIT_MISMATCH'
+  | 'GIT_SUBMODULES_UNSUPPORTED'
+  | 'GIT_LFS_UNSUPPORTED';
+
+/** A closed, user-readable refusal from source staging. */
+export class SourceBundleError extends Error {
+  constructor(
+    readonly code: SourceBundleErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SourceBundleError';
+  }
+}
+
+export interface SourceBundleDeps<Credential> {
+  readonly fetcher: ExactCommitFetcher<Credential>;
+  readonly depot: BundleDepot;
+  readonly signer: ReceiptSigner;
+  readonly receipts: SourceReceiptStore;
+}
+
+/**
+ * Fetch/upload → digest → immutable store → signed receipt.
+ *
+ * The sequence matters. Unsupported or incorrectly resolved Git input is
+ * refused before storage, and a receipt is signed only after the depot accepted
+ * the exact bytes its digest names.
+ */
+export async function stageSourceBundle<Credential>(
+  input: SourceBundleInput<Credential>,
+  deps: SourceBundleDeps<Credential>,
+  stagedAt: Date,
+): Promise<StagedSource> {
+  const prepared =
+    input.kind === 'git'
+      ? await prepareGitBundle(input, deps.fetcher)
+      : {
+          bytes: input.bytes,
+          retention: 'durable' as const,
+          source: { kind: 'upload' as const, name: input.name },
+          principal: {
+            kind: 'user' as const,
+            subject: input.principal.id,
+          },
+        };
+
+  // One owned snapshot feeds both digest and storage. Without it, an upload
+  // buffer mutated while WebCrypto was running could be stored under the
+  // digest of the bytes that existed a moment earlier.
+  const bytes = Uint8Array.from(prepared.bytes);
+  const digest = await sha256(bytes);
+  const stored = await deps.depot.putImmutable({
+    bytes,
+    digest,
+    retention: prepared.retention,
+  });
+  const statement = sourceReceiptStatement({
+    bundleDigest: digest,
+    source: prepared.source,
+    principal: prepared.principal,
+    stagedAt,
+  });
+  const receipt = await signSourceReceipt(statement, deps.signer);
+  const recorded = await deps.receipts.putImmutable(receipt);
+
+  return {
+    bundle: {
+      digest,
+      location: stored.location,
+      retention: prepared.retention,
+    },
+    receipt,
+    receiptLocation: recorded.location,
+  };
+}
+
+async function prepareGitBundle<Credential>(
+  input: Extract<SourceBundleInput<Credential>, { kind: 'git' }>,
+  fetcher: ExactCommitFetcher<Credential>,
+) {
+  // Exactly one fetch. The returned revision is checked rather than assuming a
+  // client did not resolve a branch or tag after core asked for a commit.
+  const fetched = await fetcher.fetchExactCommit({
+    repository: input.repository,
+    commit: input.commit,
+    credential: input.credential,
+  });
+
+  if (fetched.resolvedCommit !== input.commit) {
+    throw new SourceBundleError(
+      'FETCHED_COMMIT_MISMATCH',
+      `the repository returned ${fetched.resolvedCommit} instead of requested commit ${input.commit}`,
+    );
+  }
+  if (fetched.hasSubmodules) {
+    throw new SourceBundleError(
+      'GIT_SUBMODULES_UNSUPPORTED',
+      'Git submodules are not supported in v1',
+    );
+  }
+  if (fetched.hasGitLfs) {
+    throw new SourceBundleError(
+      'GIT_LFS_UNSUPPORTED',
+      'Git LFS is not supported in v1',
+    );
+  }
+
+  return {
+    bytes: fetched.bytes,
+    retention: 'ephemeral' as const,
+    source: {
+      kind: 'git' as const,
+      repository: input.repository,
+      commit: fetched.resolvedCommit,
+    },
+    principal: fetched.principal,
+  };
+}
+
+async function sha256(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  const hash = new Uint8Array(
+    await crypto.subtle.digest('SHA-256', bytes.buffer),
+  );
+  const hex = Array.from(hash, (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+  return `sha256:${hex}`;
+}

--- a/apps/spindrift/src/supply-chain/receipt.ts
+++ b/apps/spindrift/src/supply-chain/receipt.ts
@@ -1,0 +1,182 @@
+/**
+ * The signed source receipt (§16).
+ *
+ * A build backend can prove what it did with a staged bundle, but only
+ * Spindrift saw where that bundle came from. This statement closes that gap:
+ * its subject is the content digest every build route must echo, and its
+ * predicate names the source and the authenticated principal that supplied it.
+ *
+ * Git and upload deliberately share this one statement. They differ only in
+ * the source and principal variants; neither gets a weaker custody path.
+ */
+import type { BuildProvenance } from '../adapters/build/contract.ts';
+
+/** Who authenticated the act that supplied this bundle. */
+export type SourcePrincipal =
+  | {
+      readonly kind: 'githubApp';
+      /** Stable GitHub App installation identity, not a short-lived token. */
+      readonly subject: string;
+    }
+  | {
+      readonly kind: 'user';
+      /** The enrolled Spindrift user id, not their mutable display name. */
+      readonly subject: string;
+    };
+
+/** The origin Spindrift attests was staged. */
+export type ReceiptSource =
+  | {
+      readonly kind: 'git';
+      readonly repository: string;
+      /** The exact revision returned by the fetcher. */
+      readonly commit: string;
+    }
+  | {
+      readonly kind: 'upload';
+      /** An audit label only; identity is the digest in the statement subject. */
+      readonly name: string;
+    };
+
+/**
+ * One predicate for both source paths.
+ *
+ * The fixed field order is intentional. {@link sourceReceiptBytes} reconstructs
+ * this shape before signing so callers cannot change the signed bytes merely by
+ * constructing an equivalent object in a different insertion order.
+ */
+export interface SourceReceiptStatement {
+  readonly version: 1;
+  readonly subject: {
+    readonly name: 'sourceBundle';
+    /** `sha256:<hex>`, identical to `BuildSource.bundleDigest`. */
+    readonly digest: string;
+  };
+  readonly predicate: {
+    readonly source: ReceiptSource;
+    readonly principal: SourcePrincipal;
+    readonly stagedAt: string;
+  };
+}
+
+/** What signs statements; Task 26 supplies the production implementation. */
+export interface ReceiptSigner {
+  sign(payload: Uint8Array): Promise<ReceiptSignature>;
+}
+
+/**
+ * Opaque signature metadata returned by the signer.
+ *
+ * Core records it but does not invent an algorithm or key id. Those belong to
+ * the configured signing service and rotate independently of this predicate.
+ */
+export interface ReceiptSignature {
+  readonly keyId: string;
+  readonly algorithm: string;
+  readonly value: string;
+}
+
+export interface SignedSourceReceipt {
+  readonly statement: SourceReceiptStatement;
+  readonly signature: ReceiptSignature;
+}
+
+/**
+ * Durable evidence storage.
+ *
+ * A receipt that exists only in the staging process closes no custody gap after
+ * a restart. Implementations key the immutable object by
+ * `receipt.statement.subject.digest`; returning its location lets the caller
+ * retain a reference without duplicating the signed document in the database.
+ */
+export interface SourceReceiptStore {
+  putImmutable(
+    receipt: SignedSourceReceipt,
+  ): Promise<{ readonly location: string }>;
+}
+
+/** Build one statement using the only field order the signer accepts. */
+export function sourceReceiptStatement(input: {
+  readonly bundleDigest: string;
+  readonly source: ReceiptSource;
+  readonly principal: SourcePrincipal;
+  readonly stagedAt: Date;
+}): SourceReceiptStatement {
+  return {
+    version: 1,
+    subject: {
+      name: 'sourceBundle',
+      digest: input.bundleDigest,
+    },
+    predicate: {
+      source: canonicalSource(input.source),
+      principal: canonicalPrincipal(input.principal),
+      stagedAt: input.stagedAt.toISOString(),
+    },
+  };
+}
+
+/**
+ * Stable bytes for a source receipt signature.
+ *
+ * This is deliberately a narrow canonicalizer, not a generic canonical JSON
+ * implementation: the statement is closed, shallow, and rebuilt field by
+ * field. Adding a signed field therefore requires changing this function in
+ * the same review as the type.
+ */
+export function sourceReceiptBytes(
+  statement: SourceReceiptStatement,
+): Uint8Array {
+  return new TextEncoder().encode(
+    JSON.stringify({
+      version: statement.version,
+      subject: {
+        name: statement.subject.name,
+        digest: statement.subject.digest,
+      },
+      predicate: {
+        source: canonicalSource(statement.predicate.source),
+        principal: canonicalPrincipal(statement.predicate.principal),
+        stagedAt: statement.predicate.stagedAt,
+      },
+    }),
+  );
+}
+
+export async function signSourceReceipt(
+  statement: SourceReceiptStatement,
+  signer: ReceiptSigner,
+): Promise<SignedSourceReceipt> {
+  return {
+    statement,
+    signature: await signer.sign(sourceReceiptBytes(statement)),
+  };
+}
+
+/**
+ * §16's required correlation: the source receipt and backend provenance join
+ * on the digest of the immutable bundle, with no inference from repo metadata.
+ */
+export function receiptJoinsProvenance(
+  receipt: SignedSourceReceipt,
+  provenance: BuildProvenance,
+): boolean {
+  return receipt.statement.subject.digest === provenance.bundleDigest;
+}
+
+function canonicalSource(source: ReceiptSource): ReceiptSource {
+  return source.kind === 'git'
+    ? {
+        kind: 'git',
+        repository: source.repository,
+        commit: source.commit,
+      }
+    : { kind: 'upload', name: source.name };
+}
+
+function canonicalPrincipal(principal: SourcePrincipal): SourcePrincipal {
+  return {
+    kind: principal.kind,
+    subject: principal.subject,
+  };
+}

--- a/apps/spindrift/test/domain/source-bundle.test.ts
+++ b/apps/spindrift/test/domain/source-bundle.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Source custody at the seam between repository integration and every builder
+ * (Task 23).
+ *
+ * These tests fake the two far sides — the repository and the immutable bundle
+ * depot — while exercising core's real digesting, receipt construction, and
+ * signing. That makes "fetch once", "store no token", and the provenance join
+ * observable without choosing GitHub or GCS clients ahead of their tickets.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { BuildProvenance } from '../../src/adapters/build/contract.ts';
+import {
+  type BundleDepot,
+  type ExactCommitFetcher,
+  SourceBundleError,
+  stageSourceBundle,
+} from '../../src/domain/source-bundle.ts';
+import {
+  type ReceiptSigner,
+  receiptJoinsProvenance,
+  type SourceReceiptStore,
+} from '../../src/supply-chain/receipt.ts';
+
+const COMMIT = '0123456789abcdef0123456789abcdef01234567';
+const BYTES = new TextEncoder().encode('the exact source bundle');
+const DIGEST =
+  'sha256:20c50fe07e8995fc04d396f4e4b0eeddd221d86e33be9726a17e42f6429d7f95';
+
+function harness(options?: {
+  resolvedCommit?: string;
+  hasSubmodules?: boolean;
+  hasGitLfs?: boolean;
+}) {
+  const fetches: unknown[] = [];
+  const puts: unknown[] = [];
+  const signedPayloads: Uint8Array[] = [];
+  const storedReceipts: unknown[] = [];
+
+  const fetcher: ExactCommitFetcher<{ readonly token: string }> = {
+    async fetchExactCommit(input) {
+      fetches.push(input);
+      return {
+        bytes: BYTES,
+        resolvedCommit: options?.resolvedCommit ?? input.commit,
+        hasSubmodules: options?.hasSubmodules ?? false,
+        hasGitLfs: options?.hasGitLfs ?? false,
+        principal: {
+          kind: 'githubApp',
+          subject: 'installation:42',
+        },
+      };
+    },
+  };
+
+  const depot: BundleDepot = {
+    async putImmutable(input) {
+      puts.push(input);
+      return { location: `bundles/${input.digest}.tar` };
+    },
+  };
+
+  const signer: ReceiptSigner = {
+    async sign(payload) {
+      signedPayloads.push(payload);
+      return {
+        keyId: 'test-source-receipt',
+        algorithm: 'test',
+        value: 'signed',
+      };
+    },
+  };
+
+  const receipts: SourceReceiptStore = {
+    async putImmutable(receipt) {
+      storedReceipts.push(receipt);
+      return {
+        location: `receipts/${receipt.statement.subject.digest}.json`,
+      };
+    },
+  };
+
+  return {
+    fetcher,
+    depot,
+    signer,
+    receipts,
+    fetches,
+    puts,
+    signedPayloads,
+    storedReceipts,
+  };
+}
+
+describe('repository bundle staging', () => {
+  test('fetches the exact commit once and stages an ephemeral immutable bundle', async () => {
+    const farSide = harness();
+    const credential = { token: 'never-store-this' };
+
+    const result = await stageSourceBundle(
+      {
+        kind: 'git',
+        repository: 'https://example.test/owner/repo',
+        commit: COMMIT,
+        credential,
+      },
+      farSide,
+      new Date('2026-07-28T12:00:00.000Z'),
+    );
+
+    expect(farSide.fetches).toHaveLength(1);
+    expect(farSide.fetches[0]).toEqual({
+      repository: 'https://example.test/owner/repo',
+      commit: COMMIT,
+      credential,
+    });
+    expect(farSide.puts).toEqual([
+      {
+        bytes: BYTES,
+        digest: DIGEST,
+        retention: 'ephemeral',
+      },
+    ]);
+    expect((farSide.puts[0] as { bytes: Uint8Array }).bytes).not.toBe(BYTES);
+    expect(result.bundle).toEqual({
+      digest: DIGEST,
+      location: `bundles/${DIGEST}.tar`,
+      retention: 'ephemeral',
+    });
+    expect(result.receiptLocation).toBe(`receipts/${DIGEST}.json`);
+    expect(result.receipt.statement.predicate.source).toEqual({
+      kind: 'git',
+      repository: 'https://example.test/owner/repo',
+      commit: COMMIT,
+    });
+    expect(result.receipt.statement.predicate.principal).toEqual({
+      kind: 'githubApp',
+      subject: 'installation:42',
+    });
+    expect(farSide.storedReceipts).toEqual([result.receipt]);
+
+    // The fetch credential reaches only the fetcher. Neither the result nor the
+    // bytes handed to the signer retain it.
+    expect(JSON.stringify(result)).not.toContain(credential.token);
+    expect(new TextDecoder().decode(farSide.signedPayloads[0])).not.toContain(
+      credential.token,
+    );
+  });
+
+  test.each([
+    ['submodules', { hasSubmodules: true }, 'GIT_SUBMODULES_UNSUPPORTED'],
+    ['Git LFS', { hasGitLfs: true }, 'GIT_LFS_UNSUPPORTED'],
+  ] as const)(
+    'refuses %s explicitly before staging',
+    async (_name, flags, code) => {
+      const farSide = harness(flags);
+
+      const staged = stageSourceBundle(
+        {
+          kind: 'git',
+          repository: 'https://example.test/owner/repo',
+          commit: COMMIT,
+          credential: { token: 'temporary' },
+        },
+        farSide,
+        new Date(),
+      );
+
+      await expect(staged).rejects.toMatchObject({ code });
+      expect(farSide.fetches).toHaveLength(1);
+      expect(farSide.puts).toHaveLength(0);
+      expect(farSide.signedPayloads).toHaveLength(0);
+      expect(farSide.storedReceipts).toHaveLength(0);
+    },
+  );
+
+  test('refuses a fetcher that returns a different revision', async () => {
+    const farSide = harness({
+      resolvedCommit: 'ffffffffffffffffffffffffffffffffffffffff',
+    });
+
+    const staged = stageSourceBundle(
+      {
+        kind: 'git',
+        repository: 'https://example.test/owner/repo',
+        commit: COMMIT,
+        credential: { token: 'temporary' },
+      },
+      farSide,
+      new Date(),
+    );
+
+    await expect(staged).rejects.toBeInstanceOf(SourceBundleError);
+    await expect(staged).rejects.toMatchObject({
+      code: 'FETCHED_COMMIT_MISMATCH',
+    });
+    expect(farSide.puts).toHaveLength(0);
+    expect(farSide.storedReceipts).toHaveLength(0);
+  });
+});
+
+describe('archive bundle staging', () => {
+  test('stages uploads durably under the same receipt predicate', async () => {
+    const farSide = harness();
+
+    const result = await stageSourceBundle(
+      {
+        kind: 'upload',
+        bytes: BYTES,
+        name: 'site.zip',
+        principal: { id: 'user-7', displayName: 'Operator' },
+      },
+      farSide,
+      new Date('2026-07-28T12:00:00.000Z'),
+    );
+
+    expect(farSide.fetches).toHaveLength(0);
+    expect(farSide.puts).toEqual([
+      { bytes: BYTES, digest: DIGEST, retention: 'durable' },
+    ]);
+    expect(result.receipt.statement.predicate).toEqual({
+      source: { kind: 'upload', name: 'site.zip' },
+      principal: { kind: 'user', subject: 'user-7' },
+      stagedAt: '2026-07-28T12:00:00.000Z',
+    });
+  });
+
+  test('the signed receipt joins the build provenance on the bundle digest', async () => {
+    const farSide = harness();
+    const staged = await stageSourceBundle(
+      {
+        kind: 'upload',
+        bytes: BYTES,
+        name: 'source.zip',
+        principal: { id: 'user-7', displayName: 'Operator' },
+      },
+      farSide,
+      new Date(),
+    );
+    const provenance: BuildProvenance = {
+      bundleDigest: staged.bundle.digest,
+      claimedLevel: 2,
+      statement: { builder: 'far-side' },
+    };
+
+    expect(receiptJoinsProvenance(staged.receipt, provenance)).toBe(true);
+    expect(
+      receiptJoinsProvenance(staged.receipt, {
+        ...provenance,
+        bundleDigest: `sha256:${'0'.repeat(64)}`,
+      }),
+    ).toBe(false);
+    expect(staged.receipt.statement.subject.digest).toBe(
+      provenance.bundleDigest,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Implement Spindrift Task 23 as a bounded source-custody seam: exact Git commits and uploaded archives become immutable content-addressed bundles with durable signed source receipts.

## Changes

- Fetch an exact repository commit once, reject Git submodules and Git LFS, and keep fetch credentials out of staged and signed values.
- Stage repository bundles ephemerally and uploaded archives durably under a SHA-256 digest.
- Derive receipt actors from the authenticated Git fetch or Spindrift user principal, sign a canonical predicate, and persist it immutably by bundle digest.
- Test digest/provenance correlation, retention, authentication attribution, credential non-retention, immutable storage, and explicit refusals.

## Test Plan

- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:25432/spindrift bun test` — 482 passed
- [x] `mise run ts:check`
- [x] `git diff --check`

## Context

Task 23 in `.agent/plans/spindrift/plan.md` (private local tracker).
