### PR TITLE
feat(terraform): manage GitHub repository settings

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,5 +1,13 @@
 ---
 creation_rules:
+  # GitHub provider inputs are operator-managed. Atlantis receives the GitHub
+  # token through its runtime environment; this file is reserved for
+  # intentionally managed Actions secret values.
+  - path_regex: terraform/github/secrets\.sops\.ya?ml
+    encrypted_regex: "^(secrets)$"
+    key_groups:
+      - age:
+          - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
   - path_regex: clusters/.*\.sops\.ya?ml
     encrypted_regex: "^(data|stringData)$"
     key_groups:

--- a/terraform/github/.terraform.lock.hcl
+++ b/terraform/github/.terraform.lock.hcl
@@ -1,0 +1,36 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/integrations/github" {
+  version     = "6.13.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:2kD+4leuV8tBBXv+EPeehmfW6cDhIzVki61OXsGCtRI=",
+    "h1:99s0C+KmzXIsUJY0tKlgfcFUIuuXjCK0TAeeZ8HaOZQ=",
+    "h1:Mug81HyUTKKMngXMOtBxuQ8ge3dVnzt9tGcF9SxLcVE=",
+    "h1:RhCWa2aaFVKF/HzeR0fkIxZmoJvkGrv07hE0z09aPQs=",
+    "h1:YS8951MRtP4YNs2CNsDfqE7Mr9tDz/Y7xDSo18zyCkQ=",
+    "h1:Z0dj6yhxjLxg44gGNkh3zdAPY9iNkkiC+n7mEJcvUHY=",
+    "h1:a9VUv7chtxc+vro0uZo12PhBGbyeq3uKslrKLDHbkeg=",
+    "h1:awjLJy4zAQRONIVuKbsFSOpEWYWREdeeAXQHkhDXMDI=",
+    "h1:gz9DIUPAPQf0wI9dcmcNMgPBY/AwUfzKZbVnUMbAd9I=",
+    "h1:jPHxtaeO8mgFGGWdEmATq/BNGo1LkE6FYFgMa6Dum08=",
+    "h1:jXEm7QnQCF2UG4KTgDMwT2cEqezPE8a+3V0iA8N1r7k=",
+    "h1:jjeEBnfOJI+bV/rf1721l4B3fNO7Yws4AKf4NDdhiho=",
+    "h1:y0Sujto8gttV86innNp/LTMzq7CqsFpBs7XKH8AlMl4=",
+    "zh:0ab29fc21699f34345cf0bbbe44745fd1b143b7c73b410c1dc4abe05ffad0a84",
+    "zh:1aed10d06755d420bb3a893bf548ab2932297a9d094c04c5a8501e949ca186ed",
+    "zh:2a6a11c21eae408055f45b9533c07afd2e845f6d496fd1b645aec2e873012103",
+    "zh:5dd05dee677f6ebdbed00cbb1b9be444ab2d1062d345cbc9ec50a47cb41b8622",
+    "zh:6b757d034831243d67ddda869eac4368cef539848bd97511f4d68f1aa38a9c88",
+    "zh:947c9b5b238f0364c57a705beabd24d3eea3159a6f3a24c07e3fbb13657ffae0",
+    "zh:a676549a98164b61630658cbeb6c17820331ca04a049dc9b5095996a0c31ffbe",
+    "zh:a8a81b7fe41dd61eb6a6fa5e08a4dd9ee070e862868252a7fd4cfce30364efee",
+    "zh:c26a9bca4865665084e7f59b1402d7aff34ee63a418d7401a0658fa280cad4d4",
+    "zh:c638d8d0762e62ea188f86302954ef4c92803f2160f0a45fca0cd13974bd3725",
+    "zh:e739a0b7e81ca816944a18a38e679f4015edf8be7ac319815cdea865ba7727d7",
+    "zh:ec099487ea3de8999c84b3b791e242d728461e51fe344832b37bd8d521201c77",
+    "zh:f016ff9e2daab5b88185cec0795213049d105439ffd585d3309a714514ccae13",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/terraform/github/README.md
+++ b/terraform/github/README.md
@@ -1,0 +1,22 @@
+# GitHub repository
+
+This root owns the `jonpulsifer/infra` repository through the GitHub provider.
+The first adoption surface is repository metadata and merge settings. Existing
+resources must be imported into the `terraform/github` state before Atlantis is
+allowed to apply changes:
+
+```text
+tofu -chdir=terraform/github import github_repository.infra jonpulsifer/infra
+```
+
+The provider token is supplied to Atlantis as `GITHUB_TOKEN` (or `GH_TOKEN`);
+it is deliberately not stored in this repository or in a SOPS file. GitHub
+does not expose existing Actions secret values, so those resources are added
+only when their plaintext is intentionally supplied in
+`secrets.sops.yaml`. The file is encrypted with the repository's operator age
+key before it is committed.
+
+Branch protection, rulesets, labels, Actions variables/secrets, environments,
+deploy keys, and webhooks are the next adoption surfaces. They should be
+imported from the live API before declaration so the first plan is non-
+destructive.

