### PR TITLE
feat(spindrift): build a staged bundle on any of three routes

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -1,0 +1,161 @@
+# The machinery behind Spindrift's hosted build route (spec §4, §15).
+#
+# §15 puts the run in the *connected* repository, on its own Actions minutes,
+# and keeps everything it does here: what lands in somebody's repo is a thin
+# caller pinned to a commit of this file. That is why this workflow reads one
+# opaque `spec` input — a caller does not have to be regenerated when a build
+# gains a parameter.
+#
+# It also answers `workflow_dispatch`, because an uploaded archive has no
+# repository of its own and builds here instead.
+#
+# Two things it deliberately does not do:
+#
+#   * It never posts anything back. Logs are read, not pushed (§4), so the
+#     result leaves on the one channel Spindrift already reads — the last line
+#     this workflow prints.
+#   * It never signs. The build adapter returns the artifact and digest exactly
+#     as built and *core* signs that digest (§16), so no backend is
+#     disqualifiable and the claim made is the honest one.
+name: spindrift-build
+run-name: spindrift ${{ inputs.correlation }}
+
+on:
+  workflow_call:
+    inputs:
+      spec:
+        description: The build request, as JSON.
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      spec:
+        description: The build request, as JSON.
+        required: true
+        type: string
+      correlation:
+        description: How Spindrift finds this run again. Not a build input.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  # The workflow-ref-scoped cloud identity §15 names: the job federates as
+  # itself rather than holding a credential anything here has to carry.
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Read the build request
+        id: request
+        env:
+          SPEC: ${{ inputs.spec }}
+        run: |
+          set -euo pipefail
+          read_key() { printf '%s' "$SPEC" | jq -r "$1"; }
+          {
+            printf 'bundleDigest=%s\n' "$(read_key '.bundleDigest')"
+            printf 'location=%s\n'     "$(read_key '.origin.location')"
+            printf 'subpath=%s\n'      "$(read_key '.origin.subpath')"
+            printf 'destination=%s\n'  "$(read_key '.destination')"
+            printf 'frontend=%s\n'     "$(read_key '.zeroConfigFrontend')"
+            printf 'registry=%s\n'     "$(read_key '.destination | split("/")[0]')"
+            printf 'buildArgs<<SPINDRIFT_EOF\n'
+            read_key '.buildArgs | to_entries[] | "\(.key)=\(.value)"'
+            printf 'SPINDRIFT_EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      # The bundle, not the repository. §15 fetches the exact commit once and
+      # stages one immutable bundle for either builder — cloning again here
+      # would build a second tree the source receipt does not describe.
+      - name: Fetch the staged bundle
+        env:
+          LOCATION: ${{ steps.request.outputs.location }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/bundle"
+          curl --fail --silent --show-error --location "$LOCATION" \
+            | tar -xz -C "${RUNNER_TEMP}/bundle"
+
+      # §5's ladder, and the only decision made here: a Dockerfile settles how
+      # to build and never what the thing is. Where there is none, a one-line
+      # Dockerfile hands the same directory to the pinned zero-config frontend —
+      # which is what makes "one engine, two frontends" true rather than two
+      # build systems to operate (§4).
+      - name: Choose the frontend
+        id: frontend
+        env:
+          SUBPATH: ${{ steps.request.outputs.subpath }}
+          FRONTEND: ${{ steps.request.outputs.frontend }}
+        run: |
+          set -euo pipefail
+          scope="${RUNNER_TEMP}/bundle/${SUBPATH}"
+          if [ -f "${scope}/Dockerfile" ]; then
+            printf 'context=%s\nfile=%s\n' "$scope" "${scope}/Dockerfile"
+          else
+            printf '#syntax=%s\n' "$FRONTEND" > "${scope}/Dockerfile.spindrift"
+            printf 'context=%s\nfile=%s\n' "$scope" "${scope}/Dockerfile.spindrift"
+          fi >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      # The run's own token, which is the only credential this job can hold
+      # without one being stored somewhere (§13). An installation whose registry
+      # does not accept it uses the cloud route, which federates instead.
+      - name: Log in to the destination registry
+        uses: docker/login-action@371161bbe7024a29a25c5e19bfcbc0804fe9ad2c # v4
+        with:
+          registry: ${{ steps.request.outputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        with:
+          context: ${{ steps.frontend.outputs.context }}
+          file: ${{ steps.frontend.outputs.file }}
+          build-args: ${{ steps.request.outputs.buildArgs }}
+          push: true
+          tags: ${{ steps.request.outputs.destination }}
+          # BuildKit's own provenance, with materials. §16 calls this the second
+          # document — unsigned, not the isolation claim, and where the base
+          # digest comes from.
+          provenance: mode=max
+          sbom: true
+
+      # The one line Spindrift reads. Base64 because this stdout goes through
+      # the host's log processing on the way back, and a folded or decorated
+      # payload is a payload core cannot decode.
+      - name: Report what was built
+        env:
+          BUNDLE_DIGEST: ${{ steps.request.outputs.bundleDigest }}
+          DESTINATION: ${{ steps.request.outputs.destination }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          # Best effort, and null when it is not there: a base is fresh only at
+          # build time, so §16 surfaces a stale one and never corrects it — but
+          # a builder that cannot report one says so rather than guessing.
+          base="$(docker buildx imagetools inspect "${DESTINATION}@${DIGEST}" \
+            --format '{{ json .Provenance }}' 2>/dev/null \
+            | jq -r '[.. | .uri? // empty | select(startswith("pkg:docker"))][0] // empty' \
+            | grep -oE 'sha256(:|%3A)[0-9a-f]{64}' \
+            | sed 's/%3A/:/' || true)"
+          report="$(jq -nc \
+            --arg bundleDigest "$BUNDLE_DIGEST" \
+            --arg digest "$DIGEST" \
+            --arg ref "${DESTINATION}@${DIGEST}" \
+            --arg base "$base" \
+            --arg run "${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            --arg workflow "$GITHUB_WORKFLOW_REF" \
+            '{bundleDigest: $bundleDigest,
+              digest: $digest,
+              refs: [$ref],
+              baseDigest: (if $base == "" then null else $base end),
+              statement: {run: $run, workflow: $workflow}}')"
+          echo "spindrift-result $(printf '%s' "$report" | base64 | tr -d '\n')"

--- a/.github/workflows/spindrift.yml
+++ b/.github/workflows/spindrift.yml
@@ -1,0 +1,42 @@
+# Spindrift's build caller for this repository (spec §4, §15).
+#
+# The same thin caller Spindrift writes into every connected repository, except
+# that this one is committed by hand — because an uploaded archive has no
+# repository of its own and builds here, where the reusable workflow lives.
+#
+# **It is a caller and not the reusable workflow itself, deliberately.** The
+# dispatch API only accepts a ref a workflow file can be read from, so
+# dispatching the reusable workflow directly would run whatever is on the
+# default branch and quietly discard the commit pin §15 requires. A caller keeps
+# the pin where a caller always keeps it: in the `uses:`.
+#
+# The pin here is `./` rather than a SHA, and that is stronger rather than
+# weaker — a local reference resolves to the same commit as this file, so the
+# machinery that runs is by construction the machinery that was reviewed
+# alongside it. A connected repository cannot do that, which is why its caller
+# carries a SHA.
+name: spindrift
+run-name: spindrift ${{ inputs.correlation }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      spec:
+        description: The build request, as JSON. Spindrift fills this in.
+        required: true
+        type: string
+      correlation:
+        description: How Spindrift finds this run again. Not a build input.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  build:
+    uses: ./.github/workflows/spindrift-build.yml
+    with:
+      spec: ${{ inputs.spec }}

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -21,11 +21,16 @@ session. Source detection classifies one named repo or archive scope, honours an
 authoritative `spindrift.yaml`, derives workspace watch paths, and keeps
 Dockerfile selection separate from Component-kind inference.
 
-What has no implementation is the Cloud Run and static deploy adapters, every
-real build route, config delivery, and datastores. **The three screens still
-render placeholder data** from `src/web/demo/`, which is scaffolding meant to be
-deleted: the views are typed against `src/web/model.ts`, so the query commands
-that replace it have a contract to meet rather than a shape to guess.
+All three build routes exist — hosted CI, the cloud builder, and an in-cluster
+Job — and every one of them runs the same BuildKit program over the same
+staged bundle, so which route ran is a property of a Build rather than a
+different pipeline.
+
+What has no implementation is the Cloud Run and static deploy adapters,
+datastores, and signing. **The three screens still render placeholder data**
+from `src/web/demo/`, which is scaffolding meant to be deleted: the views are
+typed against `src/web/model.ts`, so the query commands that replace it have a
+contract to meet rather than a shape to guess.
 
 Two named gaps, both deliberate:
 
@@ -48,7 +53,7 @@ One image, two processes (§19); only `web` exists so far.
 | `src/db/` | the Drizzle schema, the connection, and the committed migrations |
 | `src/commands/` | the application command layer and its registry |
 | `src/domain/` | backend-neutral product rules and value types |
-| `src/adapters/` | the adapter contracts, Kubernetes delivery, DNS records, and the two stores |
+| `src/adapters/` | the adapter contracts, Kubernetes delivery, the three build routes, DNS records, and the two stores |
 | `src/reconciler/` | two loops — Target health and capabilities, and deploy convergence |
 | `src/web/` | the `web` process — the server, the dispatch surface, and the client |
 | `src/web/ui/` | shadcn primitives, in this installation's palette |
@@ -174,6 +179,53 @@ running one would produce a second digest over the same bytes. Everything else
 goes through a route, and the route's name and log fidelity land on the Build so
 a thin log reads as the runner it is rather than as a bug.
 
+**Three routes, one engine.** §4 settles BuildKit with two frontends — the
+repo's Dockerfile if present, else the pinned zero-config frontend — and
+`src/adapters/build/buildkit.ts` is what keeps that from being three
+implementations of the same idea: the cloud builder runs the program in a build
+step, the cluster runs it in a Job, and the reusable workflow runs the same
+ladder through buildx. The ladder itself runs *inside* the builder, because a
+Dockerfile settles how to build and never what the thing is (§5) — the kind was
+decided before the build was dispatched.
+
+**The result comes back through the log**, because logs are read and never
+pushed (§4). That decision has a consequence nobody states: with no ingest
+endpoint there is nowhere for a runner to hand back a digest either, so the
+runner prints one base64 marker line and core reads it out of the log it was
+already fetching. No callback, no second channel, nothing to authenticate. What
+it echoes is the bundle digest it was *handed*, and the route checks rather than
+copies it — §16's join is only a check if the runner can disagree.
+
+Each route declares a profile level and a Target sets a threshold:
+`src/domain/build-route.ts` filters on the level and then takes the
+highest-ranked survivor, which is §16's "the level is a threshold, then admin
+rank wins" in that order. The in-cluster route is L1, so an L2 Target refuses
+it however highly it is ranked — which is also why a Target cannot be both
+offline-capable and require L2. `dispatchBuild` enforces the threshold half
+wherever a placement is named, because refusing to start costs nothing while an
+artifact built below a Target's minimum is a green build followed by an
+admission failure nobody reading the build log can explain.
+
+Two halves of that are still missing and neither is this package's to finish
+alone. `targets.min_build_level` is read but nothing sets it, and there is no
+ordered per-Target route list — both belong to the Target model and the connect
+act. And **the provenance a route returns is the runner's own account of
+itself**: §16 wants core to verify the backend's provenance against the
+Target's minimum *before* signing, which means fetching the attestation the
+builder attached to the artifact and checking it. The Actions route asks
+BuildKit for one (`provenance: mode=max`) and never reads it back. Until Task 26
+does, a green Build carries a claim rather than evidence, and `route.ts` says so
+where the claim is assembled.
+
+The hosted route runs in the *connected* repository, on its own Actions minutes
+(§15), through the thin caller the configuration PR wrote there. An uploaded
+archive has no repository, so it runs where the reusable workflow lives —
+which is why `.github/workflows/spindrift-build.yml` declares both
+`workflow_call` and `workflow_dispatch`. A dispatch names no run, so the caller
+carries a correlation input it stamps into `run-name` and the route finds its
+run by that name; the correlation stays out of the spec because no part of the
+build depends on it.
+
 A **Deploy** is an intent, written under `SELECT ... FOR UPDATE` on the one
 `(Component, Target)` desired row. That locking read is the whole of the
 concurrency design: two intents for one pair serialize, and the second reads what
@@ -238,6 +290,26 @@ shallower one makes a rollback come up green and unconfigured.
 `src/reconciler/config-loop.ts` reaps on a loop; the write path reaps the key it
 just touched as a fast path.
 
+**A website is the one exception, and it is derived rather than chosen.** §10
+allows it because whatever a website bakes becomes public the moment the site
+is served, so the asymmetry that sends everything else to the store does not
+exist there — and §4 states the payoff: build arguments are ordinary rows, so
+**no builder ever holds a store credential**. `isBuildTimeConfig` takes a
+Component kind and nothing else, which is what keeps the exception too narrow
+for a developer to opt a credential into. Two consequences fall out of it: a
+website reaches no store, so the reach rule does not apply to one, and a
+website's config change produces **no Deploy** — the value was baked into the
+artifact that is already serving, so re-applying it would deliver the old value
+under a new `configVersion`. The new value arrives with the next build, and the
+act says so.
+
+The known limit, stated rather than worked around: configuration is scoped to
+(Component, Target) while a Build is keyed on (Component, commit, target-shape),
+so two Targets of the same shape wanting different website build arguments want
+two artifacts the Build key cannot tell apart. `dispatchBuild` takes the
+placement it is building for and the second dispatch collides on the unique key
+rather than quietly serving the first one's values.
+
 Delivery on a Kubernetes Target is the App chart's `ExternalSecret`, which
 fetches each pinned reference into one Secret keyed by variable name. Two things
 an installation has to supply for that to work: the operator names the
@@ -246,6 +318,12 @@ without which the chart refuses to render rather than producing an
 ExternalSecret that never syncs), and the process needs `SPINDRIFT_STORE_TOKEN`
 in its environment — the access path core writes over. A config act refuses with
 that sentence when it is missing.
+
+The cloud build route reads a second variable, `SPINDRIFT_BUILD_TOKEN`, for the
+same reason and with the same posture: two access paths to two services, each
+read per call so a rotated Secret takes effect without a restart. The other two
+routes need neither — hosted CI goes through the App key, and the in-cluster
+Job authorizes with the projected service account token.
 
 ## Naming and DNS
 

--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -1,0 +1,125 @@
+/**
+ * The program every route runs (§4).
+ *
+ * §4 settles the engine and refuses to make it a per-route choice: "**BuildKit
+ * with two frontends** — the repo's Dockerfile if present, else a zero-config
+ * builder", and "because Railpack *is* a BuildKit frontend, 'Dockerfile if
+ * present, else Railpack' is **not two build systems to operate** — it is one
+ * engine with two frontends."
+ *
+ * This module is what makes that true rather than aspirational. The cloud
+ * builder runs this in a build step, the cluster runs it in a Job, and hosted CI
+ * runs the same two frontends over the same ladder — so a build that works on
+ * one route is a build that works on the others, and the routes differ only in
+ * *where* they run and what provenance they can claim.
+ *
+ * **The ladder runs here and not in core**, which is what the build contract
+ * means by "the frontend is not here". A Dockerfile settles how to build and
+ * never what the thing is (§5) — core already decided the `kind`, and this
+ * script decides nothing except which frontend gets handed the same directory.
+ *
+ * **What the image must provide.** Declared, not discovered, so an installation
+ * that pins an image knows what it is promising: a POSIX `sh`, `wget`, `tar`,
+ * `sed`, `base64`, and `buildctl-daemonless.sh` on the path. Every one of those
+ * is in the stock BuildKit image; a hardened replacement that drops one will
+ * fail loudly on the first build rather than subtly on the hundredth.
+ */
+import type { BuildSource, BuildSpec } from './contract.ts';
+import { BUILD_REPORT_MARKER } from './report.ts';
+
+/** Everything the program needs to know, all of it already decided by core. */
+export interface BuildKitProgramInput {
+  /** Where the staged bundle is fetched from — a depot URL, opaque here. */
+  readonly bundleUrl: string;
+  /** §16's join, echoed back in the report so core can check it. */
+  readonly bundleDigest: string;
+  /** The scope inside the bundle, after §5's unwrap. */
+  readonly subpath: string;
+  /** Where the artifact is pushed. Core chose it; the route never does (§4). */
+  readonly destination: string;
+  /** The zero-config frontend the installation pinned. */
+  readonly zeroConfigFrontend: string;
+  /** §4: ordinary rows, never fetched from a store. */
+  readonly buildArgs: BuildSpec['buildArgs'];
+}
+
+/**
+ * The program for one build, from what the contract already carries.
+ *
+ * The two routes that run this in a container — the cloud builder and the
+ * cluster Job — differ in *where* they run it and in nothing else, so composing
+ * the input is here rather than twice over. §4's "one engine" is only true if
+ * one place decides what the engine is told.
+ *
+ * The frontend is the exception: it is installation configuration rather than
+ * anything the contract carries, so a route supplies it.
+ */
+export function buildKitProgramFor(
+  source: BuildSource,
+  spec: BuildSpec,
+  zeroConfigFrontend: string,
+): string {
+  return buildKitProgram({
+    // One expression for both origins, which is §4's "repo and archive share
+    // one pipeline" made literal: the program never learns which it is
+    // building, because by then the difference is only a principal on a
+    // receipt (§16).
+    bundleUrl: source.origin.location,
+    bundleDigest: source.bundleDigest,
+    subpath: source.origin.subpath,
+    destination: spec.destination,
+    zeroConfigFrontend,
+    buildArgs: spec.buildArgs,
+  });
+}
+
+/**
+ * Single-quote a value for `sh`.
+ *
+ * Every value below reaches a shell, and two of them — the destination and the
+ * build arguments — carry developer-influenced text. Quoting is therefore not
+ * tidiness: it is the boundary between a build argument and an extra command.
+ */
+function quote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * The `sh -c` program that turns a staged bundle into a pushed artifact.
+ *
+ * It ends by printing the report marker, because logs are read and never pushed
+ * (§4) — there is no endpoint for it to report a digest to, so it reports on
+ * the one channel core is already reading. `base64` output is folded by some
+ * implementations and not others, hence the `tr`: a wrapped payload is a
+ * payload core cannot decode.
+ */
+export function buildKitProgram(input: BuildKitProgramInput): string {
+  const args = Object.entries(input.buildArgs)
+    .map(([key, value]) => `  --opt ${quote(`build-arg:${key}=${value}`)} \\`)
+    .join('\n');
+
+  return `set -eu
+workspace=$(mktemp -d)
+wget -qO- ${quote(input.bundleUrl)} | tar -xz -C "$workspace"
+cd "$workspace"/${quote(input.subpath)}
+
+# §5's ladder, and the only decision this script makes: a Dockerfile settles
+# how to build. What the thing *is* was decided before the build was dispatched.
+if [ -f Dockerfile ]; then
+  set -- --frontend dockerfile.v0 --local dockerfile=.
+else
+  set -- --frontend gateway.v0 --opt source=${quote(input.zeroConfigFrontend)}
+fi
+
+buildctl-daemonless.sh build "$@" \\
+  --local context=. \\
+${args}
+  --output ${quote(`type=image,name=${input.destination},push=true`)} \\
+  --metadata-file "$workspace/metadata.json"
+
+digest=$(sed -n 's/.*"containerimage.digest"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' "$workspace/metadata.json")
+report=$(printf '{"bundleDigest":"%s","digest":"%s","refs":["%s@%s"],"baseDigest":null}' \\
+  ${quote(input.bundleDigest)} "$digest" ${quote(input.destination)} "$digest")
+echo "${BUILD_REPORT_MARKER} $(printf '%s' "$report" | base64 | tr -d '\\n')"
+`;
+}

--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -1,0 +1,327 @@
+/**
+ * The cloud build route (§4).
+ *
+ * §4 names three routes and this is the middle one: "a cloud build service", in
+ * §14's shared artifacts project, next to the registry every artifact is pushed
+ * to. It is the route with the strongest isolation claim — a managed worker the
+ * connected repository's maintainers cannot reach — which is why it is the only
+ * one this installation can honestly offer above L2.
+ *
+ * `LIVE_TEXT`, and it is earned rather than declared: the build service writes
+ * its steps' output to a log service that can be read while the build runs, so
+ * the timeline fills in as it goes (§4's amendment). The read is a poll with a
+ * page cursor and not a stream, for the same reason `observe` is a poll — a
+ * long-lived connection over the uplink is a connection that stays open while
+ * delivering nothing.
+ *
+ * **What it submits is the shared BuildKit program**, not the service's own
+ * source-to-image path. That is §4's "build is always separate from deploy"
+ * applied one level down: a backend's convenience path is a second engine with
+ * its own frontends, its own defaults, and its own idea of what a website is,
+ * and having one would make "one engine, two frontends" false the moment a
+ * build moved between routes.
+ */
+
+import { buildKitProgramFor } from './buildkit.ts';
+import type {
+  BuildAdapter,
+  BuildEvent,
+  BuildLevel,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+  LogFidelity,
+} from './contract.ts';
+import { parseBuildReport } from './report.ts';
+import {
+  buildFailed,
+  buildSucceeded,
+  deadlineFrom,
+  type PollingOptions,
+} from './route.ts';
+
+/** The transport, in the shape `fetch` already has. */
+export type Fetcher = (request: Request) => Promise<Response>;
+
+/** Mints a bearer token per request. Never a stored credential (§13). */
+export type TokenProvider = () => string | Promise<string>;
+
+/** One build, as much of it as this route reads. */
+interface CloudBuild {
+  readonly id: string;
+  readonly status?: string;
+  readonly statusDetail?: string;
+}
+
+/** One log entry, as much of it as this route reads. */
+interface LogEntry {
+  readonly textPayload?: string;
+  readonly timestamp?: string;
+}
+
+export interface CloudBuildRouteOptions extends PollingOptions {
+  readonly name: string;
+  /** The build service's API root, without a trailing slash. */
+  readonly endpoint: string;
+  /** The log service's API root, without a trailing slash. */
+  readonly logsEndpoint: string;
+  readonly project: string;
+  readonly region: string;
+  /** The BuildKit image the build step runs. Pinned by the installation. */
+  readonly image: string;
+  /** The zero-config BuildKit frontend the installation pinned (§4). */
+  readonly zeroConfigFrontend: string;
+  readonly token: TokenProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+}
+
+/**
+ * The statuses that mean the build is over.
+ *
+ * `EXPIRED` is in here and reads oddly: it is what a build that sat in the
+ * queue past its own deadline becomes, so it is terminal even though nothing
+ * ever ran.
+ */
+const TERMINAL = new Set([
+  'SUCCESS',
+  'FAILURE',
+  'INTERNAL_ERROR',
+  'TIMEOUT',
+  'CANCELLED',
+  'EXPIRED',
+]);
+
+export class CloudBuildRoute implements BuildAdapter {
+  readonly name: string;
+  readonly logFidelity: LogFidelity = 'LIVE_TEXT';
+  /**
+   * §16's profile level. A managed, ephemeral worker nobody outside the build
+   * service can reach, running a program submitted by an authenticated caller —
+   * that is the L3 claim this service makes for its own builds, and the profile
+   * is a guarantee about the *route*. Whether a concrete Build achieved it is
+   * Task 26's question, asked before signing and never taken on trust.
+   */
+  readonly buildLevel: BuildLevel = 3;
+
+  constructor(private readonly options: CloudBuildRouteOptions) {
+    this.name = options.name;
+  }
+
+  async *build(
+    source: BuildSource,
+    spec: BuildSpec,
+  ): AsyncGenerator<BuildEvent, BuildResult, void> {
+    const now = this.options.now ?? (() => new Date());
+    const logs = { backend: this.name, fidelity: this.logFidelity } as const;
+
+    if (source.origin.type === 'repo') {
+      // The bundle was staged once and every route fetches it (§15); a route
+      // that cloned again would build a second tree from the same commit and
+      // give the receipt nothing to join against.
+      yield {
+        type: 'log',
+        at: now(),
+        line: 'building from the staged bundle, not from the repository',
+      };
+    }
+
+    const program = buildKitProgramFor(
+      source,
+      spec,
+      this.options.zeroConfigFrontend,
+    );
+
+    let build: CloudBuild;
+    try {
+      build = await this.submit(program);
+    } catch (error) {
+      // §4 story 48: the failure before the build step has to be readable as
+      // text, not as an empty log and a spinner.
+      const detail = error instanceof Error ? error.message : String(error);
+      yield { type: 'log', at: now(), line: `submit failed: ${detail}` };
+      return buildFailed(
+        logs,
+        'TARGET_UNREACHABLE',
+        `could not submit a build to ${this.options.project}: ${detail}`,
+      );
+    }
+
+    yield { type: 'log', at: now(), line: `build ${build.id} submitted` };
+
+    const budget = deadlineFrom(this.options);
+    let cursor: string | undefined;
+    let log = '';
+    let status = build.status ?? 'QUEUED';
+    let statusDetail = build.statusDetail;
+
+    for (;;) {
+      const page = await this.logPage(build.id, cursor);
+      cursor = page.cursor;
+      for (const entry of page.entries) {
+        const line = entry.textPayload;
+        if (line === undefined || line.trim() === '') continue;
+        log += `${line}\n`;
+        yield {
+          type: 'log',
+          at: entry.timestamp === undefined ? now() : new Date(entry.timestamp),
+          line,
+        };
+      }
+
+      const current = await this.read(build.id);
+      if (current !== null) {
+        status = current.status ?? status;
+        statusDetail = current.statusDetail ?? statusDetail;
+      }
+      if (TERMINAL.has(status)) break;
+
+      if (budget.expired()) {
+        return buildFailed(
+          logs,
+          'TIMEOUT',
+          `build ${build.id} did not finish within the build budget`,
+          { buildId: build.id, status },
+        );
+      }
+      await budget.tick();
+    }
+
+    if (status !== 'SUCCESS') {
+      // The service's own `TIMEOUT` is core's `TIMEOUT` — a build that ran out
+      // of its own budget indicts nobody either (§6's dash).
+      return buildFailed(
+        logs,
+        status === 'TIMEOUT' || status === 'EXPIRED'
+          ? 'TIMEOUT'
+          : 'BUILD_FAILED',
+        statusDetail ?? `build ${build.id} ended ${status}`,
+        { buildId: build.id, status },
+      );
+    }
+
+    const report = parseBuildReport(log);
+    if (report === null) {
+      return buildFailed(
+        logs,
+        'INTERNAL',
+        `build ${build.id} succeeded but reported no artifact`,
+        { buildId: build.id },
+      );
+    }
+
+    return buildSucceeded({
+      source,
+      spec,
+      logs,
+      level: this.buildLevel,
+      report: {
+        ...report,
+        // The build's own record of the run — §16's backend provenance, which
+        // core verifies against the Target's minimum before signing. The route
+        // reports it and never interprets it.
+        statement: { build: build.id, project: this.options.project },
+      },
+    });
+  }
+
+  /** `projects/<p>/locations/<r>` — the parent every call hangs off. */
+  private get parent(): string {
+    return `projects/${this.options.project}/locations/${this.options.region}`;
+  }
+
+  private async submit(program: string): Promise<CloudBuild> {
+    const operation = await this.json<{
+      metadata?: { build?: CloudBuild };
+    }>(`${this.options.endpoint}/v1/${this.parent}/builds`, {
+      method: 'POST',
+      body: {
+        steps: [
+          {
+            name: this.options.image,
+            entrypoint: 'sh',
+            args: ['-c', program],
+          },
+        ],
+        // Read, never pushed: the build writes to the log service and this
+        // route polls it. Nothing is posted back to Spindrift (§4).
+        options: { logging: 'CLOUD_LOGGING_ONLY' },
+      },
+    });
+    const build = operation?.metadata?.build;
+    if (build === undefined) {
+      throw new TypeError('the build service named no build');
+    }
+    return build;
+  }
+
+  private read(id: string): Promise<CloudBuild | null> {
+    return this.json<CloudBuild>(
+      `${this.options.endpoint}/v1/${this.parent}/builds/${encodeURIComponent(id)}`,
+      { method: 'GET' },
+    );
+  }
+
+  /**
+   * One page of the build's log, and where to resume.
+   *
+   * A page cursor rather than a timestamp window: entries arrive out of order
+   * often enough that a window either repeats lines or drops them, and the log
+   * service's own cursor is the only thing that knows which it already served.
+   */
+  private async logPage(
+    id: string,
+    cursor: string | undefined,
+  ): Promise<{ entries: readonly LogEntry[]; cursor: string | undefined }> {
+    let page: { entries?: LogEntry[]; nextPageToken?: string } | null = null;
+    try {
+      page = await this.json(`${this.options.logsEndpoint}/v2/entries:list`, {
+        method: 'POST',
+        body: {
+          resourceNames: [`projects/${this.options.project}`],
+          filter: `resource.labels.build_id="${id}"`,
+          orderBy: 'timestamp asc',
+          pageSize: 200,
+          ...(cursor === undefined ? {} : { pageToken: cursor }),
+        },
+      });
+    } catch {
+      // A log service having a bad moment must not fail a build that is
+      // otherwise going fine — the status read below is the authority on
+      // whether it is going fine, and the next pass asks for the page again.
+      return { entries: [], cursor };
+    }
+    return {
+      entries: page?.entries ?? [],
+      cursor: page?.nextPageToken ?? cursor,
+    };
+  }
+
+  private async json<Result>(
+    url: string,
+    options: { method: string; body?: unknown },
+  ): Promise<Result | null> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      Authorization: `Bearer ${await this.options.token()}`,
+    };
+    if (options.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+    }
+    const request = new Request(url, {
+      method: options.method,
+      headers,
+      body:
+        options.body === undefined ? undefined : JSON.stringify(options.body),
+    });
+    const send = this.options.fetch ?? ((input: Request) => fetch(input));
+    const response = await send(request);
+    if (response.status === 404) return null;
+    if (!response.ok) {
+      throw new Error(
+        `${options.method} ${url} failed with ${response.status}: ${await response.text()}`,
+      );
+    }
+    return (await response.json()) as Result;
+  }
+}

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -43,6 +43,17 @@ export type BuildOrigin =
       commit: string;
       /** An App is repo plus subpath; the scope is named, never searched (§5). */
       subpath: string;
+      /**
+       * Where the builder fetches the staged bundle for that commit from.
+       *
+       * Present on **both** arms, because §15 stages one immutable bundle "for
+       * either builder" and a route that cloned the commit again would build a
+       * second tree — one the source receipt's digest does not describe. The
+       * repository and commit stay beside it because a backend that can bind
+       * them natively produces stronger provenance for having them (§16); they
+       * are not what gets fetched.
+       */
+      location: string;
     }
   | {
       type: 'archive';

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -1,0 +1,413 @@
+/**
+ * The hosted-CI build route (§4).
+ *
+ * §4 puts the default build "somewhere with a fast pipe rather than at home
+ * behind Starlink", and §15 puts the run in the connected repository: "the
+ * connected repo owns its Actions minutes; a **SHA-pinned reusable workflow**
+ * plus a workflow-ref-scoped cloud identity hold the machinery." Everything
+ * awkward about this file follows from that one arrangement.
+ *
+ * **Three consequences worth knowing before reading the code.**
+ *
+ * 1. **Dispatch names no run.** The dispatch API answers `204` and says nothing
+ *    about what it started, so the run has to be *found*. That is why the
+ *    caller workflow carries a correlation input it stamps into `run-name`:
+ *    matching on a name this route minted is exact, where matching on "the
+ *    newest run since I asked" is a race with anyone else pushing.
+ * 2. **The result comes back through the log.** Logs are read and never pushed
+ *    (§4), so there is no endpoint for a runner to post a digest to — the
+ *    runner prints one marker line and this route reads it out of the log it
+ *    was already fetching. See `report.ts`.
+ * 3. **An archive builds in the platform's own repository.** A repo App runs on
+ *    its own minutes, but an uploaded archive has no repository at all — so it
+ *    runs where the reusable workflow lives, which the installation already
+ *    named in `github.buildWorkflow`. That workflow declares `workflow_call`
+ *    and `workflow_dispatch` for exactly this reason.
+ *
+ * `LIVE_STATUS`, declared and not measured: on a hosted runner the step
+ * transitions are readable while the run goes and the text only lands at the
+ * end (§4, and the amendment in `04-build-path.md`). §4 makes that visible on
+ * the Build rather than hidden, because a checklist-only log is a property of
+ * where it ran and not a bug in Spindrift.
+ */
+import type { RepositoryRef } from '../../domain/repository.ts';
+import {
+  CALLER_WORKFLOW_FILE,
+  RUN_NAME_PREFIX,
+} from '../../integrations/github/config-pr.ts';
+import type {
+  BuildAdapter,
+  BuildEvent,
+  BuildLevel,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+  LogFidelity,
+} from './contract.ts';
+import { parseBuildReport } from './report.ts';
+import {
+  buildFailed,
+  buildSucceeded,
+  deadlineFrom,
+  type PollingOptions,
+} from './route.ts';
+
+/** One run of a workflow, as much of it as this route reads. */
+export interface ActionsRun {
+  readonly id: number;
+  /** The `run-name` the caller stamped, which is how a run is correlated. */
+  readonly name: string | null;
+  readonly status: string;
+  readonly conclusion: string | null;
+}
+
+/** One job of a run, and the steps inside it. */
+export interface ActionsJob {
+  readonly id: number;
+  readonly name: string;
+  readonly status: string;
+  readonly conclusion: string | null;
+  readonly steps?: readonly {
+    readonly name: string;
+    readonly status: string;
+    readonly conclusion: string | null;
+  }[];
+}
+
+/**
+ * The far side this route drives.
+ *
+ * Declared here rather than imported from the integration, the same way
+ * `ConfigurationHost` is: what this route needs is six calls, and naming them
+ * is what lets a test stand a fake behind the real client without the fake
+ * having to be a GitHub App.
+ */
+export interface ActionsHost {
+  installationFor(fullName: string): Promise<RepositoryRef>;
+  repository(
+    ref: RepositoryRef,
+    fullName: string,
+  ): Promise<{ readonly defaultBranch: string }>;
+  dispatchWorkflow(
+    ref: RepositoryRef,
+    fullName: string,
+    input: {
+      readonly workflow: string;
+      readonly branch: string;
+      readonly inputs: Readonly<Record<string, string>>;
+    },
+  ): Promise<void>;
+  workflowRuns(
+    ref: RepositoryRef,
+    fullName: string,
+    input: { readonly workflow: string; readonly branch: string },
+  ): Promise<readonly ActionsRun[]>;
+  workflowRun(
+    ref: RepositoryRef,
+    fullName: string,
+    runId: number,
+  ): Promise<{
+    readonly id: number;
+    readonly status: string;
+    readonly conclusion: string | null;
+  } | null>;
+  runJobs(
+    ref: RepositoryRef,
+    fullName: string,
+    runId: number,
+  ): Promise<readonly ActionsJob[]>;
+  jobLog(
+    ref: RepositoryRef,
+    fullName: string,
+    jobId: number,
+  ): Promise<string | null>;
+}
+
+export interface GitHubActionsRouteOptions extends PollingOptions {
+  readonly name: string;
+  readonly host: ActionsHost;
+  /**
+   * The reusable workflow, `owner/repo/.github/workflows/<file>@<sha>`, exactly
+   * as the manifest pins it.
+   *
+   * Only the repository half is read here, and the reason is the pin: a
+   * dispatch names a *branch*, so dispatching the reusable workflow directly
+   * would run whatever is on the default branch and discard the commit §15
+   * requires. This route therefore always dispatches a **caller** — the one the
+   * configuration PR wrote in a connected repository, or the one committed
+   * beside the reusable workflow here — and the caller is what holds the pin.
+   */
+  readonly buildWorkflow: string;
+  /** The zero-config BuildKit frontend the installation pinned (§4). */
+  readonly zeroConfigFrontend: string;
+  /** Injected so a test can pin the correlation it asserts on. */
+  readonly correlation?: () => string;
+  /** How long to keep looking for the run a dispatch started. */
+  readonly discoveryMs?: number;
+}
+
+/** Long enough for a queued run to appear, short enough to fail visibly. */
+export const DEFAULT_RUN_DISCOVERY_MS = 120_000;
+
+/**
+ * Where an archive builds: the repository half of the pinned reference.
+ *
+ * The manifest schema already refuses anything that does not match this shape,
+ * so a failure here is a programming error rather than a configuration one —
+ * hence the throw. `null` would push a check onto every call site for a state
+ * the boot already made impossible.
+ */
+export function reusableWorkflowRepository(reference: string): string {
+  const match = /^([^/@\s]+\/[^/@\s]+)\/\.github\/workflows\/[^@\s]+@/.exec(
+    reference,
+  );
+  if (match === null) {
+    throw new TypeError(
+      `not a pinned reusable workflow reference: ${reference}`,
+    );
+  }
+  return match[1] as string;
+}
+
+/** What the workflow is handed, and what the reusable workflow reads back. */
+export interface BuildRequestSpec {
+  readonly bundleDigest: string;
+  readonly origin: BuildSource['origin'];
+  readonly artifactType: BuildSpec['artifactType'];
+  readonly kind: BuildSpec['kind'];
+  readonly platform: BuildSpec['platform'];
+  readonly destination: string;
+  readonly buildArgs: Readonly<Record<string, string>>;
+  /** Pinned by the installation, never chosen by the runner. */
+  readonly zeroConfigFrontend: string;
+}
+
+export class GitHubActionsBuildRoute implements BuildAdapter {
+  readonly name: string;
+  readonly logFidelity: LogFidelity = 'LIVE_STATUS';
+  /**
+   * §16's profile level. A reusable workflow pinned by commit, running on a
+   * runner the repository does not control, producing signed provenance — that
+   * is L2. It is not L3: the workflow runs with the connected repository's own
+   * permissions, so its own maintainers can reach the build environment.
+   */
+  readonly buildLevel: BuildLevel = 2;
+
+  /** Where an archive builds, having no repository of its own. */
+  private readonly platformRepository: string;
+
+  constructor(private readonly options: GitHubActionsRouteOptions) {
+    this.name = options.name;
+    this.platformRepository = reusableWorkflowRepository(options.buildWorkflow);
+  }
+
+  async *build(
+    source: BuildSource,
+    spec: BuildSpec,
+  ): AsyncGenerator<BuildEvent, BuildResult, void> {
+    const now = this.options.now ?? (() => new Date());
+    const logs = { backend: this.name, fidelity: this.logFidelity } as const;
+    const { host } = this.options;
+
+    // A repo App builds where its source lives, on its own minutes (§15); an
+    // archive has no repository, so it builds where the workflow does.
+    const repository =
+      source.origin.type === 'repo'
+        ? source.origin.repository
+        : this.platformRepository;
+    // Always a caller, never the reusable workflow itself — a dispatch names a
+    // branch, so dispatching the reusable workflow directly would discard the
+    // commit §15 pins. The connected repository runs the caller the
+    // configuration PR wrote there; the platform repository runs the one
+    // committed beside the reusable workflow. Same file name, same inputs.
+    const workflow = CALLER_WORKFLOW_FILE;
+
+    const correlation = (
+      this.options.correlation ?? (() => crypto.randomUUID())
+    )();
+    const runName = `${RUN_NAME_PREFIX} ${correlation}`;
+
+    const request: BuildRequestSpec = {
+      bundleDigest: source.bundleDigest,
+      origin: source.origin,
+      artifactType: spec.artifactType,
+      kind: spec.kind,
+      platform: spec.platform,
+      destination: spec.destination,
+      buildArgs: spec.buildArgs,
+      zeroConfigFrontend: this.options.zeroConfigFrontend,
+    };
+
+    let ref: RepositoryRef;
+    let branch: string;
+    try {
+      ref = await host.installationFor(repository);
+      branch = (await host.repository(ref, repository)).defaultBranch;
+      await host.dispatchWorkflow(ref, repository, {
+        workflow,
+        branch,
+        inputs: { spec: JSON.stringify(request), correlation },
+      });
+    } catch (error) {
+      // §4 story 48: a failure *before* the build step — dispatch refused, the
+      // runner never came up — must be visible as text rather than as an empty
+      // log and a spinner. So it is yielded onto the attempt log first and
+      // becomes the verdict second.
+      const detail = error instanceof Error ? error.message : String(error);
+      yield { type: 'log', at: now(), line: `dispatch failed: ${detail}` };
+      return buildFailed(
+        logs,
+        'TARGET_UNREACHABLE',
+        `could not dispatch ${workflow} in ${repository}: ${detail}`,
+        { repository, workflow },
+      );
+    }
+
+    yield {
+      type: 'log',
+      at: now(),
+      line: `dispatched ${workflow} in ${repository} on ${branch} as “${runName}”`,
+    };
+
+    const discovery = deadlineFrom({
+      ...this.options,
+      timeoutMs: this.options.discoveryMs ?? DEFAULT_RUN_DISCOVERY_MS,
+    });
+    let run: ActionsRun | null = null;
+    while (run === null) {
+      if (discovery.expired()) {
+        yield {
+          type: 'log',
+          at: now(),
+          line: `no run named “${runName}” appeared in ${repository}`,
+        };
+        return buildFailed(
+          logs,
+          'TARGET_UNREACHABLE',
+          `the workflow was dispatched but no run appeared in ${repository}`,
+          { repository, workflow, runName },
+        );
+      }
+      await discovery.tick();
+      const runs = await host.workflowRuns(ref, repository, {
+        workflow,
+        branch,
+      });
+      run = runs.find((candidate) => candidate.name === runName) ?? null;
+    }
+
+    yield { type: 'log', at: now(), line: `run ${run.id} started` };
+
+    const budget = deadlineFrom(this.options);
+    const seen = new Set<string>();
+    let conclusion: string | null = null;
+    let jobs: readonly ActionsJob[] = [];
+
+    for (;;) {
+      jobs = await host.runJobs(ref, repository, run.id);
+      for (const event of stepEvents(jobs, seen, now())) yield event;
+
+      const current = await host.workflowRun(ref, repository, run.id);
+      if (current !== null && current.status === 'completed') {
+        conclusion = current.conclusion;
+        break;
+      }
+      if (budget.expired()) {
+        return buildFailed(
+          logs,
+          'TIMEOUT',
+          `run ${run.id} in ${repository} did not finish within the build budget`,
+          { runId: run.id },
+        );
+      }
+      await budget.tick();
+    }
+
+    // The text lands only now, which is what `LIVE_STATUS` means. Reading it
+    // even on a red run is the point: the failure is in there.
+    let log = '';
+    for (const job of jobs) {
+      const text = await host.jobLog(ref, repository, job.id);
+      if (text === null) continue;
+      log += text;
+      for (const line of text.split('\n')) {
+        if (line.trim() === '') continue;
+        yield { type: 'log', at: now(), line, step: job.name };
+      }
+    }
+
+    if (conclusion !== 'success') {
+      return buildFailed(
+        logs,
+        'BUILD_FAILED',
+        `run ${run.id} in ${repository} concluded ${conclusion ?? 'without a conclusion'}`,
+        { runId: run.id, conclusion },
+      );
+    }
+
+    const report = parseBuildReport(log);
+    if (report === null) {
+      // Green run, no report: the workflow ran something other than a Spindrift
+      // build. Reporting it as an adapter fault rather than a build failure is
+      // deliberate — nothing the developer wrote is at fault for it.
+      return buildFailed(
+        logs,
+        'INTERNAL',
+        `run ${run.id} in ${repository} succeeded but reported no artifact`,
+        { runId: run.id },
+      );
+    }
+
+    return buildSucceeded({
+      source,
+      spec,
+      logs,
+      level: this.buildLevel,
+      report,
+    });
+  }
+}
+
+/**
+ * The step transitions not yet yielded.
+ *
+ * Deduplicated on `(job, step, state)` because the jobs endpoint is polled and
+ * reports the same completed step on every pass — without this the timeline
+ * would repeat every step once per poll, which reads as a build looping.
+ */
+function stepEvents(
+  jobs: readonly ActionsJob[],
+  seen: Set<string>,
+  at: Date,
+): BuildEvent[] {
+  const events: BuildEvent[] = [];
+  for (const job of jobs) {
+    for (const step of job.steps ?? []) {
+      const state = stepState(step.status, step.conclusion);
+      if (state === null) continue;
+      const key = `${job.name}/${step.name}/${state}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      events.push({
+        type: 'step',
+        at,
+        step: `${job.name} / ${step.name}`,
+        state,
+      });
+    }
+  }
+  return events;
+}
+
+/** A step's state, or `null` for one that has not started and has nothing to say. */
+function stepState(
+  status: string,
+  conclusion: string | null,
+): 'RUNNING' | 'SUCCEEDED' | 'FAILED' | null {
+  if (status === 'in_progress') return 'RUNNING';
+  if (status !== 'completed') return null;
+  // `skipped` is not a failure and is not a success; reporting it as either
+  // would put a step on the timeline that never ran.
+  if (conclusion === 'skipped') return null;
+  return conclusion === 'success' ? 'SUCCEEDED' : 'FAILED';
+}

--- a/apps/spindrift/src/adapters/build/in-cluster.ts
+++ b/apps/spindrift/src/adapters/build/in-cluster.ts
@@ -1,0 +1,268 @@
+/**
+ * The in-cluster build route (§4).
+ *
+ * §4 puts this route on a knife edge and then justifies it: "**the home cluster
+ * never pushes across its uplink** — a geography constraint, not a capability
+ * one — but a build that never crosses it is untouched by that rule, which is
+ * what makes `in-cluster` legitimate." So this route exists for the cluster that
+ * sits beside its own registry, and for the installation that has no cloud at
+ * all — which is the case §20's extraction contract has to keep possible.
+ *
+ * **It is SLSA Build Level 1, and that is the whole of its cost.** A Job on a
+ * cluster the App is also deployed to has no isolation claim worth making: the
+ * same operators reach both. §16 turns that into a rule rather than a warning —
+ * a Target with a minimum of L2 refuses this route, which is also why §4 says a
+ * Target "cannot be both offline-capable and require L2 or above". `buildLevel`
+ * below is what `selectBuildRoute` reads to enforce it.
+ *
+ * `LIVE_TEXT`, and here it is genuinely free: the runner is a pod on a cluster
+ * this process is already connected to, so its log is one more read against an
+ * API the adapter already holds (§4's amendment).
+ */
+import type {
+  KubernetesApi,
+  KubernetesObject,
+} from '../deploy/kubernetes/api.ts';
+import { buildKitProgramFor } from './buildkit.ts';
+import type {
+  BuildAdapter,
+  BuildEvent,
+  BuildLevel,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+  LogFidelity,
+} from './contract.ts';
+import { parseBuildReport } from './report.ts';
+import {
+  buildFailed,
+  buildSucceeded,
+  deadlineFrom,
+  type PollingOptions,
+} from './route.ts';
+
+export interface InClusterRouteOptions extends PollingOptions {
+  readonly name: string;
+  readonly api: KubernetesApi;
+  /** Where the Job is created. Never created by Spindrift (§7). */
+  readonly namespace: string;
+  /** The BuildKit image the Job runs. Pinned by the installation. */
+  readonly image: string;
+  /** The zero-config BuildKit frontend the installation pinned (§4). */
+  readonly zeroConfigFrontend: string;
+  /**
+   * The service account the Job runs as.
+   *
+   * How the build authorizes its push without this process holding a registry
+   * credential: the cluster projects a token for that account, and the registry
+   * trusts it. §13's "nothing stored" reaches the builder the same way it
+   * reaches everything else.
+   */
+  readonly serviceAccount: string;
+  /** Injected so a test can pin the Job name it asserts on. */
+  readonly id?: () => string;
+}
+
+/**
+ * How long a finished Job's objects — and therefore its log — stick around.
+ *
+ * The log is read once, at the end, and then it is core's: §12 says the platform
+ * will not keep it, so the attempt log is the copy that survives. An hour is
+ * enough for an operator who was watching to go back to the pod.
+ */
+export const JOB_TTL_SECONDS = 3600;
+
+/** The label a build Job carries so its pod can be found. */
+export const JOB_LABEL = 'spindrift.dev/build';
+
+export class InClusterBuildRoute implements BuildAdapter {
+  readonly name: string;
+  readonly logFidelity: LogFidelity = 'LIVE_TEXT';
+  readonly buildLevel: BuildLevel = 1;
+
+  constructor(private readonly options: InClusterRouteOptions) {
+    this.name = options.name;
+  }
+
+  async *build(
+    source: BuildSource,
+    spec: BuildSpec,
+  ): AsyncGenerator<BuildEvent, BuildResult, void> {
+    const now = this.options.now ?? (() => new Date());
+    const logs = { backend: this.name, fidelity: this.logFidelity } as const;
+    const { api, namespace } = this.options;
+
+    const id = (this.options.id ?? (() => crypto.randomUUID().slice(0, 8)))();
+    const name = `spindrift-build-${id}`;
+    const job = this.job(
+      name,
+      buildKitProgramFor(source, spec, this.options.zeroConfigFrontend),
+    );
+
+    try {
+      await api.apply(job, 'jobs');
+    } catch (error) {
+      // §4 story 48: the failure before the build step is text, not a spinner.
+      const detail = error instanceof Error ? error.message : String(error);
+      yield {
+        type: 'log',
+        at: now(),
+        line: `could not create the build Job: ${detail}`,
+      };
+      return buildFailed(
+        logs,
+        'TARGET_UNREACHABLE',
+        `could not create Job ${name} in ${namespace}: ${detail}`,
+        { job: name },
+      );
+    }
+
+    yield {
+      type: 'log',
+      at: now(),
+      line: `Job ${name} created in ${namespace}`,
+    };
+
+    const budget = deadlineFrom(this.options);
+    let delivered = 0;
+    let log = '';
+    let outcome: 'succeeded' | 'failed' | null = null;
+
+    for (;;) {
+      log = (await this.readLog(name)) ?? log;
+      // Only what is new. The API serves the whole log every time, so a route
+      // that yielded all of it each pass would repeat the build's output once
+      // per poll interval.
+      const lines = log.split('\n');
+      for (const line of lines.slice(delivered)) {
+        if (line.trim() === '') continue;
+        yield { type: 'log', at: now(), line, step: name };
+      }
+      delivered = lines.length;
+
+      outcome = await this.outcome(name);
+      if (outcome !== null) break;
+
+      if (budget.expired()) {
+        return buildFailed(
+          logs,
+          'TIMEOUT',
+          `Job ${name} did not finish within the build budget`,
+          { job: name },
+        );
+      }
+      await budget.tick();
+    }
+
+    // One last read: the log the pod wrote between the previous poll and the
+    // Job reaching a terminal count is the log that says why it failed.
+    log = (await this.readLog(name)) ?? log;
+    for (const line of log.split('\n').slice(delivered)) {
+      if (line.trim() === '') continue;
+      yield { type: 'log', at: now(), line, step: name };
+    }
+
+    if (outcome === 'failed') {
+      return buildFailed(logs, 'BUILD_FAILED', `Job ${name} failed`, {
+        job: name,
+      });
+    }
+
+    const report = parseBuildReport(log);
+    if (report === null) {
+      return buildFailed(
+        logs,
+        'INTERNAL',
+        `Job ${name} succeeded but reported no artifact`,
+        { job: name },
+      );
+    }
+
+    return buildSucceeded({
+      source,
+      spec,
+      logs,
+      level: this.buildLevel,
+      // §16: the backend's provenance. A Job on a cluster can claim what ran
+      // and where, and nothing more — which is exactly what L1 means, and is
+      // why this document is small rather than absent.
+      report: { ...report, statement: { job: name, namespace } },
+    });
+  }
+
+  /**
+   * The Job one build runs as.
+   *
+   * `backoffLimit: 0` because a retry is core's to decide, not the cluster's: a
+   * Job that retried itself would push a second artifact for one Build row, and
+   * §4's "no ordinal" rests on a Build recording one artifact.
+   */
+  private job(name: string, program: string): KubernetesObject {
+    return {
+      apiVersion: 'batch/v1',
+      kind: 'Job',
+      metadata: {
+        name,
+        namespace: this.options.namespace,
+        labels: { [JOB_LABEL]: name },
+      },
+      spec: {
+        backoffLimit: 0,
+        ttlSecondsAfterFinished: JOB_TTL_SECONDS,
+        template: {
+          metadata: { labels: { [JOB_LABEL]: name } },
+          spec: {
+            restartPolicy: 'Never',
+            serviceAccountName: this.options.serviceAccount,
+            containers: [
+              {
+                name: 'build',
+                image: this.options.image,
+                command: ['sh', '-c', program],
+              },
+            ],
+          },
+        },
+      },
+    };
+  }
+
+  /** Whether the Job is over, and how. `null` while it is still going. */
+  private async outcome(name: string): Promise<'succeeded' | 'failed' | null> {
+    const job = await this.options.api.get({
+      apiVersion: 'batch/v1',
+      plural: 'jobs',
+      namespace: this.options.namespace,
+      name,
+    });
+    // A Job that is gone is a Job something else deleted mid-build. Reporting
+    // it as failed is the honest reading: nothing pushed an artifact, and there
+    // is no longer anything to wait for.
+    if (job === null) return 'failed';
+
+    const status = (job.status ?? {}) as {
+      succeeded?: number;
+      failed?: number;
+    };
+    if ((status.succeeded ?? 0) > 0) return 'succeeded';
+    if ((status.failed ?? 0) > 0) return 'failed';
+    return null;
+  }
+
+  /** The build pod's log, or `null` while there is no pod or no output yet. */
+  private async readLog(name: string): Promise<string | null> {
+    const pods = await this.options.api.list(
+      {
+        apiVersion: 'v1',
+        plural: 'pods',
+        namespace: this.options.namespace,
+      },
+      { labelSelector: `${JOB_LABEL}=${name}` },
+    );
+    const pod = pods?.[0]?.metadata.name;
+    if (pod === undefined) return null;
+    return this.options.api.logs(this.options.namespace, pod, {
+      container: 'build',
+    });
+  }
+}

--- a/apps/spindrift/src/adapters/build/report.ts
+++ b/apps/spindrift/src/adapters/build/report.ts
@@ -1,0 +1,112 @@
+/**
+ * How a runner tells core what it built, on the one channel core already reads.
+ *
+ * §4 settles that **build logs are read, not pushed** — "reading is outbound
+ * only, needs no public ingest endpoint, and surfaces the failures that happen
+ * *before* the instrumented step". That decision has a consequence nobody states
+ * but every route runs into: if core never exposes an ingest endpoint, a runner
+ * has no way to hand back a digest either. So the result travels the same way
+ * the logs do — the runner prints one line, core reads it out of the log it was
+ * already fetching. No second channel, no callback, nothing to authenticate.
+ *
+ * **All three routes report this way, including the cloud builder.** Its API
+ * does have a results field — but it is populated only for images the build
+ * service itself pushed, and every route here pushes from BuildKit directly, so
+ * that field is empty on exactly the builds that matter. One reporting path for
+ * three routes also keeps §16's join real everywhere: the digest core checks is
+ * the one the runner echoed, not one core already knew and copied.
+ *
+ * **Base64, so the log cannot corrupt the report.** A runner's stdout goes
+ * through a CI's own log processing on the way here: it may be prefixed with a
+ * timestamp, grouped, folded, or coloured. A base64 payload survives every one
+ * of those, and — more to the point — cannot be *forged* by a build that
+ * happens to print JSON, because the marker plus a valid base64 document is not
+ * something an ordinary compiler emits.
+ */
+import { z } from 'zod';
+
+/**
+ * The prefix a report line starts with.
+ *
+ * Deliberately not a `::workflow-command::`: one CI's command syntax is that
+ * CI's, and a marker that means something to the runner's own log processor is
+ * a marker the runner's log processor may swallow.
+ */
+export const BUILD_REPORT_MARKER = 'spindrift-result';
+
+/** A digest, in the only form anything here accepts. */
+const digest = z
+  .string()
+  .trim()
+  .regex(/^sha256:[0-9a-f]{64}$/, 'must be a sha256 digest');
+
+/**
+ * What a runner reports.
+ *
+ * `bundleDigest` is here, echoed rather than inferred, because §16 makes it the
+ * join between the source receipt and the provenance document — and a route
+ * that echoes a digest it was *not* given is a route whose provenance points at
+ * the wrong source. {@link parseBuildReport} does not check that; the adapter
+ * does, against what it dispatched, which is the only place the expected value
+ * exists.
+ */
+export const buildReportSchema = z
+  .object({
+    bundleDigest: z.string().trim().min(1),
+    digest,
+    /** Every address the digest was pushed to. At least one, or nothing can pull it. */
+    refs: z.array(z.string().trim().min(1)).min(1),
+    /**
+     * The base image, from the builder's own materials (§16). Null where the
+     * runner could not report one — a files artifact has no base, and a runner
+     * without the tooling to read its own provenance says so rather than
+     * guessing. Stale bases are surfaced, never auto-corrected.
+     */
+    baseDigest: digest.nullable(),
+    /**
+     * The backend's provenance document, opaque here and read by core (§16).
+     * Absent where the backend produced none; a route whose provenance is
+     * missing is one Task 26 refuses to sign, which is the point.
+     */
+    statement: z.unknown().optional(),
+  })
+  .strict();
+
+export type BuildReport = z.infer<typeof buildReportSchema>;
+
+/** Compose the line a runner prints. Used by the tests and by nothing in `src/`. */
+export function encodeBuildReport(report: BuildReport): string {
+  return `${BUILD_REPORT_MARKER} ${btoa(JSON.stringify(report))}`;
+}
+
+/**
+ * The report a log carries, or `null` when it carries none.
+ *
+ * **The last marker wins.** A build that retried a step prints two, and the one
+ * that describes what was actually pushed is the last one — taking the first
+ * would report a digest that a later push replaced.
+ *
+ * Malformed is the same answer as absent, on purpose. The caller's next move is
+ * identical either way — fail the build and say the runner reported nothing
+ * usable — and distinguishing them would mean this function had an opinion
+ * about *why* a runner misbehaved.
+ */
+export function parseBuildReport(log: string): BuildReport | null {
+  const prefix = `${BUILD_REPORT_MARKER} `;
+  for (const line of log.split('\n').reverse()) {
+    const at = line.indexOf(prefix);
+    if (at === -1) continue;
+    const payload = line.slice(at + prefix.length).trim();
+    if (payload === '') continue;
+
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(atob(payload));
+    } catch {
+      continue;
+    }
+    const parsed = buildReportSchema.safeParse(decoded);
+    if (parsed.success) return parsed.data;
+  }
+  return null;
+}

--- a/apps/spindrift/src/adapters/build/route.ts
+++ b/apps/spindrift/src/adapters/build/route.ts
@@ -1,0 +1,169 @@
+/**
+ * What the three build routes share, which is less than it looks.
+ *
+ * The three backends have nothing in common mechanically — a workflow dispatch,
+ * a cloud API, a Kubernetes Job — so this module holds only the parts that are
+ * the *contract's* shape rather than any backend's: how a green result is
+ * assembled from a runner's report, how a red one is assembled from a reason,
+ * and how a poll loop is bounded.
+ *
+ * **Waiting is injected, not imported.** Every route polls, and a test that
+ * polls in real time is a test that takes a real minute — so the clock and the
+ * sleep are constructor material for all three, and a test drives a whole build
+ * to its verdict in microseconds without a single fake timer.
+ */
+import type { FailureReason } from '../deploy/contract.ts';
+import type {
+  BuildLevel,
+  BuildLogs,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+} from './contract.ts';
+import type { BuildReport } from './report.ts';
+
+/** Sleeps for a while. Injected so a test's build takes no wall-clock time. */
+export type Sleeper = (milliseconds: number) => Promise<void>;
+
+/** The real one, which {@link deadlineFrom} falls back to when none is given. */
+export const realSleeper: Sleeper = (milliseconds) =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+/** How a route paces itself, and when it gives up. */
+export interface PollingOptions {
+  /** How long between reads of the backend's status. */
+  readonly intervalMs?: number;
+  /**
+   * How long a build may run before the route reports `TIMEOUT`.
+   *
+   * A route must have one: a backend that never reaches a terminal state would
+   * otherwise leave the Build `RUNNING` forever, and §6's `TIMEOUT` — the one
+   * reason that indicts nobody — is exactly the verdict for that.
+   */
+  readonly timeoutMs?: number;
+  readonly now?: () => Date;
+  readonly sleep?: Sleeper;
+}
+
+/** A poll interval that reads as attentive without hammering a CI's API. */
+export const DEFAULT_POLL_INTERVAL_MS = 5_000;
+
+/** Long enough for a cold container build, short enough to not hang a screen. */
+export const DEFAULT_BUILD_TIMEOUT_MS = 45 * 60_000;
+
+/** The bounded loop all three routes wait in. */
+export class Deadline {
+  private readonly startedAt: number;
+
+  constructor(
+    private readonly options: Required<
+      Pick<PollingOptions, 'intervalMs' | 'timeoutMs'>
+    > & {
+      readonly now: () => Date;
+      readonly sleep: Sleeper;
+    },
+  ) {
+    this.startedAt = options.now().getTime();
+  }
+
+  /** Whether the budget is spent. Checked before each read, never after. */
+  expired(): boolean {
+    return (
+      this.options.now().getTime() - this.startedAt >= this.options.timeoutMs
+    );
+  }
+
+  /** Wait one interval. */
+  tick(): Promise<void> {
+    return this.options.sleep(this.options.intervalMs);
+  }
+}
+
+/** Build a {@link Deadline} from whatever the caller supplied. */
+export function deadlineFrom(options: PollingOptions = {}): Deadline {
+  return new Deadline({
+    intervalMs: options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs: options.timeoutMs ?? DEFAULT_BUILD_TIMEOUT_MS,
+    now: options.now ?? (() => new Date()),
+    sleep: options.sleep ?? realSleeper,
+  });
+}
+
+/**
+ * A red verdict.
+ *
+ * Every field of the failure arm is filled here rather than at each call site,
+ * because the arm's whole job is to be impossible to confuse with a green one:
+ * `artifact`, `provenance`, and `baseDigest` are `null` on it by construction,
+ * and a route that wants to report a digest has to say `SUCCEEDED` to do it.
+ */
+export function buildFailed(
+  logs: BuildLogs,
+  reason: FailureReason,
+  detail?: string,
+  debug?: unknown,
+): BuildResult {
+  return {
+    status: 'FAILED',
+    artifact: null,
+    logs,
+    provenance: null,
+    baseDigest: null,
+    reason,
+    ...(detail === undefined ? {} : { detail }),
+    ...(debug === undefined ? {} : { debug }),
+  };
+}
+
+/**
+ * A green verdict, from what a runner reported.
+ *
+ * **The bundle digest is checked, not copied**, and what that check is worth is
+ * worth being exact about. §16 makes the digest "a build parameter on every
+ * route" so that the source receipt and the provenance document have a join,
+ * and every route here does hand it to the runner and compare what comes back.
+ * What it catches is a runner that built something other than what it was
+ * dispatched — a stale cached bundle, a mis-wired route, a report from another
+ * build. What it does **not** catch is a runner that lies, because the value it
+ * echoes is the value it was given.
+ *
+ * **The honest gap, and it is Task 26's**: `statement` below is the runner's
+ * own account of itself, not an attestation anything verified. §16 wants core
+ * to "verify the build backend's provenance against the Target's minimum level
+ * **before** signing", and doing that means fetching the attestation the
+ * builder attached to the artifact and checking it — none of which happens
+ * here. Until it does, a green Build carries a claim rather than evidence.
+ */
+export function buildSucceeded(input: {
+  readonly source: BuildSource;
+  readonly spec: BuildSpec;
+  readonly logs: BuildLogs;
+  readonly level: BuildLevel;
+  readonly report: BuildReport;
+}): BuildResult {
+  const { source, spec, logs, level, report } = input;
+
+  if (report.bundleDigest !== source.bundleDigest) {
+    return buildFailed(
+      logs,
+      'INTERNAL',
+      `the runner reported a build of bundle ${report.bundleDigest} but was handed ${source.bundleDigest}`,
+    );
+  }
+
+  return {
+    status: 'SUCCEEDED',
+    artifact: {
+      type: spec.artifactType,
+      digest: report.digest,
+      refs: [...report.refs],
+    },
+    logs,
+    provenance: {
+      bundleDigest: source.bundleDigest,
+      claimedLevel: level,
+      statement: report.statement ?? null,
+    },
+    baseDigest: report.baseDigest,
+  };
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/api.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/api.ts
@@ -167,6 +167,34 @@ export class KubernetesApi {
     await this.send('DELETE', resourcePath(ref));
   }
 
+  /**
+   * One pod's log as text, or `null` when the pod has none yet.
+   *
+   * Read rather than followed: a `follow=true` connection is a long-lived
+   * stream, and every other read in this adapter is a poll for the reason §6
+   * gives — a watch over the uplink stays open while delivering nothing. A
+   * caller that wants the tail asks again and takes what is new.
+   *
+   * A pod that has not started yet answers `400`, which is not a fault: the
+   * container is pulling, and the honest answer is that there is no log.
+   */
+  async logs(
+    namespace: string,
+    pod: string,
+    options: { readonly container?: string } = {},
+  ): Promise<string | null> {
+    const query =
+      options.container === undefined
+        ? ''
+        : `?container=${encodeURIComponent(options.container)}`;
+    const response = await this.send(
+      'GET',
+      `/api/v1/namespaces/${namespace}/pods/${pod}/log${query}`,
+      { tolerate: [400] },
+    );
+    return response === null ? null : await response.text();
+  }
+
   /** Whether the API serves a kind at all — §13's checklist, one call. */
   async servesKind(apiVersion: string, kind: string): Promise<boolean> {
     const path = apiVersion.includes('/')
@@ -198,7 +226,12 @@ export class KubernetesApi {
   private async send(
     method: string,
     path: string,
-    options: { body?: unknown; contentType?: string } = {},
+    options: {
+      body?: unknown;
+      contentType?: string;
+      /** Statuses the caller has a value for, returned instead of thrown. */
+      tolerate?: readonly number[];
+    } = {},
   ): Promise<Response | null> {
     const url = `${this.endpoint.apiServer}${path}`;
     const headers: Record<string, string> = {
@@ -222,6 +255,7 @@ export class KubernetesApi {
     // Absence is an answer every caller here has a value for, so it comes back
     // rather than being raised.
     if (response.status === 404) return null;
+    if (options.tolerate?.includes(response.status)) return null;
     if (!response.ok) {
       throw new KubernetesRequestError(
         method,

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -22,14 +22,22 @@
  */
 
 import type { AdapterRegistry } from '../commands/types.ts';
-import type { StoreAdapter, TargetAdapter } from '../config/manifest.schema.ts';
+import type {
+  BuildRouteConfig,
+  StoreAdapter,
+  TargetAdapter,
+} from '../config/manifest.schema.ts';
 import type { InstallationManifest } from '../config/manifest.ts';
+import type { BuildRouteProfile } from '../domain/build-route.ts';
 import type { RepositoryHost } from '../domain/repository.ts';
 import { GitHubApp } from '../integrations/github/app.ts';
 import type { Fetcher } from '../integrations/github/http.ts';
+import { CloudBuildRoute } from './build/cloud-build.ts';
 import type { BuildAdapter } from './build/contract.ts';
+import { GitHubActionsBuildRoute } from './build/github-actions.ts';
+import { InClusterBuildRoute } from './build/in-cluster.ts';
 import type { DeployAdapter } from './deploy/contract.ts';
-import type { TokenProvider } from './deploy/kubernetes/api.ts';
+import { KubernetesApi, type TokenProvider } from './deploy/kubernetes/api.ts';
 import { KubernetesDeployAdapter } from './deploy/kubernetes/index.ts';
 import type { SecretStore } from './store/contract.ts';
 import { SecretManagerStore } from './store/gcp-secret-manager.ts';
@@ -90,6 +98,8 @@ export interface RegistryOptions {
   readonly env?: Record<string, string | undefined>;
   /** Likewise for the store's own access path, which authorizes separately. */
   readonly storeToken?: () => string | Promise<string>;
+  /** And for the cloud builder's, which authorizes separately again. */
+  readonly buildToken?: () => string | Promise<string>;
 }
 
 /**
@@ -111,7 +121,11 @@ export function createAdapterRegistry(
   // once: it caches the imported signing key and one installation token per
   // installation, and a per-request instance would mint a JWT per call.
   const appKey = (options.env ?? Bun.env)[GITHUB_APP_KEY_VAR]?.trim();
-  const repositoryHost: RepositoryHost | null = appKey
+  // Held as its concrete type, not as `RepositoryHost`, because the hosted
+  // build route needs the Actions calls the repository interfaces do not
+  // declare — and one object serves both so a build and a configuration PR
+  // share the App's token cache rather than each minting their own.
+  const app = appKey
     ? new GitHubApp({
         appId: options.manifest.github.appId,
         privateKeyPem: appKey,
@@ -119,10 +133,19 @@ export function createAdapterRegistry(
         ...(options.fetch ? { fetch: options.fetch } : {}),
       })
     : null;
+  const repositoryHost: RepositoryHost | null = app;
   const store = createSecretStore(
     options.manifest,
     options.storeToken ?? storeToken(options.env ?? Bun.env),
   );
+
+  // §16's ordered list: the manifest's order *is* the admin rank, so the map is
+  // built from it in order and `buildRouteProfiles` reads it back the same way.
+  const buildRoutes = new Map<string, BuildAdapter>();
+  for (const route of options.manifest.build.routes) {
+    const built = createBuildRoute(route, options, app);
+    if (built !== null) buildRoutes.set(route.name, built);
+  }
 
   const deployAdapters: Partial<Record<TargetAdapter, DeployAdapter>> = {
     kubernetes,
@@ -138,16 +161,17 @@ export function createAdapterRegistry(
     },
 
     /**
-     * No build route exists yet (Milestone 4).
+     * The build route the installation configured under that name (§4).
      *
      * §4 makes the set of routes an installation's configuration rather than a
-     * closed vocabulary, so "this installation has no build route named X" is
-     * already the sentence `dispatchBuild` prints for every name — including,
-     * for now, all of them. An archive of finished output still deploys,
-     * because a supplied artifact consults no route at all.
+     * closed vocabulary, so an unknown name is answered with `null` and
+     * `dispatchBuild` prints "this installation has no build route named X".
+     * The same `null` covers a route this installation configured but cannot
+     * construct — a hosted-CI route with no App key — because the two are one
+     * fact to whoever is trying to build: the route is not available here.
      */
-    build(_route: string): BuildAdapter | null {
-      return null;
+    build(route: string): BuildAdapter | null {
+      return buildRoutes.get(route) ?? null;
     },
 
     /**
@@ -177,6 +201,121 @@ export function createAdapterRegistry(
     repository(): RepositoryHost | null {
       return repositoryHost;
     },
+  };
+}
+
+/**
+ * The build routes this installation has, in rank order, as selection sees them.
+ *
+ * Derived from the manifest rather than from the registry map, so a route the
+ * installation configured but cannot construct still appears — placement should
+ * be able to say "the hosted route is configured and this process has no App
+ * key" rather than silently pretending the route was never named.
+ */
+export function buildRouteProfiles(
+  manifest: InstallationManifest,
+): BuildRouteProfile[] {
+  return manifest.build.routes.map((route) => ({
+    name: route.name,
+    level: BUILD_ROUTE_LEVELS[route.adapter],
+  }));
+}
+
+/**
+ * Each route kind's profile level (§16).
+ *
+ * A table rather than a construction, because a level has to be readable
+ * *without* building the route: placement asks whether a Target could ever use
+ * a route, and building one to find out would mean an installation missing a
+ * credential also lost the ability to explain why.
+ *
+ * Kept in step with the classes themselves by `test/adapters/build-routes.test.ts`,
+ * which constructs each one and compares.
+ */
+const BUILD_ROUTE_LEVELS = {
+  'github-actions': 2,
+  'cloud-build': 3,
+  'in-cluster': 1,
+} as const satisfies Record<BuildRouteConfig['adapter'], 1 | 2 | 3>;
+
+/**
+ * One configured route, or `null` where this process cannot construct it.
+ *
+ * The hosted route is the only one that can come back `null`: it runs through
+ * the repository host, and an installation with no App key has no repository
+ * integration at all (§15). The other two authorize with tokens read at the
+ * moment of use, so they construct even where those tokens are absent — and
+ * fail loudly on the first build rather than silently at boot.
+ */
+function createBuildRoute(
+  route: BuildRouteConfig,
+  options: RegistryOptions,
+  app: GitHubApp | null,
+): BuildAdapter | null {
+  const { manifest } = options;
+  const zeroConfigFrontend = manifest.build.zeroConfigFrontend;
+
+  switch (route.adapter) {
+    case 'github-actions': {
+      const workflow = manifest.github.buildWorkflow;
+      // Both halves are §15's: no App key means no repository integration, and
+      // no pinned workflow means there is nothing to dispatch. Either way this
+      // installation has not finished wiring hosted CI.
+      if (app === null || workflow === null) return null;
+      return new GitHubActionsBuildRoute({
+        name: route.name,
+        host: app,
+        buildWorkflow: workflow,
+        zeroConfigFrontend,
+      });
+    }
+    case 'cloud-build':
+      return new CloudBuildRoute({
+        name: route.name,
+        endpoint: route.endpoint,
+        logsEndpoint: route.logsEndpoint,
+        project: route.project,
+        region: route.region,
+        image: route.image,
+        zeroConfigFrontend,
+        token: options.buildToken ?? buildToken(options.env ?? Bun.env),
+        ...(options.fetch ? { fetch: options.fetch } : {}),
+      });
+    case 'in-cluster':
+      return new InClusterBuildRoute({
+        name: route.name,
+        api: new KubernetesApi({
+          apiServer: route.endpoint,
+          token: options.token ?? projectedServiceAccountToken(),
+          ...(options.fetch ? { fetch: options.fetch } : {}),
+        }),
+        namespace: route.namespace,
+        image: route.image,
+        serviceAccount: route.serviceAccount,
+        zeroConfigFrontend,
+      });
+  }
+}
+
+/**
+ * The bearer token the cloud build route submits with.
+ *
+ * A second variable rather than the store's, because they are two access paths
+ * to two different services and one value good for both would be a value
+ * broader than either needs. Read per call for the same reason the store's is:
+ * a value captured at boot stops working the moment the Secret is rotated.
+ */
+export const BUILD_TOKEN_VARIABLE = 'SPINDRIFT_BUILD_TOKEN';
+
+export function buildToken(env: Record<string, string | undefined> = Bun.env) {
+  return (): string => {
+    const token = env[BUILD_TOKEN_VARIABLE]?.trim();
+    if (!token) {
+      throw new AdapterUnavailableError(
+        `${BUILD_TOKEN_VARIABLE} is not set: this installation cannot submit a cloud build`,
+      );
+    }
+    return token;
   };
 }
 

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -23,14 +23,34 @@
  *   fidelity are recorded on the Build so an operator can see why a log is thin
  *   rather than reading it as a bug.
  */
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
-import type { BuildSource, BuildSpec } from '../../adapters/build/contract.ts';
-import { apps, builds, components } from '../../db/schema.ts';
+import type {
+  BuildAdapter,
+  BuildSource,
+  BuildSpec,
+} from '../../adapters/build/contract.ts';
+import { apps, builds, components, targets } from '../../db/schema.ts';
 import { recordBuildEvent } from '../../domain/attempt-log.ts';
+import {
+  buildRouteCandidates,
+  DEFAULT_MINIMUM_BUILD_LEVEL,
+} from '../../domain/build-route.ts';
 import { DEFAULT_PLATFORM } from '../../domain/placement.ts';
 import { buildOriginOf, type Source } from '../../domain/source.ts';
-import { type Command, failed, ok } from '../types.ts';
+import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
+import { type Command, type CommandContext, failed, ok } from '../types.ts';
+
+/**
+ * §4's per-App build limit.
+ *
+ * A constant rather than a manifest value: it exists to stop one App's push
+ * loop from taking every runner an installation has, and the number that does
+ * that is a property of "how many is obviously too many" rather than of any
+ * particular installation. It becomes configuration the first time an operator
+ * has a reason to disagree with it.
+ */
+export const CONCURRENT_BUILDS_PER_APP = 3;
 
 export const dispatchBuildInput = z
   .object({
@@ -42,6 +62,22 @@ export const dispatchBuildInput = z
      * not interpret — it hands it to the registry and reports what comes back.
      */
     route: z.string().trim().min(1),
+    /**
+     * The Target this build's placement resolved to, where the artifact's
+     * contents depend on it.
+     *
+     * Only a `website` needs it, and only because §10 scopes configuration to
+     * (Component, Target) while §2 keys a Build on (Component, commit,
+     * target-shape). For everything else configuration is delivered at runtime
+     * and the shape is the whole of what a build depends on, so this is absent
+     * and nothing reads it.
+     *
+     * **The known limit, stated rather than worked around**: two Targets of the
+     * same shape with different website build arguments want two artifacts and
+     * the Build key cannot tell them apart. The second dispatch collides on the
+     * unique key rather than silently serving the first one's values.
+     */
+    placementTargetId: z.uuid().optional(),
   })
   .strict();
 
@@ -54,6 +90,50 @@ export interface DispatchBuildResult {
   readonly artifactDigest: string | null;
   /** The route that ran, as recorded on the Build (§4). */
   readonly runner: string;
+}
+
+/**
+ * Why this Target will not take a build from this route, or `null`.
+ *
+ * §16: "each Target has a minimum build level defaulting to L2 plus an ordered
+ * list of build routes: **the level is a threshold, then admin rank wins**."
+ * The rank half belongs to whoever *chooses* a route; by the time a route has
+ * been named the only question left is the threshold, which is the Target's.
+ *
+ * Checked here rather than left to admission because the failure is cheaper and
+ * far more legible now: refusing to start costs nothing, while an artifact
+ * built below a Target's minimum is a green build followed by a deploy that a
+ * policy engine rejects for reasons nobody reading the build log can see.
+ *
+ * A dispatch that names no placement is not checked, because there is no Target
+ * whose threshold could apply — which is also why a build for a shape rather
+ * than for a Target is legitimate (§2).
+ */
+async function routeRefusedByTarget(
+  context: CommandContext,
+  input: DispatchBuildInput,
+  adapter: BuildAdapter,
+): Promise<string | null> {
+  if (input.placementTargetId === undefined) return null;
+
+  const [target] = await context.db
+    .select({ name: targets.name, minBuildLevel: targets.minBuildLevel })
+    .from(targets)
+    .where(eq(targets.id, input.placementTargetId));
+  if (target === undefined) return null;
+
+  const [candidate] = buildRouteCandidates(
+    [{ name: adapter.name, level: adapter.buildLevel }],
+    {
+      minimumLevel: (target.minBuildLevel ?? DEFAULT_MINIMUM_BUILD_LEVEL) as
+        | 1
+        | 2
+        | 3,
+    },
+  );
+  return candidate === undefined || candidate.eligible
+    ? null
+    : `${target.name} will not take a build from ${adapter.name}: ${candidate.reason}`;
 }
 
 export const dispatchBuild: Command<
@@ -120,11 +200,34 @@ export const dispatchBuild: Command<
     );
   }
 
+  // §4: "concurrent builds up to a per-App limit". Counted rather than queued,
+  // because §4 also removes the ordinal — a build records an artifact rather
+  // than deploying one, so nothing is waiting on a slot and refusing is a more
+  // honest answer than a queue whose position means nothing.
+  const running = await context.db
+    .select({ id: builds.id })
+    .from(builds)
+    .innerJoin(components, eq(builds.componentId, components.id))
+    .where(and(eq(components.appId, app.id), eq(builds.status, 'RUNNING')));
+  if (running.length >= CONCURRENT_BUILDS_PER_APP) {
+    return failed(
+      'NOT_BUILDABLE',
+      `${app.name} already has ${running.length} builds running, which is this installation's limit`,
+    );
+  }
+
+  // §16: "the level is a threshold, then admin rank wins." The threshold half
+  // is the Target's, so it is only checkable where a placement is named — and
+  // where one is, a route below it is refused here rather than producing an
+  // artifact the Target would refuse to admit anyway.
+  const refusal = await routeRefusedByTarget(context, input, adapter);
+  if (refusal !== null) return failed('NOT_BUILDABLE', refusal);
+
   // The staged bundle's own columns, not the artifact's. §15 stages a bundle for
-  // either builder, and a Build that has not run has no artifact refs to borrow
-  // an address from — reading them here is how a source upload reaches its
-  // builder with an empty location.
-  if (app.sourceKind === 'archive' && build.bundleLocation === null) {
+  // either builder — a repo commit and an upload alike — and a Build that has
+  // not run has no artifact refs to borrow an address from, so a missing
+  // location is what would otherwise reach a route as an empty URL.
+  if (build.bundleLocation === null) {
     return failed(
       'NOT_BUILDABLE',
       `Build ${build.id} has no staged bundle location, so no route can fetch it`,
@@ -139,11 +242,12 @@ export const dispatchBuild: Command<
           commit: build.commit,
           // §5: an App is repo plus subpath, and the developer named it there.
           subpath: app.sourceRepoSubpath ?? '.',
+          location: build.bundleLocation,
         }
       : {
           kind: 'archive',
           digest: build.bundleDigest,
-          location: build.bundleLocation ?? '',
+          location: build.bundleLocation,
           contents: 'source',
           // Per Build: the unwrap is a fact about the bytes that were uploaded.
           subpath: build.bundleSubpath ?? '.',
@@ -167,7 +271,23 @@ export const dispatchBuild: Command<
      * choice the build makes. An adapter never picks its own destination (§4).
      */
     destination: context.manifest.supplyChain.registry,
-    buildArgs: {},
+    /**
+     * §4: "a website's build-time config is passed as build arguments as
+     * ordinary rows, not fetched from a store — whatever a website bakes
+     * becomes public anyway, so no builder ever holds a store credential."
+     *
+     * Read here rather than by the route, so that the one place a value
+     * reaches a builder is the one place the contract says it may.
+     */
+    buildArgs:
+      input.placementTargetId === undefined ||
+      !isBuildTimeConfig(component.kind)
+        ? {}
+        : await readBuildArgs(
+            context.db,
+            component.id,
+            input.placementTargetId,
+          ),
   };
 
   const attempt = {

--- a/apps/spindrift/src/commands/config/build-args.ts
+++ b/apps/spindrift/src/commands/config/build-args.ts
@@ -1,0 +1,82 @@
+/**
+ * A website's build-time configuration (§4, §10).
+ *
+ * §10 makes exactly one exception to "one mechanism, no classification", and
+ * states the reason rather than the rule: "a website's build-time config is
+ * **derived mechanically from Component kind** and lives as ordinary rows,
+ * because **whatever a website bakes becomes public either way**, so the
+ * asymmetry does not exist there."
+ *
+ * Both halves of that sentence are load-bearing here.
+ *
+ * **Derived, never chosen.** {@link isBuildTimeConfig} takes a kind and nothing
+ * else. There is no flag on the input, no per-key setting, and no way for a
+ * service's configuration to become a build argument — which is what keeps the
+ * exception narrow enough to be safe. A developer cannot opt a credential into
+ * it, because there is nothing to opt.
+ *
+ * **Ordinary rows, so no builder holds a store credential.** §4 says it
+ * outright: build arguments are "ordinary rows, never fetched from a store".
+ * That is the whole security argument for this exception — the alternative is a
+ * builder that can read the vault, which is a far larger surface than a public
+ * value in a public bundle.
+ *
+ * What a website therefore cannot do is reference a stored secret. That is not
+ * an omission: a value baked into a static site is readable by anyone who loads
+ * the site, so a store that pretended otherwise would be selling a guarantee it
+ * cannot keep.
+ */
+import { and, eq } from 'drizzle-orm';
+import type { Database } from '../../db/client.ts';
+import { configItems, PINNED_ENVIRONMENT } from '../../db/schema.ts';
+import type { ComponentKind } from '../../domain/desired-state.ts';
+
+/**
+ * Whether this kind's configuration is baked at build time.
+ *
+ * A `website` has no runtime to hold an environment: what a static bundle knows
+ * it learned while it was being built. Everything else has a process, and a
+ * process reads its configuration when it starts — which is why the exception
+ * stops here rather than becoming a per-key choice.
+ */
+export function isBuildTimeConfig(kind: ComponentKind): boolean {
+  return kind === 'website';
+}
+
+/**
+ * The build arguments for one (Component, Target), as a builder takes them.
+ *
+ * Only `plain` rows: a `secret_ref` row holds a pinned reference and no value,
+ * so there is nothing here that could accidentally resolve one. The two kinds
+ * never mix on one Component, because the kind decides which is written.
+ *
+ * Sorted by key so two reads of the same configuration produce the same
+ * arguments in the same order — a build that differed only in argument order
+ * would produce a different digest for the same inputs.
+ */
+export async function readBuildArgs(
+  db: Database,
+  componentId: string,
+  targetId: string,
+): Promise<Record<string, string>> {
+  const rows = await db
+    .select({ key: configItems.key, value: configItems.plainValue })
+    .from(configItems)
+    .where(
+      and(
+        eq(configItems.componentId, componentId),
+        eq(configItems.targetId, targetId),
+        eq(configItems.environment, PINNED_ENVIRONMENT),
+        eq(configItems.kind, 'plain'),
+      ),
+    );
+
+  return Object.fromEntries(
+    rows
+      .filter((row) => row.value !== null)
+      .map((row) => [row.key, row.value as string])
+      .sort(([left], [right]) =>
+        (left as string).localeCompare(right as string),
+      ),
+  );
+}

--- a/apps/spindrift/src/commands/config/set.ts
+++ b/apps/spindrift/src/commands/config/set.ts
@@ -51,6 +51,7 @@ import {
   storeOfRecordFor,
   VARIABLE_NAME,
 } from '../../domain/config.ts';
+import type { ComponentKind } from '../../domain/desired-state.ts';
 import { checkDeployable, placeIntent } from '../deploys/create.ts';
 import {
   type AdapterRegistry,
@@ -61,6 +62,7 @@ import {
   failed,
   ok,
 } from '../types.ts';
+import { isBuildTimeConfig } from './build-args.ts';
 import {
   configScopeFor,
   type PinnedConfig,
@@ -141,8 +143,19 @@ export const setConfig: Command<SetConfigInput, ConfigChangeResult> = async (
 export interface ConfigSubject {
   readonly componentId: string;
   readonly targetId: string;
+  /** §10's exception is derived from this and from nothing else. */
+  readonly kind: ComponentKind;
   readonly scope: ConfigScope;
-  readonly store: SecretStore;
+  /**
+   * `null` exactly when this Component's configuration is baked at build time
+   * (§10's narrow website exception).
+   *
+   * A website reaches no store because it needs none: its configuration is
+   * ordinary rows a builder receives as build arguments, which is what keeps
+   * §4's "no builder ever holds a store credential" structural rather than a
+   * rule somebody has to remember.
+   */
+  readonly store: SecretStore | null;
 }
 
 /**
@@ -184,8 +197,12 @@ export async function configSubject(
     };
   }
 
-  const adapter = storeOfRecordOf(context, target);
-  if (adapter === null) {
+  // The reach rule is about delivery, and a website's configuration is not
+  // delivered — it is baked (§10). Checking a store a website will never touch
+  // would refuse a perfectly good act on a Target that reaches no vault.
+  const buildTime = isBuildTimeConfig(component.kind);
+  const adapter = buildTime ? null : storeOfRecordOf(context, target);
+  if (!buildTime && adapter === null) {
     return {
       failure: {
         code: 'NOT_DEPLOYABLE',
@@ -207,10 +224,11 @@ export async function configSubject(
   return {
     componentId: component.id,
     targetId: target.id,
+    kind: component.kind,
     scope,
-    // Non-null by construction: `storeOfRecordOf` only chooses an adapter the
-    // registry answered for.
-    store: context.adapters.store(adapter)!,
+    // Non-null unless this is a website: `storeOfRecordOf` only ever chooses an
+    // adapter the registry answered for.
+    store: adapter === null ? null : context.adapters.store(adapter),
   };
 }
 
@@ -258,13 +276,25 @@ export async function applyConfigChange(
 ): Promise<CommandResult<ConfigChangeResult>> {
   const now = context.clock.now();
   const written: string[] = [];
+  // Narrowed once, here, so nothing below asserts a store it cannot see: the
+  // store is present exactly when the configuration is delivered rather than
+  // baked, and `configSubject` is what established that.
+  const { store } = subject;
 
   for (const entry of entries) {
-    const reference = await subject.store.put(
-      subject.scope,
-      entry.key,
-      entry.value,
-    );
+    // §10's narrow exception, and the one place it is applied: a website's
+    // value never crosses the store seam, because it is going to be public the
+    // moment the site is served. Everything else goes to the store, unread.
+    const row =
+      store === null
+        ? {
+            kind: 'plain' as const,
+            storeRef: null,
+            storeVersion: null,
+            plainValue: entry.value,
+          }
+        : await pinnedRow(store, subject.scope, entry);
+
     await context.db
       .insert(configItems)
       .values({
@@ -272,11 +302,9 @@ export async function applyConfigChange(
         targetId: subject.targetId,
         environment: PINNED_ENVIRONMENT,
         key: entry.key,
-        kind: 'secret_ref',
-        storeRef: reference.key,
-        storeVersion: reference.version,
         createdAt: now,
         updatedAt: now,
+        ...row,
       })
       .onConflictDoUpdate({
         target: [
@@ -285,12 +313,7 @@ export async function applyConfigChange(
           configItems.environment,
           configItems.key,
         ],
-        set: {
-          kind: 'secret_ref',
-          storeRef: reference.key,
-          storeVersion: reference.version,
-          updatedAt: now,
-        },
+        set: { ...row, updatedAt: now },
       });
     written.push(entry.key);
     await audit(context, subject, entry.key, 'set', now);
@@ -315,8 +338,13 @@ export async function applyConfigChange(
   // is gone from the document still has versions in the store that nothing else
   // will ever come back for. The newest N survive either way, so a rollback
   // inside the retention window still resolves.
-  for (const key of [...written, ...removals]) {
-    await reapKey(subject, key);
+  //
+  // A website has nothing to reap: its rows *are* the values, so there are no
+  // versions in a store to fall past a depth.
+  if (store !== null) {
+    for (const key of [...written, ...removals]) {
+      await reapKey(subject, key);
+    }
   }
 
   const pinned = await readPinnedConfig(
@@ -337,12 +365,39 @@ export async function applyConfigChange(
   });
 }
 
+/**
+ * Write one value to the store and return the row that pins it (§10).
+ *
+ * The value is an argument and never a return: what comes back is the reference
+ * the store minted, which is the only thing above this line that a database
+ * column will ever hold.
+ */
+async function pinnedRow(
+  store: SecretStore,
+  scope: ConfigScope,
+  entry: { key: string; value: string },
+): Promise<{
+  kind: 'secret_ref';
+  storeRef: string;
+  storeVersion: string;
+  plainValue: null;
+}> {
+  const reference = await store.put(scope, entry.key, entry.value);
+  return {
+    kind: 'secret_ref',
+    storeRef: reference.key,
+    storeVersion: reference.version,
+    plainValue: null,
+  };
+}
+
 /** Destroy every version of one key past the retention depth (§10). */
 export async function reapKey(
   subject: ConfigSubject,
   key: string,
   retention: number = CONFIG_RETENTION,
 ): Promise<number> {
+  if (subject.store === null) return 0;
   const versions = await subject.store.versions(subject.scope, key);
   const expired = reapable(versions, retention);
   for (const version of expired) {
@@ -365,6 +420,18 @@ async function deployChange(
   subject: ConfigSubject,
   pinned: PinnedConfig,
 ): Promise<{ deployId: number | null; notDeployed: string | null }> {
+  // A website's value was baked into the artifact that is already serving, so
+  // re-applying that artifact would deliver the old value with a new
+  // `configVersion` beside it — green, and wrong. The new value reaches the
+  // site the next time one is built, and saying so is the honest answer.
+  if (isBuildTimeConfig(subject.kind)) {
+    return {
+      deployId: null,
+      notDeployed:
+        'a website bakes its configuration into the artifact, so this value reaches the site on its next build',
+    };
+  }
+
   const [desired] = await context.db
     .select({ buildId: componentTargetDesired.desiredBuildId })
     .from(componentTargetDesired)

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -57,6 +57,84 @@ export const targetAdapterSchema = z.enum(['kubernetes', 'cloudrun', 'static']);
 export const storeAdapterSchema = z.enum(['onepassword', 'gcp-secret-manager']);
 
 /**
+ * Which of §4's three build routes a configured route is one of.
+ *
+ * The *kind* is a closed vocabulary because each one is a different piece of
+ * code; the *set of routes an installation has* is not, which is why `routes`
+ * below is a list an operator writes rather than one of these three per
+ * installation. §4: "which routes exist is an installation's configuration."
+ */
+export const buildRouteAdapterSchema = z.enum([
+  'github-actions',
+  'cloud-build',
+  'in-cluster',
+]);
+
+/**
+ * One configured build route.
+ *
+ * A discriminated union rather than a bag of optional keys, for the same reason
+ * `TargetConnection` is one: a `github-actions` route with a cluster namespace
+ * is not a state this model has a name for.
+ *
+ * **No credential appears in any variant** (§13). Each route's access path is
+ * minted per request — the App key for hosted CI, a federated token for the
+ * cloud builder, the projected service account token in-cluster.
+ */
+export const buildRouteSchema = z.discriminatedUnion('adapter', [
+  z
+    .object({
+      /** What this route is called, as `Target.buildRoutes` names it. */
+      name: nonEmptyString,
+      adapter: z.literal('github-actions'),
+    })
+    .strict(),
+  z
+    .object({
+      name: nonEmptyString,
+      adapter: z.literal('cloud-build'),
+      /**
+       * The build service's API root, without a trailing slash. A value for
+       * the same reason `github.apiBaseUrl` is one: a regional or
+       * perimeter-fronted endpoint is a legitimate installation choice.
+       */
+      endpoint: z.url(),
+      /** Where the build's own logs are read from — §4's "logs are read". */
+      logsEndpoint: z.url(),
+      /** The project builds run in — §14's shared artifacts project. */
+      project: nonEmptyString,
+      /** The location builds are submitted to. */
+      region: nonEmptyString,
+      /**
+       * The BuildKit image the build step runs, pinned by the installation.
+       *
+       * Present here as well as on the in-cluster route because §4 makes the
+       * engine one thing that runs in several places — the route decides where,
+       * never what.
+       */
+      image: nonEmptyString,
+    })
+    .strict(),
+  z
+    .object({
+      name: nonEmptyString,
+      adapter: z.literal('in-cluster'),
+      /** The API server the build Job is created against. */
+      endpoint: z.url(),
+      /** The namespace it is created in. Never created by Spindrift. */
+      namespace: nonEmptyString,
+      /** The BuildKit image the Job runs, pinned by the installation. */
+      image: nonEmptyString,
+      /**
+       * The service account the Job runs as — how it authorizes a push
+       * without this process holding a registry credential.
+       */
+      serviceAccount: nonEmptyString,
+    })
+    .strict(),
+]);
+
+/**
  * A Target as the manifest seeds it. The connect act (Task 13) owns the rest of
  * the model; this is only what must exist before the first boot can place
  * anything.
@@ -218,6 +296,38 @@ export const installationManifestSchema = z
       })
       .strict(),
 
+    build: z
+      .object({
+        /**
+         * Every build route this installation has, **in admin rank order**
+         * (§16: "an ordered list of build routes... the level is a threshold,
+         * then admin rank wins"). The order of this array is the rank.
+         *
+         * May be empty. An installation with no route can still deploy an
+         * uploaded archive of finished output, because a supplied artifact
+         * consults no route at all (§4) — so an empty list is a supported
+         * installation rather than a misconfiguration.
+         */
+        routes: z
+          .array(buildRouteSchema)
+          .refine(
+            (routes) =>
+              new Set(routes.map((r) => r.name)).size === routes.length,
+            'build route names must be unique',
+          ),
+        /**
+         * The zero-config BuildKit frontend, pinned by the installation (§4:
+         * "one engine, two frontends — the repo's Dockerfile if present, else
+         * a zero-config builder").
+         *
+         * A value rather than a constant because it is an image every build
+         * this installation runs pulls and trusts, so which one — and pinned to
+         * which digest — is the operator's call, not the software's.
+         */
+        zeroConfigFrontend: nonEmptyString,
+      })
+      .strict(),
+
     secretStore: z
       .object({
         /** Which store adapter this installation delivers config through. */
@@ -261,6 +371,8 @@ export const installationManifestSchema = z
 
 export type TargetAdapter = z.infer<typeof targetAdapterSchema>;
 export type StoreAdapter = z.infer<typeof storeAdapterSchema>;
+export type BuildRouteAdapter = z.infer<typeof buildRouteAdapterSchema>;
+export type BuildRouteConfig = z.infer<typeof buildRouteSchema>;
 export type TargetSeed = z.infer<typeof targetSeedSchema>;
 export type GatewayAuthConfig = z.infer<typeof gatewayAuthSchema>;
 export type InstallationManifest = z.infer<typeof installationManifestSchema>;

--- a/apps/spindrift/src/domain/build-route.ts
+++ b/apps/spindrift/src/domain/build-route.ts
@@ -1,0 +1,149 @@
+/**
+ * Which route builds for which Target (§16).
+ *
+ * §16 settles the rule in one sentence — "each Target has a minimum build level
+ * defaulting to L2 plus an ordered list of build routes: **the level is a
+ * threshold, then admin rank wins**" — and the order of those two clauses is the
+ * whole design. A threshold is not a preference: a route below the Target's
+ * minimum is not a worse choice than one above it, it is not a choice at all.
+ * Rank only ever breaks a tie among routes that already cleared the bar.
+ *
+ * The consequence §4 states outright is the one worth checking a test against:
+ * **`in-cluster` is L1, so an L2+ Target refuses it**, which is also why "a
+ * Target cannot be both offline-capable and require L2 or above".
+ *
+ * The answer's shape is §3's, not a boolean: every route this Target could not
+ * use comes back listed with the sentence behind it, because "nothing can build
+ * for this Target" is an answer a developer can act on and a silent empty
+ * result is not.
+ */
+import type { BuildLevel } from '../adapters/build/contract.ts';
+
+/**
+ * §16's default. A Target that states nothing requires an isolated builder,
+ * which is the safe direction to be wrong in: the route it excludes is the one
+ * running on hardware the App is also deployed to.
+ */
+export const DEFAULT_MINIMUM_BUILD_LEVEL: BuildLevel = 2;
+
+/** What selection knows about one configured route. Rank is its position. */
+export interface BuildRouteProfile {
+  readonly name: string;
+  /**
+   * The level this route's *profile* guarantees (§16). Not the level a
+   * concrete Build achieved — that belongs to the verified Build, and Task 26
+   * is what checks the two agree before signing.
+   */
+  readonly level: BuildLevel;
+}
+
+/** What selection knows about the Target being built for. */
+export interface BuildRouteDemand {
+  /** §16's threshold. Absent means {@link DEFAULT_MINIMUM_BUILD_LEVEL}. */
+  readonly minimumLevel?: BuildLevel | null;
+  /**
+   * The routes this Target admits, if it narrows them. Absent means every
+   * configured route, still in the installation's rank order.
+   *
+   * A name here that no route has is not an error: an installation may retire a
+   * route without editing every Target, and the honest reading of a Target
+   * naming a route that is gone is that the route is unavailable — which is
+   * exactly what {@link buildRouteCandidates} reports.
+   */
+  readonly routes?: readonly string[] | null;
+}
+
+/**
+ * The two ways a route can fail to be usable.
+ *
+ * Exported as a list as well as a type because it is vocabulary — the name of
+ * something this software knows, identical in every installation — and the
+ * extraction scanner reads the list rather than being told the strings twice.
+ */
+export const BUILD_ROUTE_REFUSALS = ['below-minimum', 'not-admitted'] as const;
+
+/** Why one route is not usable for one Target. */
+export type BuildRouteRefusal =
+  | {
+      readonly kind: (typeof BUILD_ROUTE_REFUSALS)[0];
+      readonly required: BuildLevel;
+    }
+  | { readonly kind: (typeof BUILD_ROUTE_REFUSALS)[1] };
+
+/** One route, and whether this Target can build on it. */
+export interface BuildRouteCandidate {
+  readonly route: string;
+  readonly level: BuildLevel;
+  readonly eligible: boolean;
+  /** The sentence a developer reads. Empty exactly when `eligible`. */
+  readonly reason: string;
+  readonly refusal?: BuildRouteRefusal;
+}
+
+function sentence(refusal: BuildRouteRefusal, level: BuildLevel): string {
+  return refusal.kind === 'below-minimum'
+    ? `this route guarantees SLSA Build Level ${level} and this Target requires at least L${refusal.required}`
+    : 'this Target does not admit this route';
+}
+
+/**
+ * Every configured route, in rank order, annotated with whether this Target can
+ * build on it.
+ *
+ * Order is the input's order and is never re-sorted: the array of routes *is*
+ * the admin rank (§16), so sorting here would replace an operator's arrangement
+ * with this function's opinion of one.
+ */
+export function buildRouteCandidates(
+  routes: readonly BuildRouteProfile[],
+  demand: BuildRouteDemand = {},
+): BuildRouteCandidate[] {
+  const required = demand.minimumLevel ?? DEFAULT_MINIMUM_BUILD_LEVEL;
+  const admitted = demand.routes == null ? null : new Set(demand.routes);
+
+  return routes.map((route) => {
+    const refusal: BuildRouteRefusal | null =
+      admitted !== null && !admitted.has(route.name)
+        ? { kind: 'not-admitted' }
+        : route.level < required
+          ? { kind: 'below-minimum', required }
+          : null;
+
+    return refusal === null
+      ? { route: route.name, level: route.level, eligible: true, reason: '' }
+      : {
+          route: route.name,
+          level: route.level,
+          eligible: false,
+          reason: sentence(refusal, route.level),
+          refusal,
+        };
+  });
+}
+
+/** What selection came back with, in the grammar §3 uses everywhere else. */
+export interface BuildRouteSelection {
+  /** The route to run, or `null` when nothing cleared the threshold. */
+  readonly route: string | null;
+  /** Every route considered, eligible or not, in rank order. */
+  readonly candidates: readonly BuildRouteCandidate[];
+}
+
+/**
+ * The route a build for this Target runs on: the first eligible one by rank.
+ *
+ * `null` with reasons rather than a throw, because "no route can build for this
+ * Target" is a state an installation can genuinely be in — an L2 Target and only
+ * the in-cluster route configured — and the creation flow has to be able to stop
+ * on it before a Build row exists (§18's unmet prerequisite).
+ */
+export function selectBuildRoute(
+  routes: readonly BuildRouteProfile[],
+  demand: BuildRouteDemand = {},
+): BuildRouteSelection {
+  const candidates = buildRouteCandidates(routes, demand);
+  return {
+    route: candidates.find((candidate) => candidate.eligible)?.route ?? null,
+    candidates,
+  };
+}

--- a/apps/spindrift/src/domain/source.ts
+++ b/apps/spindrift/src/domain/source.ts
@@ -44,6 +44,15 @@ export interface RepoSource {
   readonly commit: string;
   /** §5: "the scope is named, never searched." */
   readonly subpath: string;
+  /**
+   * Where the staged bundle for that commit is fetched from.
+   *
+   * A repo source carries an address for the same reason an archive does: §15
+   * fetches the commit **once** and stages one immutable bundle "for either
+   * builder", so what a route pulls is the bundle and never the repository. The
+   * url and commit above name what was fetched; this names what exists now.
+   */
+  readonly location: string;
 }
 
 /** An App sourced from an upload (§4). */
@@ -103,6 +112,7 @@ export function buildOriginOf(source: Source): BuildOrigin {
         repository: source.url,
         commit: source.commit,
         subpath: source.subpath,
+        location: source.location,
       }
     : {
         type: 'archive',

--- a/apps/spindrift/src/integrations/github/app.ts
+++ b/apps/spindrift/src/integrations/github/app.ts
@@ -428,6 +428,189 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
     return pull.number;
   }
 
+  // --- Actions, which the hosted build route runs on --------------------
+  //
+  // §4 puts the build on "hosted CI on the fast-pipe side" and §15 puts the run
+  // in the connected repository, on its own minutes. Everything below is what
+  // dispatching one and then *reading* it takes — there is no push endpoint
+  // here, and that is the point: logs are read, not pushed (§4).
+
+  /**
+   * Which installation covers a repository.
+   *
+   * Authorized by the App's own JWT rather than an installation token, because
+   * the answer is what an installation token would have to be minted *from* —
+   * and it is why a build route can start from a repository name alone, without
+   * core threading an installation id through the build contract.
+   */
+  async installationFor(fullName: string): Promise<InstallationRef> {
+    const jwt = await this.appJwt();
+    const http = new GitHubHttp({
+      baseUrl: this.config.baseUrl,
+      authorization: () => `Bearer ${jwt}`,
+      ...(this.config.fetch ? { fetch: this.config.fetch } : {}),
+    });
+    const installation = await http.json<{ id: number }>({
+      method: 'GET',
+      path: `/repos/${fullName}/installation`,
+    });
+    if (installation === null) {
+      throw new TypeError('the installation endpoint tolerates no status');
+    }
+    return { installationId: String(installation.id) };
+  }
+
+  /**
+   * Ask a workflow to run.
+   *
+   * `ref` is a **branch**, never a commit: the dispatch API only accepts a ref
+   * a workflow file can be read from, so which commit gets *built* travels in
+   * the inputs instead. That split is why the build route resolves the default
+   * branch first and puts the exact commit in the spec.
+   */
+  async dispatchWorkflow(
+    ref: InstallationRef,
+    fullName: string,
+    input: {
+      readonly workflow: string;
+      readonly branch: string;
+      readonly inputs: Readonly<Record<string, string>>;
+    },
+  ): Promise<void> {
+    await this.http(ref).send({
+      method: 'POST',
+      path: `/repos/${fullName}/actions/workflows/${encodeURIComponent(input.workflow)}/dispatches`,
+      body: { ref: input.branch, inputs: input.inputs },
+    });
+  }
+
+  /**
+   * Recent runs of one workflow on one branch, newest first.
+   *
+   * The dispatch API answers `204` and names no run, so the run has to be found
+   * afterwards — which is the whole reason the caller workflow carries a
+   * correlation input and stamps it into `run-name`. This returns the page; the
+   * route matches on the name, because only the route knows what it sent.
+   */
+  async workflowRuns(
+    ref: InstallationRef,
+    fullName: string,
+    input: { readonly workflow: string; readonly branch: string },
+  ): Promise<
+    readonly {
+      readonly id: number;
+      readonly name: string | null;
+      readonly status: string;
+      readonly conclusion: string | null;
+    }[]
+  > {
+    const runs = await this.http(ref).json<{
+      workflow_runs?: {
+        id: number;
+        name?: string | null;
+        status: string;
+        conclusion: string | null;
+      }[];
+    }>({
+      method: 'GET',
+      path:
+        `/repos/${fullName}/actions/workflows/${encodeURIComponent(input.workflow)}/runs` +
+        `?event=workflow_dispatch&branch=${encodeURIComponent(input.branch)}&per_page=30`,
+    });
+    if (runs === null) {
+      throw new TypeError('the runs endpoint tolerates no status');
+    }
+    return (runs.workflow_runs ?? []).map((run) => ({
+      id: run.id,
+      name: run.name ?? null,
+      status: run.status,
+      conclusion: run.conclusion,
+    }));
+  }
+
+  /** One run's current status. */
+  async workflowRun(
+    ref: InstallationRef,
+    fullName: string,
+    runId: number,
+  ): Promise<{
+    readonly id: number;
+    readonly status: string;
+    readonly conclusion: string | null;
+  } | null> {
+    return this.http(ref).json({
+      method: 'GET',
+      path: `/repos/${fullName}/actions/runs/${runId}`,
+    });
+  }
+
+  /**
+   * The jobs of one run and the steps inside them.
+   *
+   * This is the whole of `LIVE_STATUS` (§4): on a hosted runner the step
+   * transitions are readable while the run is going, and the text is not — so
+   * the route yields these as they change and fetches the log at the end.
+   */
+  async runJobs(
+    ref: InstallationRef,
+    fullName: string,
+    runId: number,
+  ): Promise<
+    readonly {
+      readonly id: number;
+      readonly name: string;
+      readonly status: string;
+      readonly conclusion: string | null;
+      readonly steps?: readonly {
+        readonly name: string;
+        readonly status: string;
+        readonly conclusion: string | null;
+      }[];
+    }[]
+  > {
+    const jobs = await this.http(ref).json<{
+      jobs?: {
+        id: number;
+        name: string;
+        status: string;
+        conclusion: string | null;
+        steps?: { name: string; status: string; conclusion: string | null }[];
+      }[];
+    }>({
+      method: 'GET',
+      path: `/repos/${fullName}/actions/runs/${runId}/jobs?per_page=100`,
+    });
+    if (jobs === null) {
+      throw new TypeError('the jobs endpoint tolerates no status');
+    }
+    return jobs.jobs ?? [];
+  }
+
+  /**
+   * One job's log as text, or `null` when the host has none for it.
+   *
+   * Per job rather than per run on purpose: the run-level endpoint answers with
+   * a zip archive, and unpacking one to read text this endpoint already serves
+   * as text would be a decompressor in the dependency graph for nothing.
+   *
+   * A `404` is tolerated because a job that never started has no log, and an
+   * empty log is a truthful thing to show — unlike lost access, which every
+   * other call in this module still classifies.
+   */
+  async jobLog(
+    ref: InstallationRef,
+    fullName: string,
+    jobId: number,
+  ): Promise<string | null> {
+    const response = await this.http(ref).send({
+      method: 'GET',
+      path: `/repos/${fullName}/actions/jobs/${jobId}/logs`,
+      accept: 'text/plain',
+      tolerate: [404],
+    });
+    return response === null ? null : await response.text();
+  }
+
   /**
    * §15's one fetch: "fetches the exact commit **once** and stages an immutable
    * source bundle for either builder, storing no token."

--- a/apps/spindrift/src/integrations/github/config-pr.ts
+++ b/apps/spindrift/src/integrations/github/config-pr.ts
@@ -38,6 +38,27 @@ export const SPINDRIFT_FILE = 'spindrift.yaml';
 /** The one CI caller the transaction carries. */
 export const WORKFLOW_PATH = '.github/workflows/spindrift.yml';
 
+/**
+ * The caller's file name, which is what a dispatch addresses.
+ *
+ * The same in every repository — including the platform's own, which commits a
+ * caller by hand for the archive builds that have no repository of their own —
+ * so the build route addresses one name rather than branching on which kind of
+ * repository it is dispatching into.
+ */
+export const CALLER_WORKFLOW_FILE = WORKFLOW_PATH.slice(
+  WORKFLOW_PATH.lastIndexOf('/') + 1,
+);
+
+/**
+ * The prefix a correlated run's name carries, so a human can read it too.
+ *
+ * Declared beside the caller that stamps it rather than beside the route that
+ * matches on it: the two have to agree exactly, and the file that *writes* the
+ * `run-name` is the one that decides what it says.
+ */
+export const RUN_NAME_PREFIX = 'spindrift';
+
 /** The branch the configuration PR is opened from. */
 export const CONFIG_BRANCH = 'spindrift/configure';
 
@@ -128,6 +149,13 @@ export function serializeSpindriftFile(proposal: DetectionProposal): string {
  * reusable workflow is pinned by commit and versioned by the platform, so it is
  * the right place for that shape to live.
  *
+ * **`correlation` is the one exception, and it is not a build parameter.** The
+ * dispatch API answers `204` and names no run, so a dispatched build has to be
+ * found again; stamping the value into `run-name` is what makes finding it
+ * exact rather than a race against whoever else pushed. It stays out of `spec`
+ * because nothing about the build depends on it — the reusable workflow never
+ * reads it.
+ *
  * `id-token: write` is the workflow-ref-scoped cloud identity §15 names: the
  * job federates as itself rather than holding a credential this file would
  * have to carry.
@@ -138,12 +166,17 @@ export function buildWorkflowCaller(buildWorkflow: string): string {
 # Spindrift dispatches this workflow when it needs a build. The run happens
 # here, on this repository’s own Actions minutes; everything it does lives in
 # the reusable workflow below, which is pinned by commit.
-name: spindrift
+name: ${RUN_NAME_PREFIX}
+run-name: ${RUN_NAME_PREFIX} \${{ inputs.correlation }}
 on:
   workflow_dispatch:
     inputs:
       spec:
         description: The build request, as JSON. Spindrift fills this in.
+        required: true
+        type: string
+      correlation:
+        description: How Spindrift finds this run again. Not a build input.
         required: true
         type: string
 permissions:

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -37,6 +37,7 @@ const source: BuildSource = {
     repository: 'https://git.example.test/app',
     commit: 'c0ffee',
     subpath: '.',
+    location: 'staged://bundle',
   },
 };
 

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -1,0 +1,672 @@
+/**
+ * The three build routes (Task 25, §4, §16).
+ *
+ * Every test drives a real route against a fake of its far-side HTTP API
+ * (§ Seam 2) — so the real dispatch bodies, the real polling, and the real
+ * reading of a runner's report all run. The conformance suite already asserts
+ * that all three satisfy the contract identically; what is here is the part of
+ * each route that is *its own*, plus the three rules §4 makes that a plausible
+ * implementation would quietly break:
+ *
+ * - **Logs are read, not pushed**, so a failure *before* the build step — a
+ *   dispatch refused, a Job that could not be created — has to arrive as text
+ *   rather than as an empty log and a spinner (§4 story 48).
+ * - **The bundle digest is a parameter on every route**, and it is checked
+ *   rather than copied: a runner that reports a build of some other bundle has
+ *   produced a provenance that points at the wrong source (§16).
+ * - **`in-cluster` is L1**, which is what makes an L2 Target refuse it.
+ */
+import { describe, expect, test } from 'bun:test';
+import { buildKitProgram } from '../../src/adapters/build/buildkit.ts';
+import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
+import type {
+  BuildEvent,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+} from '../../src/adapters/build/contract.ts';
+import {
+  GitHubActionsBuildRoute,
+  reusableWorkflowRepository,
+} from '../../src/adapters/build/github-actions.ts';
+import { InClusterBuildRoute } from '../../src/adapters/build/in-cluster.ts';
+import {
+  BUILD_REPORT_MARKER,
+  encodeBuildReport,
+} from '../../src/adapters/build/report.ts';
+import { KubernetesApi } from '../../src/adapters/deploy/kubernetes/api.ts';
+import { buildRouteProfiles } from '../../src/adapters/registry.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import {
+  buildWorkflowCaller,
+  RUN_NAME_PREFIX,
+} from '../../src/integrations/github/config-pr.ts';
+import {
+  FakeCloudBuild,
+  type FakeCloudBuildOptions,
+} from '../harness/fakes/cloud-build-api.ts';
+import {
+  FakeGitHub,
+  type FakeGitHubOptions,
+  testAppKey,
+} from '../harness/fakes/github-api.ts';
+import {
+  FakeKubernetes,
+  type FakeKubernetesOptions,
+} from '../harness/fakes/kubernetes-api.ts';
+
+const appKey = await testAppKey();
+
+const PLATFORM_REPO = 'example/platform';
+const WORKFLOW_REF = `${PLATFORM_REPO}/.github/workflows/spindrift-build.yml@${'f'.repeat(40)}`;
+const FRONTEND = 'registry.example.test/zero-config:pinned';
+
+const spec: BuildSpec = {
+  artifactType: 'image',
+  kind: 'service',
+  platform: { os: 'linux', arch: 'amd64' },
+  destination: 'registry.example.test/app',
+  buildArgs: {},
+};
+
+function archiveSource(digest = 'sha256:bundle'): BuildSource {
+  return {
+    bundleDigest: digest,
+    origin: { type: 'archive', location: 'staged://bundle', subpath: '.' },
+  };
+}
+
+function repoSource(repository: string): BuildSource {
+  return {
+    bundleDigest: 'sha256:bundle',
+    origin: {
+      type: 'repo',
+      repository,
+      commit: 'c0ffee',
+      subpath: 'apps/web',
+      location: 'staged://bundle',
+    },
+  };
+}
+
+/**
+ * A clock that only moves when the route waits.
+ *
+ * Every route's budget is measured against `now`, so a test that stubbed the
+ * sleep and left the clock alone would have a route that polls forever without
+ * ever timing out — which is how a timeout goes untested. Advancing the clock
+ * *inside* the sleep is what makes a poll loop's own budget observable, with no
+ * wall-clock time spent.
+ */
+function fakeClock(): {
+  now: () => Date;
+  sleep: (ms: number) => Promise<void>;
+} {
+  let elapsed = 0;
+  return {
+    now: () => new Date(elapsed),
+    sleep: async (ms: number) => {
+      elapsed += ms;
+    },
+  };
+}
+
+/** What every route in this file is paced with unless a test says otherwise. */
+const PACING = { intervalMs: 1_000, timeoutMs: 600_000 } as const;
+
+/** Drive a route to its verdict, collecting the timeline it yielded. */
+async function run(
+  stream: AsyncGenerator<BuildEvent, BuildResult, void>,
+): Promise<{ events: BuildEvent[]; result: BuildResult }> {
+  const events: BuildEvent[] = [];
+  let step = await stream.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return { events, result: step.value };
+}
+
+/** Every log line the route yielded, joined — what a person would read. */
+function text(events: readonly BuildEvent[]): string {
+  return events
+    .filter((event) => event.type === 'log')
+    .map((event) => (event as { line: string }).line)
+    .join('\n');
+}
+
+// --- The hosted route --------------------------------------------------
+
+function hostedRoute(
+  options: FakeGitHubOptions = {},
+  pacing: { discoveryMs?: number; timeoutMs?: number } = {},
+): {
+  host: FakeGitHub;
+  route: GitHubActionsBuildRoute;
+} {
+  const host = new FakeGitHub({ fullName: PLATFORM_REPO, ...options });
+  return {
+    host,
+    route: new GitHubActionsBuildRoute({
+      name: 'hosted',
+      host: new GitHubApp({
+        appId: '1',
+        privateKeyPem: appKey.pem,
+        baseUrl: host.baseUrl,
+        fetch: host.fetch,
+      }),
+      buildWorkflow: WORKFLOW_REF,
+      zeroConfigFrontend: FRONTEND,
+      correlation: () => 'fixed-correlation',
+      ...PACING,
+      ...pacing,
+      ...fakeClock(),
+    }),
+  };
+}
+
+describe('the hosted build route', () => {
+  test('a repo build runs in the connected repository, on its own minutes', async () => {
+    // §15: "the connected repo owns its Actions minutes". The workflow it
+    // dispatches is the thin caller the configuration PR wrote there, not the
+    // reusable workflow — which lives somewhere the repository cannot see.
+    const { host, route } = hostedRoute({ fullName: 'someone/their-app' });
+    const { result } = await run(
+      route.build(repoSource('someone/their-app'), spec),
+    );
+
+    expect(result.status).toBe('SUCCEEDED');
+    expect(host.dispatches).toHaveLength(1);
+    expect(host.dispatches[0]?.workflow).toBe('spindrift.yml');
+    expect(host.dispatches[0]?.branch).toBe('main');
+  });
+
+  test('an archive builds where the workflow lives, having no repository', async () => {
+    const { host, route } = hostedRoute();
+    const { result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('SUCCEEDED');
+    // The *caller*, not the reusable workflow: a dispatch names a branch, so
+    // dispatching the reusable workflow directly would run whatever is on the
+    // default branch and discard the commit §15 pins. The caller holds the pin.
+    expect(host.dispatches[0]?.workflow).toBe('spindrift.yml');
+  });
+
+  test('the correlation is what finds the run, and travels outside the spec', async () => {
+    const { host, route } = hostedRoute();
+    await run(route.build(archiveSource(), spec));
+
+    const dispatch = host.dispatches[0];
+    expect(dispatch?.inputs.correlation).toBe('fixed-correlation');
+    // Nothing about the build depends on it, so the reusable workflow never
+    // reads it — which is only true if it is not in the spec.
+    expect(JSON.parse(dispatch?.inputs.spec ?? '{}')).not.toHaveProperty(
+      'correlation',
+    );
+  });
+
+  test('the spec carries the bundle digest and the pinned frontend', async () => {
+    const { host, route } = hostedRoute();
+    await run(route.build(archiveSource(), spec));
+
+    const request = JSON.parse(host.dispatches[0]?.inputs.spec ?? '{}');
+    expect(request.bundleDigest).toBe('sha256:bundle');
+    expect(request.zeroConfigFrontend).toBe(FRONTEND);
+    expect(request.destination).toBe(spec.destination);
+  });
+
+  test('a dispatch that is refused is a failure with the reason in the log', async () => {
+    // §4 story 48: "a failure *before* my build step — dispatch failed, the
+    // runner never came up — is visible instead of an empty log and a spinner."
+    const { host, route } = hostedRoute();
+    host.accessLost = true;
+
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('TARGET_UNREACHABLE');
+    }
+    expect(text(events)).toContain('dispatch failed');
+    expect(text(events).length).toBeGreaterThan(0);
+  });
+
+  test('a dispatch whose run never appears fails, and says so', async () => {
+    const { route } = hostedRoute(
+      { actions: { discoveryDelay: 1000 } },
+      { discoveryMs: 5_000 },
+    );
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('TARGET_UNREACHABLE');
+      expect(result.detail).toContain('no run appeared');
+    }
+    expect(text(events)).toContain('no run named');
+  });
+
+  test('a red run is a build failure carrying the runner’s own log', async () => {
+    const { route } = hostedRoute({ actions: { conclusion: 'failure' } });
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') expect(result.reason).toBe('BUILD_FAILED');
+    // The text lands at the end — that is what `LIVE_STATUS` means — but it
+    // does land, because the failure is in it.
+    expect(text(events)).toContain('exporting to image');
+  });
+
+  test('step transitions arrive once each, not once per poll', async () => {
+    const { route } = hostedRoute({ actions: { duration: 4 } });
+    const { events } = await run(route.build(archiveSource(), spec));
+
+    const steps = events.filter((event) => event.type === 'step');
+    const keys = steps.map(
+      (event) =>
+        `${(event as { step: string }).step}/${(event as { state: string }).state}`,
+    );
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test('a green run that reports no artifact is an adapter fault, not the developer’s', async () => {
+    const { route } = hostedRoute({ actions: { log: () => 'nothing useful' } });
+    const { result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    // Nothing the developer wrote is at fault for a runner that ran something
+    // else, so the blame this reason carries is the platform's.
+    if (result.status === 'FAILED') expect(result.reason).toBe('INTERNAL');
+  });
+
+  test('a runner reporting another bundle’s build is refused', async () => {
+    // §16's join is only worth having if the route can disagree with the
+    // runner. Echoing whatever core already knew would make it vacuous.
+    const { route } = hostedRoute({
+      actions: {
+        log: () =>
+          encodeBuildReport({
+            bundleDigest: 'sha256:some-other-bundle',
+            digest: `sha256:${'a'.repeat(64)}`,
+            refs: ['registry.example.test/app@sha256:a'],
+            baseDigest: null,
+          }),
+      },
+    });
+    const { result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('INTERNAL');
+      expect(result.detail).toContain('sha256:some-other-bundle');
+    }
+  });
+
+  test('the reusable workflow reference names where an archive builds', () => {
+    expect(reusableWorkflowRepository(WORKFLOW_REF)).toBe(PLATFORM_REPO);
+  });
+
+  test('the platform repository commits the caller an archive build dispatches', async () => {
+    // The route dispatches one file name in every repository. A connected
+    // repository gets it from the configuration PR; this one has to have
+    // committed it, or every archive build fails at dispatch.
+    const caller = await Bun.file(
+      new URL('../../../../.github/workflows/spindrift.yml', import.meta.url),
+    ).text();
+    expect(caller).toContain('workflow_dispatch:');
+    expect(caller).toContain('uses: ./.github/workflows/spindrift-build.yml');
+  });
+
+  test('the reusable workflow prints the marker core reads', async () => {
+    // YAML cannot import the constant, so this is what keeps the two in step:
+    // a workflow that stopped printing it would produce green runs that report
+    // no artifact, which reads as an adapter fault and is not one.
+    const workflow = await Bun.file(
+      new URL(
+        '../../../../.github/workflows/spindrift-build.yml',
+        import.meta.url,
+      ),
+    ).text();
+    expect(workflow).toContain(BUILD_REPORT_MARKER);
+  });
+
+  test('the caller in somebody’s repository accepts what this route sends', async () => {
+    // The coupling worth a test: this route dispatches inputs a workflow file
+    // in *another repository* has to declare, and that file is generated by a
+    // different module. A caller missing an input is a build that fails at
+    // dispatch in every connected repository at once.
+    const { host, route } = hostedRoute();
+    await run(route.build(archiveSource(), spec));
+    const sent = Object.keys(host.dispatches[0]?.inputs ?? {}).sort();
+
+    const caller = buildWorkflowCaller(WORKFLOW_REF);
+    for (const input of sent) expect(caller).toContain(`${input}:`);
+    // And the correlation has to reach `run-name`, or the run this route goes
+    // looking for is not named what it expects. Assembled rather than written
+    // out, because a workflow expression and a template literal wear the same
+    // syntax and the linter cannot tell which one this file meant.
+    const expression = ['${', '{ inputs.correlation }', '}'].join('');
+    expect(caller).toContain(`run-name: ${RUN_NAME_PREFIX} ${expression}`);
+  });
+});
+
+// --- The cloud route ---------------------------------------------------
+
+function cloudRoute(
+  options: FakeCloudBuildOptions = {},
+  pacing: { timeoutMs?: number } = {},
+): {
+  api: FakeCloudBuild;
+  route: CloudBuildRoute;
+} {
+  const api = new FakeCloudBuild(options);
+  return {
+    api,
+    route: new CloudBuildRoute({
+      name: 'cloud',
+      endpoint: api.endpoint,
+      logsEndpoint: api.logsEndpoint,
+      project: 'example-builds',
+      region: 'example-region',
+      image: 'registry.example.test/buildkit:pinned',
+      zeroConfigFrontend: FRONTEND,
+      token: api.token,
+      fetch: api.fetch,
+      ...PACING,
+      ...pacing,
+      ...fakeClock(),
+    }),
+  };
+}
+
+describe('the cloud build route', () => {
+  test('submits the shared BuildKit program, never the service’s own source path', async () => {
+    // §4: "Cloud Run is driven with an explicit image, never its free
+    // build-from-source path" — and the same reasoning one level down keeps
+    // the engine one thing rather than a second set of frontends.
+    const { api, route } = cloudRoute();
+    await run(route.build(archiveSource(), spec));
+
+    expect(api.programs).toHaveLength(1);
+    expect(api.programs[0]).toContain('buildctl-daemonless.sh');
+    expect(api.programs[0]).toContain(FRONTEND);
+  });
+
+  test('the log arrives while the build runs', async () => {
+    const { events, result } = await run(
+      cloudRoute({ duration: 3 }).route.build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('SUCCEEDED');
+    expect(text(events)).toContain('exporting to image');
+  });
+
+  test('a page is served once, because the cursor is honoured', async () => {
+    const { events } = await run(
+      cloudRoute({ duration: 3 }).route.build(archiveSource(), spec),
+    );
+
+    const lines = text(events).split('\n');
+    const starts = lines.filter((line) => line === 'Starting Step #0');
+    expect(starts).toHaveLength(1);
+  });
+
+  test('a log service having a bad moment does not fail a good build', async () => {
+    const { result } = await run(
+      cloudRoute({ breakLogs: true }).route.build(archiveSource(), spec),
+    );
+
+    // The status read is the authority on whether the build went fine; without
+    // a log there is no report, so the honest verdict is that nothing was
+    // reported rather than that the build failed.
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') expect(result.reason).toBe('INTERNAL');
+  });
+
+  test('a refused submit is a failure with the reason in the log', async () => {
+    const { events, result } = await run(
+      cloudRoute({ refuseSubmit: 403 }).route.build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('TARGET_UNREACHABLE');
+    }
+    expect(text(events)).toContain('submit failed');
+  });
+
+  test('the service’s own timeout indicts nobody', async () => {
+    const { result } = await run(
+      cloudRoute({ status: 'TIMEOUT' }).route.build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('FAILED');
+    // §6's table gives `TIMEOUT` a dash rather than a blame, and a build that
+    // ran out of its own budget is the same situation.
+    if (result.status === 'FAILED') expect(result.reason).toBe('TIMEOUT');
+  });
+
+  test('a build that never finishes runs out of core’s budget', async () => {
+    const { result } = await run(
+      cloudRoute({ duration: 1000 }, { timeoutMs: 5_000 }).route.build(
+        archiveSource(),
+        spec,
+      ),
+    );
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') expect(result.reason).toBe('TIMEOUT');
+  });
+});
+
+// --- The in-cluster route ----------------------------------------------
+
+function clusterRoute(options: FakeKubernetesOptions = {}): {
+  cluster: FakeKubernetes;
+  route: InClusterBuildRoute;
+} {
+  const digest = `sha256:${'c'.repeat(64)}`;
+  const cluster = new FakeKubernetes({
+    status: () => ({ succeeded: 1 }),
+    lists: {
+      pods: [
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: { name: 'build-pod', namespace: 'builds' },
+        },
+      ],
+    },
+    logs: () =>
+      [
+        '#1 load build definition',
+        encodeBuildReport({
+          bundleDigest: 'sha256:bundle',
+          digest,
+          refs: [`registry.example.test/app@${digest}`],
+          baseDigest: null,
+        }),
+      ].join('\n'),
+    ...options,
+  });
+  return {
+    cluster,
+    route: new InClusterBuildRoute({
+      name: 'local',
+      api: new KubernetesApi({
+        apiServer: cluster.apiServer,
+        token: cluster.token,
+        fetch: cluster.fetch,
+      }),
+      namespace: 'builds',
+      image: 'registry.example.test/buildkit:pinned',
+      serviceAccount: 'builder',
+      zeroConfigFrontend: FRONTEND,
+      id: () => 'fixed',
+      ...PACING,
+      ...fakeClock(),
+    }),
+  };
+}
+
+describe('the in-cluster build route', () => {
+  test('is SLSA Build Level 1, which is what an L2 Target refuses', () => {
+    expect(clusterRoute().route.buildLevel).toBe(1);
+  });
+
+  test('creates a Job that will not retry itself', async () => {
+    const { cluster, route } = clusterRoute();
+    await run(route.build(archiveSource(), spec));
+
+    const job = cluster.get('jobs/builds/spindrift-build-fixed');
+    const jobSpec = job?.spec as {
+      backoffLimit: number;
+      ttlSecondsAfterFinished: number;
+      template: { spec: { serviceAccountName: string } };
+    };
+    // A Job that retried would push a second artifact for one Build row, and
+    // §4's "no ordinal" rests on a Build recording one artifact.
+    expect(jobSpec.backoffLimit).toBe(0);
+    expect(jobSpec.ttlSecondsAfterFinished).toBeGreaterThan(0);
+    // §13's "nothing stored": the push authorizes as the account the cluster
+    // projects a token for, not as a credential this process holds.
+    expect(jobSpec.template.spec.serviceAccountName).toBe('builder');
+  });
+
+  test('reads the pod’s log as it goes and yields only what is new', async () => {
+    const { route } = clusterRoute({
+      status: (reads) => (reads > 2 ? { succeeded: 1 } : { active: 1 }),
+      logs: (_pod, reads) =>
+        reads < 3
+          ? '#1 load build definition'
+          : [
+              '#1 load build definition',
+              encodeBuildReport({
+                bundleDigest: 'sha256:bundle',
+                digest: `sha256:${'c'.repeat(64)}`,
+                refs: ['registry.example.test/app@sha256:c'],
+                baseDigest: null,
+              }),
+            ].join('\n'),
+    });
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('SUCCEEDED');
+    const first = text(events)
+      .split('\n')
+      .filter((line) => line === '#1 load build definition');
+    expect(first).toHaveLength(1);
+  });
+
+  test('a failed Job is a build failure', async () => {
+    const { route } = clusterRoute({ status: () => ({ failed: 1 }) });
+    const { result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') expect(result.reason).toBe('BUILD_FAILED');
+  });
+
+  test('a Job that could not be created is a failure with the reason in the log', async () => {
+    const { route } = clusterRoute({
+      refuse: { status: 403, body: 'forbidden' },
+    });
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('TARGET_UNREACHABLE');
+    }
+    expect(text(events)).toContain('could not create the build Job');
+  });
+});
+
+// --- The levels selection reads ----------------------------------------
+
+describe('the route level table', () => {
+  test('says what each route class says about itself', () => {
+    // `buildRouteProfiles` reads a table rather than constructing routes,
+    // because placement has to be able to explain a route it cannot build. A
+    // table that drifted from the classes would make that explanation wrong.
+    const manifest = {
+      build: {
+        routes: [
+          { name: 'hosted', adapter: 'github-actions' as const },
+          {
+            name: 'cloud',
+            adapter: 'cloud-build' as const,
+            endpoint: 'https://builds.example.test',
+            logsEndpoint: 'https://logs.example.test',
+            project: 'p',
+            region: 'r',
+            image: 'i',
+          },
+          {
+            name: 'local',
+            adapter: 'in-cluster' as const,
+            endpoint: 'https://cluster.example.test',
+            namespace: 'n',
+            image: 'i',
+            serviceAccount: 's',
+          },
+        ],
+        zeroConfigFrontend: FRONTEND,
+      },
+    } as Parameters<typeof buildRouteProfiles>[0];
+
+    const levels = Object.fromEntries(
+      buildRouteProfiles(manifest).map((profile) => [
+        profile.name,
+        profile.level,
+      ]),
+    );
+    expect(levels.hosted).toBe(hostedRoute().route.buildLevel);
+    expect(levels.cloud).toBe(cloudRoute().route.buildLevel);
+    expect(levels.local).toBe(clusterRoute().route.buildLevel);
+  });
+});
+
+// --- The program itself ------------------------------------------------
+
+describe('the BuildKit program', () => {
+  const program = buildKitProgram({
+    bundleUrl: 'staged://bundle',
+    bundleDigest: 'sha256:bundle',
+    subpath: 'apps/web',
+    destination: 'registry.example.test/app',
+    zeroConfigFrontend: FRONTEND,
+    buildArgs: { PUBLIC_URL: 'https://app.example.test' },
+  });
+
+  test('runs §5’s ladder: a Dockerfile settles how to build', () => {
+    expect(program).toContain('if [ -f Dockerfile ]');
+    expect(program).toContain('--frontend dockerfile.v0');
+    expect(program).toContain(`--opt source='${FRONTEND}'`);
+  });
+
+  test('passes build arguments as build arguments', () => {
+    expect(program).toContain(
+      `--opt 'build-arg:PUBLIC_URL=https://app.example.test'`,
+    );
+  });
+
+  test('ends by printing the one line core reads', () => {
+    expect(program).toContain('spindrift-result');
+    // A folded payload is a payload core cannot decode.
+    expect(program).toContain("tr -d '\\n'");
+  });
+
+  test('quotes every value that reaches the shell', () => {
+    const hostile = buildKitProgram({
+      bundleUrl: "staged://bundle'; rm -rf /; echo '",
+      bundleDigest: 'sha256:bundle',
+      subpath: '.',
+      destination: 'registry.example.test/app',
+      zeroConfigFrontend: FRONTEND,
+      buildArgs: { EVIL: "'; rm -rf /; echo '" },
+    });
+    // Neither value may end its own quoting: the escape is what keeps a build
+    // argument a build argument rather than an extra command.
+    expect(hostile).not.toContain("'; rm -rf /; echo '\n");
+    expect(hostile).toContain(`'\\''`);
+  });
+});

--- a/apps/spindrift/test/commands/build-args.test.ts
+++ b/apps/spindrift/test/commands/build-args.test.ts
@@ -1,0 +1,464 @@
+/**
+ * A website's build-time configuration (Task 31, §4, §10).
+ *
+ * §10 allows exactly one exception to "everything goes to the store", and §4
+ * says why it is safe: "whatever a website bakes becomes public anyway, so **no
+ * builder ever holds a store credential**." Both halves are asserted here,
+ * because an implementation that got either one wrong would still look like it
+ * worked:
+ *
+ * - A website's value must **not** reach the store. A version put there and
+ *   never read would pass every other test in the suite while quietly requiring
+ *   the builder to be able to read it back.
+ * - A service's value must **still** reach the store. An exception that widened
+ *   to every kind is the failure this exception is worth being narrow about.
+ *
+ * And the mechanical half: the arguments have to actually arrive at the route,
+ * because build arguments core computed and never handed over are configuration
+ * that silently does nothing.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { and, eq } from 'drizzle-orm';
+import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
+import { CONCURRENT_BUILDS_PER_APP } from '../../src/commands/builds/dispatch.ts';
+import { dispatchBuild, setConfig } from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  configItems,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import type { ComponentKind } from '../../src/domain/desired-state.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import {
+  CAPABLE_DISCOVERY,
+  FakeDeployAdapter,
+} from '../harness/fakes/deploy-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+const clock: Clock = { now: () => new Date('2024-06-01T00:00:00.000Z') };
+
+let store: FakeSecretStore;
+let route: FakeBuildAdapter;
+
+beforeEach(() => {
+  store = new FakeSecretStore({ adapter: manifest.secretStore.adapter });
+  route = new FakeBuildAdapter({ name: 'hosted' });
+});
+
+function registry(
+  deployAdapter: DeployAdapter,
+  options: { store?: boolean } = {},
+): AdapterRegistry {
+  return {
+    deploy: (adapter) =>
+      adapter === deployAdapter.adapter ? deployAdapter : null,
+    build: (name) => (name === route.name ? route : null),
+    store: (adapter) =>
+      options.store === false || adapter !== store.adapter ? null : store,
+    repository: () => null,
+  };
+}
+
+async function context(adapters: AdapterRegistry): Promise<CommandContext> {
+  const [user] = await database()
+    .db.insert(users)
+    .values({ displayName: 'Operator' })
+    .returning();
+  return {
+    principal: { id: user!.id, displayName: user!.displayName },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** An App, one Component of the given kind, and a Target to configure it on. */
+async function fixture(
+  kind: ComponentKind,
+  options: { reachesStore?: boolean; minBuildLevel?: number } = {},
+) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'shop', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind, expose: true })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: `cluster-${crypto.randomUUID()}`,
+        adapter: 'kubernetes',
+        ...(options.minBuildLevel === undefined
+          ? {}
+          : { minBuildLevel: options.minBuildLevel }),
+        discovery: {
+          ...CAPABLE_DISCOVERY,
+          reachableSecretStores:
+            options.reachesStore === false
+              ? []
+              : CAPABLE_DISCOVERY.reachableSecretStores,
+        },
+      }),
+    )
+    .returning();
+  return { app: app!, component: component!, target: target! };
+}
+
+/** A Build with a staged bundle, ready for a route to be handed it. */
+async function stagedBuild(componentId: string) {
+  const digest = `sha256:${'1'.repeat(64)}`;
+  const [build] = await database()
+    .db.insert(builds)
+    .values({
+      componentId,
+      commit: digest,
+      targetShape: 'files',
+      artifactType: 'files',
+      bundleDigest: digest,
+      bundleLocation: 'bundles/site.zip',
+      status: 'PENDING',
+    })
+    .returning();
+  return build!;
+}
+
+describe('a website’s configuration is baked, not delivered', () => {
+  test('the value is an ordinary row and the store is never touched', async () => {
+    // §4: "no builder ever holds a store credential" — which is only true if
+    // there is nothing in the store for a builder to need one for.
+    const { component, target } = await fixture('website');
+
+    const result = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'PUBLIC_API', value: 'https://api.example.test' }],
+      },
+      await context(registry(new FakeDeployAdapter({ adapter: 'kubernetes' }))),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(store.puts).toEqual([]);
+
+    const [row] = await database()
+      .db.select()
+      .from(configItems)
+      .where(eq(configItems.componentId, component.id));
+    expect(row?.kind).toBe('plain');
+    expect(row?.plainValue).toBe('https://api.example.test');
+    expect(row?.storeRef).toBeNull();
+  });
+
+  test('a website cannot reference a stored secret, on any Target', async () => {
+    // The reach rule is about delivery, and nothing here is delivered. A
+    // website on a Target in front of no vault is a supported arrangement.
+    const { component, target } = await fixture('website', {
+      reachesStore: false,
+    });
+
+    const result = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'PUBLIC_API', value: 'https://api.example.test' }],
+      },
+      await context(
+        registry(new FakeDeployAdapter({ adapter: 'kubernetes' }), {
+          store: false,
+        }),
+      ),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(store.puts).toEqual([]);
+  });
+
+  test('the change produces no Deploy, and says why', async () => {
+    // Re-applying the artifact that is already serving would deliver the old
+    // value with a new `configVersion` beside it — green, and wrong.
+    const { component, target } = await fixture('website');
+
+    const result = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'PUBLIC_API', value: 'https://api.example.test' }],
+      },
+      await context(registry(new FakeDeployAdapter({ adapter: 'kubernetes' }))),
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.deployId).toBeNull();
+      expect(result.value.notDeployed).toContain('next build');
+    }
+  });
+
+  test('the pinned document stays empty, because there is nothing pinned', async () => {
+    // `configVersion` is a hash over *pinned references* (§10). A plain row has
+    // none, so a website's delivery document is empty — which is what keeps a
+    // build argument out of a delivery CR.
+    const { component, target } = await fixture('website');
+    const registered = registry(
+      new FakeDeployAdapter({ adapter: 'kubernetes' }),
+    );
+
+    const first = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'A', value: 'one' }],
+      },
+      await context(registered),
+    );
+    const second = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'B', value: 'two' }],
+      },
+      await context(registered),
+    );
+
+    expect(first.ok && second.ok).toBe(true);
+    if (first.ok && second.ok) {
+      expect(second.value.configVersion).toBe(first.value.configVersion);
+    }
+  });
+});
+
+describe('the route receives them as build arguments', () => {
+  test('a website’s rows arrive on the build spec', async () => {
+    const { component, target } = await fixture('website');
+    const registered = registry(
+      new FakeDeployAdapter({ adapter: 'kubernetes' }),
+    );
+    const ctx = await context(registered);
+
+    await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [
+          { key: 'PUBLIC_API', value: 'https://api.example.test' },
+          { key: 'SITE_NAME', value: 'shop' },
+        ],
+      },
+      ctx,
+    );
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted', placementTargetId: target.id },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(true);
+    expect(route.built[0]?.spec.buildArgs).toEqual({
+      PUBLIC_API: 'https://api.example.test',
+      SITE_NAME: 'shop',
+    });
+  });
+
+  test('without a placement there are no arguments to derive', async () => {
+    // A Build is keyed on shape and configuration is keyed on Target (§2, §10),
+    // so a dispatch that names no placement has no Target to read rows for —
+    // and inventing one would bake some other Target's values.
+    const { component, target } = await fixture('website');
+    const registered = registry(
+      new FakeDeployAdapter({ adapter: 'kubernetes' }),
+    );
+    const ctx = await context(registered);
+
+    await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'PUBLIC_API', value: 'https://api.example.test' }],
+      },
+      ctx,
+    );
+
+    const build = await stagedBuild(component.id);
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, ctx);
+
+    expect(route.built[0]?.spec.buildArgs).toEqual({});
+  });
+});
+
+describe('a Target’s minimum build level is a threshold', () => {
+  test('a Target refuses a route below its minimum, before anything runs', async () => {
+    // §16: "the level is a threshold, then admin rank wins." Refusing at
+    // dispatch costs nothing; an artifact built below the minimum is a green
+    // build followed by an admission failure nobody reading the build log can
+    // explain.
+    const { component, target } = await fixture('service', {
+      minBuildLevel: 3,
+    });
+    route = new FakeBuildAdapter({ name: 'hosted', buildLevel: 1 });
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted', placementTargetId: target.id },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(false);
+    if (!dispatched.ok) {
+      expect(dispatched.failure.message).toContain('L3');
+    }
+    expect(route.built).toHaveLength(0);
+  });
+
+  test('a route at or above the minimum runs', async () => {
+    const { component, target } = await fixture('service', {
+      minBuildLevel: 2,
+    });
+    route = new FakeBuildAdapter({ name: 'hosted', buildLevel: 2 });
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted', placementTargetId: target.id },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(true);
+    expect(route.built).toHaveLength(1);
+  });
+
+  test('a dispatch naming no placement has no threshold to clear', async () => {
+    // A Build is keyed on a shape and not on a Target (§2), so a build with no
+    // placement is legitimate — there is simply no Target whose minimum applies.
+    const { component } = await fixture('service', { minBuildLevel: 3 });
+    route = new FakeBuildAdapter({ name: 'hosted', buildLevel: 1 });
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(true);
+  });
+});
+
+describe('builds run concurrently up to a per-App limit', () => {
+  test('the limit is refused rather than queued', async () => {
+    // §4 removes the ordinal, so nothing is waiting on a slot: a build records
+    // an artifact rather than deploying one, and a queue position would mean
+    // nothing. Refusing is the honest answer.
+    const { app, component } = await fixture('service');
+    const ctx = await context(
+      registry(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    for (let n = 0; n < CONCURRENT_BUILDS_PER_APP; n += 1) {
+      await database()
+        .db.insert(builds)
+        .values({
+          componentId: component.id,
+          commit: `sha256:${String(n).repeat(64).slice(0, 64)}`,
+          targetShape: 'image',
+          artifactType: 'image',
+          bundleDigest: `sha256:${'2'.repeat(64)}`,
+          bundleLocation: 'bundles/site.zip',
+          status: 'RUNNING',
+        });
+    }
+
+    const build = await stagedBuild(component.id);
+    const dispatched = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      ctx,
+    );
+
+    expect(dispatched.ok).toBe(false);
+    if (!dispatched.ok) {
+      expect(dispatched.failure.message).toContain(app.name);
+    }
+    expect(route.built).toHaveLength(0);
+  });
+});
+
+describe('the exception stays narrow', () => {
+  test('a service’s value still goes to the store, unread', async () => {
+    const { component, target } = await fixture('service');
+
+    const result = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'TOKEN', value: 'hunter2' }],
+      },
+      await context(registry(new FakeDeployAdapter({ adapter: 'kubernetes' }))),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(store.puts.map((put) => put.key)).toEqual(['TOKEN']);
+
+    const [row] = await database()
+      .db.select()
+      .from(configItems)
+      .where(
+        and(
+          eq(configItems.componentId, component.id),
+          eq(configItems.key, 'TOKEN'),
+        ),
+      );
+    expect(row?.kind).toBe('secret_ref');
+    expect(row?.plainValue).toBeNull();
+  });
+
+  test('a service gets no build arguments, whatever it is configured with', async () => {
+    // Derived mechanically from kind (§10) and from nothing else: there is no
+    // input a developer could use to opt a credential into a build argument.
+    const { component, target } = await fixture('service');
+    const registered = registry(
+      new FakeDeployAdapter({ adapter: 'kubernetes' }),
+    );
+    const ctx = await context(registered);
+
+    await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'TOKEN', value: 'hunter2' }],
+      },
+      ctx,
+    );
+
+    const build = await stagedBuild(component.id);
+    await dispatchBuild(
+      { buildId: build.id, route: 'hosted', placementTargetId: target.id },
+      ctx,
+    );
+
+    expect(route.built[0]?.spec.buildArgs).toEqual({});
+  });
+});

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -311,7 +311,7 @@ export function storeAdapterSuite(
  */
 export const ADAPTERS = {
   deploy: ['fake', 'kubernetes'],
-  build: ['fake'],
+  build: ['fake', 'github-actions', 'cloud-build', 'in-cluster'],
   store: [
     'fake native',
     'fake immutable item per version',

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -13,11 +13,19 @@
  * tell `NATIVE` from `IMMUTABLE_ITEM_PER_VERSION` — a tested claim rather than a
  * stated one.
  */
+import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
+import { GitHubActionsBuildRoute } from '../../src/adapters/build/github-actions.ts';
+import { InClusterBuildRoute } from '../../src/adapters/build/in-cluster.ts';
+import { encodeBuildReport } from '../../src/adapters/build/report.ts';
+import { KubernetesApi } from '../../src/adapters/deploy/kubernetes/api.ts';
 import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
 import { SecretManagerStore } from '../../src/adapters/store/gcp-secret-manager.ts';
 import { OnePasswordStore } from '../../src/adapters/store/onepassword.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeCloudBuild } from '../harness/fakes/cloud-build-api.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { FakeGitHub, testAppKey } from '../harness/fakes/github-api.ts';
 import { FakeKubernetes } from '../harness/fakes/kubernetes-api.ts';
 import { FakeOnePasswordConnect } from '../harness/fakes/onepassword-connect.ts';
 import { FakeSecretManager } from '../harness/fakes/secret-manager-api.ts';
@@ -28,6 +36,30 @@ import {
   deployAdapterSuite,
   storeAdapterSuite,
 } from './adapter-suite.ts';
+
+/**
+ * One key for every hosted-CI route the suite constructs.
+ *
+ * Generated once at module load rather than per construction: the suite builds
+ * a fresh adapter for each assertion, and an RSA keypair per test is seconds of
+ * wall clock spent proving nothing about the contract.
+ */
+const appKey = await testAppKey();
+
+/** What the in-cluster Job prints, ending with the one line core reads. */
+function inClusterBuildLog(): string {
+  const digest = `sha256:${'c'.repeat(64)}`;
+  return [
+    '#1 load build definition',
+    '#8 exporting to image',
+    encodeBuildReport({
+      bundleDigest: 'sha256:bundle',
+      digest,
+      refs: [`registry.example.test/app@${digest}`],
+      baseDigest: null,
+    }),
+  ].join('\n');
+}
 
 deployAdapterSuite('fake', () => new FakeDeployAdapter(), 'files');
 
@@ -80,6 +112,78 @@ deployAdapterSuite(
 );
 
 buildAdapterSuite('fake', () => new FakeBuildAdapter());
+
+// The three real routes, each with a fake of its far-side HTTP API behind the
+// real client. They run the identical assertions, which is what makes §4's
+// claim — that a Build is the same object whoever built it — a tested one.
+// Every one of them is driven with `sleep` stubbed and a one-millisecond
+// interval: the polling is real, the waiting is not.
+buildAdapterSuite('github-actions', () => {
+  const host = new FakeGitHub();
+  return new GitHubActionsBuildRoute({
+    name: 'github-actions',
+    host: new GitHubApp({
+      appId: '1',
+      privateKeyPem: appKey.pem,
+      baseUrl: host.baseUrl,
+      fetch: host.fetch,
+    }),
+    buildWorkflow: `${host.fullName}/.github/workflows/spindrift-build.yml@${'f'.repeat(40)}`,
+    zeroConfigFrontend: 'registry.example.test/zero-config:pinned',
+    correlation: () => 'conformance',
+    intervalMs: 1,
+    sleep: async () => {},
+  });
+});
+
+buildAdapterSuite('cloud-build', () => {
+  const api = new FakeCloudBuild();
+  return new CloudBuildRoute({
+    name: 'cloud-build',
+    endpoint: api.endpoint,
+    logsEndpoint: api.logsEndpoint,
+    project: 'example-builds',
+    region: 'example-region',
+    image: 'registry.example.test/buildkit:pinned',
+    zeroConfigFrontend: 'registry.example.test/zero-config:pinned',
+    token: api.token,
+    fetch: api.fetch,
+    intervalMs: 1,
+    sleep: async () => {},
+  });
+});
+
+buildAdapterSuite('in-cluster', () => {
+  const cluster = new FakeKubernetes({
+    status: () => ({ succeeded: 1 }),
+    lists: {
+      pods: [
+        {
+          apiVersion: 'v1',
+          kind: 'Pod',
+          metadata: { name: 'build-pod', namespace: 'builds' },
+        },
+      ],
+    },
+    logs: (_pod, reads) =>
+      reads < 2 ? '#1 load build definition' : inClusterBuildLog(),
+  });
+  return new InClusterBuildRoute({
+    name: 'in-cluster',
+    api: new KubernetesApi({
+      apiServer: cluster.apiServer,
+      token: cluster.token,
+      fetch: cluster.fetch,
+    }),
+    namespace: 'builds',
+    image: 'registry.example.test/buildkit:pinned',
+    serviceAccount: 'builder',
+    zeroConfigFrontend: 'registry.example.test/zero-config:pinned',
+    id: () => 'conformance',
+    intervalMs: 1,
+    sleep: async () => {},
+  });
+});
 
 // Both pinning strategies run the same suite, because §10's claim is that
 // nothing above the seam can tell them apart. One of them passing would not

--- a/apps/spindrift/test/domain/build-route.test.ts
+++ b/apps/spindrift/test/domain/build-route.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Which route builds for which Target (Task 25, §16).
+ *
+ * §16's rule is two clauses in one sentence and the order of them is the whole
+ * design: "the level is a threshold, **then** admin rank wins". These tests are
+ * mostly about that order — a threshold that behaved like a preference would
+ * pass a naive test and put an L1 build on an L2 Target.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  buildRouteCandidates,
+  DEFAULT_MINIMUM_BUILD_LEVEL,
+  selectBuildRoute,
+} from '../../src/domain/build-route.ts';
+
+/** The three routes an installation has, in admin rank order. */
+const ROUTES = [
+  { name: 'local', level: 1 as const },
+  { name: 'hosted', level: 2 as const },
+  { name: 'cloud', level: 3 as const },
+];
+
+describe('build route selection', () => {
+  test('the default minimum is L2, which is what excludes the in-cluster route', () => {
+    expect(DEFAULT_MINIMUM_BUILD_LEVEL).toBe(2);
+
+    const { route, candidates } = selectBuildRoute(ROUTES);
+    expect(route).toBe('hosted');
+
+    const local = candidates.find((candidate) => candidate.route === 'local');
+    expect(local?.eligible).toBe(false);
+    expect(local?.reason).toContain('L2');
+  });
+
+  test('an L2+ Target refuses in-cluster even when it is ranked first', () => {
+    // The whole point of a threshold: rank cannot promote a route below it.
+    // §4 states the consequence outright — a Target cannot be both
+    // offline-capable and require L2 or above.
+    const { route } = selectBuildRoute(ROUTES, { minimumLevel: 2 });
+    expect(route).not.toBe('local');
+  });
+
+  test('an L1 Target takes the highest-ranked route, not the highest level', () => {
+    const { route } = selectBuildRoute(ROUTES, { minimumLevel: 1 });
+    expect(route).toBe('local');
+  });
+
+  test('an L3 Target takes the only route that clears the bar', () => {
+    const { route, candidates } = selectBuildRoute(ROUTES, { minimumLevel: 3 });
+    expect(route).toBe('cloud');
+    expect(candidates.filter((candidate) => candidate.eligible)).toHaveLength(
+      1,
+    );
+  });
+
+  test('rank is the input’s order and is never re-sorted', () => {
+    // The array of routes *is* the admin rank (§16). Sorting here would replace
+    // an operator's arrangement with this function's opinion of one.
+    const reversed = [...ROUTES].reverse();
+    expect(buildRouteCandidates(reversed).map((c) => c.route)).toEqual([
+      'cloud',
+      'hosted',
+      'local',
+    ]);
+    expect(selectBuildRoute(reversed, { minimumLevel: 1 }).route).toBe('cloud');
+  });
+
+  test('a Target that narrows the list gets only what it admits', () => {
+    const { route, candidates } = selectBuildRoute(ROUTES, {
+      minimumLevel: 1,
+      routes: ['cloud'],
+    });
+    expect(route).toBe('cloud');
+    expect(
+      candidates.find((candidate) => candidate.route === 'hosted')?.reason,
+    ).toContain('does not admit');
+  });
+
+  test('a Target naming a route that is gone is not an error', () => {
+    // An installation may retire a route without editing every Target. The
+    // honest reading is that the route is unavailable, which is what the
+    // annotated non-candidates already say.
+    const { route } = selectBuildRoute(ROUTES, { routes: ['retired'] });
+    expect(route).toBeNull();
+  });
+
+  test('“nowhere can build this” is an answer with reasons, not an empty list', () => {
+    // The creation flow has to be able to stop on this before a Build row
+    // exists (§18's unmet prerequisite), which needs a sentence to show.
+    const { route, candidates } = selectBuildRoute(
+      [{ name: 'local', level: 1 }],
+      { minimumLevel: 2 },
+    );
+    expect(route).toBeNull();
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.reason).not.toBe('');
+  });
+
+  test('an installation with no routes configured is a supported installation', () => {
+    // An uploaded archive of finished output consults no route at all (§4), so
+    // this is a real state rather than a misconfiguration.
+    expect(selectBuildRoute([]).route).toBeNull();
+    expect(selectBuildRoute([]).candidates).toEqual([]);
+  });
+
+  test('an eligible route carries no reason, and an ineligible one always does', () => {
+    for (const candidate of buildRouteCandidates(ROUTES)) {
+      expect(candidate.reason === '').toBe(candidate.eligible);
+    }
+  });
+});

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -18,9 +18,11 @@ import { describe, expect, test } from 'bun:test';
 import { readdir } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 import {
+  buildRouteAdapterSchema,
   storeAdapterSchema,
   targetAdapterSchema,
 } from '../../src/config/manifest.schema.ts';
+import { BUILD_ROUTE_REFUSALS } from '../../src/domain/build-route.ts';
 import { KUBERNETES_DELIVERY_FLAVOURS } from '../../src/domain/target.ts';
 
 const APP = join(import.meta.dir, '../..');
@@ -63,9 +65,18 @@ const NOT_A_WORD = /[-\d]/;
 const PROJECT_ID_ALLOWLIST = new Set<string>([
   ...targetAdapterSchema.options,
   ...storeAdapterSchema.options,
+  ...buildRouteAdapterSchema.options,
   // Delivery flavours wear the same shape and are the same kind of thing: the
   // name of a mechanism this software knows, identical in every installation.
   ...KUBERNETES_DELIVERY_FLAVOURS,
+  // Why a build route is not usable for a Target — vocabulary again, read from
+  // the domain rather than restated, so adding one does not break a test here.
+  ...BUILD_ROUTE_REFUSALS,
+  // An encoding, and a key in a workflow file. Neither names anything; both
+  // wear the shape because they are lowercase words carrying a digit or a
+  // hyphen, which is the whole of what this scanner can see.
+  'base64',
+  'run-name',
   // HTTP header names. `src/web/` is scoped out of this scanner for exactly
   // this reason (see BROWSER_SOURCE), but the auth surface writes headers from
   // outside that directory and must not be scoped out wholesale — it is one of

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -39,6 +39,27 @@ github:
   # the connected repository's own permissions.
   buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
 
+# Rank order: a build takes the first route that clears the Target's minimum
+# SLSA Build Level, so the order of this list is the admin rank §16 names.
+build:
+  routes:
+    - name: hosted
+      adapter: github-actions
+    - name: managed
+      adapter: cloud-build
+      endpoint: https://builds.example.test
+      logsEndpoint: https://logs.example.test
+      project: example-builds
+      region: example-region
+      image: registry.example.test/buildkit:pinned
+    - name: local
+      adapter: in-cluster
+      endpoint: https://cluster.example.test
+      namespace: example-builds
+      image: registry.example.test/buildkit:pinned
+      serviceAccount: example-builder
+  zeroConfigFrontend: registry.example.test/zero-config:pinned
+
 secretStore:
   adapter: gcp-secret-manager
   endpoint: https://secrets.example.test

--- a/apps/spindrift/test/harness/fakes/cloud-build-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloud-build-api.ts
@@ -1,0 +1,195 @@
+/**
+ * A fake of the cloud build service and its log service (Task 25, § Seam 2).
+ *
+ * § Seam 2: "a fake of the far-side HTTP API behind the real client, with the
+ * test asserting the requests that were made." So this is two APIs rather than
+ * a fake adapter — the route's real submit body, its real status polling, and
+ * its real page-cursored log reads all run against it.
+ *
+ * Two behaviours are modelled because the route has to survive them:
+ *
+ * - **A build does not finish on the first read.** `duration` is how many status
+ *   reads it takes, so a route that submitted and assumed would fail here.
+ * - **The log arrives in pages, and the cursor is the only thing that knows
+ *   what was already served.** A route that re-read page one would see its own
+ *   output repeat, which is the bug the cursor exists to prevent.
+ */
+
+import type { Fetcher } from '../../../src/adapters/build/cloud-build.ts';
+import { encodeBuildReport } from '../../../src/adapters/build/report.ts';
+
+export const BUILD_HOST = 'https://builds.invalid';
+export const LOGS_HOST = 'https://logs.invalid';
+
+export interface RecordedRequest {
+  method: string;
+  url: string;
+  body: unknown;
+  authorization: string | null;
+}
+
+export interface FakeCloudBuildOptions {
+  /** Status reads before the build reaches a terminal status. */
+  duration?: number;
+  /** How it ends, in the service's own vocabulary. */
+  status?: string;
+  /** Lines the build writes, given the program it was submitted with. */
+  log?: (program: string) => readonly string[];
+  /** When set, submitting is refused with this status. */
+  refuseSubmit?: number;
+  /** When set, every log read fails — the route must survive it. */
+  breakLogs?: boolean;
+  token?: string;
+}
+
+interface FakeBuild {
+  id: string;
+  reads: number;
+  lines: readonly string[];
+  /** How many lines have been served, which is what the cursor encodes. */
+  served: number;
+}
+
+export class FakeCloudBuild {
+  readonly endpoint = BUILD_HOST;
+  readonly logsEndpoint = LOGS_HOST;
+  readonly requests: RecordedRequest[] = [];
+  /** Every program submitted — the assertion surface for what got built. */
+  readonly programs: string[] = [];
+
+  private readonly builds = new Map<string, FakeBuild>();
+  private counter = 0;
+  private readonly options: Required<
+    Omit<FakeCloudBuildOptions, 'refuseSubmit' | 'token'>
+  > &
+    Pick<FakeCloudBuildOptions, 'refuseSubmit' | 'token'>;
+
+  constructor(options: FakeCloudBuildOptions = {}) {
+    this.options = {
+      duration: options.duration ?? 1,
+      status: options.status ?? 'SUCCESS',
+      log: options.log ?? defaultBuildLog,
+      breakLogs: options.breakLogs ?? false,
+      ...(options.refuseSubmit === undefined
+        ? {}
+        : { refuseSubmit: options.refuseSubmit }),
+      ...(options.token === undefined ? {} : { token: options.token }),
+    };
+  }
+
+  /** Mint the token provider the route is constructed with. */
+  token = (): string => this.options.token ?? 'federated-token';
+
+  readonly fetch: Fetcher = async (request) => {
+    const url = new URL(request.url);
+    const raw = request.method === 'GET' ? null : await request.text();
+    const body = raw === null || raw === '' ? null : JSON.parse(raw);
+    this.requests.push({
+      method: request.method,
+      url: `${url.origin}${url.pathname}`,
+      body,
+      authorization: request.headers.get('Authorization'),
+    });
+
+    if (url.origin === LOGS_HOST) return this.logs(body);
+    if (url.origin !== BUILD_HOST) return json(404, { error: 'no such host' });
+
+    if (request.method === 'POST' && url.pathname.endsWith('/builds')) {
+      return this.submit(body as { steps?: { args?: string[] }[] });
+    }
+
+    const read = url.pathname.match(/\/builds\/([^/]+)$/);
+    if (read !== null && request.method === 'GET')
+      return this.read(read[1] ?? '');
+
+    return json(404, { error: 'no such path' });
+  };
+
+  private submit(body: { steps?: { args?: string[] }[] }): Response {
+    if (this.options.refuseSubmit !== undefined) {
+      return json(this.options.refuseSubmit, { error: 'refused' });
+    }
+    const program = body.steps?.[0]?.args?.[1] ?? '';
+    this.programs.push(program);
+    this.counter += 1;
+    const id = `build-${this.counter}`;
+    this.builds.set(id, {
+      id,
+      reads: 0,
+      lines: this.options.log(program),
+      served: 0,
+    });
+    return json(200, { metadata: { build: { id, status: 'QUEUED' } } });
+  }
+
+  private read(id: string): Response {
+    const build = this.builds.get(id);
+    if (build === undefined) return json(404, { error: 'no such build' });
+    build.reads += 1;
+    return json(200, {
+      id,
+      status:
+        build.reads > this.options.duration ? this.options.status : 'WORKING',
+    });
+  }
+
+  /**
+   * One page of one build's log.
+   *
+   * The cursor is "how many lines this build has already served", encoded as a
+   * string — which is enough to catch a route that ignores it and enough to be
+   * read by a test that wants to know how many pages there were.
+   */
+  private logs(body: unknown): Response {
+    if (this.options.breakLogs) return json(503, { error: 'log service down' });
+
+    const request = (body ?? {}) as { filter?: string; pageToken?: string };
+    const id = /build_id="([^"]+)"/.exec(request.filter ?? '')?.[1] ?? '';
+    const build = this.builds.get(id);
+    if (build === undefined) return json(200, { entries: [] });
+
+    const from = Number(request.pageToken ?? '0');
+    const entries = build.lines.slice(from).map((line) => ({
+      textPayload: line,
+      timestamp: '2026-07-28T00:00:00Z',
+    }));
+    build.served = build.lines.length;
+    return json(200, {
+      entries,
+      nextPageToken: String(build.lines.length),
+    });
+  }
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+/**
+ * What a green build writes: some output, then the one line core reads.
+ *
+ * The digests are read back out of the program the route submitted, so the
+ * report echoes what this build was actually asked to do — which is what makes
+ * §16's join a real check here rather than two constants agreeing.
+ */
+function defaultBuildLog(program: string): readonly string[] {
+  const bundleDigest = /'(sha256:[^']+)'/.exec(program)?.[1] ?? '';
+  const destination =
+    /type=image,name=([^,]+),push=true/.exec(program)?.[1] ??
+    'registry.invalid/app';
+  const digest = `sha256:${'b'.repeat(64)}`;
+  return [
+    'Starting Step #0',
+    '#8 exporting to image',
+    encodeBuildReport({
+      bundleDigest,
+      digest,
+      refs: [`${destination}@${digest}`],
+      baseDigest: null,
+    }),
+    'Finished Step #0',
+  ];
+}

