### PR TITLE
fix(spindrift): declare target connections

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -591,8 +591,8 @@ vocabulary is lowercase hyphenated words, and so is a project id, so over a
 browser bundle it reports dozens of findings and no bugs. The test says so at
 length, and the exemption is itself tested.
 
-The validated manifest lives in Spindrift's Postgres database. Point the first
-boot of an empty installation at a bootstrap document:
+The validated manifest is durable in Spindrift's Postgres database. Point a
+process at its deployment declaration:
 
 ```bash
 export SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml
@@ -600,11 +600,13 @@ export SPINDRIFT_MANIFEST_PATH=test/fixtures/installation.example.yaml
 export SPINDRIFT_MANIFEST="$(cat test/fixtures/installation.example.yaml)"
 ```
 
-The first process atomically stores the document; later boots read the database
-row and ignore changed bootstrap input. Boot fails loudly, naming every
-offending key, when the stored document is invalid or when both the row and
-bootstrap are absent. Nothing has a default, because a default here would name
-someone's homelab.
+A process validates and reconciles the declared document into the singleton row
+before constructing adapters. A process with no declaration recovers the last
+validated value from Postgres. Boot fails loudly, naming every offending key,
+when a declaration or stored document is invalid, or when both are absent.
+Target connection facts in the document are desired state; omitting them leaves
+an in-product connection untouched. Nothing has a default, because a default
+here would name someone's homelab.
 
 ## Usage
 

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -24,26 +24,28 @@
  * stranded, by asking the adapter to `observe` each orphaned Deploy (§13:
  * "reconnect re-adopts via `observe`").
  */
-import { and, eq, isNotNull, sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { operatorValuesIssues } from '../../adapters/deploy/kubernetes/values.ts';
 import {
   type TargetAdapter,
   targetNameSchema,
 } from '../../config/manifest.schema.ts';
-import { deploys, targets } from '../../db/schema.ts';
+import { targets } from '../../db/schema.ts';
 import {
   deriveHealth,
   type PrerequisiteResult,
 } from '../../domain/capabilities.ts';
 import {
-  type DeployTargetRef,
   type TargetConnection,
   type TargetHealth,
   targetNames,
 } from '../../domain/target.ts';
-import { inspectTarget } from '../../reconciler/target-loop.ts';
-import { type Command, type CommandContext, failed, ok } from '../types.ts';
+import {
+  inspectTarget,
+  readoptTargetDeploys,
+} from '../../reconciler/target-loop.ts';
+import { type Command, failed, ok } from '../types.ts';
 
 /**
  * The delivery flavour a Kubernetes Target declares (§6).
@@ -300,7 +302,7 @@ export const connectTarget: Command<
 
     if (existing.status === 'disconnected') {
       readopted.push(
-        ...(await readopt(
+        ...(await readoptTargetDeploys(
           context,
           existing.id,
           { name, adapter, connection },
@@ -321,52 +323,3 @@ export const connectTarget: Command<
 
   return ok({ targets: registered, readopted });
 };
-
-/**
- * Re-adopt what a disconnect stranded (§13).
- *
- * The adapter's `observe` is the authority, not core's memory: a workload that
- * kept running while the Target was disconnected is adopted back, and one that
- * is gone stays orphaned rather than being resurrected as live. A Deploy with no
- * `ref` was never placed, so there is nothing to ask about.
- */
-async function readopt(
-  context: CommandContext,
-  targetId: string,
-  target: DeployTargetRef,
-  now: Date,
-): Promise<string[]> {
-  const deployAdapter = context.adapters.deploy(target.adapter);
-  if (deployAdapter === null) return [];
-
-  const stranded = await context.db
-    .select()
-    .from(deploys)
-    .where(
-      and(
-        eq(deploys.targetId, targetId),
-        isNotNull(deploys.orphanedAt),
-        isNotNull(deploys.ref),
-      ),
-    );
-
-  const adopted: string[] = [];
-  for (const deploy of stranded) {
-    let observed: Awaited<ReturnType<typeof deployAdapter.observe>>;
-    try {
-      observed = await deployAdapter.observe(target, deploy.ref!);
-    } catch {
-      // Connect still succeeds. An adapter that cannot answer leaves the
-      // Deploy stranded, which is the honest state — not an error to raise.
-      continue;
-    }
-    if (observed === null) continue;
-
-    await context.db
-      .update(deploys)
-      .set({ orphanedAt: null, phase: observed.phase, updatedAt: now })
-      .where(eq(deploys.id, deploy.id));
-    adopted.push(String(deploy.id));
-  }
-  return adopted;
-}

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -1,93 +1,154 @@
 /**
- * Postgres ownership of the installation manifest.
+ * Durable storage for the declared installation manifest.
  *
  * Parsing and validation stay in `manifest.ts`; this module owns the singleton
- * row and the one-time transition from its bootstrap configuration — including
- * ordered Target identities — to durable state.
+ * row and reconciles a deployment declaration — including ordered Target
+ * identities — into durable state.
  */
+import { isDeepStrictEqual } from 'node:util';
+import { sql } from 'drizzle-orm';
 import type { Database } from '../db/client.ts';
 import { installation, targets } from '../db/schema.ts';
 import { unreachablePrerequisites } from '../domain/capabilities.ts';
-import type { InstallationManifest } from './manifest.schema.ts';
-import { loadManifest, ManifestError, validateManifest } from './manifest.ts';
+import type { TargetConnection } from '../domain/target.ts';
+import type { InstallationManifest, TargetSeed } from './manifest.schema.ts';
+import {
+  loadManifest,
+  loadManifestIfPresent,
+  ManifestError,
+  validateManifest,
+} from './manifest.ts';
 
 type Env = Record<string, string | undefined>;
 
 /**
- * Load the database-owned manifest, seeding it once from boot configuration.
+ * Reconcile declared configuration into the durable singleton, then load it.
  *
- * The insert is intentionally conflict-tolerant: `web` and `reconciler` may
- * start together against an empty database. One wins the singleton row and
- * both read that same committed value afterward. Once the row exists, mounted
- * bootstrap configuration is ignored rather than becoming a competing source
- * of desired state.
+ * A mounted or inline declaration is the deployment's desired configuration,
+ * so a validated change updates the row before adapters are constructed. The
+ * row remains a recovery source for a process started without a declaration.
+ * `web` and `reconciler` mount the same ConfigMap revision in production, so
+ * concurrent upserts converge on the same document.
  */
 export async function loadStoredManifest(
   db: Database,
   env: Env = Bun.env,
 ): Promise<InstallationManifest> {
-  const stored = await readStoredManifest(db);
-  let manifest = stored;
-  if (manifest === null) {
-    const bootstrap = await loadManifest(env);
-    await db
-      .insert(installation)
-      .values({ manifest: bootstrap })
-      .onConflictDoNothing({ target: installation.id });
-
-    manifest = await readStoredManifest(db);
-    if (manifest === null) {
-      throw new ManifestError(
-        'installation manifest bootstrap completed without a stored manifest',
-      );
-    }
+  const declared = await loadManifestIfPresent(env);
+  if (declared !== null) {
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(installation)
+        .values({ manifest: declared })
+        .onConflictDoUpdate({
+          target: installation.id,
+          set: { manifest: declared },
+        });
+      await reconcileManifestTargets(tx, declared);
+    });
+    return declared;
   }
 
-  await seedManifestTargets(db, manifest);
+  const manifest = await readStoredManifest(db);
+  if (manifest === null) {
+    // Preserve loadManifest's precise absent-source error for an empty store.
+    await loadManifest(env);
+    throw new ManifestError(
+      'installation manifest reconciliation completed without a stored manifest',
+    );
+  }
+
+  await db.transaction(async (tx) => {
+    await reconcileManifestTargets(tx, manifest);
+  });
   return manifest;
 }
 
 /**
- * Materialize the manifest's ordered Target identities without pretending they
- * are connected.
+ * Materialize the manifest's ordered Target identities and declared
+ * connections.
  *
- * A Target seed carries only a name and adapter. Connection facts remain null
- * until the operator supplies them through `connectTarget`; that command
- * updates this durable row in place and preserves the manifest-established
- * rank. Conflict tolerance makes concurrent web/reconciler startup safe and
- * lets later boots repair a partially completed seed.
+ * An omitted connection leaves existing product-owned connection state alone.
+ * A declared connection is desired state: it creates a connected row and
+ * resets changed connection facts to an unhealthy, awaiting-inspection
+ * checklist. A disconnected row stays disconnected until reconciler startup
+ * can inspect and safely re-adopt its Deploys. Keeping this work in the manifest
+ * transaction means an incompatible target cannot poison the durable
+ * declaration.
  */
