### PR TITLE
feat(spindrift): stream live status and logs (Ticket 08)

### DIFF
--- a/apps/spindrift/src/db/notify.ts
+++ b/apps/spindrift/src/db/notify.ts
@@ -1,0 +1,65 @@
+/**
+ * In-process wake-up for attempt-event poll loops (§6, Transport shape).
+ *
+ * **Purely an optimization, never the delivery path.** The poll loop in
+ * `src/web/streams.ts` converges identically with every notification
+ * dropped — this only shortens the sleep, never extends it.
+ *
+ * When the web process itself writes an attempt event (build callbacks,
+ * webhook-triggered builds), the write path fires `notifyAttemptEvent`,
+ * which wakes every pump loop subscribed to that component. The
+ * reconciler runs in a separate process and its writes arrive on the
+ * next poll tick (up to 750ms), which is the same latency this install
+ * has when the web process restarts and loses all in-process state.
+ *
+ * **Why not Postgres `LISTEN`/`NOTIFY`?** Bun's native SQL client
+ * (`bun:SQL`) does not yet expose a session-level `LISTEN` API. Adding
+ * a `postgres.js` dependency for one notification channel is a bigger
+ * change than the latency improvement justifies, and the plan is
+ * explicit that NOTIFY is an optimization — one that can land later
+ * when the client supports it, without changing the pump logic at all.
+ */
+
+type Listener = () => void;
+
+const listeners = new Map<string, Set<Listener>>();
+
+/**
+ * Wake every pump loop watching events for this component.
+ *
+ * Called from `src/domain/attempt-log.ts` after each successful insert.
+ * Fire-and-forget: a lost notification only delays the next poll.
+ */
+export function notifyAttemptEvent(componentId: string): void {
+  const set = listeners.get(componentId);
+  if (set === undefined) return;
+  for (const listener of set) {
+    try {
+      listener();
+    } catch {
+      // A listener that throws is a listener that is going away.
+    }
+  }
+}
+
+/**
+ * Subscribe to in-process wake-ups for one component's attempt events.
+ *
+ * Returns an unsubscribe function. The caller (the pump loop) calls it
+ * when the WebSocket closes.
+ */
+export function onAttemptEvent(
+  componentId: string,
+  listener: Listener,
+): () => void {
+  let set = listeners.get(componentId);
+  if (set === undefined) {
+    set = new Set();
+    listeners.set(componentId, set);
+  }
+  set.add(listener);
+  return () => {
+    set.delete(listener);
+    if (set.size === 0) listeners.delete(componentId);
+  };
+}

--- a/apps/spindrift/src/domain/attempt-log.ts
+++ b/apps/spindrift/src/domain/attempt-log.ts
@@ -41,6 +41,7 @@ import {
   type FailureReason,
 } from '../adapters/deploy/contract.ts';
 import type { Database } from '../db/client.ts';
+import { notifyAttemptEvent } from '../db/notify.ts';
 import { attemptEvents } from '../db/schema.ts';
 
 /** The cursor a resumed read starts after — an `attemptEvents.id` value. */
@@ -205,6 +206,10 @@ async function insertEvent(
     reason: reason ?? null,
     blame: reason ? blameFor(reason) : null,
   });
+
+  // Wake any WebSocket pump loops watching this component (Transport shape).
+  // Fire-and-forget: a lost notification only delays the next poll.
+  notifyAttemptEvent(args.componentId);
 }
 
 /**

--- a/apps/spindrift/src/web/streams.ts
+++ b/apps/spindrift/src/web/streams.ts
@@ -12,6 +12,7 @@ import type {
 } from '../adapters/deploy/contract.ts';
 import type { RequestAuthentication } from '../auth/types.ts';
 import type { CommandContext, Principal } from '../commands/types.ts';
+import { onAttemptEvent } from '../db/notify.ts';
 import { components, deploys, targets } from '../db/schema.ts';
 import {
   type AttemptLogCursor,
@@ -36,6 +37,8 @@ interface AttemptSocketData {
   readonly deployId?: number;
   cursor: AttemptLogCursor | null;
   closed: boolean;
+  /** Tear down the in-process event subscription (Transport shape). */
+  unsubscribe: (() => void) | null;
 }
 
 interface RuntimeSocketData {
@@ -146,6 +149,7 @@ async function upgradeAttempt(
       ...(deployId === null ? {} : { deployId }),
       cursor: after === null ? null : after,
       closed: false,
+      unsubscribe: null,
     },
   });
   return upgraded
