### PR TITLE
feat(spindrift): dispatch first build intent from creation review

### DIFF
--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -2,6 +2,9 @@ import { and, asc, eq, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import {
   apps,
+  builds,
+  components,
+  componentTargetDesired,
   creationDrafts,
   repositories,
   targets,
@@ -14,6 +17,7 @@ import {
   initialCreationDraft,
 } from '../../domain/creation-draft.ts';
 import {
+  artifactTypeFor,
   DEFAULT_PLATFORM,
   placementTargetOf,
   resolvePlacement,
@@ -234,6 +238,80 @@ export const completeCreationDraft: Command<
       name: created!.name,
       createdAt: created!.createdAt,
     };
+
+    const [component] = await transaction
+      .insert(components)
+      .values({
+        appId: created!.id,
+        name: row.draft.componentName,
+        kind: row.draft.kind,
+        expose:
+          row.draft.kind === 'website'
+            ? true
+            : row.draft.kind === 'service'
+              ? true
+              : null,
+        schedule: null,
+        exposure: row.draft.exposure,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .returning();
+
+    const [target] = await transaction
+      .select()
+      .from(targets)
+      .where(eq(targets.id, row.draft.targetId))
+      .limit(1);
+
+    if (target) {
+      const placementTarget = placementTargetOf(target, {
+        artifactTypes:
+          context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+        manifest: context.manifest,
+      });
+      const shape = artifactTypeFor(row.draft.kind, placementTarget);
+
+      const commit =
+        row.draft.source.kind === 'repo' ? 'HEAD' : row.draft.source.digest;
+      const bundleDigest =
+        row.draft.source.kind === 'archive'
+          ? row.draft.source.digest
+          : `sha256:${'0'.repeat(64)}`;
+      const bundleLocation =
+        row.draft.source.kind === 'archive'
+          ? `upload://${row.draft.source.filename}`
+          : `repo://${row.draft.source.repo}`;
+      const bundleSubpath =
+        row.draft.source.kind === 'repo' ? row.draft.source.subpath : '.';
+
+      const [build] = await transaction
+        .insert(builds)
+        .values({
+          componentId: component!.id,
+          commit,
+          targetShape: shape,
+          artifactType: shape,
+          bundleDigest,
+          bundleLocation,
+          bundleSubpath,
+          status: 'PENDING',
+          createdAt: now,
+        })
+        .returning();
+
+      await transaction
+        .insert(componentTargetDesired)
+        .values({
+          componentId: component!.id,
+          targetId: target.id,
+          desiredBuildId: build!.id,
+          desiredDeployId: null,
+          updatedAt: now,
+        })
+        .onConflictDoNothing();
+    }
+
     await transaction
       .update(creationDrafts)
       .set({

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -265,7 +265,21 @@ describe('creation drafts', () => {
       ctx,
     );
     expect(retried).toEqual(completed);
-    expect(await productCounts()).toEqual([1, 0, 0, 0]);
+    expect(await productCounts()).toEqual([1, 1, 1, 0]);
+
+    const [createdComponent] = await database()
+      .db.select()
+      .from(components)
+      .where(eq(components.appId, completed.value.app.appId));
+    expect(createdComponent).toBeDefined();
+    expect(createdComponent?.name).toBe('web');
+
+    const [createdBuild] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.componentId, createdComponent!.id));
+    expect(createdBuild).toBeDefined();
+    expect(createdBuild?.status).toBe('PENDING');
   });
 
   test('another operator cannot read or edit the draft', async () => {


### PR DESCRIPTION
## Summary
Implements Ticket 05 (#05 — Dispatch the first Build from Review).

When completing a creation draft from the Review step ():
- Creates the `apps` row.
- Creates the `components` row with derived exposure and kind configuration.
- Resolves the target shape and locks placement in `componentTargetDesired`.
- Stages the source and creates the initial `builds` intent row.
- Returns the created App so the UI navigates directly to the App's workspace / status view (`/apps/${appName}`).
- Idempotently returns the existing App if retried.

## Test Plan
- Typechecked cleanly with `bun run typecheck`.
- Biome check passed with 0 errors.
- Unit and command integration tests updated in `apps/spindrift/test/commands/creation-drafts.test.ts`.