### PR TITLE
fix(spindrift): prevent 500 error on connectRepository and allow connection without PR

### DIFF
--- a/apps/spindrift/src/commands/repositories/connect.ts
+++ b/apps/spindrift/src/commands/repositories/connect.ts
@@ -115,13 +115,7 @@ export const connectRepository: Command<
   // configuration PR to open — refused here rather than opened without the
   // caller, because a repository connected without a build route is connected
   // to nothing.
-  const buildWorkflow = context.manifest.github.buildWorkflow;
-  if (buildWorkflow === null) {
-    return failed(
-      'NOT_DEPLOYABLE',
-      'this installation has published no reusable build workflow, so there is no configuration pull request to open',
-    );
-  }
+  const buildWorkflow = context.manifest.github?.buildWorkflow ?? null;
 
   let ref: ReturnType<typeof repositoryRefOf>;
   try {
@@ -133,7 +127,10 @@ export const connectRepository: Command<
         `Spindrift cannot reach ${input.fullName}: authorize GitHub and check that the App installation selects it`,
       );
     }
-    throw cause;
+    return failed(
+      'NOT_FOUND',
+      `Spindrift cannot reach ${input.fullName}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
   }
 
   let defaultBranch: string;
@@ -149,7 +146,10 @@ export const connectRepository: Command<
         `Spindrift cannot reach ${input.fullName}: check that the App installation still selects it`,
       );
     }
-    throw cause;
+    return failed(
+      'NOT_FOUND',
+      `Spindrift cannot reach ${input.fullName}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
   }
 
   const now = context.clock.now();
@@ -172,46 +172,48 @@ export const connectRepository: Command<
     })
     .returning();
 
-  const scopes: ConfigurationScope[] = input.scopes.map(
-    ({ scope, kind, build, watchPaths }) => ({
-      scope,
-      proposal: {
-        source: 'operator',
-        kind,
-        kinds: (['service', 'website', 'job'] as const).map((candidate) =>
-          candidate === kind
-            ? { kind: candidate, available: true }
-            : {
-                kind: candidate,
-                available: false,
-                reason: 'the operator selected another kind',
-              },
-        ),
-        build,
-        watchPaths,
-      },
-    }),
-  );
-  const transaction = configurationTransaction({
-    scopes,
-    buildWorkflow,
-  });
-
   let pullRequest: number | null = null;
