### PR TITLE
fix(spindrift): make redeploy refuse honestly instead of rebuilding

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -1,20 +1,43 @@
 /**
- * `deployApp` — trigger a deploy or kick off a build for an App (§2, §4, §6).
+ * `deployApp` — deploy an App's newest artifact, or start the Build it needs
+ * (§2, §4, §6).
  *
- * If a succeeded Build with a verified artifact exists for the App's primary
- * Component and placement Target, this command creates a Deploy intent.
- * If the latest build failed, has no artifact, or a rebuild is needed, it
- * creates a new PENDING Build and Deploy intent, which the reconciler's
- * build loop and deploy loop pick up and run.
+ * The workspace has one button, so this command decides which of two acts the
+ * operator meant. What it may never do is quietly substitute one for the other.
+ *
+ * - **There is a succeeded Build with an artifact.** The intent goes through
+ *   {@link createDeploy}, the one path that takes §6's locking read on the
+ *   desired row behind `checkDeployable`'s gates — Target connected, artifact
+ *   present, signature re-verified against the recorded digest, verified Build
+ *   Level at or above the Target's policy, artifact shape matched, config
+ *   migration satisfied. **Its refusal is returned unchanged.** A refusal is a
+ *   fact about the world carrying the sentence the operator has to read —
+ *   "Build 4 signature did not verify", "that Target is disconnected, so
+ *   nothing new can be placed on it" — and rebuilding instead would answer a
+ *   question nobody asked while hiding the one that was.
+ * - **There is nothing deployable yet** — no Build at all, the last one failed,
+ *   or it succeeded without an artifact. A PENDING Build is written for the
+ *   build loop to dispatch, and that is the whole act.
+ *
+ * **This command writes no `deploys` row of its own**, on either branch. That
+ * is the point rather than an omission: §6's check-and-set is only a
+ * correctness argument if every intent is written through the one pair that
+ * implements it — `checkDeployable` then `placeIntent` — which is what
+ * `createDeploy` composes and what `rollbackDeploy` and `setConfig` call
+ * directly, and is why all of them refuse identically. A Build that has not
+ * succeeded could not pass `checkDeployable` anyway, so an intent written for
+ * one here would name an artifact that does not exist (§4: "a build records an
+ * artifact rather than deploying one").
  */
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { builds, componentTargetDesired, deploys } from '../../db/schema.ts';
+import { builds, componentTargetDesired } from '../../db/schema.ts';
 import { createDeploy } from '../deploys/create.ts';
 import { type Command, failed, ok } from '../types.ts';
 
 export const deployAppInput = z
   .object({
+    /** The App's id, or its name where that names exactly one App. */
     name: z.string().trim().min(1),
   })
   .strict();
