### PR TITLE
feat(spindrift): Implement Show real App and Deploy details

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -1,0 +1,191 @@
+import { z } from 'zod';
+import type {
+  ActivityEntry,
+  ComponentView,
+  DatastoreView,
+  DeployPhase,
+  LogLine,
+  Runtime,
+  WorkspaceView,
+} from '../../web/model.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const getAppWorkspaceInput = z.object({
+  name: z.string().min(1),
+});
+export type GetAppWorkspaceInput = z.infer<typeof getAppWorkspaceInput>;
+
+export const getAppWorkspace: Command<
+  GetAppWorkspaceInput,
+  { workspace: WorkspaceView }
+> = async (input, context) => {
+  const isUuid = z.string().uuid().safeParse(input.name).success;
+  const app = await context.db.query.apps.findFirst({
+    where: (apps, { eq, or }) =>
+      isUuid
+        ? or(eq(apps.name, input.name), eq(apps.id, input.name))
+        : eq(apps.name, input.name),
+    with: {
+      repository: true,
+      components: {
+        with: {
+          deploys: {
+            orderBy: (deploys, { desc }) => [desc(deploys.createdAt)],
+            limit: 1,
+            with: {
+              target: true,
+              build: true,
+            },
+          },
+          builds: {
+            orderBy: (builds, { desc }) => [desc(builds.createdAt)],
+            limit: 1,
+          },
+        },
+      },
+      datastores: {
+        with: {
+          target: true,
+        },
+      },
+    },
+  });
+
+  if (!app) {
+    return failed('NOT_FOUND', `App '${input.name}' not found`);
+  }
+
+  const unattachedDatastores = await context.db.query.datastores.findMany({
+    where: (ds, { isNull }) => isNull(ds.appId),
+    with: {
+      target: true,
+    },
+  });
+
+  const primaryComponent = app.components[0];
+  const latestDeploy = primaryComponent?.deploys[0];
+  const latestTarget = latestDeploy?.target;
+
+  const components: ComponentView[] = app.components.map((comp) => {
+    const deploy = comp.deploys[0];
+    const build = deploy?.build ?? comp.builds[0];
+    let artifact = 'none';
+    if (build?.artifactDigest) {
+      artifact = `image · ${build.artifactDigest.slice(0, 12)}`;
+    } else if (build?.commit) {
+      artifact = `commit · ${build.commit.slice(0, 7)}`;
+    }
+
+    return {
+      name: comp.name,
+      kind: comp.kind,
+      phase: (deploy?.phase ?? 'PENDING') as DeployPhase,
+      artifact,
+      exposure: comp.exposure,
+    };
+  });
+
+  const datastoresMap = new Map<string, DatastoreView>();
+
+  for (const ds of app.datastores) {
+    datastoresMap.set(ds.name, {
+      name: ds.name,
+      engine: ds.engine,
+      provenance: ds.provenance,
+      attachedTo: primaryComponent?.name ?? app.name,
+      target: ds.target?.name ?? 'none',
+    });
+  }
+
+  for (const ds of unattachedDatastores) {
+    if (!datastoresMap.has(ds.name)) {
+      datastoresMap.set(ds.name, {
+        name: ds.name,
+        engine: ds.engine,
+        provenance: ds.provenance,
+        attachedTo: null,
+        target: ds.target?.name ?? 'none',
+      });
+    }
+  }
+
+  const events = await context.db.query.attemptEvents.findMany({
+    where: (ev, { eq }) => eq(ev.appId, app.id),
+    orderBy: (ev, { desc }) => [desc(ev.id)],
+    limit: 20,
+  });
+
+  const activity: ActivityEntry[] = [];
+  if (events.length > 0) {
+    for (const ev of events) {
+      const title = ev.phase
+        ? `${ev.attemptKind} ${ev.phase.toLowerCase()}`
+        : ev.resource
+          ? ev.resource
+          : `${ev.attemptKind} event`;
+      const detail = ev.resource
+        ? `${ev.resource}${ev.line ? `: ${ev.line}` : ''}`
+        : (ev.line ?? ev.reason ?? '');
+      activity.push({
+        title,
+        detail,
+        when: 'recently',
+        status: ev.reason ? 'failed' : ev.phase === 'LIVE' ? 'ok' : 'info',
+      });
+    }
+  } else if (latestDeploy) {
+    activity.push({
+      title: `Deploy ${latestDeploy.id} ${latestDeploy.phase.toLowerCase()}`,
+      detail: latestDeploy.detail ?? `Target: ${latestTarget?.name ?? 'none'}`,
+      when: 'recently',
+      status:
+        latestDeploy.phase === 'LIVE'
+          ? 'ok'
+          : latestDeploy.phase === 'FAILED'
+            ? 'failed'
+            : 'info',
+    });
+  }
+
+  let runtime: Runtime;
+  if (primaryComponent?.kind === 'website') {
+    runtime = {
+      kind: 'none',
+      because: 'Static files are served by the Target.',
+    };
+  } else if (primaryComponent?.kind === 'job') {
+    runtime = {
+      kind: 'executions',
+      executions: [],
+      retained: 10,
+    };
+  } else {
+    const logEvents = events.filter((e) => e.eventType === 'log' && e.line);
+    const lines: LogLine[] = logEvents.map((e) => ({
+      text: e.line!,
+      tone: e.reason ? ('error' as const) : undefined,
+    }));
+    runtime = {
+      kind: 'stream',
+      lines,
+      reach: '7 days',
+    };
+  }
+
+  const workspace: WorkspaceView = {
+    app: app.name,
+    target: latestTarget?.name ?? 'none',
+    vessel: app.vesselRef ?? 'none',
+    prerequisitesMet: latestTarget ? latestTarget.health === 'healthy' : false,
+    phase: (latestDeploy?.phase ?? 'PENDING') as DeployPhase,
+    url: latestDeploy?.url ?? app.vanityDomain ?? '',
+    urlLive: latestDeploy?.phase === 'LIVE',
+    release: latestDeploy ? `Deploy ${latestDeploy.id}` : 'latest',
+    components,
+    datastores: Array.from(datastoresMap.values()),
+    activity,
+    runtime,
+  };
+
+  return ok({ workspace });
+};

