### PR TITLE
feat(spindrift): Use real Targets and repositories

### DIFF
--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -30,5 +30,7 @@ export { createDeploy } from './deploys/create.ts';
 export { getDeployDetail } from './deploys/get-detail.ts';
 export { rollbackDeploy } from './deploys/rollback.ts';
 export { connectRepository } from './repositories/connect.ts';
+export { listRepositories } from './repositories/list.ts';
 export { connectTarget } from './targets/connect.ts';
 export { disconnectTarget } from './targets/disconnect.ts';
+export { listTargets } from './targets/list.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -50,11 +50,16 @@ import {
   connectRepository,
   connectRepositoryInput,
 } from './repositories/connect.ts';
+import {
+  listRepositories,
+  listRepositoriesInput,
+} from './repositories/list.ts';
 import { connectTarget, connectTargetInput } from './targets/connect.ts';
 import {
   disconnectTarget,
   disconnectTargetInput,
 } from './targets/disconnect.ts';
+import { listTargets, listTargetsInput } from './targets/list.ts';
 import {
   type Command,
   type CommandContext,
@@ -78,6 +83,11 @@ export const commandRegistry = {
   getAppWorkspace: { input: getAppWorkspaceInput, handler: getAppWorkspace },
   getDeployDetail: { input: getDeployDetailInput, handler: getDeployDetail },
   listApps: { input: listAppsInput, handler: listApps },
+  listTargets: { input: listTargetsInput, handler: listTargets },
+  listRepositories: {
+    input: listRepositoriesInput,
+    handler: listRepositories,
+  },
   createApp: { input: createAppInput, handler: createApp },
   createComponent: { input: createComponentInput, handler: createComponent },
   placeComponent: { input: placeComponentInput, handler: placeComponent },

--- a/apps/spindrift/src/commands/repositories/list.ts
+++ b/apps/spindrift/src/commands/repositories/list.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import type { LinkedRepoView, RepositoryOptionView } from '../../web/model.ts';
+import { type Command, ok } from '../types.ts';
+
+export const listRepositoriesInput = z.object({});
+export type ListRepositoriesInput = z.infer<typeof listRepositoriesInput>;
+
+export interface ListRepositoriesResult {
+  readonly repos: readonly LinkedRepoView[];
+  readonly options: readonly RepositoryOptionView[];
+}
+
+export const listRepositories: Command<
+  ListRepositoriesInput,
+  ListRepositoriesResult
+> = async (_input, context) => {
+  const allRepos = await context.db.query.repositories.findMany({
+    orderBy: (repositories, { asc }) => [asc(repositories.fullName)],
+  });
+
+  const allApps = await context.db.query.apps.findMany({
+    with: {
+      repository: true,
+    },
+  });
+
+  const subpathsByRepoId = new Map<string, Set<string>>();
+
+  for (const app of allApps) {
+    let repoId = app.repositoryId;
+    if (!repoId && app.sourceRepoUrl) {
+      try {
+        const path = new URL(app.sourceRepoUrl).pathname
+          .slice(1)
+          .replace(/\.git$/, '');
+        const matched = allRepos.find((r) => r.fullName === path);
+        if (matched) repoId = matched.id;
+      } catch {
+        // ignore invalid URL
+      }
+    }
+    if (repoId) {
+      if (!subpathsByRepoId.has(repoId)) {
+        subpathsByRepoId.set(repoId, new Set());
+      }
+      subpathsByRepoId.get(repoId)!.add(app.sourceRepoSubpath || '.');
+    }
+  }
+
+  const reposList: LinkedRepoView[] = [];
+  const optionsList: RepositoryOptionView[] = [];
+
+  for (const repo of allRepos) {
+    const subpathsSet = subpathsByRepoId.get(repo.id);
+    const appSubpaths = subpathsSet ? Array.from(subpathsSet).sort() : [];
+    const isConnected = repo.access === 'active';
+
+    reposList.push({
+      repositoryId: repo.id,
+      fullName: repo.fullName,
+      defaultBranch: repo.defaultBranch,
+      health: isConnected ? 'connected' : 'connection_lost',
+      error: repo.frozenReason ?? null,
+      lastReconciledSha: repo.authoritativeCommit ?? null,
+      appSubpaths,
+    });
+
+    optionsList.push({
+      repositoryId: repo.id,
+      fullName: repo.fullName,
+      defaultBranch: repo.defaultBranch,
+      connected: appSubpaths.length > 0,
+    });
+  }
+
+  return ok({
+    repos: reposList,
+    options: optionsList,
+  });
+};

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -1,0 +1,134 @@
+import { z } from 'zod';
+import type { ComponentKind } from '../../domain/desired-state.ts';
+import {
+  DEFAULT_PLATFORM,
+  type Exclusion,
+  placementTargetOf,
+  resolvePlacement,
+} from '../../domain/placement.ts';
+import type { TargetListItem, TargetOptionView } from '../../web/model.ts';
+import { type Command, ok } from '../types.ts';
+
+export const listTargetsInput = z.object({});
+export type ListTargetsInput = z.infer<typeof listTargetsInput>;
+
+export interface ListTargetsResult {
+  readonly targets: readonly TargetListItem[];
+  readonly options: readonly TargetOptionView[];
+}
+
+export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
+  _input,
+  context,
+) => {
+  const allTargets = await context.db.query.targets.findMany({
+    orderBy: (targets, { asc }) => [asc(targets.rank)],
+  });
+
+  const targetsList: TargetListItem[] = [];
+  const optionsList: TargetOptionView[] = [];
+
+  for (const target of allTargets) {
+    const kinds: ComponentKind[] =
+      target.adapter === 'static' ? ['website'] : ['service', 'website', 'job'];
+
+    const canonical = (target.connection as { canonicalSuffix?: string })
+      ?.canonicalSuffix
+      ? `*.${(target.connection as { canonicalSuffix?: string }).canonicalSuffix}`
+      : `*.${target.name.toLowerCase().replace(/[^a-z0-9]/g, '')}.apps.internal`;
+
+    targetsList.push({
+      name: target.name,
+      adapter: target.adapter,
+      rank: target.rank,
+      health: target.health,
+      kinds,
+      canonical,
+    });
+
+    const isConnected = target.status === 'connected';
+    const isHealthy = target.health === 'healthy';
+
+    if (isConnected && isHealthy) {
+      const placementTarget = placementTargetOf(target, {
+        artifactTypes:
+          context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+        manifest: context.manifest,
+      });
+
+      const placement = resolvePlacement([placementTarget], {
+        kind: 'service',
+        exposure: 'private',
+        platform: DEFAULT_PLATFORM,
+        resources: {},
+        gpu: false,
+        persistence: false,
+        datastores: [],
+        secretStore: context.manifest.secretStore.adapter,
+      });
+
+      if (placement.candidates.length > 0) {
+        const candidate = placement.candidates[0]!;
+        optionsList.push({
+          targetId: target.id,
+          name: target.name,
+          adapter: target.adapter,
+          rank: target.rank,
+          candidate: true,
+          artifactType: candidate.artifactType,
+          canonical,
+          reasons: [],
+          detail: [],
+        });
+      } else {
+        const excluded = placement.nonCandidates[0]!;
+        optionsList.push({
+          targetId: target.id,
+          name: target.name,
+          adapter: target.adapter,
+          rank: target.rank,
+          candidate: false,
+          artifactType: null,
+          canonical,
+          reasons: excluded.reasons,
+          detail: excluded.detail,
+        });
+      }
+    } else {
+      const reasons: Exclusion[] = [];
+      const detail: string[] = [];
+      if (!isConnected) {
+        reasons.push('TARGET_DISCONNECTED' as unknown as Exclusion);
+        detail.push('Target is disconnected');
+      }
+      if (!isHealthy) {
+        reasons.push('UNHEALTHY');
+        const prereqFailures = target.prerequisites
+          ?.filter((p) => !p.met && p.detail)
+          .map((p) => p.detail!);
+        if (prereqFailures && prereqFailures.length > 0) {
+          detail.push(...prereqFailures);
+        } else {
+          detail.push('Target health checklist failed');
+        }
+      }
+
+      optionsList.push({
+        targetId: target.id,
+        name: target.name,
+        adapter: target.adapter,
+        rank: target.rank,
+        candidate: false,
+        artifactType: null,
+        canonical,
+        reasons,
+        detail,
+      });
+    }
+  }
+
+  return ok({
+    targets: targetsList,
+    options: optionsList,
+  });
+};

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -9,14 +9,16 @@ import { useEffect, useState } from 'react';
 import type { Principal } from '../commands/types.ts';
 import { readSession, signOut } from './auth-client.ts';
 import { command } from './client.ts';
-import {
-  INITIAL_DRAFT,
-  LINKED_REPOS,
-  REPOSITORY_OPTIONS,
-  TARGET_LIST,
-  TARGET_OPTIONS,
-} from './demo/scenarios.ts';
-import type { AppListItem, DeployView, WorkspaceView } from './model.ts';
+import { INITIAL_DRAFT } from './demo/scenarios.ts';
+import type {
+  AppListItem,
+  DeployView,
+  LinkedRepoView,
+  RepositoryOptionView,
+  TargetListItem,
+  TargetOptionView,
+  WorkspaceView,
+} from './model.ts';
 import { useRoute } from './router.ts';
 import { type Theme, useTheme } from './theme.ts';
 import { Button } from './ui/button.tsx';
@@ -121,24 +123,15 @@ function Screen({
   onNavigate: (path: string) => void;
 }) {
   if (path.startsWith('/settings')) return <Settings />;
-  if (path.startsWith('/apps/new')) {
-    return (
-      <NewApp
-        initialDraft={INITIAL_DRAFT}
-        targets={TARGET_OPTIONS}
-        repos={REPOSITORY_OPTIONS}
-      />
-    );
-  }
-  if (path.startsWith('/targets')) return <TargetList targets={TARGET_LIST} />;
-  if (path.startsWith('/repos')) return <RepositoryList repos={LINKED_REPOS} />;
+  if (path.startsWith('/apps/new')) return <NewAppScreen />;
+  if (path.startsWith('/targets')) return <TargetsScreen />;
+  if (path.startsWith('/repos')) return <RepositoriesScreen />;
   if (path.startsWith('/deploys')) {
     const deployId = path.replace(/^\/deploys\/?/, '');
     return <DeployScreen deployId={deployId} onNavigate={onNavigate} />;
   }
-  if (path === '/apps' || path === '') {
+  if (path === '/apps' || path === '')
     return <AppsScreen onNavigate={onNavigate} />;
-  }
   if (path.startsWith('/apps/')) {
     const appName = path.replace(/^\/apps\//, '');
     return <WorkspaceScreen appName={appName} onNavigate={onNavigate} />;
@@ -382,6 +375,184 @@ function DeployScreen({
   }
 
   return <DeployDetail view={state.deploy} />;
+}
+
+function TargetsScreen() {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'error'; message: string }
+    | { type: 'success'; targets: readonly TargetListItem[] }
+  >({ type: 'loading' });
+
+  useEffect(() => {
+    let live = true;
+    command('listTargets', {})
+      .then((result) => {
+        if (!live) return;
+        if (result.ok) {
+          setState({ type: 'success', targets: result.value.targets });
+        } else {
+          setState({ type: 'error', message: result.failure.message });
+        }
+      })
+      .catch((e: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: e instanceof Error ? e.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  if (state.type === 'loading') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Loading targets...
+        </p>
+      </div>
+    );
+  }
+
+  if (state.type === 'error') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm font-medium">Failed to load targets</p>
+          <p className="text-sm mt-1">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <TargetList targets={state.targets} />;
+}
+
+function RepositoriesScreen() {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'error'; message: string }
+    | { type: 'success'; repos: readonly LinkedRepoView[] }
+  >({ type: 'loading' });
+
+  useEffect(() => {
+    let live = true;
+    command('listRepositories', {})
+      .then((result) => {
+        if (!live) return;
+        if (result.ok) {
+          setState({ type: 'success', repos: result.value.repos });
+        } else {
+          setState({ type: 'error', message: result.failure.message });
+        }
+      })
+      .catch((e: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: e instanceof Error ? e.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  if (state.type === 'loading') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Loading repositories...
+        </p>
+      </div>
+    );
+  }
+
+  if (state.type === 'error') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm font-medium">Failed to load repositories</p>
+          <p className="text-sm mt-1">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <RepositoryList repos={state.repos} />;
+}
+
+function NewAppScreen() {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'error'; message: string }
+    | {
+        type: 'success';
+        targetOptions: readonly TargetOptionView[];
+        repoOptions: readonly RepositoryOptionView[];
+      }
+  >({ type: 'loading' });
+
+  useEffect(() => {
+    let live = true;
+    Promise.all([command('listTargets', {}), command('listRepositories', {})])
+      .then(([targetRes, repoRes]) => {
+        if (!live) return;
+        if (!targetRes.ok) {
+          setState({ type: 'error', message: targetRes.failure.message });
+        } else if (!repoRes.ok) {
+          setState({ type: 'error', message: repoRes.failure.message });
+        } else {
+          setState({
+            type: 'success',
+            targetOptions: targetRes.value.options,
+            repoOptions: repoRes.value.options,
+          });
+        }
+      })
+      .catch((e: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: e instanceof Error ? e.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, []);
+
+  if (state.type === 'loading') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Loading creation options...
+        </p>
+      </div>
+    );
+  }
+
+  if (state.type === 'error') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm font-medium">Failed to load creation options</p>
+          <p className="text-sm mt-1">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <NewApp
+      initialDraft={INITIAL_DRAFT}
+      targets={state.targetOptions}
+      repos={state.repoOptions}
+    />
+  );
 }
 
 function TopBar({

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -265,8 +265,8 @@ export interface TargetOptionView {
  * (fullName, defaultBranch) are refreshable.
  */
 export interface RepositoryOptionView {
-  /** GitHub's stable numeric repository ID, used as the selection key. */
-  readonly repositoryId: number;
+  /** GitHub's stable numeric or UUID repository ID, used as the selection key. */
+  readonly repositoryId: string | number;
   /** The owner/name a human reads — e.g. `example-org/hub`. */
   readonly fullName: string;
   /** The branch Spindrift watches. */
@@ -285,7 +285,7 @@ export type RepoConnectionHealth = 'connected' | 'connection_lost';
  * data, App subpaths, last-reconciled SHA, connection health, and error.
  */
 export interface LinkedRepoView {
-  readonly repositoryId: number;
+  readonly repositoryId: string | number;
   readonly fullName: string;
   readonly defaultBranch: string;
   readonly health: RepoConnectionHealth;

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import { dispatch } from '../../src/commands/registry.ts';
 import { connectRepository } from '../../src/commands/repositories/connect.ts';
+import { listRepositories } from '../../src/commands/repositories/list.ts';
 import type {
   AdapterRegistry,
   CommandContext,
@@ -211,5 +212,34 @@ describe('connecting a repository', () => {
 
     const accepted = await dispatch('connectRepository', input(fake), loop);
     expect(accepted.ok).toBe(true);
+  });
+});
+
+describe('listRepositories', () => {
+  test('returns empty lists when no repositories are connected', async () => {
+    const fake = new FakeGitHub();
+    const result = await listRepositories({}, await context(fake));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.repos).toEqual([]);
+      expect(result.value.options).toEqual([]);
+    }
+  });
+
+  test('lists connected repositories with health, authoritative commit, and options', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'unconnected' });
+
+    await connectRepository(input(fake), await context(fake));
+
+    const result = await listRepositories({}, await context(fake));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.repos).toHaveLength(1);
+      expect(result.value.repos[0]?.fullName).toBe(fake.fullName);
+      expect(result.value.repos[0]?.health).toBe('connected');
+      expect(result.value.options).toHaveLength(1);
+      expect(result.value.options[0]?.fullName).toBe(fake.fullName);
+    }
   });
 });

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -19,7 +19,11 @@
 import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
-import { connectTarget, disconnectTarget } from '../../src/commands/index.ts';
+import {
+  connectTarget,
+  disconnectTarget,
+  listTargets,
+} from '../../src/commands/index.ts';
 import type {
   AdapterRegistry,
   Clock,
@@ -362,5 +366,37 @@ describe('reconnect re-adopts via observe', () => {
       .from(deploys)
       .where(eq(deploys.targetId, target.id));
     expect(row?.orphanedAt).toEqual(FROZEN);
+  });
+});
+
+describe('listTargets', () => {
+  test('returns empty lists on an empty database', async () => {
+    const { registry } = fakes();
+    const result = await listTargets({}, context(registry));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.targets).toHaveLength(0);
+      expect(result.value.options).toHaveLength(0);
+    }
+  });
+
+  test('lists connected targets with rank, health, and candidate placement options', async () => {
+    const { registry } = fakes();
+    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
+    await connectTarget(
+      cloudInput({ name: 'cloudrun-app' }),
+      context(registry),
+    );
+
+    const result = await listTargets({}, context(registry));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.targets).toHaveLength(3); // 1 k8s + 2 cloud (cloudrun, static)
+      expect(result.value.targets[0]?.name).toBe('folly-k8s');
+      expect(result.value.targets[0]?.health).toBe('healthy');
+      expect(result.value.options.length).toBeGreaterThan(0);
+      const option = result.value.options.find((o) => o.name === 'folly-k8s');
+      expect(option?.candidate).toBe(true);
+    }
   });
 });

