### PR TITLE
fix(cd): stop selective CD from committing the Trivy cache

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -118,27 +118,66 @@ jobs:
           exit-code: 0
           severity: CRITICAL,HIGH
       - name: Update manifest digest for selective continuous delivery
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.manifests != '[]' && matrix.manifests != ''
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           IMAGE_NAME: ${{ matrix.image }}
           DIGEST: ${{ steps.push.outputs.digest }}
           MANIFESTS: ${{ toJson(matrix.manifests) }}
         run: |
           set -euo pipefail
-          updated=false
           mapfile -t targets < <(jq -r '.[]' <<<"$MANIFESTS")
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "$IMAGE_NAME has no deploy targets in .github/containers.json"
+            exit 0
+          fi
+
           for manifest in "${targets[@]}"; do
-            if [ -f "$manifest" ]; then
-              echo "Updating digest for $IMAGE_NAME in $manifest..."
-              sed -i -E "s|(@sha256:)[0-9a-f]{64}|\1${DIGEST}|g" "$manifest"
-              updated=true
+            # A declared target that is missing, or that pins no digest, means
+            # the deploy map is wrong. Fail loudly: a silent no-op here is
+            # indistinguishable from a successful deploy.
+            if [ ! -f "$manifest" ]; then
+              echo "::error::$manifest is a deploy target for $IMAGE_NAME but does not exist"
+              exit 1
             fi
+            pins=$(grep -cE '@sha256:[0-9a-f]{64}' "$manifest" || true)
+            if [ "$pins" -eq 0 ]; then
+              echo "::error::$manifest pins no image digest, so $IMAGE_NAME can never roll from it"
+              exit 1
+            fi
+            # The rewrite is a blanket one; more than one pin means it would
+            # stamp this image's digest onto some other image.
+            if [ "$pins" -gt 1 ]; then
+              echo "::error::$manifest pins $pins digests; rewriting would clobber images other than $IMAGE_NAME"
+              exit 1
+            fi
+            echo "Updating digest for $IMAGE_NAME in $manifest..."
+            # DIGEST already carries the sha256: prefix, so the capture group
+            # must not be replayed into the replacement.
+            sed -i -E "s|@sha256:[0-9a-f]{64}|@${DIGEST}|g" "$manifest"
           done
 
-          if [ "$updated" = "true" ] && ! git diff --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add .
-            git commit -m "fix(cd): update ${IMAGE_NAME} image digest to ${DIGEST}"
-            git push
+          if git diff --quiet -- "${targets[@]}"; then
+            echo "$IMAGE_NAME manifests already pin $DIGEST"
+            exit 0
           fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Stage only the manifests this step edited. A blanket `git add .`
+          # also sweeps up whatever the build and scan steps left behind — the
+          # Trivy action's multi-gigabyte vulnerability DB under .cache/ is
+          # what wedged this step shut.
+          git add -- "${targets[@]}"
+          git commit -m "fix(cd): update ${IMAGE_NAME} image digest to ${DIGEST}"
+
+          # Sibling matrix jobs push to main concurrently. Each owns different
+          # manifests, so a rejected push only needs replaying on top of theirs.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              exit 0
+            fi
+            echo "push rejected (attempt ${attempt}/5); rebasing onto origin/main"
+            git pull --rebase origin main
+          done
+          echo "::error::could not push the ${IMAGE_NAME} digest update after 5 attempts"
+          exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ docs/.trash/
 node_modules/
 .turbo/
 
+# ─── Tool caches ─────────────────────────────────────────────────────────────
+# aquasecurity/trivy-action caches its vulnerability DB in the workspace at
+# .cache/trivy — trivy.db alone is over 1GB, well past GitHub's 100MB limit.
+.cache/
+
 # ─── IDE / Editor ────────────────────────────────────────────────────────────
 .vscode/
 .idea/

--- a/clusters/folly/apps/tronbyt/07-rackstat-deployment.yaml
+++ b/clusters/folly/apps/tronbyt/07-rackstat-deployment.yaml
@@ -24,8 +24,8 @@ spec:
           type: RuntimeDefault
       containers:
         - name: rackstat
-          image: docker.io/jonpulsifer/rackstat:latest
-          imagePullPolicy: Always
+          image: docker.io/jonpulsifer/rackstat:latest@sha256:c9e2af5bd5cdbc0a995d775dd13a0be1263d2287df646ee9d2322b3f6c06266a
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
## Root cause

The digest-update step in `containers.yml` staged with `git add .`. The step immediately before it is the Trivy image scan, and `aquasecurity/trivy-action` caches its vulnerability DB into `${{ github.workspace }}/.cache/trivy`. `trivy.db` alone is 1.17 GB, so every push was rejected by GitHub's 100 MB file limit:

```
remote: error: File .cache/trivy/db/trivy.db is 1173.25 MB; this exceeds GitHub's file size limit of 100.00 MB
 ! [remote rejected] main -> main (pre-receive hook declined)
```

Selective CD landed in 2e101e49 (2026-08-01); the Trivy image scan landed in 26a03795 (2026-07-28). The cache was always there, so **no `fix(cd): update ...` commit has ever landed on main** — this never worked once, it did not regress.

## Three further defects in the same step

Fixing the `git add` alone would have produced a green check and still-broken deploys.

1. **The digest was malformed.** `s|(@sha256:)[0-9a-f]{64}|\1${DIGEST}|g` replays the capture group, but `steps.push.outputs.digest` already carries the `sha256:` prefix — it writes `@sha256:sha256:…`. Every deploy would have been an unpullable image reference.
2. **Concurrent matrix jobs raced.** `fail-fast: false` with up to 7 images pushing to `main`; a change to `containers.yml` rebuilds all of them. Whoever lost the race got a rejected push and a green check. Now retries onto `origin/main`.
3. **Misconfigured deploy targets were silent no-ops.** A target that is missing, pins no digest, or pins more than one just did nothing. The multi-pin case is the dangerous one — the rewrite is blanket, so a manifest with two images gets one image's digest stamped onto both. All three now fail loudly, consistent with how `detect-containers.sh` treats unclassified images.

`rackstat` was the live instance of #3: declared in the deploy map, but `clusters/folly/apps/tronbyt/07-rackstat-deployment.yaml` pinned `:latest` with no digest, so Flux could never roll it. Pinned to its current published digest (resolved from Docker Hub) and switched to `IfNotPresent` to match the other digest-pinned manifests.

`.gitignore` gains `.cache/` as belt-and-suspenders — it also covers local `trivy` runs and the `trivy.yml` workflow.

## Verification

Extracted the step into a scratch git lab and ran 8 scenarios: happy path (single correct digest), idempotent re-run, empty target list, the three hard-fail modes, and a push race with a `.cache/trivy/db/trivy.db` sitting in the workspace. The commit touched 1 file and the cache stayed out *before* `.gitignore` was in play; both racing jobs' changes survived. The rebase retry was also verified against a `--depth=1` shallow clone, which is what `actions/checkout` gives CI.

`kubectl kustomize clusters/folly/apps/tronbyt` renders; `mise run lint` and `shellcheck` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)