### PR TITLE
chore(spindrift): deploy target connection fix

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -25,7 +25,7 @@ spec:
   values:
     # Renovate pins the digest on this line. Flux picks up the change
     # and rolls out the new image automatically.
-    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:068160573f67112f61a965bc4dcb7938d1c1cb438f125ad62031f33a6889a0fe
+    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:4c3c7c31a96e8c18d446e49674c7a7e68f49a9216e00807a825801418dbc2e04
     # Substituted by the apps Kustomization from the cluster-secrets Secret, so
     # the zone is read rather than restated. external-dns publishes the record
     # from the HTTPRoute and cert-manager issues the certificate, so this line


### PR DESCRIPTION
## Summary

Pins the Spindrift image built from merge commit `6cd6483efe9ff4f5c6dec9a68b069b7d5233f207`, which contains the declarative target connection fix from #1346.

The published OCI image is `ghcr.io/jonpulsifer/spindrift@sha256:4c3c7c31a96e8c18d446e49674c7a7e68f49a9216e00807a825801418dbc2e04`; its `org.opencontainers.image.revision` label matches that merge commit.

## Validation

- merge-triggered container workflow completed successfully
- image vulnerability scan completed successfully
- `mise run k8s:render-apps`

This explicit signed digest PR supersedes stale Renovate PR #1348, which still points at an earlier image revision.