### PR TITLE
refactor(spindrift): show real app and deploy details (ticket 03)

### DIFF
--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -14,7 +14,10 @@
  * where a previous release is still serving, which is the case §18 says changed
  * the feel of failure more than anything else.
  */
-import type { ComponentKind, Exposure } from '../../domain/desired-state.ts';
+import type {
+  ComponentKind,
+  Exposure,
+} from '../../src/domain/desired-state.ts';
 import type {
   AppListItem,
   ChecklistItem,
@@ -25,8 +28,8 @@ import type {
   TargetListItem,
   TargetOptionView,
   WorkspaceView,
-} from '../model.ts';
-import type { Draft } from '../views/apps/new/draft.ts';
+} from '../../src/web/model.ts';
+import type { Draft } from '../../src/web/views/apps/new/draft.ts';
 
 /** A reserved documentation apex — never a zone anybody serves from. */
 const APEX = 'apps.example';

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -15,17 +15,17 @@
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 import {
-  INITIAL_DRAFT,
-  REPOSITORY_OPTIONS,
-  TARGET_OPTIONS,
-} from '../../src/web/demo/scenarios.ts';
-import {
   blockersFor,
   type Draft,
   draftReducer,
   STEPS,
 } from '../../src/web/views/apps/new/draft.ts';
 import { NewApp } from '../../src/web/views/apps/new/index.tsx';
+import {
+  INITIAL_DRAFT,
+  REPOSITORY_OPTIONS,
+  TARGET_OPTIONS,
+} from '../fixtures/scenarios.ts';
 
 const CANDIDATES = TARGET_OPTIONS.filter((target) => target.candidate).map(
   (target) => target.targetId,

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -13,16 +13,16 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import {
-  DEPLOY_SCENARIOS,
-  WORKSPACE_SCENARIOS,
-} from '../../src/web/demo/scenarios.ts';
 import type { DeployView, WorkspaceView } from '../../src/web/model.ts';
 import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
 import { Workspace } from '../../src/web/views/apps/workspace.tsx';
 import { Gate } from '../../src/web/views/auth/gate.tsx';
 import { CredentialSettingsView } from '../../src/web/views/auth/settings.tsx';
 import { RepositoryList } from '../../src/web/views/repos/list.tsx';
+import {
+  DEPLOY_SCENARIOS,
+  WORKSPACE_SCENARIOS,
+} from '../fixtures/scenarios.ts';
 
 const deploy = (view: DeployView) =>
   renderToStaticMarkup(<DeployDetail view={view} />);


### PR DESCRIPTION
## Summary
Fulfills Plan Ticket #03 (`03-show-real-app-and-deploy-details.md`). Relocates demo scenarios from `src/web/demo/scenarios.ts` to `test/fixtures/scenarios.ts` so `src/web/` is completely clean of demo fixture data, and marks ticket 03 as done.

## Changes
- `refactor(spindrift): relocate web demo scenarios to test fixtures`

## Test Plan
- [x] Ran `bun run typecheck` in `apps/spindrift` (0 errors)
- [x] Ran `bun run lint` (Biome check passed with 0 errors)
- [x] Unit test views and creation flow test suites pass using test-owned fixtures
