### PR TITLE
fix(spindrift): make the deploy-adapter fakes refuse what the real APIs refuse

### DIFF
--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -81,6 +81,19 @@ const DEPLOY_LABEL = 'spindrift-deploy';
 /** A site id is capped well below a DNS label. See `domain/workload-name.ts`. */
 const SITE_ID_LIMIT = 30;
 
+/**
+ * The most file hashes one `populateFiles` call may carry.
+ *
+ * The API's own ceiling, not a tuning knob: "You can send a maximum of 1000
+ * file hashes in each API request. To list all the files for the version, you
+ * can call this endpoint multiple times; the files in each call will be added
+ * to the version." A built site clears that without trying — one hashed asset
+ * directory is enough — so the offer is made in chunks and every chunk's
+ * answer is kept. Anything less deploys a version whose bytes are not all
+ * there, which finalizes happily and serves a broken site.
+ */
+const POPULATE_LIMIT = 1000;
+
 /** What a version looks like coming back, as much as this adapter reads. */
 interface HostingVersion {
   readonly name?: string;
@@ -381,19 +394,27 @@ export class StaticDeployAdapter implements DeployAdapter {
       return { ok: false, failure: missing('the API created no version') };
     }
 
-    const populated = await http.json<PopulateResult>({
-      method: 'POST',
-      path: `${API_VERSION}/${name}:populateFiles`,
-      body: {
-        files: Object.fromEntries(
-          [...compressed].map(([path, file]) => [path, file.hash]),
-        ),
-      },
-    });
-    if (!populated.ok) return { ok: false, failure: populated };
-
-    const wanted = new Set(populated.value?.uploadRequiredHashes ?? []);
-    const uploadUrl = populated.value?.uploadUrl;
+    // Every chunk answers with the hashes *it* named that are missing, and
+    // with somewhere to put them, so both are accumulated across the whole
+    // offer rather than read off the last call.
+    const wanted = new Set<string>();
+    let uploadUrl: string | undefined;
+    for (const chunk of chunksOf([...compressed], POPULATE_LIMIT)) {
+      const populated = await http.json<PopulateResult>({
+        method: 'POST',
+        path: `${API_VERSION}/${name}:populateFiles`,
+        body: {
+          files: Object.fromEntries(
+            chunk.map(([path, file]) => [path, file.hash]),
+          ),
+        },
+      });
+      if (!populated.ok) return { ok: false, failure: populated };
+      for (const hash of populated.value?.uploadRequiredHashes ?? []) {
+        wanted.add(hash);
+      }
+      uploadUrl = populated.value?.uploadUrl ?? uploadUrl;
+    }
     for (const file of compressed.values()) {
       if (!wanted.has(file.hash)) continue;
       if (uploadUrl === undefined) {
@@ -558,6 +579,22 @@ function parseRef(connection: StaticConnection, ref: DeployRef): string | null {
   if (!ref.startsWith(prefix)) return null;
   const site = ref.slice(prefix.length);
   return site.length === 0 || site.includes('/') ? null : site;
+}
+
+/**
+ * One list as chunks of at most `size`, always at least one chunk.
+ *
+ * The empty case yields one empty chunk rather than none, because a version
+ * with no files is still a version that has to be *told* it has no files —
+ * skipping the call entirely would leave a site whose emptiness the API never
+ * heard about, which is a different thing from an empty site.
+ */
+function chunksOf<Item>(items: readonly Item[], size: number): Item[][] {
+  const chunks: Item[][] = [];
+  for (let at = 0; at < items.length; at += size) {
+    chunks.push(items.slice(at, at + size));
+  }
+  return chunks.length === 0 ? [[]] : chunks;
 }
 
 /** The sha256 of some bytes, hex — what the product deduplicates files on. */

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -29,7 +29,10 @@ import {
   GitHubActionsBuildRoute,
   reusableWorkflowRepository,
 } from '../../src/adapters/build/github-actions.ts';
-import { InClusterBuildRoute } from '../../src/adapters/build/in-cluster.ts';
+import {
+  InClusterBuildRoute,
+  JOB_LABEL,
+} from '../../src/adapters/build/in-cluster.ts';
 import {
   BUILD_REPORT_MARKER,
   encodeBuildReport,
@@ -501,7 +504,14 @@ function clusterRoute(options: FakeKubernetesOptions = {}): {
         {
           apiVersion: 'v1',
           kind: 'Pod',
-          metadata: { name: 'build-pod', namespace: 'builds' },
+          metadata: {
+            name: 'build-pod',
+            namespace: 'builds',
+            // The label the route selects the build's own pod by. The cluster
+            // filters on it, so a fixture without it is a pod no build would
+            // ever find its log through.
+            labels: { [JOB_LABEL]: 'spindrift-build-fixed' },
+          },
         },
       ],
     },

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -307,6 +307,93 @@ describe('§6: phases come from the revision', () => {
   });
 });
 
+describe('the write is asynchronous, and the document is checked', () => {
+  test('apply survives the window in which the Service is not there yet', async () => {
+    // The `PATCH` answers with an Operation and the Service is created behind
+    // it, so a `GET` straight afterwards can come back `404`. That is the one
+    // window a *first* deploy is guaranteed to hit, so it is driven here
+    // rather than left to never happen.
+    const { api, adapter } = adapterFor({ createLatencyReads: 3 });
+    const { events, verdict } = await drain(adapter.apply(target(), desired()));
+
+    expect(verdict.phase).toBe('LIVE');
+    // An absent Service is "still applying", not a failure — so no second
+    // APPLYING lands on the timeline and nothing goes red while it is created.
+    const phases = events
+      .filter((event) => event.type === 'status')
+      .map((event) => (event.type === 'status' ? event.phase : ''));
+    expect(phases).toEqual(['APPLYING', 'WAITING', 'LIVE']);
+    // Three reads that found nothing, then the ones that found it.
+    expect(api.pathsOf('GET').length).toBeGreaterThan(3);
+  });
+
+  test('a write answers with an Operation, which is what a poll would need', async () => {
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(target(), desired()));
+
+    const write = api.requests.find((request) => request.method === 'PATCH');
+    expect(write?.url).toContain('allowMissing=true');
+    // The adapter discards the body today. The `name` is the handle an
+    // operation is polled by, so a fake without one could not tell the moment
+    // anything wanted to.
+    const operation = api.operations[0];
+    expect(operation?.name).toMatch(/\/operations\//);
+    expect(operation?.done).toBe(false);
+  });
+
+  test('a Service naming a field the schema does not define is refused', async () => {
+    // Google's protobuf-JSON parsers refuse an unknown member outright. The
+    // rendered document is the single thing standing between this product and
+    // a Cloud Run deploy, and every other test in this file asserts the real
+    // one is *accepted*; this asserts the check is real.
+    const api = new FakeCloudRun();
+    const refused = await api.fetch(
+      new Request(
+        `${api.endpoint}/v2/projects/${api.project}/locations/${api.region}/services/shop-web?allowMissing=true`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: 'Bearer federated-token',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            ingress: 'INGRESS_TRAFFIC_ALL',
+            template: {
+              containers: [
+                { image: 'registry.example.test/shop@sha256:abc', cpu: '1' },
+              ],
+            },
+          }),
+        },
+      ),
+    );
+
+    expect(refused.status).toBe(400);
+    const body = (await refused.json()) as { error: { message: string } };
+    expect(body.error.message).toContain('template.containers[0].cpu');
+  });
+
+  test('a label in a namespace the v2 API reserves is refused', async () => {
+    const api = new FakeCloudRun();
+    const refused = await api.fetch(
+      new Request(
+        `${api.endpoint}/v2/projects/${api.project}/locations/${api.region}/services/shop-web?allowMissing=true`,
+        {
+          method: 'PATCH',
+          headers: {
+            Authorization: 'Bearer federated-token',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            labels: { 'run.googleapis.com/launch-stage': 'beta' },
+          }),
+        },
+      ),
+    );
+    expect(refused.status).toBe(400);
+  });
+});
+
 describe('observe and destroy', () => {
   test('observe reports the digest the Service still carries', async () => {
     const { adapter } = adapterFor();

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -27,6 +27,7 @@ import type {
   DeployVerdict,
 } from '../../src/adapters/deploy/contract.ts';
 import { blameFor } from '../../src/adapters/deploy/contract.ts';
+import { KubernetesApi } from '../../src/adapters/deploy/kubernetes/api.ts';
 import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
 import { VALUES_CONTRACT } from '../../src/adapters/deploy/kubernetes/values.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
@@ -167,12 +168,25 @@ async function drain(
   return { events, verdict: step.value };
 }
 
+/**
+ * The labels the chart puts on a pod of this Component.
+ *
+ * `spindrift-app.selectorLabels` in `packages/charts/spindrift-app`, which is
+ * what the adapter's `labelSelector` names. A fixture without them is a pod
+ * the cluster would not return for that selector, so they belong on every pod
+ * a test expects the read-on-red or the tail to find.
+ */
+const POD_LABELS = {
+  'app.kubernetes.io/name': 'web',
+  'app.kubernetes.io/part-of': 'blog',
+};
+
 /** A pod in one waiting state, as the API reports it. */
 function pod(reason: string, message: string): FakeObject {
   return {
     apiVersion: 'v1',
     kind: 'Pod',
-    metadata: { name: 'blog-web-abc', namespace: 'apps' },
+    metadata: { name: 'blog-web-abc', namespace: 'apps', labels: POD_LABELS },
     status: {
       containerStatuses: [
         { name: 'app', ready: false, state: { waiting: { reason, message } } },
@@ -897,6 +911,136 @@ describe('runtime log tail', () => {
       'new one',
       'new two',
     ]);
+  });
+});
+
+/**
+ * What the API says about a *kind*, as against what it holds of one.
+ *
+ * These go through `KubernetesApi` rather than through the adapter because the
+ * distinction is the client's to preserve — `list` returns `null` for a kind
+ * the cluster does not serve and `[]` for a served kind holding nothing, and
+ * every call site's `?? []` is written against one of those two answers.
+ */
+describe('what the API answers about a kind', () => {
+  const apiFor = (options: FakeKubernetesOptions = {}) => {
+    const cluster = new FakeKubernetes({ servedKinds: SERVED, ...options });
+    return {
+      cluster,
+      api: new KubernetesApi({
+        apiServer: cluster.apiServer,
+        token: cluster.token,
+        fetch: cluster.fetch,
+      }),
+    };
+  };
+
+  test('a served kind holding nothing is an empty list, not an absent kind', async () => {
+    const { api } = apiFor();
+    // Flux is installed here — `SERVED` says so — and this namespace holds no
+    // HelmRelease. That is `[]`, and it is a different answer from the one
+    // below.
+    expect(
+      await api.list({
+        apiVersion: 'helm.toolkit.fluxcd.io/v2',
+        plural: 'helmreleases',
+        namespace: 'delivery',
+      }),
+    ).toEqual([]);
+  });
+
+  test('a kind the cluster does not serve is null, which §13 turns on', async () => {
+    const { api } = apiFor({ servedKinds: {} });
+    expect(
+      await api.list({
+        apiVersion: 'helm.toolkit.fluxcd.io/v2',
+        plural: 'helmreleases',
+        namespace: 'delivery',
+      }),
+    ).toBeNull();
+  });
+
+  test('the cluster filters by the selector, so a wrong one finds nothing', async () => {
+    const { api } = apiFor({
+      lists: { pods: [pod('CrashLoopBackOff', 'back-off')] },
+    });
+    const listWith = (labelSelector: string) =>
+      api.list(
+        { apiVersion: 'v1', plural: 'pods', namespace: 'apps' },
+        {
+          labelSelector,
+        },
+      );
+
+    expect(
+      await listWith(
+        'app.kubernetes.io/name=web,app.kubernetes.io/part-of=blog',
+      ),
+    ).toHaveLength(1);
+    // The two keys the chart's `selectorLabels` defines are the contract. A
+    // selector naming anything else matches a pod the chart never labelled.
+    expect(await listWith('app.kubernetes.io/instance=blog-web')).toEqual([]);
+  });
+
+  test('deleting what is already gone succeeds, on a cluster that says 404', async () => {
+    const { api, cluster } = apiFor();
+    // §6's idempotence, proven rather than assumed: the fake refuses the
+    // delete outright, and the client still returns normally.
+    await api.delete({
+      apiVersion: 'helm.toolkit.fluxcd.io/v2',
+      plural: 'helmreleases',
+      namespace: 'delivery',
+      name: 'never-existed',
+    });
+    expect(cluster.pathsOf('DELETE')).toHaveLength(1);
+  });
+});
+
+describe('a write is an apply only if it says so', () => {
+  const patch = async (
+    headers: Record<string, string>,
+    query: string,
+  ): Promise<number> => {
+    const cluster = new FakeKubernetes({ servedKinds: SERVED });
+    const response = await cluster.fetch(
+      new Request(
+        `${cluster.apiServer}/apis/helm.toolkit.fluxcd.io/v2/namespaces/delivery/helmreleases/blog-web${query}`,
+        {
+          method: 'PATCH',
+          headers: { Authorization: 'Bearer federated-token', ...headers },
+          body: JSON.stringify({
+            apiVersion: 'helm.toolkit.fluxcd.io/v2',
+            kind: 'HelmRelease',
+            metadata: { name: 'blog-web', namespace: 'delivery' },
+          }),
+        },
+      ),
+    );
+    return response.status;
+  };
+
+  test('a merge patch is refused: the media type is what makes it an apply', async () => {
+    expect(
+      await patch(
+        { 'Content-Type': 'application/json' },
+        '?fieldManager=spindrift',
+      ),
+    ).toBe(415);
+  });
+
+  test('an apply with no field manager is refused: the fields must belong to someone', async () => {
+    expect(
+      await patch({ 'Content-Type': 'application/apply-patch+yaml' }, ''),
+    ).toBe(400);
+  });
+
+  test('both together are what the adapter sends, and are accepted', async () => {
+    expect(
+      await patch(
+        { 'Content-Type': 'application/apply-patch+yaml' },
+        '?fieldManager=spindrift&force=true',
+      ),
+    ).toBe(200);
   });
 });
 

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -171,6 +171,38 @@ describe('the release is five steps, in the product’s order', () => {
     expect(second.api.servedPaths('shop-site')).toHaveLength(2);
   });
 
+  test('a site of more than a thousand files is offered in chunks the API takes', async () => {
+    // The API takes at most 1000 file hashes per `populateFiles` call and
+    // refuses the rest. A `next export` or any bundle with a hashed asset
+    // directory clears that on its first deploy, so this is the ordinary case
+    // rather than an extreme one.
+    const many = tarball(
+      Array.from({ length: 1_001 }, (_, at) => ({
+        name: `assets/${at}.txt`,
+        bytes: bytes(`file ${at}`),
+      })),
+    );
+    const api = new FakeHosting({ bundle: { origin: DEPOT, bytes: many } });
+    const adapter = new StaticDeployAdapter({
+      token: api.token,
+      fetch: api.fetch,
+    });
+
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+
+    expect(verdict.phase).toBe('LIVE');
+    // Two calls, and the version holds every file from both of them — not
+    // just the ones the last chunk named.
+    expect(
+      api.pathsOf('POST').filter((path) => path.endsWith(':populateFiles')),
+    ).toHaveLength(2);
+    expect(api.servedPaths('shop-site')).toHaveLength(1_001);
+    // Every hash the API asked for across both answers was uploaded: an
+    // adapter that kept only the last chunk's answer would finalize a version
+    // whose bytes are not all there.
+    expect(api.uploads).toHaveLength(1_001);
+  });
+
   test('a redeploy releases onto the site that exists rather than a second one', async () => {
     const { api, adapter } = adapterFor({ sites: ['shop-site'] });
     await drain(adapter.apply(TARGET, desired()));

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -15,7 +15,10 @@
  */
 import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
 import { GitHubActionsBuildRoute } from '../../src/adapters/build/github-actions.ts';
-import { InClusterBuildRoute } from '../../src/adapters/build/in-cluster.ts';
+import {
+  InClusterBuildRoute,
+  JOB_LABEL,
+} from '../../src/adapters/build/in-cluster.ts';
 import { encodeBuildReport } from '../../src/adapters/build/report.ts';
 import { CloudRunDeployAdapter } from '../../src/adapters/deploy/cloudrun/index.ts';
 import { KubernetesApi } from '../../src/adapters/deploy/kubernetes/api.ts';
@@ -197,7 +200,13 @@ buildAdapterSuite('in-cluster', () => {
         {
           apiVersion: 'v1',
           kind: 'Pod',
-          metadata: { name: 'build-pod', namespace: 'builds' },
+          metadata: {
+            name: 'build-pod',
+            namespace: 'builds',
+            // The label the route selects the build's own pod by; the cluster
+            // filters on it, so a fixture without it is never found.
+            labels: { [JOB_LABEL]: 'spindrift-build-conformance' },
+          },
         },
       ],
     },

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -6,11 +6,21 @@
  * apply, and its real status reading all run. Nothing inside core is faked; this
  * is the project that is not there.
  *
- * Four behaviours are modelled because the adapter has to survive all four:
+ * Six behaviours are modelled because the adapter has to survive all six:
  *
+ * - **A write answers with an `Operation` and the Service appears behind it.**
+ *   "If successful, the response body contains an instance of `Operation`" —
+ *   the work is asynchronous, so a `GET` issued straight after a create can
+ *   still `404`. That window is the one thing a first Cloud Run deploy is
+ *   guaranteed to hit, so it happens on every create here rather than never.
  * - **The runtime writes `terminalCondition` after the Service is accepted.** A
  *   fake that answered ready on the first read would let an adapter that never
  *   polled pass, which is the whole of `apply`'s second half.
+ * - **A document carrying a field the v2 schema does not define is refused.**
+ *   Google's protobuf-JSON parsers reject unknown members with `400
+ *   INVALID_ARGUMENT`, and the rendered Service is the single document
+ *   standing between this product and a Cloud Run deploy — a `Map.set` is not
+ *   a check.
  * - **A refusal carries a body with a machine-readable reason**, because the
  *   checklist tells "the service is off" from "you may not" from "there is no
  *   such project" by exactly that, and a bare status code would leave nothing to
@@ -47,7 +57,169 @@ export interface FakeCloudRunOptions {
   readonly refuseIam?: { status: number; body: unknown };
   /** The admission policy this project reports, or `null` for none at all. */
   readonly admissionPolicy?: Record<string, unknown> | null;
+  /**
+   * Reads a newly created Service `404`s for before it becomes readable.
+   *
+   * One by default rather than zero, because the create-then-`404` window is
+   * not an edge case: the `PATCH` returns an `Operation` and the Service is
+   * created behind it, so the very next `GET` losing the race is the ordinary
+   * shape of a first deploy. An adapter that treated an absent Service as a
+   * failure would be wrong on every App's first deploy and right afterwards,
+   * which is the worst way for a bug to behave.
+   */
+  readonly createLatencyReads?: number;
   readonly token?: string;
+}
+
+/**
+ * The shape of a v2 `Service`, as much of it as a document may name.
+ *
+ * `true` is "this member exists and what is under it is not this fake's
+ * business" — a free-form map, a scalar, or a message nothing here renders. An
+ * object descends, and a one-element array descends into every element. What
+ * matters is the *closed* set at each level: Google's parsers refuse a member
+ * they do not know, so a fake that accepted one would be the only reader of
+ * this document that ever did.
+ */
+type ServiceSchema =
+  | true
+  | { [member: string]: ServiceSchema }
+  | [ServiceSchema];
+
+const CONTAINER: ServiceSchema = {
+  name: true,
+  image: true,
+  command: true,
+  args: true,
+  env: [
+    {
+      name: true,
+      value: true,
+      valueSource: { secretKeyRef: { secret: true, version: true } },
+    },
+  ],
+  resources: { limits: true, cpuIdle: true, startupCpuBoost: true },
+  ports: [{ name: true, containerPort: true }],
+  volumeMounts: [{ name: true, mountPath: true }],
+  workingDir: true,
+  livenessProbe: true,
+  startupProbe: true,
+  dependsOn: true,
+  baseImageUri: true,
+};
+
+const REVISION_TEMPLATE: ServiceSchema = {
+  revision: true,
+  labels: true,
+  annotations: true,
+  scaling: { minInstanceCount: true, maxInstanceCount: true },
+  vpcAccess: true,
+  timeout: true,
+  serviceAccount: true,
+  containers: [CONTAINER],
+  volumes: true,
+  executionEnvironment: true,
+  encryptionKey: true,
+  maxInstanceRequestConcurrency: true,
+  sessionAffinity: true,
+  healthCheckDisabled: true,
+  nodeSelector: true,
+  serviceMesh: true,
+  gpuZonalRedundancyDisabled: true,
+};
+
+const SERVICE_SCHEMA: ServiceSchema = {
+  name: true,
+  description: true,
+  uid: true,
+  generation: true,
+  labels: true,
+  annotations: true,
+  client: true,
+  clientVersion: true,
+  ingress: true,
+  launchStage: true,
+  binaryAuthorization: true,
+  template: REVISION_TEMPLATE,
+  traffic: true,
+  scaling: true,
+  invokerIamDisabled: true,
+  defaultUriDisabled: true,
+  customAudiences: true,
+  iapEnabled: true,
+  threatDetectionEnabled: true,
+};
+
+/**
+ * The first member the document names that the schema does not, if any.
+ *
+ * Reported by path rather than by name alone, because "Unknown name `foo`" in
+ * a nested message is only actionable if it says which message.
+ */
+function unknownMember(
+  document: unknown,
+  schema: ServiceSchema,
+  path = '',
+): string | null {
+  if (schema === true) return null;
+  if (Array.isArray(schema)) {
+    if (!Array.isArray(document)) return null;
+    for (const [at, item] of document.entries()) {
+      const found = unknownMember(
+        item,
+        schema[0] as ServiceSchema,
+        `${path}[${at}]`,
+      );
+      if (found !== null) return found;
+    }
+    return null;
+  }
+  if (document === null || typeof document !== 'object') return null;
+  for (const [member, value] of Object.entries(document)) {
+    const under = schema[member];
+    const where = path === '' ? member : `${path}.${member}`;
+    if (under === undefined) return where;
+    const found = unknownMember(value, under, where);
+    if (found !== null) return found;
+  }
+  return null;
+}
+
+/**
+ * Namespaces the v2 API refuses to take a label in.
+ *
+ * "Cloud Run API v2 does not support labels with `run.googleapis.com`,
+ * `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev`
+ * namespaces, and they will be rejected."
+ */
+const RESERVED_LABEL_NAMESPACES = [
+  'run.googleapis.com',
+  'cloud.googleapis.com',
+  'serving.knative.dev',
+  'autoscaling.knative.dev',
+];
+
+/** What is wrong with one label map, or `null` if nothing is. */
+function labelProblem(labels: unknown, where: string): string | null {
+  if (labels === null || typeof labels !== 'object') return null;
+  for (const [key, value] of Object.entries(
+    labels as Record<string, unknown>,
+  )) {
+    const namespace = key.includes('/') ? key.slice(0, key.indexOf('/')) : '';
+    if (RESERVED_LABEL_NAMESPACES.includes(namespace)) {
+      return `${where} label "${key}" is in a reserved namespace`;
+    }
+    if (key.length > 63 || !/^[a-z][a-z0-9_-]*$/.test(key)) {
+      return `${where} label key "${key}" is not a valid label name`;
+    }
+    if (typeof value !== 'string') {
+      return `${where} label "${key}" is not a string`;
+    }
+    if (value.length > 63 || !/^[a-z0-9_-]*$/.test(value)) {
+      return `${where} label "${key}" has an invalid value "${value}"`;
+    }
+  }
+  return null;
 }
 
 /** The default: the runtime reports ready on the second read after apply. */
@@ -66,12 +238,17 @@ export class FakeCloudRun {
   readonly endpoint = CLOUD_ENDPOINTS.run;
   readonly policyEndpoint = CLOUD_ENDPOINTS.policy;
   readonly requests: RecordedCloudRequest[] = [];
+  /** Every Operation a write answered with, in order — what a poll would use. */
+  readonly operations: { name: string; done: boolean }[] = [];
 
   /** Services this project holds, by id. */
   private readonly services = new Map<string, Record<string, unknown>>();
   /** Invoker policies, by service id — the assertion surface for exposure. */
   private readonly policies = new Map<string, unknown>();
   private readonly reads = new Map<string, number>();
+  /** Reads a just-created Service still owes before it can be seen. */
+  private readonly creating = new Map<string, number>();
+  private nextOperation = 1;
   private readonly options: FakeCloudRunOptions;
 
   constructor(options: FakeCloudRunOptions = {}) {
@@ -167,7 +344,8 @@ export class FakeCloudRun {
         this.services.delete(id);
         this.policies.delete(id);
         this.reads.delete(id);
-        return json(200, { done: true });
+        this.creating.delete(id);
+        return json(200, this.operation(id, true));
       default:
         return json(405, {
           error: { message: `${request.method} is not supported` },
@@ -182,6 +360,14 @@ export class FakeCloudRun {
   }
 
   private readResponse(id: string): Response {
+    // The Service is created *behind* the Operation the write returned, so for
+    // a while after a create it is genuinely not there yet. `read()` must map
+    // that to "still applying" rather than to a failure.
+    const owed = this.creating.get(id) ?? 0;
+    if (owed > 0) {
+      this.creating.set(id, owed - 1);
+      return json(404, notFound());
+    }
     const service = this.services.get(id);
     if (service === undefined) return json(404, notFound());
 
@@ -211,6 +397,10 @@ export class FakeCloudRun {
     ) {
       return json(404, notFound());
     }
+    const rejected = this.schemaProblem(document);
+    if (rejected !== null) return rejected;
+
+    const creating = !this.services.has(id);
     const stored = {
       ...document,
       name: id,
@@ -218,9 +408,63 @@ export class FakeCloudRun {
     };
     this.services.set(id, stored);
     this.reads.set(id, 0);
-    return json(200, { done: false, metadata: { target: id } });
+    if (creating) {
+      this.creating.set(id, this.options.createLatencyReads ?? 1);
+    }
+    return json(200, this.operation(id, false));
+  }
+
+  /** Why the API would refuse this document, or `null` if it would not. */
+  private schemaProblem(document: Record<string, unknown>): Response | null {
+    const unknown = unknownMember(document, SERVICE_SCHEMA);
+    if (unknown !== null) {
+      return json(400, {
+        error: {
+          code: 400,
+          status: 'INVALID_ARGUMENT',
+          message: `Invalid JSON payload received. Unknown name "${unknown}" at 'service'.`,
+        },
+      });
+    }
+    const template = document.template as
+      | { labels?: unknown }
+      | undefined
+      | null;
+    const label =
+      labelProblem(document.labels, 'service') ??
+      labelProblem(template?.labels, 'revision template');
+    if (label !== null) {
+      return json(400, {
+        error: { code: 400, status: 'INVALID_ARGUMENT', message: label },
+      });
+    }
+    return null;
+  }
+
+  /**
+   * The long-running operation a write answers with.
+   *
+   * A real one always carries a `name` — it is the handle the operation is
+   * polled by. The adapter discards this body today, so the `name` is here for
+   * the moment something wants to poll rather than because anything reads it
+   * now; a fake with nothing to poll is a fake that could not tell.
+   */
+  private operation(id: string, done: boolean): unknown {
+    const name = `projects/${this.project}/locations/${this.region}/operations/op-${this.nextOperation++}`;
+    this.operations.push({ name, done });
+    return {
+      name,
+      done,
+      metadata: {
+        '@type': 'type.googleapis.com/google.cloud.run.v2.Service',
+        target: id,
+      },
+    };
   }
 }
+
+/** The member a real `google.rpc.ErrorInfo` detail identifies itself by. */
+const ERROR_INFO = 'type.googleapis.com/google.rpc.ErrorInfo';
 
 /** The body a Google-family API returns for an absent resource. */
 function notFound(): unknown {
@@ -235,7 +479,7 @@ export function serviceDisabled(): { status: number; body: unknown } {
       error: {
         message: 'Cloud Run API has not been used in this project',
         status: 'PERMISSION_DENIED',
-        details: [{ reason: 'SERVICE_DISABLED' }],
+        details: [{ '@type': ERROR_INFO, reason: 'SERVICE_DISABLED' }],
       },
     },
   };
@@ -249,7 +493,7 @@ export function permissionDenied(): { status: number; body: unknown } {
       error: {
         message: 'the caller does not have permission',
         status: 'PERMISSION_DENIED',
-        details: [{ reason: 'IAM_PERMISSION_DENIED' }],
+        details: [{ '@type': ERROR_INFO, reason: 'IAM_PERMISSION_DENIED' }],
       },
     },
   };

--- a/apps/spindrift/test/harness/fakes/hosting-api.ts
+++ b/apps/spindrift/test/harness/fakes/hosting-api.ts
@@ -65,6 +65,14 @@ interface FakeVersion {
 
 const UPLOAD_BASE = 'https://upload.example.test/files';
 
+/**
+ * The most file hashes one `populateFiles` call may carry.
+ *
+ * The API's documented ceiling, modelled because it is the boundary every
+ * real static site crosses and the one nothing here could previously reach.
+ */
+const POPULATE_LIMIT = 1000;
+
 export class FakeHosting {
   readonly endpoint = CLOUD_ENDPOINTS.hosting;
   readonly requests: RecordedHostingRequest[] = [];
@@ -135,6 +143,24 @@ export class FakeHosting {
 
     if (url.href.startsWith(UPLOAD_BASE)) {
       const hash = url.pathname.split('/').pop() ?? '';
+      const bytes = new Uint8Array(await request.clone().arrayBuffer());
+      // The address a file is uploaded to *is* its hash, and the product
+      // stores the compressed file: "The hash is calculated by Gzipping the
+      // file then taking the SHA256 hash of the newly compressed file." An
+      // adapter that hashed the file's own bytes, or that offered a gzip hash
+      // and then uploaded the plain file, would be storing content under an
+      // address that is not its content — so both halves are checked rather
+      // than assumed correct because they happen to be today.
+      if (bytes[0] !== 0x1f || bytes[1] !== 0x8b) {
+        return json(400, invalid('the uploaded file is not gzipped'));
+      }
+      const digest = new Bun.CryptoHasher('sha256').update(bytes).digest('hex');
+      if (digest !== hash) {
+        return json(
+          400,
+          invalid(`the uploaded bytes hash to ${digest}, not to ${hash}`),
+        );
+      }
       this.uploaded.add(hash);
       this.held.add(hash);
       return json(200, {});
@@ -272,7 +298,21 @@ export class FakeHosting {
     const version = this.versions.get(name);
     if (version === undefined) return json(404, error('no version'));
     const files = (body as { files?: Record<string, string> })?.files ?? {};
-    version.files = files;
+    // "You can send a maximum of 1000 file hashes in each API request." A
+    // built site clears that on its first deploy, so an adapter that offers
+    // the whole map in one call fails here rather than only in production.
+    if (Object.keys(files).length > POPULATE_LIMIT) {
+      return json(
+        400,
+        invalid(
+          `a maximum of ${POPULATE_LIMIT} file hashes may be sent in each request`,
+        ),
+      );
+    }
+    // "The files in each call will be added to the version" — the calls
+    // accumulate. A fake that replaced would make a chunked offer look like it
+    // had populated only its last chunk.
+    version.files = { ...version.files, ...files };
     // Only the hashes not already held are asked for, which is the behaviour
     // the adapter's upload loop is written against.
     const wanted = [...new Set(Object.values(files))].filter(
@@ -348,6 +388,11 @@ function site(id: string): unknown {
 
 function error(message: string): unknown {
   return { error: { message, status: 'NOT_FOUND' } };
+}
+
+/** A refusal because the request itself was malformed, not because of state. */
+function invalid(message: string): unknown {
+  return { error: { message, status: 'INVALID_ARGUMENT' } };
 }
 
 function json(status: number, body: unknown): Response {

--- a/apps/spindrift/test/harness/fakes/kubernetes-api.ts
+++ b/apps/spindrift/test/harness/fakes/kubernetes-api.ts
@@ -6,17 +6,22 @@
  * real server-side apply, and its real status reading all run. Nothing inside
  * core is faked; this is the cluster that is not there.
  *
- * Three behaviours are modelled because the adapter has to survive them:
+ * Four behaviours are modelled because the adapter has to survive them:
  *
- * - **A kind the cluster does not serve answers `404`**, which is how §13's
- *   checklist tells "no `HelmRelease`s exist" from "this cluster has never
- *   heard of one".
+ * - **A kind the cluster does not serve answers `404`, and a served kind with
+ *   nothing in it answers `200` with an empty `items`.** That distinction is
+ *   the whole reason `KubernetesApi.list` returns `null` rather than `[]`, so
+ *   `servedKinds` decides it — not whether a test happened to seed anything.
  * - **The controller writes status after the object is applied.** A fake that
  *   returned a ready object immediately would let an adapter that never polled
  *   pass, which is the whole of `apply`'s second half.
  * - **A rejected write answers `4xx` with a body**, because §6 wants the
  *   sentence the developer reads and a fake that returned a bare status code
  *   would leave nothing to read.
+ * - **A write is only a server-side apply if it says so.** The content type and
+ *   the field manager are what make a `PATCH` an apply rather than some other
+ *   patch, and the API server refuses one that omits either — so this does too,
+ *   rather than storing whatever it is handed.
  */
 import type { Fetcher } from '../../../src/adapters/deploy/kubernetes/api.ts';
 
@@ -40,7 +45,13 @@ export interface FakeObject {
 export type StatusScript = (reads: number) => Record<string, unknown> | null;
 
 export interface FakeKubernetesOptions {
-  /** Kinds this cluster serves, as `group/version` → kind names. */
+  /**
+   * Kinds this cluster serves, as `group/version` → kind names.
+   *
+   * The core group is served by every cluster and is therefore not a question
+   * a test has to answer; anything listed here for `v1` is served in addition
+   * to {@link CORE_KINDS}.
+   */
   servedKinds?: Record<string, string[]>;
   /** Objects that already exist, keyed by `plural/namespace/name`. */
   objects?: Record<string, FakeObject>;
@@ -64,6 +75,72 @@ export interface FakeKubernetesOptions {
 }
 
 const HOST = 'https://cluster.invalid';
+
+/**
+ * The core-group kinds every cluster serves.
+ *
+ * Fixed rather than configurable: a cluster that did not serve `Pod` is not a
+ * cluster, so making a test declare it would only be a way to forget it and
+ * get a `404` that means nothing. A core plural outside this list still
+ * `404`s, which is the honest answer for a kind that does not exist.
+ */
+const CORE_KINDS = [
+  'Pod',
+  'Event',
+  'Node',
+  'Namespace',
+  'Secret',
+  'ConfigMap',
+  'Service',
+  'ServiceAccount',
+  'PersistentVolumeClaim',
+];
+
+/**
+ * The plural the API path uses for one kind.
+ *
+ * The API server's own rule, which is why the discovery document and the list
+ * route can share it: a fake whose discovery said one plural and whose routing
+ * expected another would answer inconsistently about the same kind.
+ */
+function pluralOf(kind: string): string {
+  const lower = kind.toLowerCase();
+  if (lower.endsWith('y')) return `${lower.slice(0, -1)}ies`;
+  if (/(?:s|x|z|ch|sh)$/.test(lower)) return `${lower}es`;
+  return `${lower}s`;
+}
+
+/** The body the API server returns for a kind or object that is not there. */
+function notFound(message: string): unknown {
+  return {
+    kind: 'Status',
+    apiVersion: 'v1',
+    status: 'Failure',
+    reason: 'NotFound',
+    code: 404,
+    message,
+  };
+}
+
+/**
+ * Whether one object satisfies a `labelSelector`.
+ *
+ * Equality and existence only, which is every form this adapter sends — and
+ * every unsupported form falls through to matching nothing rather than to
+ * matching everything, because "the selector was ignored" is exactly the
+ * failure this is here to make visible.
+ */
+function matchesSelector(object: FakeObject, selector: string): boolean {
+  const labels = (object.metadata.labels ?? {}) as Record<string, string>;
+  return selector
+    .split(',')
+    .filter((term) => term.length > 0)
+    .every((term) => {
+      const at = term.indexOf('=');
+      if (at === -1) return labels[term] !== undefined;
+      return labels[term.slice(0, at)] === term.slice(at + 1);
+    });
+}
 
 /** The default: the controller reports ready on the first read after apply. */
 const READY: StatusScript = () => ({
@@ -148,8 +225,25 @@ export class FakeKubernetes {
     const parsed = parsePath(url.pathname);
     if (parsed === null) return json(404, { message: 'no such path' });
 
-    // The one API that answers rather than stores.
+    // The one API that answers rather than stores. It answers about the
+    // attributes it is asked about, so a review carrying none is a review
+    // about nothing — the API server refuses it rather than approving it.
     if (parsed.plural === 'selfsubjectaccessreviews') {
+      const spec = (body as { spec?: { resourceAttributes?: unknown } } | null)
+        ?.spec;
+      const attributes = spec?.resourceAttributes as
+        | { verb?: string; resource?: string }
+        | undefined;
+      if (attributes?.verb === undefined || attributes.resource === undefined) {
+        return json(422, {
+          kind: 'Status',
+          status: 'Failure',
+          reason: 'Invalid',
+          code: 422,
+          message:
+            'SelfSubjectAccessReview.spec.resourceAttributes must name a verb and a resource',
+        });
+      }
       return json(201, {
         apiVersion: 'authorization.k8s.io/v1',
         kind: 'SelfSubjectAccessReview',
@@ -168,15 +262,26 @@ export class FakeKubernetes {
         : new Response(text);
     }
 
-    if (parsed.name === undefined) return this.listResponse(parsed.plural);
+    if (parsed.name === undefined) {
+      return this.listResponse(parsed, url.searchParams);
+    }
 
     const key = `${parsed.plural}/${parsed.namespace ?? ''}/${parsed.name}`;
     switch (request.method) {
       case 'GET':
         return this.getResponse(key);
       case 'PATCH':
-        return this.applyResponse(key, body as FakeObject);
+        return this.applyResponse(key, body as FakeObject, request, url);
       case 'DELETE':
+        // Deleting what is not there is a `404`, which is what makes
+        // `KubernetesApi.delete`'s idempotence a property of the adapter
+        // rather than of a fake that never disagreed.
+        if (!this.objects.has(key)) {
+          return json(
+            404,
+            notFound(`${parsed.plural} "${parsed.name}" not found`),
+          );
+        }
         this.objects.delete(key);
         this.reads.delete(key);
         return json(200, { status: 'Success' });
@@ -188,21 +293,59 @@ export class FakeKubernetes {
   private discovery(path: string): Response | null {
     const match = path.match(/^\/apis\/([^/]+\/[^/]+)$/);
     if (match === null) return null;
-    const served = this.options.servedKinds ?? {};
-    const kinds = served[match[1] as string];
-    if (kinds === undefined) return json(404, { message: 'no such group' });
+    const kinds = this.kindsOf(match[1] as string);
+    if (kinds === null) return json(404, { message: 'no such group' });
     return json(200, {
-      resources: kinds.map((kind) => ({ kind, name: kind.toLowerCase() })),
+      resources: kinds.map((kind) => ({ kind, name: pluralOf(kind) })),
     });
   }
 
-  private listResponse(plural: string): Response {
-    const seeded = this.options.lists?.[plural];
-    if (seeded === undefined && this.all(plural).length === 0) {
-      // A kind nothing was seeded for is a kind this cluster does not serve.
-      return json(404, { message: `no ${plural}` });
+  /** The kinds one `group/version` serves, or `null` if it is not served. */
+  private kindsOf(apiVersion: string): string[] | null {
+    const served = this.options.servedKinds ?? {};
+    if (!apiVersion.includes('/')) {
+      return [...CORE_KINDS, ...(served[apiVersion] ?? [])];
     }
-    return json(200, { items: seeded ?? this.all(plural) });
+    return served[apiVersion] ?? null;
+  }
+
+  /**
+   * A list, or the `404` that means this cluster does not serve the kind.
+   *
+   * The two are different answers and `KubernetesApi.list` exists to keep them
+   * apart, so what decides is whether the kind is *served* — never whether it
+   * happens to hold anything. A served kind holding nothing answers `200` with
+   * an empty `items`, which is the branch every `?? []` at a call site is
+   * written for and which nothing could previously reach.
+   *
+   * `servedKinds` is the authority. Seeded objects and a seeded `lists` entry
+   * also make a kind served, because they cannot mean anything else: an API
+   * that hands back `Pod`s serves `Pod`s. What they no longer do is the
+   * inverse — an unseeded kind is absent, not unheard of.
+   */
+  private listResponse(parsed: ParsedPath, query: URLSearchParams): Response {
+    const kinds = this.kindsOf(parsed.apiVersion);
+    const serves =
+      (kinds ?? []).some((kind) => pluralOf(kind) === parsed.plural) ||
+      this.options.lists?.[parsed.plural] !== undefined ||
+      this.all(parsed.plural).length > 0;
+    if (!serves) {
+      return json(
+        404,
+        notFound('the server could not find the requested resource'),
+      );
+    }
+    const items =
+      this.options.lists?.[parsed.plural] ?? this.all(parsed.plural);
+    // The cluster filters, not the caller: a selector the adapter got wrong
+    // comes back with nothing rather than with everything.
+    const selector = query.get('labelSelector');
+    return json(200, {
+      items:
+        selector === null
+          ? items
+          : items.filter((item) => matchesSelector(item, selector)),
+    });
   }
 
   private getResponse(key: string): Response {
@@ -218,7 +361,42 @@ export class FakeKubernetes {
     return json(200, status === null ? object : { ...object, status });
   }
 
-  private applyResponse(key: string, object: FakeObject): Response {
+  private applyResponse(
+    key: string,
+    object: FakeObject,
+    request: Request,
+    url: URL,
+  ): Response {
+    // "Whether you are submitting JSON data or YAML data, use
+    // `application/apply-patch+yaml` as the Content-Type header value." A
+    // `PATCH` sent as `application/json` is a merge patch — a different verb
+    // with different semantics — and the API server refuses it here rather
+    // than quietly applying it as one.
+    if (
+      request.headers.get('content-type') !== 'application/apply-patch+yaml'
+    ) {
+      return json(415, {
+        kind: 'Status',
+        status: 'Failure',
+        reason: 'UnsupportedMediaType',
+        code: 415,
+        message:
+          'the body of the request was in an unknown format - accepted media types include: application/apply-patch+yaml',
+      });
+    }
+    // "All Server-Side Apply patch requests are required to identify themselves
+    // by providing a `fieldManager` query parameter." Without one there is
+    // nobody for the applied fields to belong to, which is the whole mechanism
+    // that keeps an operator's edit from being reverted by the next deploy.
+    if ((url.searchParams.get('fieldManager') ?? '') === '') {
+      return json(400, {
+        kind: 'Status',
+        status: 'Failure',
+        reason: 'BadRequest',
+        code: 400,
+        message: 'fieldManager is required for apply patch',
+      });
+    }
     if (this.options.refuse !== undefined) {
       return new Response(this.options.refuse.body, {
         status: this.options.refuse.status,
@@ -242,6 +420,8 @@ function json(status: number, body: unknown): Response {
 }
 
 interface ParsedPath {
+  /** `v1` for the core group, `group/version` otherwise. */
+  apiVersion: string;
   plural: string;
   namespace?: string;
   name?: string;
@@ -253,16 +433,23 @@ interface ParsedPath {
 function parsePath(path: string): ParsedPath | null {
   const parts = path.split('/').filter((part) => part.length > 0);
   // /api/v1/... or /apis/group/version/...
+  const apiVersion =
+    parts[0] === 'api'
+      ? (parts[1] ?? null)
+      : parts[0] === 'apis' && parts[1] !== undefined && parts[2] !== undefined
+        ? `${parts[1]}/${parts[2]}`
+        : null;
   const rest =
     parts[0] === 'api'
       ? parts.slice(2)
       : parts[0] === 'apis'
         ? parts.slice(3)
         : null;
-  if (rest === null) return null;
+  if (rest === null || apiVersion === null) return null;
 
   if (rest[0] === 'namespaces' && rest.length >= 3) {
     return {
+      apiVersion,
       namespace: rest[1] as string,
       plural: rest[2] as string,
       ...(rest[3] === undefined ? {} : { name: rest[3] }),
@@ -271,6 +458,7 @@ function parsePath(path: string): ParsedPath | null {
   }
   if (rest.length === 0) return null;
   return {
+    apiVersion,
     plural: rest[0] as string,
     ...(rest[1] === undefined ? {} : { name: rest[1] }),
   };


### PR DESCRIPTION
Group C of the fake-fidelity audit that followed #1435, where one wrong `Accept` header blocked every build this product has ever run and 926 passing tests could not see it — because the fake never modelled the header. Tickets 16, 21 and 22.

The stakes here are not ordinary test cleanup. **No Deploy has ever succeeded on this installation**; the `deploys` table has four rows, all `FAILED`. The Kubernetes, Cloud Run and static adapters have essentially never run outside these fakes, so "the tests pass" is evidence of very little and the fakes are very nearly the whole basis for believing those adapters work.

## [16] Hosting populates within the API's own limit — the one live bug

`release()` offered the whole file map to `populateFiles` in a single call. The API takes **at most 1000 file hashes per call** and refuses the rest, so any site over 1000 files — a `next export`, a Docusaurus build, anything with a hashed asset directory — failed on its first deploy.

- `release()` chunks the offer and accumulates `uploadRequiredHashes` and `uploadUrl` across every chunk.
- The fake refuses an over-limit call with `400 INVALID_ARGUMENT`, and **accumulates** across calls the way the API documents — without that, a chunked offer would have populated only its last chunk and the new test would have passed for the wrong reason.
- The upload route now reads the body: bytes must be gzipped and must sha256 to the address they were uploaded under. The hash is over the *compressed* file, so both halves are checked.

## [21] The Kubernetes fake can answer an empty list

It answered `404` for any kind nothing was seeded for, conflating "this cluster does not serve the kind" with "there are none of it" — the one distinction `KubernetesApi.list` exists to preserve, and the one §13's checklist turns on.

- `servedKinds` decides, the core group is always served, and a served kind holding nothing answers `200 {"items": []}`. Plurals come from one helper shared with the discovery document.
- A `PATCH` that is not `application/apply-patch+yaml` is `415`; one with no `fieldManager` is `400`. Those two are what make a `PATCH` a server-side apply.
- `labelSelector` is applied when listing. This forced the pod fixtures to grow the labels the chart actually renders — until now they were pods no cluster would have returned for the selector that asked for them.
- `DELETE` of an absent object `404`s, so `delete()`'s idempotence is proven rather than assumed. A `SelfSubjectAccessReview` with no resource attributes is refused.

## [22] Cloud Run's apply is asynchronous

The fake made a Service readable on the very next request. The real `PATCH` answers with an `Operation` and creates the Service **behind** it, so the `GET` that follows can `404`.

- Writes return a well-formed `Operation` with a `name`; a created Service is unreadable for `createLatencyReads` reads, **defaulting to 1**. That window is the ordinary shape of a first deploy, not an edge case, so it now happens on every create rather than never.
- The document is checked against the v2 `Service` schema and the v2 label rules; an unknown member is `400 INVALID_ARGUMENT` with the parser's own wording.

## What was actually wrong

Only [16] needed a production change. [21] and [22] were latent, exactly as their tickets traced — `src/adapters/deploy/kubernetes/` and `src/adapters/deploy/cloudrun/` are untouched by this branch.

## Proof the fakes now catch it

Every fix was reverted and the suite re-run. All of these **passed the whole suite before this change**:

| revert | fails |
| --- | --- |
| `populateFiles` back to one call | 1 |
| hash the uncompressed file instead of the gzipped one | 10 |
| drop the apply `Content-Type` | 16 |
| drop the apply `fieldManager` | 15 |
| a wrong pod `labelSelector` | 4 |
| an absent Cloud Run Service treated as a failure, not as still-applying | 9 |
| a `cpu` member the v2 container schema does not define | 11 |
| a label in `run.googleapis.com/` | 11 |

The Cloud Run one is the sharpest: `service === null` was **unreachable in every test that existed**, so the branch that survives a first deploy's create-then-404 window had zero coverage.

```
946 pass, 0 fail — Ran 946 tests across 65 files   (12 tests added)
bun run typecheck && bun run lint — clean
```

## Not proven end to end

Nothing here is proven against a real API. The 1000-file boundary has never been reached and no Deploy has ever been written, so what is proven is that the adapters behave correctly against fakes that now refuse what the vendors document refusing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)