### PR TITLE
feat(spindrift): deploy to the cloud runtime and to static hosting

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -345,6 +345,22 @@ read per call so a rotated Secret takes effect without a restart. The other two
 routes need neither — hosted CI goes through the App key, and the in-cluster
 Job authorizes with the projected service account token.
 
+**A cloud Target needs no variable at all**, and that is §13's one auth mode
+arriving where the spec wanted it: "native OIDC federation, nothing stored".
+`src/adapters/deploy/cloud/federation.ts` reads a projected token, exchanges it
+at the pool's STS endpoint, and optionally impersonates a service account —
+`cloud.federation` in the manifest is that `external_account` credential
+document, field for field, so an operator who has one copies it.
+
+The mistake it exists to prevent is worth naming, because it is the convenient
+one: **the default service account token is the wrong token.** It is minted for
+this cluster's own API server, and a cloud API refuses it — the symptom would be
+a `401` on every cloud deploy, blamed on the Target. So `tokenPath` is required
+configuration naming the *separately* projected volume whose audience is the
+pool, with no default that could quietly be the wrong one. An installation that
+configured no federation gets a provider that refuses with that sentence, rather
+than a Target that silently cannot be assessed.
+
 ## The three deploy backends
 
 One contract, three renderings, and **one conformance suite that every one of
@@ -390,17 +406,25 @@ delivers no config still holds the one kind that asks for none. Applying it
 anyway would make "picking the static Target *means* public" (§13) unreachable
 by construction.
 
-Two things stated rather than worked around:
+Three things stated rather than worked around:
 
 - **Cloud Run advertises no egress filtering** (§8). It has network controls and
   not the by-name allowlist §8 specifies, and a capability reported on the
   strength of something adjacent is a workload placed somewhere its egress was
   never actually constrained.
