### PR TITLE
feat(spindrift): implement cryptographically real artifact admission verification (§16)

### DIFF
--- a/apps/spindrift-verifier/main.go
+++ b/apps/spindrift-verifier/main.go
@@ -25,6 +25,8 @@ func main() {
 		runSignCommand(os.Args[2:])
 	case "verify-image":
 		runVerifyImageLegacyCommand(os.Args[2:])
+	case "verify-signature":
+		runVerifySignatureCommand(os.Args[2:])
 	case "sign-legacy":
 		runSignLegacyCommand(os.Args[2:])
 	default:
@@ -64,7 +66,7 @@ func runVerifyCommand(args []string) {
 func runSignCommand(args []string) {
 	fs := flag.NewFlagSet("sign", flag.ExitOnError)
 	requestPath := fs.String("request-path", "", "Path to sign request JSON file (stdin if empty)")
-	
+
 	// Check if this is legacy cosign invocation: e.g. "sign --yes --key ..."
 	if len(args) > 0 && args[0] != "-request-path" && args[0] != "--request-path" {
 		runSignLegacyCommand(args)
@@ -200,6 +202,33 @@ func runSignLegacyCommand(args []string) {
 	}
 	os.Stdout.Write(bundleJSON)
 	fmt.Println()
+}
+
+// runVerifySignatureCommand independently re-checks a recorded CoreSignature
+// bundle against the digest it is supposed to cover, pinned to Spindrift's
+// trusted signer key. Core admission calls this at every image deploy, on both
+// Kubernetes and Cloud Run paths: fail-closed admission consumes the real
+// signature format, not a stored placeholder.
+func runVerifySignatureCommand(args []string) {
+	fs := flag.NewFlagSet("verify-signature", flag.ExitOnError)
+	artifactDigest := fs.String("artifact-digest", "", "The digest the bundle must cover")
+	bundlePath := fs.String("bundle-path", "", "Path to the signature bundle JSON file")
+	signerKey := fs.String("signer-key", "", "Path to the trusted Spindrift signer key (the same key Sign used)")
+	_ = fs.Parse(args)
+
+	if *artifactDigest == "" || *bundlePath == "" || *signerKey == "" {
+		fmt.Fprintln(os.Stderr, "error: --artifact-digest, --bundle-path, and --signer-key are required")
+		os.Exit(1)
+	}
+	bundleData, err := os.ReadFile(*bundlePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading bundle path: %v\n", err)
+		os.Exit(1)
+	}
+	if err := verifier.VerifySignature(bundleData, *artifactDigest, *signerKey); err != nil {
+		fmt.Fprintf(os.Stderr, "signature did not verify: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func readInputData(path string) ([]byte, error) {

--- a/apps/spindrift-verifier/pkg/verifier/sign.go
+++ b/apps/spindrift-verifier/pkg/verifier/sign.go
@@ -1,34 +1,98 @@
 package verifier
 
 import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
 	"time"
 )
 
-// Sign generates a CoreSignature envelope for an admitted artifact.
+// SignatureMediaType is the envelope content type Spindrift's own signature
+// carries. It is not the sigstore bundle mediaType — until a KMS-backed signer
+// is wired, the bundle is a reviewable Ed25519 statement the platform's own
+// verifier can re-check with no network and no third-party trust.
+const SignatureMediaType = "application/vnd.spindrift.signature.v1+json"
+
+// SignatureBundle is the verifiable payload of a CoreSignature.
+//
+// Every field a verifier needs is embedded: the public key, the algorithm, the
+// artifact digest the signature covers, and the signature itself. A bundle
+// that carries only a mediaType is a placeholder and is rejected by
+// VerifySignature.
+//
+// The public key inside the bundle is **not trusted on its own**. Admission
+// pins Spindrift's signing key by passing the same key reference to
+// VerifySignature that Sign used; the bundle's public key must match the one
+// derived from that reference before the signature is even looked at. Without
+// this pinning the bundle would verify against any key an attacker chose.
+type SignatureBundle struct {
+	MediaType      string `json:"mediaType"`
+	Algorithm      string `json:"algorithm"`
+	PublicKey      string `json:"publicKey"`
+	ArtifactDigest string `json:"artifactDigest"`
+	Signature      string `json:"signature"`
+}
+
+// kmsPrefix marks a KMS URI signer reference. The reviewable offline path uses
+// an Ed25519 private key file; a KMS-backed signer is the production target but
+// is not wired yet. Both Sign and VerifySignature refuse this prefix loudly
+// rather than silently degrading — "cryptographically real" means the signature
+// means something, and a placeholder key is the opposite.
+const kmsPrefix = "gcpkms://"
+
+// Sign generates a real Ed25519 CoreSignature envelope for an admitted
+// artifact.
+//
+// The configured signer is, for the reviewable offline path, an Ed25519
+// private key read from the file named by req.Key. A KMS URI is refused loudly
+// rather than silently producing a placeholder — the whole point of
+// cryptographically real admission is that the signature means something.
 func Sign(req SignRequest, now func() time.Time) SignResponse {
 	if now == nil {
 		now = time.Now
 	}
 
 	if req.Artifact.Digest == "" {
-		return SignResponse{
-			Version: "v1",
-			OK:      false,
-			Code:    "SIGNING_FAILED",
-			Message: "artifact has no digest",
-		}
+		return signFail("artifact has no digest")
 	}
 	if req.Key == "" {
-		return SignResponse{
-			Version: "v1",
-			OK:      false,
-			Code:    "SIGNING_FAILED",
-			Message: "key is required for signing",
-		}
+		return signFail("key is required for signing")
+	}
+	if strings.HasPrefix(req.Key, kmsPrefix) {
+		return signFail(fmt.Sprintf(
+			"KMS signer %q is configured but not wired; the reviewable offline path reads an Ed25519 private key file",
+			req.Key,
+		))
 	}
 
-	bundle := json.RawMessage(`{"mediaType":"application/vnd.dev.sigstore.bundle.v0.3+json"}`)
+	priv, err := loadEd25519Key(req.Key)
+	if err != nil {
+		return signFail(fmt.Sprintf("could not load signing key: %v", err))
+	}
+
+	pubDER, err := x509.MarshalPKIXPublicKey(priv.Public())
+	if err != nil {
+		return signFail(fmt.Sprintf("could not marshal public key: %v", err))
+	}
+	sig := ed25519.Sign(priv, []byte(req.Artifact.Digest))
+
+	bundle := SignatureBundle{
+		MediaType:      SignatureMediaType,
+		Algorithm:      "ed25519",
+		PublicKey:      base64.StdEncoding.EncodeToString(pubDER),
+		ArtifactDigest: req.Artifact.Digest,
+		Signature:      base64.StdEncoding.EncodeToString(sig),
+	}
+	bundleJSON, err := json.Marshal(bundle)
+	if err != nil {
+		return signFail(fmt.Sprintf("could not marshal signature bundle: %v", err))
+	}
 
 	return SignResponse{
 		Version: "v1",
@@ -37,8 +101,115 @@ func Sign(req SignRequest, now func() time.Time) SignResponse {
 			ArtifactDigest: req.Artifact.Digest,
 			Signer:         req.Key,
 			Format:         "cosign",
-			Bundle:         bundle,
+			Bundle:         bundleJSON,
 			SignedAt:       now().UTC().Format(time.RFC3339Nano),
 		},
 	}
+}
+
+func signFail(message string) SignResponse {
+	return SignResponse{
+		Version: "v1",
+		OK:      false,
+		Code:    "SIGNING_FAILED",
+		Message: message,
+	}
+}
+
+// VerifySignature independently verifies a CoreSignature bundle against the
+// artifact digest it is supposed to cover, pinned to a trusted signer key.
+//
+// signerKey is the same reference Sign used — a path to an Ed25519 private key
+// file. The verifier derives the expected public key from it and requires the
+// bundle's embedded public key to match before the signature is checked, so a
+// bundle signed by any other key fails even though it is internally
+// self-consistent. This is the half of "cryptographically real" the previous
+// placeholder lacked: admission proves *Spindrift's* key signed the digest, not
+// *some* key.
+//
+// A KMS URI is refused with the same message Sign returns, so the two sides
+// fail symmetrically until KMS is wired.
+func VerifySignature(bundleJSON json.RawMessage, artifactDigest, signerKey string) error {
+	if len(bundleJSON) == 0 {
+		return errors.New("signature bundle is empty")
+	}
+	if signerKey == "" {
+		return errors.New("a trusted signer key is required to pin admission")
+	}
+	if strings.HasPrefix(signerKey, kmsPrefix) {
+		return fmt.Errorf(
+			"KMS signer %q is configured but verification is not wired; the reviewable offline path reads an Ed25519 private key file",
+			signerKey,
+		)
+	}
+	var bundle SignatureBundle
+	if err := json.Unmarshal(bundleJSON, &bundle); err != nil {
+		return fmt.Errorf("could not parse signature bundle: %w", err)
+	}
+	if bundle.MediaType != SignatureMediaType {
+		return fmt.Errorf("unsupported signature mediaType %q", bundle.MediaType)
+	}
+	if bundle.Algorithm != "ed25519" {
+		return fmt.Errorf("unsupported signature algorithm %q", bundle.Algorithm)
+	}
+	if bundle.ArtifactDigest != artifactDigest {
+		return fmt.Errorf("bundle covers digest %q, not %q", bundle.ArtifactDigest, artifactDigest)
+	}
+
+	// Pin the signer: the public key in the bundle must be the one derived
+	// from the trusted signer key file, or admission refuses. Without this
+	// check any Ed25519 key the attacker chose would verify.
+	priv, err := loadEd25519Key(signerKey)
+	if err != nil {
+		return fmt.Errorf("could not load the trusted signer key: %w", err)
+	}
+	expectedPubDER, err := x509.MarshalPKIXPublicKey(priv.Public())
+	if err != nil {
+		return fmt.Errorf("could not derive the trusted public key: %w", err)
+	}
+	if bundle.PublicKey != base64.StdEncoding.EncodeToString(expectedPubDER) {
+		return errors.New("bundle public key does not match the trusted Spindrift signer")
+	}
+
+	pubDER, err := base64.StdEncoding.DecodeString(bundle.PublicKey)
+	if err != nil {
+		return fmt.Errorf("could not decode public key: %w", err)
+	}
+	pubIface, err := x509.ParsePKIXPublicKey(pubDER)
+	if err != nil {
+		return fmt.Errorf("could not parse public key: %w", err)
+	}
+	pub, ok := pubIface.(ed25519.PublicKey)
+	if !ok {
+		return errors.New("public key is not an Ed25519 key")
+	}
+	sig, err := base64.StdEncoding.DecodeString(bundle.Signature)
+	if err != nil {
+		return fmt.Errorf("could not decode signature: %w", err)
+	}
+	if !ed25519.Verify(pub, []byte(artifactDigest), sig) {
+		return errors.New("signature does not verify against the artifact digest")
+	}
+	return nil
+}
+
+// loadEd25519Key reads a PKCS8 PEM Ed25519 private key from a file path.
+func loadEd25519Key(path string) (ed25519.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block in %s", path)
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse PKCS8 key: %w", err)
+	}
+	priv, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, errors.New("key is not an Ed25519 private key")
+	}
+	return priv, nil
 }

--- a/apps/spindrift-verifier/pkg/verifier/sign_test.go
+++ b/apps/spindrift-verifier/pkg/verifier/sign_test.go
@@ -1,0 +1,246 @@
+package verifier
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeEd25519Key writes a PKCS8 PEM Ed25519 private key to a temp file and
+// returns its path. The signer reads the same encoding in production.
+func writeEd25519Key(t *testing.T) string {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	_ = pub
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "signer.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: der,
+	}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return path
+}
+
+func TestSign_RealEd25519ProducesVerifiableBundle(t *testing.T) {
+	keyPath := writeEd25519Key(t)
+	req := SignRequest{
+		Version: "v1",
+		Artifact: Artifact{
+			Digest: testDigest,
+			Refs:   []string{"registry.example.test/apps/shop@" + testDigest},
+		},
+		Key: keyPath,
+	}
+
+	resp := Sign(req, mockNow)
+	if !resp.OK {
+		t.Fatalf("expected OK true, got false: %s", resp.Message)
+	}
+	if resp.Signature == nil {
+		t.Fatalf("expected non-nil signature")
+	}
+	if resp.Signature.ArtifactDigest != testDigest {
+		t.Errorf("expected digest %s, got %s", testDigest, resp.Signature.ArtifactDigest)
+	}
+	if resp.Signature.Format != "cosign" {
+		t.Errorf("expected envelope format cosign, got %s", resp.Signature.Format)
+	}
+
+	var bundle SignatureBundle
+	if err := json.Unmarshal(resp.Signature.Bundle, &bundle); err != nil {
+		t.Fatalf("bundle is not valid JSON: %v", err)
+	}
+	if bundle.Algorithm != "ed25519" {
+		t.Errorf("expected algorithm ed25519, got %s", bundle.Algorithm)
+	}
+	if bundle.ArtifactDigest != testDigest {
+		t.Errorf("bundle artifact digest mismatch: %s", bundle.ArtifactDigest)
+	}
+	if bundle.PublicKey == "" {
+		t.Errorf("expected embedded public key")
+	}
+	if bundle.Signature == "" {
+		t.Errorf("expected a real signature, not a placeholder")
+	}
+	if bundle.MediaType == "application/vnd.dev.sigstore.bundle.v0.3+json" {
+		t.Errorf("the placeholder mediaType must not survive a real signature")
+	}
+
+	// The signature must be a 64-byte Ed25519 signature.
+	sig, err := base64.StdEncoding.DecodeString(bundle.Signature)
+	if err != nil {
+		t.Fatalf("signature is not base64: %v", err)
+	}
+	if len(sig) != ed25519.SignatureSize {
+		t.Fatalf("expected %d-byte signature, got %d", ed25519.SignatureSize, len(sig))
+	}
+}
+
+func TestSign_BundleIsIndependentlyVerifiable(t *testing.T) {
+	keyPath := writeEd25519Key(t)
+	resp := Sign(SignRequest{
+		Artifact: Artifact{Digest: testDigest},
+		Key:      keyPath,
+	}, mockNow)
+	if !resp.OK {
+		t.Fatalf("sign: %s", resp.Message)
+	}
+
+	if err := VerifySignature(resp.Signature.Bundle, testDigest, keyPath); err != nil {
+		t.Fatalf("independent verification of a successful signature failed: %v", err)
+	}
+}
+
+func TestSign_TamperedSignatureFailsVerification(t *testing.T) {
+	keyPath := writeEd25519Key(t)
+	resp := Sign(SignRequest{
+		Artifact: Artifact{Digest: testDigest},
+		Key:      keyPath,
+	}, mockNow)
+	if !resp.OK {
+		t.Fatalf("sign: %s", resp.Message)
+	}
+
+	var bundle SignatureBundle
+	if err := json.Unmarshal(resp.Signature.Bundle, &bundle); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	sig, _ := base64.StdEncoding.DecodeString(bundle.Signature)
+	sig[0] ^= 0xff
+	bundle.Signature = base64.StdEncoding.EncodeToString(sig)
+	tampered, _ := json.Marshal(bundle)
+
+	if err := VerifySignature(tampered, testDigest, keyPath); err == nil {
+		t.Fatalf("a tampered signature verified; expected failure")
+	}
+}
+
+func TestSign_WrongDigestFailsVerification(t *testing.T) {
+	keyPath := writeEd25519Key(t)
+	resp := Sign(SignRequest{
+		Artifact: Artifact{Digest: testDigest},
+		Key:      keyPath,
+	}, mockNow)
+	if !resp.OK {
+		t.Fatalf("sign: %s", resp.Message)
+	}
+
+	if err := VerifySignature(resp.Signature.Bundle, "sha256:"+repeat('c', 64), keyPath); err == nil {
+		t.Fatalf("verification against a different digest succeeded; expected failure")
+	}
+}
+
+func TestSign_BundleFromAnotherSignerIsRefusedAtAdmission(t *testing.T) {
+	// A bundle signed by a different key. It is internally self-consistent
+	// — the signature verifies under its own public key — but admission
+	// refuses because the public key is not Spindrift's trusted signer.
+	otherKey := writeEd25519Key(t)
+	trustedKey := writeEd25519Key(t)
+	resp := Sign(SignRequest{
+		Artifact: Artifact{Digest: testDigest},
+		Key:      otherKey,
+	}, mockNow)
+	if !resp.OK {
+		t.Fatalf("sign: %s", resp.Message)
+	}
+
+	err := VerifySignature(resp.Signature.Bundle, testDigest, trustedKey)
+	if err == nil {
+		t.Fatalf("a bundle signed by another key was admitted; expected refusal")
+	}
+	if !strings.Contains(err.Error(), "does not match the trusted Spindrift signer") {
+		t.Errorf("expected a signer-mismatch refusal, got: %v", err)
+	}
+}
+
+func TestSign_KMSKeyRefused(t *testing.T) {
+	resp := Sign(SignRequest{
+		Artifact: Artifact{Digest: testDigest},
+		Key:      "gcpkms://projects/example/locations/global/keyRings/keys/signer",
+	}, mockNow)
+	if resp.OK {
+		t.Fatalf("KMS signer was accepted; expected loud refusal")
+	}
+	if resp.Code != "SIGNING_FAILED" {
+		t.Errorf("expected SIGNING_FAILED, got %s", resp.Code)
+	}
+	if !strings.Contains(resp.Message, "KMS signer") {
+		t.Errorf("expected a KMS-specific message, got: %s", resp.Message)
+	}
+}
+
+func TestVerifySignature_KMSKeyRefused(t *testing.T) {
+	keyPath := writeEd25519Key(t)
+	resp := Sign(SignRequest{
+		Artifact: Artifact{Digest: testDigest},
+		Key:      keyPath,
+	}, mockNow)
+	if !resp.OK {
+		t.Fatalf("sign: %s", resp.Message)
+	}
+	err := VerifySignature(resp.Signature.Bundle, testDigest, "gcpkms://projects/example/keys/signer")
+	if err == nil {
+		t.Fatalf("KMS verifier was accepted; expected loud refusal")
+	}
+}
+
+func TestSign_MissingKeyFileFails(t *testing.T) {
+	resp := Sign(SignRequest{
+		Artifact: Artifact{Digest: testDigest},
+		Key:      "/nonexistent/path/signer.pem",
+	}, mockNow)
+	if resp.OK {
+		t.Fatalf("expected OK false for a missing key file")
+	}
+	if resp.Code != "SIGNING_FAILED" {
+		t.Errorf("expected code SIGNING_FAILED, got %s", resp.Code)
+	}
+}
+
+func TestSign_MissingDigestFails(t *testing.T) {
+	keyPath := writeEd25519Key(t)
+	resp := Sign(SignRequest{
+		Artifact: Artifact{},
+		Key:      keyPath,
+	}, mockNow)
+	if resp.OK {
+		t.Fatalf("expected OK false for missing digest")
+	}
+	if resp.Code != "SIGNING_FAILED" {
+		t.Errorf("expected code SIGNING_FAILED, got %s", resp.Code)
+	}
+}
+
+func TestVerifySignature_PlaceholderBundleRejected(t *testing.T) {
+	keyPath := writeEd25519Key(t)
+	placeholder, _ := json.Marshal(SignatureBundle{
+		MediaType: "application/vnd.dev.sigstore.bundle.v0.3+json",
+	})
+	if err := VerifySignature(placeholder, testDigest, keyPath); err == nil {
+		t.Fatalf("a mediaType-only placeholder verified; expected failure")
+	}
+}
+
+func repeat(b byte, n int) string {
+	out := make([]byte, n)
+	for i := range out {
+		out[i] = b
+	}
+	return string(out)
+}

--- a/apps/spindrift-verifier/pkg/verifier/types.go
+++ b/apps/spindrift-verifier/pkg/verifier/types.go
@@ -16,9 +16,17 @@ type Artifact struct {
 	Refs   []string `json:"refs,omitempty"`
 }
 
-// Provenance holds the raw in-toto statement and claimed build level.
+// Provenance holds the raw in-toto statement, the backend's signature over
+// that statement, and the claimed build level.
+//
+// Statement is the isolation claim being verified; Signature is the backend's
+// Ed25519 signature over the exact statement bytes, proving the statement is
+// authentic and untampered. A statement with no signature is accepted only by
+// routes that configured no BuilderPublicKey — nobody claimed cryptographic
+// authenticity, so none is checked.
 type Provenance struct {
 	Statement    json.RawMessage `json:"statement"`
+	Signature    string          `json:"signature,omitempty"`
 	ClaimedLevel int             `json:"claimedLevel"`
 }
 
@@ -26,18 +34,23 @@ type Provenance struct {
 type Expectations struct {
 	Backend           string `json:"backend"`
 	ExpectedBuilderID string `json:"expectedBuilderId"`
-	MinimumLevel      int    `json:"minimumLevel"`
-	MaximumLevel      int    `json:"maximumLevel"`
-	SourceURI         string `json:"sourceUri"`
-	BundleDigest      string `json:"bundleDigest"`
+	// BuilderPublicKey, when set, is the base64 SPKI public key the backend's
+	// provenance signature must verify against. A route that sets this rejects
+	// any statement whose signature is absent or does not verify — the
+	// cryptographic authenticity half of admission.
+	BuilderPublicKey string `json:"builderPublicKey,omitempty"`
+	MinimumLevel     int    `json:"minimumLevel"`
+	MaximumLevel     int    `json:"maximumLevel"`
+	SourceURI        string `json:"sourceUri"`
+	BundleDigest     string `json:"bundleDigest"`
 }
 
 // VerificationResponse is the versioned JSON result returned by verification.
 type VerificationResponse struct {
-	Version    string                        `json:"version"`
-	OK         bool                          `json:"ok"`
-	Code       string                        `json:"code,omitempty"`
-	Message    string                        `json:"message,omitempty"`
+	Version    string                       `json:"version"`
+	OK         bool                         `json:"ok"`
+	Code       string                       `json:"code,omitempty"`
+	Message    string                       `json:"message,omitempty"`
 	Assessment *BackendProvenanceAssessment `json:"assessment,omitempty"`
 }
 

--- a/apps/spindrift-verifier/pkg/verifier/verify.go
+++ b/apps/spindrift-verifier/pkg/verifier/verify.go
@@ -1,10 +1,15 @@
 package verifier
 
-import "encoding/json"
-import "fmt"
-import "regexp"
-import "strings"
-import "time"
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
 
 var slsaVersionRegex = regexp.MustCompile(`(?i)slsa[^/]*/v(\d+(?:\.\d+)?)`)
 
@@ -74,6 +79,85 @@ func Verify(req VerificationRequest, now func() time.Time) VerificationResponse 
 			OK:      false,
 			Code:    "PROVENANCE_INVALID",
 			Message: fmt.Sprintf("%s provenance builder mismatch: expected %s, got %s", backend, req.Expectations.ExpectedBuilderID, extractedBuilderID),
+		}
+	}
+
+	// 4b. Provenance authenticity: when the route configured a builder public
+	// key, the backend's signature over the exact statement bytes must verify
+	// against it. This is the cryptographic half of "provenance
+	// authenticity" — a statement nobody signed, or signed by a different key,
+	// or modified after signing, is rejected with no silent fallback.
+	if req.Expectations.BuilderPublicKey != "" {
+		var sig []byte
+		if req.Provenance.Signature != "" {
+			decoded, err := base64.StdEncoding.DecodeString(req.Provenance.Signature)
+			if err != nil {
+				return VerificationResponse{
+					Version: "v1",
+					OK:      false,
+					Code:    "PROVENANCE_INVALID",
+					Message: fmt.Sprintf("%s provenance signature is not base64: %v", backend, err),
+				}
+			}
+			sig = decoded
+		}
+		if len(sig) == 0 {
+			return VerificationResponse{
+				Version: "v1",
+				OK:      false,
+				Code:    "PROVENANCE_INVALID",
+				Message: fmt.Sprintf("%s provenance carries no signature for a route that requires authenticity", backend),
+			}
+		}
+		pubDER, err := base64.StdEncoding.DecodeString(req.Expectations.BuilderPublicKey)
+		if err != nil {
+			return VerificationResponse{
+				Version: "v1",
+				OK:      false,
+				Code:    "PROVENANCE_INVALID",
+				Message: fmt.Sprintf("configured builder public key is not base64: %v", err),
+			}
+		}
+		pubIface, err := x509.ParsePKIXPublicKey(pubDER)
+		if err != nil {
+			return VerificationResponse{
+				Version: "v1",
+				OK:      false,
+				Code:    "PROVENANCE_INVALID",
+				Message: fmt.Sprintf("configured builder public key is not parseable: %v", err),
+			}
+		}
+		pub, ok := pubIface.(ed25519.PublicKey)
+		if !ok {
+			return VerificationResponse{
+				Version: "v1",
+				OK:      false,
+				Code:    "PROVENANCE_INVALID",
+				Message: "configured builder public key is not an Ed25519 key",
+			}
+		}
+		if !ed25519.Verify(pub, req.Provenance.Statement, sig) {
+			return VerificationResponse{
+				Version: "v1",
+				OK:      false,
+				Code:    "PROVENANCE_INVALID",
+				Message: fmt.Sprintf("%s provenance signature does not verify against the statement (tampered or signed by another key)", backend),
+			}
+		}
+	}
+
+	// 4c. Subject binding: when the statement names a subject, its digest must
+	// be the artifact being admitted. A provenance document that names a
+	// different artifact does not bind this one, and "wrong subject" is exactly
+	// the failure that catches.
+	if subjectDigest := extractSubjectDigest(stmt); subjectDigest != "" {
+		if subjectDigest != req.Artifact.Digest {
+			return VerificationResponse{
+				Version: "v1",
+				OK:      false,
+				Code:    "PROVENANCE_INVALID",
+				Message: fmt.Sprintf("%s provenance subject names %q, not the admitted artifact %s", backend, subjectDigest, req.Artifact.Digest),
+			}
 		}
 	}
 
@@ -182,3 +266,30 @@ func extractSLSAVersion(stmt map[string]interface{}) string {
 	}
 	return "1.2"
 }
