### PR TITLE
feat(spindrift): connect repositories through the GitHub App

### DIFF
--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -24,6 +24,9 @@
 import type { AdapterRegistry } from '../commands/types.ts';
 import type { StoreAdapter, TargetAdapter } from '../config/manifest.schema.ts';
 import type { InstallationManifest } from '../config/manifest.ts';
+import type { RepositoryHost } from '../domain/repository.ts';
+import { GitHubApp } from '../integrations/github/app.ts';
+import type { Fetcher } from '../integrations/github/http.ts';
 import type { BuildAdapter } from './build/contract.ts';
 import type { DeployAdapter } from './deploy/contract.ts';
 import type { TokenProvider } from './deploy/kubernetes/api.ts';
@@ -62,10 +65,27 @@ export function projectedServiceAccountToken(
   };
 }
 
+/**
+ * Where the GitHub App's private key is read from (§15: "bootstrapped from a
+ * SOPS Secret").
+ *
+ * An environment variable rather than a manifest key, and the split is the one
+ * §20 already draws: the manifest is non-secret installation configuration and
+ * is rendered into a ConfigMap, while this is the one long-lived credential
+ * this integration has. An installation without it simply has no repository
+ * integration — which is a supported installation, because §2's other source is
+ * an uploaded archive.
+ */
+export const GITHUB_APP_KEY_VAR = 'SPINDRIFT_GITHUB_APP_KEY';
+
 export interface RegistryOptions {
   readonly manifest: InstallationManifest;
   /** Injected so a test can stand a fake far side behind the real client. */
   readonly token?: TokenProvider;
+  /** Injected for the same reason, for the repository host's transport. */
+  readonly fetch?: Fetcher;
+  /** Defaults to the process environment; a test passes its own. */
+  readonly env?: Record<string, string | undefined>;
 }
 
 /**
@@ -82,6 +102,19 @@ export function createAdapterRegistry(
     chart: options.manifest.charts.app,
     token: options.token ?? projectedServiceAccountToken(),
   });
+
+  // §15's repository host, when this installation was given the App key. Built
+  // once: it caches the imported signing key and one installation token per
+  // installation, and a per-request instance would mint a JWT per call.
+  const appKey = (options.env ?? Bun.env)[GITHUB_APP_KEY_VAR]?.trim();
+  const repositoryHost: RepositoryHost | null = appKey
+    ? new GitHubApp({
+        appId: options.manifest.github.appId,
+        privateKeyPem: appKey,
+        baseUrl: options.manifest.github.apiBaseUrl,
+        ...(options.fetch ? { fetch: options.fetch } : {}),
+      })
+    : null;
 
   const deployAdapters: Partial<Record<TargetAdapter, DeployAdapter>> = {
     kubernetes,
@@ -125,6 +158,18 @@ export function createAdapterRegistry(
         `this installation selected the ${options.manifest.secretStore.adapter satisfies StoreAdapter} store, ` +
           'but no endpoint is configured for it — config delivery is not built yet',
       );
+    },
+
+    /**
+     * §15's repository host, or `null` when no App key was supplied.
+     *
+     * `null` rather than a throw, following the same rule the other lookups
+     * do: an installation with no repository integration is a configuration
+     * fact, and `connectRepository` reports it as a refusal an operator can
+     * act on.
+     */
+    repository(): RepositoryHost | null {
+      return repositoryHost;
     },
   };
 }

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -22,5 +22,6 @@ export { createComponent } from './components/create.ts';
 export { createApp } from './create-app.ts';
 export { createDeploy } from './deploys/create.ts';
 export { rollbackDeploy } from './deploys/rollback.ts';
+export { connectRepository } from './repositories/connect.ts';
 export { connectTarget } from './targets/connect.ts';
 export { disconnectTarget } from './targets/disconnect.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -40,6 +40,10 @@ import { createApp, createAppInput } from './create-app.ts';
 import { createDeploy, createDeployInput } from './deploys/create.ts';
 import { rollbackDeploy, rollbackDeployInput } from './deploys/rollback.ts';
 import type * as commands from './index.ts';
+import {
+  connectRepository,
+  connectRepositoryInput,
+} from './repositories/connect.ts';
 import { connectTarget, connectTargetInput } from './targets/connect.ts';
 import {
   disconnectTarget,
@@ -71,6 +75,10 @@ export const commandRegistry = {
   dispatchBuild: { input: dispatchBuildInput, handler: dispatchBuild },
   createDeploy: { input: createDeployInput, handler: createDeploy },
   rollbackDeploy: { input: rollbackDeployInput, handler: rollbackDeploy },
+  connectRepository: {
+    input: connectRepositoryInput,
+    handler: connectRepository,
+  },
   connectTarget: { input: connectTargetInput, handler: connectTarget },
   disconnectTarget: {
     input: disconnectTargetInput,

--- a/apps/spindrift/src/commands/repositories/connect.ts
+++ b/apps/spindrift/src/commands/repositories/connect.ts
@@ -1,0 +1,205 @@
+/**
+ * `connectRepository` — turn on Git integration for one repository (§15).
+ *
+ * §15 makes this act one thing an operator reviews: "**One human-editable
+ * configuration PR per repository is the transaction**." So the command writes
+ * one `repositories` row, opens one pull request, and stops. In particular it
+ * **adopts nothing** — `authoritativeCommit` stays null until the repo loop
+ * reads a default-branch commit, which is what makes user story 19 ("only the
+ * default-branch merge becomes authoritative") a property of the schema rather
+ * than of anybody's discipline. The result says so out loud.
+ *
+ * Connecting twice is the same act twice. The row is keyed on the repository's
+ * full name and re-adopted rather than duplicated, and the configuration branch
+ * is force-updated to the newly composed transaction — a second connection is
+ * somebody correcting the first, and leaving the old branch in place would
+ * leave them reviewing a pull request that no longer says what Spindrift
+ * thinks.
+ */
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { repositories } from '../../db/schema.ts';
+import { repositoryRefOf } from '../../domain/repository.ts';
+import {
+  type ConfigurationScope,
+  configurationTransaction,
+  openConfigurationPullRequest,
+} from '../../integrations/github/config-pr.ts';
+import { GitHubAccessError } from '../../integrations/github/http.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+/** `owner/name` — the only handle the repository API takes. */
+const fullName = z
+  .string()
+  .trim()
+  .regex(/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/, 'must be owner/name');
+
+/** §5's named scope: a repo-relative directory, `.` for the root. */
+const scopePath = z
+  .string()
+  .trim()
+  .min(1)
+  .refine(
+    (value) => !value.startsWith('/') && !value.split(/[\\/]/).includes('..'),
+    'must stay inside the repository',
+  );
+
+/** §2: "kind = service | website | job". */
+const componentKind = z.enum(['service', 'website', 'job']);
+
+const kindOption = z.object({
+  kind: componentKind,
+  available: z.boolean(),
+  reason: z.string().optional(),
+});
+
+/**
+ * The build half of a detection proposal, mirrored for untrusted input.
+ *
+ * §5's `DetectionProposal` is the authority on this shape; this is the gate that
+ * lets a browser hand one over. The two are kept in step by
+ * `configurationTransaction` taking the *domain* type — a drift between them is
+ * a compile error at the call below, not a runtime surprise.
+ */
+const proposalBuild = z.discriminatedUnion('frontend', [
+  z.object({
+    frontend: z.literal('dockerfile'),
+    dockerfile: scopePath,
+  }),
+  z.object({
+    frontend: z.literal('railpack'),
+    buildCommand: z.string().min(1).nullable(),
+    outputDirectory: z.string().min(1).nullable(),
+  }),
+]);
+
+const proposal = z.object({
+  source: z.enum(['railpack', 'spindrift-file']),
+  kind: componentKind,
+  kinds: z.array(kindOption),
+  build: proposalBuild,
+  watchPaths: z.array(scopePath).min(1),
+});
+
+export const connectRepositoryInput = z
+  .object({
+    fullName,
+    /** The App installation this repository is reached through. */
+    installationId: z.string().trim().min(1),
+    /** One entry per App subpath the transaction will carry (§5, §15). */
+    scopes: z
+      .array(z.object({ scope: scopePath, proposal }))
+      .min(1, 'a configuration pull request needs at least one scope'),
+  })
+  .strict();
+
+/**
+ * The domain shape, not `z.infer` of the schema above.
+ *
+ * The schema is the gate untrusted input passes through; the *type* is what the
+ * command layer works in, and it is `ConfigurationScope` — §5's own
+ * `DetectionProposal` — so that composing the transaction is a plain call
+ * rather than a cast. A drift between the two is a compile error at that call.
+ */
+export type ConnectRepositoryInput = {
+  readonly fullName: string;
+  readonly installationId: string;
+  readonly scopes: readonly ConfigurationScope[];
+};
+
+export interface ConnectRepositoryResult {
+  readonly repositoryId: string;
+  readonly fullName: string;
+  readonly defaultBranch: string;
+  /** The configuration pull request an operator now has to merge. */
+  readonly pullRequest: number;
+  /** Always null: nothing is authoritative before that merge (§15). */
+  readonly authoritativeCommit: null;
+}
+
+export const connectRepository: Command<
+  ConnectRepositoryInput,
+  ConnectRepositoryResult
+> = async (input, context) => {
+  const host = context.adapters.repository();
+  if (host === null) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this installation has no repository integration, so nothing can be connected to one',
+    );
+  }
+
+  // §15's transaction carries one CI caller, and the caller has to name a
+  // pinned reusable workflow. An installation that has not published one has no
+  // configuration PR to open — refused here rather than opened without the
+  // caller, because a repository connected without a build route is connected
+  // to nothing.
+  const buildWorkflow = context.manifest.github.buildWorkflow;
+  if (buildWorkflow === null) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this installation has published no reusable build workflow, so there is no configuration pull request to open',
+    );
+  }
+
+  const ref = repositoryRefOf({ installationId: input.installationId });
+
+  let defaultBranch: string;
+  try {
+    ({ defaultBranch } = await host.repository(ref, input.fullName));
+  } catch (cause) {
+    // §15's lost-access rule reaches back to here: a repository the App cannot
+    // see is a fact about the world, reported as a refusal the operator can act
+    // on, never an exception the dispatch surface turns into a 500.
+    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
+      return failed(
+        'NOT_FOUND',
+        `Spindrift cannot reach ${input.fullName}: check that the App installation still selects it`,
+      );
+    }
+    throw cause;
+  }
+
+  const now = context.clock.now();
+  const [row] = await context.db
+    .insert(repositories)
+    .values({
+      fullName: input.fullName,
+      installationId: input.installationId,
+      defaultBranch,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: repositories.fullName,
+      set: {
+        installationId: input.installationId,
+        defaultBranch,
+        updatedAt: now,
+      },
+    })
+    .returning();
+
+  const transaction = configurationTransaction({
+    scopes: input.scopes,
+    buildWorkflow,
+  });
+  const opened = await openConfigurationPullRequest(host, ref, {
+    fullName: input.fullName,
+    defaultBranch,
+    transaction,
+  });
+
+  await context.db
+    .update(repositories)
+    .set({ configPullRequest: opened.number, updatedAt: now })
+    .where(eq(repositories.id, row!.id));
+
+  return ok({
+    repositoryId: row!.id,
+    fullName: row!.fullName,
+    defaultBranch,
+    pullRequest: opened.number,
+    authoritativeCommit: null,
+  });
+};

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -27,6 +27,7 @@ import type {
   TargetAdapter,
 } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
+import type { RepositoryHost } from '../domain/repository.ts';
 
 /**
  * Who is acting.
@@ -76,6 +77,18 @@ export interface AdapterRegistry {
   build(route: string): BuildAdapter | null;
   /** §10: one store of record per installation, selected by the manifest. */
   store(): SecretStore;
+  /**
+   * §15's repository host. `null` when this installation has no repository
+   * integration configured — which is a legitimate installation, not a fault:
+   * §2's other source is an uploaded archive, and it needs no repository at all.
+   *
+   * Not one of §6's three adapter contracts, and it is here anyway, because
+   * this interface is "the adapters a command may reach the outside world
+   * through" and a repository is unambiguously one of those. Keeping it out
+   * would only mean threading a second far side through the command layer
+   * beside the context, which is the shape the context exists to prevent.
+   */
+  repository(): RepositoryHost | null;
 }
 
 /**

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -179,6 +179,42 @@ export const installationManifestSchema = z
           /^[0-9]+$/,
           'must be a numeric GitHub App id',
         ),
+        /**
+         * Base URL of the repository host's REST API, without a trailing
+         * slash.
+         *
+         * A value rather than a constant because an installation running
+         * against a self-hosted enterprise deployment reaches its own host, and
+         * §20 puts anything that names one installation's world here. The
+         * public host is a legitimate value for it; it is not a default,
+         * because there are none.
+         */
+        apiBaseUrl: z
+          .url()
+          .refine((value) => !value.endsWith('/'), 'must not end with a slash'),
+        /**
+         * The reusable build workflow the configuration PR's one caller calls
+         * (§15).
+         *
+         * **Pinned to a commit, and the schema is what enforces it.** §15 gives
+         * the connected repository the Actions minutes and the billing, which
+         * means the workflow runs with that repository's own permissions —
+         * so a mutable ref here would let whoever can move it run arbitrary
+         * steps in every connected repository at once. A branch or tag is
+         * refused rather than warned about.
+         *
+         * Nullable, stated the way `auth.gateway` is: an installation that has
+         * not published a reusable workflow yet has no honest value to put here,
+         * and a placeholder commit would be a configuration that looks complete
+         * and fails at the first build. Null means repositories cannot be
+         * connected — `connectRepository` says so — and nothing else changes.
+         */
+        buildWorkflow: nonEmptyString
+          .regex(
+            /^[^/@\s]+\/[^/@\s]+\/\.github\/workflows\/[^@\s]+@[0-9a-f]{40}$/,
+            'must be owner/repo/.github/workflows/<file>@<40-character commit sha>',
+          )
+          .nullable(),
       })
       .strict(),
 

--- a/apps/spindrift/src/db/migrations/0006_repositories.sql
+++ b/apps/spindrift/src/db/migrations/0006_repositories.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "public"."repository_access" AS ENUM('active', 'frozen');--> statement-breakpoint
+CREATE TABLE "repositories" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"full_name" text NOT NULL,
+	"installation_id" text NOT NULL,
+	"default_branch" text NOT NULL,
+	"authoritative_commit" text,
+	"config_pull_request" integer,
+	"access" "repository_access" DEFAULT 'active' NOT NULL,
+	"frozen_reason" text,
+	"frozen_at" timestamp with time zone,
+	"reconciled_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "repositories_full_name_unique" UNIQUE("full_name"),
+	CONSTRAINT "repositories_frozen_has_reason" CHECK (("repositories"."access" = 'frozen') = ("repositories"."frozen_reason" is not null))
+);
+--> statement-breakpoint
+ALTER TABLE "apps" ADD COLUMN "repository_id" uuid;--> statement-breakpoint
+ALTER TABLE "apps" ADD CONSTRAINT "apps_repository_id_repositories_id_fk" FOREIGN KEY ("repository_id") REFERENCES "public"."repositories"("id") ON DELETE restrict ON UPDATE no action;

