### PR TITLE
fix(spindrift): seed manifest targets and harden image rollout

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -371,6 +371,17 @@
       automerge: true,
     },
     {
+      // A first-party :latest digest can be built from main immediately before
+      // another merge. Automatic merging can then deploy that older revision
+      // after newer code lands. Keep these pins reviewed so the image revision
+      // can be checked against the desired rollout.
+      description: 'Require review for first-party moving-tag digest pins',
+      matchDatasources: ['docker'],
+      matchPackageNames: ['/^ghcr\\.io\\/jonpulsifer\\//'],
+      matchUpdateTypes: ['digest', 'pinDigest'],
+      automerge: false,
+    },
+    {
       // Digest lookups carry no release timestamp, so the global 3-day age
       // gate would hold them as pending forever (timestamp-required). Digests
       // track moving tags we already chose (first-party :latest pins), so no

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -95,15 +95,23 @@ jobs:
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
-          push: ${{ github.event_name != 'pull_request' }}
+          # PRs validate images but never publish them. Spell the publishing
+          # authority positively so adding another event cannot make it push.
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
           build-args: ${{ matrix.build-args }}
           platforms: ${{ matrix.platforms }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Keep PR cache records away from main publishing builds and keep
+          # unrelated images out of each other's default `buildkit` scope.
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ github.event_name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ github.event_name }}
+          # The Spindrift runner is cheap and is the layer that packages its
+          # two entrypoints. Always rebuild it; dependency/build stages remain
+          # cached.
+          no-cache-filters: ${{ matrix.image == 'spindrift' && 'runner' || '' }}
           secret-files: ${{ matrix.image == 'slingshot' && format('gcp_credentials={0}', steps.gcp_auth.outputs.credentials_file_path) || '' }}
           sbom: true
           provenance: true

--- a/apps/spindrift/Dockerfile
+++ b/apps/spindrift/Dockerfile
@@ -58,6 +58,10 @@ COPY --from=builder --chmod=755 /app/apps/spindrift/src ./apps/spindrift/src
 COPY --from=builder --chmod=755 /app/apps/spindrift/dist ./apps/spindrift/dist
 COPY --from=base /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=supply-chain-tools /spindrift-verifier /usr/local/bin/spindrift-verifier