-- **Cloud Run runs no job yet**, and `KINDS_BY_ADAPTER` says so. A job there is
-  a second resource with its own API and a schedule living in a separate
-  scheduling service, which belongs with jobs rather than with this Service
-  path. Until it exists a job is a non-candidate there with the reason stated
-  (§3's grammar), refused at Place rather than accepted and failed at apply.
+- **Cloud Run runs no job yet**, and `KINDS_BY_ADAPTER` says so. This diverges
+  from §3 and §6, which give `cloudrun` all three kinds: a job there is a second
+  resource with its own API and a schedule living in a separate scheduling
+  service, and none of that is the Service path. Until it exists a job is a
+  non-candidate there with the reason stated (§3's grammar), refused at Place
+  rather than accepted and failed at apply — and widening the row is the first
+  thing jobs will do.
+- **`Private` has no audience on Cloud Run.** §9 gives it "one
+  admin-configured Private audience per Target" and no Target carries one, so a
+  `private` Component gets an empty invoker policy: reachable at its address and
+  refusing everyone. Wrong in the safe direction, and it stays there until the
+  authenticated edge lands — which the plan already calls the largest
+  non-Spindrift dependency.
 
 Exposure reaches the cloud runtime as two mechanisms, because the runtime
 answers two separate questions: *who can route to it* is ingress, and *who may
@@ -455,17 +479,33 @@ The unproxied leg costs something, and §9 absorbs it on purpose:
 `VANITY_LEG_LOSSES` says the leg buffers the whole response, so **WebSockets and
 SSE die there and requests cap at sixty seconds**. Two-layer naming is what
 makes that absorbable — the app stays fully capable at its canonical name — so
-these are constants the UI **states**, never something worked around. A
-workaround would be a second edge, which is the external load balancer §9
-declines to have. `VANITY_CEILING` is reported the same way: roughly twenty is a
-fact about one apex's certificate, so `vanityRation` counts and nothing refuses
-the twenty-first.
+the answer is to **state** them, never to work around them. A workaround would
+be a second edge, which is the external load balancer §9 declines to have.
+`VANITY_CEILING` is the same kind of fact: roughly twenty is a property of one
+apex's certificate, so `vanityRation` counts and nothing refuses the
+twenty-first.
+
+**Both are values with no reader yet.** The rules are here and tested; the
+screens that state them are Milestone 8, and nothing counts minted names, so
+`vanityRation` is only ever asked about a number a caller supplies. They are
+here rather than later because the leg they describe exists now and the rule is
+what an adapter would otherwise each invent.
 
 On a static Target the vanity name is a **domain on the site that is already
 serving**, which is what makes §9's "moving an App between backends is one
 record re-point" true there rather than aspirational: the name is a function of
 the label and the zone alone, so a move changes what is underneath it and never
 what anyone bookmarked.
+
+**The non-metal vanity leg itself is not built.** §9 closes it with "the same
+site with a zero-file version carrying a rewrite", which is what a *Cloud Run*
+Component's vanity name would need — and the Cloud Run adapter reads no
+hostname at all, because there the platform names its own and the canonical
+comes back across the seam. So an App on Cloud Run with a vanity label has a
+name nothing serves. The static path above is the case where the name lands on
+the site that already holds the files; the leg in front of another backend
+wants the same `DNSEndpoint` machinery the status name does, and it waits with
+it.
 
 One name is contended and one is not. The canonical is per Component, so it
 never collides. The **vanity name is per App**, so an App with two

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -26,8 +26,13 @@ Job — and every one of them runs the same BuildKit program over the same
 staged bundle, so which route ran is a property of a Build rather than a
 different pipeline.
 
-What has no implementation is the Cloud Run and static deploy adapters,
-datastores, and signing. **The three screens still render placeholder data**
+All three deploy backends exist too — a cluster through its GitOps operator, the
+cloud runtime through its own API, and static hosting through a release — and
+one conformance suite runs over every one of them, which is what keeps "core
+describes, the adapter renders" a tested claim rather than a stated one.
+
+What has no implementation is datastores, jobs, runtime log tails, and signing.
+**The three screens still render placeholder data**
 from `src/web/demo/`, which is scaffolding meant to be deleted: the views are
 typed against `src/web/model.ts`, so the query commands that replace it have a
 contract to meet rather than a shape to guess.
@@ -53,7 +58,7 @@ One image, two processes (§19); only `web` exists so far.
 | `src/db/` | the Drizzle schema, the connection, and the committed migrations |
 | `src/commands/` | the application command layer and its registry |
 | `src/domain/` | backend-neutral product rules and value types |
-| `src/adapters/` | the adapter contracts, Kubernetes delivery, the three build routes, DNS records, and the two stores |
+| `src/adapters/` | the adapter contracts, the three deploy backends, the three build routes, DNS records, and the two stores |
 | `src/reconciler/` | two loops — Target health and capabilities, and deploy convergence |
 | `src/web/` | the `web` process — the server, the dispatch surface, and the client |
 | `src/web/ui/` | shadcn primitives, in this installation's palette |
@@ -152,7 +157,11 @@ is a compile error, and so is a registry key that is not a command.
 ## Targets, capabilities, and placement
 
 A `Target` is flat and has exactly one adapter type, so connecting a cloud
-project registers two of them — `cloudrun` and `static`. **Connect always
+project registers two of them — `cloudrun` and `static`. That one act asks for
+both control APIs, and each Target keeps only the endpoint its own adapter
+drives: an endpoint is connection material for exactly the reason a cluster's
+API server is, because two connected projects may sit behind different regional
+or perimeter-fronted endpoints and neither is more correct. **Connect always
 succeeds**: an unreachable cluster still produces a Target, unhealthy, with every
 unmet prerequisite and the sentence behind it. **Disconnect strands rather than
 stops**: live Deploys go orphaned, nothing is destroyed, the confirmation names
@@ -160,9 +169,14 @@ what it left running, and reconnecting re-adopts whatever `observe` still finds.
 
 One loop (`src/reconciler/target-loop.ts`) refreshes health and capabilities
 together, because a connect-time snapshot rots. It stores what was observed and
-never what was concluded — `verifiedDeploy` (which requires an *enforcing* policy
-engine, not an installed one) and `offlineDeploy` (a static check over the chart,
-image, and verifier references) are derived at read time.
+never what was concluded — `verifiedDeploy` and `offlineDeploy` are derived at
+read time. `verifiedDeploy` requires an *enforcing* verifier rather than an
+installed one, and that rule holds across both of §16's verifiers: a cluster
+whose policy engine is auditing and a project whose admission policy is dry-run —
+or whose evaluation mode admits everything however it enforces — both report
+capable of nothing. A Cloud Run Target whose connection names no policy endpoint
+reports the same, because nobody said where to look, which is the direction a
+claim about verification has to fail in.
 
 Placement is a filter, not a scheduler. Derived requirements — nothing is
 authored by a developer — narrow connected Targets to candidates, the
@@ -310,7 +324,13 @@ two artifacts the Build key cannot tell apart. `dispatchBuild` takes the
 placement it is building for and the second dispatch collides on the unique key
 rather than quietly serving the first one's values.
 
-Delivery on a Kubernetes Target is the App chart's `ExternalSecret`, which
+Delivery follows the Target, and both renderings carry a pinned *reference*
+rather than a value because that is all core has. On a Cloud Run Target each
+variable is a `secretKeyRef` the revision resolves at start from its own
+project's store, over the runtime's access path rather than core's — which is
+why no credential appears anywhere in that document.
+
+On a Kubernetes Target it is the App chart's `ExternalSecret`, which
 fetches each pinned reference into one Secret keyed by variable name. Two things
 an installation has to supply for that to work: the operator names the
 `ClusterSecretStore` in the Target's chart-values (`platform.secretStore.name`,
@@ -324,6 +344,78 @@ same reason and with the same posture: two access paths to two services, each
 read per call so a rotated Secret takes effect without a restart. The other two
 routes need neither — hosted CI goes through the App key, and the in-cluster
 Job authorizes with the projected service account token.
+
+## The three deploy backends
+
+One contract, three renderings, and **one conformance suite that every one of
+them passes** (`test/conformance/`). What differs between them is not how much
+of the contract they implement — it is what their backend is actually able to
+be honest about.
+
+**A cluster** is driven through its GitOps operator, as above. **Cloud Run** is
+driven through the runtime's own API: `apply` writes one Service with
+`allowMissing`, so create-and-update are the same call and idempotence costs
+core no memory of whether it placed this before. **Static hosting** is five
+calls, because the product's contract is that a version is immutable once
+finalized and a release is what makes one serve — version, populate, upload,
+finalize, release. The hash offered on populate is over the *gzipped* bytes,
+which is what the product stores and therefore what it deduplicates on, so a
+redeploy of an unchanged site uploads nothing.
+
+**A `files` artifact is a gzipped tar**, and the static adapter reads one with
+`src/adapters/deploy/static/bundle.ts` rather than a dependency: it is the same
+format `buildkit.ts` already unpacks, read from the other end, and §20 wants a
+package that prunes to something self-contained. The bundle is untrusted input,
+so a path that escapes the bundle is refused rather than normalized away — that
+would be the only path in this system by which one App could reach another's.
+
+**The checklist a Target is assessed against is its adapter type's**, not one
+list for all three (`PREREQUISITES_BY_ADAPTER`). §13's list is written in a
+cluster's terms because a cluster is the backend it was written about, and a
+Cloud Run Target has no delivery operator to run and no chart to pin — a row
+that can never fail teaches a reader that something was checked when nothing
+was. Both cloud backends answer three items from **one probe**, separated by the
+shape of the refusal: a `SERVICE_DISABLED` is the API being off, a bare `403` is
+the federated identity, a `404` is the vessel. Three separate calls would be
+three answers that can disagree, so that a Target reads authorized against a
+project that does not exist.
+
+**A store is reachable, or the kind does not need one.** A cluster's writable
+store is discovered and can genuinely be absent; a Cloud Run revision resolves
+its own project's store natively; **static hosting reaches no store at all**,
+because it has no runtime to resolve a reference with. That last one is why
+§10's website exception matters structurally rather than only as a convenience:
+placement does not apply the reach rule to a `website`, so a Target that
+delivers no config still holds the one kind that asks for none. Applying it
+anyway would make "picking the static Target *means* public" (§13) unreachable
+by construction.
+
+Two things stated rather than worked around:
+
+- **Cloud Run advertises no egress filtering** (§8). It has network controls and
+  not the by-name allowlist §8 specifies, and a capability reported on the
+  strength of something adjacent is a workload placed somewhere its egress was
+  never actually constrained.
+- **Cloud Run runs no job yet**, and `KINDS_BY_ADAPTER` says so. A job there is
+  a second resource with its own API and a schedule living in a separate
+  scheduling service, which belongs with jobs rather than with this Service
+  path. Until it exists a job is a non-candidate there with the reason stated
+  (§3's grammar), refused at Place rather than accepted and failed at apply.
+
+Exposure reaches the cloud runtime as two mechanisms, because the runtime
+answers two separate questions: *who can route to it* is ingress, and *who may
+invoke it* is IAM. Only `public` relaxes the second. §9's **transitions fail
+closed**, and the ordering is where that lives: a tightening exposure writes the
+invoker policy *before* the Service and again after it, so the closed state is
+asserted on every deploy rather than inherited from the platform's default;
+opening can only happen after, because granting invoke on something that is not
+there is not a call the API takes. A public deploy whose grant fails is red, not
+quietly private.
+
+**Static hosting serves `Public` only** (§9), and a non-public Component
+reaching it is refused as `INTERNAL` rather than `REJECTED` — placement already
+excludes this Target for one, so one arriving is core's bug and not a
+developer's.
 
 ## Naming and DNS
 
@@ -341,12 +433,39 @@ a route carrying a hostname *is* the record, and it is garbage collected with
 the release that owns it.
 
 `src/adapters/dns/cr.ts` builds `DNSEndpoint` objects for the names that have no
-route to hang on — the live-from-creation status name, and the vanity leg on a
-non-metal Target. **Neither of those is built, so nothing calls it yet**; it is
-here because external-dns's `crd` source is configured for exactly that gap.
+route to hang on — the live-from-creation status name, and a vanity leg standing
+in front of a backend that cannot carry the name itself. **The status name is
+not built, so nothing calls it for that yet**; it is here because external-dns's
+`crd` source is configured for exactly that gap.
 `test/extraction/no-dns-credential.test.ts` is the grep that keeps "no zone
 credential" true, and it also asserts DNS is still being described somewhere, so
 the negative claim cannot be satisfied by there being no DNS at all.
+
+**Proxying is a per-Target property**, and §9's sentence makes it one with the
+causality running the opposite way to how it reads: "the vanity record is
+unproxied on that leg, **so** proxying becomes a per-Target property." The proxy
+is not a preference — it is the only way a name reaches a metal cluster at all,
+because the cluster's load-balancer range is RFC1918 and public reach goes
+through the tunnel. A backend that answers on the public internet by itself
+needs no such hop. So `vanityProxied` is derived from the adapter type, which
+*is* a per-Target property because a Target has exactly one (§13), and storing
+it would let an operator assert something the backend contradicts.
+
+The unproxied leg costs something, and §9 absorbs it on purpose:
+`VANITY_LEG_LOSSES` says the leg buffers the whole response, so **WebSockets and
+SSE die there and requests cap at sixty seconds**. Two-layer naming is what
+makes that absorbable — the app stays fully capable at its canonical name — so
+these are constants the UI **states**, never something worked around. A
+workaround would be a second edge, which is the external load balancer §9
+declines to have. `VANITY_CEILING` is reported the same way: roughly twenty is a
+fact about one apex's certificate, so `vanityRation` counts and nothing refuses
+the twenty-first.
+
+On a static Target the vanity name is a **domain on the site that is already
+serving**, which is what makes §9's "moving an App between backends is one
+record re-point" true there rather than aspirational: the name is a function of
+the label and the zone alone, so a move changes what is underneath it and never
+what anyone bookmarked.
 
 One name is contended and one is not. The canonical is per Component, so it
 never collides. The **vanity name is per App**, so an App with two

--- a/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
@@ -1,0 +1,139 @@
+/**
+ * §13's checklist, as a cloud Target answers it.
+ *
+ * The two cloud adapters are assessed against the same three items
+ * (`PREREQUISITES_BY_ADAPTER`), and both learn all three from **one call**: the
+ * list of what already exists in the project. That is deliberate. Three separate
+ * probes would be three chances to be rate-limited, three latencies on a loop
+ * that runs on a schedule, and — worse — three answers that can disagree, so
+ * that a Target reads authorized against a project that does not exist.
+ *
+ * What separates the three items is the *shape of the refusal*, which is the
+ * one thing a cloud API is reliably precise about:
+ *
+ * | The probe said | Unmet | Because |
+ * | --- | --- | --- |
+ * | `200` | — | it exists, the service is on, and this identity may read it |
+ * | `403` + `SERVICE_DISABLED` | `PLATFORM_API` | the service is off in this project |
+ * | `401`/`403` | `OIDC_FEDERATION` | the federated identity may not act here |
+ * | `404` | `VESSEL` | there is no such project or location |
+ * | anything else | all three | nothing was established, and saying so beats guessing |
+ *
+ * **An item that could not be assessed is reported unmet**, with a detail saying
+ * so rather than asserting a fault it did not observe. §13 makes an unmet item a
+ * non-candidate with a stated reason, and "not assessed" is a stated reason —
+ * whereas reporting it met would be core deciding that what it failed to check
+ * was fine.
+ */
+import type {
+  Prerequisite,
+  PrerequisiteResult,
+} from '../../../domain/capabilities.ts';
+import type { CloudResponse } from './http.ts';
+
+/** The three items a cloud Target is assessed against, in display order. */
+export const CLOUD_PREREQUISITES = [
+  'PLATFORM_API',
+  'OIDC_FEDERATION',
+  'VESSEL',
+] as const satisfies readonly Prerequisite[];
+
+/** What the probe was asking about, in the sentences an operator reads. */
+export interface CloudChecklistSubject {
+  /** The vessel project (§14). */
+  readonly project: string;
+  /** What the service is called where the operator would go to enable it. */
+  readonly service: string;
+  /** The resource the probe listed, named for the failure sentence. */
+  readonly scope: string;
+}
+
+/**
+ * The reason code a cloud API uses for "this service is not turned on here".
+ *
+ * Matched as a substring of whatever the error carried rather than only as the
+ * parsed `reason`, because the same fact arrives as a `reason` detail on some
+ * calls and only inside the message on others — and an operator whose project
+ * has the API switched off should not get "you are not authorized", which sends
+ * them to fix a permission that is already correct.
+ */
+const SERVICE_DISABLED = 'SERVICE_DISABLED';
+
+/** Fold one probe into §13's three cloud items. */
+export function cloudChecklist(
+  probe: CloudResponse<unknown>,
+  subject: CloudChecklistSubject,
+): readonly PrerequisiteResult[] {
+  if (probe.ok) return CLOUD_PREREQUISITES.map((name) => ({ name, met: true }));
+
+  if (probe.kind === 'transport') {
+    return allUnmet(
+      `${subject.service} could not be reached: ${probe.message}`,
+    );
+  }
+
+  const disabled =
+    probe.reason === SERVICE_DISABLED || probe.body.includes(SERVICE_DISABLED);
+  if (disabled) {
+    return checklist({
+      PLATFORM_API: {
+        met: false,
+        detail: `the ${subject.service} API is not enabled on ${subject.project}`,
+      },
+      OIDC_FEDERATION: notAssessed(subject.service),
+      VESSEL: notAssessed(subject.service),
+    });
+  }
+
+  if (probe.status === 401 || probe.status === 403) {
+    return checklist({
+      PLATFORM_API: { met: true },
+      OIDC_FEDERATION: {
+        met: false,
+        detail: `the federated identity may not act on ${subject.scope}: ${probe.message}`,
+      },
+      // Not assessed rather than met: a project that refuses to answer has not
+      // told us it exists, and a refusal is exactly what a project that is not
+      // there looks like from outside.
+      VESSEL: notAssessed(subject.service),
+    });
+  }
+
+  if (probe.status === 404) {
+    return checklist({
+      // It answered, which is more than a disabled service does.
+      PLATFORM_API: { met: true },
+      OIDC_FEDERATION: notAssessed(subject.service),
+      VESSEL: {
+        met: false,
+        detail: `${subject.scope} does not exist, and Spindrift never creates a project (§14)`,
+      },
+    });
+  }
+
+  return allUnmet(
+    `${subject.service} answered ${probe.status}: ${probe.message}`,
+  );
+}
+
+/** Every item unmet, with one sentence — the Target nothing is known about. */
+function allUnmet(detail: string): readonly PrerequisiteResult[] {
+  return CLOUD_PREREQUISITES.map((name) => ({ name, met: false, detail }));
+}
+
+function notAssessed(service: string): { met: false; detail: string } {
+  return {
+    met: false,
+    detail: `not assessed: the ${service} probe did not get far enough to check this`,
+  };
+}
+
+/** Assemble the three in their declared order, so the UI never reorders them. */
+function checklist(
+  answers: Record<
+    (typeof CLOUD_PREREQUISITES)[number],
+    { met: true } | { met: false; detail: string }
+  >,
+): readonly PrerequisiteResult[] {
+  return CLOUD_PREREQUISITES.map((name) => ({ name, ...answers[name] }));
+}

--- a/apps/spindrift/src/adapters/deploy/cloud/federation.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/federation.ts
@@ -1,0 +1,216 @@
+/**
+ * Reaching a cloud Target with no stored credential (§13).
+ *
+ * §13 settles one auth mode — "**native OIDC federation, nothing stored**" —
+ * and this is it. The pod projects a token, the token is exchanged for a
+ * federated one, and the federated one is optionally used to impersonate a
+ * service account. Nothing is held: the projected token is re-read from disk on
+ * every exchange because the kubelet rewrites it, and the access token that
+ * comes back is cached only until shortly before it expires.
+ *
+ * **The projected token is not the cluster's own service account token.** That
+ * one is minted for this cluster's API server, and a cloud API refuses it — so
+ * the path here is a *separately* projected volume whose audience is the
+ * workload-identity pool. Sending the default token would produce a `401` on
+ * every cloud call, blamed on the Target, and it is exactly the mistake this
+ * file exists to make impossible: `tokenPath` is required configuration with no
+ * default that could be the wrong one.
+ *
+ * The shape mirrors an `external_account` credential document field for field —
+ * audience, token url, credential source, impersonation url — because an
+ * operator configuring this has one of those already and copying it should be
+ * the whole of the work.
+ */
+import type { Fetcher, TokenProvider } from './http.ts';
+
+/** What every exchange asks for. Cloud APIs are gated on this one scope. */
+const SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+
+/** The token-exchange grant, as the standard names it. */
+const GRANT = 'urn:ietf:params:oauth:grant-type:token-exchange';
+const ACCESS_TOKEN = 'urn:ietf:params:oauth:token-type:access_token';
+const JWT = 'urn:ietf:params:oauth:token-type:jwt';
+
+/**
+ * How long before expiry a cached token is thrown away.
+ *
+ * A token that expires while a request is in flight fails a deploy for a reason
+ * nobody can act on, so the cache gives up its last minute rather than spending
+ * it. One extra exchange an hour is not a cost worth optimising.
+ */
+const EXPIRY_SKEW_MS = 60_000;
+
+export interface FederationConfig {
+  /**
+   * The workload-identity pool provider this cluster's tokens are trusted by.
+   *
+   * Installation-specific, and therefore a manifest value (§20): it names one
+   * installation's cloud, one pool, and one provider.
+   */
+  readonly audience: string;
+  /** Where a projected token is exchanged for a federated one. */
+  readonly tokenUrl: string;
+  /**
+   * Where the projected token is read from.
+   *
+   * A path with no default. The one that would be convenient — the default
+   * service account token — is precisely the wrong one, so requiring the
+   * operator to say which volume they projected is what keeps the mistake from
+   * being the easy option.
+   */
+  readonly tokenPath: string;
+  /**
+   * The service account to impersonate, as a `generateAccessToken` url, or
+   * `null` to use the federated token directly.
+   *
+   * Null is a supported configuration rather than an omission: direct resource
+   * access grants the federated identity roles on its own, which is one fewer
+   * identity to reason about where the cloud resources allow it.
+   */
+  readonly impersonationUrl: string | null;
+}
+
+export interface FederationOptions extends FederationConfig {
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+  /** Injected so a test does not need a file at an absolute path. */
+  readonly readToken?: (path: string) => Promise<string>;
+  readonly now?: () => number;
+}
+
+/** Raised when federation cannot produce a token to call a cloud API with. */
+export class FederationError extends Error {
+  override readonly name = 'FederationError';
+}
+
+/** One cached access token and the moment it stops being usable. */
+interface CachedToken {
+  readonly value: string;
+  readonly expiresAt: number;
+}
+
+/**
+ * A token provider that federates, caching what it mints.
+ *
+ * One provider serves every cloud Target because the exchange is per
+ * *installation* rather than per Target: the pool trusts this cluster, and
+ * which project a call lands in is decided by the call, not by the identity
+ * making it.
+ */
+export function workloadIdentityToken(
+  options: FederationOptions,
+): TokenProvider {
+  let cached: CachedToken | null = null;
+  /** The exchange in flight, so a burst of calls makes one round trip. */
+  let inflight: Promise<CachedToken> | null = null;
+
+  const clock = () => options.now?.() ?? Date.now();
+
+  return async (): Promise<string> => {
+    const current = cached;
+    if (current !== null && clock() < current.expiresAt - EXPIRY_SKEW_MS) {
+      return current.value;
+    }
+    if (inflight === null) {
+      inflight = exchange(options, clock).finally(() => {
+        inflight = null;
+      });
+    }
+    cached = await inflight;
+    return cached.value;
+  };
+}
+
+/** Projected token → federated token → (optionally) an impersonated one. */
+async function exchange(
+  options: FederationOptions,
+  clock: () => number,
+): Promise<CachedToken> {
+  const subject = (await readProjectedToken(options)).trim();
+  if (subject === '') {
+    throw new FederationError(
+      `the projected token at ${options.tokenPath} is empty: this process cannot reach a cloud Target`,
+    );
+  }
+
+  const federated = await post<{
+    access_token?: string;
+    expires_in?: number;
+  }>(options, options.tokenUrl, {
+    audience: options.audience,
+    grantType: GRANT,
+    requestedTokenType: ACCESS_TOKEN,
+    scope: SCOPE,
+    subjectTokenType: JWT,
+    subjectToken: subject,
+  });
+  const value = federated.access_token;
+  if (value === undefined) {
+    throw new FederationError('the token exchange returned no access token');
+  }
+  const expiresAt = clock() + (federated.expires_in ?? 3600) * 1_000;
+
+  if (options.impersonationUrl === null) {
+    return { value, expiresAt };
+  }
+
+  const impersonated = await post<{
+    accessToken?: string;
+    expireTime?: string;
+  }>(options, options.impersonationUrl, { scope: [SCOPE] }, value);
+  const token = impersonated.accessToken;
+  if (token === undefined) {
+    throw new FederationError('impersonation returned no access token');
+  }
+  const expiry =
+    impersonated.expireTime === undefined
+      ? expiresAt
+      : Date.parse(impersonated.expireTime);
+  return {
+    value: token,
+    // A far side that answered with an unparseable expiry gets the federated
+    // token's, which is never longer — a cache that guessed long would serve a
+    // dead token, and one that guessed short only costs an exchange.
+    expiresAt: Number.isFinite(expiry) ? expiry : expiresAt,
+  };
+}
+
+/** Read the projected token, freshly, because the kubelet rewrites the file. */
+async function readProjectedToken(options: FederationOptions): Promise<string> {
+  if (options.readToken !== undefined) {
+    return options.readToken(options.tokenPath);
+  }
+  const file = Bun.file(options.tokenPath);
+  if (!(await file.exists())) {
+    throw new FederationError(
+      `no projected token at ${options.tokenPath}: this process cannot reach a cloud Target. ` +
+        'A pod needs a projected service account token volume whose audience is the workload-identity pool.',
+    );
+  }
+  return file.text();
+}
+
+/** One JSON POST, with whatever the far side said on a refusal. */
+async function post<Result>(
+  options: FederationOptions,
+  url: string,
+  body: unknown,
+  bearer?: string,
+): Promise<Result> {
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+  if (bearer !== undefined) headers.Authorization = `Bearer ${bearer}`;
+
+  const send = options.fetch ?? ((request: Request) => fetch(request));
+  const response = await send(
+    new Request(url, { method: 'POST', headers, body: JSON.stringify(body) }),
+  );
+  if (!response.ok) {
+    throw new FederationError(
+      `${url} refused the exchange with ${response.status}: ${await response.text()}`,
+    );
+  }
+  return (await response.json()) as Result;
+}

--- a/apps/spindrift/src/adapters/deploy/cloud/http.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/http.ts
@@ -1,0 +1,226 @@
+/**
+ * What the two cloud deploy adapters share: an HTTP seam a test can put a fake
+ * far side behind.
+ *
+ * § Seam 2 names the pattern — "a fake of the far-side HTTP API behind the real
+ * client, with the test asserting the requests that were made" — and that only
+ * works if the client takes its transport rather than reaching for a global. So
+ * both adapters go through {@link CloudHttp} instead of calling `fetch`.
+ *
+ * It is deliberately not the store's `StoreHttp`, and the difference is the
+ * whole reason this file exists: a store turns a `404` into `null` and raises
+ * everything else, because absence is a value its contract has. A deploy adapter
+ * cannot do that. §6 requires it to distinguish "this project refuses me" from
+ * "this project is not there" from "the service is off", and all three arrive as
+ * status codes with a body — so this client **returns the failure** rather than
+ * throwing it, and the adapter decides which of §6's reasons it is.
+ *
+ * The token is a provider, not a string. §13 settles one auth mode — "native
+ * OIDC federation, nothing stored" — so a credential here is minted per request
+ * by whatever federates, and a client that accepted a string would be holding
+ * one.
+ */
+
+/** The transport, in the shape `fetch` already has. */
+export type Fetcher = (request: Request) => Promise<Response>;
+
+/** Mints a bearer token per request. Never a stored credential (§13). */
+export type TokenProvider = () => string | Promise<string>;
+
+/** Where one cloud API is reached and how a request to it is authorized. */
+export interface CloudEndpoint {
+  /** Base URL of the API, without a trailing slash. */
+  readonly baseUrl: string;
+  readonly token: TokenProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+}
+
+/**
+ * What the far side said, as an answer rather than as an exception.
+ *
+ * `ok` carries the parsed body; every other arm carries enough for the adapter
+ * to pick a §6 reason. `transport` is the case with no status at all — DNS
+ * failed, the socket died, the uplink is down — which is unambiguously
+ * `TARGET_UNREACHABLE` and is the one arm a status-code table cannot express.
+ */
+export type CloudResponse<Result> =
+  | { readonly ok: true; readonly value: Result }
+  | {
+      readonly ok: false;
+      readonly kind: 'status';
+      readonly status: number;
+      readonly body: string;
+      /** The API's own machine-readable reason, where it gave one. */
+      readonly reason: string | null;
+      readonly message: string;
+    }
+  | {
+      readonly ok: false;
+      readonly kind: 'transport';
+      readonly message: string;
+    };
+
+/** One request's worth of options. */
+export interface CloudRequest {
+  method: string;
+  /** Appended to the endpoint's base URL; must begin with a slash. */
+  path: string;
+  /** Serialized as JSON when present. */
+  body?: unknown;
+  /** Query parameters, appended in the order given. */
+  query?: Readonly<Record<string, string | undefined>>;
+}
+
+/**
+ * The shape a Google-family API reports an error in.
+ *
+ * Read defensively — every field is optional — because the one thing worse than
+ * an unhelpful failure message is a failure while producing the failure message.
+ */
+interface CloudError {
+  error?: {
+    message?: string;
+    status?: string;
+    details?: { reason?: string }[];
+  };
+}
+
+export class CloudHttp {
+  constructor(private readonly endpoint: CloudEndpoint) {}
+
+  /** Send a request and parse a JSON response. Never throws. */
+  async json<Result>(options: CloudRequest): Promise<CloudResponse<Result>> {
+    const url = this.url(options);
+    let response: Response;
+    try {
+      const headers: Record<string, string> = {
+        Accept: 'application/json',
+        Authorization: `Bearer ${await this.endpoint.token()}`,
+      };
+      if (options.body !== undefined) {
+        headers['Content-Type'] = 'application/json';
+      }
+      const request = new Request(url, {
+        method: options.method,
+        headers,
+        body:
+          options.body === undefined ? undefined : JSON.stringify(options.body),
+      });
+      const send = this.endpoint.fetch ?? ((input: Request) => fetch(input));
+      response = await send(request);
+    } catch (cause) {
+      return {
+        ok: false,
+        kind: 'transport',
+        message: cause instanceof Error ? cause.message : String(cause),
+      };
+    }
+
+    if (!response.ok) return failureOf(response, await response.text());
+
+    // A `204` and an empty body are the same thing to a caller that asked for a
+    // resource back: there was no document. `undefined` cast to the result type
+    // is what every one of these APIs' delete verbs actually returns.
+    const text = await response.text();
+    if (text.trim() === '') return { ok: true, value: undefined as Result };
+    try {
+      return { ok: true, value: JSON.parse(text) as Result };
+    } catch (cause) {
+      return {
+        ok: false,
+        kind: 'transport',
+        message: `the API answered ${response.status} with a body that is not JSON: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      };
+    }
+  }
+
+  /**
+   * Send bytes with a content type the API chose, and read nothing back.
+   *
+   * Uploading a file is the one call neither adapter can express as JSON, and
+   * it is deliberately a separate verb rather than an overload: an upload takes
+   * an absolute URL the API handed out, so it does not hang off `baseUrl` at
+   * all and must not be able to accidentally be given a path.
+   */
+  async upload(input: {
+    readonly url: string;
+    readonly bytes: Uint8Array;
+    readonly contentType: string;
+  }): Promise<CloudResponse<void>> {
+    try {
+      const request = new Request(input.url, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${await this.endpoint.token()}`,
+          'Content-Type': input.contentType,
+        },
+        body: input.bytes as unknown as BodyInit,
+      });
+      const send =
+        this.endpoint.fetch ?? ((request: Request) => fetch(request));
+      const response = await send(request);
+      if (!response.ok) return failureOf(response, await response.text());
+      return { ok: true, value: undefined };
+    } catch (cause) {
+      return {
+        ok: false,
+        kind: 'transport',
+        message: cause instanceof Error ? cause.message : String(cause),
+      };
+    }
+  }
+
+  /** Fetch bytes from an address the artifact named. Never throws. */
+  async bytes(url: string): Promise<CloudResponse<Uint8Array<ArrayBuffer>>> {
+    try {
+      const send =
+        this.endpoint.fetch ?? ((request: Request) => fetch(request));
+      const response = await send(new Request(url, { method: 'GET' }));
+      if (!response.ok) return failureOf(response, await response.text());
+      return { ok: true, value: new Uint8Array(await response.arrayBuffer()) };
+    } catch (cause) {
+      return {
+        ok: false,
+        kind: 'transport',
+        message: cause instanceof Error ? cause.message : String(cause),
+      };
+    }
+  }
+
+  private url(options: CloudRequest): string {
+    const url = new URL(`${this.endpoint.baseUrl}${options.path}`);
+    for (const [key, value] of Object.entries(options.query ?? {})) {
+      if (value !== undefined) url.searchParams.set(key, value);
+    }
+    return url.toString();
+  }
+}
+
+/** One failed response, with whatever the API was willing to say about it. */
+function failureOf<Result>(
+  response: Response,
+  body: string,
+): CloudResponse<Result> {
+  let parsed: CloudError | null = null;
+  try {
+    parsed = JSON.parse(body) as CloudError;
+  } catch {
+    parsed = null;
+  }
+  const reason =
+    parsed?.error?.details?.find((detail) => detail.reason !== undefined)
+      ?.reason ??
+    parsed?.error?.status ??
+    null;
+  return {
+    ok: false,
+    kind: 'status',
+    status: response.status,
+    body,
+    reason,
+    message: parsed?.error?.message ?? body ?? response.statusText,
+  };
+}

--- a/apps/spindrift/src/adapters/deploy/cloud/verdict.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/verdict.ts
@@ -1,0 +1,83 @@
+/**
+ * What the two cloud deploy adapters conclude from a refused call, and how a
+ * checklist is ordered.
+ *
+ * Both were written twice before this file existed, identically, which is the
+ * signal that they are properties of the *contract* rather than of either
+ * backend: §6's failure vocabulary is closed and shared, so two adapters
+ * mapping a `403` differently would put two meanings on one word in a UI that
+ * shows the user one timeline.
+ *
+ * Nothing backend-specific lives here. A cloud API's own reason codes are read
+ * by the adapter that knows them — `cloudrun/status.ts` for a revision's
+ * condition, `cloud/checklist.ts` for a probe's refusal — and only the part
+ * that is the same for any HTTP control plane is shared.
+ */
+import type {
+  Prerequisite,
+  PrerequisiteResult,
+} from '../../../domain/capabilities.ts';
+import { prerequisitesFor } from '../../../domain/capabilities.ts';
+import type { DeployRef, DeployVerdict } from '../contract.ts';
+import type { CloudResponse } from './http.ts';
+
+/** A refusal, as {@link CloudHttp} hands one back. */
+export type CloudFailure = Extract<CloudResponse<unknown>, { ok: false }>;
+
+/**
+ * A call that never landed, in §6's vocabulary.
+ *
+ * Two lines separate three quite different situations, and the split is §6's
+ * blame column rather than an HTTP convention:
+ *
+ * - **No status at all** — the socket died, DNS failed, the uplink is down.
+ *   Unambiguously the Target being unreachable.
+ * - **A 4xx that is not an auth failure** — the project refusing this document:
+ *   an org policy, a quota, an invalid spec. §6 puts all of those under
+ *   `REJECTED` and blames the developer, because every one is answered by
+ *   changing the request.
+ * - **An auth failure or a 5xx** — the project being unavailable to Spindrift,
+ *   which indicts the platform and not the person deploying.
+ */
+export function cloudWriteFailure(
+  failure: CloudFailure,
+  ref: DeployRef,
+): Extract<DeployVerdict, { phase: 'FAILED' }> {
+  if (failure.kind === 'transport') {
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: 'TARGET_UNREACHABLE',
+      detail: failure.message,
+    };
+  }
+  const rejected = failure.status >= 400 && failure.status < 500;
+  const authFailure = failure.status === 401 || failure.status === 403;
+  return {
+    phase: 'FAILED',
+    ref,
+    reason: rejected && !authFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
+    detail: failure.message,
+    debug: { status: failure.status, reason: failure.reason },
+  };
+}
+
+/**
+ * A checklist in its adapter type's declared order (§13).
+ *
+ * The order is the one the UI shows, so it belongs to the adapter type rather
+ * than to whichever probe happened to answer first. An item nobody answered is
+ * filled in as unmet: `deriveHealth` reads an unanswered row as unmet anyway,
+ * and saying "not assessed" is more useful than a row that is silently absent.
+ */
+export function orderedChecklist(
+  results: readonly PrerequisiteResult[],
+  adapter: Parameters<typeof prerequisitesFor>[0],
+): readonly PrerequisiteResult[] {
+  const found = new Map<Prerequisite, PrerequisiteResult>(
+    results.map((result) => [result.name, result]),
+  );
+  return prerequisitesFor(adapter).map(
+    (name) => found.get(name) ?? { name, met: false, detail: 'not assessed' },
+  );
+}

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -1,0 +1,618 @@
+/**
+ * The Cloud Run deploy adapter (§6).
+ *
+ * Accepts an `image`, talks to the runtime's own API directly, and reads status
+ * from the revision's conditions. There is no operator in between and nothing
+ * to install: §6's "the GitOps operator *is* the pluggable machinery" has no
+ * analogue here, which is why this adapter is smaller than the Kubernetes one
+ * and why the Target's connection carries an endpoint rather than a flavour.
+ *
+ * **Never the build-from-source path** (§4). The runtime will happily take a
+ * source archive and build it, and taking that offer would give this
+ * installation a second build engine — with its own frontends, its own
+ * defaults, and its own idea of what a website is — reachable only from one of
+ * three backends. §4's "build is always separate from deploy" is what forbids
+ * it, `service.ts` is where the document that carries no build is rendered, and
+ * `test/adapters/cloudrun.test.ts` is what notices if one appears.
+ *
+ * **Nothing here watches.** `apply` polls the Service it just wrote for a
+ * bounded window and `observe` is one read, exactly as the Kubernetes adapter
+ * does — and here the poll is not even a compromise: this backend has no watch
+ * to give up (plan, Transport shape).
+ *
+ * **No egress filtering is advertised** (§8). The runtime has network controls,
+ * but not the by-name egress allowlist §8 specifies, and a capability reported
+ * `true` on the strength of something adjacent is how a workload ends up placed
+ * somewhere its egress was never actually constrained.
+ */
+import type {
+  StoreAdapter,
+  TargetAdapter,
+} from '../../../config/manifest.schema.ts';
+import {
+  type PolicyEngineState,
+  type PrerequisiteResult,
+  prerequisitesFor,
+  type TargetDiscovery,
+  type TargetInspection,
+} from '../../../domain/capabilities.ts';
+import {
+  type ArtifactType,
+  artifactAddress,
+  type DesiredState,
+  type Exposure,
+} from '../../../domain/desired-state.ts';
+import type { CloudRunConnection } from '../../../domain/target.ts';
+import { cloudChecklist } from '../cloud/checklist.ts';
+import {
+  CloudHttp,
+  type CloudResponse,
+  type Fetcher,
+  type TokenProvider,
+} from '../cloud/http.ts';
+import type {
+  DeployAdapter,
+  DeployEvent,
+  DeployPhase,
+  DeployRef,
+  DeployTarget,
+  DeployVerdict,
+  FailureReason,
+  ObservedState,
+} from '../contract.ts';
+import {
+  allowsUnauthenticated,
+  cloudRunService,
+  invokerPolicy,
+  serviceId,
+} from './service.ts';
+import {
+  type CloudRunService,
+  type CloudRunStatus,
+  cloudRunStatus,
+  servingDigest,
+} from './status.ts';
+
+export interface CloudRunAdapterOptions {
+  /** Mints a bearer token per request. Never a stored credential (§13). */
+  readonly token: TokenProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+  /** The fast cadence, while an attempt is in flight (plan, Transport shape). */
+  readonly pollIntervalMs?: number;
+  /** How long an attempt may run before it is `TIMEOUT` (§6). */
+  readonly timeoutMs?: number;
+  /** Injected so a test does not spend the cadence it is asserting about. */
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly now?: () => number;
+}
+
+const DEFAULT_POLL_MS = 2_000;
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
+
+/** How the operator would name the service in the sentence about enabling it. */
+const SERVICE_NAME = 'Cloud Run';
+
+/**
+ * What the runtime runs.
+ *
+ * A property of the backend rather than of a project — there is no call that
+ * reports it — and it is stated here rather than left empty because an empty
+ * `arch` means "no architecture excluded" to placement, which would let an
+ * `arm64` build be placed somewhere it cannot run.
+ */
+const RUNTIME_ARCH = ['amd64'] as const;
+
+/**
+ * The largest single workload the runtime admits (§3's `resourceCeiling`).
+ *
+ * Documented limits of the service rather than a project's own quota, which is
+ * lower for most projects and not readable from the API this adapter holds. So
+ * it is a ceiling in the honest direction: a workload this rejects genuinely
+ * does not fit anywhere, and one it admits may still be refused by a quota —
+ * which §8 already routes to `REJECTED` and surfaces at Place as
+ * `QUOTA_EXHAUSTED` when something has measured it.
+ */
+const RESOURCE_CEILING = { cpu: '8', memory: '32Gi' } as const;
+
+/** The one store a Cloud Run revision can resolve a reference from natively. */
+const NATIVE_STORE: readonly StoreAdapter[] = ['gcp-secret-manager'];
+
+/** What a binary-authorization policy says, as much as this adapter reads. */
+interface AdmissionPolicy {
+  readonly globalPolicyEvaluationMode?: string;
+  readonly defaultAdmissionRule?: {
+    readonly evaluationMode?: string;
+    readonly enforcementMode?: string;
+  };
+}
+
+/** The enforcement mode that actually blocks rather than only recording. */
+const BLOCKING = 'ENFORCED_BLOCK_AND_AUDIT_LOG';
+/** The evaluation mode that verifies nothing, whatever its enforcement says. */
+const VERIFIES_NOTHING = 'ALWAYS_ALLOW';
+
+export class CloudRunDeployAdapter implements DeployAdapter {
+  readonly adapter: TargetAdapter = 'cloudrun';
+  /** §6's table: `cloudrun` takes an image. */
+  readonly artifactTypes: readonly ArtifactType[] = ['image'];
+
+  constructor(private readonly options: CloudRunAdapterOptions) {}
+
+  async *apply(
+    target: DeployTarget,
+    desired: DesiredState,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      return this.internal('this Target is not a Cloud Run Target');
+    }
+    if (!this.artifactTypes.includes(desired.artifact.type)) {
+      yield this.status('FAILED', { reason: 'INTERNAL' });
+      return this.internal(
+        `cloudrun does not accept a ${desired.artifact.type} artifact`,
+      );
+    }
+    const image = artifactAddress(desired.artifact);
+    if (image === null) {
+      yield this.status('FAILED', { reason: 'INTERNAL' });
+      return this.internal('the artifact carries no address to pull it by');
+    }
+
+    const id = serviceId(desired);
+    const ref = refOf(connection, id);
+    const http = this.http(connection);
+
+    yield this.status('APPLYING', { resource: id });
+
+    // §9: "tightening drops public reach first and stays red if the stricter
+    // boundary does not come up." So for every non-public exposure the invoker
+    // policy is written *before* the Service — a bounded outage is preferred
+    // over a window in which the new revision is up and still reachable by
+    // whoever the old one let in. On a Target that has nothing there yet this
+    // call finds no Service and does nothing, which is why the policy is
+    // written again after the rollout below: the closed state is **asserted**
+    // on every deploy rather than inherited from the platform's default.
+    if (!allowsUnauthenticated(desired.exposure)) {
+      const tightened = await this.setInvoker(
+        http,
+        connection,
+        id,
+        desired.exposure,
+      );
+      if (tightened !== null) {
+        yield this.status('FAILED', { resource: id, reason: tightened.reason });
+        return { ...tightened, ref };
+      }
+    }
+
+    const document = cloudRunService(desired, {
+      project: connection.project,
+      image,
+    });
+    const applied = await http.json<unknown>({
+      method: 'PATCH',
+      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}`,
+      // Create-or-update in one call, which is what makes `apply` idempotent
+      // without core having to remember whether it placed this before.
+      query: { allowMissing: 'true' },
+      body: document,
+    });
+    if (!applied.ok) {
+      const verdict = writeFailure(applied, ref);
+      yield this.status('FAILED', { resource: id, reason: verdict.reason });
+      return verdict;
+    }
+    yield this.log(`applied service ${id}`, id);
+
+    const verdict = yield* this.awaitVerdict(http, connection, id, ref);
+    if (verdict.phase !== 'LIVE') return verdict;
+
+    // Now that the Service exists, the policy this exposure means is written
+    // whichever direction it moved. Opening can only happen here — granting
+    // invoke on something that is not there is not a call the API takes — and
+    // tightening repeats a write it may already have made, which is idempotent
+    // and is what makes "no non-public mode has a bypassable origin" this
+    // adapter's guarantee rather than the platform default's.
+    const written = await this.setInvoker(
+      http,
+      connection,
+      id,
+      desired.exposure,
+    );
+    if (written !== null) {
+      yield this.status('FAILED', { resource: id, reason: written.reason });
+      return { ...written, ref };
+    }
+    return verdict;
+  }
+
+  async observe(
+    target: DeployTarget,
+    ref: DeployRef,
+  ): Promise<ObservedState | null> {
+    const connection = this.connectionOf(target);
+    if (connection === null) return null;
+    const id = parseRef(connection, ref);
+    if (id === null) return null;
+
+    const read = await this.read(this.http(connection), connection, id);
+    if (read === null) return null;
+
+    const status = cloudRunStatus(read);
+    return {
+      ref,
+      phase: status.phase,
+      artifactDigest: servingDigest(read),
+      ...(status.reason === undefined ? {} : { reason: status.reason }),
+      ...(status.detail === undefined ? {} : { detail: status.detail }),
+    };
+  }
+
+  async destroy(target: DeployTarget, ref: DeployRef): Promise<void> {
+    const connection = this.connectionOf(target);
+    if (connection === null) return;
+    const id = parseRef(connection, ref);
+    if (id === null) return;
+
+    const deleted = await this.http(connection).json<unknown>({
+      method: 'DELETE',
+      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}`,
+    });
+    // §6's idempotence: destroying what is already gone succeeds. Every other
+    // refusal is raised, because a delete that silently did nothing is how an
+    // orphaned Service outlives the App that paid for it.
+    if (deleted.ok) return;
+    if (deleted.kind === 'status' && deleted.status === 404) return;
+    throw new Error(
+      deleted.kind === 'status'
+        ? `deleting service ${id} failed with ${deleted.status}: ${deleted.message}`
+        : `deleting service ${id} failed: ${deleted.message}`,
+    );
+  }
+
+  /**
+   * One pass of §13's checklist and §3's discovery, in one call.
+   *
+   * The checklist comes from a single probe — see `cloud/checklist.ts` — and
+   * discovery is mostly properties of the runtime rather than of a project,
+   * because there is no call that reports them. Which is fine, and is why they
+   * are constants with the reasoning written down beside them: a value core
+   * invented and a value core read are equally honest as long as nobody has to
+   * guess which one they are looking at.
+   */
+  async inspect(target: DeployTarget): Promise<TargetInspection> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      throw new Error(`${target.name} is not a Cloud Run Target`);
+    }
+    const http = this.http(connection);
+
+    const probe = await http.json<unknown>({
+      method: 'GET',
+      path: `/v2/${parentOf(connection)}/services`,
+      query: { pageSize: '1' },
+    });
+
+    const prerequisites = cloudChecklist(probe, {
+      project: connection.project,
+      service: SERVICE_NAME,
+      scope: `${connection.project} in ${connection.region}`,
+    });
+
+    return {
+      prerequisites: order(prerequisites, this.adapter),
+      discovery: await this.discover(connection),
+    };
+  }
+
+  // --- apply's second half -------------------------------------------------
+
+  private async *awaitVerdict(
+    http: CloudHttp,
+    connection: CloudRunConnection,
+    id: string,
+    ref: DeployRef,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    const deadline =
+      this.clock() + (this.options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    // `apply` already emitted APPLYING, so treat that as the first reported
+    // phase: a Service whose terminal condition has not appeared yet must not
+    // put a second identical event on the timeline.
+    let reported: DeployPhase = 'APPLYING';
+
+    for (;;) {
+      const service = await this.read(http, connection, id);
+      const status: CloudRunStatus =
+        service === null ? { phase: 'APPLYING' } : cloudRunStatus(service);
+
+      if (status.phase !== reported) {
+        reported = status.phase;
+        yield this.status(status.phase, {
+          resource: id,
+          ...(status.reason === undefined ? {} : { reason: status.reason }),
+          ...(status.detail === undefined ? {} : { detail: status.detail }),
+        });
+      }
+
+      if (status.phase === 'LIVE') {
+        // §9: the platform names its own, so the canonical address comes back
+        // across this seam rather than being handed in. A Service reported
+        // ready with no `uri` is the one case core cannot fill in, and an
+        // absent url is more honest than a name core assembled.
+        const uri = service?.uri;
+        return {
+          phase: 'LIVE',
+          ref,
+          ...(uri === undefined ? {} : { url: uri }),
+        };
+      }
+
+      if (status.phase === 'FAILED') {
+        // §6's read on red is already done: unlike a cluster, the runtime puts
+        // the reason on the object itself, so there are no pods to go and look
+        // at. What §12 wants — the diagnosis surviving the platform's own
+        // retention — is served by persisting `debug` on the Deploy row.
+        return {
+          phase: 'FAILED',
+          ref,
+          reason: status.reason ?? 'STARTUP_FAILED',
+          ...(status.detail === undefined ? {} : { detail: status.detail }),
+          debug: status.debug,
+        };
+      }
+
+      if (this.clock() >= deadline) {
+        yield this.status('FAILED', { resource: id, reason: 'TIMEOUT' });
+        return {
+          phase: 'FAILED',
+          ref,
+          reason: 'TIMEOUT',
+          detail: status.detail ?? 'the revision did not settle in time',
+          debug: status.debug,
+        };
+      }
+
+      await this.wait();
+    }
+  }
+
+  /** Write the invoker policy for one exposure, or say why it could not. */
+  private async setInvoker(
+    http: CloudHttp,
+    connection: CloudRunConnection,
+    id: string,
+    exposure: Exposure,
+  ): Promise<Omit<Extract<DeployVerdict, { phase: 'FAILED' }>, 'ref'> | null> {
+    const written = await http.json<unknown>({
+      method: 'POST',
+      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}:setIamPolicy`,
+      body: invokerPolicy(exposure),
+    });
+    if (written.ok) return null;
+    // A Service that does not exist yet cannot have a policy, and on the
+    // tightening path that is the normal case rather than a failure: there is
+    // no public reach to drop from something that was never placed.
+    if (
+      written.kind === 'status' &&
+      written.status === 404 &&
+      !allowsUnauthenticated(exposure)
+    ) {
+      return null;
+    }
+    const failure = writeFailure(written, id);
+    return {
+      phase: 'FAILED',
+      reason: failure.reason,
+      detail: `the invoker policy for ${exposure} could not be written: ${failure.detail}`,
+      debug: failure.debug,
+    };
+  }
+
+  // --- inspect's second half -----------------------------------------------
+
+  private async discover(
+    connection: CloudRunConnection,
+  ): Promise<TargetDiscovery> {
+    return {
+      arch: [...RUNTIME_ARCH],
+      // The runtime does offer accelerators, in some regions and behind their
+      // own quota, and neither fact is readable from the call this adapter
+      // makes. Reported `false` because a GPU capability that is wrong makes a
+      // workload placeable where it cannot run, and one that is missing only
+      // makes it placeable somewhere else.
+      gpu: false,
+      resourceCeiling: { ...RESOURCE_CEILING },
+      // §11 keeps a Datastore a top-level noun with its own placement; nothing
+      // this adapter drives hosts one, and a managed database beside it is
+      // `external` provenance rather than something discovered here.
+      persistence: false,
+      postgres: false,
+      redis: false,
+      // §8: advertised as absent, deliberately. See the file's header.
+      egressFiltering: false,
+      policyEngine: await this.admissionPolicy(connection),
+      logHistorySeconds: connection.logHistorySeconds ?? 0,
+      servedHosts: connection.servedHosts ?? [],
+      reachableRegistries: connection.reachableRegistries ?? [],
+      // A revision resolves a pinned reference from its own project's store
+      // over its own access path (§10's "one store of record, several access
+      // paths"), so this is a property of the runtime rather than something
+      // installed in the project.
+      reachableSecretStores: [...NATIVE_STORE],
+    };
+  }
+
+  /**
+   * What this project's admission policy was found doing (§16, §32).
+   *
+   * §16's "one signature, two verifiers" makes this the cloud half, and §32's
+   * rule applies unchanged: **enforcing, not installed.** Two ways a policy
+   * proves nothing while looking configured, and both are reported `AUDIT` —
+   * a dry-run enforcement that only writes a log entry, and an evaluation mode
+   * that admits everything however it is enforced.
+   *
+   * A Target whose connection names no policy endpoint reports nothing
+   * installed, which derives `verifiedDeploy: false`. That is the direction
+   * this has to fail in: nobody said where to look, so nothing was verified.
+   */
+  private async admissionPolicy(
+    connection: CloudRunConnection,
+  ): Promise<PolicyEngineState> {
+    if (connection.policyEndpoint === undefined) {
+      return { installed: false, mode: null };
+    }
+    const read = await new CloudHttp({
+      baseUrl: connection.policyEndpoint,
+      token: this.options.token,
+      ...(this.options.fetch === undefined
+        ? {}
+        : { fetch: this.options.fetch }),
+    }).json<AdmissionPolicy>({
+      method: 'GET',
+      path: `/v1/projects/${encodeURIComponent(connection.project)}/policy`,
+    });
+    if (!read.ok || read.value === undefined) {
+      return { installed: false, mode: null };
+    }
+
+    const rule = read.value.defaultAdmissionRule;
+    const blocking = rule?.enforcementMode === BLOCKING;
+    const verifies =
+      rule?.evaluationMode !== undefined &&
+      rule.evaluationMode !== VERIFIES_NOTHING;
+    return {
+      installed: true,
+      mode: blocking && verifies ? 'ENFORCE' : 'AUDIT',
+    };
+  }
+
+  // --- plumbing ------------------------------------------------------------
+
+  private http(connection: CloudRunConnection): CloudHttp {
+    return new CloudHttp({
+      baseUrl: connection.endpoint,
+      token: this.options.token,
+      ...(this.options.fetch === undefined
+        ? {}
+        : { fetch: this.options.fetch }),
+    });
+  }
+
+  private connectionOf(target: DeployTarget): CloudRunConnection | null {
+    return target.connection.adapter === 'cloudrun' ? target.connection : null;
+  }
+
+  /** One Service, or `null` where there is nothing there. */
+  private async read(
+    http: CloudHttp,
+    connection: CloudRunConnection,
+    id: string,
+  ): Promise<CloudRunService | null> {
+    const read = await http.json<CloudRunService>({
+      method: 'GET',
+      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}`,
+    });
+    return read.ok ? (read.value ?? null) : null;
+  }
+
+  private internal(detail: string): DeployVerdict {
+    return { phase: 'FAILED', reason: 'INTERNAL', detail };
+  }
+
+  private status(
+    phase: DeployPhase,
+    extra: { resource?: string; reason?: FailureReason; detail?: string } = {},
+  ): DeployEvent {
+    return { type: 'status', at: new Date(this.clock()), phase, ...extra };
+  }
+
+  private log(line: string, resource?: string): DeployEvent {
+    return {
+      type: 'log',
+      at: new Date(this.clock()),
+      line,
+      ...(resource === undefined ? {} : { resource }),
+    };
+  }
+
+  private clock(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+
+  private async wait(): Promise<void> {
+    const interval = this.options.pollIntervalMs ?? DEFAULT_POLL_MS;
+    if (this.options.sleep !== undefined) {
+      await this.options.sleep(interval);
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  }
+}
+
+/** `projects/<p>/locations/<r>` — the parent every call hangs off. */
+function parentOf(connection: CloudRunConnection): string {
+  return `projects/${connection.project}/locations/${connection.region}`;
+}
+
+/**
+ * The adapter's own handle on what `apply` placed — opaque to core (§6).
+ *
+ * It carries the project and the region as well as the id because an operator
+ * may reconnect a Target against a different project, and a ref that named only
+ * the Service would then be read against the wrong one — reporting a healthy
+ * workload that is not the one this Deploy placed.
+ */
+function refOf(connection: CloudRunConnection, id: string): DeployRef {
+  return `${parentOf(connection)}/services/${id}`;
+}
+
+/** The id this ref names on this connection, or `null` if it names another. */
+function parseRef(
+  connection: CloudRunConnection,
+  ref: DeployRef,
+): string | null {
+  const prefix = `${parentOf(connection)}/services/`;
+  if (!ref.startsWith(prefix)) return null;
+  const id = ref.slice(prefix.length);
+  return id.length === 0 || id.includes('/') ? null : id;
+}
+
+/** A call that never landed, in §6's vocabulary. */
+function writeFailure(
+  failure: Extract<CloudResponse<unknown>, { ok: false }>,
+  ref: DeployRef,
+): Extract<DeployVerdict, { phase: 'FAILED' }> {
+  if (failure.kind === 'transport') {
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: 'TARGET_UNREACHABLE',
+      detail: failure.message,
+    };
+  }
+  // A 4xx that is not an auth failure is the project refusing this document —
+  // an org policy, a quota, an invalid spec — which §6 puts under one reason.
+  // An auth failure or a 5xx is the project being unavailable to Spindrift,
+  // which is a different blame entirely.
+  const rejected = failure.status >= 400 && failure.status < 500;
+  const authFailure = failure.status === 401 || failure.status === 403;
+  return {
+    phase: 'FAILED',
+    ref,
+    reason: rejected && !authFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
+    detail: failure.message,
+    debug: { status: failure.status, reason: failure.reason },
+  };
+}
+
+/** The checklist in its adapter's declared order, so the UI never reorders it. */
+function order(
+  results: readonly PrerequisiteResult[],
+  adapter: TargetAdapter,
+): readonly PrerequisiteResult[] {
+  const found = new Map(results.map((result) => [result.name, result]));
+  return prerequisitesFor(adapter).map(
+    (name) => found.get(name) ?? { name, met: false, detail: 'not assessed' },
+  );
+}

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -29,12 +29,10 @@ import type {
   StoreAdapter,
   TargetAdapter,
 } from '../../../config/manifest.schema.ts';
-import {
-  type PolicyEngineState,
-  type PrerequisiteResult,
-  prerequisitesFor,
-  type TargetDiscovery,
-  type TargetInspection,
+import type {
+  PolicyEngineState,
+  TargetDiscovery,
+  TargetInspection,
 } from '../../../domain/capabilities.ts';
 import {
   type ArtifactType,
@@ -44,12 +42,8 @@ import {
 } from '../../../domain/desired-state.ts';
 import type { CloudRunConnection } from '../../../domain/target.ts';
 import { cloudChecklist } from '../cloud/checklist.ts';
-import {
-  CloudHttp,
-  type CloudResponse,
-  type Fetcher,
-  type TokenProvider,
-} from '../cloud/http.ts';
+import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
+import { cloudWriteFailure, orderedChecklist } from '../cloud/verdict.ts';
 import type {
   DeployAdapter,
   DeployEvent,
@@ -199,7 +193,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       body: document,
     });
     if (!applied.ok) {
-      const verdict = writeFailure(applied, ref);
+      const verdict = cloudWriteFailure(applied, ref);
       yield this.status('FAILED', { resource: id, reason: verdict.reason });
       return verdict;
     }
@@ -301,7 +295,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     });
 
     return {
-      prerequisites: order(prerequisites, this.adapter),
+      prerequisites: orderedChecklist(prerequisites, this.adapter),
       discovery: await this.discover(connection),
     };
   }
@@ -400,7 +394,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     ) {
       return null;
     }
