### PR TITLE
feat(spindrift): run the reconciler process

### DIFF
--- a/apps/spindrift/Dockerfile
+++ b/apps/spindrift/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 #
-# One image (§19). Today it starts one process — `web`; `reconciler` is the
-# second entrypoint off this same image and arrives with the deploy loop.
+# One image, two process entrypoints (§19): `web` is the image default and the
+# installer selects `reconciler` with its own command.
 #
 # The client is built here and **served as files at runtime**, which is what
 # keeps the compile-time toolchain out of the running container. The server

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -50,7 +50,8 @@ Two named gaps, both deliberate:
 
 ## Shape
 
-One image, two processes (§19); only `web` exists so far.
+One image, two processes (§19): `web` serves the product surface and
+`reconciler` independently supervises the polling work.
 
 | Path | What it is |
 | --- | --- |
@@ -59,7 +60,7 @@ One image, two processes (§19); only `web` exists so far.
 | `src/commands/` | the application command layer and its registry |
 | `src/domain/` | backend-neutral product rules and value types |
 | `src/adapters/` | the adapter contracts, the three deploy backends, the three build routes, DNS records, and the two stores |
-| `src/reconciler/` | two loops — Target health and capabilities, and deploy convergence |
+| `src/reconciler/` | the reconciler process and its Target, repository, config, and Deploy loops |
 | `src/supply-chain/` | provenance verification, core signing, and derived posture |
 | `src/web/` | the `web` process — the server, the dispatch surface, and the client |
 | `src/web/ui/` | shadcn primitives, in this installation's palette |
@@ -620,6 +621,10 @@ SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml \
 # What the image runs: serves dist/, so `build` has to have happened.
 SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml \
   bun run --cwd apps/spindrift start