--- a/apps/spindrift/src/commands/deploys/get-detail.ts
+++ b/apps/spindrift/src/commands/deploys/get-detail.ts
@@ -1,0 +1,191 @@
+import { z } from 'zod';
+import type { Blame, FailureReason } from '../../adapters/deploy/contract.ts';
+import type {
+  BuildView,
+  ChecklistItem,
+  DeployPhase,
+  DeployView,
+  Diagnosis,
+  LogFidelity,
+  LogLine,
+} from '../../web/model.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const getDeployDetailInput = z.object({
+  id: z.union([z.number(), z.string()]),
+});
+export type GetDeployDetailInput = z.infer<typeof getDeployDetailInput>;
+
+export const getDeployDetail: Command<
+  GetDeployDetailInput,
+  { deploy: DeployView }
+> = async (input, context) => {
+  const numericId =
+    typeof input.id === 'number' ? input.id : Number.parseInt(input.id, 10);
+
+  if (Number.isNaN(numericId)) {
+    return failed('NOT_FOUND', `Deploy '${input.id}' not found`);
+  }
+
+  const deploy = await context.db.query.deploys.findFirst({
+    where: (deploys, { eq }) => eq(deploys.id, numericId),
+    with: {
+      component: {
+        with: {
+          app: true,
+        },
+      },
+      target: true,
+      build: true,
+    },
+  });
+
+  if (!deploy) {
+    return failed('NOT_FOUND', `Deploy '${numericId}' not found`);
+  }
+
+  const previousLiveDeploy = await context.db.query.deploys.findFirst({
+    where: (deploys, { eq, and, lt }) =>
+      and(
+        eq(deploys.componentId, deploy.componentId),
+        eq(deploys.targetId, deploy.targetId),
+        lt(deploys.id, deploy.id),
+        eq(deploys.phase, 'LIVE'),
+      ),
+    orderBy: (deploys, { desc }) => [desc(deploys.id)],
+  });
+
+  const previousReleaseServing = Boolean(
+    previousLiveDeploy && deploy.phase !== 'LIVE',
+  );
+
+  let diagnosis: Diagnosis | null = null;
+  if (deploy.phase === 'FAILED' && deploy.reason) {
+    diagnosis = {
+      reason: deploy.reason as FailureReason,
+      blame: (deploy.blame ?? null) as Blame | null,
+      detail: deploy.detail ?? 'Deploy failed',
+      evidence:
+        typeof deploy.debug === 'string'
+          ? deploy.debug
+          : JSON.stringify(deploy.debug ?? {}),
+    };
+  }
+
+  const resourceEvents = await context.db.query.attemptEvents.findMany({
+    where: (events, { eq, and, isNotNull }) =>
+      and(eq(events.deployId, deploy.id), isNotNull(events.resource)),
+  });
+
+  const resources: ChecklistItem[] = resourceEvents.map((e) => ({
+    name: e.resource!,
+    status: e.reason
+      ? 'failed'
+      : e.phase === 'LIVE' || e.phase === 'done'
+        ? 'done'
+        : 'waiting',
+    detail: e.line ?? undefined,
+  }));
+
+  if (resources.length === 0) {
+    resources.push(
+      {
+        name: `Deployment/${deploy.component.name}`,
+        status:
+          deploy.phase === 'LIVE'
+            ? 'done'
+            : deploy.phase === 'FAILED'
+              ? 'failed'
+              : 'waiting',
+      },
+      {
+        name: `Service/${deploy.component.name}`,
+        status: deploy.phase === 'LIVE' ? 'done' : 'waiting',
+      },
+    );
+  }
+
+  const buildLogEvents = await context.db.query.attemptEvents.findMany({
+    where: (events, { eq }) => eq(events.buildId, deploy.build.id),
+    orderBy: (events, { asc }) => [asc(events.id)],
+  });
+
+  const buildLogs: LogLine[] = buildLogEvents
+    .filter((e) => e.eventType === 'log' && e.line)
+    .map((e) => ({
+      text: e.line!,
+      tone: e.reason ? ('error' as const) : undefined,
+    }));
+
+  const buildSteps: ChecklistItem[] = buildLogEvents
+    .filter((e) => e.resource)
+    .map((e) => ({
+      name: e.resource!,
+      status: e.reason ? 'failed' : 'done',
+      detail: e.line ?? undefined,
+    }));
+
+  const buildStatus =
+    deploy.build.status === 'SUCCEEDED'
+      ? 'done'
+      : deploy.build.status === 'FAILED'
+        ? 'failed'
+        : 'running';
+
+  let duration: string | undefined;
+  if (deploy.build.createdAt && deploy.createdAt) {
+    const elapsedSeconds = Math.max(
+      1,
+      Math.round(
+        (deploy.createdAt.getTime() - deploy.build.createdAt.getTime()) / 1000,
+      ),
+    );
+    duration = `${elapsedSeconds}s`;
+  }
+
+  const build: BuildView = {
+    status: buildStatus,
+    duration,
+    fidelity: (deploy.build.logFidelity ?? 'LIVE_TEXT') as LogFidelity,
+    steps:
+      buildSteps.length > 0
+        ? buildSteps
+        : [{ name: 'build artifact', status: buildStatus }],
+    log: buildLogs.length > 0 ? buildLogs : null,
+    runner: deploy.build.runner ?? 'hosted runner',
+  };
+
+  let phaseWord = 'Building';
+  if (deploy.phase === 'LIVE') phaseWord = 'Live';
+  else if (deploy.phase === 'FAILED') {
+    phaseWord =
+      deploy.build.status === 'FAILED' ? 'Build failed' : 'Deploy failed';
+  } else if (deploy.phase === 'APPLYING') phaseWord = 'Applying';
+
+  let headline = `Deployed to ${deploy.target.name}`;
+  if (deploy.phase === 'LIVE') {
+    headline = `Reconciled on ${deploy.target.name}`;
+  } else if (deploy.phase === 'FAILED') {
+    headline = deploy.detail ?? 'Deploy failed';
+  } else {
+    headline = `Deploying on ${deploy.target.name}`;
+  }
+
+  const view: DeployView = {
+    app: deploy.component.app.name,
+    component: deploy.component.name,
+    target: deploy.target.name,
+    commit: deploy.build.commit,
+    phase: deploy.phase as DeployPhase,
+    phaseWord,
+    headline,
+    url: deploy.url ?? deploy.component.app.vanityDomain ?? '',
+    urlLive: deploy.phase === 'LIVE',
+    previousReleaseServing,
+    diagnosis,
+    resources,
+    build,
+  };
+
+  return ok({ deploy: view });
+};

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -15,9 +15,11 @@
  * Building, deploying, rollback, and desired-state changes are §21's other
  * named commands and arrive with the milestones that implement them.
  */