@@ -288,6 +292,14 @@ export async function readStreamPage(
 
 export const streamWebSocket: Bun.WebSocketHandler<StreamSocketData> = {
   open(socket) {
+    // Subscribe to in-process wake-ups so the pump fires immediately when
+    // the web process itself writes an event (Transport shape).
+    if (socket.data.kind === 'attempt') {
+      socket.data.unsubscribe = onAttemptEvent(
+        socket.data.componentId,
+        () => void pump(socket),
+      );
+    }
     void pump(socket);
   },
   message() {
@@ -295,6 +307,10 @@ export const streamWebSocket: Bun.WebSocketHandler<StreamSocketData> = {
   },
   close(socket) {
     socket.data.closed = true;
+    if (socket.data.kind === 'attempt') {
+      socket.data.unsubscribe?.();
+      socket.data.unsubscribe = null;
+    }
   },
 };
 

--- a/apps/spindrift/test/web/streams.test.ts
+++ b/apps/spindrift/test/web/streams.test.ts
@@ -291,4 +291,160 @@ describe('authenticated attempt stream', () => {
       reason: 'STARTUP_FAILED',
     });
   });
+
+  test('events written by the reconciler while no pump is connected are picked up on resume without gaps', async () => {
+    // Simulates a controller restart: the web process was down (or the
+    // WebSocket was disconnected), the reconciler kept writing events, and
+    // then a new web process or a new WebSocket connection picks up from
+    // the last cursor. This proves the durable cursor survives the gap.
+    const seeded = await seedAttempt();
+    const principal = {
+      id: seeded.user.id,
+      displayName: seeded.user.displayName,
+    };
+
+    // Phase 1: A pump reads the first event and records a cursor.
+    await recordBuildEvent(
+      database().db,
+      {
+        appId: seeded.app.id,
+        componentId: seeded.component.id,
+        buildId: seeded.build.id,
+      },
+      { type: 'log', line: 'step 1' },
+    );
+
+    let firstData: StreamSocketData | null = null;
+    const firstServer = {
+      upgrade: (_request: Request, options: { data: StreamSocketData }) => {
+        firstData = options.data;
+        return true;
+      },
+    } as unknown as Bun.Server<StreamSocketData>;
+    const firstCtx = await context(principal);
+    await streamRoutes({
+      authenticate: async () => ({ kind: 'authenticated', principal }),
+      context: () => firstCtx,
+    })[ATTEMPT_STREAM_PATH]!(
+      request(`buildId=${seeded.build.id}`),
+      firstServer,
+    );
+    const firstPage = await readStreamPage(firstData!);
+    expect(firstPage.kind).toBe('attempt');
+    if (firstPage.kind !== 'attempt') return;
+    expect(firstPage.entries).toHaveLength(1);
+    const savedCursor = firstPage.cursor;
+
+    // Phase 2: While no WebSocket is connected (simulating web downtime),
+    // the reconciler writes multiple events. No pump is running.
+    await recordBuildEvent(
+      database().db,
+      {
+        appId: seeded.app.id,
+        componentId: seeded.component.id,
+        buildId: seeded.build.id,
+      },
+      { type: 'log', line: 'step 2' },
+    );
+    await recordBuildEvent(
+      database().db,
+      {
+        appId: seeded.app.id,
+        componentId: seeded.component.id,
+        buildId: seeded.build.id,
+      },
+      { type: 'log', line: 'step 3' },
+    );
+    await recordDeployEvent(
+      database().db,
+      {
+        appId: seeded.app.id,
+        componentId: seeded.component.id,
+        deployId: seeded.deploy.id,
+      },
+      { type: 'status', phase: 'APPLYING' },
+    );
+
+    // Phase 3: A completely new context (simulating a restarted web
+    // process) resumes from the saved cursor. All events written during
+    // the gap must appear, in order, with no duplicates.
+    let resumedData: StreamSocketData | null = null;
+    const newServer = {
+      upgrade: (_request: Request, options: { data: StreamSocketData }) => {
+        resumedData = options.data;
+        return true;
+      },
+    } as unknown as Bun.Server<StreamSocketData>;
+    const newCtx = await context(principal);
+    await streamRoutes({
+      authenticate: async () => ({ kind: 'authenticated', principal }),
+      context: () => newCtx,
+    })[ATTEMPT_STREAM_PATH]!(
+      request(
+        `buildId=${seeded.build.id}&deployId=${seeded.deploy.id}&after=${encodeURIComponent(String(savedCursor))}`,
+      ),
+      newServer,
+    );
+    const resumed = await readStreamPage(resumedData!);
+    expect(resumed.kind).toBe('attempt');
+    if (resumed.kind !== 'attempt') return;
+    // Exactly the 3 events written during the gap, nothing from before
+    expect(resumed.entries).toHaveLength(3);
+    expect(resumed.entries.map((e) => e.type)).toEqual([
+      'log',
+      'log',
+      'status',
+    ]);
+    if (resumed.entries[0]?.type === 'log') {
+      expect(resumed.entries[0].line).toBe('step 2');
+    }
+    if (resumed.entries[1]?.type === 'log') {
+      expect(resumed.entries[1].line).toBe('step 3');
+    }
+    if (resumed.entries[2]?.type === 'status') {
+      expect(resumed.entries[2].phase).toBe('APPLYING');
+    }
+  });
+});
+
+describe('in-process attempt event notifications', () => {
+  test('notifyAttemptEvent wakes a subscribed listener', async () => {
+    const { notifyAttemptEvent, onAttemptEvent } = await import(
+      '../../src/db/notify.ts'
+    );
+    const wakes: string[] = [];
+    const unsub = onAttemptEvent('comp-1', () => wakes.push('woke'));
+
+    notifyAttemptEvent('comp-1');
+    expect(wakes).toEqual(['woke']);
+
+    // A second component's events do not wake this listener.
+    notifyAttemptEvent('comp-2');
+    expect(wakes).toEqual(['woke']);
+
+    // After unsubscribing, no more wakes.
+    unsub();
+    notifyAttemptEvent('comp-1');
+    expect(wakes).toEqual(['woke']);
+  });
+
+  test('recordBuildEvent fires the in-process notification', async () => {
+    const { onAttemptEvent } = await import('../../src/db/notify.ts');
+    const seeded = await seedAttempt();
+    const wakes: string[] = [];
+    const unsub = onAttemptEvent(seeded.component.id, () => wakes.push('woke'));
+
+    await recordBuildEvent(
+      database().db,
+      {
+        appId: seeded.app.id,
+        componentId: seeded.component.id,
+        buildId: seeded.build.id,
+      },
+      { type: 'log', line: 'triggers notification' },
+    );
+
+    expect(wakes).toEqual(['woke']);
+    unsub();
+  });
 });


### PR DESCRIPTION
## Summary
Implements Ticket 08 (Stream live status and logs) for Spindrift v1. Adds an in-process event notification bus to eliminate pump polling delay for in-process attempt events, along with unit and controller restart tests.

## Changes
- `feat(spindrift): add in-process event notification bus for live streams`
  - Created `src/db/notify.ts` in-process event bus for immediate WebSocket pump wake-ups.
  - Wired `notifyAttemptEvent` into `recordBuildEvent` and `recordDeployEvent` in `src/domain/attempt-log.ts`.
  - Subscribed WebSocket pump loop in `src/web/streams.ts` to `onAttemptEvent` listeners.
  - Added controller restart gap tests and in-process notification unit tests in `test/web/streams.test.ts`.

## Test Plan
- [x] Run `bun run typecheck` cleanly in `apps/spindrift`.
- [x] Run `bun test test/web/stream-client.test.ts` (pass).
- [x] Verify Biome code formatting with `bun run lint`.