--- a/apps/spindrift/test/harness/fakes/github-api.ts
+++ b/apps/spindrift/test/harness/fakes/github-api.ts
@@ -18,6 +18,7 @@
  * new endpoint fails here rather than silently passing against a permissive
  * stand-in.
  */
+import { encodeBuildReport } from '../../../src/adapters/build/report.ts';
 import type { Fetcher } from '../../../src/integrations/github/http.ts';
 
 const BASE = 'https://api.git.invalid';
@@ -48,12 +49,49 @@ interface StoredCommit {
   parents: string[];
 }
 
+/** One dispatch the client asked for. */
+export interface RecordedDispatch {
+  workflow: string;
+  branch: string;
+  inputs: Record<string, string>;
+}
+
+/**
+ * How this host's Actions behave.
+ *
+ * The two delays are what make the fake worth having: a dispatch that named its
+ * run immediately, or a run that was finished the moment it was found, would let
+ * a route that never polled pass — and polling is most of what the route does.
+ */
+export interface FakeActionsOptions {
+  /** List calls before a dispatched run becomes visible. `0` is immediate. */
+  discoveryDelay?: number;
+  /** Status reads before the run completes. */
+  duration?: number;
+  /** How it ends. Anything but `success` is a failed build. */
+  conclusion?: string;
+  /**
+   * The job log, given the spec that was dispatched. The default composes a
+   * valid report, because a green run that reports nothing is its own test
+   * rather than the state every other test wants to start from.
+   */
+  log?: (spec: Record<string, unknown>) => string;
+}
+
+interface FakeRun {
+  id: number;
+  name: string;
+  reads: number;
+  log: string;
+}
+
 export interface FakeGitHubOptions {
   /** `owner/name` of the one repository this host serves. */
   fullName?: string;
   defaultBranch?: string;
   /** The installation the App must present a token for. */
   installationId?: string;
+  actions?: FakeActionsOptions;
   /**
    * The clock token expiry is measured from.
    *
@@ -83,6 +121,8 @@ export class FakeGitHub {
   readonly pulls: RecordedPullRequest[] = [];
   /** Every commit whose archive was downloaded — "fetch once" is checkable. */
   readonly tarballs: string[] = [];
+  /** Every workflow dispatch, in order — the assertion surface for a build. */
+  readonly dispatches: RecordedDispatch[] = [];
 
   defaultBranch: string;
 
@@ -102,6 +142,10 @@ export class FakeGitHub {
   private counter = 0;
   private pullNumber = 0;
   private tokenCounter = 0;
+  private runNumber = 0;
+  private listCalls = 0;
+  private readonly runs: FakeRun[] = [];
+  private readonly actions: Required<FakeActionsOptions>;
   private readonly now: () => Date;
 
   constructor(options: FakeGitHubOptions = {}) {
@@ -109,6 +153,12 @@ export class FakeGitHub {
     this.defaultBranch = options.defaultBranch ?? 'main';
     this.installationId = options.installationId ?? '4242';
     this.now = options.now ?? (() => new Date());
+    this.actions = {
+      discoveryDelay: options.actions?.discoveryDelay ?? 1,
+      duration: options.actions?.duration ?? 1,
+      conclusion: options.actions?.conclusion ?? 'success',
+      log: options.actions?.log ?? defaultBuildLog,
+    };
   }
 
   get baseUrl(): string {
@@ -227,11 +277,109 @@ export class FakeGitHub {
 
     const body = raw === null || raw === '' ? {} : JSON.parse(raw);
     return (
+      this.actionsEndpoints(rest, request.method, body) ??
       this.readEndpoints(rest, url, request.method) ??
       this.writeEndpoints(rest, request.method, body) ??
       this.notFound()
     );
   };
+
+  /**
+   * The Actions half, which models one thing carefully: **a dispatch names no
+   * run.** It answers `204`, and the run has to be found afterwards by the name
+   * the caller stamped — so this fake creates the run without telling anyone,
+   * makes it visible only after `discoveryDelay` list calls, and finishes it
+   * after `duration` status reads.
+   */
+  private actionsEndpoints(
+    rest: string,
+    method: string,
+    body: Record<string, unknown>,
+  ): Response | null {
+    if (rest === '/installation' && method === 'GET') {
+      return this.json({ id: Number(this.installationId) });
+    }
+
+    const dispatch = rest.match(/^\/actions\/workflows\/([^/]+)\/dispatches$/);
+    if (dispatch && method === 'POST') {
+      const inputs = (body.inputs ?? {}) as Record<string, string>;
+      this.dispatches.push({
+        workflow: decodeURIComponent(dispatch[1] ?? ''),
+        branch: String(body.ref ?? ''),
+        inputs,
+      });
+      this.runNumber += 1;
+      const spec = JSON.parse(inputs.spec ?? '{}') as Record<string, unknown>;
+      this.runs.push({
+        id: this.runNumber,
+        // Exactly what the caller workflow's `run-name` would produce.
+        name: `spindrift ${inputs.correlation ?? ''}`,
+        reads: 0,
+        log: this.actions.log(spec),
+      });
+      return new Response(null, { status: 204 });
+    }
+
+    const list = rest.match(/^\/actions\/workflows\/([^/]+)\/runs$/);
+    if (list && method === 'GET') {
+      this.listCalls += 1;
+      const visible =
+        this.listCalls > this.actions.discoveryDelay ? this.runs : [];
+      return this.json({
+        workflow_runs: visible.map((run) => ({
+          id: run.id,
+          name: run.name,
+          status: 'queued',
+          conclusion: null,
+        })),
+      });
+    }
+
+    const read = rest.match(/^\/actions\/runs\/(\d+)$/);
+    if (read && method === 'GET') {
+      const run = this.runs.find((each) => each.id === Number(read[1]));
+      if (run === undefined) return this.notFound();
+      run.reads += 1;
+      const done = run.reads > this.actions.duration;
+      return this.json({
+        id: run.id,
+        status: done ? 'completed' : 'in_progress',
+        conclusion: done ? this.actions.conclusion : null,
+      });
+    }
+
+    const jobs = rest.match(/^\/actions\/runs\/(\d+)\/jobs$/);
+    if (jobs && method === 'GET') {
+      const run = this.runs.find((each) => each.id === Number(jobs[1]));
+      if (run === undefined) return this.notFound();
+      const done = run.reads > this.actions.duration;
+      return this.json({
+        jobs: [
+          {
+            id: run.id,
+            name: 'build',
+            status: done ? 'completed' : 'in_progress',
+            conclusion: done ? this.actions.conclusion : null,
+            steps: [
+              {
+                name: 'Build and push',
+                status: done ? 'completed' : 'in_progress',
+                conclusion: done ? this.actions.conclusion : null,
+              },
+            ],
+          },
+        ],
+      });
+    }
+
+    const log = rest.match(/^\/actions\/jobs\/(\d+)\/logs$/);
+    if (log && method === 'GET') {
+      const run = this.runs.find((each) => each.id === Number(log[1]));
+      return run === undefined ? this.notFound() : new Response(run.log);
+    }
+
+    return null;
+  }
 
   private readEndpoints(
     rest: string,
@@ -345,6 +493,28 @@ export class FakeGitHub {
 
     return null;
   }
+}
+
+/**
+ * What a green run's log looks like: some output, then the one line core reads.
+ *
+ * The bundle digest is echoed from the spec that was dispatched rather than
+ * fixed, which is what lets a test assert §16's join is real — and what lets a
+ * test break it deliberately by supplying its own log.
+ */
+function defaultBuildLog(spec: Record<string, unknown>): string {
+  const digest = `sha256:${'a'.repeat(64)}`;
+  const destination = String(spec.destination ?? 'registry.invalid/app');
+  return [
+    '2026-07-28T00:00:00Z #1 [internal] load build definition',
+    '2026-07-28T00:00:01Z #8 exporting to image',
+    encodeBuildReport({
+      bundleDigest: String(spec.bundleDigest ?? ''),
+      digest,
+      refs: [`${destination}@${digest}`],
+      baseDigest: null,
+    }),
+  ].join('\n');
 }
 
 /**

--- a/apps/spindrift/test/harness/fakes/kubernetes-api.ts
+++ b/apps/spindrift/test/harness/fakes/kubernetes-api.ts
@@ -52,6 +52,14 @@ export interface FakeKubernetesOptions {
   /** What a `SelfSubjectAccessReview` answers. */
   allowed?: boolean;
   token?: string;
+  /**
+   * What a pod's log reads, by pod name and by read count.
+   *
+   * A function of the read rather than a string because a build's log grows
+   * while the build runs: a fake that served the whole log on the first read
+   * would let a route that never polled — and never yielded a timeline — pass.
+   */
+  logs?: (pod: string, reads: number) => string | null;
 }
 
 const HOST = 'https://cluster.invalid';
@@ -147,6 +155,17 @@ export class FakeKubernetes {
       });
     }
 
+    if (parsed.subresource === 'log') {
+      const reads = (this.reads.get(url.pathname) ?? 0) + 1;
+      this.reads.set(url.pathname, reads);
+      const text = this.options.logs?.(parsed.name ?? '', reads) ?? null;
+      // A pod whose container has not started answers `400`, which is not a
+      // fault: the honest answer is that there is no log yet.
+      return text === null
+        ? json(400, { message: 'container is waiting to start' })
+        : new Response(text);
+    }
+
     if (parsed.name === undefined) return this.listResponse(parsed.plural);
 
     const key = `${parsed.plural}/${parsed.namespace ?? ''}/${parsed.name}`;
@@ -224,6 +243,8 @@ interface ParsedPath {
   plural: string;
   namespace?: string;
   name?: string;
+  /** `log`, `status`, and the rest — a segment after the object's name. */
+  subresource?: string;
 }
 
 /** The inverse of `resourcePath` — what the adapter addressed. */
@@ -243,6 +264,7 @@ function parsePath(path: string): ParsedPath | null {
       namespace: rest[1] as string,
       plural: rest[2] as string,
       ...(rest[3] === undefined ? {} : { name: rest[3] }),
+      ...(rest[4] === undefined ? {} : { subresource: rest[4] }),
     };
   }
   if (rest.length === 0) return null;


