### PR TITLE
feat(spindrift): complete first Build dispatch from Review

### DIFF
--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -30,6 +30,7 @@ import type {
 import type { InstallationManifest } from '../config/manifest.ts';
 import type { BuildRouteProfile } from '../domain/build-route.ts';
 import type { RepositoryHost } from '../domain/repository.ts';
+import type { RepositorySourceStager } from '../domain/source-bundle.ts';
 import { GitHubApp } from '../integrations/github/app.ts';
 import type { Fetcher } from '../integrations/github/http.ts';
 import { CoreSupplyChain, CosignSigner } from '../supply-chain/sign.ts';
@@ -124,6 +125,8 @@ export interface RegistryOptions {
   readonly buildToken?: () => string | Promise<string>;
   /** And for the cloud runtimes a Target is deployed to. */
   readonly cloudToken?: () => string | Promise<string>;
+  /** Source depot wiring, supplied by the live source-ingestion installation. */
+  readonly source?: RepositorySourceStager;
 }
 
 /**
@@ -251,6 +254,10 @@ export function createAdapterRegistry(
      */
     repository(): RepositoryHost | null {
       return repositoryHost;
+    },
+
+    source() {
+      return options.source ?? null;
     },
 
     supplyChain() {

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -40,6 +40,12 @@ export const getAppWorkspace: Command<
             orderBy: (builds, { desc }) => [desc(builds.createdAt)],
             limit: 1,
           },
+          desiredTargets: {
+            limit: 1,
+            with: {
+              target: true,
+            },
+          },
         },
       },
       datastores: {
@@ -64,21 +70,23 @@ export const getAppWorkspace: Command<
   const primaryComponent = app.components[0];
   const latestDeploy = primaryComponent?.deploys[0];
   const latestTarget = latestDeploy?.target;
+  const desiredTarget = primaryComponent?.desiredTargets[0]?.target;
+  const workspaceTarget = latestTarget ?? desiredTarget;
 
   const components: ComponentView[] = app.components.map((comp) => {
     const deploy = comp.deploys[0];
     const build = deploy?.build ?? comp.builds[0];
     let artifact = 'none';
     if (build?.artifactDigest) {
-      artifact = `image · ${build.artifactDigest.slice(0, 12)}`;
+      artifact = `${build.artifactType} · ${build.artifactDigest.slice(0, 12)}`;
     } else if (build?.commit) {
-      artifact = `commit · ${build.commit.slice(0, 7)}`;
+      artifact = `${build.artifactType} from ${build.commit.slice(0, 7)}`;
     }
 
     return {
       name: comp.name,
       kind: comp.kind,
-      phase: (deploy?.phase ?? 'PENDING') as DeployPhase,
+      phase: phaseFor(deploy?.phase, build?.status),
       artifact,
       exposure: comp.exposure,
     };
@@ -178,13 +186,19 @@ export const getAppWorkspace: Command<
 
   const workspace: WorkspaceView = {
     app: app.name,
-    target: latestTarget?.name ?? 'none',
+    target: workspaceTarget?.name ?? 'none',
     vessel: app.vesselRef ?? 'none',
-    prerequisitesMet: latestTarget ? latestTarget.health === 'healthy' : false,
-    phase: (latestDeploy?.phase ?? 'PENDING') as DeployPhase,
+    prerequisitesMet: workspaceTarget
+      ? workspaceTarget.health === 'healthy'
+      : false,
+    phase: phaseFor(latestDeploy?.phase, primaryComponent?.builds[0]?.status),
     url: latestDeploy?.url ?? app.vanityDomain ?? '',
     urlLive: latestDeploy?.phase === 'LIVE',
-    release: latestDeploy ? `Deploy ${latestDeploy.id}` : 'latest',
+    release: latestDeploy
+      ? `Deploy ${latestDeploy.id}`
+      : primaryComponent?.builds[0]
+        ? `Build ${primaryComponent.builds[0].id}`
+        : 'none',
     components,
     datastores: Array.from(datastoresMap.values()),
     activity,
@@ -193,6 +207,23 @@ export const getAppWorkspace: Command<
 
   return ok({ workspace });
 };
+
+function phaseFor(
+  deploy: DeployPhase | undefined,
+  build: 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED' | undefined,
+): DeployPhase {
+  if (deploy !== undefined) return deploy;
+  switch (build) {
+    case 'RUNNING':
+      return 'APPLYING';
+    case 'SUCCEEDED':
+      return 'WAITING';
+    case 'FAILED':
+      return 'FAILED';
+    default:
+      return 'PENDING';
+  }
+}
 
 function reachOf(seconds: number): string {
   if (seconds <= 0) return 'live only';

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -30,7 +30,13 @@ import type {
   BuildSource,
   BuildSpec,
 } from '../../adapters/build/contract.ts';
-import { apps, builds, components, targets } from '../../db/schema.ts';
+import {
+  apps,
+  builds,
+  components,
+  repositories,
+  targets,
+} from '../../db/schema.ts';
 import { recordBuildEvent } from '../../domain/attempt-log.ts';
 import {
   buildRouteCandidates,
@@ -39,7 +45,12 @@ import {
 import { DEFAULT_PLATFORM } from '../../domain/placement.ts';
 import { buildOriginOf, type Source } from '../../domain/source.ts';
 import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
-import { type Command, type CommandContext, failed, ok } from '../types.ts';
+import {
+  type CommandContext,
+  type CommandResult,
+  failed,
+  ok,
+} from '../types.ts';
 
 /**
  * §4's per-App build limit.
@@ -92,6 +103,11 @@ export interface DispatchBuildResult {
   readonly runner: string;
 }
 
+export type BuildDispatchContext = Pick<
+  CommandContext,
+  'db' | 'adapters' | 'clock' | 'manifest'
+>;
+
 /**
  * Why this Target will not take a build from this route, or `null`.
  *
@@ -115,7 +131,7 @@ interface TargetBuildPolicy {
 }
 
 async function targetBuildPolicy(
-  context: CommandContext,
+  context: Pick<CommandContext, 'db'>,
   targetId: string | undefined,
 ): Promise<TargetBuildPolicy | null> {
   if (targetId === undefined) return null;
@@ -147,10 +163,10 @@ function routeRefusedByTarget(
     : `${policy.name} will not take a build from ${adapter.name}: ${candidate.reason}`;
 }
 
-export const dispatchBuild: Command<
-  DispatchBuildInput,
-  DispatchBuildResult
-> = async (input, context) => {
+export const dispatchBuild = async (
+  input: DispatchBuildInput,
+  context: BuildDispatchContext,
+): Promise<CommandResult<DispatchBuildResult>> => {
   const [build] = await context.db
     .select()
     .from(builds)
@@ -180,6 +196,14 @@ export const dispatchBuild: Command<
       `Component ${component.id} names an App that no longer exists`,
     );
   }
+  const [repository] =
+    app.repositoryId === null
+      ? []
+      : await context.db
+          .select({ fullName: repositories.fullName })
+          .from(repositories)
+          .where(eq(repositories.id, app.repositoryId))
+          .limit(1);
 
   // §4's supplied artifact: an archive of finished output already *is* the
   // artifact, digested over the bundle core staged. There is no route to run and
@@ -253,7 +277,7 @@ export const dispatchBuild: Command<
     app.sourceKind === 'repo'
       ? {
           kind: 'repo',
-          url: app.sourceRepoUrl ?? '',
+          url: repository?.fullName ?? app.sourceRepoUrl ?? '',
           commit: build.commit,
           // §5: an App is repo plus subpath, and the developer named it there.
           subpath: app.sourceRepoSubpath ?? '.',
@@ -311,76 +335,157 @@ export const dispatchBuild: Command<
     buildId: build.id,
   };
 
-  await context.db
+  const [claimed] = await context.db
     .update(builds)
     .set({
       status: 'RUNNING',
       runner: adapter.name,
       logFidelity: adapter.logFidelity,
     })
-    .where(eq(builds.id, build.id));
-
-  const stream = adapter.build(buildSource, spec);
-  let next = await stream.next();
-  while (!next.done) {
-    const event = next.value;
-    // §6's one attempt-scoped log: build events and deploy events land on the
-    // same stream for the same attempt, so the UI subscribes once.
-    await recordBuildEvent(
-      context.db,
-      attempt,
-      event.type === 'log'
-        ? {
-            type: 'log',
-            line: event.line,
-            ...(event.step ? { resource: event.step } : {}),
-          }
-        : { type: 'status', phase: event.state, resource: event.step },
+    .where(and(eq(builds.id, build.id), eq(builds.status, 'PENDING')))
+    .returning({ id: builds.id });
+  if (claimed === undefined) {
+    const [current] = await context.db
+      .select({
+        status: builds.status,
+        artifactDigest: builds.artifactDigest,
+        runner: builds.runner,
+      })
+      .from(builds)
+      .where(eq(builds.id, build.id));
+    if (current?.status === 'SUCCEEDED') {
+      return ok({
+        buildId: build.id,
+        status: 'SUCCEEDED',
+        artifactDigest: current.artifactDigest,
+        runner: current.runner ?? 'supplied',
+      });
+    }
+    if (current?.status === 'FAILED') {
+      return ok({
+        buildId: build.id,
+        status: 'FAILED',
+        artifactDigest: null,
+        runner: current.runner ?? adapter.name,
+      });
+    }
+    return failed(
+      'NOT_BUILDABLE',
+      `Build ${build.id} is already running on ${current?.runner ?? adapter.name}`,
     );
-    next = await stream.next();
   }
-  const result = next.value;
 
-  if (result.status === 'FAILED') {
+  try {
+    const stream = adapter.build(buildSource, spec);
+    let next = await stream.next();
+    while (!next.done) {
+      const event = next.value;
+      // §6's one attempt-scoped log: build events and deploy events land on the
+      // same stream for the same attempt, so the UI subscribes once.
+      await recordBuildEvent(
+        context.db,
+        attempt,
+        event.type === 'log'
+          ? {
+              type: 'log',
+              line: event.line,
+              ...(event.step ? { resource: event.step } : {}),
+            }
+          : { type: 'status', phase: event.state, resource: event.step },
+      );
+      next = await stream.next();
+    }
+    const result = next.value;
+
+    if (result.status === 'FAILED') {
+      await recordBuildEvent(context.db, attempt, {
+        type: 'status',
+        phase: 'FAILED',
+        reason: result.reason,
+      });
+      await context.db
+        .update(builds)
+        .set({ status: 'FAILED' })
+        .where(eq(builds.id, build.id));
+      return ok({
+        buildId: build.id,
+        status: 'FAILED' as const,
+        artifactDigest: null,
+        runner: adapter.name,
+      });
+    }
+
+    const finalized = await context.adapters.supplyChain().finalize({
+      artifact: result.artifact,
+      provenance: result.provenance,
+      backend: adapter.name,
+      expectedBuilderId: adapter.provenanceBuilderId,
+      maximumLevel: adapter.buildLevel,
+      // A shape-only Build has no Target policy yet. It is assessed at the
+      // route's achieved level and every actual Deploy checks the Target's current
+      // threshold again, which is what makes a later policy raise prospective.
+      minimumLevel: targetPolicy?.minimumLevel ?? 1,
+      source: buildSource,
+    });
+    if (!finalized.ok) {
+      await recordBuildEvent(context.db, attempt, {
+        type: 'log',
+        line: `supply-chain admission failed: ${finalized.message}`,
+        resource: 'provenance',
+      });
+      await recordBuildEvent(context.db, attempt, {
+        type: 'status',
+        phase: 'FAILED',
+        reason: 'BUILD_FAILED',
+      });
+      await context.db
+        .update(builds)
+        .set({ status: 'FAILED' })
+        .where(eq(builds.id, build.id));
+      return ok({
+        buildId: build.id,
+        status: 'FAILED' as const,
+        artifactDigest: null,
+        runner: adapter.name,
+      });
+    }
+
     await recordBuildEvent(context.db, attempt, {
       type: 'status',
-      phase: 'FAILED',
-      reason: result.reason,
+      phase: 'SUCCEEDED',
     });
+
     await context.db
       .update(builds)
-      .set({ status: 'FAILED' })
+      .set({
+        status: 'SUCCEEDED',
+        artifactDigest: result.artifact.digest,
+        artifactRefs: [...result.artifact.refs],
+        baseDigest: result.baseDigest,
+        provenance: finalized.assessment,
+        verifiedBuildLevel: finalized.assessment.achievedLevel,
+        signature: finalized.signature,
+        buildkitProvenanceRef: result.buildkitProvenanceRef,
+        sbomRef: result.sbomRef,
+      })
       .where(eq(builds.id, build.id));
+
     return ok({
       buildId: build.id,
-      status: 'FAILED' as const,
-      artifactDigest: null,
+      status: 'SUCCEEDED' as const,
+      artifactDigest: result.artifact.digest,
       runner: adapter.name,
     });
-  }
-
-  const finalized = await context.adapters.supplyChain().finalize({
-    artifact: result.artifact,
-    provenance: result.provenance,
-    backend: adapter.name,
-    expectedBuilderId: adapter.provenanceBuilderId,
-    maximumLevel: adapter.buildLevel,
-    // A shape-only Build has no Target policy yet. It is assessed at the
-    // route's achieved level and every actual Deploy checks the Target's current
-    // threshold again, which is what makes a later policy raise prospective.
-    minimumLevel: targetPolicy?.minimumLevel ?? 1,
-    source: buildSource,
-  });
-  if (!finalized.ok) {
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
     await recordBuildEvent(context.db, attempt, {
       type: 'log',
-      line: `supply-chain admission failed: ${finalized.message}`,
-      resource: 'provenance',
+      line: `build dispatch failed: ${detail}`,
     });
     await recordBuildEvent(context.db, attempt, {
       type: 'status',
       phase: 'FAILED',
-      reason: 'BUILD_FAILED',
+      reason: 'INTERNAL',
     });
     await context.db
       .update(builds)
@@ -393,31 +498,4 @@ export const dispatchBuild: Command<
       runner: adapter.name,
     });
   }
-
-  await recordBuildEvent(context.db, attempt, {
-    type: 'status',
-    phase: 'SUCCEEDED',
-  });
-
-  await context.db
-    .update(builds)
-    .set({
-      status: 'SUCCEEDED',
-      artifactDigest: result.artifact.digest,
-      artifactRefs: [...result.artifact.refs],
-      baseDigest: result.baseDigest,
-      provenance: finalized.assessment,
-      verifiedBuildLevel: finalized.assessment.achievedLevel,
-      signature: finalized.signature,
-      buildkitProvenanceRef: result.buildkitProvenanceRef,
-      sbomRef: result.sbomRef,
-    })
-    .where(eq(builds.id, build.id));
-
-  return ok({
-    buildId: build.id,
-    status: 'SUCCEEDED' as const,
-    artifactDigest: result.artifact.digest,
-    runner: adapter.name,
-  });
 };

--- a/apps/spindrift/src/commands/builds/route.ts
+++ b/apps/spindrift/src/commands/builds/route.ts
@@ -1,0 +1,29 @@
+import { eq } from 'drizzle-orm';
+import { buildRouteProfiles } from '../../adapters/registry.ts';
+import { targets } from '../../db/schema.ts';
+import {
+  DEFAULT_MINIMUM_BUILD_LEVEL,
+  selectBuildRoute,
+} from '../../domain/build-route.ts';
+import type { BuildDispatchContext } from './dispatch.ts';
+
+/** Select the highest-ranked configured route that clears one Target's policy. */
+export async function routeForTarget(
+  targetId: string,
+  context: BuildDispatchContext,
+): Promise<string | null> {
+  const [target] = await context.db
+    .select({ minimumLevel: targets.minBuildLevel })
+    .from(targets)
+    .where(eq(targets.id, targetId))
+    .limit(1);
+  if (!target) return null;
+  const selected = selectBuildRoute(buildRouteProfiles(context.manifest), {
+    minimumLevel:
+      (target.minimumLevel as 1 | 2 | 3 | null) ?? DEFAULT_MINIMUM_BUILD_LEVEL,
+  });
+  return selected.route !== null &&
+    context.adapters.build(selected.route) !== null
+    ? selected.route
+    : null;
+}

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -16,14 +16,25 @@ import {
   creationDraftSchema,
   initialCreationDraft,
 } from '../../domain/creation-draft.ts';
+import type { ArtifactType } from '../../domain/desired-state.ts';
 import {
   artifactTypeFor,
   DEFAULT_PLATFORM,
   placementTargetOf,
   resolvePlacement,
 } from '../../domain/placement.ts';
+import { repositoryRefOf } from '../../domain/repository.ts';
+import { SUPPLIED_ARTIFACT_TYPE } from '../../domain/source.ts';
+import type { StagedSourceBundle } from '../../domain/source-bundle.ts';
+import { routeForTarget } from '../builds/route.ts';
 import type { CreateAppResult } from '../create-app.ts';
-import { type Command, type CommandContext, failed, ok } from '../types.ts';
+import {
+  type Command,
+  type CommandContext,
+  type CommandResult,
+  failed,
+  ok,
+} from '../types.ts';
 
 const identity = z.object({ id: z.uuid() }).strict();
 const versionedIdentity = z
@@ -55,8 +66,21 @@ export type CompleteCreationDraftInput = z.infer<
 export interface ReviewCreationDraftResult extends CreationDraftView {}
 export interface CompleteCreationDraftResult {
   readonly draft: CreationDraftView;
-  readonly app: CreateAppResult | null;
+  readonly app: CompletedCreation | null;
 }
+
+export interface CompletedCreation extends CreateAppResult {
+  readonly componentId: string;
+  readonly componentName: string;
+  readonly targetId: string;
+  readonly buildId: number;
+  readonly buildStatus: 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';
+}
+
+const preparations = new Map<
+  string,
+  Promise<CommandResult<PreparedCreation>>
+>();
 
 export const startCreationDraft: Command<
   StartCreationDraftInput,
@@ -163,164 +187,358 @@ export const reviewCreationDraft: Command<
 export const completeCreationDraft: Command<
   CompleteCreationDraftInput,
   CompleteCreationDraftResult
-> = async (input, context) =>
-  context.db.transaction(async (transaction) => {
-    const txContext = {
-      ...context,
-      db: transaction as unknown as CommandContext['db'],
-    };
-    const [row] = await transaction
-      .select()
-      .from(creationDrafts)
-      .where(
-        and(
-          eq(creationDrafts.id, input.id),
-          eq(creationDrafts.userId, context.principal.id),
-        ),
-      )
-      .for('update')
-      .limit(1);
-    if (!row) {
-      return failed(
-        'NOT_FOUND',
-        `there is no creation draft with id ${input.id}`,
-      );
-    }
-    if (row.revision !== input.revision) {
-      return stale<CompleteCreationDraftResult>();
-    }
+> = async (input, context) => {
+  const before = await owned(input.id, context);
+  if (!before) {
+    return failed(
+      'NOT_FOUND',
+      `there is no creation draft with id ${input.id}`,
+    );
+  }
+  if (before.revision !== input.revision) {
+    return stale<CompleteCreationDraftResult>();
+  }
 
-    if (row.completedAppId !== null) {
-      const completed = await transaction.query.apps.findFirst({
-        where: (apps, { eq }) => eq(apps.id, row.completedAppId!),
-      });
-      if (!completed) {
-        throw new Error('creation draft points at an App that does not exist');
+  // A completed draft is a receipt for an act that already happened. Replaying
+  // it must not be re-blocked by source access or Target health changing later.
+  let prepared: CommandResult<PreparedCreation> | null = null;
+  if (before.completedAppId === null) {
+    const beforeView = await viewOf(before, context);
+    if (!beforeView.ready) return ok({ draft: beforeView, app: null });
+
+    // External staging happens before durable product intent. Immutable storage
+    // makes a retry harmless, while a failure here leaves the resumable draft
+    // and no half-created App.
+    prepared = await prepareOnce(before.id, before.revision, () =>
+      prepareCreation(before.draft, context),
+    );
+  }
+  if (prepared !== null && !prepared.ok) return prepared;
+
+  const durable = await context.db.transaction(
+    async (
+      transaction,
+    ): Promise<CommandResult<CompleteCreationDraftResult>> => {
+      const txContext = {
+        ...context,
+        db: transaction as unknown as CommandContext['db'],
+      };
+      const [row] = await transaction
+        .select()
+        .from(creationDrafts)
+        .where(
+          and(
+            eq(creationDrafts.id, input.id),
+            eq(creationDrafts.userId, context.principal.id),
+          ),
+        )
+        .for('update')
+        .limit(1);
+      if (!row) {
+        return failed(
+          'NOT_FOUND',
+          `there is no creation draft with id ${input.id}`,
+        );
       }
-      return ok({
-        draft: {
-          id: row.id,
-          revision: row.revision,
-          draft: row.draft,
-          blockers: [],
-          ready: true,
-        },
-        app: {
-          appId: completed.id,
-          name: completed.name,
-          createdAt: completed.createdAt,
-        },
-      });
-    }
+      if (row.revision !== input.revision) {
+        return stale<CompleteCreationDraftResult>();
+      }
 
-    const draft = await viewOf(row, txContext);
-    if (!draft.ready) return ok({ draft, app: null });
+      if (row.completedAppId !== null) {
+        return completedCreation(row, txContext);
+      }
 
-    const now = context.clock.now();
-    const [created] = await transaction
-      .insert(apps)
-      .values({
-        name: row.draft.appName,
-        sourceKind: row.draft.source.kind,
-        sourceRepoUrl:
-          row.draft.source.kind === 'repo' ? row.draft.source.url : null,
-        sourceRepoSubpath:
-          row.draft.source.kind === 'repo' ? row.draft.source.subpath : null,
-        sourceArchiveDigest:
-          row.draft.source.kind === 'archive' ? row.draft.source.digest : null,
-        vesselRef: row.draft.vessel.name,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
-    const app: CreateAppResult = {
-      appId: created!.id,
-      name: created!.name,
-      createdAt: created!.createdAt,
-    };
+      const draft = await viewOf(row, txContext);
+      if (!draft.ready) return ok({ draft, app: null });
+      if (prepared === null || !prepared.ok) {
+        throw new Error('a ready creation draft has no prepared source');
+      }
 
-    const [component] = await transaction
-      .insert(components)
-      .values({
-        appId: created!.id,
-        name: row.draft.componentName,
-        kind: row.draft.kind,
-        expose:
-          row.draft.kind === 'website'
-            ? true
-            : row.draft.kind === 'service'
-              ? true
+      const now = context.clock.now();
+      const [created] = await transaction
+        .insert(apps)
+        .values({
+          name: row.draft.appName,
+          sourceKind: row.draft.source.kind,
+          sourceRepoUrl:
+            row.draft.source.kind === 'repo' ? row.draft.source.url : null,
+          sourceRepoSubpath:
+            row.draft.source.kind === 'repo' ? row.draft.source.subpath : null,
+          sourceArchiveDigest:
+            row.draft.source.kind === 'archive'
+              ? row.draft.source.digest
               : null,
-        schedule: null,
-        exposure: row.draft.exposure,
-        createdAt: now,
+          repositoryId: prepared.value.repositoryId,
+          vesselRef: row.draft.vessel.name,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      const app: CreateAppResult = {
+        appId: created!.id,
+        name: created!.name,
+        createdAt: created!.createdAt,
+      };
+      const [component] = await transaction
+        .insert(components)
+        .values({
+          appId: app.appId,
+          name: row.draft.componentName,
+          kind: row.draft.kind,
+          expose: row.draft.kind === 'job' ? null : true,
+          exposure: row.draft.exposure,
+          createdAt: now,
+          updatedAt: now,
+        })
+        .returning();
+      await transaction.insert(componentTargetDesired).values({
+        componentId: component!.id,
+        targetId: row.draft.targetId,
         updatedAt: now,
-      })
-      .returning();
-
-    const [target] = await transaction
-      .select()
-      .from(targets)
-      .where(eq(targets.id, row.draft.targetId))
-      .limit(1);
-
-    if (target) {
-      const placementTarget = placementTargetOf(target, {
-        artifactTypes:
-          context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
-        manifest: context.manifest,
       });
-      const shape = artifactTypeFor(row.draft.kind, placementTarget);
-
-      const commit =
-        row.draft.source.kind === 'repo' ? 'HEAD' : row.draft.source.digest;
-      const bundleDigest =
-        row.draft.source.kind === 'archive'
-          ? row.draft.source.digest
-          : `sha256:${'0'.repeat(64)}`;
-      const bundleLocation =
-        row.draft.source.kind === 'archive'
-          ? `upload://${row.draft.source.filename}`
-          : `repo://${row.draft.source.repo}`;
-      const bundleSubpath =
-        row.draft.source.kind === 'repo' ? row.draft.source.subpath : '.';
-
       const [build] = await transaction
         .insert(builds)
         .values({
           componentId: component!.id,
-          commit,
-          targetShape: shape,
-          artifactType: shape,
-          bundleDigest,
-          bundleLocation,
-          bundleSubpath,
-          status: 'PENDING',
+          commit: prepared.value.commit,
+          targetShape: prepared.value.artifactType,
+          artifactType: prepared.value.artifactType,
+          artifactDigest: prepared.value.supplied
+            ? prepared.value.bundleDigest
+            : null,
+          artifactRefs: prepared.value.supplied
+            ? [prepared.value.bundleLocation]
+            : null,
+          bundleDigest: prepared.value.bundleDigest,
+          bundleLocation: prepared.value.bundleLocation,
+          bundleSubpath: prepared.value.subpath,
+          status: prepared.value.supplied ? 'SUCCEEDED' : 'PENDING',
           createdAt: now,
         })
         .returning();
-
       await transaction
-        .insert(componentTargetDesired)
-        .values({
-          componentId: component!.id,
-          targetId: target.id,
-          desiredBuildId: build!.id,
-          desiredDeployId: null,
+        .update(creationDrafts)
+        .set({
+          completedAppId: app.appId,
           updatedAt: now,
         })
-        .onConflictDoNothing();
-    }
+        .where(eq(creationDrafts.id, row.id));
+      return ok({
+        draft,
+        app: {
+          ...app,
+          componentId: component!.id,
+          componentName: component!.name,
+          targetId: row.draft.targetId,
+          buildId: build!.id,
+          buildStatus: build!.status,
+        },
+      });
+    },
+  );
+  return durable;
+};
 
-    await transaction
-      .update(creationDrafts)
-      .set({
-        completedAppId: app.appId,
-        updatedAt: now,
-      })
-      .where(eq(creationDrafts.id, row.id));
-    return ok({ draft, app });
+interface PreparedCreation {
+  readonly repositoryId: string | null;
+  readonly commit: string;
+  readonly artifactType: ArtifactType;
+  readonly bundleDigest: string;
+  readonly bundleLocation: string;
+  readonly subpath: string;
+  readonly supplied: boolean;
+}
+
+async function prepareOnce(
+  draftId: string,
+  revision: number,
+  prepare: () => Promise<CommandResult<PreparedCreation>>,
+): Promise<CommandResult<PreparedCreation>> {
+  const key = `${draftId}:${revision}`;
+  const existing = preparations.get(key);
+  if (existing !== undefined) return existing;
+  const pending = prepare();
+  preparations.set(key, pending);
+  try {
+    return await pending;
+  } finally {
+    if (preparations.get(key) === pending) preparations.delete(key);
+  }
+}
+
+async function prepareCreation(
+  draft: typeof creationDraftSchema._output,
+  context: CommandContext,
+) {
+  const [target] = await context.db
+    .select()
+    .from(targets)
+    .where(eq(targets.id, draft.targetId))
+    .limit(1);
+  if (!target) {
+    return failed<PreparedCreation>(
+      'NOT_FOUND',
+      `there is no Target with id ${draft.targetId}`,
+    );
+  }
+  const placementArtifactType = artifactTypeFor(
+    draft.kind,
+    placementTargetOf(target, {
+      artifactTypes:
+        context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+      manifest: context.manifest,
+    }),
+  );
+
+  if (draft.source.kind === 'archive') {
+    const location = draft.source.location;
+    if (!location) {
+      return failed<PreparedCreation>(
+        'NOT_BUILDABLE',
+        `${draft.source.filename} has not been staged`,
+      );
+    }
+    const supplied = draft.source.contents === 'artifact';
+    if (
+      supplied &&
+      !(context.adapters.deploy(target.adapter)?.artifactTypes ?? []).includes(
+        SUPPLIED_ARTIFACT_TYPE,
+      )
+    ) {
+      return failed<PreparedCreation>(
+        'NOT_DEPLOYABLE',
+        `${target.name} cannot take uploaded finished files`,
+      );
+    }
+    const route = supplied ? null : await routeForTarget(target.id, context);
+    if (!supplied && route === null) return noBuildRoute(target.name);
+    return ok({
+      repositoryId: null,
+      commit: draft.source.digest,
+      artifactType: supplied ? SUPPLIED_ARTIFACT_TYPE : placementArtifactType,
+      bundleDigest: draft.source.digest,
+      bundleLocation: location,
+      subpath: draft.source.subpath ?? '.',
+      supplied,
+    });
+  }
+
+  const [repository] = await context.db
+    .select()
+    .from(repositories)
+    .where(eq(repositories.fullName, draft.source.repo))
+    .limit(1);
+  if (
+    repository?.access !== 'active' ||
+    repository.authoritativeCommit === null
+  ) {
+    return failed<PreparedCreation>(
+      'NOT_BUILDABLE',
+      `${draft.source.repo} has no authoritative commit ready to stage`,
+    );
+  }
+  const stager = context.adapters.source?.() ?? null;
+  if (stager === null) {
+    return failed<PreparedCreation>(
+      'NOT_BUILDABLE',
+      'this installation has no repository source depot configured',
+    );
+  }
+  const route = await routeForTarget(target.id, context);
+  if (route === null) return noBuildRoute(target.name);
+  let staged: StagedSourceBundle;
+  try {
+    staged = await stager.stageRepository({
+      ref: repositoryRefOf(repository),
+      repository: repository.fullName,
+      commit: repository.authoritativeCommit,
+      stagedAt: context.clock.now(),
+    });
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    return failed<PreparedCreation>(
+      'NOT_BUILDABLE',
+      `could not stage ${repository.fullName}: ${detail}`,
+    );
+  }
+  return ok({
+    repositoryId: repository.id,
+    commit: repository.authoritativeCommit,
+    artifactType: placementArtifactType,
+    bundleDigest: staged.digest,
+    bundleLocation: staged.location,
+    subpath: draft.source.subpath,
+    supplied: false,
   });
+}
+
+function noBuildRoute(target: string) {
+  return failed<PreparedCreation>(
+    'NOT_BUILDABLE',
+    `this installation has no eligible build route for ${target}`,
+  );
+}
+
+async function completedCreation(
+  row: typeof creationDrafts.$inferSelect,
+  context: CommandContext,
+): Promise<CommandResult<CompleteCreationDraftResult>> {
+  const completed = await context.db.query.apps.findFirst({
+    where: (apps, { eq }) => eq(apps.id, row.completedAppId!),
+  });
+  const [component] =
+    completed === undefined
+      ? []
+      : await context.db
+          .select()
+          .from(components)
+          .where(
+            and(
+              eq(components.appId, completed.id),
+              eq(components.name, row.draft.componentName),
+            ),
+          )
+          .limit(1);
+  const [build] =
+    component === undefined
+      ? []
+      : await context.db
+          .select()
+          .from(builds)
+          .where(eq(builds.componentId, component.id))
+          .orderBy(asc(builds.id))
+          .limit(1);
+  const [placement] =
+    component === undefined
+      ? []
+      : await context.db
+          .select({ targetId: componentTargetDesired.targetId })
+          .from(componentTargetDesired)
+          .where(eq(componentTargetDesired.componentId, component.id))
+          .limit(1);
+  if (!completed || !component || !build || !placement) {
+    throw new Error('creation draft points at an incomplete App intent');
+  }
+  return ok({
+    draft: {
+      id: row.id,
+      revision: row.revision,
+      draft: row.draft,
+      blockers: [],
+      ready: true,
+    },
+    app: {
+      appId: completed.id,
+      name: completed.name,
+      createdAt: completed.createdAt,
+      componentId: component.id,
+      componentName: component.name,
+      targetId: placement.targetId,
+      buildId: build.id,
+      buildStatus: build.status,
+    },
+  });
+}
 
 async function conflictOrMissing(
   id: string,
@@ -405,7 +623,10 @@ async function revalidate(
 
   if (draft.source.kind === 'repo') {
     const [repository] = await context.db
-      .select({ access: repositories.access })
+      .select({
+        access: repositories.access,
+        authoritativeCommit: repositories.authoritativeCommit,
+      })
       .from(repositories)
       .where(eq(repositories.fullName, draft.source.repo))
       .limit(1);
@@ -416,7 +637,55 @@ async function revalidate(
         remediation:
           'Restore the GitHub App installation access or choose another repository. The draft is kept.',
       });
+    } else if (repository.authoritativeCommit === null) {
+      blockers.push({
+        code: 'SOURCE_UNAVAILABLE',
+        title: `The repository ${draft.source.repo} has no authoritative commit ready.`,
+        remediation:
+          'Wait for default-branch reconciliation, then review this draft again.',
+      });
+    } else if ((context.adapters.source?.() ?? null) === null) {
+      blockers.push({
+        code: 'SOURCE_UNAVAILABLE',
+        title: 'Repository source staging is unavailable.',
+        remediation:
+          'Configure the installation source depot, then review this draft again.',
+      });
     }
+  }
+
+  const selectedTarget = connected.find(
+    (target) => target.id === draft.targetId,
+  );
+  if (
+    draft.source.kind === 'archive' &&
+    draft.source.contents === 'artifact' &&
+    selectedTarget !== undefined &&
+    !(
+      context.adapters.deploy(selectedTarget.adapter)?.artifactTypes ?? []
+    ).includes(SUPPLIED_ARTIFACT_TYPE) &&
+    !blockers.some((blocker) => blocker.code === 'TARGET_UNAVAILABLE')
+  ) {
+    blockers.push({
+      code: 'TARGET_UNAVAILABLE',
+      title: `${selectedTarget.name} cannot take uploaded finished files.`,
+      remediation:
+        'Choose a static Target for this supplied artifact, or upload source that Spindrift can build for this Target.',
+    });
+  }
+  const needsBuilder =
+    draft.source.kind === 'repo' || draft.source.contents !== 'artifact';
+  if (
+    needsBuilder &&
+    selectedTarget !== undefined &&
+    (await routeForTarget(selectedTarget.id, context)) === null
+  ) {
+    blockers.push({
+      code: 'BUILD_ROUTE_UNAVAILABLE',
+      title: `No eligible build route can build for ${selectedTarget.name}.`,
+      remediation:
+        'Configure a route that clears this Target’s minimum Build Level, then review the draft again.',
+    });
   }
 
   return blockers;

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -29,6 +29,7 @@ import type {
 } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
 import type { RepositoryHost } from '../domain/repository.ts';
+import type { RepositorySourceStager } from '../domain/source-bundle.ts';
 import type { SupplyChain } from '../supply-chain/sign.ts';
 
 /**
@@ -101,6 +102,8 @@ export interface AdapterRegistry {
    * beside the context, which is the shape the context exists to prevent.
    */
   repository(): RepositoryHost | null;
+  /** Immutable repository staging, absent until a source depot is configured. */
+  source?(): RepositorySourceStager | null;
   /**
    * Core's verifier and signer (§16).
    *

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -1042,6 +1042,7 @@ export const componentsRelations = relations(components, ({ one, many }) => ({
   builds: many(builds),
   deploys: many(deploys),
   configItems: many(configItems),
+  desiredTargets: many(componentTargetDesired),
 }));
 
 export const buildsRelations = relations(builds, ({ one, many }) => ({

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -62,6 +62,12 @@ const source = z.discriminatedUnion('kind', [
       kind: z.literal('archive'),
       filename: z.string().min(1),
       digest: z.string().regex(/^sha256:[0-9a-f]{64}$/),
+      /** Durable location written by the upload/staging boundary. */
+      location: z.string().min(1).nullable().optional(),
+      /** Finished output bypasses a builder; source follows the ordinary path. */
+      contents: z.enum(['artifact', 'source']).optional(),
+      /** Scope after a lone top-level directory is unwrapped. */
+      subpath: z.string().min(1).optional(),
     })
     .strict(),
 ]);
@@ -132,6 +138,8 @@ export const CREATION_BLOCKER_CODES = [
   'TARGET_UNAVAILABLE',
   'CONFIG_INCOMPLETE',
   'REPOSITORY_UNAVAILABLE',
+  'SOURCE_UNAVAILABLE',
+  'BUILD_ROUTE_UNAVAILABLE',
 ] as const;
 
 export type CreationBlockerCode = (typeof CREATION_BLOCKER_CODES)[number];
@@ -175,6 +183,9 @@ export function initialCreationDraft(input: {
           kind: 'archive',
           filename: 'upload.zip',
           digest: `sha256:${'0'.repeat(64)}`,
+          location: null,
+          contents: 'source',
+          subpath: '.',
         },
     appName: name,
     componentName: 'web',
@@ -274,6 +285,15 @@ export function blockersFor(
       code: 'CONFIG_INCOMPLETE',
       title: `${missing.length} configuration key${missing.length === 1 ? '' : 's'} still needs a value.`,
       remediation: `Supply ${missing.map((key) => key.name).join(', ')} on Configure. Values are write-only once stored, so they cannot be filled in later from here.`,
+    });
+  }
+
+  if (draft.source.kind === 'archive' && !draft.source.location) {
+    blockers.push({
+      code: 'SOURCE_UNAVAILABLE',
+      title: `${draft.source.filename} has not been staged.`,
+      remediation:
+        'Upload the archive on Source before Review. The draft is kept while the upload is incomplete.',
     });
   }
 

--- a/apps/spindrift/src/domain/source-bundle.ts
+++ b/apps/spindrift/src/domain/source-bundle.ts
@@ -21,6 +21,7 @@ import {
   signSourceReceipt,
   sourceReceiptStatement,
 } from '../supply-chain/receipt.ts';
+import type { RepositoryRef } from './repository.ts';
 
 export type BundleRetention = 'ephemeral' | 'durable';
 
@@ -37,6 +38,20 @@ export interface StagedSource {
   readonly receipt: SignedSourceReceipt;
   /** Durable address of the signed evidence, keyed by the bundle digest. */
   readonly receiptLocation: string;
+}
+
+/**
+ * Fetch, store, and attest one exact repository commit as a single far-side
+ * capability. The command receives only the immutable bundle; credentials and
+ * receipt mechanics cannot leak into its transaction.
+ */
+export interface RepositorySourceStager {
+  stageRepository(input: {
+    readonly ref: RepositoryRef;
+    readonly repository: string;
+    readonly commit: string;
+    readonly stagedAt: Date;
+  }): Promise<StagedSourceBundle>;
 }
 
 /**

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -1,0 +1,100 @@
+/**
+ * Durable Build convergence.
+ *
+ * Review writes a PENDING Build and returns immediately so the browser can
+ * open the real status surface. This loop owns the long-running runner stream;
+ * an HTTP request never has to stay open for the duration of a build.
+ */
+import { asc, eq } from 'drizzle-orm';
+import {
+  type BuildDispatchContext,
+  dispatchBuild,
+} from '../commands/builds/dispatch.ts';
+import { routeForTarget } from '../commands/builds/route.ts';
+import {
+  builds,
+  components,
+  componentTargetDesired,
+  targets,
+} from '../db/schema.ts';
+
+export const DEFAULT_BUILD_INTERVALS = {
+  activeMs: 1_000,
+  idleMs: 5_000,
+} as const;
+
+export interface BuildLoopOptions {
+  readonly signal: AbortSignal;
+  readonly intervals?: {
+    readonly activeMs: number;
+    readonly idleMs: number;
+  };
+  readonly onPass?: () => void;
+}
+
+/** Run every dispatchable PENDING Build once; atomic claiming prevents doubles. */
+export async function runBuildPass(
+  context: BuildDispatchContext,
+): Promise<number> {
+  const rows = await context.db
+    .select({
+      buildId: builds.id,
+      targetId: componentTargetDesired.targetId,
+    })
+    .from(builds)
+    .innerJoin(components, eq(builds.componentId, components.id))
+    .innerJoin(
+      componentTargetDesired,
+      eq(componentTargetDesired.componentId, components.id),
+    )
+    .innerJoin(targets, eq(targets.id, componentTargetDesired.targetId))
+    .where(eq(builds.status, 'PENDING'))
+    .orderBy(asc(builds.id), asc(targets.rank));
+
+  let dispatched = 0;
+  const visited = new Set<number>();
+  for (const row of rows) {
+    if (visited.has(row.buildId)) continue;
+    visited.add(row.buildId);
+    const route = await routeForTarget(row.targetId, context);
+    if (route === null) continue;
+    const result = await dispatchBuild(
+      {
+        buildId: row.buildId,
+        route,
+        placementTargetId: row.targetId,
+      },
+      context,
+    );
+    if (result.ok) dispatched += 1;
+  }
+  return dispatched;
+}
+
+export async function runBuildLoop(
+  context: BuildDispatchContext,
+  options: BuildLoopOptions,
+): Promise<void> {
+  const intervals = options.intervals ?? DEFAULT_BUILD_INTERVALS;
+  while (!options.signal.aborted) {
+    const dispatched = await runBuildPass(context);
+    options.onPass?.();
+    await abortableSleep(
+      dispatched > 0 ? intervals.activeMs : intervals.idleMs,
+      options.signal,
+    );
+  }
+}
+
+function abortableSleep(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    const done = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', done);
+      resolve();
+    };
+    const timer = setTimeout(done, ms);
+    signal.addEventListener('abort', done, { once: true });
+  });
+}

--- a/apps/spindrift/src/reconciler/process.ts
+++ b/apps/spindrift/src/reconciler/process.ts
@@ -8,12 +8,18 @@
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
+import { DEFAULT_BUILD_INTERVALS, runBuildLoop } from './build-loop.ts';
 import { DEFAULT_REAP_INTERVAL_MS, runConfigLoop } from './config-loop.ts';
 import { DEFAULT_INTERVALS, runDeployLoop } from './deploy-loop.ts';
 import { runRepoLoop } from './repo-loop.ts';
 import { runTargetLoop } from './target-loop.ts';
 
-export type ReconcilerLoopName = 'target' | 'repository' | 'config' | 'deploy';
+export type ReconcilerLoopName =
+  | 'target'
+  | 'repository'
+  | 'config'
+  | 'build'
+  | 'deploy';
 
 /** One independently supervised process loop. */
 interface SupervisedLoop {
@@ -143,6 +149,15 @@ export async function runReconciler(
           intervals: DEFAULT_INTERVALS,
           signal,
           onPass: () => passed('deploy'),
+        }),
+    },
+    {
+      name: 'build',
+      run: (signal) =>
+        runBuildLoop(context, {
+          intervals: DEFAULT_BUILD_INTERVALS,
+          signal,
+          onPass: () => passed('build'),
         }),
     },
   ];

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -649,7 +649,7 @@ function NewAppScreen({
       initial={state.draft}
       targets={state.targetOptions}
       repos={state.repoOptions}
-      onCreated={(app) => onNavigate(`/apps/${app.name}`)}
+      onCreated={(app) => onNavigate(`/apps/${app.id}`)}
     />
   );
 }

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -61,10 +61,7 @@ export function NewApp({
   const blockers = [
     ...localBlockers,
     ...serverBlockers.filter(
-      (server) =>
-        !localBlockers.some((local) => local.code === server.code) &&
-        (server.code === 'REPOSITORY_UNAVAILABLE' ||
-          server.code === 'TARGET_UNAVAILABLE'),
+      (server) => !localBlockers.some((local) => local.code === server.code),
     ),
   ];
   const last = draft.step === STEPS.length - 1;

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -7,6 +7,7 @@ import {
   saveCreationDraft,
   startCreationDraft,
 } from '../../src/commands/creation-drafts/lifecycle.ts';
+import { dispatch } from '../../src/commands/registry.ts';
 import type {
   AdapterRegistry,
   CommandContext,
@@ -15,22 +16,29 @@ import {
   apps,
   builds,
   components,
+  componentTargetDesired,
   creationDrafts,
   deploys,
   repositories,
   targets,
   users,
 } from '../../src/db/schema.ts';
+import { runBuildPass } from '../../src/reconciler/build-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
+const builder = new FakeBuildAdapter({ name: 'hosted' });
+const stagedRepositories: string[] = [];
+const supplyChain = new SupplyChainHarness();
 
 const adapters: AdapterRegistry = {
-  deploy: () => ({
-    adapter: 'kubernetes',
-    artifactTypes: ['image'],
+  deploy: (adapter) => ({
+    adapter,
+    artifactTypes: adapter === 'static' ? ['files'] : ['image'],
     apply: async function* () {
       yield {
         type: 'status',
@@ -46,15 +54,25 @@ const adapters: AdapterRegistry = {
     },
     tail: async () => ({ kind: 'stream', entries: [], cursor: null, reach: 0 }),
   }),
-  build: () => null,
+  build: (name) => (name === builder.name ? builder : null),
   store: () => null,
   repository: () => null,
-  supplyChain: () => {
-    throw new Error('creation drafts do not reach the supply chain');
-  },
+  source: () => ({
+    async stageRepository(input) {
+      stagedRepositories.push(`${input.repository}@${input.commit}`);
+      return {
+        digest: `sha256:${'b'.repeat(64)}`,
+        location: `https://bundles.example.test/${input.commit}.tar.gz`,
+        retention: 'ephemeral',
+      };
+    },
+  }),
+  supplyChain: () => supplyChain,
 };
 
-async function context(): Promise<CommandContext> {
+async function context(
+  registry: AdapterRegistry = adapters,
+): Promise<CommandContext> {
   const [principal] = await database()
     .db.insert(users)
     .values({ displayName: 'Operator' })
@@ -63,18 +81,21 @@ async function context(): Promise<CommandContext> {
     principal: { id: principal!.id, displayName: principal!.displayName },
     clock: { now: () => new Date('2026-07-29T12:00:00.000Z') },
     db: database().db,
-    adapters,
+    adapters: registry,
     manifest: await fixtureManifest(),
   };
 }
 
-async function seedCapabilities() {
+async function seedCapabilities(
+  targetOverrides: Parameters<typeof targetValues>[0] = {},
+) {
   const [repository] = await database()
     .db.insert(repositories)
     .values({
       fullName: 'example/app',
       installationId: '123',
       defaultBranch: 'main',
+      authoritativeCommit: '1111111111111111111111111111111111111111',
       access: 'active',
     })
     .returning();
@@ -86,6 +107,7 @@ async function seedCapabilities() {
         rank: 1,
         publicExposure: true,
         discovery: CAPABLE_DISCOVERY,
+        ...targetOverrides,
       }),
     )
     .returning();
@@ -218,7 +240,7 @@ describe('creation drafts', () => {
     expect(recovered.ok).toBe(true);
   });
 
-  test('a clean draft creates one App and retries return that same App', async () => {
+  test('a clean repository draft creates and dispatches one complete first-Build intent', async () => {
     const { repository, target } = await seedCapabilities();
     const ctx = await context();
     const started = await startCreationDraft({}, ctx);
@@ -249,6 +271,20 @@ describe('creation drafts', () => {
     );
     expect(completed.ok).toBe(true);
     if (!completed.ok || completed.value.app === null) return;
+    expect(completed.value.app).toMatchObject({
+      componentName: 'web',
+      targetId: target.id,
+      buildStatus: 'PENDING',
+    });
+    expect(completed.value.app.buildId).toBeGreaterThan(0);
+    expect(stagedRepositories).toEqual([
+      'example/app@1111111111111111111111111111111111111111',
+    ]);
+    expect(builder.built).toHaveLength(0);
+    expect(await productCounts()).toEqual([1, 1, 1, 0]);
+    expect(
+      await database().db.select().from(componentTargetDesired),
+    ).toHaveLength(1);
     await database()
       .db.update(repositories)
       .set({
@@ -265,21 +301,395 @@ describe('creation drafts', () => {
       ctx,
     );
     expect(retried).toEqual(completed);
+    expect(await runBuildPass(ctx)).toBe(1);
+    expect(builder.built).toHaveLength(1);
+    expect(builder.built[0]?.source).toMatchObject({
+      bundleDigest: `sha256:${'b'.repeat(64)}`,
+      origin: {
+        type: 'repo',
+        repository: 'example/app',
+        commit: '1111111111111111111111111111111111111111',
+        subpath: '.',
+        location:
+          'https://bundles.example.test/1111111111111111111111111111111111111111.tar.gz',
+      },
+    });
+    const [finished] = await database().db.select().from(builds);
+    expect(finished?.status).toBe('SUCCEEDED');
     expect(await productCounts()).toEqual([1, 1, 1, 0]);
+  });
 
-    const [createdComponent] = await database()
-      .db.select()
-      .from(components)
-      .where(eq(components.appId, completed.value.app.appId));
-    expect(createdComponent).toBeDefined();
-    expect(createdComponent?.name).toBe('web');
+  test('completion is reachable through the validated command boundary', async () => {
+    await seedCapabilities();
+    const ctx = await context();
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
 
-    const [createdBuild] = await database()
-      .db.select()
-      .from(builds)
-      .where(eq(builds.componentId, createdComponent!.id));
-    expect(createdBuild).toBeDefined();
-    expect(createdBuild?.status).toBe('PENDING');
+    const completed = await dispatch(
+      'completeCreationDraft',
+      { id: started.value.id, revision: started.value.revision },
+      ctx,
+    );
+
+    expect(completed).toMatchObject({
+      ok: true,
+      value: {
+        app: {
+          name: started.value.draft.appName,
+          buildStatus: 'PENDING',
+        },
+      },
+    });
+    expect(await productCounts()).toEqual([1, 1, 1, 0]);
+  });
+
+  test('concurrent Review retries hand one durable Build to the runner once', async () => {
+    await seedCapabilities();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      markEntered = resolve;
+    });
+    let calls = 0;
+    let stageCalls = 0;
+    const base = new FakeBuildAdapter({ name: 'hosted' });
+    const delayed = {
+      name: base.name,
+      logFidelity: base.logFidelity,
+      buildLevel: base.buildLevel,
+      provenanceBuilderId: base.provenanceBuilderId,
+      async *build(
+        source: Parameters<typeof base.build>[0],
+        spec: Parameters<typeof base.build>[1],
+      ) {
+        calls += 1;
+        markEntered();
+        await gate;
+        return yield* base.build(source, spec);
+      },
+    };
+    const registry: AdapterRegistry = {
+      ...adapters,
+      build: (name) => (name === delayed.name ? delayed : null),
+      source: () => ({
+        async stageRepository(input) {
+          stageCalls += 1;
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          return {
+            digest: `sha256:${'b'.repeat(64)}`,
+            location: `https://bundles.example.test/${input.commit}.tar.gz`,
+            retention: 'ephemeral',
+          };
+        },
+      }),
+    };
+    const ctx = await context(registry);
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+    const saved = await saveCreationDraft(
+      {
+        id: started.value.id,
+        revision: started.value.revision,
+        draft: { ...started.value.draft, step: 4 },
+      },
+      ctx,
+    );
+    if (!saved.ok) throw new Error(saved.failure.message);
+
+    const input = { id: saved.value.id, revision: saved.value.revision };
+    const [first, second] = await Promise.all([
+      completeCreationDraft(input, ctx),
+      completeCreationDraft(input, ctx),
+    ]);
+    expect(stageCalls).toBe(1);
+    expect(calls).toBe(0);
+
+    const left = runBuildPass(ctx);
+    const right = runBuildPass(ctx);
+    await entered;
+    expect(calls).toBe(1);
+    release();
+    await Promise.all([left, right]);
+
+    expect(first.ok && first.value.app?.appId).toBe(
+      second.ok && second.value.app?.appId,
+    );
+    expect(first.ok && first.value.app?.buildId).toBe(
+      second.ok && second.value.app?.buildId,
+    );
+    expect(calls).toBe(1);
+    expect(await productCounts()).toEqual([1, 1, 1, 0]);
+  });
+
+  test('a staged source archive follows the same builder path', async () => {
+    await seedCapabilities();
+    const ctx = await context();
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+    const beforeBuilds = builder.built.length;
+    const digest = `sha256:${'c'.repeat(64)}`;
+    const saved = await saveCreationDraft(
+      {
+        id: started.value.id,
+        revision: started.value.revision,
+        draft: {
+          ...started.value.draft,
+          entry: 'upload',
+          source: {
+            kind: 'archive',
+            filename: 'source.zip',
+            digest,
+            location: 'https://bundles.example.test/source.zip',
+            contents: 'source',
+            subpath: 'service',
+          },
+          step: 4,
+        },
+      },
+      ctx,
+    );
+    if (!saved.ok) throw new Error(saved.failure.message);
+
+    const completed = await completeCreationDraft(
+      { id: saved.value.id, revision: saved.value.revision },
+      ctx,
+    );
+
+    expect(completed.ok && completed.value.app?.buildStatus).toBe('PENDING');
+    expect(await runBuildPass(ctx)).toBe(1);
+    expect(builder.built).toHaveLength(beforeBuilds + 1);
+    expect(builder.built.at(-1)?.source).toEqual({
+      bundleDigest: digest,
+      origin: {
+        type: 'archive',
+        location: 'https://bundles.example.test/source.zip',
+        subpath: 'service',
+      },
+    });
+  });
+
+  test('a supplied finished archive creates a files Build without invoking a builder', async () => {
+    const { target } = await seedCapabilities({
+      adapter: 'static',
+      name: 'cdn',
+    });
+    const ctx = await context();
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+    const beforeBuilds = builder.built.length;
+    const digest = `sha256:${'d'.repeat(64)}`;
+    const saved = await saveCreationDraft(
+      {
+        id: started.value.id,
+        revision: started.value.revision,
+        draft: {
+          ...started.value.draft,
+          entry: 'upload',
+          source: {
+            kind: 'archive',
+            filename: 'dist.zip',
+            digest,
+            location: 'https://bundles.example.test/dist.zip',
+            contents: 'artifact',
+            subpath: '.',
+          },
+          detection: {
+            ...started.value.draft.detection,
+            kind: 'website',
+          },
+          kind: 'website',
+          exposure: 'public',
+          targetId: target.id,
+          step: 4,
+        },
+      },
+      ctx,
+    );
+    if (!saved.ok) throw new Error(saved.failure.message);
+
+    const completed = await completeCreationDraft(
+      { id: saved.value.id, revision: saved.value.revision },
+      ctx,
+    );
+
+    expect(completed.ok && completed.value.app?.buildStatus).toBe('SUCCEEDED');
+    expect(builder.built).toHaveLength(beforeBuilds);
+    const [build] = await database().db.select().from(builds);
+    expect(build).toMatchObject({
+      artifactType: 'files',
+      artifactDigest: digest,
+      artifactRefs: ['https://bundles.example.test/dist.zip'],
+      runner: null,
+    });
+  });
+
+  test('a supplied finished archive requires a files-capable target', async () => {
+    const { target } = await seedCapabilities();
+    const ctx = await context();
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+    const saved = await saveCreationDraft(
+      {
+        id: started.value.id,
+        revision: started.value.revision,
+        draft: {
+          ...started.value.draft,
+          entry: 'upload',
+          source: {
+            kind: 'archive',
+            filename: 'dist.zip',
+            digest: `sha256:${'f'.repeat(64)}`,
+            location: 'https://bundles.example.test/dist.zip',
+            contents: 'artifact',
+            subpath: '.',
+          },
+          detection: {
+            ...started.value.draft.detection,
+            kind: 'website',
+          },
+          kind: 'website',
+          exposure: 'public',
+          targetId: target.id,
+          step: 4,
+        },
+      },
+      ctx,
+    );
+    if (!saved.ok) throw new Error(saved.failure.message);
+
+    const completed = await completeCreationDraft(
+      { id: saved.value.id, revision: saved.value.revision },
+      ctx,
+    );
+
+    expect(completed.ok).toBe(true);
+    if (!completed.ok) return;
+    expect(completed.value.app).toBeNull();
+    expect(completed.value.draft.blockers).toContainEqual(
+      expect.objectContaining({ code: 'TARGET_UNAVAILABLE' }),
+    );
+    expect(await productCounts()).toEqual([0, 0, 0, 0]);
+  });
+
+  test('an unstaged archive leaves the resumable draft and no product intent', async () => {
+    await seedCapabilities();
+    const ctx = await context();
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+    const saved = await saveCreationDraft(
+      {
+        id: started.value.id,
+        revision: started.value.revision,
+        draft: {
+          ...started.value.draft,
+          source: {
+            kind: 'archive',
+            filename: 'missing.zip',
+            digest: `sha256:${'e'.repeat(64)}`,
+            location: null,
+            contents: 'source',
+            subpath: '.',
+          },
+          step: 4,
+        },
+      },
+      ctx,
+    );
+    if (!saved.ok) throw new Error(saved.failure.message);
+
+    const completed = await completeCreationDraft(
+      { id: saved.value.id, revision: saved.value.revision },
+      ctx,
+    );
+
+    expect(completed).toMatchObject({
+      ok: true,
+      value: {
+        app: null,
+        draft: {
+          ready: false,
+          blockers: [{ code: 'SOURCE_UNAVAILABLE' }],
+        },
+      },
+    });
+    expect(await productCounts()).toEqual([0, 0, 0, 0]);
+    expect(await getCreationDraft({ id: saved.value.id }, ctx)).toMatchObject({
+      ok: true,
+    });
+  });
+
+  test('repository staging failure is a refusal before durable intent', async () => {
+    await seedCapabilities();
+    const registry: AdapterRegistry = {
+      ...adapters,
+      source: () => ({
+        async stageRepository() {
+          throw new Error('bundle depot is unavailable');
+        },
+      }),
+    };
+    const ctx = await context(registry);
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+
+    const completed = await completeCreationDraft(
+      { id: started.value.id, revision: started.value.revision },
+      ctx,
+    );
+
+    expect(completed).toMatchObject({
+      ok: false,
+      failure: {
+        code: 'NOT_BUILDABLE',
+        message: expect.stringContaining('bundle depot is unavailable'),
+      },
+    });
+    expect(await productCounts()).toEqual([0, 0, 0, 0]);
+    expect(await getCreationDraft({ id: started.value.id }, ctx)).toMatchObject(
+      { ok: true },
+    );
+  });
+
+  test('a runner crash after durable intent is visible as a failed Build', async () => {
+    await seedCapabilities();
+    const crashing = {
+      name: 'hosted',
+      logFidelity: 'LIVE_TEXT' as const,
+      buildLevel: 2 as const,
+      provenanceBuilderId: 'https://builders.example.test/crashing',
+      async *build(): AsyncGenerator<never, never, void> {
+        yield* [];
+        throw new Error('runner connection vanished');
+      },
+    };
+    const registry: AdapterRegistry = {
+      ...adapters,
+      build: (name) => (name === crashing.name ? crashing : null),
+    };
+    const ctx = await context(registry);
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+
+    const completed = await completeCreationDraft(
+      { id: started.value.id, revision: started.value.revision },
+      ctx,
+    );
+
+    expect(completed).toMatchObject({
+      ok: true,
+      value: {
+        app: {
+          buildStatus: 'PENDING',
+        },
+      },
+    });
+    expect(await runBuildPass(ctx)).toBe(1);
+    expect(await productCounts()).toEqual([1, 1, 1, 0]);
+    const [build] = await database().db.select().from(builds);
+    expect(build?.status).toBe('FAILED');
   });
 
   test('another operator cannot read or edit the draft', async () => {

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -10,7 +10,12 @@ import type {
   Clock,
   CommandContext,
 } from '../../src/commands/types.ts';
-import { builds, deploys, targets } from '../../src/db/schema.ts';
+import {
+  builds,
+  componentTargetDesired,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
 
@@ -169,6 +174,67 @@ describe('getAppWorkspace command', () => {
     if (workspace.runtime.kind === 'none') {
       expect(workspace.runtime.because).toContain('Static files are served');
     }
+  });
+
+  test('projects the locked Target and first Build before a Deploy exists', async () => {
+    const ctx = context();
+    const createdApp = await createApp(
+      {
+        name: `queued-${crypto.randomUUID().slice(0, 8)}`,
+        sourceKind: 'archive',
+        archiveDigest: `sha256:${'c'.repeat(64)}`,
+        vesselRef: 'driftwood',
+      },
+      ctx,
+    );
+    if (!createdApp.ok) throw new Error(createdApp.failure.message);
+    const createdComp = await createComponent(
+      {
+        appId: createdApp.value.appId,
+        name: 'site',
+        kind: 'website',
+        exposure: 'public',
+      },
+      ctx,
+    );
+    if (!createdComp.ok) throw new Error(createdComp.failure.message);
+    const [target] = await database()
+      .db.insert(targets)
+      .values(targetValues({ adapter: 'static', name: 'cdn' }))
+      .returning();
+    await database().db.insert(componentTargetDesired).values({
+      componentId: createdComp.value.componentId,
+      targetId: target!.id,
+    });
+    await database()
+      .db.insert(builds)
+      .values({
+        componentId: createdComp.value.componentId,
+        commit: `sha256:${'c'.repeat(64)}`,
+        targetShape: 'files',
+        artifactType: 'files',
+        artifactDigest: `sha256:${'d'.repeat(64)}`,
+        status: 'SUCCEEDED',
+      });
+
+    const result = await getAppWorkspace({ name: createdApp.value.appId }, ctx);
+
+    expect(result).toMatchObject({
+      ok: true,
+      value: {
+        workspace: {
+          target: 'cdn',
+          phase: 'WAITING',
+          release: expect.stringMatching(/^Build /),
+          components: [
+            {
+              phase: 'WAITING',
+              artifact: expect.stringMatching(/^files · /),
+            },
+          ],
+        },
+      },
+    });
   });
 });
 

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -1,7 +1,7 @@
 /**
  * The reconciler process (§19, ticket 06).
  *
- * This is the lifecycle seam above the four individual loop suites. It proves
+ * This is the lifecycle seam above the five individual loop suites. It proves
  * that a systemic failure escaping one loop is retried without taking its
  * siblings down, and that one shutdown signal releases every supervisor.
  */
@@ -62,6 +62,7 @@ describe('reconciler process lifecycle', () => {
           if (
             (passes.get('target') ?? 0) === 2 &&
             passes.has('config') &&
+            passes.has('build') &&
             passes.has('deploy')
           ) {
             shutdown.abort();
@@ -121,6 +122,7 @@ describe('reconciler loop composition', () => {
           if (
             passed.has('target') &&
             passed.has('config') &&
+            passed.has('build') &&
             passed.has('deploy') &&
             events.some((candidate) => candidate.type === 'disabled')
           ) {
@@ -135,7 +137,7 @@ describe('reconciler loop composition', () => {
         .filter((event) => event.type === 'pass')
         .map((event) => event.loop)
         .sort(),
-    ).toEqual(['config', 'deploy', 'target']);
+    ).toEqual(['build', 'config', 'deploy', 'target']);
     expect(events.find((event) => event.type === 'disabled')).toEqual({
       type: 'disabled',
       loop: 'repository',
@@ -162,6 +164,7 @@ describe('reconciler loop composition', () => {
             passed.has('target') &&
             passed.has('repository') &&
             passed.has('config') &&
+            passed.has('build') &&
             passed.has('deploy')
           ) {
             shutdown.abort();
@@ -171,6 +174,7 @@ describe('reconciler loop composition', () => {
     );
 
     expect([...passed].sort()).toEqual([
+      'build',
       'config',
       'deploy',
       'repository',


### PR DESCRIPTION
## Summary

Complete the first-Build path from a persisted creation draft: stage source, atomically create the App/Component/placement/Build intent, and expose the resulting Build through the real workspace.

## Changes

- stage authoritative repository commits and consume staged archive metadata
- distinguish source archives from supplied finished artifacts
- add idempotent Build claiming and reconciler-owned dispatch
- project pre-Deploy placement and Build state in the App workspace
- navigate to created Apps by UUID
- cover success, blocking, replay, concurrency, runner failure, and command-boundary behavior

## Test Plan

- [x] `mise run ts:check`
- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test apps/spindrift/test/commands/creation-drafts.test.ts apps/spindrift/test/commands/workspace-deploy-details.test.ts apps/spindrift/test/reconciler/process.test.ts`
- [x] Full Spindrift suite before rebase: 872 passed, 0 failed

## Known follow-up

- replace the process-local runner lifecycle with a durable dispatch identity and lease
- bind dispatch to an explicit Target when a Component has multiple placements
- make the per-App concurrency limit atomic across reconciler replicas
- select the first available eligible route rather than stopping at an unavailable top-ranked route

## Context

- `.agent/context/context.md`
- `.agent/context/plan.md`
