### PR TITLE
fix(spindrift): stabilize migration job identity

### DIFF
--- a/packages/charts/spindrift/templates/_helpers.tpl
+++ b/packages/charts/spindrift/templates/_helpers.tpl
@@ -39,11 +39,12 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
-The migration Job's name carries the image digest, so a new image is a new Job
-rather than an immutable-field conflict on the old one.
+The migration Job's name carries a digest of every operator-controlled input to
+its immutable pod template. A changed migration becomes a new Job; an unrelated
+chart revision leaves the completed Job alone.
 */}}
 {{- define "spindrift.migrationName" -}}
-{{- $tag := last (splitList ":" .Values.image) -}}
-{{- $safe := $tag | lower | replace "." "-" | replace "@" "-" | replace "_" "-" | replace "+" "-" | trunc 20 | trimSuffix "-" -}}
-{{ include "spindrift.fullname" . }}-migrate-{{ $safe }}
+{{- $inputs := dict "image" .Values.image "command" .Values.database.migration.command "sandbox" .Values.sandbox "envFromSecret" .Values.envFromSecret -}}
+{{- $digest := toJson $inputs | sha256sum | trunc 20 -}}
+{{ include "spindrift.fullname" . }}-migrate-{{ $digest }}
 {{- end }}

--- a/packages/charts/spindrift/templates/migration.yaml
+++ b/packages/charts/spindrift/templates/migration.yaml
@@ -6,12 +6,13 @@ Migrations as a Job, for an installation that wants them applied that way.
 migrations as an out-of-band operator act — so a release that turns this on has
 to supply a command that invokes the library.
 
-The Job's name carries the image digest, so a redeploy of the same image is the
-same Job (already complete, nothing rerun) and a new image is a new Job — rather
-than an attempted mutation of a completed Job's immutable pod template. That is
-`packages/charts/app`'s pattern, kept rather than replaced with a Helm hook:
-a hook would make Flux block on the Job, and the digest-named Job already gives
-run-once-per-image without the coupling.
+The Job's name carries a digest of its execution inputs, so an unchanged
+migration is the same completed Job and changed inputs create a new one. The pod
+template deliberately excludes revision-varying chart labels: Kubernetes makes
+that template immutable, and a Git chart revision must not turn an unrelated
+label change into a failed upgrade. This keeps `packages/charts/app`'s Job
+pattern rather than replacing it with a Helm hook that would couple Flux to the
+Job.
 */}}
 {{- if and .Values.database.enabled .Values.database.migration.enabled }}
 apiVersion: batch/v1
@@ -28,8 +29,7 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "spindrift.labels" . | nindent 8 }}
-        app.kubernetes.io/component: migration
+        {{- include "spindrift.selectorLabels" (dict "Release" .Release "Values" .Values "Chart" .Chart "component" "migration") | nindent 8 }}
     spec:
       restartPolicy: OnFailure
       {{- if .Values.sandbox }}

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -123,6 +123,46 @@ describe('Secret-backed authentication configuration', () => {
   });
 });
 
+describe('migration Job identity', () => {
+  const database = {
+    enabled: true,
+    migration: {
+      enabled: true,
+      command: 'bun run migrate',
+    },
+  };
+
+  test('is stable for the same execution inputs and excludes chart revision labels', async () => {
+    const first = one(await render({ database }), 'Job');
+    const second = one(await render({ database }), 'Job');
+
+    expect(first.metadata.name).toBe(second.metadata.name);
+    expect(first.metadata.name).toMatch(/^spindrift-migrate-[a-f0-9]{20}$/);
+    expect(first.spec.template.metadata.labels).toEqual({
+      'app.kubernetes.io/name': 'spindrift',
+      'app.kubernetes.io/component': 'migration',
+    });
+  });
+
+  test('changes when an immutable execution input changes', async () => {
+    const first = one(await render({ database }), 'Job');
+    const changed = one(
+      await render({
+        database: {
+          ...database,
+          migration: {
+            enabled: true,
+            command: 'bun run migrate --strict',
+          },
+        },
+      }),
+      'Job',
+    );
+
+    expect(changed.metadata.name).not.toBe(first.metadata.name);
+  });
+});
+
 describe('declared installation manifest', () => {
   test('mounts ordinary configuration from a ConfigMap in every process', async () => {
     const objects = await render({


### PR DESCRIPTION
## Summary

Makes the migration Job identity depend on its immutable execution inputs rather than a truncated image suffix, and removes revision-varying Helm chart labels from the immutable pod template.

This fixes the rollout exposed after #1351 enabled Git revision chart reconciliation: Helm reached the new chart and took ownership of the stale manifest ConfigMap, but Kubernetes rejected the completed migration Job because only its `helm.sh/chart` pod-template label changed. The failed release rolled back cleanly.

The new Job name differs for image, command, sandbox, or Secret input changes, while unrelated chart revisions reuse the same completed Job without an immutable-field patch.

## Validation

- `bun test packages/charts/spindrift/tests/render.test.ts` — 11 pass, 0 fail
- `mise run k8s:render-apps`
- regression asserts stable identity and labels for equal execution inputs
- regression asserts a changed immutable command produces a new Job name