### PR DESCRIPTION
## Summary

Milestone 4's remaining work: §4's three build routes, and §10's narrow website exception. A staged bundle can now become an artifact on hosted CI, a cloud builder, or an in-cluster Job — all three enrolled in the one conformance suite, each driven in tests by a fake of its far-side HTTP API behind the real client.

## Changes

**One engine, three places to run it.** §4 settles BuildKit with two frontends and refuses to make it a per-route choice, so the ladder — the repo's Dockerfile if present, else the pinned zero-config frontend — lives in one generated program the cloud builder runs in a build step and the cluster runs in a Job. The ladder runs *inside* the builder: a Dockerfile settles how to build and never what the thing is, and the kind was decided before the build was dispatched.

**The result comes back through the log.** Logs are read and never pushed, and the consequence nobody states is that with no ingest endpoint there is nowhere to hand back a digest either. A runner prints one base64 marker line and core reads it out of the log it was already fetching — no callback, no second channel, nothing to authenticate. What it echoes is the bundle digest it was handed, and the route compares rather than copies it, which catches a runner that built something other than what it was sent.

**The hosted route always dispatches a caller, never the reusable workflow.** A dispatch names a *branch*, so dispatching `spindrift-build.yml` directly would run whatever is on the default branch and discard the commit pin §15 requires. A connected repository runs the caller its configuration PR wrote; this repository commits one beside the reusable workflow (`uses: ./…`, so it is the same commit by construction) for the archive builds that have no repository of their own. A dispatch also names no run, so the caller stamps a correlation into `run-name` and the route finds its run by that name.

