### PR TITLE
fix(spindrift): include supplyChain.signer in installationManifest

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -48,6 +48,7 @@ spec:
       supplyChain:
         registry: ghcr.io/jonpulsifer
         verifier: ghcr.io/jonpulsifer/spindrift-verifier
+        signer: gcpkms://projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer
       github:
         appId: "334190"
         apiBaseUrl: https://api.github.com


### PR DESCRIPTION
## Summary

Fixes `ManifestError: /etc/spindrift/manifest.yaml: invalid installation manifest - supplyChain.signer: Invalid input` during initial installation manifest validation.

### Changes
- Added missing `supplyChain.signer` KMS key URI (`gcpkms://projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer`) to `installationManifest` in `clusters/offsite/apps/spindrift/helm-release.yaml`.