### PR TITLE
fix(vector): add dangerously_allow_unconfined_template_resolution to Loki sinks

### DIFF
--- a/clusters/base/monitoring/vector.yaml
+++ b/clusters/base/monitoring/vector.yaml
@@ -69,6 +69,7 @@ spec:
           tenant_id: "1"
           encoding:
             codec: json
+          dangerously_allow_unconfined_template_resolution: true
           labels:
             job: "kubernetes"
             cluster: "${CLUSTER_NAME}"
@@ -84,6 +85,7 @@ spec:
           tenant_id: "1"
           encoding:
             codec: json
+          dangerously_allow_unconfined_template_resolution: true
           labels:
             job: "systemd-journal"
             cluster: "${CLUSTER_NAME}"


### PR DESCRIPTION
## Problem
Vector 0.57.0 DaemonSet on offsite cluster has both pods in CrashLoopBackOff (8 days, thousands of restarts) due to:

```
ERROR vector::topology::builder: Configuration error. error=Sink "loki_journald": template references event fields (["host"]) but has no literal string prefix
ERROR vector::topology::builder: Configuration error. error=Sink "loki_kubernetes": template references event fields (["kubernetes.container_name"]) but has no literal string prefix
```

## Fix
Add `dangerously_allow_unconfined_template_resolution: true` to both Loki sink configs to opt out of Vector 0.57.0's new template confinement security requirement.

## Verification
- [ ] Flux reconciles successfully on offsite cluster
- [ ] Vector pods transition to Running