+# Fail the image build at the packaging seam rather than shipping a chart
+# command whose module the runtime image does not contain.
+RUN test -f /app/apps/spindrift/src/web/server.ts \
+  && test -f /app/apps/spindrift/src/reconciler/main.ts
 WORKDIR /app/apps/spindrift
 USER 65532:65532
 EXPOSE 3000

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -27,7 +27,10 @@
 import { and, eq, isNotNull, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { operatorValuesIssues } from '../../adapters/deploy/kubernetes/values.ts';
-import type { TargetAdapter } from '../../config/manifest.schema.ts';
+import {
+  type TargetAdapter,
+  targetNameSchema,
+} from '../../config/manifest.schema.ts';
 import { deploys, targets } from '../../db/schema.ts';
 import {
   deriveHealth,
@@ -41,17 +44,6 @@ import {
 } from '../../domain/target.ts';
 import { inspectTarget } from '../../reconciler/target-loop.ts';
 import { type Command, type CommandContext, failed, ok } from '../types.ts';
-
-/** A stable identifier, unique within the installation (§13). */
-const targetName = z
-  .string()
-  .trim()
-  .min(1)
-  .max(63)
-  .regex(
-    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
-    'must be lowercase letters, digits and hyphens',
-  );
 
 /**
  * The delivery flavour a Kubernetes Target declares (§6).
@@ -90,7 +82,7 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('kubernetes'),
-      name: targetName,
+      name: targetNameSchema,
       /** §13's prerequisite is OIDC against this, not a credential for it. */
       apiServer: z.url(),
       /** Where an App's workloads land. Never created by Spindrift (§7). */
@@ -109,7 +101,7 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
     .object({
       kind: z.literal('cloud'),
       /** One name; both of the project's Targets are derived from it. */
-      name: targetName,
+      name: targetNameSchema,
       project: z.string().trim().min(1),
       region: z.string().trim().min(1),
       /**

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -1,9 +1,9 @@
 /**
  * Postgres ownership of the installation manifest.
  *
- * Parsing and validation stay in `manifest.ts`; this module owns only the
- * singleton row and the one-time transition from bootstrap configuration to
- * durable state.
+ * Parsing and validation stay in `manifest.ts`; this module owns the singleton
+ * row and the one-time transition from its bootstrap configuration — including
+ * ordered Target identities — to durable state.
  */
 import type { Database } from '../db/client.ts';
 import { installation, targets } from '../db/schema.ts';
@@ -61,10 +61,19 @@ async function seedManifestTargets(
   db: Database,
   manifest: InstallationManifest,
 ): Promise<void> {
-  await db
-    .insert(targets)
-    .values(
-      manifest.targets.map((target, rank) => ({
+  for (const [rank, target] of manifest.targets.entries()) {
+    const existing = await db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, target.name),
+    });
+    if (existing !== undefined && existing.adapter !== target.adapter) {
+      throw new ManifestError(
+        `manifest Target ${target.name} uses ${target.adapter}, but the stored Target uses ${existing.adapter}`,
+      );
+    }
+
+    await db
+      .insert(targets)
+      .values({
         ...target,
         rank,
         status: 'disconnected' as const,
@@ -74,9 +83,12 @@ async function seedManifestTargets(
           'Target connection has not been configured',
           target.adapter,
         ),
-      })),
-    )
-    .onConflictDoNothing({ target: targets.name });
+      })
+      .onConflictDoUpdate({
+        target: targets.name,
+        set: { rank },
+      });
+  }
 }
 
 async function readStoredManifest(

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -6,7 +6,8 @@
  * durable state.
  */
 import type { Database } from '../db/client.ts';
-import { installation } from '../db/schema.ts';
+import { installation, targets } from '../db/schema.ts';
+import { unreachablePrerequisites } from '../domain/capabilities.ts';
 import type { InstallationManifest } from './manifest.schema.ts';
 import { loadManifest, ManifestError, validateManifest } from './manifest.ts';
 
@@ -26,21 +27,56 @@ export async function loadStoredManifest(
   env: Env = Bun.env,
 ): Promise<InstallationManifest> {
   const stored = await readStoredManifest(db);
-  if (stored !== null) return stored;
+  let manifest = stored;
+  if (manifest === null) {
+    const bootstrap = await loadManifest(env);
+    await db
+      .insert(installation)
+      .values({ manifest: bootstrap })
+      .onConflictDoNothing({ target: installation.id });
 
-  const bootstrap = await loadManifest(env);
-  await db
-    .insert(installation)
-    .values({ manifest: bootstrap })
-    .onConflictDoNothing({ target: installation.id });
-
-  const seeded = await readStoredManifest(db);
-  if (seeded === null) {
-    throw new ManifestError(
-      'installation manifest bootstrap completed without a stored manifest',
-    );
+    manifest = await readStoredManifest(db);
+    if (manifest === null) {
+      throw new ManifestError(
+        'installation manifest bootstrap completed without a stored manifest',
+      );
+    }
   }
-  return seeded;
+
+  await seedManifestTargets(db, manifest);
+  return manifest;
+}
+
+/**
+ * Materialize the manifest's ordered Target identities without pretending they
+ * are connected.
+ *
+ * A Target seed carries only a name and adapter. Connection facts remain null
+ * until the operator supplies them through `connectTarget`; that command
+ * updates this durable row in place and preserves the manifest-established
+ * rank. Conflict tolerance makes concurrent web/reconciler startup safe and
+ * lets later boots repair a partially completed seed.
+ */
+async function seedManifestTargets(
+  db: Database,
+  manifest: InstallationManifest,
+): Promise<void> {
+  await db
+    .insert(targets)
+    .values(
+      manifest.targets.map((target, rank) => ({
+        ...target,
+        rank,
+        status: 'disconnected' as const,
+        connection: null,
+        health: 'unhealthy' as const,
+        prerequisites: unreachablePrerequisites(
+          'Target connection has not been configured',
+          target.adapter,
+        ),
+      })),
+    )
+    .onConflictDoNothing({ target: targets.name });
 }
 
 async function readStoredManifest(

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -16,6 +16,14 @@ import { z } from 'zod';
 /** A non-empty string with no surrounding whitespace. */
 const nonEmptyString = z.string().trim().min(1);
 
+/** A Target identifier accepted by both the manifest and the connect act. */
+export const targetNameSchema = nonEmptyString
+  .max(63)
+  .regex(
+    /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
+    'must be lowercase letters, digits and hyphens',
+  );
+
 /** A DNS zone apex, e.g. `apps.example.test` or `localhost`. */
 const zone = nonEmptyString.regex(
   /^(localhost|(?!-)[a-z0-9-]+(\.[a-z0-9-]+)+)$/,
@@ -142,7 +150,7 @@ export const buildRouteSchema = z.discriminatedUnion('adapter', [
 export const targetSeedSchema = z
   .object({
     /** Stable identifier, unique within the installation. */
-    name: nonEmptyString,
+    name: targetNameSchema,
     /** Which delivery adapter drives it. */
     adapter: targetAdapterSchema,
   })
@@ -411,7 +419,33 @@ export const installationManifestSchema = z
         (targets) =>
           new Set(targets.map((t) => t.name)).size === targets.length,
         'target names must be unique',
-      ),
+      )
+      .superRefine((targets, context) => {
+        const seeds = new Map(targets.map((target) => [target.name, target]));
+        targets.forEach((target, index) => {
+          if (target.adapter === 'kubernetes') return;
+
+          const suffix = `-${target.adapter}`;
+          const base = target.name.endsWith(suffix)
+            ? target.name.slice(0, -suffix.length)
+            : '';
+          const counterpart =
+            target.adapter === 'cloudrun' ? 'static' : 'cloudrun';
+          const counterpartName = `${base}-${counterpart}`;
+          if (
+            base.length === 0 ||
+            seeds.get(counterpartName)?.adapter !== counterpart
+          ) {
+            context.addIssue({
+              code: 'custom',
+              path: [index, 'name'],
+              message:
+                'cloud Targets must be a matched <name>-cloudrun and ' +
+                '<name>-static pair',
+            });
+          }
+        });
+      }),
   })
   .strict();
 

--- a/apps/spindrift/src/db/migrations/0010_manifest_target_seeds.sql
+++ b/apps/spindrift/src/db/migrations/0010_manifest_target_seeds.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "targets" ALTER COLUMN "connection" DROP NOT NULL;

--- a/apps/spindrift/src/db/migrations/meta/0010_snapshot.json
+++ b/apps/spindrift/src/db/migrations/meta/0010_snapshot.json
@@ -1,0 +1,1900 @@
+{
+  "id": "e0d85987-6c71-4236-815c-5e205823bc60",
+  "prevId": "58e8a636-1ebb-4379-b1a0-d8ff92dd692b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "app_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_repo_url": {
+          "name": "source_repo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_repo_subpath": {
+          "name": "source_repo_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_archive_digest": {
+          "name": "source_archive_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vessel_ref": {
+          "name": "vessel_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vanity_domain": {
+          "name": "vanity_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apps_repository_id_repositories_id_fk": {
+          "name": "apps_repository_id_repositories_id_fk",
+          "tableFrom": "apps",
+          "tableTo": "repositories",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.attempt_events": {
+      "name": "attempt_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_kind": {
+          "name": "attempt_kind",
+          "type": "attempt_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deploy_id": {
+          "name": "deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "attempt_event_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line": {
+          "name": "line",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "attempt_events_app_id_apps_id_fk": {
+          "name": "attempt_events_app_id_apps_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_component_id_components_id_fk": {
+          "name": "attempt_events_component_id_components_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_build_id_builds_id_fk": {
+          "name": "attempt_events_build_id_builds_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "attempt_events_deploy_id_deploys_id_fk": {
+          "name": "attempt_events_deploy_id_deploys_id_fk",
+          "tableFrom": "attempt_events",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "attempt_events_exactly_one_attempt": {
+          "name": "attempt_events_exactly_one_attempt",
+          "value": "(\"attempt_events\".\"build_id\" is not null) <> (\"attempt_events\".\"deploy_id\" is not null)"
+        },
+        "attempt_events_kind_matches_reference": {
+          "name": "attempt_events_kind_matches_reference",
+          "value": "(\"attempt_events\".\"attempt_kind\" = 'build' and \"attempt_events\".\"build_id\" is not null) or (\"attempt_events\".\"attempt_kind\" = 'deploy' and \"attempt_events\".\"deploy_id\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.builds": {
+      "name": "builds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commit": {
+          "name": "commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_shape": {
+          "name": "target_shape",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_type": {
+          "name": "artifact_type",
+          "type": "artifact_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_digest": {
+          "name": "artifact_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifact_refs": {
+          "name": "artifact_refs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "build_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "base_digest": {
+          "name": "base_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner": {
+          "name": "runner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "log_fidelity": {
+          "name": "log_fidelity",
+          "type": "log_fidelity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified_build_level": {
+          "name": "verified_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signature": {
+          "name": "signature",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "buildkit_provenance_ref": {
+          "name": "buildkit_provenance_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sbom_ref": {
+          "name": "sbom_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_digest": {
+          "name": "bundle_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_location": {
+          "name": "bundle_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bundle_subpath": {
+          "name": "bundle_subpath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "builds_component_id_components_id_fk": {
+          "name": "builds_component_id_components_id_fk",
+          "tableFrom": "builds",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "builds_component_commit_shape_unique": {
+          "name": "builds_component_commit_shape_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "commit",
+            "target_shape"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.component_target_desired": {
+      "name": "component_target_desired",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_build_id": {
+          "name": "desired_build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "desired_deploy_id": {
+          "name": "desired_deploy_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "component_target_desired_component_id_components_id_fk": {
+          "name": "component_target_desired_component_id_components_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_target_id_targets_id_fk": {
+          "name": "component_target_desired_target_id_targets_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_build_id_builds_id_fk": {
+          "name": "component_target_desired_desired_build_id_builds_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "desired_build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "component_target_desired_desired_deploy_id_deploys_id_fk": {
+          "name": "component_target_desired_desired_deploy_id_deploys_id_fk",
+          "tableFrom": "component_target_desired",
+          "tableTo": "deploys",
+          "columnsFrom": [
+            "desired_deploy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "component_target_desired_pair_unique": {
+          "name": "component_target_desired_pair_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.components": {
+      "name": "components",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "component_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expose": {
+          "name": "expose",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "components_app_id_apps_id_fk": {
+          "name": "components_app_id_apps_id_fk",
+          "tableFrom": "components",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "components_app_id_name_unique": {
+          "name": "components_app_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "app_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_audit_events": {
+      "name": "config_audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "config_action",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_audit_events_component_id_components_id_fk": {
+          "name": "config_audit_events_component_id_components_id_fk",
+          "tableFrom": "config_audit_events",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_audit_events_target_id_targets_id_fk": {
+          "name": "config_audit_events_target_id_targets_id_fk",
+          "tableFrom": "config_audit_events",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_audit_events_user_id_users_id_fk": {
+          "name": "config_audit_events_user_id_users_id_fk",
+          "tableFrom": "config_audit_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.config_items": {
+      "name": "config_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "config_item_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'secret_ref'"
+        },
+        "store_ref": {
+          "name": "store_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_version": {
+          "name": "store_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plain_value": {
+          "name": "plain_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "config_items_component_id_components_id_fk": {
+          "name": "config_items_component_id_components_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "config_items_target_id_targets_id_fk": {
+          "name": "config_items_target_id_targets_id_fk",
+          "tableFrom": "config_items",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "config_items_scope_key_unique": {
+          "name": "config_items_scope_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "component_id",
+            "target_id",
+            "environment",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "config_items_environment_pinned": {
+          "name": "config_items_environment_pinned",
+          "value": "\"config_items\".\"environment\" = 'default'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sign_count": {
+          "name": "sign_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "credentials_user_id_users_id_fk": {
+          "name": "credentials_user_id_users_id_fk",
+          "tableFrom": "credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credentials_credential_id_unique": {
+          "name": "credentials_credential_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "credential_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.datastores": {
+      "name": "datastores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engine": {
+          "name": "engine",
+          "type": "datastore_engine",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provenance": {
+          "name": "provenance",
+          "type": "datastore_provenance",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_ref": {
+          "name": "connection_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "datastores_app_id_apps_id_fk": {
+          "name": "datastores_app_id_apps_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "datastores_target_id_targets_id_fk": {
+          "name": "datastores_target_id_targets_id_fk",
+          "tableFrom": "datastores",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deploys": {
+      "name": "deploys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "component_id": {
+          "name": "component_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "build_id": {
+          "name": "build_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phase": {
+          "name": "phase",
+          "type": "deploy_phase",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "reason": {
+          "name": "reason",
+          "type": "deploy_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blame": {
+          "name": "blame",
+          "type": "blame",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "debug": {
+          "name": "debug",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_version": {
+          "name": "config_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_document": {
+          "name": "config_document",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "exposure": {
+          "name": "exposure",
+          "type": "exposure_state",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "orphaned_at": {
+          "name": "orphaned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drifted_at": {
+          "name": "drifted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "observed_digest": {
+          "name": "observed_digest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deploys_component_id_components_id_fk": {
+          "name": "deploys_component_id_components_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "components",
+          "columnsFrom": [
+            "component_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "deploys_target_id_targets_id_fk": {
+          "name": "deploys_target_id_targets_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "targets",
+          "columnsFrom": [
+            "target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "deploys_build_id_builds_id_fk": {
+          "name": "deploys_build_id_builds_id_fk",
+          "tableFrom": "deploys",
+          "tableTo": "builds",
+          "columnsFrom": [
+            "build_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrolments": {
+      "name": "enrolments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "enrolments_user_id_users_id_fk": {
+          "name": "enrolments_user_id_users_id_fk",
+          "tableFrom": "enrolments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "enrolments_token_hash_unique": {
+          "name": "enrolments_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation": {
+      "name": "installation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "default": 1
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "installation_singleton": {
+          "name": "installation_singleton",
+          "value": "\"installation\".\"id\" = 1"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.repositories": {
+      "name": "repositories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authoritative_commit": {
+          "name": "authoritative_commit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_pull_request": {
+          "name": "config_pull_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access": {
+          "name": "access",
+          "type": "repository_access",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "frozen_reason": {
+          "name": "frozen_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_at": {
+          "name": "frozen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reconciled_at": {
+          "name": "reconciled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "repositories_full_name_unique": {
+          "name": "repositories_full_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "full_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "repositories_frozen_has_reason": {
+          "name": "repositories_frozen_has_reason",
+          "value": "(\"repositories\".\"access\" = 'frozen') = (\"repositories\".\"frozen_reason\" is not null)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.targets": {
+      "name": "targets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "adapter": {
+          "name": "adapter",
+          "type": "target_adapter",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "target_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connected'"
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection": {
+          "name": "connection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "health": {
+          "name": "health",
+          "type": "target_health",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prerequisites": {
+          "name": "prerequisites",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discovery": {
+          "name": "discovery",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inspected_at": {
+          "name": "inspected_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_exposure": {
+          "name": "public_exposure",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_build_level": {
+          "name": "min_build_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "targets_name_unique": {
+          "name": "targets_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gateway_identity": {
+          "name": "gateway_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_gateway_identity_unique": {
+          "name": "users_gateway_identity_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "gateway_identity"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webauthn_challenges": {
+      "name": "webauthn_challenges",
+      "schema": "",
+      "columns": {
+        "challenge": {
+          "name": "challenge",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "webauthn_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "webauthn_challenges_user_id_users_id_fk": {
+          "name": "webauthn_challenges_user_id_users_id_fk",
+          "tableFrom": "webauthn_challenges",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.app_source_kind": {
+      "name": "app_source_kind",
+      "schema": "public",
+      "values": [
+        "repo",
+        "archive"
+      ]
+    },
+    "public.artifact_type": {
+      "name": "artifact_type",
+      "schema": "public",
+      "values": [
+        "image",
+        "files"
+      ]
+    },
+    "public.attempt_event_type": {
+      "name": "attempt_event_type",
+      "schema": "public",
+      "values": [
+        "log",
+        "status"
+      ]
+    },
+    "public.attempt_kind": {
+      "name": "attempt_kind",
+      "schema": "public",
+      "values": [
+        "build",
+        "deploy"
+      ]
+    },
+    "public.blame": {
+      "name": "blame",
+      "schema": "public",
+      "values": [
+        "developer",
+        "platform"
+      ]
+    },
+    "public.build_status": {
+      "name": "build_status",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED"
+      ]
+    },
+    "public.component_kind": {
+      "name": "component_kind",
+      "schema": "public",
+      "values": [
+        "service",
+        "website",
+        "job"
+      ]
+    },
+    "public.config_action": {
+      "name": "config_action",
+      "schema": "public",
+      "values": [
+        "set",
+        "removed"
+      ]
+    },
+    "public.config_item_kind": {
+      "name": "config_item_kind",
+      "schema": "public",
+      "values": [
+        "secret_ref",
+        "plain"
+      ]
+    },
+    "public.datastore_engine": {
+      "name": "datastore_engine",
+      "schema": "public",
+      "values": [
+        "postgres",
+        "redis"
+      ]
+    },
+    "public.datastore_provenance": {
+      "name": "datastore_provenance",
+      "schema": "public",
+      "values": [
+        "managed",
+        "external"
+      ]
+    },
+    "public.deploy_phase": {
+      "name": "deploy_phase",
+      "schema": "public",
+      "values": [
+        "PENDING",
+        "APPLYING",
+        "WAITING",
+        "LIVE",
+        "FAILED"
+      ]
+    },
+    "public.deploy_reason": {
+      "name": "deploy_reason",
+      "schema": "public",
+      "values": [
+        "BUILD_FAILED",
+        "ARTIFACT_UNAVAILABLE",
+        "REJECTED",
+        "STARTUP_FAILED",
+        "UNHEALTHY",
+        "TIMEOUT",
+        "TARGET_UNREACHABLE",
+        "INTERNAL"
+      ]
+    },
+    "public.exposure_state": {
+      "name": "exposure_state",
+      "schema": "public",
+      "values": [
+        "internal",
+        "private",
+        "public"
+      ]
+    },
+    "public.log_fidelity": {
+      "name": "log_fidelity",
+      "schema": "public",
+      "values": [
+        "LIVE_TEXT",
+        "LIVE_STATUS",
+        "ON_COMPLETION"
+      ]
+    },
+    "public.repository_access": {
+      "name": "repository_access",
+      "schema": "public",
+      "values": [
+        "active",
+        "frozen"
+      ]
+    },
+    "public.target_adapter": {
+      "name": "target_adapter",
+      "schema": "public",
+      "values": [
+        "kubernetes",
+        "cloudrun",
+        "static"
+      ]
+    },
+    "public.target_health": {
+      "name": "target_health",
+      "schema": "public",
+      "values": [
+        "healthy",
+        "unhealthy"
+      ]
+    },
+    "public.target_status": {
+      "name": "target_status",
+      "schema": "public",
+      "values": [
+        "connected",
+        "disconnected"
+      ]
+    },
+    "public.webauthn_purpose": {
+      "name": "webauthn_purpose",
+      "schema": "public",
+      "values": [
+        "enrol",
+        "sign_in",
+        "credential_admin",
+        "add_passkey"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785273764040,
       "tag": "0009_installation_manifest",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785288376240,
+      "tag": "0010_manifest_target_seeds",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -648,8 +648,11 @@ export const targets = pgTable(
      * How the adapter reaches this Target — `TargetConnection` in
      * `src/domain/target.ts`. Never a credential: §13 settles one auth mode,
      * "native OIDC federation, nothing stored."
+     *
+     * Null means the manifest has established the Target's identity and rank,
+     * but an operator has not supplied its connection facts yet.
      */
-    connection: jsonb('connection').$type<TargetConnection>().notNull(),
+    connection: jsonb('connection').$type<TargetConnection>(),
     /** §13: the standing checklist's last verdict. */
     health: targetHealth('health').notNull(),
     /** One `PrerequisiteResult` per item, with the sentence behind each. */

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -41,6 +41,18 @@ export type TargetConnection =
   | CloudRunConnection
   | StaticConnection;
 
+/** A stored Target after its operator has supplied adapter connection facts. */
+export type TargetWithConnection<
+  T extends { connection: TargetConnection | null },
+> = T & { readonly connection: TargetConnection };
+
+/** Refine a manifest seed away from Targets an adapter can actually address. */
+export function hasTargetConnection<
+  T extends { connection: TargetConnection | null },
+>(target: T): target is TargetWithConnection<T> {
+  return target.connection !== null;
+}
+
 /**
  * How a Cloud Run Target is reached (§13, §14).
  *
@@ -211,10 +223,10 @@ export function deployTargetOf(target: {
 /**
  * Whether the Target passes §13's standing checklist.
  *
- * Two states, not three. A Target is only ever created by the connect act, and
- * that act runs one pass of the checklist before it returns — so there is no
- * moment at which a Target exists and has never been assessed, and no
- * `unknown` for the UI to render as a shrug.
+ * Two states, not three. A manifest-seeded Target starts unhealthy with every
+ * prerequisite carrying the reason that it has not been connected. The connect
+ * act replaces that checklist with one real inspection before it returns, so
+ * there is no `unknown` for the UI to render as a shrug.
  */
 export type TargetHealth = 'healthy' | 'unhealthy';
 

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -63,7 +63,11 @@ import {
 } from '../domain/diagnosis.ts';
 import { displayUrl, hostnameFor } from '../domain/naming.ts';
 import { DEFAULT_PLATFORM } from '../domain/placement.ts';
-import { deployTargetOf, type TargetConnection } from '../domain/target.ts';
+import {
+  deployTargetOf,
+  hasTargetConnection,
+  type TargetWithConnection,
+} from '../domain/target.ts';
 
 /** What the loop needs. No principal: nobody asked for it to run. */
 export interface DeployLoopContext {
@@ -219,9 +223,7 @@ interface AttemptSubject {
   readonly app: typeof apps.$inferSelect;
   readonly component: typeof components.$inferSelect;
   readonly build: typeof builds.$inferSelect;
-  readonly target: typeof targets.$inferSelect & {
-    readonly connection: TargetConnection;
-  };
+  readonly target: TargetWithConnection<typeof targets.$inferSelect>;
   readonly adapter: DeployAdapter;
 }
 
@@ -569,16 +571,17 @@ async function subjectOf(
     .innerJoin(targets, eq(deploys.targetId, targets.id))
     .where(eq(deploys.id, deploy.id));
 
-  if (row === undefined || row.target.connection === null) {
-    return null;
-  }
-  const adapter = context.adapters.deploy(row.target.adapter);
+  if (row === undefined) return null;
+  const target = row.target;
+  if (!hasTargetConnection(target)) return null;
+
+  const adapter = context.adapters.deploy(target.adapter);
   if (adapter === null) return null;
 
   return {
     deploy,
     ...row,
-    target: { ...row.target, connection: row.target.connection },
+    target,
     adapter,
   };
 }

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -63,7 +63,7 @@ import {
 } from '../domain/diagnosis.ts';
 import { displayUrl, hostnameFor } from '../domain/naming.ts';
 import { DEFAULT_PLATFORM } from '../domain/placement.ts';
-import { deployTargetOf } from '../domain/target.ts';
+import { deployTargetOf, type TargetConnection } from '../domain/target.ts';
 
 /** What the loop needs. No principal: nobody asked for it to run. */
 export interface DeployLoopContext {
@@ -219,7 +219,9 @@ interface AttemptSubject {
   readonly app: typeof apps.$inferSelect;
   readonly component: typeof components.$inferSelect;
   readonly build: typeof builds.$inferSelect;
-  readonly target: typeof targets.$inferSelect;
+  readonly target: typeof targets.$inferSelect & {
+    readonly connection: TargetConnection;
+  };
   readonly adapter: DeployAdapter;
 }
 
@@ -567,11 +569,18 @@ async function subjectOf(
     .innerJoin(targets, eq(deploys.targetId, targets.id))
     .where(eq(deploys.id, deploy.id));
 
-  if (row === undefined) return null;
+  if (row === undefined || row.target.connection === null) {
+    return null;
+  }
   const adapter = context.adapters.deploy(row.target.adapter);
   if (adapter === null) return null;
 
-  return { deploy, ...row, adapter };
+  return {
+    deploy,
+    ...row,
+    target: { ...row.target, connection: row.target.connection },
+    adapter,
+  };
 }
 
 /** How the loop runs, and how to stop it. */

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -33,6 +33,7 @@ import {
 import {
   type DeployTargetRef,
   deployTargetOf,
+  hasTargetConnection,
   type TargetHealth,
 } from '../domain/target.ts';
 
@@ -115,14 +116,13 @@ export async function refreshTarget(
   context: TargetLoopContext,
   target: Pick<Target, 'id' | 'name' | 'adapter' | 'health' | 'connection'>,
 ): Promise<TargetRefresh> {
-  const connection = target.connection;
-  if (connection === null) {
+  if (!hasTargetConnection(target)) {
     throw new Error(`Target ${target.name} has no connection to refresh`);
   }
   const now = context.clock.now();
   const { prerequisites, discovery } = await inspectTarget(
     context,
-    deployTargetOf({ ...target, connection }),
+    deployTargetOf(target),
   );
   const health = deriveHealth(prerequisites, target.adapter);
 
@@ -165,7 +165,7 @@ export async function refreshAllTargets(
   for (const target of connected) {
     // A manifest seed is disconnected, so this is defensive against a
     // malformed row rather than part of the ordinary bootstrap path.
-    if (target.connection === null) continue;
+    if (!hasTargetConnection(target)) continue;
     // Sequential rather than concurrent: the far sides are other people's
     // control planes, and a fleet of Targets refreshing in lockstep is a
     // thundering herd against every one of them at once.

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -115,10 +115,14 @@ export async function refreshTarget(
   context: TargetLoopContext,
   target: Pick<Target, 'id' | 'name' | 'adapter' | 'health' | 'connection'>,
 ): Promise<TargetRefresh> {
+  const connection = target.connection;
+  if (connection === null) {
+    throw new Error(`Target ${target.name} has no connection to refresh`);
+  }
   const now = context.clock.now();
   const { prerequisites, discovery } = await inspectTarget(
     context,
-    deployTargetOf(target),
+    deployTargetOf({ ...target, connection }),
   );
   const health = deriveHealth(prerequisites, target.adapter);
 
@@ -159,6 +163,9 @@ export async function refreshAllTargets(
 
   const refreshed: TargetRefresh[] = [];
   for (const target of connected) {
+    // A manifest seed is disconnected, so this is defensive against a
+    // malformed row rather than part of the ordinary bootstrap path.
+    if (target.connection === null) continue;
     // Sequential rather than concurrent: the far sides are other people's
     // control planes, and a fleet of Targets refreshing in lockstep is a
     // thundering herd against every one of them at once.

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -3,8 +3,8 @@
  *
  * Shows every deployment Target the control plane knows about, its adapter
  * type, rank, health, supported kinds, and canonical hostname pattern. This
- * is an admin view — Targets are created through the manifest (§7) and
- * connected through `connectTarget` (§14), not through this UI.
+ * is an admin view — Target identities and rank come from the manifest (§7),
+ * while connection facts come from `connectTarget` (§14), not from this UI.
  *
  * The view exists because §18 names **Apps / Datastores / Targets** as the
  * global navigation, and a Target's health, rank, and canonical pattern are
@@ -41,9 +41,9 @@ export function TargetList({
           Deployment targets
         </h1>
         <p className="mt-1 max-w-prose text-sm text-muted-foreground">
-          Where Spindrift can deploy apps. Targets are created through the
-          manifest and connected by the reconciler — this surface shows their
-          current health and capabilities.
+          Where Spindrift can deploy apps. Targets are declared in the manifest
+          and connected by an operator — this surface shows their current health
+          and capabilities.
         </p>
       </header>
 
@@ -51,8 +51,7 @@ export function TargetList({
         <Card>
           <CardContent className="py-12 text-center">
             <p className="text-sm text-muted-foreground">
-              No targets connected. The reconciler will connect Targets from the
-              manifest when it starts.
+              No Targets are configured for this installation.
             </p>
           </CardContent>
         </Card>

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -248,6 +248,34 @@ describe('the act is credential-shaped though the noun is flat', () => {
     const rows = await database().db.select().from(targets);
     expect(rows).toHaveLength(3);
   });
+
+  test('connect fills a manifest-seeded Target without changing its rank', async () => {
+    const { registry } = fakes();
+    const [seed] = await database()
+      .db.insert(targets)
+      .values({
+        name: 'cluster',
+        adapter: 'kubernetes',
+        rank: 4,
+        status: 'disconnected',
+        connection: null,
+        health: 'unhealthy',
+      })
+      .returning();
+
+    const result = await connectTarget(
+      clusterInput({ name: 'cluster' }),
+      context(registry),
+    );
+
+    if (!result.ok) throw new Error('connect refused');
+    const [connected] = result.value.targets;
+    expect(connected?.id).toBe(seed?.id);
+    expect(connected?.rank).toBe(4);
+    expect((await targetRow('cluster'))?.connection).toEqual(
+      connectionFor('kubernetes'),
+    );
+  });
 });
 
 describe('disconnect strands rather than stops', () => {

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -276,6 +276,42 @@ describe('the act is credential-shaped though the noun is flat', () => {
       connectionFor('kubernetes'),
     );
   });
+
+  test('one cloud connect fills its matched manifest-seeded pair', async () => {
+    const { registry } = fakes();
+    const seeds = await database()
+      .db.insert(targets)
+      .values([
+        {
+          name: 'vessel-cloudrun',
+          adapter: 'cloudrun',
+          rank: 2,
+          status: 'disconnected',
+          connection: null,
+          health: 'unhealthy',
+        },
+        {
+          name: 'vessel-static',
+          adapter: 'static',
+          rank: 3,
+          status: 'disconnected',
+          connection: null,
+          health: 'unhealthy',
+        },
+      ])
+      .returning();
+
+    const result = await connectTarget(
+      cloudInput({ name: 'vessel' }),
+      context(registry),
+    );
+
+    if (!result.ok) throw new Error('connect refused');
+    expect(result.value.targets.map(({ id, rank }) => ({ id, rank }))).toEqual(
+      seeds.map(({ id, rank }) => ({ id, rank })),
+    );
+    expect(await database().db.select().from(targets)).toHaveLength(2);
+  });
 });
 
 describe('disconnect strands rather than stops', () => {

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../src/config/manifest.ts';
 import { loadStoredManifest } from '../../src/config/manifest-store.ts';
 import { createDb } from '../../src/db/client.ts';
-import { installation } from '../../src/db/schema.ts';
+import { installation, targets } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 
 const database = withIsolatedDatabase();
@@ -26,6 +26,51 @@ describe('the stored installation manifest', () => {
 
     const later = await loadStoredManifest(database().db, {});
     expect(later).toEqual(first);
+  });
+
+  test('seeds manifest Targets as disconnected rows in manifest rank order', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+
+    const rows = await database().db.query.targets.findMany({
+      orderBy: (targets, { asc }) => [asc(targets.rank)],
+    });
+    expect(
+      rows.map(({ name, adapter, rank, status, health, connection }) => ({
+        name,
+        adapter,
+        rank,
+        status,
+        health,
+        connection,
+      })),
+    ).toEqual([
+      {
+        name: 'cluster',
+        adapter: 'kubernetes',
+        rank: 0,
+        status: 'disconnected',
+        health: 'unhealthy',
+        connection: null,
+      },
+      {
+        name: 'cloud',
+        adapter: 'cloudrun',
+        rank: 1,
+        status: 'disconnected',
+        health: 'unhealthy',
+        connection: null,
+      },
+      {
+        name: 'hosting',
+        adapter: 'static',
+        rank: 2,
+        status: 'disconnected',
+        health: 'unhealthy',
+        connection: null,
+      },
+    ]);
   });
 
   test('the database wins over changed bootstrap configuration', async () => {
@@ -61,6 +106,7 @@ describe('the stored installation manifest', () => {
     ]);
     expect(second).toEqual(first);
     expect(['example', 'replacement']).toContain(first.installation);
+    expect(await database().db.select().from(targets)).toHaveLength(3);
   });
 
   test('the database enforces that there is only one installation', async () => {

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
 import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
 import {
   MANIFEST_INLINE_VAR,
@@ -55,7 +56,7 @@ describe('the stored installation manifest', () => {
         connection: null,
       },
       {
-        name: 'cloud',
+        name: 'cloud-cloudrun',
         adapter: 'cloudrun',
         rank: 1,
         status: 'disconnected',
@@ -63,7 +64,7 @@ describe('the stored installation manifest', () => {
         connection: null,
       },
       {
-        name: 'hosting',
+        name: 'cloud-static',
         adapter: 'static',
         rank: 2,
         status: 'disconnected',
@@ -87,6 +88,23 @@ describe('the stored installation manifest', () => {
     });
     expect(later).toEqual(first);
     expect(later.installation).toBe('example');
+  });
+
+  test('repairs a stored Target rank from manifest order', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    await database()
+      .db.update(targets)
+      .set({ rank: 99 })
+      .where(eq(targets.name, 'cluster'));
+
+    await loadStoredManifest(database().db, {});
+
+    const cluster = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(cluster?.rank).toBe(0);
   });
 
   test('simultaneous processes converge on the one winning bootstrap', async () => {

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -126,8 +126,16 @@ describe('boot fails loudly', () => {
   });
 
   test('on duplicate target names', () => {
-    const document = fixtureText.replace('name: cloud\n', 'name: cluster\n');
+    const document = fixtureText.replace(
+      'name: cloud-cloudrun\n',
+      'name: cluster\n',
+    );
     expect(() => parseManifest(document, 'test')).toThrow(/unique/);
+  });
+
+  test('when cloud Targets are not a connectable pair', () => {
+    const document = fixtureText.replace('name: cloud-static', 'name: hosting');
+    expect(() => parseManifest(document, 'test')).toThrow(/matched/);
   });
 
   test('with no targets at all', () => {

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -79,7 +79,7 @@ secretStore:
 targets:
   - name: cluster
     adapter: kubernetes
-  - name: cloud
+  - name: cloud-cloudrun
     adapter: cloudrun
-  - name: hosting
+  - name: cloud-static
     adapter: static


### PR DESCRIPTION
## Summary
Seed manifest-declared Targets into durable database rows before reconciliation, preserving manifest rank while leaving connection facts for the operator-owned connect act. Harden Spindrift image publishing so stale pre-merge images cannot silently roll out a missing reconciler entrypoint.

## Changes
- Seed disconnected Target rows from the stored manifest and add the nullable-connection migration.
- Align manifest and connect Target identities, including matched cloud Target pairs and rank convergence.
- Rebuild the Spindrift runner layer, isolate PR/main caches, assert both runtime entrypoints are packaged, publish only from main, and require review for first-party moving-tag digest pins.
- Correct the Targets UI copy so it no longer claims the reconciler supplies connection facts.

## Test Plan
- [x] `mise run ts:check`
- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test` — 868 passed
- [x] Focused manifest, Target command, and reconciler tests — 74 passed
- [x] `nix run nixpkgs#actionlint -- .github/workflows/containers.yml`
- [x] Local Turbo prune contains `src/reconciler/main.ts`
- [x] Live image inspection reproduced the missing entrypoint and identified the image revision as pre-merge