--- a/terraform/github/repository.tf
+++ b/terraform/github/repository.tf
@@ -1,0 +1,23 @@
+locals {
+  repository = "infra"
+}
+
+resource "github_repository" "infra" {
+  name        = local.repository
+  description = "home ops are the best ops"
+  visibility  = "public"
+
+  has_issues   = true
+  has_projects = true
+  has_wiki     = false
+
+  delete_branch_on_merge = true
+  allow_squash_merge     = true
+  allow_merge_commit     = true
+  allow_rebase_merge     = true
+}
+
+output "repository" {
+  description = "Managed repository full name."
+  value       = github_repository.infra.full_name
+}

--- a/terraform/github/secrets.sops.yaml
+++ b/terraform/github/secrets.sops.yaml
@@ -1,0 +1,20 @@
+# This file is intentionally encrypted before committing. Add only values that
+# Terraform must manage (for example Actions secret plaintexts). GitHub never
+# returns existing secret values, so adoption must be explicit and should not
+# rotate a secret accidentally.
+secrets: {}
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAxdmUxR092SmMvNWZrOEtm
+            OVd3VWVjZFY4ZDc3VFpFQ0hZbGQ1MG51OG1RCmQwQWJNMFBlK1pTTWFFSWMrSG9x
+            ZmVuNmhSTllSalI3TE1Bb3pBNWtnUTgKLS0tIHlid2VhWk9kbFJyNklmMmt1eVF2
+            Z3loc3laUG8vckI1elR2bCtYRnJIenMKIR/lEB9rDY9xfkAiUEHt8dGPA6vAHBLz
+            pEwSffMfrcUHwIFHPm48BXNVlGqaNAu7zq8apmVXdFq4CAMWkle5Dw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+    encrypted_regex: ^(secrets)$
+    lastmodified: "2026-07-30T02:02:43Z"
+    mac: ENC[AES256_GCM,data:/v3HeYRCMEoTxiCQ0wNTbJ98kVz3VtpbOowfg76izI94p9UFD8CSKGWIUZKO7N56RHQ3GjB5LHwfSC1p36PAeRfj4A4EofvWegGbo1XZXnTCPxr2z/Cj4LbcEL3NlFI0Usi/8IjTS/EqIQlxyPpJzewOtdHFbp9zzkQSOBaPn6M=,iv:/9HqyLj/8Xn7wLjbQnbjnGHOAntYFOuuz4YJ9ZZumf8=,tag:varjQV4gyiGxtc5u6IX31Q==,type:str]
+    version: 3.13.3

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  backend "gcs" {
+    bucket = "homelab-ng"
+    prefix = "terraform/github"
+  }
+
+  required_version = ">= 1.5.6"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# The provider reads GITHUB_TOKEN (or GH_TOKEN) from the environment. Keeping
+# the bootstrap token outside Terraform avoids putting it in this repository or
+# into state. Run Atlantis with the token supplied as an environment secret.
+provider "github" {}


### PR DESCRIPTION
## Summary
Adds an OpenTofu root for managing jonpulsifer/infra GitHub repository settings, with an encrypted SOPS scaffold for intentionally managed Actions secrets.

## Changes
- feat(terraform): manage GitHub repository settings

## Test Plan
- [x] OpenTofu formatting check
- [x] git diff --check
- [x] SOPS decrypt verification
- [ ] Import existing repository into Atlantis-managed state
- [ ] Expand adoption to branch protection, labels, Actions settings, environments, deploy keys, and webhooks

## Notes
Provider schema validation was unavailable because the downloaded GitHub provider failed its local plugin handshake; provider initialization and lockfile generation succeeded.
