### PR TITLE
ci(workflows): make containers and typescript verification skippable when inactive

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -3,23 +3,9 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'apps/**'
-      - 'packages/**'
-      - 'images/**'
-      - '.github/workflows/containers.yml'
-      - '.github/scripts/detect-containers.sh'
-      - '.github/containers.json'
   pull_request:
     branches:
       - main
-    paths:
-      - 'apps/**'
-      - 'packages/**'
-      - 'images/**'
-      - '.github/workflows/containers.yml'
-      - '.github/scripts/detect-containers.sh'
-      - '.github/containers.json'
 
 # Cancel superseded runs on the same ref instead of letting them pile up.
 concurrency:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -3,32 +3,8 @@ name: TypeScript
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "apps/hub/**"
-      - "apps/slingshot/**"
-      - "apps/spindrift/**"
-      - "packages/charts/**"
-      - "packages/k6/**"
-      - "packages/typescript-config/**"
-      - "package.json"
-      - "bun.lock"
-      - "turbo.json"
-      - "biome.json"
-      - ".github/workflows/typescript.yml"
   push:
     branches: [main]
-    paths:
-      - "apps/hub/**"
-      - "apps/slingshot/**"
-      - "apps/spindrift/**"
-      - "packages/charts/**"
-      - "packages/k6/**"
-      - "packages/typescript-config/**"
-      - "package.json"
-      - "bun.lock"
-      - "turbo.json"
-      - "biome.json"
-      - ".github/workflows/typescript.yml"
 
 permissions:
   contents: read
@@ -39,7 +15,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      has_changes: ${{ steps.changed-paths.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - id: changed-paths
+        uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
+        with:
+          files: |
+            apps/hub/**
+            apps/slingshot/**
+            apps/spindrift/**
+            packages/charts/**
+            packages/k6/**
+            packages/typescript-config/**
+            package.json
+            bun.lock
+            turbo.json
+            biome.json
+            .github/workflows/typescript.yml
+
   validate:
+    needs: detect
+    if: needs.detect.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
## Summary
Enables `containers` and `TypeScript` workflows to run on all PRs so they can be set as required status checks in GitHub Branch Protection, while skipping work quickly (~5s) when no relevant files are modified.

## Changes
- Removed top-level `paths:` trigger restrictions from `.github/workflows/containers.yml` so its `detect` job runs on all PRs.
- Removed top-level `paths:` trigger restrictions from `.github/workflows/typescript.yml` and added a `detect` job (`tj-actions/changed-files`) to conditionally run the `validate` job.

## Test Plan
- [x] Verified routing test suite (`bash .github/scripts/validation-impact_test.sh`).
- [x] Verified `mise run check`.