### PR TITLE
Connect this repository to Spindrift (1 scope)

### DIFF
--- a/spindrift.yaml
+++ b/spindrift.yaml
@@ -1,0 +1,14 @@
+# Managed by Spindrift, and yours to edit.
+#
+# This file is what Spindrift knows about this directory. Once it is on the
+# default branch it is authoritative: what is written here wins over what
+# detection would otherwise guess.
+version: 1
+component:
+  kind: service
+build:
+  frontend: dockerfile
+  file: apps/spindrift/Dockerfile
+watchPaths:
+  - apps/spindrift
+  - packages


### PR DESCRIPTION
Spindrift wrote this. Merging it into the default branch is what connects this repository — nothing here takes effect until then, and an unmerged or closed pull request changes nothing.

| scope | kind | build | proposed by |
| --- | --- | --- | --- |
| `.` | service | dockerfile | operator |

Each `spindrift.yaml` is yours to edit, here or later. Once it is on the default branch it wins over detection.

`.github/workflows/spindrift.yml` runs builds for this repository on its own Actions minutes. It calls a reusable workflow pinned by commit (this is the platform repo, so it uses `./` which resolves to the same commit).
