### PR TITLE
fix(ai-agent): add SandboxWarmPool template to fix WarmPoolNotFound

### DIFF
--- a/packages/charts/ai-agent/templates/sandboxwarmpool.yaml
+++ b/packages/charts/ai-agent/templates/sandboxwarmpool.yaml
@@ -1,0 +1,13 @@
+{{- if not .Values.hermes.enabled -}}
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: shadow-pool-{{ include "ai-agent.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  sandboxTemplateRef:
+    name: {{ include "ai-agent.fullname" . }}
+{{- end }}


### PR DESCRIPTION
## Problem

The dave agent-sandbox HelmRelease on the offsite cluster has been FAILED for 8 days:
- SandboxClaim 'dave-ai-agent' reports WarmPoolNotFound
- The agent-sandbox controller requires a SandboxWarmPool to exist when --extensions is enabled
- The Helm chart creates a SandboxClaim but no SandboxWarmPool

## Fix

Add a `sandboxwarmpool.yaml` template to the ai-agent Helm chart that creates a SandboxWarmPool alongside the SandboxClaim. The warm pool name follows the controller's naming convention (`shadow-pool-<fullname>`) and references the same SandboxTemplate.

## Verification

- `helm template` confirmed the warm pool renders correctly as `shadow-pool-dave-ai-agent`
- The warm pool has `sandboxTemplateRef.name: dave-ai-agent` matching the claim's template
- After merge, Flux will pick up the new chart and the controller should provision the sandbox