### PR TITLE
fix(spindrift): hold the store fakes to the real APIs' rules

### DIFF
--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -55,8 +55,53 @@ interface CloudBuild {
 
 /** One log entry, as much of it as this route reads. */
 interface LogEntry {
+  /**
+   * The log service's own identity for this entry. It is what makes re-reading
+   * a window cheap: the same entry seen twice is recognised rather than
+   * re-emitted, so the route never needs a cursor it cannot trust.
+   */
+  readonly insertId?: string;
   readonly textPayload?: string;
   readonly timestamp?: string;
+}
+
+/**
+ * How far behind the newest entry already read a fresh search reaches.
+ *
+ * Entries are ingested out of order, so a window that started exactly at the
+ * newest timestamp would step over anything that arrived late. A minute is
+ * generous against the log service's own ingestion latency, and re-reading a
+ * minute costs nothing because {@link keyOf} recognises what was already
+ * emitted.
+ */
+const LOG_LATENESS_MS = 60_000;
+
+/**
+ * Pages one search follows before leaving the rest to the next poll.
+ *
+ * A bound rather than a limit anyone should hit: the next poll re-reads the
+ * window anyway, so stopping early loses nothing but a few seconds of latency.
+ */
+const MAX_LOG_PAGES = 50;
+
+/**
+ * How long a concluded build's log is drained for before the route gives up on
+ * the report.
+ *
+ * The build being over does not mean its log is: ingestion runs behind the
+ * writer, and the report line is written in the final seconds of the run. This
+ * is the only budget spent waiting for something that has already happened.
+ */
+const LOG_TAIL_TIMEOUT_MS = 60_000;
+
+/** What the route carries between reads of one build's log. */
+interface LogTail {
+  /** Entries already emitted, by {@link keyOf}. */
+  readonly seen: Set<string>;
+  /** The newest entry timestamp seen, which anchors the next search's window. */
+  newest: Date | null;
+  /** Everything emitted, joined — what {@link parseBuildReport} reads. */
+  log: string;
 }
 
 export interface CloudBuildRouteOptions extends PollingOptions {
@@ -152,24 +197,12 @@ export class CloudBuildRoute implements BuildAdapter {
     yield { type: 'log', at: now(), line: `build ${build.id} submitted` };
 
     const budget = deadlineFrom(this.options);
-    let cursor: string | undefined;
-    let log = '';
+    const tail: LogTail = { seen: new Set(), newest: null, log: '' };
     let status = build.status ?? 'QUEUED';
     let statusDetail = build.statusDetail;
 
     for (;;) {
-      const page = await this.logPage(build.id, cursor);
-      cursor = page.cursor;
-      for (const entry of page.entries) {
-        const line = entry.textPayload;
-        if (line === undefined || line.trim() === '') continue;
-        log += `${line}\n`;
-        yield {
-          type: 'log',
-          at: entry.timestamp === undefined ? now() : new Date(entry.timestamp),
-          line,
-        };
-      }
+      yield* this.readLog(build.id, tail, now);
 
       const current = await this.read(build.id);
       if (current !== null) {
@@ -188,6 +221,28 @@ export class CloudBuildRoute implements BuildAdapter {
       }
       await budget.tick();
     }
+
+    // The log read above happened *before* the status read that ended the loop,
+    // so everything the build wrote in its last seconds is still unread — and
+    // that is precisely the region that carries the report (`report.ts`: the
+    // result travels the same way the logs do). A loop that stopped here would
+    // record a green build as `succeeded but reported no artifact`, so the read
+    // after the conclusion is the load-bearing one, not a courtesy.
+    const drain = deadlineFrom({
+      ...this.options,
+      timeoutMs: LOG_TAIL_TIMEOUT_MS,
+    });
+    for (;;) {
+      yield* this.readLog(build.id, tail, now);
+      // A red build's report is not coming; one final read for the operator's
+      // sake is the whole of what it is owed.
+      if (status !== 'SUCCESS') break;
+      if (parseBuildReport(tail.log) !== null) break;
+      if (drain.expired()) break;
+      await drain.tick();
+    }
+
+    const log = tail.log;
 
     if (status !== 'SUCCESS') {
       // The service's own `TIMEOUT` is core's `TIMEOUT` — a build that ran out
@@ -265,38 +320,82 @@ export class CloudBuildRoute implements BuildAdapter {
   }
 
   /**
-   * One page of the build's log, and where to resume.
+   * Everything the build's log has gained since the last read, as events.
    *
-   * A page cursor rather than a timestamp window: entries arrive out of order
-   * often enough that a window either repeats lines or drops them, and the log
-   * service's own cursor is the only thing that knows which it already served.
+   * **One poll is one search.** `entries.list`'s `nextPageToken` is a
+   * continuation of *this* search — "retrieve the next batch of results from
+   * the preceding call to this method" — and not a watermark on a live log. A
+   * route that saved one and presented it seconds later would be paginating a
+   * snapshot of the past, so the token is followed to the end of the search it
+   * belongs to and then dropped.
+   *
+   * What replaces it is a timestamp window plus per-entry identity: each poll
+   * re-searches the last {@link LOG_LATENESS_MS} and {@link keyOf} drops what
+   * was already emitted. That is what tolerates out-of-order ingestion, which a
+   * cursor never did.
+   *
+   * **An empty page carrying a token is not a caught-up log.** The vendor is
+   * explicit that it means "the search found no log entries so far but it did
+   * not have time to search all the possible log entries", so the token is
+   * followed rather than read as an end.
    */
-  private async logPage(
+  private async *readLog(
     id: string,
-    cursor: string | undefined,
-  ): Promise<{ entries: readonly LogEntry[]; cursor: string | undefined }> {
-    let page: { entries?: LogEntry[]; nextPageToken?: string } | null = null;
-    try {
-      page = await this.json(`${this.options.logsEndpoint}/v2/entries:list`, {
-        method: 'POST',
-        body: {
-          resourceNames: [`projects/${this.options.project}`],
-          filter: `resource.labels.build_id="${id}"`,
-          orderBy: 'timestamp asc',
-          pageSize: 200,
-          ...(cursor === undefined ? {} : { pageToken: cursor }),
-        },
-      });
-    } catch {
-      // A log service having a bad moment must not fail a build that is
-      // otherwise going fine — the status read below is the authority on
-      // whether it is going fine, and the next pass asks for the page again.
-      return { entries: [], cursor };
+    tail: LogTail,
+    now: () => Date,
+  ): AsyncGenerator<BuildEvent, void, void> {
+    const filter = [
+      `resource.labels.build_id="${id}"`,
+      ...(tail.newest === null
+        ? []
+        : [
+            `timestamp>="${new Date(tail.newest.getTime() - LOG_LATENESS_MS).toISOString()}"`,
+          ]),
+    ].join(' AND ');
+
+    let token: string | undefined;
+    for (let page = 0; page < MAX_LOG_PAGES; page += 1) {
+      let answer: { entries?: LogEntry[]; nextPageToken?: string } | null;
+      try {
+        answer = await this.json(
+          `${this.options.logsEndpoint}/v2/entries:list`,
+          {
+            method: 'POST',
+            body: {
+              resourceNames: [`projects/${this.options.project}`],
+              filter,
+              orderBy: 'timestamp asc',
+              pageSize: 200,
+              ...(token === undefined ? {} : { pageToken: token }),
+            },
+          },
+        );
+      } catch {
+        // A log service having a bad moment must not fail a build that is
+        // otherwise going fine — the status read is the authority on whether it
+        // is going fine, and the next pass searches the same window again.
+        return;
+      }
+
+      for (const entry of answer?.entries ?? []) {
+        const key = keyOf(entry);
+        if (tail.seen.has(key)) continue;
+        tail.seen.add(key);
+
+        const at = timestampOf(entry);
+        if (at !== null && (tail.newest === null || at > tail.newest)) {
+          tail.newest = at;
+        }
+
+        const line = entry.textPayload;
+        if (line === undefined || line.trim() === '') continue;
+        tail.log += `${line}\n`;
+        yield { type: 'log', at: at ?? now(), line };
+      }
+
+      token = answer?.nextPageToken;
+      if (token === undefined || token === '') return;
     }
-    return {
-      entries: page?.entries ?? [],
-      cursor: page?.nextPageToken ?? cursor,
-    };
   }
 
   private async json<Result>(
@@ -326,4 +425,26 @@ export class CloudBuildRoute implements BuildAdapter {
     }
     return (await response.json()) as Result;
   }
+}
+
+/**
+ * What makes two reads of the same entry the same entry.
+ *
+ * `insertId` is the log service's own identity and is what this relies on. The
+ * fallback exists because an entry without one still has to be deduplicated
+ * somehow, and it deliberately collapses two identical lines written in the
+ * same second — losing a duplicated line is a smaller wrong than emitting the
+ * whole window again on every poll.
+ */
+function keyOf(entry: LogEntry): string {
+  if (entry.insertId !== undefined && entry.insertId !== '') {
+    return entry.insertId;
+  }
+  return `${entry.timestamp ?? ''} ${entry.textPayload ?? ''}`;
+}
+
+function timestampOf(entry: LogEntry): Date | null {
+  if (entry.timestamp === undefined) return null;
+  const at = new Date(entry.timestamp);
+  return Number.isNaN(at.getTime()) ? null : at;
 }

--- a/apps/spindrift/src/adapters/store/gcp-secret-manager.ts
+++ b/apps/spindrift/src/adapters/store/gcp-secret-manager.ts
@@ -22,6 +22,7 @@
  * - It never reuses a version. `addVersion` is the only write, so a put is
  *   always a new version rather than an edit of one.
  */
+import { createHash } from 'node:crypto';
 import type { StoreAdapter } from '../../config/manifest.schema.ts';
 import type {
   ConfigScope,
@@ -73,6 +74,12 @@ const ANNOTATION = {
   key: 'spindrift-key',
 } as const;
 
+/** The ceiling `projects.secrets.create` puts on a secret id. */
+const MAX_ID_LENGTH = 255;
+
+/** Hex characters of scope digest a truncated id ends with. */
+const DIGEST_LENGTH = 16;
+
 /**
  * A Secret Manager secret id: `[A-Za-z0-9_-]{1,255}`.
  *
@@ -81,12 +88,36 @@ const ANNOTATION = {
  * exact scope. `--` separates the four parts because a sanitized part can
  * contain a single `-` (App and Component names are DNS labels) but the pair is
  * only ever what this function put there.
+ *
+ * **The ceiling is the alphabet's other half and is enforced here.** App,
+ * Component and Target names are DNS labels of up to 63 characters each and a
+ * variable name has no ceiling at all, so four parts and three separators clear
+ * 255 without anything unreasonable happening — and the API refuses the create,
+ * not the character that pushed it over.
+ *
+ * Truncating alone would widen the one hazard this scheme already carries: two
+ * distinct scopes landing on one id, which is what {@link assertScopeMatches}
+ * exists to catch. So an id over the ceiling gives up the last
+ * {@link DIGEST_LENGTH} characters of legibility to a digest of the **exact,
+ * unsanitized** scope. Two long scopes now need both a shared prefix and a
+ * 64-bit digest collision to meet, where sanitizing alone needed only a flatten
+ * — so the truncated form separates strictly more pairs than the sanitized one,
+ * which is what keeps this from trading a length bug for a collision bug.
+ * `assertScopeMatches` still stands behind it: a digest is a legibility aid,
+ * not a proof.
  */
 function secretId(scope: ConfigScope, key: string): string {
   const sanitize = (part: string) => part.replace(/[^A-Za-z0-9_-]/g, '_');
-  return [scope.app, scope.component, scope.target, key]
-    .map(sanitize)
-    .join('--');
+  const parts = [scope.app, scope.component, scope.target, key];
+  const legible = parts.map(sanitize).join('--');
+  if (legible.length <= MAX_ID_LENGTH) return legible;
+
+  const digest = createHash('sha256')
+    .update(JSON.stringify(parts))
+    .digest('hex')
+    .slice(0, DIGEST_LENGTH);
+  const head = legible.slice(0, MAX_ID_LENGTH - DIGEST_LENGTH - 2);
+  return `${head}--${digest}`;
 }
 
 /** The version number out of a version resource name. */

--- a/apps/spindrift/src/adapters/store/onepassword.ts
+++ b/apps/spindrift/src/adapters/store/onepassword.ts
@@ -28,8 +28,9 @@
  * - Items are addressed by a title Spindrift owns, `app/component/target/KEY`,
  *   which exists so an operator reading the vault can see what a value is for.
  *   It is **not** what the adapter reads back: the variable a version fills
- *   comes from the concealed field's label, the same rule the cloud store
- *   follows with an annotation. A name is for humans; metadata is the authority.
+ *   comes from the label of the concealed field in {@link SECTION}, the same
+ *   rule the cloud store follows with an annotation. A name is for humans;
+ *   metadata is the authority.
  */
 import type { StoreAdapter } from '../../config/manifest.schema.ts';
 import type {
@@ -54,10 +55,30 @@ interface ConnectItemOverview {
   createdAt: string;
 }
 
+/** The subset of one field of a Connect item this adapter reads. */
+interface ConnectField {
+  type?: string;
+  label?: string;
+  section?: { id?: string };
+}
+
 /** The subset of a full Connect item this adapter reads. */
 interface ConnectItem extends ConnectItemOverview {
-  fields?: { label?: string; value?: string }[];
+  fields?: ConnectField[];
 }
+
+/**
+ * The section every field this adapter writes lives in, and the marker
+ * {@link keyOf} reads an item back by.
+ *
+ * Connect populates a created item with its **category's default fields** —
+ * `username`, `credential`, `notesPlain` on an `API_CREDENTIAL` — that the
+ * caller never sent. Several of them carry a label and one of them is
+ * `CONCEALED`, so neither position nor type alone distinguishes the field
+ * Spindrift wrote from one Connect invented. A section does: a category default
+ * belongs to no section, and this id is Spindrift's own.
+ */
+const SECTION = 'spindrift';
 
 /**
  * The item title for one scoped variable. Spindrift's naming, not the store's —
@@ -71,13 +92,17 @@ function itemTitle(scope: ConfigScope, key: string): string {
 /**
  * The variable an item fills, as `put` was given it.
  *
- * The concealed field's label is where `put` wrote it, so an item without one is
- * an item this adapter did not write — reported as absent rather than guessed at
- * from the title.
+ * The label of the concealed field in {@link SECTION} is where `put` wrote it,
+ * so an item without one is an item this adapter did not write — reported as
+ * absent rather than guessed at from the title, and never mistaken for a field
+ * the category brought with it.
  */
 function keyOf(item: ConnectItem): string | null {
   for (const field of item.fields ?? []) {
-    if (field.label !== undefined) return field.label;
+    if (field.section?.id !== SECTION) continue;
+    if (field.type !== 'CONCEALED') continue;
+    if (field.label === undefined || field.label === '') continue;
+    return field.label;
   }
   return null;
 }
@@ -107,7 +132,10 @@ export class OnePasswordStore implements SecretStore {
         vault: { id: this.vault },
         title,
         category: 'API_CREDENTIAL',
-        fields: [{ type: 'CONCEALED', label: key, value }],
+        sections: [{ id: SECTION, label: 'Spindrift' }],
+        fields: [
+          { type: 'CONCEALED', label: key, value, section: { id: SECTION } },
+        ],
       },
     });
 
@@ -154,6 +182,11 @@ export class OnePasswordStore implements SecretStore {
     // The filter is sent because Connect supports it and a vault can be large;
     // the same predicate is applied here because a Connect that ignored it
     // would otherwise return the whole vault as versions of one key.
+    //
+    // The `key` attached is the caller's rather than one read back, because a
+    // list answers with overviews and no fields. That cannot disagree with what
+    // `describe` reads: `put` derives the title from the key, so an item that
+    // matches this title is an item whose section field is labelled `key`.
     return overviews
       .filter((item) => item.title === title)
       .map((item) => ({
@@ -180,3 +213,5 @@ export class OnePasswordStore implements SecretStore {
     );
   }
 }
+
+export { itemTitle as itemTitleFor, SECTION as SPINDRIFT_SECTION };

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -485,6 +485,96 @@ describe('the cloud build route', () => {
     expect(result.status).toBe('FAILED');
     if (result.status === 'FAILED') expect(result.reason).toBe('TIMEOUT');
   });
+
+  test('a report ingested only after the build concludes is still read', async () => {
+    // The report region is written in the build's last seconds and the log
+    // service ingests behind the writer, so the read that finds it is the one
+    // *after* the status turned `SUCCESS`. A loop that stopped at the status
+    // read records this green build as `succeeded but reported no artifact`.
+    const { result } = await run(
+      cloudRoute().route.build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('SUCCEEDED');
+    if (result.status === 'SUCCEEDED') {
+      expect(result.artifact?.digest).toBe(`sha256:${'b'.repeat(64)}`);
+    }
+  });
+
+  test('the whole log is read, including the lines written after the last poll', async () => {
+    const { events } = await run(
+      cloudRoute().route.build(archiveSource(), spec),
+    );
+
+    // `Finished Step #0` is written after the report, so it is the line a route
+    // that read one page too few would be missing.
+    expect(text(events)).toContain('Finished Step #0');
+  });
+
+  test('every poll starts a fresh search rather than resuming an old cursor', async () => {
+    // `nextPageToken` continues one search; it is not a watermark on a live
+    // log. A route that carried one across polls would be paginating a snapshot
+    // of the past, so a token may only be presented within the poll that minted
+    // it.
+    const { api, route } = cloudRoute({ duration: 3 });
+    await run(route.build(archiveSource(), spec));
+
+    let fresh = true;
+    for (const request of api.requests) {
+      if (request.url.endsWith('entries:list')) {
+        if (fresh) {
+          expect((request.body as { pageToken?: string }).pageToken).toBe(
+            undefined,
+          );
+        }
+        fresh = false;
+        continue;
+      }
+      // A status read (or the submit) ends the poll the token belonged to.
+      fresh = true;
+    }
+  });
+
+  test('a search cut short is not mistaken for a caught-up log', async () => {
+    // The vendor documents an empty page carrying a token as "the search found
+    // no log entries so far but it did not have time to search all the possible
+    // log entries" — a route that read it as an end would report no artifact.
+    const { result, events } = await run(
+      cloudRoute({ cutShort: true }).route.build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('SUCCEEDED');
+    expect(text(events)).toContain('exporting to image');
+  });
+
+  test('the log service refuses a search that names no parent resource', async () => {
+    // `entries.list` documents `resourceNames` as required. The fake refuses a
+    // search without it, so the route sending it is not a matter of trust.
+    const { api, route } = cloudRoute();
+    await run(route.build(archiveSource(), spec));
+
+    const searches = api.requests.filter((request) =>
+      request.url.endsWith('entries:list'),
+    );
+    expect(searches.length).toBeGreaterThan(0);
+    for (const search of searches) {
+      expect(
+        (search.body as { resourceNames?: string[] }).resourceNames,
+      ).toEqual(['projects/example-builds']);
+    }
+
+    const refused = await api.fetch(
+      new Request(`${api.logsEndpoint}/v2/entries:list`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${api.token()}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ filter: 'resource.labels.build_id="build-1"' }),
+      }),
+    );
+    expect(refused.status).toBe(400);
+  });
 });
 
 // --- The in-cluster route ----------------------------------------------

--- a/apps/spindrift/test/adapters/store-implementations.test.ts
+++ b/apps/spindrift/test/adapters/store-implementations.test.ts
@@ -19,7 +19,10 @@ import {
   secretIdFor,
 } from '../../src/adapters/store/gcp-secret-manager.ts';
 import { StoreRequestError } from '../../src/adapters/store/http.ts';
-import { OnePasswordStore } from '../../src/adapters/store/onepassword.ts';
+import {
+  OnePasswordStore,
+  SPINDRIFT_SECTION,
+} from '../../src/adapters/store/onepassword.ts';
 import { FakeOnePasswordConnect } from '../harness/fakes/onepassword-connect.ts';
 import { FakeSecretManager } from '../harness/fakes/secret-manager-api.ts';
 
@@ -76,12 +79,74 @@ describe('1Password over Connect', () => {
       (request) => request.method === 'POST',
     );
     expect(created?.body).toMatchObject({
+      // Connect has no default for either, and refuses a create without them.
+      vault: { id: connect.vault },
+      category: 'API_CREDENTIAL',
       title: 'invoices/web/metal/DATABASE_URL',
+      sections: [{ id: SPINDRIFT_SECTION }],
       fields: [
-        { type: 'CONCEALED', label: 'DATABASE_URL', value: 'postgres://x' },
+        {
+          type: 'CONCEALED',
+          label: 'DATABASE_URL',
+          value: 'postgres://x',
+          section: { id: SPINDRIFT_SECTION },
+        },
       ],
     });
     expect(connect.valueOf(reference.version)).toBe('postgres://x');
+  });
+
+  test('reads back the variable it wrote, not a category default', async () => {
+    const { connect, store } = onepassword();
+    const reference = await store.put(scope, 'DATABASE_URL', 'postgres://x');
+
+    // Connect populates an API_CREDENTIAL with `username`, `credential` and
+    // `notesPlain` of its own. They come back in front of the caller's field
+    // and two of them are labelled, so an adapter reading "the first labelled
+    // field" reads `username` — a variable name that was never written, on a
+    // §10 read-back whose whole job is to prove a pin still resolves.
+    const item = (await connect
+      .fetch(
+        new Request(
+          `${connect.baseUrl}/v1/vaults/${connect.vault}/items/${reference.version}`,
+          { headers: { Authorization: 'Bearer connect-token' } },
+        ),
+      )
+      .then((response) => response.json())) as {
+      fields: { label?: string; type?: string }[];
+    };
+    expect(item.fields[0]?.label).not.toBe('DATABASE_URL');
+    expect(item.fields.map((field) => field.label)).toContain('credential');
+
+    const described = await store.describe(reference);
+    expect(described?.key).toBe('DATABASE_URL');
+  });
+
+  test('an item without a Spindrift field is not one this store wrote', async () => {
+    const { connect, store } = onepassword();
+    const created = (await connect
+      .fetch(
+        new Request(`${connect.baseUrl}/v1/vaults/${connect.vault}/items`, {
+          method: 'POST',
+          headers: { Authorization: 'Bearer connect-token' },
+          body: JSON.stringify({
+            vault: { id: connect.vault },
+            title: 'invoices/web/metal/DATABASE_URL',
+            category: 'LOGIN',
+            fields: [],
+          }),
+        }),
+      )
+      .then((response) => response.json())) as { id: string };
+
+    // Titled exactly as Spindrift titles one, and carrying nothing Spindrift
+    // wrote. Absent beats guessing the variable out of the title.
+    expect(
+      await store.describe({
+        key: 'invoices/web/metal/DATABASE_URL',
+        version: created.id,
+      }),
+    ).toBeNull();
   });
 
   test('never reads a value back', async () => {
@@ -160,6 +225,59 @@ describe('Secret Manager', () => {
     expect(
       api.requests.some((request) => request.path.includes(':access')),
     ).toBe(false);
+  });
+
+  test('the create carries a replication policy', async () => {
+    const { api, store } = secretManager();
+    await store.put(scope, 'DATABASE_URL', 'one');
+
+    // The Secret resource has no default for it and the API refuses a create
+    // without one, so dropping this line would break every write this
+    // installation makes and nothing else would say so.
+    const created = api.requests.find((request) =>
+      /\/secrets\?secretId=/.test(request.path),
+    );
+    expect(created?.body).toMatchObject({ replication: { automatic: {} } });
+  });
+
+  test('a scope past the id ceiling still names a secret the API accepts', async () => {
+    const { api, store } = secretManager();
+    const long = {
+      app: 'a'.repeat(63),
+      component: 'c'.repeat(63),
+      target: 't'.repeat(63),
+    };
+    const key = `K${'E'.repeat(120)}Y`;
+
+    // Three DNS labels at their own ceiling plus a long variable name clears
+    // 255 without anything unreasonable happening, and the API refuses the
+    // create rather than truncating for us.
+    const id = secretIdFor(long, key);
+    expect(id.length).toBeLessThanOrEqual(255);
+    expect(id).toMatch(/^[A-Za-z0-9_-]{1,255}$/);
+
+    const reference = await store.put(long, key, 'one');
+    expect(reference.key).toBe(id);
+    expect(api.annotationsOf(id)).toMatchObject({ 'spindrift-key': key });
+    expect((await store.describe(reference))?.key).toBe(key);
+  });
+
+  test('truncated ids keep two long scopes apart', async () => {
+    // Long enough that every id below is truncated, and identical far past the
+    // cut — so the head alone cannot tell any of them apart.
+    const long = { app: 'a'.repeat(240), component: 'web', target: 'metal' };
+
+    // Truncation on its own would widen the collision the sanitizer already
+    // opens. The digest of the exact scope is what keeps two scopes sharing a
+    // head apart…
+    expect(secretIdFor(long, 'TOKEN')).not.toBe(
+      secretIdFor({ ...long, component: 'worker' }, 'TOKEN'),
+    );
+    // …and what separates two that sanitizing flattens onto one name, which
+    // the untruncated form never could.
+    expect(secretIdFor({ ...long, app: `${long.app}.` }, 'TOKEN')).not.toBe(
+      secretIdFor({ ...long, app: `${long.app}/` }, 'TOKEN'),
+    );
   });
 
   test('records the exact scope as annotations', async () => {
@@ -244,5 +362,80 @@ describe('Secret Manager', () => {
     expect(store.put(scope, 'DATABASE_URL', 'one')).rejects.toThrow(
       StoreRequestError,
     );
+  });
+});
+
+/**
+ * The far side, driven directly.
+ *
+ * Everything above goes through an adapter that is correct today, so it proves
+ * the adapter and not the fake. These go straight at the fake, because a fake
+ * more permissive than the real API is how a production bug becomes a green
+ * test — and the fake is the half of that pair no adapter test can reach.
+ */
+describe('the store fakes refuse what the real APIs refuse', () => {
+  test('Secret Manager refuses an id outside its alphabet or ceiling', async () => {
+    const api = new FakeSecretManager();
+    for (const id of ['has/slash', 'has.dot', 'x'.repeat(256), '']) {
+      const response = await api.fetch(
+        new Request(
+          `${api.baseUrl}/v1/projects/${api.project}/secrets?secretId=${encodeURIComponent(id)}`,
+          {
+            method: 'POST',
+            headers: { Authorization: 'Bearer federated-token' },
+            body: JSON.stringify({ replication: { automatic: {} } }),
+          },
+        ),
+      );
+      expect(response.status).toBe(400);
+    }
+    expect(api.secretCount).toBe(0);
+  });
+
+  test('Secret Manager refuses a create with no replication policy', async () => {
+    const api = new FakeSecretManager();
+    for (const body of [{}, { replication: {} }]) {
+      const response = await api.fetch(
+        new Request(
+          `${api.baseUrl}/v1/projects/${api.project}/secrets?secretId=fine`,
+          {
+            method: 'POST',
+            headers: { Authorization: 'Bearer federated-token' },
+            body: JSON.stringify(body),
+          },
+        ),
+      );
+      expect(response.status).toBe(400);
+    }
+    expect(api.secretCount).toBe(0);
+  });
+
+  test('Connect refuses a create with no vault or no category', async () => {
+    const connect = new FakeOnePasswordConnect();
+    const bodies = [
+      { title: 'invoices/web/metal/TOKEN', category: 'API_CREDENTIAL' },
+      { title: 'invoices/web/metal/TOKEN', vault: { id: connect.vault } },
+      {
+        title: 'invoices/web/metal/TOKEN',
+        vault: { id: 'another-vault' },
+        category: 'API_CREDENTIAL',
+      },
+      {
+        title: 'invoices/web/metal/TOKEN',
+        vault: { id: connect.vault },
+        category: 'NOT_A_CATEGORY',
+      },
+    ];
+    for (const body of bodies) {
+      const response = await connect.fetch(
+        new Request(`${connect.baseUrl}/v1/vaults/${connect.vault}/items`, {
+          method: 'POST',
+          headers: { Authorization: 'Bearer connect-token' },
+          body: JSON.stringify(body),
+        }),
+      );
+      expect(response.status).toBe(422);
+    }
+    expect(connect.itemCount).toBe(0);
   });
 });

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -347,9 +347,12 @@ export function storeAdapterSuite(
 export const ADAPTERS = {
   deploy: ['fake', 'kubernetes', 'cloudrun', 'static'],
   build: ['fake', 'github-actions', 'cloud-build', 'in-cluster'],
+  // The two fakes name the real store whose reference shape each one produces,
+  // because a suite comparing two shapes no store can hold would prove §10's
+  // "nothing above the seam can tell which strategy produced it" of nothing.
   store: [
-    'fake native',
-    'fake immutable item per version',
+    'fake native, standing for gcp-secret-manager',
+    'fake immutable item per version, standing for onepassword',
     'onepassword',
     'gcp-secret-manager',
   ],

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -224,12 +224,18 @@ buildAdapterSuite('in-cluster', () => {
 // Both pinning strategies run the same suite, because §10's claim is that
 // nothing above the seam can tell them apart. One of them passing would not
 // establish that.
+//
+// Each fake stands for the real store that pins that way and names its
+// references as that store does — `NATIVE` for Secret Manager's `--`-joined id,
+// `IMMUTABLE_ITEM_PER_VERSION` for 1Password's `/`-joined title. The labels say
+// so, because a reference shape neither store can hold would make this suite
+// compare two impossibilities and call them the same.
 storeAdapterSuite(
-  'fake native',
+  'fake native, standing for gcp-secret-manager',
   () => new FakeSecretStore({ pinning: 'NATIVE' }),
 );
 storeAdapterSuite(
-  'fake immutable item per version',
+  'fake immutable item per version, standing for onepassword',
   () => new FakeSecretStore({ pinning: 'IMMUTABLE_ITEM_PER_VERSION' }),
 );
 

--- a/apps/spindrift/test/harness/fakes/build-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/build-adapter.ts
@@ -6,6 +6,7 @@
  * handed — so a test can assert that the bundle digest reached the route, which
  * is §16's whole join — and replays a scripted result.
  */
+import { createHash } from 'node:crypto';
 import type {
   BuildAdapter,
   BuildEvent,

--- a/apps/spindrift/test/harness/fakes/cloud-build-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloud-build-api.ts
@@ -6,13 +6,21 @@
  * a fake adapter — the route's real submit body, its real status polling, and
  * its real page-cursored log reads all run against it.
  *
- * Two behaviours are modelled because the route has to survive them:
+ * Three behaviours are modelled because the route has to survive them:
  *
  * - **A build does not finish on the first read.** `duration` is how many status
  *   reads it takes, so a route that submitted and assumed would fail here.
- * - **The log arrives in pages, and the cursor is the only thing that knows
- *   what was already served.** A route that re-read page one would see its own
- *   output repeat, which is the bug the cursor exists to prevent.
+ * - **The log is ingested behind the writer.** A build writes as it runs and
+ *   finishes writing when it finishes; the log service only serves what had
+ *   been written by the previous status read. The report line lives in the last
+ *   region a build writes, so a route that stops reading the moment the status
+ *   turns terminal never sees it — which is the failure this models.
+ * - **A page token continues one search, not the log.** `entries.list` mints a
+ *   token against a *frozen* result set, exactly as the vendor documents it:
+ *   "retrieve the next batch of results from the preceding call to this
+ *   method". A route that saved one and presented it a poll later would be
+ *   paginating a snapshot of the past, so this fake freezes the snapshot rather
+ *   than treating the token as a watermark.
  */
 
 import type { Fetcher } from '../../../src/adapters/build/cloud-build.ts';
@@ -20,6 +28,9 @@ import { encodeBuildReport } from '../../../src/adapters/build/report.ts';
 
 export const BUILD_HOST = 'https://builds.invalid';
 export const LOGS_HOST = 'https://logs.invalid';
+
+/** When the first line of any build's log was ingested. */
+const INGEST_EPOCH = Date.parse('2026-07-28T00:00:00.000Z');
 
 export interface RecordedRequest {
   method: string;
@@ -35,6 +46,18 @@ export interface FakeCloudBuildOptions {
   status?: string;
   /** Lines the build writes, given the program it was submitted with. */
   log?: (program: string) => readonly string[];
+  /**
+   * Entries one page carries, whatever `pageSize` asked for. Small on purpose:
+   * the real service answers with fewer than requested routinely, and a route
+   * that read one page per poll would be permanently behind its own log.
+   */
+  pageSize?: number;
+  /**
+   * Answer the first page of every search empty *and with a token*, which the
+   * vendor documents as "the search found no log entries so far but it did not
+   * have time to search all the possible log entries" — not as a caught-up log.
+   */
+  cutShort?: boolean;
   /** When set, submitting is refused with this status. */
   refuseSubmit?: number;
   /** When set, every log read fails — the route must survive it. */
@@ -42,12 +65,27 @@ export interface FakeCloudBuildOptions {
   token?: string;
 }
 
+/** One ingested log entry, in the shape the log service serves it. */
+interface FakeEntry {
+  insertId: string;
+  textPayload: string;
+  timestamp: string;
+}
+
 interface FakeBuild {
   id: string;
   reads: number;
   lines: readonly string[];
-  /** How many lines have been served, which is what the cursor encodes. */
-  served: number;
+  /** Lines the build has written. Not yet what the log service will serve. */
+  written: number;
+  /** Lines the log service has ingested, which is what it will serve. */
+  ingested: FakeEntry[];
+}
+
+/** One `entries.list` search, frozen at the moment it was issued. */
+interface FakeSearch {
+  entries: readonly FakeEntry[];
+  from: number;
 }
 
 export class FakeCloudBuild {
@@ -58,7 +96,9 @@ export class FakeCloudBuild {
   readonly programs: string[] = [];
 
   private readonly builds = new Map<string, FakeBuild>();
+  private readonly searches = new Map<string, FakeSearch>();
   private counter = 0;
+  private searchCounter = 0;
   private readonly options: Required<
     Omit<FakeCloudBuildOptions, 'refuseSubmit' | 'token'>
   > &
@@ -69,6 +109,8 @@ export class FakeCloudBuild {
       duration: options.duration ?? 1,
       status: options.status ?? 'SUCCESS',
       log: options.log ?? defaultBuildLog,
+      pageSize: options.pageSize ?? 2,
+      cutShort: options.cutShort ?? false,
       breakLogs: options.breakLogs ?? false,
       ...(options.refuseSubmit === undefined
         ? {}
@@ -125,28 +167,47 @@ export class FakeCloudBuild {
       id,
       reads: 0,
       lines: this.options.log(program),
-      served: 0,
+      written: 0,
+      ingested: [],
     });
     return json(200, { metadata: { build: { id, status: 'QUEUED' } } });
   }
 
+  /**
+   * One status read, which is also when the build gets to write.
+   *
+   * The last region a build writes is the one that matters — `#8 exporting to
+   * image` and the report line — and it is written on the same tick the status
+   * turns terminal. That is not fake convenience; it is what a BuildKit run
+   * does, and it is why the read *after* the terminal status is the load-bearing
+   * one.
+   */
   private read(id: string): Response {
     const build = this.builds.get(id);
     if (build === undefined) return json(404, { error: 'no such build' });
     build.reads += 1;
+    const terminal = build.reads > this.options.duration;
+    build.written = terminal
+      ? build.lines.length
+      : Math.max(
+          build.written,
+          Math.floor(
+            (build.lines.length * build.reads) / (this.options.duration + 1),
+          ),
+        );
     return json(200, {
       id,
-      status:
-        build.reads > this.options.duration ? this.options.status : 'WORKING',
+      status: terminal ? this.options.status : 'WORKING',
     });
   }
 
   /**
    * One page of one build's log.
    *
-   * The cursor is "how many lines this build has already served", encoded as a
-   * string — which is enough to catch a route that ignores it and enough to be
-   * read by a test that wants to know how many pages there were.
+   * A request with no `pageToken` is a *new* search over whatever has been
+   * ingested by now; a request with one continues that earlier search's frozen
+   * result set. Nothing here lets a token act as a watermark, because nothing
+   * in the real API does.
    */
   private logs(body: unknown): Response {
     if (this.options.breakLogs) return json(503, { error: 'log service down' });
@@ -165,20 +226,59 @@ export class FakeCloudBuild {
     ) {
       return json(400, { error: 'resourceNames is required' });
     }
-    const id = /build_id="([^"]+)"/.exec(request.filter ?? '')?.[1] ?? '';
+
+    if (request.pageToken !== undefined) {
+      const search = this.searches.get(request.pageToken);
+      if (search === undefined) {
+        return json(400, { error: 'invalid pageToken' });
+      }
+      return this.page(search.entries, search.from);
+    }
+
+    const filter = request.filter ?? '';
+    const id = /build_id="([^"]+)"/.exec(filter)?.[1] ?? '';
     const build = this.builds.get(id);
     if (build === undefined) return json(200, { entries: [] });
 
-    const from = Number(request.pageToken ?? '0');
-    const entries = build.lines.slice(from).map((line) => ({
-      textPayload: line,
-      timestamp: '2026-07-28T00:00:00Z',
-    }));
-    build.served = build.lines.length;
-    return json(200, {
-      entries,
-      nextPageToken: String(build.lines.length),
-    });
+    this.ingest(build);
+    const since = /timestamp>="([^"]+)"/.exec(filter)?.[1];
+    const entries =
+      since === undefined
+        ? [...build.ingested]
+        : build.ingested.filter((entry) => entry.timestamp >= since);
+
+    // A cut-short search answers nothing and hands back a token anyway. The
+    // entries are still there; the route has to follow the token to see them.
+    return this.page(entries, 0, this.options.cutShort);
+  }
+
+  /** Ingestion catches up to what the build had written at its last status read. */
+  private ingest(build: FakeBuild): void {
+    while (build.ingested.length < build.written) {
+      const index = build.ingested.length;
+      build.ingested.push({
+        insertId: `${build.id}-${index}`,
+        textPayload: build.lines[index] ?? '',
+        timestamp: new Date(INGEST_EPOCH + index * 1_000).toISOString(),
+      });
+    }
+  }
+
+  private page(
+    entries: readonly FakeEntry[],
+    from: number,
+    cutShort = false,
+  ): Response {
+    const slice = cutShort
+      ? []
+      : entries.slice(from, from + this.options.pageSize);
+    const next = from + slice.length;
+    if (next >= entries.length) return json(200, { entries: slice });
+
+    this.searchCounter += 1;
+    const token = `search-${this.searchCounter}`;
+    this.searches.set(token, { entries, from: next });
+    return json(200, { entries: slice, nextPageToken: token });
   }
 }
 

--- a/apps/spindrift/test/harness/fakes/onepassword-connect.ts
+++ b/apps/spindrift/test/harness/fakes/onepassword-connect.ts
@@ -13,21 +13,63 @@
  * vault's overviews with the `filter` Connect supports, and delete. Anything
  * else answers `404`, so an adapter that started calling a fifth endpoint would
  * fail rather than silently pass against a permissive stand-in.
+ *
+ * **A created item comes back with more fields than were sent.** Connect
+ * populates the category's own defaults, and the caller's fields arrive after
+ * them — see {@link CATEGORY_DEFAULTS}. A fake that echoed only what it was
+ * given would put the caller's one concealed field at index 0 and let an
+ * adapter identify it by position, which is a rule the real service does not
+ * honour and production is the only place that would say so.
  */
 import type { Fetcher } from '../../../src/adapters/store/http.ts';
+
+interface StoredSection {
+  id: string;
+  label?: string;
+}
 
 interface StoredField {
   type: string;
   label?: string;
   value?: string;
+  section?: { id?: string };
 }
 
 interface StoredItem {
   id: string;
   title: string;
+  category: string;
   createdAt: string;
+  sections: StoredSection[];
+  /** What Connect returns: the category's defaults, then the caller's. */
   fields: StoredField[];
+  /** Only the caller's, held so a test can assert what was written. */
+  own: StoredField[];
 }
+
+/**
+ * The fields Connect adds to a created item on its own, per category.
+ *
+ * Auto-populated from the category template, not from the request — so they
+ * arrive labelled, in front of the caller's fields, and one of them is
+ * `CONCEALED`. That is what makes "the first labelled field" and "the first
+ * concealed field" both wrong ways to find the field Spindrift wrote.
+ *
+ * A second category is modelled so the defaults are visibly per-category rather
+ * than a constant this fake sprinkles on everything.
+ */
+const CATEGORY_DEFAULTS: Record<string, readonly StoredField[]> = {
+  API_CREDENTIAL: [
+    { type: 'STRING', label: 'username' },
+    { type: 'CONCEALED', label: 'credential' },
+    { type: 'STRING', label: 'notesPlain' },
+  ],
+  LOGIN: [
+    { type: 'STRING', label: 'username' },
+    { type: 'CONCEALED', label: 'password' },
+    { type: 'STRING', label: 'notesPlain' },
+  ],
+};
 
 /** Every request the adapter made, for a test to assert against. */
 export interface RecordedRequest {
@@ -69,9 +111,14 @@ export class FakeOnePasswordConnect {
     return this.items.size;
   }
 
-  /** What was written under one item id. Never reachable through the contract. */
+  /**
+   * What was written under one item id. Never reachable through the contract.
+   *
+   * Reads the caller's own fields, not the rendered item — a category default
+   * has no value to report and index 0 is one of them.
+   */
   valueOf(itemId: string): string | null {
-    return this.items.get(itemId)?.fields[0]?.value ?? null;
+    return this.items.get(itemId)?.own[0]?.value ?? null;
   }
 
   /** The transport to hand the adapter. */
@@ -116,27 +163,61 @@ export class FakeOnePasswordConnect {
     return json({ message: 'method not allowed' }, 405);
   };
 
+  /**
+   * Create an item, refusing the three things Connect refuses.
+   *
+   * `title` alone is not a create: an item belongs to a vault and is built from
+   * a category template, and Connect has a default for neither. An adapter that
+   * dropped `vault` or `category` would fail on the first real call and pass
+   * against a fake that only looked at the title.
+   */
   private create(body: unknown): Response {
-    const requested = body as { title?: string; fields?: StoredField[] };
+    const requested = body as {
+      title?: string;
+      category?: string;
+      vault?: { id?: string };
+      sections?: StoredSection[];
+      fields?: StoredField[];
+    };
     if (typeof requested?.title !== 'string') {
       return json({ message: 'title is required' }, 422);
     }
+    if (typeof requested.vault?.id !== 'string') {
+      return json({ message: 'vault.id is required' }, 422);
+    }
+    if (requested.vault.id !== this.vault) {
+      return json({ message: 'item vault does not match the path' }, 422);
+    }
+    if (typeof requested.category !== 'string') {
+      return json({ message: 'category is required' }, 422);
+    }
+    const defaults = CATEGORY_DEFAULTS[requested.category];
+    if (defaults === undefined) {
+      return json({ message: `unknown category ${requested.category}` }, 422);
+    }
+
     this.counter += 1;
+    const own = requested.fields ?? [];
     const item: StoredItem = {
       // Connect mints the id, which is why the adapter never has to invent a
       // version number and never has to count what already exists.
       id: `item-${this.counter}`,
       title: requested.title,
+      category: requested.category,
       createdAt: new Date(Date.UTC(2024, 0, this.counter)).toISOString(),
-      fields: requested.fields ?? [],
+      sections: requested.sections ?? [],
+      fields: [...defaults.map((field) => ({ ...field })), ...own],
+      own,
     };
     this.items.set(item.id, item);
-    return json(item, 200);
+    return json(render(item), 200);
   }
 
   private get(itemId: string): Response {
     const item = this.items.get(itemId);
-    return item ? json(item, 200) : json({ message: 'no such item' }, 404);
+    return item
+      ? json(render(item), 200)
+      : json({ message: 'no such item' }, 404);
   }
 
   /**
@@ -159,6 +240,12 @@ export class FakeOnePasswordConnect {
     }
     return new Response(null, { status: 204 });
   }
+}
+
+/** The item as Connect answers with it — `own` is this fake's bookkeeping. */
+function render(item: StoredItem) {
+  const { own: _own, ...rest } = item;
+  return rest;
 }
 
 function json(body: unknown, status: number): Response {

--- a/apps/spindrift/test/harness/fakes/secret-manager-api.ts
+++ b/apps/spindrift/test/harness/fakes/secret-manager-api.ts
@@ -17,6 +17,16 @@
  *   permissive fake without doing so.
  * - **Listing is paginated**, at a deliberately tiny page, because core reaps
  *   config from that list and a single-page fake would never run the loop.
+ *
+ * And `secrets.create` is held to its own two rules, because a fake that takes
+ * any id and any body would let the adapter drift into producing creates the
+ * real API refuses — which is a production-only bug by construction:
+ *
+ * - **The id must match `[A-Za-z0-9_-]{1,255}`.** The alphabet the adapter has
+ *   always sanitized to; the ceiling it did not enforce until it had to.
+ * - **The body must carry a replication policy.** The `Secret` resource has no
+ *   default for it, so a create without one is refused, and every write this
+ *   installation makes would fail on it.
  */
 import type { Fetcher } from '../../../src/adapters/store/http.ts';
 
@@ -51,6 +61,9 @@ export interface FakeSecretManagerOptions {
 }
 
 const BASE = 'https://secretmanager.invalid';
+
+/** The id `projects.secrets.create` accepts, alphabet and ceiling both. */
+const SECRET_ID = /^[A-Za-z0-9_-]{1,255}$/;
 
 export class FakeSecretManager {
   readonly project: string;
@@ -174,10 +187,46 @@ export class FakeSecretManager {
 
   private createSecret(id: string | null, body: unknown): Response {
     if (!id) return json({ error: { message: 'secretId is required' } }, 400);
+    // Both refusals come before the conflict check, as the real API's argument
+    // validation does: a malformed create is invalid whether or not the id it
+    // names is taken.
+    if (!SECRET_ID.test(id)) {
+      return json(
+        {
+          error: {
+            status: 'INVALID_ARGUMENT',
+            message:
+              `Secret ID [${id}] does not match the expected format ` +
+              '[[a-zA-Z_0-9-]+] or is longer than 255 characters',
+          },
+        },
+        400,
+      );
+    }
+    const requested = body as {
+      replication?: { automatic?: unknown; userManaged?: unknown };
+      annotations?: Record<string, string>;
+    };
+    // `Replication` is a oneof with no default, so neither an absent block nor
+    // an empty one names a policy.
+    const replication = requested?.replication;
+    if (
+      replication?.automatic === undefined &&
+      replication?.userManaged === undefined
+    ) {
+      return json(
+        {
+          error: {
+            status: 'INVALID_ARGUMENT',
+            message: 'Secret.replication must be specified.',
+          },
+        },
+        400,
+      );
+    }
     if (this.secrets.has(id)) {
       return json({ error: { message: 'already exists' } }, 409);
     }
-    const requested = body as { annotations?: Record<string, string> };
     const secret: StoredSecret = {
       id,
       annotations: requested?.annotations ?? {},

--- a/apps/spindrift/test/harness/fakes/store-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/store-adapter.ts
@@ -7,6 +7,22 @@
  * above the seam can tell which produced it — a claim the conformance suite can
  * only falsify if both are runnable.
  *
+ * **Each strategy stands in for the real store that uses it**, and names its
+ * references the way that store does:
+ *
+ * - `NATIVE` stands for `gcp-secret-manager`, so a key is {@link secretIdFor}'s
+ *   `--`-joined id in Secret Manager's alphabet, and a version is the number the
+ *   far side counted.
+ * - `IMMUTABLE_ITEM_PER_VERSION` stands for `onepassword`, so a key is
+ *   {@link itemTitleFor}'s `/`-joined title — the same for every version, since
+ *   the item id is what moves — and a version is an opaque id Connect minted.
+ *
+ * The naming functions are imported rather than reimplemented on purpose. A
+ * shape invented here would be a third one that neither real store emits, and a
+ * reference no store can hold makes every assertion above the seam — a rendered
+ * Cloud Run `secretKeyRef`, a `configVersion` hash — agree about something
+ * impossible.
+ *
  * Values written are held so `put`/`describe` round-trips can be asserted, but
  * they are never returned across the contract: §10's read-back is metadata, and
  * the value crosses in one direction only.
@@ -18,6 +34,8 @@ import type {
   SecretStore,
   SecretVersion,
 } from '../../../src/adapters/store/contract.ts';
+import { secretIdFor } from '../../../src/adapters/store/gcp-secret-manager.ts';
+import { itemTitleFor } from '../../../src/adapters/store/onepassword.ts';
 import type { StoreAdapter } from '../../../src/config/manifest.schema.ts';
 
 interface StoredVersion {
@@ -31,10 +49,14 @@ export interface FakeSecretStoreOptions {
   pinning?: PinningStrategy;
 }
 
-/** The store's own name for a scoped key — the adapter's business, per §10. */
-function itemName(scope: ConfigScope, key: string): string {
-  return `${scope.app}/${scope.component}/${scope.target}/${key}`;
-}
+/** Which real store each strategy stands for, and how that store names. */
+const STANDS_FOR: Record<
+  PinningStrategy,
+  { adapter: StoreAdapter; name: (scope: ConfigScope, key: string) => string }
+> = {
+  NATIVE: { adapter: 'gcp-secret-manager', name: secretIdFor },
+  IMMUTABLE_ITEM_PER_VERSION: { adapter: 'onepassword', name: itemTitleFor },
+};
 
 export class FakeSecretStore implements SecretStore {
   readonly adapter: StoreAdapter;
@@ -47,11 +69,15 @@ export class FakeSecretStore implements SecretStore {
 
   /** Keyed by the reference's own identity, so a lookup is what a read is. */
   private readonly stored = new Map<string, StoredVersion>();
+  private readonly name: (scope: ConfigScope, key: string) => string;
   private counter = 0;
 
   constructor(options: FakeSecretStoreOptions = {}) {
-    this.adapter = options.adapter ?? 'gcp-secret-manager';
     this.pinning = options.pinning ?? 'NATIVE';
+    // The adapter follows the strategy unless a test says otherwise, so a store
+    // constructed with only a pinning is never internally contradictory.
+    this.adapter = options.adapter ?? STANDS_FOR[this.pinning].adapter;
+    this.name = STANDS_FOR[this.pinning].name;
   }
 
   async put(
@@ -61,16 +87,16 @@ export class FakeSecretStore implements SecretStore {
   ): Promise<SecretReference> {
     this.puts.push({ scope, key });
     this.counter += 1;
-    const sequence = String(this.counter);
-    const item = itemName(scope, key);
+    const item = this.name(scope, key);
 
     // The two strategies differ in where the version lives, and in nothing
-    // else a caller can observe: NATIVE addresses a version of one item, and
-    // IMMUTABLE_ITEM_PER_VERSION mints a fresh item and reports it as one.
+    // else a caller can observe: NATIVE addresses a numbered version of one
+    // item, and IMMUTABLE_ITEM_PER_VERSION mints a fresh item under the same
+    // name and reports the id it was given as the version.
     const reference: SecretReference =
       this.pinning === 'NATIVE'
-        ? { key: item, version: sequence }
-        : { key: `${item}@${sequence}`, version: sequence };
+        ? { key: item, version: String(this.counter) }
+        : { key: item, version: `item-${this.counter}` };
 
     this.stored.set(referenceId(reference), {
       value,
@@ -84,13 +110,13 @@ export class FakeSecretStore implements SecretStore {
   }
 
   async versions(scope: ConfigScope, key: string): Promise<SecretVersion[]> {
-    const item = itemName(scope, key);
+    const item = this.name(scope, key);
+    // Ordered by when it was written rather than by parsing the version, which
+    // is a number under one strategy and an opaque minted id under the other.
     return [...this.stored.values()]
-      .filter(({ version }) => version.reference.key.split('@')[0] === item)
+      .filter(({ version }) => version.reference.key === item)
       .map(({ version }) => version)
-      .sort(
-        (a, b) => Number(b.reference.version) - Number(a.reference.version),
-      );
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   }
 
   async destroy(reference: SecretReference): Promise<void> {


### PR DESCRIPTION
Tickets 19 and 20 from the Group C fake-fidelity audit — the same class as #13, where a single wrong `Accept` header blocked every build and 926 passing tests missed it because the fake never modelled the header.

Both adapters are correct today. Neither was **held** correct: the fakes accepted requests the real APIs refuse, so the next edit to either one would have been a production-only bug.

## Ticket 19 — Secret Manager naming and creation

**The id ceiling.** `secretId()` now enforces the `[A-Za-z0-9_-]{1,255}` its own doc comment already cited. Three DNS labels at 63 each plus a variable name with no ceiling clears 255 without anything unreasonable happening, and the API refuses the create rather than the character that pushed it over.

Truncation on its own would widen the collision `assertScopeMatches` exists to catch, so an id over the ceiling gives up its last 18 characters to `--` plus a 16-hex digest of the **exact, unsanitized** scope. Two long scopes now need a shared head *and* a 64-bit digest collision, where sanitizing alone needed only a flatten — strictly fewer collisions than before, not more. `assertScopeMatches` stays: a short digest is a legibility aid, not a proof.

**The fake.** `secrets.create` refuses an id outside the alphabet or ceiling (`400` / `INVALID_ARGUMENT`, before the already-exists check, as argument validation goes first), and refuses a body with no replication policy — including an empty `replication: {}`, since `Replication` is a oneof with no default.

**The reference shape.** `FakeSecretStore` was emitting keys containing `/`, which Secret Manager's alphabet excludes and which `cloudrun/service.ts:127` would have rendered into a malformed resource name. Each strategy now stands for the real store that pins that way and *imports* that store's naming function rather than reimplementing it — `secretIdFor` for `NATIVE`, `itemTitleFor` for `IMMUTABLE_ITEM_PER_VERSION`. The conformance labels say which is which.

## Ticket 20 — reading a Connect item back

`keyOf()` took the **first labelled field**. Connect populates an `API_CREDENTIAL` with `username`, `credential` and `notesPlain` that the caller never sent; `credential` is concealed *and* labelled, so neither position nor type distinguishes Spindrift's field from the category's. A section does — a category default belongs to none. `put` now writes into a Spindrift-owned section and `keyOf` reads the labelled `CONCEALED` field from it.

No migration path, deliberately: this store has not been exercised by a completed Deploy, so there is nothing in the field written under the old rule.

The fake returns the category defaults ahead of the caller's fields, in Connect's order, and refuses a create with no `vault.id`, a `vault.id` naming another vault, or a missing or unknown `category` — all `422`, as Connect's reference documents.

## The evidence

The passing suite is not the evidence; reverting is. Each source fix reverted on its own:

| Reverted | Tests that fail |
| --- | --- |
| the `secretId()` length branch | 2 |
| `replication: { automatic: {} }` | 13 — every Secret Manager test and the whole `store contract: gcp-secret-manager` block |
| `keyOf()` → first labelled field | 3, including `store contract: onepassword > round-trips a pinned version reference` — it reads back `username`, the silently-wrong-data failure the ticket predicted |
| `vault` and `category` off the create body | 11 |

```
947 pass, 0 fail — Ran 947 tests across 65 files   (13 added)
bun run typecheck && bun run lint — clean
```

**Not proven against either live API.** Everything here is against the fakes and the vendors' documented refusals. No Secret Manager secret has been written by this installation, and the category defaults are modelled from the 1Password reference rather than observed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)