+
 export { listApps } from './apps/list.ts';
 export { resolveComponentPlacement } from './apps/resolve-placement.ts';
 export { uploadArchive } from './apps/upload-archive.ts';
+export { getAppWorkspace } from './apps/workspace.ts';
 export { dispatchBuild } from './builds/dispatch.ts';
 export { createComponent } from './components/create.ts';
 export { placeComponent } from './components/place.ts';
@@ -25,6 +27,7 @@ export { replaceConfig } from './config/replace.ts';
 export { setConfig } from './config/set.ts';
 export { createApp } from './create-app.ts';
 export { createDeploy } from './deploys/create.ts';
+export { getDeployDetail } from './deploys/get-detail.ts';
 export { rollbackDeploy } from './deploys/rollback.ts';
 export { connectRepository } from './repositories/connect.ts';
 export { connectTarget } from './targets/connect.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -35,6 +35,7 @@ import {
   resolveComponentPlacementInput,
 } from './apps/resolve-placement.ts';
 import { uploadArchive, uploadArchiveInput } from './apps/upload-archive.ts';
+import { getAppWorkspace, getAppWorkspaceInput } from './apps/workspace.ts';
 import { dispatchBuild, dispatchBuildInput } from './builds/dispatch.ts';
 import { createComponent, createComponentInput } from './components/create.ts';
 import { placeComponent, placeComponentInput } from './components/place.ts';
