### PR TITLE
feat(spindrift-demo): static site demo with build-time vars

### DIFF
--- a/.github/containers.json
+++ b/.github/containers.json
@@ -10,6 +10,7 @@
     "hub",
     "slingshot",
     "spindrift",
+    "spindrift-demo",
     "spindrift-verifier"
   ],
   "ignore": [

--- a/apps/spindrift-demo/Dockerfile
+++ b/apps/spindrift-demo/Dockerfile
@@ -7,13 +7,16 @@ FROM cgr.dev/chainguard/node:latest-dev@sha256:5ca3303bfbcd7eeec7e71466d56a334c8
 ARG BUN_VERSION=1.3.14
 ENV BUN_INSTALL=/usr/local
 USER root
-RUN apk add --no-cache bash curl git \
+RUN apk add --no-cache bash curl \
   && curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
 
 FROM base AS builder
+ARG BUILD_COMMIT=unknown
+ARG BUILD_BRANCH=unknown
+ARG BUILD_TIME
 WORKDIR /app
 COPY . .
-RUN bun run build.ts
+RUN cd apps/spindrift-demo && BUILD_COMMIT="${BUILD_COMMIT}" BUILD_BRANCH="${BUILD_BRANCH}" BUILD_TIME="${BUILD_TIME:-$(date -Iseconds)}" bun run build.ts
 
 FROM cgr.dev/chainguard/node:latest@sha256:2b9627fec21321fad828adf6c5ceb91c6f377b772b48a738533a1225c0145a90 AS runner
 ENV NODE_ENV=production \

--- a/apps/spindrift-demo/Dockerfile
+++ b/apps/spindrift-demo/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+#
+# Static site demo — build dist/ with build-time git facts, then serve the
+# folder with bun.  The toolchain stays in the builder stage; the runtime
+# image only carries the static files and a bun binary to serve them.
+FROM cgr.dev/chainguard/node:latest-dev@sha256:5ca3303bfbcd7eeec7e71466d56a334c8f40323b59a92e174131bf038bdd81ca AS base
+ARG BUN_VERSION=1.3.14
+ENV BUN_INSTALL=/usr/local
+USER root
+RUN apk add --no-cache bash curl git \
+  && curl -fsSL https://bun.sh/install | bash -s -- "bun-v${BUN_VERSION}"
+
+FROM base AS builder
+WORKDIR /app
+COPY . .
+RUN bun run build.ts
+
+FROM cgr.dev/chainguard/node:latest@sha256:2b9627fec21321fad828adf6c5ceb91c6f377b772b48a738533a1225c0145a90 AS runner
+ENV NODE_ENV=production \
+  PORT=3000
+WORKDIR /app
+COPY --from=base /usr/local/bin/bun /usr/local/bin/bun
+COPY --from=builder --chmod=755 /app/apps/spindrift-demo/dist ./dist
+COPY --from=builder --chmod=755 /app/apps/spindrift-demo/serve.ts ./serve.ts
+USER 65532:65532
+EXPOSE 3000
+ENTRYPOINT []
+CMD ["/usr/local/bin/bun", "run", "serve.ts"]

--- a/apps/spindrift-demo/build.json
+++ b/apps/spindrift-demo/build.json
@@ -1,0 +1,13 @@
+[
+  {
+    "image": "spindrift-demo",
+    "context": ".",
+    "file": "apps/spindrift-demo/Dockerfile",
+    "platforms": "linux/amd64",
+    "watch": [
+      "apps/spindrift-demo",
+      "package.json",
+      "bun.lock"
+    ]
+  }
+]

--- a/apps/spindrift-demo/build.ts
+++ b/apps/spindrift-demo/build.ts
@@ -12,7 +12,7 @@ const OUT = join(import.meta.dir, "dist");
 
 // ── build-time facts ────────────────────────────────────────────────────────
 
-const commit = (() => {
+const commit = Bun.env.BUILD_COMMIT || (() => {
   const proc = Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], {
     stdout: "pipe",
     stderr: "pipe",
@@ -20,7 +20,7 @@ const commit = (() => {
   return proc.stdout.toString().trim() || "unknown";
 })();
 
-const branch = (() => {
+const branch = Bun.env.BUILD_BRANCH || (() => {
   const proc = Bun.spawnSync(["git", "rev-parse", "--abbrev-ref", "HEAD"], {
     stdout: "pipe",
     stderr: "pipe",
@@ -28,7 +28,7 @@ const branch = (() => {
   return proc.stdout.toString().trim() || "unknown";
 })();
 
-const stamp = new Date().toISOString();
+const stamp = Bun.env.BUILD_TIME || new Date().toISOString();
 
 // ── inject ──────────────────────────────────────────────────────────────────
 

--- a/apps/spindrift-demo/build.ts
+++ b/apps/spindrift-demo/build.ts
@@ -1,0 +1,49 @@
+/**
+ * spindrift-demo build — inject build-time vars into the static site.
+ *
+ * Reads git commit/branch, stamps the current time, replaces placeholders in
+ * the HTML template, and copies everything to dist/.
+ */
+import { readFile, mkdir, rm, cp } from "node:fs/promises";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dir, "src");
+const OUT = join(import.meta.dir, "dist");
+
+// ── build-time facts ────────────────────────────────────────────────────────
+
+const commit = (() => {
+  const proc = Bun.spawnSync(["git", "rev-parse", "--short", "HEAD"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return proc.stdout.toString().trim() || "unknown";
+})();
+
+const branch = (() => {
+  const proc = Bun.spawnSync(["git", "rev-parse", "--abbrev-ref", "HEAD"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return proc.stdout.toString().trim() || "unknown";
+})();
+
+const stamp = new Date().toISOString();
+
+// ── inject ──────────────────────────────────────────────────────────────────
+
+let html = await readFile(join(SRC, "index.html"), "utf-8");
+html = html.replace("{{BUILD_COMMIT}}", commit);
+html = html.replace("{{BUILD_BRANCH}}", branch);
+html = html.replace("{{BUILD_TIME}}", stamp);
+
+// ── emit ────────────────────────────────────────────────────────────────────
+
+await rm(OUT, { recursive: true, force: true });
+await mkdir(OUT, { recursive: true });
+
+await Bun.write(join(OUT, "index.html"), html);
+await cp(join(SRC, "style.css"), join(OUT, "style.css"));
+await cp(join(SRC, "client.js"), join(OUT, "client.js"));
+
+console.log(`spindrift-demo → dist/ (commit ${commit} on ${branch})`);

--- a/apps/spindrift-demo/package.json
+++ b/apps/spindrift-demo/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "spindrift-demo",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "bun run build.ts",
+    "dev": "bun run build.ts && bun run --hot serve.ts",
+    "start": "bun run serve.ts"
+  }
+}

--- a/apps/spindrift-demo/plain/client.js
+++ b/apps/spindrift-demo/plain/client.js
@@ -1,0 +1,155 @@
+/* ── load time ───────────────────────────────────────────────────────────── */
+
+document.getElementById('load-time').textContent = new Date().toISOString();
+
+/* ── spray canvas ────────────────────────────────────────────────────────── */
+
+const canvas = document.getElementById('spray');
+const ctx = canvas.getContext('2d');
+
+let width, height;
+const particles = [];
+const MAX = 50;
+
+function resize() {
+  width = canvas.width = window.innerWidth;
+  height = canvas.height = window.innerHeight;
+}
+resize();
+window.addEventListener('resize', resize);
+
+class Spray {
+  constructor() {
+    this.reset(true);
+  }
+  reset(init) {
+    this.x = Math.random() * width;
+    this.y = init ? Math.random() * height : height + 10;
+    this.r = Math.random() * 2 + 0.5;
+    this.vx = (Math.random() - 0.5) * 0.4;
+    this.vy = -(Math.random() * 0.6 + 0.2);
+    this.life = 1;
+    this.decay = Math.random() * 0.005 + 0.003;
+    this.opacity = Math.random() * 0.5 + 0.2;
+  }
+  update() {
+    this.x += this.vx;
+    this.y += this.vy;
+    this.life -= this.decay;
+    if (this.life <= 0) this.reset(false);
+  }
+  draw() {
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.r, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(60,198,208,${(this.life * this.opacity).toFixed(3)})`;
+    ctx.fill();
+  }
+}
+
+for (let i = 0; i < MAX; i++) particles.push(new Spray());
+
+function frame() {
+  ctx.clearRect(0, 0, width, height);
+  for (const p of particles) { p.update(); p.draw(); }
+  requestAnimationFrame(frame);
+}
+frame();
+
+/* ── vessel fleet ────────────────────────────────────────────────────────── */
+
+const VESSELS = [
+  { name: 'wave-rider',     kind: 'ingress',    status: 'ok' },
+  { name: 'spray-collector', kind: 'daemonset', status: 'ok' },
+  { name: 'foam-dispenser',  kind: 'deploy',    status: 'ok' },
+  { name: 'salt-harvester',  kind: 'statefulset', status: 'warn' },
+  { name: 'tide-gauger',     kind: 'cronjob',   status: 'ok' },
+  { name: 'reef-monitor',    kind: 'deploy',    status: 'ok' },
+];
+
+const vesselsEl = document.getElementById('vessels');
+
+for (const v of VESSELS) {
+  const card = document.createElement('div');
+  card.className = 'vessel';
+
+  const dot = document.createElement('span');
+  dot.className = `vessel-dot ${v.status}${v.status === 'ok' ? ' pulse' : ''}`;
+
+  const info = document.createElement('div');
+  info.className = 'vessel-info';
+
+  const name = document.createElement('span');
+  name.className = 'vessel-name';
+  name.textContent = v.name;
+
+  const meta = document.createElement('span');
+  meta.className = 'vessel-meta';
+  meta.textContent = `${v.kind} · ${v.status === 'ok' ? 'healthy' : v.status === 'warn' ? 'degraded' : 'down'}`;
+
+  info.append(name, meta);
+  card.append(dot, info);
+  vesselsEl.appendChild(card);
+}
+
+/* ── deploy log ──────────────────────────────────────────────────────────── */
+
+const LOG_LINES = [
+  { cls: 'info',  text: '$ spindrift reconcile --fleet' },
+  { cls: 'faint', text: '  scanning git tree ...' },
+  { cls: 'ok',    text: '  ✓ 6 manifests discovered (2.1 KiB)' },
+  { cls: 'faint', text: '  diffing against live state ...' },
+  { cls: 'info',  text: '  → wave-rider: no drift' },
+  { cls: 'info',  text: '  → spray-collector: no drift' },
+  { cls: 'info',  text: '  → foam-dispenser: no drift' },
+  { cls: 'warn',  text: '  → salt-harvester: 1 replica pending (image pull)' },
+  { cls: 'info',  text: '  → tide-gauger: no drift' },
+  { cls: 'info',  text: '  → reef-monitor: no drift' },
+  { cls: 'faint', text: '  reconciling ...' },
+  { cls: 'ok',    text: '  ✓ cluster converged (847 ms)' },
+  { cls: 'faint', text: '  ---' },
+  { cls: 'info',  text: '  static assets ready for liftoff.' },
+  { cls: 'ok',    text: '  🚀 deploy complete.' },
+];
+
+const terminalLines = document.getElementById('terminal-lines');
+const cursor = document.querySelector('.cursor');
+
+let lineIdx = 0;
+let charIdx = 0;
+let currentLineEl = null;
+
+function typeNext() {
+  if (lineIdx >= LOG_LINES.length) {
+    cursor.style.display = 'none';
+    return;
+  }
+
+  const entry = LOG_LINES[lineIdx];
+
+  if (charIdx === 0) {
+    currentLineEl = document.createElement('div');
+    currentLineEl.className = `line ${entry.cls}`;
+    terminalLines.appendChild(currentLineEl);
+  }
+
+  currentLineEl.textContent += entry.text[charIdx];
+  charIdx++;
+
+  terminalLines.parentElement.scrollTop = terminalLines.parentElement.scrollHeight;
+
+  if (charIdx >= entry.text.length) {
+    lineIdx++;
+    charIdx = 0;
+    setTimeout(typeNext, 120);
+  } else {
+    const delay = entry.text[charIdx - 1] === ' ' ? 30 : 18 + Math.random() * 25;
+    setTimeout(typeNext, delay);
+  }
+}
+
+setTimeout(typeNext, 400);
+
+/* ── render time ─────────────────────────────────────────────────────────── */
+
+const renderMs = Math.round(performance.now());
+document.getElementById('render-ms').textContent = renderMs;

--- a/apps/spindrift-demo/plain/index.html
+++ b/apps/spindrift-demo/plain/index.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Spindrift Fleet Command</title>
+<meta name="description" content="A demo static site — spindrift fleet status dashboard">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<canvas id="spray"></canvas>
+
+<div class="shell">
+  <header class="masthead">
+    <div class="logo">
+      <span class="logo-mark">🌊</span>
+      <h1>Spindrift <b>Fleet Command</b></h1>
+    </div>
+    <p class="tagline">Every vessel accounted for. Every wave ridden.</p>
+  </header>
+
+  <section class="build-card">
+    <div class="build-label">deploy</div>
+    <div class="build-rows">
+      <div class="build-row">
+        <span class="key">mode</span>
+        <code class="val">static — no build step</code>
+      </div>
+      <div class="build-row">
+        <span class="key">loaded</span>
+        <code class="val" id="load-time"></code>
+      </div>
+    </div>
+  </section>
+
+  <section class="fleet">
+    <h2>Fleet Status</h2>
+    <div class="vessels" id="vessels">
+      <!-- populated by client.js -->
+    </div>
+  </section>
+
+  <section class="logbook">
+    <h2>Deploy Log</h2>
+    <div class="terminal" id="terminal">
+      <div class="terminal-lines" id="terminal-lines"></div>
+      <span class="cursor">▊</span>
+    </div>
+  </section>
+
+  <footer class="foot">
+    <p>⚡ static site demo · <span id="render-ms"></span> ms to paint</p>
+  </footer>
+</div>
+
+<script src="client.js"></script>
+</body>
+</html>

--- a/apps/spindrift-demo/plain/style.css
+++ b/apps/spindrift-demo/plain/style.css
@@ -1,0 +1,286 @@
+/* ── spindrift fleet command ─────────────────────────────────────────────── */
+
+:root {
+  --deep: #0a1628;
+  --navy: #0f1f3d;
+  --slate: #1a2d4a;
+  --foam: #e8f0f8;
+  --spray: #6db3c9;
+  --cyan: #3cc6d0;
+  --amber: #f0a848;
+  --green: #4cd964;
+  --red: #ff5c5c;
+  --muted: #5a7a9a;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Outfit', system-ui, sans-serif;
+  background: var(--deep);
+  color: var(--foam);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* ── spray canvas ─────────────────────────────────────────────────────── */
+
+#spray {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+/* ── shell ────────────────────────────────────────────────────────────── */
+
+.shell {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 2rem;
+}
+
+/* ── masthead ─────────────────────────────────────────────────────────── */
+
+.masthead {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.logo-mark {
+  font-size: 2.8rem;
+  filter: drop-shadow(0 0 12px rgba(60,198,208,0.4));
+  animation: bob 3s ease-in-out infinite;
+}
+
+@keyframes bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+.logo h1 {
+  font-size: 2.2rem;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+  color: var(--foam);
+}
+
+.logo h1 b {
+  font-weight: 700;
+  color: var(--cyan);
+}
+
+.tagline {
+  font-size: 1rem;
+  color: var(--muted);
+  font-weight: 300;
+  letter-spacing: 0.02em;
+}
+
+/* ── build card ───────────────────────────────────────────────────────── */
+
+.build-card {
+  background: var(--navy);
+  border: 1px solid rgba(60,198,208,0.2);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.build-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(60,198,208,0.05) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.build-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--cyan);
+  margin-bottom: 0.75rem;
+}
+
+.build-rows {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem 2rem;
+}
+
+.build-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.build-row .key {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.build-row .val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--foam);
+  background: rgba(0,0,0,0.3);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+}
+
+/* ── fleet ────────────────────────────────────────────────────────────── */
+
+.fleet { margin-bottom: 2rem; }
+
+.fleet h2, .logbook h2 {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--muted);
+  margin-bottom: 0.75rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.vessels {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+.vessel {
+  background: var(--navy);
+  border: 1px solid rgba(109,179,201,0.15);
+  border-radius: 10px;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  transition: border-color 0.3s, transform 0.2s;
+  cursor: default;
+}
+
+.vessel:hover {
+  border-color: rgba(60,198,208,0.4);
+  transform: translateY(-2px);
+}
+
+.vessel-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.vessel-dot.ok    { background: var(--green);  box-shadow: 0 0 8px rgba(76,217,100,0.6); }
+.vessel-dot.warn  { background: var(--amber); box-shadow: 0 0 8px rgba(240,168,72,0.6); }
+.vessel-dot.down  { background: var(--red);   box-shadow: 0 0 8px rgba(255,92,92,0.6); }
+
+.vessel-dot.pulse {
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 4px rgba(76,217,100,0.4); }
+  50%      { box-shadow: 0 0 14px rgba(76,217,100,0.8); }
+}
+
+.vessel-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.vessel-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--foam);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vessel-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--muted);
+}
+
+/* ── terminal / deploy log ────────────────────────────────────────────── */
+
+.terminal {
+  background: #0a101e;
+  border: 1px solid rgba(109,179,201,0.15);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  min-height: 160px;
+  max-height: 280px;
+  overflow-y: auto;
+  position: relative;
+}
+
+.terminal-lines {
+  color: var(--muted);
+}
+
+.terminal .line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.terminal .line.info  { color: var(--spray); }
+.terminal .line.ok    { color: var(--green); }
+.terminal .line.warn  { color: var(--amber); }
+.terminal .line.err   { color: var(--red); }
+.terminal .line.faint { color: var(--muted); }
+
+.terminal .cursor {
+  color: var(--cyan);
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0; }
+}
+
+/* ── footer ───────────────────────────────────────────────────────────── */
+
+.foot {
+  text-align: center;
+  margin-top: 2.5rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  letter-spacing: 0.03em;
+}
+
+/* ── responsive ───────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .shell { padding: 2rem 1rem 1.5rem; }
+  .logo { flex-direction: column; gap: 0.25rem; }
+  .logo-mark { font-size: 2.2rem; }
+  .logo h1 { font-size: 1.6rem; }
+  .vessels { grid-template-columns: 1fr; }
+}

--- a/apps/spindrift-demo/serve.ts
+++ b/apps/spindrift-demo/serve.ts
@@ -1,0 +1,27 @@
+/**
+ * Static file server — serves dist/ for production, or src/ for dev.
+ */
+const dir = Bun.env.NODE_ENV === "production" ? "dist" : "src";
+
+Bun.serve({
+  port: Number(Bun.env.PORT) || 3000,
+  async fetch(req) {
+    const url = new URL(req.url);
+    let path = url.pathname === "/" ? "/index.html" : url.pathname;
+    const file = Bun.file(`./${dir}${path}`);
+    if (await file.exists()) {
+      return new Response(file, {
+        headers: {
+          "content-type":
+            path.endsWith(".html") ? "text/html; charset=utf-8"
+            : path.endsWith(".css") ? "text/css; charset=utf-8"
+            : path.endsWith(".js") ? "application/javascript; charset=utf-8"
+            : "application/octet-stream",
+        },
+      });
+    }
+    return new Response("404", { status: 404 });
+  },
+});
+
+console.log(`spindrift-demo → http://localhost:${Bun.env.PORT || 3000} (${dir}/)`);

--- a/apps/spindrift-demo/src/client.js
+++ b/apps/spindrift-demo/src/client.js
@@ -1,0 +1,151 @@
+/* ── spray canvas ────────────────────────────────────────────────────────── */
+
+const canvas = document.getElementById('spray');
+const ctx = canvas.getContext('2d');
+
+let width, height;
+const particles = [];
+const MAX = 50;
+
+function resize() {
+  width = canvas.width = window.innerWidth;
+  height = canvas.height = window.innerHeight;
+}
+resize();
+window.addEventListener('resize', resize);
+
+class Spray {
+  constructor() {
+    this.reset(true);
+  }
+  reset(init) {
+    this.x = Math.random() * width;
+    this.y = init ? Math.random() * height : height + 10;
+    this.r = Math.random() * 2 + 0.5;
+    this.vx = (Math.random() - 0.5) * 0.4;
+    this.vy = -(Math.random() * 0.6 + 0.2);
+    this.life = 1;
+    this.decay = Math.random() * 0.005 + 0.003;
+    this.opacity = Math.random() * 0.5 + 0.2;
+  }
+  update() {
+    this.x += this.vx;
+    this.y += this.vy;
+    this.life -= this.decay;
+    if (this.life <= 0) this.reset(false);
+  }
+  draw() {
+    ctx.beginPath();
+    ctx.arc(this.x, this.y, this.r, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(60,198,208,${(this.life * this.opacity).toFixed(3)})`;
+    ctx.fill();
+  }
+}
+
+for (let i = 0; i < MAX; i++) particles.push(new Spray());
+
+function frame() {
+  ctx.clearRect(0, 0, width, height);
+  for (const p of particles) { p.update(); p.draw(); }
+  requestAnimationFrame(frame);
+}
+frame();
+
+/* ── vessel fleet ────────────────────────────────────────────────────────── */
+
+const VESSELS = [
+  { name: 'wave-rider',     kind: 'ingress',    status: 'ok' },
+  { name: 'spray-collector', kind: 'daemonset', status: 'ok' },
+  { name: 'foam-dispenser',  kind: 'deploy',    status: 'ok' },
+  { name: 'salt-harvester',  kind: 'statefulset', status: 'warn' },
+  { name: 'tide-gauger',     kind: 'cronjob',   status: 'ok' },
+  { name: 'reef-monitor',    kind: 'deploy',    status: 'ok' },
+];
+
+const vesselsEl = document.getElementById('vessels');
+
+for (const v of VESSELS) {
+  const card = document.createElement('div');
+  card.className = 'vessel';
+
+  const dot = document.createElement('span');
+  dot.className = `vessel-dot ${v.status}${v.status === 'ok' ? ' pulse' : ''}`;
+
+  const info = document.createElement('div');
+  info.className = 'vessel-info';
+
+  const name = document.createElement('span');
+  name.className = 'vessel-name';
+  name.textContent = v.name;
+
+  const meta = document.createElement('span');
+  meta.className = 'vessel-meta';
+  meta.textContent = `${v.kind} · ${v.status === 'ok' ? 'healthy' : v.status === 'warn' ? 'degraded' : 'down'}`;
+
+  info.append(name, meta);
+  card.append(dot, info);
+  vesselsEl.appendChild(card);
+}
+
+/* ── deploy log ──────────────────────────────────────────────────────────── */
+
+const LOG_LINES = [
+  { cls: 'info',  text: '$ spindrift reconcile --fleet' },
+  { cls: 'faint', text: '  scanning git tree ...' },
+  { cls: 'ok',    text: '  ✓ 6 manifests discovered (2.1 KiB)' },
+  { cls: 'faint', text: '  diffing against live state ...' },
+  { cls: 'info',  text: '  → wave-rider: no drift' },
+  { cls: 'info',  text: '  → spray-collector: no drift' },
+  { cls: 'info',  text: '  → foam-dispenser: no drift' },
+  { cls: 'warn',  text: '  → salt-harvester: 1 replica pending (image pull)' },
+  { cls: 'info',  text: '  → tide-gauger: no drift' },
+  { cls: 'info',  text: '  → reef-monitor: no drift' },
+  { cls: 'faint', text: '  reconciling ...' },
+  { cls: 'ok',    text: '  ✓ cluster converged (847 ms)' },
+  { cls: 'faint', text: '  ---' },
+  { cls: 'info',  text: '  static assets ready for liftoff.' },
+  { cls: 'ok',    text: '  🚀 deploy complete.' },
+];
+
+const terminalLines = document.getElementById('terminal-lines');
+const cursor = document.querySelector('.cursor');
+
+let lineIdx = 0;
+let charIdx = 0;
+let currentLineEl = null;
+
+function typeNext() {
+  if (lineIdx >= LOG_LINES.length) {
+    cursor.style.display = 'none';
+    return;
+  }
+
+  const entry = LOG_LINES[lineIdx];
+
+  if (charIdx === 0) {
+    currentLineEl = document.createElement('div');
+    currentLineEl.className = `line ${entry.cls}`;
+    terminalLines.appendChild(currentLineEl);
+  }
+
+  currentLineEl.textContent += entry.text[charIdx];
+  charIdx++;
+
+  terminalLines.parentElement.scrollTop = terminalLines.parentElement.scrollHeight;
+
+  if (charIdx >= entry.text.length) {
+    lineIdx++;
+    charIdx = 0;
+    setTimeout(typeNext, 120);
+  } else {
+    const delay = entry.text[charIdx - 1] === ' ' ? 30 : 18 + Math.random() * 25;
+    setTimeout(typeNext, delay);
+  }
+}
+
+setTimeout(typeNext, 400);
+
+/* ── render time ─────────────────────────────────────────────────────────── */
+
+const renderMs = Math.round(performance.now());
+document.getElementById('render-ms').textContent = renderMs;

--- a/apps/spindrift-demo/src/index.html
+++ b/apps/spindrift-demo/src/index.html
@@ -1,0 +1,67 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Spindrift Fleet Command</title>
+<meta name="description" content="A demo static site — spindrift fleet status dashboard">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🌊</text></svg>">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<canvas id="spray"></canvas>
+
+<div class="shell">
+  <header class="masthead">
+    <div class="logo">
+      <span class="logo-mark">🌊</span>
+      <h1>Spindrift <b>Fleet Command</b></h1>
+    </div>
+    <p class="tagline">Every vessel accounted for. Every wave ridden.</p>
+  </header>
+
+  <section class="build-card">
+    <div class="build-label">build</div>
+    <div class="build-rows">
+      <div class="build-row">
+        <span class="key">commit</span>
+        <code class="val">{{BUILD_COMMIT}}</code>
+      </div>
+      <div class="build-row">
+        <span class="key">branch</span>
+        <code class="val">{{BUILD_BRANCH}}</code>
+      </div>
+      <div class="build-row">
+        <span class="key">stamped</span>
+        <code class="val">{{BUILD_TIME}}</code>
+      </div>
+    </div>
+  </section>
+
+  <section class="fleet">
+    <h2>Fleet Status</h2>
+    <div class="vessels" id="vessels">
+      <!-- populated by client.js -->
+    </div>
+  </section>
+
+  <section class="logbook">
+    <h2>Deploy Log</h2>
+    <div class="terminal" id="terminal">
+      <div class="terminal-lines" id="terminal-lines"></div>
+      <span class="cursor">▊</span>
+    </div>
+  </section>
+
+  <footer class="foot">
+    <p>⚡ static site demo · <span id="render-ms"></span> ms to paint</p>
+  </footer>
+</div>
+
+<script src="client.js"></script>
+</body>
+</html>

--- a/apps/spindrift-demo/src/style.css
+++ b/apps/spindrift-demo/src/style.css
@@ -1,0 +1,286 @@
+/* ── spindrift fleet command ─────────────────────────────────────────────── */
+
+:root {
+  --deep: #0a1628;
+  --navy: #0f1f3d;
+  --slate: #1a2d4a;
+  --foam: #e8f0f8;
+  --spray: #6db3c9;
+  --cyan: #3cc6d0;
+  --amber: #f0a848;
+  --green: #4cd964;
+  --red: #ff5c5c;
+  --muted: #5a7a9a;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  font-family: 'Outfit', system-ui, sans-serif;
+  background: var(--deep);
+  color: var(--foam);
+  min-height: 100vh;
+  overflow-x: hidden;
+}
+
+/* ── spray canvas ─────────────────────────────────────────────────────── */
+
+#spray {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+/* ── shell ────────────────────────────────────────────────────────────── */
+
+.shell {
+  position: relative;
+  z-index: 1;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 2rem;
+}
+
+/* ── masthead ─────────────────────────────────────────────────────────── */
+
+.masthead {
+  text-align: center;
+  margin-bottom: 2.5rem;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.logo-mark {
+  font-size: 2.8rem;
+  filter: drop-shadow(0 0 12px rgba(60,198,208,0.4));
+  animation: bob 3s ease-in-out infinite;
+}
+
+@keyframes bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-6px); }
+}
+
+.logo h1 {
+  font-size: 2.2rem;
+  font-weight: 300;
+  letter-spacing: -0.02em;
+  color: var(--foam);
+}
+
+.logo h1 b {
+  font-weight: 700;
+  color: var(--cyan);
+}
+
+.tagline {
+  font-size: 1rem;
+  color: var(--muted);
+  font-weight: 300;
+  letter-spacing: 0.02em;
+}
+
+/* ── build card ───────────────────────────────────────────────────────── */
+
+.build-card {
+  background: var(--navy);
+  border: 1px solid rgba(60,198,208,0.2);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 2rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.build-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(60,198,208,0.05) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.build-label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--cyan);
+  margin-bottom: 0.75rem;
+}
+
+.build-rows {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem 2rem;
+}
+
+.build-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.build-row .key {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.build-row .val {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.85rem;
+  color: var(--foam);
+  background: rgba(0,0,0,0.3);
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+}
+
+/* ── fleet ────────────────────────────────────────────────────────────── */
+
+.fleet { margin-bottom: 2rem; }
+
+.fleet h2, .logbook h2 {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--muted);
+  margin-bottom: 0.75rem;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.vessels {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+.vessel {
+  background: var(--navy);
+  border: 1px solid rgba(109,179,201,0.15);
+  border-radius: 10px;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  transition: border-color 0.3s, transform 0.2s;
+  cursor: default;
+}
+
+.vessel:hover {
+  border-color: rgba(60,198,208,0.4);
+  transform: translateY(-2px);
+}
+
+.vessel-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.vessel-dot.ok    { background: var(--green);  box-shadow: 0 0 8px rgba(76,217,100,0.6); }
+.vessel-dot.warn  { background: var(--amber); box-shadow: 0 0 8px rgba(240,168,72,0.6); }
+.vessel-dot.down  { background: var(--red);   box-shadow: 0 0 8px rgba(255,92,92,0.6); }
+
+.vessel-dot.pulse {
+  animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { box-shadow: 0 0 4px rgba(76,217,100,0.4); }
+  50%      { box-shadow: 0 0 14px rgba(76,217,100,0.8); }
+}
+
+.vessel-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.vessel-name {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--foam);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.vessel-meta {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--muted);
+}
+
+/* ── terminal / deploy log ────────────────────────────────────────────── */
+
+.terminal {
+  background: #0a101e;
+  border: 1px solid rgba(109,179,201,0.15);
+  border-radius: 10px;
+  padding: 1rem 1.25rem;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  min-height: 160px;
+  max-height: 280px;
+  overflow-y: auto;
+  position: relative;
+}
+
+.terminal-lines {
+  color: var(--muted);
+}
+
+.terminal .line {
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.terminal .line.info  { color: var(--spray); }
+.terminal .line.ok    { color: var(--green); }
+.terminal .line.warn  { color: var(--amber); }
+.terminal .line.err   { color: var(--red); }
+.terminal .line.faint { color: var(--muted); }
+
+.terminal .cursor {
+  color: var(--cyan);
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0; }
+}
+
+/* ── footer ───────────────────────────────────────────────────────────── */
+
+.foot {
+  text-align: center;
+  margin-top: 2.5rem;
+  font-size: 0.75rem;
+  color: var(--muted);
+  letter-spacing: 0.03em;
+}
+
+/* ── responsive ───────────────────────────────────────────────────────── */
+
+@media (max-width: 480px) {
+  .shell { padding: 2rem 1rem 1.5rem; }
+  .logo { flex-direction: column; gap: 0.25rem; }
+  .logo-mark { font-size: 2.2rem; }
+  .logo h1 { font-size: 1.6rem; }
+  .vessels { grid-template-columns: 1fr; }
+}


### PR DESCRIPTION
## Summary
Add `apps/spindrift-demo` — a static-site demo for showcasing build-time variable injection and zero-toolchain deployment, themed as a spindrift fleet-command dashboard.

## Changes
- feat(spindrift-demo): add static site demo with build-time var injection

## Test Plan
- [ ] `bun run apps/spindrift-demo/build.ts` — produces `dist/` with git commit/branch/timestamp injected
- [ ] `python3 -m http.server -d apps/spindrift-demo/plain 8080` — serves the plain version with zero build
- [ ] `docker build -f apps/spindrift-demo/Dockerfile .` — builds the container image

## Context
No context file — this is a new static demo app.
