### PR TITLE
feat(spindrift): persist installation manifest in database

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -590,7 +590,8 @@ vocabulary is lowercase hyphenated words, and so is a project id, so over a
 browser bundle it reports dozens of findings and no bugs. The test says so at
 length, and the exemption is itself tested.
 
-Point the process at one:
+The validated manifest lives in Spindrift's Postgres database. Point the first
+boot of an empty installation at a bootstrap document:
 
 ```bash
 export SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml
@@ -598,8 +599,11 @@ export SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml
 export SPINDRIFT_MANIFEST="$(cat test/fixtures/installation.example.yaml)"
 ```
 
-Boot fails loudly, naming every offending key, if it is missing or incomplete.
-Nothing has a default, because a default here would name someone's homelab.
+The first process atomically stores the document; later boots read the database
+row and ignore changed bootstrap input. Boot fails loudly, naming every
+offending key, when the stored document is invalid or when both the row and
+bootstrap are absent. Nothing has a default, because a default here would name
+someone's homelab.
 
 ## Usage
 

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -1,0 +1,56 @@
+/**
+ * Postgres ownership of the installation manifest.
+ *
+ * Parsing and validation stay in `manifest.ts`; this module owns only the
+ * singleton row and the one-time transition from bootstrap configuration to
+ * durable state.
+ */
+import type { Database } from '../db/client.ts';
+import { installation } from '../db/schema.ts';
+import type { InstallationManifest } from './manifest.schema.ts';
+import { loadManifest, ManifestError, validateManifest } from './manifest.ts';
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * Load the database-owned manifest, seeding it once from boot configuration.
+ *
+ * The insert is intentionally conflict-tolerant: `web` and `reconciler` may
+ * start together against an empty database. One wins the singleton row and
+ * both read that same committed value afterward. Once the row exists, mounted
+ * bootstrap configuration is ignored rather than becoming a competing source
+ * of desired state.
+ */
+export async function loadStoredManifest(
+  db: Database,
+  env: Env = Bun.env,
+): Promise<InstallationManifest> {
+  const stored = await readStoredManifest(db);
+  if (stored !== null) return stored;
+
+  const bootstrap = await loadManifest(env);
+  await db
+    .insert(installation)
+    .values({ manifest: bootstrap })
+    .onConflictDoNothing({ target: installation.id });
+
+  const seeded = await readStoredManifest(db);
+  if (seeded === null) {
+    throw new ManifestError(
+      'installation manifest bootstrap completed without a stored manifest',
+    );
+  }
+  return seeded;
+}
+
+async function readStoredManifest(
+  db: Database,
+): Promise<InstallationManifest | null> {
+  const [stored] = await db
+    .select({ manifest: installation.manifest })
+    .from(installation)
+    .limit(1);
+  return stored
+    ? validateManifest(stored.manifest, 'database installation manifest')
+    : null;
+}

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -1,12 +1,13 @@
 /**
  * Loading and validating the installation manifest.
  *
- * The manifest is read once at boot from a mounted file (the chart renders it
- * from values into a ConfigMap) or, for tests and local runs, from an inline
- * document in the environment. Validation failures are fatal and name every
- * offending key at once — a half-configured installation must not reach the
- * point where it can place a workload.
+ * The manifest lives in Postgres. An empty installation bootstraps it from a
+ * mounted file (the chart renders one from values into a ConfigMap) or, for
+ * tests and local runs, from an inline environment document. Validation
+ * failures are fatal and name every offending key at once — a half-configured
+ * installation must not reach the point where it can place a workload.
  */
+
 import {
   type InstallationManifest,
   installationManifestSchema,
@@ -49,7 +50,15 @@ export function parseManifest(
     );
   }
 
