### PR TITLE
feat(ci): add selective continuous delivery for container images

### DIFF
--- a/.github/containers.json
+++ b/.github/containers.json
@@ -13,6 +13,30 @@
     "spindrift-demo",
     "spindrift-verifier"
   ],
+  "deploy": {
+    "actions-runner": [
+      "clusters/base/apps/arc/infra.yaml"
+    ],
+    "ai-agents": [
+      "clusters/offsite/apps/dave.yaml"
+    ],
+    "atlantis": [
+      "clusters/offsite/apps/atlantis/helm-release.yaml"
+    ],
+    "hub": [
+      "clusters/offsite/apps/hub/helm-release.yaml"
+    ],
+    "netbench": [
+      "clusters/base/apps/iperf3/iperf3-daemonset.yaml",
+      "clusters/folly/apps/netbench/03-deployment.yaml"
+    ],
+    "rackstat": [
+      "clusters/folly/apps/tronbyt/07-rackstat-deployment.yaml"
+    ],
+    "spindrift": [
+      "clusters/offsite/apps/spindrift/helm-release.yaml"
+    ]
+  },
   "ignore": [
     "bashcurljq",
     "kernel-builder",

--- a/.github/scripts/detect-containers.sh
+++ b/.github/scripts/detect-containers.sh
@@ -85,6 +85,7 @@ for dockerfile in "${dockerfiles[@]}"; do
     file=$(jq -r '.file        // ""' <<<"$entry")
     build_args=$(jq -r '."build-args" // ""' <<<"$entry")
     platforms=$(jq -r '.platforms   // ""' <<<"$entry")
+    deploy_manifests=$(jq -c --arg img "$image" '.deploy[$img] // []' "$manifest")
 
     should_build="$rebuild_all"
     if [[ "$should_build" != "true" ]]; then
@@ -100,8 +101,8 @@ for dockerfile in "${dockerfiles[@]}"; do
     if [[ "$should_build" == "true" ]]; then
       includes=$(jq -cn --argjson a "$includes" \
         --arg img "$image" --arg ctx "$context" --arg f "$file" --arg ba "$build_args" \
-        --arg p "$platforms" \
-        '$a + [{"image":$img,"context":$ctx,"file":$f,"build-args":$ba,"platforms":$p}]')
+        --arg p "$platforms" --argjson m "$deploy_manifests" \
+        '$a + [{"image":$img,"context":$ctx,"file":$f,"build-args":$ba,"platforms":$p,"manifests":$m}]')
     fi
   done
 done

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -38,7 +38,7 @@ jobs:
     if: needs.detect.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
       packages: write
     strategy:
@@ -117,3 +117,28 @@ jobs:
           ignore-unfixed: true
           exit-code: 0
           severity: CRITICAL,HIGH
+      - name: Update manifest digest for selective continuous delivery
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.manifests != '[]' && matrix.manifests != ''
+        env:
+          IMAGE_NAME: ${{ matrix.image }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+          MANIFESTS: ${{ toJson(matrix.manifests) }}
+        run: |
+          set -euo pipefail
+          updated=false
+          mapfile -t targets < <(jq -r '.[]' <<<"$MANIFESTS")
+          for manifest in "${targets[@]}"; do
+            if [ -f "$manifest" ]; then
+              echo "Updating digest for $IMAGE_NAME in $manifest..."
+              sed -i -E "s|(@sha256:)[0-9a-f]{64}|\1${DIGEST}|g" "$manifest"
+              updated=true
+            fi
+          done
+
+          if [ "$updated" = "true" ] && ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add .
+            git commit -m "fix(cd): update ${IMAGE_NAME} image digest to ${DIGEST}"
+            git push
+          fi

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -14,7 +14,7 @@ metadata:
   name: spindrift
   namespace: spindrift
 spec:
-  interval: 1h
+  interval: 5m
   chart:
     spec:
       chart: packages/charts/spindrift


### PR DESCRIPTION
## Summary
Adds extensible selective continuous delivery for built container images to automatically update target Kubernetes manifest image digests in `clusters/` upon successful build in GitHub Actions, and decreases Spindrift's Flux reconcile interval to 5m.

## Changes
- `.github/containers.json`: Added `deploy` mapping connecting built container images (`spindrift`, `hub`, `ai-agents`, `actions-runner`, `netbench`, `rackstat`, `atlantis`) to target Kubernetes manifest path(s).
- `.github/scripts/detect-containers.sh`: Passed `manifests` into matrix output for each detected container build.
- `.github/workflows/containers.yml`: Added `contents: write` permissions and a dynamic step to update image digests in target manifests and push to `main` upon build completion.
- `clusters/offsite/apps/spindrift/helm-release.yaml`: Reduced Flux `spec.interval` from `1h` to `5m`.

## Test Plan
- [x] Tested `.github/scripts/detect-containers.sh` locally with sample changed files to verify correct `manifests` matrix output.
- [x] Ran `mise run k8s:render-apps` to ensure offsite and folly Kubernetes manifests render cleanly.
- [x] Ran `mise run docs:check` to verify documentation contract compliance.