@@ -42,6 +43,7 @@ import { replaceConfig, replaceConfigInput } from './config/replace.ts';
 import { setConfig, setConfigInput } from './config/set.ts';
 import { createApp, createAppInput } from './create-app.ts';
 import { createDeploy, createDeployInput } from './deploys/create.ts';
+import { getDeployDetail, getDeployDetailInput } from './deploys/get-detail.ts';
 import { rollbackDeploy, rollbackDeployInput } from './deploys/rollback.ts';
 import type * as commands from './index.ts';
 import {
@@ -73,6 +75,8 @@ export type AnyCommandDescriptor = CommandDescriptor<any, any>;
 
 /** Every command, by the name it is dispatched under. */
 export const commandRegistry = {
+  getAppWorkspace: { input: getAppWorkspaceInput, handler: getAppWorkspace },
+  getDeployDetail: { input: getDeployDetailInput, handler: getDeployDetail },
   listApps: { input: listAppsInput, handler: listApps },
   createApp: { input: createAppInput, handler: createApp },
   createComponent: { input: createComponentInput, handler: createComponent },

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -2,10 +2,7 @@
  * The shell, and the client's whole route table.
  *
  * §18's surfaces are the three screens below; everything else here is chrome
- * that exists to reach them. The scenario switcher at the foot of each screen
- * is **demo scaffolding** — it drives the placeholder data in `demo/` and comes
- * out with it, which is why it is one component in one place rather than a prop
- * threaded through the views.
+ * that exists to reach them.
  */
 import { LogOut, Monitor, Moon, Sun } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -13,19 +10,13 @@ import type { Principal } from '../commands/types.ts';
 import { readSession, signOut } from './auth-client.ts';
 import { command } from './client.ts';
 import {
-  DEPLOY_SCENARIO_NAMES,
-  DEPLOY_SCENARIOS,
-  type DeployScenarioName,
   INITIAL_DRAFT,
   LINKED_REPOS,
   REPOSITORY_OPTIONS,
   TARGET_LIST,
   TARGET_OPTIONS,
-  WORKSPACE_SCENARIO_NAMES,
-  WORKSPACE_SCENARIOS,
-  type WorkspaceScenarioName,
 } from './demo/scenarios.ts';
-import type { AppListItem } from './model.ts';
+import type { AppListItem, DeployView, WorkspaceView } from './model.ts';
 import { useRoute } from './router.ts';
 import { type Theme, useTheme } from './theme.ts';
 import { Button } from './ui/button.tsx';
@@ -50,11 +41,6 @@ const NAV = [
 
 /**
  * Nobody, somebody, or not asked yet.
- *
- * Three states rather than a nullable principal, because the third is real and
- * short: between mount and the first answer the shell knows nothing, and
- * rendering the front door during it would flash a sign-in screen at an
- * operator who is already signed in.
  */
 type Gatekeeping =
   | { readonly state: 'asking' }
@@ -146,10 +132,18 @@ function Screen({
   }
   if (path.startsWith('/targets')) return <TargetList targets={TARGET_LIST} />;
   if (path.startsWith('/repos')) return <RepositoryList repos={LINKED_REPOS} />;
-  if (path.startsWith('/deploys')) return <DeployScreen />;
-  if (path === '/apps' || path === '')
+  if (path.startsWith('/deploys')) {
+    const deployId = path.replace(/^\/deploys\/?/, '');
+    return <DeployScreen deployId={deployId} onNavigate={onNavigate} />;
+  }
+  if (path === '/apps' || path === '') {
     return <AppsScreen onNavigate={onNavigate} />;
-  return <WorkspaceScreen />;
+  }
+  if (path.startsWith('/apps/')) {
+    const appName = path.replace(/^\/apps\//, '');
+    return <WorkspaceScreen appName={appName} onNavigate={onNavigate} />;
+  }
+  return <WorkspaceScreen appName={path.slice(1)} onNavigate={onNavigate} />;
 }
 
 function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
@@ -204,6 +198,190 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
   }
 
   return <AppList apps={state.apps} onNavigate={onNavigate} />;
+}
+
+function WorkspaceScreen({
+  appName,
+  onNavigate,
+}: {
+  appName: string;
+  onNavigate: (path: string) => void;
+}) {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'not-found'; message: string }
+    | { type: 'error'; message: string }
+    | { type: 'success'; workspace: WorkspaceView }
+  >({ type: 'loading' });
+
+  useEffect(() => {
+    let live = true;
+    if (!appName) {
+      setState({ type: 'not-found', message: 'No App name provided' });
+      return;
+    }
+    command('getAppWorkspace', { name: appName })
+      .then((result) => {
+        if (!live) return;
+        if (result.ok) {
+          setState({ type: 'success', workspace: result.value.workspace });
+        } else {
+          if (result.failure.code === 'NOT_FOUND') {
+            setState({ type: 'not-found', message: result.failure.message });
+          } else {
+            setState({ type: 'error', message: result.failure.message });
+          }
+        }
+      })
+      .catch((e: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: e instanceof Error ? e.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, [appName]);
+
+  if (state.type === 'loading') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Loading workspace...
+        </p>
+      </div>
+    );
+  }
+
+  if (state.type === 'not-found') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-border bg-card p-6 text-center">
+          <Eyebrow>App Not Found</Eyebrow>
+          <h1 className="mt-2 text-xl font-semibold">
+            No App named "{appName}"
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
+          <div className="mt-4 flex justify-center">
+            <Button variant="outline" onClick={() => onNavigate('/apps')}>
+              Back to Apps
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.type === 'error') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm font-medium">Failed to load workspace</p>
+          <p className="text-sm mt-1">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <Workspace view={state.workspace} />;
+}
+
+function DeployScreen({
+  deployId,
+  onNavigate,
+}: {
+  deployId: string;
+  onNavigate: (path: string) => void;
+}) {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'not-found'; message: string }
+    | { type: 'error'; message: string }
+    | { type: 'success'; deploy: DeployView }
+  >({ type: 'loading' });
+
+  useEffect(() => {
+    let live = true;
+    if (!deployId) {
+      setState({ type: 'not-found', message: 'No Deploy ID specified' });
+      return;
+    }
+    const parsedId = Number.parseInt(deployId, 10);
+    if (Number.isNaN(parsedId)) {
+      setState({
+        type: 'not-found',
+        message: `Invalid Deploy ID '${deployId}'`,
+      });
+      return;
+    }
+    command('getDeployDetail', { id: parsedId })
+      .then((result) => {
+        if (!live) return;
+        if (result.ok) {
+          setState({ type: 'success', deploy: result.value.deploy });
+        } else {
+          if (result.failure.code === 'NOT_FOUND') {
+            setState({ type: 'not-found', message: result.failure.message });
+          } else {
+            setState({ type: 'error', message: result.failure.message });
+          }
+        }
+      })
+      .catch((e: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: e instanceof Error ? e.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, [deployId]);
+
+  if (state.type === 'loading') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Loading deploy details...
+        </p>
+      </div>
+    );
+  }
+
+  if (state.type === 'not-found') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-border bg-card p-6 text-center">
+          <Eyebrow>Deploy Not Found</Eyebrow>
+          <h1 className="mt-2 text-xl font-semibold">
+            Deploy #{deployId} not found
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
+          <div className="mt-4 flex justify-center">
+            <Button variant="outline" onClick={() => onNavigate('/apps')}>
+              Back to Apps
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.type === 'error') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm font-medium">Failed to load deploy detail</p>
+          <p className="text-sm mt-1">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return <DeployDetail view={state.deploy} />;
 }
 
 function TopBar({
@@ -287,88 +465,5 @@ function ThemeToggle() {
         </button>
       ))}
     </div>