@@ -22,17 +45,32 @@ export const deployAppInput = z
 export type DeployAppInput = z.infer<typeof deployAppInput>;
 
 export interface DeployAppResult {
-  readonly deployId: number;
+  /**
+   * The intent that was written, or `null` when a Build had to start first.
+   *
+   * `null` is not a failure — it is the difference between "this is going live"
+   * and "this is being built", and the screen sends the operator somewhere
+   * different for each.
+   */
+  readonly deployId: number | null;
+  /** The Build this act is about: the one being deployed, or the one started. */
   readonly buildId: number;
-  readonly phase: string;
+  /** `PENDING` for a written intent, `BUILDING` when only a Build was started. */
+  readonly phase: 'PENDING' | 'BUILDING';
 }
 
 export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
   input,
   context,
 ) => {
-  const isUuid = z.string().uuid().safeParse(input.name).success;
-  const app = await context.db.query.apps.findFirst({
+  // `apps` carries no unique constraint on `name` — `components` has
+  // `unique(appId, name)` and `targets` has `unique(name)`, `apps` has neither —
+  // so a name is not an identifier and `findFirst` on one silently picks a row.
+  // Reading every match instead makes the ambiguity sayable: a name two Apps
+  // answer to is refused with both ids rather than acted on, which is §3's
+  // listed-and-annotated grammar rather than a coin flip on live infrastructure.
+  const isUuid = z.uuid().safeParse(input.name).success;
+  const matches = await context.db.query.apps.findMany({
     where: (appsTable, { eq: eqOp, or: orOp }) =>
       isUuid
         ? orOp(eqOp(appsTable.name, input.name), eqOp(appsTable.id, input.name))
@@ -63,9 +101,21 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     },
   });
 
-  if (!app) {
+  if (matches.length === 0) {
     return failed('NOT_FOUND', `App '${input.name}' not found`);
   }
+
+  if (matches.length > 1) {
+    return failed(
+      'INVALID_INPUT',
+      `${matches.length} Apps answer to '${input.name}', so this would deploy an arbitrary one — deploy by id: ${matches
+        .map((candidate) => candidate.id)
+        .join(', ')}`,
+      [{ path: 'name', message: 'names more than one App' }],
+    );
+  }
+
+  const app = matches[0]!;
 
   const primaryComponent = app.components[0];
   if (!primaryComponent) {
@@ -99,13 +149,16 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
       context,
     );
 
-    if (deployAttempt.ok) {
-      return ok({
-        deployId: deployAttempt.value.deployId,
-        buildId: latestBuild.id,
-        phase: deployAttempt.value.phase,
-      });
-    }
+    // The refusal travels out exactly as `createDeploy` wrote it. Anything else
+    // here would be a second admission policy, and there is only supposed to be
+    // one.
+    if (!deployAttempt.ok) return deployAttempt;
+
+    return ok({
+      deployId: deployAttempt.value.deployId,
+      buildId: latestBuild.id,
+      phase: 'PENDING' as const,
+    });
   }
 
   const now = context.clock.now();
@@ -116,6 +169,9 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     buildToRun.status === 'FAILED' ||
     buildToRun.status === 'SUCCEEDED'
   ) {
+    // `builds_component_commit_shape_unique` makes a rerun of the same commit
+    // collide with the attempt it is rerunning, so it becomes a new row keyed by
+    // when it was asked for.
     const baseCommit = buildToRun?.commit ?? 'HEAD';
     const commitRef = baseCommit.includes('#')
       ? `${baseCommit.split('#')[0]}#${now.getTime()}`
@@ -151,6 +207,11 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
       .where(eq(builds.id, buildToRun.id));
   }
 
+  // The desired row, and nothing on it. `runBuildPass` joins Build → Component →
+  // this row → Target to find the route to dispatch on, so a Build with no such
+  // row is one no loop can see. `desiredBuildId` and `desiredDeployId` stay
+  // untouched: those say what should be *live* here, and only an intent written
+  // under §6's lock gets to answer that.
   await context.db
     .insert(componentTargetDesired)
     .values({
@@ -160,43 +221,9 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     })
     .onConflictDoNothing();
 
-  const [desired] = await context.db
-    .select()
-    .from(componentTargetDesired)
-    .where(
-      and(
-        eq(componentTargetDesired.componentId, primaryComponent.id),
-        eq(componentTargetDesired.targetId, targetId),
-      ),
-    );
-
-  const [deploy] = await context.db
-    .insert(deploys)
-    .values({
-      componentId: primaryComponent.id,
-      targetId,
-      buildId: buildToRun!.id,
-      phase: 'PENDING',
-      exposure: primaryComponent.exposure,
-      createdAt: now,
-      updatedAt: now,
-    })
-    .returning();
-
-  if (desired) {
-    await context.db
-      .update(componentTargetDesired)
-      .set({
-        desiredBuildId: buildToRun!.id,
-        desiredDeployId: deploy!.id,
-        updatedAt: now,
-      })
-      .where(eq(componentTargetDesired.id, desired.id));
-  }
-
   return ok({
-    deployId: deploy!.id,
+    deployId: null,
     buildId: buildToRun!.id,
-    phase: 'PENDING',
+    phase: 'BUILDING' as const,
   });
 };

--- a/apps/spindrift/src/commands/deploys/get-detail.ts
+++ b/apps/spindrift/src/commands/deploys/get-detail.ts
@@ -194,6 +194,7 @@ export const getDeployDetail: Command<
     buildId: deploy.build.id,
     componentId: deploy.component.id,
     targetId: deploy.target.id,
+    appId: deploy.component.app.id,
     app: deploy.component.app.name,
     component: deploy.component.name,
     target: deploy.target.name,

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -215,6 +215,12 @@ function WorkspaceScreen({
   >({ type: 'loading' });
   const [deploying, setDeploying] = useState(false);
   const [deployError, setDeployError] = useState<string | null>(null);
+  /**
+   * Bumped when the button started a Build rather than a Deploy. There is no
+   * deploy screen to send the operator to in that case, so the workspace they
+   * are already on re-reads itself and the new Build shows up in its activity.
+   */
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -245,7 +251,7 @@ function WorkspaceScreen({
     return () => {
       live = false;
     };
-  }, [appName]);
+  }, [appName, reloadToken]);
 
   const runtime =
     state.type === 'success' && state.workspace.runtime.kind === 'stream'
