### PR TITLE
chore(spindrift): bump chart to 0.1.1 to force Helm reconciliation with new image

### DIFF
--- a/packages/charts/spindrift/Chart.yaml
+++ b/packages/charts/spindrift/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spindrift
 description: The Spindrift installer chart — the web and reconciler Deployments, their database, and the route the UI is served on
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "latest"


### PR DESCRIPTION
The HelmRelease uses `reconcileStrategy: Revision`, so Helm only triggers an upgrade when the chart source changes. Renovate bumped the image from `da98497` to `868c823` but that only changed the HelmRelease values, not the chart directory. The deployment is stuck on the old image `318eeb3`.

Bumping the chart version forces Flux to create a new HelmChart artifact and trigger the upgrade with the new image.