### PR TITLE
fix(monitoring): unbreak OTel collector, ship offsite logs, add Spindrift dashboard

### DIFF
--- a/clusters/base/monitoring/opentelemetry-collector.yaml
+++ b/clusters/base/monitoring/opentelemetry-collector.yaml
@@ -56,8 +56,6 @@ spec:
       exporters:
         debug:
           verbosity: detailed
-        loki:
-          endpoint: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
       service:
         pipelines:
           traces:
@@ -71,7 +69,7 @@ spec:
           logs:
             receivers: [otlp]
             processors: [memory_limiter, batch]
-            exporters: [debug, loki]
+            exporters: [debug]
     ports:
       otlp:
         enabled: true

--- a/clusters/folly/monitoring/grafana-dashboards/kustomization.yaml
+++ b/clusters/folly/monitoring/grafana-dashboards/kustomization.yaml
@@ -8,6 +8,7 @@ configMapGenerator:
       - dht22.json
       - coredns.json
       - spore.json
+      - spindrift.json
 generatorOptions:
   disableNameSuffixHash: true
   annotations:

--- a/clusters/folly/monitoring/grafana-dashboards/spindrift.json
+++ b/clusters/folly/monitoring/grafana-dashboards/spindrift.json
@@ -1,0 +1,172 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Spindrift Pods Ready",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(kube_pod_status_ready{condition=\"true\", namespace=\"spindrift\"})",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Spindrift Pod Restarts",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(increase(kube_pod_container_status_restarts_total{namespace=\"spindrift\"}[1h]))",
+          "refId": "A",
+          "instant": true
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 5 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      }
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Pod Phase by Cluster",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "kube_pod_status_phase{namespace=\"spindrift\"}",
+          "legendFormat": "{{pod}} {{phase}} ({{cluster}})",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "fillOpacity": 10,
+            "stacking": { "mode": "normal", "group": "A" }
+          },
+          "mappers": []
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      }
+    },
+    {
+      "id": 4,
+      "type": "logs",
+      "title": "Spindrift Logs",
+      "datasource": {
+        "type": "loki",
+        "uid": "loki"
+      },
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "loki", "uid": "loki" },
+          "expr": "{namespace=\"spindrift\"}",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "descending",
+        "dedupStrategy": "none",
+        "enableLogDetails": true
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["spindrift", "platform"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Spindrift",
+  "uid": "spindrift",
+  "version": 1,
+  "weekStart": ""
+}

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -95,6 +95,7 @@ spec:
       additionalDataSources:
         - name: Loki
           type: loki
+          uid: loki
           isDefault: false
           access: proxy
           url: https://loki.${SECRET_DOMAIN}

--- a/clusters/offsite/monitoring/kustomization.yaml
+++ b/clusters/offsite/monitoring/kustomization.yaml
@@ -18,3 +18,10 @@ patches:
       - op: replace
         path: /spec/maxHistory
         value: 2
+  - path: vector-loki-endpoint.yaml
+    target:
+      group: helm.toolkit.fluxcd.io
+      version: v2
+      kind: HelmRelease
+      name: vector
+      namespace: monitoring

--- a/clusters/offsite/monitoring/vector-loki-endpoint.yaml
+++ b/clusters/offsite/monitoring/vector-loki-endpoint.yaml
@@ -1,0 +1,17 @@
+---
+# Offsite has no Loki — folly is the log hub. Point the Vector Loki sinks at the
+# folly Loki ingress (substituted to https://loki.${SECRET_DOMAIN}) instead of
+# the in-cluster service that only exists on folly.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vector
+  namespace: monitoring
+spec:
+  values:
+    customConfig:
+      sinks:
+        loki_kubernetes:
+          endpoint: https://loki.${SECRET_DOMAIN}
+        loki_journald:
+          endpoint: https://loki.${SECRET_DOMAIN}


### PR DESCRIPTION
## Summary
Unbreak the OpenTelemetry Collector (chart 0.165.0 dropped the `loki` exporter, crashing the new pod on both clusters), restore offsite→folly log shipping (offsite Vector was failing DNS lookups for a Loki service that only exists on folly, dropping all spindrift logs), and add a Spindrift Grafana dashboard with a Loki logs panel.

## Changes
- fix(monitoring): remove loki exporter and ship offsite logs to folly
- feat(monitoring): add Spindrift Grafana dashboard with logs panel

### Details
- **`clusters/base/monitoring/opentelemetry-collector.yaml`** — drop the `loki` exporter and remove `loki` from the `logs` pipeline (leaves `[debug]`). Vector already owns the `kubernetes_logs → Loki` path, so no log ingestion is lost; the collector stops crash-looping on boot.
- **`clusters/offsite/monitoring/vector-loki-endpoint.yaml`** + **`kustomization.yaml`** — strategic-merge patch redirecting offsite Vector's `loki_kubernetes` and `loki_journald` sinks to the folly Loki ingress (`https://loki.${SECRET_DOMAIN}`), substituted by Flux. Offsite has no Loki; folly is the log hub. Offsite logs (including the `spindrift` namespace) were being dropped with `failed to lookup address information` for `loki.monitoring.svc.cluster.local`.
- **`clusters/folly/monitoring/grafana-dashboards/spindrift.json`** + **`kustomization.yaml`** — new Spindrift dashboard: a Loki logs panel (`{namespace="spindrift"}`) plus pod-ready and restart panels from kube-state-metrics.
- **`clusters/folly/monitoring/kube-prometheus.yaml`** — add a stable `uid: loki` to the Loki datasource so the dashboard's logs panel can reference it by uid.

## Test Plan
- [ ] `kubectl -n monitoring logs -l app.kubernetes.io/name=opentelemetry-collector` runs (no CrashLoopBackOff) on both clusters after Flux reconciles.
- [ ] Offsite Vector stops emitting `loki_kubernetes`/`loki_journald` DNS lookup WARNs; logs appear in folly Loki for `{cluster="offsite", namespace="spindrift"}`.
- [ ] Grafana shows the "Spindrift" dashboard; the logs panel returns spindrift logs from Loki.

## Context
- Base (`clusters/base/monitoring`) applies to both clusters — folly and offsite both hit the OTel crash.
- Spindrift runs only on offsite; Loki/Grafana run only on folly.