@@ -342,10 +348,22 @@ function WorkspaceScreen({
     setDeploying(true);
     setDeployError(null);
     try {
-      const result = await command('deployApp', { name: appName });
+      // By id where the workspace knows one: `apps` does not constrain `name`,
+      // and the command refuses a name two Apps answer to rather than guessing.
+      const result = await command('deployApp', {
+        name: state.workspace.appId ?? appName,
+      });
       if (result.ok) {
-        onNavigate(`/deploys/${result.value.deployId}`);
+        if (result.value.deployId === null) {
+          // A Build was started, so there is no deploy screen yet. Re-read the
+          // workspace rather than navigating somewhere that does not exist.
+          setReloadToken((token) => token + 1);
+        } else {
+          onNavigate(`/deploys/${result.value.deployId}`);
+        }
       } else {
+        // The sentence the command refused with, unedited — a disconnected
+        // Target, a signature that did not verify. Nothing is retried behind it.
         setDeployError(result.failure.message);
       }
     } catch (e: unknown) {
@@ -465,10 +483,21 @@ function DeployScreen({
     setRedeploying(true);
     setRedeployError(null);
     try {
-      const result = await command('deployApp', { name: state.deploy.app });
+      // The App's id, not its name: `apps` has no unique constraint on `name`,
+      // so redeploying by name would act on whichever row shares it.
+      const result = await command('deployApp', { name: state.deploy.appId });
       if (result.ok) {
-        onNavigate(`/deploys/${result.value.deployId}`);
+        if (result.value.deployId === null) {
+          // Nothing was deployable, so a Build started instead. The workspace is
+          // where a Build in flight is visible; this screen belongs to a deploy
+          // that does not exist yet.
+          onNavigate(`/apps/${state.deploy.appId}`);
+        } else {
+          onNavigate(`/deploys/${result.value.deployId}`);
+        }
       } else {
+        // Surfaced verbatim and acted on no further: a refused redeploy is a
+        // fact about this artifact and this Target, not a cue to build another.
         setRedeployError(result.failure.message);
       }
     } catch (e: unknown) {

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -119,6 +119,12 @@ export interface DeployView {
   readonly buildId: number;
   readonly componentId: string;
   readonly targetId: string;
+  /**
+   * The App's id, beside its name because only the id identifies it: `apps` has
+   * no unique constraint on `name`, so the redeploy button on this screen has to
+   * act on the id or it acts on whichever row shares the name.
+   */
+  readonly appId: string;
   readonly app: string;
   readonly component: string;
   readonly target: string;

--- a/apps/spindrift/test/commands/build-dispatch-followups.test.ts
+++ b/apps/spindrift/test/commands/build-dispatch-followups.test.ts
@@ -119,7 +119,7 @@ describe('build dispatch follow-ups', () => {
       .values({
         componentId: comp!.id,
         commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
-        targetShape: 'container',
+        targetShape: 'image',
         artifactType: 'image',
         status: 'RUNNING',
         dispatchId: dispatchId1,
@@ -183,7 +183,7 @@ describe('build dispatch follow-ups', () => {
       .values({
         componentId: comp!.id,
         commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
-        targetShape: 'container',
+        targetShape: 'image',
         artifactType: 'image',
         bundleDigest:
           'sha256:2222222222222222222222222222222222222222222222222222222222222222',
@@ -236,7 +236,7 @@ describe('build dispatch follow-ups', () => {
       await ctx.db.insert(builds).values({
         componentId: comp!.id,
         commit: `commit-${i}`.padEnd(40, '0'),
-        targetShape: `shape-${i}`,
+        targetShape: 'image',
         artifactType: 'image',
         status: 'RUNNING',
         leasedAt: ctx.clock.now(),
@@ -249,7 +249,7 @@ describe('build dispatch follow-ups', () => {
       .values({
         componentId: comp!.id,
         commit: 'new-commit'.padEnd(40, '0'),
-        targetShape: 'new-shape',
+        targetShape: 'image',
         artifactType: 'image',
         bundleDigest:
           'sha256:3333333333333333333333333333333333333333333333333333333333333333',

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
 import { createApp } from '../../src/commands/create-app.ts';
 import {
   createComponent,
@@ -303,7 +304,7 @@ describe('getDeployDetail command', () => {
       .values({
         componentId: createdComp.value.componentId,
         commit: '7f3d2c1',
-        targetShape: 'kubernetes',
+        targetShape: 'image',
         artifactType: 'image',
         artifactDigest: 'sha256:1234567890abcdef',
         status: 'SUCCEEDED',
@@ -392,7 +393,7 @@ describe('getDeployDetail command', () => {
       .values({
         componentId: createdComp.value.componentId,
         commit: '1111111',
-        targetShape: 'kubernetes',
+        targetShape: 'image',
         artifactType: 'image',
         status: 'SUCCEEDED',
       })
@@ -414,7 +415,7 @@ describe('getDeployDetail command', () => {
       .values({
         componentId: createdComp.value.componentId,
         commit: '2222222',
-        targetShape: 'kubernetes',
+        targetShape: 'image',
         artifactType: 'image',
         status: 'FAILED',
       })
@@ -501,7 +502,7 @@ describe('deployApp command', () => {
       .values({
         componentId: createdComp.value.componentId,
         commit: '1234567',
-        targetShape: 'kubernetes',
+        targetShape: 'image',
         artifactType: 'image',
         artifactDigest:
           'sha256:1111222233334444555566667777888899990000111122223333444455556666',
@@ -525,10 +526,145 @@ describe('deployApp command', () => {
     if (!result.ok) return;
 
     expect(result.value.deployId).toBeGreaterThan(0);
+    expect(result.value.phase).toBe('PENDING');
+    // The existing artifact is what gets deployed. A second Build here would
+    // mean the intent path refused and something built instead of saying so.
     expect(result.value.buildId).toBe(buildRow!.id);
+    const buildRows = await ctx.db
+      .select()
+      .from(builds)
+      .where(eq(builds.componentId, createdComp.value.componentId));
+    expect(buildRows).toHaveLength(1);
   });
 
-  test('kicks off a new pending build and deploy when build failed', async () => {
+  test('surfaces the refusal and writes nothing when the Target is disconnected', async () => {
+    // The whole point of the button going through `createDeploy`: a refusal is
+    // a sentence the operator has to read, not a cue to build something else.
+    const ctx = context();
+    const appName = `refused-${crypto.randomUUID().slice(0, 8)}`;
+    const createdApp = await createApp(
+      {
+        name: appName,
+        sourceKind: 'repo',
+        repoUrl: 'https://github.com/acme/refused.git',
+      },
+      ctx,
+    );
+    expect(createdApp.ok).toBe(true);
+    if (!createdApp.ok) return;
+
+    const createdComp = await createComponent(
+      {
+        appId: createdApp.value.appId,
+        name: 'web',
+        kind: 'service',
+        expose: true,
+        exposure: 'private',
+      },
+      ctx,
+    );
+    expect(createdComp.ok).toBe(true);
+    if (!createdComp.ok) return;
+
+    const [targetRow] = await ctx.db
+      .insert(targets)
+      .values(targetValues({ adapter: 'kubernetes', status: 'disconnected' }))
+      .returning();
+
+    await ctx.db.insert(componentTargetDesired).values({
+      componentId: createdComp.value.componentId,
+      targetId: targetRow!.id,
+    });
+
+    const [buildRow] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: createdComp.value.componentId,
+        commit: 'refused-commit',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest:
+          'sha256:1111222233334444555566667777888899990000111122223333444455556666',
+        status: 'SUCCEEDED',
+        verifiedBuildLevel: 2,
+        signature: {
+          artifactDigest:
+            'sha256:1111222233334444555566667777888899990000111122223333444455556666',
+          signer: 'gcpkms://test/signer',
+          format: 'cosign',
+          bundle: {
+            mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
+          },
+          signedAt: FROZEN.toISOString(),
+        },
+      })
+      .returning();
+
+    const result = await deployApp({ name: appName }, ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain(targetRow!.name);
+    expect(result.failure.message).toContain('disconnected');
+
+    // Nothing was written behind the refusal: no second Build, no intent.
+    const buildRows = await ctx.db
+      .select()
+      .from(builds)
+      .where(eq(builds.componentId, createdComp.value.componentId));
+    expect(buildRows).toHaveLength(1);
+    expect(buildRows[0]!.id).toBe(buildRow!.id);
+
+    const deployRows = await ctx.db
+      .select()
+      .from(deploys)
+      .where(eq(deploys.componentId, createdComp.value.componentId));
+    expect(deployRows).toHaveLength(0);
+  });
+
+  test('refuses a name two Apps answer to rather than deploying an arbitrary one', async () => {
+    // `apps` has no unique constraint on `name`, so this is a live shape:
+    // offsite currently holds two Apps called `infra`.
+    const ctx = context();
+    const appName = `twinned-${crypto.randomUUID().slice(0, 8)}`;
+    const first = await createApp(
+      {
+        name: appName,
+        sourceKind: 'repo',
+        repoUrl: 'https://github.com/acme/first.git',
+      },
+      ctx,
+    );
+    const second = await createApp(
+      {
+        name: appName,
+        sourceKind: 'repo',
+        repoUrl: 'https://github.com/acme/second.git',
+      },
+      ctx,
+    );
+    expect(first.ok).toBe(true);
+    expect(second.ok).toBe(true);
+    if (!(first.ok && second.ok)) return;
+
+    const result = await deployApp({ name: appName }, ctx);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.failure.code).toBe('INVALID_INPUT');
+    expect(result.failure.message).toContain(first.value.appId);
+    expect(result.failure.message).toContain(second.value.appId);
+
+    // The id resolves the ambiguity the name cannot.
+    const byId = await deployApp({ name: first.value.appId }, ctx);
+    expect(byId.ok).toBe(false);
+    if (byId.ok) return;
+    expect(byId.failure.code).toBe('NOT_FOUND');
+    expect(byId.failure.message).toContain('no components');
+  });
+
+  test('starts a Build and writes no intent when the last build failed', async () => {
     const ctx = context();
     const appName = `rebuild-${crypto.randomUUID().slice(0, 8)}`;
     const createdApp = await createApp(
@@ -568,7 +704,7 @@ describe('deployApp command', () => {
     await ctx.db.insert(builds).values({
       componentId: createdComp.value.componentId,
       commit: 'failed-commit',
-      targetShape: 'kubernetes',
+      targetShape: 'image',
       artifactType: 'image',
       status: 'FAILED',
     });
@@ -577,7 +713,22 @@ describe('deployApp command', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
-    expect(result.value.deployId).toBeGreaterThan(0);
-    expect(result.value.phase).toBe('PENDING');
+    // A Build, and only a Build. An intent naming a PENDING Build would name an
+    // artifact that does not exist, and could not pass `checkDeployable`.
+    expect(result.value.deployId).toBeNull();
+    expect(result.value.phase).toBe('BUILDING');
+    expect(result.value.buildId).toBeGreaterThan(0);
+
+    const pending = await ctx.db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    expect(pending[0]!.status).toBe('PENDING');
+
+    const deployRows = await ctx.db
+      .select()
+      .from(deploys)
+      .where(eq(deploys.componentId, createdComp.value.componentId));
+    expect(deployRows).toHaveLength(0);
   });
 });

--- a/apps/spindrift/test/domain/attempt-log.test.ts
+++ b/apps/spindrift/test/domain/attempt-log.test.ts
@@ -62,7 +62,7 @@ async function seedAttempt() {
     .values({
       componentId: component!.id,
       commit: 'deadbeef',
-      targetShape: 'kubernetes:image',
+      targetShape: 'image',
       artifactType: 'image',
     })
     .returning();

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -77,6 +77,7 @@ const BASE = {
   buildId: 41,
   componentId: '00000000-0000-4000-8000-000000000041',
   targetId: '00000000-0000-4000-8000-000000000042',
+  appId: '00000000-0000-4000-8000-000000000040',
   app: 'almanac',
   component: 'web',
   target: 'Metal',

--- a/apps/spindrift/test/reconciler/repo-loop.test.ts
+++ b/apps/spindrift/test/reconciler/repo-loop.test.ts
@@ -132,7 +132,7 @@ async function liveDeploy(appId: string) {
     .values({
       componentId: component!.id,
       commit: '1111111111111111111111111111111111111111',
-      targetShape: 'kubernetes',
+      targetShape: 'image',
       artifactType: 'image',
       artifactDigest: `sha256:${'a'.repeat(64)}`,
       status: 'SUCCEEDED',


### PR DESCRIPTION
Closes the deploy button's second, unguarded write path (ticket 14).

## The bug

`deployApp` called `createDeploy` and then discarded its refusal:

```ts
if (deployAttempt.ok) {
  return ok({ … });
}
// no else. The reason is dropped on the floor.
```

It fell through to raw inserts that reproduced the deploy transaction's *steps* without its transaction, without the `SELECT … FOR UPDATE` locking read §6 calls the whole correctness argument, and without any of `checkDeployable`'s gates — Target connected, artifact present, signature re-verified, verified Build Level ≥ the Target's policy, artifact shape matched, config migration satisfied.

Three consequences: the check-and-set was gone, so two concurrent redeploys could interleave; an artifact whose signature failed verification could be written as a Deploy intent, which is exactly the fail-closed guarantee ticket 07 claims; and the operator saw a silent rebuild where they should have seen *"Build 4 signature did not verify"* or *"that Target is disconnected"*.

## What changed

**The refusal is returned unchanged.** `if (!deployAttempt.ok) return deployAttempt;` — a refused deploy surfaces its sentence and writes nothing. This was the ticket's open decision; option (a), settled.

**Only one place writes an intent.** `insert(deploys)` now appears exactly once in `src/` — `src/commands/deploys/create.ts` — so every intent path runs `checkDeployable` then `placeIntent`'s locking read, the same pair `rollbackDeploy` and `setConfig` call. The rebuild branch survives, narrowed to what was never a refusal (no Build, a failed one, or one that succeeded without an artifact) and writes **only** a PENDING Build: an intent naming an unbuilt artifact could not pass `checkDeployable`, and the deploy loop reads `build.artifactDigest` unconditionally when it applies.

`DeployAppResult.deployId` is now `number | null` and `phase` is `'PENDING' | 'BUILDING'`. Both UI call sites render the refusal verbatim, and on a build-only outcome stay on / return to the workspace instead of navigating to a deploy screen that does not exist.

**Unambiguous App resolution.** `apps` has no unique constraint on `name` — `components` has `unique(appId, name)`, `targets` has `unique(name)`, `apps` has neither — and production holds two Apps named `infra`, so the button acted on an arbitrary row. `findFirst` became `findMany`, refusing `INVALID_INPUT` with both ids when a name is ambiguous. The workspace passes `WorkspaceView.appId`; the deploy screen passes a new `DeployView.appId`.

The unique constraint itself is **deliberately not added**. It cannot apply against the live database while the duplicates exist — the migration would fail at startup and take the installation down — and deleting those rows is a product action, not something a migration may do. Resolving by id plus refusing an ambiguous name satisfies the requirement without that hazard. (Worth noting for whoever adds it later: `src/db/migrations/meta/` has no `0014_snapshot.json`, so it would have to be hand-written the way `0014` was.)

**Impossible fixtures corrected.** `targetShape` values `artifactTypeFor` can never return — it yields only `'image'` or `'files'` — appeared throughout the suite: `'kubernetes'`, `'kubernetes:image'`, `'container'`, plus `` `shape-${i}` ``/`'new-shape'` uniqueness noise. All now `'image'`; the commits in those rows already differ, so `builds_component_commit_shape_unique` still separates them.

## The failing test was a true positive

`workspace-deploy-details.test.ts:528` expected the succeeded Build to be reused and got a second one. Its fixture's impossible `targetShape` made the shape check refuse, the refusal was swallowed, and a rebuild happened — the assertion was pointing straight at the swallow. It passes now, for the right reason.

Two new tests: a disconnected Target refuses with its sentence and writes neither a second Build nor a Deploy; a name two Apps answer to is refused with both ids while the id still resolves.

## Validation

```
DATABASE_URL=… bun test   929 pass, 0 fail   (927 before, plus the two new ones)
bun run typecheck         clean
bun run lint              clean
```

## Follow-ups found, deliberately left out of scope

- When the latest Build is `RUNNING`, `deployApp` resets it to `PENDING` and clears `dispatchId`/`leasedAt`, orphaning the run in flight. Pre-existing; belongs with the build-dispatch work.
- Nothing writes a Deploy intent when a Build succeeds, so the build branch dead-ends until the operator presses deploy again. Also true before this change — the intent it used to write named an unbuilt artifact and could not have applied. Making it a real chain is continuous deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)