### PR TITLE
fix(spindrift): build log, verifier process, and artifact digests (tickets 15, 17, 18)

### DIFF
--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -55,8 +55,53 @@ interface CloudBuild {
 
 /** One log entry, as much of it as this route reads. */
 interface LogEntry {
+  /**
+   * The log service's own identity for this entry. It is what makes re-reading
+   * a window cheap: the same entry seen twice is recognised rather than
+   * re-emitted, so the route never needs a cursor it cannot trust.
+   */
+  readonly insertId?: string;
   readonly textPayload?: string;
   readonly timestamp?: string;
+}
+
+/**
+ * How far behind the newest entry already read a fresh search reaches.
+ *
+ * Entries are ingested out of order, so a window that started exactly at the
+ * newest timestamp would step over anything that arrived late. A minute is
+ * generous against the log service's own ingestion latency, and re-reading a
+ * minute costs nothing because {@link keyOf} recognises what was already
+ * emitted.
+ */
+const LOG_LATENESS_MS = 60_000;
+
+/**
+ * Pages one search follows before leaving the rest to the next poll.
+ *
+ * A bound rather than a limit anyone should hit: the next poll re-reads the
+ * window anyway, so stopping early loses nothing but a few seconds of latency.
+ */
+const MAX_LOG_PAGES = 50;
+
+/**
+ * How long a concluded build's log is drained for before the route gives up on
+ * the report.
+ *
+ * The build being over does not mean its log is: ingestion runs behind the
+ * writer, and the report line is written in the final seconds of the run. This
+ * is the only budget spent waiting for something that has already happened.
+ */
+const LOG_TAIL_TIMEOUT_MS = 60_000;
+
+/** What the route carries between reads of one build's log. */
+interface LogTail {
+  /** Entries already emitted, by {@link keyOf}. */
+  readonly seen: Set<string>;
+  /** The newest entry timestamp seen, which anchors the next search's window. */
+  newest: Date | null;
+  /** Everything emitted, joined — what {@link parseBuildReport} reads. */
+  log: string;
 }
 
 export interface CloudBuildRouteOptions extends PollingOptions {
@@ -152,24 +197,12 @@ export class CloudBuildRoute implements BuildAdapter {
     yield { type: 'log', at: now(), line: `build ${build.id} submitted` };
 
     const budget = deadlineFrom(this.options);
-    let cursor: string | undefined;
-    let log = '';
+    const tail: LogTail = { seen: new Set(), newest: null, log: '' };
     let status = build.status ?? 'QUEUED';
     let statusDetail = build.statusDetail;
 
     for (;;) {
-      const page = await this.logPage(build.id, cursor);
-      cursor = page.cursor;
-      for (const entry of page.entries) {
-        const line = entry.textPayload;
-        if (line === undefined || line.trim() === '') continue;
-        log += `${line}\n`;
-        yield {
-          type: 'log',
-          at: entry.timestamp === undefined ? now() : new Date(entry.timestamp),
-          line,
-        };
-      }
+      yield* this.readLog(build.id, tail, now);
 
       const current = await this.read(build.id);
       if (current !== null) {
@@ -188,6 +221,28 @@ export class CloudBuildRoute implements BuildAdapter {
       }
       await budget.tick();
     }
+
+    // The log read above happened *before* the status read that ended the loop,
+    // so everything the build wrote in its last seconds is still unread — and
+    // that is precisely the region that carries the report (`report.ts`: the
+    // result travels the same way the logs do). A loop that stopped here would
+    // record a green build as `succeeded but reported no artifact`, so the read
+    // after the conclusion is the load-bearing one, not a courtesy.
+    const drain = deadlineFrom({
+      ...this.options,
+      timeoutMs: LOG_TAIL_TIMEOUT_MS,
+    });
+    for (;;) {
+      yield* this.readLog(build.id, tail, now);
+      // A red build's report is not coming; one final read for the operator's
+      // sake is the whole of what it is owed.
+      if (status !== 'SUCCESS') break;
+      if (parseBuildReport(tail.log) !== null) break;
+      if (drain.expired()) break;
+      await drain.tick();
+    }
+
+    const log = tail.log;
 
     if (status !== 'SUCCESS') {
       // The service's own `TIMEOUT` is core's `TIMEOUT` — a build that ran out
@@ -265,38 +320,82 @@ export class CloudBuildRoute implements BuildAdapter {
   }
 
   /**
-   * One page of the build's log, and where to resume.
+   * Everything the build's log has gained since the last read, as events.
    *
-   * A page cursor rather than a timestamp window: entries arrive out of order
-   * often enough that a window either repeats lines or drops them, and the log
-   * service's own cursor is the only thing that knows which it already served.
+   * **One poll is one search.** `entries.list`'s `nextPageToken` is a
+   * continuation of *this* search — "retrieve the next batch of results from
+   * the preceding call to this method" — and not a watermark on a live log. A
+   * route that saved one and presented it seconds later would be paginating a
+   * snapshot of the past, so the token is followed to the end of the search it
+   * belongs to and then dropped.
+   *
+   * What replaces it is a timestamp window plus per-entry identity: each poll
+   * re-searches the last {@link LOG_LATENESS_MS} and {@link keyOf} drops what
+   * was already emitted. That is what tolerates out-of-order ingestion, which a
+   * cursor never did.
+   *
+   * **An empty page carrying a token is not a caught-up log.** The vendor is
+   * explicit that it means "the search found no log entries so far but it did
+   * not have time to search all the possible log entries", so the token is
+   * followed rather than read as an end.
    */
-  private async logPage(
+  private async *readLog(
     id: string,
-    cursor: string | undefined,
-  ): Promise<{ entries: readonly LogEntry[]; cursor: string | undefined }> {
-    let page: { entries?: LogEntry[]; nextPageToken?: string } | null = null;
-    try {
-      page = await this.json(`${this.options.logsEndpoint}/v2/entries:list`, {
-        method: 'POST',
-        body: {
-          resourceNames: [`projects/${this.options.project}`],
-          filter: `resource.labels.build_id="${id}"`,
-          orderBy: 'timestamp asc',
-          pageSize: 200,
-          ...(cursor === undefined ? {} : { pageToken: cursor }),
-        },
-      });
-    } catch {
-      // A log service having a bad moment must not fail a build that is
-      // otherwise going fine — the status read below is the authority on
-      // whether it is going fine, and the next pass asks for the page again.
-      return { entries: [], cursor };
+    tail: LogTail,
+    now: () => Date,
+  ): AsyncGenerator<BuildEvent, void, void> {
+    const filter = [
+      `resource.labels.build_id="${id}"`,
+      ...(tail.newest === null
+        ? []
+        : [
+            `timestamp>="${new Date(tail.newest.getTime() - LOG_LATENESS_MS).toISOString()}"`,
+          ]),
+    ].join(' AND ');
+
+    let token: string | undefined;
+    for (let page = 0; page < MAX_LOG_PAGES; page += 1) {
+      let answer: { entries?: LogEntry[]; nextPageToken?: string } | null;
+      try {
+        answer = await this.json(
+          `${this.options.logsEndpoint}/v2/entries:list`,
+          {
+            method: 'POST',
+            body: {
+              resourceNames: [`projects/${this.options.project}`],
+              filter,
+              orderBy: 'timestamp asc',
+              pageSize: 200,
+              ...(token === undefined ? {} : { pageToken: token }),
+            },
+          },
+        );
+      } catch {
+        // A log service having a bad moment must not fail a build that is
+        // otherwise going fine — the status read is the authority on whether it
+        // is going fine, and the next pass searches the same window again.
+        return;
+      }
+
+      for (const entry of answer?.entries ?? []) {
+        const key = keyOf(entry);
+        if (tail.seen.has(key)) continue;
+        tail.seen.add(key);
+
+        const at = timestampOf(entry);
+        if (at !== null && (tail.newest === null || at > tail.newest)) {
+          tail.newest = at;
+        }
+
+        const line = entry.textPayload;
+        if (line === undefined || line.trim() === '') continue;
+        tail.log += `${line}\n`;
+        yield { type: 'log', at: at ?? now(), line };
+      }
+
+      token = answer?.nextPageToken;
+      if (token === undefined || token === '') return;
     }
-    return {
-      entries: page?.entries ?? [],
-      cursor: page?.nextPageToken ?? cursor,
-    };
   }
 
   private async json<Result>(
@@ -326,4 +425,26 @@ export class CloudBuildRoute implements BuildAdapter {
     }
     return (await response.json()) as Result;
   }
+}
+
+/**
+ * What makes two reads of the same entry the same entry.
+ *
+ * `insertId` is the log service's own identity and is what this relies on. The
+ * fallback exists because an entry without one still has to be deduplicated
+ * somehow, and it deliberately collapses two identical lines written in the
+ * same second — losing a duplicated line is a smaller wrong than emitting the
+ * whole window again on every poll.
+ */
+function keyOf(entry: LogEntry): string {
+  if (entry.insertId !== undefined && entry.insertId !== '') {
+    return entry.insertId;
+  }
+  return `${entry.timestamp ?? ''} ${entry.textPayload ?? ''}`;
+}
+
+function timestampOf(entry: LogEntry): Date | null {
+  if (entry.timestamp === undefined) return null;
+  const at = new Date(entry.timestamp);
+  return Number.isNaN(at.getTime()) ? null : at;
 }

--- a/apps/spindrift/src/adapters/build/report.ts
+++ b/apps/spindrift/src/adapters/build/report.ts
@@ -24,6 +24,7 @@
  * something an ordinary compiler emits.
  */
 import { z } from 'zod';
+import { digestSchema as digest } from '../../domain/digest.ts';
 
 /**
  * The prefix a report line starts with.
@@ -33,12 +34,6 @@ import { z } from 'zod';
  * a marker the runner's log processor may swallow.
  */
 export const BUILD_REPORT_MARKER = 'spindrift-result';
-
-/** A digest, in the only form anything here accepts. */
-const digest = z
-  .string()
-  .trim()
-  .regex(/^sha256:[0-9a-f]{64}$/, 'must be a sha256 digest');
 
 /**
  * What a runner reports.

--- a/apps/spindrift/src/commands/apps/upload-archive.ts
+++ b/apps/spindrift/src/commands/apps/upload-archive.ts
@@ -29,6 +29,7 @@ import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { builds, components, targets } from '../../db/schema.ts';
 import type { ArtifactType } from '../../domain/desired-state.ts';
+import { digestSchema } from '../../domain/digest.ts';
 import { artifactTypeFor, placementTargetOf } from '../../domain/placement.ts';
 import {
   type ArchiveSource,
@@ -39,10 +40,7 @@ import {
 import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
 /** A content digest over the staged bundle (§16). */
-const bundleDigest = z
-  .string()
-  .trim()
-  .regex(/^sha256:[0-9a-f]{64}$/, 'must be a sha256 digest');
+const bundleDigest = digestSchema;
 
 export const uploadArchiveInput = z
   .object({

--- a/apps/spindrift/src/commands/create-app.ts
+++ b/apps/spindrift/src/commands/create-app.ts
@@ -14,6 +14,7 @@
  */
 import { z } from 'zod';
 import { apps } from '../db/schema.ts';
+import { digestSchema } from '../domain/digest.ts';
 import { type Command, ok } from './types.ts';
 
 /** A DNS-safe label: the name appears in canonical hostnames (§9). */
@@ -47,10 +48,7 @@ const vanityLabel = z
 const vesselRef = z.string().trim().min(1);
 
 /** A content digest of the uploaded bundle (§4: the bundle digest joins the receipt to its provenance). */
-const archiveDigest = z
-  .string()
-  .trim()
-  .regex(/^sha256:[0-9a-f]{64}$/, 'must be a sha256 digest');
+const archiveDigest = digestSchema;
 
 const common = {
   name: appName,

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -6,6 +6,7 @@
  */
 import { z } from 'zod';
 import type { ComponentKind, Exposure } from './desired-state.ts';
+import { digestSchema } from './digest.ts';
 
 export const ENTRIES = [
   {
@@ -61,7 +62,7 @@ const source = z.discriminatedUnion('kind', [
     .object({
       kind: z.literal('archive'),
       filename: z.string().min(1),
-      digest: z.string().regex(/^sha256:[0-9a-f]{64}$/),
+      digest: digestSchema,
       /** Durable location written by the upload/staging boundary. */
       location: z.string().min(1).nullable().optional(),
       /** Finished output bypasses a builder; source follows the ordinary path. */

--- a/apps/spindrift/src/domain/digest.ts
+++ b/apps/spindrift/src/domain/digest.ts
@@ -1,0 +1,33 @@
+/**
+ * What a digest is, in one place.
+ *
+ * §16 joins the source receipt to the provenance document on a digest, and the
+ * deploy path pins an artifact by one — so "is this a digest" is a rule the
+ * product enforces at four boundaries: a runner's build report, an archive
+ * upload, an App creation, and a persisted creation draft. It was written out
+ * four times, identically, which is three chances for the definitions to drift
+ * apart and no way for a test to notice: a fake that hands back
+ * `sha256:fake-0` only has to satisfy whichever copy happens to be on its path,
+ * and the fakes satisfied none of them.
+ *
+ * Lowercase hex only, deliberately. A digest is compared for equality all the
+ * way through — receipt against provenance, provenance against artifact — and a
+ * value that differs only in case would compare unequal while naming the same
+ * bytes, so the one canonical spelling is enforced at the boundary rather than
+ * normalized later.
+ */
+import { z } from 'zod';
+
+/** The only shape anything here accepts. */
+export const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+/** A digest, trimmed of the whitespace a copied-and-pasted one carries. */
+export const digestSchema = z
+  .string()
+  .trim()
+  .regex(DIGEST_PATTERN, 'must be a sha256 digest');
+
+/** Whether a value is a digest, for the paths that answer rather than parse. */
+export function isDigest(value: string): boolean {
+  return DIGEST_PATTERN.test(value.trim());
+}

--- a/apps/spindrift/src/supply-chain/sign.ts
+++ b/apps/spindrift/src/supply-chain/sign.ts
@@ -13,10 +13,11 @@ import type {
   BuildProvenance,
   BuildSource,
 } from '../adapters/build/contract.ts';
-import { type Artifact, immutableImageRef } from '../domain/desired-state.ts';
+import type { Artifact } from '../domain/desired-state.ts';
 import {
   type BackendProvenanceAssessment,
   bunProcessExecutor,
+  digestPinnedRef,
   type ProcessExecutor,
   type ProvenanceVerifier,
 } from './verify.ts';
@@ -172,7 +173,7 @@ export class CosignSigner implements ArtifactSigner {
     const directory = await mkdtemp(join(tmpdir(), 'spindrift-signature-'));
     const bundlePath = join(directory, 'bundle.json');
     try {
-      const command = this.imageCommand(artifact, bundlePath);
+      const command = this.signCommand(artifact, bundlePath);
       const result = await this.processes.run(command);
       if (result.exitCode !== 0) {
         const detail = result.stderr.trim() || result.stdout.trim();
@@ -193,11 +194,13 @@ export class CosignSigner implements ArtifactSigner {
     }
   }
 
-  private imageCommand(
+  private signCommand(
     artifact: Artifact,
     bundlePath: string,
   ): readonly string[] {
-    const immutableRef = immutableImageRef(artifact);
+    // Any artifact type, so long as the reference names the digest: §16 signs
+    // the digest, and a `files` artifact has one.
+    const immutableRef = digestPinnedRef(artifact);
     if (immutableRef === null) {
       throw new Error(`artifact ${artifact.digest} has no immutable reference`);
     }

--- a/apps/spindrift/src/supply-chain/verify.ts
+++ b/apps/spindrift/src/supply-chain/verify.ts
@@ -13,7 +13,7 @@ import type {
   BuildProvenance,
   BuildSource,
 } from '../adapters/build/contract.ts';
-import { type Artifact, immutableImageRef } from '../domain/desired-state.ts';
+import type { Artifact } from '../domain/desired-state.ts';
 
 export interface ProcessResult {
   readonly exitCode: number;
@@ -24,6 +24,23 @@ export interface ProcessResult {
 /** The native process seam; tests replace the far side, never this module. */
 export interface ProcessExecutor {
   run(command: readonly string[]): Promise<ProcessResult>;
+}
+
+/**
+ * The reference that pins an artifact to its digest, whatever it is made of.
+ *
+ * `immutableImageRef` is the deploy side's version of this and gates on
+ * `type === 'image'`, which is right there — a workload needs an image. It is
+ * wrong here. §16 says core "signs that digest", and the digest of a `files`
+ * artifact is as signable as an image's; the property this module needs is only
+ * that the reference names the digest rather than a tag, which is what closes
+ * the check/use race the verifier's own contract warns about. Gating on image
+ * meant every static-site build was refused before the verifier was spawned.
+ */
+export function digestPinnedRef(artifact: Artifact): string | null {
+  return (
+    artifact.refs.find((ref) => ref.endsWith(`@${artifact.digest}`)) ?? null
+  );
 }
 
 /** Execute one pinned tool without a shell. */
@@ -92,6 +109,24 @@ export interface SlsaVerifierOptions {
  *
  * It verifies an immutable reference and a copied envelope. No tag reaches the
  * tool, closing the check/use race the verifier's own contract warns about.
+ *
+ * **Two limitations of the `verify-image` path, recorded rather than hidden.**
+ * `apps/spindrift-verifier/main.go` builds that path's request with
+ * `ClaimedLevel: 2`, `MinimumLevel: 1`, `MaximumLevel: 2` and
+ * `Backend: "hosted"` hardcoded, and nothing on the command line conveys any of
+ * them:
+ *
+ * 1. *The level is decided here, not there.* Those constants make the binary's
+ *    own level arithmetic inert on this path — `min(2, 2) = 2 >= 1` always
+ *    passes — so the achieved level is entirely {@link lowerLevel} below,
+ *    against the route profile's ceiling. That matches §16 ("guarantees belong
+ *    to code-defined backend/runner profiles"), but it does mean an L3 claim
+ *    rests on {@link CloudBuildRoute}'s constant and on nothing the envelope
+ *    says. Passing the level through would need a flag on both sides and a new
+ *    verifier image; it would not change any verdict today.
+ * 2. *`--source-uri` is accepted and ignored.* `Expectations.SourceURI` is
+ *    declared in `pkg/verifier/types.go` and never read by `Verify`, so the
+ *    only source binding anything checks is {@link bundleDigestOf} below.
  */
 export class SlsaVerifier implements ProvenanceVerifier {
   private readonly executable: string;
@@ -112,12 +147,12 @@ export class SlsaVerifier implements ProvenanceVerifier {
         message: `${input.backend} returned no backend provenance`,
       };
     }
-    const immutableRef = immutableImageRef(input.artifact);
+    const immutableRef = digestPinnedRef(input.artifact);
     if (immutableRef === null) {
       return {
         ok: false,
         code: 'PROVENANCE_INVALID',
-        message: `${input.backend} returned no immutable image reference for ${input.artifact.digest}`,
+        message: `${input.backend} returned no immutable reference for ${input.artifact.digest}`,
       };
     }
 

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -18,6 +18,9 @@ import type {
   BuildSpec,
   LogFidelity,
 } from '../../src/adapters/build/contract.ts';
+import { digestSchema } from '../../src/domain/digest.ts';
+import { digestPinnedRef } from '../../src/supply-chain/verify.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 
 /** A type-level claim that fails to compile if `T` is not exactly `true`. */
 type Assert<T extends true> = T;
@@ -144,5 +147,60 @@ describe('log fidelity', () => {
       'ON_COMPLETION',
     ];
     expect(fidelities).toContain(route.logFidelity);
+  });
+});
+
+/**
+ * The same term, applied to the fake route (Task 18).
+ *
+ * A fake that reports something the product would refuse is a fake that lets
+ * every downstream assertion pass against an artifact the real system cannot
+ * produce. `sha256:fake-0` and `<destination>@fake` were exactly that: the
+ * digest fails the product's own definition in `src/domain/digest.ts`, and the
+ * ref fails `digestPinnedRef` — the gate the real verifier applies before it
+ * spawns anything.
+ */
+describe('the fake route reports what the product would accept', () => {
+  async function built(adapter: FakeBuildAdapter) {
+    const stream = adapter.build(source, spec);
+    let step = await stream.next();
+    while (!step.done) step = await stream.next();
+    return step.value;
+  }
+
+  test('its digest is a digest, and its ref pins that digest', async () => {
+    const result = await built(new FakeBuildAdapter());
+
+    expect(result.status).toBe('SUCCEEDED');
+    if (result.status !== 'SUCCEEDED' || result.artifact === null) return;
+    expect(digestSchema.safeParse(result.artifact.digest).success).toBe(true);
+    expect(digestPinnedRef(result.artifact)).toBe(
+      result.artifact.refs[0] ?? null,
+    );
+  });
+
+  test('a scripted digest is pinned by the ref too', async () => {
+    const digest = `sha256:${'7'.repeat(64)}`;
+    const result = await built(
+      new FakeBuildAdapter({
+        script: [{ result: { status: 'SUCCEEDED', digest } }],
+      }),
+    );
+
+    if (result.status !== 'SUCCEEDED' || result.artifact === null) return;
+    expect(result.artifact.digest).toBe(digest);
+    expect(digestPinnedRef(result.artifact)).toBe(
+      `${spec.destination}@${digest}`,
+    );
+  });
+
+  test('successive builds report different digests', async () => {
+    // One digest for every build would make "the deploy moved to the new
+    // artifact" unfalsifiable.
+    const adapter = new FakeBuildAdapter();
+    const first = await built(adapter);
+    const second = await built(adapter);
+    if (first.status !== 'SUCCEEDED' || second.status !== 'SUCCEEDED') return;
+    expect(first.artifact?.digest).not.toBe(second.artifact?.digest);
   });
 });

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -485,6 +485,96 @@ describe('the cloud build route', () => {
     expect(result.status).toBe('FAILED');
     if (result.status === 'FAILED') expect(result.reason).toBe('TIMEOUT');
   });
+
+  test('a report ingested only after the build concludes is still read', async () => {
+    // The report region is written in the build's last seconds and the log
+    // service ingests behind the writer, so the read that finds it is the one
+    // *after* the status turned `SUCCESS`. A loop that stopped at the status
+    // read records this green build as `succeeded but reported no artifact`.
+    const { result } = await run(
+      cloudRoute().route.build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('SUCCEEDED');
+    if (result.status === 'SUCCEEDED') {
+      expect(result.artifact?.digest).toBe(`sha256:${'b'.repeat(64)}`);
+    }
+  });
+
+  test('the whole log is read, including the lines written after the last poll', async () => {
+    const { events } = await run(
+      cloudRoute().route.build(archiveSource(), spec),
+    );
+
+    // `Finished Step #0` is written after the report, so it is the line a route
+    // that read one page too few would be missing.
+    expect(text(events)).toContain('Finished Step #0');
+  });
+
+  test('every poll starts a fresh search rather than resuming an old cursor', async () => {
+    // `nextPageToken` continues one search; it is not a watermark on a live
+    // log. A route that carried one across polls would be paginating a snapshot
+    // of the past, so a token may only be presented within the poll that minted
+    // it.
+    const { api, route } = cloudRoute({ duration: 3 });
+    await run(route.build(archiveSource(), spec));
+
+    let fresh = true;
+    for (const request of api.requests) {
+      if (request.url.endsWith('entries:list')) {
+        if (fresh) {
+          expect((request.body as { pageToken?: string }).pageToken).toBe(
+            undefined,
+          );
+        }
+        fresh = false;
+        continue;
+      }
+      // A status read (or the submit) ends the poll the token belonged to.
+      fresh = true;
+    }
+  });
+
+  test('a search cut short is not mistaken for a caught-up log', async () => {
+    // The vendor documents an empty page carrying a token as "the search found
+    // no log entries so far but it did not have time to search all the possible
+    // log entries" — a route that read it as an end would report no artifact.
+    const { result, events } = await run(
+      cloudRoute({ cutShort: true }).route.build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('SUCCEEDED');
+    expect(text(events)).toContain('exporting to image');
+  });
+
+  test('the log service refuses a search that names no parent resource', async () => {
+    // `entries.list` documents `resourceNames` as required. The fake refuses a
+    // search without it, so the route sending it is not a matter of trust.
+    const { api, route } = cloudRoute();
+    await run(route.build(archiveSource(), spec));
+
+    const searches = api.requests.filter((request) =>
+      request.url.endsWith('entries:list'),
+    );
+    expect(searches.length).toBeGreaterThan(0);
+    for (const search of searches) {
+      expect(
+        (search.body as { resourceNames?: string[] }).resourceNames,
+      ).toEqual(['projects/example-builds']);
+    }
+
+    const refused = await api.fetch(
+      new Request(`${api.logsEndpoint}/v2/entries:list`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${api.token()}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ filter: 'resource.labels.build_id="build-1"' }),
+      }),
+    );
+    expect(refused.status).toBe(400);
+  });
 });
 
 // --- The in-cluster route ----------------------------------------------

--- a/apps/spindrift/test/commands/config.test.ts
+++ b/apps/spindrift/test/commands/config.test.ts
@@ -50,7 +50,10 @@ import {
   FakeDeployAdapter,
 } from '../harness/fakes/deploy-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
-import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
@@ -180,13 +183,7 @@ async function succeededBuild(componentId: string, seed: number) {
       bundleLocation: `bundles/${seed}.zip`,
       status: 'SUCCEEDED',
       verifiedBuildLevel: 2,
-      signature: {
-        artifactDigest: digest(seed),
-        signer: 'gcpkms://test/signer',
-        format: 'cosign',
-        bundle: { mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json' },
-        signedAt: FROZEN.toISOString(),
-      },
+      signature: testSignature(digest(seed), FROZEN.toISOString()),
     })
     .returning();
   return build!;

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -46,7 +46,10 @@ import { policyDrift } from '../../src/supply-chain/posture.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
@@ -154,13 +157,10 @@ async function succeededBuild(
       bundleLocation: `bundles/${seed}.zip`,
       status: 'SUCCEEDED',
       verifiedBuildLevel,
-      signature: {
-        artifactDigest: digest(seed),
-        signer: 'gcpkms://test/signer',
-        format: 'cosign',
-        bundle: { mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json' },
-        signedAt: FROZEN.toISOString(),
-      },
+      // A signature the pinned verifier will actually admit: §16's gate is
+      // real now, so a placeholder bundle would be refused here exactly as it
+      // would in production.
+      signature: testSignature(digest(seed), FROZEN.toISOString()),
     })
     .returning();
   return build!;

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -19,7 +19,10 @@ import {
   targets,
 } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
 
 const manifest = await fixtureManifest();
@@ -508,16 +511,10 @@ describe('deployApp command', () => {
           'sha256:1111222233334444555566667777888899990000111122223333444455556666',
         status: 'SUCCEEDED',
         verifiedBuildLevel: 2,
-        signature: {
-          artifactDigest:
-            'sha256:1111222233334444555566667777888899990000111122223333444455556666',
-          signer: 'gcpkms://test/signer',
-          format: 'cosign',
-          bundle: {
-            mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          },
-          signedAt: FROZEN.toISOString(),
-        },
+        signature: testSignature(
+          'sha256:1111222233334444555566667777888899990000111122223333444455556666',
+          FROZEN.toISOString(),
+        ),
       })
       .returning();
 
@@ -587,16 +584,10 @@ describe('deployApp command', () => {
           'sha256:1111222233334444555566667777888899990000111122223333444455556666',
         status: 'SUCCEEDED',
         verifiedBuildLevel: 2,
-        signature: {
-          artifactDigest:
-            'sha256:1111222233334444555566667777888899990000111122223333444455556666',
-          signer: 'gcpkms://test/signer',
-          format: 'cosign',
-          bundle: {
-            mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          },
-          signedAt: FROZEN.toISOString(),
-        },
+        signature: testSignature(
+          'sha256:1111222233334444555566667777888899990000111122223333444455556666',
+          FROZEN.toISOString(),
+        ),
       })
       .returning();
 

--- a/apps/spindrift/test/conformance/second-target-admission.test.ts
+++ b/apps/spindrift/test/conformance/second-target-admission.test.ts
@@ -48,7 +48,10 @@ import {
   CAPABLE_DISCOVERY,
   FakeDeployAdapter,
 } from '../harness/fakes/deploy-adapter.ts';
-import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
 import {
   clusterInput,
   fixtureManifest,
@@ -222,15 +225,7 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
         bundleLocation: 'bundles/multi.zip',
         status: 'SUCCEEDED',
         verifiedBuildLevel: 2,
-        signature: {
-          artifactDigest: artifactDig,
-          signer: 'gcpkms://test/signer',
-          format: 'cosign',
-          bundle: {
-            mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          },
-          signedAt: FROZEN.toISOString(),
-        },
+        signature: testSignature(artifactDig, FROZEN.toISOString()),
       })
       .returning();
 
@@ -300,15 +295,7 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
         artifactDigest: digest(200),
         status: 'SUCCEEDED',
         verifiedBuildLevel: 2,
-        signature: {
-          artifactDigest: digest(200),
-          signer: 'gcpkms://test/signer',
-          format: 'cosign',
-          bundle: {
-            mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          },
-          signedAt: FROZEN.toISOString(),
-        },
+        signature: testSignature(digest(200), FROZEN.toISOString()),
       })
       .returning();
 
@@ -394,15 +381,7 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
         bundleLocation: 'bundles/e2e.zip',
         status: 'SUCCEEDED',
         verifiedBuildLevel: 2,
-        signature: {
-          artifactDigest: artifactDig,
-          signer: 'gcpkms://test/signer',
-          format: 'cosign',
-          bundle: {
-            mediaType: 'application/vnd.dev.sigstore.bundle.v0.3+json',
-          },
-          signedAt: FROZEN.toISOString(),
-        },
+        signature: testSignature(artifactDig, FROZEN.toISOString()),
       })
       .returning();
 

--- a/apps/spindrift/test/harness/fakes/build-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/build-adapter.ts
@@ -6,6 +6,7 @@
  * handed — so a test can assert that the bundle digest reached the route, which
  * is §16's whole join — and replays a scripted result.
  */
+import { createHash } from 'node:crypto';
 import type {
   BuildAdapter,
   BuildEvent,
@@ -99,23 +100,31 @@ export class FakeBuildAdapter implements BuildAdapter {
       };
     }
 
+    const digest =
+      scripted.result.digest ?? fakeDigest(`${this.name}-${this.builds}`);
+
     return {
       status: 'SUCCEEDED',
       artifact: {
         type: spec.artifactType,
-        digest: scripted.result.digest ?? `sha256:${this.name}-${this.builds}`,
-        refs: [`${spec.destination}@${scripted.result.digest ?? 'fake'}`],
+        digest,
+        refs: [`${spec.destination}@${digest}`],
       },
       logs,
       provenance: {
         // Echoed, never invented: this is the join §16 asks a route for.
         bundleDigest: source.bundleDigest,
         claimedLevel: this.buildLevel,
-        statement: { fake: true },
+        statement: fakeStatement({
+          builderId: this.provenanceBuilderId,
+          bundleDigest: source.bundleDigest,
+          destination: spec.destination,
+          digest,
+        }),
       },
       baseDigest: scripted.result.baseDigest ?? null,
-      buildkitProvenanceRef: `${spec.destination}@${scripted.result.digest ?? 'fake'}#buildkit`,
-      sbomRef: `${spec.destination}@${scripted.result.digest ?? 'fake'}#spdx`,
+      buildkitProvenanceRef: `${spec.destination}@${digest}#buildkit`,
+      sbomRef: `${spec.destination}@${digest}#spdx`,
     };
   }
 
@@ -125,4 +134,56 @@ export class FakeBuildAdapter implements BuildAdapter {
     this.builds += 1;
     return this.script[index] ?? DEFAULT_BUILD;
   }
+}
+
+/**
+ * A digest the product would accept.
+ *
+ * `sha256:fake-0` was the old default, and three places in `src/` validate a
+ * digest against `^sha256:[0-9a-f]{64}$` — so every command test that ran a
+ * build through to a Deploy ran on an artifact the real system cannot produce
+ * and would refuse. Hashing the label keeps it deterministic and readable in a
+ * diff while being a real digest.
+ */
+export function fakeDigest(label: string): string {
+  return `sha256:${createHash('sha256').update(label).digest('hex')}`;
+}
+
+/**
+ * The provenance document a route reports (§16).
+ *
+ * `{ fake: true }` was here, and it made the verification chain vacuous: the
+ * real {@link import('../../../src/supply-chain/verify.ts').SlsaVerifier} reads
+ * the *verified envelope* for `predicate.buildDefinition.externalParameters
+ * .bundleDigest` and refuses when it does not name the source bundle. A
+ * statement without that path fails that check, so nothing that ran against the
+ * old value was ever asserting the join §16 is built on.
+ *
+ * The shape is an in-toto v1 statement because that is what the pinned verifier
+ * parses — subject digest, builder id, and bundle digest all live where
+ * `apps/spindrift-verifier/pkg/verifier/verify.go` looks for them.
+ */
+export function fakeStatement(input: {
+  builderId: string;
+  bundleDigest: string;
+  destination: string;
+  digest: string;
+}): unknown {
+  return {
+    _type: 'https://in-toto.io/Statement/v1',
+    subject: [
+      {
+        name: input.destination,
+        digest: { sha256: input.digest.replace(/^sha256:/, '') },
+      },
+    ],
+    predicateType: 'https://slsa.dev/provenance/v1',
+    predicate: {
+      buildDefinition: {
+        buildType: 'https://spindrift.dev/buildkit/v1',
+        externalParameters: { bundleDigest: input.bundleDigest },
+      },
+      runDetails: { builder: { id: input.builderId } },
+    },
+  };
 }

--- a/apps/spindrift/test/harness/fakes/cloud-build-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloud-build-api.ts
@@ -6,13 +6,21 @@
  * a fake adapter — the route's real submit body, its real status polling, and
  * its real page-cursored log reads all run against it.
  *
- * Two behaviours are modelled because the route has to survive them:
+ * Three behaviours are modelled because the route has to survive them:
  *
  * - **A build does not finish on the first read.** `duration` is how many status
  *   reads it takes, so a route that submitted and assumed would fail here.
- * - **The log arrives in pages, and the cursor is the only thing that knows
- *   what was already served.** A route that re-read page one would see its own
- *   output repeat, which is the bug the cursor exists to prevent.
+ * - **The log is ingested behind the writer.** A build writes as it runs and
+ *   finishes writing when it finishes; the log service only serves what had
+ *   been written by the previous status read. The report line lives in the last
+ *   region a build writes, so a route that stops reading the moment the status
+ *   turns terminal never sees it — which is the failure this models.
+ * - **A page token continues one search, not the log.** `entries.list` mints a
+ *   token against a *frozen* result set, exactly as the vendor documents it:
+ *   "retrieve the next batch of results from the preceding call to this
+ *   method". A route that saved one and presented it a poll later would be
+ *   paginating a snapshot of the past, so this fake freezes the snapshot rather
+ *   than treating the token as a watermark.
  */
 
 import type { Fetcher } from '../../../src/adapters/build/cloud-build.ts';
@@ -20,6 +28,9 @@ import { encodeBuildReport } from '../../../src/adapters/build/report.ts';
 
 export const BUILD_HOST = 'https://builds.invalid';
 export const LOGS_HOST = 'https://logs.invalid';
+
+/** When the first line of any build's log was ingested. */
+const INGEST_EPOCH = Date.parse('2026-07-28T00:00:00.000Z');
 
 export interface RecordedRequest {
   method: string;
@@ -35,6 +46,18 @@ export interface FakeCloudBuildOptions {
   status?: string;
   /** Lines the build writes, given the program it was submitted with. */
   log?: (program: string) => readonly string[];
+  /**
+   * Entries one page carries, whatever `pageSize` asked for. Small on purpose:
+   * the real service answers with fewer than requested routinely, and a route
+   * that read one page per poll would be permanently behind its own log.
+   */
+  pageSize?: number;
+  /**
+   * Answer the first page of every search empty *and with a token*, which the
+   * vendor documents as "the search found no log entries so far but it did not
+   * have time to search all the possible log entries" — not as a caught-up log.
+   */
+  cutShort?: boolean;
   /** When set, submitting is refused with this status. */
   refuseSubmit?: number;
   /** When set, every log read fails — the route must survive it. */
@@ -42,12 +65,27 @@ export interface FakeCloudBuildOptions {
   token?: string;
 }
 
+/** One ingested log entry, in the shape the log service serves it. */
+interface FakeEntry {
+  insertId: string;
+  textPayload: string;
+  timestamp: string;
+}
+
 interface FakeBuild {
   id: string;
   reads: number;
   lines: readonly string[];
-  /** How many lines have been served, which is what the cursor encodes. */
-  served: number;
+  /** Lines the build has written. Not yet what the log service will serve. */
+  written: number;
+  /** Lines the log service has ingested, which is what it will serve. */
+  ingested: FakeEntry[];
+}
+
+/** One `entries.list` search, frozen at the moment it was issued. */
+interface FakeSearch {
+  entries: readonly FakeEntry[];
+  from: number;
 }
 
 export class FakeCloudBuild {
@@ -58,7 +96,9 @@ export class FakeCloudBuild {
   readonly programs: string[] = [];
 
   private readonly builds = new Map<string, FakeBuild>();
+  private readonly searches = new Map<string, FakeSearch>();
   private counter = 0;
+  private searchCounter = 0;
   private readonly options: Required<
     Omit<FakeCloudBuildOptions, 'refuseSubmit' | 'token'>
   > &
@@ -69,6 +109,8 @@ export class FakeCloudBuild {
       duration: options.duration ?? 1,
       status: options.status ?? 'SUCCESS',
       log: options.log ?? defaultBuildLog,
+      pageSize: options.pageSize ?? 2,
+      cutShort: options.cutShort ?? false,
       breakLogs: options.breakLogs ?? false,
       ...(options.refuseSubmit === undefined
         ? {}
@@ -125,28 +167,47 @@ export class FakeCloudBuild {
       id,
       reads: 0,
       lines: this.options.log(program),
-      served: 0,
+      written: 0,
+      ingested: [],
     });
     return json(200, { metadata: { build: { id, status: 'QUEUED' } } });
   }
 
+  /**
+   * One status read, which is also when the build gets to write.
+   *
+   * The last region a build writes is the one that matters — `#8 exporting to
+   * image` and the report line — and it is written on the same tick the status
+   * turns terminal. That is not fake convenience; it is what a BuildKit run
+   * does, and it is why the read *after* the terminal status is the load-bearing
+   * one.
+   */
   private read(id: string): Response {
     const build = this.builds.get(id);
     if (build === undefined) return json(404, { error: 'no such build' });
     build.reads += 1;
+    const terminal = build.reads > this.options.duration;
+    build.written = terminal
+      ? build.lines.length
+      : Math.max(
+          build.written,
+          Math.floor(
+            (build.lines.length * build.reads) / (this.options.duration + 1),
+          ),
+        );
     return json(200, {
       id,
-      status:
-        build.reads > this.options.duration ? this.options.status : 'WORKING',
+      status: terminal ? this.options.status : 'WORKING',
     });
   }
 
   /**
    * One page of one build's log.
    *
-   * The cursor is "how many lines this build has already served", encoded as a
-   * string — which is enough to catch a route that ignores it and enough to be
-   * read by a test that wants to know how many pages there were.
+   * A request with no `pageToken` is a *new* search over whatever has been
+   * ingested by now; a request with one continues that earlier search's frozen
+   * result set. Nothing here lets a token act as a watermark, because nothing
+   * in the real API does.
    */
   private logs(body: unknown): Response {
     if (this.options.breakLogs) return json(503, { error: 'log service down' });
@@ -165,20 +226,59 @@ export class FakeCloudBuild {
     ) {
       return json(400, { error: 'resourceNames is required' });
     }
-    const id = /build_id="([^"]+)"/.exec(request.filter ?? '')?.[1] ?? '';
+
+    if (request.pageToken !== undefined) {
+      const search = this.searches.get(request.pageToken);
+      if (search === undefined) {
+        return json(400, { error: 'invalid pageToken' });
+      }
+      return this.page(search.entries, search.from);
+    }
+
+    const filter = request.filter ?? '';
+    const id = /build_id="([^"]+)"/.exec(filter)?.[1] ?? '';
     const build = this.builds.get(id);
     if (build === undefined) return json(200, { entries: [] });
 
-    const from = Number(request.pageToken ?? '0');
-    const entries = build.lines.slice(from).map((line) => ({
-      textPayload: line,
-      timestamp: '2026-07-28T00:00:00Z',
-    }));
-    build.served = build.lines.length;
-    return json(200, {
-      entries,
-      nextPageToken: String(build.lines.length),
-    });
+    this.ingest(build);
+    const since = /timestamp>="([^"]+)"/.exec(filter)?.[1];
+    const entries =
+      since === undefined
+        ? [...build.ingested]
+        : build.ingested.filter((entry) => entry.timestamp >= since);
+
+    // A cut-short search answers nothing and hands back a token anyway. The
+    // entries are still there; the route has to follow the token to see them.
+    return this.page(entries, 0, this.options.cutShort);
+  }
+
+  /** Ingestion catches up to what the build had written at its last status read. */
+  private ingest(build: FakeBuild): void {
+    while (build.ingested.length < build.written) {
+      const index = build.ingested.length;
+      build.ingested.push({
+        insertId: `${build.id}-${index}`,
+        textPayload: build.lines[index] ?? '',
+        timestamp: new Date(INGEST_EPOCH + index * 1_000).toISOString(),
+      });
+    }
+  }
+
+  private page(
+    entries: readonly FakeEntry[],
+    from: number,
+    cutShort = false,
+  ): Response {
+    const slice = cutShort
+      ? []
+      : entries.slice(from, from + this.options.pageSize);
+    const next = from + slice.length;
+    if (next >= entries.length) return json(200, { entries: slice });
+
+    this.searchCounter += 1;
+    const token = `search-${this.searchCounter}`;
+    this.searches.set(token, { entries, from: next });
+    return json(200, { entries: slice, nextPageToken: token });
   }
 }
 

--- a/apps/spindrift/test/harness/fakes/supply-chain.ts
+++ b/apps/spindrift/test/harness/fakes/supply-chain.ts
@@ -1,28 +1,386 @@
 /**
- * Far-side doubles for core's real supply-chain policy.
+ * The far side of core's supply chain: the pinned `spindrift-verifier` process.
  *
- * Tests run {@link CoreSupplyChain}; only the native verifier process and KMS
- * signer behind its contracts are faked. This preserves verify → policy → sign
- * in command tests while still letting them script a backend refusal.
+ * § Testing: **"Fake the far side, not our side."** The far side here is a
+ * subprocess, and all three of core's supply-chain classes already expose a
+ * {@link ProcessExecutor} seam for it. So {@link SupplyChainHarness} composes
+ * the *real* {@link SlsaVerifier}, {@link CosignSigner} and
+ * {@link SpindriftSignatureVerifier} over {@link FakeVerifierProcess} — their
+ * real argv construction, their real temp-file handling, their real stdout
+ * parsing and their real refusal paths all run in every test that touches a
+ * build or a deploy.
+ *
+ * {@link FakeVerifierProcess} answers the argv `apps/spindrift-verifier/main.go`
+ * answers, refuses what it refuses, and prints what it prints — including the
+ * detail that `verify-image --print-provenance` echoes the *provenance file it
+ * was handed* (`verify.go`: `Envelope: req.Provenance.Statement`), which is what
+ * makes the TypeScript side's bundle-digest binding a real check.
+ *
+ * **The signature is genuinely cryptographic.** `sign` mints a real Ed25519
+ * keypair derived from the signer reference and signs the digest; the bundle it
+ * writes carries the same five fields `pkg/verifier/sign.go` writes;
+ * `verify-signature` pins the embedded public key against the trusted signer
+ * before checking the signature. A tampered bundle, a bundle covering another
+ * digest, or a bundle signed by a different key all fail here exactly as they
+ * would in production.
+ *
+ * Scripted answers survive for the tests that need a backend to refuse — but
+ * they are an override on top of the real class, not a replacement for it, so
+ * the unscripted path every other test runs is the real one.
  */
+import {
+  createHash,
+  createPrivateKey,
+  createPublicKey,
+  sign as signWith,
+  verify as verifyWith,
+} from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
 import type { Artifact } from '../../../src/domain/desired-state.ts';
 import {
   type ArtifactSigner,
+  type CoreSignature,
   CoreSupplyChain,
+  CosignSigner,
   type FinalizeArtifactInput,
   type SignatureVerification,
+  type SignatureVerifier,
   type VerifySignatureInput,
 } from '../../../src/supply-chain/sign.ts';
-import type {
-  ProvenanceVerification,
-  ProvenanceVerifier,
-  VerifyProvenanceInput,
+import { SpindriftSignatureVerifier } from '../../../src/supply-chain/signature.ts';
+import {
+  type ProcessExecutor,
+  type ProcessResult,
+  type ProvenanceVerification,
+  type ProvenanceVerifier,
+  SlsaVerifier,
+  type VerifyProvenanceInput,
 } from '../../../src/supply-chain/verify.ts';
 
+/** The signer reference the harness signs and admits with. */
+export const TEST_SIGNER_KEY = '/spindrift/test-signer.key';
+
+/** What `pkg/verifier/sign.go` writes, field for field. */
+const SIGNATURE_MEDIA_TYPE = 'application/vnd.spindrift.signature.v1+json';
+
+/** PKCS#8 header for a raw 32-byte Ed25519 seed. */
+const PKCS8_ED25519_PREFIX = Buffer.from(
+  '302e020100300506032b657004220420',
+  'hex',
+);
+
+/** A PKCS#8 Ed25519 key, seeded by the signer reference itself. */
+function derFor(reference: string): Buffer {
+  const seed = createHash('sha256').update(reference).digest();
+  return Buffer.concat([PKCS8_ED25519_PREFIX, seed]);
+}
+
+/**
+ * A keypair that is the same every time for a given signer reference.
+ *
+ * The real signer loads an Ed25519 private key from the path it was given, so
+ * the fake derives one from that path instead: same reference, same key, and a
+ * *different* reference is genuinely a different key — which is what makes the
+ * admission pin testable rather than assumed.
+ */
+function keyFor(reference: string) {
+  return createPrivateKey({
+    key: derFor(reference),
+    format: 'der',
+    type: 'pkcs8',
+  });
+}
+
+function publicKeyObjectOf(reference: string) {
+  // Derived from the private key, the way the binary derives the expected
+  // public key from the signer reference it was pinned to.
+  return createPublicKey(
+    keyFor(reference).export({ format: 'pem', type: 'pkcs8' }).toString(),
+  );
+}
+
+function publicKeyOf(reference: string): string {
+  return publicKeyObjectOf(reference)
+    .export({ format: 'der', type: 'spki' })
+    .toString('base64');
+}
+
+/**
+ * A signature the pinned verifier will admit, for a fixture that inserts a
+ * SUCCEEDED Build directly.
+ *
+ * A stored `{ mediaType: … }` and nothing else is exactly the placeholder
+ * `pkg/verifier/sign.go` documents as rejected, so a fixture carrying one is a
+ * fixture whose deploy would be refused in production. This mints what the
+ * harness's own signer would have written for that digest.
+ */
+export function testSignature(
+  artifactDigest: string,
+  signedAt = '2024-06-01T00:00:01.000Z',
+): CoreSignature {
+  return {
+    artifactDigest,
+    signer: TEST_SIGNER_KEY,
+    format: 'cosign',
+    bundle: {
+      mediaType: SIGNATURE_MEDIA_TYPE,
+      algorithm: 'ed25519',
+      publicKey: publicKeyOf(TEST_SIGNER_KEY),
+      artifactDigest,
+      signature: signWith(
+        null,
+        Buffer.from(artifactDigest),
+        keyFor(TEST_SIGNER_KEY),
+      ).toString('base64'),
+    },
+    signedAt,
+  };
+}
+
+/** One invocation, as the harness recorded it. */
+export interface RecordedProcess {
+  readonly command: readonly string[];
+  readonly result: ProcessResult;
+}
+
+export interface FakeVerifierProcessOptions {
+  /** The signer reference whose key the process holds. */
+  readonly signerKey?: string;
+  /**
+   * Refuse `verify-image` with this message on stderr, as the binary does when
+   * `verifier.Verify` answers `!ok`.
+   */
+  readonly refuseVerify?: string;
+  /** Refuse `sign` with this message on stderr. */
+  readonly refuseSign?: string;
+}
+
+/**
+ * The pinned verifier binary, as a process.
+ *
+ * Everything it refuses, `main.go` and `pkg/verifier` refuse for the same
+ * reason and with the same words. Everything it accepts, they accept.
+ */
+export class FakeVerifierProcess implements ProcessExecutor {
+  /** Every invocation, in order — the assertion surface for argv. */
+  readonly runs: RecordedProcess[] = [];
+
+  constructor(private readonly options: FakeVerifierProcessOptions = {}) {}
+
+  async run(command: readonly string[]): Promise<ProcessResult> {
+    const result = await this.dispatch(command);
+    this.runs.push({ command: [...command], result });
+    return result;
+  }
+
+  /** Every invocation of one subcommand, for a test that wants only those. */
+  callsTo(subcommand: string): readonly RecordedProcess[] {
+    return this.runs.filter((run) => run.command[1] === subcommand);
+  }
+
+  private dispatch(command: readonly string[]): Promise<ProcessResult> {
+    switch (command[1]) {
+      case 'verify-image':
+        return this.verifyImage(command.slice(2));
+      case 'sign':
+        return this.sign(command.slice(2));
+      case 'verify-signature':
+        return this.verifySignature(command.slice(2));
+      default:
+        return Promise.resolve(
+          failed(`unknown command: ${command[1] ?? ''}\n`),
+        );
+    }
+  }
+
+  /**
+   * `verify-image`, which is the legacy slsa-verifier-shaped path core calls.
+   *
+   * The refusals below are `pkg/verifier/verify.go` steps 1-4c in order, and
+   * the success case prints `Assessment.Envelope` — the provenance file,
+   * verbatim — because that is what the binary prints.
+   */
+  private async verifyImage(args: readonly string[]): Promise<ProcessResult> {
+    const flags = legacyFlags(args, [
+      'provenance-path',
+      'source-uri',
+      'builder-id',
+    ]);
+    if (flags.values['provenance-path'] === undefined) {
+      return failed('error: --provenance-path is required\n');
+    }
+
+    let raw: string;
+    try {
+      raw = await readFile(flags.values['provenance-path'], 'utf8');
+    } catch (error) {
+      return failed(`error reading provenance path: ${String(error)}\n`);
+    }
+
+    if (this.options.refuseVerify !== undefined) {
+      return failed(`${this.options.refuseVerify}\n`);
+    }
+
+    const ref = flags.positional[0] ?? '';
+    const digest = ref.includes('@')
+      ? ref.slice(ref.lastIndexOf('@') + 1)
+      : ref;
+    if (digest === '') {
+      return failed(
+        'hosted returned no immutable image reference for digest\n',
+      );
+    }
+
+    if (raw.trim() === '' || raw.trim() === 'null') {
+      return failed('hosted returned no backend provenance\n');
+    }
+    let statement: Record<string, unknown>;
+    try {
+      statement = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      return failed(
+        'hosted provenance did not verify: invalid JSON statement\n',
+      );
+    }
+
+    const builderId = builderIdOf(statement);
+    const expected = flags.values['builder-id'];
+    if (
+      builderId !== null &&
+      expected !== undefined &&
+      builderId !== expected
+    ) {
+      return failed(
+        `hosted provenance builder mismatch: expected ${expected}, got ${builderId}\n`,
+      );
+    }
+
+    const subject = subjectDigestOf(statement);
+    if (subject !== null && subject !== digest) {
+      return failed(
+        `hosted provenance subject names "${subject}", not the admitted artifact ${digest}\n`,
+      );
+    }
+
+    // `--print-provenance` prints the envelope, which is the statement it was
+    // handed. Nothing is synthesised here, which is the point: the bundle
+    // digest core binds against has to have come out of the document.
+    return { exitCode: 0, stdout: `${raw}\n`, stderr: '' };
+  }
+
+  /** `sign`, in cosign's flag shape — what {@link CosignSigner} builds. */
+  private async sign(args: readonly string[]): Promise<ProcessResult> {
+    const flags = legacyFlags(args, ['key', 'bundle']);
+    if (this.options.refuseSign !== undefined) {
+      return failed(`${this.options.refuseSign}\n`);
+    }
+
+    const ref = flags.positional[0] ?? '';
+    const digest = ref.includes('@')
+      ? ref.slice(ref.lastIndexOf('@') + 1)
+      : ref;
+    if (digest === '') return failed('artifact has no digest\n');
+    const key = flags.values.key;
+    if (key === undefined || key === '') {
+      return failed('key is required for signing\n');
+    }
+
+    const bundle = JSON.stringify({
+      mediaType: SIGNATURE_MEDIA_TYPE,
+      algorithm: 'ed25519',
+      publicKey: publicKeyOf(key),
+      artifactDigest: digest,
+      signature: signWith(null, Buffer.from(digest), keyFor(key)).toString(
+        'base64',
+      ),
+    });
+    if (flags.values.bundle !== undefined) {
+      await writeFile(flags.values.bundle, bundle, { mode: 0o600 });
+    }
+    return { exitCode: 0, stdout: `${bundle}\n`, stderr: '' };
+  }
+
+  /** `verify-signature`, including the signer pin admission depends on. */
+  private async verifySignature(
+    args: readonly string[],
+  ): Promise<ProcessResult> {
+    const flags = legacyFlags(args, [
+      'artifact-digest',
+      'bundle-path',
+      'signer-key',
+    ]);
+    const digest = flags.values['artifact-digest'];
+    const path = flags.values['bundle-path'];
+    const signerKey = flags.values['signer-key'];
+    if (digest === undefined || path === undefined || signerKey === undefined) {
+      return failed(
+        'error: --artifact-digest, --bundle-path, and --signer-key are required\n',
+      );
+    }
+
+    let bundle: {
+      mediaType?: string;
+      algorithm?: string;
+      publicKey?: string;
+      artifactDigest?: string;
+      signature?: string;
+    };
+    try {
+      bundle = JSON.parse(await readFile(path, 'utf8'));
+    } catch (error) {
+      return failed(`signature did not verify: ${String(error)}\n`);
+    }
+
+    if (bundle.mediaType !== SIGNATURE_MEDIA_TYPE) {
+      return failed(
+        `signature did not verify: unsupported signature mediaType "${bundle.mediaType ?? ''}"\n`,
+      );
+    }
+    if (bundle.algorithm !== 'ed25519') {
+      return failed(
+        `signature did not verify: unsupported signature algorithm "${bundle.algorithm ?? ''}"\n`,
+      );
+    }
+    if (bundle.artifactDigest !== digest) {
+      return failed(
+        `signature did not verify: bundle covers digest "${bundle.artifactDigest ?? ''}", not "${digest}"\n`,
+      );
+    }
+    // The pin: the bundle's own key is not trusted, the configured one is.
+    if (bundle.publicKey !== publicKeyOf(signerKey)) {
+      return failed(
+        'signature did not verify: bundle public key is not the trusted Spindrift signer\n',
+      );
+    }
+    const ok =
+      bundle.signature !== undefined &&
+      verifyWith(
+        null,
+        Buffer.from(digest),
+        publicKeyObjectOf(signerKey),
+        Buffer.from(bundle.signature, 'base64'),
+      );
+    if (!ok) {
+      return failed(
+        'signature did not verify: signature does not verify against the digest\n',
+      );
+    }
+    return { exitCode: 0, stdout: '', stderr: '' };
+  }
+}
+
+/**
+ * Records what core asked for, then asks the real verifier.
+ *
+ * Recording is not faking: the delegate below is the production class. The
+ * optional answer is the one escape hatch, for the tests whose subject is "the
+ * backend refused" rather than "the verifier ran".
+ */
 class RecordingVerifier implements ProvenanceVerifier {
   readonly verified: VerifyProvenanceInput[] = [];
 
   constructor(
+    private readonly inner: ProvenanceVerifier,
     private readonly answer?: (
       input: VerifyProvenanceInput,
     ) => ProvenanceVerification | Promise<ProvenanceVerification>,
@@ -31,47 +389,37 @@ class RecordingVerifier implements ProvenanceVerifier {
   async verify(input: VerifyProvenanceInput): Promise<ProvenanceVerification> {
     this.verified.push(input);
     if (this.answer) return this.answer(input);
-    return {
-      ok: true,
-      assessment: {
-        artifactDigest: input.artifact.digest,
-        bundleDigest: input.source.bundleDigest,
-        backend: input.backend,
-        builderId: `fake://${input.backend}`,
-        slsaVersion: '1.2',
-        achievedLevel: input.maximumLevel,
-        verifiedAt: '2024-06-01T00:00:00.000Z',
-        envelope: input.provenance.statement,
-      },
-    };
+    return this.inner.verify(input);
   }
 }
 
 class RecordingSigner implements ArtifactSigner {
   readonly signed: Artifact[] = [];
+  /** A KMS refusing is a far-side event, so a test may script one. */
   failure: Error | null = null;
 
-  async sign(artifact: Artifact) {
+  constructor(private readonly inner: ArtifactSigner) {}
+
+  async sign(artifact: Artifact): Promise<CoreSignature> {
     if (this.failure !== null) throw this.failure;
+    const signature = await this.inner.sign(artifact);
     this.signed.push(artifact);
-    return {
-      artifactDigest: artifact.digest,
-      signer: 'fake://core',
-      format: 'cosign' as const,
-      bundle: { fake: true },
-      signedAt: '2024-06-01T00:00:01.000Z',
-    };
+    return signature;
   }
 }
 
 /**
- * A signature verifier that records each admission check and answers what a
- * test scripted. Accepts by default, so the common "admission proceeds" path
- * needs no setup; a refusal is one scripted answer away.
+ * Records each admission check, then runs the real one.
+ *
+ * The default answer used to be `{ ok: true }`, so every deploy test passed
+ * §16's signature gate for free. It now runs the pinned verifier over the
+ * bundle the signer actually wrote.
  */
-export class RecordingSignatureVerifier {
+export class RecordingSignatureVerifier implements SignatureVerifier {
   readonly admissions: VerifySignatureInput[] = [];
+
   constructor(
+    private readonly inner: SignatureVerifier,
     private readonly answer?: (
       input: VerifySignatureInput,
     ) => SignatureVerification | Promise<SignatureVerification>,
@@ -80,7 +428,7 @@ export class RecordingSignatureVerifier {
   async verify(input: VerifySignatureInput): Promise<SignatureVerification> {
     this.admissions.push(input);
     if (this.answer) return this.answer(input);
-    return { ok: true, reason: null };
+    return this.inner.verify(input);
   }
 }
 
@@ -89,6 +437,8 @@ export class SupplyChainHarness extends CoreSupplyChain {
   readonly signed: Artifact[];
   readonly signatureChecks: RecordingSignatureVerifier;
   readonly signing: RecordingSigner;
+  /** The process every one of the three real classes ran against. */
+  readonly processes: FakeVerifierProcess;
 
   constructor(
     answer?: (
@@ -97,11 +447,23 @@ export class SupplyChainHarness extends CoreSupplyChain {
     signatureAnswer?: (
       input: VerifySignatureInput,
     ) => SignatureVerification | Promise<SignatureVerification>,
+    options: FakeVerifierProcessOptions = {},
   ) {
-    const verifier = new RecordingVerifier(answer);
-    const signer = new RecordingSigner();
-    const signatureVerifier = new RecordingSignatureVerifier(signatureAnswer);
+    const processes = new FakeVerifierProcess(options);
+    const now = () => new Date('2024-06-01T00:00:01.000Z');
+    const verifier = new RecordingVerifier(
+      new SlsaVerifier({ processes, now }),
+      answer,
+    );
+    const signer = new RecordingSigner(
+      new CosignSigner({ key: TEST_SIGNER_KEY, processes, now }),
+    );
+    const signatureVerifier = new RecordingSignatureVerifier(
+      new SpindriftSignatureVerifier({ processes, signerKey: TEST_SIGNER_KEY }),
+      signatureAnswer,
+    );
     super(verifier, signer, signatureVerifier);
+    this.processes = processes;
     this.signed = signer.signed;
     this.signing = signer;
     this.signatureChecks = signatureVerifier;
@@ -111,4 +473,60 @@ export class SupplyChainHarness extends CoreSupplyChain {
     this.finalized.push(input);
     return super.finalize(input);
   }
+}
+
+function failed(stderr: string): ProcessResult {
+  return { exitCode: 1, stdout: '', stderr };
+}
+
+/**
+ * The manual argv walk `main.go` does instead of `fs.Parse`.
+ *
+ * Modelled rather than replaced by a parser, because the binary's own loop is
+ * what core's argv has to satisfy: `--flag value` pairs, bare `--flag` treated
+ * as a boolean, and the first non-flag argument taken as the reference.
+ */
+function legacyFlags(
+  args: readonly string[],
+  named: readonly string[],
+): { values: Record<string, string>; positional: string[] } {
+  const values: Record<string, string> = {};
+  const positional: string[] = [];
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index] ?? '';
+    const name = arg.replace(/^--?/, '');
+    if (arg.startsWith('-') && named.includes(name)) {
+      const value = args[index + 1];
+      if (value !== undefined) {
+        values[name] = value;
+        index += 1;
+      }
+      continue;
+    }
+    if (arg.startsWith('-')) continue;
+    positional.push(arg);
+  }
+  return { values, positional };
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function builderIdOf(statement: Record<string, unknown>): string | null {
+  const builder = record(
+    record(record(statement.predicate)?.runDetails)?.builder,
+  );
+  const id = builder?.id;
+  return typeof id === 'string' && id !== '' ? id : null;
+}
+
+function subjectDigestOf(statement: Record<string, unknown>): string | null {
+  const subjects = statement.subject;
+  if (!Array.isArray(subjects) || subjects.length === 0) return null;
+  const digest = record(record(subjects[0])?.digest)?.sha256;
+  if (typeof digest !== 'string' || digest === '') return null;
+  return digest.startsWith('sha256:') ? digest : `sha256:${digest}`;
 }

--- a/apps/spindrift/test/supply-chain/finalize.test.ts
+++ b/apps/spindrift/test/supply-chain/finalize.test.ts
@@ -15,6 +15,10 @@ import type {
   ProvenanceVerifier,
 } from '../../src/supply-chain/verify.ts';
 import { SlsaVerifier } from '../../src/supply-chain/verify.ts';
+import {
+  FakeVerifierProcess,
+  TEST_SIGNER_KEY,
+} from '../harness/fakes/supply-chain.ts';
 
 const DIGEST = `sha256:${'a'.repeat(64)}`;
 const BUNDLE = `sha256:${'b'.repeat(64)}`;
@@ -406,5 +410,287 @@ describe('the pinned verify-signature process boundary', () => {
     expect(checked.reason).toBe(
       'signature does not verify against the artifact digest',
     );
+  });
+});
+
+/**
+ * The real classes over the pinned binary's process seam (Task 17).
+ *
+ * Everything above this point either drives `CoreSupplyChain` over hand-written
+ * doubles or drives one real class over a process that always says yes. What is
+ * here is the part that used to be unreachable: the verifier's own refusals,
+ * its `min()`, its four-deep read of the envelope, and a signature that is
+ * signed and re-verified rather than asserted.
+ */
+describe('the real verifier over the pinned process', () => {
+  function statement(overrides: {
+    bundleDigest?: string | null;
+    builderId?: string;
+    subject?: string;
+  }): unknown {
+    return {
+      _type: 'https://in-toto.io/Statement/v1',
+      subject: [
+        {
+          name: 'registry.example.test/apps/shop',
+          digest: {
+            sha256: (overrides.subject ?? DIGEST).replace(/^sha256:/, ''),
+          },
+        },
+      ],
+      predicateType: 'https://slsa.dev/provenance/v1',
+      predicate: {
+        buildDefinition: {
+          externalParameters:
+            overrides.bundleDigest === null
+              ? {}
+              : { bundleDigest: overrides.bundleDigest ?? BUNDLE },
+        },
+        runDetails: {
+          builder: {
+            id:
+              overrides.builderId ??
+              'https://github.com/actions/runner/github-hosted',
+          },
+        },
+      },
+    };
+  }
+
+  function verifying(processes: FakeVerifierProcess) {
+    return new SlsaVerifier({
+      processes,
+      now: () => new Date('2024-06-01T00:00:00.000Z'),
+    });
+  }
+
+  test('the achieved level is the lower of the claim and the profile ceiling', async () => {
+    // `min(claimedLevel, maximumLevel)` had no coverage while the fake answered
+    // `achievedLevel: input.maximumLevel`, so a route claiming less than its
+    // profile permits was recorded at its ceiling.
+    const processes = new FakeVerifierProcess();
+    const claimingLess = await verifying(processes).verify({
+      ...input(),
+      provenance: {
+        bundleDigest: BUNDLE,
+        claimedLevel: 1,
+        statement: statement({}),
+      },
+      maximumLevel: 3,
+    });
+
+    expect(claimingLess.ok).toBe(true);
+    if (!claimingLess.ok) return;
+    expect(claimingLess.assessment.achievedLevel).toBe(1);
+  });
+
+  test('a claim above the profile ceiling is capped, not honoured', async () => {
+    const processes = new FakeVerifierProcess();
+    const claimingMore = await verifying(processes).verify({
+      ...input(),
+      provenance: {
+        bundleDigest: BUNDLE,
+        claimedLevel: 3,
+        statement: statement({}),
+      },
+      maximumLevel: 2,
+    });
+
+    expect(claimingMore.ok).toBe(true);
+    if (!claimingMore.ok) return;
+    expect(claimingMore.assessment.achievedLevel).toBe(2);
+  });
+
+  test('a verified envelope naming another bundle refuses', async () => {
+    // §16's join, checked rather than copied: the *verified* document has to
+    // name the bundle core staged, or the provenance describes another build.
+    const other = `sha256:${'d'.repeat(64)}`;
+    const result = await verifying(new FakeVerifierProcess()).verify({
+      ...input(),
+      provenance: {
+        bundleDigest: BUNDLE,
+        claimedLevel: 2,
+        statement: statement({ bundleDigest: other }),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('PROVENANCE_INVALID');
+    expect(result.message).toContain(`names bundle ${other}`);
+  });
+
+  test('a verified envelope that binds no bundle at all refuses', async () => {
+    const result = await verifying(new FakeVerifierProcess()).verify({
+      ...input(),
+      provenance: {
+        bundleDigest: BUNDLE,
+        claimedLevel: 2,
+        statement: statement({ bundleDigest: null }),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('PROVENANCE_INVALID');
+    expect(result.message).toContain('does not bind the source bundle digest');
+  });
+
+  test('an artifact with no digest-pinned reference never spawns anything', async () => {
+    // The check/use race the verifier's contract warns about: a tag can move
+    // between the check and the pull, so a tag never reaches the tool.
+    const processes = new FakeVerifierProcess();
+    const result = await verifying(processes).verify({
+      ...input(),
+      artifact: {
+        type: 'image',
+        digest: DIGEST,
+        refs: ['registry.example.test/apps/shop:latest'],
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('PROVENANCE_INVALID');
+    expect(result.message).toContain('no immutable reference');
+    expect(processes.runs).toHaveLength(0);
+  });
+
+  test('a builder the route did not expect refuses at the binary', async () => {
+    const result = await verifying(new FakeVerifierProcess()).verify({
+      ...input(),
+      provenance: {
+        bundleDigest: BUNDLE,
+        claimedLevel: 2,
+        statement: statement({
+          builderId: 'https://github.com/untrusted/workflows/build.yml',
+        }),
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe('PROVENANCE_INVALID');
+    expect(result.message).toContain('builder mismatch');
+  });
+
+  test('a files artifact is verified and signed like any other digest', async () => {
+    // §16 says core "signs that digest", and a static site has one. Gating the
+    // supply chain on `type === 'image'` refused every files build before the
+    // verifier was even spawned.
+    const processes = new FakeVerifierProcess();
+    const artifact: Artifact = {
+      type: 'files',
+      digest: DIGEST,
+      refs: [`registry.example.test/artifacts@${DIGEST}`],
+    };
+    const verified = await verifying(processes).verify({
+      ...input(),
+      artifact,
+      provenance: {
+        bundleDigest: BUNDLE,
+        claimedLevel: 2,
+        statement: statement({}),
+      },
+    });
+
+    expect(verified.ok).toBe(true);
+    const signature = await new CosignSigner({
+      key: TEST_SIGNER_KEY,
+      processes,
+    }).sign(artifact);
+    expect(signature.artifactDigest).toBe(DIGEST);
+  });
+});
+
+describe('a signature that is signed and re-verified, not asserted', () => {
+  const ARTIFACT_REF = `registry.example.test/apps/shop@${DIGEST}`;
+
+  async function signOnce(processes: FakeVerifierProcess) {
+    return new CosignSigner({ key: TEST_SIGNER_KEY, processes }).sign({
+      type: 'image',
+      digest: DIGEST,
+      refs: [ARTIFACT_REF],
+    });
+  }
+
+  test('what the signer wrote is what admission admits', async () => {
+    const processes = new FakeVerifierProcess();
+    const signature = await signOnce(processes);
+
+    const admitted = await new SpindriftSignatureVerifier({
+      processes,
+      signerKey: TEST_SIGNER_KEY,
+    }).verify({ artifactDigest: DIGEST, signature });
+
+    expect(admitted).toEqual({ ok: true, reason: null });
+    // The bundle came back through the file the signer wrote, not through
+    // stdout — which is the path `CosignSigner` prefers and had never been
+    // exercised against a process that writes one.
+    expect(processes.callsTo('sign')).toHaveLength(1);
+  });
+
+  test('a bundle covering another digest is refused at admission', async () => {
+    const processes = new FakeVerifierProcess();
+    const signature = await signOnce(processes);
+
+    const admitted = await new SpindriftSignatureVerifier({
+      processes,
+      signerKey: TEST_SIGNER_KEY,
+    }).verify({ artifactDigest: `sha256:${'e'.repeat(64)}`, signature });
+
+    expect(admitted.ok).toBe(false);
+    if (admitted.ok) return;
+    expect(admitted.reason).toContain('bundle covers digest');
+  });
+
+  test('a bundle signed by another key is refused even though it is self-consistent', async () => {
+    // The pin: admission derives the expected public key from the trusted
+    // signer reference, so a bundle whose own key verifies its own signature
+    // still fails.
+    const signature = await signOnce(
+      new FakeVerifierProcess({ signerKey: '/spindrift/other.key' }),
+    );
+    const forged = {
+      ...signature,
+      bundle: {
+        ...(signature.bundle as Record<string, unknown>),
+        publicKey:
+          'MCowBQYDK2VwAyEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      },
+    };
+
+    const admitted = await new SpindriftSignatureVerifier({
+      processes: new FakeVerifierProcess(),
+      signerKey: TEST_SIGNER_KEY,
+    }).verify({ artifactDigest: DIGEST, signature: forged });
+
+    expect(admitted.ok).toBe(false);
+    if (admitted.ok) return;
+    expect(admitted.reason).toContain('not the trusted Spindrift signer');
+  });
+
+  test('a tampered signature is refused', async () => {
+    const processes = new FakeVerifierProcess();
+    const signature = await signOnce(processes);
+    const bundle = signature.bundle as { signature: string };
+    const tampered = {
+      ...signature,
+      bundle: {
+        ...bundle,
+        signature: Buffer.from(
+          Buffer.from(bundle.signature, 'base64').reverse(),
+        ).toString('base64'),
+      },
+    };
+
+    const admitted = await new SpindriftSignatureVerifier({
+      processes,
+      signerKey: TEST_SIGNER_KEY,
+    }).verify({ artifactDigest: DIGEST, signature: tampered });
+
+    expect(admitted.ok).toBe(false);
+    if (admitted.ok) return;
+    expect(admitted.reason).toContain('does not verify');
   });
 });


### PR DESCRIPTION
Group D — three fake-fidelity tickets that overlap pairwise, so one branch.

## 15 — read the Cloud Build log the way Cloud Logging serves it

**Live.** `CloudBuildRoute` fetched a log page, read the status, and broke on a
terminal one — so everything the build wrote in its last seconds was never asked
for. The report rides *inside* the log (`report.ts`) and BuildKit writes its
export region at the end, so every green cloud build would have been recorded
`succeeded but reported no artifact`. Same failure shape as the 415 in #1435, on
a different route.

It also carried `nextPageToken` across polls as a tail watermark. Cloud
Logging's token continues one search over a frozen result set, and an empty page
carrying one means the search was *cut short*, not that the log is caught up.

The route now opens a fresh search each poll, follows the token to the end of
that search, and drops it; a timestamp window plus per-entry `insertId` replaces
the cursor, which is what tolerates out-of-order ingestion. After a terminal
status it drains the log until the report appears or 60s of drain budget is
spent.

The fake models the *lateness*, not only the paging.

## 17 — fake the verifier process, not the verifier

`SupplyChainHarness` replaced `SlsaVerifier`, `CosignSigner` and the signature
verifier wholesale with doubles that always succeed, so §16's verify → policy →
sign chain had never executed a line of its real logic. All three already expose
a `ProcessExecutor` seam built for this.

The harness now composes the real three over `FakeVerifierProcess`, which
answers the argv `apps/spindrift-verifier/main.go` answers and refuses what
`pkg/verifier` refuses — including that `verify-image --print-provenance` echoes
the provenance file it was handed, which is what makes the bundle-digest binding
a real read. Its signature is genuinely Ed25519: `sign` derives a key from the
signer reference and writes the five-field bundle `sign.go` writes, and
`verify-signature` pins the embedded public key before checking it.

**Two live defects fell out.**

1. The supply chain gated on `immutableImageRef`, which returns `null` for any
   artifact that is not an image — so every `files` artifact was refused
   `PROVENANCE_INVALID` *before the verifier was spawned*, and no static site
   could ever have been signed or deployed. §16 says core signs *the digest*;
   `digestPinnedRef` replaces the image gate with the property that matters.
2. Every fixture storing a signature stored `{ mediaType }` and nothing else —
   precisely the placeholder `sign.go` documents as rejected. 14 deploy tests
   were passing an admission gate production would refuse.

**Recorded, not fixed:** `main.go`'s `verify-image` path hardcodes
`ClaimedLevel: 2 / Min 1 / Max 2 / Backend "hosted"`, and
`Expectations.SourceURI` is declared and never read. Both are documented on
`SlsaVerifier` with why they change no verdict today.

## 18 — make fake artifacts carry digests the product would accept

`FakeBuildAdapter` invented `sha256:fake-0` and `<destination>@fake`. Four
places validate `^sha256:[0-9a-f]{64}$`; the ref is not digest-pinned at all.
The digest fix landed with 17, which needed it before the real verifier could
run. What is durable here: `src/domain/digest.ts` owns the one definition and
the four sites import it, and `build-contract.test.ts` runs the fake's own
output through the product's `digestSchema` and `digestPinnedRef` so they cannot
drift apart again.

`FakeDeployAdapter`'s refs and `FakeSecretStore`'s item names are the same class
and belong to the concurrent deploy and store branches; left alone deliberately.

## Proof the fakes catch the bugs

Each source fix reverted against the new fakes:

| reverted | tests failing |
| --- | --- |
| the post-terminal log drain | 3 |
| `nextPageToken` as a durable cursor | 2 |
| `digestPinnedRef` back to the image gate | 2 |
| `bundleDigestOf`'s four-deep path | 8 |
| the fake's digest back to `sha256:fake-0` | 3 |

And before any `src/` change, swapping the supply-chain doubles for the real
classes turned **19** previously-green tests red.

## Validation

```
953 pass, 0 fail — Ran 953 tests across 65 files   (934 baseline, 19 added)
bun run typecheck && bun run lint — clean
```

None of this is proven end to end: the cloud route has never run in this
installation, and the real verifier binary has never seen a real artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)