### PR TITLE
chore(tofu): bump OpenTofu to 1.12.5 (dev + Atlantis)

### DIFF
--- a/images/atlantis/Dockerfile
+++ b/images/atlantis/Dockerfile
@@ -1,5 +1,16 @@
 FROM ghcr.io/runatlantis/atlantis:v0.46.0@sha256:e79363da6b55182d0cb13d7d9deb1cef51528f309a64254755c80df09cbfd698
 USER root
+
+# Bump OpenTofu past the bundled 1.12.3.
+ARG OPENTOFU_VERSION=1.12.5
+RUN apk add --no-cache unzip \
+    && curl -fsSL "https://github.com/opentofu/opentofu/releases/download/v${OPENTOFU_VERSION}/tofu_${OPENTOFU_VERSION}_linux_amd64.zip" -o /tmp/tofu.zip \
+    && unzip -o /tmp/tofu.zip -d /usr/local/bin/ \
+    && rm /tmp/tofu.zip \
+    && chmod +x /usr/local/bin/tofu \
+    && tofu --version \
+    && apk del unzip
+
 RUN echo https://downloads.1password.com/linux/alpinelinux/stable/ >> /etc/apk/repositories && \
     wget https://downloads.1password.com/linux/keys/alpinelinux/support@1password.com-61ddfc31.rsa.pub -P /etc/apk/keys && \
     apk add --no-cache 1password-cli && \

--- a/mise.toml
+++ b/mise.toml
@@ -23,7 +23,7 @@ shfmt = "latest"
 sops = "latest"
 # tofu is the apply-path binary (Atlantis runs ATLANTIS_DEFAULT_TF_DISTRIBUTION=opentofu);
 # terraform stays installed for anything not yet migrated.
-opentofu = "latest"
+opentofu = "1.12.5"
 terraform = "latest"
 terraform-docs = "latest"
 vim = "latest"


### PR DESCRIPTION
## Summary
Bump OpenTofu from 1.12.3 (bundled in Atlantis) to 1.12.5 — explicitly pin the dev version and override the Atlantis image's bundled binary.

## Changes
- `mise.toml`: pin opentofu to explicit 1.12.5 (was `"latest"`)
- `images/atlantis/Dockerfile`: override Atlantis's bundled OpenTofu 1.12.3 with 1.12.5

## Test Plan
- [ ] CI validates all Terraform roots with 1.12.5
- [ ] Atlantis container builds and `tofu --version` reports 1.12.5
