### PR TITLE
feat(spindrift): deploy otel collector and instrument application

### DIFF
--- a/apps/spindrift/package.json
+++ b/apps/spindrift/package.json
@@ -13,6 +13,16 @@
   },
   "//dependencies": "What the *server* imports at runtime, and nothing else. The UI's libraries are build inputs: they are compiled into dist/ and the shipped image never resolves them, so they sit in devDependencies and `bun install --production` leaves them out. test/web/routes.test.ts asserts the server's module graph agrees.",
   "dependencies": {
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/api-logs": "^0.57.0",
+    "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+    "@opentelemetry/resources": "^1.30.0",
+    "@opentelemetry/sdk-logs": "^0.57.0",
+    "@opentelemetry/sdk-metrics": "^1.30.0",
+    "@opentelemetry/sdk-node": "^0.57.0",
+    "@opentelemetry/semantic-conventions": "^1.30.0",
     "drizzle-orm": "0.45.2",
     "zod": "4.4.3"
   },

--- a/apps/spindrift/src/reconciler/main.ts
+++ b/apps/spindrift/src/reconciler/main.ts
@@ -27,15 +27,31 @@ try {
   process.off('SIGTERM', stop);
 }
 
+import {
+  logError,
+  logInfo,
+  logWarn,
+  reconcilerErrorCounter,
+  reconcilerLoopCounter,
+} from '../telemetry/index.ts';
+
 function report(event: ReconcilerProcessEvent): void {
   if (event.type === 'failure') {
-    console.error(
+    reconcilerErrorCounter.add(1, { loop: event.loop });
+    logError(
       `spindrift reconciler → ${event.loop} loop failed; retrying in ${event.retryInMs}ms`,
       event.cause,
+      { loop: event.loop, retryInMs: event.retryInMs },
     );
   } else if (event.type === 'disabled') {
-    console.log(
+    logWarn(
       `spindrift reconciler → ${event.loop} loop disabled: ${event.reason}`,
+      { loop: event.loop, reason: event.reason },
     );
+  } else {
+    reconcilerLoopCounter.add(1, { loop: event.loop });
+    logInfo(`spindrift reconciler → ${event.loop} loop processed event`, {
+      loop: event.loop,
+    });
   }
 }

--- a/apps/spindrift/src/reconciler/start.ts
+++ b/apps/spindrift/src/reconciler/start.ts
@@ -31,12 +31,16 @@ export interface StartReconcilerOptions {
   readonly onEvent?: (event: ReconcilerProcessEvent) => void;
 }
 
+import { initTelemetry } from '../telemetry/index.ts';
+
 /**
  * Load durable installation state, construct adapters, and run until shutdown.
  */
 export async function startReconciler(
   options: StartReconcilerOptions,
 ): Promise<void> {
+  initTelemetry('reconciler');
+
   const env = options.env ?? Bun.env;
   const ownedClient = options.client === undefined;
   const client = options.client ?? createClient(env);

--- a/apps/spindrift/src/telemetry/index.ts
+++ b/apps/spindrift/src/telemetry/index.ts
@@ -1,0 +1,174 @@
+import {
+  type Counter,
+  type Histogram,
+  type Meter,
+  metrics,
+  type Tracer,
+  trace,
+} from '@opentelemetry/api';
+import { logs, SeverityNumber } from '@opentelemetry/api-logs';
+import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
+import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs';
+import { PeriodicExportingMetricReader } from '@opentelemetry/sdk-metrics';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import {
+  ATTR_SERVICE_NAME,
+  ATTR_SERVICE_VERSION,
+} from '@opentelemetry/semantic-conventions';
+
+const OTLP_ENDPOINT =
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT ||
+  'http://opentelemetry-collector.monitoring.svc.cluster.local:4318';
+const SERVICE_NAME = process.env.OTEL_SERVICE_NAME || 'spindrift';
+const SERVICE_VERSION = process.env.SPINDRIFT_VERSION || '1.0.0';
+
+let sdkInstance: NodeSDK | null = null;
+
+export function initTelemetry(component = 'web'): NodeSDK | null {
+  if (sdkInstance) {
+    return sdkInstance;
+  }
+
+  const resource = new Resource({
+    [ATTR_SERVICE_NAME]: `${SERVICE_NAME}-${component}`,
+    [ATTR_SERVICE_VERSION]: SERVICE_VERSION,
+  });
+
+  const traceExporter = new OTLPTraceExporter({
+    url: `${OTLP_ENDPOINT}/v1/traces`,
+  });
+
+  const metricExporter = new OTLPMetricExporter({
+    url: `${OTLP_ENDPOINT}/v1/metrics`,
+  });
+
+  const logExporter = new OTLPLogExporter({
+    url: `${OTLP_ENDPOINT}/v1/logs`,
+  });
+
+  const metricReader = new PeriodicExportingMetricReader({
+    exporter: metricExporter,
+    exportIntervalMillis: 10000,
+  });
+
+  const logRecordProcessor = new BatchLogRecordProcessor(logExporter);
+
+  sdkInstance = new NodeSDK({
+    resource,
+    traceExporter,
+    metricReader,
+    logRecordProcessor,
+  });
+
+  try {
+    sdkInstance.start();
+    console.log(
+      `[Telemetry] OpenTelemetry initialized for ${SERVICE_NAME}-${component} -> ${OTLP_ENDPOINT}`,
+    );
+  } catch (error) {
+    console.error('[Telemetry] Failed to initialize OpenTelemetry SDK:', error);
+  }
+
+  process.on('SIGTERM', async () => {
+    if (sdkInstance) {
+      try {
+        await sdkInstance.shutdown();
+        console.log('[Telemetry] SDK shut down successfully');
+      } catch (err) {
+        console.error('[Telemetry] Error shutting down SDK', err);
+      }
+    }
+  });
+
+  return sdkInstance;
+}
+
+export const tracer: Tracer = trace.getTracer('spindrift');
+export const meter: Meter = metrics.getMeter('spindrift');
+
+export const httpRequestCounter: Counter = meter.createCounter(
+  'http_requests_total',
+  {
+    description: 'Total number of HTTP requests received',
+  },
+);
+
+export const httpRequestDuration: Histogram = meter.createHistogram(
+  'http_request_duration_seconds',
+  {
+    description: 'HTTP request duration in seconds',
+    unit: 's',
+  },
+);
+
+export const reconcilerLoopCounter: Counter = meter.createCounter(
+  'reconciler_loop_total',
+  {
+    description: 'Total reconciler loop executions',
+  },
+);
+
+export const reconcilerLoopDuration: Histogram = meter.createHistogram(
+  'reconciler_loop_duration_seconds',
+  {
+    description: 'Reconciler loop execution duration in seconds',
+    unit: 's',
+  },
+);
+
+export const reconcilerErrorCounter: Counter = meter.createCounter(
+  'reconciler_errors_total',
+  {
+    description: 'Total reconciler loop errors',
+  },
+);
+
+const logger = logs.getLogger('spindrift');
+
+export function logInfo(message: string, attributes: Record<string, any> = {}) {
+  console.log(`[INFO] ${message}`, attributes);
+  try {
+    logger.emit({
+      severityNumber: SeverityNumber.INFO,
+      severityText: 'INFO',
+      body: message,
+      attributes,
+    });
+  } catch {}
+}
+
+export function logWarn(message: string, attributes: Record<string, any> = {}) {
+  console.warn(`[WARN] ${message}`, attributes);
+  try {
+    logger.emit({
+      severityNumber: SeverityNumber.WARN,
+      severityText: 'WARN',
+      body: message,
+      attributes,
+    });
+  } catch {}
+}
+
+export function logError(
+  message: string,
+  error?: unknown,
+  attributes: Record<string, any> = {},
+) {
+  console.error(`[ERROR] ${message}`, error, attributes);
+  try {
+    logger.emit({
+      severityNumber: SeverityNumber.ERROR,
+      severityText: 'ERROR',
+      body: `${message}${error instanceof Error ? `: ${error.message}` : ''}`,
+      attributes: {
+        ...attributes,
+        ...(error instanceof Error
+          ? { 'error.stack': error.stack, 'error.message': error.message }
+          : {}),
+      },
+    });
+  } catch {}
+}

--- a/apps/spindrift/src/web/dispatch.ts
+++ b/apps/spindrift/src/web/dispatch.ts
@@ -153,103 +153,44 @@ export function commandRoutes(
   );
 }
 
-import {
-  httpRequestCounter,
-  httpRequestDuration,
-  logError,
-  logInfo,
-  tracer,
-} from '../telemetry/index.ts';
-
 async function handle(
   name: CommandName,
   request: Request,
   deps: DispatchDeps,
 ): Promise<Response> {
-  const startTime = Date.now();
+  if (request.method !== 'POST') {
+    // A command is an act. Making one reachable by GET would make it
+    // link-followable, pre-fetchable, and cacheable — three ways to run it
+    // without anybody asking.
+    return refuse('METHOD_NOT_ALLOWED', 'a command is dispatched with POST');
+  }
 
-  return tracer.startActiveSpan(`command ${name}`, async (span) => {
-    span.setAttribute('command.name', name);
-    span.setAttribute('http.method', request.method);
+  const authentication = await deps.authenticate(request);
+  if (authentication.kind === 'anonymous') {
+    return refuse(
+      'UNAUTHENTICATED',
+      'this surface is reachable only with a session',
+    );
+  }
+  if (authentication.kind === 'forbidden') {
+    return refuse('FORBIDDEN', authentication.message);
+  }
+  const { principal } = authentication;
 
-    if (request.method !== 'POST') {
-      const response = refuse(
-        'METHOD_NOT_ALLOWED',
-        'a command is dispatched with POST',
-      );
-      span.setStatus({ code: 2, message: 'Method not allowed' }); // 2 = ERROR
-      span.end();
-      return response;
-    }
+  let input: unknown;
+  try {
+    input = await request.json();
+  } catch {
+    return refuse('MALFORMED_REQUEST', 'the request body is not JSON');
+  }
 
-    const authentication = await deps.authenticate(request);
-    if (authentication.kind === 'anonymous') {
-      const response = refuse(
-        'UNAUTHENTICATED',
-        'this surface is reachable only with a session',
-      );
-      span.setStatus({ code: 2, message: 'Unauthenticated' });
-      span.end();
-      return response;
-    }
-    if (authentication.kind === 'forbidden') {
-      const response = refuse('FORBIDDEN', authentication.message);
-      span.setStatus({ code: 2, message: authentication.message });
-      span.end();
-      return response;
-    }
-    const { principal } = authentication;
-    span.setAttribute('principal.id', principal.id);
-
-    let input: unknown;
-    try {
-      input = await request.json();
-    } catch {
-      const response = refuse(
-        'MALFORMED_REQUEST',
-        'the request body is not JSON',
-      );
-      span.setStatus({ code: 2, message: 'Malformed JSON' });
-      span.end();
-      return response;
-    }
-
-    try {
-      const result = await dispatch(name, input, deps.context(principal));
-      const status = result.ok ? 200 : STATUS[result.failure.code];
-      const durationSec = (Date.now() - startTime) / 1000;
-
-      httpRequestCounter.add(1, { command: name, status: String(status) });
-      httpRequestDuration.record(durationSec, {
-        command: name,
-        status: String(status),
-      });
-
-      if (result.ok) {
-        span.setStatus({ code: 1 }); // 1 = OK
-        logInfo(`command ${name} succeeded`, { name, durationSec });
-        span.end();
-        return Response.json(result, { status: 200 });
-      }
-      span.setStatus({ code: 2, message: result.failure.message });
-      logError(`command ${name} failed: ${result.failure.message}`, undefined, {
-        name,
-        code: result.failure.code,
-      });
-      span.end();
-      return Response.json(result, { status: STATUS[result.failure.code] });
-    } catch (cause) {
-      const message = cause instanceof Error ? cause.message : String(cause);
-      const durationSec = (Date.now() - startTime) / 1000;
-
-      httpRequestCounter.add(1, { command: name, status: '500' });
-      httpRequestDuration.record(durationSec, { command: name, status: '500' });
-
-      span.setStatus({ code: 2, message });
-      span.recordException(cause instanceof Error ? cause : new Error(message));
-      logError(`command ${name} internal error: ${message}`, cause, { name });
-      span.end();
-      return refuse('INTERNAL', message);
-    }
-  });
+  try {
+    const result = await dispatch(name, input, deps.context(principal));
+    return result.ok
+      ? Response.json(result, { status: 200 })
+      : Response.json(result, { status: STATUS[result.failure.code] });
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    return refuse('INTERNAL', message);
+  }
 }

--- a/apps/spindrift/src/web/dispatch.ts
+++ b/apps/spindrift/src/web/dispatch.ts
@@ -153,44 +153,103 @@ export function commandRoutes(
   );
 }
 
+import {
+  httpRequestCounter,
+  httpRequestDuration,
+  logError,
+  logInfo,
+  tracer,
+} from '../telemetry/index.ts';
+
 async function handle(
   name: CommandName,
   request: Request,
   deps: DispatchDeps,
 ): Promise<Response> {
-  if (request.method !== 'POST') {
-    // A command is an act. Making one reachable by GET would make it
-    // link-followable, pre-fetchable, and cacheable — three ways to run it
-    // without anybody asking.
-    return refuse('METHOD_NOT_ALLOWED', 'a command is dispatched with POST');
-  }
+  const startTime = Date.now();
 
-  const authentication = await deps.authenticate(request);
-  if (authentication.kind === 'anonymous') {
-    return refuse(
-      'UNAUTHENTICATED',
-      'this surface is reachable only with a session',
-    );
-  }
-  if (authentication.kind === 'forbidden') {
-    return refuse('FORBIDDEN', authentication.message);
-  }
-  const { principal } = authentication;
+  return tracer.startActiveSpan(`command ${name}`, async (span) => {
+    span.setAttribute('command.name', name);
+    span.setAttribute('http.method', request.method);
 
-  let input: unknown;
-  try {
-    input = await request.json();
-  } catch {
-    return refuse('MALFORMED_REQUEST', 'the request body is not JSON');
-  }
+    if (request.method !== 'POST') {
+      const response = refuse(
+        'METHOD_NOT_ALLOWED',
+        'a command is dispatched with POST',
+      );
+      span.setStatus({ code: 2, message: 'Method not allowed' }); // 2 = ERROR
+      span.end();
+      return response;
+    }
 
-  try {
-    const result = await dispatch(name, input, deps.context(principal));
-    return result.ok
-      ? Response.json(result, { status: 200 })
-      : Response.json(result, { status: STATUS[result.failure.code] });
-  } catch (cause) {
-    const message = cause instanceof Error ? cause.message : String(cause);
-    return refuse('INTERNAL', message);
-  }
+    const authentication = await deps.authenticate(request);
+    if (authentication.kind === 'anonymous') {
+      const response = refuse(
+        'UNAUTHENTICATED',
+        'this surface is reachable only with a session',
+      );
+      span.setStatus({ code: 2, message: 'Unauthenticated' });
+      span.end();
+      return response;
+    }
+    if (authentication.kind === 'forbidden') {
+      const response = refuse('FORBIDDEN', authentication.message);
+      span.setStatus({ code: 2, message: authentication.message });
+      span.end();
+      return response;
+    }
+    const { principal } = authentication;
+    span.setAttribute('principal.id', principal.id);
+
+    let input: unknown;
+    try {
+      input = await request.json();
+    } catch {
+      const response = refuse(
+        'MALFORMED_REQUEST',
+        'the request body is not JSON',
+      );
+      span.setStatus({ code: 2, message: 'Malformed JSON' });
+      span.end();
+      return response;
+    }
+
+    try {
+      const result = await dispatch(name, input, deps.context(principal));
+      const status = result.ok ? 200 : STATUS[result.failure.code];
+      const durationSec = (Date.now() - startTime) / 1000;
+
+      httpRequestCounter.add(1, { command: name, status: String(status) });
+      httpRequestDuration.record(durationSec, {
+        command: name,
+        status: String(status),
+      });
+
+      if (result.ok) {
+        span.setStatus({ code: 1 }); // 1 = OK
+        logInfo(`command ${name} succeeded`, { name, durationSec });
+        span.end();
+        return Response.json(result, { status: 200 });
+      }
+      span.setStatus({ code: 2, message: result.failure.message });
+      logError(`command ${name} failed: ${result.failure.message}`, undefined, {
+        name,
+        code: result.failure.code,
+      });
+      span.end();
+      return Response.json(result, { status: STATUS[result.failure.code] });
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : String(cause);
+      const durationSec = (Date.now() - startTime) / 1000;
+
+      httpRequestCounter.add(1, { command: name, status: '500' });
+      httpRequestDuration.record(durationSec, { command: name, status: '500' });
+
+      span.setStatus({ code: 2, message });
+      span.recordException(cause instanceof Error ? cause : new Error(message));
+      logError(`command ${name} internal error: ${message}`, cause, { name });
+      span.end();
+      return refuse('INTERNAL', message);
+    }
+  });
 }

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -39,7 +39,67 @@ import { type StreamSocketData, streamWebSocket } from './streams.ts';
  */
 export const ENROLMENT_TOKEN_VAR = 'SPINDRIFT_ENROLMENT_TOKEN';
 
-import { initTelemetry, logInfo } from '../telemetry/index.ts';
+import {
+  httpRequestCounter,
+  httpRequestDuration,
+  initTelemetry,
+  logInfo,
+  tracer,
+} from '../telemetry/index.ts';
+
+function instrumentRoutes<T extends Record<string, any>>(routes: T): T {
+  const instrumented: Record<string, any> = {};
+  for (const [path, handler] of Object.entries(routes)) {
+    if (typeof handler === 'function') {
+      instrumented[path] = async (req: Request) => {
+        const startTime = Date.now();
+        return tracer.startActiveSpan(
+          `HTTP ${req.method} ${path}`,
+          async (span) => {
+            span.setAttribute('http.method', req.method);
+            span.setAttribute('http.target', path);
+
+            try {
+              const res = await (
+                handler as (r: Request) => Promise<Response> | Response
+              )(req);
+              const durationSec = (Date.now() - startTime) / 1000;
+              const status = res.status ?? 200;
+
+              httpRequestCounter.add(1, { path, status: String(status) });
+              httpRequestDuration.record(durationSec, {
+                path,
+                status: String(status),
+              });
+
+              span.setAttribute('http.status_code', status);
+              span.setStatus({ code: status < 400 ? 1 : 2 });
+              span.end();
+              return res;
+            } catch (err) {
+              const durationSec = (Date.now() - startTime) / 1000;
+              httpRequestCounter.add(1, { path, status: '500' });
+              httpRequestDuration.record(durationSec, {
+                path,
+                status: '500',
+              });
+
+              span.setStatus({ code: 2, message: String(err) });
+              span.recordException(
+                err instanceof Error ? err : new Error(String(err)),
+              );
+              span.end();
+              throw err;
+            }
+          },
+        );
+      };
+    } else {
+      instrumented[path] = handler;
+    }
+  }
+  return instrumented as T;
+}
 
 export async function start(
   client: Record<string, ClientRoute>,
@@ -68,23 +128,25 @@ export async function start(
     gateway: manifest.auth.gateway,
   };
 
+  const rawRoutes = webRoutes(
+    client,
+    {
+      authenticate: (request) => authenticateRequest(request, auth),
+      context: (principal) => ({
+        principal,
+        clock: systemClock,
+        db,
+        adapters,
+        manifest,
+      }),
+    },
+    auth,
+  );
+
   const server = Bun.serve<StreamSocketData>({
     port: Number(Bun.env.PORT ?? 3000),
     development,
-    routes: webRoutes(
-      client,
-      {
-        authenticate: (request) => authenticateRequest(request, auth),
-        context: (principal) => ({
-          principal,
-          clock: systemClock,
-          db,
-          adapters,
-          manifest,
-        }),
-      },
-      auth,
-    ),
+    routes: instrumentRoutes(rawRoutes),
     websocket: streamWebSocket,
   });
 

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -39,10 +39,14 @@ import { type StreamSocketData, streamWebSocket } from './streams.ts';
  */
 export const ENROLMENT_TOKEN_VAR = 'SPINDRIFT_ENROLMENT_TOKEN';
 
+import { initTelemetry, logInfo } from '../telemetry/index.ts';
+
 export async function start(
   client: Record<string, ClientRoute>,
   { development }: { development: boolean },
 ): Promise<void> {
+  initTelemetry('web');
+
   const db = createDb();
   const manifest = await loadStoredManifest(db);
   assertTrustedGatewayBoundary(manifest);
@@ -84,5 +88,8 @@ export async function start(
     websocket: streamWebSocket,
   });
 
-  console.log(`spindrift web → ${server.url} (${manifest.installation})`);
+  logInfo(`spindrift web → ${server.url} (${manifest.installation})`, {
+    url: String(server.url),
+    installation: manifest.installation,
+  });
 }

--- a/bun.lock
+++ b/bun.lock
@@ -110,6 +110,16 @@
     "apps/spindrift": {
       "name": "spindrift",
       "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.57.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.57.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.57.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.57.0",
+        "@opentelemetry/resources": "^1.30.0",
+        "@opentelemetry/sdk-logs": "^0.57.0",
+        "@opentelemetry/sdk-metrics": "^1.30.0",
+        "@opentelemetry/sdk-node": "^0.57.0",
+        "@opentelemetry/semantic-conventions": "^1.30.0",
         "drizzle-orm": "0.45.2",
         "zod": "4.4.3",
       },
@@ -425,6 +435,60 @@
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.11", "", { "os": "win32", "cpu": "x64" }, "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.57.2", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A=="],
+
+    "@opentelemetry/context-async-hooks": ["@opentelemetry/context-async-hooks@1.30.1", "", { "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@1.30.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ=="],
+
+    "@opentelemetry/exporter-logs-otlp-grpc": ["@opentelemetry/exporter-logs-otlp-grpc@0.57.2", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-grpc-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/sdk-logs": "0.57.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-eovEy10n3umjKJl2Ey6TLzikPE+W4cUQ4gCwgGP1RqzTGtgDra0WjIqdy29ohiUKfvmbiL3MndZww58xfIvyFw=="],
+
+    "@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/sdk-logs": "0.57.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-0rygmvLcehBRp56NQVLSleJ5ITTduq/QfU7obOkyWgPpFHulwpw2LYTqNIz5TczKZuy5YY+5D3SDnXZL1tXImg=="],
+
+    "@opentelemetry/exporter-logs-otlp-proto": ["@opentelemetry/exporter-logs-otlp-proto@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-logs": "0.57.2", "@opentelemetry/sdk-trace-base": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ta0ithCin0F8lu9eOf4lEz9YAScecezCHkMMyDkvd9S7AnZNX5ikUmC5EQOQADU+oCcgo/qkQIaKcZvQ0TYKDw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-grpc": ["@opentelemetry/exporter-metrics-otlp-grpc@0.57.2", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "1.30.1", "@opentelemetry/exporter-metrics-otlp-http": "0.57.2", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-grpc-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-metrics": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-r70B8yKR41F0EC443b5CGB4rUaOMm99I5N75QQt6sHKxYDzSEc6gm48Diz1CI1biwa5tDPznpylTrywO/pT7qw=="],
+
+    "@opentelemetry/exporter-metrics-otlp-http": ["@opentelemetry/exporter-metrics-otlp-http@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-metrics": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ttb9+4iKw04IMubjm3t0EZsYRNWr3kg44uUuzfo9CaccYlOh8cDooe4QObDUkvx9d5qQUrbEckhrWKfJnKhemA=="],
+
+    "@opentelemetry/exporter-metrics-otlp-proto": ["@opentelemetry/exporter-metrics-otlp-proto@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/exporter-metrics-otlp-http": "0.57.2", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-metrics": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-HX068Q2eNs38uf7RIkNN9Hl4Ynl+3lP0++KELkXMCpsCbFO03+0XNNZ1SkwxPlP9jrhQahsMPMkzNXpq3fKsnw=="],
+
+    "@opentelemetry/exporter-prometheus": ["@opentelemetry/exporter-prometheus@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-metrics": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-VqIqXnuxWMWE/1NatAGtB1PvsQipwxDcdG4RwA/umdBcW3/iOHp0uejvFHTRN2O78ZPged87ErJajyUBPUhlDQ=="],
+
+    "@opentelemetry/exporter-trace-otlp-grpc": ["@opentelemetry/exporter-trace-otlp-grpc@0.57.2", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-grpc-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-gHU1vA3JnHbNxEXg5iysqCWxN9j83d7/epTYBZflqQnTyCC4N7yZXn/dMM+bEmyhQPGjhCkNZLx4vZuChH1PYw=="],
+
+    "@opentelemetry/exporter-trace-otlp-http": ["@opentelemetry/exporter-trace-otlp-http@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-sB/gkSYFu+0w2dVQ0PWY9fAMl172PKMZ/JrHkkW8dmjCL0CYkmXeE+ssqIL/yBUTPOvpLIpenX5T9RwXRBW/3g=="],
+
+    "@opentelemetry/exporter-trace-otlp-proto": ["@opentelemetry/exporter-trace-otlp-proto@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-awDdNRMIwDvUtoRYxRhja5QYH6+McBLtoz1q9BeEsskhZcrGmH/V1fWpGx8n+Rc+542e8pJA6y+aullbIzQmlw=="],
+
+    "@opentelemetry/exporter-zipkin": ["@opentelemetry/exporter-zipkin@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": "^1.0.0" } }, "sha512-6S2QIMJahIquvFaaxmcwpvQQRD/YFaMTNoIxrfPIPOeITN+a8lfEcPDxNxn8JDAaxkg+4EnXhz8upVDYenoQjA=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@types/shimmer": "^1.2.0", "import-in-the-middle": "^1.8.1", "require-in-the-middle": "^7.1.1", "semver": "^7.5.2", "shimmer": "^1.2.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg=="],
+
+    "@opentelemetry/otlp-exporter-base": ["@opentelemetry/otlp-exporter-base@0.57.2", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-transformer": "0.57.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-XdxEzL23Urhidyebg5E6jZoaiW5ygP/mRjxLHixogbqwDy2Faduzb5N0o/Oi+XTIJu+iyxXdVORjXax+Qgfxag=="],
+
+    "@opentelemetry/otlp-grpc-exporter-base": ["@opentelemetry/otlp-grpc-exporter-base@0.57.2", "", { "dependencies": { "@grpc/grpc-js": "^1.7.1", "@opentelemetry/core": "1.30.1", "@opentelemetry/otlp-exporter-base": "0.57.2", "@opentelemetry/otlp-transformer": "0.57.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-USn173KTWy0saqqRB5yU9xUZ2xdgb1Rdu5IosJnm9aV4hMTuFFRTUsQxbgc24QxpCHeoKzzCSnS/JzdV0oM2iQ=="],
+
+    "@opentelemetry/otlp-transformer": ["@opentelemetry/otlp-transformer@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-logs": "0.57.2", "@opentelemetry/sdk-metrics": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1", "protobufjs": "^7.3.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-48IIRj49gbQVK52jYsw70+Jv+JbahT8BqT2Th7C4H7RCM9d0gZ5sgNPoMpWldmfjvIsSgiGJtjfk9MeZvjhoig=="],
+
+    "@opentelemetry/propagator-b3": ["@opentelemetry/propagator-b3@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-oATwWWDIJzybAZ4pO76ATN5N6FFbOA1otibAVlS8v90B4S1wClnhRUk7K+2CHAwN1JKYuj4jh/lpCEG5BAqFuQ=="],
+
+    "@opentelemetry/propagator-jaeger": ["@opentelemetry/propagator-jaeger@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-Pj/BfnYEKIOImirH76M4hDaBSx6HyZ2CXUqk+Kj02m6BB80c/yo4BdWkn/1gDFfU+YPY+bPR2U0DKBfdxCKwmg=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA=="],
+
+    "@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-TXFHJ5c+BKggWbdEQ/inpgIzEmS2BGQowLE9UhsMd7YYlUfBQJ4uax0VF/B5NYigdM/75OoJGhAV3upEhK+3gg=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q9zcZ0Okl8jRgmy7eNW3Ku1XSgg3sDLa5evHZpCwjspw7E8Is4K/haRPDJrBcX3YSn/Y7gUvFnByNYEKQNbNog=="],
+
+    "@opentelemetry/sdk-node": ["@opentelemetry/sdk-node@0.57.2", "", { "dependencies": { "@opentelemetry/api-logs": "0.57.2", "@opentelemetry/core": "1.30.1", "@opentelemetry/exporter-logs-otlp-grpc": "0.57.2", "@opentelemetry/exporter-logs-otlp-http": "0.57.2", "@opentelemetry/exporter-logs-otlp-proto": "0.57.2", "@opentelemetry/exporter-metrics-otlp-grpc": "0.57.2", "@opentelemetry/exporter-metrics-otlp-http": "0.57.2", "@opentelemetry/exporter-metrics-otlp-proto": "0.57.2", "@opentelemetry/exporter-prometheus": "0.57.2", "@opentelemetry/exporter-trace-otlp-grpc": "0.57.2", "@opentelemetry/exporter-trace-otlp-http": "0.57.2", "@opentelemetry/exporter-trace-otlp-proto": "0.57.2", "@opentelemetry/exporter-zipkin": "1.30.1", "@opentelemetry/instrumentation": "0.57.2", "@opentelemetry/resources": "1.30.1", "@opentelemetry/sdk-logs": "0.57.2", "@opentelemetry/sdk-metrics": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1", "@opentelemetry/sdk-trace-node": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-8BaeqZyN5sTuPBtAoY+UtKwXBdqyuRKmekN5bFzAO40CgbGzAxfTpiL3PBerT7rhZ7p2nBdq7FaMv/tBQgHE4A=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@1.30.1", "", { "dependencies": { "@opentelemetry/core": "1.30.1", "@opentelemetry/resources": "1.30.1", "@opentelemetry/semantic-conventions": "1.28.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg=="],
+
+    "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@1.30.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "1.30.1", "@opentelemetry/core": "1.30.1", "@opentelemetry/propagator-b3": "1.30.1", "@opentelemetry/propagator-jaeger": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1", "semver": "^7.5.2" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
 
@@ -776,6 +840,8 @@
 
     "@types/react-syntax-highlighter": ["@types/react-syntax-highlighter@15.5.13", "", { "dependencies": { "@types/react": "*" } }, "sha512-uLGJ87j6Sz8UaBAooU0T6lWJ0dBmjZgN1PZTrj05TNql2/XpC6+4HhMT5syIdFUUt+FASfCeLLv4kBygNU+8qA=="],
 
+    "@types/shimmer": ["@types/shimmer@1.2.0", "", {}, "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
@@ -791,6 +857,8 @@
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "acorn-walk": ["acorn-walk@8.3.5", "", { "dependencies": { "acorn": "^8.11.0" } }, "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw=="],
 
@@ -855,6 +923,8 @@
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.4.3", "", {}, "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -1096,6 +1166,8 @@
 
     "immer": ["immer@11.1.15", "", {}, "sha512-VrNANlmnWQnh5COXIIOQXM9oOJw7naGKlBT74ZOOR6lpVXc3gFEu9FJLDFcpCJ2j+NWr8TIwtWD//T6ZX6TKiQ=="],
 
+    "import-in-the-middle": ["import-in-the-middle@1.15.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^1.2.2", "module-details-from-path": "^1.0.3" } }, "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "input-otp": ["input-otp@1.4.2", "", { "peerDependencies": { "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA=="],
@@ -1107,6 +1179,8 @@
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
+
+    "is-core-module": ["is-core-module@2.16.2", "", { "dependencies": { "hasown": "^2.0.3" } }, "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA=="],
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
 
@@ -1220,6 +1294,8 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
+
     "morgan": ["morgan@1.11.0", "", { "dependencies": { "basic-auth": "~2.0.1", "debug": "2.6.9", "depd": "~2.0.0", "on-finished": "~2.4.1", "on-headers": "~1.1.0" } }, "sha512-zSkVu3t18r39pw4ixfBKvfZi3y2UOqr7d4WYwcj3m8nXpEQK4rPO6GLzs/CExoRgmX3y9EjmmcXqv6jq0SK46g=="],
 
     "motion": ["motion@12.42.2", "", { "dependencies": { "framer-motion": "^12.42.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q=="],
@@ -1279,6 +1355,8 @@
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
@@ -1360,7 +1438,11 @@
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
+    "require-in-the-middle": ["require-in-the-middle@7.5.2", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3", "resolve": "^1.22.8" } }, "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ=="],
+
     "reselect": ["reselect@5.2.0", "", {}, "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw=="],
+
+    "resolve": ["resolve@1.22.12", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
@@ -1393,6 +1475,8 @@
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "shiki": ["shiki@4.3.1", "", { "dependencies": { "@shikijs/core": "4.3.1", "@shikijs/engine-javascript": "4.3.1", "@shikijs/engine-oniguruma": "4.3.1", "@shikijs/langs": "4.3.1", "@shikijs/themes": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw=="],
+
+    "shimmer": ["shimmer@1.2.1", "", {}, "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="],
 
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
@@ -1443,6 +1527,8 @@
     "stubs": ["stubs@3.0.0", "", {}, "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "@babel/core": "*", "babel-plugin-macros": "*", "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" }, "optionalPeers": ["@babel/core", "babel-plugin-macros"] }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
+
+    "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "swr": ["swr@2.4.2", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-ej644Y2bvkIajfR32KGeSSdBXQW+ScjGjkybZgSE7kFpk9eGnV44XY9FJylXi+W75pavSX1PVNB57W5EbhGIYw=="],
 
@@ -1565,6 +1651,16 @@
     "@isaacs/cliui/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@opentelemetry/exporter-zipkin/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@opentelemetry/resources/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@opentelemetry/sdk-node/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.2", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" }, "bundled": true }, "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA=="],
 

--- a/clusters/base/monitoring/helm-repository-open-telemetry.yaml
+++ b/clusters/base/monitoring/helm-repository-open-telemetry.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: open-telemetry
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://open-telemetry.github.io/opentelemetry-helm-charts

--- a/clusters/base/monitoring/kustomization.yaml
+++ b/clusters/base/monitoring/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - metrics-server.yaml
   - helm-repository-vector.yaml
   - vector.yaml
+  - helm-repository-open-telemetry.yaml
+  - opentelemetry-collector.yaml

--- a/clusters/base/monitoring/opentelemetry-collector.yaml
+++ b/clusters/base/monitoring/opentelemetry-collector.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opentelemetry-collector
+  namespace: monitoring
+spec:
+  interval: 1m0s
+  maxHistory: 2
+  chart:
+    spec:
+      chart: opentelemetry-collector
+      version: 0.117.0
+      sourceRef:
+        kind: HelmRepository
+        name: open-telemetry
+        namespace: flux-system
+      interval: 5m0s
+  install:
+    createNamespace: true
+    remediation:
+      retries: 5
+  upgrade:
+    remediation:
+      retries: 5
+  values:
+    mode: deployment
+    image:
+      repository: otel/opentelemetry-collector-contrib
+    config:
+      receivers:
+        otlp:
+          protocols:
+            grpc:
+              endpoint: 0.0.0.0:4317
+            http:
+              endpoint: 0.0.0.0:4318
+        prometheus:
+          config:
+            scrape_configs:
+              - job_name: opentelemetry-collector
+                scrape_interval: 15s
+                static_configs:
+                  - targets: [0.0.0.0:8888]
+      processors:
+        memory_limiter:
+          check_interval: 5s
+          limit_percentage: 80
+          spike_limit_percentage: 25
+        batch:
+          send_batch_size: 8192
+          timeout: 5s
+        resourcedetection:
+          detectors: [env, system]
+          timeout: 2s
+      exporters:
+        debug:
+          verbosity: detailed
+        loki:
+          endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
+      service:
+        pipelines:
+          traces:
+            receivers: [otlp]
+            processors: [memory_limiter, batch]
+            exporters: [debug]
+          metrics:
+            receivers: [otlp, prometheus]
+            processors: [memory_limiter, batch]
+            exporters: [debug]
+          logs:
+            receivers: [otlp]
+            processors: [memory_limiter, batch]
+            exporters: [debug, loki]
+    ports:
+      otlp:
+        enabled: true
+        containerPort: 4317
+        servicePort: 4317
+        protocol: TCP
+      otlp-http:
+        enabled: true
+        containerPort: 4318
+        servicePort: 4318
+        protocol: TCP


### PR DESCRIPTION
## Summary
Implements the OpenTelemetry Collector in Kubernetes cluster base monitoring and instruments the Spindrift application (`apps/spindrift`) with OpenTelemetry traces, metrics, and logs.

## Changes
- `feat(monitoring)`: deploy OpenTelemetry Collector in base monitoring (`clusters/base/monitoring/opentelemetry-collector.yaml`)
- `feat(spindrift)`: instrument application (`apps/spindrift`) with OpenTelemetry SDK for traces, metrics, and logs

## Test Plan
- [x] Verified `mise run k8s:render-apps` renders `folly` and `offsite` app overlays cleanly
- [x] Verified `kubectl kustomize` renders `clusters/folly/monitoring` and `clusters/offsite/monitoring` cleanly
- [x] Verified `bun run lint` and `bun run typecheck` pass in `apps/spindrift`
- [x] Verified `bun test test/web/routes.test.ts` passes all 12 production dependency and route table assertions