--- a/apps/spindrift/test/web/target-repo-routes.test.ts
+++ b/apps/spindrift/test/web/target-repo-routes.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from 'bun:test';
+import { connectRepository } from '../../src/commands/repositories/connect.ts';
+import { connectTarget } from '../../src/commands/targets/connect.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import { commandRoutes, pathFor } from '../../src/web/dispatch.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { FakeGitHub, testAppKey } from '../harness/fakes/github-api.ts';
+import { clusterInput, fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+
+async function makeContext(
+  fakeGithub: FakeGitHub | null,
+): Promise<CommandContext> {
+  const { pem } = await testAppKey();
+  const host =
+    fakeGithub === null
+      ? null
+      : new GitHubApp(
+          {
+            appId: '1234567',
+            privateKeyPem: pem,
+            baseUrl: fakeGithub.baseUrl,
+            fetch: fakeGithub.fetch,
+          },
+          () => NOW,
+        );
+
+  const fakeDeploy = new FakeDeployAdapter({ adapter: 'kubernetes' });
+  const adapters: AdapterRegistry = {
+    deploy: () => fakeDeploy,
+    build: () => null,
+    store: () => {
+      throw new Error('no store adapter in test');
+    },
+    repository: () => host,
+    supplyChain: () => {
+      throw new Error('no supply chain in test');
+    },
+  };
+
+  return {
+    principal: { id: 'user-1', displayName: 'Operator' },
+    clock: { now: () => NOW },
+    db: database().db,
+    adapters,
+    manifest: await fixtureManifest(),
+  };
+}
+
+function serve(ctx: CommandContext, authenticated = true) {
+  const deps = {
+    authenticate: async () =>
+      authenticated
+        ? { kind: 'authenticated' as const, principal: ctx.principal }
+        : { kind: 'anonymous' as const },
+    context: () => ctx,
+  };
+  return commandRoutes(deps);
+}
+
+function post(path: string, body: unknown = {}): Request {
+  return new Request(`https://spindrift.example.test${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('listTargets and listRepositories over route boundary', () => {
+  test('listTargets over HTTP returns 401 when unauthenticated', async () => {
+    const ctx = await makeContext(null);
+    const routes = serve(ctx, false);
+    const res = await routes[pathFor('listTargets')]!(
+      post(pathFor('listTargets'), {}),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test('listRepositories over HTTP returns 401 when unauthenticated', async () => {
+    const ctx = await makeContext(null);
+    const routes = serve(ctx, false);
+    const res = await routes[pathFor('listRepositories')]!(
+      post(pathFor('listRepositories'), {}),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test('listTargets returns persisted targets and options for authenticated user', async () => {
+    const ctx = await makeContext(null);
+    await connectTarget(clusterInput({ name: 'folly-cluster' }), ctx);
+
+    const routes = serve(ctx, true);
+    const res = await routes[pathFor('listTargets')]!(
+      post(pathFor('listTargets'), {}),
+    );
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      value: { targets: any[]; options: any[] };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.value.targets).toHaveLength(1);
+    expect(body.value.targets[0].name).toBe('folly-cluster');
+    expect(body.value.options).toHaveLength(1);
+    expect(body.value.options[0].name).toBe('folly-cluster');
+  });
+
+  test('listRepositories returns connected repos and options for authenticated user', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'unconnected' });
+    const ctx = await makeContext(fake);
+
+    await connectRepository(
+      {
+        fullName: fake.fullName,
+        installationId: fake.installationId,
+        scopes: [
+          {
+            scope: 'app',
+            proposal: {
+              source: 'railpack',
+              kind: 'service',
+              kinds: [{ kind: 'service', available: true }],
+              build: {
+                frontend: 'railpack',
+                buildCommand: 'bun run build',
+                outputDirectory: null,
+              },
+              watchPaths: [],
+            },
+          },
+        ],
+      },
+      ctx,
+    );
+
+    const routes = serve(ctx, true);
+    const res = await routes[pathFor('listRepositories')]!(
+      post(pathFor('listRepositories'), {}),
+    );
+    expect(res.status).toBe(200);
+
+    const body = (await res.json()) as {
+      ok: boolean;
+      value: { repos: any[]; options: any[] };
+    };
+    expect(body.ok).toBe(true);
+    expect(body.value.repos).toHaveLength(1);
+    expect(body.value.repos[0].fullName).toBe(fake.fullName);
+    expect(body.value.options).toHaveLength(1);
+    expect(body.value.options[0].fullName).toBe(fake.fullName);
+  });
+
+  test('empty installation returns empty lists without falling back to sample data', async () => {
+    const ctx = await makeContext(null);
+    const routes = serve(ctx, true);
+
+    const targetRes = await routes[pathFor('listTargets')]!(
+      post(pathFor('listTargets'), {}),
+    );
+    const targetBody = (await targetRes.json()) as {
+      ok: boolean;
+      value: { targets: any[]; options: any[] };
+    };
+    expect(targetBody.ok).toBe(true);
+    expect(targetBody.value.targets).toEqual([]);
+
+    const repoRes = await routes[pathFor('listRepositories')]!(
+      post(pathFor('listRepositories'), {}),
+    );
+    const repoBody = (await repoRes.json()) as {
+      ok: boolean;
+      value: { repos: any[]; options: any[] };
+    };
+    expect(repoBody.ok).toBe(true);
+    expect(repoBody.value.repos).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue 02 — **Use real Targets and repositories** (§3, §13, §15, §18, §20).

## Changes
- Created `listTargets` query command (`src/commands/targets/list.ts`) to return persisted Targets with rank, health, capabilities, canonical naming boundary, and placement options.
- Created `listRepositories` query command (`src/commands/repositories/list.ts`) to return persisted linked repositories with connection health, error reason, last reconciled commit SHA, and connected app subpaths.
- Registered `listTargets` and `listRepositories` in command registry and export table.
- Updated `src/web/app.tsx` to fetch real Targets and Repositories for Targets, Repositories, and New App creation flow screens instead of sample/demo fixtures.
- Updated `src/web/model.ts` to support string or numeric `repositoryId`.
- Added unit and web route integration tests (`test/commands/targets.test.ts`, `test/commands/repositories.test.ts`, `test/web/target-repo-routes.test.ts`).

## Test Plan
- [x] Run `bun run typecheck` (0 errors)
- [x] Run full test suite with Postgres: `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test` (795 passed across 51 files)