`in-cluster` is L1, and `dispatchBuild` enforces §16's threshold wherever a placement is named — refusing to start costs nothing, while an artifact built below a Target's minimum is a green build followed by an admission failure nobody reading the build log can explain. Concurrency is capped per App and refused rather than queued, since §4 removes the ordinal and a queue position would mean nothing.

**A website's configuration is baked, not delivered.** Derived from the Component kind and from nothing else, so there is no input a developer could use to opt a credential into a build argument. It never reaches the store — which is the whole security argument, because the alternative is a builder that can read the vault — and it produces no Deploy, because re-applying the artifact already serving would deliver the old value under a new `configVersion`.

## Named gaps

Both are in the README rather than left implicit:

- Nothing sets a Target's `min_build_level` yet — it is read, not written. That belongs with the Target model and the connect act.
- **The provenance a route returns is the runner's own account of itself**, not an attestation anything verified. The Actions route asks BuildKit for one (`provenance: mode=max`) and never reads it back. §16's "verify the backend's provenance before signing" is Task 26's; until it lands, a green Build carries a claim rather than evidence.

## Before merge — the installation manifest

The manifest schema gains a **required** `build` block, so `clusters/offsite/apps/spindrift/secret.sops.yaml` needs it before the next image digest bump reaches the cluster, or the pod fails to boot on manifest validation. Insert into the `SPINDRIFT_MANIFEST` string, immediately before `secretStore: {`:

```
build: {routes: [],zeroConfigFrontend: ghcr.io/railwayapp/railpack:railpack-frontend},
```

An empty route list is deliberate: `github.buildWorkflow` must be pinned to a 40-character commit sha, and the commit carrying `spindrift-build.yml` does not exist until this merges. Configuring a real route is a second step.

## Test Plan

- [ ] `bun run --cwd apps/spindrift typecheck` and `lint` — both clean
- [ ] `DATABASE_URL=… bun test` in `apps/spindrift` — 659 pass against real Postgres
- [ ] `bun test test/conformance` — all three new routes green against the one suite
- [ ] `bun test test/extraction` — no installation literal escaped into `src/`
- [ ] Both new workflow files parse (`yq -e '.jobs.build.steps | length'`)