-async function seedManifestTargets(
-  db: Database,
+async function reconcileManifestTargets(
+  db: Pick<Database, 'insert' | 'query'>,
   manifest: InstallationManifest,
 ): Promise<void> {
   for (const [rank, target] of manifest.targets.entries()) {
+    const { name, adapter } = target;
+    const declaredConnection = connectionFromSeed(target);
     const existing = await db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, target.name),
+      where: (targets, { eq }) => eq(targets.name, name),
     });
-    if (existing !== undefined && existing.adapter !== target.adapter) {
+    if (existing !== undefined && existing.adapter !== adapter) {
       throw new ManifestError(
-        `manifest Target ${target.name} uses ${target.adapter}, but the stored Target uses ${existing.adapter}`,
+        `manifest Target ${name} uses ${adapter}, but the stored Target uses ${existing.adapter}`,
       );
     }
+
+    const awaitingInspection = unreachablePrerequisites(
+      'Declared Target connection is awaiting inspection',
+      adapter,
+    );
+    const hasConnectionChange =
+      declaredConnection !== null &&
+      !isDeepStrictEqual(existing?.connection, declaredConnection);
 
     await db
       .insert(targets)
       .values({
-        ...target,
+        name,
+        adapter,
         rank,
-        status: 'disconnected' as const,
-        connection: null,
+        status:
+          declaredConnection === null
+            ? ('disconnected' as const)
+            : ('connected' as const),
+        connection: declaredConnection,
         health: 'unhealthy' as const,
-        prerequisites: unreachablePrerequisites(
-          'Target connection has not been configured',
-          target.adapter,
-        ),
+        prerequisites:
+          declaredConnection === null
+            ? unreachablePrerequisites(
+                'Target connection has not been configured',
+                adapter,
+              )
+            : awaitingInspection,
       })
       .onConflictDoUpdate({
         target: targets.name,
-        set: { rank },
+        set: hasConnectionChange
+          ? {
+              rank,
+              ...(existing?.status === 'disconnected'
+                ? {}
+                : { status: 'connected' as const }),
+              connection: declaredConnection,
+              health: 'unhealthy' as const,
+              prerequisites: awaitingInspection,
+              discovery: null,
+              inspectedAt: null,
+              updatedAt: sql`now()`,
+            }
+          : { rank },
       });
+  }
+}
+
+function connectionFromSeed(target: TargetSeed): TargetConnection | null {
+  if (target.connection === undefined) return null;
+  switch (target.adapter) {
+    case 'kubernetes':
+      return { adapter: 'kubernetes', ...target.connection };
+    case 'cloudrun':
+      return { adapter: 'cloudrun', ...target.connection };
+    case 'static':
+      return { adapter: 'static', ...target.connection };
   }
 }
 

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -142,19 +142,92 @@ export const buildRouteSchema = z.discriminatedUnion('adapter', [
     .strict(),
 ]);
 
