### PR TITLE
feat(spindrift): wire up redeploy button on deploy detail screen

### DIFF
--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -398,6 +398,9 @@ function DeployScreen({
     | { type: 'success'; deploy: DeployView }
   >({ type: 'loading' });
 
+  const [redeploying, setRedeploying] = useState(false);
+  const [redeployError, setRedeployError] = useState<string | null>(null);
+
   useEffect(() => {
     let live = true;
     let stopStream: (() => void) | null = null;
@@ -457,6 +460,25 @@ function DeployScreen({
     };
   }, [deployId]);
 
+  const handleRedeploy = async () => {
+    if (state.type !== 'success') return;
+    setRedeploying(true);
+    setRedeployError(null);
+    try {
+      const result = await command('deployApp', { name: state.deploy.app });
+      if (result.ok) {
+        onNavigate(`/deploys/${result.value.deployId}`);
+      } else {
+        setRedeployError(result.failure.message);
+      }
+    } catch (e: unknown) {
+      setRedeployError(e instanceof Error ? e.message : 'Redeploy failed');
+    } finally {
+      setRedeploying(false);
+    }
+  };
+
+
   if (state.type === 'loading') {
     return (
       <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
@@ -497,7 +519,33 @@ function DeployScreen({
     );
   }
 
-  return <DeployDetail view={state.deploy} />;
+  return (
+    <>
+      {redeployError ? (
+        <div className="mx-auto mt-4 w-full max-w-[1040px] px-5">
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">Redeploy failed</p>
+              <p className="text-sm mt-0.5">{redeployError}</p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setRedeployError(null)}
+            >
+              Dismiss
+            </Button>
+          </div>
+        </div>
+      ) : null}
+      <DeployDetail
+        view={state.deploy}
+        onRedeploy={handleRedeploy}
+        redeploying={redeploying}
+        onNavigate={onNavigate}
+      />
+    </>
+  );
 }
 
 function TargetsScreen() {

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -478,7 +478,6 @@ function DeployScreen({
     }
   };
 
-
   if (state.type === 'loading') {
     return (
       <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -21,12 +21,14 @@
  * takes one immutable view; its controller replaces that view as authenticated
  * attempt events arrive.
  */
+import { RefreshCw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Checklist } from '../../components/checklist.tsx';
 import { DiagnosisPanel } from '../../components/diagnosis.tsx';
 import { LogPane, Notice } from '../../components/log-pane.tsx';
 import { PhasePill, StepGlyph, statusWord } from '../../components/status.tsx';
 import type { DeployView } from '../../model.ts';
+import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, Eyebrow } from '../../ui/card.tsx';
 import {
   Collapsible,
@@ -35,11 +37,25 @@ import {
 } from '../../ui/collapsible.tsx';
 import { cn } from '../../ui/utils.ts';
 
-export function DeployDetail({ view }: { view: DeployView }) {
+export function DeployDetail({
+  view,
+  onRedeploy,
+  redeploying = false,
+  onNavigate,
+}: {
+  view: DeployView;
+  onRedeploy?: () => void;
+  redeploying?: boolean;
+  onNavigate?: (path: string) => void;
+}) {
   return (
     <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-4 px-5 py-6">
-      <Chrome view={view} />
-      <Hero view={view} />
+      <Chrome view={view} onNavigate={onNavigate} />
+      <Hero
+        view={view}
+        onRedeploy={onRedeploy}
+        redeploying={redeploying}
+      />
 
       {view.diagnosis ? (
         <DiagnosisPanel
@@ -74,11 +90,27 @@ export function DeployDetail({ view }: { view: DeployView }) {
  * every phase — identity, not status. The runner carries its `logFidelity`
  * because that is the fact explaining why the log below may be silent (§4).
  */
-function Chrome({ view }: { view: DeployView }) {
+function Chrome({
+  view,
+  onNavigate,
+}: {
+  view: DeployView;
+  onNavigate?: (path: string) => void;
+}) {
   return (
     <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
       <p className="font-mono text-sm">
-        <span className="font-semibold">{view.app}</span>
+        {onNavigate ? (
+          <button
+            type="button"
+            onClick={() => onNavigate(`/apps/${view.app}`)}
+            className="font-semibold hover:underline"
+          >
+            {view.app}
+          </button>
+        ) : (
+          <span className="font-semibold">{view.app}</span>
+        )}
         <span className="mx-1.5 text-muted-foreground">/</span>
         <span className="text-subtle">{view.component}</span>
       </p>
@@ -111,7 +143,15 @@ function Meta({ label, value }: { label: string; value: string }) {
  * The URL is the answer to the only question a developer opens this screen
  * with, so it is never further down than the phase that describes it.
  */
-function Hero({ view }: { view: DeployView }) {
+function Hero({
+  view,
+  onRedeploy,
+  redeploying = false,
+}: {
+  view: DeployView;
+  onRedeploy?: () => void;
+  redeploying?: boolean;
+}) {
   return (
     <Card className="flex flex-wrap items-center gap-4 px-5 py-5">
       <div className="flex flex-col gap-2">
@@ -119,6 +159,21 @@ function Hero({ view }: { view: DeployView }) {
         <h1 className="text-[27px] font-semibold leading-tight tracking-[-0.02em]">
           {view.headline}
         </h1>
+        {onRedeploy ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRedeploy}
+            disabled={redeploying}
+            className="self-start"
+          >
+            <RefreshCw
+              aria-hidden="true"
+              className={cn('size-3.5', redeploying && 'animate-spin')}
+            />
+            {redeploying ? 'Deploying…' : 'Redeploy'}
+          </Button>
+        ) : null}
       </div>
       <UrlBlock view={view} />
     </Card>

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -51,11 +51,7 @@ export function DeployDetail({
   return (
     <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-4 px-5 py-6">
       <Chrome view={view} onNavigate={onNavigate} />
-      <Hero
-        view={view}
-        onRedeploy={onRedeploy}
-        redeploying={redeploying}
-      />
+      <Hero view={view} onRedeploy={onRedeploy} redeploying={redeploying} />
 
       {view.diagnosis ? (
         <DiagnosisPanel


### PR DESCRIPTION
## Summary
Wires up the Redeploy button on the deploy detail screen in spindrift. Clicking it calls `deployApp` for the current app and navigates directly to the new deploy.

## Changes
- feat(spindrift): wire up redeploy button on deploy detail screen

## Test Plan
- [ ] Open any deploy detail page (`/deploys/<id>`)
- [ ] Click **Redeploy** — button should spin, then navigate to the new deploy
- [ ] Simulate a failure (e.g. app not found) — inline error banner should appear and be dismissible
- [ ] App name in the breadcrumb header should be a clickable link back to the workspace
