### PR TITLE
fix(spindrift): read job logs with a media type GitHub will serve

### DIFF
--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -329,7 +329,34 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     // even on a red run is the point: the failure is in there.
     let log = '';
     for (const job of jobs) {
-      const text = await host.jobLog(ref, repository, job.id);
+      let text: string | null;
+      try {
+        text = await host.jobLog(ref, repository, job.id);
+      } catch (error) {
+        // A verdict of its own, and the reason it is not the dispatch's: by now
+        // the workflow has been dispatched, correlated, and concluded, so
+        // `dispatch failed:` would name the one part that demonstrably worked
+        // and send an operator to read a green run's logs looking for a refusal
+        // that is not in them.
+        //
+        // It is still a failure, because consequence 2 above holds: the report
+        // rides the log, so a log this route cannot read is a build that cannot
+        // say what it built (`report.ts`). `TARGET_UNREACHABLE` is §6's
+        // platform-blamed reason for an API that would not answer, which is
+        // exactly what this is — nothing the developer wrote is at fault.
+        const detail = error instanceof Error ? error.message : String(error);
+        yield {
+          type: 'log',
+          at: now(),
+          line: `could not read the log of job ${job.id}: ${detail}`,
+        };
+        return buildFailed(
+          logs,
+          'TARGET_UNREACHABLE',
+          `run ${run.id} in ${repository} concluded ${conclusion ?? 'without a conclusion'} but its log could not be read, and a build reports what it built in its log: ${detail}`,
+          { runId: run.id, jobId: job.id, conclusion },
+        );
+      }
       if (text === null) continue;
       log += text;
       for (const line of text.split('\n')) {

--- a/apps/spindrift/src/integrations/github/app.ts
+++ b/apps/spindrift/src/integrations/github/app.ts
@@ -580,6 +580,13 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
    * A `404` is tolerated because a job that never started has no log, and an
    * empty log is a truthful thing to show — unlike lost access, which every
    * other call in this module still classifies.
+   *
+   * **The text is read without asking for a text media type**, which reads
+   * backwards and is the whole point. The endpoint *negotiates* as JSON and
+   * *answers* with a redirect to a plain-text blob, so it refuses
+   * `Accept: text/plain` with a `415` — "Must accept 'application/json'" — and
+   * serves the log to the module's default `application/vnd.github+json`. The
+   * media type names what the endpoint speaks, not what comes back through it.
    */
   async jobLog(
     ref: InstallationRef,
@@ -589,7 +596,6 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
     const response = await this.http(ref).send({
       method: 'GET',
       path: `/repos/${fullName}/actions/jobs/${jobId}/logs`,
-      accept: 'text/plain',
       tolerate: [404],
     });
     return response === null ? null : await response.text();

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -253,6 +253,38 @@ describe('the hosted build route', () => {
     expect(text(events)).toContain('exporting to image');
   });
 
+  test('the log is asked for as JSON, which is the only thing the host serves', async () => {
+    // The endpoint negotiates as JSON and answers with a redirect to a text
+    // blob, so asking for `text/plain` — the media type of the *answer* — is a
+    // `415` and a build that dispatched perfectly is recorded as failed. It
+    // shipped that way, and no test could see it until the fake negotiated too.
+    const { host, route } = hostedRoute();
+    const { result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('SUCCEEDED');
+    const read = host.requests.find((request) =>
+      request.path.includes('/actions/jobs/'),
+    );
+    expect(read?.accept).toBe('application/vnd.github+json');
+  });
+
+  test('a log the host will not serve fails the build without blaming the dispatch', async () => {
+    // The run was dispatched, correlated, and concluded green; only the text
+    // could not be fetched. Naming that `dispatch failed:` sends an operator to
+    // look for a refusal that is not there — but it is still a failure, because
+    // the artifact digest travels in the log and nowhere else (`report.ts`).
+    const { route } = hostedRoute({ actions: { logStatus: 500 } });
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('TARGET_UNREACHABLE');
+      expect(result.detail).toContain('could not be read');
+    }
+    expect(text(events)).toContain('could not read the log of job');
+    expect(text(events)).not.toContain('dispatch failed');
+  });
+
   test('step transitions arrive once each, not once per poll', async () => {
     const { route } = hostedRoute({ actions: { duration: 4 } });
     const { events } = await run(route.build(archiveSource(), spec));

--- a/apps/spindrift/test/harness/fakes/github-api.ts
+++ b/apps/spindrift/test/harness/fakes/github-api.ts
@@ -17,6 +17,15 @@
  * Anything it does not model answers `404`, so a client that started calling a
  * new endpoint fails here rather than silently passing against a permissive
  * stand-in.
+ *
+ * **It negotiates content, because the real API does and a fake that did not
+ * would be strictly more permissive than the thing it stands for.** That is not
+ * a hypothetical: `jobLog` shipped asking for `text/plain`, every test passed,
+ * and every build in production died on the `415` this fake now answers with.
+ * The two endpoints that serve anything other than plain JSON are the two
+ * modelled here — job logs, which negotiate as JSON and answer with text, and
+ * contents, which answers raw bytes only to a client that asked for them. A
+ * request whose `Accept` the real API would refuse is refused here.
  */
 import { encodeBuildReport } from '../../../src/adapters/build/report.ts';
 import type { Fetcher } from '../../../src/integrations/github/http.ts';
@@ -30,6 +39,8 @@ export interface RecordedRequest {
   path: string;
   body: unknown;
   authorization: string | null;
+  /** What the client said it would take — assertable, because it matters. */
+  accept: string | null;
 }
 
 /** One pull request the client opened. */
@@ -73,6 +84,12 @@ export interface FakeActionsOptions {
    * rather than the state every other test wants to start from.
    */
   log?: (spec: Record<string, unknown>) => string;
+  /**
+   * The status the logs endpoint answers with. `200` serves the log; anything
+   * else stands in for a host that concluded a run and then would not hand over
+   * its text — the one failure a green run can still die of.
+   */
+  logStatus?: number;
 }
 
 interface FakeRun {
@@ -100,6 +117,27 @@ export interface FakeGitHubOptions {
  */
 function objectId(counter: number): string {
   return counter.toString(16).padStart(40, '0');
+}
+
+/**
+ * Whether an `Accept` names a media type the host will negotiate as JSON.
+ *
+ * Deliberately not a full RFC 7231 matcher — it exists to draw one line, the
+ * one the real API's own refusal draws: "Must accept 'application/json'".
+ * `application/vnd.github+json` is that, spelled the way GitHub spells it, and
+ * `text/plain` is not.
+ */
+function acceptsJson(accept: string | null): boolean {
+  if (accept === null || accept.trim() === '') return true;
+  return accept.split(',').some((entry) => {
+    const media = entry.split(';')[0]?.trim() ?? '';
+    return (
+      media === '*/*' ||
+      media === 'application/*' ||
+      media === 'application/json' ||
+      /^application\/vnd\.github(\.[^+]+)?\+json$/.test(media)
+    );
+  });
 }
 
 export class FakeGitHub {
@@ -143,6 +181,7 @@ export class FakeGitHub {
       duration: options.actions?.duration ?? 1,
       conclusion: options.actions?.conclusion ?? 'success',
       log: options.actions?.log ?? defaultBuildLog,
+      logStatus: options.actions?.logStatus ?? 200,
     };
   }
 
@@ -205,16 +244,29 @@ export class FakeGitHub {
     return new Response('{"message":"Not Found"}', { status: 404 });
   }
 
+  /** The host's own refusal, message and all, for an `Accept` it will not serve. */
+  private unsupportedMediaType(accept: string | null): Response {
+    return this.json(
+      {
+        message: `Unsupported 'Accept' header: '${accept ?? ''}'. Must accept 'application/json'.`,
+        status: '415',
+      },
+      415,
+    );
+  }
+
   /** The transport to hand the real client. */
   readonly fetch: Fetcher = async (request) => {
     const url = new URL(request.url);
     const path = `${url.pathname}${url.search}`;
     const raw = request.method === 'GET' ? null : await request.text();
+    const accept = request.headers.get('Accept');
     this.requests.push({
       method: request.method,
       path,
       body: raw === null || raw === '' ? null : JSON.parse(raw),
       authorization: request.headers.get('Authorization'),
+      accept,
     });
 
     if (this.rateLimited) {
@@ -263,8 +315,8 @@ export class FakeGitHub {
 
     const body = raw === null || raw === '' ? {} : JSON.parse(raw);
     return (
-      this.actionsEndpoints(rest, request.method, body) ??
-      this.readEndpoints(rest, url, request.method) ??
+      this.actionsEndpoints(rest, request.method, body, accept) ??
+      this.readEndpoints(rest, url, request.method, accept) ??
       this.writeEndpoints(rest, request.method, body) ??
       this.notFound()
     );
@@ -281,6 +333,7 @@ export class FakeGitHub {
     rest: string,
     method: string,
     body: Record<string, unknown>,
+    accept: string | null,
   ): Response | null {
     if (rest === '/installation' && method === 'GET') {
       return this.json({ id: Number(this.installationId) });
@@ -360,8 +413,17 @@ export class FakeGitHub {
 
     const log = rest.match(/^\/actions\/jobs\/(\d+)\/logs$/);
     if (log && method === 'GET') {
+      // The endpoint negotiates as JSON and *answers* with a redirect to a
+      // plain-text blob. Asking for the media type of the answer is the mistake
+      // that reads as obviously correct, so it is the one refused first — before
+      // the job is even looked up, exactly as the real API refuses it.
+      if (!acceptsJson(accept)) return this.unsupportedMediaType(accept);
       const run = this.runs.find((each) => each.id === Number(log[1]));
-      return run === undefined ? this.notFound() : new Response(run.log);
+      if (run === undefined) return this.notFound();
+      if (this.actions.logStatus !== 200) {
+        return this.json({ message: 'Server Error' }, this.actions.logStatus);
+      }
+      return new Response(run.log);
     }
 
     return null;
@@ -371,6 +433,7 @@ export class FakeGitHub {
     rest: string,
     url: URL,
     method: string,
+    accept: string | null,
   ): Response | null {
     if (method !== 'GET') return null;
 
@@ -404,7 +467,18 @@ export class FakeGitHub {
       const ref = url.searchParams.get('ref') ?? this.defaultBranch;
       const at = this.branches.get(ref) ?? ref;
       const file = this.filesAt(at)[decodeURIComponent(contents[1] ?? '')];
-      return file === undefined ? this.notFound() : new Response(file);
+      if (file === undefined) return this.notFound();
+      // Raw bytes only to a client that asked for them. To anyone else this
+      // endpoint answers metadata with the file base64'd inside it — so a caller
+      // that dropped the raw media type reads a JSON envelope where it expected
+      // a `spindrift.yaml`, here as in production.
+      return accept === 'application/vnd.github.raw'
+        ? new Response(file)
+        : this.json({
+            name: decodeURIComponent(contents[1] ?? ''),
+            content: btoa(file),
+            encoding: 'base64',
+          });
     }
 
     const tarball = rest.match(/^\/tarball\/(.+)$/);

--- a/apps/spindrift/test/integrations/github/app.test.ts
+++ b/apps/spindrift/test/integrations/github/app.test.ts
@@ -214,3 +214,59 @@ describe('what the far side refusing means', () => {
     ).rejects.toMatchObject({ code: 'ACCESS_LOST' });
   });
 });
+
+/**
+ * Content negotiation, asserted against the fake directly.
+ *
+ * Two endpoints here serve something other than plain JSON, and the client gets
+ * one media type wrong in each direction — so these assert the *host's* half of
+ * the contract, not the client's. A fake that answered everything to everyone
+ * would make the client's half untestable, which is exactly how `jobLog` shipped
+ * asking for `text/plain` and failed every build in production.
+ */
+describe('the media types this host serves', () => {
+  function get(fake: FakeGitHub, path: string, accept: string) {
+    return fake.fetch(
+      new Request(`${fake.baseUrl}${path}`, { headers: { Accept: accept } }),
+    );
+  }
+
+  test('a job log asked for as text is refused, as the real API refuses it', async () => {
+    const fake = new FakeGitHub();
+    const refused = await get(
+      fake,
+      `/repos/${fake.fullName}/actions/jobs/1/logs`,
+      'text/plain',
+    );
+
+    expect(refused.status).toBe(415);
+    expect(await refused.text()).toContain("Must accept 'application/json'");
+  });
+
+  test('a job log asked for as JSON gets past negotiation to the job itself', async () => {
+    const fake = new FakeGitHub();
+    const answered = await get(
+      fake,
+      `/repos/${fake.fullName}/actions/jobs/1/logs`,
+      'application/vnd.github+json',
+    );
+
+    // 404 because no run was dispatched — which is the point: negotiation let
+    // this through, and the endpoint got as far as looking the job up.
+    expect(answered.status).toBe(404);
+  });
+
+  test('file contents are raw only to a client that asked for raw', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'spindrift.yaml': 'version: 1' });
+    const path = `/repos/${fake.fullName}/contents/spindrift.yaml?ref=main`;
+
+    const raw = await get(fake, path, 'application/vnd.github.raw');
+    expect(await raw.text()).toBe('version: 1');
+
+    // The default media type answers metadata, so a caller that dropped the raw
+    // override would parse a JSON envelope as if it were the file.
+    const envelope = await get(fake, path, 'application/vnd.github+json');
+    expect(await envelope.json()).toMatchObject({ encoding: 'base64' });
+  });
+});


### PR DESCRIPTION
Ticket 13 — *Let a Build report what it built*.

## The defect

`jobLog()` asked for `Accept: text/plain`. The Actions job-logs endpoint negotiates as JSON and *answers* with a redirect to a plain-text blob, so it refuses that header outright:

```console
$ gh api -H "Accept: text/plain" repos/jonpulsifer/infra/actions/jobs/91324563009/logs
{"message":"Unsupported 'Accept' header: 'text/plain'. Must accept 'application/json'.","status":"415"}
```

`415` is not in `tolerate`, so the call threw — and the throw escaped `build()` entirely, because the only try/catch in `github-actions.ts` wraps *dispatch* while the log read happens after the run has already concluded. Live `attempt_events` for the one build that ever dispatched cleanly:

```text
build 3 | status | SUCCEEDED        <- the workflow genuinely succeeded
build 3 | log    | build dispatch failed: GET .../logs failed with 415: …
build 3 | status | FAILED | platform
```

This is not a lost log. The runner reports its artifact digest by printing a marker line into the job log, and `report.ts` settles that there is deliberately no second channel — so the 415 severed the only path from a finished build to a deployable artifact. No artifact, no signature, no Deploy. The empty `deploys` table is downstream of this one line.

## The fix

- **`src/integrations/github/app.ts`** — drop the `accept` override so the module's default `application/vnd.github+json` applies, as every other call in the file already does.
- **`src/adapters/build/github-actions.ts`** — a log-read failure gets its own verdict. It still fails the build (the report rides the log), but as `TARGET_UNREACHABLE` with a sentence naming the log, not as a `dispatch failed:` for the one part that demonstrably worked.
- **`test/harness/fakes/github-api.ts`** — the durable half. The fake never inspected `Accept`; the only match for the word was in a comment. It was strictly more permissive than the real API, which is why 926 passing tests validated a contract GitHub does not honour. It now answers `415` to a job log asked for as text, and serves raw file contents only to a client that asked for raw — the other endpoint here whose media type is load-bearing.

## Verification

Reverting the one-line `app.ts` fix now fails **6** tests in `build-routes.test.ts` instead of 0 — the fake catches the class of bug, not just this instance.

```
931 pass, 1 fail — Ran 932 tests across 65 files
bun run typecheck && bun run lint — clean
```

The single failure is `workspace-deploy-details.test.ts › creates deploy intent for app with succeeded build`, which is pre-existing and belongs to ticket 14 (`deployApp` swallowing a `createDeploy` refusal). Untouched here.

Five tests added: two on the hosted build route (the log is asked for as JSON; an unreadable log fails without blaming the dispatch) and three on the fake's own content negotiation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)