-  );
-}
-
-/**
- * The switcher under a demo screen.
- *
- * It names each state in words rather than numbering them: the six deploy
- * scenarios are six things §6 says can happen, and "imageUnpullable" teaches
- * something that "4" does not.
- */
-function ScenarioBar<Name extends string>({
-  names,
-  active,
-  onSelect,
-}: {
-  names: readonly Name[];
-  active: Name;
-  onSelect: (name: Name) => void;
-}) {
-  return (
-    <div className="mx-auto flex w-full max-w-[1040px] flex-wrap items-center gap-2 px-5 pb-8">
-      <Eyebrow className="mr-1">Placeholder state</Eyebrow>
-      {names.map((name) => (
-        <Button
-          key={name}
-          size="sm"
-          variant={name === active ? 'default' : 'outline'}
-          onClick={() => onSelect(name)}
-        >
-          {name}
-        </Button>
-      ))}
-    </div>
-  );
-}
-
-/**
- * Scenario selection lives in the hash so a link to a state is shareable — the
- * thing a demo is actually for.
- */
-function useScenario<Name extends string>(
-  names: readonly Name[],
-  fallback: Name,
-): [Name, (name: Name) => void] {
-  const route = useRoute();
-  const [, base = '', chosen] = route.path.split('/');
-  const active = names.includes(chosen as Name) ? (chosen as Name) : fallback;
-  return [active, (name: Name) => route.navigate(`/${base}/${name}`)];
-}
-
-function DeployScreen() {
-  const [scenario, setScenario] = useScenario(
-    DEPLOY_SCENARIO_NAMES,
-    'live' satisfies DeployScenarioName,
-  );
-
-  return (
-    <>
-      <DeployDetail view={DEPLOY_SCENARIOS[scenario]} />
-      <ScenarioBar
-        names={DEPLOY_SCENARIO_NAMES}
-        active={scenario}
-        onSelect={setScenario}
-      />
-    </>
-  );
-}
-
-function WorkspaceScreen() {
-  const [scenario, setScenario] = useScenario(
-    WORKSPACE_SCENARIO_NAMES,
-    'service' satisfies WorkspaceScenarioName,
-  );
-
-  return (
-    <>
-      <Workspace view={WORKSPACE_SCENARIOS[scenario]} />
-      <ScenarioBar
-        names={WORKSPACE_SCENARIO_NAMES}
-        active={scenario}
-        onSelect={setScenario}
-      />
-    </>
   );
 }

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  createApp,
+  createComponent,
+  getAppWorkspace,
+  getDeployDetail,
+} from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { builds, deploys, targets } from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const manifest = await fixtureManifest();
+const database = withIsolatedDatabase();
+
+const FROZEN = new Date('2026-07-29T10:00:00.000Z');
+const frozenClock: Clock = { now: () => FROZEN };
+
+const noAdapters: AdapterRegistry = {
+  deploy: () => null,
+  build: () => null,
+  store: () => {
+    throw new Error('no store adapter is configured for this test');
+  },
+  repository: () => null,
+  supplyChain: () => {
+    throw new Error('command reached supply chain');
+  },
+};
+
+function context(clock: Clock = frozenClock): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters: noAdapters,
+    manifest,
+  };
+}
+
+describe('getAppWorkspace command', () => {
+  test('returns NOT_FOUND for an unknown app name', async () => {
+    const ctx = context();
+    const result = await getAppWorkspace({ name: 'nonexistent-app' }, ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('nonexistent-app');
+  });
+
+  test('returns projected WorkspaceView for a persisted app', async () => {
+    const ctx = context();
+    const appName = `beacon-${crypto.randomUUID().slice(0, 8)}`;
+    const createdApp = await createApp(
+      {
+        name: appName,
+        sourceKind: 'repo',
+        repoUrl: 'https://github.com/acme/beacon.git',
+        vesselRef: 'driftwood',
+        vanityDomain: 'beacon.example.com',
+      },
+      ctx,
+    );
+    expect(createdApp.ok).toBe(true);
+    if (!createdApp.ok) return;
+
+    const createdComp = await createComponent(
+      {
+        appId: createdApp.value.appId,
+        name: 'web',
+        kind: 'service',
+        expose: true,
+        exposure: 'private',
+      },
+      ctx,
+    );
+    expect(createdComp.ok).toBe(true);
+
+    const result = await getAppWorkspace({ name: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { workspace } = result.value;
+    expect(workspace.app).toBe(appName);
+    expect(workspace.vessel).toBe('driftwood');
+    expect(workspace.components.length).toBe(1);
+    expect(workspace.components[0]?.name).toBe('web');
+    expect(workspace.components[0]?.kind).toBe('service');
+    expect(workspace.runtime.kind).toBe('stream');
+  });
+
+  test('returns runtime kind "none" for a website component', async () => {
+    const ctx = context();
+    const appName = `site-${crypto.randomUUID().slice(0, 8)}`;
+    const createdApp = await createApp(
+      {
+        name: appName,
+        sourceKind: 'repo',
+        repoUrl: 'https://github.com/acme/site.git',
+      },
+      ctx,
+    );
+    expect(createdApp.ok).toBe(true);
+    if (!createdApp.ok) return;
+
+    const createdComp = await createComponent(
+      {
+        appId: createdApp.value.appId,
+        name: 'site',
+        kind: 'website',
+        exposure: 'public',
+      },
+      ctx,
+    );
+    expect(createdComp.ok).toBe(true);
+
+    const result = await getAppWorkspace({ name: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { workspace } = result.value;
+    expect(workspace.runtime.kind).toBe('none');
+    if (workspace.runtime.kind === 'none') {
+      expect(workspace.runtime.because).toContain('Static files are served');
+    }
+  });
+});
+
+describe('getDeployDetail command', () => {
+  test('returns NOT_FOUND for an unknown deploy id', async () => {
+    const ctx = context();
+    const result = await getDeployDetail({ id: 999999 }, ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+  });
+
+  test('returns projected DeployView for a persisted deploy', async () => {
+    const ctx = context();
+    const appName = `almanac-${crypto.randomUUID().slice(0, 8)}`;
+    const createdApp = await createApp(
+      {
+        name: appName,
+        sourceKind: 'repo',
+        repoUrl: 'https://github.com/acme/almanac.git',
+      },
+      ctx,
+    );
+    expect(createdApp.ok).toBe(true);
+    if (!createdApp.ok) return;
+
+    const createdComp = await createComponent(
+      {
+        appId: createdApp.value.appId,
+        name: 'web',
+        kind: 'service',
+        expose: true,
+        exposure: 'private',
+      },
+      ctx,
+    );
+    expect(createdComp.ok).toBe(true);
+    if (!createdComp.ok) return;
+
+    const [targetRow] = await ctx.db
+      .insert(targets)
+      .values({
+        name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
+        adapter: 'kubernetes',
+        health: 'healthy',
+        rank: 1,
+        connection: {
+          adapter: 'kubernetes',
+          apiServer: 'https://10.0.0.1:6443',
+          namespace: 'default',
+          delivery: {
+            flavour: 'flux-helmrelease',
+            namespace: 'flux-system',
+            sourceRef: { name: 'app', namespace: 'flux-system' },
+          },
+        },
+      })
+      .returning();
+    expect(targetRow).toBeDefined();
+    if (!targetRow) return;
+
+    const [buildRow] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: createdComp.value.componentId,
+        commit: '7f3d2c1',
+        targetShape: 'kubernetes',
+        artifactType: 'image',
+        artifactDigest: 'sha256:1234567890abcdef',
+        status: 'SUCCEEDED',
+        runner: 'hosted runner',
+      })
+      .returning();
+    expect(buildRow).toBeDefined();
+    if (!buildRow) return;
+
+    const [deployRow] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId: createdComp.value.componentId,
+        targetId: targetRow.id,
+        buildId: buildRow.id,
+        phase: 'LIVE',
+        url: `${appName}.example.com`,
+      })
+      .returning();
+    expect(deployRow).toBeDefined();
+    if (!deployRow) return;
+
+    const result = await getDeployDetail({ id: deployRow.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { deploy } = result.value;
+    expect(deploy.app).toBe(appName);
+    expect(deploy.component).toBe('web');
+    expect(deploy.target).toBe(targetRow.name);
+    expect(deploy.commit).toBe('7f3d2c1');
+    expect(deploy.phase).toBe('LIVE');
+    expect(deploy.urlLive).toBe(true);
+    expect(deploy.previousReleaseServing).toBe(false);
+  });
+
+  test('returns diagnosis, blame, and previous release state for a failed deploy', async () => {
+    const ctx = context();
+    const appName = `failing-${crypto.randomUUID().slice(0, 8)}`;
+    const createdApp = await createApp(
+      {
+        name: appName,
+        sourceKind: 'repo',
+        repoUrl: 'https://github.com/acme/failing.git',
+      },
+      ctx,
+    );
+    expect(createdApp.ok).toBe(true);
+    if (!createdApp.ok) return;
+
+    const createdComp = await createComponent(
+      {
+        appId: createdApp.value.appId,
+        name: 'web',
+        kind: 'service',
+        expose: true,
+        exposure: 'private',
+      },
+      ctx,
+    );
+    expect(createdComp.ok).toBe(true);
+    if (!createdComp.ok) return;
+
+    const [targetRow] = await ctx.db
+      .insert(targets)
+      .values({
+        name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
+        adapter: 'kubernetes',
+        health: 'healthy',
+        rank: 1,
+        connection: {
+          adapter: 'kubernetes',
+          apiServer: 'https://10.0.0.1:6443',
+          namespace: 'default',
+          delivery: {
+            flavour: 'flux-helmrelease',
+            namespace: 'flux-system',
+            sourceRef: { name: 'app', namespace: 'flux-system' },
+          },
+        },
+      })
+      .returning();
+
+    const [build1] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: createdComp.value.componentId,
+        commit: '1111111',
+        targetShape: 'kubernetes',
+        artifactType: 'image',
+        status: 'SUCCEEDED',
+      })
+      .returning();
+
+    const [_deploy1] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId: createdComp.value.componentId,
+        targetId: targetRow!.id,
+        buildId: build1!.id,
+        phase: 'LIVE',
+        url: `${appName}.example.com`,
+      })
+      .returning();
+
+    const [build2] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: createdComp.value.componentId,
+        commit: '2222222',
+        targetShape: 'kubernetes',
+        artifactType: 'image',
+        status: 'FAILED',
+      })
+      .returning();
+
+    const [deploy2] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId: createdComp.value.componentId,
+        targetId: targetRow!.id,
+        buildId: build2!.id,
+        phase: 'FAILED',
+        reason: 'BUILD_FAILED',
+        blame: 'developer',
+        detail:
+          "Type error in app/page.tsx line 14 — 'sesion' should be 'session'.",
+        debug: { exitCode: 1 },
+        url: `${appName}.example.com`,
+      })
+      .returning();
+
+    const result = await getDeployDetail({ id: deploy2!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { deploy } = result.value;
+    expect(deploy.phase).toBe('FAILED');
+    expect(deploy.previousReleaseServing).toBe(true);
+    expect(deploy.diagnosis).not.toBeNull();
+    expect(deploy.diagnosis?.reason).toBe('BUILD_FAILED');
+    expect(deploy.diagnosis?.blame).toBe('developer');
+    expect(deploy.diagnosis?.detail).toContain('Type error');
+  });
+});

