### PR TITLE
fix(spindrift): stage source bundles where a builder can fetch them

### DIFF
--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -366,6 +366,19 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     }
 
     if (conclusion !== 'success') {
+      const scaffolding = failedScaffoldingStep(jobs);
+      if (scaffolding !== null) {
+        return buildFailed(
+          logs,
+          // §6 blames the **platform** for an object that could not be
+          // fetched, which is what this is: the workflow never reached the
+          // developer's code because the platform's own preamble did not
+          // finish.
+          'ARTIFACT_UNAVAILABLE',
+          `run ${run.id} in ${repository} failed in “${scaffolding}”, a step of Spindrift's own build workflow rather than of the App's build`,
+          { runId: run.id, conclusion, step: scaffolding },
+        );
+      }
       return buildFailed(
         logs,
         'BUILD_FAILED',
@@ -395,6 +408,48 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       report,
     });
   }
+}
+
+/**
+ * The one step of the reusable workflow the developer owns.
+ *
+ * Everything else in that file is Spindrift's: reading the request, fetching
+ * the staged bundle, choosing a frontend, logging in to the registry, printing
+ * the report. The App's own code is compiled in exactly one step, and naming it
+ * is what lets this route tell "your build failed" apart from "our scaffolding
+ * failed" — a distinction §6 spends its whole blame column on.
+ *
+ * Coupled to the workflow by name, which is sound only because the manifest
+ * pins that workflow by SHA (`github.buildWorkflow`): the file this route
+ * dispatches cannot change under it without the pin rolling too.
+ */
+export const DEVELOPER_BUILD_STEP = 'Build and push';
+
+/**
+ * The Spindrift-owned step a red run failed in, or `null` when the App's own
+ * build is what failed.
+ *
+ * This is the fix for a build that reported `blame = developer` for a failure
+ * that was entirely the platform's: the workflow was handed a bundle location
+ * it could not resolve, died in the fetch step, and the developer was sent to
+ * read a Dockerfile that was never compiled. A run that never reached
+ * {@link DEVELOPER_BUILD_STEP} cannot have failed because of anything the
+ * developer wrote.
+ *
+ * A run whose jobs report no steps at all answers `null` — the conservative
+ * direction, because claiming platform blame without evidence would mask real
+ * build failures behind a chip that says "not your fault".
+ */
+function failedScaffoldingStep(jobs: readonly ActionsJob[]): string | null {
+  let scaffolding: string | null = null;
+  for (const job of jobs) {
+    for (const step of job.steps ?? []) {
+      if (stepState(step.status, step.conclusion) !== 'FAILED') continue;
+      if (step.name === DEVELOPER_BUILD_STEP) return null;
+      scaffolding ??= step.name;
+    }
+  }
+  return scaffolding;
 }
 
 /**

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -43,7 +43,7 @@ import { GitHubApp } from '../integrations/github/app.ts';
 import { CredentialKeyring } from '../integrations/github/credential-crypto.ts';
 import type { Fetcher } from '../integrations/github/http.ts';
 import { GitHubDeviceOAuth } from '../integrations/github/oauth.ts';
-import { stageArchiveBytes } from '../storage/archives.ts';
+import { sourceDepotFor, stageArchiveBytes } from '../storage/archives.ts';
 import { CoreSupplyChain, CosignSigner } from '../supply-chain/sign.ts';
 import { SpindriftSignatureVerifier } from '../supply-chain/signature.ts';
 import { SlsaVerifier } from '../supply-chain/verify.ts';
@@ -285,6 +285,11 @@ export function createAdapterRegistry(
     source() {
       if (options.source !== undefined) return options.source;
       if (app === null) return null;
+      // §15 stages one immutable bundle "for either builder", so a repository
+      // commit lands in the same durable depot an upload does. It is the same
+      // fix and the same reason: a bundle on this pod's disk is unfetchable by
+      // a hosted runner whatever kind of source produced it.
+      const depot = sourceDepotFor(options.manifest);
       const defaultSourceStager: RepositorySourceStager = {
         async stageRepository(input) {
           const staged = await stageSourceBundle(
@@ -299,8 +304,12 @@ export function createAdapterRegistry(
               depot: {
                 async putImmutable(item) {
                   const archived = await stageArchiveBytes(
-                    `bundle-${item.digest.replace('sha256:', '')}.zip`,
+                    // A gzipped tar, because that is what the repository host's
+                    // tarball endpoint answers with and what the reusable
+                    // workflow's `tar -xz` expects.
+                    `bundle-${item.digest.replace('sha256:', '')}.tgz`,
                     item.bytes,
+                    depot,
                   );
                   return { location: archived.location };
                 },
@@ -325,6 +334,7 @@ export function createAdapterRegistry(
                   const archived = await stageArchiveBytes(
                     `receipt-${receipt.statement.subject.digest.replace('sha256:', '')}.json`,
                     bytes,
+                    depot,
                   );
                   return { location: archived.location };
                 },

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -45,6 +45,7 @@ import {
 } from '../../domain/build-route.ts';
 import { DEFAULT_PLATFORM } from '../../domain/placement.ts';
 import { buildOriginOf, type Source } from '../../domain/source.ts';
+import { parseGcsLocation, signedObjectUrl } from '../../storage/signed-url.ts';
 import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
 import {
   type CommandContext,
@@ -174,6 +175,52 @@ function routeRefusedByTarget(
     : `${policy.name} will not take a build from ${adapter.name}: ${candidate.reason}`;
 }
 
+/**
+ * The stored bundle address, turned into one a builder can actually fetch.
+ *
+ * A depot address is `gs://bucket/object`: durable, shared between replicas,
+ * and unresolvable by anything without a Google credential — which every
+ * builder §15 stages for is, because the hosted route's runner is a machine on
+ * the public internet. So it is exchanged here for a short-TTL V4 signed URL.
+ *
+ * **A failure to mint one is a refusal, not a warning.** Dispatching anyway is
+ * what produced this function: a route handed an address it could not resolve
+ * ran a workflow that failed at its first step, and the developer was sent to
+ * debug a Dockerfile over a location Spindrift itself had made unusable. A
+ * refusal costs one dispatch and says the true thing.
+ *
+ * Any other scheme passes through untouched. An `https://` location is already
+ * fetchable, and an `upload://` handle names this process's own disk — the
+ * no-depot fallback — which is honest about being unfetchable and is left to
+ * fail where it fails rather than being dressed up here.
+ */
+async function fetchableBundleLocation(
+  context: Pick<BuildDispatchContext, 'manifest'>,
+  location: string,
+): Promise<CommandResult<string>> {
+  if (parseGcsLocation(location) === null) return ok(location);
+
+  const federation = context.manifest?.cloud?.federation ?? null;
+  if (federation === null) {
+    return failed(
+      'NOT_BUILDABLE',
+      `the staged bundle is in cloud storage and this installation configures no federation to reach it, so no route could fetch ${location}`,
+    );
+  }
+
+  try {
+    return ok(await signedObjectUrl({ location, federation }));
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    // The object path, never the URL: a signed URL is a bearer capability and
+    // this sentence lands on the operator-visible attempt log.
+    return failed(
+      'NOT_BUILDABLE',
+      `could not mint a signed URL for the staged bundle at ${location}, so no route could fetch it: ${detail}`,
+    );
+  }
+}
+
 export const dispatchBuild = async (
   input: DispatchBuildInput,
   context: BuildDispatchContext,
@@ -295,6 +342,17 @@ export const dispatchBuild = async (
     );
   }
 