+
+// extractSubjectDigest returns the sha256 digest the statement names as its
+// subject, as a "sha256:<hex>" string, or "" when the statement names none.
+// The subject binds the provenance to the artifact it claims to describe.
+func extractSubjectDigest(stmt map[string]interface{}) string {
+	subjects, _ := stmt["subject"].([]interface{})
+	if len(subjects) == 0 {
+		return ""
+	}
+	first, _ := subjects[0].(map[string]interface{})
+	if first == nil {
+		return ""
+	}
+	digest, _ := first["digest"].(map[string]interface{})
+	if digest == nil {
+		return ""
+	}
+	h, _ := digest["sha256"].(string)
+	if h == "" {
+		return ""
+	}
+	if strings.HasPrefix(h, "sha256:") {
+		return h
+	}
+	return "sha256:" + h
+}
+

--- a/apps/spindrift-verifier/pkg/verifier/verify_authenticity_test.go
+++ b/apps/spindrift-verifier/pkg/verifier/verify_authenticity_test.go
@@ -1,0 +1,189 @@
+package verifier
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// signedStatement returns the statement bytes, a base64 Ed25519 signature
+// over those bytes, and the builder's base64 SPKI public key — the three
+// things a real backend's provenance carries for cryptographic authenticity.
+func signedStatement(t *testing.T, statement map[string]interface{}) (json.RawMessage, string, string) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	stmtBytes, _ := json.Marshal(statement)
+	sig := ed25519.Sign(priv, stmtBytes)
+	der, _ := x509.MarshalPKIXPublicKey(pub)
+	return stmtBytes, base64.StdEncoding.EncodeToString(sig), base64.StdEncoding.EncodeToString(der)
+}
+
+func statementWithSubject(bundle, subject string) map[string]interface{} {
+	return map[string]interface{}{
+		"_type":         "https://in-toto.io/Statement/v1",
+		"predicateType": "https://slsa.dev/provenance/v1",
+		"subject": []map[string]interface{}{
+			{"name": "image", "digest": map[string]string{"sha256": strings.TrimPrefix(subject, "sha256:")}},
+		},
+		"predicate": map[string]interface{}{
+			"buildDefinition": map[string]interface{}{
+				"externalParameters": map[string]string{"bundleDigest": bundle},
+			},
+			"runDetails": map[string]interface{}{
+				"builder": map[string]string{"id": "https://github.com/actions/runner/github-hosted"},
+			},
+		},
+	}
+}
+
+func TestVerify_SignedProvenanceAuthentic(t *testing.T) {
+	stmt := statementWithSubject(testBundle, testDigest)
+	stmtBytes, sig, pub := signedStatement(t, stmt)
+	req := VerificationRequest{
+		Artifact: Artifact{Digest: testDigest, Refs: []string{"r@" + testDigest}},
+		Provenance: Provenance{
+			Statement:    stmtBytes,
+			ClaimedLevel: 2,
+			Signature:    sig,
+		},
+		Expectations: Expectations{
+			Backend:           "hosted",
+			ExpectedBuilderID: "https://github.com/actions/runner/github-hosted",
+			BuilderPublicKey:  pub,
+			BundleDigest:      testBundle,
+			MinimumLevel:      2,
+			MaximumLevel:      2,
+		},
+	}
+	resp := Verify(req, mockNow)
+	if !resp.OK {
+		t.Fatalf("expected OK for authentic signed provenance; got %s: %s", resp.Code, resp.Message)
+	}
+}
+
+func TestVerify_TamperedProvenanceRejected(t *testing.T) {
+	stmt := statementWithSubject(testBundle, testDigest)
+	stmtBytes, sig, pub := signedStatement(t, stmt)
+
+	// Mutate the statement after it was signed — the signature no longer
+	// covers what is being admitted.
+	var mutated map[string]interface{}
+	if err := json.Unmarshal(stmtBytes, &mutated); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	pred := mutated["predicate"].(map[string]interface{})
+	pred["runDetails"].(map[string]interface{})["builder"].(map[string]interface{})["id"] = "https://evil.example/runner"
+	mutatedBytes, _ := json.Marshal(mutated)
+
+	req := VerificationRequest{
+		Artifact: Artifact{Digest: testDigest, Refs: []string{"r@" + testDigest}},
+		Provenance: Provenance{
+			Statement:    mutatedBytes,
+			ClaimedLevel: 2,
+			Signature:    sig,
+		},
+		Expectations: Expectations{
+			Backend:           "hosted",
+			ExpectedBuilderID: "https://github.com/actions/runner/github-hosted",
+			BuilderPublicKey:  pub,
+			BundleDigest:      testBundle,
+		},
+	}
+	resp := Verify(req, mockNow)
+	if resp.OK {
+		t.Fatalf("tampered provenance was admitted; expected rejection")
+	}
+	if resp.Code != "PROVENANCE_INVALID" {
+		t.Errorf("expected PROVENANCE_INVALID, got %s", resp.Code)
+	}
+}
+
+func TestVerify_ProvenanceSignedByWrongKeyRejected(t *testing.T) {
+	stmt := statementWithSubject(testBundle, testDigest)
+	stmtBytes, sig, _ := signedStatement(t, stmt)
+	// A different builder key is configured as the expected one; the
+	// statement was signed by the first key, so authenticity fails.
+	otherPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	otherDER, _ := x509.MarshalPKIXPublicKey(otherPub)
+
+	req := VerificationRequest{
+		Artifact: Artifact{Digest: testDigest, Refs: []string{"r@" + testDigest}},
+		Provenance: Provenance{
+			Statement:    stmtBytes,
+			ClaimedLevel: 2,
+			Signature:    sig,
+		},
+		Expectations: Expectations{
+			Backend:           "hosted",
+			ExpectedBuilderID: "https://github.com/actions/runner/github-hosted",
+			BuilderPublicKey:  base64.StdEncoding.EncodeToString(otherDER),
+			BundleDigest:      testBundle,
+		},
+	}
+	resp := Verify(req, mockNow)
+	if resp.OK {
+		t.Fatalf("provenance signed by an unknown key was admitted; expected rejection")
+	}
+}
+
+func TestVerify_WrongSubjectRejected(t *testing.T) {
+	stmt := statementWithSubject(testBundle, "sha256:"+repeat('d', 64))
+	stmtBytes, sig, pub := signedStatement(t, stmt)
+	req := VerificationRequest{
+		Artifact: Artifact{Digest: testDigest, Refs: []string{"r@" + testDigest}},
+		Provenance: Provenance{
+			Statement:    stmtBytes,
+			ClaimedLevel: 2,
+			Signature:    sig,
+		},
+		Expectations: Expectations{
+			Backend:           "hosted",
+			ExpectedBuilderID: "https://github.com/actions/runner/github-hosted",
+			BuilderPublicKey:  pub,
+			BundleDigest:      testBundle,
+		},
+	}
+	resp := Verify(req, mockNow)
+	if resp.OK {
+		t.Fatalf("provenance naming a different subject was admitted; expected rejection")
+	}
+	if resp.Code != "PROVENANCE_INVALID" {
+		t.Errorf("expected PROVENANCE_INVALID, got %s", resp.Code)
+	}
+}
+
+func TestVerify_InflatedClaimedLevelCapped(t *testing.T) {
+	stmt := statementWithSubject(testBundle, testDigest)
+	stmtBytes, sig, pub := signedStatement(t, stmt)
+	req := VerificationRequest{
+		Artifact: Artifact{Digest: testDigest, Refs: []string{"r@" + testDigest}},
+		Provenance: Provenance{
+			Statement: stmtBytes,
+			// The backend claims L3, but this route's profile only permits L2.
+			ClaimedLevel: 3,
+			Signature:    sig,
+		},
+		Expectations: Expectations{
+			Backend:           "hosted",
+			ExpectedBuilderID: "https://github.com/actions/runner/github-hosted",
+			BuilderPublicKey:  pub,
+			BundleDigest:      testBundle,
+			MinimumLevel:      2,
+			MaximumLevel:      2,
+		},
+	}
+	resp := Verify(req, mockNow)
+	if !resp.OK {
+		t.Fatalf("expected OK; got %s: %s", resp.Code, resp.Message)
+	}
+	if resp.Assessment.AchievedLevel != 2 {
+		t.Errorf("claimed L3 must be capped to the profile's maximum L2, got %d", resp.Assessment.AchievedLevel)
+	}
+}

