### PR TITLE
fix(spindrift): pass installationManifest as inline SPINDRIFT_MANIFEST env var

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -32,6 +32,70 @@ spec:
     # from the HTTPRoute and cert-manager issues the certificate, so this line
     # is the whole of what makes the UI reachable with TLS.
     hostname: spindrift.${SECRET_DOMAIN}
+    # Non-secret declared configuration. Core validates and reconciles it into
+    # durable Postgres state whenever a process starts.
+    installationManifest:
+      installation: offsite
+      dns:
+        apexZone: lolwtf.dev
+        vanityZone: lolwtf.dev
+      cloud:
+        artifactsProject: trusted-builds
+        homeVesselProject: bluenose
+        federation:
+          audience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
+          tokenUrl: https://sts.googleapis.com/v1/token
+          tokenPath: /var/run/secrets/spindrift/gcp-token
+          impersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
+      charts:
+        app: packages/charts/spindrift-app
+        installer: packages/charts/spindrift
+      supplyChain:
+        registry: ghcr.io/jonpulsifer
+        verifier: ghcr.io/jonpulsifer/spindrift-verifier
+        signer: gcpkms://projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer
+      github:
+        clientId: Iv1.918d699f36ee7afc
+        oauthBaseUrl: https://github.com
+        apiBaseUrl: https://api.github.com
+        buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
+      build:
+        routes:
+          - name: hosted
+            adapter: github-actions
+        zeroConfigFrontend: ghcr.io/railwayapp/railpack:railpack-frontend
+      secretStore:
+        adapter: onepassword
+        endpoint: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+        container: homelab
+      targets:
+        - name: offsite
+          adapter: kubernetes
+          connection:
+            apiServer: https://kubernetes.default.svc
+            namespace: spindrift-apps
+            delivery:
+              flavour: flux-helmrelease
+              namespace: spindrift-apps
+              sourceRef:
+                name: infra
+                namespace: flux-system
+            chartContract: "2"
+        - name: bluenose-cloudrun
+          adapter: cloudrun
+          connection:
+            project: bluenose
+            region: northamerica-northeast1
+            endpoint: https://run.googleapis.com
+        - name: bluenose-static
+          adapter: static
+          connection:
+            project: bluenose
+            endpoint: https://firebasehosting.googleapis.com
+      controlPlane:
+        hostname: spindrift.lolwtf.ca
+      auth:
+        gateway: null
     # The Secret carries only the one-time enrolment token and optional
     # integration credentials.
     envFromSecret: spindrift-env

--- a/packages/charts/spindrift/templates/deployment.yaml
+++ b/packages/charts/spindrift/templates/deployment.yaml
@@ -136,6 +136,10 @@ spec:
                   name: {{ include "spindrift.databaseName" $top }}-app
                   key: uri
             {{- end }}
+            {{- if not (empty $top.Values.installationManifest) }}
+            - name: SPINDRIFT_MANIFEST
+              value: {{ toJson $top.Values.installationManifest | quote }}
+            {{- end }}
             {{- range $top.Values.env }}
             - name: {{ .name }}
               value: {{ .value | quote }}

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -224,6 +224,17 @@ describe('ui-driven installation configuration', () => {
       ).toBe(false);
     }
   });
+
+  test('renders inline installation manifest env var when installationManifest values are provided', async () => {
+    const objects = await render({
+      installationManifest: { installation: 'offsite' },
+    });
+    const web = one(objects, 'Deployment', 'spindrift-web');
+    expect(web.spec.template.spec.containers[0].env).toContainEqual({
+      name: 'SPINDRIFT_MANIFEST',
+      value: JSON.stringify({ installation: 'offsite' }),
+    });
+  });
 });
 
 describe('authenticated Gateway trust', () => {


### PR DESCRIPTION
## Summary
Pass `Values.installationManifest` as an inline `SPINDRIFT_MANIFEST` environment variable in the Spindrift Helm chart deployment template and restore the `installationManifest:` configuration values in the offsite `HelmRelease`.

This fixes the deployment failure where Spindrift failed on startup with `ManifestError: no installation manifest` (because no stored manifest exists in Postgres yet and no file manifest is mounted).

## Changes
- Render `SPINDRIFT_MANIFEST` env var in `packages/charts/spindrift/templates/deployment.yaml` when `installationManifest` values are provided.
- Restore `installationManifest:` values in `clusters/offsite/apps/spindrift/helm-release.yaml`.
- Add chart test for inline installation manifest env var rendering in `packages/charts/spindrift/tests/render.test.ts`.

## Test Plan
- [x] Verified Helm chart render tests (`bun test packages/charts/spindrift/tests/render.test.ts`)
- [x] Verified `kubectl kustomize clusters/offsite/apps` renders cleanly