+  // The durable address becomes a fetchable one here and nowhere earlier. A
+  // signed URL is a bearer capability with a TTL in minutes, so minting it at
+  // dispatch is what keeps it out of the Build row, out of the attempt log, and
+  // out of any window between staging and running. What is persisted is the
+  // `gs://` object; what a route is handed is a URL that resolves.
+  const fetchable = await fetchableBundleLocation(
+    context,
+    build.bundleLocation,
+  );
+  if (!fetchable.ok) return fetchable;
+
   const source: Source =
     app.sourceKind === 'repo'
       ? {
@@ -303,12 +361,12 @@ export const dispatchBuild = async (
           commit: build.commit,
           // §5: an App is repo plus subpath, and the developer named it there.
           subpath: app.sourceRepoSubpath ?? '.',
-          location: build.bundleLocation,
+          location: fetchable.value,
         }
       : {
           kind: 'archive',
           digest: build.bundleDigest,
-          location: build.bundleLocation,
+          location: fetchable.value,
           contents: 'source',
           // Per Build: the unwrap is a fact about the bytes that were uploaded.
           subpath: build.bundleSubpath ?? '.',

--- a/apps/spindrift/src/storage/archives.ts
+++ b/apps/spindrift/src/storage/archives.ts
@@ -4,20 +4,70 @@
  * §4: "Archive upload accepts real bytes, stages them durably, and follows the
  * supplied-artifact or source-build path selected during creation."
  *
- * Compute SHA-256 digest over exact uploaded bytes (§16) and stage to disk
- * under the storage directory so builders and reconcilers can fetch them.
+ * Compute SHA-256 digest over exact uploaded bytes (§16) and stage the bundle
+ * to the installation's **source depot** — the GCS bucket the manifest names —
+ * so that both builders §15 stages for can fetch it.
+ *
+ * **The pod's own disk is not a depot.** It used to be one, and it could not
+ * work: a bundle written to `tmpdir()` is not shared with the reconciler, not
+ * shared with a second replica, and gone on the next restart, so no builder
+ * anywhere could fetch it under any scheme. The local directory survives here
+ * only as the fallback for an installation with no depot configured — a
+ * developer running the process on a laptop — and it announces itself as such
+ * by keeping the `upload://` handle, which is deliberately not a URL. A
+ * location that cannot be fetched should not be spelled like one that can.
  */
 import { createHash } from 'node:crypto';
 import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { FederationOptions } from '../adapters/deploy/cloud/federation.ts';
+import type { InstallationManifest } from '../config/manifest.ts';
+import { uploadToGcsBucket } from './cloud.ts';
 
 export interface StagedArchive {
   readonly digest: string;
   readonly location: string;
-  readonly filepath: string;
+  /** Where the bytes landed on local disk, or `null` when they went to a depot. */
+  readonly filepath: string | null;
   readonly filename: string;
   readonly size: number;
+}
+
+/**
+ * The durable destination bundles are staged to.
+ *
+ * A bucket plus the federation that reaches it, because §13 allows no third
+ * thing: there is no credential to carry alongside them.
+ */
+export interface SourceDepot {
+  readonly bucket: string;
+  readonly federation: FederationOptions;
+}
+
+/** Bucket override for an operator running the process outside its chart. */
+export const ARTIFACTS_BUCKET_VAR = 'SPINDRIFT_ARTIFACTS_BUCKET';
+
+/**
+ * The depot this installation stages to, or `null` when it has none.
+ *
+ * `null` rather than a throw, the same way every adapter lookup answers: an
+ * installation with no bucket or no federation is a configuration fact callers
+ * report — as a refusal, or by falling back to local disk — rather than an
+ * exception thrown from inside staging.
+ */
+export function sourceDepotFor(
+  manifest: Pick<InstallationManifest, 'sources' | 'cloud'> | null | undefined,
+  bucketOverride?: string | null,
+): SourceDepot | null {
+  const bucket =
+    bucketOverride?.trim() ||
+    process.env[ARTIFACTS_BUCKET_VAR]?.trim() ||
+    manifest?.sources?.defaultBucket?.trim() ||
+    manifest?.sources?.buckets?.[0]?.trim();
+  const federation = manifest?.cloud?.federation ?? null;
+  if (!bucket || federation === null) return null;
+  return { bucket, federation };
 }
 
 export function storageDir(): string {
@@ -32,31 +82,73 @@ export function digestOfBytes(bytes: Uint8Array): string {
   return `sha256:${hash}`;
 }
 
-/** Stage archive bytes durably and return the digest and location. */
+/**
+ * The object one bundle occupies, in the depot or on disk.
+ *
+ * Content-addressed, which is what makes the depot immutable in the sense §15
+ * requires: the same bytes always name the same object, so staging them twice
+ * writes the same object rather than replacing anything.
+ */
+export function depotObjectName(filename: string, digest: string): string {
+  const hex = digest.replace('sha256:', '');
+  const ext = filename.includes('.') ? filename.split('.').pop() : 'zip';
+  return `${hex}.${ext}`;
+}
+
+/**
+ * Stage archive bytes durably and return the digest and location.
+ *
+ * With a depot, the location is the `gs://` object address — durable, shared
+ * between replicas, and the thing a signed URL is minted from at dispatch.
+ * Without one, the bytes go to local disk under an `upload://` handle that no
+ * builder can fetch, which is the honest answer for an installation that
+ * configured no depot.
+ */
 export async function stageArchiveBytes(
   filename: string,
   bytes: Uint8Array,
+  depot?: SourceDepot | null,
 ): Promise<StagedArchive> {
+  const digest = digestOfBytes(bytes);
+  const objectName = depotObjectName(filename, digest);
+
+  if (depot !== undefined && depot !== null) {
+    const stored = await uploadToGcsBucket({
+      bucketName: depot.bucket,
+      objectName,
+      bytes,
+      federation: depot.federation,
+    });
+    return {
+      digest,
+      location: stored.location,
+      filepath: null,
+      filename,
+      size: stored.size,
+    };
+  }
+
   const dir = storageDir();
   await mkdir(dir, { recursive: true });
-
-  const digest = digestOfBytes(bytes);
-  const hex = digest.replace('sha256:', '');
-  const ext = filename.includes('.') ? filename.split('.').pop() : 'zip';
-  const filepath = join(dir, `${hex}.${ext}`);
-
+  const filepath = join(dir, objectName);
   await writeFile(filepath, bytes);
 
   return {
     digest,
-    location: `upload://${hex}`,
+    location: `upload://${digest.replace('sha256:', '')}`,
     filepath,
     filename,
     size: bytes.byteLength,
   };
 }
 
-/** Read a staged archive by its sha256 digest or hex handle. */
+/**
+ * Read a locally staged archive by its sha256 digest or hex handle.
+ *
+ * Local only, and only meaningful for the no-depot fallback above: a depot
+ * bundle is addressed by its `gs://` location and fetched by whoever holds a
+ * signed URL for it, never read back through this process.
+ */
 export async function readStagedArchive(
   digestOrHex: string,
 ): Promise<Uint8Array | null> {

--- a/apps/spindrift/src/storage/cloud.ts
+++ b/apps/spindrift/src/storage/cloud.ts
@@ -5,14 +5,14 @@
  * Tests bucket access permissions via WIF without static service account keys.
  */
 import {
-  type FederationConfig,
   FederationError,
+  type FederationOptions,
   workloadIdentityToken,
 } from '../adapters/deploy/cloud/federation.ts';
 
 export interface TestBucketPermissionsInput {
   readonly bucketName: string;
-  readonly federation: FederationConfig;
+  readonly federation: FederationOptions;
 }
 
 export interface TestBucketPermissionsResult {
@@ -30,7 +30,7 @@ export async function testGcsBucketPermissions({
   const getToken = workloadIdentityToken(federation);
   const token = await getToken();
 
-  const send = (federation as any).fetch ?? fetch;
+  const send = federation.fetch ?? ((request: Request) => fetch(request));
   const url = `https://storage.googleapis.com/storage/v1/b/${encodeURIComponent(bucketName)}`;
   const response = await send(
     new Request(url, {
@@ -61,7 +61,7 @@ export interface UploadToGcsInput {
   readonly bucketName: string;
   readonly objectName: string;
   readonly bytes: Uint8Array;
-  readonly federation: FederationConfig;
+  readonly federation: FederationOptions;
 }
 
 /** Upload an archive bundle directly to a GCS bucket using WIF token authentication. */
@@ -74,7 +74,7 @@ export async function uploadToGcsBucket({
   const getToken = workloadIdentityToken(federation);
   const token = await getToken();
 
-  const send = (federation as any).fetch ?? fetch;
+  const send = federation.fetch ?? ((request: Request) => fetch(request));
   const url = `https://storage.googleapis.com/upload/storage/v1/b/${encodeURIComponent(bucketName)}/o?uploadType=media&name=${encodeURIComponent(objectName)}`;
   const response = await send(
     new Request(url, {

--- a/apps/spindrift/src/storage/signed-url.ts
+++ b/apps/spindrift/src/storage/signed-url.ts
@@ -1,0 +1,277 @@
+/**
+ * Handing a hosted runner a URL it can fetch, without giving it a credential.
+ *
+ * §15 stages one immutable bundle "for either builder", and the hosted route's
+ * builder is a GitHub-hosted runner: a machine on the public internet with no
+ * standing relationship to this installation's cloud project. It cannot read
+ * `gs://` and it holds nothing that would let it authenticate to GCS. So the
+ * durable object address has to be turned into something `curl` resolves, and
+ * the reusable workflow — SHA-pinned by the manifest, therefore not ours to
+ * change — already does exactly one thing with what it is handed:
+ * `curl --fail --location "$LOCATION"`.
+ *
+ * A **V4 signed URL** is what fits that sentence. It is a bearer capability and
+ * that is the accepted tradeoff, bounded two ways: the TTL is minutes, and the
+ * URL is minted at dispatch rather than stored, so nothing durable holds one.
+ *
+ * **There is no private key here, and that is the whole point of §13.** V4
+ * signing normally means a service-account key file; instead the string-to-sign
+ * goes to IAM's `signBlob`, authorized by the *federated* token — the one from
+ * before impersonation. That is deliberate: the workload-identity principal
+ * already holds `roles/iam.serviceAccountTokenCreator` on the impersonated
+ * service account, or `impersonationUrl` could not work at all, and that role
+ * is precisely what `signBlob` checks. Signing as the impersonated token would
+ * instead require the service account to hold that role on *itself*, which is a
+ * separate grant nothing else in this installation needs.
+ */
+import {
+  FederationError,
+  type FederationOptions,
+  workloadIdentityToken,
+} from '../adapters/deploy/cloud/federation.ts';
+
+/** Where a signed URL points. GCS serves signed requests on this host. */
+const STORAGE_HOST = 'storage.googleapis.com';
+
+/** The only V4 algorithm GCS accepts, and the one `signBlob` produces. */
+const ALGORITHM = 'GOOG4-RSA-SHA256';
+
+/** V4's request scope. GCS takes `auto` for the region on a signed GET. */
+const SCOPE_SUFFIX = 'auto/storage/goog4_request';
+
+/**
+ * How long a minted URL stays good.
+ *
+ * Fifteen minutes is ample for a runner to pull a source bundle and short
+ * enough that a URL leaked through a workflow run's outputs is a capability
+ * that has already expired by the time anyone reads it. The ticket that settled
+ * the signed-URL design named this number; it is not a tuning knob.
+ */
+export const SIGNED_URL_TTL_SECONDS = 900;
+
+/** A `gs://bucket/object` address, split into the two parts signing needs. */
+export interface GcsObject {
+  readonly bucket: string;
+  readonly object: string;
+}
+
+/**
+ * Parse a `gs://` address, or `null` for anything else.
+ *
+ * `null` rather than a throw because the caller's question is "is this an
+ * object I should sign?", and every other location scheme — a local
+ * `upload://` handle, an already-fetchable `https://` URL — is a legitimate
+ * answer of "no" rather than an error.
+ */
+export function parseGcsLocation(location: string): GcsObject | null {
+  if (!location.startsWith('gs://')) return null;
+  const rest = location.slice('gs://'.length);
+  const slash = rest.indexOf('/');
+  if (slash <= 0) return null;
+  const bucket = rest.slice(0, slash);
+  const object = rest.slice(slash + 1);
+  if (object === '') return null;
+  return { bucket, object };
+}
+
+export interface SignedUrlInput {
+  /** The object to sign a GET for, as `gs://bucket/object`. */
+  readonly location: string;
+  readonly federation: FederationOptions;
+  readonly ttlSeconds?: number;
+  /** Injected so a test can sign at a fixed instant. */
+  readonly now?: () => Date;
+}
+
+/**
+ * Mint a short-TTL V4 signed URL for one GCS object.
+ *
+ * Throws {@link FederationError} — the same type every other federated call
+ * raises — so a caller that already handles "this installation could not reach
+ * its cloud" handles this too.
+ */
+export async function signedObjectUrl({
+  location,
+  federation,
+  ttlSeconds = SIGNED_URL_TTL_SECONDS,
+  now = () => new Date(),
+}: SignedUrlInput): Promise<string> {
+  const target = parseGcsLocation(location);
+  if (target === null) {
+    throw new FederationError(
+      `${location} is not a gs:// object address, so no signed URL can be minted for it`,
+    );
+  }
+
+  const signer = signingServiceAccount(federation);
+  const at = now();
+  const timestamp = basicIso(at);
+  const datestamp = timestamp.slice(0, 8);
+  const scope = `${datestamp}/${SCOPE_SUFFIX}`;
+
+  // Signed headers are `host` alone. Adding any other header would oblige the
+  // runner to send it, and the runner is a `curl` invocation we do not control.
+  const query = canonicalQuery({
+    'X-Goog-Algorithm': ALGORITHM,
+    'X-Goog-Credential': `${signer}/${scope}`,
+    'X-Goog-Date': timestamp,
+    'X-Goog-Expires': String(ttlSeconds),
+    'X-Goog-SignedHeaders': 'host',
+  });
+
+  const path = `/${encodePath(target.bucket)}/${encodePath(target.object)}`;
+  const canonicalRequest = [
+    'GET',
+    path,
+    query,
+    `host:${STORAGE_HOST}`,
+    '',
+    'host',
+    // The body is not signed: GCS names this literal for a GET, and a runner
+    // sends no body to hash anyway.
+    'UNSIGNED-PAYLOAD',
+  ].join('\n');
+
+  const stringToSign = [
+    ALGORITHM,
+    timestamp,
+    scope,
+    await sha256Hex(canonicalRequest),
+  ].join('\n');
+
+  const signature = await signBlob(federation, signer, stringToSign);
+  return `https://${STORAGE_HOST}${path}?${query}&X-Goog-Signature=${signature}`;
+}
+
+/**
+ * The service account a signature is made in the name of.
+ *
+ * Read off `impersonationUrl` because that is where the installation already
+ * names it — §13 shapes the federation block after an `external_account`
+ * document, and the impersonation URL is that document's service-account field.
+ * A `null` impersonation URL means the installation reaches its cloud as the
+ * federated identity directly, and a federated identity is not a service
+ * account: it has no key GCS can verify a signature against, so there is
+ * nothing to sign with and saying so is the only honest answer.
+ */
+function signingServiceAccount(federation: FederationOptions): string {
+  const url = federation.impersonationUrl;
+  if (url === null) {
+    throw new FederationError(
+      'this installation federates without impersonating a service account, ' +
+        'so it has no identity to sign a storage URL as. A hosted build route ' +
+        'needs `cloud.federation.impersonationUrl` set to the controller service account.',
+    );
+  }
+  const match = /\/serviceAccounts\/([^/:]+):/.exec(url);
+  if (match === null) {
+    throw new FederationError(
+      `could not read a service account out of the impersonation URL ${url}`,
+    );
+  }
+  return decodeURIComponent(match[1]!);
+}
+
+/** `POST …:signBlob`, returning the signature hex-encoded as V4 wants it. */
+async function signBlob(
+  federation: FederationOptions,
+  serviceAccount: string,
+  payload: string,
+): Promise<string> {
+  // Deliberately not `federation` as given: the token wanted here is the
+  // federated one, before impersonation. See this file's header.
+  const getToken = workloadIdentityToken({
+    ...federation,
+    impersonationUrl: null,
+  });
+  const token = await getToken();
+
+  const url = `https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${encodeURIComponent(serviceAccount)}:signBlob`;
+  const send = federation.fetch ?? ((request: Request) => fetch(request));
+  const response = await send(
+    new Request(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        payload: base64(new TextEncoder().encode(payload)),
+      }),
+    }),
+  );
+  if (!response.ok) {
+    throw new FederationError(
+      `signing a storage URL as ${serviceAccount} was refused with ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  const body = (await response.json()) as { signedBlob?: string };
+  if (typeof body.signedBlob !== 'string') {
+    throw new FederationError(
+      `signing a storage URL as ${serviceAccount} returned no signature`,
+    );
+  }
+  return hex(bytesOfBase64(body.signedBlob));
+}
+
+/** V4's canonical query: percent-encoded pairs, sorted by encoded key. */
+function canonicalQuery(params: Record<string, string>): string {
+  const encoded = new Map(
+    Object.entries(params).map(
+      ([key, value]) => [encodeComponent(key), encodeComponent(value)] as const,
+    ),
+  );
+  return [...encoded.keys()]
+    .sort()
+    .map((key) => `${key}=${encoded.get(key)}`)
+    .join('&');
+}
+
+/**
+ * Percent-encode one query key or value.
+ *
+ * `encodeURIComponent` leaves `!'()*` alone and V4 requires them encoded, so
+ * they are finished by hand. Everything outside the unreserved set must be
+ * escaped or the signature covers a different string than the URL carries.
+ */
+function encodeComponent(value: string): string {
+  return encodeURIComponent(value).replace(
+    /[!'()*]/g,
+    (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
+
+/** The same encoding, except `/` stays a separator because this is a path. */
+function encodePath(value: string): string {
+  return value.split('/').map(encodeComponent).join('/');
+}
+
+/** `YYYYMMDDTHHMMSSZ`, which is the only timestamp form V4 accepts. */
+function basicIso(at: Date): string {
+  return `${at.toISOString().replace(/[-:]/g, '').split('.')[0]}Z`;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(value),
+  );
+  return hex(new Uint8Array(digest));
+}
+
+function hex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+    '',
+  );
+}
+
+function base64(bytes: Uint8Array): string {
+  return btoa(String.fromCharCode(...bytes));
+}
+
+function bytesOfBase64(value: string): Uint8Array {
+  const binary = atob(value);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}

--- a/apps/spindrift/src/web/upload.ts
+++ b/apps/spindrift/src/web/upload.ts
@@ -8,8 +8,11 @@
  * computes the SHA-256 digest, stages the archive to durable storage, and
  * returns the digest and location.
  */
-import { type StagedArchive, stageArchiveBytes } from '../storage/archives.ts';
-import { uploadToGcsBucket } from '../storage/cloud.ts';
+import {
+  type StagedArchive,
+  sourceDepotFor,
+  stageArchiveBytes,
+} from '../storage/archives.ts';
 import type { DispatchDeps } from './dispatch.ts';
 
 export const UPLOAD_PATH = '/internal/upload';
@@ -103,45 +106,30 @@ export async function handleUpload(
       bytes = new Uint8Array(buffer);
     }
 
-    const staged: StagedArchive = await stageArchiveBytes(filename, bytes);
-
-    let location = staged.location;
+    // One staging call, to one place. It used to be two — local disk first,
+    // then the bucket on top — which meant the bytes were written twice and the
+    // location came back describing whichever step happened to run, so a depot
+    // that was configured but unreachable still answered with a pod-local
+    // handle no builder could fetch. A depot failure is now a `500` that says
+    // so, because a staged bundle nobody can retrieve is not a staged bundle.
     const context = deps.context(authentication.principal);
-    const bucket =
-      request.headers.get('x-bucket')?.trim() ||
-      process.env.SPINDRIFT_ARTIFACTS_BUCKET?.trim() ||
-      context.manifest?.sources?.defaultBucket?.trim() ||
-      context.manifest?.sources?.buckets?.[0]?.trim();
+    const depot = sourceDepotFor(
+      context.manifest,
+      request.headers.get('x-bucket'),
+    );
 
-    if (bucket) {
-      const federation = context.manifest?.cloud?.federation;
-      if (federation) {
-        try {
-          const hex = staged.digest.replace('sha256:', '');
-          const ext = filename.includes('.')
-            ? filename.split('.').pop()
-            : 'zip';
-          const gcs = await uploadToGcsBucket({
-            bucketName: bucket,
-            objectName: `${hex}.${ext}`,
-            bytes,
-            federation,
-          });
-          location = gcs.location;
-        } catch (error: unknown) {
-          const message =
-            error instanceof Error
-              ? error.message
-              : `Cloud storage upload to gs://${bucket} failed`;
-          return Response.json(
-            {
-              ok: false,
-              failure: { code: 'STORAGE_FAILURE', message },
-            },
-            { status: 500 },
-          );
-        }
-      }
+    let staged: StagedArchive;
+    try {
+      staged = await stageArchiveBytes(filename, bytes, depot);
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : `Staging ${filename} to gs://${depot?.bucket} failed`;
+      return Response.json(
+        { ok: false, failure: { code: 'STORAGE_FAILURE', message } },
+        { status: 500 },
+      );
     }
 
     return Response.json(
@@ -149,7 +137,7 @@ export async function handleUpload(
         ok: true,
         value: {
           digest: staged.digest,
-          location,
+          location: staged.location,
           filename: staged.filename,
           size: staged.size,
         },

--- a/apps/spindrift/test/adapters/build-blame.test.ts
+++ b/apps/spindrift/test/adapters/build-blame.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Who a red hosted run indicts (ticket 23, item 5).
+ *
+ * §6's blame column is the point: `blame` is "the most useful thing the UI
+ * knows", and a developer sent to debug a Dockerfile that was never compiled is
+ * the exact harm it exists to prevent. Build 9 recorded `blame = developer` for
+ * a run that died in Spindrift's own fetch step, because every non-green
+ * conclusion mapped to `BUILD_FAILED`.
+ */
+import { describe, expect, test } from 'bun:test';
+import type {
+  BuildEvent,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+} from '../../src/adapters/build/contract.ts';
+import {
+  type ActionsHost,
+  type ActionsJob,
+  DEVELOPER_BUILD_STEP,
+  GitHubActionsBuildRoute,
+} from '../../src/adapters/build/github-actions.ts';
+import { blameFor } from '../../src/adapters/deploy/contract.ts';
+
+const WORKFLOW =
+  'jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6';
+
+const source: BuildSource = {
+  bundleDigest: 'sha256:bundle',
+  origin: {
+    type: 'repo',
+    repository: 'jonpulsifer/infra',
+    commit: 'c0ffee',
+    subpath: '.',
+    location: 'https://storage.googleapis.com/depot/bundle.tgz?signed',
+  },
+};
+
+const spec: BuildSpec = {
+  artifactType: 'image',
+  kind: 'service',
+  platform: { os: 'linux', arch: 'amd64' },
+  destination: 'registry.example.test/app',
+  buildArgs: {},
+};
+
+/**
+ * A host whose run always fails, with the steps a test names.
+ *
+ * Faked at {@link ActionsHost}, which is the contract this route declares for
+ * exactly this reason: what a verdict depends on here is the *shape of the
+ * steps*, and nothing else about GitHub needs to be real to vary that.
+ */
+function hostWithSteps(steps: NonNullable<ActionsJob['steps']>): ActionsHost {
+  return {
+    installationFor: async () => ({ installationId: '1' }),
+    repository: async () => ({ defaultBranch: 'main' }),
+    dispatchWorkflow: async () => {},
+    workflowRuns: async () => [
+      { id: 9, name: 'spindrift fixed-correlation', status: 'completed' },
+    ],
+    workflowRun: async () => ({
+      id: 9,
+      status: 'completed',
+      conclusion: 'failure',
+    }),
+    runJobs: async () => [
+      {
+        id: 91,
+        name: 'build',
+        status: 'completed',
+        conclusion: 'failure',
+        steps,
+      },
+    ],
+    jobLog: async () => 'curl: (1) Protocol "upload" not supported\n',
+  } as unknown as ActionsHost;
+}
+
+function routeOver(host: ActionsHost): GitHubActionsBuildRoute {
+  let elapsed = 0;
+  return new GitHubActionsBuildRoute({
+    name: 'hosted',
+    host,
+    buildWorkflow: WORKFLOW,
+    zeroConfigFrontend: 'ghcr.io/railwayapp/railpack:railpack-frontend',
+    correlation: () => 'fixed-correlation',
+    intervalMs: 1_000,
+    timeoutMs: 600_000,
+    now: () => new Date(elapsed),
+    sleep: async (ms: number) => {
+      elapsed += ms;
+    },
+  });
+}
+
+async function verdict(host: ActionsHost): Promise<BuildResult> {
+  const stream = routeOver(host).build(source, spec);
+  let step = await stream.next();
+  const events: BuildEvent[] = [];
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return step.value;
+}
+
+const ok = { status: 'completed', conclusion: 'success' } as const;
+const broke = { status: 'completed', conclusion: 'failure' } as const;
+
+describe('blame on a red hosted run', () => {
+  test('a failure in the platform’s own fetch step is the platform’s', async () => {
+    // Build 9, verbatim: the runner was handed `upload://<hex>`, `curl` refused
+    // the scheme, and `tar` fell over on the empty stream. Nothing the
+    // developer wrote had run yet.
+    const result = await verdict(
+      hostWithSteps([
+        { name: 'Read the build request', ...ok },
+        { name: 'Fetch the staged bundle', ...broke },
+      ]),
+    );
+
+    expect(result.status).toBe('FAILED');
+    if (result.status !== 'FAILED') return;
+    expect(result.reason).toBe('ARTIFACT_UNAVAILABLE');
+    expect(blameFor(result.reason)).toBe('platform');
+    expect(result.detail).toContain('Fetch the staged bundle');
+  });
+
+  test('a failure in the App’s own build step is still the developer’s', async () => {
+    // The fix must not launder real build failures into platform blame — a
+    // compile error is precisely what §6 gives `BUILD_FAILED` to the developer
+    // for.
+    const result = await verdict(
+      hostWithSteps([
+        { name: 'Fetch the staged bundle', ...ok },
+        { name: DEVELOPER_BUILD_STEP, ...broke },
+      ]),
+    );
+
+    expect(result.status).toBe('FAILED');
+    if (result.status !== 'FAILED') return;
+    expect(result.reason).toBe('BUILD_FAILED');
+    expect(blameFor(result.reason)).toBe('developer');
+  });
+
+  test('a run reporting no steps keeps the developer verdict', async () => {
+    // The conservative direction. Claiming platform blame with no evidence
+    // would put a "not your fault" chip on every genuine build failure whose
+    // steps this route could not read.
+    const result = await verdict(hostWithSteps([]));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status !== 'FAILED') return;
+    expect(result.reason).toBe('BUILD_FAILED');
+  });
+
+  test('a skipped step is not a failed one', async () => {
+    // Every step after a failure is `skipped`, so counting those as failures
+    // would blame the platform for the step that merely came after the App's.
+    const result = await verdict(
+      hostWithSteps([
+        { name: DEVELOPER_BUILD_STEP, ...broke },
+        {
+          name: 'Report what was built',
+          status: 'completed',
+          conclusion: 'skipped',
+        },
+      ]),
+    );
+
+    expect(result.status).toBe('FAILED');
+    if (result.status !== 'FAILED') return;
+    expect(result.reason).toBe('BUILD_FAILED');
+  });
+});

--- a/apps/spindrift/test/commands/build-bundle-location.test.ts
+++ b/apps/spindrift/test/commands/build-bundle-location.test.ts
@@ -1,0 +1,236 @@
+/**
+ * What a build route is handed as its bundle location (ticket 23).
+ *
+ * §15 stages one immutable bundle "for either builder", and the durable address
+ * of that bundle is a `gs://` object nothing without a Google credential can
+ * resolve. Turning it into something the builder can fetch is `dispatchBuild`'s
+ * job, and getting it wrong is what produced a build that died at `curl` and
+ * blamed the developer for it.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { dispatchBuild } from '../../src/commands/builds/dispatch.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+  componentTargetDesired,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const baseManifest = await fixtureManifest();
+
+const BUNDLE_DIGEST =
+  'sha256:3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03';
+const DEPOT_LOCATION =
+  'gs://bluenose-spindrift-source/3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03.tgz';
+
+/** A cloud that answers the token exchange and signs, and records nothing else. */
+function fakeCloud() {
+  return async (request: Request): Promise<Response> => {
+    if (request.url.includes(':signBlob')) {
+      return Response.json({ signedBlob: btoa('\x01\x02') });
+    }
+    return Response.json({ access_token: 'federated', expires_in: 3600 });
+  };
+}
+
+describe('the bundle location a route is dispatched with', () => {
+  let ctx: CommandContext;
+  let route: FakeBuildAdapter;
+
+  async function seedBuild(
+    location: string,
+    sourceKind: 'repo' | 'archive' = 'repo',
+  ) {
+    const [app] = await ctx.db
+      .insert(apps)
+      .values({
+        name: `app-${sourceKind}-${location.length}`,
+        sourceKind,
+        sourceRepoUrl: 'jonpulsifer/infra',
+        sourceRepoSubpath: 'apps/spindrift',
+      })
+      .returning();
+    const [component] = await ctx.db
+      .insert(components)
+      .values({ appId: app!.id, name: 'web', kind: 'service' })
+      .returning();
+    const [target] = await ctx.db.select().from(targets).limit(1);
+    await ctx.db
+      .insert(componentTargetDesired)
+      .values({ componentId: component!.id, targetId: target!.id });
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: component!.id,
+        commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: BUNDLE_DIGEST,
+        bundleLocation: location,
+      })
+      .returning();
+    return build!;
+  }
+
+  function withFederation(federation: unknown): CommandContext {
+    return {
+      ...ctx,
+      manifest: {
+        ...baseManifest,
+        cloud: { ...baseManifest.cloud, federation },
+      },
+    } as CommandContext;
+  }
+
+  const signable = {
+    audience: '//iam.googleapis.com/projects/1/locations/global/x/y',
+    tokenUrl: 'https://sts.googleapis.test/v1/token',
+    tokenPath: '/var/run/secrets/spindrift/gcp-token',
+    impersonationUrl:
+      'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+    fetch: fakeCloud(),
+    readToken: async () => 'projected-jwt',
+  };
+
+  beforeEach(async () => {
+    const { client, db } = database();
+    await db.delete(attemptEvents);
+    await db.delete(componentTargetDesired);
+    await db.delete(builds);
+    await db.delete(components);
+    await db.delete(apps);
+    await db.delete(targets);
+    await db.delete(users);
+
+    const [operator] = await db
+      .insert(users)
+      .values({ displayName: 'Operator' })
+      .returning();
+    await db
+      .insert(targets)
+      .values(targetValues({ name: 'target-a', rank: 1 }));
+
+    route = new FakeBuildAdapter();
+    const adapters: AdapterRegistry = {
+      deploy: () => null,
+      build: (name) => (name === 'hosted' ? route : null),
+      store: () => new FakeSecretStore(),
+      supplyChain: () => new SupplyChainHarness(),
+      repository: () => null,
+    };
+
+    ctx = {
+      client,
+      db,
+      adapters,
+      clock: { now: () => new Date('2026-08-01T12:00:00.000Z') },
+      manifest: baseManifest,
+      operatorId: operator!.id,
+      principal: {
+        type: 'user',
+        id: operator!.id,
+        displayName: 'Operator',
+      },
+    } as CommandContext;
+  });
+
+  test('a depot address reaches the route as a URL curl can follow', async () => {
+    // The defect verbatim: the route used to receive the stored location, and
+    // the stored location was not a URL. `curl` answered
+    // "Protocol upload not supported or disabled in libcurl" and the build died
+    // before it read a line of the App's code.
+    const context = withFederation(signable);
+    const build = await seedBuild(DEPOT_LOCATION);
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+    expect(result.ok).toBe(true);
+
+    const origin = route.built[0]?.source.origin;
+    expect(origin?.location.startsWith('https://storage.googleapis.com/')).toBe(
+      true,
+    );
+    expect(new URL(origin!.location).searchParams.get('X-Goog-Signature')).toBe(
+      '0102',
+    );
+  });
+
+  test('an archive source is resolved the same way a repository one is', async () => {
+    // Build 9 was `origin.type = repo` and still carried an `upload://`
+    // location, because §15 stages one bundle for either builder. Both arms
+    // read the same column, so both arms have to be resolved here.
+    const context = withFederation(signable);
+    const build = await seedBuild(DEPOT_LOCATION, 'archive');
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+    expect(result.ok).toBe(true);
+    expect(route.built[0]?.source.origin.type).toBe('archive');
+    expect(route.built[0]?.source.origin.location.startsWith('https://')).toBe(
+      true,
+    );
+  });
+
+  test('the signed URL never lands on the operator-visible attempt log', async () => {
+    // It is a bearer capability with a short TTL. The log records the object,
+    // which is the thing an operator actually wants to look up anyway.
+    const context = withFederation(signable);
+    const build = await seedBuild(DEPOT_LOCATION);
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+
+    const events = await context.db.select().from(attemptEvents);
+    const written = JSON.stringify(events);
+    expect(written).not.toContain('X-Goog-Signature');
+    expect(written).not.toContain('storage.googleapis.com');
+  });
+
+  test('a location that is already fetchable passes through untouched', async () => {
+    const context = withFederation(signable);
+    const build = await seedBuild('https://staging.lolwtf.ca/bundle.tar.gz');
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+    expect(result.ok).toBe(true);
+    expect(route.built[0]?.source.origin.location).toBe(
+      'https://staging.lolwtf.ca/bundle.tar.gz',
+    );
+  });
+
+  test('refuses rather than dispatching a location no route could resolve', async () => {
+    // Dispatching anyway is exactly what produced build 9: a green runner, a
+    // dead `curl`, and a developer sent to debug a Dockerfile that never ran.
+    const context = withFederation(null);
+    const build = await seedBuild(DEPOT_LOCATION);
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.code).toBe('NOT_BUILDABLE');
+      expect(result.failure.message).toContain('no federation');
+      expect(result.failure.message).toContain(DEPOT_LOCATION);
+    }
+    expect(route.built).toHaveLength(0);
+  });
+});

--- a/apps/spindrift/test/storage/cloud.test.ts
+++ b/apps/spindrift/test/storage/cloud.test.ts
@@ -57,7 +57,6 @@ describe('cloud storage WIF permissions and publishing', () => {
       bucketName: 'test-bucket',
       federation: {
         ...mockFederation,
-        // @ts-expect-error test fetch injection
         fetch: mockFetch,
         readToken: async () => 'projected-jwt-token',
       },
@@ -106,7 +105,6 @@ describe('cloud storage WIF permissions and publishing', () => {
       bytes: payload,
       federation: {
         ...mockFederation,
-        // @ts-expect-error test fetch injection
         fetch: mockFetch,
         readToken: async () => 'projected-jwt-token',
       },

--- a/apps/spindrift/test/storage/source-depot.test.ts
+++ b/apps/spindrift/test/storage/source-depot.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Staging a bundle where a builder can fetch it, and minting the URL that lets
+ * it (ticket 23).
+ *
+ * The defect these cover is not a wrong value, it is a wrong *place*: bundles
+ * were written to the web pod's own `tmpdir()` and handed to a GitHub-hosted
+ * runner as `upload://<hex>`. Neither half could work — the scheme is not a
+ * scheme, and the bytes are on a disk nothing outside that one pod can reach.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  digestOfBytes,
+  readStagedArchive,
+  type SourceDepot,
+  sourceDepotFor,
+  stageArchiveBytes,
+} from '../../src/storage/archives.ts';
+import {
+  parseGcsLocation,
+  SIGNED_URL_TTL_SECONDS,
+  signedObjectUrl,
+} from '../../src/storage/signed-url.ts';
+
+const federation = {
+  audience:
+    '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov',
+  tokenUrl: 'https://sts.googleapis.test/v1/token',
+  tokenPath: '/var/run/secrets/spindrift/gcp-token',
+  impersonationUrl:
+    'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+};
+
+const manifest = {
+  sources: {
+    buckets: ['bluenose-spindrift-source'],
+    defaultBucket: 'bluenose-spindrift-source',
+  },
+  cloud: {
+    artifactsProject: 'artifacts',
+    homeVesselProject: 'vessel',
+    federation,
+  },
+} as unknown as Parameters<typeof sourceDepotFor>[0];
+
+/** A far side that answers the token exchange, the upload, and `signBlob`. */
+function fakeCloud(): {
+  fetch: (request: Request) => Promise<Response>;
+  uploads: { url: string; bytes: Uint8Array }[];
+  signed: string[];
+  impersonated: number;
+} {
+  const uploads: { url: string; bytes: Uint8Array }[] = [];
+  const signed: string[] = [];
+  let impersonated = 0;
+  const state = {
+    uploads,
+    signed,
+    get impersonated() {
+      return impersonated;
+    },
+    fetch: async (request: Request): Promise<Response> => {
+      const url = request.url;
+      if (url.includes('sts.googleapis.test')) {
+        return Response.json({
+          access_token: 'federated-token',
+          expires_in: 3600,
+        });
+      }
+      if (url.includes(':generateAccessToken')) {
+        impersonated += 1;
+        return Response.json({ accessToken: 'impersonated-token' });
+      }
+      if (url.includes(':signBlob')) {
+        const body = (await request.json()) as { payload: string };
+        signed.push(atob(body.payload));
+        // Two bytes, so the hex encoding is checkable without arithmetic.
+        return Response.json({ signedBlob: btoa('\x01\xfe') });
+      }
+      if (url.includes('storage.googleapis.com/upload/')) {
+        uploads.push({
+          url,
+          bytes: new Uint8Array(await request.arrayBuffer()),
+        });
+        return Response.json({ kind: 'storage#object' });
+      }
+      return new Response('unexpected', { status: 500 });
+    },
+  };
+  return state;
+}
+
+describe('the source depot', () => {
+  test('reads the bucket and the federation the installation declares', () => {
+    const depot = sourceDepotFor(manifest);
+    expect(depot?.bucket).toBe('bluenose-spindrift-source');
+    expect(depot?.federation.impersonationUrl).toBe(
+      federation.impersonationUrl,
+    );
+  });
+
+  test('is absent when there is no federation to reach the bucket with', () => {
+    // A bucket name with nothing that can write to it is not a depot, and
+    // answering with one would stage bundles into a call that always fails.
+    const depot = sourceDepotFor({
+      ...manifest,
+      cloud: { ...manifest?.cloud, federation: null },
+    } as never);
+    expect(depot).toBeNull();
+  });
+
+  test('stages bundle bytes into the bucket, addressed by their digest', async () => {
+    const cloud = fakeCloud();
+    const bytes = new TextEncoder().encode('a source bundle');
+    const depot: SourceDepot = {
+      bucket: 'bluenose-spindrift-source',
+      federation: {
+        ...federation,
+        fetch: cloud.fetch,
+        readToken: async () => 'jwt',
+      },
+    };
+
+    const staged = await stageArchiveBytes('bundle.tgz', bytes, depot);
+    const hex = digestOfBytes(bytes).replace('sha256:', '');
+
+    expect(staged.location).toBe(`gs://bluenose-spindrift-source/${hex}.tgz`);
+    // Nothing on this pod's disk: that is the whole point of the change.
+    expect(staged.filepath).toBeNull();
+    expect(await readStagedArchive(staged.digest)).toBeNull();
+    expect(cloud.uploads).toHaveLength(1);
+    expect(cloud.uploads[0]?.bytes).toEqual(bytes);
+  });
+
+  test('falls back to local disk under a handle that is not a URL', async () => {
+    // An installation with no depot gets the old behaviour, and the location it
+    // records says so: `upload://` cannot be mistaken for something fetchable.
+    const bytes = new TextEncoder().encode(`local ${Math.random()}`);
+    const staged = await stageArchiveBytes('bundle.tgz', bytes, null);
+
+    expect(staged.location.startsWith('upload://')).toBe(true);
+    expect(staged.filepath).not.toBeNull();
+    expect(await readStagedArchive(staged.digest)).toEqual(bytes);
+  });
+});
+
+describe('signing a bundle URL', () => {
+  const location = 'gs://bluenose-spindrift-source/abc123.tgz';
+
+  test('reads a gs:// address, and declines anything that is not one', () => {
+    expect(parseGcsLocation(location)).toEqual({
+      bucket: 'bluenose-spindrift-source',
+      object: 'abc123.tgz',
+    });
+    expect(parseGcsLocation('upload://abc123')).toBeNull();
+    expect(parseGcsLocation('https://example.test/bundle.tgz')).toBeNull();
+    expect(parseGcsLocation('gs://bucket-with-no-object')).toBeNull();
+  });
+
+  test('mints an https URL a plain curl can follow', async () => {
+    const cloud = fakeCloud();
+    const url = await signedObjectUrl({
+      location,
+      federation: {
+        ...federation,
+        fetch: cloud.fetch,
+        readToken: async () => 'jwt',
+      },
+      now: () => new Date('2026-08-01T12:00:00.000Z'),
+    });
+
+    const parsed = new URL(url);
+    expect(parsed.origin).toBe('https://storage.googleapis.com');
+    expect(parsed.pathname).toBe('/bluenose-spindrift-source/abc123.tgz');
+    expect(parsed.searchParams.get('X-Goog-Algorithm')).toBe(
+      'GOOG4-RSA-SHA256',
+    );
+    expect(parsed.searchParams.get('X-Goog-Date')).toBe('20260801T120000Z');
+    expect(parsed.searchParams.get('X-Goog-SignedHeaders')).toBe('host');
+    expect(parsed.searchParams.get('X-Goog-Credential')).toBe(
+      'controller@vessel.iam.gserviceaccount.com/20260801/auto/storage/goog4_request',
+    );
+    // Hex, not base64: V4 puts the signature in the query as hex.
+    expect(parsed.searchParams.get('X-Goog-Signature')).toBe('01fe');
+  });
+
+  test('expires in minutes, because the URL is a bearer capability', async () => {
+    const cloud = fakeCloud();
+    const url = await signedObjectUrl({
+      location,
+      federation: {
+        ...federation,
+        fetch: cloud.fetch,
+        readToken: async () => 'jwt',
+      },
+    });
+    expect(new URL(url).searchParams.get('X-Goog-Expires')).toBe(
+      String(SIGNED_URL_TTL_SECONDS),
+    );
+    expect(SIGNED_URL_TTL_SECONDS).toBeLessThanOrEqual(900);
+  });
+
+  test('signs with the federated token, never the impersonated one', async () => {
+    // `signBlob` is authorized by `serviceAccountTokenCreator`, which the
+    // workload identity holds on the service account — impersonating first
+    // would instead need that role held on itself, a grant nothing else needs.
+    const cloud = fakeCloud();
+    await signedObjectUrl({
+      location,
+      federation: {
+        ...federation,
+        fetch: cloud.fetch,
+        readToken: async () => 'jwt',
+      },
+    });
+
+    expect(cloud.impersonated).toBe(0);
+    expect(cloud.signed).toHaveLength(1);
+    expect(cloud.signed[0]?.startsWith('GOOG4-RSA-SHA256\n')).toBe(true);
+  });
+
+  test('refuses when the installation impersonates no service account', async () => {
+    const cloud = fakeCloud();
+    const attempt = signedObjectUrl({
+      location,
+      federation: {
+        ...federation,
+        impersonationUrl: null,
+        fetch: cloud.fetch,
+        readToken: async () => 'jwt',
+      },
+    });
+    // A federated identity has no key GCS can verify a signature against, so
+    // there is nothing to sign with and the sentence says which knob is missing.
+    expect(attempt).rejects.toThrow('impersonationUrl');
+  });
+});


### PR DESCRIPTION
Closes the only thing between this installation and its first ever Deploy.

## The defect

`stageArchiveBytes` staged source bundles to `join(tmpdir(), 'spindrift-archives')` — the web pod's own ephemeral disk — and recorded them as `upload://<hex>`. The reusable workflow then ran `curl --fail --location "$LOCATION"` and died:

```
LOCATION: upload://3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03
curl: (1) Protocol "upload" not supported or disabled in libcurl
```

Two independent defects, and the second is the serious one. `upload://` is not a URL scheme. But even with the scheme fixed the bytes are unreachable: pod-local, lost on restart, not shared with the reconciler or a second replica.

This affected **repo-sourced builds too**, not just uploads — build 9 had `origin.type = repo` and still got an `upload://` location, because §15 stages one immutable bundle for either builder.

## What changed

**Bundles go to the depot the installation already declares.** `stageArchiveBytes` takes a `SourceDepot` (`sourceDepotFor(manifest)` → `sources.defaultBucket` + `cloud.federation`) and stages through the existing `uploadToGcsBucket`. Local `tmpdir()` survives only as the no-depot fallback, and keeps the `upload://` handle deliberately: a location nothing can fetch should not be spelled like one that can.

**The signed URL is minted at dispatch, not at staging.** What a Build persists is the durable `gs://` object; `dispatchBuild` mints a short-TTL V4 signed URL immediately before handing the `Source` to a route. Same capability on the same wire, but a 15-minute TTL cannot go stale behind a PENDING queue, and `artifactRefs` on the supplied-artifact arm stays durable.

**Signing uses no private key.** The string-to-sign goes to IAM `signBlob` authorized by the *federated* token — the one from before impersonation — because the workload-identity principal already holds `serviceAccountTokenCreator` on the impersonated SA, which is exactly what `signBlob` checks. No new Terraform, no new IAM binding, no WIF provider.

**`.github/workflows/spindrift-build.yml` is untouched** and the manifest's `@0a7d0ea0` pin does not roll. That was the point of the chosen design.

**A failure to mint is a refusal**, not a warning: `dispatchBuild` returns `NOT_BUILDABLE` with a readable sentence rather than dispatching a location it knows no route can resolve. The sentence carries the object path — the signed URL never reaches the operator-visible attempt log, and a test asserts that.

**Blame (ticket item 5).** Every non-green conclusion mapped to `BUILD_FAILED` → developer. A red run whose failed steps are all Spindrift's own workflow scaffolding — anything other than `Build and push` — now reports `ARTIFACT_UNAVAILABLE`, which §6 blames on the platform. A run reporting no steps keeps the developer verdict, so genuine build failures are not laundered into "not your fault".

## Validation

```
952 pass, 0 fail   (934 before, 18 added)
bun run typecheck && bun run lint   clean
```

## Not done here

Ticket criterion 4 — "a build dispatched to the hosted route fetches its bundle and proceeds past the extract step" — is left unchecked. The code path is done and covered, but proving it needs the image built, the digest bumped in `clusters/offsite/apps/spindrift/helm-release.yaml`, Flux reconciled, and a real dispatch. That gets checked off from the live installation, not from CI.

## Unrelated flake noticed while validating

`test/auth/credential-admin.test.ts:208` forges a signature by replacing the last base64 character with `x`; when the signature already ends in `x`, or the mutated trailing bits decode to the same bytes, the forgery is a no-op and the assertion verifies. Failed once in ~10 full runs, then passed 6/6 in isolation on both this branch and a clean checkout. Worth its own ticket; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)