-  const result = installationManifestSchema.safeParse(parsed);
+  return validateManifest(parsed, source);
+}
+
+/** Validate a parsed or stored manifest and report every bad field together. */
+export function validateManifest(
+  manifest: unknown,
+  source: string,
+): InstallationManifest {
+  const result = installationManifestSchema.safeParse(manifest);
   if (!result.success) {
     const issues = result.error.issues
       .map((issue) => {

--- a/apps/spindrift/src/db/migrations/0009_installation_manifest.sql
+++ b/apps/spindrift/src/db/migrations/0009_installation_manifest.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "installation" (
+	"id" integer PRIMARY KEY DEFAULT 1 NOT NULL,
+	"manifest" jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "installation_singleton" CHECK ("installation"."id" = 1)
+);

--- a/apps/spindrift/src/db/migrations/meta/0009_snapshot.json
+++ b/apps/spindrift/src/db/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1900 @@
+{
+  "id": "58e8a636-1ebb-4379-b1a0-d8ff92dd692b",
+  "prevId": "edaca1be-05cb-445c-bbd3-ab6b3fd80194",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "app_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repo_url": {
+          "name": "source_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repo_subpath": {
+          "name": "source_repo_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_archive_digest": {
+          "name": "source_archive_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vessel_ref": {
+          "name": "vessel_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vanity_domain": {
+          "name": "vanity_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_repository_id_repositories_id_fk": {
+          "name": "apps_repository_id_repositories_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempt_events": {
+      "name": "attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_kind": {
+          "name": "attempt_kind",
+          "type": "attempt_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_id": {
+          "name": "deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "attempt_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attempt_events_app_id_apps_id_fk": {
+          "name": "attempt_events_app_id_apps_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_component_id_components_id_fk": {
+          "name": "attempt_events_component_id_components_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_build_id_builds_id_fk": {
+          "name": "attempt_events_build_id_builds_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_deploy_id_deploys_id_fk": {
+          "name": "attempt_events_deploy_id_deploys_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempt_events_exactly_one_attempt": {
+          "name": "attempt_events_exactly_one_attempt",
+          "value": "(\"attempt_events\".\"build_id\" is not null) <> (\"attempt_events\".\"deploy_id\" is not null)"
+        },
+        "attempt_events_kind_matches_reference": {
+          "name": "attempt_events_kind_matches_reference",
+          "value": "(\"attempt_events\".\"attempt_kind\" = 'build' and \"attempt_events\".\"build_id\" is not null) or (\"attempt_events\".\"attempt_kind\" = 'deploy' and \"attempt_events\".\"deploy_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_shape": {
+          "name": "target_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "artifact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_digest": {
+          "name": "artifact_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_refs": {
+          "name": "artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "build_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "base_digest": {
+          "name": "base_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_fidelity": {
+          "name": "log_fidelity",
+          "type": "log_fidelity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_build_level": {
+          "name": "verified_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildkit_provenance_ref": {
+          "name": "buildkit_provenance_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbom_ref": {
+          "name": "sbom_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_location": {
+          "name": "bundle_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_subpath": {
+          "name": "bundle_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_component_id_components_id_fk": {
+          "name": "builds_component_id_components_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "builds_component_commit_shape_unique": {
+          "name": "builds_component_commit_shape_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "commit",
+            "target_shape"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_target_desired": {
+      "name": "component_target_desired",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_build_id": {
+          "name": "desired_build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_deploy_id": {
+          "name": "desired_deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "component_target_desired_component_id_components_id_fk": {
+          "name": "component_target_desired_component_id_components_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_target_id_targets_id_fk": {
+          "name": "component_target_desired_target_id_targets_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_build_id_builds_id_fk": {
+          "name": "component_target_desired_desired_build_id_builds_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "desired_build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_deploy_id_deploys_id_fk": {
+          "name": "component_target_desired_desired_deploy_id_deploys_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "desired_deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "component_target_desired_pair_unique": {
+          "name": "component_target_desired_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.components": {
+      "name": "components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "component_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expose": {
+          "name": "expose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "components_app_id_apps_id_fk": {
+          "name": "components_app_id_apps_id_fk",
+          "tableFrom": "components",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "components_app_id_name_unique": {
+          "name": "components_app_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_audit_events": {
+      "name": "config_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "config_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_audit_events_component_id_components_id_fk": {
+          "name": "config_audit_events_component_id_components_id_fk",
+          "tableFrom": "config_audit_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_audit_events_target_id_targets_id_fk": {
+          "name": "config_audit_events_target_id_targets_id_fk",
+          "tableFrom": "config_audit_events",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_audit_events_user_id_users_id_fk": {
+          "name": "config_audit_events_user_id_users_id_fk",
+          "tableFrom": "config_audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_items": {
+      "name": "config_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "config_item_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret_ref'"
+        },
+        "store_ref": {
+          "name": "store_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_version": {
+          "name": "store_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_value": {
+          "name": "plain_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_items_component_id_components_id_fk": {
+          "name": "config_items_component_id_components_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_items_target_id_targets_id_fk": {
+          "name": "config_items_target_id_targets_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_items_scope_key_unique": {
+          "name": "config_items_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id",
+            "environment",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "config_items_environment_pinned": {
+          "name": "config_items_environment_pinned",
+          "value": "\"config_items\".\"environment\" = 'default'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sign_count": {
+          "name": "sign_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credentials_credential_id_unique": {
+          "name": "credentials_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datastores": {
+      "name": "datastores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "datastore_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "datastore_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_ref": {
+          "name": "connection_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datastores_app_id_apps_id_fk": {
+          "name": "datastores_app_id_apps_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "datastores_target_id_targets_id_fk": {
+          "name": "datastores_target_id_targets_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deploys": {
+      "name": "deploys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "deploy_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_document": {
+          "name": "config_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drifted_at": {
+          "name": "drifted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_digest": {
+          "name": "observed_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deploys_component_id_components_id_fk": {
+          "name": "deploys_component_id_components_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deploys_target_id_targets_id_fk": {
+          "name": "deploys_target_id_targets_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "deploys_build_id_builds_id_fk": {
+          "name": "deploys_build_id_builds_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrolments": {
+      "name": "enrolments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "enrolments_user_id_users_id_fk": {
+          "name": "enrolments_user_id_users_id_fk",
+          "tableFrom": "enrolments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrolments_token_hash_unique": {
+          "name": "enrolments_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation": {
+      "name": "installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "installation_singleton": {
+          "name": "installation_singleton",
+          "value": "\"installation\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authoritative_commit": {
+          "name": "authoritative_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_pull_request": {
+          "name": "config_pull_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access": {
+          "name": "access",
+          "type": "repository_access",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "frozen_reason": {
+          "name": "frozen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_at": {
+          "name": "frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_full_name_unique": {
+          "name": "repositories_full_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "full_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repositories_frozen_has_reason": {
+          "name": "repositories_frozen_has_reason",
+          "value": "(\"repositories\".\"access\" = 'frozen') = (\"repositories\".\"frozen_reason\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "target_adapter",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "target_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "health": {
+          "name": "health",
+          "type": "target_health",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery": {
+          "name": "discovery",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_exposure": {
+          "name": "public_exposure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_build_level": {
+          "name": "min_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "targets_name_unique": {
+          "name": "targets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway_identity": {
+          "name": "gateway_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_gateway_identity_unique": {
+          "name": "users_gateway_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "gateway_identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webauthn_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.app_source_kind": {
+      "name": "app_source_kind",
+      "schema": "public",
+      "values": [
+        "repo",
+        "archive"
+      ]
+    },
+    "public.artifact_type": {
+      "name": "artifact_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "files"
+      ]
+    },
+    "public.attempt_event_type": {
+      "name": "attempt_event_type",
+      "schema": "public",
+      "values": [
+        "log",
+        "status"
+      ]
+    },
+    "public.attempt_kind": {
+      "name": "attempt_kind",
+      "schema": "public",
+      "values": [
+        "build",
+        "deploy"
+      ]
+    },
+    "public.blame": {
+      "name": "blame",
+      "schema": "public",
+      "values": [
+        "developer",
+        "platform"
+      ]
+    },
+    "public.build_status": {
+      "name": "build_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.component_kind": {
+      "name": "component_kind",
+      "schema": "public",
+      "values": [
+        "service",
+        "website",
+        "job"
+      ]
+    },
+    "public.config_action": {
+      "name": "config_action",
+      "schema": "public",
+      "values": [
+        "set",
+        "removed"
+      ]
+    },
+    "public.config_item_kind": {
+      "name": "config_item_kind",
+      "schema": "public",
+      "values": [
+        "secret_ref",
+        "plain"
+      ]
+    },
+    "public.datastore_engine": {
+      "name": "datastore_engine",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "redis"
+      ]
+    },
+    "public.datastore_provenance": {
+      "name": "datastore_provenance",
+      "schema": "public",
+      "values": [
+        "managed",
+        "external"
+      ]
+    },
+    "public.deploy_phase": {
+      "name": "deploy_phase",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPLYING",
+        "WAITING",
+        "LIVE",
+        "FAILED"
+      ]
+    },
+    "public.deploy_reason": {
+      "name": "deploy_reason",
+      "schema": "public",
+      "values": [
+        "BUILD_FAILED",
+        "ARTIFACT_UNAVAILABLE",
+        "REJECTED",
+        "STARTUP_FAILED",
+        "UNHEALTHY",
+        "TIMEOUT",
+        "TARGET_UNREACHABLE",
+        "INTERNAL"
+      ]
+    },
+    "public.exposure_state": {
+      "name": "exposure_state",
+      "schema": "public",
+      "values": [
+        "internal",
+        "private",
+        "public"
+      ]
+    },
+    "public.log_fidelity": {
+      "name": "log_fidelity",
+      "schema": "public",
+      "values": [
+        "LIVE_TEXT",
+        "LIVE_STATUS",
+        "ON_COMPLETION"
+      ]
+    },
+    "public.repository_access": {
+      "name": "repository_access",
+      "schema": "public",
+      "values": [
+        "active",
+        "frozen"
+      ]
+    },
+    "public.target_adapter": {
+      "name": "target_adapter",
+      "schema": "public",
+      "values": [
+        "kubernetes",
+        "cloudrun",
+        "static"
+      ]
+    },
+    "public.target_health": {
+      "name": "target_health",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy"
+      ]
+    },
+    "public.target_status": {
+      "name": "target_status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "disconnected"
+      ]
+    },
+    "public.webauthn_purpose": {
+      "name": "webauthn_purpose",
+      "schema": "public",
+      "values": [
+        "enrol",
+        "sign_in",
+        "credential_admin",
+        "add_passkey"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1785264152666,
       "tag": "0008_supply_chain",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1785273764040,
+      "tag": "0009_installation_manifest",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -43,6 +43,7 @@ import {
   DEPLOY_PHASES,
   FAILURE_REASONS,
 } from '../adapters/deploy/contract.ts';
+import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type {
   PrerequisiteResult,
   TargetDiscovery,
@@ -203,6 +204,28 @@ export const webauthnPurpose = pgEnum('webauthn_purpose', [
   'credential_admin',
   'add_passkey',
 ]);
+
+// --- Installation ----------------------------------------------------------
+
+/**
+ * The one installation this control plane represents.
+ *
+ * The manifest is ordinary configuration, not a credential, and §12 makes
+ * Postgres the durable source for Spindrift-owned state. A bootstrap document
+ * may seed this row once; after that, every process reads the same database
+ * value instead of treating a mounted file as a second source of truth.
+ */
+export const installation = pgTable(
+  'installation',
+  {
+    id: integer('id').primaryKey().default(1),
+    manifest: jsonb('manifest').$type<InstallationManifest>().notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [check('installation_singleton', sql`${table.id} = 1`)],
+);
 
 // --- Repository ------------------------------------------------------------
 

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -22,10 +22,8 @@ import { createAdapterRegistry } from '../adapters/registry.ts';
 import type { EnrolmentDeps } from '../auth/enrol.ts';
 import { authenticateRequest, type GatewayDeps } from '../auth/gateway.ts';
 import { systemClock } from '../commands/types.ts';
-import {
-  assertTrustedGatewayBoundary,
-  loadManifest,
-} from '../config/manifest.ts';
+import { assertTrustedGatewayBoundary } from '../config/manifest.ts';
+import { loadStoredManifest } from '../config/manifest-store.ts';
 import { createDb } from '../db/client.ts';
 import { type ClientRoute, webRoutes } from './routes.ts';
 
@@ -44,9 +42,9 @@ export async function start(
   client: Record<string, ClientRoute>,
   { development }: { development: boolean },
 ): Promise<void> {
-  const manifest = await loadManifest();
-  assertTrustedGatewayBoundary(manifest);
   const db = createDb();
+  const manifest = await loadStoredManifest(db);
+  assertTrustedGatewayBoundary(manifest);
   const adapters = createAdapterRegistry({ manifest });
 
   const auth: EnrolmentDeps & GatewayDeps = {

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
+import {
+  MANIFEST_INLINE_VAR,
+  ManifestError,
+} from '../../src/config/manifest.ts';
+import { loadStoredManifest } from '../../src/config/manifest-store.ts';
+import { createDb } from '../../src/db/client.ts';
+import { installation } from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+const FIXTURE = new URL(
+  '../fixtures/installation.example.yaml',
+  import.meta.url,
+);
+const fixtureText = await Bun.file(FIXTURE).text();
+const fixtureManifest = Bun.YAML.parse(fixtureText) as InstallationManifest;
+
+describe('the stored installation manifest', () => {
+  test('bootstraps once, then boots from the database alone', async () => {
+    const first = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    expect(first.installation).toBe('example');
+
+    const later = await loadStoredManifest(database().db, {});
+    expect(later).toEqual(first);
+  });
+
+  test('the database wins over changed bootstrap configuration', async () => {
+    const first = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    const changed = fixtureText.replace(
+      'installation: example',
+      'installation: replacement',
+    );
+
+    const later = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: changed,
+    });
+    expect(later).toEqual(first);
+    expect(later.installation).toBe('example');
+  });
+
+  test('simultaneous processes converge on the one winning bootstrap', async () => {
+    const contender = createDb(database().connect());
+    const replacement = fixtureText.replace(
+      'installation: example',
+      'installation: replacement',
+    );
+
+    const [first, second] = await Promise.all([
+      loadStoredManifest(database().db, {
+        [MANIFEST_INLINE_VAR]: fixtureText,
+      }),
+      loadStoredManifest(contender, {
+        [MANIFEST_INLINE_VAR]: replacement,
+      }),
+    ]);
+    expect(second).toEqual(first);
+    expect(['example', 'replacement']).toContain(first.installation);
+  });
+
+  test('the database enforces that there is only one installation', async () => {
+    await database()
+      .db.insert(installation)
+      .values({ manifest: fixtureManifest });
+
+    await expect(
+      Promise.resolve(
+        database()
+          .db.insert(installation)
+          .values({ id: 2, manifest: fixtureManifest }),
+      ),
+    ).rejects.toThrow();
+  });
+
+  test('fails closed when the stored document is malformed', async () => {
+    const malformed = JSON.stringify({ installation: 'broken' });
+    await database().client`
+      INSERT INTO installation (manifest)
+      VALUES (${malformed}::jsonb)
+    `;
+
+    await expect(loadStoredManifest(database().db, {})).rejects.toThrow(
+      /database installation manifest/,
+    );
+  });
+
+  test('fails loudly when the database is empty and no bootstrap exists', async () => {
+    await expect(loadStoredManifest(database().db, {})).rejects.toThrow(
+      ManifestError,
+    );
+  });
+});

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -31,17 +31,50 @@ spec:
     # from the HTTPRoute and cert-manager issues the certificate, so this line
     # is the whole of what makes the UI reachable with TLS.
     hostname: spindrift.${SECRET_DOMAIN}
-    # The Secret carries the installation manifest and its one-time enrolment
-    # token. Nothing installation-specific is in the chart.
+    # Non-secret first-boot configuration. Core stores the validated document
+    # in Postgres; the database row is authoritative after bootstrap.
+    installationManifest:
+      installation: offsite
+      dns:
+        apexZone: lolwtf.dev
+        vanityZone: lolwtf.dev
+      cloud:
+        artifactsProject: trusted-builds
+        homeVesselProject: homelab-ng
+        federation: null
+      charts:
+        app: packages/charts/spindrift-app
+        installer: packages/charts/spindrift
+      supplyChain:
+        registry: ghcr.io/jonpulsifer
+        verifier: ghcr.io/jonpulsifer/spindrift-verifier
+      github:
+        appId: "334190"
+        apiBaseUrl: https://api.github.com
+        buildWorkflow: null
+      build:
+        routes: []
+        zeroConfigFrontend: ghcr.io/railwayapp/railpack:railpack-frontend
+      secretStore:
+        adapter: onepassword
+        endpoint: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+        container: homelab
+      targets:
+        - name: offsite
+          adapter: kubernetes
+      controlPlane:
+        hostname: spindrift.lolwtf.ca
+      auth:
+        gateway: null
+    # The Secret carries only the one-time enrolment token and optional
+    # integration credentials.
     envFromSecret: spindrift-env
     serviceAccount:
       token:
         gcpAudience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
     ingress:
       enabled: true
-    # §19's own database. Nothing connects to it yet — the web process reads no
-    # rows — but it is the installation's store and the reconciler will need it,
-    # so it is provisioned now rather than bolted on later.
+    # §19's own database, including the installation manifest singleton.
     database:
       enabled: true
       size: 2Gi

--- a/clusters/offsite/apps/spindrift/secret.sops.yaml
+++ b/clusters/offsite/apps/spindrift/secret.sops.yaml
@@ -5,7 +5,6 @@ metadata:
     namespace: spindrift
 type: Opaque
 stringData:
-    SPINDRIFT_MANIFEST: ENC[AES256_GCM,data:mCyHUTHgzCAU+KeKaN15o6LG5r2b/3Z9f8FNWiRWIyrpyno3suQee+qaV7qy5L7/KAGfghjFRRI+iOZVjIaWI+r92tzAOu0sl0w0g9XXbDLbH498O4KDDOx+doCqNFPJ4jbt0Q5J6hmxdWRuB8M5ygAUQHHBPVsAQcc+7EdCn4nkv7Rti0zqgOIrPdX9vEaxc02A2KhPV1x8x3Wsi2lNJH1KJQUcchiBrhTNYiZTYGUpiffuJ+eop5goSMt8n+lTvEjij+pd8uWrjAiV2sVatFT6SrpEyynfRGy0hOUxolAG28wfju3OxwfWJKcTj8+5vK83kTJ+YrBGQqtgssdw6RDX6p/7OBdxcLeYExu6QsCDzSix8zlhc9R2dFrwHJtQGuMBOjvQBd9+iBwY1JCBJFVS23nlA6YJ4CYXqOIAlJlDFRGpu+tvsIgRuRG17vpZtypOmwd2we4lYsemKKKRvUKlBUPWonbNyvxnevUh/bHksBafgyethOLHVYNkHyQllV0pjDc2uFMGgzscJrQjMGHwC50KPLnYN2if21uJASSd4kiBD68rks6cdsQW8l4LN+TTto1clpASWNCn+N81eUF2MzHnBqq2/nqpc+ceOHaTlfp/qIyvEfBrogWpH29OX/bb63ZEkS1mJJEN9QsZHiCS32QWKUuOSHZE3G5C8xw2o6XB52XXC2uPPkNatpgCr6K0aJDuGd7Nd39vBIrK3cIw68C7aAgBi2RMSJM2VL1EMqxm06cKhY+mbhH4rCH/ZN1DmGz59hT+jvBtU2iQviCuWVm9YbN5QRklLDvr3fC2jyBfI3RMN7YOLTUeEzpSWXLiNuFjigXZ3xP7yLlRZ91gJdDIxkSd1Tyj6JPNKzLe/n9b9TxxUui0LPhG7BKPEqiCBseOGn249YJgaSqvqQRWQemIrIbxiheVKiVaXUibKj+hCtnQ69rRNmFVkAR4qwoRbbP8BnBYMRXEVaDguzBLtqDlgk2lk3/T/mBHx9VRkaQ10TswzGULgUueB7eWIjKCMcDtZ+8WryPlBxYzanq89PiLMKsHG3wI5lvMkTRe9vajQgvWec0gCWforDS0l/9hgMsPPGZfIE1IADQq7F9s9V8ymopUnPJEt04JmkFcJEDjvEa0pL4TTT8=,iv:MGSldrFwSGbJtExzQYggmPZzyKeWIEsFXg4qC5hRgvw=,tag:w+ESw/Igh7plVRj1MZZteg==,type:str]
     SPINDRIFT_ENROLMENT_TOKEN: ENC[AES256_GCM,data:E2jTCHsS9uwPGy9jalmW1rkZwDi0AyBBnhoHSYv0/bxQPU7YN+3IQMKbc+Ccg6MaQQYbIcrdKKeAE/IEOK4/KQ==,iv:73Vh2reflDImfj4sYLfKLkSPZdHvan3VwmSA/lSI2LM=,tag:wy0DDB3x764hNJXHjM+h/g==,type:str]
 sops:
     age:
@@ -19,6 +18,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-07-28T20:55:53Z"
-    mac: ENC[AES256_GCM,data:hjRtQu2YF19/c3GRS5m1mDi0CYi1YhaSbKgtwxhybWwXukaVDaHKOChIFWZ5D0HE0t944pUvHrrqEVWKzykIyO+ZGSgWzTcfxg2rEeb0iZhj7/WCdxZUvFVeDgzJYgUSFE++y9A+8d6klyQ/DeZAwl0AijHmsv+kZsRSIm81gpY=,iv:RGcaR+Hl2ZFW79k7Plb5FsfDBRgzvj7383NE4GCjBeY=,tag:s/nhLihqk+4lwqcDNpY+lw==,type:str]
+    lastmodified: "2026-07-28T21:22:24Z"
+    mac: ENC[AES256_GCM,data:rTFYqjxsGq+chEIrcmRuPn0E0fB4A/yYSkBjWC3tn1tfN0A1YsKU4YApzycOCfboLiGt8Q3uekZawes2MRn2alOpug6iZ09t2STv3CDf0EuGQI55PYveyJtsX43ZfBvSno393FQmZ8RdukbZVOOBXG9QJqXLwQv9GSaMzPd8/VI=,iv:t8BHjCdmhlO/IP+nQJ0qXJLxOjr88ZAl7/iETvbcYa4=,tag:u51O1zrO62xWKmr/11X0gQ==,type:str]
     version: 3.13.3

--- a/packages/charts/spindrift/templates/deployment.yaml
+++ b/packages/charts/spindrift/templates/deployment.yaml
@@ -5,8 +5,8 @@ loop that owns its own lifecycle."
 
 They are rendered from one template with one difference each — the command and
 the component label — so the two processes cannot drift apart in the things
-that must not differ: the image, the database credential, the manifest, and the
-security context.
+that must not differ: the image, the database credential, the manifest
+bootstrap, and the security context.
 
 The reconciler serves nothing and is therefore given no port and no probe. A
 loop that claims work with `SELECT … FOR UPDATE SKIP LOCKED` has no readiness to
@@ -101,6 +101,10 @@ spec:
                   name: {{ include "spindrift.databaseName" $top }}-app
                   key: uri
             {{- end }}
+            {{- if $top.Values.installationManifest }}
+            - name: SPINDRIFT_MANIFEST_PATH
+              value: /etc/spindrift/manifest.yaml
+            {{- end }}
             {{- range $top.Values.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}
@@ -124,6 +128,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if $top.Values.installationManifest }}
+            - name: installation-manifest
+              mountPath: /etc/spindrift
+              readOnly: true
+            {{- end }}
             {{- if $process.federates }}
             - name: federated-identity
               mountPath: {{ $top.Values.serviceAccount.token.mountPath }}
@@ -144,6 +153,11 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if $top.Values.installationManifest }}
+        - name: installation-manifest
+          configMap:
+            name: {{ include "spindrift.fullname" $top }}-installation-manifest
+        {{- end }}
         {{- if $process.federates }}
         - name: federated-identity
           projected:

--- a/packages/charts/spindrift/templates/installation-manifest.yaml
+++ b/packages/charts/spindrift/templates/installation-manifest.yaml
@@ -1,0 +1,15 @@
+{{- with .Values.installationManifest }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "spindrift.fullname" $ }}-installation-manifest
+  namespace: {{ include "spindrift.namespace" $ }}
+  labels:
+    {{- include "spindrift.labels" $ | nindent 4 }}
+data:
+  # Ordinary, non-secret first-boot configuration. Core validates this
+  # document before atomically seeding its singleton database row; later boots
+  # read the stored row and ignore this bootstrap copy.
+  manifest.yaml: |
+    {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -85,6 +85,50 @@ describe('Secret-backed authentication configuration', () => {
   });
 });
 
+describe('installation manifest bootstrap', () => {
+  test('mounts ordinary configuration from a ConfigMap in every process', async () => {
+    const objects = await render({
+      installationManifest: { installation: 'example' },
+      reconciler: { enabled: true },
+      envFromSecret: 'spindrift-env',
+    });
+    const manifest = one(
+      objects,
+      'ConfigMap',
+      'spindrift-installation-manifest',
+    );
+    expect(Bun.YAML.parse(manifest.data?.['manifest.yaml'] ?? '')).toEqual({
+      installation: 'example',
+    });
+
+    const deployments = objects.filter(
+      (object) => object.kind === 'Deployment',
+    );
+    expect(deployments).toHaveLength(2);
+    for (const deployment of deployments) {
+      const pod = deployment.spec.template.spec;
+      expect(pod.volumes).toContainEqual({
+        name: 'installation-manifest',
+        configMap: { name: 'spindrift-installation-manifest' },
+      });
+      expect(pod.containers[0].volumeMounts).toContainEqual({
+        name: 'installation-manifest',
+        mountPath: '/etc/spindrift',
+        readOnly: true,
+      });
+      expect(pod.containers[0].env).toContainEqual({
+        name: 'SPINDRIFT_MANIFEST_PATH',
+        value: '/etc/spindrift/manifest.yaml',
+      });
+      expect(
+        pod.containers[0].env.some(
+          (item: { name: string }) => item.name === 'SPINDRIFT_MANIFEST',
+        ),
+      ).toBe(false);
+    }
+  });
+});
+
 describe('authenticated Gateway trust', () => {
   test('is disabled without a network boundary', async () => {
     const objects = await render();

--- a/packages/charts/spindrift/tests/render.ts
+++ b/packages/charts/spindrift/tests/render.ts
@@ -13,6 +13,7 @@ const CHART = dirname(import.meta.dir);
 export interface RenderedObject {
   apiVersion: string;
   kind: string;
+  data?: Record<string, string>;
   metadata: {
     name: string;
     namespace?: string;

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -2,14 +2,14 @@
 #
 # §20 line 3: "everything naming this installation is a value in the
 # installation manifest; a literal outside it is a bug." This file holds no
-# installation name at all — not a zone, not a project, not a cluster. The one
-# installation-shaped value a release supplies is `hostname`, which is where
-# *this control plane* is served, and it is empty here.
+# installation name at all — not a zone, not a project, not a cluster. A
+# release supplies the manifest document plus `hostname`, which is where this
+# control plane is served; both are empty here.
 #
-# The installation manifest itself does not appear as chart values either. It
-# reaches the process through `envFromSecret` as `SPINDRIFT_MANIFEST`, because
-# it carries a GitHub App id and this repository is public — the same reason
-# Atlantis keeps its app id in a SOPS Secret rather than in a HelmRelease.
+# The installation manifest is ordinary configuration. On the first boot it is
+# mounted from a ConfigMap and atomically seeds Spindrift's database; the stored
+# row is authoritative afterward. Public identifiers such as a GitHub App id do
+# not make the document a credential.
 
 image: ""
 
@@ -65,10 +65,12 @@ command: "bun run src/web/server.ts"
 # so rather than the chart assuming a runtime class exists.
 sandbox: false
 
-# The Secret carrying `SPINDRIFT_MANIFEST`, `SPINDRIFT_ENROLMENT_TOKEN`, and
-# repository credentials when that integration is configured. Required in
-# practice: the process refuses to boot without a manifest, which is the §20
-# discipline working as intended.
+# First-boot configuration only. Once the database has an installation row,
+# changing this value does not overwrite it.
+installationManifest: {}
+
+# The Secret carrying `SPINDRIFT_ENROLMENT_TOKEN` and repository credentials
+# when those integrations are configured. It contains credentials only.
 envFromSecret: ""
 
 # Header authentication is safe only behind a Gateway that strips and replaces


### PR DESCRIPTION
## Summary

- make Postgres authoritative for the Spindrift installation manifest after a one-time bootstrap
- render the non-secret bootstrap manifest from a ConfigMap and keep the SOPS Secret credential-only
- add a singleton installation table with race-safe bootstrap behavior

## Test plan

- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test apps/spindrift/test` (780 pass)
- [x] `bun test packages/charts/spindrift/tests` (6 pass)
- [x] `mise run ts:check`
- [x] `mise run k8s:render-apps`
- [x] SOPS decrypt round-trip confirms only `SPINDRIFT_ENROLMENT_TOKEN` remains

## Deployment

Migration `0009_installation_manifest.sql` is additive and safe to apply before the new image rolls out. The first updated process bootstraps the singleton row from the ConfigMap; subsequent boots read only from Postgres.