--- a/apps/spindrift/src/db/migrations/meta/0006_snapshot.json
+++ b/apps/spindrift/src/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1715 @@
+{
+  "id": "2daaf0b7-1ca8-4068-86c7-52c4b0f946bb",
+  "prevId": "77900033-3569-4529-9852-8f0b8723ca2f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "app_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repo_url": {
+          "name": "source_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repo_subpath": {
+          "name": "source_repo_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_archive_digest": {
+          "name": "source_archive_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vessel_ref": {
+          "name": "vessel_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vanity_domain": {
+          "name": "vanity_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_repository_id_repositories_id_fk": {
+          "name": "apps_repository_id_repositories_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempt_events": {
+      "name": "attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_kind": {
+          "name": "attempt_kind",
+          "type": "attempt_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_id": {
+          "name": "deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "attempt_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attempt_events_app_id_apps_id_fk": {
+          "name": "attempt_events_app_id_apps_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_component_id_components_id_fk": {
+          "name": "attempt_events_component_id_components_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_build_id_builds_id_fk": {
+          "name": "attempt_events_build_id_builds_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_deploy_id_deploys_id_fk": {
+          "name": "attempt_events_deploy_id_deploys_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempt_events_exactly_one_attempt": {
+          "name": "attempt_events_exactly_one_attempt",
+          "value": "(\"attempt_events\".\"build_id\" is not null) <> (\"attempt_events\".\"deploy_id\" is not null)"
+        },
+        "attempt_events_kind_matches_reference": {
+          "name": "attempt_events_kind_matches_reference",
+          "value": "(\"attempt_events\".\"attempt_kind\" = 'build' and \"attempt_events\".\"build_id\" is not null) or (\"attempt_events\".\"attempt_kind\" = 'deploy' and \"attempt_events\".\"deploy_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_shape": {
+          "name": "target_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "artifact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_digest": {
+          "name": "artifact_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_refs": {
+          "name": "artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "build_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "base_digest": {
+          "name": "base_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_fidelity": {
+          "name": "log_fidelity",
+          "type": "log_fidelity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_location": {
+          "name": "bundle_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_subpath": {
+          "name": "bundle_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_component_id_components_id_fk": {
+          "name": "builds_component_id_components_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "builds_component_commit_shape_unique": {
+          "name": "builds_component_commit_shape_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "commit",
+            "target_shape"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_target_desired": {
+      "name": "component_target_desired",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_build_id": {
+          "name": "desired_build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_deploy_id": {
+          "name": "desired_deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "component_target_desired_component_id_components_id_fk": {
+          "name": "component_target_desired_component_id_components_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_target_id_targets_id_fk": {
+          "name": "component_target_desired_target_id_targets_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_build_id_builds_id_fk": {
+          "name": "component_target_desired_desired_build_id_builds_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "desired_build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_deploy_id_deploys_id_fk": {
+          "name": "component_target_desired_desired_deploy_id_deploys_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "desired_deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "component_target_desired_pair_unique": {
+          "name": "component_target_desired_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.components": {
+      "name": "components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "component_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expose": {
+          "name": "expose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "components_app_id_apps_id_fk": {
+          "name": "components_app_id_apps_id_fk",
+          "tableFrom": "components",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "components_app_id_name_unique": {
+          "name": "components_app_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_items": {
+      "name": "config_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "config_item_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret_ref'"
+        },
+        "store_ref": {
+          "name": "store_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_value": {
+          "name": "plain_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_items_component_id_components_id_fk": {
+          "name": "config_items_component_id_components_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_items_target_id_targets_id_fk": {
+          "name": "config_items_target_id_targets_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_items_scope_key_unique": {
+          "name": "config_items_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id",
+            "environment",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "config_items_environment_pinned": {
+          "name": "config_items_environment_pinned",
+          "value": "\"config_items\".\"environment\" = 'default'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sign_count": {
+          "name": "sign_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credentials_credential_id_unique": {
+          "name": "credentials_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datastores": {
+      "name": "datastores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "datastore_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "datastore_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_ref": {
+          "name": "connection_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datastores_app_id_apps_id_fk": {
+          "name": "datastores_app_id_apps_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "datastores_target_id_targets_id_fk": {
+          "name": "datastores_target_id_targets_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deploys": {
+      "name": "deploys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "deploy_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drifted_at": {
+          "name": "drifted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_digest": {
+          "name": "observed_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deploys_component_id_components_id_fk": {
+          "name": "deploys_component_id_components_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deploys_target_id_targets_id_fk": {
+          "name": "deploys_target_id_targets_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "deploys_build_id_builds_id_fk": {
+          "name": "deploys_build_id_builds_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrolments": {
+      "name": "enrolments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "enrolments_user_id_users_id_fk": {
+          "name": "enrolments_user_id_users_id_fk",
+          "tableFrom": "enrolments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrolments_token_hash_unique": {
+          "name": "enrolments_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authoritative_commit": {
+          "name": "authoritative_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_pull_request": {
+          "name": "config_pull_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access": {
+          "name": "access",
+          "type": "repository_access",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "frozen_reason": {
+          "name": "frozen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_at": {
+          "name": "frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_full_name_unique": {
+          "name": "repositories_full_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "full_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repositories_frozen_has_reason": {
+          "name": "repositories_frozen_has_reason",
+          "value": "(\"repositories\".\"access\" = 'frozen') = (\"repositories\".\"frozen_reason\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "target_adapter",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "target_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "target_health",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery": {
+          "name": "discovery",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_exposure": {
+          "name": "public_exposure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_build_level": {
+          "name": "min_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "targets_name_unique": {
+          "name": "targets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway_identity": {
+          "name": "gateway_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_gateway_identity_unique": {
+          "name": "users_gateway_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "gateway_identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webauthn_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.app_source_kind": {
+      "name": "app_source_kind",
+      "schema": "public",
+      "values": [
+        "repo",
+        "archive"
+      ]
+    },
+    "public.artifact_type": {
+      "name": "artifact_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "files"
+      ]
+    },
+    "public.attempt_event_type": {
+      "name": "attempt_event_type",
+      "schema": "public",
+      "values": [
+        "log",
+        "status"
+      ]
+    },
+    "public.attempt_kind": {
+      "name": "attempt_kind",
+      "schema": "public",
+      "values": [
+        "build",
+        "deploy"
+      ]
+    },
+    "public.blame": {
+      "name": "blame",
+      "schema": "public",
+      "values": [
+        "developer",
+        "platform"
+      ]
+    },
+    "public.build_status": {
+      "name": "build_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.component_kind": {
+      "name": "component_kind",
+      "schema": "public",
+      "values": [
+        "service",
+        "website",
+        "job"
+      ]
+    },
+    "public.config_item_kind": {
+      "name": "config_item_kind",
+      "schema": "public",
+      "values": [
+        "secret_ref",
+        "plain"
+      ]
+    },
+    "public.datastore_engine": {
+      "name": "datastore_engine",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "redis"
+      ]
+    },
+    "public.datastore_provenance": {
+      "name": "datastore_provenance",
+      "schema": "public",
+      "values": [
+        "managed",
+        "external"
+      ]
+    },
+    "public.deploy_phase": {
+      "name": "deploy_phase",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPLYING",
+        "WAITING",
+        "LIVE",
+        "FAILED"
+      ]
+    },
+    "public.deploy_reason": {
+      "name": "deploy_reason",
+      "schema": "public",
+      "values": [
+        "BUILD_FAILED",
+        "ARTIFACT_UNAVAILABLE",
+        "REJECTED",
+        "STARTUP_FAILED",
+        "UNHEALTHY",
+        "TIMEOUT",
+        "TARGET_UNREACHABLE",
+        "INTERNAL"
+      ]
+    },
+    "public.exposure_state": {
+      "name": "exposure_state",
+      "schema": "public",
+      "values": [
+        "internal",
+        "private",
+        "public"
+      ]
+    },
+    "public.log_fidelity": {
+      "name": "log_fidelity",
+      "schema": "public",
+      "values": [
+        "LIVE_TEXT",
+        "LIVE_STATUS",
+        "ON_COMPLETION"
+      ]
+    },
+    "public.repository_access": {
+      "name": "repository_access",
+      "schema": "public",
+      "values": [
+        "active",
+        "frozen"
+      ]
+    },
+    "public.target_adapter": {
+      "name": "target_adapter",
+      "schema": "public",
+      "values": [
+        "kubernetes",
+        "cloudrun",
+        "static"
+      ]
+    },
+    "public.target_health": {
+      "name": "target_health",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy"
+      ]
+    },
+    "public.target_status": {
+      "name": "target_status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "disconnected"
+      ]
+    },
+    "public.webauthn_purpose": {
+      "name": "webauthn_purpose",
+      "schema": "public",
+      "values": [
+        "enrol",
+        "sign_in",
+        "credential_admin",
+        "add_passkey"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1785195253314,
       "tag": "0005_credential_admin",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1785208095073,
+      "tag": "0006_repositories",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -59,6 +59,22 @@ import type { TargetConnection } from '../domain/target.ts';
 /** §2: "source = repo(url, subpath) | archive(upload)". */
 export const appSourceKind = pgEnum('app_source_kind', ['repo', 'archive']);
 
+/**
+ * §15: "Lost access **freezes source-driven changes and never destroys a
+ * Deploy**."
+ *
+ * Two states, and the pair is the whole point. `frozen` has to be a value a
+ * query can select on, because the alternative to a state is an action — and
+ * the only actions available to code that has just lost read access to a
+ * repository are to do nothing quietly or to tear something down. The first is
+ * indistinguishable from a repository nobody pushes to, and the second is the
+ * outage §15 forbids.
+ */
+export const repositoryAccess = pgEnum('repository_access', [
+  'active',
+  'frozen',
+]);
+
 /** §2: "kind = service | website | job". */
 export const componentKind = pgEnum('component_kind', [
   'service',
@@ -185,6 +201,73 @@ export const webauthnPurpose = pgEnum('webauthn_purpose', [
   'add_passkey',
 ]);
 
+// --- Repository ------------------------------------------------------------
+
+/**
+ * One connected repository (§15).
+ *
+ * Not one of §2's five nouns, and deliberately not folded into `apps`: a
+ * repository is reached through one App *installation*, has one default branch,
+ * and can lose access — three facts that belong to the repository and would have
+ * to be repeated on, and kept consistent across, every App that names it. A
+ * monorepo with four Apps in four subpaths is one row here and four there.
+ *
+ * **No credential column.** §15: Spindrift "stages an immutable source bundle
+ * for either builder, storing no token." What is stored is the installation's
+ * identity; the token is minted per request from the App's own key and never
+ * survives the call it was minted for.
+ */
+export const repositories = pgTable(
+  'repositories',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** `owner/name` — the only handle the repository API takes. */
+    fullName: text('full_name').notNull(),
+    /**
+     * Which installation of the GitHub App reaches it. A string because the
+     * far side's numeric id is an opaque handle here, not an integer core does
+     * arithmetic on.
+     */
+    installationId: text('installation_id').notNull(),
+    /** §15: only the default branch is authoritative, so it is stored, not assumed. */
+    defaultBranch: text('default_branch').notNull(),
+    /**
+     * §15: "**only its default-branch merge push becomes authoritative**."
+     *
+     * This is the commit whose configuration Spindrift has adopted — never a PR
+     * head, never a branch tip it merely observed. It stays null until a
+     * default-branch commit has actually been reconciled, which is what makes
+     * "an unmerged PR changes nothing" a fact about a column rather than a
+     * promise about a code path.
+     */
+    authoritativeCommit: text('authoritative_commit'),
+    /** The configuration pull request this connection opened, once it exists. */
+    configPullRequest: integer('config_pull_request'),
+    access: repositoryAccess('access').notNull().default('active'),
+    /** Set exactly when `access = 'frozen'`; the sentence an operator reads. */
+    frozenReason: text('frozen_reason'),
+    frozenAt: timestamp('frozen_at', { withTimezone: true }),
+    /** When the repo loop last completed a pass against it. */
+    reconciledAt: timestamp('reconciled_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // Connecting a repository twice must re-adopt the existing row rather than
+    // produce a second one: two rows for one repository would each reconcile it,
+    // and the loop would race itself over one authoritative commit.
+    unique('repositories_full_name_unique').on(table.fullName),
+    check(
+      'repositories_frozen_has_reason',
+      sql`(${table.access} = 'frozen') = (${table.frozenReason} is not null)`,
+    ),
+  ],
+);
+
 // --- App and Component -------------------------------------------------
 
 /**
@@ -201,6 +284,18 @@ export const apps = pgTable('apps', {
   sourceRepoUrl: text('source_repo_url'),
   /** Set when `sourceKind = 'repo'`; the scope is named, never searched (§5). */
   sourceRepoSubpath: text('source_repo_subpath'),
+  /**
+   * The connected repository this App's scope lives in, when there is one.
+   *
+   * Nullable because an archive App has no repository and a repo App may have
+   * been created before anyone connected its repository — §15 makes Git
+   * integration a thing an operator turns on, not a precondition of authoring.
+   * `restrict` rather than `cascade`: disconnecting a repository must never be
+   * a way to delete an App, which is the same rule §15 states about Deploys.
+   */
+  repositoryId: uuid('repository_id').references(() => repositories.id, {
+    onDelete: 'restrict',
+  }),
   /** Set when `sourceKind = 'archive'`: the uploaded bundle's digest. */
   sourceArchiveDigest: text('source_archive_digest'),
   /** §14: the cloud project this App's own resources live in, if any. */
@@ -794,9 +889,17 @@ export const attemptEvents = pgTable(
 
 // --- Relations (query-builder convenience; no schema effect) ---------------
 
-export const appsRelations = relations(apps, ({ many }) => ({
+export const appsRelations = relations(apps, ({ one, many }) => ({
   components: many(components),
   datastores: many(datastores),
+  repository: one(repositories, {
+    fields: [apps.repositoryId],
+    references: [repositories.id],
+  }),
+}));
+
+export const repositoriesRelations = relations(repositories, ({ many }) => ({
+  apps: many(apps),
 }));
 
 export const componentsRelations = relations(components, ({ one, many }) => ({
@@ -905,6 +1008,8 @@ export const attemptEventsRelations = relations(attemptEvents, ({ one }) => ({
 
 export type App = typeof apps.$inferSelect;
 export type NewApp = typeof apps.$inferInsert;
+export type Repository = typeof repositories.$inferSelect;
+export type NewRepository = typeof repositories.$inferInsert;
 export type Component = typeof components.$inferSelect;
 export type NewComponent = typeof components.$inferInsert;
 export type Build = typeof builds.$inferSelect;

--- a/apps/spindrift/src/domain/repository.ts
+++ b/apps/spindrift/src/domain/repository.ts
@@ -1,0 +1,121 @@
+/**
+ * The repository host, as core names it (§15).
+ *
+ * §15 settles one host — "reuse the existing selected-repository GitHub App" —
+ * but core still declares the far side rather than importing it, for the same
+ * reason `target.ts` declares `TargetConnection` instead of speaking any
+ * cluster's API: the command layer and the repo loop are the two things §20's
+ * extraction contract has to keep portable, and neither of them should know
+ * what a GitHub App is. `src/integrations/github/` implements these interfaces;
+ * nothing in `src/commands/` or `src/reconciler/` imports it.
+ *
+ * **The reference grants nothing.** §15 says Spindrift stores no token, so what
+ * core holds and passes around is {@link RepositoryRef} — an installation
+ * identity, which is a string in a database column. Every credential is minted
+ * inside the host at the moment of use, which is what makes "storing no token"
+ * a fact about the types rather than a rule somebody has to remember.
+ */
+
+/**
+ * How core names one installation of whatever integration reaches a repository.
+ *
+ * A single field, and it stays an object anyway: what a host needs to reach a
+ * repository is the kind of thing that grows (an enterprise's own endpoint, a
+ * second app), and a bare string would make every one of those a change at
+ * every call site.
+ */
+export interface RepositoryRef {
+  /** Opaque to core; meaningful only to the host that issued it. */
+  readonly installationId: string;
+}
+
+/** What reconciliation reads (§15). */
+export interface RepositoryReader {
+  /** The repository's own facts. §15 reads the default branch, never assumes it. */
+  repository(
+    ref: RepositoryRef,
+    fullName: string,
+  ): Promise<{ readonly defaultBranch: string }>;
+  /** The commit a branch currently points at. */
+  branchHead(
+    ref: RepositoryRef,
+    fullName: string,
+    branch: string,
+  ): Promise<string>;
+  /** One file at one exact commit, or `null` when it is not there. */
+  readFile(
+    ref: RepositoryRef,
+    fullName: string,
+    commit: string,
+    path: string,
+  ): Promise<string | null>;
+}
+
+/**
+ * What opening the configuration pull request writes (§15).
+ *
+ * Git's own object model rather than a "put this file" verb, because §15 makes
+ * the whole PR one transaction: blobs, one tree over the default branch's, one
+ * commit, one branch, one pull request. A per-file write verb would make the
+ * transaction a sequence of commits and give a partially written configuration
+ * a way to exist.
+ */
+export interface RepositoryWriter {
+  /** The tree one commit points at. */
+  commitTree(
+    ref: RepositoryRef,
+    fullName: string,
+    commit: string,
+  ): Promise<string>;
+  /** Store one file's bytes and return the blob they are addressed by. */
+  createBlob(
+    ref: RepositoryRef,
+    fullName: string,
+    contents: string,
+  ): Promise<string>;
+  /** A tree layered over an existing one — everything else is left alone. */
+  createTree(
+    ref: RepositoryRef,
+    fullName: string,
+    baseTree: string,
+    entries: readonly { readonly path: string; readonly blob: string }[],
+  ): Promise<string>;
+  /** One commit over one tree. */
+  createCommit(
+    ref: RepositoryRef,
+    fullName: string,
+    input: {
+      readonly message: string;
+      readonly tree: string;
+      readonly parent: string;
+    },
+  ): Promise<string>;
+  /** Point a branch at a commit, creating it if it is not there. */
+  setBranch(
+    ref: RepositoryRef,
+    fullName: string,
+    branch: string,
+    commit: string,
+  ): Promise<void>;
+  /** Open the pull request and return its number. */
+  openPullRequest(
+    ref: RepositoryRef,
+    fullName: string,
+    input: {
+      readonly title: string;
+      readonly body: string;
+      readonly head: string;
+      readonly base: string;
+    },
+  ): Promise<number>;
+}
+
+/** Everything one repository host does. */
+export interface RepositoryHost extends RepositoryReader, RepositoryWriter {}
+
+/** The reference for a stored repository row. */
+export function repositoryRefOf(row: {
+  readonly installationId: string;
+}): RepositoryRef {
+  return { installationId: row.installationId };
+}

--- a/apps/spindrift/src/integrations/github/app.ts
+++ b/apps/spindrift/src/integrations/github/app.ts
@@ -1,0 +1,494 @@
+/**
+ * The GitHub App this installation already has (§15).
+ *
+ * §15: "Reuse the existing selected-repository GitHub App and bot identity,
+ * bootstrapped from a SOPS Secret." Two consequences run through this whole
+ * file:
+ *
+ * - **The App's key is the only long-lived credential, and it never leaves.**
+ *   Everything else is minted from it per call — an App JWT good for minutes,
+ *   an installation token good for an hour — so the thing core passes around as
+ *   a "credential" is an {@link InstallationRef}, which is a number in a
+ *   database column and grants nothing on its own. That is what lets §15's
+ *   "storing no token" be structural: there is no type in this module's public
+ *   surface that a token fits into.
+ * - **A selected-repository App can be un-selected at any time**, and the
+ *   response when that happens is a `404` indistinguishable from a repository
+ *   that never existed. So access is a *state* this module reports
+ *   ({@link GitHubAccessError} with `ACCESS_LOST`) and the repo loop turns into
+ *   a freeze, rather than an exception any single call site tries to interpret.
+ *
+ * This module also implements {@link ExactCommitFetcher}, which is the seam
+ * `src/domain/source-bundle.ts` stages through. The credential type it is
+ * generic over is instantiated here as the installation reference, so the token
+ * is minted inside {@link GitHubApp.fetchExactCommit} and is unreachable from
+ * the staged result.
+ */
+import type {
+  ExactCommitFetcher,
+  FetchedCommit,
+} from '../../domain/source-bundle.ts';
+import { type Fetcher, GitHubAccessError, GitHubHttp } from './http.ts';
+
+/** How core names one installation of the App. Grants nothing by itself. */
+export interface InstallationRef {
+  /** The far side's installation id, opaque to core. */
+  readonly installationId: string;
+}
+
+/** The App's own identity and signing key, from the installation Secret. */
+export interface GitHubAppConfig {
+  /** Numeric App id, as the manifest carries it. */
+  readonly appId: string;
+  /**
+   * The App's private key, PEM, **PKCS#8**.
+   *
+   * WebCrypto imports PKCS#8 and nothing else, and this integration has no
+   * ASN.1 code — so a PKCS#1 key (`BEGIN RSA PRIVATE KEY`, which is what the
+   * GitHub UI hands you) is refused at construction with the conversion
+   * command in the message. Refusing loudly beats a silent mis-parse that
+   * surfaces as an unexplained `401` an hour later.
+   */
+  readonly privateKeyPem: string;
+  readonly baseUrl: string;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+}
+
+/** Raised when the configured App key cannot be used to sign a JWT. */
+export class GitHubAppKeyError extends Error {
+  override readonly name = 'GitHubAppKeyError';
+}
+
+/** A minted installation access token and the moment it stops working. */
+interface InstallationToken {
+  readonly token: string;
+  readonly expiresAt: Date;
+}
+
+const PKCS8_HEADER = '-----BEGIN PRIVATE KEY-----';
+const PKCS1_HEADER = '-----BEGIN RSA PRIVATE KEY-----';
+
+/**
+ * An App JWT is valid for ten minutes at most; nine leaves room for the clock
+ * skew the far side tolerates without landing on its own limit.
+ */
+const APP_JWT_LIFETIME_SECONDS = 9 * 60;
+
+/**
+ * How long before an installation token expires it stops being reused.
+ *
+ * A token that expires mid-request is a `401` that reads exactly like lost
+ * access, which is the one misclassification this integration must not make —
+ * so the margin is generous rather than tight.
+ */
+const TOKEN_REFRESH_MARGIN_MS = 60_000;
+
+function base64url(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes))
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+    .replaceAll('=', '');
+}
+
+function encodeJson(value: unknown): string {
+  return base64url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+/** Decode a PEM body to DER, refusing the key format WebCrypto cannot import. */
+function pkcs8Der(pem: string): Uint8Array {
+  const trimmed = pem.trim();
+  if (trimmed.startsWith(PKCS1_HEADER)) {
+    throw new GitHubAppKeyError(
+      'the GitHub App key is PKCS#1; convert it with `openssl pkcs8 -topk8 -nocrypt -in key.pem -out key.pkcs8.pem` and store that',
+    );
+  }
+  if (!trimmed.startsWith(PKCS8_HEADER)) {
+    throw new GitHubAppKeyError(
+      'the GitHub App key is not a PKCS#8 PEM private key',
+    );
+  }
+  const body = trimmed
+    .replaceAll(/-----(BEGIN|END) PRIVATE KEY-----/g, '')
+    .replaceAll(/\s+/g, '');
+  return Uint8Array.from(atob(body), (character) => character.charCodeAt(0));
+}
+
+/**
+ * The App, and everything reached through one of its installations.
+ *
+ * One object rather than a function per call because the two caches — the
+ * imported signing key and the per-installation token — are what keep a loop
+ * over a dozen repositories from minting a dozen JWTs a minute, and a cache
+ * that is not owned by something is a module-level global.
+ */
+export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
+  private readonly tokens = new Map<string, InstallationToken>();
+  private signingKey: Promise<CryptoKey> | null = null;
+
+  constructor(
+    private readonly config: GitHubAppConfig,
+    private readonly now: () => Date = () => new Date(),
+  ) {}
+
+  /**
+   * The App's own JWT: proves *which App is asking*, and nothing about a
+   * repository. It is only ever presented to the token endpoint.
+   */
+  async appJwt(): Promise<string> {
+    const issuedAt = Math.floor(this.now().getTime() / 1000);
+    // Backdating by a minute is the documented remedy for the far side's clock
+    // running slightly behind this one, which it rejects outright.
+    const claims = {
+      iat: issuedAt - 60,
+      exp: issuedAt + APP_JWT_LIFETIME_SECONDS,
+      iss: this.config.appId,
+    };
+    const signingInput = `${encodeJson({ alg: 'RS256', typ: 'JWT' })}.${encodeJson(claims)}`;
+    const signature = await crypto.subtle.sign(
+      'RSASSA-PKCS1-v1_5',
+      await this.key(),
+      new TextEncoder().encode(signingInput),
+    );
+    return `${signingInput}.${base64url(new Uint8Array(signature))}`;
+  }
+
+  /**
+   * A bearer value for one installation, minted or reused.
+   *
+   * Returned as a full `Authorization` value rather than a bare token so that
+   * no caller has to know the scheme — and so that grepping this package for a
+   * token-shaped string finds this method rather than a dozen call sites.
+   */
+  private authorizationFor(ref: InstallationRef): () => Promise<string> {
+    return async () => `Bearer ${await this.installationToken(ref)}`;
+  }
+
+  private async installationToken(ref: InstallationRef): Promise<string> {
+    const cached = this.tokens.get(ref.installationId);
+    if (
+      cached !== undefined &&
+      cached.expiresAt.getTime() - this.now().getTime() >
+        TOKEN_REFRESH_MARGIN_MS
+    ) {
+      return cached.token;
+    }
+
+    const jwt = await this.appJwt();
+    const http = new GitHubHttp({
+      baseUrl: this.config.baseUrl,
+      authorization: () => `Bearer ${jwt}`,
+      ...(this.config.fetch ? { fetch: this.config.fetch } : {}),
+    });
+    const minted = await http.json<{ token: string; expires_at: string }>({
+      method: 'POST',
+      path: `/app/installations/${encodeURIComponent(ref.installationId)}/access_tokens`,
+    });
+    if (minted === null) {
+      throw new TypeError('the token endpoint tolerates no status');
+    }
+
+    const token = {
+      token: minted.token,
+      expiresAt: new Date(minted.expires_at),
+    };
+    this.tokens.set(ref.installationId, token);
+    return token.token;
+  }
+
+  private key(): Promise<CryptoKey> {
+    this.signingKey ??= crypto.subtle.importKey(
+      'pkcs8',
+      pkcs8Der(this.config.privateKeyPem).buffer as ArrayBuffer,
+      { name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-256' },
+      false,
+      ['sign'],
+    );
+    return this.signingKey;
+  }
+
+  /** A client scoped to one installation. */
+  private http(ref: InstallationRef): GitHubHttp {
+    return new GitHubHttp({
+      baseUrl: this.config.baseUrl,
+      authorization: this.authorizationFor(ref),
+      ...(this.config.fetch ? { fetch: this.config.fetch } : {}),
+    });
+  }
+
+  /**
+   * The repository's own facts. §15 reads the default branch, never assumes it.
+   *
+   * Narrowed to that one field because it is the only one core has a use for —
+   * a wider return would be a promise about a far side's response shape that
+   * `RepositoryReader` does not make.
+   */
+  async repository(
+    ref: InstallationRef,
+    fullName: string,
+  ): Promise<{ readonly defaultBranch: string }> {
+    const repository = await this.http(ref).json<{ default_branch: string }>({
+      method: 'GET',
+      path: `/repos/${fullName}`,
+    });
+    if (repository === null) {
+      throw new TypeError('the repository endpoint tolerates no status');
+    }
+    return { defaultBranch: repository.default_branch };
+  }
+
+  /**
+   * The commit one branch currently points at.
+   *
+   * Only ever called for the default branch. §15 makes that the one ref whose
+   * merge is authoritative, so resolving any other would be resolving something
+   * the model has no place to put.
+   */
+  async branchHead(
+    ref: InstallationRef,
+    fullName: string,
+    branch: string,
+  ): Promise<string> {
+    const head = await this.http(ref).json<{ object: { sha: string } }>({
+      method: 'GET',
+      path: `/repos/${fullName}/git/ref/heads/${branch}`,
+    });
+    if (head === null) {
+      throw new TypeError('the ref endpoint tolerates no status');
+    }
+    return head.object.sha;
+  }
+
+  /**
+   * One file at one exact commit, or `null` when it is not there.
+   *
+   * `404` is tolerated here and nowhere else in this module: a repository with
+   * no `spindrift.yaml` in a scope is an ordinary, expected state, and the
+   * commit was already reachable — the call that resolved it would have raised
+   * `ACCESS_LOST` first if it were not.
+   */
+  async readFile(
+    ref: InstallationRef,
+    fullName: string,
+    commit: string,
+    path: string,
+  ): Promise<string | null> {
+    const response = await this.http(ref).send({
+      method: 'GET',
+      path: `/repos/${fullName}/contents/${path}?ref=${encodeURIComponent(commit)}`,
+      accept: 'application/vnd.github.raw',
+      tolerate: [404],
+    });
+    return response === null ? null : await response.text();
+  }
+
+  // --- The Git data API, which the configuration PR is written through -----
+  //
+  // These six exist so `openConfigurationPullRequest` can put the whole file
+  // set in **one commit**. The contents API would have been fewer concepts and
+  // one call per file, but each of those calls is a commit and each needs the
+  // existing blob sha when the file is already there — so a repository that had
+  // been connected before would take a different code path from one that had
+  // not, for a transaction §15 says is one thing.
+
+  /** The tree one commit points at. */
+  async commitTree(
+    ref: InstallationRef,
+    fullName: string,
+    commit: string,
+  ): Promise<string> {
+    const found = await this.http(ref).json<{ tree: { sha: string } }>({
+      method: 'GET',
+      path: `/repos/${fullName}/git/commits/${commit}`,
+    });
+    if (found === null) {
+      throw new TypeError('the commit endpoint tolerates no status');
+    }
+    return found.tree.sha;
+  }
+
+  /** Store one file's bytes and return the blob they are addressed by. */
+  async createBlob(
+    ref: InstallationRef,
+    fullName: string,
+    contents: string,
+  ): Promise<string> {
+    const blob = await this.http(ref).json<{ sha: string }>({
+      method: 'POST',
+      path: `/repos/${fullName}/git/blobs`,
+      body: { content: contents, encoding: 'utf-8' },
+    });
+    if (blob === null) {
+      throw new TypeError('the blob endpoint tolerates no status');
+    }
+    return blob.sha;
+  }
+
+  /** A tree layered over an existing one — everything else is left alone. */
+  async createTree(
+    ref: InstallationRef,
+    fullName: string,
+    baseTree: string,
+    entries: readonly { readonly path: string; readonly blob: string }[],
+  ): Promise<string> {
+    const tree = await this.http(ref).json<{ sha: string }>({
+      method: 'POST',
+      path: `/repos/${fullName}/git/trees`,
+      body: {
+        base_tree: baseTree,
+        tree: entries.map((entry) => ({
+          path: entry.path,
+          // A non-executable regular file. The configuration PR writes YAML and
+          // nothing else, so no other mode is reachable.
+          mode: '100644',
+          type: 'blob',
+          sha: entry.blob,
+        })),
+      },
+    });
+    if (tree === null) {
+      throw new TypeError('the tree endpoint tolerates no status');
+    }
+    return tree.sha;
+  }
+
+  /** One commit over one tree. */
+  async createCommit(
+    ref: InstallationRef,
+    fullName: string,
+    input: {
+      readonly message: string;
+      readonly tree: string;
+      readonly parent: string;
+    },
+  ): Promise<string> {
+    const commit = await this.http(ref).json<{ sha: string }>({
+      method: 'POST',
+      path: `/repos/${fullName}/git/commits`,
+      body: {
+        message: input.message,
+        tree: input.tree,
+        parents: [input.parent],
+      },
+    });
+    if (commit === null) {
+      throw new TypeError('the commit endpoint tolerates no status');
+    }
+    return commit.sha;
+  }
+
+  /**
+   * Point a branch at a commit, creating it if it is not there.
+   *
+   * Force is set on the update path because the only branch this is ever called
+   * for is Spindrift's own configuration branch: re-running a connection should
+   * replace what it wrote last time rather than fail on a non-fast-forward, and
+   * the branch holds nothing a human authored.
+   */
+  async setBranch(
+    ref: InstallationRef,
+    fullName: string,
+    branch: string,
+    commit: string,
+  ): Promise<void> {
+    const updated = await this.http(ref).send({
+      method: 'PATCH',
+      path: `/repos/${fullName}/git/refs/heads/${branch}`,
+      body: { sha: commit, force: true },
+      tolerate: [404],
+    });
+    if (updated !== null) return;
+
+    await this.http(ref).send({
+      method: 'POST',
+      path: `/repos/${fullName}/git/refs`,
+      body: { ref: `refs/heads/${branch}`, sha: commit },
+    });
+  }
+
+  /** Open the pull request and return its number. */
+  async openPullRequest(
+    ref: InstallationRef,
+    fullName: string,
+    input: {
+      readonly title: string;
+      readonly body: string;
+      readonly head: string;
+      readonly base: string;
+    },
+  ): Promise<number> {
+    const pull = await this.http(ref).json<{ number: number }>({
+      method: 'POST',
+      path: `/repos/${fullName}/pulls`,
+      body: input,
+    });
+    if (pull === null) {
+      throw new TypeError('the pulls endpoint tolerates no status');
+    }
+    return pull.number;
+  }
+
+  /**
+   * §15's one fetch: "fetches the exact commit **once** and stages an immutable
+   * source bundle for either builder, storing no token."
+   *
+   * **The revision is resolved before the archive is fetched, and reported as
+   * the far side resolved it.** `stageSourceBundle` compares that against what
+   * was asked for and refuses a mismatch, which is only a check worth having if
+   * this method can actually disagree with its caller — echoing the input would
+   * make it vacuous. Resolving first also means the archive and both feature
+   * probes address one immutable sha, so a push landing mid-fetch cannot give
+   * three calls three different trees.
+   *
+   * "Once" is about the archive, which is the expensive, ordering-sensitive
+   * fetch; the metadata calls beside it are reads of an already-immutable
+   * object.
+   *
+   * The two unsupported-feature flags are answered from the tree rather than
+   * from the archive's contents, because the archive is the thing being handed
+   * to a builder and by then it is too late to say no — §15 makes submodules
+   * and LFS explicitly unsupported, and `stageSourceBundle` refuses them
+   * *before* storage on the strength of what is reported here.
+   */
+  async fetchExactCommit(input: {
+    readonly repository: string;
+    readonly commit: string;
+    readonly credential: InstallationRef;
+  }): Promise<FetchedCommit> {
+    const { repository, commit, credential } = input;
+
+    const resolved = await this.http(credential).json<{ sha: string }>({
+      method: 'GET',
+      path: `/repos/${repository}/commits/${encodeURIComponent(commit)}`,
+    });
+    if (resolved === null) {
+      throw new TypeError('the commit endpoint tolerates no status');
+    }
+
+    const [bytes, gitmodules, gitattributes] = await Promise.all([
+      this.http(credential).bytes({
+        method: 'GET',
+        path: `/repos/${repository}/tarball/${encodeURIComponent(resolved.sha)}`,
+      }),
+      this.readFile(credential, repository, resolved.sha, '.gitmodules'),
+      this.readFile(credential, repository, resolved.sha, '.gitattributes'),
+    ]);
+
+    return {
+      bytes,
+      resolvedCommit: resolved.sha,
+      hasSubmodules: gitmodules !== null,
+      // A `.gitattributes` is ordinary; one that routes a path through the LFS
+      // filter is what makes a checkout depend on a second fetch nobody staged.
+      hasGitLfs:
+        gitattributes !== null && /filter\s*=\s*lfs/.test(gitattributes),
+      principal: {
+        kind: 'githubApp',
+        subject: `installation:${credential.installationId}`,
+      },
+    };
+  }
+}
+
+export type { GitHubAccessCode } from './http.ts';
+export { GitHubAccessError };

--- a/apps/spindrift/src/integrations/github/config-pr.ts
+++ b/apps/spindrift/src/integrations/github/config-pr.ts
@@ -1,0 +1,284 @@
+/**
+ * The one configuration pull request (§15).
+ *
+ * §15: "**One human-editable configuration PR per repository is the
+ * transaction**, carrying each App subpath's Spindrift file and one thin CI
+ * caller. Only its default-branch merge push becomes authoritative."
+ *
+ * Every word of that is load-bearing here:
+ *
+ * - **One PR, not one per scope.** Connecting a monorepo with four Apps is one
+ *   thing an operator reviews and merges, not four. That is why this module
+ *   composes a file *set* and writes it as a single commit rather than
+ *   exposing a per-scope call somebody would loop over.
+ * - **Human-editable**, which is why the Spindrift file is emitted by
+ *   {@link serializeSpindriftFile} rather than by a general YAML writer. A
+ *   general writer produces valid flow-style YAML — `{version: 1, component:
+ *   {kind: service}}` — and nobody edits that. The shape is closed and small,
+ *   so writing it out block-style costs a few lines and buys a file a person
+ *   will actually change.
+ * - **Exactly the Spindrift files plus one CI caller.** Nothing else goes in
+ *   the tree. A configuration PR that also touched a lockfile, a README, or a
+ *   second workflow would be a PR whose review is about something other than
+ *   the connection.
+ * - **Nothing here is authoritative.** This module opens a PR and returns its
+ *   number. It writes no App, no Component, and no Build; the repo loop adopts
+ *   configuration only from the default branch, so an unmerged PR — including
+ *   one this module just opened — changes nothing.
+ */
+import type { DetectionProposal } from '../../domain/detection/ladder.ts';
+import type {
+  RepositoryRef,
+  RepositoryWriter,
+} from '../../domain/repository.ts';
+
+/** The Spindrift file's name inside each scope (§5). */
+export const SPINDRIFT_FILE = 'spindrift.yaml';
+
+/** The one CI caller the transaction carries. */
+export const WORKFLOW_PATH = '.github/workflows/spindrift.yml';
+
+/** The branch the configuration PR is opened from. */
+export const CONFIG_BRANCH = 'spindrift/configure';
+
+/** One scope's proposal, as detection produced it. */
+export interface ConfigurationScope {
+  /** Repo-relative directory, `.` for the repository root (§5's named scope). */
+  readonly scope: string;
+  readonly proposal: DetectionProposal;
+}
+
+/** One file the pull request writes. */
+export interface ConfigurationFile {
+  /** Repo-relative path. */
+  readonly path: string;
+  readonly contents: string;
+}
+
+/** The composed transaction, before anything has been sent anywhere. */
+export interface ConfigurationTransaction {
+  readonly branch: string;
+  readonly title: string;
+  readonly body: string;
+  readonly commitMessage: string;
+  readonly files: readonly ConfigurationFile[];
+}
+
+/** Quote a scalar only where YAML would otherwise read it as something else. */
+function scalar(value: string): string {
+  return /^[A-Za-z0-9][\w./-]*$/.test(value) ? value : JSON.stringify(value);
+}
+
+/**
+ * Serialize one scope's detection proposal as its in-repo Spindrift file.
+ *
+ * §15 calls this "a **lossless** serialization of Spindrift's config for one
+ * git-integrated scope". Lossless is checkable rather than asserted: what comes
+ * out of here parses back through `parseSpindriftFile` to the same proposal,
+ * and the test that says so is the only thing keeping the two in step as the
+ * schema grows.
+ *
+ * `kinds` is deliberately *not* emitted. It is the disabled-with-reasons
+ * grammar the UI renders (§5) — a statement about what detection considered,
+ * not about what this scope is. Writing it into the repository would make a
+ * reason somebody read once into a value the next detection run has to honour.
+ */
+export function serializeSpindriftFile(proposal: DetectionProposal): string {
+  const lines = [
+    '# Managed by Spindrift, and yours to edit.',
+    '#',
+    '# This file is what Spindrift knows about this directory. Once it is on the',
+    '# default branch it is authoritative: what is written here wins over what',
+    '# detection would otherwise guess.',
+    'version: 1',
+    'component:',
+    `  kind: ${proposal.kind}`,
+    'build:',
+    `  frontend: ${proposal.build.frontend}`,
+  ];
+
+  if (proposal.build.frontend === 'dockerfile') {
+    lines.push(`  file: ${scalar(proposal.build.dockerfile)}`);
+  } else {
+    const { buildCommand, outputDirectory } = proposal.build;
+    lines.push(
+      `  command: ${buildCommand === null ? 'null' : scalar(buildCommand)}`,
+      `  outputDirectory: ${outputDirectory === null ? 'null' : scalar(outputDirectory)}`,
+    );
+  }
+
+  lines.push('watchPaths:');
+  for (const path of proposal.watchPaths) {
+    lines.push(`  - ${scalar(path)}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+/**
+ * The thin CI caller (§4, §15).
+ *
+ * Thin is the requirement, and it has two halves. **The run happens in the
+ * connected repository** — §15 gives that repository the Actions minutes and
+ * the billing — while **the machinery lives in the pinned reusable workflow**,
+ * so what lands in somebody's repo is a dispatch trigger and a `uses:`.
+ *
+ * The single opaque `spec` input is what keeps it thin over time. A caller with
+ * one input per build parameter would have to be regenerated — and re-reviewed,
+ * in every connected repository — each time a build gained a parameter. The
+ * reusable workflow is pinned by commit and versioned by the platform, so it is
+ * the right place for that shape to live.
+ *
+ * `id-token: write` is the workflow-ref-scoped cloud identity §15 names: the
+ * job federates as itself rather than holding a credential this file would
+ * have to carry.
+ */
+export function buildWorkflowCaller(buildWorkflow: string): string {
+  return `# Managed by Spindrift.
+#
+# Spindrift dispatches this workflow when it needs a build. The run happens
+# here, on this repository’s own Actions minutes; everything it does lives in
+# the reusable workflow below, which is pinned by commit.
+name: spindrift
+on:
+  workflow_dispatch:
+    inputs:
+      spec:
+        description: The build request, as JSON. Spindrift fills this in.
+        required: true
+        type: string
+permissions:
+  contents: read
+  id-token: write
+jobs:
+  build:
+    uses: ${buildWorkflow}
+    with:
+      spec: \${{ inputs.spec }}
+`;
+}
+
+/** What the pull request body says, in the order an operator reads it. */
+function pullRequestBody(scopes: readonly ConfigurationScope[]): string {
+  const rows = scopes
+    .map(
+      ({ scope, proposal }) =>
+        `| \`${scope}\` | ${proposal.kind} | ${proposal.build.frontend} | ${proposal.source} |`,
+    )
+    .join('\n');
+
+  return `Spindrift wrote this. Merging it into the default branch is what connects this repository — nothing here takes effect until then, and an unmerged or closed pull request changes nothing.
+
+| scope | kind | build | detected by |
+| --- | --- | --- | --- |
+${rows}
+
+Each \`${SPINDRIFT_FILE}\` is yours to edit, here or later. Once it is on the default branch it wins over detection.
+
+\`${WORKFLOW_PATH}\` runs builds for this repository on its own Actions minutes. It calls a reusable workflow pinned by commit.
+`;
+}
+
+/**
+ * Compose the transaction. Pure: nothing is sent, so a test can read exactly
+ * what would be written before deciding whether a far side is involved.
+ */
+export function configurationTransaction(input: {
+  readonly scopes: readonly ConfigurationScope[];
+  readonly buildWorkflow: string;
+}): ConfigurationTransaction {
+  if (input.scopes.length === 0) {
+    throw new RangeError(
+      'a configuration pull request needs at least one scope',
+    );
+  }
+
+  const files: ConfigurationFile[] = input.scopes.map(
+    ({ scope, proposal }) => ({
+      path: scope === '.' ? SPINDRIFT_FILE : `${scope}/${SPINDRIFT_FILE}`,
+      contents: serializeSpindriftFile(proposal),
+    }),
+  );
+  files.push({
+    path: WORKFLOW_PATH,
+    contents: buildWorkflowCaller(input.buildWorkflow),
+  });
+
+  const scopeCount =
+    input.scopes.length === 1 ? '1 scope' : `${input.scopes.length} scopes`;
+  return {
+    branch: CONFIG_BRANCH,
+    title: `Connect this repository to Spindrift (${scopeCount})`,
+    body: pullRequestBody(input.scopes),
+    commitMessage: 'Add Spindrift configuration',
+    files,
+  };
+}
+
+/**
+ * What opening the transaction needs: the writer, plus the one read that finds
+ * the base commit.
+ *
+ * Declared as an intersection of the domain's interfaces rather than restated,
+ * so `GitHubApp` satisfying `RepositoryHost` is the same fact as it satisfying
+ * this.
+ */
+export type ConfigurationHost = RepositoryWriter & {
+  branchHead(
+    ref: RepositoryRef,
+    fullName: string,
+    branch: string,
+  ): Promise<string>;
+};
+
+/** Where the opened pull request can be found. */
+export interface OpenedConfigurationPullRequest {
+  readonly number: number;
+  readonly branch: string;
+  readonly commit: string;
+}
+
+/**
+ * Write the transaction to a branch and open the pull request for it.
+ *
+ * The base is the default branch, and it is read here rather than taken as a
+ * parameter so the branch cannot be cut from a ref that is not the one whose
+ * merge will be authoritative.
+ */
+export async function openConfigurationPullRequest(
+  host: ConfigurationHost,
+  ref: RepositoryRef,
+  input: {
+    readonly fullName: string;
+    readonly defaultBranch: string;
+    readonly transaction: ConfigurationTransaction;
+  },
+): Promise<OpenedConfigurationPullRequest> {
+  const { fullName, defaultBranch, transaction } = input;
+
+  const base = await host.branchHead(ref, fullName, defaultBranch);
+  const baseTree = await host.commitTree(ref, fullName, base);
+
+  const entries = await Promise.all(
+    transaction.files.map(async (file) => ({
+      path: file.path,
+      blob: await host.createBlob(ref, fullName, file.contents),
+    })),
+  );
+
+  const tree = await host.createTree(ref, fullName, baseTree, entries);
+  const commit = await host.createCommit(ref, fullName, {
+    message: transaction.commitMessage,
+    tree,
+    parent: base,
+  });
+  await host.setBranch(ref, fullName, transaction.branch, commit);
+
+  const number = await host.openPullRequest(ref, fullName, {
+    title: transaction.title,
+    body: transaction.body,
+    head: transaction.branch,
+    base: defaultBranch,
+  });
+
+  return { number, branch: transaction.branch, commit };
+}

--- a/apps/spindrift/src/integrations/github/http.ts
+++ b/apps/spindrift/src/integrations/github/http.ts
@@ -1,0 +1,178 @@
+/**
+ * The transport every call to the repository host goes through (§15, § Seam 2).
+ *
+ * § Seam 2 names the pattern this repo already uses for a far side that speaks
+ * HTTP: "a fake of the far-side HTTP API behind the real client, with the test
+ * asserting the requests that were made" (`apps/ddnsd/main_test.go`). That only
+ * works if the client takes its transport, so {@link GitHubEndpoint} carries a
+ * `fetch` and nothing in this integration calls the global.
+ *
+ * **Why this is not `adapters/store/http.ts`.** The two differ on the only
+ * things a transport decides. A store's `404` is an answer — absence is a value
+ * its contract has — whereas here a `404` is very often the *symptom of lost
+ * access*, because a repository the App can no longer see is indistinguishable
+ * from one that never existed. And this client has to fetch bytes, not only
+ * JSON. Sharing a class across those two would mean one of the two callers
+ * reading a status code the other one already interpreted.
+ *
+ * Hence {@link GitHubAccessError}: the one place where "the far side said no"
+ * is turned into the closed vocabulary §15's freeze rule is written against.
+ */
+
+/** The transport, in the shape `fetch` already has. */
+export type Fetcher = (request: Request) => Promise<Response>;
+
+/**
+ * Mints an `Authorization` value per request.
+ *
+ * A provider rather than a string for the same reason the store adapters take
+ * one: §15 stores no token, so every credential here is short-lived and minted
+ * at the moment of use. A client holding a string would be holding a token.
+ */
+export type AuthorizationProvider = () => string | Promise<string>;
+
+/** Where the repository host is, and how a request to it is authorized. */
+export interface GitHubEndpoint {
+  /** Base URL of the REST API, without a trailing slash. */
+  readonly baseUrl: string;
+  readonly authorization: AuthorizationProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+}
+
+/**
+ * Why a call to the repository host did not succeed.
+ *
+ * Closed, and the closing is the point. §15 turns exactly one of these into a
+ * state — `ACCESS_LOST` freezes the repository — so the classification has to
+ * happen once, here, rather than at each call site guessing from a status code.
+ *
+ * - `ACCESS_LOST`: `401`, `403`, or `404`. **All three, deliberately.** A
+ *   repository the installation was removed from answers `404` exactly as a
+ *   repository that never existed does; there is no response that distinguishes
+ *   them, and treating one as a fault and the other as a freeze would make the
+ *   behaviour depend on a difference nobody can observe.
+ * - `RATE_LIMITED`: `429`, or a `403` carrying the rate-limit marker. Split out
+ *   because it is emphatically *not* lost access — freezing a repository
+ *   because the hour's quota ran out would turn a delay into an operator
+ *   incident.
+ * - `UNAVAILABLE`: everything else. The far side is having a bad time; the next
+ *   pass of the loop will ask again.
+ */
+export type GitHubAccessCode = 'ACCESS_LOST' | 'RATE_LIMITED' | 'UNAVAILABLE';
+
+/** A far side that answered, but not with success. */
+export class GitHubAccessError extends Error {
+  override readonly name = 'GitHubAccessError';
+
+  constructor(
+    readonly code: GitHubAccessCode,
+    readonly method: string,
+    readonly url: string,
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`${method} ${url} failed with ${status}: ${body}`);
+  }
+}
+
+/** The REST API version this client's response parsing was written against. */
+const API_VERSION = '2022-11-28';
+
+/** The header the host sets when a `403` is a quota refusal, not a permission one. */
+const RATE_LIMIT_REMAINING = 'X-RateLimit-Remaining';
+
+function classify(response: Response): GitHubAccessCode {
+  if (response.status === 429) return 'RATE_LIMITED';
+  if (response.status === 403) {
+    return response.headers.get(RATE_LIMIT_REMAINING) === '0'
+      ? 'RATE_LIMITED'
+      : 'ACCESS_LOST';
+  }
+  if (response.status === 401 || response.status === 404) return 'ACCESS_LOST';
+  return 'UNAVAILABLE';
+}
+
+/** One request's worth of options. */
+interface RequestOptions {
+  method: string;
+  /** Appended to the endpoint's base URL; must begin with a slash. */
+  path: string;
+  /** Serialized as JSON when present. */
+  body?: unknown;
+  /** What the caller will read. Bytes skip content negotiation for JSON. */
+  accept?: string;
+  /**
+   * Statuses the caller has a value for, returned instead of thrown.
+   *
+   * Only ever `404`, and only from the two calls that ask whether a *file*
+   * exists — where absence is the answer, not a symptom. Everything else lets
+   * the classification above stand, so an installation that lost access does
+   * not silently read as a repository with no configuration in it.
+   */
+  tolerate?: readonly number[];
+}
+
+/**
+ * The client this integration makes its calls through.
+ *
+ * Deliberately thin: it authorizes, negotiates content, and classifies a
+ * refusal. Retries and backoff belong to the loop, which is the only thing that
+ * knows whether it is worth waiting.
+ */
+export class GitHubHttp {
+  constructor(private readonly endpoint: GitHubEndpoint) {}
+
+  /** Send a request and parse a JSON response. `null` on a tolerated status. */
+  async json<Result>(options: RequestOptions): Promise<Result | null> {
+    const response = await this.send(options);
+    if (response === null) return null;
+    return (await response.json()) as Result;
+  }
+
+  /** Send a request and read the response body as bytes. */
+  async bytes(options: RequestOptions): Promise<Uint8Array> {
+    const response = await this.send(options);
+    // Unreachable without `tolerate`, which no byte-returning call passes: the
+    // archive download has no meaning for "absent" that is not lost access.
+    if (response === null) {
+      throw new TypeError('a tolerated status cannot return bytes');
+    }
+    return new Uint8Array(await response.arrayBuffer());
+  }
+
+  /** Send one request. `null` when the status was tolerated by the caller. */
+  async send(options: RequestOptions): Promise<Response | null> {
+    const url = `${this.endpoint.baseUrl}${options.path}`;
+    const headers: Record<string, string> = {
+      Accept: options.accept ?? 'application/vnd.github+json',
+      Authorization: await this.endpoint.authorization(),
+      // Pinning the API version is what keeps a far-side default from changing
+      // the shape of a response this client parses.
+      'X-GitHub-Api-Version': API_VERSION,
+    };
+    if (options.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    const request = new Request(url, {
+      method: options.method,
+      headers,
+      body:
+        options.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+
+    const send = this.endpoint.fetch ?? ((input: Request) => fetch(input));
+    const response = await send(request);
+
+    if (response.ok) return response;
+    if (options.tolerate?.includes(response.status)) return null;
+    throw new GitHubAccessError(
+      classify(response),
+      options.method,
+      url,
+      response.status,
+      await response.text(),
+    );
+  }
+}

--- a/apps/spindrift/src/integrations/github/webhook.ts
+++ b/apps/spindrift/src/integrations/github/webhook.ts
@@ -1,0 +1,342 @@
+/**
+ * The signed repository webhook (§15, §21).
+ *
+ * §21 names this one of the only externally reachable endpoints, and §15 pairs
+ * it with periodic default-branch reconciliation so "a missed delivery
+ * self-heals". Those two sentences set the whole posture of this module:
+ *
+ * - **The signature is the authentication, so it is checked before anything is
+ *   parsed.** The body is untrusted bytes until the HMAC matches; parsing first
+ *   would run a JSON decoder on whatever the internet sent.
+ * - **A delivery is a hint, never a fact.** Nothing here writes. It classifies
+ *   one delivery into {@link WebhookDelivery} and hands it to the repo loop,
+ *   which does the same work whether it was woken by a delivery or by its own
+ *   timer. That is what makes the loop the correctness path and this the
+ *   latency optimization — the same shape the deploy loop takes with
+ *   `LISTEN`/`NOTIFY`.
+ * - **Everything unrecognized is `ignored`, with a reason.** A repository host
+ *   sends events nobody subscribed to and adds new ones over time; a parser
+ *   that threw on those would turn a product decision made elsewhere into a
+ *   `500` on this installation's public endpoint.
+ */
+
+/** The header carrying the HMAC over the raw body. */
+export const SIGNATURE_HEADER = 'X-Hub-Signature-256';
+/** The header naming which event was delivered. */
+export const EVENT_HEADER = 'X-GitHub-Event';
+
+/**
+ * What one delivery means to Spindrift.
+ *
+ * Three kinds and a fourth that means nothing, chosen because §15 gives exactly
+ * three things a delivery can tell this system: the default branch moved,
+ * access went away, or access came back.
+ */
+export type WebhookDelivery =
+  | {
+      /** A push to some ref. Whether it is *the* ref is the loop's question. */
+      readonly kind: 'push';
+      /** `owner/name`. */
+      readonly repository: string;
+      /** The full ref, e.g. `refs/heads/main`. */
+      readonly ref: string;
+      /** The repository's default branch as the delivery reported it. */
+      readonly defaultBranch: string;
+      /** The commit the ref now points at. */
+      readonly head: string;
+    }
+  | {
+      /**
+       * The App lost access to one or more repositories: the installation was
+       * deleted or suspended, or repositories were removed from a
+       * selected-repository App.
+       */
+      readonly kind: 'accessLost';
+      readonly installationId: string;
+      /**
+       * The repositories named by the delivery. Empty means *every* repository
+       * of that installation, which is what a deletion or suspension is — the
+       * delivery names an installation, not a list.
+       */
+      readonly repositories: readonly string[];
+      /** The sentence an operator reads on the frozen repository. */
+      readonly detail: string;
+    }
+  | {
+      /** Access came back: an unsuspend, or repositories added. */
+      readonly kind: 'accessRestored';
+      readonly installationId: string;
+      /** Empty means every repository of that installation. */
+      readonly repositories: readonly string[];
+    }
+  | {
+      readonly kind: 'ignored';
+      /** Why nothing was derived from it, for a log line. */
+      readonly reason: string;
+    };
+
+/** Why a delivery was refused before it was parsed. */
+export type WebhookRejectionCode =
+  | 'SIGNATURE_MISSING'
+  | 'SIGNATURE_MALFORMED'
+  | 'SIGNATURE_MISMATCH'
+  | 'EVENT_MISSING'
+  | 'BODY_MALFORMED';
+
+/**
+ * A delivery that will not be interpreted.
+ *
+ * Distinct from an `ignored` delivery, and the distinction is the security
+ * boundary: `ignored` means "authenticated, and nothing to do"; this means "not
+ * authenticated, or not a request at all". The endpoint answers `202` to the
+ * first and `4xx` to the second, and conflating them would make an attacker's
+ * unsigned body indistinguishable from a `ping`.
+ */
+export class WebhookRejected extends Error {
+  override readonly name = 'WebhookRejected';
+
+  constructor(
+    readonly code: WebhookRejectionCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+const SIGNATURE_PREFIX = 'sha256=';
+
+function hexToBytes(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0 || !/^[0-9a-f]*$/i.test(hex)) return null;
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let index = 0; index < bytes.length; index += 1) {
+    bytes[index] = Number.parseInt(hex.slice(index * 2, index * 2 + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Compare two byte strings without leaking where they diverge.
+ *
+ * The length is compared first and separately, which does leak *that* — but the
+ * length of a SHA-256 HMAC is a constant an attacker already knows, and the
+ * alternative (padding to a fixed width) would compare bytes that mean nothing.
+ */
+function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let difference = 0;
+  for (let index = 0; index < a.length; index += 1) {
+    difference |= (a[index] ?? 0) ^ (b[index] ?? 0);
+  }
+  return difference === 0;
+}
+
+/**
+ * Check the HMAC over the **raw body bytes**.
+ *
+ * Bytes, not a string, and not a re-serialized object: the signature covers
+ * exactly what was sent, and any round trip through a parser is a chance to
+ * canonicalize a byte the sender did not. A caller that has already parsed the
+ * body has already lost the ability to verify it.
+ */
+export async function verifyWebhookSignature(
+  body: Uint8Array,
+  signature: string | null,
+  secret: string,
+): Promise<void> {
+  if (signature === null || signature.length === 0) {
+    throw new WebhookRejected(
+      'SIGNATURE_MISSING',
+      `the delivery carried no ${SIGNATURE_HEADER}`,
+    );
+  }
+  if (!signature.startsWith(SIGNATURE_PREFIX)) {
+    throw new WebhookRejected(
+      'SIGNATURE_MALFORMED',
+      `${SIGNATURE_HEADER} must be ${SIGNATURE_PREFIX}<hex>`,
+    );
+  }
+  const presented = hexToBytes(signature.slice(SIGNATURE_PREFIX.length));
+  if (presented === null) {
+    throw new WebhookRejected(
+      'SIGNATURE_MALFORMED',
+      `${SIGNATURE_HEADER} is not hexadecimal`,
+    );
+  }
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const expected = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, body as BufferSource),
+  );
+
+  if (!equalBytes(expected, presented)) {
+    throw new WebhookRejected(
+      'SIGNATURE_MISMATCH',
+      'the delivery signature does not match this installation’s secret',
+    );
+  }
+}
+
+/** The fields this module reads out of a delivery, all optional until checked. */
+interface DeliveryBody {
+  action?: string;
+  ref?: string;
+  after?: string;
+  repository?: { full_name?: string; default_branch?: string };
+  installation?: { id?: number | string };
+  repositories_removed?: { full_name?: string }[];
+  repositories_added?: { full_name?: string }[];
+}
+
+function installationIdOf(body: DeliveryBody): string | null {
+  const id = body.installation?.id;
+  return id === undefined ? null : String(id);
+}
+
+function namesOf(
+  entries: { full_name?: string }[] | undefined,
+): readonly string[] {
+  return (entries ?? [])
+    .map((entry) => entry.full_name)
+    .filter((name): name is string => name !== undefined);
+}
+
+/**
+ * Interpret one **already verified** delivery.
+ *
+ * Separate from verification so the ordering is visible at the call site rather
+ * than trusted to a flag: {@link handleWebhookDelivery} is the composed form,
+ * and this is what a test drives when it is asserting classification rather
+ * than authentication.
+ */
+export function parseWebhookDelivery(
+  event: string,
+  body: unknown,
+): WebhookDelivery {
+  if (typeof body !== 'object' || body === null) {
+    throw new WebhookRejected(
+      'BODY_MALFORMED',
+      'the delivery body is not an object',
+    );
+  }
+  const delivery = body as DeliveryBody;
+  const installationId = installationIdOf(delivery);
+
+  if (event === 'push') {
+    const repository = delivery.repository?.full_name;
+    const defaultBranch = delivery.repository?.default_branch;
+    if (
+      repository === undefined ||
+      defaultBranch === undefined ||
+      delivery.ref === undefined ||
+      delivery.after === undefined
+    ) {
+      throw new WebhookRejected(
+        'BODY_MALFORMED',
+        'the push delivery named no repository, ref, or head commit',
+      );
+    }
+    return {
+      kind: 'push',
+      repository,
+      ref: delivery.ref,
+      defaultBranch,
+      head: delivery.after,
+    };
+  }
+
+  if (installationId === null) {
+    return { kind: 'ignored', reason: `${event} names no installation` };
+  }
+
+  if (event === 'installation') {
+    switch (delivery.action) {
+      case 'deleted':
+        return {
+          kind: 'accessLost',
+          installationId,
+          repositories: [],
+          detail: 'the GitHub App installation was deleted',
+        };
+      case 'suspend':
+        return {
+          kind: 'accessLost',
+          installationId,
+          repositories: [],
+          detail: 'the GitHub App installation was suspended',
+        };
+      case 'unsuspend':
+        return { kind: 'accessRestored', installationId, repositories: [] };
+      default:
+        return {
+          kind: 'ignored',
+          reason: `installation.${delivery.action ?? 'unknown'} changes no access`,
+        };
+    }
+  }
+
+  if (event === 'installation_repositories') {
+    const removed = namesOf(delivery.repositories_removed);
+    if (removed.length > 0) {
+      return {
+        kind: 'accessLost',
+        installationId,
+        repositories: removed,
+        detail: 'the repository was removed from the GitHub App installation',
+      };
+    }
+    const added = namesOf(delivery.repositories_added);
+    if (added.length > 0) {
+      return { kind: 'accessRestored', installationId, repositories: added };
+    }
+    return {
+      kind: 'ignored',
+      reason: 'the delivery added and removed no repository',
+    };
+  }
+
+  return { kind: 'ignored', reason: `${event} is not subscribed to` };
+}
+
+/** One raw delivery, exactly as it arrived. */
+export interface RawDelivery {
+  readonly event: string | null;
+  readonly signature: string | null;
+  readonly body: Uint8Array;
+}
+
+/**
+ * Verify, then interpret. The order is the whole contract.
+ *
+ * The body is decoded only after the HMAC over its bytes matched, so the JSON
+ * parser never runs on unauthenticated input.
+ */
+export async function handleWebhookDelivery(
+  delivery: RawDelivery,
+  secret: string,
+): Promise<WebhookDelivery> {
+  await verifyWebhookSignature(delivery.body, delivery.signature, secret);
+
+  if (delivery.event === null || delivery.event.length === 0) {
+    throw new WebhookRejected(
+      'EVENT_MISSING',
+      `the delivery carried no ${EVENT_HEADER}`,
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = JSON.parse(new TextDecoder().decode(delivery.body));
+  } catch (cause) {
+    throw new WebhookRejected(
+      'BODY_MALFORMED',
+      `the delivery body is not JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+  return parseWebhookDelivery(delivery.event, body);
+}

--- a/apps/spindrift/src/reconciler/repo-loop.ts
+++ b/apps/spindrift/src/reconciler/repo-loop.ts
@@ -1,0 +1,518 @@
+/**
+ * The repository loop (§15).
+ *
+ * §15 gives Spindrift "a signed repository webhook **plus** periodic
+ * default-branch reconciliation", and says why: "so that a missed delivery
+ * self-heals". This file is the second half, and it is the correctness path —
+ * the webhook only shortens a wait. Everything here is correct with every
+ * delivery dropped, exactly as the deploy loop is correct with every
+ * `NOTIFY` dropped, and for the same reason: an endpoint on the public
+ * internet is not a delivery guarantee.
+ *
+ * Three rules run through it.
+ *
+ * **Only the default branch is authoritative.** Configuration is adopted from
+ * one commit on one branch, and `repositories.authoritative_commit` is where
+ * that lands. A pull request — including the configuration PR Spindrift itself
+ * opened — is on a branch, so nothing this loop does can be affected by one
+ * until it merges. That is not a code path to be careful about; it is that
+ * there is no code path reading any other ref.
+ *
+ * **The repository's configuration is one transaction.** §15 makes the whole
+ * PR the unit, so a default-branch commit carrying an unparseable Spindrift
+ * file is a commit that is **not adopted at all** — the good scopes in it do
+ * not land while a bad one is ignored. The loop reports why and tries again on
+ * the next pass, which is what turns a typo into a visible, self-clearing state
+ * rather than a partial adoption nobody can see.
+ *
+ * **Lost access freezes and never destroys.** §15: "Lost access **freezes
+ * source-driven changes and never destroys a Deploy**." Mechanically: the only
+ * write this file makes on lost access is an `UPDATE` of one `repositories`
+ * row. There is no `delete` anywhere in it, and no write to `apps`,
+ * `components`, `builds`, or `deploys` at all — so what is running keeps
+ * running, and what stops is the one thing that genuinely cannot continue,
+ * which is reading new source.
+ *
+ * What this loop does **not** do is dispatch a build. §5 makes default-branch
+ * HEAD the trigger, but a Build has to name a route, and the routes arrive with
+ * the build adapters. Until then the loop's job ends at adopting a commit and
+ * saying which scopes it changed, which is the fact a dispatcher will need.
+ */
+import { eq } from 'drizzle-orm';
+import type { Clock } from '../commands/types.ts';
+import type { Database } from '../db/client.ts';
+import { apps, type Repository, repositories } from '../db/schema.ts';
+import type { DetectionProposal } from '../domain/detection/ladder.ts';
+import { parseSpindriftFile } from '../domain/detection/spindrift-file.ts';
+import {
+  type RepositoryReader,
+  type RepositoryRef,
+  repositoryRefOf,
+} from '../domain/repository.ts';
+import { SPINDRIFT_FILE } from '../integrations/github/config-pr.ts';
+import { GitHubAccessError } from '../integrations/github/http.ts';
+import type { WebhookDelivery } from '../integrations/github/webhook.ts';
+
+/** What the loop needs. No principal: nobody asked for it to run. */
+export interface RepoLoopContext {
+  readonly db: Database;
+  readonly clock: Clock;
+  /**
+   * The far side, as the domain names it — never a GitHub client. The loop
+   * reads three things and writes none, which is what `RepositoryReader` is.
+   */
+  readonly host: RepositoryReader;
+}
+
+/** What one scope's Spindrift file said, or why it said nothing. */
+export type ScopeOutcome =
+  | {
+      readonly scope: string;
+      readonly appId: string;
+      readonly outcome: 'adopted';
+      readonly proposal: DetectionProposal;
+      /** Whether this differs from what the previously adopted commit held. */
+      readonly changed: boolean;
+    }
+  | {
+      readonly scope: string;
+      readonly appId: string;
+      /** No Spindrift file at this scope. Not an error: detection still applies. */
+      readonly outcome: 'absent';
+    }
+  | {
+      readonly scope: string;
+      readonly appId: string;
+      readonly outcome: 'invalid';
+      readonly detail: string;
+    };
+
+/** What one pass over one repository did. */
+export type RepositoryReconciliation =
+  | {
+      readonly repositoryId: string;
+      readonly fullName: string;
+      /** The default branch had not moved since the adopted commit. */
+      readonly outcome: 'unchanged';
+      readonly commit: string;
+    }
+  | {
+      readonly repositoryId: string;
+      readonly fullName: string;
+      readonly outcome: 'adopted';
+      readonly commit: string;
+      readonly scopes: readonly ScopeOutcome[];
+      /** Set when this pass also cleared a freeze. */
+      readonly thawed?: true;
+    }
+  | {
+      readonly repositoryId: string;
+      readonly fullName: string;
+      /** A commit was reached but not adopted: a scope's file did not parse. */
+      readonly outcome: 'rejected';
+      readonly commit: string;
+      readonly scopes: readonly ScopeOutcome[];
+    }
+  | {
+      readonly repositoryId: string;
+      readonly fullName: string;
+      readonly outcome: 'frozen';
+      readonly detail: string;
+    }
+  | {
+      readonly repositoryId: string;
+      readonly fullName: string;
+      /**
+       * The host could not be reached, or refused for a reason that is not
+       * about access. Explicitly **not** a freeze: a rate limit or a bad hour
+       * at the far side is a delay, and turning it into an operator-visible
+       * frozen state would cry wolf until nobody read the state at all.
+       */
+      readonly outcome: 'unavailable';
+      readonly detail: string;
+    };
+
+/** Where a scope's Spindrift file lives. `.` is the repository root (§5). */
+function spindriftPath(subpath: string | null): string {
+  const scope = subpath ?? '.';
+  return scope === '.' ? SPINDRIFT_FILE : `${scope}/${SPINDRIFT_FILE}`;
+}
+
+/**
+ * Freeze one repository (§15).
+ *
+ * One `UPDATE`, and the row it touches is the only row in the database that
+ * describes source access. Nothing about what is deployed is reachable from
+ * here, which is the mechanical form of "never destroys a Deploy".
+ */
+async function freeze(
+  context: RepoLoopContext,
+  repository: Pick<Repository, 'id' | 'fullName'>,
+  detail: string,
+): Promise<RepositoryReconciliation> {
+  const now = context.clock.now();
+  await context.db
+    .update(repositories)
+    .set({
+      access: 'frozen',
+      frozenReason: detail,
+      frozenAt: now,
+      updatedAt: now,
+    })
+    .where(eq(repositories.id, repository.id));
+
+  return {
+    repositoryId: repository.id,
+    fullName: repository.fullName,
+    outcome: 'frozen',
+    detail,
+  };
+}
+
+/** Clear a freeze. Source-driven changes resume; nothing else changes. */
+async function thaw(
+  context: RepoLoopContext,
+  repositoryId: string,
+): Promise<void> {
+  const now = context.clock.now();
+  await context.db
+    .update(repositories)
+    .set({
+      access: 'active',
+      frozenReason: null,
+      frozenAt: null,
+      updatedAt: now,
+    })
+    .where(eq(repositories.id, repositoryId));
+}
+
+/**
+ * One pass over one repository.
+ *
+ * Never throws for anything the far side did. A loop over a fleet has to
+ * survive one bad repository, and an access error is the input to a decision
+ * here rather than an exception somebody above has to interpret.
+ */
+export async function reconcileRepository(
+  context: RepoLoopContext,
+  repository: Repository,
+): Promise<RepositoryReconciliation> {
+  const ref = repositoryRefOf(repository);
+  const now = context.clock.now();
+
+  let defaultBranch: string;
+  let head: string;
+  try {
+    const facts = await context.host.repository(ref, repository.fullName);
+    defaultBranch = facts.defaultBranch;
+    head = await context.host.branchHead(
+      ref,
+      repository.fullName,
+      defaultBranch,
+    );
+  } catch (cause) {
+    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
+      return freeze(
+        context,
+        repository,
+        'Spindrift can no longer read this repository',
+      );
+    }
+    return {
+      repositoryId: repository.id,
+      fullName: repository.fullName,
+      outcome: 'unavailable',
+      detail: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+
+  // Reaching the repository is what proves access came back. A freeze is
+  // cleared here rather than only on a webhook, because §15's periodic
+  // reconciliation is the path that has to work when a delivery was missed —
+  // including the delivery that would have said access was restored.
+  const thawed = repository.access === 'frozen';
+  if (thawed) await thaw(context, repository.id);
+
+  if (head === repository.authoritativeCommit) {
+    await context.db
+      .update(repositories)
+      .set({ defaultBranch, reconciledAt: now, updatedAt: now })
+      .where(eq(repositories.id, repository.id));
+    return {
+      repositoryId: repository.id,
+      fullName: repository.fullName,
+      outcome: 'unchanged',
+      commit: head,
+    };
+  }
+
+  const scoped = await context.db
+    .select({
+      id: apps.id,
+      subpath: apps.sourceRepoSubpath,
+    })
+    .from(apps)
+    .where(eq(apps.repositoryId, repository.id));
+
+  const previous = repository.authoritativeCommit;
+  const outcomes: ScopeOutcome[] = [];
+  for (const app of scoped) {
+    const scope = app.subpath ?? '.';
+    const path = spindriftPath(app.subpath);
+    let document: string | null;
+    try {
+      document = await context.host.readFile(
+        ref,
+        repository.fullName,
+        head,
+        path,
+      );
+    } catch (cause) {
+      if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
+        return freeze(
+          context,
+          repository,
+          'Spindrift can no longer read this repository',
+        );
+      }
+      return {
+        repositoryId: repository.id,
+        fullName: repository.fullName,
+        outcome: 'unavailable',
+        detail: cause instanceof Error ? cause.message : String(cause),
+      };
+    }
+
+    if (document === null) {
+      outcomes.push({ scope, appId: app.id, outcome: 'absent' });
+      continue;
+    }
+
+    let proposal: DetectionProposal;
+    try {
+      proposal = parseSpindriftFile(document, path);
+    } catch (cause) {
+      outcomes.push({
+        scope,
+        appId: app.id,
+        outcome: 'invalid',
+        detail: cause instanceof Error ? cause.message : String(cause),
+      });
+      continue;
+    }
+
+    let changed = true;
+    if (previous !== null) {
+      // "Changed" is a comparison against the previously adopted commit, not a
+      // guess from the push payload's file list: a force-push, a revert, and a
+      // merge all move the branch without saying what a scope's file now says.
+      const before = await readScopeFile(
+        context,
+        ref,
+        repository,
+        previous,
+        path,
+      );
+      changed = before !== document;
+    }
+
+    outcomes.push({
+      scope,
+      appId: app.id,
+      outcome: 'adopted',
+      proposal,
+      changed,
+    });
+  }
+
+  if (outcomes.some((outcome) => outcome.outcome === 'invalid')) {
+    // Not adopted, and `authoritative_commit` deliberately left where it was:
+    // the previous commit's configuration is still what governs, and the next
+    // pass will try this one again.
+    await context.db
+      .update(repositories)
+      .set({ defaultBranch, reconciledAt: now, updatedAt: now })
+      .where(eq(repositories.id, repository.id));
+    return {
+      repositoryId: repository.id,
+      fullName: repository.fullName,
+      outcome: 'rejected',
+      commit: head,
+      scopes: outcomes,
+    };
+  }
+
+  await context.db
+    .update(repositories)
+    .set({
+      defaultBranch,
+      authoritativeCommit: head,
+      reconciledAt: now,
+      updatedAt: now,
+    })
+    .where(eq(repositories.id, repository.id));
+
+  return {
+    repositoryId: repository.id,
+    fullName: repository.fullName,
+    outcome: 'adopted',
+    commit: head,
+    scopes: outcomes,
+    ...(thawed ? { thawed: true as const } : {}),
+  };
+}
+
+/** A scope's file at an older commit, or `null` if it was not there either. */
+async function readScopeFile(
+  context: RepoLoopContext,
+  ref: RepositoryRef,
+  repository: Repository,
+  commit: string,
+  path: string,
+): Promise<string | null> {
+  try {
+    return await context.host.readFile(ref, repository.fullName, commit, path);
+  } catch {
+    // A commit that has been garbage-collected, or a history rewrite. Not
+    // knowing what a scope looked like before is a reason to treat it as
+    // changed, never a reason to fail the pass.
+    return null;
+  }
+}
+
+/**
+ * One pass over every connected repository.
+ *
+ * Frozen repositories are **included**, not skipped. A freeze is a state to
+ * recover from, and the only thing that can observe recovery is an attempt to
+ * read — so skipping them would make a freeze permanent until somebody noticed
+ * by hand.
+ */
+export async function reconcileAllRepositories(
+  context: RepoLoopContext,
+): Promise<readonly RepositoryReconciliation[]> {
+  const connected = await context.db.select().from(repositories);
+
+  const passes: RepositoryReconciliation[] = [];
+  for (const repository of connected) {
+    // Sequential: the far side is somebody else's API with a shared rate limit,
+    // and a fleet of repositories reconciling in lockstep is the fastest way to
+    // spend an hour's quota in a second.
+    passes.push(await reconcileRepository(context, repository));
+  }
+  return passes;
+}
+
+/**
+ * Apply one **already verified** webhook delivery.
+ *
+ * A shortcut, never a source of truth. Every branch here either does what the
+ * periodic pass would have done anyway, or does nothing — so a delivery that
+ * never arrives costs latency and nothing else.
+ */
+export async function applyWebhookDelivery(
+  context: RepoLoopContext,
+  delivery: WebhookDelivery,
+): Promise<readonly RepositoryReconciliation[]> {
+  if (delivery.kind === 'ignored') return [];
+
+  if (delivery.kind === 'push') {
+    // §15: only the default branch is authoritative. A push to any other ref is
+    // discarded here rather than reconciled-and-discarded, because reconciling
+    // would read the default branch and find nothing new — the same answer, one
+    // round trip later.
+    if (delivery.ref !== `refs/heads/${delivery.defaultBranch}`) return [];
+    const [repository] = await context.db
+      .select()
+      .from(repositories)
+      .where(eq(repositories.fullName, delivery.repository));
+    if (repository === undefined) return [];
+    return [await reconcileRepository(context, repository)];
+  }
+
+  const affected = await repositoriesOf(
+    context,
+    delivery.installationId,
+    delivery.repositories,
+  );
+
+  if (delivery.kind === 'accessLost') {
+    const frozen: RepositoryReconciliation[] = [];
+    for (const repository of affected) {
+      frozen.push(await freeze(context, repository, delivery.detail));
+    }
+    return frozen;
+  }
+
+  // Restored access is not taken at the delivery's word: the freeze is cleared
+  // by a pass that actually read the repository, which is the same evidence the
+  // periodic path uses.
+  const passes: RepositoryReconciliation[] = [];
+  for (const repository of affected) {
+    passes.push(await reconcileRepository(context, repository));
+  }
+  return passes;
+}
+
+/**
+ * The rows one installation-scoped delivery names.
+ *
+ * An empty name list means the whole installation — a deletion or a suspension
+ * names no repository because it applies to all of them.
+ */
+async function repositoriesOf(
+  context: RepoLoopContext,
+  installationId: string,
+  names: readonly string[],
+): Promise<Repository[]> {
+  const all = await context.db
+    .select()
+    .from(repositories)
+    .where(eq(repositories.installationId, installationId));
+  if (names.length === 0) return all;
+
+  const named = new Set(names);
+  return all.filter((repository) => named.has(repository.fullName));
+}
+
+/** How often the loop runs, and how to stop it. */
+export interface RepoLoopOptions {
+  readonly intervalMs: number;
+  readonly signal?: AbortSignal;
+  /** Called after each pass — where an installation wires logging or metrics. */
+  readonly onPass?: (passes: readonly RepositoryReconciliation[]) => void;
+}
+
+/**
+ * Run the loop until aborted.
+ *
+ * The interval is fixed rather than adaptive, unlike the deploy loop's. There
+ * is no in-flight window here to be fast for: a repository is either at its
+ * adopted commit or it is not, and the webhook is what covers the latency the
+ * interval would otherwise be shortened for.
+ */
+export async function runRepoLoop(
+  context: RepoLoopContext,
+  options: RepoLoopOptions,
+): Promise<void> {
+  while (!options.signal?.aborted) {
+    options.onPass?.(await reconcileAllRepositories(context));
+    if (options.signal?.aborted) return;
+    await sleep(options.intervalMs, options.signal);
+  }
+}
+
+/** A sleep that wakes early on abort rather than holding the loop open. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -81,6 +81,7 @@ function registryOf(
     store: () => {
       throw new Error('a deploy command reached the secret store');
     },
+    repository: () => null,
   };
 }
 

--- a/apps/spindrift/test/commands/placement.test.ts
+++ b/apps/spindrift/test/commands/placement.test.ts
@@ -58,6 +58,7 @@ function fakes() {
     store: () => {
       throw new Error('no store adapter is configured for this test');
     },
+    repository: () => null,
   };
   return registry;
 }

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -1,0 +1,212 @@
+/**
+ * `connectRepository` (Task 24, §15).
+ *
+ * The command is the whole of user stories 18 and 19: connecting a repository
+ * is "**a thing I review and merge rather than a thing that happens to my
+ * repo**", and "**only the default-branch merge of that PR becomes
+ * authoritative**". Both are asserted here as facts about the row the command
+ * wrote — `authoritativeCommit` is null when it returns, and stays null however
+ * many times it is called.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { dispatch } from '../../src/commands/registry.ts';
+import { connectRepository } from '../../src/commands/repositories/connect.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { repositories } from '../../src/db/schema.ts';
+import type { DetectionProposal } from '../../src/domain/detection/ladder.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import {
+  CONFIG_BRANCH,
+  SPINDRIFT_FILE,
+  WORKFLOW_PATH,
+} from '../../src/integrations/github/config-pr.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeGitHub, testAppKey } from '../harness/fakes/github-api.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+
+const proposal: DetectionProposal = {
+  source: 'railpack',
+  kind: 'service',
+  kinds: [{ kind: 'service', available: true }],
+  build: {
+    frontend: 'railpack',
+    buildCommand: 'bun run build',
+    outputDirectory: null,
+  },
+  watchPaths: ['services/api'],
+};
+
+async function context(fake: FakeGitHub | null): Promise<CommandContext> {
+  const { pem } = await testAppKey();
+  const host =
+    fake === null
+      ? null
+      : new GitHubApp(
+          {
+            appId: '1234567',
+            privateKeyPem: pem,
+            baseUrl: fake.baseUrl,
+            fetch: fake.fetch,
+          },
+          () => NOW,
+        );
+
+  const adapters: AdapterRegistry = {
+    deploy: () => null,
+    build: () => null,
+    store: () => {
+      throw new Error('no store adapter is configured for this test');
+    },
+    repository: () => host,
+  };
+
+  return {
+    principal: { id: 'user-1', displayName: 'Operator' },
+    clock: { now: () => NOW },
+    db: database().db,
+    adapters,
+    manifest: await fixtureManifest(),
+  };
+}
+
+const input = (fake: FakeGitHub) => ({
+  fullName: fake.fullName,
+  installationId: fake.installationId,
+  scopes: [{ scope: 'services/api', proposal }],
+});
+
+describe('connecting a repository', () => {
+  test('writes one row, opens one pull request, and adopts nothing', async () => {
+    const fake = new FakeGitHub();
+    const base = fake.commitFiles('main', { 'README.md': 'unconnected' });
+
+    const result = await connectRepository(input(fake), await context(fake));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toMatchObject({
+      fullName: fake.fullName,
+      defaultBranch: 'main',
+      pullRequest: 1,
+      // Stated rather than omitted: opening the pull request adopted nothing.
+      authoritativeCommit: null,
+    });
+
+    const [row] = await database()
+      .db.select()
+      .from(repositories)
+      .where(eq(repositories.id, result.value.repositoryId));
+    expect(row).toMatchObject({
+      fullName: fake.fullName,
+      installationId: fake.installationId,
+      defaultBranch: 'main',
+      access: 'active',
+      authoritativeCommit: null,
+      configPullRequest: 1,
+    });
+
+    // The default branch is untouched; the transaction is on its own branch.
+    expect(fake.head('main')).toBe(base);
+    const written = fake.filesAt(fake.head(CONFIG_BRANCH) ?? '');
+    expect(Object.keys(written).sort()).toEqual(
+      ['README.md', WORKFLOW_PATH, `services/api/${SPINDRIFT_FILE}`].sort(),
+    );
+  });
+
+  test('connecting twice re-adopts the one row rather than duplicating it', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'unconnected' });
+
+    const first = await connectRepository(input(fake), await context(fake));
+    const second = await connectRepository(input(fake), await context(fake));
+
+    expect(first.ok && second.ok).toBe(true);
+    if (!(first.ok && second.ok)) return;
+    expect(second.value.repositoryId).toBe(first.value.repositoryId);
+    expect(await database().db.select().from(repositories)).toHaveLength(1);
+  });
+
+  test('refuses a repository the App installation cannot see', async () => {
+    const fake = new FakeGitHub();
+    fake.accessLost = true;
+
+    const result = await connectRepository(input(fake), await context(fake));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('still selects it');
+    // Nothing was written on the way to refusing.
+    expect(await database().db.select().from(repositories)).toEqual([]);
+  });
+
+  test('refuses when this installation has published no build workflow', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'unconnected' });
+    const base = await context(fake);
+
+    // A repository connected without a build route is connected to nothing, so
+    // the transaction is refused rather than opened without its one caller.
+    const result = await connectRepository(input(fake), {
+      ...base,
+      manifest: {
+        ...base.manifest,
+        github: { ...base.manifest.github, buildWorkflow: null },
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('reusable build workflow');
+    expect(await database().db.select().from(repositories)).toEqual([]);
+    expect(fake.pulls).toEqual([]);
+  });
+
+  test('refuses when this installation has no repository integration', async () => {
+    const result = await connectRepository(
+      {
+        fullName: 'example/app',
+        installationId: '4242',
+        scopes: [{ scope: 'services/api', proposal }],
+      },
+      await context(null),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+  });
+
+  test('is reachable through dispatch, which is what validates its input', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'unconnected' });
+    const loop = await context(fake);
+
+    // The registry validates and the handler trusts — the same split every
+    // other command takes, which is why the handler holds no schema of its own.
+    const refused = await dispatch(
+      'connectRepository',
+      { fullName: 'not-a-full-name', installationId: '', scopes: [] },
+      loop,
+    );
+    expect(refused.ok).toBe(false);
+    if (!refused.ok) {
+      expect(refused.failure.code).toBe('INVALID_INPUT');
+      expect(refused.failure.issues?.length).toBeGreaterThan(0);
+    }
+    // Refused before the far side was reached at all.
+    expect(fake.requests).toEqual([]);
+
+    const accepted = await dispatch('connectRepository', input(fake), loop);
+    expect(accepted.ok).toBe(true);
+  });
+});

--- a/apps/spindrift/test/commands/smoke.test.ts
+++ b/apps/spindrift/test/commands/smoke.test.ts
@@ -46,6 +46,7 @@ const noAdapters: AdapterRegistry = {
   store: () => {
     throw new Error('no store adapter is configured for this test');
   },
+  repository: () => null,
 };
 
 function context(clock: Clock = frozenClock): CommandContext {

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -72,6 +72,7 @@ function fakes(
     store: () => {
       throw new Error('no store adapter is configured for this test');
     },
+    repository: () => null,
   };
   return {
     registry,

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -137,3 +137,45 @@ describe('boot fails loudly', () => {
     );
   });
 });
+
+/**
+ * §15 gives the connected repository the Actions minutes and the billing, so
+ * the caller Spindrift writes into somebody's repository runs with that
+ * repository's own permissions. A ref that can be moved is therefore a way to
+ * run arbitrary steps in every connected repository at once, and the schema is
+ * where that is refused rather than warned about.
+ */
+describe('the reusable build workflow ref', () => {
+  const line = (value: string) => `  buildWorkflow: ${value}`;
+  const current = fixtureText
+    .split('\n')
+    .find((row) => row.trim().startsWith('buildWorkflow:'));
+
+  test.each([
+    ['a branch', 'example/platform/.github/workflows/build.yml@main'],
+    ['a tag', 'example/platform/.github/workflows/build.yml@v1.2.3'],
+    [
+      'an abbreviated sha',
+      'example/platform/.github/workflows/build.yml@4bf1f21',
+    ],
+    ['no ref at all', 'example/platform/.github/workflows/build.yml'],
+    [
+      'a path that is not a workflow',
+      `example/platform/build.yml@${'0'.repeat(40)}`,
+    ],
+  ] as const)('refuses %s', (_name, ref) => {
+    expect(() =>
+      parseManifest(fixtureText.replace(current ?? '', line(ref)), 'test'),
+    ).toThrow(/buildWorkflow/);
+  });
+
+  test('accepts null, which is an installation that has published none', () => {
+    // Stated the way `auth.gateway` is. A placeholder commit would be a
+    // configuration that looks complete and fails at the first build.
+    const manifest = parseManifest(
+      fixtureText.replace(current ?? '', line('null')),
+      'test',
+    );
+    expect(manifest.github.buildWorkflow).toBeNull();
+  });
+});

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -34,6 +34,10 @@ supplyChain:
 
 github:
   appId: '1234567'
+  apiBaseUrl: https://api.git.example.test
+  # Pinned to a commit, never a branch: the caller this ref lands in runs with
+  # the connected repository's own permissions.
+  buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
 
 secretStore:
   adapter: gcp-secret-manager

--- a/apps/spindrift/test/harness/context.ts
+++ b/apps/spindrift/test/harness/context.ts
@@ -34,6 +34,7 @@ const noAdapters: AdapterRegistry = {
   deploy: () => unreachable('deploy adapter'),
   build: () => unreachable('build adapter'),
   store: () => unreachable('secret store'),
+  repository: () => unreachable('repository host'),
 };
 
 /**

--- a/apps/spindrift/test/harness/fakes/github-api.ts
+++ b/apps/spindrift/test/harness/fakes/github-api.ts
@@ -1,0 +1,380 @@
+/**
+ * A fake of the repository host's HTTP API (Task 24, § Seam 2).
+ *
+ * § Seam 2: real backends are stood in for "the way `apps/ddnsd/main_test.go`
+ * already does it in this repo: **a fake of the far-side HTTP API behind the
+ * real client**, with the test asserting the requests that were made." So this
+ * is the API, not a fake `RepositoryHost` — every assertion about
+ * `GitHubApp` runs through its real URL construction, its real JSON bodies, its
+ * real Git-data-API sequencing, and its real classification of a `404`.
+ *
+ * It models a small but genuine git object store: blobs, trees, commits, and
+ * branches, with a `base_tree` layering that actually layers. That is what lets
+ * a test ask the question Task 24's first acceptance criterion asks — *what is
+ * in the tree the configuration PR wrote* — rather than asserting on the
+ * requests and hoping they compose.
+ *
+ * Anything it does not model answers `404`, so a client that started calling a
+ * new endpoint fails here rather than silently passing against a permissive
+ * stand-in.
+ */
+import type { Fetcher } from '../../../src/integrations/github/http.ts';
+
+const BASE = 'https://api.git.invalid';
+
+/** How long a minted installation token lives, as the real host defines it. */
+const TOKEN_LIFETIME_MS = 60 * 60 * 1000;
+
+/** Every request the client made, for a test to assert against. */
+export interface RecordedRequest {
+  method: string;
+  /** Path and query, without the base URL. */
+  path: string;
+  body: unknown;
+  authorization: string | null;
+}
+
+/** One pull request the client opened. */
+export interface RecordedPullRequest {
+  number: number;
+  title: string;
+  body: string;
+  head: string;
+  base: string;
+}
+
+interface StoredCommit {
+  tree: string;
+  parents: string[];
+}
+
+export interface FakeGitHubOptions {
+  /** `owner/name` of the one repository this host serves. */
+  fullName?: string;
+  defaultBranch?: string;
+  /** The installation the App must present a token for. */
+  installationId?: string;
+  /**
+   * The clock token expiry is measured from.
+   *
+   * Shared with the client under test on purpose: a token's lifetime is the one
+   * thing the two sides have to agree about, and a fake using the wall clock
+   * against a client using an injected one would re-mint on every call for
+   * reasons that have nothing to do with the code being tested.
+   */
+  now?: () => Date;
+}
+
+/**
+ * Object ids are a counter in hex, not a hash.
+ *
+ * They only have to be distinct and stable within one test, and a real digest
+ * would make an assertion about a tree depend on the exact bytes of a YAML
+ * comment.
+ */
+function objectId(counter: number): string {
+  return counter.toString(16).padStart(40, '0');
+}
+
+export class FakeGitHub {
+  readonly fullName: string;
+  readonly installationId: string;
+  readonly requests: RecordedRequest[] = [];
+  readonly pulls: RecordedPullRequest[] = [];
+  /** Every commit whose archive was downloaded — "fetch once" is checkable. */
+  readonly tarballs: string[] = [];
+
+  defaultBranch: string;
+
+  /**
+   * Set to stop answering anything. Models the whole of §15's lost access: an
+   * installation removed from a repository, deleted, or suspended all present
+   * as a `404` this client cannot tell apart.
+   */
+  accessLost = false;
+  /** Set to answer every call with a quota refusal instead. */
+  rateLimited = false;
+
+  private readonly blobs = new Map<string, string>();
+  private readonly trees = new Map<string, Map<string, string>>();
+  private readonly commits = new Map<string, StoredCommit>();
+  private readonly branches = new Map<string, string>();
+  private counter = 0;
+  private pullNumber = 0;
+  private tokenCounter = 0;
+  private readonly now: () => Date;
+
+  constructor(options: FakeGitHubOptions = {}) {
+    this.fullName = options.fullName ?? 'example/app';
+    this.defaultBranch = options.defaultBranch ?? 'main';
+    this.installationId = options.installationId ?? '4242';
+    this.now = options.now ?? (() => new Date());
+  }
+
+  get baseUrl(): string {
+    return BASE;
+  }
+
+  /** The commit a branch points at, or `undefined`. */
+  head(branch: string): string | undefined {
+    return this.branches.get(branch);
+  }
+
+  /** Every path and its contents at one commit — what a test asserts on. */
+  filesAt(commit: string): Record<string, string> {
+    const tree = this.trees.get(this.commits.get(commit)?.tree ?? '');
+    const files: Record<string, string> = {};
+    for (const [path, blob] of tree ?? []) {
+      files[path] = this.blobs.get(blob) ?? '';
+    }
+    return files;
+  }
+
+  /** Put a commit carrying exactly these files on a branch. */
+  commitFiles(branch: string, files: Record<string, string>): string {
+    const tree = new Map<string, string>();
+    for (const [path, contents] of Object.entries(files)) {
+      tree.set(path, this.putBlob(contents));
+    }
+    const treeId = this.nextId();
+    this.trees.set(treeId, tree);
+    const commit = this.nextId();
+    const parent = this.branches.get(branch);
+    this.commits.set(commit, {
+      tree: treeId,
+      parents: parent === undefined ? [] : [parent],
+    });
+    this.branches.set(branch, commit);
+    return commit;
+  }
+
+  private nextId(): string {
+    this.counter += 1;
+    return objectId(this.counter);
+  }
+
+  private putBlob(contents: string): string {
+    const id = this.nextId();
+    this.blobs.set(id, contents);
+    return id;
+  }
+
+  private json(value: unknown, status = 200): Response {
+    return new Response(JSON.stringify(value), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  private notFound(): Response {
+    return new Response('{"message":"Not Found"}', { status: 404 });
+  }
+
+  /** The transport to hand the real client. */
+  readonly fetch: Fetcher = async (request) => {
+    const url = new URL(request.url);
+    const path = `${url.pathname}${url.search}`;
+    const raw = request.method === 'GET' ? null : await request.text();
+    this.requests.push({
+      method: request.method,
+      path,
+      body: raw === null || raw === '' ? null : JSON.parse(raw),
+      authorization: request.headers.get('Authorization'),
+    });
+
+    if (this.rateLimited) {
+      return new Response('{"message":"rate limit exceeded"}', {
+        status: 403,
+        headers: { 'X-RateLimit-Remaining': '0' },
+      });
+    }
+
+    // Minting an installation token is the one call that presents the App JWT
+    // rather than a token, so it is answered before the access check: an App
+    // whose installation was deleted still gets to ask.
+    const minting = url.pathname.match(
+      /^\/app\/installations\/([^/]+)\/access_tokens$/,
+    );
+    if (minting && request.method === 'POST') {
+      if (minting[1] !== this.installationId) return this.notFound();
+      this.tokenCounter += 1;
+      const value = `installation-token-${this.tokenCounter}`;
+      return this.json(
+        {
+          token: value,
+          expires_at: new Date(
+            this.now().getTime() + TOKEN_LIFETIME_MS,
+          ).toISOString(),
+        },
+        201,
+      );
+    }
+
+    if (this.accessLost) return this.notFound();
+
+    const prefix = `/repos/${this.fullName}`;
+    if (!url.pathname.startsWith(`${prefix}/`) && url.pathname !== prefix) {
+      return this.notFound();
+    }
+    const rest = url.pathname.slice(prefix.length);
+
+    if (rest === '' && request.method === 'GET') {
+      return this.json({
+        full_name: this.fullName,
+        default_branch: this.defaultBranch,
+      });
+    }
+
+    const body = raw === null || raw === '' ? {} : JSON.parse(raw);
+    return (
+      this.readEndpoints(rest, url, request.method) ??
+      this.writeEndpoints(rest, request.method, body) ??
+      this.notFound()
+    );
+  };
+
+  private readEndpoints(
+    rest: string,
+    url: URL,
+    method: string,
+  ): Response | null {
+    if (method !== 'GET') return null;
+
+    const branch = rest.match(/^\/git\/ref\/heads\/(.+)$/);
+    if (branch) {
+      const commit = this.branches.get(decodeURIComponent(branch[1] ?? ''));
+      return commit === undefined
+        ? this.notFound()
+        : this.json({ object: { sha: commit } });
+    }
+
+    const gitCommit = rest.match(/^\/git\/commits\/(.+)$/);
+    if (gitCommit) {
+      const stored = this.commits.get(gitCommit[1] ?? '');
+      return stored === undefined
+        ? this.notFound()
+        : this.json({ sha: gitCommit[1], tree: { sha: stored.tree } });
+    }
+
+    const commit = rest.match(/^\/commits\/(.+)$/);
+    if (commit) {
+      const requested = decodeURIComponent(commit[1] ?? '');
+      const resolved = this.branches.get(requested) ?? requested;
+      return this.commits.has(resolved)
+        ? this.json({ sha: resolved })
+        : this.notFound();
+    }
+
+    const contents = rest.match(/^\/contents\/(.+)$/);
+    if (contents) {
+      const ref = url.searchParams.get('ref') ?? this.defaultBranch;
+      const at = this.branches.get(ref) ?? ref;
+      const file = this.filesAt(at)[decodeURIComponent(contents[1] ?? '')];
+      return file === undefined ? this.notFound() : new Response(file);
+    }
+
+    const tarball = rest.match(/^\/tarball\/(.+)$/);
+    if (tarball) {
+      const at = decodeURIComponent(tarball[1] ?? '');
+      if (!this.commits.has(at)) return this.notFound();
+      this.tarballs.push(at);
+      return new Response(new TextEncoder().encode(`tarball:${at}`));
+    }
+
+    return null;
+  }
+
+  private writeEndpoints(
+    rest: string,
+    method: string,
+    body: Record<string, unknown>,
+  ): Response | null {
+    if (rest === '/git/blobs' && method === 'POST') {
+      return this.json({ sha: this.putBlob(String(body.content ?? '')) }, 201);
+    }
+
+    if (rest === '/git/trees' && method === 'POST') {
+      const base = this.trees.get(String(body.base_tree ?? ''));
+      const tree = new Map(base ?? []);
+      for (const entry of (body.tree ?? []) as {
+        path: string;
+        sha: string;
+      }[]) {
+        tree.set(entry.path, entry.sha);
+      }
+      const id = this.nextId();
+      this.trees.set(id, tree);
+      return this.json({ sha: id }, 201);
+    }
+
+    if (rest === '/git/commits' && method === 'POST') {
+      const id = this.nextId();
+      this.commits.set(id, {
+        tree: String(body.tree ?? ''),
+        parents: (body.parents ?? []) as string[],
+      });
+      return this.json({ sha: id }, 201);
+    }
+
+    const update = rest.match(/^\/git\/refs\/heads\/(.+)$/);
+    if (update && method === 'PATCH') {
+      const name = decodeURIComponent(update[1] ?? '');
+      if (!this.branches.has(name)) return this.notFound();
+      this.branches.set(name, String(body.sha ?? ''));
+      return this.json({ ref: `refs/heads/${name}` });
+    }
+
+    if (rest === '/git/refs' && method === 'POST') {
+      const name = String(body.ref ?? '').replace('refs/heads/', '');
+      this.branches.set(name, String(body.sha ?? ''));
+      return this.json({ ref: body.ref }, 201);
+    }
+
+    if (rest === '/pulls' && method === 'POST') {
+      this.pullNumber += 1;
+      const pull = {
+        number: this.pullNumber,
+        title: String(body.title ?? ''),
+        body: String(body.body ?? ''),
+        head: String(body.head ?? ''),
+        base: String(body.base ?? ''),
+      };
+      this.pulls.push(pull);
+      return this.json(pull, 201);
+    }
+
+    return null;
+  }
+}
+
+/**
+ * A throwaway RSA key in the one format {@link GitHubApp} accepts.
+ *
+ * Generated per call rather than checked in: a private key in a repository is a
+ * private key in a repository, even a test one, and generating it here also
+ * gives the test the matching public key to verify a signed JWT against.
+ */
+export async function testAppKey(): Promise<{
+  pem: string;
+  publicKey: CryptoKey;
+}> {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: 'RSASSA-PKCS1-v1_5',
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: 'SHA-256',
+    },
+    true,
+    ['sign', 'verify'],
+  );
+  const pkcs8 = new Uint8Array(
+    await crypto.subtle.exportKey('pkcs8', pair.privateKey),
+  );
+  const base64 = btoa(String.fromCharCode(...pkcs8));
+  const lines = base64.match(/.{1,64}/g) ?? [];
+  return {
+    pem: `-----BEGIN PRIVATE KEY-----\n${lines.join('\n')}\n-----END PRIVATE KEY-----\n`,
+    publicKey: pair.publicKey,
+  };
+}

--- a/apps/spindrift/test/integrations/github/app.test.ts
+++ b/apps/spindrift/test/integrations/github/app.test.ts
@@ -1,0 +1,321 @@
+/**
+ * The GitHub App integration (Task 24, §15).
+ *
+ * Two claims §15 makes are properties of this file rather than of anybody's
+ * discipline, and both are asserted here:
+ *
+ * - **"Storing no token."** The only long-lived credential is the App key; the
+ *   App JWT and the installation token are minted per use. The tests check that
+ *   what leaves this module — a `FetchedCommit` staged by
+ *   `src/domain/source-bundle.ts` — carries neither.
+ * - **Lost access is a state, not a fault.** A selected-repository App can be
+ *   un-selected at any time, and the response is a `404` indistinguishable from
+ *   a repository that never existed. So `ACCESS_LOST` has to cover `401`, `403`
+ *   and `404`, and a rate limit must *not* be mistaken for it — freezing a
+ *   repository because an hour's quota ran out would turn a delay into an
+ *   operator incident.
+ */
+import { describe, expect, test } from 'bun:test';
+import { stageSourceBundle } from '../../../src/domain/source-bundle.ts';
+import {
+  GitHubApp,
+  GitHubAppKeyError,
+} from '../../../src/integrations/github/app.ts';
+import { GitHubAccessError } from '../../../src/integrations/github/http.ts';
+import { FakeGitHub, testAppKey } from '../../harness/fakes/github-api.ts';
+
+const APP_ID = '1234567';
+
+async function app(
+  fake: FakeGitHub,
+  now: () => Date = () => new Date('2026-07-28T12:00:00.000Z'),
+) {
+  const { pem, publicKey } = await testAppKey();
+  return {
+    publicKey,
+    app: new GitHubApp(
+      {
+        appId: APP_ID,
+        privateKeyPem: pem,
+        baseUrl: fake.baseUrl,
+        fetch: fake.fetch,
+      },
+      now,
+    ),
+  };
+}
+
+function decodeSegment(segment: string): Record<string, unknown> {
+  const padded = segment.replaceAll('-', '+').replaceAll('_', '/');
+  return JSON.parse(atob(padded));
+}
+
+describe('the App’s own JWT', () => {
+  test('is signed by the App key and claims the App id', async () => {
+    const fake = new FakeGitHub();
+    const { app: github, publicKey } = await app(fake);
+    const jwt = await github.appJwt();
+
+    const [header, claims, signature] = jwt.split('.');
+    expect(decodeSegment(header ?? '')).toEqual({ alg: 'RS256', typ: 'JWT' });
+
+    const payload = decodeSegment(claims ?? '');
+    const issuedAt = Math.floor(
+      new Date('2026-07-28T12:00:00.000Z').getTime() / 1000,
+    );
+    expect(payload.iss).toBe(APP_ID);
+    // Backdated by a minute: the documented remedy for a far side whose clock
+    // runs behind this one, which it otherwise rejects outright.
+    expect(payload.iat).toBe(issuedAt - 60);
+    expect(payload.exp).toBeLessThanOrEqual(issuedAt + 600);
+
+    const verified = await crypto.subtle.verify(
+      'RSASSA-PKCS1-v1_5',
+      publicKey,
+      Uint8Array.from(
+        atob((signature ?? '').replaceAll('-', '+').replaceAll('_', '/')),
+        (character) => character.charCodeAt(0),
+      ),
+      new TextEncoder().encode(`${header}.${claims}`),
+    );
+    expect(verified).toBe(true);
+  });
+
+  test('refuses the PKCS#1 key the App UI hands out, and says how to convert it', async () => {
+    const github = new GitHubApp({
+      appId: APP_ID,
+      privateKeyPem:
+        '-----BEGIN RSA PRIVATE KEY-----\nAAAA\n-----END RSA PRIVATE KEY-----',
+      baseUrl: 'https://api.git.invalid',
+    });
+    const signed = github.appJwt();
+    await expect(signed).rejects.toBeInstanceOf(GitHubAppKeyError);
+    await expect(signed).rejects.toThrow(/openssl pkcs8 -topk8/);
+  });
+});
+
+describe('installation tokens', () => {
+  test('are minted once and reused until they are close to expiring', async () => {
+    const fake = new FakeGitHub({
+      now: () => new Date('2026-07-28T12:00:00.000Z'),
+    });
+    const { app: github } = await app(fake);
+    const ref = { installationId: fake.installationId };
+
+    await github.repository(ref, fake.fullName);
+    await github.repository(ref, fake.fullName);
+    await github.branchHead(ref, fake.fullName, 'main').catch(() => null);
+
+    expect(
+      fake.requests.filter((request) =>
+        request.path.includes('/access_tokens'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('are re-minted once the cached one is inside the refresh margin', async () => {
+    let clock = new Date('2026-07-28T12:00:00.000Z');
+    const fake = new FakeGitHub({ now: () => clock });
+    const { app: github } = await app(fake, () => clock);
+    const ref = { installationId: fake.installationId };
+
+    await github.repository(ref, fake.fullName);
+    // The fake's tokens live an hour. A token that expires mid-request is a
+    // `401` that reads exactly like lost access, which is the one
+    // misclassification this integration must not make.
+    clock = new Date(clock.getTime() + 60 * 60 * 1000);
+    await github.repository(ref, fake.fullName);
+
+    expect(
+      fake.requests.filter((request) =>
+        request.path.includes('/access_tokens'),
+      ),
+    ).toHaveLength(2);
+  });
+});
+
+describe('reading a repository', () => {
+  test('reports the default branch rather than assuming one', async () => {
+    const fake = new FakeGitHub({ defaultBranch: 'trunk' });
+    const { app: github } = await app(fake);
+    await expect(
+      github.repository({ installationId: fake.installationId }, fake.fullName),
+    ).resolves.toEqual({ defaultBranch: 'trunk' });
+  });
+
+  test('returns null for a file that is not there, and only for that', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'spindrift.yaml': 'version: 1' });
+    const { app: github } = await app(fake);
+    const ref = { installationId: fake.installationId };
+
+    await expect(
+      github.readFile(ref, fake.fullName, commit, 'spindrift.yaml'),
+    ).resolves.toBe('version: 1');
+    await expect(
+      github.readFile(ref, fake.fullName, commit, 'nowhere.yaml'),
+    ).resolves.toBeNull();
+  });
+});
+
+describe('fetching one exact commit', () => {
+  test('resolves the revision, downloads one archive, and names the principal', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'hello' });
+    const { app: github } = await app(fake);
+
+    const fetched = await github.fetchExactCommit({
+      repository: fake.fullName,
+      commit,
+      credential: { installationId: fake.installationId },
+    });
+
+    expect(fetched.resolvedCommit).toBe(commit);
+    expect(fetched.hasSubmodules).toBe(false);
+    expect(fetched.hasGitLfs).toBe(false);
+    expect(fetched.principal).toEqual({
+      kind: 'githubApp',
+      subject: `installation:${fake.installationId}`,
+    });
+    // §15: "fetches the exact commit **once**".
+    expect(fake.tarballs).toEqual([commit]);
+  });
+
+  test('reports the revision the far side resolved, not the one asked for', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'hello' });
+    const { app: github } = await app(fake);
+
+    // Asking by branch name is what `stageSourceBundle`'s mismatch check exists
+    // to catch. It can only catch it if this reports what actually resolved.
+    const fetched = await github.fetchExactCommit({
+      repository: fake.fullName,
+      commit: 'main',
+      credential: { installationId: fake.installationId },
+    });
+    expect(fetched.resolvedCommit).toBe(commit);
+  });
+
+  test.each([
+    ['.gitmodules', 'a submodule declaration', 'hasSubmodules'],
+    ['.gitattributes', '*.psd filter=lfs diff=lfs merge=lfs', 'hasGitLfs'],
+  ] as const)(
+    'reports %s so staging can refuse it',
+    async (path, contents, flag) => {
+      const fake = new FakeGitHub();
+      const commit = fake.commitFiles('main', { [path]: contents });
+      const { app: github } = await app(fake);
+
+      const fetched = await github.fetchExactCommit({
+        repository: fake.fullName,
+        commit,
+        credential: { installationId: fake.installationId },
+      });
+      expect(fetched[flag]).toBe(true);
+    },
+  );
+
+  test('an ordinary .gitattributes is not LFS', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', {
+      '.gitattributes': '* text=auto eol=lf',
+    });
+    const { app: github } = await app(fake);
+
+    const fetched = await github.fetchExactCommit({
+      repository: fake.fullName,
+      commit,
+      credential: { installationId: fake.installationId },
+    });
+    expect(fetched.hasGitLfs).toBe(false);
+  });
+
+  test('stages through source-bundle with no token in the result', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'hello' });
+    const { app: github } = await app(fake);
+
+    const signedPayloads: Uint8Array[] = [];
+    const staged = await stageSourceBundle(
+      {
+        kind: 'git',
+        repository: fake.fullName,
+        commit,
+        credential: { installationId: fake.installationId },
+      },
+      {
+        fetcher: github,
+        depot: {
+          async putImmutable(input) {
+            return { location: `bundles/${input.digest}.tar` };
+          },
+        },
+        signer: {
+          async sign(payload) {
+            signedPayloads.push(payload);
+            return { keyId: 'test', algorithm: 'test', value: 'signed' };
+          },
+        },
+        receipts: {
+          async putImmutable(receipt) {
+            return { location: `receipts/${receipt.statement.subject.digest}` };
+          },
+        },
+      },
+      new Date('2026-07-28T12:00:00.000Z'),
+    );
+
+    expect(staged.bundle.retention).toBe('ephemeral');
+    expect(staged.receipt.statement.predicate.principal).toEqual({
+      kind: 'githubApp',
+      subject: `installation:${fake.installationId}`,
+    });
+    // The minted token reached the transport and nothing else.
+    expect(JSON.stringify(staged)).not.toContain('installation-token');
+    expect(new TextDecoder().decode(signedPayloads[0])).not.toContain(
+      'installation-token',
+    );
+  });
+});
+
+describe('what the far side refusing means', () => {
+  test('a repository the App can no longer see is lost access', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'hello' });
+    const { app: github } = await app(fake);
+    fake.accessLost = true;
+
+    const read = github.repository(
+      { installationId: fake.installationId },
+      fake.fullName,
+    );
+    await expect(read).rejects.toBeInstanceOf(GitHubAccessError);
+    await expect(read).rejects.toMatchObject({ code: 'ACCESS_LOST' });
+  });
+
+  test('a quota refusal is emphatically not lost access', async () => {
+    const fake = new FakeGitHub();
+    const { app: github } = await app(fake);
+    fake.rateLimited = true;
+
+    const read = github.repository(
+      { installationId: fake.installationId },
+      fake.fullName,
+    );
+    await expect(read).rejects.toMatchObject({ code: 'RATE_LIMITED' });
+  });
+
+  test('a repository this host does not serve is lost access, not a null', async () => {
+    const fake = new FakeGitHub();
+    const { app: github } = await app(fake);
+
+    // `readFile` tolerates a 404 and everything else does not. A repository
+    // that answers 404 for *itself* must not be readable as "no such file".
+    await expect(
+      github.repository(
+        { installationId: fake.installationId },
+        'example/somebody-elses',
+      ),
+    ).rejects.toMatchObject({ code: 'ACCESS_LOST' });
+  });
+});

--- a/apps/spindrift/test/integrations/github/config-pr.test.ts
+++ b/apps/spindrift/test/integrations/github/config-pr.test.ts
@@ -1,0 +1,266 @@
+/**
+ * The one configuration pull request (Task 24, §15).
+ *
+ * Task 24's first acceptance criterion — "a fake GitHub API asserts the PR
+ * contains **exactly** the Spindrift files plus one workflow caller" — is the
+ * whole reason `test/harness/fakes/github-api.ts` models blobs, trees, and
+ * `base_tree` layering rather than only recording requests. `exactly` is a
+ * claim about the resulting tree, and a test that asserted on the calls would
+ * be asserting that the right things were *asked for*, which is a weaker and
+ * much easier thing to be right about by accident.
+ *
+ * The second claim tested here is §15's "**lossless** serialization": what
+ * Spindrift writes into a repository has to parse back to what Spindrift meant,
+ * or the file it asks a human to edit is a file it will misread.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { DetectionProposal } from '../../../src/domain/detection/ladder.ts';
+import { parseSpindriftFile } from '../../../src/domain/detection/spindrift-file.ts';
+import { GitHubApp } from '../../../src/integrations/github/app.ts';
+import {
+  buildWorkflowCaller,
+  CONFIG_BRANCH,
+  configurationTransaction,
+  openConfigurationPullRequest,
+  SPINDRIFT_FILE,
+  serializeSpindriftFile,
+  WORKFLOW_PATH,
+} from '../../../src/integrations/github/config-pr.ts';
+import { FakeGitHub, testAppKey } from '../../harness/fakes/github-api.ts';
+
+const BUILD_WORKFLOW =
+  'example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809';
+
+const railpack: DetectionProposal = {
+  source: 'railpack',
+  kind: 'website',
+  kinds: [{ kind: 'website', available: true }],
+  build: {
+    frontend: 'railpack',
+    buildCommand: 'bun run build',
+    outputDirectory: 'dist',
+  },
+  watchPaths: ['apps/site', 'packages/ui'],
+};
+
+const dockerfile: DetectionProposal = {
+  source: 'railpack',
+  kind: 'service',
+  kinds: [{ kind: 'service', available: true }],
+  build: { frontend: 'dockerfile', dockerfile: 'Dockerfile' },
+  watchPaths: ['services/api'],
+};
+
+async function app(fake: FakeGitHub): Promise<GitHubApp> {
+  const { pem } = await testAppKey();
+  return new GitHubApp({
+    appId: '1234567',
+    privateKeyPem: pem,
+    baseUrl: fake.baseUrl,
+    fetch: fake.fetch,
+  });
+}
+
+describe('the Spindrift file Spindrift writes', () => {
+  test.each([
+    ['a zero-config build', railpack],
+    ['a Dockerfile build', dockerfile],
+  ] as const)('round-trips through its own parser: %s', (_name, proposal) => {
+    const parsed = parseSpindriftFile(serializeSpindriftFile(proposal));
+
+    expect(parsed.kind).toBe(proposal.kind);
+    expect(parsed.build).toEqual(proposal.build);
+    expect(parsed.watchPaths).toEqual(proposal.watchPaths);
+    // The parser reports the file as the source, which is the point of writing
+    // it: §5's ladder puts an in-repo file above detection.
+    expect(parsed.source).toBe('spindrift-file');
+  });
+
+  test('round-trips a zero-config build that declares neither command', () => {
+    const bare: DetectionProposal = {
+      ...railpack,
+      build: {
+        frontend: 'railpack',
+        buildCommand: null,
+        outputDirectory: null,
+      },
+    };
+    expect(parseSpindriftFile(serializeSpindriftFile(bare)).build).toEqual(
+      bare.build,
+    );
+  });
+
+  test('is block-style YAML a person can edit', () => {
+    const written = serializeSpindriftFile(railpack);
+    expect(written).toContain('component:\n  kind: website');
+    expect(written).toContain('watchPaths:\n  - apps/site');
+    expect(written).not.toContain('{');
+  });
+});
+
+describe('the CI caller', () => {
+  test('calls the pinned reusable workflow and nothing else', () => {
+    const caller = buildWorkflowCaller(BUILD_WORKFLOW);
+    expect(caller).toContain(`uses: ${BUILD_WORKFLOW}`);
+    // §15: the run happens in the connected repository, so the trigger is a
+    // dispatch Spindrift makes rather than a push this repository takes.
+    expect(caller).toContain('workflow_dispatch:');
+    expect(caller).not.toContain('on: push');
+    // §15's workflow-ref-scoped cloud identity: federated, never a stored
+    // credential this file would have to carry.
+    expect(caller).toContain('id-token: write');
+    expect(caller).not.toMatch(/secrets\./);
+  });
+});
+
+describe('the transaction', () => {
+  test('is one file per scope plus exactly one caller', () => {
+    const transaction = configurationTransaction({
+      scopes: [
+        { scope: 'apps/site', proposal: railpack },
+        { scope: 'services/api', proposal: dockerfile },
+      ],
+      buildWorkflow: BUILD_WORKFLOW,
+    });
+
+    expect(transaction.files.map((file) => file.path)).toEqual([
+      `apps/site/${SPINDRIFT_FILE}`,
+      `services/api/${SPINDRIFT_FILE}`,
+      WORKFLOW_PATH,
+    ]);
+    expect(transaction.branch).toBe(CONFIG_BRANCH);
+  });
+
+  test('puts a root scope’s file at the repository root', () => {
+    const transaction = configurationTransaction({
+      scopes: [{ scope: '.', proposal: railpack }],
+      buildWorkflow: BUILD_WORKFLOW,
+    });
+    expect(transaction.files[0]?.path).toBe(SPINDRIFT_FILE);
+  });
+
+  test('refuses to be a pull request about nothing', () => {
+    expect(() =>
+      configurationTransaction({ scopes: [], buildWorkflow: BUILD_WORKFLOW }),
+    ).toThrow(RangeError);
+  });
+});
+
+describe('opening it against the repository API', () => {
+  async function open(fake: FakeGitHub) {
+    const base = fake.commitFiles('main', {
+      'README.md': 'the repository as it was',
+      'apps/site/package.json': '{}',
+    });
+    const transaction = configurationTransaction({
+      scopes: [
+        { scope: 'apps/site', proposal: railpack },
+        { scope: 'services/api', proposal: dockerfile },
+      ],
+      buildWorkflow: BUILD_WORKFLOW,
+    });
+    const opened = await openConfigurationPullRequest(
+      await app(fake),
+      { installationId: fake.installationId },
+      {
+        fullName: fake.fullName,
+        defaultBranch: 'main',
+        transaction,
+      },
+    );
+    return { opened, transaction, base };
+  }
+
+  test('writes exactly the Spindrift files plus one workflow caller', async () => {
+    const fake = new FakeGitHub();
+    const { opened, base } = await open(fake);
+
+    const before = fake.filesAt(base);
+    const after = fake.filesAt(opened.commit);
+    const added = Object.keys(after).filter((path) => !(path in before));
+
+    expect(added.sort()).toEqual(
+      [
+        WORKFLOW_PATH,
+        `apps/site/${SPINDRIFT_FILE}`,
+        `services/api/${SPINDRIFT_FILE}`,
+      ].sort(),
+    );
+    // Nothing else in the repository is touched: the review is about the
+    // connection and nothing more.
+    expect(after['README.md']).toBe('the repository as it was');
+    expect(after['apps/site/package.json']).toBe('{}');
+    expect(after[WORKFLOW_PATH]).toContain(`uses: ${BUILD_WORKFLOW}`);
+    expect(
+      parseSpindriftFile(after[`services/api/${SPINDRIFT_FILE}`] ?? '').build,
+    ).toEqual(dockerfile.build);
+  });
+
+  test('is one commit, on its own branch, off the default branch', async () => {
+    const fake = new FakeGitHub();
+    const { opened, base } = await open(fake);
+
+    expect(opened.branch).toBe(CONFIG_BRANCH);
+    expect(fake.head(CONFIG_BRANCH)).toBe(opened.commit);
+    // The default branch has not moved: §15 makes its merge the authoritative
+    // act, and opening a pull request is not that act.
+    expect(fake.head('main')).toBe(base);
+
+    const commits = fake.requests.filter(
+      (request) =>
+        request.method === 'POST' && request.path.endsWith('/git/commits'),
+    );
+    expect(commits).toHaveLength(1);
+  });
+
+  test('opens one pull request against the default branch', async () => {
+    const fake = new FakeGitHub();
+    const { opened } = await open(fake);
+
+    expect(fake.pulls).toHaveLength(1);
+    expect(fake.pulls[0]).toMatchObject({
+      number: opened.number,
+      head: CONFIG_BRANCH,
+      base: 'main',
+    });
+    expect(fake.pulls[0]?.body).toContain('apps/site');
+    expect(fake.pulls[0]?.body).toContain('services/api');
+  });
+
+  test('re-running the connection replaces the branch rather than failing', async () => {
+    const fake = new FakeGitHub();
+    const first = await open(fake);
+    const second = await open(fake);
+
+    expect(second.opened.commit).not.toBe(first.opened.commit);
+    expect(fake.head(CONFIG_BRANCH)).toBe(second.opened.commit);
+    // The second run patched the existing ref rather than trying to create it
+    // twice — a second connection is somebody correcting the first.
+    expect(
+      fake.requests.filter((request) => request.method === 'PATCH'),
+    ).toHaveLength(2);
+    expect(
+      fake.requests.filter(
+        (request) =>
+          request.method === 'POST' && request.path.endsWith('/git/refs'),
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('presents an installation token, never the App JWT', async () => {
+    const fake = new FakeGitHub();
+    await open(fake);
+
+    const minting = fake.requests.filter((request) =>
+      request.path.includes('/access_tokens'),
+    );
+    expect(minting).toHaveLength(1);
+    // Every other call carries the minted token. A JWT is three base64 segments
+    // and would show up here as one; a token is the opaque value the far side
+    // handed back.
+    for (const request of fake.requests) {
+      if (request.path.includes('/access_tokens')) continue;
+      expect(request.authorization).toBe('Bearer installation-token-1');
+    }
+  });
+});

--- a/apps/spindrift/test/integrations/github/webhook.test.ts
+++ b/apps/spindrift/test/integrations/github/webhook.test.ts
@@ -1,0 +1,252 @@
+/**
+ * The signed repository webhook (Task 24, §15, §21).
+ *
+ * §21 makes this one of the only externally reachable endpoints, so the tests
+ * that matter most are the ones about what it refuses. The load-bearing one is
+ * `does not parse an unsigned body`: everything after verification treats the
+ * payload as structured data, and a parser that runs before the HMAC matches is
+ * a parser the internet can reach.
+ *
+ * The classification tests exist because §15 gives a delivery exactly three
+ * things it can say — the branch moved, access went away, access came back —
+ * and everything else has to fall through to `ignored` rather than throw. A
+ * repository host adds events over time, and a `500` on this endpoint would be
+ * somebody else's product decision becoming this installation's incident.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  handleWebhookDelivery,
+  parseWebhookDelivery,
+  verifyWebhookSignature,
+  WebhookRejected,
+} from '../../../src/integrations/github/webhook.ts';
+
+const SECRET = 'a shared secret nobody else has';
+
+async function sign(body: string, secret = SECRET): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body)),
+  );
+  const hex = Array.from(mac, (byte) => byte.toString(16).padStart(2, '0'));
+  return `sha256=${hex.join('')}`;
+}
+
+function delivery(event: string, payload: unknown) {
+  const body = JSON.stringify(payload);
+  return {
+    body,
+    bytes: new TextEncoder().encode(body),
+    event,
+  };
+}
+
+const push = {
+  ref: 'refs/heads/main',
+  after: '1111111111111111111111111111111111111111',
+  repository: { full_name: 'example/app', default_branch: 'main' },
+  installation: { id: 4242 },
+};
+
+describe('signature verification', () => {
+  test('accepts a delivery signed with this installation’s secret', async () => {
+    const { body, bytes } = delivery('push', push);
+    await expect(
+      verifyWebhookSignature(bytes, await sign(body), SECRET),
+    ).resolves.toBeUndefined();
+  });
+
+  test.each([
+    ['no signature at all', null, 'SIGNATURE_MISSING'],
+    ['an empty signature', '', 'SIGNATURE_MISSING'],
+    ['a signature with no scheme', 'deadbeef', 'SIGNATURE_MALFORMED'],
+    ['a signature that is not hex', 'sha256=zzzz', 'SIGNATURE_MALFORMED'],
+  ] as const)('refuses %s', async (_name, signature, code) => {
+    const { bytes } = delivery('push', push);
+    const verified = verifyWebhookSignature(bytes, signature, SECRET);
+    await expect(verified).rejects.toBeInstanceOf(WebhookRejected);
+    await expect(verified).rejects.toMatchObject({ code });
+  });
+
+  test('refuses a signature made with a different secret', async () => {
+    const { body, bytes } = delivery('push', push);
+    const verified = verifyWebhookSignature(
+      bytes,
+      await sign(body, 'somebody else’s secret'),
+      SECRET,
+    );
+    await expect(verified).rejects.toMatchObject({
+      code: 'SIGNATURE_MISMATCH',
+    });
+  });
+
+  test('refuses a body altered after it was signed', async () => {
+    const { body } = delivery('push', push);
+    const signature = await sign(body);
+    const tampered = new TextEncoder().encode(
+      body.replace('refs/heads/main', 'refs/heads/evil'),
+    );
+    await expect(
+      verifyWebhookSignature(tampered, signature, SECRET),
+    ).rejects.toMatchObject({ code: 'SIGNATURE_MISMATCH' });
+  });
+});
+
+describe('the whole endpoint', () => {
+  test('does not parse an unsigned body', async () => {
+    // Not JSON at all. If verification ran second, the parser would be the
+    // thing that refused this — and the parser would be reachable unsigned.
+    const handled = handleWebhookDelivery(
+      {
+        event: 'push',
+        signature: null,
+        body: new TextEncoder().encode('{not json'),
+      },
+      SECRET,
+    );
+    await expect(handled).rejects.toMatchObject({ code: 'SIGNATURE_MISSING' });
+  });
+
+  test('refuses a signed body that is not JSON', async () => {
+    const body = '{not json';
+    const handled = handleWebhookDelivery(
+      {
+        event: 'push',
+        signature: await sign(body),
+        body: new TextEncoder().encode(body),
+      },
+      SECRET,
+    );
+    await expect(handled).rejects.toMatchObject({ code: 'BODY_MALFORMED' });
+  });
+
+  test('refuses a signed delivery that names no event', async () => {
+    const { body, bytes } = delivery('push', push);
+    const handled = handleWebhookDelivery(
+      { event: null, signature: await sign(body), body: bytes },
+      SECRET,
+    );
+    await expect(handled).rejects.toMatchObject({ code: 'EVENT_MISSING' });
+  });
+
+  test('classifies a verified push', async () => {
+    const { body, bytes } = delivery('push', push);
+    await expect(
+      handleWebhookDelivery(
+        { event: 'push', signature: await sign(body), body: bytes },
+        SECRET,
+      ),
+    ).resolves.toEqual({
+      kind: 'push',
+      repository: 'example/app',
+      ref: 'refs/heads/main',
+      defaultBranch: 'main',
+      head: push.after,
+    });
+  });
+});
+
+describe('classification', () => {
+  test('a push carries its ref rather than a verdict about it', () => {
+    // Whether this ref is *the* ref is the loop's question: the delivery says
+    // what moved, and only the stored default branch says what matters.
+    expect(
+      parseWebhookDelivery('push', { ...push, ref: 'refs/heads/topic' }),
+    ).toMatchObject({ kind: 'push', ref: 'refs/heads/topic' });
+  });
+
+  test('refuses a push missing what a push is', () => {
+    expect(() =>
+      parseWebhookDelivery('push', {
+        repository: { full_name: 'example/app' },
+      }),
+    ).toThrow(WebhookRejected);
+  });
+
+  test.each([
+    ['deleted', 'the GitHub App installation was deleted'],
+    ['suspend', 'the GitHub App installation was suspended'],
+  ] as const)(
+    'installation.%s is lost access to everything',
+    (action, detail) => {
+      expect(
+        parseWebhookDelivery('installation', {
+          action,
+          installation: { id: 4242 },
+        }),
+      ).toEqual({
+        kind: 'accessLost',
+        installationId: '4242',
+        // Empty means every repository of the installation, which is what a
+        // deletion is: the delivery names an installation, not a list.
+        repositories: [],
+        detail,
+      });
+    },
+  );
+
+  test('installation.unsuspend is restored access', () => {
+    expect(
+      parseWebhookDelivery('installation', {
+        action: 'unsuspend',
+        installation: { id: 4242 },
+      }),
+    ).toEqual({
+      kind: 'accessRestored',
+      installationId: '4242',
+      repositories: [],
+    });
+  });
+
+  test('a removed repository is lost access to that repository only', () => {
+    expect(
+      parseWebhookDelivery('installation_repositories', {
+        action: 'removed',
+        installation: { id: 4242 },
+        repositories_removed: [{ full_name: 'example/app' }],
+      }),
+    ).toMatchObject({
+      kind: 'accessLost',
+      installationId: '4242',
+      repositories: ['example/app'],
+    });
+  });
+
+  test('an added repository is restored access', () => {
+    expect(
+      parseWebhookDelivery('installation_repositories', {
+        action: 'added',
+        installation: { id: 4242 },
+        repositories_added: [{ full_name: 'example/app' }],
+      }),
+    ).toMatchObject({ kind: 'accessRestored', repositories: ['example/app'] });
+  });
+
+  test.each([
+    ['ping', {}],
+    ['issues', { action: 'opened', installation: { id: 4242 } }],
+    [
+      'installation',
+      { action: 'new_permissions_accepted', installation: { id: 4242 } },
+    ],
+    [
+      'installation_repositories',
+      { action: 'added', installation: { id: 4242 } },
+    ],
+  ] as const)('ignores %s rather than throwing', (event, payload) => {
+    const parsed = parseWebhookDelivery(event, payload);
+    expect(parsed.kind).toBe('ignored');
+  });
+
+  test('refuses a body that is not an object', () => {
+    expect(() => parseWebhookDelivery('push', 'a string')).toThrow(
+      WebhookRejected,
+    );
+  });
+});

--- a/apps/spindrift/test/reconciler/repo-loop.test.ts
+++ b/apps/spindrift/test/reconciler/repo-loop.test.ts
@@ -1,0 +1,534 @@
+/**
+ * The repository loop (Task 24, §15).
+ *
+ * Two of Task 24's three acceptance criteria live here, and both are stated as
+ * facts about the database rather than about a return value:
+ *
+ * - **"An unmerged PR changes nothing."** The configuration pull request is
+ *   opened on a branch, and the loop adopts only from the default branch. The
+ *   test opens a real transaction through the real client against the fake API,
+ *   then reconciles, and asserts that nothing was adopted — the same assertion
+ *   whether the PR exists or not.
+ * - **"Revoked access sets a frozen state with every Deploy intact."** The test
+ *   snapshots every `apps`, `builds`, and `deploys` row, takes access away, and
+ *   asserts the snapshot is byte-identical afterwards while the repository is
+ *   frozen with a sentence on it.
+ *
+ * Everything runs against a real Postgres through the harness, because
+ * "changes nothing" and "intact" are claims about rows and a fake would be
+ * asserting them against itself.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import {
+  apps,
+  builds,
+  components,
+  deploys,
+  repositories,
+  targets,
+} from '../../src/db/schema.ts';
+import type { DetectionProposal } from '../../src/domain/detection/ladder.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import {
+  configurationTransaction,
+  openConfigurationPullRequest,
+} from '../../src/integrations/github/config-pr.ts';
+import {
+  applyWebhookDelivery,
+  type RepoLoopContext,
+  reconcileAllRepositories,
+  reconcileRepository,
+} from '../../src/reconciler/repo-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeGitHub, testAppKey } from '../harness/fakes/github-api.ts';
+import { targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+
+const BUILD_WORKFLOW =
+  'example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809';
+
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+const clock = { now: () => NOW };
+
+const proposal: DetectionProposal = {
+  source: 'railpack',
+  kind: 'service',
+  kinds: [{ kind: 'service', available: true }],
+  build: {
+    frontend: 'railpack',
+    buildCommand: 'bun run build',
+    outputDirectory: null,
+  },
+  watchPaths: ['services/api'],
+};
+
+const SPINDRIFT_YAML = [
+  'version: 1',
+  'component:',
+  '  kind: service',
+  'build:',
+  '  frontend: railpack',
+  '  command: bun run build',
+  '  outputDirectory: null',
+  'watchPaths:',
+  '  - services/api',
+  '',
+].join('\n');
+
+async function host(fake: FakeGitHub): Promise<GitHubApp> {
+  const { pem } = await testAppKey();
+  return new GitHubApp(
+    {
+      appId: '1234567',
+      privateKeyPem: pem,
+      baseUrl: fake.baseUrl,
+      fetch: fake.fetch,
+    },
+    () => NOW,
+  );
+}
+
+async function context(fake: FakeGitHub): Promise<RepoLoopContext> {
+  return { db: database().db, clock, host: await host(fake) };
+}
+
+/** One connected repository with one App scoped into it. */
+async function connect(
+  fake: FakeGitHub,
+  subpath: string | null = 'services/api',
+) {
+  const db = database().db;
+  const [repository] = await db
+    .insert(repositories)
+    .values({
+      fullName: fake.fullName,
+      installationId: fake.installationId,
+      defaultBranch: fake.defaultBranch,
+    })
+    .returning();
+  const [app] = await db
+    .insert(apps)
+    .values({
+      name: 'invoices',
+      sourceKind: 'repo',
+      sourceRepoUrl: `https://git.invalid/${fake.fullName}`,
+      sourceRepoSubpath: subpath,
+      repositoryId: repository!.id,
+    })
+    .returning();
+  return { repository: repository!, app: app! };
+}
+
+/** A live Deploy, so "never destroys a Deploy" has something to be about. */
+async function liveDeploy(appId: string) {
+  const db = database().db;
+  const [component] = await db
+    .insert(components)
+    .values({ appId, name: 'api', kind: 'service', expose: true })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(targetValues({ name: 'cluster', rank: 1 }))
+    .returning();
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: '1111111111111111111111111111111111111111',
+      targetShape: 'kubernetes',
+      artifactType: 'image',
+      artifactDigest: `sha256:${'a'.repeat(64)}`,
+      status: 'SUCCEEDED',
+    })
+    .returning();
+  const [deploy] = await db
+    .insert(deploys)
+    .values({
+      componentId: component!.id,
+      targetId: target!.id,
+      buildId: build!.id,
+      phase: 'LIVE',
+      url: 'https://invoices.apps.example.test',
+    })
+    .returning();
+  return { component: component!, deploy: deploy! };
+}
+
+async function reload(repositoryId: string) {
+  const [row] = await database()
+    .db.select()
+    .from(repositories)
+    .where(eq(repositories.id, repositoryId));
+  return row!;
+}
+
+describe('adopting the default branch', () => {
+  test('adopts a scope’s Spindrift file and records the commit', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository, app } = await connect(fake);
+
+    const pass = await reconcileRepository(await context(fake), repository);
+
+    expect(pass).toMatchObject({ outcome: 'adopted', commit });
+    expect(pass.outcome === 'adopted' && pass.scopes).toEqual([
+      {
+        scope: 'services/api',
+        appId: app.id,
+        outcome: 'adopted',
+        proposal: {
+          ...proposal,
+          source: 'spindrift-file',
+          kinds: [
+            {
+              kind: 'service',
+              available: true,
+              reason: 'asserted by spindrift.yaml',
+            },
+          ],
+        },
+        // First adoption: there is no earlier commit to have differed from.
+        changed: true,
+      },
+    ]);
+    expect((await reload(repository.id)).authoritativeCommit).toBe(commit);
+  });
+
+  test('a scope with no Spindrift file is absent, not an error', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'nothing here' });
+    const { repository } = await connect(fake);
+
+    const pass = await reconcileRepository(await context(fake), repository);
+
+    expect(pass.outcome).toBe('adopted');
+    expect(pass.outcome === 'adopted' && pass.scopes[0]?.outcome).toBe(
+      'absent',
+    );
+    expect((await reload(repository.id)).authoritativeCommit).toBe(commit);
+  });
+
+  test('a second pass over an unchanged branch adopts nothing again', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+
+    await reconcileRepository(loop, repository);
+    const second = await reconcileRepository(loop, await reload(repository.id));
+
+    expect(second.outcome).toBe('unchanged');
+  });
+
+  test('reports whether a scope actually changed between adopted commits', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+      'README.md': 'first',
+    });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    await reconcileRepository(loop, repository);
+
+    // A commit that moves the branch without touching the scope's file.
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+      'README.md': 'second',
+    });
+    const pass = await reconcileRepository(loop, await reload(repository.id));
+
+    expect(pass.outcome).toBe('adopted');
+    expect(pass.outcome === 'adopted' && pass.scopes[0]).toMatchObject({
+      outcome: 'adopted',
+      changed: false,
+    });
+  });
+
+  test('a commit carrying an unparseable file is rejected whole', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    await reconcileRepository(loop, repository);
+    const adopted = (await reload(repository.id)).authoritativeCommit;
+
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': 'version: 1\ncomponent:\n  kind: banana\n',
+    });
+    const pass = await reconcileRepository(loop, await reload(repository.id));
+
+    expect(pass.outcome).toBe('rejected');
+    expect(pass.outcome === 'rejected' && pass.scopes[0]).toMatchObject({
+      outcome: 'invalid',
+    });
+    // The previously adopted commit is still what governs: §15 makes the
+    // repository's configuration one transaction, so half of it does not land.
+    expect((await reload(repository.id)).authoritativeCommit).toBe(adopted);
+  });
+});
+
+describe('an unmerged configuration pull request', () => {
+  test('changes nothing', async () => {
+    const fake = new FakeGitHub();
+    const base = fake.commitFiles('main', { 'README.md': 'unconnected' });
+    const { repository } = await connect(fake);
+    const github = await host(fake);
+
+    // The real client writes the real transaction to its own branch.
+    const opened = await openConfigurationPullRequest(
+      github,
+      { installationId: fake.installationId },
+      {
+        fullName: fake.fullName,
+        defaultBranch: 'main',
+        transaction: configurationTransaction({
+          scopes: [{ scope: 'services/api', proposal }],
+          buildWorkflow: BUILD_WORKFLOW,
+        }),
+      },
+    );
+    expect(fake.pulls).toHaveLength(1);
+
+    const pass = await reconcileRepository(
+      { db: database().db, clock, host: github },
+      repository,
+    );
+
+    // The branch the PR is on carries a Spindrift file. The default branch does
+    // not, so the scope reconciles as absent and the adopted commit is the
+    // default branch's — never the pull request's.
+    expect(pass.outcome).toBe('adopted');
+    expect(pass.outcome === 'adopted' && pass.scopes[0]?.outcome).toBe(
+      'absent',
+    );
+    const row = await reload(repository.id);
+    expect(row.authoritativeCommit).toBe(base);
+    expect(row.authoritativeCommit).not.toBe(opened.commit);
+  });
+
+  test('becomes authoritative only once it is on the default branch', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'unconnected' });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    await reconcileRepository(loop, repository);
+
+    // Merging is somebody moving the default branch, which is the only act §15
+    // treats as authoritative.
+    const merged = fake.commitFiles('main', {
+      'README.md': 'unconnected',
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const pass = await reconcileRepository(loop, await reload(repository.id));
+
+    expect(pass.outcome === 'adopted' && pass.scopes[0]?.outcome).toBe(
+      'adopted',
+    );
+    expect((await reload(repository.id)).authoritativeCommit).toBe(merged);
+  });
+});
+
+describe('losing access', () => {
+  async function snapshot() {
+    const db = database().db;
+    return {
+      apps: await db.select().from(apps),
+      components: await db.select().from(components),
+      builds: await db.select().from(builds),
+      deploys: await db.select().from(deploys),
+    };
+  }
+
+  test('freezes the repository and leaves every Deploy intact', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository, app } = await connect(fake);
+    await liveDeploy(app.id);
+    const loop = await context(fake);
+    await reconcileRepository(loop, repository);
+
+    const before = await snapshot();
+    fake.accessLost = true;
+    const pass = await reconcileRepository(loop, await reload(repository.id));
+
+    expect(pass).toMatchObject({ outcome: 'frozen' });
+    const row = await reload(repository.id);
+    expect(row.access).toBe('frozen');
+    expect(row.frozenReason).toContain('no longer read this repository');
+    expect(row.frozenAt).toEqual(NOW);
+    // Source-driven changes stop; nothing that is running is touched.
+    expect(await snapshot()).toEqual(before);
+    // And the last known-good configuration still governs.
+    expect(row.authoritativeCommit).not.toBeNull();
+  });
+
+  test('a rate limit is a delay, not a freeze', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'hello' });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    fake.rateLimited = true;
+
+    const pass = await reconcileRepository(loop, repository);
+
+    expect(pass.outcome).toBe('unavailable');
+    expect((await reload(repository.id)).access).toBe('active');
+  });
+
+  test('a later pass that can read again clears the freeze', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    fake.accessLost = true;
+    await reconcileRepository(loop, repository);
+    expect((await reload(repository.id)).access).toBe('frozen');
+
+    fake.accessLost = false;
+    const pass = await reconcileRepository(loop, await reload(repository.id));
+
+    expect(pass).toMatchObject({ outcome: 'adopted', thawed: true, commit });
+    const row = await reload(repository.id);
+    expect(row.access).toBe('active');
+    expect(row.frozenReason).toBeNull();
+  });
+
+  test('a frozen repository is still visited by the loop', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'hello' });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    fake.accessLost = true;
+    await reconcileRepository(loop, repository);
+
+    fake.accessLost = false;
+    const passes = await reconcileAllRepositories(loop);
+
+    // A freeze is a state to recover from, so skipping frozen repositories
+    // would make it permanent until somebody noticed by hand.
+    expect(passes).toHaveLength(1);
+    expect((await reload(repository.id)).access).toBe('active');
+  });
+});
+
+describe('a verified webhook delivery', () => {
+  test('a default-branch push reconciles that repository now', async () => {
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository } = await connect(fake);
+
+    const passes = await applyWebhookDelivery(await context(fake), {
+      kind: 'push',
+      repository: fake.fullName,
+      ref: 'refs/heads/main',
+      defaultBranch: 'main',
+      head: commit,
+    });
+
+    expect(passes).toHaveLength(1);
+    expect((await reload(repository.id)).authoritativeCommit).toBe(commit);
+  });
+
+  test('a push to any other ref does nothing at all', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'services/api/spindrift.yaml': SPINDRIFT_YAML,
+    });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+
+    const passes = await applyWebhookDelivery(loop, {
+      kind: 'push',
+      repository: fake.fullName,
+      ref: 'refs/heads/spindrift/configure',
+      defaultBranch: 'main',
+      head: '2222222222222222222222222222222222222222',
+    });
+
+    expect(passes).toEqual([]);
+    expect((await reload(repository.id)).authoritativeCommit).toBeNull();
+    // Not one call was made: reconciling would have read the default branch and
+    // found nothing new, one round trip later.
+    expect(fake.requests).toEqual([]);
+  });
+
+  test('a push naming a repository nobody connected does nothing', async () => {
+    const fake = new FakeGitHub();
+    const loop = await context(fake);
+
+    expect(
+      await applyWebhookDelivery(loop, {
+        kind: 'push',
+        repository: 'example/unconnected',
+        ref: 'refs/heads/main',
+        defaultBranch: 'main',
+        head: '3333333333333333333333333333333333333333',
+      }),
+    ).toEqual([]);
+  });
+
+  test('a deleted installation freezes every repository it reached', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'hello' });
+    const { repository, app } = await connect(fake);
+    await liveDeploy(app.id);
+    const loop = await context(fake);
+
+    const passes = await applyWebhookDelivery(loop, {
+      kind: 'accessLost',
+      installationId: fake.installationId,
+      repositories: [],
+      detail: 'the GitHub App installation was deleted',
+    });
+
+    expect(passes).toHaveLength(1);
+    const row = await reload(repository.id);
+    expect(row.access).toBe('frozen');
+    expect(row.frozenReason).toBe('the GitHub App installation was deleted');
+    // Nothing else in the delivery path can reach a Deploy.
+    expect(await database().db.select().from(deploys)).toHaveLength(1);
+  });
+
+  test('restored access is confirmed by a read, not taken at its word', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'hello' });
+    const { repository } = await connect(fake);
+    const loop = await context(fake);
+    fake.accessLost = true;
+    await reconcileRepository(loop, repository);
+
+    // The delivery says access is back while the far side still refuses.
+    const passes = await applyWebhookDelivery(loop, {
+      kind: 'accessRestored',
+      installationId: fake.installationId,
+      repositories: [fake.fullName],
+    });
+
+    expect(passes[0]?.outcome).toBe('frozen');
+    expect((await reload(repository.id)).access).toBe('frozen');
+  });
+
+  test('an ignored delivery is not a database round trip', async () => {
+    const fake = new FakeGitHub();
+    expect(
+      await applyWebhookDelivery(await context(fake), {
+        kind: 'ignored',
+        reason: 'ping is not subscribed to',
+      }),
+    ).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/reconciler/target-loop.test.ts
+++ b/apps/spindrift/test/reconciler/target-loop.test.ts
@@ -64,6 +64,7 @@ function fakes() {
     store: () => {
       throw new Error('no store adapter is configured for this test');
     },
+    repository: () => null,
   };
   return {
     registry,

--- a/apps/spindrift/test/web/auth-routes.test.ts
+++ b/apps/spindrift/test/web/auth-routes.test.ts
@@ -70,6 +70,7 @@ function serve() {
             store: () => {
               throw new Error('no store in this test');
             },
+            repository: () => null,
           },
           manifest: manifest,
         }) satisfies CommandContext,

--- a/clusters/offsite/apps/spindrift/secret.sops.yaml
+++ b/clusters/offsite/apps/spindrift/secret.sops.yaml
@@ -10,7 +10,7 @@ stringData:
     #ENC[AES256_GCM,data:iENp88W2iq7sgJrMV5BTZHh+nuE8qtLknyTArYmeEPJMZOAe150f5ZYDRf8QwuHtWwaMxSuchX3V1OQ8QJcEpnuzSyIWtFawRlF1yDO/Vg==,iv:IorC46BKrUHtc78Zox4wZZdwRKTeMV5ggJGvCIi0Atk=,tag:Q1C13EGTH3nY4N9Rb2k6IA==,type:comment]
     #ENC[AES256_GCM,data:t/B+beSJUfuw1iAQFJS58TVGpLi8vrSXydfhYj4zvvrJqTd8dC1eaU0mitcKOOes2YNQZ2dac6U9YSRWBJc0krQZTpA5fYT36ZeYhw==,iv:zDQbkZ1SQLYNEssjXcKma5A3NgQz61CLjpGBJG9SY8Q=,tag:tYA5vkga1y6IX7IbbC27+w==,type:comment]
     #ENC[AES256_GCM,data:unAkSE7lzxAfOJR0Gb9BHk+9oXH2UOOtLSDPUezCft5jh1aF87Mi5nRAPadgJj9OkAUVEYjPPf+KXIUPDcLpROMQR7WPzyHgP1FK,iv:4THmbJ9OPKs84cNQRhdXANs8AI2H6YR06rBR397gjic=,tag:N7kwoZjcBiADAyEC3eI5Kw==,type:comment]
-    SPINDRIFT_MANIFEST: ENC[AES256_GCM,data:8o0ogsB1oUXX5PT0Exaz0t2YldFYblNybb5fJli6XPXdBi6QXrz4qVwUFdmVafaosTS9k4Z9USRb+StBWFftoIIzatK+y7tivDqJAIcPe2dDk25n4UeR1Zs5D4gh/vJJ/0Q9D/WFy+sGeQv8wipTvwquS4z3uFE3iDfyzgBesp7O449qwBQEpd4KO+hp2L+uhxBCgAF9oSrna7F485yrGVVBeU8i8pZol+7J1REaRNN+8rzCY3Ig3e5q2nr6Wq+Ymx63Ib89asGpUWZMWotQmIiOV5PgcUrhAEiM9NheeIb7dR3uCE+MoHAbYDpWLCanxTcbODrM56BFPn7hdFyscjRGbGNnpq4eZ0uyxE1gqOErqKPU34DAp4nAB88BAbU1CJsxFt/ZVMNZ+TwVcFCPasRckOui7JiiSdXv9htp4SuWek6U9ZjD0zRu5RwV0T2fFztsjCW9frp7Bns/ziyRXnbZUiaTigIjksxYlXJmC9JRcQH/dODWQgO00XVoh62dnzzwS6x31q0tBEuyu6E2oyTEBgWW9f/frVegd1d95UeGn2sU9b0FrVtJH71LFZRaEN0Mat3I52vObhuyzoOXDmatjNpIcxYYnk88ZpQV+Seb28s0HyDrYrzGpkVql3DWHC5Bs4M3LXA9tyEJs6QfziGvCA==,iv:ZWi6BbqlByLsWxRk7swPrGsAFUhFYRiNn7EdAsRGsz8=,tag:jopgLbUJKOKK1gdDhBbAew==,type:str]
+    SPINDRIFT_MANIFEST: ENC[AES256_GCM,data:WW9R/ZF1P0siQgVwZlfnphA/IyuiHFy2j6sqXN0oZk9s7DzG6FqSY8GkdERHTwdE4i/wcMrUEj3cSAT9XYedeB9ZC71vnW4o0JmEVnCJHFJlGYz6hbM4PtzlQ4n3cnOLD0vqhiVGuxj2M5r+NFudFB0y4zVdTdDrlbjk0A1goiHdk4SE7JwQqm7UnVyDQDd0X+L+DDWlN+STdKF1QMaQ1+LI4aubV8EkhaT4L+BTHN/HxAw0REt0x9XfxH1l+P2G3XKJw2ydbegiw0xUwKAvKgfdZHL9Ff1SFM/0kUwgPZmfjR7n2vsEeubMWUmWRgy5mkHRD3Zt0XQQr1nBNmWItGmsA0rHJYFDHjBwXkYffsvyEP3vhTx3OTFOov2/iTM7A6+9Rxri6htagvb61Qeq0cgSxau2HqcfLY1MzoSAWsBf4yStnrTGk1ZRkYeojAXtGmeWfDDK7O6H0O3ShTWaHeIEsLiYHQkqEU+wDi7wQm1vqZm8Os0dSw+tQwdVsiDkMSdbDGMk0sDlzP5tqcg0ggxOn7OQ//RVBji4Ym1DwBtivjDPP1PeF6Mak4oA4kgdU3AVei/S93gr1ForMvnbpnZQgXl035AIbw0QcPaEBuz2cPI6LoCiO05ZclUeqB1Pw6oNIkIEOs+SkQBPGWnHvXGTqSdXtx/r9fsN2gV+xznxY4FMlWdaHx4Kwgyf3ugEG6Wh6mY7Dac1T1unraELMpak6OpUl4di/LwSKA==,iv:YEtkOFkp/OQCzRZvDO05zG5Vg6glXebUQm/LNnLMwI8=,tag:iWwu/ZlNNboqwukZy4wKwQ==,type:str]
     SPINDRIFT_ENROLMENT_TOKEN: ENC[AES256_GCM,data:YeeLFGjz8vsX5CkudHuMeq4zlEcM7Mug6GdiWHg/rCIW2Up84gRNaPTNH41q3wo+J2R2y4D2BtqHTabJicuJKw==,iv:sViBSOc+aoeA3EfbXvWaQXTPjBkW4jZqes6UasJglr4=,tag:eo0u2YjkBcHpeQIAKcn/FQ==,type:str]
 sops:
     age:
@@ -24,6 +24,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-27T23:38:28Z"
-    mac: ENC[AES256_GCM,data:ACF/P+HHWx5i+NPpL+wRNkcwq8p3+sqBTrdRA0Pf2sYvcsfCj5ynOWsvrm25BLQfGjYGif7yZp0Qef1wz8ZjoBc5LGdwpKrx6KwxBkSphxv3c44SEa1i5+6U519M4YmOnbhwR+AmsO8Ln++djCbdLWVkL/SX1VF2FIUa9cUZ9OU=,iv:2N1Ibaex8hwPz5RPSSxeKNd6o/zvwqUAL0B+qQJ33vs=,tag:CMyhwdiaC1cMT0+NLtxg0Q==,type:str]
+    lastmodified: "2026-07-28T03:31:13Z"
+    mac: ENC[AES256_GCM,data:bNEeIh8a0H7HKPJY6G8U0x10kUNg/MDkpbIjNekbPKBxJXASkaK4EWUi1++m2EhvkrK2wQpNla1Fm2Owb8cbZL9oSv6taFtzJGr1yzCrcGXBJec99Z0vPIHt5AsH3JOn577+o8KhQHLv+Gea24BWBCp799Qdak8SFYzE7fscpCU=,iv:A5hicoTQh0gyC9JYDqF+l1jtMH78cEuea9p+voyBe5U=,tag:dpPXBZrP5CMWZE6Mz2NL5A==,type:str]
     version: 3.13.3


### PR DESCRIPTION
## Summary

Task 24 of `.agent/plans/spindrift/plan.md` — the GitHub App integration and the
configuration pull request (§15). A repository can be connected: Spindrift opens
one human-editable PR carrying a `spindrift.yaml` per scope plus one thin CI
caller, adopts configuration only from the default branch, and freezes rather
than destroys when it loses access.

## Changes

- **`src/integrations/github/`** — `http.ts` (injectable transport, and the one
  place a refusal is classified), `app.ts` (App JWT, per-installation token
  cache, the `ExactCommitFetcher` Task 23 stages through, the Git data API),
  `webhook.ts` (HMAC over raw bytes, then classification), `config-pr.ts` (the
  transaction, composed and opened).
- **`src/reconciler/repo-loop.ts`** — periodic default-branch reconciliation,
  the freeze/thaw path, and webhook application.
- **`src/domain/repository.ts`** — core's name for the far side, so the command
  layer and the loop import no GitHub client.
- **Schema** — `repositories` table and `apps.repository_id`, migration `0006`.
- **`connectRepository`** — a registry command, reachable through dispatch.
- **`clusters/offsite/apps/spindrift/secret.sops.yaml`** — the two new manifest
  keys, so the installation still boots.

## Notes for review

Three decisions worth disagreeing with if you do:

1. **`github.buildWorkflow` is nullable and offsite's is `null`.** The reusable
   workflow arrives with the build adapters (Task 25). A placeholder commit
   would be configuration that looks complete and fails at the first build, so
   `connectRepository` refuses with that reason until one is published — stated
   the way `auth.gateway: null` already is.
2. **`AdapterRegistry` gained a fourth lookup, `repository()`.** Not one of §6's
   three adapter contracts, and there anyway: the interface is "the far side a
   command may reach", and the alternative was threading a second far side
   through the command layer beside the context.
3. **Lost access covers `401`, `403` and `404` alike.** A selected-repository
   App that has been un-selected answers `404` exactly as a repository that
   never existed does; there is no response that tells them apart. A rate limit
   is split out so an hour's quota never freezes anything.

**Not wired yet, and consistent with the rest of the milestone:** there is no
HTTP route for the webhook and no caller for the loop — `runTargetLoop` and
`runDeployLoop` have no callers either, because the reconciler entrypoint does
not exist. `SPINDRIFT_GITHUB_APP_KEY` is not in the Secret, so `repository()`
returns `null` and the command refuses cleanly rather than half-working.

## Test Plan

- [ ] `mise run ts:check` — clean
- [ ] `DATABASE_URL=... bun test` in `apps/spindrift/` — 564 pass (was 482)
- [ ] `mise run k8s:render-apps` — renders clean
- [ ] `sops -d clusters/offsite/apps/spindrift/secret.sops.yaml` round-trips and
      the manifest inside it parses through the real loader
- [ ] The three acceptance criteria, as tests: the PR tree is exactly the
      Spindrift files plus one caller (`test/integrations/github/config-pr.test.ts`);
      an unmerged PR changes nothing, and revoked access freezes with every
      Deploy row byte-identical (`test/reconciler/repo-loop.test.ts`)