--- a/apps/spindrift-verifier/pkg/verifier/verify_test.go
+++ b/apps/spindrift-verifier/pkg/verifier/verify_test.go
@@ -180,12 +180,13 @@ func TestVerify_LevelBelowPolicy(t *testing.T) {
 }
 
 func TestSign_Valid(t *testing.T) {
+	keyPath := writeEd25519Key(t)
 	req := SignRequest{
 		Version: "v1",
 		Artifact: Artifact{
 			Digest: testDigest,
 		},
-		Key: "gcpkms://projects/example/locations/global/keyRings/keys/cryptoKeys/signer",
+		Key: keyPath,
 	}
 
 	resp := Sign(req, mockNow)

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -33,6 +33,7 @@ import type { RepositoryHost } from '../domain/repository.ts';
 import { GitHubApp } from '../integrations/github/app.ts';
 import type { Fetcher } from '../integrations/github/http.ts';
 import { CoreSupplyChain, CosignSigner } from '../supply-chain/sign.ts';
+import { SpindriftSignatureVerifier } from '../supply-chain/signature.ts';
 import { SlsaVerifier } from '../supply-chain/verify.ts';
 import { CloudBuildRoute } from './build/cloud-build.ts';
 import type { BuildAdapter } from './build/contract.ts';
@@ -148,6 +149,13 @@ export function createAdapterRegistry(
   const supplyChain = new CoreSupplyChain(
     new SlsaVerifier(),
     new CosignSigner({ key: options.manifest.supplyChain.signer }),
+    // §16: admission re-verifies the recorded signature against the recorded
+    // digest, pinned to Spindrift's own signer. The signer and verifier are
+    // the same pinned binary, so this is the process boundary around the
+    // verify half, not a second trust root.
+    new SpindriftSignatureVerifier({
+      signerKey: options.manifest.supplyChain.signer,
+    }),
   );
 
   // §16's ordered list: the manifest's order *is* the admin rank, so the map is

--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -335,6 +335,22 @@ export async function checkDeployable(
         `Build ${build.id} achieved verified Build Level ${build.verifiedBuildLevel}, and ${target.name} currently requires L${requiredLevel}`,
       );
     }
+    // Cryptographically real admission: the recorded signature is re-verified
+    // against the recorded artifact digest before any intent row is written.
+    // This is the gate both image adapters — Kubernetes and Cloud Run — share,
+    // so the real signature format is consumed on both admission paths. A
+    // signature that does not verify fails closed; nothing is deployed.
+    const admitted = await context.adapters.supplyChain().verifySignature({
+      artifactDigest: build.artifactDigest,
+      signature: build.signature,
+    });
+    if (!admitted.ok) {
+      return refuse(
+        'NOT_DEPLOYABLE',
+        `Build ${build.id} signature did not verify` +
+          (admitted.reason === null ? '' : `: ${admitted.reason}`),
+      );
+    }
   }
 
   // §3: "changing placement across shapes forces a rebuild." The Build's key

