### PR TITLE
fix(spindrift): reconcile Git chart revisions

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -18,6 +18,7 @@ spec:
   chart:
     spec:
       chart: packages/charts/spindrift
+      reconcileStrategy: Revision
       sourceRef:
         kind: GitRepository
         name: infra


### PR DESCRIPTION
## Summary

Sets `reconcileStrategy: Revision` for Spindrift’s GitRepository-backed chart.

Without this, the HelmChart source advances to a new Git revision but helm-controller keeps reporting chart version `0.1.1` and does not upgrade changed templates. That left the manually recreated installation ConfigMap and projected CA volume stale even after #1346 and #1349 merged.

With revision reconciliation, Flux renders chart content from each merged Git revision. Helm ownership takeover remains enabled by the existing default (`disableTakeOwnership: false`), so the declared ConfigMap can replace the client-side-owned drift through the controller rather than a manual patch.

## Validation

- `mise run k8s:render-apps`
- live read-only inspection confirmed the HelmChart source artifact is at the merged Git revision while the Helm release manifest is still the old chart content