-    const failure = writeFailure(written, id);
+    const failure = cloudWriteFailure(written, id);
     return {
       phase: 'FAILED',
       reason: failure.reason,
@@ -576,43 +570,4 @@ function parseRef(
   if (!ref.startsWith(prefix)) return null;
   const id = ref.slice(prefix.length);
   return id.length === 0 || id.includes('/') ? null : id;
-}
-
-/** A call that never landed, in §6's vocabulary. */
-function writeFailure(
-  failure: Extract<CloudResponse<unknown>, { ok: false }>,
-  ref: DeployRef,
-): Extract<DeployVerdict, { phase: 'FAILED' }> {
-  if (failure.kind === 'transport') {
-    return {
-      phase: 'FAILED',
-      ref,
-      reason: 'TARGET_UNREACHABLE',
-      detail: failure.message,
-    };
-  }
-  // A 4xx that is not an auth failure is the project refusing this document —
-  // an org policy, a quota, an invalid spec — which §6 puts under one reason.
-  // An auth failure or a 5xx is the project being unavailable to Spindrift,
-  // which is a different blame entirely.
-  const rejected = failure.status >= 400 && failure.status < 500;
-  const authFailure = failure.status === 401 || failure.status === 403;
-  return {
-    phase: 'FAILED',
-    ref,
-    reason: rejected && !authFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
-    detail: failure.message,
-    debug: { status: failure.status, reason: failure.reason },
-  };
-}
-
-/** The checklist in its adapter's declared order, so the UI never reorders it. */
-function order(
-  results: readonly PrerequisiteResult[],
-  adapter: TargetAdapter,
-): readonly PrerequisiteResult[] {
-  const found = new Map(results.map((result) => [result.name, result]));
-  return prerequisitesFor(adapter).map(
-    (name) => found.get(name) ?? { name, met: false, detail: 'not assessed' },
-  );
 }

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -1,0 +1,177 @@
+/**
+ * `DesiredState` rendered as one Cloud Run Service (§6).
+ *
+ * §6 settles the direction of the seam: **core describes, the adapter renders.**
+ * This file is the rendering, kept apart from the adapter that applies it for
+ * the reason `dns/cr.ts` is kept apart from the client that writes it — a pure
+ * function returning a plain object is a document a test can assert on exactly,
+ * without a fake API standing by to catch it.
+ *
+ * **Never the build-from-source path** (§4). The runtime's own convenience path
+ * would take a source archive and build it, which is a second engine with its
+ * own frontends and its own idea of what a website is: §4's "build is always
+ * separate from deploy" applied one level down. What is rendered here therefore
+ * carries an image and nothing that could cause a build — and
+ * {@link cloudRunService} is where a test asserts that, because it is the whole
+ * document.
+ */
+import type {
+  ConfigEntry,
+  DesiredState,
+  Exposure,
+} from '../../../domain/desired-state.ts';
+
+/** The ingress settings the runtime accepts, in its own vocabulary. */
+export const INGRESS = {
+  all: 'INGRESS_TRAFFIC_ALL',
+  internalOnly: 'INGRESS_TRAFFIC_INTERNAL_ONLY',
+} as const;
+
+/**
+ * The port a container is contacted on.
+ *
+ * Fixed rather than configurable, matching §7's fixed port for the chart: the
+ * runtime passes it as `PORT` and every zero-config build honours that, so a
+ * per-Component port would be a knob whose only effect is to break the ones
+ * that read the variable.
+ */
+export const CONTAINER_PORT = 8080;
+
+/** What the caller must supply that `DesiredState` does not carry. */
+export interface CloudRunRenderContext {
+  /** The vessel project the Service lives in (§14). */
+  readonly project: string;
+  /** The image the revision pulls, pinned by digest where the artifact has one. */
+  readonly image: string;
+}
+
+/**
+ * How exposure reaches the runtime (§9).
+ *
+ * Two mechanisms, because exposure is two questions the runtime answers
+ * separately: *who can route to it* is ingress, and *who may invoke it* is IAM.
+ * Only `public` relaxes the second, which is what "no non-public mode may have a
+ * bypassable origin" means here — the authenticated edge §9 wants on `private`
+ * is the runtime's own invoker check, enabled by leaving it on.
+ */
+export function ingressFor(exposure: Exposure): string {
+  return exposure === 'internal' ? INGRESS.internalOnly : INGRESS.all;
+}
+
+/** Whether this exposure means anyone at all may invoke the Service (§9). */
+export function allowsUnauthenticated(exposure: Exposure): boolean {
+  return exposure === 'public';
+}
+
+/**
+ * One Service document, ready to be applied.
+ *
+ * The `labels` carry the same three names the Kubernetes adapter puts on its
+ * delivery object, and for the same reason: a human reading the project should
+ * be able to tell which App and Component a Service belongs to without asking
+ * Spindrift. They wear the product's own prefix rather than the well-known
+ * Kubernetes keys, because a label key here may hold neither a dot nor a slash
+ * — and an unprefixed `app` in somebody's project is a collision waiting for
+ * whichever tool gets there second.
+ *
+ * The Deploy id goes on the **revision template** and never on the Service,
+ * mirroring §7's rule that the deploy label goes on the pod template — a value
+ * that changes every deploy belongs where changing it is the point.
+ */
+export function cloudRunService(
+  desired: DesiredState,
+  context: CloudRunRenderContext,
+): Record<string, unknown> {
+  const labels = {
+    'spindrift-managed': 'true',
+    'spindrift-app': desired.app,
+    'spindrift-component': desired.component,
+  };
+
+  return {
+    labels,
+    ingress: ingressFor(desired.exposure),
+    template: {
+      labels: { ...labels, 'spindrift-deploy': desired.deploy },
+      containers: [
+        {
+          image: context.image,
+          ports: [{ containerPort: CONTAINER_PORT }],
+          env: environment(desired.config, context.project),
+          ...(resourceLimits(desired) === null
+            ? {}
+            : { resources: { limits: resourceLimits(desired) } }),
+        },
+      ],
+    },
+  };
+}
+
+/**
+ * Config as the runtime reads it (§10).
+ *
+ * **Per key, never per blob**, and every entry is a pinned *reference* rather
+ * than a value: core has never read one, so there is nothing here it could
+ * inline even if the shape allowed it. The runtime resolves each reference at
+ * revision start from the same store of record core wrote to, over its own
+ * access path — which is why no credential appears in this document.
+ */
+function environment(
+  config: readonly ConfigEntry[],
+  project: string,
+): readonly Record<string, unknown>[] {
+  return config.map((entry) => ({
+    name: entry.name,
+    valueSource: {
+      secretKeyRef: {
+        secret: `projects/${project}/secrets/${entry.secret.key}`,
+        version: entry.secret.version,
+      },
+    },
+  }));
+}
+
+/**
+ * What the revision asks for, or `null` when it asks for nothing.
+ *
+ * Absent rather than defaulted: the runtime has its own defaults, and a value
+ * invented here would be core quietly deciding a workload's size — which is the
+ * scheduler §3 says placement is not.
+ */
+function resourceLimits(desired: DesiredState): Record<string, string> | null {
+  const limits: Record<string, string> = {};
+  if (desired.requirements.resources.cpu !== undefined) {
+    limits.cpu = desired.requirements.resources.cpu;
+  }
+  if (desired.requirements.resources.memory !== undefined) {
+    limits.memory = desired.requirements.resources.memory;
+  }
+  return Object.keys(limits).length === 0 ? null : limits;
+}
+
+/**
+ * The IAM policy that matches one exposure state.
+ *
+ * A whole policy rather than a binding to add, because the verb this is handed
+ * to replaces what is there: §9's "transitions fail closed" needs the *removal*
+ * of public reach to be as expressible as the grant, and a client that could
+ * only add would leave a tightened Component reachable by the binding nobody
+ * took away.
+ */
+export function invokerPolicy(exposure: Exposure): Record<string, unknown> {
+  return {
+    policy: {
+      bindings: allowsUnauthenticated(exposure)
+        ? [{ role: 'roles/run.invoker', members: ['allUsers'] }]
+        : [],
+    },
+  };
+}
+
+/** One Service per (App, Component), so a re-deploy is a new revision. */
+export function serviceId(desired: DesiredState): string {
+  // The runtime caps a service id at 63 characters, the same ceiling a
+  // Kubernetes name has, so the two adapters truncate identically rather than
+  // each inventing a limit.
+  return `${desired.app}-${desired.component}`.slice(0, 63);
+}

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -20,6 +20,7 @@ import type {
   DesiredState,
   Exposure,
 } from '../../../domain/desired-state.ts';
+import { workloadName } from '../../../domain/workload-name.ts';
 
 /** The ingress settings the runtime accepts, in its own vocabulary. */
 export const INGRESS = {
@@ -82,6 +83,7 @@ export function cloudRunService(
   desired: DesiredState,
   context: CloudRunRenderContext,
 ): Record<string, unknown> {
+  const limits = resourceLimits(desired);
   const labels = {
     'spindrift-managed': 'true',
     'spindrift-app': desired.app,
@@ -98,9 +100,7 @@ export function cloudRunService(
           image: context.image,
           ports: [{ containerPort: CONTAINER_PORT }],
           env: environment(desired.config, context.project),
-          ...(resourceLimits(desired) === null
-            ? {}
-            : { resources: { limits: resourceLimits(desired) } }),
+          ...(limits === null ? {} : { resources: { limits } }),
         },
       ],
     },
@@ -157,6 +157,14 @@ function resourceLimits(desired: DesiredState): Record<string, string> | null {
  * of public reach to be as expressible as the grant, and a client that could
  * only add would leave a tightened Component reachable by the binding nobody
  * took away.
+ *
+ * **A named gap, in the direction that fails closed.** §9 gives `Private` "one
+ * admin-configured Private audience per Target", and no Target carries one yet
+ * — so a `private` Component gets an empty binding list, which is invokable by
+ * nobody rather than by an audience. It is reachable at its address and
+ * refuses everyone, which is wrong in the safe direction; the plan already
+ * treats the authenticated edge as the largest non-Spindrift dependency (Risk
+ * 2), and the audience belongs with it rather than being invented here.
  */
 export function invokerPolicy(exposure: Exposure): Record<string, unknown> {
   return {
@@ -168,10 +176,13 @@ export function invokerPolicy(exposure: Exposure): Record<string, unknown> {
   };
 }
 
+/**
+ * The longest name the runtime accepts for a Service — the same ceiling a
+ * Kubernetes object name has, which is why both go through one helper.
+ */
+const SERVICE_ID_LIMIT = 63;
+
 /** One Service per (App, Component), so a re-deploy is a new revision. */
 export function serviceId(desired: DesiredState): string {
-  // The runtime caps a service id at 63 characters, the same ceiling a
-  // Kubernetes name has, so the two adapters truncate identically rather than
-  // each inventing a limit.
-  return `${desired.app}-${desired.component}`.slice(0, 63);
+  return workloadName(desired, SERVICE_ID_LIMIT);
 }

--- a/apps/spindrift/src/adapters/deploy/cloudrun/status.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/status.ts
@@ -1,0 +1,150 @@
+/**
+ * What a Cloud Run Service says, in §6's vocabulary rather than its own.
+ *
+ * §6 gives the user **one shared vocabulary** along one timeline, so the
+ * runtime's condition states and reason enums never reach core. This is the
+ * translation, and it is a pure function over the document for the same reason
+ * the Kubernetes flavours' translations are: the interesting cases are the ones
+ * where the platform is precise about *why*, and a test should be able to hand
+ * them over one at a time.
+ *
+ * **Status comes from the revision, not from the apply.** A Service accepted by
+ * the API has not started anything: `terminalCondition` is what turns pending
+ * into a verdict, which is why §6's phases come from the platform and never from
+ * core's idea of readiness.
+ */
+import type { DeployPhase, FailureReason } from '../contract.ts';
+
+/** The Service fields this adapter reads. Everything else is left alone. */
+export interface CloudRunService {
+  readonly uri?: string;
+  readonly terminalCondition?: CloudRunCondition;
+  readonly conditions?: readonly CloudRunCondition[];
+  readonly template?: {
+    readonly containers?: readonly { readonly image?: string }[];
+  };
+}
+
+/** One condition, as much of it as this adapter reads. */
+export interface CloudRunCondition {
+  readonly type?: string;
+  readonly state?: string;
+  readonly message?: string;
+  readonly reason?: string;
+  readonly revisionReason?: string;
+  readonly executionReason?: string;
+}
+
+/** The translated verdict, in the shape core reads. */
+export interface CloudRunStatus {
+  phase: DeployPhase;
+  reason?: FailureReason;
+  detail?: string;
+  debug?: unknown;
+}
+
+/**
+ * Reasons the runtime gives, mapped to §6's closed set.
+ *
+ * The group that matters most is the first: every one of them is the artifact
+ * being unpullable, which §6 blames on the **platform**. That is the case §6
+ * singles out — "the build is green and every instinct wrongly says *look at my
+ * app*" — and it is the whole reason this table is written out rather than
+ * collapsed into a default.
+ */
+const REASONS: Readonly<Record<string, FailureReason>> = {
+  CONTAINER_MISSING: 'ARTIFACT_UNAVAILABLE',
+  CONTAINER_IMAGE_UNAUTHORIZED: 'ARTIFACT_UNAVAILABLE',
+  CONTAINER_IMAGE_AUTHORIZATION_CHECK_FAILED: 'ARTIFACT_UNAVAILABLE',
+  CONTAINER_PERMISSION_DENIED: 'ARTIFACT_UNAVAILABLE',
+
+  PROGRESS_DEADLINE_EXCEEDED: 'TIMEOUT',
+
+  HEALTH_CHECK_CONTAINER_ERROR: 'UNHEALTHY',
+
+  // Admission-shaped refusals: an org policy, a key the project may not use, a
+  // limit already reached. §6 puts all of them under one reason, and blames the
+  // developer, because every one of them is answered by changing the request.
+  ENCRYPTION_KEY_PERMISSION_DENIED: 'REJECTED',
+  ACTIVE_REVISION_LIMIT_REACHED: 'REJECTED',
+  MIN_INSTANCES_NOT_PROVISIONED: 'REJECTED',
+};
+
+/**
+ * The state values a terminal condition can hold.
+ *
+ * `CONDITION_RECONCILING` and `CONDITION_PENDING` are both "still going"; the
+ * runtime distinguishes them and core does not, because §6's `WAITING` covers
+ * exactly the period in which neither answer has arrived.
+ */
+const SUCCEEDED = 'CONDITION_SUCCEEDED';
+const FAILED = 'CONDITION_FAILED';
+
+/** Translate one Service document into §6's phase and reason. */
+export function cloudRunStatus(service: CloudRunService): CloudRunStatus {
+  const terminal = service.terminalCondition;
+  if (terminal === undefined) {
+    // Applied, and the runtime has not yet said anything about it.
+    return { phase: 'WAITING' };
+  }
+
+  if (terminal.state === SUCCEEDED) return { phase: 'LIVE' };
+
+  if (terminal.state !== FAILED) {
+    return {
+      phase: 'WAITING',
+      ...(terminal.message === undefined ? {} : { detail: terminal.message }),
+    };
+  }
+
+  // The runtime reports a failure in up to three places and only some of them
+  // are set for any one failure, so all three are consulted in the order that
+  // puts the most specific first. A reason nobody set leaves `reason` unmapped,
+  // which is handled below rather than guessed at here.
+  const stated =
+    terminal.revisionReason ?? terminal.executionReason ?? terminal.reason;
+  const mapped = stated === undefined ? undefined : REASONS[stated];
+  const failing = failingCondition(service);
+
+  return {
+    phase: 'FAILED',
+    // §6's Covers column puts "revision will not start" under `STARTUP_FAILED`,
+    // which is what an unrecognised failure of a revision is: the runtime said
+    // the rollout failed, and the least wrong thing to tell a developer is that
+    // their revision did not come up.
+    reason: mapped ?? 'STARTUP_FAILED',
+    detail:
+      terminal.message ??
+      failing?.message ??
+      (stated === undefined
+        ? 'the runtime reported the rollout failed and gave no reason'
+        : `the runtime reported ${stated}`),
+    debug: {
+      terminalCondition: terminal,
+      ...(failing === undefined ? {} : { condition: failing }),
+    },
+  };
+}
+
+/** The first non-terminal condition that is itself failing, for its message. */
+function failingCondition(
+  service: CloudRunService,
+): CloudRunCondition | undefined {
+  return (service.conditions ?? []).find(
+    (condition) => condition.state === FAILED,
+  );
+}
+
+/**
+ * The digest actually serving, as the Service still carries it.
+ *
+ * Read off the template's image rather than off the latest ready revision,
+ * because the template is what core wrote and what drift is measured against.
+ * An image with no digest yields an empty string, which compares unequal to
+ * every desired digest — drift is surfaced rather than assumed away (§6).
+ */
+export function servingDigest(service: CloudRunService): string {
+  const image = service.template?.containers?.[0]?.image ?? '';
+  const at = image.lastIndexOf('@');
+  return at === -1 ? '' : image.slice(at + 1);
+}

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -27,8 +27,9 @@ import type {
 } from '../../../config/manifest.schema.ts';
 import {
   type PolicyEngineState,
-  PREREQUISITES,
+  type Prerequisite,
   type PrerequisiteResult,
+  prerequisitesFor,
   type TargetDiscovery,
   type TargetInspection,
 } from '../../../domain/capabilities.ts';
@@ -371,11 +372,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
   ): Promise<readonly PrerequisiteResult[]> {
     const delivery = connection.delivery;
     const results = new Map<string, PrerequisiteResult>();
-    const set = (
-      name: (typeof PREREQUISITES)[number],
-      met: boolean,
-      detail?: string,
-    ): void => {
+    const set = (name: Prerequisite, met: boolean, detail?: string): void => {
       results.set(name, met ? { name, met } : { name, met: false, detail });
     };
 
@@ -425,7 +422,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       `the App chart at this Target declares value contract ${pinned}; this Spindrift renders ${VALUES_CONTRACT}`,
     );
 
-    return PREREQUISITES.map(
+    return prerequisitesFor(this.adapter).map(
       (name) =>
         results.get(name) ?? {
           name,

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -41,6 +41,7 @@ import type {
   KubernetesConnection,
   KubernetesDelivery,
 } from '../../../domain/target.ts';
+import { workloadName } from '../../../domain/workload-name.ts';
 import type {
   DeployAdapter,
   DeployEvent,
@@ -723,9 +724,12 @@ function appliedDigest(flavour: Flavour, object: KubernetesObject): string {
   return app?.artifactDigest ?? '';
 }
 
+/** The longest name an object may carry, which every adapter shortens to. */
+const RELEASE_NAME_LIMIT = 63;
+
 /** One release per (Component, Target), so a re-deploy is an upgrade. */
 function releaseName(desired: DesiredState): string {
-  return `${desired.app}-${desired.component}`.slice(0, 63);
+  return workloadName(desired, RELEASE_NAME_LIMIT);
 }
 
 function resourceLabel(object: KubernetesObject): string {

--- a/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
@@ -13,7 +13,10 @@
  * as a portable mechanism: Flux merges `valuesFrom` and then overwrites it
  * inline, and Argo has no equivalent at all.
  */
-import type { DesiredState } from '../../../domain/desired-state.ts';
+import {
+  artifactAddress,
+  type DesiredState,
+} from '../../../domain/desired-state.ts';
 import type { KubernetesConnection } from '../../../domain/target.ts';
 
 /**
@@ -140,8 +143,7 @@ export function configSecretName(desired: DesiredState): string {
  * `INTERNAL` rather than rendering a release that cannot pull.
  */
 export function imageReference(desired: DesiredState): string | null {
-  const [reference] = desired.artifact.refs;
-  return reference ?? null;
+  return artifactAddress(desired.artifact);
 }
 
 /**

--- a/apps/spindrift/src/adapters/deploy/static/bundle.ts
+++ b/apps/spindrift/src/adapters/deploy/static/bundle.ts
@@ -1,0 +1,222 @@
+/**
+ * Reading a `files` artifact back into the files it holds.
+ *
+ * §6's artifact is a digest and the addresses it can be pulled by, and for the
+ * `files` shape what is at those addresses is **a gzipped tar**. That is not a
+ * choice made here — `adapters/build/buildkit.ts` fetches a staged bundle with
+ * `tar -xz`, so it is already the one format every route agrees on, and this is
+ * the same format read from the other end.
+ *
+ * It is hand-written rather than a dependency, and the reason is §20: the
+ * extraction contract wants a package that prunes to something self-contained,
+ * and a tar reader is ninety lines of a format that has not changed since 1988.
+ * What it deliberately does **not** do is anything a tar can do that a website
+ * cannot contain — devices, hard links, symlinks — because a static host serves
+ * bytes at paths and has no representation for any of them.
+ *
+ * **The bundle is untrusted input.** It arrives from a builder or from whoever
+ * uploaded an archive, so {@link readBundle} refuses a path that escapes the
+ * root rather than trusting that no `../` appears in one. A deploy that wrote
+ * outside its own site would be the only path in this system by which one App
+ * could reach another's.
+ */
+
+/** One file the bundle holds, at the path it will be served from. */
+export interface BundleFile {
+  /** Rooted at the site, with a leading slash — the shape hosting wants. */
+  readonly path: string;
+  /**
+   * Its contents, in a buffer this runtime's compression accepts.
+   *
+   * The explicit `ArrayBuffer` parameter is not decoration: a `Uint8Array` may
+   * be backed by shared memory, which cannot be compressed in place, and the
+   * type is what keeps a caller from discovering that at run time.
+   */
+  readonly bytes: Uint8Array<ArrayBuffer>;
+}
+
+/** Why a bundle could not be read. A closed set, so a caller can say which. */
+export type BundleErrorCode =
+  | 'NOT_GZIP'
+  | 'MALFORMED_TAR'
+  | 'PATH_ESCAPES_BUNDLE';
+
+export class BundleError extends Error {
+  constructor(
+    readonly code: BundleErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'BundleError';
+  }
+}
+
+/** Tar's fixed block size, which every field offset below is relative to. */
+const BLOCK = 512;
+
+/** Header field offsets, as the format defines them. */
+const NAME = { at: 0, length: 100 };
+const SIZE = { at: 124, length: 12 };
+const TYPE_FLAG = 156;
+const PREFIX = { at: 345, length: 155 };
+
+/**
+ * The type flags this reader understands.
+ *
+ * `\0` and `0` are both a regular file — the first is the original format, the
+ * second is ustar, and archives in the wild carry both. `L` and `x` are the two
+ * ways a long path arrives: GNU's own extension, and the pax record that
+ * replaced it. Everything else is skipped with its data, which is what makes an
+ * archive containing a symlink deploy the files around it rather than fail.
+ */
+const REGULAR = new Set(['\0', '0']);
+const DIRECTORY = '5';
+const GNU_LONG_NAME = 'L';
+const PAX_HEADER = 'x';
+
+/**
+ * Read a gzipped tar into its files.
+ *
+ * Directories are dropped rather than represented: hosting has no directories,
+ * only paths, and a bundle's empty directory has nothing to serve.
+ */
+export function readBundle(
+  gzipped: Uint8Array<ArrayBuffer>,
+): readonly BundleFile[] {
+  let tar: Uint8Array;
+  try {
+    tar = Bun.gunzipSync(gzipped);
+  } catch (cause) {
+    throw new BundleError(
+      'NOT_GZIP',
+      `the artifact is not a gzipped tar: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+  }
+
+  const files: BundleFile[] = [];
+  /** Set by a long-name header, consumed by the entry that follows it. */
+  let pendingName: string | null = null;
+  let offset = 0;
+
+  while (offset + BLOCK <= tar.length) {
+    const header = tar.subarray(offset, offset + BLOCK);
+    // Two consecutive zero blocks end an archive; one is enough to stop on,
+    // because nothing valid follows a header with no name.
+    if (header.every((byte) => byte === 0)) break;
+
+    const size = octal(header, SIZE);
+    const flag = String.fromCharCode(header[TYPE_FLAG] ?? 0);
+    const dataAt = offset + BLOCK;
+    if (dataAt + size > tar.length) {
+      throw new BundleError(
+        'MALFORMED_TAR',
+        'the archive ends inside an entry it declared',
+      );
+    }
+    const data = tar.subarray(dataAt, dataAt + size);
+    // Entries are padded up to the next block boundary.
+    offset = dataAt + Math.ceil(size / BLOCK) * BLOCK;
+
+    if (flag === GNU_LONG_NAME) {
+      pendingName = trimNul(new TextDecoder().decode(data));
+      continue;
+    }
+    if (flag === PAX_HEADER) {
+      pendingName = paxPath(data) ?? pendingName;
+      continue;
+    }
+
+    const name = pendingName ?? joinedName(header);
+    pendingName = null;
+    if (flag === DIRECTORY || name === '' || name.endsWith('/')) continue;
+    if (!REGULAR.has(flag)) continue;
+
+    files.push({ path: servePath(name), bytes: Uint8Array.from(data) });
+  }
+
+  return files;
+}
+
+/**
+ * A bundle path as the path it is served at.
+ *
+ * Three normalizations, in order: the leading `./` every archiver writes is
+ * dropped, the result is checked for anything that would leave the bundle, and
+ * a leading slash is added because that is the form hosting addresses files by.
+ */
+function servePath(name: string): string {
+  const cleaned = name.replace(/^\.\//, '').replace(/^\/+/, '');
+  const segments = cleaned.split('/');
+  if (segments.some((segment) => segment === '..')) {
+    throw new BundleError(
+      'PATH_ESCAPES_BUNDLE',
+      `the archive contains ${name}, which points outside itself`,
+    );
+  }
+  return `/${segments.filter((segment) => segment !== '.').join('/')}`;
+}
+
+/** `prefix` and `name`, which is how ustar carries a path over 100 bytes. */
+function joinedName(header: Uint8Array): string {
+  const name = text(header, NAME);
+  const prefix = text(header, PREFIX);
+  return prefix === '' ? name : `${prefix}/${name}`;
+}
+
+/**
+ * The `path` record of a pax extended header.
+ *
+ * Records are `<length> <key>=<value>\n`, and the length counts itself — which
+ * is why this reads keys rather than splitting on newlines: a value is allowed
+ * to contain one.
+ */
+function paxPath(data: Uint8Array): string | null {
+  const text = new TextDecoder().decode(data);
+  let at = 0;
+  while (at < text.length) {
+    const space = text.indexOf(' ', at);
+    if (space === -1) return null;
+    const length = Number(text.slice(at, space));
+    if (!Number.isFinite(length) || length <= 0) return null;
+    const record = text.slice(space + 1, at + length).replace(/\n$/, '');
+    const equals = record.indexOf('=');
+    if (equals !== -1 && record.slice(0, equals) === 'path') {
+      return record.slice(equals + 1);
+    }
+    at += length;
+  }
+  return null;
+}
+
+/** A NUL-terminated ASCII field. */
+function text(
+  header: Uint8Array,
+  field: { at: number; length: number },
+): string {
+  return trimNul(
+    new TextDecoder().decode(
+      header.subarray(field.at, field.at + field.length),
+    ),
+  );
+}
+
+/** A NUL- or space-padded octal field, which is how tar writes every number. */
+function octal(
+  header: Uint8Array,
+  field: { at: number; length: number },
+): number {
+  const raw = text(header, field).trim();
+  if (raw === '') return 0;
+  const value = Number.parseInt(raw, 8);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new BundleError('MALFORMED_TAR', `unreadable numeric field: ${raw}`);
+  }
+  return value;
+}
+
+function trimNul(value: string): string {
+  const end = value.indexOf('\0');
+  return end === -1 ? value : value.slice(0, end);
+}

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -28,11 +28,9 @@ import type {
   StoreAdapter,
   TargetAdapter,
 } from '../../../config/manifest.schema.ts';
-import {
-  type PrerequisiteResult,
-  prerequisitesFor,
-  type TargetDiscovery,
-  type TargetInspection,
+import type {
+  TargetDiscovery,
+  TargetInspection,
 } from '../../../domain/capabilities.ts';
 import {
   type ArtifactType,
@@ -40,13 +38,14 @@ import {
   type DesiredState,
 } from '../../../domain/desired-state.ts';
 import type { StaticConnection } from '../../../domain/target.ts';
+import { workloadName } from '../../../domain/workload-name.ts';
 import { cloudChecklist } from '../cloud/checklist.ts';
+import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
 import {
-  CloudHttp,
-  type CloudResponse,
-  type Fetcher,
-  type TokenProvider,
-} from '../cloud/http.ts';
+  type CloudFailure,
+  cloudWriteFailure,
+  orderedChecklist,
+} from '../cloud/verdict.ts';
 import type {
   DeployAdapter,
   DeployEvent,
@@ -71,18 +70,13 @@ export interface StaticAdapterOptions {
 const SERVICE_NAME = 'static hosting';
 
 /** The API version every call below hangs off. */
-const V = '/v1beta1';
+const API_VERSION = '/v1beta1';
 
 /** The label a version carries so `observe` can report what is serving. */
 const DIGEST_LABEL = 'spindrift-digest';
 const DEPLOY_LABEL = 'spindrift-deploy';
 
-/**
- * A site id is capped well below a DNS label, so a long App plus a long
- * Component has to be shortened — and shortened *deterministically*, because a
- * second deploy that produced a different id would create a second site rather
- * than release to the first.
- */
+/** A site id is capped well below a DNS label. See `domain/workload-name.ts`. */
 const SITE_ID_LIMIT = 30;
 
 /** What a version looks like coming back, as much as this adapter reads. */
@@ -164,14 +158,14 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const created = await this.ensureSite(http, connection, site);
     if (created.ok === false) {
-      const failure = writeFailure(created.failure, ref);
+      const failure = cloudWriteFailure(created.failure, ref);
       yield this.status('FAILED', { resource: site, reason: failure.reason });
       return failure;
     }
 
     const released = await this.release(http, site, desired, files);
     if (released.ok === false) {
-      const failure = writeFailure(released.failure, ref);
+      const failure = cloudWriteFailure(released.failure, ref);
       yield this.status('FAILED', { resource: site, reason: failure.reason });
       return failure;
     }
@@ -187,7 +181,7 @@ export class StaticDeployAdapter implements DeployAdapter {
         desired.hostname.vanity,
       );
       if (attached.ok === false) {
-        const failure = writeFailure(attached.failure, ref);
+        const failure = cloudWriteFailure(attached.failure, ref);
         yield this.status('FAILED', { resource: site, reason: failure.reason });
         return failure;
       }
@@ -230,7 +224,7 @@ export class StaticDeployAdapter implements DeployAdapter {
       releases?: readonly HostingRelease[];
     }>({
       method: 'GET',
-      path: `${V}/sites/${encodeURIComponent(site)}/releases`,
+      path: `${API_VERSION}/sites/${encodeURIComponent(site)}/releases`,
       query: { pageSize: '1' },
     });
     if (!releases.ok) return null;
@@ -253,7 +247,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const deleted = await this.http(connection).json<unknown>({
       method: 'DELETE',
-      path: `${V}/sites/${encodeURIComponent(site)}`,
+      path: `${API_VERSION}/sites/${encodeURIComponent(site)}`,
     });
     if (deleted.ok) return;
     if (deleted.kind === 'status' && deleted.status === 404) return;
@@ -273,12 +267,12 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const probe = await this.http(connection).json<unknown>({
       method: 'GET',
-      path: `${V}/projects/${encodeURIComponent(connection.project)}/sites`,
+      path: `${API_VERSION}/projects/${encodeURIComponent(connection.project)}/sites`,
       query: { pageSize: '1' },
     });
 
     return {
-      prerequisites: order(
+      prerequisites: orderedChecklist(
         cloudChecklist(probe, {
           project: connection.project,
           service: SERVICE_NAME,
@@ -318,7 +312,7 @@ export class StaticDeployAdapter implements DeployAdapter {
   ): Promise<Outcome<HostingSite>> {
     const read = await http.json<HostingSite>({
       method: 'GET',
-      path: `${V}/sites/${encodeURIComponent(site)}`,
+      path: `${API_VERSION}/sites/${encodeURIComponent(site)}`,
     });
     if (read.ok && read.value !== undefined) {
       return { ok: true, value: read.value };
@@ -329,7 +323,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const created = await http.json<HostingSite>({
       method: 'POST',
-      path: `${V}/projects/${encodeURIComponent(connection.project)}/sites`,
+      path: `${API_VERSION}/projects/${encodeURIComponent(connection.project)}/sites`,
       query: { siteId: site },
       body: {},
     });
@@ -361,7 +355,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const version = await http.json<HostingVersion>({
       method: 'POST',
-      path: `${V}/sites/${encodeURIComponent(site)}/versions`,
+      path: `${API_VERSION}/sites/${encodeURIComponent(site)}/versions`,
       body: {
         labels: {
           [DIGEST_LABEL]: desired.artifact.digest,
@@ -377,7 +371,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const populated = await http.json<PopulateResult>({
       method: 'POST',
-      path: `${V}/${name}:populateFiles`,
+      path: `${API_VERSION}/${name}:populateFiles`,
       body: {
         files: Object.fromEntries(
           [...compressed].map(([path, file]) => [path, file.hash]),
@@ -408,7 +402,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const finalized = await http.json<HostingVersion>({
       method: 'PATCH',
-      path: `${V}/${name}`,
+      path: `${API_VERSION}/${name}`,
       query: { updateMask: 'status' },
       body: { status: 'FINALIZED' },
     });
@@ -416,7 +410,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
     const released = await http.json<HostingRelease>({
       method: 'POST',
-      path: `${V}/sites/${encodeURIComponent(site)}/releases`,
+      path: `${API_VERSION}/sites/${encodeURIComponent(site)}/releases`,
       query: { versionName: name },
       body: {},
     });
@@ -432,7 +426,7 @@ export class StaticDeployAdapter implements DeployAdapter {
   ): Promise<Outcome<void>> {
     const attached = await http.json<unknown>({
       method: 'POST',
-      path: `${V}/sites/${encodeURIComponent(site)}/domains`,
+      path: `${API_VERSION}/sites/${encodeURIComponent(site)}/domains`,
       body: { site, domainName: domain },
     });
     if (attached.ok) return { ok: true, value: undefined };
@@ -528,29 +522,17 @@ type Outcome<Value> =
   | { readonly ok: true; readonly value: Value }
   | {
       readonly ok: false;
-      readonly failure: Extract<CloudResponse<unknown>, { ok: false }>;
+      readonly failure: CloudFailure;
     };
 
 /** A far side that answered successfully and left out what was asked for. */
-function missing(
-  message: string,
-): Extract<CloudResponse<unknown>, { ok: false }> {
+function missing(message: string): CloudFailure {
   return { ok: false, kind: 'transport', message };
 }
 
-/**
- * One site per (App, Component), shortened deterministically when it must be.
- *
- * A site id is capped at thirty characters, which two ordinary names exceed
- * easily. Truncating alone would make two Components of one App collide on a
- * site — the worse failure, since the second deploy would silently replace the
- * first — so the tail carries a digest of the full name, which cannot.
- */
+/** One site per (App, Component), within the length the product allows. */
 export function siteId(desired: DesiredState): string {
-  const full = `${desired.app}-${desired.component}`;
-  if (full.length <= SITE_ID_LIMIT) return full;
-  const hash = new Bun.CryptoHasher('sha256').update(full).digest('hex');
-  return `${full.slice(0, SITE_ID_LIMIT - 8)}-${hash.slice(0, 7)}`;
+  return workloadName(desired, SITE_ID_LIMIT);
 }
 
 /** The adapter's own handle on what `apply` placed — opaque to core (§6). */
@@ -603,39 +585,4 @@ function bundleFailure(
     reason: 'INTERNAL',
     detail: cause instanceof Error ? cause.message : String(cause),
   };
-}
-
-/** A call that never landed, in §6's vocabulary. */
-function writeFailure(
-  failure: Extract<CloudResponse<unknown>, { ok: false }>,
-  ref: DeployRef,
-): Extract<DeployVerdict, { phase: 'FAILED' }> {
-  if (failure.kind === 'transport') {
-    return {
-      phase: 'FAILED',
-      ref,
-      reason: 'TARGET_UNREACHABLE',
-      detail: failure.message,
-    };
-  }
-  const rejected = failure.status >= 400 && failure.status < 500;
-  const authFailure = failure.status === 401 || failure.status === 403;
-  return {
-    phase: 'FAILED',
-    ref,
-    reason: rejected && !authFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
-    detail: failure.message,
-    debug: { status: failure.status, reason: failure.reason },
-  };
-}
-
-/** The checklist in its adapter's declared order, so the UI never reorders it. */
-function order(
-  results: readonly PrerequisiteResult[],
-  adapter: TargetAdapter,
-): readonly PrerequisiteResult[] {
-  const found = new Map(results.map((result) => [result.name, result]));
-  return prerequisitesFor(adapter).map(
-    (name) => found.get(name) ?? { name, met: false, detail: 'not assessed' },
-  );
 }

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -1,0 +1,641 @@
+/**
+ * The static-hosting deploy adapter (§6, §9).
+ *
+ * Accepts `files`, talks to the hosting product's API directly, and reads status
+ * from the release the API returns. There is no rollout to watch: a release is
+ * atomic and synchronous, so §6's `WAITING` phase is a state this backend never
+ * occupies — which is the honest reason this adapter does not poll, rather than
+ * a corner cut.
+ *
+ * **`Public` only** (§9). "No non-public mode may have a bypassable origin. A
+ * rendering that leaves an unauthenticated alternate origin is **disqualified
+ * rather than shipped with a caveat** — which is why the static hosting product
+ * serves `Public` only, and why a Private website takes the server-image
+ * rendering." The origin here is the site's own address, which the product will
+ * always answer on; no authenticated edge can be put in front of it that the
+ * origin does not bypass. So a non-public exposure reaching `apply` is refused,
+ * and refused as `INTERNAL` rather than `REJECTED`: placement excludes this
+ * Target for a non-public Component (`onlyPublic` in `domain/placement.ts`), so
+ * one arriving here is core's bug and not a developer's.
+ *
+ * **The site names itself** (§9). The product mints the address, so the
+ * canonical name comes back across this seam on the verdict rather than being
+ * handed in — and the vanity name is added to the same site as a domain, which
+ * is what makes "moving an App between backends is one record re-point" true
+ * for this backend.
+ */
+import type {
+  StoreAdapter,
+  TargetAdapter,
+} from '../../../config/manifest.schema.ts';
+import {
+  type PrerequisiteResult,
+  prerequisitesFor,
+  type TargetDiscovery,
+  type TargetInspection,
+} from '../../../domain/capabilities.ts';
+import {
+  type ArtifactType,
+  artifactAddress,
+  type DesiredState,
+} from '../../../domain/desired-state.ts';
+import type { StaticConnection } from '../../../domain/target.ts';
+import { cloudChecklist } from '../cloud/checklist.ts';
+import {
+  CloudHttp,
+  type CloudResponse,
+  type Fetcher,
+  type TokenProvider,
+} from '../cloud/http.ts';
+import type {
+  DeployAdapter,
+  DeployEvent,
+  DeployPhase,
+  DeployRef,
+  DeployTarget,
+  DeployVerdict,
+  FailureReason,
+  ObservedState,
+} from '../contract.ts';
+import { BundleError, type BundleFile, readBundle } from './bundle.ts';
+
+export interface StaticAdapterOptions {
+  /** Mints a bearer token per request. Never a stored credential (§13). */
+  readonly token: TokenProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+  readonly now?: () => number;
+}
+
+/** How the operator would name the product in the sentence about enabling it. */
+const SERVICE_NAME = 'static hosting';
+
+/** The API version every call below hangs off. */
+const V = '/v1beta1';
+
+/** The label a version carries so `observe` can report what is serving. */
+const DIGEST_LABEL = 'spindrift-digest';
+const DEPLOY_LABEL = 'spindrift-deploy';
+
+/**
+ * A site id is capped well below a DNS label, so a long App plus a long
+ * Component has to be shortened — and shortened *deterministically*, because a
+ * second deploy that produced a different id would create a second site rather
+ * than release to the first.
+ */
+const SITE_ID_LIMIT = 30;
+
+/** What a version looks like coming back, as much as this adapter reads. */
+interface HostingVersion {
+  readonly name?: string;
+  readonly status?: string;
+  readonly labels?: Readonly<Record<string, string>>;
+}
+
+/** What `populateFiles` answers: which of the offered hashes it wants. */
+interface PopulateResult {
+  readonly uploadRequiredHashes?: readonly string[];
+  readonly uploadUrl?: string;
+}
+
+/** One release, as much of it as this adapter reads. */
+interface HostingRelease {
+  readonly name?: string;
+  readonly version?: HostingVersion;
+}
+
+/** One site, as much of it as this adapter reads. */
+interface HostingSite {
+  readonly name?: string;
+  readonly defaultUrl?: string;
+}
+
+export class StaticDeployAdapter implements DeployAdapter {
+  readonly adapter: TargetAdapter = 'static';
+  /** §6's table: `static` takes files. */
+  readonly artifactTypes: readonly ArtifactType[] = ['files'];
+
+  constructor(private readonly options: StaticAdapterOptions) {}
+
+  async *apply(
+    target: DeployTarget,
+    desired: DesiredState,
+  ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      return this.internal('this Target is not a static hosting Target');
+    }
+    if (!this.artifactTypes.includes(desired.artifact.type)) {
+      yield this.status('FAILED', { reason: 'INTERNAL' });
+      return this.internal(
+        `static hosting does not accept a ${desired.artifact.type} artifact`,
+      );
+    }
+    if (desired.exposure !== 'public') {
+      // §9, and see the file header: this backend has no non-bypassable origin
+      // to put a boundary in front of, so the rendering is disqualified rather
+      // than shipped with a caveat.
+      yield this.status('FAILED', { reason: 'INTERNAL' });
+      return this.internal(
+        `static hosting serves Public only, and this Component is ${desired.exposure} (§9)`,
+      );
+    }
+    const location = artifactAddress(desired.artifact);
+    if (location === null) {
+      yield this.status('FAILED', { reason: 'INTERNAL' });
+      return this.internal('the artifact carries no address to fetch it from');
+    }
+
+    const site = siteId(desired);
+    const ref = refOf(connection, site);
+    const http = this.http(connection);
+
+    yield this.status('APPLYING', { resource: site });
+
+    let files: readonly BundleFile[];
+    try {
+      files = await this.fetchBundle(http, location);
+    } catch (cause) {
+      const failure = bundleFailure(cause, ref);
+      yield this.status('FAILED', { resource: site, reason: failure.reason });
+      return failure;
+    }
+    yield this.log(`the bundle holds ${files.length} files`, site);
+
+    const created = await this.ensureSite(http, connection, site);
+    if (created.ok === false) {
+      const failure = writeFailure(created.failure, ref);
+      yield this.status('FAILED', { resource: site, reason: failure.reason });
+      return failure;
+    }
+
+    const released = await this.release(http, site, desired, files);
+    if (released.ok === false) {
+      const failure = writeFailure(released.failure, ref);
+      yield this.status('FAILED', { resource: site, reason: failure.reason });
+      return failure;
+    }
+    yield this.log(`released ${released.value}`, site);
+
+    // §9's one record re-point, made real for this backend: the vanity name is
+    // a domain on the site that is already serving, so moving an App here from
+    // another backend moves one name rather than rebuilding a leg.
+    if (desired.hostname.vanity !== undefined) {
+      const attached = await this.attachDomain(
+        http,
+        site,
+        desired.hostname.vanity,
+      );
+      if (attached.ok === false) {
+        const failure = writeFailure(attached.failure, ref);
+        yield this.status('FAILED', { resource: site, reason: failure.reason });
+        return failure;
+      }
+      yield this.log(
+        `the vanity name ${desired.hostname.vanity} is on this site`,
+        site,
+      );
+    }
+
+    const address = created.value.defaultUrl;
+    yield this.status('LIVE', { resource: site });
+    return {
+      phase: 'LIVE',
+      ref,
+      // §9: the platform names its own. A site with no reported address is the
+      // one case core cannot fill in, and saying nothing beats assembling a
+      // name the product did not give.
+      ...(address === undefined ? {} : { url: address }),
+    };
+  }
+
+  /**
+   * What is serving, read from the release rather than from what was written.
+   *
+   * The digest comes off the released version's labels, which is the only place
+   * it can come from: the product stores files and has no notion of an artifact.
+   * A version released by something other than Spindrift therefore reports an
+   * empty digest and shows as drift — which is right, because it is.
+   */
+  async observe(
+    target: DeployTarget,
+    ref: DeployRef,
+  ): Promise<ObservedState | null> {
+    const connection = this.connectionOf(target);
+    if (connection === null) return null;
+    const site = parseRef(connection, ref);
+    if (site === null) return null;
+
+    const releases = await this.http(connection).json<{
+      releases?: readonly HostingRelease[];
+    }>({
+      method: 'GET',
+      path: `${V}/sites/${encodeURIComponent(site)}/releases`,
+      query: { pageSize: '1' },
+    });
+    if (!releases.ok) return null;
+
+    const latest = releases.value?.releases?.[0];
+    if (latest === undefined) return null;
+
+    return {
+      ref,
+      phase: 'LIVE',
+      artifactDigest: latest.version?.labels?.[DIGEST_LABEL] ?? '',
+    };
+  }
+
+  async destroy(target: DeployTarget, ref: DeployRef): Promise<void> {
+    const connection = this.connectionOf(target);
+    if (connection === null) return;
+    const site = parseRef(connection, ref);
+    if (site === null) return;
+
+    const deleted = await this.http(connection).json<unknown>({
+      method: 'DELETE',
+      path: `${V}/sites/${encodeURIComponent(site)}`,
+    });
+    if (deleted.ok) return;
+    if (deleted.kind === 'status' && deleted.status === 404) return;
+    throw new Error(
+      deleted.kind === 'status'
+        ? `deleting site ${site} failed with ${deleted.status}: ${deleted.message}`
+        : `deleting site ${site} failed: ${deleted.message}`,
+    );
+  }
+
+  /** One pass of §13's checklist and §3's discovery, in one call. */
+  async inspect(target: DeployTarget): Promise<TargetInspection> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      throw new Error(`${target.name} is not a static hosting Target`);
+    }
+
+    const probe = await this.http(connection).json<unknown>({
+      method: 'GET',
+      path: `${V}/projects/${encodeURIComponent(connection.project)}/sites`,
+      query: { pageSize: '1' },
+    });
+
+    return {
+      prerequisites: order(
+        cloudChecklist(probe, {
+          project: connection.project,
+          service: SERVICE_NAME,
+          scope: connection.project,
+        }),
+        this.adapter,
+      ),
+      discovery: this.discover(connection),
+    };
+  }
+
+  // --- apply's steps -------------------------------------------------------
+
+  /** Fetch the bundle and read it into files. Throws; `apply` catches. */
+  private async fetchBundle(
+    http: CloudHttp,
+    location: string,
+  ): Promise<readonly BundleFile[]> {
+    const fetched = await http.bytes(location);
+    if (!fetched.ok) {
+      // §6 blames the **platform** for an artifact that cannot be fetched, and
+      // this is exactly that case: the build is green and the bytes are not
+      // there. Raised as a typed error so `apply` maps it to the right reason
+      // rather than to whichever one this branch happened to be near.
+      throw new ArtifactUnavailable(
+        `the artifact at ${location} could not be fetched: ${fetched.message}`,
+      );
+    }
+    return readBundle(fetched.value);
+  }
+
+  /** The site, created if this is the first deploy to it. */
+  private async ensureSite(
+    http: CloudHttp,
+    connection: StaticConnection,
+    site: string,
+  ): Promise<Outcome<HostingSite>> {
+    const read = await http.json<HostingSite>({
+      method: 'GET',
+      path: `${V}/sites/${encodeURIComponent(site)}`,
+    });
+    if (read.ok && read.value !== undefined) {
+      return { ok: true, value: read.value };
+    }
+    if (!read.ok && !(read.kind === 'status' && read.status === 404)) {
+      return { ok: false, failure: read };
+    }
+
+    const created = await http.json<HostingSite>({
+      method: 'POST',
+      path: `${V}/projects/${encodeURIComponent(connection.project)}/sites`,
+      query: { siteId: site },
+      body: {},
+    });
+    if (!created.ok) return { ok: false, failure: created };
+    return { ok: true, value: created.value ?? {} };
+  }
+
+  /**
+   * Version → populate → upload → finalize → release.
+   *
+   * Five calls and no shortcut, because the product's contract is that a
+   * version is immutable once finalized and a release is what makes one serve.
+   * The upload step asks *which* files it does not already hold, which is what
+   * makes a redeploy of an unchanged site cheap — and is also why the hash
+   * offered is over the **gzipped** bytes rather than the file's own: that is
+   * what the product stores and therefore what it deduplicates on.
+   */
+  private async release(
+    http: CloudHttp,
+    site: string,
+    desired: DesiredState,
+    files: readonly BundleFile[],
+  ): Promise<Outcome<string>> {
+    const compressed = new Map<string, { hash: string; bytes: Uint8Array }>();
+    for (const file of files) {
+      const bytes = Bun.gzipSync(file.bytes);
+      compressed.set(file.path, { hash: sha256Hex(bytes), bytes });
+    }
+
+    const version = await http.json<HostingVersion>({
+      method: 'POST',
+      path: `${V}/sites/${encodeURIComponent(site)}/versions`,
+      body: {
+        labels: {
+          [DIGEST_LABEL]: desired.artifact.digest,
+          [DEPLOY_LABEL]: desired.deploy,
+        },
+      },
+    });
+    if (!version.ok) return { ok: false, failure: version };
+    const name = version.value?.name;
+    if (name === undefined) {
+      return { ok: false, failure: missing('the API created no version') };
+    }
+
+    const populated = await http.json<PopulateResult>({
+      method: 'POST',
+      path: `${V}/${name}:populateFiles`,
+      body: {
+        files: Object.fromEntries(
+          [...compressed].map(([path, file]) => [path, file.hash]),
+        ),
+      },
+    });
+    if (!populated.ok) return { ok: false, failure: populated };
+
+    const wanted = new Set(populated.value?.uploadRequiredHashes ?? []);
+    const uploadUrl = populated.value?.uploadUrl;
+    for (const file of compressed.values()) {
+      if (!wanted.has(file.hash)) continue;
+      if (uploadUrl === undefined) {
+        return {
+          ok: false,
+          failure: missing(
+            'the API asked for files and gave nowhere to put them',
+          ),
+        };
+      }
+      const uploaded = await http.upload({
+        url: `${uploadUrl}/${file.hash}`,
+        bytes: file.bytes,
+        contentType: 'application/octet-stream',
+      });
+      if (!uploaded.ok) return { ok: false, failure: uploaded };
+    }
+
+    const finalized = await http.json<HostingVersion>({
+      method: 'PATCH',
+      path: `${V}/${name}`,
+      query: { updateMask: 'status' },
+      body: { status: 'FINALIZED' },
+    });
+    if (!finalized.ok) return { ok: false, failure: finalized };
+
+    const released = await http.json<HostingRelease>({
+      method: 'POST',
+      path: `${V}/sites/${encodeURIComponent(site)}/releases`,
+      query: { versionName: name },
+      body: {},
+    });
+    if (!released.ok) return { ok: false, failure: released };
+    return { ok: true, value: released.value?.name ?? name };
+  }
+
+  /** Put the vanity name on this site (§9). An existing one is not an error. */
+  private async attachDomain(
+    http: CloudHttp,
+    site: string,
+    domain: string,
+  ): Promise<Outcome<void>> {
+    const attached = await http.json<unknown>({
+      method: 'POST',
+      path: `${V}/sites/${encodeURIComponent(site)}/domains`,
+      body: { site, domainName: domain },
+    });
+    if (attached.ok) return { ok: true, value: undefined };
+    // The name is already on this site, which is the state being asked for.
+    if (attached.kind === 'status' && attached.status === 409) {
+      return { ok: true, value: undefined };
+    }
+    return { ok: false, failure: attached };
+  }
+
+  // --- inspect's second half -----------------------------------------------
+
+  private discover(connection: StaticConnection): TargetDiscovery {
+    return {
+      // Files are served, not run. An empty `arch` excludes no Target on
+      // architecture, which is right: there is nothing here for an
+      // architecture to be wrong about.
+      arch: [],
+      gpu: false,
+      resourceCeiling: {},
+      persistence: false,
+      postgres: false,
+      redis: false,
+      egressFiltering: false,
+      // §16's verifiers check images at admission. Nothing is admitted here —
+      // there is no image and no runtime — so there is nothing to enforce, and
+      // reporting an engine would make `verifiedDeploy` true of a Target that
+      // verifies nothing.
+      policyEngine: { installed: false, mode: null },
+      // §17: static hosting gets an **honest empty state** rather than a
+      // duration. Zero is that: a tail can reach back no distance at all,
+      // because no process ever wrote a line.
+      logHistorySeconds: 0,
+      servedHosts: connection.servedHosts ?? [],
+      // Nothing is pulled: the files were uploaded, and the site holds them.
+      reachableRegistries: [],
+      // §10's reach rule, from the other side. A site has no runtime to resolve
+      // a reference with, so it reaches no store — which is exactly why §10's
+      // website exception exists, and why placement does not apply the reach
+      // rule to the one kind this Target runs.
+      reachableSecretStores: [] as readonly StoreAdapter[],
+    };
+  }
+
+  // --- plumbing ------------------------------------------------------------
+
+  private http(connection: StaticConnection): CloudHttp {
+    return new CloudHttp({
+      baseUrl: connection.endpoint,
+      token: this.options.token,
+      ...(this.options.fetch === undefined
+        ? {}
+        : { fetch: this.options.fetch }),
+    });
+  }
+
+  private connectionOf(target: DeployTarget): StaticConnection | null {
+    return target.connection.adapter === 'static' ? target.connection : null;
+  }
+
+  private internal(detail: string): DeployVerdict {
+    return { phase: 'FAILED', reason: 'INTERNAL', detail };
+  }
+
+  private status(
+    phase: DeployPhase,
+    extra: { resource?: string; reason?: FailureReason; detail?: string } = {},
+  ): DeployEvent {
+    return { type: 'status', at: new Date(this.clock()), phase, ...extra };
+  }
+
+  private log(line: string, resource?: string): DeployEvent {
+    return {
+      type: 'log',
+      at: new Date(this.clock()),
+      line,
+      ...(resource === undefined ? {} : { resource }),
+    };
+  }
+
+  private clock(): number {
+    return this.options.now?.() ?? Date.now();
+  }
+}
+
+/** The artifact was addressed and the bytes were not there (§6's platform blame). */
+class ArtifactUnavailable extends Error {
+  override readonly name = 'ArtifactUnavailable';
+}
+
+/** A step that either produced something or carries the refusal that stopped it. */
+type Outcome<Value> =
+  | { readonly ok: true; readonly value: Value }
+  | {
+      readonly ok: false;
+      readonly failure: Extract<CloudResponse<unknown>, { ok: false }>;
+    };
+
+/** A far side that answered successfully and left out what was asked for. */
+function missing(
+  message: string,
+): Extract<CloudResponse<unknown>, { ok: false }> {
+  return { ok: false, kind: 'transport', message };
+}
+
+/**
+ * One site per (App, Component), shortened deterministically when it must be.
+ *
+ * A site id is capped at thirty characters, which two ordinary names exceed
+ * easily. Truncating alone would make two Components of one App collide on a
+ * site — the worse failure, since the second deploy would silently replace the
+ * first — so the tail carries a digest of the full name, which cannot.
+ */
+export function siteId(desired: DesiredState): string {
+  const full = `${desired.app}-${desired.component}`;
+  if (full.length <= SITE_ID_LIMIT) return full;
+  const hash = new Bun.CryptoHasher('sha256').update(full).digest('hex');
+  return `${full.slice(0, SITE_ID_LIMIT - 8)}-${hash.slice(0, 7)}`;
+}
+
+/** The adapter's own handle on what `apply` placed — opaque to core (§6). */
+function refOf(connection: StaticConnection, site: string): DeployRef {
+  return `${connection.project}/sites/${site}`;
+}
+
+/** The site this ref names on this connection, or `null` if it names another. */
+function parseRef(connection: StaticConnection, ref: DeployRef): string | null {
+  const prefix = `${connection.project}/sites/`;
+  if (!ref.startsWith(prefix)) return null;
+  const site = ref.slice(prefix.length);
+  return site.length === 0 || site.includes('/') ? null : site;
+}
+
+/** The sha256 of some bytes, hex — what the product deduplicates files on. */
+function sha256Hex(bytes: Uint8Array<ArrayBuffer>): string {
+  return new Bun.CryptoHasher('sha256').update(bytes).digest('hex');
+}
+
+/** A bundle that could not be read, in §6's vocabulary. */
+function bundleFailure(
+  cause: unknown,
+  ref: DeployRef,
+): Extract<DeployVerdict, { phase: 'FAILED' }> {
+  if (cause instanceof ArtifactUnavailable) {
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: 'ARTIFACT_UNAVAILABLE',
+      detail: cause.message,
+    };
+  }
+  if (cause instanceof BundleError) {
+    // The bytes arrived and are not what a `files` artifact is. That is the
+    // build having produced something unusable, which §6 blames on the
+    // developer under `BUILD_FAILED` — the one reason that crosses contracts,
+    // and the reason §22 put in the shared vocabulary for exactly this.
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: 'BUILD_FAILED',
+      detail: cause.message,
+      debug: { code: cause.code },
+    };
+  }
+  return {
+    phase: 'FAILED',
+    ref,
+    reason: 'INTERNAL',
+    detail: cause instanceof Error ? cause.message : String(cause),
+  };
+}
+
+/** A call that never landed, in §6's vocabulary. */
+function writeFailure(
+  failure: Extract<CloudResponse<unknown>, { ok: false }>,
+  ref: DeployRef,
+): Extract<DeployVerdict, { phase: 'FAILED' }> {
+  if (failure.kind === 'transport') {
+    return {
+      phase: 'FAILED',
+      ref,
+      reason: 'TARGET_UNREACHABLE',
+      detail: failure.message,
+    };
+  }
+  const rejected = failure.status >= 400 && failure.status < 500;
+  const authFailure = failure.status === 401 || failure.status === 403;
+  return {
+    phase: 'FAILED',
+    ref,
+    reason: rejected && !authFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
+    detail: failure.message,
+    debug: { status: failure.status, reason: failure.reason },
+  };
+}
+
+/** The checklist in its adapter's declared order, so the UI never reorders it. */
+function order(
+  results: readonly PrerequisiteResult[],
+  adapter: TargetAdapter,
+): readonly PrerequisiteResult[] {
+  const found = new Map(results.map((result) => [result.name, result]));
+  return prerequisitesFor(adapter).map(
+    (name) => found.get(name) ?? { name, met: false, detail: 'not assessed' },
+  );
+}

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -36,9 +36,11 @@ import { CloudBuildRoute } from './build/cloud-build.ts';
 import type { BuildAdapter } from './build/contract.ts';
 import { GitHubActionsBuildRoute } from './build/github-actions.ts';
 import { InClusterBuildRoute } from './build/in-cluster.ts';
+import { CloudRunDeployAdapter } from './deploy/cloudrun/index.ts';
 import type { DeployAdapter } from './deploy/contract.ts';
 import { KubernetesApi, type TokenProvider } from './deploy/kubernetes/api.ts';
 import { KubernetesDeployAdapter } from './deploy/kubernetes/index.ts';
+import { StaticDeployAdapter } from './deploy/static/index.ts';
 import type { SecretStore } from './store/contract.ts';
 import { SecretManagerStore } from './store/gcp-secret-manager.ts';
 import { OnePasswordStore } from './store/onepassword.ts';
@@ -147,12 +149,21 @@ export function createAdapterRegistry(
     if (built !== null) buildRoutes.set(route.name, built);
   }
 
+  // The two cloud adapters hold no per-Target state either: each Target's
+  // connection carries its own endpoint and project, so one instance drives
+  // every connected project the same way the cluster adapter drives every
+  // cluster.
+  const cloudToken = options.token ?? projectedServiceAccountToken();
   const deployAdapters: Partial<Record<TargetAdapter, DeployAdapter>> = {
     kubernetes,
-    // `cloudrun` and `static` arrive with Milestone 5. Absent rather than
-    // stubbed: a stub would make a Target of that type look placeable and fail
-    // at apply, which is precisely the "why can I not deploy here" §13 wants
-    // answered on the Target instead.
+    cloudrun: new CloudRunDeployAdapter({
+      token: cloudToken,
+      ...(options.fetch ? { fetch: options.fetch } : {}),
+    }),
+    static: new StaticDeployAdapter({
+      token: cloudToken,
+      ...(options.fetch ? { fetch: options.fetch } : {}),
+    }),
   };
 
   return {

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -36,6 +36,7 @@ import { CloudBuildRoute } from './build/cloud-build.ts';
 import type { BuildAdapter } from './build/contract.ts';
 import { GitHubActionsBuildRoute } from './build/github-actions.ts';
 import { InClusterBuildRoute } from './build/in-cluster.ts';
+import { workloadIdentityToken } from './deploy/cloud/federation.ts';
 import { CloudRunDeployAdapter } from './deploy/cloudrun/index.ts';
 import type { DeployAdapter } from './deploy/contract.ts';
 import { KubernetesApi, type TokenProvider } from './deploy/kubernetes/api.ts';
@@ -102,6 +103,8 @@ export interface RegistryOptions {
   readonly storeToken?: () => string | Promise<string>;
   /** And for the cloud builder's, which authorizes separately again. */
   readonly buildToken?: () => string | Promise<string>;
+  /** And for the cloud runtimes a Target is deployed to. */
+  readonly cloudToken?: () => string | Promise<string>;
 }
 
 /**
@@ -153,15 +156,21 @@ export function createAdapterRegistry(
   // connection carries its own endpoint and project, so one instance drives
   // every connected project the same way the cluster adapter drives every
   // cluster.
-  const cloudToken = options.token ?? projectedServiceAccountToken();
+  //
+  // **Not the projected service account token this cluster is reached with.**
+  // That one is minted for this cluster's own API server and a cloud API
+  // refuses it; the failure would be a `401` on every cloud deploy, blamed on
+  // the Target. What belongs here is a federated token, which is what
+  // `cloudTokenFor` mints — see `cloud/federation.ts`.
+  const cloud = cloudTokenFor(options);
   const deployAdapters: Partial<Record<TargetAdapter, DeployAdapter>> = {
     kubernetes,
     cloudrun: new CloudRunDeployAdapter({
-      token: cloudToken,
+      token: cloud,
       ...(options.fetch ? { fetch: options.fetch } : {}),
     }),
     static: new StaticDeployAdapter({
-      token: cloudToken,
+      token: cloud,
       ...(options.fetch ? { fetch: options.fetch } : {}),
     }),
   };
@@ -328,6 +337,33 @@ export function buildToken(env: Record<string, string | undefined> = Bun.env) {
     }
     return token;
   };
+}
+
+/**
+ * How this installation reaches a cloud Target's control API.
+ *
+ * **No credential, in either arm.** §13 settles one auth mode — "native OIDC
+ * federation, nothing stored" — and `cloud/federation.ts` is the whole of it:
+ * a projected token, exchanged, optionally impersonating. An installation that
+ * configured no federation gets a provider that refuses rather than one that is
+ * absent, because §13's "connect always succeeds" means a cloud Target still
+ * exists and still has to be able to say why it is unreachable.
+ */
+function cloudTokenFor(options: RegistryOptions): TokenProvider {
+  if (options.cloudToken !== undefined) return options.cloudToken;
+
+  const federation = options.manifest.cloud.federation;
+  if (federation === null) {
+    return () => {
+      throw new AdapterUnavailableError(
+        'this installation configured no cloud federation, so it cannot reach a cloud Target',
+      );
+    };
+  }
+  return workloadIdentityToken({
+    ...federation,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+  });
 }
 
 /**

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -112,6 +112,24 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
       name: targetName,
       project: z.string().trim().min(1),
       region: z.string().trim().min(1),
+      /**
+       * The two control APIs this act registers a Target against — the runtime's
+       * and the hosting product's.
+       *
+       * Two values for one act, which reads like a leak of the split §13 says
+       * the operator should not have to think about. It is the opposite: the
+       * operator connects one project, and the fact that doing so produces two
+       * Targets is precisely why both endpoints are asked for here rather than
+       * in two separate connect flows.
+       */
+      runEndpoint: z.url(),
+      hostingEndpoint: z.url(),
+      /** Where this project's admission policy is read from (§16). */
+      policyEndpoint: z.url().optional(),
+      /** §33's static reachability input, and §3's stated capabilities. */
+      servedHosts: z.array(z.string().trim().min(1)).optional(),
+      reachableRegistries: z.array(z.string().trim().min(1)).optional(),
+      logHistorySeconds: z.number().int().nonnegative().optional(),
     })
     .strict(),
 ]);
@@ -170,9 +188,34 @@ function connectionFor(
   if (input.kind !== 'cloud') {
     throw new Error('a cluster does not register a cloud Target');
   }
-  return adapter === 'cloudrun'
-    ? { adapter, project: input.project, region: input.region }
-    : { adapter, project: input.project };
+  if (adapter === 'cloudrun') {
+    return {
+      adapter,
+      project: input.project,
+      region: input.region,
+      endpoint: input.runEndpoint,
+      ...(input.policyEndpoint === undefined
+        ? {}
+        : { policyEndpoint: input.policyEndpoint }),
+      ...(input.servedHosts === undefined
+        ? {}
+        : { servedHosts: input.servedHosts }),
+      ...(input.reachableRegistries === undefined
+        ? {}
+        : { reachableRegistries: input.reachableRegistries }),
+      ...(input.logHistorySeconds === undefined
+        ? {}
+        : { logHistorySeconds: input.logHistorySeconds }),
+    };
+  }
+  return {
+    adapter,
+    project: input.project,
+    endpoint: input.hostingEndpoint,
+    ...(input.servedHosts === undefined
+      ? {}
+      : { servedHosts: input.servedHosts }),
+  };
 }
 
 export const connectTarget: Command<
@@ -214,7 +257,7 @@ export const connectTarget: Command<
       adapter,
       connection,
     });
-    const health = deriveHealth(prerequisites);
+    const health = deriveHealth(prerequisites, adapter);
 
     if (existing === undefined) {
       // §13: "Rank is one global ordered list." A new Target joins the end of

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -215,6 +215,47 @@ export const installationManifestSchema = z
          * do not choose one (§14).
          */
         homeVesselProject: nonEmptyString,
+        /**
+         * How this installation reaches a cloud Target, with nothing stored
+         * (§13's one auth mode).
+         *
+         * The shape is an `external_account` credential document's, field for
+         * field, because an operator configuring this has one already and
+         * copying it should be the whole of the work.
+         *
+         * Nullable, stated the way `auth.gateway` and `github.buildWorkflow`
+         * are: an installation with no cloud Targets has no honest value to put
+         * here, and a placeholder would be a configuration that looks complete
+         * and fails on the first deploy. Null means cloud Targets cannot be
+         * reached, and nothing else changes.
+         */
+        federation: z
+          .object({
+            /** The workload-identity pool provider this cluster is trusted by. */
+            audience: nonEmptyString,
+            /** Where a projected token is exchanged for a federated one. */
+            tokenUrl: z.url(),
+            /**
+             * Where the projected token is read from.
+             *
+             * No default, and deliberately so: the convenient path — the
+             * default service account token — is minted for this cluster's own
+             * API server and a cloud API refuses it. Requiring the operator to
+             * name the volume they projected keeps the wrong token from being
+             * the easy one.
+             */
+            tokenPath: nonEmptyString.regex(
+              /^\//,
+              'must be an absolute path inside the pod',
+            ),
+            /**
+             * The service account to impersonate, as a `generateAccessToken`
+             * url, or null to use the federated identity's own grants.
+             */
+            impersonationUrl: z.url().nullable(),
+          })
+          .strict()
+          .nullable(),
       })
       .strict(),
 

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -44,13 +44,20 @@ import type {
 } from './desired-state.ts';
 
 /**
- * §13's standing prerequisite checklist.
+ * Every prerequisite any Target can be asked about (§13).
  *
  * "Connect always succeeds; health is a standing prerequisite checklist —
  * Flux-or-Argo, a reachable writable store, OIDC both ways, the vessel, chart
  * contract compatibility. An unmet item makes the Target a non-candidate with a
  * stated reason, which merges capability refresh and health into one loop, not
  * two."
+ *
+ * This list is the **vocabulary**, not any one Target's checklist — see
+ * {@link PREREQUISITES_BY_ADAPTER}, which is what a Target is actually assessed
+ * against. §13's list is written in a cluster's terms because a cluster is the
+ * backend it was written about; a Cloud Run Target has no delivery operator and
+ * no chart, and a checklist row that can never fail is a row that teaches a
+ * reader the wrong thing about what was checked.
  *
  * `OIDC_FEDERATION` is one item rather than two because §13 states it as "both
  * ways": half of a federation is not a state a Target can usefully be in, and
@@ -62,6 +69,12 @@ import type {
  * from a repository rather than from OCI (plan, Milestone 3) — **it is the
  * first thing that breaks on extraction**, and naming it here is what makes
  * that visible as a stated reason rather than as a deploy that fails late.
+ *
+ * `PLATFORM_API` is the cloud backends' equivalent of `DELIVERY_OPERATOR`, and
+ * it is a separate name rather than a reuse because the two are unmet for
+ * unrelated reasons and clear by unrelated remediations: one is an operator
+ * this cluster does not run, the other is a service this project has not
+ * enabled.
  */
 export const PREREQUISITES = [
   'DELIVERY_OPERATOR',
@@ -70,9 +83,47 @@ export const PREREQUISITES = [
   'OIDC_FEDERATION',
   'VESSEL',
   'CHART_CONTRACT',
+  'PLATFORM_API',
 ] as const;
 
 export type Prerequisite = (typeof PREREQUISITES)[number];
+
+/**
+ * The checklist one adapter type is assessed against.
+ *
+ * A Target has exactly one adapter type (§13), so its checklist is decided by
+ * the code that drives it rather than by anything an operator states. The two
+ * cloud rows are identical and deliberately short: what a cloud Target can fail
+ * at before anything is deployed to it is the service being off, the identity
+ * being unauthorized, and the vessel not existing.
+ *
+ * The store is absent from both, and that is not an oversight. A cluster can
+ * genuinely have no writable store — nothing installs one by default — so
+ * `WRITABLE_STORE` is a real failure there. A cloud runtime reads its own
+ * project's secret manager natively, and static hosting has no runtime to read
+ * anything at all; both facts belong in `reachableSecretStores`, where
+ * placement's reach rule (§10) already consumes them, rather than as a health
+ * row that would be permanently green on one and permanently red on the other.
+ */
+export const PREREQUISITES_BY_ADAPTER = {
+  kubernetes: [
+    'DELIVERY_OPERATOR',
+    'CHART_SOURCE',
+    'WRITABLE_STORE',
+    'OIDC_FEDERATION',
+    'VESSEL',
+    'CHART_CONTRACT',
+  ],
+  cloudrun: ['PLATFORM_API', 'OIDC_FEDERATION', 'VESSEL'],
+  static: ['PLATFORM_API', 'OIDC_FEDERATION', 'VESSEL'],
+} as const satisfies Record<TargetAdapter, readonly Prerequisite[]>;
+
+/** What a Target of this adapter type is asked, in the order it is shown. */
+export function prerequisitesFor(
+  adapter: TargetAdapter,
+): readonly Prerequisite[] {
+  return PREREQUISITES_BY_ADAPTER[adapter];
+}
 
 /** One checklist item, and the sentence behind an unmet one. */
 export interface PrerequisiteResult {
@@ -197,14 +248,24 @@ export interface TargetCapabilities {
 /**
  * Which Component kinds each adapter type can run.
  *
- * From the adapter type, per §3 — a property of the code, not of a Target. The
- * `static` row is the one that matters: it takes a website and nothing else,
- * which is what makes "picking the static Target *mean* public" (§13) a
- * consequence of the model rather than a rule bolted on top of it.
+ * From the adapter type, per §3 — **a property of the code, not of a Target**,
+ * and that phrase decides what belongs in each row: what the adapter driving it
+ * actually renders. The `static` row is the one that matters most: it takes a
+ * website and nothing else, which is what makes "picking the static Target
+ * *mean* public" (§13) a consequence of the model rather than a rule bolted on
+ * top of it.
+ *
+ * **`cloudrun` runs no job yet**, and that is this table's honest reading
+ * rather than a disagreement with §3. A job on this backend is a second
+ * resource with its own API and a schedule that lives in a separate scheduling
+ * service — Task 33's work, not the Service path Task 28 built. Until it
+ * exists, a job's placement here is a non-candidate with the sentence "this
+ * Target does not run jobs" (§3's grammar), which is refused at Place rather
+ * than accepted and failed at apply.
  */
 export const KINDS_BY_ADAPTER = {
   kubernetes: ['service', 'website', 'job'],
-  cloudrun: ['service', 'website', 'job'],
+  cloudrun: ['service', 'website'],
   static: ['website'],
 } as const satisfies Record<TargetAdapter, readonly ComponentKind[]>;
 
@@ -303,8 +364,13 @@ export function resolveCapabilities(
  */
 export function unreachablePrerequisites(
   detail: string,
+  adapter: TargetAdapter,
 ): readonly PrerequisiteResult[] {
-  return PREREQUISITES.map((name) => ({ name, met: false, detail }));
+  return prerequisitesFor(adapter).map((name) => ({
+    name,
+    met: false,
+    detail,
+  }));
 }
 
 /** Capabilities for a Target nothing could be discovered about. */
@@ -370,12 +436,20 @@ interface TargetRow {
   publicExposure: boolean | null;
 }
 
-/** Healthy is every item met. §13 makes an unmet item a non-candidate. */
+/**
+ * Healthy is every item met. §13 makes an unmet item a non-candidate.
+ *
+ * The adapter is a parameter because it decides *which* items had to be met: a
+ * checklist that answered fewer rows than its Target is asked is treated as
+ * unhealthy, so an adapter that silently stops reporting one cannot make a
+ * Target look healthier than it was assessed.
+ */
 export function deriveHealth(
   prerequisites: readonly PrerequisiteResult[],
+  adapter: TargetAdapter,
 ): 'healthy' | 'unhealthy' {
   const seen = new Set(prerequisites.filter((p) => p.met).map((p) => p.name));
-  return PREREQUISITES.every((name) => seen.has(name))
+  return prerequisitesFor(adapter).every((name) => seen.has(name))
     ? 'healthy'
     : 'unhealthy';
 }

--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -39,6 +39,22 @@ export interface Artifact {
 }
 
 /**
+ * The address an adapter pulls the artifact by, or `null` when it has none.
+ *
+ * §4 lets a Build report several — the same digest is reachable at a mirror as
+ * well as at the registry it was pushed to — and every backend needs exactly
+ * one. The first is taken rather than a preferred one selected, because
+ * preference would need a cost model, and §3 declines to have one.
+ *
+ * `null` is a real answer, and every adapter treats it as `INTERNAL`: an
+ * artifact with no address is a Build that recorded a digest and nowhere to get
+ * it, which is core's bug rather than the backend's.
+ */
+export function artifactAddress(artifact: Artifact): string | null {
+  return artifact.refs[0] ?? null;
+}
+
+/**
  * The three exposure states, with `private` the default (§9).
  *
  * - `internal` — Target-private, authenticated at the workload boundary.

--- a/apps/spindrift/src/domain/naming.ts
+++ b/apps/spindrift/src/domain/naming.ts
@@ -81,6 +81,93 @@ export function vanity(label: string, vanityZone: string): string {
   return `${label}.${vanityZone}`;
 }
 
+/**
+ * §9's hard ceiling on vanity names: "roughly 20".
+ *
+ * **Not a policy anyone chose.** One apex gets one free universal certificate,
+ * and that certificate is what caps how many single-label names can be minted
+ * under it. So this is a fact about the zone being reported, not a limit being
+ * imposed — which is why {@link vanityRation} returns a count rather than
+ * throwing, and why the UI's job is to say how many are left rather than to
+ * refuse the twenty-first.
+ */
+export const VANITY_CEILING = 20;
+
+/** What is left of the ration, for the UI to state rather than enforce. */
+export interface VanityRation {
+  readonly used: number;
+  readonly ceiling: number;
+  readonly remaining: number;
+  /** True once the next name may not get a certificate. */
+  readonly exhausted: boolean;
+}
+
+/** The ration, given how many vanity names this installation has minted. */
+export function vanityRation(used: number): VanityRation {
+  const remaining = Math.max(0, VANITY_CEILING - used);
+  return {
+    used,
+    ceiling: VANITY_CEILING,
+    remaining,
+    exhausted: remaining === 0,
+  };
+}
+
+/**
+ * Whether a Target's vanity name is served through the proxying edge (§9).
+ *
+ * §9 makes this **a per-Target property**, and the sentence it makes it one in
+ * is worth quoting because the causality runs the opposite way to how it reads:
+ * "the vanity record is unproxied on that leg, **so** proxying becomes a
+ * per-Target property." The proxy is not a preference — it is the only way a
+ * name reaches a metal cluster at all, because §9's forcing fact is that the
+ * cluster's load-balancer range is RFC1918 and public reach goes through the
+ * tunnel. A backend that answers on the public internet by itself needs no such
+ * hop, and putting one in front of it would buy nothing and cost the losses in
+ * {@link VANITY_LEG_LOSSES}.
+ *
+ * It is derived from the adapter type rather than stored, which is a per-Target
+ * property exactly because a Target has exactly one adapter type (§13). Storing
+ * it would let an operator assert something the backend contradicts.
+ */
+export function vanityProxied(adapter: TargetAdapter): boolean {
+  return coreMintsCanonical(adapter);
+}
+
+/**
+ * What is lost at a vanity name that is not proxied (§9).
+ *
+ * §9 records these as a **real loss, absorbed on purpose**: "the vanity leg
+ * buffers the full response, so WebSockets and SSE die there and requests cap at
+ * 60 seconds". Two-layer naming is what makes that absorbable — the app stays
+ * fully capable at its canonical name — so the answer is to **state them in the
+ * UI, never to work around them**. A workaround would be a second edge, which
+ * is the external load balancer §9 declines to have.
+ *
+ * They are constants rather than prose in a component so that the screen showing
+ * them and the test asserting they are shown read the same values.
+ */
+export const VANITY_LEG_LOSSES = {
+  /** The leg buffers the whole response before sending any of it. */
+  buffersResponse: true,
+  /** Which is why a stream never arrives: it is complete or it is nothing. */
+  streamingProtocols: false,
+  /** And why a slow request is cut rather than waited out. */
+  maxRequestSeconds: 60,
+} as const;
+
+/**
+ * Whether a Component reached at its vanity name still works as intended.
+ *
+ * The one thing the losses above make a *decision* rather than a caveat: an App
+ * that streams is an App whose vanity name is worse than no vanity name, and
+ * saying so at the moment a name is chosen is cheaper than saying it after
+ * somebody's WebSocket has been failing in production for a week.
+ */
+export function vanityCarriesStreams(adapter: TargetAdapter): boolean {
+  return vanityProxied(adapter) || VANITY_LEG_LOSSES.streamingProtocols;
+}
+
 /** What {@link hostnameFor} needs to answer §6's `hostname` field. */
 export interface HostnameContext {
   readonly app: string;

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -347,7 +347,18 @@ export function exclusionsFor(
 
   // §10's reach rule: "a store must be reachable by **the Target the Component
   // is placed on** — not by every Target."
-  if (!can.reachableSecretStores.includes(requirements.secretStore)) {
+  //
+  // It does not bind a `website`, because a website reaches no store at all:
+  // §10's one exception makes its configuration build arguments derived from
+  // the kind, so there is nothing at run time for a store to deliver. Applying
+  // the rule anyway would exclude every Target that cannot deliver config from
+  // holding a Component that never asks for any — which is exactly what static
+  // hosting is, and it would make §13's "picking the static Target *means*
+  // public" unreachable by construction.
+  if (
+    requirements.kind !== 'website' &&
+    !can.reachableSecretStores.includes(requirements.secretStore)
+  ) {
     reasons.push('STORE_UNREACHABLE');
   }
 

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -348,13 +348,19 @@ export function exclusionsFor(
   // §10's reach rule: "a store must be reachable by **the Target the Component
   // is placed on** — not by every Target."
   //
-  // It does not bind a `website`, because a website reaches no store at all:
-  // §10's one exception makes its configuration build arguments derived from
-  // the kind, so there is nothing at run time for a store to deliver. Applying
-  // the rule anyway would exclude every Target that cannot deliver config from
-  // holding a Component that never asks for any — which is exactly what static
-  // hosting is, and it would make §13's "picking the static Target *means*
-  // public" unreachable by construction.
+  // It does not bind a `website`, because a website reaches no store at all.
+  // That is not a judgement made here: §10's one exception makes a website's
+  // configuration build arguments **derived mechanically from Component kind**,
+  // and `commands/config/isBuildTimeConfig` is that derivation — it takes a
+  // kind and nothing else, so a website has no runtime rows for a store to
+  // deliver whichever rendering it takes. The two must agree, and this comment
+  // is where a future reader is told they are locked together rather than
+  // re-deriving the question from the spec.
+  //
+  // Applying the rule anyway would exclude every Target that cannot deliver
+  // config from holding a Component that never asks for any — which is exactly
+  // what static hosting is, and it would make §13's "picking the static Target
+  // *means* public" unreachable by construction.
   if (
     requirements.kind !== 'website' &&
     !can.reachableSecretStores.includes(requirements.secretStore)

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -38,17 +38,61 @@ import type { TargetAdapter } from '../config/manifest.schema.ts';
  */
 export type TargetConnection =
   | KubernetesConnection
-  | {
-      adapter: 'cloudrun';
-      /** The vessel project this Target deploys into (§14). */
-      project: string;
-      region: string;
-    }
-  | {
-      adapter: 'static';
-      /** The vessel project this Target's sites live in (§14). */
-      project: string;
-    };
+  | CloudRunConnection
+  | StaticConnection;
+
+/**
+ * How a Cloud Run Target is reached (§13, §14).
+ *
+ * `endpoint` is the exact analogue of {@link KubernetesConnection.apiServer}:
+ * the control API this Target is driven through. It is connection material
+ * rather than an installation-wide manifest value for the same reason a cluster's
+ * is — two connected projects may sit behind different regional or
+ * perimeter-fronted endpoints, and neither is more correct than the other.
+ *
+ * **No credential here either** (§13). What authorizes a call is minted per
+ * request by whatever federates.
+ */
+export interface CloudRunConnection {
+  adapter: 'cloudrun';
+  /** The vessel project this Target deploys into (§14). */
+  project: string;
+  region: string;
+  /** The runtime's API root, without a trailing slash. */
+  endpoint: string;
+  /**
+   * The binary-authorization API root, where this project's admission policy is
+   * read from (§16: "one signature, two verifiers").
+   *
+   * Optional, and absent means **not known** rather than absent-so-fine: with
+   * nowhere to look, `verifiedDeploy` derives `false`, which is the direction a
+   * claim about verification has to fail in.
+   */
+  policyEndpoint?: string;
+  /** §33's static reachability input, stated by the operator (§3). */
+  servedHosts?: readonly string[];
+  reachableRegistries?: readonly string[];
+  /** §18: how far back a tail can honestly reach, in seconds. */
+  logHistorySeconds?: number;
+}
+
+/**
+ * How a static-hosting Target is reached (§13, §14).
+ *
+ * No region: the hosting product serves one site from its own edge rather than
+ * from a location an operator picks, so there is nothing here for a region to
+ * name. No log history either — §17 gives static hosting an honest empty state
+ * rather than a duration, because there is no runtime to have produced output.
+ */
+export interface StaticConnection {
+  adapter: 'static';
+  /** The vessel project this Target's sites live in (§14). */
+  project: string;
+  /** The hosting product's API root, without a trailing slash. */
+  endpoint: string;
+  /** §33's static reachability input, stated by the operator (§3). */
+  servedHosts?: readonly string[];
+}
 
 /**
  * How a Kubernetes Target is reached, and by which GitOps operator.

--- a/apps/spindrift/src/domain/workload-name.ts
+++ b/apps/spindrift/src/domain/workload-name.ts
@@ -1,0 +1,47 @@
+/**
+ * What a backend calls the thing core placed.
+ *
+ * Every deploy adapter needs one name per (App, Component) — a release, a
+ * service, a site — and every backend caps it at a different length. Three
+ * adapters each solving that separately is how two of them end up truncating
+ * and one of them ends up correct, so the rule lives here once.
+ *
+ * **Truncation alone is the bug.** `<app>-<component>` cut to a limit makes two
+ * Components of one long-named App the same name, and the failure that produces
+ * is the quiet one: the second deploy is an *upgrade of the first*, so one
+ * Component silently starts serving the other's image. A digest tail cannot
+ * collide that way, and it stays deterministic, which the truncation also has
+ * to be — a second deploy that computed a different name would create a second
+ * workload rather than replace the first.
+ *
+ * This is not a DNS name and `naming.ts` is not its home: §9's names are what a
+ * user types, chosen for how they read and constrained by certificates. This is
+ * an identifier a backend imposes a length on, and the only thing it owes
+ * anyone is being the same one next time.
+ */
+
+/** How many characters of digest a shortened name carries. */
+const DIGEST_LENGTH = 7;
+
+/** What a name is assembled from. */
+export interface WorkloadNameParts {
+  readonly app: string;
+  readonly component: string;
+}
+
+/**
+ * The name one backend uses, within the length that backend allows.
+ *
+ * Under the limit the name is `<app>-<component>`, which is what a human
+ * reading the backend expects to see. Over it, enough of that is kept to stay
+ * recognisable and the rest is a digest of the **full** name — so two names
+ * that were different before the cut are still different after it.
+ */
+export function workloadName(parts: WorkloadNameParts, limit: number): string {
+  const full = `${parts.app}-${parts.component}`;
+  if (full.length <= limit) return full;
+
+  const hash = new Bun.CryptoHasher('sha256').update(full).digest('hex');
+  const kept = Math.max(1, limit - DIGEST_LENGTH - 1);
+  return `${full.slice(0, kept)}-${hash.slice(0, DIGEST_LENGTH)}`;
+}

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -72,6 +72,7 @@ export async function inspectTarget(
     return {
       prerequisites: unreachablePrerequisites(
         `this installation has no ${target.adapter} adapter`,
+        target.adapter,
       ),
       discovery: null,
     };
@@ -86,6 +87,7 @@ export async function inspectTarget(
     return {
       prerequisites: unreachablePrerequisites(
         cause instanceof Error ? cause.message : String(cause),
+        target.adapter,
       ),
       discovery: null,
     };
@@ -118,7 +120,7 @@ export async function refreshTarget(
     context,
     deployTargetOf(target),
   );
-  const health = deriveHealth(prerequisites);
+  const health = deriveHealth(prerequisites, target.adapter);
 
   await context.db
     .update(targets)

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -1,0 +1,484 @@
+/**
+ * The Cloud Run deploy adapter (Task 28, §6, §8, §9, §16).
+ *
+ * Every test drives the real adapter against a fake of the runtime's HTTP API
+ * (§ Seam 2) and asserts what the project would have been sent, or what the
+ * adapter concluded from what it was told. Nothing here reaches core.
+ *
+ * The claims worth stating up front, because each is a rule §4, §6, §8 or §9
+ * makes that a plausible implementation would break:
+ *
+ * - **The document carries an image and nothing that could cause a build.** The
+ *   runtime offers a source-to-image path and taking it would give this
+ *   installation a second build engine reachable from one backend only (§4).
+ * - **Exposure is written before the Service when it tightens** and after it
+ *   when it opens, because §9's transitions fail closed.
+ * - **Phases come from the revision.** The adapter polls; it never decides that
+ *   something is ready.
+ * - **`ARTIFACT_UNAVAILABLE` blames the platform**, which is §6's whole reason
+ *   for having blame at all: the build is green and the instinct is wrong.
+ * - **No egress filtering is advertised** (§8), and `verifiedDeploy` needs an
+ *   *enforcing* policy rather than a configured one (§32).
+ */
+import { describe, expect, test } from 'bun:test';
+import { CloudRunDeployAdapter } from '../../src/adapters/deploy/cloudrun/index.ts';
+import {
+  cloudRunService,
+  INGRESS,
+  ingressFor,
+} from '../../src/adapters/deploy/cloudrun/service.ts';
+import { cloudRunStatus } from '../../src/adapters/deploy/cloudrun/status.ts';
+import type {
+  DeployEvent,
+  DeployTarget,
+  DeployVerdict,
+} from '../../src/adapters/deploy/contract.ts';
+import { blameFor } from '../../src/adapters/deploy/contract.ts';
+import {
+  deriveHealth,
+  deriveVerifiedDeploy,
+} from '../../src/domain/capabilities.ts';
+import type { DesiredState, Exposure } from '../../src/domain/desired-state.ts';
+import type { CloudRunConnection } from '../../src/domain/target.ts';
+import {
+  FakeCloudRun,
+  type FakeCloudRunOptions,
+  permissionDenied,
+  serviceDisabled,
+} from '../harness/fakes/cloudrun-api.ts';
+import { CLOUD_ENDPOINTS } from '../harness/installation.ts';
+
+const CONNECTION: CloudRunConnection = {
+  adapter: 'cloudrun',
+  project: 'example-vessel',
+  region: 'somewhere',
+  endpoint: CLOUD_ENDPOINTS.run,
+  policyEndpoint: CLOUD_ENDPOINTS.policy,
+};
+
+function target(overrides: Partial<CloudRunConnection> = {}): DeployTarget {
+  return {
+    name: 'cloud',
+    adapter: 'cloudrun',
+    connection: { ...CONNECTION, ...overrides },
+  };
+}
+
+function desired(overrides: Partial<DesiredState> = {}): DesiredState {
+  return {
+    deploy: 'deploy-1',
+    app: 'shop',
+    component: 'web',
+    target: 'cloud',
+    kind: 'service',
+    artifact: {
+      type: 'image',
+      digest: 'sha256:abc',
+      refs: ['registry.example.test/shop@sha256:abc'],
+    },
+    exposure: 'private',
+    config: [],
+    requirements: { platform: { os: 'linux', arch: 'amd64' }, resources: {} },
+    hostname: { canonical: '' },
+    ...overrides,
+  };
+}
+
+/** The adapter, with the waiting stubbed: the polling is real, the sleep is not. */
+function adapterFor(options: FakeCloudRunOptions = {}): {
+  api: FakeCloudRun;
+  adapter: CloudRunDeployAdapter;
+} {
+  const api = new FakeCloudRun(options);
+  return {
+    api,
+    adapter: new CloudRunDeployAdapter({
+      token: api.token,
+      fetch: api.fetch,
+      pollIntervalMs: 1,
+      sleep: async () => {},
+    }),
+  };
+}
+
+async function drain(
+  stream: AsyncGenerator<DeployEvent, DeployVerdict, void>,
+): Promise<{ events: DeployEvent[]; verdict: DeployVerdict }> {
+  const events: DeployEvent[] = [];
+  let step = await stream.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return { events, verdict: step.value };
+}
+
+describe('§4: never the build-from-source path', () => {
+  test('the applied document carries an image and nothing that builds', async () => {
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(target(), desired()));
+
+    const service = api.service('shop-web') as Record<string, unknown>;
+    const template = service.template as {
+      containers: { image: string }[];
+    };
+    expect(template.containers[0]?.image).toBe(
+      'registry.example.test/shop@sha256:abc',
+    );
+    // The runtime would happily accept either of these and build the result,
+    // which is the second engine §4 forbids.
+    expect(service).not.toHaveProperty('buildConfig');
+    expect(template).not.toHaveProperty('source');
+    expect(JSON.stringify(service)).not.toContain('sourceArchive');
+  });
+
+  test('a files artifact is refused as core’s bug, not the developer’s', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(
+      adapter.apply(
+        target(),
+        desired({
+          artifact: { type: 'files', digest: 'sha256:f', refs: ['x'] },
+        }),
+      ),
+    );
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('INTERNAL');
+      expect(blameFor(verdict.reason)).toBe('platform');
+    }
+  });
+});
+
+describe('§9: exposure reaches the runtime as two mechanisms', () => {
+  test('internal is the only state that closes ingress', () => {
+    expect(ingressFor('internal')).toBe(INGRESS.internalOnly);
+    expect(ingressFor('private')).toBe(INGRESS.all);
+    expect(ingressFor('public')).toBe(INGRESS.all);
+  });
+
+  test('only public leaves an unauthenticated invoker', async () => {
+    for (const exposure of ['internal', 'private', 'public'] as const) {
+      const { api, adapter } = adapterFor();
+      const { verdict } = await drain(
+        adapter.apply(target(), desired({ exposure })),
+      );
+      expect(verdict.phase).toBe('LIVE');
+
+      const policy = api.policy('shop-web') as {
+        policy: { bindings: { members: string[] }[] };
+      };
+      const members = policy.policy.bindings.flatMap(
+        (binding) => binding.members,
+      );
+      expect(members.includes('allUsers')).toBe(exposure === 'public');
+    }
+  });
+
+  test('tightening writes the policy before the Service, opening after it', async () => {
+    // §9: "tightening drops public reach first and stays red if the stricter
+    // boundary does not come up." Ordering is the whole of that promise, so it
+    // is asserted on the request log rather than on the end state.
+    const tightening = adapterFor();
+    await drain(
+      tightening.adapter.apply(target(), desired({ exposure: 'private' })),
+    );
+    const beforeApply = tightening.api.requests.findIndex((request) =>
+      request.path.endsWith(':setIamPolicy'),
+    );
+    const applyAt = tightening.api.requests.findIndex(
+      (request) => request.method === 'PATCH',
+    );
+    expect(beforeApply).toBeGreaterThan(-1);
+    expect(beforeApply).toBeLessThan(applyAt);
+
+    const opening = adapterFor();
+    await drain(
+      opening.adapter.apply(target(), desired({ exposure: 'public' })),
+    );
+    const grantAt = opening.api.requests.findIndex((request) =>
+      request.path.endsWith(':setIamPolicy'),
+    );
+    const placedAt = opening.api.requests.findIndex(
+      (request) => request.method === 'PATCH',
+    );
+    expect(grantAt).toBeGreaterThan(placedAt);
+  });
+
+  test('a public deploy whose grant fails is red, not quietly private', async () => {
+    const { adapter } = adapterFor({ refuseIam: permissionDenied() });
+    const { verdict } = await drain(
+      adapter.apply(target(), desired({ exposure: 'public' })),
+    );
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.detail).toContain('invoker policy');
+    }
+  });
+});
+
+describe('§6: phases come from the revision', () => {
+  test('apply polls until the terminal condition succeeds', async () => {
+    const { api, adapter } = adapterFor();
+    const { events, verdict } = await drain(adapter.apply(target(), desired()));
+
+    expect(verdict.phase).toBe('LIVE');
+    // The default fake reports reconciling first, so an adapter that trusted
+    // its own write would never have seen WAITING.
+    const phases = events
+      .filter((event) => event.type === 'status')
+      .map((event) => (event.type === 'status' ? event.phase : ''));
+    expect(phases).toContain('WAITING');
+    expect(api.pathsOf('GET').length).toBeGreaterThan(1);
+  });
+
+  test('the platform names its own, and the name comes back on the verdict', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desired()));
+    // §9: core mints nothing here, so a canonical address that core never
+    // supplied must arrive across this seam or the App has no address at all.
+    expect(verdict.phase).toBe('LIVE');
+    if (verdict.phase === 'LIVE') {
+      expect(verdict.url).toBe('https://shop-web.run.example.test');
+    }
+  });
+
+  test('a pull failure blames the platform, not the developer', () => {
+    // §6 singles this case out: the build is green and every instinct says
+    // "look at my app".
+    const status = cloudRunStatus({
+      terminalCondition: {
+        type: 'Ready',
+        state: 'CONDITION_FAILED',
+        revisionReason: 'CONTAINER_IMAGE_UNAUTHORIZED',
+        message: 'the image could not be pulled',
+      },
+    });
+    expect(status.phase).toBe('FAILED');
+    expect(status.reason).toBe('ARTIFACT_UNAVAILABLE');
+    expect(blameFor('ARTIFACT_UNAVAILABLE')).toBe('platform');
+  });
+
+  test('a failure with no stated reason is a revision that would not start', () => {
+    const status = cloudRunStatus({
+      terminalCondition: { type: 'Ready', state: 'CONDITION_FAILED' },
+    });
+    expect(status.reason).toBe('STARTUP_FAILED');
+    expect(status.detail).toContain('gave no reason');
+  });
+
+  test('a red verdict keeps what the platform said, because it will not', async () => {
+    const { adapter } = adapterFor({
+      service: () => ({
+        terminalCondition: {
+          type: 'Ready',
+          state: 'CONDITION_FAILED',
+          revisionReason: 'HEALTH_CHECK_CONTAINER_ERROR',
+          message: 'the container did not become ready',
+        },
+      }),
+    });
+    const { verdict } = await drain(adapter.apply(target(), desired()));
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      // §12: the diagnosis is persisted because the platform's own retention
+      // will outlive nothing.
+      expect(verdict.reason).toBe('UNHEALTHY');
+      expect(verdict.debug).toBeDefined();
+    }
+  });
+
+  test('a project that refuses the write is REJECTED, an unreachable one is not', async () => {
+    const refused = adapterFor({
+      refuse: { status: 400, body: { error: { message: 'invalid spec' } } },
+    });
+    const first = await drain(refused.adapter.apply(target(), desired()));
+    expect(first.verdict.phase).toBe('FAILED');
+    if (first.verdict.phase === 'FAILED') {
+      expect(first.verdict.reason).toBe('REJECTED');
+    }
+
+    const denied = adapterFor({ refuse: permissionDenied() });
+    const second = await drain(denied.adapter.apply(target(), desired()));
+    if (second.verdict.phase === 'FAILED') {
+      expect(second.verdict.reason).toBe('TARGET_UNREACHABLE');
+      expect(blameFor('TARGET_UNREACHABLE')).toBe('platform');
+    }
+  });
+});
+
+describe('observe and destroy', () => {
+  test('observe reports the digest the Service still carries', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desired()));
+    if (verdict.phase !== 'LIVE') throw new Error('nothing was placed');
+
+    const observed = await adapter.observe(target(), verdict.ref);
+    expect(observed?.artifactDigest).toBe('sha256:abc');
+  });
+
+  test('a ref from another project is not read against this one', async () => {
+    const { adapter } = adapterFor();
+    await drain(adapter.apply(target(), desired()));
+    // An operator may reconnect a Target against a different project; a ref
+    // that did not say which would report somebody else's workload as this
+    // Deploy's.
+    const elsewhere = 'projects/other/locations/somewhere/services/shop-web';
+    expect(await adapter.observe(target(), elsewhere)).toBeNull();
+  });
+
+  test('destroy removes the Service and is idempotent', async () => {
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desired()));
+    if (verdict.phase !== 'LIVE') throw new Error('nothing was placed');
+
+    await adapter.destroy(target(), verdict.ref);
+    expect(api.service('shop-web')).toBeUndefined();
+    await adapter.destroy(target(), verdict.ref);
+    expect(await adapter.observe(target(), verdict.ref)).toBeNull();
+  });
+});
+
+describe('§13: one probe, three answers', () => {
+  test('a reachable project meets every item', async () => {
+    const { adapter } = adapterFor();
+    const { prerequisites } = await adapter.inspect(target());
+    expect(prerequisites.every((item) => item.met)).toBe(true);
+    expect(deriveHealth(prerequisites, 'cloudrun')).toBe('healthy');
+  });
+
+  test('a disabled service is not a permission problem', async () => {
+    // The remediation is entirely different, and sending an operator to fix a
+    // permission that is already correct is the failure this distinction
+    // exists to prevent.
+    const { adapter } = adapterFor({ refuseList: serviceDisabled() });
+    const { prerequisites } = await adapter.inspect(target());
+    const platform = prerequisites.find((item) => item.name === 'PLATFORM_API');
+    expect(platform?.met).toBe(false);
+    expect(platform?.detail).toContain('not enabled');
+    expect(
+      prerequisites.find((item) => item.name === 'OIDC_FEDERATION')?.detail,
+    ).toContain('not assessed');
+  });
+
+  test('a refusal is the federation, and a missing project is the vessel', async () => {
+    const denied = adapterFor({ refuseList: permissionDenied() });
+    const first = await denied.adapter.inspect(target());
+    expect(
+      first.prerequisites.find((item) => item.name === 'OIDC_FEDERATION')?.met,
+    ).toBe(false);
+    expect(
+      first.prerequisites.find((item) => item.name === 'PLATFORM_API')?.met,
+    ).toBe(true);
+
+    const absent = adapterFor({
+      refuseList: { status: 404, body: { error: { message: 'no project' } } },
+    });
+    const second = await absent.adapter.inspect(target());
+    const vessel = second.prerequisites.find((item) => item.name === 'VESSEL');
+    expect(vessel?.met).toBe(false);
+    expect(vessel?.detail).toContain('never creates a project');
+  });
+});
+
+describe('§8 and §32: what this Target is honest about', () => {
+  test('no egress filtering is advertised', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(target());
+    // §8's egress control is a by-name allowlist. This backend has network
+    // controls and not that one, and a capability reported on the strength of
+    // something adjacent is a workload placed where its egress was never
+    // constrained.
+    expect(discovery.egressFiltering).toBe(false);
+  });
+
+  test('an enforcing policy verifies and a dry-run one does not', async () => {
+    const enforcing = adapterFor({
+      admissionPolicy: {
+        defaultAdmissionRule: {
+          evaluationMode: 'REQUIRE_ATTESTATION',
+          enforcementMode: 'ENFORCED_BLOCK_AND_AUDIT_LOG',
+        },
+      },
+    });
+    const strict = await enforcing.adapter.inspect(target());
+    expect(deriveVerifiedDeploy(strict.discovery.policyEngine)).toBe(true);
+
+    const auditing = adapterFor({
+      admissionPolicy: {
+        defaultAdmissionRule: {
+          evaluationMode: 'REQUIRE_ATTESTATION',
+          enforcementMode: 'DRYRUN_AUDIT_LOG_ONLY',
+        },
+      },
+    });
+    const lax = await auditing.adapter.inspect(target());
+    expect(lax.discovery.policyEngine.installed).toBe(true);
+    expect(deriveVerifiedDeploy(lax.discovery.policyEngine)).toBe(false);
+  });
+
+  test('a policy that admits everything verifies nothing, however it enforces', async () => {
+    const { adapter } = adapterFor({
+      admissionPolicy: {
+        defaultAdmissionRule: {
+          evaluationMode: 'ALWAYS_ALLOW',
+          enforcementMode: 'ENFORCED_BLOCK_AND_AUDIT_LOG',
+        },
+      },
+    });
+    const { discovery } = await adapter.inspect(target());
+    expect(deriveVerifiedDeploy(discovery.policyEngine)).toBe(false);
+  });
+
+  test('a Target naming no policy endpoint claims no verified deploy', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(
+      target({ policyEndpoint: undefined }),
+    );
+    // Nobody said where to look, so nothing was verified. This is the
+    // direction a claim about verification has to fail in.
+    expect(discovery.policyEngine).toEqual({ installed: false, mode: null });
+  });
+});
+
+describe('§10: config crosses as a pinned reference and never as a value', () => {
+  test('every variable is a reference into the vessel’s own store', () => {
+    const document = cloudRunService(
+      desired({
+        config: [
+          { name: 'TOKEN', secret: { key: 'shop-web-token', version: '3' } },
+        ],
+      }),
+      {
+        project: 'example-vessel',
+        image: 'registry.example.test/shop@sha256:abc',
+      },
+    );
+    const template = document.template as {
+      containers: { env: { name: string; valueSource: unknown }[] }[];
+    };
+    const variable = template.containers[0]?.env[0];
+    expect(variable?.name).toBe('TOKEN');
+    expect(variable?.valueSource).toEqual({
+      secretKeyRef: {
+        secret: 'projects/example-vessel/secrets/shop-web-token',
+        version: '3',
+      },
+    });
+    // There is nothing here that could be a value: core never read one.
+    expect(JSON.stringify(document)).not.toContain('"value"');
+  });
+});
+
+describe('the exposure a Target rejects is a state, not a crash', () => {
+  test('every exposure state produces a document', () => {
+    const states: Exposure[] = ['internal', 'private', 'public'];
+    for (const exposure of states) {
+      const document = cloudRunService(desired({ exposure }), {
+        project: 'example-vessel',
+        image: 'registry.example.test/shop@sha256:abc',
+      });
+      expect(document.ingress).toBe(ingressFor(exposure));
+    }
+  });
+});

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -17,7 +17,7 @@ import {
   type FailureReason,
   reasonCovers,
 } from '../../src/adapters/deploy/contract.ts';
-import { PREREQUISITES } from '../../src/domain/capabilities.ts';
+import { prerequisitesFor } from '../../src/domain/capabilities.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
 import { connectionFor } from '../harness/installation.ts';
@@ -148,7 +148,10 @@ const refuses: DeployAdapter = {
   async destroy() {},
   async inspect() {
     return {
-      prerequisites: PREREQUISITES.map((name) => ({ name, met: true })),
+      prerequisites: prerequisitesFor('kubernetes').map((name) => ({
+        name,
+        met: true,
+      })),
       discovery: CAPABLE_DISCOVERY,
     };
   },

--- a/apps/spindrift/test/adapters/federation.test.ts
+++ b/apps/spindrift/test/adapters/federation.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Reaching a cloud Target with no stored credential (§13).
+ *
+ * §13 settles one auth mode — "native OIDC federation, **nothing stored**" —
+ * and a claim like that needs a test that can fail. The claims here:
+ *
+ * - **The projected token is read from disk on every exchange**, because the
+ *   kubelet rewrites it and a value captured once stops working part way
+ *   through the day.
+ * - **The exchange is a real exchange.** What goes to a cloud API is the token
+ *   STS handed back, never the projected one — sending that would be a `401` on
+ *   every cloud call, blamed on the Target.
+ * - **Impersonation is optional**, because direct resource access is a
+ *   supported configuration rather than an omission.
+ * - **A token is cached until shortly before it expires**, so a burst of calls
+ *   is one round trip and an expiring token is dropped before it can fail a
+ *   deploy mid-flight.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  FederationError,
+  workloadIdentityToken,
+} from '../../src/adapters/deploy/cloud/federation.ts';
+
+const AUDIENCE = '//iam.example.test/projects/1/pools/example/providers/one';
+const TOKEN_URL = 'https://sts.example.test/v1/token';
+const IMPERSONATION_URL =
+  'https://iamcredentials.example.test/v1/projects/-/serviceAccounts/one:generateAccessToken';
+const TOKEN_PATH = '/var/run/secrets/cloud/token';
+
+interface Recorded {
+  url: string;
+  body: Record<string, unknown>;
+  authorization: string | null;
+}
+
+/** A far side that exchanges, and records exactly what it was asked. */
+function federation(
+  options: {
+    impersonate?: boolean;
+    expiresIn?: number;
+    stsStatus?: number;
+    projected?: (path: string) => Promise<string>;
+    now?: () => number;
+  } = {},
+) {
+  const requests: Recorded[] = [];
+  let minted = 0;
+
+  const fetch = async (request: Request): Promise<Response> => {
+    const body = (await request.clone().json()) as Record<string, unknown>;
+    requests.push({
+      url: request.url,
+      body,
+      authorization: request.headers.get('authorization'),
+    });
+    if (request.url === TOKEN_URL) {
+      if (options.stsStatus !== undefined) {
+        return new Response('the pool refused this token', {
+          status: options.stsStatus,
+        });
+      }
+      minted += 1;
+      return Response.json({
+        access_token: `federated-${minted}`,
+        expires_in: options.expiresIn ?? 3600,
+      });
+    }
+    return Response.json({
+      accessToken: `impersonated-${minted}`,
+      expireTime: new Date((options.now?.() ?? 0) + 3_600_000).toISOString(),
+    });
+  };
+
+  let reads = 0;
+  const provider = workloadIdentityToken({
+    audience: AUDIENCE,
+    tokenUrl: TOKEN_URL,
+    tokenPath: TOKEN_PATH,
+    impersonationUrl: options.impersonate === true ? IMPERSONATION_URL : null,
+    fetch,
+    readToken:
+      options.projected ??
+      (async (path) => {
+        reads += 1;
+        return `projected-for-${path}-${reads}`;
+      }),
+    ...(options.now === undefined ? {} : { now: options.now }),
+  });
+
+  return { provider, requests, projectedReads: () => reads };
+}
+
+describe('§13: nothing stored, so every token is minted', () => {
+  test('what reaches a cloud API is the exchanged token, never the projected one', async () => {
+    const { provider, requests } = federation();
+    const token = await provider();
+
+    expect(token).toBe('federated-1');
+    // The projected token is the *subject* of an exchange. A provider that
+    // handed it straight to a cloud API would be sending a token minted for
+    // this cluster's own API server, which every cloud API refuses.
+    const exchange = requests[0];
+    expect(exchange?.url).toBe(TOKEN_URL);
+    expect(exchange?.body.subjectToken).toContain('projected-for-');
+    expect(exchange?.body.audience).toBe(AUDIENCE);
+    expect(token).not.toContain('projected-for-');
+  });
+
+  test('the projected token is re-read on every exchange, never captured', async () => {
+    // The kubelet rewrites the file, so a value read once at start-up stops
+    // working part way through the day — the classic failure this path exists
+    // to avoid.
+    let at = 0;
+    const { provider, projectedReads } = federation({
+      expiresIn: 1,
+      now: () => {
+        at += 600_000;
+        return at;
+      },
+    });
+    await provider();
+    await provider();
+    expect(projectedReads()).toBe(2);
+  });
+
+  test('an impersonated token is what comes back where one is configured', async () => {
+    const { provider, requests } = federation({ impersonate: true });
+    expect(await provider()).toBe('impersonated-1');
+
+    const impersonation = requests[1];
+    expect(impersonation?.url).toBe(IMPERSONATION_URL);
+    // Impersonation authorizes with the federated token, which is the whole
+    // point of the two-step: the projected token never leaves the exchange.
+    expect(impersonation?.authorization).toBe('Bearer federated-1');
+  });
+
+  test('no impersonation url is a configuration, not an omission', async () => {
+    const { provider, requests } = federation();
+    expect(await provider()).toBe('federated-1');
+    // Direct resource access grants the federated identity roles of its own,
+    // which is one fewer identity to reason about where it is allowed.
+    expect(requests).toHaveLength(1);
+  });
+});
+
+describe('caching, and giving up the last minute of a token', () => {
+  test('a burst of calls is one exchange', async () => {
+    const { provider, requests } = federation({ now: () => 1_000 });
+    const [first, second, third] = await Promise.all([
+      provider(),
+      provider(),
+      provider(),
+    ]);
+    expect([first, second, third]).toEqual([
+      'federated-1',
+      'federated-1',
+      'federated-1',
+    ]);
+    expect(requests).toHaveLength(1);
+  });
+
+  test('a token near expiry is dropped rather than served', async () => {
+    // A token that expires while a request is in flight fails a deploy for a
+    // reason nobody can act on, so the cache gives up its last minute.
+    let now = 0;
+    const { provider, requests } = federation({
+      expiresIn: 90,
+      now: () => now,
+    });
+    expect(await provider()).toBe('federated-1');
+    now = 20_000;
+    expect(await provider()).toBe('federated-1');
+    // 90s lifetime, 60s skew: past 30s the cached token is no longer offered.
+    now = 40_000;
+    expect(await provider()).toBe('federated-2');
+    expect(requests).toHaveLength(2);
+  });
+});
+
+describe('failing loudly rather than deploying with nothing', () => {
+  test('a refused exchange names the pool that refused it', async () => {
+    const { provider } = federation({ stsStatus: 403 });
+    expect(provider()).rejects.toThrow(FederationError);
+  });
+
+  test('an empty projected token is a refusal, not an empty bearer', async () => {
+    const { provider } = federation({ projected: async () => '   ' });
+    // An empty string would be sent as `Bearer `, and the failure would arrive
+    // as an authorization error against the Target rather than as the
+    // misconfiguration it is.
+    expect(provider()).rejects.toThrow(FederationError);
+  });
+});

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -1,0 +1,459 @@
+/**
+ * The static-hosting deploy adapter and its bundle reader (Task 29, §6, §9, §17).
+ *
+ * Every test drives the real adapter against a fake of the product's HTTP API
+ * (§ Seam 2), with a **real gzipped tar** written by `test/harness/tar.ts`
+ * rather than by the reader under test — a round trip through one
+ * implementation proves that implementation self-consistent and nothing else.
+ *
+ * The claims worth stating up front:
+ *
+ * - **`Public` only** (§9). A non-public Component reaching this adapter is
+ *   core's bug, because placement excludes this Target for one.
+ * - **The five-step release is the product's contract**, and a version that was
+ *   never finalized must not serve.
+ * - **The site names itself** (§9), so the address comes back on the verdict.
+ * - **The vanity name goes on the site that is already serving**, which is what
+ *   makes moving an App between backends one record re-point.
+ * - **A bundle is untrusted input**: a path that leaves the bundle is refused.
+ */
+import { describe, expect, test } from 'bun:test';
+import type {
+  DeployEvent,
+  DeployTarget,
+  DeployVerdict,
+} from '../../src/adapters/deploy/contract.ts';
+import { blameFor } from '../../src/adapters/deploy/contract.ts';
+import {
+  BundleError,
+  readBundle,
+} from '../../src/adapters/deploy/static/bundle.ts';
+import {
+  StaticDeployAdapter,
+  siteId,
+} from '../../src/adapters/deploy/static/index.ts';
+import { deriveHealth } from '../../src/domain/capabilities.ts';
+import type { DesiredState } from '../../src/domain/desired-state.ts';
+import type { StaticConnection } from '../../src/domain/target.ts';
+import {
+  FakeHosting,
+  type FakeHostingOptions,
+} from '../harness/fakes/hosting-api.ts';
+import { CLOUD_ENDPOINTS } from '../harness/installation.ts';
+import { bytes, header, tar, tarball } from '../harness/tar.ts';
+
+const DEPOT = 'https://artifacts.example.test';
+
+const CONNECTION: StaticConnection = {
+  adapter: 'static',
+  project: 'example-vessel',
+  endpoint: CLOUD_ENDPOINTS.hosting,
+};
+
+const TARGET: DeployTarget = {
+  name: 'hosting',
+  adapter: 'static',
+  connection: CONNECTION,
+};
+
+function desired(overrides: Partial<DesiredState> = {}): DesiredState {
+  return {
+    deploy: 'deploy-1',
+    app: 'shop',
+    component: 'site',
+    target: 'hosting',
+    kind: 'website',
+    artifact: {
+      type: 'files',
+      digest: 'sha256:bundle',
+      refs: [`${DEPOT}/bundles/sha256:bundle`],
+    },
+    exposure: 'public',
+    config: [],
+    requirements: { platform: { os: 'linux', arch: 'amd64' }, resources: {} },
+    hostname: { canonical: '' },
+    ...overrides,
+  };
+}
+
+/** A site of two files, which is enough for order and dedup to be visible. */
+const SITE = tarball([
+  { name: 'index.html', bytes: bytes('<!doctype html>home') },
+  { name: 'assets/app.css', bytes: bytes('body{}') },
+]);
+
+function adapterFor(options: FakeHostingOptions = {}): {
+  api: FakeHosting;
+  adapter: StaticDeployAdapter;
+} {
+  const api = new FakeHosting({
+    bundle: { origin: DEPOT, bytes: SITE },
+    ...options,
+  });
+  return {
+    api,
+    adapter: new StaticDeployAdapter({ token: api.token, fetch: api.fetch }),
+  };
+}
+
+async function drain(
+  stream: AsyncGenerator<DeployEvent, DeployVerdict, void>,
+): Promise<{ events: DeployEvent[]; verdict: DeployVerdict }> {
+  const events: DeployEvent[] = [];
+  let step = await stream.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return { events, verdict: step.value };
+}
+
+describe('§9: static hosting serves Public only', () => {
+  test('a private website is refused, and refused as core’s bug', async () => {
+    for (const exposure of ['internal', 'private'] as const) {
+      const { api, adapter } = adapterFor();
+      const { verdict } = await drain(
+        adapter.apply(TARGET, desired({ exposure })),
+      );
+      expect(verdict.phase).toBe('FAILED');
+      if (verdict.phase === 'FAILED') {
+        // Placement already excludes this Target for a non-public Component,
+        // so one arriving here is core's bug and not the developer's — which
+        // is the difference between INTERNAL and REJECTED.
+        expect(verdict.reason).toBe('INTERNAL');
+        expect(blameFor(verdict.reason)).toBe('platform');
+        expect(verdict.detail).toContain('Public only');
+      }
+      // And nothing was placed on the way to refusing.
+      expect(api.hasSite('shop-site')).toBe(false);
+    }
+  });
+});
+
+describe('the release is five steps, in the product’s order', () => {
+  test('a site is created, populated, finalized, and released', async () => {
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.hasSite('shop-site')).toBe(true);
+    expect(api.servedPaths('shop-site')).toEqual([
+      '/assets/app.css',
+      '/index.html',
+    ]);
+    // A draft version must not be what serves: the product refuses to release
+    // one, and the fake refuses for the same reason.
+    expect(api.serving('shop-site')?.status).toBe('FINALIZED');
+  });
+
+  test('the platform names its own, and the name comes back on the verdict', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+    expect(verdict.phase).toBe('LIVE');
+    if (verdict.phase === 'LIVE') {
+      expect(verdict.url).toBe('https://shop-site.hosted.example.test');
+    }
+  });
+
+  test('only the files the product does not hold are uploaded', async () => {
+    // The hash offered is over the gzipped bytes, which is what the product
+    // stores and therefore what it deduplicates on — so a redeploy of an
+    // unchanged site uploads nothing.
+    const first = adapterFor();
+    await drain(first.adapter.apply(TARGET, desired()));
+    expect(first.api.uploads).toHaveLength(2);
+
+    const held = first.api.uploads;
+    const second = adapterFor({ held });
+    await drain(second.adapter.apply(TARGET, desired()));
+    expect(second.api.uploads).toEqual([]);
+    // And the site still serves both files: not uploading is not not-serving.
+    expect(second.api.servedPaths('shop-site')).toHaveLength(2);
+  });
+
+  test('a redeploy releases onto the site that exists rather than a second one', async () => {
+    const { api, adapter } = adapterFor({ sites: ['shop-site'] });
+    await drain(adapter.apply(TARGET, desired()));
+    await drain(adapter.apply(TARGET, desired({ deploy: 'deploy-2' })));
+
+    expect(api.serving('shop-site')?.labels['spindrift-deploy']).toBe(
+      'deploy-2',
+    );
+    expect(
+      api.pathsOf('POST').filter((path) => path.endsWith('/sites')),
+    ).toEqual([]);
+  });
+});
+
+describe('§9: the vanity name is one record on the serving site', () => {
+  test('a vanity name is attached to the site that is already serving', async () => {
+    const { api, adapter } = adapterFor();
+    await drain(
+      adapter.apply(
+        TARGET,
+        desired({ hostname: { canonical: '', vanity: 'shop.example.test' } }),
+      ),
+    );
+    // §9: "moving an App between backends is one record re-point." On this
+    // backend the record is a domain on the site, so a move is this one call
+    // rather than a leg to stand up.
+    expect(api.domainsOf('shop-site')).toEqual(['shop.example.test']);
+  });
+
+  test('a name already on the site is the state being asked for', async () => {
+    const { adapter } = adapterFor({
+      domainAnswer: { status: 409, body: { error: { message: 'exists' } } },
+    });
+    const { verdict } = await drain(
+      adapter.apply(
+        TARGET,
+        desired({ hostname: { canonical: '', vanity: 'shop.example.test' } }),
+      ),
+    );
+    expect(verdict.phase).toBe('LIVE');
+  });
+
+  test('no vanity name means no record is written', async () => {
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(TARGET, desired()));
+    expect(api.domainsOf('shop-site')).toEqual([]);
+  });
+});
+
+describe('§6: what a failure is, and whose it is', () => {
+  test('an artifact that cannot be fetched blames the platform', async () => {
+    const { adapter } = adapterFor({
+      // Nothing is served at the depot, so the address resolves to a refusal.
+      bundle: { origin: 'https://nowhere.example.test', bytes: SITE },
+    });
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(blameFor(verdict.reason)).toBe('platform');
+    }
+  });
+
+  test('bytes that are not a bundle are the build having produced rubbish', async () => {
+    const { adapter } = adapterFor({
+      bundle: { origin: DEPOT, bytes: bytes('this is not a gzip') },
+    });
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('BUILD_FAILED');
+      expect(blameFor(verdict.reason)).toBe('developer');
+    }
+  });
+
+  test('a refused write is REJECTED and an unreachable product is not', async () => {
+    const refused = adapterFor({
+      refuseVersion: { status: 400, body: { error: { message: 'bad' } } },
+    });
+    const first = await drain(refused.adapter.apply(TARGET, desired()));
+    if (first.verdict.phase === 'FAILED') {
+      expect(first.verdict.reason).toBe('REJECTED');
+    }
+
+    const denied = adapterFor({
+      refuseVersion: { status: 403, body: { error: { message: 'nope' } } },
+    });
+    const second = await drain(denied.adapter.apply(TARGET, desired()));
+    if (second.verdict.phase === 'FAILED') {
+      expect(second.verdict.reason).toBe('TARGET_UNREACHABLE');
+    }
+  });
+});
+
+describe('observe, destroy, and what the site is called', () => {
+  test('observe reports the digest of what is released', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+    if (verdict.phase !== 'LIVE') throw new Error('nothing was placed');
+
+    const observed = await adapter.observe(TARGET, verdict.ref);
+    expect(observed?.artifactDigest).toBe('sha256:bundle');
+    expect(observed?.phase).toBe('LIVE');
+  });
+
+  test('a site released by something else reports drift rather than agreement', async () => {
+    // The digest lives on a label Spindrift wrote. A version released by hand
+    // carries none, which compares unequal to every desired digest — which is
+    // exactly what drift is, and §6 surfaces it rather than correcting it.
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(TARGET, desired()));
+    const serving = api.serving('shop-site');
+    if (serving !== undefined) serving.labels = {};
+
+    const observed = await adapter.observe(
+      TARGET,
+      'example-vessel/sites/shop-site',
+    );
+    expect(observed?.artifactDigest).toBe('');
+  });
+
+  test('destroy removes the site and is idempotent', async () => {
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+    if (verdict.phase !== 'LIVE') throw new Error('nothing was placed');
+
+    await adapter.destroy(TARGET, verdict.ref);
+    expect(api.hasSite('shop-site')).toBe(false);
+    await adapter.destroy(TARGET, verdict.ref);
+    expect(await adapter.observe(TARGET, verdict.ref)).toBeNull();
+  });
+
+  test('a long name is shortened deterministically, never collided', () => {
+    const long = desired({
+      app: 'a-very-long-application-name',
+      component: 'the-front-end',
+    });
+    const other = desired({
+      app: 'a-very-long-application-name',
+      component: 'the-back-end',
+    });
+    expect(siteId(long).length).toBeLessThanOrEqual(30);
+    expect(siteId(long)).toBe(siteId({ ...long }));
+    // Truncation alone would make these one site, and the second deploy would
+    // silently replace the first.
+    expect(siteId(long)).not.toBe(siteId(other));
+  });
+});
+
+describe('§13 and §17: what this Target is honest about', () => {
+  test('a reachable project meets every item on its own checklist', async () => {
+    const { adapter } = adapterFor();
+    const { prerequisites } = await adapter.inspect(TARGET);
+    expect(deriveHealth(prerequisites, 'static')).toBe('healthy');
+    // The chart rows are not asked, because there is no chart here to pin.
+    expect(prerequisites.map((item) => item.name)).not.toContain(
+      'CHART_CONTRACT',
+    );
+  });
+
+  test('runtime log history is zero, which is the honest empty state', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(TARGET);
+    // §17 gives static hosting an honest empty state rather than a duration:
+    // no process ever wrote a line, so a tail reaches back no distance at all.
+    expect(discovery.logHistorySeconds).toBe(0);
+  });
+
+  test('a site reaches no store, which is why §10 exempts a website', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(TARGET);
+    expect(discovery.reachableSecretStores).toEqual([]);
+    expect(discovery.reachableRegistries).toEqual([]);
+  });
+
+  test('nothing is admitted here, so nothing claims a verified deploy', async () => {
+    const { adapter } = adapterFor();
+    const { discovery } = await adapter.inspect(TARGET);
+    expect(discovery.policyEngine).toEqual({ installed: false, mode: null });
+  });
+});
+
+describe('the bundle reader', () => {
+  test('reads regular files and drops directories', () => {
+    const files = readBundle(
+      tarball([
+        { name: 'assets/', bytes: new Uint8Array(), type: '5' },
+        { name: 'assets/app.css', bytes: bytes('body{}') },
+        { name: 'index.html', bytes: bytes('hi') },
+      ]),
+    );
+    expect(files.map((file) => file.path)).toEqual([
+      '/assets/app.css',
+      '/index.html',
+    ]);
+    expect(new TextDecoder().decode(files[1]?.bytes)).toBe('hi');
+  });
+
+  test('the leading ./ every archiver writes is not part of the path', () => {
+    const files = readBundle(
+      tarball([{ name: './index.html', bytes: bytes('hi') }]),
+    );
+    expect(files[0]?.path).toBe('/index.html');
+  });
+
+  test('a path that leaves the bundle is refused, not normalized away', () => {
+    // The bundle is untrusted input. Writing outside a site would be the only
+    // path in this system by which one App could reach another's.
+    expect(() =>
+      readBundle(
+        tarball([{ name: '../elsewhere/evil.html', bytes: bytes('x') }]),
+      ),
+    ).toThrow(BundleError);
+  });
+
+  test('a GNU long name is used in place of the truncated header', () => {
+    const long = `${'deep/'.repeat(25)}index.html`;
+    const archive = tar([
+      { name: '././@LongLink', bytes: bytes(`${long}\0`), type: 'L' },
+      { name: long.slice(0, 99), bytes: bytes('hi') },
+    ]);
+    expect(readBundle(Bun.gzipSync(archive))[0]?.path).toBe(`/${long}`);
+  });
+
+  test('a pax path record is used in place of the truncated header', () => {
+    const long = `${'nested/'.repeat(20)}page.html`;
+    const record = paxRecord('path', long);
+    const archive = tar([
+      { name: 'PaxHeaders/0', bytes: record, type: 'x' },
+      { name: long.slice(0, 99), bytes: bytes('hi') },
+    ]);
+    expect(readBundle(Bun.gzipSync(archive))[0]?.path).toBe(`/${long}`);
+  });
+
+  test('an entry a website cannot contain is skipped, not fatal', () => {
+    // A symlink has no representation at a static host; the files around it
+    // still deploy, which is more useful than refusing the whole site.
+    const archive = tar([
+      { name: 'link', bytes: new Uint8Array(), type: '2' },
+      { name: 'index.html', bytes: bytes('hi') },
+    ]);
+    expect(readBundle(Bun.gzipSync(archive)).map((file) => file.path)).toEqual([
+      '/index.html',
+    ]);
+  });
+
+  test('an archive that ends inside an entry is malformed, not silently short', () => {
+    // Cut inside the entry's declared data rather than after it: the reader
+    // must notice the archive claiming more than it carries, which is what
+    // separates a truncated download from a short file.
+    const truncated = tar([
+      { name: 'big.bin', bytes: bytes('x'.repeat(1000)) },
+    ]).slice(0, 700);
+    expect(() => readBundle(Bun.gzipSync(truncated))).toThrow(BundleError);
+  });
+
+  test('bytes that are not gzip say so', () => {
+    try {
+      readBundle(bytes('plain text'));
+      throw new Error('the reader accepted something that is not a bundle');
+    } catch (cause) {
+      expect(cause).toBeInstanceOf(BundleError);
+      if (cause instanceof BundleError) expect(cause.code).toBe('NOT_GZIP');
+    }
+  });
+});
+
+/** One pax record, in the `<length> <key>=<value>\n` form the format uses. */
+function paxRecord(key: string, value: string): Uint8Array<ArrayBuffer> {
+  const body = `${key}=${value}\n`;
+  // The length counts itself, so it is solved for rather than measured.
+  let length = body.length + 3;
+  while (`${length}`.length + 1 + body.length !== length) {
+    length = `${length}`.length + 1 + body.length;
+  }
+  return bytes(`${length} ${body}`);
+}
+
+/** The header writer is exercised by the reader above; this pins its shape. */
+describe('the test harness writes a real ustar header', () => {
+  test('a header is one block with a valid checksum', () => {
+    const block = header({ name: 'index.html', bytes: bytes('hi') });
+    expect(block.length).toBe(512);
+    expect(new TextDecoder().decode(block.subarray(257, 262))).toBe('ustar');
+  });
+});

--- a/apps/spindrift/test/commands/placement.test.ts
+++ b/apps/spindrift/test/commands/placement.test.ts
@@ -33,7 +33,11 @@ import {
 import type { ComponentKind } from '../../src/domain/desired-state.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { clusterInput, fixtureManifest } from '../harness/installation.ts';
+import {
+  cloudInput,
+  clusterInput,
+  fixtureManifest,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -77,12 +81,7 @@ function context(registry: AdapterRegistry): CommandContext {
 async function connectEverything(registry: AdapterRegistry) {
   await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
   await connectTarget(
-    {
-      kind: 'cloud',
-      name: 'vessel',
-      project: 'example-vessel',
-      region: 'here',
-    },
+    cloudInput({ name: 'vessel', region: 'here' }),
     context(registry),
   );
   const rows = await database().db.select().from(targets);

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -40,6 +40,8 @@ import {
   type FakeDeployAdapterOptions,
 } from '../harness/fakes/deploy-adapter.ts';
 import {
+  CLOUD_ENDPOINTS,
+  cloudInput,
   clusterInput,
   connectionFor,
   fixtureManifest,
@@ -192,12 +194,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
   test('connecting a cloud project registers both of its Targets', async () => {
     const { registry } = fakes();
     const result = await connectTarget(
-      {
-        kind: 'cloud',
-        name: 'vessel',
-        project: 'example-vessel',
-        region: 'here',
-      },
+      cloudInput({ name: 'vessel', region: 'here' }),
       context(registry),
     );
 
@@ -210,14 +207,18 @@ describe('the act is credential-shaped though the noun is flat', () => {
     ]);
     expect(result.value.targets.map((t) => t.rank)).toEqual([0, 1]);
 
+    // Each Target keeps only the endpoint its own adapter drives: one connect
+    // act asked for both, and neither Target carries the other's.
     expect((await targetRow('vessel-cloudrun'))?.connection).toEqual({
       adapter: 'cloudrun',
       project: 'example-vessel',
       region: 'here',
+      endpoint: CLOUD_ENDPOINTS.run,
     });
     expect((await targetRow('vessel-static'))?.connection).toEqual({
       adapter: 'static',
       project: 'example-vessel',
+      endpoint: CLOUD_ENDPOINTS.hosting,
     });
   });
 
@@ -226,7 +227,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
     const input = clusterInput({ name: 'cluster' });
 
     await connectTarget(
-      { kind: 'cloud', name: 'vessel', project: 'p', region: 'r' },
+      cloudInput({ name: 'vessel', project: 'p', region: 'r' }),
       context(registry),
     );
     const first = await connectTarget(input, context(registry));

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -26,7 +26,10 @@ import type {
   DeployTarget,
 } from '../../src/adapters/deploy/contract.ts';
 import type { SecretStore } from '../../src/adapters/store/contract.ts';
-import { prerequisitesFor } from '../../src/domain/capabilities.ts';
+import {
+  PREREQUISITES,
+  prerequisitesFor,
+} from '../../src/domain/capabilities.ts';
 import type {
   ArtifactType,
   DesiredState,
@@ -185,6 +188,17 @@ export function deployAdapterSuite(
       expect(inspection.prerequisites.map((item) => item.name).sort()).toEqual(
         [...prerequisitesFor(made.adapter)].sort(),
       );
+      // Comparing against the adapter's own list is a weaker pin than comparing
+      // against one global list, so the teeth it gives up are put back here:
+      // an adapter cannot shrink its checklist to nothing and be trivially
+      // healthy, and every row it does answer has to be from the one
+      // vocabulary. `test/domain/capabilities.test.ts` holds the other half —
+      // that no cloud Target is asked a chart question, and that a checklist
+      // answered against the wrong adapter's list reads unhealthy.
+      expect(inspection.prerequisites.length).toBeGreaterThan(0);
+      for (const item of inspection.prerequisites) {
+        expect(PREREQUISITES).toContain(item.name);
+      }
     });
 
     test('inspect reports observations, not judgements', async () => {

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -26,7 +26,7 @@ import type {
   DeployTarget,
 } from '../../src/adapters/deploy/contract.ts';
 import type { SecretStore } from '../../src/adapters/store/contract.ts';
-import { PREREQUISITES } from '../../src/domain/capabilities.ts';
+import { prerequisitesFor } from '../../src/domain/capabilities.ts';
 import type {
   ArtifactType,
   DesiredState,
@@ -39,6 +39,9 @@ const enrolled = {
   build: new Set<string>(),
   store: new Set<string>(),
 };
+
+/** Where a `files` artifact is fetched from, as a depot addresses one. */
+export const BUNDLE_DEPOT = 'https://artifacts.example.test';
 
 /** A `DesiredState` of the given artifact type — the neutral one, not a mock. */
 export function desiredState(
@@ -53,13 +56,24 @@ export function desiredState(
     kind: artifactType === 'files' ? 'website' : 'service',
     // A real address, because an adapter that has to pull one cannot place
     // anything without it — and "the artifact carries no address" is a core
-    // bug, not a shape the contract's own suite should exercise.
+    // bug, not a shape the contract's own suite should exercise. The two shapes
+    // are addressed differently because they are: an image is pulled from a
+    // registry, and a bundle of files is fetched from the depot that staged it.
     artifact: {
       type: artifactType,
       digest,
-      refs: [`registry.example.test/conformance@${digest}`],
+      refs: [
+        artifactType === 'files'
+          ? `${BUNDLE_DEPOT}/bundles/${digest}`
+          : `registry.example.test/conformance@${digest}`,
+      ],
     },
-    exposure: 'private',
+    // Exposure follows the shape rather than being fixed, because §9 ties the
+    // two: a `files` artifact only ever lands on static hosting, which serves
+    // `Public` only — so a private one is a state no Target accepts, and a
+    // suite that asked for one would be asserting against a placement core
+    // would never make.
+    exposure: artifactType === 'files' ? 'public' : 'private',
     config: [],
     requirements: {
       platform: { os: 'linux', arch: 'amd64' },
@@ -157,12 +171,19 @@ export function deployAdapterSuite(
     });
 
     test('inspect answers the whole checklist, exactly once each', async () => {
-      const inspection = await make().inspect(target);
+      const made = make();
+      const inspection = await made.inspect(target);
       // §13 merges health and capability refresh into one loop, which only
       // works if one pass answers every item — a partial checklist would leave
-      // core deciding what an absent item means.
+      // core deciding what an absent item means, and `deriveHealth` treats an
+      // unanswered row as unmet.
+      //
+      // The checklist compared against is this adapter type's, not the whole
+      // vocabulary: a Cloud Run Target has no delivery operator to assess, and
+      // a suite that demanded one would force every cloud adapter to report a
+      // row that can only ever be a lie in one direction or the other.
       expect(inspection.prerequisites.map((item) => item.name).sort()).toEqual(
-        [...PREREQUISITES].sort(),
+        [...prerequisitesFor(made.adapter)].sort(),
       );
     });
 
@@ -310,7 +331,7 @@ export function storeAdapterSuite(
  * inferred from a directory listing that would silently agree with itself.
  */
 export const ADAPTERS = {
-  deploy: ['fake', 'kubernetes'],
+  deploy: ['fake', 'kubernetes', 'cloudrun', 'static'],
   build: ['fake', 'github-actions', 'cloud-build', 'in-cluster'],
   store: [
     'fake native',

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -17,21 +17,27 @@ import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
 import { GitHubActionsBuildRoute } from '../../src/adapters/build/github-actions.ts';
 import { InClusterBuildRoute } from '../../src/adapters/build/in-cluster.ts';
 import { encodeBuildReport } from '../../src/adapters/build/report.ts';
+import { CloudRunDeployAdapter } from '../../src/adapters/deploy/cloudrun/index.ts';
 import { KubernetesApi } from '../../src/adapters/deploy/kubernetes/api.ts';
 import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
+import { StaticDeployAdapter } from '../../src/adapters/deploy/static/index.ts';
 import { SecretManagerStore } from '../../src/adapters/store/gcp-secret-manager.ts';
 import { OnePasswordStore } from '../../src/adapters/store/onepassword.ts';
 import { GitHubApp } from '../../src/integrations/github/app.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeCloudBuild } from '../harness/fakes/cloud-build-api.ts';
+import { FakeCloudRun } from '../harness/fakes/cloudrun-api.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import { FakeGitHub, testAppKey } from '../harness/fakes/github-api.ts';
+import { FakeHosting } from '../harness/fakes/hosting-api.ts';
 import { FakeKubernetes } from '../harness/fakes/kubernetes-api.ts';
 import { FakeOnePasswordConnect } from '../harness/fakes/onepassword-connect.ts';
 import { FakeSecretManager } from '../harness/fakes/secret-manager-api.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { bytes, tarball } from '../harness/tar.ts';
 import {
   assertEveryAdapterEnrolled,
+  BUNDLE_DEPOT,
   buildAdapterSuite,
   deployAdapterSuite,
   storeAdapterSuite,
@@ -109,6 +115,38 @@ deployAdapterSuite(
     });
   },
   'files',
+);
+
+deployAdapterSuite(
+  'cloudrun',
+  () => {
+    const api = new FakeCloudRun();
+    return new CloudRunDeployAdapter({
+      token: api.token,
+      fetch: api.fetch,
+      pollIntervalMs: 1,
+      sleep: async () => {},
+    });
+  },
+  'files',
+);
+
+deployAdapterSuite(
+  'static',
+  () => {
+    const api = new FakeHosting({
+      // The one file every website has, so the release has something to carry
+      // and the upload step actually runs.
+      bundle: {
+        origin: BUNDLE_DEPOT,
+        bytes: tarball([
+          { name: 'index.html', bytes: bytes('<!doctype html>hello') },
+        ]),
+      },
+    });
+    return new StaticDeployAdapter({ token: api.token, fetch: api.fetch });
+  },
+  'image',
 );
 
 buildAdapterSuite('fake', () => new FakeBuildAdapter());

--- a/apps/spindrift/test/domain/capabilities.test.ts
+++ b/apps/spindrift/test/domain/capabilities.test.ts
@@ -11,6 +11,7 @@
  *   references rather than assumed from one.
  */
 import { describe, expect, test } from 'bun:test';
+import { targetAdapterSchema } from '../../src/config/manifest.schema.ts';
 import {
   type CapabilityContext,
   deriveHealth,
@@ -20,6 +21,7 @@ import {
   KINDS_BY_ADAPTER,
   noCapabilities,
   PREREQUISITES,
+  prerequisitesFor,
   resolveCapabilities,
   type TargetDiscovery,
 } from '../../src/domain/capabilities.ts';
@@ -156,21 +158,64 @@ describe('the provenances that are not discovered', () => {
 describe('health is the whole checklist', () => {
   test('healthy is every item met', () => {
     expect(
-      deriveHealth(PREREQUISITES.map((name) => ({ name, met: true }))),
+      deriveHealth(
+        prerequisitesFor('kubernetes').map((name) => ({ name, met: true })),
+        'kubernetes',
+      ),
     ).toBe('healthy');
   });
 
   test('one unmet item is unhealthy', () => {
-    const checklist = PREREQUISITES.map((name) => ({
+    const checklist = prerequisitesFor('kubernetes').map((name) => ({
       name,
       met: name !== 'OIDC_FEDERATION',
     }));
-    expect(deriveHealth(checklist)).toBe('unhealthy');
+    expect(deriveHealth(checklist, 'kubernetes')).toBe('unhealthy');
   });
 
   test('a partial checklist is unhealthy, never healthy by omission', () => {
     // An item nobody answered is an item nobody checked. Reading absence as
     // success is how a Target ends up green on a prerequisite it never met.
-    expect(deriveHealth([{ name: 'VESSEL', met: true }])).toBe('unhealthy');
+    expect(deriveHealth([{ name: 'VESSEL', met: true }], 'kubernetes')).toBe(
+      'unhealthy',
+    );
+  });
+});
+
+describe('the checklist is the adapter type\u2019s, not one list for all three', () => {
+  test('every adapter type is assessed against a non-empty checklist', () => {
+    for (const adapter of targetAdapterSchema.options) {
+      expect(prerequisitesFor(adapter).length).toBeGreaterThan(0);
+    }
+  });
+
+  test('a cloud Target is never asked about a chart or a delivery operator', () => {
+    // §13's list is written in a cluster's terms because a cluster is what it
+    // was written about. A Cloud Run Target has no operator to run and no chart
+    // to pin, and a row that can never fail teaches a reader that something was
+    // checked when nothing was.
+    for (const adapter of ['cloudrun', 'static'] as const) {
+      expect(prerequisitesFor(adapter)).not.toContain('DELIVERY_OPERATOR');
+      expect(prerequisitesFor(adapter)).not.toContain('CHART_SOURCE');
+      expect(prerequisitesFor(adapter)).not.toContain('CHART_CONTRACT');
+    }
+  });
+
+  test('every checklist is drawn from the one vocabulary', () => {
+    for (const adapter of targetAdapterSchema.options) {
+      for (const name of prerequisitesFor(adapter)) {
+        expect(PREREQUISITES).toContain(name);
+      }
+    }
+  });
+
+  test('a cloud Target answering a cluster checklist is unhealthy', () => {
+    // The rows it answered are all met; they are simply not the rows a Cloud
+    // Run Target is asked, so health must not read them as an answer.
+    const cluster = prerequisitesFor('kubernetes').map((name) => ({
+      name,
+      met: true,
+    }));
+    expect(deriveHealth(cluster, 'cloudrun')).toBe('unhealthy');
   });
 });

--- a/apps/spindrift/test/domain/naming.test.ts
+++ b/apps/spindrift/test/domain/naming.test.ts
@@ -26,7 +26,12 @@ import {
   displayUrl,
   hostnameFor,
   isLabel,
+  VANITY_CEILING,
+  VANITY_LEG_LOSSES,
   vanity,
+  vanityCarriesStreams,
+  vanityProxied,
+  vanityRation,
 } from '../../src/domain/naming.ts';
 
 const APEX = 'apps.example.test';
@@ -171,5 +176,73 @@ describe('§9: DNS is a custom resource, not an API call', () => {
       servedBy: 'tunnel.example.test',
     });
     expect(records.every((record) => record.recordType === 'CNAME')).toBe(true);
+  });
+});
+
+describe('§9: the vanity layer, and what it costs', () => {
+  test('the ceiling is a fact about the certificate, reported not enforced', () => {
+    // §9's "hard ceiling: roughly 20 vanity names" is a property of one apex's
+    // free certificate. Nothing here refuses the twenty-first: the UI's job is
+    // to say how many are left, and a limit core imposed would be a policy
+    // somebody chose rather than the one the zone actually has.
+    expect(vanityRation(0)).toEqual({
+      used: 0,
+      ceiling: VANITY_CEILING,
+      remaining: VANITY_CEILING,
+      exhausted: false,
+    });
+    expect(vanityRation(VANITY_CEILING).exhausted).toBe(true);
+    expect(vanityRation(VANITY_CEILING + 5).remaining).toBe(0);
+  });
+
+  test('proxying is per-Target, and follows who mints the canonical name', () => {
+    // §9: "the vanity record is unproxied on that leg, **so** proxying becomes
+    // a per-Target property." The proxy is not a preference — it is the only
+    // way a name reaches a cluster whose load-balancer range is RFC1918.
+    expect(vanityProxied('kubernetes')).toBe(true);
+    for (const adapter of ['cloudrun', 'static'] as const) {
+      expect(vanityProxied(adapter)).toBe(false);
+      // The two are the same question asked twice: a backend that names its
+      // own workloads is a backend the internet already reaches.
+      expect(coreMintsCanonical(adapter)).toBe(false);
+    }
+  });
+
+  test('the losses on the unproxied leg are stated, not worked around', () => {
+    // §9 absorbs these on purpose, and the reason it can is that the app stays
+    // fully capable at its canonical name. Working around them would mean a
+    // second edge, which is the external load balancer §9 declines to have.
+    expect(VANITY_LEG_LOSSES.buffersResponse).toBe(true);
+    expect(VANITY_LEG_LOSSES.streamingProtocols).toBe(false);
+    expect(VANITY_LEG_LOSSES.maxRequestSeconds).toBe(60);
+  });
+
+  test('an App that streams keeps its streams only on the proxied leg', () => {
+    expect(vanityCarriesStreams('kubernetes')).toBe(true);
+    expect(vanityCarriesStreams('cloudrun')).toBe(false);
+    expect(vanityCarriesStreams('static')).toBe(false);
+  });
+
+  test('moving between backends re-points one record and renames nothing', () => {
+    // §9's whole reason for a second layer: "the name a developer shares is
+    // backend-agnostic and moving an App between backends is one record
+    // re-point." So the name is a function of the label and the zone alone —
+    // if the adapter appeared in it, a move would change what people had
+    // bookmarked.
+    const shared = vanity('shop', VANITY_ZONE);
+    for (const adapter of ['kubernetes', 'cloudrun', 'static'] as const) {
+      const hostname = hostnameFor({
+        app: 'shop',
+        component: 'web',
+        adapter,
+        apexZone: APEX,
+        vanityZone: VANITY_ZONE,
+        vanityLabel: 'shop',
+      });
+      expect(hostname.vanity).toBe(shared);
+      // What does change is the canonical underneath it, and on two of the
+      // three that is the platform's own name arriving across the deploy seam.
+      expect(hostname.canonical === '').toBe(!coreMintsCanonical(adapter));
+    }
   });
 });

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -329,3 +329,90 @@ describe('the rest of the derived requirements', () => {
     expect(reasons).toContain('NO_GPU');
   });
 });
+
+describe('§9: a Private website takes the server-image rendering', () => {
+  test('the whole resolution routes it away from static hosting', () => {
+    // §9: "a rendering that leaves an unauthenticated alternate origin is
+    // disqualified rather than shipped with a caveat — which is why the static
+    // hosting product serves `Public` only, and why a Private website takes
+    // the server-image rendering."
+    const placement = resolvePlacement(
+      [
+        target({ id: 'cdn', name: 'hosting', adapter: 'static', rank: 0 }),
+        target({ id: 'cluster', name: 'cluster', rank: 1 }),
+      ],
+      requirements({ kind: 'website', exposure: 'private' }),
+    );
+
+    // Static outranks the cluster and is still not what is suggested.
+    expect(placement.suggested?.target.id).toBe('cluster');
+    expect(placement.suggested?.artifactType).toBe('image');
+    expect(placement.candidates.map((one) => one.target.id)).toEqual([
+      'cluster',
+    ]);
+    // And the one that lost says why, rather than simply not appearing (§3).
+    const excluded = placement.nonCandidates.find(
+      (one) => one.target.id === 'cdn',
+    );
+    expect(excluded?.reasons).toContain('EXPOSURE_UNSUPPORTED');
+    expect(excluded?.detail.join(' ')).toContain('only serve public');
+  });
+
+  test('the same website going public reaches static hosting as files', () => {
+    const placement = resolvePlacement(
+      [
+        target({ id: 'cdn', name: 'hosting', adapter: 'static', rank: 0 }),
+        target({ id: 'cluster', name: 'cluster', rank: 1 }),
+      ],
+      requirements({ kind: 'website', exposure: 'public' }),
+    );
+    expect(placement.suggested?.target.id).toBe('cdn');
+    expect(placement.suggested?.artifactType).toBe('files');
+  });
+});
+
+describe('§10: the reach rule does not bind a website', () => {
+  test('a Target that reaches no store still holds a website', () => {
+    // §10's one exception makes a website's configuration build arguments
+    // derived from its kind, so there is nothing at run time for a store to
+    // deliver. Static hosting reaches no store precisely because it has no
+    // runtime — and applying the rule anyway would exclude it from the one
+    // kind it exists to run.
+    const cdn = target({
+      adapter: 'static',
+      discovery: { reachableSecretStores: [] },
+    });
+    expect(
+      exclusionsFor(cdn, requirements({ kind: 'website', exposure: 'public' })),
+    ).toEqual([]);
+  });
+
+  test('a service on the same Target is still bound by it', () => {
+    // The exemption is the kind's, not the Target's: a Component with a
+    // runtime that reads configuration needs somewhere to read it from.
+    const unreachable = target({
+      discovery: { reachableSecretStores: [] },
+    });
+    expect(exclusionsFor(unreachable, requirements())).toContain(
+      'STORE_UNREACHABLE',
+    );
+  });
+});
+
+describe('§3: a kind an adapter does not render is refused at Place', () => {
+  test('a job is a non-candidate on the cloud runtime, with the reason', () => {
+    // `KINDS_BY_ADAPTER` is "a property of the code": the Cloud Run adapter
+    // renders Services, and a job there is Task 33's work. Until it exists the
+    // honest answer is a non-candidate with a stated reason, which fails at
+    // Place rather than at apply.
+    const cloud = target({ adapter: 'cloudrun' });
+    const reasons = exclusionsFor(cloud, requirements({ kind: 'job' }));
+    expect(reasons).toContain('KIND_UNSUPPORTED');
+  });
+
+  test('a service and a website are both rendered there', () => {
+    const cloud = target({ adapter: 'cloudrun' });
+    expect(exclusionsFor(cloud, requirements({ kind: 'service' }))).toEqual([]);
+    expect(exclusionsFor(cloud, requirements({ kind: 'website' }))).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/domain/workload-name.test.ts
+++ b/apps/spindrift/test/domain/workload-name.test.ts
@@ -1,0 +1,66 @@
+/**
+ * What a backend calls the thing core placed.
+ *
+ * One rule, three backends, and the reason it is one rule is the failure mode
+ * truncation has: `<app>-<component>` cut to a limit makes two Components of one
+ * long-named App **the same name**, and a re-deploy of the same name is an
+ * upgrade — so one Component silently starts serving the other's image. Nothing
+ * goes red. That is the quiet failure this file exists to make impossible.
+ */
+import { describe, expect, test } from 'bun:test';
+import { workloadName } from '../../src/domain/workload-name.ts';
+
+describe('a name under the limit is the plain one', () => {
+  test('what a human reading the backend expects to see', () => {
+    expect(workloadName({ app: 'shop', component: 'web' }, 63)).toBe(
+      'shop-web',
+    );
+  });
+
+  test('a name exactly at the limit is not shortened', () => {
+    const name = workloadName({ app: 'a'.repeat(20), component: 'b' }, 22);
+    expect(name).toBe(`${'a'.repeat(20)}-b`);
+    expect(name).toHaveLength(22);
+  });
+});
+
+describe('over the limit, the tail is a digest and never a cut', () => {
+  const app = 'a-very-long-application-name-indeed';
+
+  test('the result fits, at every limit a backend imposes', () => {
+    // 30 is the static site id, 63 the Service and the Kubernetes object.
+    for (const limit of [30, 63]) {
+      expect(
+        workloadName({ app, component: 'the-front-end' }, limit).length,
+      ).toBeLessThanOrEqual(limit);
+    }
+  });
+
+  test('two Components of one App stay two names', () => {
+    // Truncation alone collides here, and the second deploy would replace the
+    // first rather than fail.
+    const front = workloadName({ app, component: 'the-front-end' }, 30);
+    const back = workloadName({ app, component: 'the-back-end' }, 30);
+    expect(front).not.toBe(back);
+  });
+
+  test('the same input is the same name, every time', () => {
+    // A second deploy that computed a different name would create a second
+    // workload rather than replace the first.
+    expect(workloadName({ app, component: 'web' }, 30)).toBe(
+      workloadName({ app, component: 'web' }, 30),
+    );
+  });
+
+  test('enough of the plain name survives to be recognisable', () => {
+    expect(workloadName({ app, component: 'web' }, 30)).toStartWith('a-very-');
+  });
+
+  test('an absurdly small limit still produces a name', () => {
+    // No backend has one this small; the guard exists so that a limit nobody
+    // anticipated produces a name rather than an empty string.
+    expect(workloadName({ app, component: 'web' }, 4).length).toBeGreaterThan(
+      0,
+    );
+  });
+});

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -72,10 +72,14 @@ const PROJECT_ID_ALLOWLIST = new Set<string>([
   // Why a build route is not usable for a Target — vocabulary again, read from
   // the domain rather than restated, so adding one does not break a test here.
   ...BUILD_ROUTE_REFUSALS,
-  // An encoding, and a key in a workflow file. Neither names anything; both
-  // wear the shape because they are lowercase words carrying a digit or a
-  // hyphen, which is the whole of what this scanner can see.
+  // An encoding, a digest algorithm, and a key in a workflow file. None of the
+  // three names anything; all wear the shape because they are lowercase words
+  // carrying a digit or a hyphen, which is the whole of what this scanner can
+  // see. The algorithm is §16's — correlation joins on digests everywhere in
+  // the supply chain, so naming the function that produces one is this
+  // system's vocabulary in every installation.
   'base64',
+  'sha256',
   'run-name',
   // HTTP header names. `src/web/` is scoped out of this scanner for exactly
   // this reason (see BROWSER_SOURCE), but the auth surface writes headers from

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -23,6 +23,15 @@ dns:
 cloud:
   artifactsProject: example-artifacts
   homeVesselProject: example-home
+  # §13's one auth mode: the pod projects a token, the token is exchanged, and
+  # nothing is stored. The path is a *separately* projected volume whose
+  # audience is the pool below — not the default service account token, which is
+  # minted for this cluster's own API server and which a cloud API refuses.
+  federation:
+    audience: //iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster
+    tokenUrl: https://sts.example.test/v1/token
+    tokenPath: /var/run/secrets/cloud/token
+    impersonationUrl: https://iamcredentials.example.test/v1/projects/-/serviceAccounts/spindrift@example-home.example.test:generateAccessToken
 
 charts:
   app: example/spindrift-app

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -1,0 +1,263 @@
+/**
+ * A fake Cloud Run API (Task 28, § Seam 2).
+ *
+ * "A fake of the far-side HTTP API behind the real client, with the test
+ * asserting the requests that were made" — so the adapter's real paths, its real
+ * apply, and its real status reading all run. Nothing inside core is faked; this
+ * is the project that is not there.
+ *
+ * Four behaviours are modelled because the adapter has to survive all four:
+ *
+ * - **The runtime writes `terminalCondition` after the Service is accepted.** A
+ *   fake that answered ready on the first read would let an adapter that never
+ *   polled pass, which is the whole of `apply`'s second half.
+ * - **A refusal carries a body with a machine-readable reason**, because the
+ *   checklist tells "the service is off" from "you may not" from "there is no
+ *   such project" by exactly that, and a bare status code would leave nothing to
+ *   tell them apart with.
+ * - **The IAM policy is a resource that can be read back**, so a test can assert
+ *   §9's fail-closed ordering rather than only that a call was made.
+ * - **The admission policy lives at its own endpoint**, which is how a Target
+ *   that names none is distinguishable from one whose policy admits everything.
+ */
+import type { Fetcher } from '../../../src/adapters/deploy/cloud/http.ts';
+import { CLOUD_ENDPOINTS } from '../installation.ts';
+
+export interface RecordedCloudRequest {
+  method: string;
+  /** Path and query, which is what an `allowMissing` assertion needs. */
+  url: string;
+  path: string;
+  body: unknown;
+}
+
+/** What one applied Service's status becomes, read by read. */
+export type ServiceScript = (reads: number) => Record<string, unknown> | null;
+
+export interface FakeCloudRunOptions {
+  readonly project?: string;
+  readonly region?: string;
+  /** What a Service's condition fields become over successive reads. */
+  readonly service?: ServiceScript;
+  /** When set, every write is refused with this status and body. */
+  readonly refuse?: { status: number; body: unknown };
+  /** When set, the list probe `inspect` makes is refused with this. */
+  readonly refuseList?: { status: number; body: unknown };
+  /** When set, `:setIamPolicy` is refused with this. */
+  readonly refuseIam?: { status: number; body: unknown };
+  /** The admission policy this project reports, or `null` for none at all. */
+  readonly admissionPolicy?: Record<string, unknown> | null;
+  readonly token?: string;
+}
+
+/** The default: the runtime reports ready on the second read after apply. */
+const READY: ServiceScript = (reads) =>
+  reads < 2
+    ? { terminalCondition: { type: 'Ready', state: 'CONDITION_RECONCILING' } }
+    : {
+        terminalCondition: {
+          type: 'Ready',
+          state: 'CONDITION_SUCCEEDED',
+          message: 'ok',
+        },
+      };
+
+export class FakeCloudRun {
+  readonly endpoint = CLOUD_ENDPOINTS.run;
+  readonly policyEndpoint = CLOUD_ENDPOINTS.policy;
+  readonly requests: RecordedCloudRequest[] = [];
+
+  /** Services this project holds, by id. */
+  private readonly services = new Map<string, Record<string, unknown>>();
+  /** Invoker policies, by service id — the assertion surface for exposure. */
+  private readonly policies = new Map<string, unknown>();
+  private readonly reads = new Map<string, number>();
+  private readonly options: FakeCloudRunOptions;
+
+  constructor(options: FakeCloudRunOptions = {}) {
+    this.options = options;
+  }
+
+  get project(): string {
+    return this.options.project ?? 'example-vessel';
+  }
+
+  get region(): string {
+    return this.options.region ?? 'somewhere';
+  }
+
+  /** Mint the token provider the adapter is constructed with. */
+  token = (): string => this.options.token ?? 'federated-token';
+
+  /** What the project holds now — the assertion surface for a write. */
+  service(id: string): Record<string, unknown> | undefined {
+    return this.services.get(id);
+  }
+
+  /** The invoker policy written for one Service, if any was. */
+  policy(id: string): unknown {
+    return this.policies.get(id);
+  }
+
+  /** Requests the adapter made, in order — what § Seam 2 asserts on. */
+  pathsOf(method: string): string[] {
+    return this.requests
+      .filter((request) => request.method === method)
+      .map((request) => request.path);
+  }
+
+  fetch: Fetcher = async (request) => {
+    const url = new URL(request.url);
+    const body =
+      request.method === 'GET' || request.method === 'DELETE'
+        ? null
+        : await request.clone().json();
+    this.requests.push({
+      method: request.method,
+      url: `${url.pathname}${url.search}`,
+      path: url.pathname,
+      body,
+    });
+
+    if (request.headers.get('authorization') !== `Bearer ${this.token()}`) {
+      return json(401, { error: { message: 'unauthenticated' } });
+    }
+
+    if (url.origin === new URL(this.policyEndpoint).origin) {
+      return this.admissionResponse();
+    }
+
+    const parent = `/v2/projects/${this.project}/locations/${this.region}/services`;
+    if (!url.pathname.startsWith(parent)) {
+      return json(404, {
+        error: { message: 'no such path', status: 'NOT_FOUND' },
+      });
+    }
+
+    const rest = url.pathname.slice(parent.length).replace(/^\//, '');
+    if (rest === '') {
+      if (this.options.refuseList !== undefined) {
+        return json(
+          this.options.refuseList.status,
+          this.options.refuseList.body,
+        );
+      }
+      return json(200, { services: [...this.services.values()] });
+    }
+
+    const [id, verb] = rest.split(':', 2);
+    if (id === undefined || id === '') return json(404, notFound());
+
+    if (verb === 'setIamPolicy') {
+      if (this.options.refuseIam !== undefined) {
+        return json(this.options.refuseIam.status, this.options.refuseIam.body);
+      }
+      if (!this.services.has(id)) return json(404, notFound());
+      this.policies.set(id, body);
+      return json(200, (body as { policy?: unknown })?.policy ?? {});
+    }
+
+    switch (request.method) {
+      case 'GET':
+        return this.readResponse(id);
+      case 'PATCH':
+        return this.applyResponse(url, id, body as Record<string, unknown>);
+      case 'DELETE':
+        if (!this.services.has(id)) return json(404, notFound());
+        this.services.delete(id);
+        this.policies.delete(id);
+        this.reads.delete(id);
+        return json(200, { done: true });
+      default:
+        return json(405, {
+          error: { message: `${request.method} is not supported` },
+        });
+    }
+  };
+
+  private admissionResponse(): Response {
+    const policy = this.options.admissionPolicy;
+    if (policy === undefined || policy === null) return json(404, notFound());
+    return json(200, policy);
+  }
+
+  private readResponse(id: string): Response {
+    const service = this.services.get(id);
+    if (service === undefined) return json(404, notFound());
+
+    // The runtime writes the terminal condition *after* the Service exists,
+    // which is what makes `apply` poll rather than assume.
+    const script = this.options.service ?? READY;
+    const reads = (this.reads.get(id) ?? 0) + 1;
+    this.reads.set(id, reads);
+    const status = script(reads);
+    return json(200, status === null ? service : { ...service, ...status });
+  }
+
+  private applyResponse(
+    url: URL,
+    id: string,
+    document: Record<string, unknown>,
+  ): Response {
+    if (this.options.refuse !== undefined) {
+      return json(this.options.refuse.status, this.options.refuse.body);
+    }
+    // `allowMissing` is what makes the adapter's one call create-or-update. A
+    // fake that created regardless would let the adapter drop the parameter
+    // and still pass, so the refusal is modelled rather than assumed.
+    if (
+      !this.services.has(id) &&
+      url.searchParams.get('allowMissing') !== 'true'
+    ) {
+      return json(404, notFound());
+    }
+    const stored = {
+      ...document,
+      name: id,
+      uri: `https://${id}.run.example.test`,
+    };
+    this.services.set(id, stored);
+    this.reads.set(id, 0);
+    return json(200, { done: false, metadata: { target: id } });
+  }
+}
+
+/** The body a Google-family API returns for an absent resource. */
+function notFound(): unknown {
+  return { error: { message: 'not found', status: 'NOT_FOUND' } };
+}
+
+/** A refusal because the service is switched off in this project. */
+export function serviceDisabled(): { status: number; body: unknown } {
+  return {
+    status: 403,
+    body: {
+      error: {
+        message: 'Cloud Run API has not been used in this project',
+        status: 'PERMISSION_DENIED',
+        details: [{ reason: 'SERVICE_DISABLED' }],
+      },
+    },
+  };
+}
+
+/** A refusal because this identity may not act here. */
+export function permissionDenied(): { status: number; body: unknown } {
+  return {
+    status: 403,
+    body: {
+      error: {
+        message: 'the caller does not have permission',
+        status: 'PERMISSION_DENIED',
+        details: [{ reason: 'IAM_PERMISSION_DENIED' }],
+      },
+    },
+  };
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/apps/spindrift/test/harness/fakes/deploy-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/deploy-adapter.ts
@@ -21,7 +21,8 @@ import type {
 } from '../../../src/adapters/deploy/contract.ts';
 import type { TargetAdapter } from '../../../src/config/manifest.schema.ts';
 import {
-  PREREQUISITES,
+  type Prerequisite,
+  prerequisitesFor,
   type TargetDiscovery,
   type TargetInspection,
 } from '../../../src/domain/capabilities.ts';
@@ -58,7 +59,7 @@ export interface FakeDeployAdapterOptions {
    */
   discovery?: Partial<TargetDiscovery>;
   /** Checklist items to report unmet, with the sentence behind each. */
-  unmet?: Readonly<Partial<Record<(typeof PREREQUISITES)[number], string>>>;
+  unmet?: Readonly<Partial<Record<Prerequisite, string>>>;
   /** When set, `inspect` throws — the Target that cannot be reached at all. */
   unreachable?: string;
   /**
@@ -198,7 +199,7 @@ export class FakeDeployAdapter implements DeployAdapter {
     }
     const unmet = this.options.unmet ?? {};
     return {
-      prerequisites: PREREQUISITES.map((name) =>
+      prerequisites: prerequisitesFor(this.adapter).map((name) =>
         unmet[name] === undefined
           ? { name, met: true }
           : { name, met: false, detail: unmet[name] },

--- a/apps/spindrift/test/harness/fakes/hosting-api.ts
+++ b/apps/spindrift/test/harness/fakes/hosting-api.ts
@@ -1,0 +1,358 @@
+/**
+ * A fake static-hosting API (Task 29, § Seam 2).
+ *
+ * "A fake of the far-side HTTP API behind the real client, with the test
+ * asserting the requests that were made" — so the adapter's real five-step
+ * release, its real hashing, and its real bundle reading all run.
+ *
+ * Three behaviours are modelled because the adapter depends on all three:
+ *
+ * - **`populateFiles` asks for the hashes it does not already hold**, which is
+ *   what makes a redeploy of an unchanged site cheap. A fake that always asked
+ *   for everything would let an adapter that ignored the answer pass.
+ * - **A version has to be finalized before a release will take it**, because
+ *   that ordering is the product's whole contract about immutability and an
+ *   adapter that released a draft would silently serve nothing.
+ * - **The bundle is served from wherever the artifact says it is**, over the
+ *   same injected transport, because the adapter fetching its own artifact is a
+ *   real step that a fake API alone would leave untested.
+ */
+import type { Fetcher } from '../../../src/adapters/deploy/cloud/http.ts';
+import { CLOUD_ENDPOINTS } from '../installation.ts';
+
+export interface RecordedHostingRequest {
+  method: string;
+  url: string;
+  path: string;
+  body: unknown;
+}
+
+export interface FakeHostingOptions {
+  readonly project?: string;
+  /** Sites that already exist, by id. */
+  readonly sites?: readonly string[];
+  /** Hashes the product already holds, so it will not ask for them again. */
+  readonly held?: readonly string[];
+  /**
+   * The artifact depot, and the bundle every address under it serves.
+   *
+   * Matched by origin rather than by exact URL because a `files` artifact is
+   * addressed by its own digest: a fake keyed on one URL would have to be
+   * rebuilt for every digest a test uses, which is a fixture detail leaking
+   * into what the test is actually about.
+   */
+  readonly bundle?: {
+    readonly origin: string;
+    readonly bytes: Uint8Array;
+  };
+  /** When set, the list probe `inspect` makes is refused with this. */
+  readonly refuseList?: { status: number; body: unknown };
+  /** When set, creating a version is refused with this. */
+  readonly refuseVersion?: { status: number; body: unknown };
+  /** When set, adding a domain answers with this. */
+  readonly domainAnswer?: { status: number; body: unknown };
+  readonly token?: string;
+}
+
+/** One version the fake is holding, with what has been done to it. */
+interface FakeVersion {
+  name: string;
+  site: string;
+  status: string;
+  labels: Record<string, string>;
+  files: Record<string, string>;
+}
+
+const UPLOAD_BASE = 'https://upload.example.test/files';
+
+export class FakeHosting {
+  readonly endpoint = CLOUD_ENDPOINTS.hosting;
+  readonly requests: RecordedHostingRequest[] = [];
+
+  private readonly sites = new Set<string>();
+  private readonly versions = new Map<string, FakeVersion>();
+  /** Site id → the version name currently released on it. */
+  private readonly released = new Map<string, string>();
+  /** Domains attached, by site — the assertion surface for §9's re-point. */
+  private readonly domains = new Map<string, string[]>();
+  private readonly held: Set<string>;
+  private readonly uploaded = new Set<string>();
+  private nextVersion = 1;
+
+  constructor(private readonly options: FakeHostingOptions = {}) {
+    for (const site of options.sites ?? []) this.sites.add(site);
+    this.held = new Set(options.held ?? []);
+  }
+
+  get project(): string {
+    return this.options.project ?? 'example-vessel';
+  }
+
+  /** Mint the token provider the adapter is constructed with. */
+  token = (): string => this.options.token ?? 'federated-token';
+
+  /** Whether a site exists — the assertion surface for `destroy`. */
+  hasSite(site: string): boolean {
+    return this.sites.has(site);
+  }
+
+  /** The version currently serving on one site, if any. */
+  serving(site: string): FakeVersion | undefined {
+    const name = this.released.get(site);
+    return name === undefined ? undefined : this.versions.get(name);
+  }
+
+  /** The file paths the released version holds, sorted. */
+  servedPaths(site: string): string[] {
+    return Object.keys(this.serving(site)?.files ?? {}).sort();
+  }
+
+  /** Hashes actually uploaded — what proves the adapter honoured the answer. */
+  get uploads(): string[] {
+    return [...this.uploaded].sort();
+  }
+
+  /** Domains attached to one site (§9). */
+  domainsOf(site: string): string[] {
+    return [...(this.domains.get(site) ?? [])];
+  }
+
+  pathsOf(method: string): string[] {
+    return this.requests
+      .filter((request) => request.method === method)
+      .map((request) => request.path);
+  }
+
+  fetch: Fetcher = async (request) => {
+    const url = new URL(request.url);
+
+    // The bundle is not part of the hosting API and carries no bearer token:
+    // it is an artifact address, served here so the adapter's own fetch runs.
+    const bundle = this.options.bundle;
+    if (bundle !== undefined && url.origin === new URL(bundle.origin).origin) {
+      return new Response(bundle.bytes as unknown as BodyInit);
+    }
+
+    if (url.href.startsWith(UPLOAD_BASE)) {
+      const hash = url.pathname.split('/').pop() ?? '';
+      this.uploaded.add(hash);
+      this.held.add(hash);
+      return json(200, {});
+    }
+
+    const contentType = request.headers.get('content-type') ?? '';
+    const body =
+      request.method === 'GET' ||
+      request.method === 'DELETE' ||
+      !contentType.includes('json')
+        ? null
+        : await request.clone().json();
+    this.requests.push({
+      method: request.method,
+      url: `${url.pathname}${url.search}`,
+      path: url.pathname,
+      body,
+    });
+
+    if (request.headers.get('authorization') !== `Bearer ${this.token()}`) {
+      return json(401, { error: { message: 'unauthenticated' } });
+    }
+
+    return this.route(request.method, url, body);
+  };
+
+  private route(method: string, url: URL, body: unknown): Response {
+    const path = url.pathname.replace(/^\/v1beta1\//, '');
+
+    if (path === `projects/${this.project}/sites`) {
+      if (method === 'GET') {
+        if (this.options.refuseList !== undefined) {
+          return json(
+            this.options.refuseList.status,
+            this.options.refuseList.body,
+          );
+        }
+        return json(200, { sites: [...this.sites].map((id) => site(id)) });
+      }
+      if (method === 'POST') {
+        const id = url.searchParams.get('siteId') ?? '';
+        if (id === '') return json(400, error('no siteId'));
+        this.sites.add(id);
+        return json(200, site(id));
+      }
+    }
+
+    const versionMatch = path.match(/^sites\/([^/]+)\/versions\/([^/:]+)$/);
+    if (versionMatch !== null) {
+      return this.finalize(
+        method,
+        url,
+        versionMatch[1] as string,
+        versionMatch[2] as string,
+        body,
+      );
+    }
+
+    const populateMatch = path.match(
+      /^sites\/([^/]+)\/versions\/([^/:]+):populateFiles$/,
+    );
+    if (populateMatch !== null) {
+      return this.populate(
+        `sites/${populateMatch[1]}/versions/${populateMatch[2]}`,
+        body,
+      );
+    }
+
+    const siteMatch = path.match(/^sites\/([^/]+)$/);
+    if (siteMatch !== null) {
+      const id = siteMatch[1] as string;
+      if (method === 'GET') {
+        return this.sites.has(id)
+          ? json(200, site(id))
+          : json(404, error('no site'));
+      }
+      if (method === 'DELETE') {
+        if (!this.sites.has(id)) return json(404, error('no site'));
+        this.sites.delete(id);
+        this.released.delete(id);
+        this.domains.delete(id);
+        return json(200, {});
+      }
+    }
+
+    const versionsMatch = path.match(/^sites\/([^/]+)\/versions$/);
+    if (versionsMatch !== null && method === 'POST') {
+      return this.createVersion(versionsMatch[1] as string, body);
+    }
+
+    const releasesMatch = path.match(/^sites\/([^/]+)\/releases$/);
+    if (releasesMatch !== null) {
+      const id = releasesMatch[1] as string;
+      if (method === 'GET') return this.readReleases(id);
+      if (method === 'POST') return this.release(id, url);
+    }
+
+    const domainsMatch = path.match(/^sites\/([^/]+)\/domains$/);
+    if (domainsMatch !== null && method === 'POST') {
+      if (this.options.domainAnswer !== undefined) {
+        return json(
+          this.options.domainAnswer.status,
+          this.options.domainAnswer.body,
+        );
+      }
+      const id = domainsMatch[1] as string;
+      const name = (body as { domainName?: string })?.domainName ?? '';
+      this.domains.set(id, [...(this.domains.get(id) ?? []), name]);
+      return json(200, { site: id, domainName: name });
+    }
+
+    return json(404, error('no such path'));
+  }
+
+  private createVersion(site: string, body: unknown): Response {
+    if (this.options.refuseVersion !== undefined) {
+      return json(
+        this.options.refuseVersion.status,
+        this.options.refuseVersion.body,
+      );
+    }
+    if (!this.sites.has(site)) return json(404, error('no site'));
+    const name = `sites/${site}/versions/v${this.nextVersion++}`;
+    this.versions.set(name, {
+      name,
+      site,
+      status: 'CREATED',
+      labels: (body as { labels?: Record<string, string> })?.labels ?? {},
+      files: {},
+    });
+    return json(200, { name, status: 'CREATED' });
+  }
+
+  private populate(name: string, body: unknown): Response {
+    const version = this.versions.get(name);
+    if (version === undefined) return json(404, error('no version'));
+    const files = (body as { files?: Record<string, string> })?.files ?? {};
+    version.files = files;
+    // Only the hashes not already held are asked for, which is the behaviour
+    // the adapter's upload loop is written against.
+    const wanted = [...new Set(Object.values(files))].filter(
+      (hash) => !this.held.has(hash),
+    );
+    return json(200, {
+      uploadRequiredHashes: wanted,
+      uploadUrl: UPLOAD_BASE,
+    });
+  }
+
+  private finalize(
+    method: string,
+    url: URL,
+    site: string,
+    id: string,
+    body: unknown,
+  ): Response {
+    const name = `sites/${site}/versions/${id}`;
+    const version = this.versions.get(name);
+    if (version === undefined) return json(404, error('no version'));
+    if (method !== 'PATCH') return json(405, error('not supported'));
+    if (url.searchParams.get('updateMask') !== 'status') {
+      return json(400, error('only status may be patched'));
+    }
+    version.status = (body as { status?: string })?.status ?? version.status;
+    return json(200, { name, status: version.status });
+  }
+
+  private release(site: string, url: URL): Response {
+    const name = url.searchParams.get('versionName') ?? '';
+    const version = this.versions.get(name);
+    if (version === undefined) return json(404, error('no version'));
+    // The product will not serve a draft, so neither will the fake.
+    if (version.status !== 'FINALIZED') {
+      return json(400, error(`version ${name} is ${version.status}`));
+    }
+    this.released.set(site, name);
+    return json(200, {
+      name: `sites/${site}/releases/r1`,
+      version: { name, status: version.status, labels: version.labels },
+    });
+  }
+
+  private readReleases(site: string): Response {
+    if (!this.sites.has(site)) return json(404, error('no site'));
+    const name = this.released.get(site);
+    const version = name === undefined ? undefined : this.versions.get(name);
+    return json(200, {
+      releases:
+        version === undefined
+          ? []
+          : [
+              {
+                name: `sites/${site}/releases/r1`,
+                version: {
+                  name: version.name,
+                  status: version.status,
+                  labels: version.labels,
+                },
+              },
+            ],
+    });
+  }
+}
+
+function site(id: string): unknown {
+  return {
+    name: `sites/${id}`,
+    defaultUrl: `https://${id}.hosted.example.test`,
+  };
+}
+
+function error(message: string): unknown {
+  return { error: { message, status: 'NOT_FOUND' } };
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -70,6 +70,38 @@ export type KubernetesConnectInput = Extract<
   { kind: 'kubernetes' }
 >;
 
+/**
+ * The control APIs a connected cloud project is driven through.
+ *
+ * Constants rather than per-test strings because both a Target's connection and
+ * the fake standing behind it have to agree on them: a fake serving one host
+ * while the adapter addresses another is a test that fails for a reason nobody
+ * would look for. The fakes default to these.
+ */
+export const CLOUD_ENDPOINTS = {
+  run: 'https://run.example.test',
+  hosting: 'https://hosting.example.test',
+  policy: 'https://admission.example.test',
+} as const;
+
+/** The connect input a cloud project takes, with anything overridden. */
+export function cloudInput(
+  overrides: Partial<CloudConnectInput> = {},
+): CloudConnectInput {
+  return {
+    kind: 'cloud',
+    name: 'cloud',
+    project: 'example-vessel',
+    region: 'somewhere',
+    runEndpoint: CLOUD_ENDPOINTS.run,
+    hostingEndpoint: CLOUD_ENDPOINTS.hosting,
+    ...overrides,
+  };
+}
+
+/** The cloud arm of `connectTargetInput`. */
+export type CloudConnectInput = Extract<ConnectTargetInput, { kind: 'cloud' }>;
+
 /** A connection of the shape one adapter type needs. */
 export function connectionFor(adapter: TargetAdapter): TargetConnection {
   switch (adapter) {
@@ -88,10 +120,24 @@ export function connectionFor(adapter: TargetAdapter): TargetConnection {
           : { chartContract: input.chartContract }),
       };
     }
-    case 'cloudrun':
-      return { adapter, project: 'example-vessel', region: 'somewhere' };
-    case 'static':
-      return { adapter, project: 'example-vessel' };
+    case 'cloudrun': {
+      const input = cloudInput();
+      return {
+        adapter,
+        project: input.project,
+        region: input.region,
+        endpoint: input.runEndpoint,
+        policyEndpoint: CLOUD_ENDPOINTS.policy,
+      };
+    }
+    case 'static': {
+      const input = cloudInput();
+      return {
+        adapter,
+        project: input.project,
+        endpoint: input.hostingEndpoint,
+      };
+    }
   }
 }
 

--- a/apps/spindrift/test/harness/tar.ts
+++ b/apps/spindrift/test/harness/tar.ts
@@ -1,0 +1,92 @@
+/**
+ * A tar writer, so a test can hand the static adapter a real bundle.
+ *
+ * The adapter reads a gzipped tar because that is the format every build route
+ * already agrees on (`adapters/build/buildkit.ts` unpacks one), and a reader is
+ * only worth having if something independent produced what it reads. So this
+ * writes the bytes rather than the reader's own output being fed back to it —
+ * a round trip through one implementation proves that implementation
+ * self-consistent and nothing else.
+ *
+ * It writes plain ustar with no extensions, which is the case the reader must
+ * get right; the long-name and pax paths are exercised by hand-built headers in
+ * `test/adapters/static.test.ts`, where the point is the header rather than the
+ * archive around it.
+ */
+
+const BLOCK = 512;
+
+/** One entry to put in the archive. */
+export interface TarEntry {
+  readonly name: string;
+  readonly bytes: Uint8Array;
+  /** `0` for a regular file, `5` for a directory. Defaults to a file. */
+  readonly type?: string;
+}
+
+/** A gzipped tar holding these entries, as the adapter will receive it. */
+export function tarball(entries: readonly TarEntry[]): Uint8Array<ArrayBuffer> {
+  return Bun.gzipSync(tar(entries));
+}
+
+/** An uncompressed tar holding these entries. */
+export function tar(entries: readonly TarEntry[]): Uint8Array<ArrayBuffer> {
+  const blocks: Uint8Array[] = [];
+  for (const entry of entries) {
+    blocks.push(header(entry));
+    const padded = Math.ceil(entry.bytes.length / BLOCK) * BLOCK;
+    const data = new Uint8Array(padded);
+    data.set(entry.bytes);
+    blocks.push(data);
+  }
+  // Two zero blocks end an archive.
+  blocks.push(new Uint8Array(BLOCK * 2));
+  return concat(blocks);
+}
+
+/** One 512-byte ustar header, checksum included. */
+export function header(entry: TarEntry): Uint8Array<ArrayBuffer> {
+  const block = new Uint8Array(BLOCK);
+  write(block, entry.name, 0, 100);
+  write(block, '000644 ', 100, 8);
+  write(block, '000000 ', 108, 8);
+  write(block, '000000 ', 116, 8);
+  write(block, `${entry.bytes.length.toString(8).padStart(11, '0')} `, 124, 12);
+  write(block, '00000000000 ', 136, 12);
+  // The checksum field is treated as spaces while the checksum is computed.
+  write(block, '        ', 148, 8);
+  write(block, entry.type ?? '0', 156, 1);
+  write(block, 'ustar\0', 257, 6);
+  write(block, '00', 263, 2);
+
+  let sum = 0;
+  for (const byte of block) sum += byte;
+  write(block, `${sum.toString(8).padStart(6, '0')}\0 `, 148, 8);
+  return block;
+}
+
+function write(
+  block: Uint8Array,
+  value: string,
+  at: number,
+  length: number,
+): void {
+  const bytes = new TextEncoder().encode(value);
+  block.set(bytes.subarray(0, length), at);
+}
+
+function concat(parts: readonly Uint8Array[]): Uint8Array<ArrayBuffer> {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const part of parts) {
+    out.set(part, at);
+    at += part.length;
+  }
+  return out;
+}
+
+/** Some bytes, as a `Uint8Array` the writer and the adapter both accept. */
+export function bytes(text: string): Uint8Array<ArrayBuffer> {
+  return new TextEncoder().encode(text);
+}

--- a/apps/spindrift/test/reconciler/target-loop.test.ts
+++ b/apps/spindrift/test/reconciler/target-loop.test.ts
@@ -21,7 +21,7 @@ import type {
 } from '../../src/commands/types.ts';
 import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
 import { apps, components, targets } from '../../src/db/schema.ts';
-import { PREREQUISITES } from '../../src/domain/capabilities.ts';
+import { prerequisitesFor } from '../../src/domain/capabilities.ts';
 import {
   refreshAllTargets,
   refreshTarget,
@@ -105,7 +105,9 @@ describe('one pass over every connected Target', () => {
     expect(refresh?.health).toBe('healthy');
     const row = await targetRow('cluster');
     expect(row.discovery?.arch).toEqual(['amd64', 'arm64']);
-    expect(row.prerequisites).toHaveLength(PREREQUISITES.length);
+    expect(row.prerequisites).toHaveLength(
+      prerequisitesFor('kubernetes').length,
+    );
     expect(row.inspectedAt).toEqual(clock.now());
     expect(of('kubernetes').inspected.map((t) => t.name)).toEqual(['cluster']);
   });


### PR DESCRIPTION
## Summary

Spindrift Milestone 5: the other two deploy backends. A Component can now be
placed on Cloud Run or on static hosting, and both go green against the one
adapter conformance suite the Kubernetes adapter already passes — which is what
keeps "core describes, the adapter renders" (§6) a tested claim rather than a
stated one.

Plan reference: `.agent/plans/spindrift/plan.md`, Tasks 28 and 29 (private).

## Changes

- `feat(spindrift): deploy to the cloud runtime and to static hosting`
- `fix(spindrift): federate to reach a cloud Target, and stop truncating names`

**Cloud Run** applies one Service with `allowMissing`, so create and update are
the same call. Status comes from the revision's `terminalCondition`, with the
runtime's reason enums mapped into §6's closed vocabulary. It never takes the
build-from-source path (§4) — that would be a second build engine reachable
from one of three backends only — and it advertises no egress filtering (§8),
because it has network controls and not the by-name allowlist §8 specifies.

**Static hosting** is the five-step release the product's contract requires:
version, populate, upload, finalize, release. Hashes are over the gzipped
bytes, which is what the product deduplicates on, so a redeploy of an unchanged
site uploads nothing. A `files` artifact is a gzipped tar — the format
`buildkit.ts` already unpacks — read by a small ustar reader that refuses a
path escaping the bundle. Serves `Public` only (§9).

**The vanity layer** lands in `domain/naming.ts`: proxying derived per Target,
the ~20 ceiling reported rather than enforced, and the unproxied leg's real
losses (buffered responses, no streams, 60s) as constants.

Three changes above the seam, each forced rather than chosen:

- **The prerequisite checklist is per-adapter-type.** With one global list a
  cloud Target had to report `DELIVERY_OPERATOR`/`CHART_SOURCE` either met (a
  lie) or unmet (permanently unhealthy, so unplaceable).
- **§10's reach rule no longer binds a `website`** — it reaches no store, which
  is what `isBuildTimeConfig` already decided. Without this, static hosting
  could never hold the one kind it exists to run.
- **`KINDS_BY_ADAPTER.cloudrun` narrows to `['service','website']`.** A stated
  divergence from §3: Cloud Run jobs are a second resource plus a scheduling
  service, which belongs with Task 33. A job there is a non-candidate at Place
  with the reason stated, rather than accepted and failed at apply.

The second commit is review follow-up, and two findings were real bugs:

- **The cloud adapters were handed the wrong token.** They were built with
  `projectedServiceAccountToken()` — the default projected volume, minted for
  this cluster's own API server. Sent as a Bearer to a cloud API it is refused,
  so every cloud deploy would have been a 401 blamed on the Target.
  `cloud/federation.ts` replaces it with §13's actual auth mode: projected
  token → STS exchange → optional impersonation, cached. `cloud.federation` in
  the manifest mirrors the `external_account` document
  `clusters/folly/apps/vault/gcp-wif-config.yaml` already carries, field for
  field.
- **Truncating a workload name is a silent collision.** `serviceId` and
  `releaseName` both cut `<app>-<component>` at 63 characters, so two
  Components of one long-named App become one name — and a re-deploy of that
  name is an *upgrade*, so one Component starts serving the other's image with
  nothing red anywhere. `domain/workload-name.ts` is now the one rule and all
  three adapters take it. **This fixes a pre-existing bug in the Kubernetes
  adapter, not only the new ones.**

## Test Plan

- [ ] `mise run ts:check` — typecheck and lint across the workspace
- [ ] `bun test` in `apps/spindrift` with `DATABASE_URL` set — 757 pass
- [ ] `bun test test/conformance` — both new adapters enrolled and green
- [ ] `bun test test/extraction` — the §20 literal and DNS-credential greps

No cluster or cloud change: this is application code plus its manifest schema.
Nothing here is reachable until an operator connects a cloud project, which
needs `cloud.federation` configured and the pool trusting the cluster.

## Known gaps, stated rather than implied

- **The non-metal vanity leg is not built.** §9 closes it with a zero-file site
  carrying a rewrite; the Cloud Run adapter reads no hostname, so an App there
  with a vanity label has a name nothing serves. It wants the same
  `DNSEndpoint` machinery the live-from-creation status name does, and waits
  with it.
- **`Private` has no audience on Cloud Run.** §9 wants one admin-configured
  audience per Target and no Target carries one, so a `private` Component gets
  an empty invoker policy — reachable at its address and refusing everyone.
  Wrong in the safe direction, and it stays there until the authenticated edge
  lands.
- **The vanity ration and leg losses have no reader yet.** The rules are here
  and tested; the screens that state them are Milestone 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