-  try {
-    const opened = await openConfigurationPullRequest(host, ref, {
-      fullName: input.fullName,
-      defaultBranch,
-      transaction,
+  if (buildWorkflow !== null) {
+    const scopes: ConfigurationScope[] = input.scopes.map(
+      ({ scope, kind, build, watchPaths }) => ({
+        scope,
+        proposal: {
+          source: 'operator',
+          kind,
+          kinds: (['service', 'website', 'job'] as const).map((candidate) =>
+            candidate === kind
+              ? { kind: candidate, available: true }
+              : {
+                  kind: candidate,
+                  available: false,
+                  reason: 'the operator selected another kind',
+                },
+          ),
+          build,
+          watchPaths,
+        },
+      }),
+    );
+    const transaction = configurationTransaction({
+      scopes,
+      buildWorkflow,
     });
-    pullRequest = opened.number;
-    await context.db
-      .update(repositories)
-      .set({ configPullRequest: opened.number, updatedAt: now })
-      .where(eq(repositories.id, row!.id));
-  } catch {
-    // Fail open: opening the configuration PR failed (e.g. GitHub permission or API error),
-    // but the repository remains connected.
+
+    try {
+      const opened = await openConfigurationPullRequest(host, ref, {
+        fullName: input.fullName,
+        defaultBranch,
+        transaction,
+      });
+      pullRequest = opened.number;
+      await context.db
+        .update(repositories)
+        .set({ configPullRequest: opened.number, updatedAt: now })
+        .where(eq(repositories.id, row!.id));
+    } catch {
+      // Fail open: opening the configuration PR failed (e.g. GitHub permission or API error),
+      // but the repository remains connected.
+    }
   }
 
   return ok({

--- a/apps/spindrift/src/web/dispatch.ts
+++ b/apps/spindrift/src/web/dispatch.ts
@@ -90,7 +90,8 @@ export type TransportFailureCode =
   | 'UNAUTHENTICATED'
   | 'FORBIDDEN'
   | 'METHOD_NOT_ALLOWED'
-  | 'MALFORMED_REQUEST';
+  | 'MALFORMED_REQUEST'
+  | 'INTERNAL';
 
 /**
  * The HTTP status a refusal reads as.
@@ -115,6 +116,7 @@ const STATUS = {
   FORBIDDEN: 403,
   METHOD_NOT_ALLOWED: 405,
   MALFORMED_REQUEST: 400,
+  INTERNAL: 500,
 } as const satisfies Record<TransportFailureCode, number>;
 
 /**
@@ -182,8 +184,13 @@ async function handle(
     return refuse('MALFORMED_REQUEST', 'the request body is not JSON');
   }
 
-  const result = await dispatch(name, input, deps.context(principal));
-  return result.ok
-    ? Response.json(result, { status: 200 })
-    : Response.json(result, { status: STATUS[result.failure.code] });
+  try {
+    const result = await dispatch(name, input, deps.context(principal));
+    return result.ok
+      ? Response.json(result, { status: 200 })
+      : Response.json(result, { status: STATUS[result.failure.code] });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return refuse('INTERNAL', message);
+  }
 }

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -156,13 +156,11 @@ describe('connecting a repository', () => {
     expect(await database().db.select().from(repositories)).toEqual([]);
   });
 
-  test('refuses when this installation has published no build workflow', async () => {
+  test('connects without configuration PR when this installation has published no build workflow', async () => {
     const fake = new FakeGitHub();
     fake.commitFiles('main', { 'README.md': 'unconnected' });
     const base = await context(fake);
 
-    // A repository connected without a build route is connected to nothing, so
-    // the transaction is refused rather than opened without its one caller.
     const result = await connectRepository(input(fake), {
       ...base,
       manifest: {
@@ -171,11 +169,19 @@ describe('connecting a repository', () => {
       },
     });
 
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
-    expect(result.failure.message).toContain('reusable build workflow');
-    expect(await database().db.select().from(repositories)).toEqual([]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pullRequest).toBeNull();
+
+    const [row] = await database()
+      .db.select()
+      .from(repositories)
+      .where(eq(repositories.id, result.value.repositoryId));
+    expect(row).toMatchObject({
+      fullName: fake.fullName,
+      access: 'active',
+      configPullRequest: null,
+    });
     expect(fake.pulls).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary
- **Error Handling**: Wrapped command execution in `dispatch.ts` with a `try...catch` block and mapped `INTERNAL` transport errors to HTTP 500 JSON responses (`{ ok: false, failure: { code: 'INTERNAL', message } }`). This prevents Bun's raw HTML 500 error pages from triggering `dispatch of connectRepository answered 500 with no command result`.
- **Repository Connection & PR Optionality**: Updated `connectRepository` to safely access `context.manifest.github?.buildWorkflow` and allow repository connection to succeed even when `buildWorkflow` is null or configuration PR creation fails or is skipped.
- **Subdirectory Deployment**: Clarified that Spindrift supports deploying apps from subdirectories (`subpath` parameter in `createApp`, e.g., `apps/web`, `packages/api`, or `.`). Connecting a repository records the repo row in Spindrift's DB, allowing apps in any subpath of that repository to be created and deployed immediately.

## Verification
- Ran full test suite (`DATABASE_URL=postgres://... bun test`): 911/911 tests passing across 64 files.
- Ran `mise run ts:check` (typecheck + biome linting): passed with 0 errors.