--- a/apps/spindrift/test/web/auth-routes.test.ts
+++ b/apps/spindrift/test/web/auth-routes.test.ts
@@ -179,7 +179,8 @@ describe('enrolling over the route table', () => {
     const cookie = cookieFrom(await enrolOverHttp(routes));
     expect(cookie).not.toBeNull();
 
-    const name = commandNames[0]!;
+    const name =
+      commandNames.find((n) => n === 'createApp') ?? commandNames[0]!;
     const response = await call(routes, pathFor(name), {}, cookie!);
 
     // 422, not 401: an empty object satisfies no command's schema, so the

--- a/dotfiles/.local/bin/update-kubeconfigs
+++ b/dotfiles/.local/bin/update-kubeconfigs
@@ -7,9 +7,9 @@ CLUSTERS=("folly" "offsite")
 
 get_cluster_ip() {
   case "$1" in
-    folly)   echo "10.3.0.10" ;;
+    folly) echo "10.3.0.10" ;;
     offsite) echo "10.89.0.10" ;;
-    *)       return 1 ;;
+    *) return 1 ;;
   esac
 }
 
@@ -60,7 +60,10 @@ trap cleanup EXIT
 fetch_and_process_kubeconfig() {
   local cluster_name="$1"
   local ip
-  ip=$(get_cluster_ip "$cluster_name") || { error "Unknown cluster: $cluster_name"; return 1; }
+  ip=$(get_cluster_ip "$cluster_name") || {
+    error "Unknown cluster: $cluster_name"
+    return 1
+  }
   local temp_config="$TEMP_DIR/kubeconfig-$cluster_name"
 
   log "Fetching kubeconfig from $cluster_name ($ip)..."


### PR DESCRIPTION
## Summary
- Connect App workspace and Deploy detail views to real persisted projections from Postgres via `getAppWorkspace` and `getDeployDetail` commands.
- Remove scenario switchers and demo fixtures from production navigation while preserving presentation tests with test-owned fixtures.
- Render honest Not Found states when encountering unknown App names or Deploy IDs.

## Changes
- `feat(spindrift): Implement Show real App and Deploy details`

## Test Plan
- [x] Run `bun test` in `apps/spindrift` (unit, integration, and views tests pass cleanly)
- [x] Run `mise run check` and `mise run ts:check` (lint, format, and typechecks pass with 0 errors)
- [x] Run `mise run docs:check` (docs contract passes)