--- a/apps/spindrift/src/supply-chain/sign.ts
+++ b/apps/spindrift/src/supply-chain/sign.ts
@@ -61,14 +61,51 @@ export type ArtifactFinalization =
       readonly message: string;
     };
 
+/**
+ * The outcome of re-checking a recorded {@link CoreSignature} at admission.
+ *
+ * "Cryptographically real" means the signature core recorded is verified again
+ * before a Deploy is written — fail-closed, on both the Kubernetes and Cloud
+ * Run image paths, which share this one admission gate. A `false` here refuses
+ * the deploy with the sentence the operator reads.
+ */
+export interface SignatureVerification {
+  readonly ok: boolean;
+  readonly reason: string | null;
+}
+
+export interface VerifySignatureInput {
+  readonly artifactDigest: string;
+  readonly signature: CoreSignature;
+}
+
+/**
+ * The far side behind signature re-verification: the pinned
+ * `spindrift-verifier` binary's `verify-signature` subcommand. Faked at this
+ * seam in tests; never mocked inside core.
+ */
+export interface SignatureVerifier {
+  verify(input: VerifySignatureInput): Promise<SignatureVerification>;
+}
+
 export interface SupplyChain {
   finalize(input: FinalizeArtifactInput): Promise<ArtifactFinalization>;
+  /**
+   * Re-verify a recorded artifact signature at admission (§16).
+   *
+   * Consumed by the deploy intent path before any row is written: a Build that
+   * passed finalization can still be refused here if its stored signature does
+   * not verify against its stored digest, which is what "deployment policy
+   * consumes the real signature format" means at core's admission gate.
+   */
+  verifySignature(input: VerifySignatureInput): Promise<SignatureVerification>;
 }
 
 export class CoreSupplyChain implements SupplyChain {
   constructor(
     private readonly verifier: ProvenanceVerifier,
     private readonly signer: ArtifactSigner,
+    private readonly signatureVerifier: SignatureVerifier,
   ) {}
 
   async finalize(input: FinalizeArtifactInput): Promise<ArtifactFinalization> {
@@ -97,6 +134,18 @@ export class CoreSupplyChain implements SupplyChain {
         message: `core could not sign the admitted artifact: ${detail}`,
       };
     }
+  }
+
+  async verifySignature(
+    input: VerifySignatureInput,
+  ): Promise<SignatureVerification> {
+    if (input.signature.artifactDigest !== input.artifactDigest) {
+      return {
+        ok: false,
+        reason: `recorded signature covers ${input.signature.artifactDigest}, not the admitted artifact ${input.artifactDigest}`,
+      };
+    }
+    return this.signatureVerifier.verify(input);
   }
 }
 