+const kubernetesDeliverySchema = z.discriminatedUnion('flavour', [
+  z
+    .object({
+      flavour: z.literal('flux-helmrelease'),
+      namespace: nonEmptyString,
+      sourceRef: z
+        .object({
+          name: nonEmptyString,
+          namespace: nonEmptyString,
+        })
+        .strict(),
+    })
+    .strict(),
+  z
+    .object({
+      flavour: z.literal('argo-application'),
+      namespace: nonEmptyString,
+      project: nonEmptyString,
+      repoUrl: nonEmptyString,
+      revision: nonEmptyString,
+      server: nonEmptyString,
+    })
+    .strict(),
+]);
+
 /**
- * A Target as the manifest seeds it. The connect act (Task 13) owns the rest of
- * the model; this is only what must exist before the first boot can place
- * anything.
+ * A Target declared by installation desired state.
+ *
+ * Connection facts are optional so an operator may still seed an identity and
+ * connect it through the product. When supplied, they are ordinary,
+ * credential-free platform configuration and make the connection reproducible
+ * from Git.
  */
-export const targetSeedSchema = z
-  .object({
-    /** Stable identifier, unique within the installation. */
-    name: targetNameSchema,
-    /** Which delivery adapter drives it. */
-    adapter: targetAdapterSchema,
-  })
-  .strict();
+export const targetSeedSchema = z.discriminatedUnion('adapter', [
+  z
+    .object({
+      /** Stable identifier, unique within the installation. */
+      name: targetNameSchema,
+      adapter: z.literal('kubernetes'),
+      connection: z
+        .object({
+          apiServer: z.url(),
+          namespace: nonEmptyString,
+          delivery: kubernetesDeliverySchema,
+          servedHosts: z.array(nonEmptyString).optional(),
+          reachableRegistries: z.array(nonEmptyString).optional(),
+          logHistorySeconds: z.number().int().nonnegative().optional(),
+          chartContract: nonEmptyString.optional(),
+        })
+        .strict()
+        .optional(),
+    })
+    .strict(),
+  z
+    .object({
+      name: targetNameSchema,
+      adapter: z.literal('cloudrun'),
+      connection: z
+        .object({
+          project: nonEmptyString,
+          region: nonEmptyString,
+          endpoint: z.url(),
+          policyEndpoint: z.url().optional(),
+          servedHosts: z.array(nonEmptyString).optional(),
+          reachableRegistries: z.array(nonEmptyString).optional(),
+          logHistorySeconds: z.number().int().nonnegative().optional(),
+        })
+        .strict()
+        .optional(),
+    })
+    .strict(),
+  z
+    .object({
+      name: targetNameSchema,
+      adapter: z.literal('static'),
+      connection: z
+        .object({
+          project: nonEmptyString,
+          endpoint: z.url(),
+          servedHosts: z.array(nonEmptyString).optional(),
+        })
+        .strict()
+        .optional(),
+    })
+    .strict(),
+]);
 
 export const installationManifestSchema = z
   .object({
@@ -408,9 +481,9 @@ export const installationManifestSchema = z
       .strict(),
 
     /**
-     * Targets that exist before anyone connects one, in rank order — rank is one
-     * global ordered list (§13), so the order of this array is the order
-     * placement considers them in.
+     * Targets in rank order. A Target with connection facts is reconciled as
+     * connected; one without them exists for an operator to connect in-product.
+     * Rank is one global ordered list (§13), so array order is placement order.
      */
     targets: z
       .array(targetSeedSchema)

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -1,11 +1,13 @@
 /**
  * Loading and validating the installation manifest.
  *
- * The manifest lives in Postgres. An empty installation bootstraps it from a
- * mounted file (the chart renders one from values into a ConfigMap) or, for
- * tests and local runs, from an inline environment document. Validation
- * failures are fatal and name every offending key at once — a half-configured
- * installation must not reach the point where it can place a workload.
+ * The manifest is durable in Postgres. A declared document from a mounted file
+ * (the chart renders one from values into a ConfigMap) or, for tests and local
+ * runs, an inline environment document is reconciled into that row at process
+ * start. Without a declaration, a process can still recover from the durable
+ * row. Validation failures are fatal and name every offending key at once — a
+ * half-configured installation must not reach the point where it can place a
+ * workload.
  */
 
 import {
@@ -85,6 +87,24 @@ export const DEFAULT_MANIFEST_PATH = '/etc/spindrift/manifest.yaml';
 export async function loadManifest(
   env: Env = Bun.env,
 ): Promise<InstallationManifest> {
+  const manifest = await loadManifestIfPresent(env);
+  if (manifest !== null) return manifest;
+
+  throw new ManifestError(
+    `no installation manifest: set ${MANIFEST_PATH_VAR} to a manifest file or ${MANIFEST_INLINE_VAR} to its contents`,
+  );
+}
+
+/**
+ * Read a declared manifest when one is available.
+ *
+ * An explicit missing path is still an error: it is a broken declaration, not
+ * the same state as no declaration. `null` means callers may deliberately fall
+ * back to a durable copy.
+ */
+export async function loadManifestIfPresent(
+  env: Env = Bun.env,
+): Promise<InstallationManifest | null> {
   const explicitPath = env[MANIFEST_PATH_VAR]?.trim();
   const path = explicitPath || DEFAULT_MANIFEST_PATH;
 
@@ -103,10 +123,7 @@ export async function loadManifest(
   if (inline?.trim()) {
     return parseManifest(inline, `$${MANIFEST_INLINE_VAR}`);
   }
-
-  throw new ManifestError(
-    `no installation manifest: set ${MANIFEST_PATH_VAR} to a manifest file or ${MANIFEST_INLINE_VAR} to its contents`,
-  );
+  return null;
 }
 
 /**

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -163,8 +163,9 @@ export const targetStatus = pgEnum('target_status', [
 
 /**
  * §13: "Connect always succeeds; health is a standing prerequisite checklist."
- * Two states rather than three — the connect act runs one pass of the checklist
- * before it returns, so no Target ever exists unassessed.
+ * Two states rather than three — a declared connection starts unhealthy with
+ * an awaiting-inspection reason, and the target loop replaces that provisional
+ * checklist with observations.
  */
 export const targetHealth = pgEnum('target_health', ['healthy', 'unhealthy']);
 
@@ -211,9 +212,9 @@ export const webauthnPurpose = pgEnum('webauthn_purpose', [
  * The one installation this control plane represents.
  *
  * The manifest is ordinary configuration, not a credential, and §12 makes
- * Postgres the durable source for Spindrift-owned state. A bootstrap document
- * may seed this row once; after that, every process reads the same database
- * value instead of treating a mounted file as a second source of truth.
+ * Postgres its durable store. A deployment declaration reconciles into this
+ * row at process start; without one, every process can recover the same last
+ * validated value from the database.
  */
 export const installation = pgTable(
   'installation',
@@ -650,7 +651,7 @@ export const targets = pgTable(
      * "native OIDC federation, nothing stored."
      *
      * Null means the manifest has established the Target's identity and rank,
-     * but an operator has not supplied its connection facts yet.
+     * but neither desired state nor an operator has supplied connection facts.
      */
     connection: jsonb('connection').$type<TargetConnection>(),
     /** §13: the standing checklist's last verdict. */

--- a/apps/spindrift/src/reconciler/main.ts
+++ b/apps/spindrift/src/reconciler/main.ts
@@ -1,10 +1,10 @@
 /**
  * The `reconciler` process (§19) — production entrypoint.
  *
- * Postgres owns the installation manifest after bootstrap. The process reads
- * that stored document, constructs exactly that installation's adapters, and
- * gives all four polling loops one lifecycle without giving any loop the power
- * to stop its siblings.
+ * The deployment declaration reconciles into Postgres before this process
+ * constructs exactly that installation's adapters. It then gives all four
+ * polling loops one lifecycle without giving any loop the power to stop its
+ * siblings.
  */
 import type { ReconcilerProcessEvent } from './process.ts';
 import { startReconciler } from './start.ts';

--- a/apps/spindrift/src/reconciler/start.ts
+++ b/apps/spindrift/src/reconciler/start.ts
@@ -12,6 +12,7 @@ import type { InstallationManifest } from '../config/manifest.schema.ts';
 import { loadStoredManifest } from '../config/manifest-store.ts';
 import { createClient, createDb } from '../db/client.ts';
 import { type ReconcilerProcessEvent, runReconciler } from './process.ts';
+import { restoreDeclaredTargetConnections } from './target-loop.ts';
 
 type Env = Record<string, string | undefined>;
 
@@ -46,13 +47,15 @@ export async function startReconciler(
     const adapters =
       options.createAdapters?.(manifest) ??
       createAdapterRegistry({ manifest, env });
+    const clock = options.clock ?? systemClock;
+    await restoreDeclaredTargetConnections({ db, adapters, clock }, manifest);
     options.onStarted?.(manifest);
 
     await runReconciler(
       {
         db,
         adapters,
-        clock: options.clock ?? systemClock,
+        clock,
         manifest,
       },
       {

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -20,10 +20,11 @@
  * paths that both decided what "healthy" means would be the two loops §13 says
  * this is not.
  */
-import { eq } from 'drizzle-orm';
+import { and, eq, isNotNull } from 'drizzle-orm';
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
+import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
-import { type Target, targets } from '../db/schema.ts';
+import { deploys, type Target, targets } from '../db/schema.ts';
 import {
   deriveHealth,
   type PrerequisiteResult,
@@ -93,6 +94,102 @@ export async function inspectTarget(
       discovery: null,
     };
   }
+}
+
+/**
+ * Restore connections owned by installation desired state before loops start.
+ *
+ * A disconnected row is deliberately left disconnected while the manifest is
+ * stored: adapters do not exist at that point, so reconnecting there would
+ * strand orphaned Deploys permanently. Once adapters exist, this performs the
+ * same inspect-and-readopt transition as an in-product reconnect.
+ */
+export async function restoreDeclaredTargetConnections(
+  context: TargetLoopContext,
+  manifest: InstallationManifest,
+): Promise<readonly string[]> {
+  const declared = new Set(
+    manifest.targets.flatMap((target) =>
+      target.connection === undefined ? [] : [target.name],
+    ),
+  );
+  if (declared.size === 0) return [];
+
+  const disconnected = await context.db
+    .select()
+    .from(targets)
+    .where(eq(targets.status, 'disconnected'));
+  const readopted: string[] = [];
+
+  for (const target of disconnected) {
+    if (!declared.has(target.name) || !hasTargetConnection(target)) continue;
+
+    const now = context.clock.now();
+    const ref = deployTargetOf(target);
+    const { prerequisites, discovery } = await inspectTarget(context, ref);
+    const health = deriveHealth(prerequisites, target.adapter);
+    await context.db
+      .update(targets)
+      .set({
+        status: 'connected',
+        health,
+        prerequisites,
+        discovery,
+        inspectedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(targets.id, target.id));
+    readopted.push(
+      ...(await readoptTargetDeploys(context, target.id, ref, now)),
+    );
+  }
+
+  return readopted;
+}
+
+/**
+ * Re-adopt what a disconnect stranded (§13).
+ *
+ * The adapter's `observe` is authoritative. A workload still present is
+ * adopted; one that disappeared or cannot be observed stays orphaned.
+ */
+export async function readoptTargetDeploys(
+  context: TargetLoopContext,
+  targetId: string,
+  target: DeployTargetRef,
+  now: Date,
+): Promise<string[]> {
+  const deployAdapter = context.adapters.deploy(target.adapter);
+  if (deployAdapter === null) return [];
+
+  const stranded = await context.db
+    .select()
+    .from(deploys)
+    .where(
+      and(
+        eq(deploys.targetId, targetId),
+        isNotNull(deploys.orphanedAt),
+        isNotNull(deploys.ref),
+      ),
+    );
+
+  const adopted: string[] = [];
+  for (const deploy of stranded) {
+    let observed: Awaited<ReturnType<typeof deployAdapter.observe>>;
+    try {
+      observed = await deployAdapter.observe(target, deploy.ref!);
+    } catch {
+      continue;
+    }
+    if (observed === null) continue;
+
+    await context.db
+      .update(deploys)
+      .set({ orphanedAt: null, phase: observed.phase, updatedAt: now })
+      .where(eq(deploys.id, deploy.id));
+    adopted.push(String(deploy.id));
+  }
+  return adopted;
 }
 
 /** What one Target's refresh did. */

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -29,7 +29,12 @@ import type {
   Clock,
   CommandContext,
 } from '../../src/commands/types.ts';
-import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
+import type {
+  InstallationManifest,
+  TargetAdapter,
+} from '../../src/config/manifest.schema.ts';
+import { MANIFEST_INLINE_VAR } from '../../src/config/manifest.ts';
+import { loadStoredManifest } from '../../src/config/manifest-store.ts';
 import {
   apps,
   builds,
@@ -38,6 +43,7 @@ import {
   targets,
 } from '../../src/db/schema.ts';
 import { deployState } from '../../src/domain/target.ts';
+import { restoreDeclaredTargetConnections } from '../../src/reconciler/target-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import {
   FakeDeployAdapter,
@@ -430,6 +436,52 @@ describe('reconnect re-adopts via observe', () => {
       .from(deploys)
       .where(eq(deploys.targetId, target.id));
     expect(row?.orphanedAt).toEqual(FROZEN);
+  });
+
+  test('a declarative reconnect waits for adapters, then re-adopts', async () => {
+    const { registry, of } = fakes();
+    const input = clusterInput({ name: 'cluster' });
+    await connectTarget(input, context(registry));
+    const target = (await targetRow('cluster'))!;
+    await seedLiveDeploy(target.id, 'ref-1');
+    await disconnectTarget({ name: 'cluster' }, context(registry));
+    of('kubernetes').place('ref-1', {
+      ref: 'ref-1',
+      phase: 'LIVE',
+      artifactDigest: 'sha256:beef',
+    });
+    const declared = {
+      ...manifest,
+      targets: [
+        {
+          name: input.name,
+          adapter: 'kubernetes',
+          connection: {
+            apiServer: input.apiServer,
+            namespace: input.namespace,
+            delivery: input.delivery,
+            chartContract: input.chartContract,
+          },
+        },
+      ],
+    } satisfies InstallationManifest;
+
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(declared),
+    });
+    expect((await targetRow('cluster'))?.status).toBe('disconnected');
+
+    const readopted = await restoreDeclaredTargetConnections(
+      context(registry),
+      declared,
+    );
+    expect(readopted).toHaveLength(1);
+    expect((await targetRow('cluster'))?.status).toBe('connected');
+    const [row] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.targetId, target.id));
+    expect(row?.orphanedAt).toBeNull();
   });
 });
 

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -17,9 +17,45 @@ const FIXTURE = new URL(
 );
 const fixtureText = await Bun.file(FIXTURE).text();
 const fixtureManifest = Bun.YAML.parse(fixtureText) as InstallationManifest;
+const connectedManifest = {
+  ...fixtureManifest,
+  targets: [
+    {
+      name: 'cluster',
+      adapter: 'kubernetes',
+      connection: {
+        apiServer: 'https://cluster.example.test',
+        namespace: 'apps',
+        delivery: {
+          flavour: 'flux-helmrelease',
+          namespace: 'apps',
+          sourceRef: { name: 'infra', namespace: 'flux-system' },
+        },
+        chartContract: '2',
+      },
+    },
+    {
+      name: 'cloud-cloudrun',
+      adapter: 'cloudrun',
+      connection: {
+        project: 'example-vessel',
+        region: 'example-region',
+        endpoint: 'https://run.example.test',
+      },
+    },
+    {
+      name: 'cloud-static',
+      adapter: 'static',
+      connection: {
+        project: 'example-vessel',
+        endpoint: 'https://hosting.example.test',
+      },
+    },
+  ],
+} satisfies InstallationManifest;
 
 describe('the stored installation manifest', () => {
-  test('bootstraps once, then boots from the database alone', async () => {
+  test('stores declared configuration, then boots from the database alone', async () => {
     const first = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,
     });
@@ -74,7 +110,98 @@ describe('the stored installation manifest', () => {
     ]);
   });
 
-  test('the database wins over changed bootstrap configuration', async () => {
+  test('a fresh database reconstructs every declared Target connection', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
+    });
+
+    const rows = await database().db.query.targets.findMany({
+      orderBy: (targets, { asc }) => [asc(targets.rank)],
+    });
+    expect(
+      rows.map(({ name, status, connection }) => ({
+        name,
+        status,
+        connection,
+      })),
+    ).toEqual([
+      {
+        name: 'cluster',
+        status: 'connected',
+        connection: {
+          adapter: 'kubernetes',
+          apiServer: 'https://cluster.example.test',
+          namespace: 'apps',
+          delivery: {
+            flavour: 'flux-helmrelease',
+            namespace: 'apps',
+            sourceRef: { name: 'infra', namespace: 'flux-system' },
+          },
+          chartContract: '2',
+        },
+      },
+      {
+        name: 'cloud-cloudrun',
+        status: 'connected',
+        connection: {
+          adapter: 'cloudrun',
+          project: 'example-vessel',
+          region: 'example-region',
+          endpoint: 'https://run.example.test',
+        },
+      },
+      {
+        name: 'cloud-static',
+        status: 'connected',
+        connection: {
+          adapter: 'static',
+          project: 'example-vessel',
+          endpoint: 'https://hosting.example.test',
+        },
+      },
+    ]);
+  });
+
+  test('a changed declared connection resets its assessment and timestamp', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
+    });
+    const old = new Date('2000-01-01T00:00:00.000Z');
+    await database()
+      .db.update(targets)
+      .set({ health: 'healthy', updatedAt: old })
+      .where(eq(targets.name, 'cluster'));
+    const changed = {
+      ...connectedManifest,
+      targets: connectedManifest.targets.map((target) =>
+        target.adapter === 'kubernetes'
+          ? {
+              ...target,
+              connection: {
+                ...target.connection,
+                apiServer: 'https://replacement.example.test',
+              },
+            }
+          : target,
+      ),
+    } satisfies InstallationManifest;
+
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(changed),
+    });
+
+    const cluster = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(cluster?.connection).toMatchObject({
+      apiServer: 'https://replacement.example.test',
+    });
+    expect(cluster?.health).toBe('unhealthy');
+    expect(cluster?.inspectedAt).toBeNull();
+    expect(cluster?.updatedAt.getTime()).toBeGreaterThan(old.getTime());
+  });
+
+  test('changed declared configuration updates the durable manifest', async () => {
     const first = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,
     });
@@ -86,8 +213,107 @@ describe('the stored installation manifest', () => {
     const later = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: changed,
     });
-    expect(later).toEqual(first);
-    expect(later.installation).toBe('example');
+    expect(later).not.toEqual(first);
+    expect(later.installation).toBe('replacement');
+    expect(await loadStoredManifest(database().db, {})).toEqual(later);
+  });
+
+  test('updating declared configuration preserves connected Target state', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    const before = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    await database()
+      .db.update(targets)
+      .set({
+        status: 'connected',
+        connection: {
+          adapter: 'kubernetes',
+          apiServer: 'https://cluster.example.test',
+          namespace: 'apps',
+          delivery: {
+            flavour: 'flux-helmrelease',
+            namespace: 'apps',
+            sourceRef: { name: 'infra', namespace: 'flux-system' },
+          },
+        },
+      })
+      .where(eq(targets.name, 'cluster'));
+
+    const changed = fixtureText.replace(
+      'installation: example',
+      'installation: replacement',
+    );
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: changed,
+    });
+
+    const after = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(after?.id).toBe(before?.id);
+    expect(after?.status).toBe('connected');
+    expect(after?.connection).toEqual({
+      adapter: 'kubernetes',
+      apiServer: 'https://cluster.example.test',
+      namespace: 'apps',
+      delivery: {
+        flavour: 'flux-helmrelease',
+        namespace: 'apps',
+        sourceRef: { name: 'infra', namespace: 'flux-system' },
+      },
+    });
+  });
+
+  test('an invalid declaration does not overwrite durable configuration', async () => {
+    const first = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    const malformed = fixtureText.replace(
+      'installation: example',
+      'installation: ""',
+    );
+
+    await expect(
+      loadStoredManifest(database().db, {
+        [MANIFEST_INLINE_VAR]: malformed,
+      }),
+    ).rejects.toThrow(ManifestError);
+
+    expect(await loadStoredManifest(database().db, {})).toEqual(first);
+  });
+
+  test('an incompatible Target declaration rolls back manifest and rank changes', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    await database()
+      .db.update(targets)
+      .set({ rank: 99 })
+      .where(eq(targets.name, 'cluster'));
+    const incompatible = {
+      ...fixtureManifest,
+      installation: 'incompatible',
+      targets: [
+        { name: 'cluster', adapter: 'kubernetes' },
+        { name: 'cloud-cloudrun', adapter: 'kubernetes' },
+      ],
+    } satisfies InstallationManifest;
+
+    await expect(
+      loadStoredManifest(database().db, {
+        [MANIFEST_INLINE_VAR]: JSON.stringify(incompatible),
+      }),
+    ).rejects.toThrow(/stored Target uses cloudrun/);
+
+    const [stored] = await database().db.select().from(installation);
+    expect(stored?.manifest).toEqual(fixtureManifest);
+    const cluster = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(cluster?.rank).toBe(99);
   });
 
   test('repairs a stored Target rank from manifest order', async () => {
@@ -107,23 +333,18 @@ describe('the stored installation manifest', () => {
     expect(cluster?.rank).toBe(0);
   });
 
-  test('simultaneous processes converge on the one winning bootstrap', async () => {
+  test('simultaneous processes converge on one declaration', async () => {
     const contender = createDb(database().connect());
-    const replacement = fixtureText.replace(
-      'installation: example',
-      'installation: replacement',
-    );
-
     const [first, second] = await Promise.all([
       loadStoredManifest(database().db, {
         [MANIFEST_INLINE_VAR]: fixtureText,
       }),
       loadStoredManifest(contender, {
-        [MANIFEST_INLINE_VAR]: replacement,
+        [MANIFEST_INLINE_VAR]: fixtureText,
       }),
     ]);
     expect(second).toEqual(first);
-    expect(['example', 'replacement']).toContain(first.installation);
+    expect(first.installation).toBe('example');
     expect(await database().db.select().from(targets)).toHaveLength(3);
   });
 

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -31,8 +31,8 @@ spec:
     # from the HTTPRoute and cert-manager issues the certificate, so this line
     # is the whole of what makes the UI reachable with TLS.
     hostname: spindrift.${SECRET_DOMAIN}
-    # Non-secret first-boot configuration. Core stores the validated document
-    # in Postgres; the database row is authoritative after bootstrap.
+    # Non-secret declared configuration. Core validates and reconciles it into
+    # durable Postgres state whenever a process starts.
     installationManifest:
       installation: offsite
       dns:
@@ -45,7 +45,7 @@ spec:
           audience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
           tokenUrl: https://sts.googleapis.com/v1/token
           tokenPath: /var/run/secrets/spindrift/gcp-token
-          impersonationUrl: null
+          impersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
       charts:
         app: packages/charts/spindrift-app
         installer: packages/charts/spindrift
@@ -69,10 +69,27 @@ spec:
       targets:
         - name: offsite
           adapter: kubernetes
+          connection:
+            apiServer: https://kubernetes.default.svc
+            namespace: spindrift-apps
+            delivery:
+              flavour: flux-helmrelease
+              namespace: spindrift-apps
+              sourceRef:
+                name: infra
+                namespace: flux-system
+            chartContract: "2"
         - name: bluenose-cloudrun
           adapter: cloudrun
+          connection:
+            project: bluenose
+            region: northamerica-northeast1
+            endpoint: https://run.googleapis.com
         - name: bluenose-static
           adapter: static
+          connection:
+            project: bluenose
+            endpoint: https://firebasehosting.googleapis.com
       controlPlane:
         hostname: spindrift.lolwtf.ca
       auth:

--- a/clusters/offsite/apps/spindrift/kustomization.yaml
+++ b/clusters/offsite/apps/spindrift/kustomization.yaml
@@ -1,7 +1,6 @@
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: spindrift
 resources:
   - namespace.yaml
   - secret.sops.yaml

--- a/packages/charts/spindrift/templates/deployment.yaml
+++ b/packages/charts/spindrift/templates/deployment.yaml
@@ -49,6 +49,10 @@ spec:
       labels:
         {{- include "spindrift.labels" $top | nindent 8 }}
         app.kubernetes.io/component: {{ $process.name }}
+      {{- if not (empty $top.Values.installationManifest) }}
+      annotations:
+        checksum/installation-manifest: {{ toJson $top.Values.installationManifest | sha256sum | quote }}
+      {{- end }}
     spec:
       {{- if $top.Values.sandbox }}
       runtimeClassName: gvisor
@@ -84,6 +88,8 @@ spec:
             {{- if $process.federates }}
             - name: SPINDRIFT_IDENTITY_TOKEN_PATH
               value: {{ printf "%s/token" $top.Values.serviceAccount.token.mountPath | quote }}
+            - name: NODE_EXTRA_CA_CERTS
+              value: {{ printf "%s/ca.crt" $top.Values.serviceAccount.token.mountPath | quote }}
             {{- if $top.Values.serviceAccount.token.gcpAudience }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: {{ printf "%s/gcp-credentials.json" $top.Values.serviceAccount.token.mountPath | quote }}
@@ -166,6 +172,11 @@ spec:
                   audience: {{ $top.Values.serviceAccount.token.audience | quote }}
                   expirationSeconds: {{ $top.Values.serviceAccount.token.expirationSeconds }}
                   path: token
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
               {{- if $top.Values.serviceAccount.token.gcpAudience }}
               - serviceAccountToken:
                   audience: {{ $top.Values.serviceAccount.token.gcpAudience | quote }}

--- a/packages/charts/spindrift/templates/installation-manifest.yaml
+++ b/packages/charts/spindrift/templates/installation-manifest.yaml
@@ -7,9 +7,8 @@ metadata:
   labels:
     {{- include "spindrift.labels" $ | nindent 4 }}
 data:
-  # Ordinary, non-secret first-boot configuration. Core validates this
-  # document before atomically seeding its singleton database row; later boots
-  # read the stored row and ignore this bootstrap copy.
+  # Ordinary, non-secret declared configuration. Core validates and reconciles
+  # this document into its durable singleton before constructing adapters.
   manifest.yaml: |
     {{- toYaml .Values.installationManifest | nindent 4 }}
 {{- end }}

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -59,6 +59,12 @@ describe('workload identity', () => {
             },
           },
           {
+            configMap: {
+              name: 'kube-root-ca.crt',
+              items: [{ key: 'ca.crt', path: 'ca.crt' }],
+            },
+          },
+          {
             serviceAccountToken: {
               audience:
                 '//iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite',
@@ -89,6 +95,15 @@ describe('workload identity', () => {
       name: 'GOOGLE_APPLICATION_CREDENTIALS',
       value: '/var/run/secrets/spindrift/gcp-credentials.json',
     });
+    expect(reconciler.containers[0].env).toContainEqual({
+      name: 'NODE_EXTRA_CA_CERTS',
+      value: '/var/run/secrets/spindrift/ca.crt',
+    });
+    expect(
+      web.containers[0].env.some(
+        (item: { name: string }) => item.name === 'NODE_EXTRA_CA_CERTS',
+      ),
+    ).toBe(false);
   });
 });
 
@@ -108,7 +123,7 @@ describe('Secret-backed authentication configuration', () => {
   });
 });
 
-describe('installation manifest bootstrap', () => {
+describe('declared installation manifest', () => {
   test('mounts ordinary configuration from a ConfigMap in every process', async () => {
     const objects = await render({
       installationManifest: { installation: 'example' },
@@ -130,6 +145,11 @@ describe('installation manifest bootstrap', () => {
     expect(deployments).toHaveLength(2);
     for (const deployment of deployments) {
       const pod = deployment.spec.template.spec;
+      expect(
+        deployment.spec.template.metadata.annotations?.[
+          'checksum/installation-manifest'
+        ],
+      ).toMatch(/^[a-f0-9]{64}$/);
       expect(pod.volumes).toContainEqual({
         name: 'installation-manifest',
         configMap: { name: 'spindrift-installation-manifest' },
@@ -149,6 +169,39 @@ describe('installation manifest bootstrap', () => {
         ),
       ).toBe(false);
     }
+  });
+
+  test('rolls every process when declared configuration changes', async () => {
+    const first = await render({
+      installationManifest: { installation: 'first' },
+      reconciler: { enabled: true },
+    });
+    const second = await render({
+      installationManifest: { installation: 'second' },
+      reconciler: { enabled: true },
+    });
+
+    const checksums = (objects: typeof first) =>
+      objects
+        .filter((object) => object.kind === 'Deployment')
+        .map(
+          (deployment) =>
+            deployment.spec.template.metadata.annotations[
+              'checksum/installation-manifest'
+            ],
+        );
+    expect(new Set(checksums(first))).toHaveLength(1);
+    expect(new Set(checksums(second))).toHaveLength(1);
+    expect(checksums(first)[0]).not.toBe(checksums(second)[0]);
+  });
+
+  test('does not add a manifest checksum without a declaration', async () => {
+    const deployment = one(await render(), 'Deployment', 'spindrift-web');
+    expect(
+      deployment.spec.template.metadata.annotations?.[
+        'checksum/installation-manifest'
+      ],
+    ).toBeUndefined();
   });
 });
 

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -6,10 +6,10 @@
 # release supplies the manifest document plus `hostname`, which is where this
 # control plane is served; both are empty here.
 #
-# The installation manifest is ordinary configuration. On the first boot it is
-# mounted from a ConfigMap and atomically seeds Spindrift's database; the stored
-# row is authoritative afterward. Public identifiers such as a GitHub App id do
-# not make the document a credential.
+# The installation manifest is ordinary configuration. It is mounted from a
+# ConfigMap and reconciled into Spindrift's durable database when each process
+# starts. Public identifiers such as a GitHub App id do not make the document a
+# credential.
 
 image: ""
 
@@ -65,8 +65,8 @@ command: "bun run src/web/server.ts"
 # so rather than the chart assuming a runtime class exists.
 sandbox: false
 
-# First-boot configuration only. Once the database has an installation row,
-# changing this value does not overwrite it.
+# Declared installation configuration. The chart hashes it into both pod
+# templates so a change rolls the processes that reconcile it into Postgres.
 installationManifest: {}
 
 # The Secret carrying `SPINDRIFT_ENROLMENT_TOKEN` and repository credentials

--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -5,10 +5,23 @@ resource "google_service_account" "spindrift_runtime" {
   depends_on = [google_project_service.service["iam.googleapis.com"]]
 }
 
+resource "google_service_account" "spindrift_controller" {
+  account_id   = "spindrift-controller"
+  display_name = "Spindrift platform controller"
+
+  depends_on = [google_project_service.service["iam.googleapis.com"]]
+}
+
+resource "google_service_account_iam_member" "spindrift_controller_workload_identity" {
+  service_account_id = google_service_account.spindrift_controller.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = local.spindrift_principal
+}
+
 resource "google_service_account_iam_member" "spindrift_act_as_runtime" {
   service_account_id = google_service_account.spindrift_runtime.name
   role               = "roles/iam.serviceAccountUser"
-  member             = local.spindrift_principal
+  member             = google_service_account.spindrift_controller.member
 }
 
 locals {
@@ -29,5 +42,5 @@ resource "google_project_iam_member" "spindrift" {
 
   project = local.project
   role    = each.key
-  member  = local.spindrift_principal
+  member  = google_service_account.spindrift_controller.member
 }


### PR DESCRIPTION
## Summary

- declare and transactionally reconcile all three Spindrift target connections from the offsite HelmRelease, including safe restart/re-adoption behavior
- roll manifest changes, project the cluster CA into the reconciler, and preserve the target RoleBindings in their intended namespaces
- add an impersonated Spindrift controller service account in Terraform so Firebase Hosting and Cloud Run use service-account credentials without granting controller roles to the runtime identity

## Validation

- `bun test --cwd apps/spindrift` — 836 pass, 0 fail
- `bun test packages/charts/spindrift/tests/render.test.ts` — 9 pass, 0 fail
- `mise run ts:check` — passes; one pre-existing unused-import warning remains in untouched `src/supply-chain/signature.ts`
- `mise run k8s:render-apps`
- `mise run tf:fmt`
- `mise run tf:validate` — all roots valid; existing provider deprecation warnings only
- exact offsite HelmRelease manifest validated with all three targets connected
- rendered RoleBindings verified in `flux-system` and `spindrift-apps`

## Rollout

Atlantis should plan the `terraform/gcp/projects/bluenose` identity changes. After plan review, `atlantis apply` is the only Terraform apply path; successful apply automerges and Flux applies the Kubernetes desired state. The Spindrift source change then ships through the repository container/image update workflow.

Repository connection is intentionally separate from deploy Target connection state: the handoff does not provide the GitHub App installation id or detection scopes needed to declare it safely.