+
+# The second process in the same image.
+SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml \
+  bun run --cwd apps/spindrift src/reconciler/main.ts
 ```
 
 `mise run ts:check` typechecks and lints the whole workspace, this package

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -60,7 +60,7 @@ One image, two processes (§19): `web` serves the product surface and
 | `src/commands/` | the application command layer and its registry |
 | `src/domain/` | backend-neutral product rules and value types |
 | `src/adapters/` | the adapter contracts, the three deploy backends, the three build routes, DNS records, and the two stores |
-| `src/reconciler/` | the reconciler process and its Target, repository, config, and Deploy loops |
+| `src/reconciler/` | the independently supervised reconciliation process |
 | `src/supply-chain/` | provenance verification, core signing, and derived posture |
 | `src/web/` | the `web` process — the server, the dispatch surface, and the client |
 | `src/web/ui/` | shadcn primitives, in this installation's palette |

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -59,6 +59,8 @@ import { OnePasswordStore } from './store/onepassword.ts';
  */
 export const SERVICE_ACCOUNT_TOKEN_PATH =
   '/var/run/secrets/kubernetes.io/serviceaccount/token';
+/** Installer-declared path for the reconciler's audience-scoped token. */
+export const IDENTITY_TOKEN_PATH_VAR = 'SPINDRIFT_IDENTITY_TOKEN_PATH';
 
 /** Raised when something reaches for an adapter this installation cannot build. */
 export class AdapterUnavailableError extends Error {
@@ -79,6 +81,20 @@ export function projectedServiceAccountToken(
     }
     return (await file.text()).trim();
   };
+}
+
+/**
+ * The Kubernetes credential projected for this process.
+ *
+ * The installer uses an explicit audience and mount rather than automounting a
+ * default credential. Falling back keeps non-chart development environments
+ * compatible with Kubernetes' conventional service-account path.
+ */
+export function installationServiceAccountToken(
+  env: Record<string, string | undefined> = Bun.env,
+): TokenProvider {
+  const configured = env[IDENTITY_TOKEN_PATH_VAR]?.trim();
+  return projectedServiceAccountToken(configured || SERVICE_ACCOUNT_TOKEN_PATH);
 }
 
 /**
@@ -122,7 +138,8 @@ export function createAdapterRegistry(
 ): AdapterRegistry {
   const kubernetes = new KubernetesDeployAdapter({
     chart: options.manifest.charts.app,
-    token: options.token ?? projectedServiceAccountToken(),
+    token:
+      options.token ?? installationServiceAccountToken(options.env ?? Bun.env),
   });
 
   // §15's repository host, when this installation was given the App key. Built
@@ -324,7 +341,9 @@ function createBuildRoute(
         name: route.name,
         api: new KubernetesApi({
           apiServer: route.endpoint,
-          token: options.token ?? projectedServiceAccountToken(),
+          token:
+            options.token ??
+            installationServiceAccountToken(options.env ?? Bun.env),
           ...(options.fetch ? { fetch: options.fetch } : {}),
         }),
         namespace: route.namespace,

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -17,12 +17,13 @@
  * an attempt is in flight — a bounded window, not a standing watch — and slow
  * once converged, where the slow cadence *is* the drift detection §6 asks for.
  *
- * **Claiming is `FOR UPDATE SKIP LOCKED`, and the claim is a phase, not a lock.**
- * The lock is held only long enough to move a row `PENDING -> APPLYING`; it is not
- * held across the apply. Holding a database transaction open for the length of a
- * call to somebody else's control plane would put a rollout's duration inside a
- * lock, and a `reconciler` that died mid-apply would leave the row locked until
- * the connection timed out. A phase survives the process; a lock does not.
+ * **Claiming is `FOR UPDATE SKIP LOCKED`, and the claim is a leased phase.**
+ * The lock on the Component@Target desired-state row is held only long enough
+ * to move a Deploy to `APPLYING`; it is not held across the apply. Holding a
+ * database transaction open for the length of a call to somebody else's
+ * control plane would put a rollout's duration inside a lock. The phase and its
+ * timestamp survive the process, and an abandoned claim becomes eligible after
+ * the adapter convergence budget.
  *
  * **`LISTEN`/`NOTIFY` is an optimization and never the delivery path.** It is
  * free with the Postgres already required and it cuts intent-to-pickup latency
@@ -33,7 +34,8 @@
  * `test/reconciler/deploy-loop.test.ts` runs the whole convergence with
  * notifications disabled to keep that true.
  */
-import { asc, eq, inArray } from 'drizzle-orm';
+import { and, asc, eq, gt, inArray, lte, notExists, or } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 import type {
   DeployAdapter,
   DeployEvent,
@@ -47,6 +49,7 @@ import {
   apps,
   builds,
   components,
+  componentTargetDesired,
   type Deploy,
   deploys,
   targets,
@@ -81,6 +84,10 @@ export interface DeployLoopContext {
  * converged interval.
  */
 const UNSETTLED: readonly DeployPhase[] = ['PENDING', 'APPLYING', 'WAITING'];
+const IN_FLIGHT: readonly DeployPhase[] = ['APPLYING', 'WAITING'];
+
+/** A crashed worker's phase remains durable, then becomes safely reclaimable. */
+export const DEFAULT_CLAIM_TIMEOUT_MS = 15 * 60_000;
 
 /** How often to look, given what the Deploy is doing (§6, plan Transport). */
 export interface LoopIntervals {
@@ -136,36 +143,73 @@ export async function unsettledPhases(
 }
 
 /**
- * Take one `PENDING` Deploy and mark it `APPLYING`, or return `null`.
+ * Take one eligible Deploy and mark it `APPLYING`, or return `null`.
  *
- * `SKIP LOCKED` is what lets more than one `reconciler` run without either
- * waiting on the other or both picking up the same row: a contended row is
- * skipped rather than queued behind, so a second worker moves on to the next
- * intent instead of stalling on the first.
+ * `SKIP LOCKED` on the durable Component@Target row lets more than one
+ * `reconciler` run without either waiting on the other or picking a newer intent
+ * for the same workload. In-flight phases are leases: a recent one blocks the
+ * pair, while an old one is safe to retry through the idempotent adapter seam.
  */
 export async function claimNextDeploy(
   context: DeployLoopContext,
 ): Promise<Deploy | null> {
   const now = context.clock.now();
+  const staleBefore = new Date(now.getTime() - DEFAULT_CLAIM_TIMEOUT_MS);
   return context.db.transaction(async (tx) => {
+    const activeDeploys = alias(deploys, 'active_deploys');
     const [row] = await tx
-      .select()
+      .select({ deploy: deploys })
       .from(deploys)
-      .where(eq(deploys.phase, 'PENDING'))
+      .innerJoin(
+        componentTargetDesired,
+        and(
+          eq(componentTargetDesired.componentId, deploys.componentId),
+          eq(componentTargetDesired.targetId, deploys.targetId),
+        ),
+      )
+      .where(
+        and(
+          or(
+            eq(deploys.phase, 'PENDING'),
+            and(
+              inArray(deploys.phase, [...IN_FLIGHT]),
+              lte(deploys.updatedAt, staleBefore),
+            ),
+          ),
+          // A recent in-flight Deploy owns this Component@Target. Newer intents
+          // wait rather than racing it, and a stale phase can be retried.
+          notExists(
+            tx
+              .select({ id: activeDeploys.id })
+              .from(activeDeploys)
+              .where(
+                and(
+                  eq(activeDeploys.componentId, deploys.componentId),
+                  eq(activeDeploys.targetId, deploys.targetId),
+                  inArray(activeDeploys.phase, [...IN_FLIGHT]),
+                  gt(activeDeploys.updatedAt, staleBefore),
+                ),
+              ),
+          ),
+        ),
+      )
       // Oldest intent first: a queue that reordered itself would make two
       // deploys of one Component@Target land in an order nobody asked for.
       .orderBy(asc(deploys.id))
       .limit(1)
-      .for('update', { skipLocked: true });
+      // Lock the pair's durable desired row rather than only one Deploy row.
+      // Concurrent replicas then skip the whole pair, not merely its oldest
+      // intent and move on to a newer one for the same workload.
+      .for('update', { of: componentTargetDesired, skipLocked: true });
 
     if (row === undefined) return null;
 
     await tx
       .update(deploys)
       .set({ phase: 'APPLYING', updatedAt: now })
-      .where(eq(deploys.id, row.id));
+      .where(eq(deploys.id, row.deploy.id));
 
-    return { ...row, phase: 'APPLYING' as const };
+    return { ...row.deploy, phase: 'APPLYING' as const, updatedAt: now };
   });
 }
 

--- a/apps/spindrift/src/reconciler/main.ts
+++ b/apps/spindrift/src/reconciler/main.ts
@@ -1,0 +1,49 @@
+/**
+ * The `reconciler` process (§19) — production entrypoint.
+ *
+ * Postgres owns the installation manifest after bootstrap. The process reads
+ * that stored document, constructs exactly that installation's adapters, and
+ * gives all four polling loops one lifecycle without giving any loop the power
+ * to stop its siblings.
+ */
+import { createAdapterRegistry } from '../adapters/registry.ts';
+import { systemClock } from '../commands/types.ts';
+import { loadStoredManifest } from '../config/manifest-store.ts';
+import { createClient, createDb } from '../db/client.ts';
+import { type ReconcilerProcessEvent, runReconciler } from './process.ts';
+
+const shutdown = new AbortController();
+const stop = (): void => shutdown.abort();
+process.once('SIGINT', stop);
+process.once('SIGTERM', stop);
+
+const client = createClient();
+try {
+  const db = createDb(client);
+  const manifest = await loadStoredManifest(db);
+  const adapters = createAdapterRegistry({ manifest });
+
+  console.log(`spindrift reconciler → running (${manifest.installation})`);
+  await runReconciler(
+    { db, adapters, clock: systemClock, manifest },
+    { signal: shutdown.signal, onEvent: report },
+  );
+} finally {
+  shutdown.abort();
+  process.off('SIGINT', stop);
+  process.off('SIGTERM', stop);
+  await client.close();
+}
+
+function report(event: ReconcilerProcessEvent): void {
+  if (event.type === 'failure') {
+    console.error(
+      `spindrift reconciler → ${event.loop} loop failed; retrying in ${event.retryInMs}ms`,
+      event.cause,
+    );
+  } else if (event.type === 'disabled') {
+    console.log(
+      `spindrift reconciler → ${event.loop} loop disabled: ${event.reason}`,
+    );
+  }
+}

--- a/apps/spindrift/src/reconciler/main.ts
+++ b/apps/spindrift/src/reconciler/main.ts
@@ -6,33 +6,25 @@
  * gives all four polling loops one lifecycle without giving any loop the power
  * to stop its siblings.
  */
-import { createAdapterRegistry } from '../adapters/registry.ts';
-import { systemClock } from '../commands/types.ts';
-import { loadStoredManifest } from '../config/manifest-store.ts';
-import { createClient, createDb } from '../db/client.ts';
-import { type ReconcilerProcessEvent, runReconciler } from './process.ts';
+import type { ReconcilerProcessEvent } from './process.ts';
+import { startReconciler } from './start.ts';
 
 const shutdown = new AbortController();
 const stop = (): void => shutdown.abort();
 process.once('SIGINT', stop);
 process.once('SIGTERM', stop);
 
-const client = createClient();
 try {
-  const db = createDb(client);
-  const manifest = await loadStoredManifest(db);
-  const adapters = createAdapterRegistry({ manifest });
-
-  console.log(`spindrift reconciler → running (${manifest.installation})`);
-  await runReconciler(
-    { db, adapters, clock: systemClock, manifest },
-    { signal: shutdown.signal, onEvent: report },
-  );
+  await startReconciler({
+    signal: shutdown.signal,
+    onStarted: (manifest) =>
+      console.log(`spindrift reconciler → running (${manifest.installation})`),
+    onEvent: report,
+  });
 } finally {
   shutdown.abort();
   process.off('SIGINT', stop);
   process.off('SIGTERM', stop);
-  await client.close();
 }
 
 function report(event: ReconcilerProcessEvent): void {

--- a/apps/spindrift/src/reconciler/process.ts
+++ b/apps/spindrift/src/reconciler/process.ts
@@ -1,0 +1,236 @@
+/**
+ * The reconciler process (§19).
+ *
+ * Individual loops own one kind of reconciliation. This module owns their
+ * shared lifecycle: start them together, isolate failures, retry a failed loop
+ * with bounded backoff, and stop every loop from one signal.
+ */
+import type { AdapterRegistry, Clock } from '../commands/types.ts';
+import type { InstallationManifest } from '../config/manifest.schema.ts';
+import type { Database } from '../db/client.ts';
+import { DEFAULT_REAP_INTERVAL_MS, runConfigLoop } from './config-loop.ts';
+import {
+  DEFAULT_INTERVALS,
+  type LoopIntervals,
+  runDeployLoop,
+} from './deploy-loop.ts';
+import { runRepoLoop } from './repo-loop.ts';
+import { runTargetLoop } from './target-loop.ts';
+
+export type ReconcilerLoopName = 'target' | 'repository' | 'config' | 'deploy';
+
+/** One independently supervised process loop. */
+export interface SupervisedLoop {
+  readonly name: ReconcilerLoopName;
+  run(signal: AbortSignal): Promise<void>;
+}
+
+/** Bounded exponential retry after a loop-level failure. */
+export interface RetryBackoff {
+  readonly initialMs: number;
+  readonly maximumMs: number;
+  readonly multiplier: number;
+}
+
+export const DEFAULT_RETRY_BACKOFF: RetryBackoff = {
+  initialMs: 1_000,
+  maximumMs: 60_000,
+  multiplier: 2,
+};
+
+export interface LoopFailure {
+  readonly loop: ReconcilerLoopName;
+  readonly cause: unknown;
+  readonly retryInMs: number;
+}
+
+export interface SupervisorOptions {
+  readonly signal: AbortSignal;
+  readonly retry?: RetryBackoff;
+  readonly onFailure?: (failure: LoopFailure) => void;
+}
+
+/** Everything the long-running process needs after production bootstraps it. */
+export interface ReconcilerContext {
+  readonly db: Database;
+  readonly adapters: AdapterRegistry;
+  readonly clock: Clock;
+  readonly manifest: InstallationManifest;
+}
+
+export interface ReconcilerIntervals {
+  readonly targetMs?: number;
+  readonly repositoryMs?: number;
+  readonly configMs?: number;
+  readonly deploy?: Partial<LoopIntervals>;
+}
+
+export const DEFAULT_TARGET_INTERVAL_MS = 5 * 60_000;
+export const DEFAULT_REPOSITORY_INTERVAL_MS = 5 * 60_000;
+
+/** Observable process events for production logging and lifecycle tests. */
+export type ReconcilerProcessEvent =
+  | {
+      readonly type: 'pass';
+      readonly loop: ReconcilerLoopName;
+    }
+  | {
+      readonly type: 'disabled';
+      readonly loop: 'repository';
+      readonly reason: string;
+    }
+  | ({ readonly type: 'failure' } & LoopFailure);
+
+export interface ReconcilerOptions {
+  readonly signal: AbortSignal;
+  readonly intervals?: ReconcilerIntervals;
+  readonly retry?: RetryBackoff;
+  readonly onEvent?: (event: ReconcilerProcessEvent) => void;
+}
+
+/**
+ * Supervise every loop until shutdown.
+ *
+ * Each loop gets its own retry chain. `Promise.all` is safe here because those
+ * chains absorb and report their own failures; one failed loop therefore
+ * cannot reject the aggregate and silently stop its siblings.
+ */
+export async function superviseLoops(
+  loops: readonly SupervisedLoop[],
+  options: SupervisorOptions,
+): Promise<void> {
+  if (options.signal.aborted) return;
+  await Promise.all(loops.map((loop) => superviseLoop(loop, options)));
+}
+
+/**
+ * Compose and run this installation's reconciliation loops.
+ *
+ * Repository reconciliation is the only optional loop: uploaded archives need
+ * no repository integration. Target refresh, config retention, and Deploy
+ * convergence are standing responsibilities of every installation.
+ */
+export async function runReconciler(
+  context: ReconcilerContext,
+  options: ReconcilerOptions,
+): Promise<void> {
+  if (options.signal.aborted) return;
+
+  const store = context.adapters.store(context.manifest.secretStore.adapter);
+  if (store === null) {
+    throw new Error(
+      `the installation has no ${context.manifest.secretStore.adapter} store adapter for config retention`,
+    );
+  }
+
+  const targetInterval =
+    options.intervals?.targetMs ?? DEFAULT_TARGET_INTERVAL_MS;
+  const repositoryInterval =
+    options.intervals?.repositoryMs ?? DEFAULT_REPOSITORY_INTERVAL_MS;
+  const configInterval =
+    options.intervals?.configMs ?? DEFAULT_REAP_INTERVAL_MS;
+  const deployIntervals: LoopIntervals = {
+    ...DEFAULT_INTERVALS,
+    ...options.intervals?.deploy,
+  };
+  const passed = (loop: ReconcilerLoopName): void =>
+    options.onEvent?.({ type: 'pass', loop });
+
+  const loops: SupervisedLoop[] = [
+    {
+      name: 'target',
+      run: (signal) =>
+        runTargetLoop(context, {
+          intervalMs: targetInterval,
+          signal,
+          onPass: () => passed('target'),
+        }),
+    },
+    {
+      name: 'config',
+      run: (signal) =>
+        runConfigLoop(
+          { db: context.db, store },
+          {
+            intervalMs: configInterval,
+            signal,
+            onPass: () => passed('config'),
+          },
+        ),
+    },
+    {
+      name: 'deploy',
+      run: (signal) =>
+        runDeployLoop(context, {
+          intervals: deployIntervals,
+          signal,
+          onPass: () => passed('deploy'),
+        }),
+    },
+  ];
+
+  const repository = context.adapters.repository();
+  if (repository === null) {
+    options.onEvent?.({
+      type: 'disabled',
+      loop: 'repository',
+      reason: 'this installation has no repository integration',
+    });
+  } else {
+    loops.push({
+      name: 'repository',
+      run: (signal) =>
+        runRepoLoop(
+          { db: context.db, clock: context.clock, host: repository },
+          {
+            intervalMs: repositoryInterval,
+            signal,
+            onPass: () => passed('repository'),
+          },
+        ),
+    });
+  }
+
+  await superviseLoops(loops, {
+    signal: options.signal,
+    ...(options.retry ? { retry: options.retry } : {}),
+    onFailure: (failure) => options.onEvent?.({ type: 'failure', ...failure }),
+  });
+}
+
+async function superviseLoop(
+  loop: SupervisedLoop,
+  options: SupervisorOptions,
+): Promise<void> {
+  const retry = options.retry ?? DEFAULT_RETRY_BACKOFF;
+  let retryInMs = retry.initialMs;
+
+  while (!options.signal.aborted) {
+    try {
+      await loop.run(options.signal);
+      if (options.signal.aborted) return;
+      throw new Error(`${loop.name} loop stopped before process shutdown`);
+    } catch (cause) {
+      if (options.signal.aborted) return;
+      options.onFailure?.({ loop: loop.name, cause, retryInMs });
+      await abortableSleep(retryInMs, options.signal);
+      retryInMs = Math.min(
+        retry.maximumMs,
+        Math.max(retry.initialMs, retryInMs * retry.multiplier),
+      );
+    }
+  }
+}
+
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    signal.addEventListener('abort', done, { once: true });
+  });
+}

--- a/apps/spindrift/src/reconciler/process.ts
+++ b/apps/spindrift/src/reconciler/process.ts
@@ -9,18 +9,14 @@ import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
 import { DEFAULT_REAP_INTERVAL_MS, runConfigLoop } from './config-loop.ts';
-import {
-  DEFAULT_INTERVALS,
-  type LoopIntervals,
-  runDeployLoop,
-} from './deploy-loop.ts';
+import { DEFAULT_INTERVALS, runDeployLoop } from './deploy-loop.ts';
 import { runRepoLoop } from './repo-loop.ts';
 import { runTargetLoop } from './target-loop.ts';
 
 export type ReconcilerLoopName = 'target' | 'repository' | 'config' | 'deploy';
 
 /** One independently supervised process loop. */
-export interface SupervisedLoop {
+interface SupervisedLoop {
   readonly name: ReconcilerLoopName;
   run(signal: AbortSignal): Promise<void>;
 }
@@ -32,19 +28,19 @@ export interface RetryBackoff {
   readonly multiplier: number;
 }
 
-export const DEFAULT_RETRY_BACKOFF: RetryBackoff = {
+const DEFAULT_RETRY_BACKOFF: RetryBackoff = {
   initialMs: 1_000,
   maximumMs: 60_000,
   multiplier: 2,
 };
 
-export interface LoopFailure {
+interface LoopFailure {
   readonly loop: ReconcilerLoopName;
   readonly cause: unknown;
   readonly retryInMs: number;
 }
 
-export interface SupervisorOptions {
+interface SupervisorOptions {
   readonly signal: AbortSignal;
   readonly retry?: RetryBackoff;
   readonly onFailure?: (failure: LoopFailure) => void;
@@ -58,15 +54,8 @@ export interface ReconcilerContext {
   readonly manifest: InstallationManifest;
 }
 
-export interface ReconcilerIntervals {
-  readonly targetMs?: number;
-  readonly repositoryMs?: number;
-  readonly configMs?: number;
-  readonly deploy?: Partial<LoopIntervals>;
-}
-
-export const DEFAULT_TARGET_INTERVAL_MS = 5 * 60_000;
-export const DEFAULT_REPOSITORY_INTERVAL_MS = 5 * 60_000;
+const DEFAULT_TARGET_INTERVAL_MS = 5 * 60_000;
+const DEFAULT_REPOSITORY_INTERVAL_MS = 5 * 60_000;
 
 /** Observable process events for production logging and lifecycle tests. */
 export type ReconcilerProcessEvent =
@@ -83,7 +72,6 @@ export type ReconcilerProcessEvent =
 
 export interface ReconcilerOptions {
   readonly signal: AbortSignal;
-  readonly intervals?: ReconcilerIntervals;
   readonly retry?: RetryBackoff;
   readonly onEvent?: (event: ReconcilerProcessEvent) => void;
 }
@@ -95,7 +83,7 @@ export interface ReconcilerOptions {
  * chains absorb and report their own failures; one failed loop therefore
  * cannot reject the aggregate and silently stop its siblings.
  */
-export async function superviseLoops(
+async function superviseLoops(
   loops: readonly SupervisedLoop[],
   options: SupervisorOptions,
 ): Promise<void> {
@@ -123,16 +111,6 @@ export async function runReconciler(
     );
   }
 
-  const targetInterval =
-    options.intervals?.targetMs ?? DEFAULT_TARGET_INTERVAL_MS;
-  const repositoryInterval =
-    options.intervals?.repositoryMs ?? DEFAULT_REPOSITORY_INTERVAL_MS;
-  const configInterval =
-    options.intervals?.configMs ?? DEFAULT_REAP_INTERVAL_MS;
-  const deployIntervals: LoopIntervals = {
-    ...DEFAULT_INTERVALS,
-    ...options.intervals?.deploy,
-  };
   const passed = (loop: ReconcilerLoopName): void =>
     options.onEvent?.({ type: 'pass', loop });
 
@@ -141,7 +119,7 @@ export async function runReconciler(
       name: 'target',
       run: (signal) =>
         runTargetLoop(context, {
-          intervalMs: targetInterval,
+          intervalMs: DEFAULT_TARGET_INTERVAL_MS,
           signal,
           onPass: () => passed('target'),
         }),
@@ -152,7 +130,7 @@ export async function runReconciler(
         runConfigLoop(
           { db: context.db, store },
           {
-            intervalMs: configInterval,
+            intervalMs: DEFAULT_REAP_INTERVAL_MS,
             signal,
             onPass: () => passed('config'),
           },
@@ -162,7 +140,7 @@ export async function runReconciler(
       name: 'deploy',
       run: (signal) =>
         runDeployLoop(context, {
-          intervals: deployIntervals,
+          intervals: DEFAULT_INTERVALS,
           signal,
           onPass: () => passed('deploy'),
         }),
@@ -183,7 +161,7 @@ export async function runReconciler(
         runRepoLoop(
           { db: context.db, clock: context.clock, host: repository },
           {
-            intervalMs: repositoryInterval,
+            intervalMs: DEFAULT_REPOSITORY_INTERVAL_MS,
             signal,
             onPass: () => passed('repository'),
           },

--- a/apps/spindrift/src/reconciler/start.ts
+++ b/apps/spindrift/src/reconciler/start.ts
@@ -1,0 +1,66 @@
+/**
+ * Production bootstrap for the reconciler process.
+ *
+ * Kept out of `main.ts` so startup can be integration-tested without importing
+ * a module that installs process signal handlers as a side effect.
+ */
+import type { SQL } from 'bun';
+import { createAdapterRegistry } from '../adapters/registry.ts';
+import type { AdapterRegistry, Clock } from '../commands/types.ts';
+import { systemClock } from '../commands/types.ts';
+import type { InstallationManifest } from '../config/manifest.schema.ts';
+import { loadStoredManifest } from '../config/manifest-store.ts';
+import { createClient, createDb } from '../db/client.ts';
+import { type ReconcilerProcessEvent, runReconciler } from './process.ts';
+
+type Env = Record<string, string | undefined>;
+
+export interface StartReconcilerOptions {
+  readonly signal: AbortSignal;
+  readonly env?: Env;
+  /**
+   * A caller-supplied client is already owned by that caller. Production omits
+   * it and this function closes the client it creates during shutdown.
+   */
+  readonly client?: SQL;
+  readonly clock?: Clock;
+  /** Far-side seam for integration tests; production constructs the registry. */
+  readonly createAdapters?: (manifest: InstallationManifest) => AdapterRegistry;
+  readonly onStarted?: (manifest: InstallationManifest) => void;
+  readonly onEvent?: (event: ReconcilerProcessEvent) => void;
+}
+
+/**
+ * Load durable installation state, construct adapters, and run until shutdown.
+ */
+export async function startReconciler(
+  options: StartReconcilerOptions,
+): Promise<void> {
+  const env = options.env ?? Bun.env;
+  const ownedClient = options.client === undefined;
+  const client = options.client ?? createClient(env);
+
+  try {
+    const db = createDb(client);
+    const manifest = await loadStoredManifest(db, env);
+    const adapters =
+      options.createAdapters?.(manifest) ??
+      createAdapterRegistry({ manifest, env });
+    options.onStarted?.(manifest);
+
+    await runReconciler(
+      {
+        db,
+        adapters,
+        clock: options.clock ?? systemClock,
+        manifest,
+      },
+      {
+        signal: options.signal,
+        ...(options.onEvent ? { onEvent: options.onEvent } : {}),
+      },
+    );
+  } finally {
+    if (ownedClient) await client.close();
+  }
+}

--- a/apps/spindrift/src/web/server.ts
+++ b/apps/spindrift/src/web/server.ts
@@ -6,8 +6,6 @@
  * keeps `tailwindcss`, `bun-plugin-tailwind`, and the rest of the compile-time
  * toolchain out of the runtime: an HTML import anywhere in this module's graph
  * would pull them back in whether or not a request ever reached one.
- *
- * `reconciler`, the second Deployment off the same image, does not exist yet.
  */
 import { join } from 'node:path';
 import { bundleRoutes } from './bundle.ts';

--- a/apps/spindrift/test/adapters/registry.test.ts
+++ b/apps/spindrift/test/adapters/registry.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Production adapter wiring that is not an adapter behavior of its own.
+ *
+ * The installer deliberately projects a token outside Kubernetes' default
+ * service-account path. The registry must follow that declared path while still
+ * reading the rotating file at request time.
+ */
+import { expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  IDENTITY_TOKEN_PATH_VAR,
+  installationServiceAccountToken,
+} from '../../src/adapters/registry.ts';
+
+test('the installation token provider follows the projected path', async () => {
+  const path = join('/tmp', `spindrift-identity-token-${crypto.randomUUID()}`);
+  await Bun.write(path, 'first-token\n');
+
+  try {
+    const token = installationServiceAccountToken({
+      [IDENTITY_TOKEN_PATH_VAR]: path,
+    });
+    expect(await token()).toBe('first-token');
+
+    await Bun.write(path, 'rotated-token\n');
+    expect(await token()).toBe('rotated-token');
+  } finally {
+    await Bun.file(path).delete();
+  }
+});

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -172,7 +172,7 @@ describe('claiming (§6, SKIP LOCKED)', () => {
     expect(claimed?.id).not.toBe(later!.id);
   });
 
-  test('overlapping passes cannot claim two intents for one Component@Target', async () => {
+  test('a contended pair is skipped and its newer intent waits behind the claim', async () => {
     const first = await pendingDeploy();
     const [later] = await database()
       .db.insert(deploys)
@@ -190,13 +190,22 @@ describe('claiming (§6, SKIP LOCKED)', () => {
 
     const adapter = new FakeDeployAdapter();
     const otherDb = createDb(database().connect());
-    const claims = await Promise.all([
-      claimNextDeploy(context(adapter)),
-      claimNextDeploy(context(adapter, { db: otherDb })),
-    ]);
+    let contendedClaim: Awaited<ReturnType<typeof claimNextDeploy>> = null;
+    await database().db.transaction(async (tx) => {
+      // Hold the same durable pair row that a replica's claim transaction
+      // locks. The other replica must skip the pair, including its newer
+      // Deploy, rather than depending on scheduler timing to overlap.
+      await tx
+        .select({ componentId: componentTargetDesired.componentId })
+        .from(componentTargetDesired)
+        .where(eq(componentTargetDesired.componentId, first.component.id))
+        .for('update');
+      contendedClaim = await claimNextDeploy(context(adapter, { db: otherDb }));
+    });
 
-    expect(claims.filter((claim) => claim !== null)).toHaveLength(1);
-    expect(claims.find((claim) => claim !== null)?.id).toBe(first.deploy.id);
+    expect(contendedClaim).toBeNull();
+    expect((await claimNextDeploy(context(adapter)))?.id).toBe(first.deploy.id);
+    expect(await claimNextDeploy(context(adapter, { db: otherDb }))).toBeNull();
     expect(await deployRow(later!.id)).toMatchObject({ phase: 'PENDING' });
   });
 

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -23,16 +23,19 @@ import {
   FAILURE_REASONS,
 } from '../../src/adapters/deploy/contract.ts';
 import type { AdapterRegistry, Clock } from '../../src/commands/types.ts';
+import { createDb } from '../../src/db/client.ts';
 import {
   apps,
   attemptEvents,
   builds,
   components,
+  componentTargetDesired,
   deploys,
   targets,
 } from '../../src/db/schema.ts';
 import {
   claimNextDeploy,
+  DEFAULT_CLAIM_TIMEOUT_MS,
   DEFAULT_INTERVALS,
   type DeployLoopContext,
   intervalFor,
@@ -53,11 +56,14 @@ const FROZEN = new Date('2024-06-01T00:00:00.000Z');
 const clock: Clock = { now: () => FROZEN };
 const DIGEST = `sha256:${'a'.repeat(64)}`;
 
-function context(adapter: FakeDeployAdapter): DeployLoopContext {
+function context(
+  adapter: FakeDeployAdapter,
+  overrides: Partial<DeployLoopContext> = {},
+): DeployLoopContext {
   const adapters: Pick<AdapterRegistry, 'deploy'> = {
     deploy: (name) => (name === adapter.adapter ? adapter : null),
   };
-  return { db: database().db, adapters, clock, manifest };
+  return { db: database().db, adapters, clock, manifest, ...overrides };
 }
 
 /** An App, Component, Target, Build, and one PENDING Deploy intent. */
@@ -109,6 +115,12 @@ async function pendingDeploy(
       exposure: options.exposure ?? 'private',
     })
     .returning();
+  await db.insert(componentTargetDesired).values({
+    componentId: component!.id,
+    targetId: target!.id,
+    desiredBuildId: build!.id,
+    desiredDeployId: deploy!.id,
+  });
 
   return {
     app: app!,
@@ -158,6 +170,50 @@ describe('claiming (§6, SKIP LOCKED)', () => {
     const claimed = await claimNextDeploy(context(adapter));
     expect(claimed?.id).toBe(first.deploy.id);
     expect(claimed?.id).not.toBe(later!.id);
+  });
+
+  test('overlapping passes cannot claim two intents for one Component@Target', async () => {
+    const first = await pendingDeploy();
+    const [later] = await database()
+      .db.insert(deploys)
+      .values({
+        componentId: first.component.id,
+        targetId: first.target.id,
+        buildId: first.build.id,
+        phase: 'PENDING',
+      })
+      .returning();
+    await database()
+      .db.update(componentTargetDesired)
+      .set({ desiredDeployId: later!.id })
+      .where(eq(componentTargetDesired.componentId, first.component.id));
+
+    const adapter = new FakeDeployAdapter();
+    const otherDb = createDb(database().connect());
+    const claims = await Promise.all([
+      claimNextDeploy(context(adapter)),
+      claimNextDeploy(context(adapter, { db: otherDb })),
+    ]);
+
+    expect(claims.filter((claim) => claim !== null)).toHaveLength(1);
+    expect(claims.find((claim) => claim !== null)?.id).toBe(first.deploy.id);
+    expect(await deployRow(later!.id)).toMatchObject({ phase: 'PENDING' });
+  });
+
+  test('an abandoned in-flight phase becomes claimable after its timeout', async () => {
+    const { deploy } = await pendingDeploy();
+    await database()
+      .db.update(deploys)
+      .set({
+        phase: 'WAITING',
+        updatedAt: new Date(FROZEN.getTime() - DEFAULT_CLAIM_TIMEOUT_MS - 1),
+      })
+      .where(eq(deploys.id, deploy.id));
+
+    const claimed = await claimNextDeploy(context(new FakeDeployAdapter()));
+
+    expect(claimed?.id).toBe(deploy.id);
+    expect(claimed?.phase).toBe('APPLYING');
   });
 });
 

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -1,0 +1,351 @@
+/**
+ * The reconciler process (§19, ticket 06).
+ *
+ * This is the lifecycle seam above the four individual loop suites. It proves
+ * that a systemic failure escaping one loop is retried without taking its
+ * siblings down, and that one shutdown signal releases every supervisor.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { createAdapterRegistry } from '../../src/adapters/registry.ts';
+import {
+  type AdapterRegistry,
+  type Clock,
+  systemClock,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import type { RepositoryHost } from '../../src/domain/repository.ts';
+import {
+  type ReconcilerProcessEvent,
+  runReconciler,
+  type SupervisedLoop,
+  superviseLoops,
+} from '../../src/reconciler/process.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+const DIGEST = `sha256:${'a'.repeat(64)}`;
+
+describe('reconciler process lifecycle', () => {
+  test('one failed loop retries without stopping its siblings', async () => {
+    const shutdown = new AbortController();
+    const failures: string[] = [];
+    let healthyStarts = 0;
+    let flakyStarts = 0;
+
+    const loops: readonly SupervisedLoop[] = [
+      {
+        name: 'target',
+        async run(signal) {
+          healthyStarts += 1;
+          await aborted(signal);
+        },
+      },
+      {
+        name: 'deploy',
+        async run(signal) {
+          flakyStarts += 1;
+          if (flakyStarts === 1) throw new Error('database disconnected');
+          shutdown.abort();
+          await aborted(signal);
+        },
+      },
+    ];
+
+    await superviseLoops(loops, {
+      signal: shutdown.signal,
+      retry: { initialMs: 0, maximumMs: 0, multiplier: 2 },
+      onFailure: ({ loop, cause }) => {
+        failures.push(`${loop}: ${String(cause)}`);
+      },
+    });
+
+    expect(healthyStarts).toBe(1);
+    expect(flakyStarts).toBe(2);
+    expect(failures).toEqual(['deploy: Error: database disconnected']);
+  });
+
+  test('an already-aborted process starts no loops', async () => {
+    let starts = 0;
+    await superviseLoops(
+      [
+        {
+          name: 'config',
+          async run() {
+            starts += 1;
+          },
+        },
+      ],
+      { signal: AbortSignal.abort() },
+    );
+    expect(starts).toBe(0);
+  });
+});
+
+describe('reconciler loop composition', () => {
+  test('starts every configured polling loop and reports an absent repository integration', async () => {
+    const adapters = createAdapterRegistry({
+      manifest,
+      env: {},
+      token: async () => 'cluster-token',
+      storeToken: () => 'store-token',
+      buildToken: () => 'build-token',
+      cloudToken: async () => 'cloud-token',
+    });
+    const shutdown = new AbortController();
+    const events: ReconcilerProcessEvent[] = [];
+
+    await runReconciler(
+      {
+        db: database().db,
+        adapters,
+        clock: systemClock,
+        manifest,
+      },
+      {
+        signal: shutdown.signal,
+        onEvent(event) {
+          events.push(event);
+          const passed = new Set(
+            events
+              .filter((candidate) => candidate.type === 'pass')
+              .map((candidate) => candidate.loop),
+          );
+          if (
+            passed.has('target') &&
+            passed.has('config') &&
+            passed.has('deploy') &&
+            events.some((candidate) => candidate.type === 'disabled')
+          ) {
+            shutdown.abort();
+          }
+        },
+      },
+    );
+
+    expect(
+      events
+        .filter((event) => event.type === 'pass')
+        .map((event) => event.loop)
+        .sort(),
+    ).toEqual(['config', 'deploy', 'target']);
+    expect(events.find((event) => event.type === 'disabled')).toEqual({
+      type: 'disabled',
+      loop: 'repository',
+      reason: 'this installation has no repository integration',
+    });
+  });
+
+  test('starts repository polling when the installation has that integration', async () => {
+    const configured = adaptersFor(new FakeDeployAdapter());
+    const adapters: AdapterRegistry = {
+      ...configured,
+      repository: () => unusedRepositoryHost(),
+    };
+    const shutdown = new AbortController();
+    const passed = new Set<string>();
+
+    await runReconciler(
+      { db: database().db, adapters, clock, manifest },
+      {
+        signal: shutdown.signal,
+        onEvent(event) {
+          if (event.type === 'pass') passed.add(event.loop);
+          if (
+            passed.has('target') &&
+            passed.has('repository') &&
+            passed.has('config') &&
+            passed.has('deploy')
+          ) {
+            shutdown.abort();
+          }
+        },
+      },
+    );
+
+    expect([...passed].sort()).toEqual([
+      'config',
+      'deploy',
+      'repository',
+      'target',
+    ]);
+  });
+});
+
+describe('Deploy convergence through process startup', () => {
+  test('polling takes a pending Deploy to the platform’s successful verdict', async () => {
+    const deploy = await pendingDeploy();
+    const platform = new FakeDeployAdapter();
+    const shutdown = new AbortController();
+
+    await runReconciler(
+      {
+        db: database().db,
+        adapters: adaptersFor(platform),
+        clock,
+        manifest,
+      },
+      {
+        signal: shutdown.signal,
+        onEvent(event) {
+          if (event.type === 'pass' && event.loop === 'deploy') {
+            shutdown.abort();
+          }
+        },
+      },
+    );
+
+    const [stored] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, deploy.id));
+    expect(stored?.phase).toBe('LIVE');
+    expect(stored?.ref).toBe('fake-deploy-1');
+    expect(platform.applied).toHaveLength(1);
+  });
+
+  test('polling persists the platform’s failed verdict', async () => {
+    const deploy = await pendingDeploy();
+    const platform = new FakeDeployAdapter({
+      script: [
+        {
+          verdict: {
+            phase: 'FAILED',
+            reason: 'STARTUP_FAILED',
+            detail: 'container exited before readiness',
+          },
+        },
+      ],
+    });
+    const shutdown = new AbortController();
+
+    await runReconciler(
+      {
+        db: database().db,
+        adapters: adaptersFor(platform),
+        clock,
+        manifest,
+      },
+      {
+        signal: shutdown.signal,
+        onEvent(event) {
+          if (event.type === 'pass' && event.loop === 'deploy') {
+            shutdown.abort();
+          }
+        },
+      },
+    );
+
+    const [stored] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, deploy.id));
+    expect(stored?.phase).toBe('FAILED');
+    expect(stored?.reason).toBe('STARTUP_FAILED');
+    expect(stored?.detail).toBe('container exited before readiness');
+    expect(stored?.blame).toBe('developer');
+    expect(platform.applied).toHaveLength(1);
+  });
+});
+
+function adaptersFor(platform: FakeDeployAdapter): AdapterRegistry {
+  const configured = createAdapterRegistry({
+    manifest,
+    env: {},
+    token: async () => 'cluster-token',
+    storeToken: () => 'store-token',
+    buildToken: () => 'build-token',
+    cloudToken: async () => 'cloud-token',
+  });
+  return {
+    ...configured,
+    deploy: (adapter) =>
+      adapter === platform.adapter ? platform : configured.deploy(adapter),
+  };
+}
+
+/** An App, Component, Target, Build, and one PENDING Deploy intent. */
+async function pendingDeploy() {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: `app-${crypto.randomUUID()}`, sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({
+      appId: app!.id,
+      name: 'web',
+      kind: 'service',
+      expose: true,
+      exposure: 'private',
+    })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: `cluster-${crypto.randomUUID()}`,
+        adapter: 'kubernetes',
+      }),
+    )
+    .returning();
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'abcdef0',
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: DIGEST,
+      status: 'SUCCEEDED',
+    })
+    .returning();
+  const [deploy] = await db
+    .insert(deploys)
+    .values({
+      componentId: component!.id,
+      targetId: target!.id,
+      buildId: build!.id,
+      phase: 'PENDING',
+      exposure: 'private',
+    })
+    .returning();
+  return deploy!;
+}
+
+/** No repository rows exist in this lifecycle test, so no call lands here. */
+function unusedRepositoryHost(): RepositoryHost {
+  const unused = async (): Promise<never> => {
+    throw new Error('an empty repository loop reached its far side');
+  };
+  return {
+    repository: unused,
+    branchHead: unused,
+    readFile: unused,
+    commitTree: unused,
+    createBlob: unused,
+    createTree: unused,
+    createCommit: unused,
+    setBranch: unused,
+    openPullRequest: unused,
+  };
+}
+
+function aborted(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) =>
+    signal.addEventListener('abort', () => resolve(), { once: true }),
+  );
+}

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -13,10 +13,12 @@ import {
   type Clock,
   systemClock,
 } from '../../src/commands/types.ts';
+import { MANIFEST_INLINE_VAR } from '../../src/config/manifest.ts';
 import {
   apps,
   builds,
   components,
+  componentTargetDesired,
   deploys,
   targets,
 } from '../../src/db/schema.ts';
@@ -24,9 +26,8 @@ import type { RepositoryHost } from '../../src/domain/repository.ts';
 import {
   type ReconcilerProcessEvent,
   runReconciler,
-  type SupervisedLoop,
-  superviseLoops,
 } from '../../src/reconciler/process.ts';
+import { startReconciler } from '../../src/reconciler/start.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
@@ -39,70 +40,65 @@ const DIGEST = `sha256:${'a'.repeat(64)}`;
 
 describe('reconciler process lifecycle', () => {
   test('one failed loop retries without stopping its siblings', async () => {
+    const adapters = configuredAdapters();
     const shutdown = new AbortController();
-    const failures: string[] = [];
-    let healthyStarts = 0;
-    let flakyStarts = 0;
+    const passes = new Map<string, number>();
+    const failures: Extract<ReconcilerProcessEvent, { type: 'failure' }>[] = [];
 
-    const loops: readonly SupervisedLoop[] = [
+    await runReconciler(
+      { db: database().db, adapters, clock, manifest },
       {
-        name: 'target',
-        async run(signal) {
-          healthyStarts += 1;
-          await aborted(signal);
+        signal: shutdown.signal,
+        retry: { initialMs: 0, maximumMs: 0, multiplier: 2 },
+        onEvent(event) {
+          if (event.type === 'failure') failures.push(event);
+          if (event.type !== 'pass') return;
+
+          const count = (passes.get(event.loop) ?? 0) + 1;
+          passes.set(event.loop, count);
+          if (event.loop === 'target' && count === 1) {
+            throw new Error('metrics sink disconnected');
+          }
+          if (
+            (passes.get('target') ?? 0) === 2 &&
+            passes.has('config') &&
+            passes.has('deploy')
+          ) {
+            shutdown.abort();
+          }
         },
       },
-      {
-        name: 'deploy',
-        async run(signal) {
-          flakyStarts += 1;
-          if (flakyStarts === 1) throw new Error('database disconnected');
-          shutdown.abort();
-          await aborted(signal);
-        },
-      },
-    ];
+    );
 
-    await superviseLoops(loops, {
-      signal: shutdown.signal,
-      retry: { initialMs: 0, maximumMs: 0, multiplier: 2 },
-      onFailure: ({ loop, cause }) => {
-        failures.push(`${loop}: ${String(cause)}`);
-      },
-    });
-
-    expect(healthyStarts).toBe(1);
-    expect(flakyStarts).toBe(2);
-    expect(failures).toEqual(['deploy: Error: database disconnected']);
+    expect(passes.get('target')).toBe(2);
+    expect(passes.get('config')).toBe(1);
+    expect(passes.get('deploy')).toBe(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toMatchObject({ type: 'failure', loop: 'target' });
+    expect(String(failures[0]?.cause)).toBe('Error: metrics sink disconnected');
   });
 
   test('an already-aborted process starts no loops', async () => {
-    let starts = 0;
-    await superviseLoops(
-      [
-        {
-          name: 'config',
-          async run() {
-            starts += 1;
-          },
-        },
-      ],
-      { signal: AbortSignal.abort() },
+    const events: ReconcilerProcessEvent[] = [];
+    await runReconciler(
+      {
+        db: database().db,
+        adapters: configuredAdapters(),
+        clock,
+        manifest,
+      },
+      {
+        signal: AbortSignal.abort(),
+        onEvent: (event) => events.push(event),
+      },
     );
-    expect(starts).toBe(0);
+    expect(events).toEqual([]);
   });
 });
 
 describe('reconciler loop composition', () => {
   test('starts every configured polling loop and reports an absent repository integration', async () => {
-    const adapters = createAdapterRegistry({
-      manifest,
-      env: {},
-      token: async () => 'cluster-token',
-      storeToken: () => 'store-token',
-      buildToken: () => 'build-token',
-      cloudToken: async () => 'cloud-token',
-    });
+    const adapters = configuredAdapters();
     const shutdown = new AbortController();
     const events: ReconcilerProcessEvent[] = [];
 
@@ -185,38 +181,15 @@ describe('reconciler loop composition', () => {
 
 describe('Deploy convergence through process startup', () => {
   test('polling takes a pending Deploy to the platform’s successful verdict', async () => {
-    const deploy = await pendingDeploy();
     const platform = new FakeDeployAdapter();
-    const shutdown = new AbortController();
-
-    await runReconciler(
-      {
-        db: database().db,
-        adapters: adaptersFor(platform),
-        clock,
-        manifest,
-      },
-      {
-        signal: shutdown.signal,
-        onEvent(event) {
-          if (event.type === 'pass' && event.loop === 'deploy') {
-            shutdown.abort();
-          }
-        },
-      },
-    );
-
-    const [stored] = await database()
-      .db.select()
-      .from(deploys)
-      .where(eq(deploys.id, deploy.id));
+    const { stored, bootManifest } = await reconcilePendingDeploy(platform);
     expect(stored?.phase).toBe('LIVE');
     expect(stored?.ref).toBe('fake-deploy-1');
     expect(platform.applied).toHaveLength(1);
+    expect(bootManifest).toEqual(manifest);
   });
 
   test('polling persists the platform’s failed verdict', async () => {
-    const deploy = await pendingDeploy();
     const platform = new FakeDeployAdapter({
       script: [
         {
@@ -228,39 +201,27 @@ describe('Deploy convergence through process startup', () => {
         },
       ],
     });
-    const shutdown = new AbortController();
-
-    await runReconciler(
-      {
-        db: database().db,
-        adapters: adaptersFor(platform),
-        clock,
-        manifest,
-      },
-      {
-        signal: shutdown.signal,
-        onEvent(event) {
-          if (event.type === 'pass' && event.loop === 'deploy') {
-            shutdown.abort();
-          }
-        },
-      },
-    );
-
-    const [stored] = await database()
-      .db.select()
-      .from(deploys)
-      .where(eq(deploys.id, deploy.id));
+    const { stored, bootManifest } = await reconcilePendingDeploy(platform);
     expect(stored?.phase).toBe('FAILED');
     expect(stored?.reason).toBe('STARTUP_FAILED');
     expect(stored?.detail).toBe('container exited before readiness');
     expect(stored?.blame).toBe('developer');
     expect(platform.applied).toHaveLength(1);
+    expect(bootManifest).toEqual(manifest);
   });
 });
 
 function adaptersFor(platform: FakeDeployAdapter): AdapterRegistry {
-  const configured = createAdapterRegistry({
+  const configured = configuredAdapters();
+  return {
+    ...configured,
+    deploy: (adapter) =>
+      adapter === platform.adapter ? platform : configured.deploy(adapter),
+  };
+}
+
+function configuredAdapters(): AdapterRegistry {
+  return createAdapterRegistry({
     manifest,
     env: {},
     token: async () => 'cluster-token',
@@ -268,11 +229,30 @@ function adaptersFor(platform: FakeDeployAdapter): AdapterRegistry {
     buildToken: () => 'build-token',
     cloudToken: async () => 'cloud-token',
   });
-  return {
-    ...configured,
-    deploy: (adapter) =>
-      adapter === platform.adapter ? platform : configured.deploy(adapter),
-  };
+}
+
+async function reconcilePendingDeploy(platform: FakeDeployAdapter) {
+  const deploy = await pendingDeploy();
+  const shutdown = new AbortController();
+  let bootManifest: unknown;
+  await startReconciler({
+    signal: shutdown.signal,
+    client: database().connect(),
+    clock,
+    env: { [MANIFEST_INLINE_VAR]: JSON.stringify(manifest) },
+    createAdapters(storedManifest) {
+      bootManifest = storedManifest;
+      return adaptersFor(platform);
+    },
+    onEvent(event) {
+      if (event.type === 'pass' && event.loop === 'deploy') shutdown.abort();
+    },
+  });
+  const [stored] = await database()
+    .db.select()
+    .from(deploys)
+    .where(eq(deploys.id, deploy.id));
+  return { stored, bootManifest };
 }
 
 /** An App, Component, Target, Build, and one PENDING Deploy intent. */
@@ -322,6 +302,12 @@ async function pendingDeploy() {
       exposure: 'private',
     })
     .returning();
+  await db.insert(componentTargetDesired).values({
+    componentId: component!.id,
+    targetId: target!.id,
+    desiredBuildId: build!.id,
+    desiredDeployId: deploy!.id,
+  });
   return deploy!;
 }
 
@@ -341,11 +327,4 @@ function unusedRepositoryHost(): RepositoryHost {
     setBranch: unused,
     openPullRequest: unused,
   };
-}
-
-function aborted(signal: AbortSignal): Promise<void> {
-  if (signal.aborted) return Promise.resolve();
-  return new Promise((resolve) =>
-    signal.addEventListener('abort', () => resolve(), { once: true }),
-  );
 }

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -84,8 +84,8 @@ spec:
       # arrives that way, not from a Job that would exit 0 having done nothing.
       migration:
         enabled: false
-    # §19's second Deployment. The reconciler entrypoint does not exist yet, so
-    # rendering it would be a crash-looping pod that says nothing true.
+    # The second process stays disabled while this installation has no migration
+    # runner to order schema readiness before the web and reconciler Deployments.
     reconciler:
       enabled: false
     web:

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, test } from 'bun:test';
 import { one, render } from './render.ts';
 
+describe('process topology', () => {
+  test('renders the reconciler as an opt-in second process from the same image', async () => {
+    const defaultDeployments = (await render())
+      .filter((object) => object.kind === 'Deployment')
+      .map((object) => object.metadata.name);
+    expect(defaultDeployments).toEqual(['spindrift-web']);
+
+    const objects = await render({ reconciler: { enabled: true } });
+    const web = one(objects, 'Deployment', 'spindrift-web').spec.template.spec
+      .containers[0];
+    const reconciler = one(objects, 'Deployment', 'spindrift-reconciler').spec
+      .template.spec.containers[0];
+
+    expect(reconciler.image).toBe(web.image);
+    expect(web.command).toEqual(['sh', '-c', 'bun run src/web/server.ts']);
+    expect(reconciler.command).toEqual([
+      'sh',
+      '-c',
+      'bun run src/reconciler/main.ts',
+    ]);
+  });
+});
+
 describe('workload identity', () => {
   test('only the reconciler receives audience-scoped cluster and GCP tokens', async () => {
     const objects = await render({

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -34,8 +34,8 @@ serviceAccount:
 hostname: ""
 
 # §19: "One image, two Deployments." The reconciler is the second entrypoint off
-# the same image and does not exist yet, so it is off by default rather than
-# rendered as a Deployment that would crash-loop on a missing module.
+# the same image. It remains opt-in so an installation can validate and roll out
+# the process independently of the web Deployment.
 web:
   replicas: 1
   resources:


### PR DESCRIPTION
## Summary

Run Spindrift's reconciliation loops as a production process with independent supervision, graceful shutdown, bounded retries, and replica-safe Deploy claims. The installer can render the reconciler as a separate opt-in Deployment from the same image while the live release remains disabled.

## Changes

- Add the production reconciler entrypoint and independently supervise Target, repository, config, and Deploy loops.
- Harden startup, projected identity-token wiring, stale claim recovery, and Component@Target contention.
- Add lifecycle, terminal-verdict, locking, token-rotation, and installer-render coverage.

## Test Plan

- [x] `mise run ts:check`
- [x] `mise run k8s:render-apps`
- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test --timeout 15000` — 827 passed
- [x] Standards and specification reviews — no remaining findings

## Context

- `.agent/context/context.md`
- `.agent/context/plan.md`