--- a/apps/spindrift/src/supply-chain/signature.ts
+++ b/apps/spindrift/src/supply-chain/signature.ts
@@ -1,0 +1,81 @@
+/**
+ * The production {@link SignatureVerifier}: the pinned `spindrift-verifier`
+ * binary's `verify-signature` subcommand (§16, §19).
+ *
+ * Verification and signing are the same binary, so the two paths differ by a
+ * process boundary, not by correctness — Go's `crypto/ed25519` would call the
+ * same reference implementation anyway. This module is the process boundary
+ * around the verifier half: it writes the recorded bundle to a temp file and
+ * asks the binary whether it verifies against the recorded digest.
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type {
+  CoreSignature,
+  SignatureVerification,
+  SignatureVerifier,
+  VerifySignatureInput,
+} from './sign.ts';
+import { bunProcessExecutor, type ProcessExecutor } from './verify.ts';
+
+export interface SpindriftSignatureVerifierOptions {
+  readonly executable?: string;
+  readonly processes?: ProcessExecutor;
+  /**
+   * The trusted Spindrift signer reference — the same one `Sign` used. The
+   * pinned verifier derives the expected public key from this and refuses a
+   * bundle whose embedded key does not match, so admission proves
+   * *Spindrift's* key signed the digest, not *some* key.
+   */
+  readonly signerKey: string;
+}
+
+export class SpindriftSignatureVerifier implements SignatureVerifier {
+  private readonly executable: string;
+  private readonly processes: ProcessExecutor;
+  private readonly signerKey: string;
+
+  constructor(options: SpindriftSignatureVerifierOptions) {
+    this.executable = options.executable ?? 'spindrift-verifier';
+    this.processes = options.processes ?? bunProcessExecutor;
+    this.signerKey = options.signerKey;
+  }
+
+  async verify(input: VerifySignatureInput): Promise<SignatureVerification> {
+    const directory = await mkdtemp(join(tmpdir(), 'spindrift-admission-'));
+    const bundlePath = join(directory, 'bundle.json');
+    try {
+      await writeFile(bundlePath, JSON.stringify(input.signature.bundle), {
+        mode: 0o600,
+      });
+      const result = await this.processes.run([
+        this.executable,
+        'verify-signature',
+        '--artifact-digest',
+        input.artifactDigest,
+        '--bundle-path',
+        bundlePath,
+        // Pins admission to Spindrift's own signer: the verifier derives the
+        // expected public key from this file and refuses any bundle whose
+        // embedded key does not match.
+        '--signer-key',
+        this.signerKey,
+      ]);
+      if (result.exitCode === 0) return { ok: true, reason: null };
+      const detail = result.stderr.trim() || result.stdout.trim();
+      return {
+        ok: false,
+        reason:
+          detail === ''
+            ? 'signature did not verify against the recorded digest'
+            : detail,
+      };
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+}
+
+/** Re-exported so `CoreSignature` stays a single import for callers. */
+export type { CoreSignature } from './sign.ts';

--- a/apps/spindrift/test/commands/config.test.ts
+++ b/apps/spindrift/test/commands/config.test.ts
@@ -50,6 +50,7 @@ import {
   FakeDeployAdapter,
 } from '../harness/fakes/deploy-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
@@ -98,9 +99,10 @@ function registryOf(
     // §15's repository host plays no part in config: a value reaches the store,
     // never a repository.
     repository: () => null,
-    supplyChain: () => {
-      throw new Error('config reached the supply chain');
-    },
+    // Config commands never reach the supply chain; `createDeploy` admission
+    // does, for an image Build. The harness records every finalization, so a
+    // config pass that ever called `finalize` would leave an entry here.
+    supplyChain: () => new SupplyChainHarness(),
   };
 }
 

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -70,7 +70,9 @@ function digest(seed: number): string {
 function registryOf(
   deployAdapter: DeployAdapter,
   buildAdapter?: FakeBuildAdapter,
+  supplyChain?: SupplyChainHarness,
 ): AdapterRegistry {
+  const chain = supplyChain ?? new SupplyChainHarness();
   return {
     deploy: (adapter) =>
       adapter === deployAdapter.adapter ? deployAdapter : null,
@@ -86,7 +88,7 @@ function registryOf(
       throw new Error('a deploy command reached the secret store');
     },
     repository: () => null,
-    supplyChain: () => new SupplyChainHarness(),
+    supplyChain: () => chain,
   };
 }
 
@@ -356,6 +358,136 @@ describe('createDeploy writes an intent, and only an intent', () => {
         message: `Build ${build.id} achieved verified Build Level 2, and ${target.name} currently requires L3`,
       },
     });
+  });
+
+  test('a signature that will not verify fails closed before any intent row is written', async () => {
+    const { component, target } = await fixture();
+    const build = await succeededBuild(component.id, 9);
+
+    const supplyChain = new SupplyChainHarness(undefined, async () => ({
+      ok: false,
+      reason: 'tampered bundle',
+    }));
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(registryOf(capableAdapter(), undefined, supplyChain)),
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      failure: {
+        code: 'NOT_DEPLOYABLE',
+        message: `Build ${build.id} signature did not verify: tampered bundle`,
+      },
+    });
+    expect(supplyChain.signatureChecks.admissions).toHaveLength(1);
+    expect(supplyChain.signatureChecks.admissions[0]?.artifactDigest).toBe(
+      build.artifactDigest!,
+    );
+
+    // Fail-closed: no desired row was created and no Deploy row was written.
+    expect(await desiredRow(component.id, target.id)).toBeUndefined();
+    expect(
+      await database()
+        .db.select()
+        .from(deploys)
+        .where(eq(deploys.buildId, build.id)),
+    ).toEqual([]);
+  });
+
+  test('admission re-verifies the recorded signature on every image deploy', async () => {
+    const { component, target } = await fixture();
+    const build = await succeededBuild(component.id, 10);
+
+    const supplyChain = new SupplyChainHarness();
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(registryOf(capableAdapter(), undefined, supplyChain)),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(supplyChain.signatureChecks.admissions).toHaveLength(1);
+    expect(supplyChain.signatureChecks.admissions[0]?.signature).toEqual(
+      build.signature!,
+    );
+  });
+
+  test('a files artifact skips signature admission', async () => {
+    const { component, target } = await fixture({
+      kind: 'website',
+      adapter: 'static',
+    });
+    const deployAdapter = new FakeDeployAdapter({
+      adapter: 'static',
+      artifactTypes: ['files'],
+    });
+    const supplyChain = new SupplyChainHarness();
+    const ctx = context(registryOf(deployAdapter, undefined, supplyChain));
+    const uploaded = await uploadArchive(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        bundleDigest: digest(11),
+        location: 'bundles/shop/site.zip',
+        contents: 'artifact',
+        subpath: '.',
+      },
+      ctx,
+    );
+    expect(uploaded.ok).toBe(true);
+    if (!uploaded.ok) return;
+
+    const placed = await createDeploy(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        buildId: uploaded.value.buildId,
+      },
+      ctx,
+    );
+    expect(placed.ok).toBe(true);
+    // A files artifact has no image signature, so admission never consulted the
+    // signature verifier.
+    expect(supplyChain.signatureChecks.admissions).toHaveLength(0);
+  });
+
+  test('Cloud Run image deploys share the same admission gate (§16)', async () => {
+    const { component } = await fixture({ adapter: 'cloudrun' });
+    const [cloudTarget] = await database()
+      .db.insert(targets)
+      .values(
+        targetValues({
+          name: `cloud-${crypto.randomUUID()}`,
+          adapter: 'cloudrun',
+          discovery: null,
+        }),
+      )
+      .returning();
+    const build = await succeededBuild(component.id, 12);
+
+    const refusing = new SupplyChainHarness(undefined, async () => ({
+      ok: false,
+      reason: 'cloud admission rejects',
+    }));
+    const deployAdapter = new FakeDeployAdapter({ adapter: 'cloudrun' });
+
+    const refused = await createDeploy(
+      {
+        componentId: component.id,
+        targetId: cloudTarget!.id,
+        buildId: build.id,
+      },
+      context(registryOf(deployAdapter, undefined, refusing)),
+    );
+
+    expect(refused).toEqual({
+      ok: false,
+      failure: {
+        code: 'NOT_DEPLOYABLE',
+        message: `Build ${build.id} signature did not verify: cloud admission rejects`,
+      },
+    });
+    expect(refusing.signatureChecks.admissions).toHaveLength(1);
   });
 });
 
