### PR TITLE
chore(ci): make Trivy scans informational (don't block)

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -116,5 +116,5 @@ jobs:
           trivy-config: ${{ github.workspace }}/.github/trivy.yaml
           hide-progress: false
           ignore-unfixed: true
-          exit-code: 1
+          exit-code: 0
           severity: CRITICAL,HIGH

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -71,7 +71,7 @@ jobs:
           ignore-unfixed: true
           limit-severities-for-sarif: true
           output: trivy-config.txt
-          exit-code: 1
+          exit-code: 0
           severity: CRITICAL,HIGH
       - name: Output Trivy config results
         if: always()
@@ -137,7 +137,7 @@ jobs:
           hide-progress: false
           ignore-unfixed: true
           output: trivy-fs.txt
-          exit-code: 1
+          exit-code: 0
           severity: CRITICAL,HIGH
       - name: Output Trivy filesystem results
         if: always()

--- a/apps/ddnsd/module.nix
+++ b/apps/ddnsd/module.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 with lib;
 let
   cfg = config.services.ddnsd;


### PR DESCRIPTION
## Summary
Make all three Trivy scans (config, filesystem, image) informational — findings are reported in step summaries but no longer fail builds. Also includes an incidental nixfmt reformat.

## Changes
- `trivy.yml`: `exit-code: 0` on config and filesystem scans
- `containers.yml`: `exit-code: 0` on image scan
- `apps/ddnsd/module.nix`: nixfmt reformat
