### PR TITLE
test(spindrift): tighten the cloud build fake (fake-fidelity audit)

### DIFF
--- a/apps/spindrift/test/harness/fakes/cloud-build-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloud-build-api.ts
@@ -91,6 +91,14 @@ export class FakeCloudBuild {
       authorization: request.headers.get('Authorization'),
     });
 
+    // Both services are authorized, and both refuse a request that is not.
+    // The header was recorded and never read, so a route that stopped sending
+    // it — or sent the wrong one — passed every test against a real API that
+    // would answer `401`.
+    if (request.headers.get('Authorization') !== `Bearer ${this.token()}`) {
+      return json(401, { error: 'unauthenticated' });
+    }
+
     if (url.origin === LOGS_HOST) return this.logs(body);
     if (url.origin !== BUILD_HOST) return json(404, { error: 'no such host' });
 
@@ -143,7 +151,20 @@ export class FakeCloudBuild {
   private logs(body: unknown): Response {
     if (this.options.breakLogs) return json(503, { error: 'log service down' });
 
-    const request = (body ?? {}) as { filter?: string; pageToken?: string };
+    const request = (body ?? {}) as {
+      filter?: string;
+      pageToken?: string;
+      resourceNames?: unknown;
+    };
+    // `entries.list` documents `resourceNames` as the parents to read from. A
+    // request without them is refused rather than answered, so a route that
+    // dropped the field would fail here rather than only in production.
+    if (
+      !Array.isArray(request.resourceNames) ||
+      request.resourceNames.length === 0
+    ) {
+      return json(400, { error: 'resourceNames is required' });
+    }
     const id = /build_id="([^"]+)"/.exec(request.filter ?? '')?.[1] ?? '';
     const build = this.builds.get(id);
     if (build === undefined) return json(200, { entries: [] });


### PR DESCRIPTION
Part of a fake-fidelity audit across `apps/spindrift/test/harness/fakes/`,
prompted by the `accept: text/plain` defect that failed every build this
installation ever attempted while 926 tests stayed green.

The audit found the same class of gap in every fake: the fake is strictly more
permissive than the far side, so the suite validates a contract the vendor API
does not honour. Findings are filed as tickets 15–22 in the private tracker.

This PR carries only the changes that were mechanical and provably safe. The
cloud build fake:

- recorded the `Authorization` header and never read it — every other fake in
  the harness answers `401` on a bad token, this one did not, so the route's
  bearer token was unasserted end to end;
- answered Cloud Logging `entries:list` without looking for `resourceNames`,
  which the API documents as required. The route sends it correctly today and
  nothing held it there.

Everything else the audit found needs a judgement call and became a ticket
rather than a change here.

## Validation

```
DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test   # 929/929
bun run typecheck && bun run lint                                     # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)