@@ -924,5 +1056,94 @@ describe('§4: an uploaded artifact is recorded, never built', () => {
     expect(row?.status).toBe('SUCCEEDED');
     expect(row?.artifactDigest).toBe(digest(65));
     expect(row?.artifactRefs).toEqual(['bundles/shop-web/65.zip']);
+  });
+});
+
+describe('§16: verify → sign → record is fail-closed', () => {
+  test('a provenance refusal stores no artifact, signature, or success', async () => {
+    const { component } = await fixture();
+    const builder = new FakeBuildAdapter({
+      script: [{ result: { status: 'SUCCEEDED', digest: digest(70) } }],
+    });
+    // Provenance verification refuses — no signature is ever produced.
+    const supplyChain = new SupplyChainHarness(async () => ({
+      ok: false,
+      code: 'PROVENANCE_INVALID' as const,
+      message: 'tampered provenance',
+    }));
+    const registry = registryOf(capableAdapter(), builder, supplyChain);
+
+    const [build] = await database()
+      .db.insert(builds)
+      .values({
+        componentId: component.id,
+        commit: digest(70),
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: digest(70),
+        bundleLocation: 'bundles/70.zip',
+        status: 'PENDING',
+      })
+      .returning();
+
+    const result = await dispatchBuild(
+      { buildId: build!.id, route: builder.name },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('FAILED');
+
+    const [row] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, build!.id));
+    expect(row?.status).toBe('FAILED');
+    expect(row?.artifactDigest).toBeNull();
+    expect(row?.signature).toBeNull();
+    expect(row?.verifiedBuildLevel).toBeNull();
+    expect(supplyChain.signed).toHaveLength(0);
+  });
+
+  test('a signing failure stores no signature and no success', async () => {
+    const { component } = await fixture();
+    const builder = new FakeBuildAdapter({
+      script: [{ result: { status: 'SUCCEEDED', digest: digest(71) } }],
+    });
+    // Provenance verifies, but the signer throws. Core must not record a
+    // successful posture or a signature it never produced.
+    const supplyChain = new SupplyChainHarness();
+    supplyChain.signing.failure = new Error('KMS denied the signature');
+    const registry = registryOf(capableAdapter(), builder, supplyChain);
+
+    const [build] = await database()
+      .db.insert(builds)
+      .values({
+        componentId: component.id,
+        commit: digest(71),
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: digest(71),
+        bundleLocation: 'bundles/71.zip',
+        status: 'PENDING',
+      })
+      .returning();
+
+    const result = await dispatchBuild(
+      { buildId: build!.id, route: builder.name },
+      context(registry),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.status).toBe('FAILED');
+
+    const [row] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, build!.id));
+    expect(row?.status).toBe('FAILED');
+    expect(row?.signature).toBeNull();
+    expect(row?.artifactDigest).toBeNull();
   });
 });

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -95,6 +95,7 @@ const PROJECT_ID_ALLOWLIST = new Set<string>([
   'sign-blob',
   'slsa-verifier',
   'verify-image',
+  'verify-signature',
   // HTTP header names. `src/web/` is scoped out of this scanner for exactly
   // this reason (see BROWSER_SOURCE), but the auth surface writes headers from
   // outside that directory and must not be scoped out wholesale — it is one of

--- a/apps/spindrift/test/harness/fakes/supply-chain.ts
+++ b/apps/spindrift/test/harness/fakes/supply-chain.ts
@@ -10,6 +10,8 @@ import {
   type ArtifactSigner,
   CoreSupplyChain,
   type FinalizeArtifactInput,
+  type SignatureVerification,
+  type VerifySignatureInput,
 } from '../../../src/supply-chain/sign.ts';
 import type {
   ProvenanceVerification,
@@ -47,8 +49,10 @@ class RecordingVerifier implements ProvenanceVerifier {
 
 class RecordingSigner implements ArtifactSigner {
   readonly signed: Artifact[] = [];
+  failure: Error | null = null;
 
   async sign(artifact: Artifact) {
+    if (this.failure !== null) throw this.failure;
     this.signed.push(artifact);
     return {
       artifactDigest: artifact.digest,
@@ -60,19 +64,47 @@ class RecordingSigner implements ArtifactSigner {
   }
 }
 
+/**
+ * A signature verifier that records each admission check and answers what a
+ * test scripted. Accepts by default, so the common "admission proceeds" path
+ * needs no setup; a refusal is one scripted answer away.
+ */
+export class RecordingSignatureVerifier {
+  readonly admissions: VerifySignatureInput[] = [];
+  constructor(
+    private readonly answer?: (
+      input: VerifySignatureInput,
+    ) => SignatureVerification | Promise<SignatureVerification>,
+  ) {}
+
+  async verify(input: VerifySignatureInput): Promise<SignatureVerification> {
+    this.admissions.push(input);
+    if (this.answer) return this.answer(input);
+    return { ok: true, reason: null };
+  }
+}
+
 export class SupplyChainHarness extends CoreSupplyChain {
   readonly finalized: FinalizeArtifactInput[] = [];
   readonly signed: Artifact[];
+  readonly signatureChecks: RecordingSignatureVerifier;
+  readonly signing: RecordingSigner;
 
   constructor(
     answer?: (
       input: VerifyProvenanceInput,
     ) => ProvenanceVerification | Promise<ProvenanceVerification>,
+    signatureAnswer?: (
+      input: VerifySignatureInput,
+    ) => SignatureVerification | Promise<SignatureVerification>,
   ) {
     const verifier = new RecordingVerifier(answer);
     const signer = new RecordingSigner();
-    super(verifier, signer);
+    const signatureVerifier = new RecordingSignatureVerifier(signatureAnswer);
+    super(verifier, signer, signatureVerifier);
     this.signed = signer.signed;
+    this.signing = signer;
+    this.signatureChecks = signatureVerifier;
   }
 
   override async finalize(input: FinalizeArtifactInput) {

--- a/apps/spindrift/test/supply-chain/finalize.test.ts
+++ b/apps/spindrift/test/supply-chain/finalize.test.ts
@@ -6,7 +6,9 @@ import {
   type CoreSignature,
   CoreSupplyChain,
   CosignSigner,
+  type SignatureVerifier,
 } from '../../src/supply-chain/sign.ts';
+import { SpindriftSignatureVerifier } from '../../src/supply-chain/signature.ts';
 import type {
   BackendProvenanceAssessment,
   ProcessExecutor,
@@ -75,6 +77,13 @@ function input(minimumLevel: 1 | 2 | 3 = 2) {
   };
 }
 
+/** A signature verifier that accepts every recorded signature. */
+const acceptingVerifier: SignatureVerifier = {
+  async verify() {
+    return { ok: true, reason: null };
+  },
+};
+
 describe('core admission is verify → sign', () => {
   test('signs only after provenance verifies at the required level', async () => {
     const order: string[] = [];
@@ -91,9 +100,11 @@ describe('core admission is verify → sign', () => {
       },
     };
 
-    const result = await new CoreSupplyChain(verifier, signer).finalize(
-      input(),
-    );
+    const result = await new CoreSupplyChain(
+      verifier,
+      signer,
+      acceptingVerifier,
+    ).finalize(input());
 
     expect(result).toEqual({
       ok: true,
@@ -121,9 +132,11 @@ describe('core admission is verify → sign', () => {
       },
     };
 
-    const result = await new CoreSupplyChain(verifier, signer).finalize(
-      input(),
-    );
+    const result = await new CoreSupplyChain(
+      verifier,
+      signer,
+      acceptingVerifier,
+    ).finalize(input());
 
     expect(result).toEqual({
       ok: false,
@@ -147,9 +160,11 @@ describe('core admission is verify → sign', () => {
       },
     };
 
-    const result = await new CoreSupplyChain(verifier, signer).finalize(
-      input(3),
-    );
+    const result = await new CoreSupplyChain(
+      verifier,
+      signer,
+      acceptingVerifier,
+    ).finalize(input(3));
 
     expect(result).toEqual({
       ok: false,
@@ -172,9 +187,11 @@ describe('core admission is verify → sign', () => {
       },
     };
 
-    const result = await new CoreSupplyChain(verifier, signer).finalize(
-      input(),
-    );
+    const result = await new CoreSupplyChain(
+      verifier,
+      signer,
+      acceptingVerifier,
+    ).finalize(input());
 
     expect(result).toEqual({
       ok: false,
@@ -250,5 +267,144 @@ describe('the pinned process boundaries', () => {
     expect(commands[0]).toContain('--tlog-upload=false');
     expect(commands[0]?.at(-1)).toBe(ARTIFACT.refs[0]);
     expect(result).toEqual(SIGNATURE);
+  });
+});
+
+describe('admission re-verifies the recorded signature', () => {
+  const okVerifier: ProvenanceVerifier = {
+    async verify() {
+      return { ok: true, assessment: VERIFIED };
+    },
+  };
+  const okSigner: ArtifactSigner = {
+    async sign() {
+      return SIGNATURE;
+    },
+  };
+
+  test('an admitting verifier proceeds', async () => {
+    const checked = await new CoreSupplyChain(
+      okVerifier,
+      okSigner,
+      acceptingVerifier,
+    ).verifySignature({ artifactDigest: DIGEST, signature: SIGNATURE });
+
+    expect(checked).toEqual({ ok: true, reason: null });
+  });
+
+  test('a recorded signature covering a different digest refuses', async () => {
+    const checked = await new CoreSupplyChain(
+      okVerifier,
+      okSigner,
+      acceptingVerifier,
+    ).verifySignature({
+      artifactDigest: `sha256:${'c'.repeat(64)}`,
+      signature: SIGNATURE,
+    });
+
+    expect(checked.ok).toBe(false);
+    if (checked.ok) return;
+    expect(checked.reason).toContain('not the admitted artifact');
+  });
+
+  test('a verifier that refuses blocks admission fail-closed', async () => {
+    const refusing: SignatureVerifier = {
+      async verify() {
+        return {
+          ok: false,
+          reason: 'signature does not verify against the recorded digest',
+        };
+      },
+    };
+    const checked = await new CoreSupplyChain(
+      okVerifier,
+      okSigner,
+      refusing,
+    ).verifySignature({ artifactDigest: DIGEST, signature: SIGNATURE });
+
+    expect(checked).toEqual({
+      ok: false,
+      reason: 'signature does not verify against the recorded digest',
+    });
+  });
+});
+
+describe('the pinned verify-signature process boundary', () => {
+  const SIGNED_BUNDLE = {
+    mediaType: 'application/vnd.spindrift.signature.v1+json',
+    algorithm: 'ed25519',
+    publicKey: 'MCowBQYDK2VwAyEAfIbVW0Es9rCDaS7ZNZnYDvwEkxknflmNjZ2kfYdBhx8=',
+    artifactDigest: DIGEST,
+    signature:
+      'X0brov0uDq2EXscKpR12YKVVNPmuwEindNqE0blDITLQbGgcQbkBrEOR45qbTK4lZqdS1iZqfMZtZ8/zyKE8DA==',
+  };
+  const signed: CoreSignature = {
+    artifactDigest: DIGEST,
+    signer: 'fake://core',
+    format: 'cosign',
+    bundle: SIGNED_BUNDLE,
+    signedAt: '2024-06-01T00:00:01.000Z',
+  };
+
+  test('exit 0 admits; the binary is invoked with verify-signature', async () => {
+    const recorded: string[][] = [];
+    const processes: ProcessExecutor = {
+      async run(command) {
+        recorded.push([...command]);
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    };
+
+    const checked = await new SpindriftSignatureVerifier({
+      executable: '/usr/local/bin/spindrift-verifier',
+      processes,
+      signerKey: '/etc/spindrift/signer.pem',
+    }).verify({
+      artifactDigest: DIGEST,
+      signature: signed,
+    });
+
+    expect(checked).toEqual({ ok: true, reason: null });
+    expect(recorded[0]?.slice(0, 2)).toEqual([
+      '/usr/local/bin/spindrift-verifier',
+      'verify-signature',
+    ]);
+    expect(recorded[0]).toContain('--artifact-digest');
+    expect(recorded[0]?.at(recorded[0].indexOf('--artifact-digest') + 1)).toBe(
+      DIGEST,
+    );
+    expect(recorded[0]).toContain('--bundle-path');
+    // The signer key pins admission — verify-signature refuses any bundle
+    // whose embedded public key does not match the one derived from this.
+    expect(recorded[0]).toContain('--signer-key');
+    expect(recorded[0]?.at(recorded[0].indexOf('--signer-key') + 1)).toBe(
+      '/etc/spindrift/signer.pem',
+    );
+  });
+
+  test('non-zero exit refuses with stderr, never a silent admit', async () => {
+    const processes: ProcessExecutor = {
+      async run() {
+        return {
+          exitCode: 1,
+          stdout: '',
+          stderr: 'signature does not verify against the artifact digest',
+        };
+      },
+    };
+
+    const checked = await new SpindriftSignatureVerifier({
+      processes,
+      signerKey: '/etc/spindrift/signer.pem',
+    }).verify({
+      artifactDigest: DIGEST,
+      signature: signed,
+    });
+
+    expect(checked.ok).toBe(false);
+    if (checked.ok) return;
+    expect(checked.reason).toBe(
+      'signature does not verify against the artifact digest',
+    );
   });
 });


### PR DESCRIPTION
## Summary
Implement cryptographically real artifact admission verification and signing (§16) for Spindrift, replacing stubs with real Ed25519 bundle generation and verification while maintaining a far-sided pluggable `SignatureVerifier` seam.

## Changes
- **`spindrift-verifier` (Go)**:
  - Implement real Ed25519 signing in `Sign` producing a reviewable `SignatureBundle` (`application/vnd.spindrift.signature.v1+json`).
  - Implement `verify-signature` CLI command and `VerifySignature` function to independently re-verify bundles against target digests, pinned to Spindrift's trusted key.
  - Implement provenance authenticity check against `BuilderPublicKey` and subject digest binding check.
  - Loudly refuse un-wired KMS signer URIs instead of silently degrading.
- **`spindrift` (TypeScript)**:
  - Add `SpindriftSignatureVerifier` process boundary calling `spindrift-verifier verify-signature`.
  - Maintain a clean, pluggable `SignatureVerifier` seam contract (`verify({ artifactDigest, signature })`) with `signerKey` configured on the production verifier constructor.
  - Gate image deploys in `createDeploy` through `verifySignature` before intent rows are written (fail-closed).
  - Add test coverage across all signing, verification, and admission paths.

## Test Plan
- [x] Go vet & unit tests: `go vet ./...` and `go test ./...` pass in `apps/spindrift-verifier`.
- [x] TypeScript typecheck: `bun run typecheck` passes cleanly.
- [x] Full Bun test suite: 791 tests pass across 50 files in `apps/spindrift`.