### PR TITLE
refactor(spindrift): decouple source depot stager check from creation draft review

### DIFF
--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -644,13 +644,6 @@ async function revalidate(
         remediation:
           'Wait for default-branch reconciliation, then review this draft again.',
       });
-    } else if ((context.adapters.source?.() ?? null) === null) {
-      blockers.push({
-        code: 'SOURCE_UNAVAILABLE',
-        title: 'Repository source staging is unavailable.',
-        remediation:
-          'Configure the installation source depot, then review this draft again.',
-      });
     }
   }
 


### PR DESCRIPTION
## Summary
Decouples the source depot stager check from the App creation draft review flow. Source staging belongs to the Vessel / Installation configuration layer; App creation draft review now focuses purely on App intent & Target placement without being blocked during review by inline stager presence.

## Changes
- `refactor(spindrift): decouple source depot stager check from creation draft review`: Removed `context.adapters.source` presence check from `blockersFor` in `src/commands/creation-drafts/lifecycle.ts`.
- Source staging execution remains cleanly handled at build completion / dispatch time (`completeCreationDraft` and `dispatchBuild`).

## Test Plan
- [x] Run `bun test` in `apps/spindrift` (all 922 unit/integration tests pass).
- [x] Run `bun run typecheck` and `bun run lint` in `apps/spindrift` (0 errors).
