### PR TITLE
feat(spindrift): delete Apps from the UI

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -111,6 +111,17 @@ while building them:
   and the optional Gateway binding. Every mutation requires a fresh passkey
   assertion, and the final account-root passkey cannot be removed.
 
+**Deleting an App is review-then-confirm**, from the App list row or the
+workspace header (`components/delete-app.tsx`). `deleteApp` called without
+`confirm` writes nothing and answers with what the delete would do — the
+Components, Builds, Deploys and config keys that go, the Datastores that survive
+detached (§11), and the live workloads it would strand. The confirm call goes by
+the id the review resolved. **Nothing is torn down**: as with disconnect, a
+running workload keeps running and is named again afterwards, because once the
+rows are gone that list is the only record it is there. §10 store items are
+reaped with the App, and a key the store refuses to destroy is named rather than
+failing a delete that already happened.
+
 Authenticated product operations reach the server through a dispatch surface
 generated from the command registry (`src/web/dispatch.ts`): one route per
 command, built by `Object.fromEntries` over `commandNames`. Authentication uses

--- a/apps/spindrift/src/commands/apps/delete.ts
+++ b/apps/spindrift/src/commands/apps/delete.ts
@@ -1,0 +1,332 @@
+/**
+ * `deleteApp` — remove an App and everything that is only ever its own (§2).
+ *
+ * §2 already settles what deletion means: it "detaches its Datastores and never
+ * cascades to them (§2, §11) but does cascade to its own Components, Builds,
+ * Deploys, and config items — none of those are reattachable." So the shape of
+ * this command is not a question about the model. What is a question is the two
+ * things a delete can do that nobody asked for, and both are answered the same
+ * way — by saying so first.
+ *
+ * **It is review-then-confirm, like `replaceConfig`.** The first call writes
+ * nothing and returns what the delete would do: the Components that go, the
+ * Datastores that survive detached, and — the half that matters — the live
+ * workloads it would strand. The second call, with `confirm`, does it. An act
+ * that removes a Component's whole build and deploy history on the first call is
+ * one nobody can look at before it happens, which is the same argument §10 makes
+ * about a bulk paste.
+ *
+ * **It never calls the deploy adapter.** This is `disconnectTarget`'s rule (§13)
+ * and it is here for the same reason: destroying a workload is not what "delete
+ * this record" says, and a delete that tore down a running service because its
+ * bookkeeping was being tidied would be the most destructive possible reading of
+ * the request. What the operator gets instead is the list, before they confirm
+ * and again afterwards, because after the rows are gone that list is the only
+ * record that those workloads exist.
+ *
+ * **It does reap the config store**, and that is not the same thing. §10's
+ * store items are per-key material this App put there and nothing else will ever
+ * read — a pin whose row is gone is unreachable, not merely unmanaged — so
+ * leaving them is a leak rather than a workload. A key the store refuses to
+ * destroy is named in `retainedSecrets` rather than failing the delete: the rows
+ * are already gone by then, and a refusal at that point would report a delete
+ * that happened as one that did not.
+ */
+import { and, eq, inArray, isNull, or } from 'drizzle-orm';
+import { z } from 'zod';
+import {
+  apps,
+  builds,
+  components,
+  componentTargetDesired,
+  configItems,
+  datastores,
+  deploys,
+  targets,
+} from '../../db/schema.ts';
+import { STRANDABLE_PHASES } from '../../domain/target.ts';
+import { type ConfigSubject, configSubject, reapKey } from '../config/set.ts';
+import { type Command, type CommandContext, failed, ok } from '../types.ts';
+
+export const deleteAppInput = z
+  .object({
+    /** The App's id, or its name where that names exactly one App. */
+    name: z.string().trim().min(1),
+    /**
+     * False — the default — reviews and deletes nothing.
+     *
+     * The two calls are independent: the second re-reads the App and recomputes
+     * what it is about to strand, so a deploy that went live between them is
+     * named in the confirmation rather than quietly deleted under a review that
+     * said there was nothing running.
+     */
+    confirm: z.boolean().default(false),
+  })
+  .strict();
+
+export type DeleteAppInput = z.infer<typeof deleteAppInput>;
+
+/** One workload that keeps running with nothing managing it (§13's grammar). */
+export interface StrandedWorkload {
+  readonly deployId: string;
+  readonly component: string;
+  /** Where it is still running — the operator has to go there by hand. */
+  readonly target: string;
+  readonly url: string | null;
+}
+
+/** What deleting this App does, whether or not it has been done yet. */
+export interface DeleteAppEffects {
+  readonly appId: string;
+  readonly name: string;
+  /** Gone with the App — a Component is not a thing that reattaches (§2). */
+  readonly components: readonly string[];
+  readonly builds: number;
+  readonly deploys: number;
+  /** Named, per §13 — this list is the whole point of the confirmation. */
+  readonly stranded: readonly StrandedWorkload[];
+  /** §11: these survive, detached. The App owned the attachment, not the data. */
+  readonly detachedDatastores: readonly string[];
+  /** §10 config keys, as `component/KEY`, whose store items this reaps. */
+  readonly configKeys: readonly string[];
+}
+
+export type DeleteAppResult =
+  | ({ readonly deleted: false } & DeleteAppEffects)
+  | ({
+      readonly deleted: true;
+      /**
+       * Store items that outlived their rows because the store refused to
+       * destroy them. Empty is the ordinary answer; a non-empty list is
+       * material somebody has to remove in the store's own console.
+       */
+      readonly retainedSecrets: readonly string[];
+    } & DeleteAppEffects);
+
+export const deleteApp: Command<DeleteAppInput, DeleteAppResult> = async (
+  input,
+  context,
+) => {
+  // `apps` carries no unique constraint on `name`, so a name is not an
+  // identifier — the same reason `deployApp` reads every match rather than
+  // `findFirst`. Guessing which of two Apps to deploy is recoverable; guessing
+  // which of two to delete is not.
+  const isUuid = z.uuid().safeParse(input.name).success;
+  const matches = await context.db
+    .select()
+    .from(apps)
+    .where(
+      isUuid
+        ? or(eq(apps.name, input.name), eq(apps.id, input.name))
+        : eq(apps.name, input.name),
+    );
+
+  if (matches.length === 0) {
+    return failed('NOT_FOUND', `App '${input.name}' not found`);
+  }
+
+  if (matches.length > 1) {
+    return failed(
+      'INVALID_INPUT',
+      `${matches.length} Apps answer to '${input.name}', so this would delete an arbitrary one — delete by id: ${matches
+        .map((candidate) => candidate.id)
+        .join(', ')}`,
+      [{ path: 'name', message: 'names more than one App' }],
+    );
+  }
+
+  const app = matches[0]!;
+
+  const ownComponents = await context.db
+    .select({ id: components.id, name: components.name })
+    .from(components)
+    .where(eq(components.appId, app.id));
+  const componentIds = ownComponents.map((component) => component.id);
+  const nameOf = new Map(
+    ownComponents.map((component) => [component.id, component.name]),
+  );
+
+  const ownBuilds =
+    componentIds.length === 0
+      ? []
+      : await context.db
+          .select({ id: builds.id })
+          .from(builds)
+          .where(inArray(builds.componentId, componentIds));
+
+  const ownDeploys =
+    componentIds.length === 0
+      ? []
+      : await context.db
+          .select({ id: deploys.id })
+          .from(deploys)
+          .where(inArray(deploys.componentId, componentIds));
+
+  // Read before write, for the same reason `disconnectTarget` does: the rows to
+  // name are exactly the rows about to stop being observable, and reading them
+  // afterwards would return nothing at all.
+  const strandable =
+    componentIds.length === 0
+      ? []
+      : await context.db
+          .select({
+            deployId: deploys.id,
+            url: deploys.url,
+            component: components.name,
+            target: targets.name,
+          })
+          .from(deploys)
+          .innerJoin(components, eq(deploys.componentId, components.id))
+          .innerJoin(targets, eq(deploys.targetId, targets.id))
+          .where(
+            and(
+              inArray(deploys.componentId, componentIds),
+              isNull(deploys.orphanedAt),
+              inArray(deploys.phase, [...STRANDABLE_PHASES]),
+            ),
+          );
+
+  const attached = await context.db
+    .select({ name: datastores.name })
+    .from(datastores)
+    .where(eq(datastores.appId, app.id));
+
+  // The scope a store item is reachable at is derived from rows this delete is
+  // about to remove, so it is resolved now and used after. `kind: 'secret_ref'`
+  // is the only kind with anything in a store — §10's website exception is a
+  // plain column, and it goes with the row.
+  const pinned =
+    componentIds.length === 0
+      ? []
+      : await context.db
+          .select({
+            componentId: configItems.componentId,
+            targetId: configItems.targetId,
+            key: configItems.key,
+          })
+          .from(configItems)
+          .where(
+            and(
+              inArray(configItems.componentId, componentIds),
+              eq(configItems.kind, 'secret_ref'),
+            ),
+          );
+
+  const effects: DeleteAppEffects = {
+    appId: app.id,
+    name: app.name,
+    components: ownComponents.map((component) => component.name),
+    builds: ownBuilds.length,
+    deploys: ownDeploys.length,
+    stranded: strandable.map((deploy) => ({
+      deployId: String(deploy.deployId),
+      component: deploy.component,
+      target: deploy.target,
+      url: deploy.url,
+    })),
+    detachedDatastores: attached.map((datastore) => datastore.name),
+    configKeys: pinned.map(
+      (item) =>
+        `${nameOf.get(item.componentId) ?? item.componentId}/${item.key}`,
+    ),
+  };
+
+  if (!input.confirm) {
+    return ok({ deleted: false, ...effects });
+  }
+
+  // Resolved before the rows go, used after they have: `configSubject` reads the
+  // Component and Target this scope is named from.
+  const scopes = await reapableScopes(context, pinned, nameOf);
+
+  // Ordered rather than left to the cascade. Two of these foreign keys are
+  // `restrict` — `deploys.build_id` and `component_target_desired.desired_*` —
+  // and Postgres enforces a `restrict` the moment the referenced row is deleted,
+  // including when the referencing row is being deleted by the same cascade. So
+  // the referencing rows go first, by hand; `components`, `config_items`,
+  // `config_audit_events`, and `attempt_events` still cascade off the App, and
+  // `datastores.app_id` still goes null (§11).
+  await context.db.transaction(async (tx) => {
+    if (componentIds.length > 0) {
+      await tx
+        .delete(componentTargetDesired)
+        .where(inArray(componentTargetDesired.componentId, componentIds));
+      await tx
+        .delete(deploys)
+        .where(inArray(deploys.componentId, componentIds));
+      await tx.delete(builds).where(inArray(builds.componentId, componentIds));
+    }
+    await tx.delete(apps).where(eq(apps.id, app.id));
+  });
+
+  const retainedSecrets: string[] = [];
+  for (const scope of scopes) {
+    for (const key of scope.keys) {
+      if (scope.subject === null) {
+        retainedSecrets.push(`${scope.component}/${key}`);
+        continue;
+      }
+      try {
+        // Retention zero: every version, not the tail past the depth §10 keeps
+        // for a rollback. There is nothing left to roll back to.
+        await reapKey(scope.subject, key, 0);
+      } catch {
+        retainedSecrets.push(`${scope.component}/${key}`);
+      }
+    }
+  }
+
+  return ok({ deleted: true, retainedSecrets, ...effects });
+};
+
+/** One (Component, Target) scope's keys, with the store to reap them from. */
+interface ReapableScope {
+  /** `null` when this scope reaches no store — its keys are simply retained. */
+  readonly subject: ConfigSubject | null;
+  /** The Component's name, for the sentence a retained key is reported in. */
+  readonly component: string;
+  readonly keys: readonly string[];
+}
+
+/**
+ * Group the pinned keys by scope and resolve each scope's store, before the rows
+ * that name the scope are deleted.
+ *
+ * A scope that resolves to a failure — a Target that reaches no store this
+ * installation can write to — is kept with `reap: null` rather than dropped, so
+ * its keys are reported as retained instead of silently forgotten.
+ */
+async function reapableScopes(
+  context: CommandContext,
+  pinned: readonly { componentId: string; targetId: string; key: string }[],
+  componentNames: ReadonlyMap<string, string>,
+): Promise<ReapableScope[]> {
+  const byScope = new Map<
+    string,
+    { componentId: string; targetId: string; keys: string[] }
+  >();
+  for (const item of pinned) {
+    const scopeKey = `${item.componentId} ${item.targetId}`;
+    const existing = byScope.get(scopeKey);
+    if (existing) {
+      existing.keys.push(item.key);
+    } else {
+      byScope.set(scopeKey, {
+        componentId: item.componentId,
+        targetId: item.targetId,
+        keys: [item.key],
+      });
+    }
+  }
+
+  const scopes: ReapableScope[] = [];
+  for (const scope of byScope.values()) {
+    const subject = await configSubject(context, scope);
+    scopes.push({
+      subject: 'failure' in subject ? null : subject,
+      component: componentNames.get(scope.componentId) ?? scope.componentId,
+      keys: scope.keys,
+    });
+  }
+  return scopes;
+}

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -16,6 +16,7 @@
  * named commands and arrive with the milestones that implement them.
  */
 
+export { deleteApp } from './apps/delete.ts';
 export { deployApp } from './apps/deploy.ts';
 export { listApps } from './apps/list.ts';
 export { resolveComponentPlacement } from './apps/resolve-placement.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -29,6 +29,7 @@
  * nothing left for a route to decide.
  */
 import type { z } from 'zod';
+import { deleteApp, deleteAppInput } from './apps/delete.ts';
 import { deployApp, deployAppInput } from './apps/deploy.ts';
 import { listApps, listAppsInput } from './apps/list.ts';
 import {
@@ -106,6 +107,7 @@ export type AnyCommandDescriptor = CommandDescriptor<any, any>;
 
 /** Every command, by the name it is dispatched under. */
 export const commandRegistry = {
+  deleteApp: { input: deleteAppInput, handler: deleteApp },
   deployApp: { input: deployAppInput, handler: deployApp },
   getAppWorkspace: { input: getAppWorkspaceInput, handler: getAppWorkspace },
   getDeployDetail: { input: getDeployDetailInput, handler: getDeployDetail },

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import type { Principal } from '../commands/types.ts';
 import { readSession, signOut } from './auth-client.ts';
 import { command, type InputOf } from './client.ts';
+import { DeleteAppDialog, useAppDeletion } from './components/delete-app.tsx';
 import type {
   AppListItem,
   DeployView,
@@ -153,6 +154,19 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     | { type: 'success'; apps: readonly AppListItem[] }
   >({ type: 'loading' });
 
+  // The row goes when the App does. Re-reading the list instead would be a
+  // second round trip to learn something this screen was just told.
+  const deletion = useAppDeletion((name) => {
+    setState((current) =>
+      current.type === 'success'
+        ? {
+            type: 'success',
+            apps: current.apps.filter((app) => app.name !== name),
+          }
+        : current,
+    );
+  });
+
   useEffect(() => {
     let live = true;
     command('listApps', {})
@@ -197,7 +211,12 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     );
   }
 
-  return <AppList apps={state.apps} onNavigate={onNavigate} />;
+  return (
+    <>
+      <AppList apps={state.apps} onNavigate={onNavigate} deletion={deletion} />
+      <DeleteAppDialog deletion={deletion} />
+    </>
+  );
 }
 
 function WorkspaceScreen({
@@ -221,6 +240,9 @@ function WorkspaceScreen({
    * are already on re-reads itself and the new Build shows up in its activity.
    */
   const [reloadToken, setReloadToken] = useState(0);
+
+  // There is no workspace left to stand on once the App is gone.
+  const deletion = useAppDeletion(() => onNavigate('/apps'));
 
   useEffect(() => {
     let live = true;
@@ -397,7 +419,9 @@ function WorkspaceScreen({
         onDeploy={handleDeploy}
         deploying={deploying}
         onNavigate={onNavigate}
+        deletion={deletion}
       />
+      <DeleteAppDialog deletion={deletion} />
     </>
   );
 }

--- a/apps/spindrift/src/web/components/delete-app.tsx
+++ b/apps/spindrift/src/web/components/delete-app.tsx
@@ -1,0 +1,427 @@
+/**
+ * Deleting an App, in the two calls the command takes (§2).
+ *
+ * `deleteApp` reviews before it acts, so the screen does too: the first call
+ * writes nothing and answers with what the delete would do, and this is where
+ * that answer is read aloud. **The confirmation is the feature** — an App with
+ * nothing deployed deletes with a glance at one sentence, and an App with a live
+ * workload cannot be deleted without the operator having been shown the workload
+ * that will keep running with nothing managing it.
+ *
+ * Two things are stated rather than hidden, both because the row that recorded
+ * them is about to stop existing:
+ *
+ * - **Stranded workloads.** Nothing is torn down (§13) — after the delete, this
+ *   list is the only record that those workloads are there, so the flow does not
+ *   close on its own when there is one. The operator dismisses it.
+ * - **Retained secrets.** §10's store items are reaped with the App; the ones a
+ *   store refused are named, because nothing will reach them again.
+ *
+ * The confirm call goes by `appId`, never by the name that was typed: the review
+ * already resolved which App this is, and re-resolving a name that a second App
+ * has since taken would delete the wrong one.
+ */
+import { AlertTriangle, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type {
+  DeleteAppEffects,
+  StrandedWorkload,
+} from '../../commands/apps/delete.ts';
+import { command } from '../client.ts';
+import { Button } from '../ui/button.tsx';
+import { Eyebrow } from '../ui/card.tsx';
+
+export type AppDeletion =
+  | { readonly kind: 'idle' }
+  /** The review call is in flight. */
+  | { readonly kind: 'reviewing'; readonly name: string }
+  | {
+      readonly kind: 'confirming';
+      readonly name: string;
+      readonly effects: DeleteAppEffects;
+    }
+  | {
+      readonly kind: 'deleting';
+      readonly name: string;
+      readonly effects: DeleteAppEffects;
+    }
+  /** Done, and something outlived it that somebody has to go and deal with. */
+  | {
+      readonly kind: 'aftermath';
+      readonly name: string;
+      readonly stranded: readonly StrandedWorkload[];
+      readonly retainedSecrets: readonly string[];
+    }
+  | {
+      readonly kind: 'failed';
+      readonly name: string;
+      readonly message: string;
+    };
+
+export interface AppDeletionControls {
+  readonly state: AppDeletion;
+  /** Ask what deleting this App would do. Nothing is written. */
+  review(name: string): void;
+  /** Do it. Only meaningful from `confirming`. */
+  confirm(): void;
+  /** Back out, or acknowledge the aftermath. */
+  dismiss(): void;
+}
+
+/**
+ * The flow, without the chrome.
+ *
+ * `onDeleted` fires once per completed delete, after the operator has seen any
+ * aftermath — so a caller can navigate away or drop a row without racing the
+ * one screen that still names what was stranded.
+ */
+export function useAppDeletion(
+  onDeleted: (name: string) => void,
+): AppDeletionControls {
+  const [state, setState] = useState<AppDeletion>({ kind: 'idle' });
+
+  // Held in a ref so `confirm` does not have to be rebuilt — and every pending
+  // request re-checked — every time a parent re-renders with a new closure.
+  const deleted = useRef(onDeleted);
+  deleted.current = onDeleted;
+
+  const review = useCallback((name: string) => {
+    setState({ kind: 'reviewing', name });
+    command('deleteApp', { name, confirm: false })
+      .then((result) => {
+        if (!result.ok) {
+          setState({ kind: 'failed', name, message: result.failure.message });
+          return;
+        }
+        setState({ kind: 'confirming', name, effects: result.value });
+      })
+      .catch((error: unknown) => {
+        setState({
+          kind: 'failed',
+          name,
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Could not reach the server',
+        });
+      });
+  }, []);
+
+  const confirm = useCallback(() => {
+    setState((current) => {
+      if (current.kind !== 'confirming') return current;
+      const { name, effects } = current;
+
+      command('deleteApp', { name: effects.appId, confirm: true })
+        .then((result) => {
+          if (!result.ok) {
+            setState({ kind: 'failed', name, message: result.failure.message });
+            return;
+          }
+          const value = result.value;
+          const retained = value.deleted ? value.retainedSecrets : [];
+          if (value.stranded.length === 0 && retained.length === 0) {
+            setState({ kind: 'idle' });
+            deleted.current(name);
+            return;
+          }
+          setState({
+            kind: 'aftermath',
+            name,
+            stranded: value.stranded,
+            retainedSecrets: retained,
+          });
+        })
+        .catch((error: unknown) => {
+          setState({
+            kind: 'failed',
+            name,
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Could not reach the server',
+          });
+        });
+
+      return { kind: 'deleting', name, effects };
+    });
+  }, []);
+
+  const dismiss = useCallback(() => {
+    setState((current) => {
+      // The App is already gone by then; the caller has to hear about it even
+      // though what closed the panel was a dismissal rather than a success.
+      if (current.kind === 'aftermath') deleted.current(current.name);
+      return { kind: 'idle' };
+    });
+  }, []);
+
+  return { state, review, confirm, dismiss };
+}
+
+/** The trash affordance, so no screen writes its own. */
+export function DeleteAppButton({
+  name,
+  deletion,
+  label = false,
+}: {
+  name: string;
+  deletion: AppDeletionControls;
+  /** Show the word beside the icon — the workspace has room, a list row does not. */
+  label?: boolean;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size={label ? 'default' : 'icon'}
+      aria-label={`Delete ${name}`}
+      title={`Delete ${name}`}
+      className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+      onClick={(event) => {
+        // A list row is a link to the workspace; deleting is not navigating.
+        event.stopPropagation();
+        deletion.review(name);
+      }}
+    >
+      <Trash2 aria-hidden="true" />
+      {label ? 'Delete' : null}
+    </Button>
+  );
+}
+
+/**
+ * The modal. A native `<dialog>` rather than a div: focus containment and
+ * Escape are the two things a hand-rolled overlay reliably gets wrong, and a
+ * destructive confirmation is the worst place to get them wrong.
+ */
+export function DeleteAppDialog({
+  deletion,
+}: {
+  deletion: AppDeletionControls;
+}) {
+  const { state, confirm, dismiss } = deletion;
+  const ref = useRef<HTMLDialogElement>(null);
+  const open = state.kind !== 'idle';
+
+  useEffect(() => {
+    const node = ref.current;
+    if (node === null) return;
+    if (open && !node.open) node.showModal();
+    if (!open && node.open) node.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={ref}
+      className={
+        'm-auto w-[min(32rem,calc(100vw-2rem))] rounded-lg border border-border ' +
+        'bg-card p-0 text-foreground backdrop:bg-black/50'
+      }
+      onCancel={(event) => {
+        // Escape during the delete itself would close a panel over an act that
+        // is still running, and the result would land on nothing.
+        if (state.kind === 'deleting') event.preventDefault();
+        else dismiss();
+      }}
+    >
+      <div className="flex flex-col gap-4 p-5">
+        <Body state={state} />
+        <Actions state={state} onConfirm={confirm} onDismiss={dismiss} />
+      </div>
+    </dialog>
+  );
+}
+
+function Body({ state }: { state: AppDeletion }) {
+  if (state.kind === 'idle') return null;
+
+  if (state.kind === 'reviewing') {
+    return (
+      <p className="animate-pulse text-sm text-muted-foreground">
+        Working out what deleting {state.name} would do...
+      </p>
+    );
+  }
+
+  if (state.kind === 'failed') {
+    return (
+      <div>
+        <Eyebrow>Delete failed</Eyebrow>
+        <h2 className="mt-1 text-lg font-semibold tracking-tight">
+          {state.name} was not deleted
+        </h2>
+        <p className="mt-2 text-sm text-destructive">{state.message}</p>
+      </div>
+    );
+  }
+
+  if (state.kind === 'aftermath') {
+    return (
+      <div>
+        <Eyebrow>Deleted</Eyebrow>
+        <h2 className="mt-1 text-lg font-semibold tracking-tight">
+          {state.name} is gone, and this is not
+        </h2>
+        {state.stranded.length > 0 ? (
+          <>
+            <p className="mt-2 text-sm text-muted-foreground">
+              These workloads are still running. Nothing manages them now, so
+              removing them is a manual job on the Target.
+            </p>
+            <Stranded stranded={state.stranded} />
+          </>
+        ) : null}
+        {state.retainedSecrets.length > 0 ? (
+          <>
+            <p className="mt-3 text-sm text-muted-foreground">
+              These config items are still in the store — nothing will read them
+              again:
+            </p>
+            <ul className="mt-1.5 flex flex-col gap-1">
+              {state.retainedSecrets.map((secret) => (
+                <li key={secret} className="font-mono text-xs text-subtle">
+                  {secret}
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : null}
+      </div>
+    );
+  }
+
+  const { effects } = state;
+  return (
+    <div>
+      <Eyebrow>Delete App</Eyebrow>
+      <h2 className="mt-1 text-lg font-semibold tracking-tight">
+        Delete {effects.name}?
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {summarize(effects)} This cannot be undone.
+      </p>
+
+      {effects.stranded.length > 0 ? (
+        <div className="mt-3 rounded-md border border-destructive/50 bg-destructive/10 p-3">
+          <p className="flex items-center gap-2 text-sm font-medium text-destructive">
+            <AlertTriangle aria-hidden="true" className="size-4" />
+            {effects.stranded.length === 1
+              ? 'One workload is live and will keep running'
+              : `${effects.stranded.length} workloads are live and will keep running`}
+          </p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Deleting the App does not stop them. You will have to remove them on
+            the Target by hand.
+          </p>
+          <Stranded stranded={effects.stranded} />
+        </div>
+      ) : null}
+
+      {effects.detachedDatastores.length > 0 ? (
+        <p className="mt-3 text-sm text-muted-foreground">
+          {effects.detachedDatastores.join(', ')}{' '}
+          {effects.detachedDatastores.length === 1
+            ? 'survives, detached'
+            : 'survive, detached'}{' '}
+          — a Datastore is not deleted with the App it was attached to.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function Stranded({ stranded }: { stranded: readonly StrandedWorkload[] }) {
+  return (
+    <ul className="mt-2 flex flex-col gap-1">
+      {stranded.map((workload) => (
+        <li
+          key={workload.deployId}
+          className="flex flex-wrap items-baseline gap-x-2 font-mono text-xs"
+        >
+          <span className="font-semibold">{workload.component}</span>
+          <span className="text-muted-foreground">on {workload.target}</span>
+          {workload.url ? (
+            <span className="text-subtle">{workload.url}</span>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** What goes, in one sentence — counts rather than a list nobody reads. */
+function summarize(effects: DeleteAppEffects): string {
+  const parts: string[] = [];
+  if (effects.components.length > 0) {
+    parts.push(
+      effects.components.length === 1
+        ? `its Component ${effects.components[0]}`
+        : `its ${effects.components.length} Components`,
+    );
+  }
+  if (effects.builds > 0) {
+    parts.push(
+      `${effects.builds} ${effects.builds === 1 ? 'Build' : 'Builds'}`,
+    );
+  }
+  if (effects.deploys > 0) {
+    parts.push(
+      `${effects.deploys} ${effects.deploys === 1 ? 'Deploy' : 'Deploys'}`,
+    );
+  }
+  if (effects.configKeys.length > 0) {
+    parts.push(
+      `${effects.configKeys.length} config ${
+        effects.configKeys.length === 1 ? 'key' : 'keys'
+      }`,
+    );
+  }
+  if (parts.length === 0) return 'Nothing else belongs to it.';
+  const last = parts.pop() as string;
+  const list = parts.length === 0 ? last : `${parts.join(', ')} and ${last}`;
+  return `This removes ${list}.`;
+}
+
+function Actions({
+  state,
+  onConfirm,
+  onDismiss,
+}: {
+  state: AppDeletion;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}) {
+  if (state.kind === 'idle') return null;
+
+  if (state.kind === 'reviewing') {
+    return (
+      <div className="flex justify-end">
+        <Button variant="outline" onClick={onDismiss}>
+          Cancel
+        </Button>
+      </div>
+    );
+  }
+
+  if (state.kind === 'failed' || state.kind === 'aftermath') {
+    return (
+      <div className="flex justify-end">
+        <Button onClick={onDismiss}>
+          {state.kind === 'aftermath' ? 'Understood' : 'Close'}
+        </Button>
+      </div>
+    );
+  }
+
+  const deleting = state.kind === 'deleting';
+  return (
+    <div className="flex justify-end gap-2">
+      <Button variant="outline" onClick={onDismiss} disabled={deleting}>
+        Cancel
+      </Button>
+      <Button variant="destructive" onClick={onConfirm} disabled={deleting}>
+        {deleting ? 'Deleting...' : `Delete ${state.effects.name}`}
+      </Button>
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/views/apps/list.tsx
+++ b/apps/spindrift/src/web/views/apps/list.tsx
@@ -8,8 +8,19 @@
  *
  * An empty list is its own onboarding: the first thing a fresh install sees is
  * the New App action, not a dashboard with empty charts.
+ *
+ * The one exception to "the one action is New App" is the trash affordance on
+ * each row. It is here rather than only in the workspace because the App this
+ * list most often has too many of is the one nothing was ever deployed from, and
+ * making the operator open a workspace to throw one away is what leaves a fresh
+ * install's failed first attempts on the screen forever. What it opens is a
+ * review, not a delete — `components/delete-app.tsx` owns that whole flow.
  */
 import { ExternalLink, Globe, Plus, Server, Zap } from 'lucide-react';
+import {
+  type AppDeletionControls,
+  DeleteAppButton,
+} from '../../components/delete-app.tsx';
 import type { AppListItem, DeployPhase } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
@@ -53,9 +64,11 @@ function phaseTone(
 export function AppList({
   apps,
   onNavigate,
+  deletion,
 }: {
   apps: readonly AppListItem[];
   onNavigate: (path: string) => void;
+  deletion: AppDeletionControls;
 }) {
   return (
     <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
@@ -90,48 +103,57 @@ export function AppList({
       ) : (
         <div className="flex flex-col gap-2">
           {apps.map((app) => (
-            <button
+            // A row is a navigation and a delete, so the row itself is not the
+            // button: an interactive control inside a `<button>` is neither
+            // valid HTML nor reachable by keyboard.
+            <div
               key={app.name}
-              type="button"
-              onClick={() => onNavigate(`/apps/${app.name}`)}
               className={cn(
-                'flex items-center gap-4 rounded-lg border border-border bg-card px-4 py-3.5 text-left transition-colors',
-                'hover:border-primary hover:bg-secondary/60',
+                'group flex items-center gap-2 rounded-lg border border-border bg-card pr-2 transition-colors',
+                'focus-within:border-primary hover:border-primary hover:bg-secondary/60',
               )}
             >
-              {kindIcon(app.kind)}
+              <button
+                type="button"
+                onClick={() => onNavigate(`/apps/${app.name}`)}
+                className="flex min-w-0 flex-1 items-center gap-4 px-4 py-3.5 text-left"
+              >
+                {kindIcon(app.kind)}
 
-              <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-semibold">{app.name}</span>
-                  <Badge tone={phaseTone(app.phase)}>
-                    {app.phase.toLowerCase()}
-                  </Badge>
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="text-sm font-semibold">{app.name}</span>
+                    <Badge tone={phaseTone(app.phase)}>
+                      {app.phase.toLowerCase()}
+                    </Badge>
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+                    <span className="font-mono text-xs text-muted-foreground">
+                      {app.target}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {app.source}
+                    </span>
+                  </div>
                 </div>
-                <div className="mt-0.5 flex flex-wrap items-center gap-x-3 gap-y-0.5">
+
+                <div className="hidden flex-col items-end gap-0.5 sm:flex">
                   <span className="font-mono text-xs text-muted-foreground">
-                    {app.target}
+                    {app.url}
                   </span>
-                  <span className="text-xs text-muted-foreground">
-                    {app.source}
-                  </span>
+                  <span className="text-xs text-subtle">{app.release}</span>
                 </div>
-              </div>
 
-              <div className="hidden flex-col items-end gap-0.5 sm:flex">
-                <span className="font-mono text-xs text-muted-foreground">
-                  {app.url}
-                </span>
-                <span className="text-xs text-subtle">{app.release}</span>
-              </div>
+                {app.urlLive ? (
+                  <ExternalLink
+                    aria-hidden="true"
+                    className="size-3.5 shrink-0 text-muted-foreground"
+                  />
+                ) : null}
+              </button>
 
-              {app.urlLive ? (
-                <ExternalLink
-                  aria-hidden="true"
-                  className="size-3.5 shrink-0 text-muted-foreground"
-                />
-              ) : null}
-            </button>
+              <DeleteAppButton name={app.name} deletion={deletion} />
+            </div>
           ))}
         </div>
       )}

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -17,6 +17,10 @@
  */
 import { ChevronRight, ExternalLink } from 'lucide-react';
 import type { ReactNode } from 'react';
+import {
+  type AppDeletionControls,
+  DeleteAppButton,
+} from '../../components/delete-app.tsx';
 import { EmptyState, LogPane } from '../../components/log-pane.tsx';
 import { PhasePill } from '../../components/status.tsx';
 import type {
@@ -35,11 +39,18 @@ export function Workspace({
   onDeploy,
   deploying = false,
   onNavigate,
+  deletion,
 }: {
   view: WorkspaceView;
   onDeploy?: () => void;
   deploying?: boolean;
   onNavigate?: (path: string) => void;
+  /**
+   * Absent where there is nothing to navigate back to after a delete — the
+   * screen owns where the operator lands, so a caller that cannot answer that
+   * question does not offer the act.
+   */
+  deletion?: AppDeletionControls;
 }) {
   const primary = view.components[0];
 
@@ -53,6 +64,9 @@ export function Workspace({
           <h1 className="text-2xl font-semibold tracking-tight">{view.app}</h1>
         </div>
         <div className="ml-auto flex gap-2">
+          {deletion ? (
+            <DeleteAppButton name={view.app} deletion={deletion} label />
+          ) : null}
           <Button variant="outline" asChild>
             <a href={`https://${view.url}`}>
               Open app <ExternalLink aria-hidden="true" />

--- a/apps/spindrift/test/commands/delete-app.test.ts
+++ b/apps/spindrift/test/commands/delete-app.test.ts
@@ -1,0 +1,383 @@
+/**
+ * `deleteApp` (§2, §11, §13).
+ *
+ * Every test here is an assertion about a promise the command makes that a
+ * straightforward `DELETE FROM apps` would break:
+ *
+ * - **The review writes nothing.** The first call is the confirmation's source
+ *   of truth, so an App is still there afterwards with every row it had.
+ * - **Deletion cascades to what is only the App's, and detaches what is not.**
+ *   Components, Builds and Deploys go (§2); a Datastore survives with
+ *   `app_id = null` (§11), because reattachment to a different App is the whole
+ *   reason it is a top-level noun.
+ * - **A live workload is named and left running** (§13). No `destroy` is ever
+ *   called, and the confirmation names what keeps running — after the rows are
+ *   gone, that list is the only record they exist.
+ * - **The `restrict` foreign keys do not block it.** `deploys.build_id` and
+ *   `component_target_desired.desired_*` are `restrict`, and Postgres enforces
+ *   one the moment its referenced row is deleted. A delete that leaned on the
+ *   cascade would fail here, which is why the command deletes in order.
+ *
+ * Rows are what is asserted, not return values: a command that reported a
+ * deletion it did not perform would pass a test of its own output.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { deleteApp } from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  componentTargetDesired,
+  datastores,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+/** One fake per adapter type, so a test can ask whether it was ever called. */
+function fakes() {
+  const made = new Map<string, FakeDeployAdapter>();
+  const registry: AdapterRegistry = {
+    deploy(adapter) {
+      let fake = made.get(adapter);
+      if (!fake) {
+        fake = new FakeDeployAdapter({ adapter });
+        made.set(adapter, fake);
+      }
+      return fake;
+    },
+    build: () => null,
+    // Reaching a store would mean this delete tried to reap config it was never
+    // given; the throw is the assertion.
+    store: () => {
+      throw new Error('no store adapter is configured for this test');
+    },
+    repository: () => null,
+    supplyChain: () => {
+      throw new Error('deleteApp reached the supply chain');
+    },
+  };
+  return {
+    registry,
+    of(adapter: string): FakeDeployAdapter {
+      const fake = made.get(adapter);
+      if (fake === undefined)
+        throw new Error(`no ${adapter} adapter was built`);
+      return fake;
+    },
+    built: () => made,
+  };
+}
+
+function context(registry: AdapterRegistry): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters: registry,
+    manifest,
+  };
+}
+
+/** A connected Target to hang Deploys off. */
+async function seedTarget(name: string) {
+  const [target] = await database()
+    .db.insert(targets)
+    .values({ name, adapter: 'kubernetes', rank: 0, health: 'healthy' })
+    .returning();
+  return target!;
+}
+
+/**
+ * An App with one Component, and — where a Target is given — a Build, a live
+ * Deploy, and the desired row whose `restrict` references are the interesting
+ * part.
+ */
+async function seedApp(
+  name: string,
+  options: { targetId?: string; phase?: 'LIVE' | 'FAILED' } = {},
+) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name, sourceKind: 'repo' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind: 'service' })
+    .returning();
+
+  if (options.targetId === undefined) {
+    return { app: app!, component: component!, build: null, deploy: null };
+  }
+
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'abcdef0',
+      targetShape: 'image',
+      artifactType: 'image',
+      status: 'SUCCEEDED',
+      artifactDigest: 'sha256:abc',
+    })
+    .returning();
+  const [deploy] = await db
+    .insert(deploys)
+    .values({
+      componentId: component!.id,
+      targetId: options.targetId,
+      buildId: build!.id,
+      phase: options.phase ?? 'LIVE',
+      ref: 'apps/web',
+      url: 'web.example.test',
+    })
+    .returning();
+  // The two `restrict` references, both pointed at rows this delete removes.
+  await db.insert(componentTargetDesired).values({
+    componentId: component!.id,
+    targetId: options.targetId,
+    desiredBuildId: build!.id,
+    desiredDeployId: deploy!.id,
+  });
+
+  return { app: app!, component: component!, build: build!, deploy: deploy! };
+}
+
+describe('the review writes nothing', () => {
+  test('it names what would go, and everything is still there', async () => {
+    const target = await seedTarget('folly');
+    const seeded = await seedApp('review-me', { targetId: target.id });
+    const { registry } = fakes();
+
+    const result = await deleteApp(
+      { name: 'review-me', confirm: false },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.deleted).toBe(false);
+    expect(result.value.appId).toBe(seeded.app.id);
+    expect(result.value.components).toEqual(['web']);
+    expect(result.value.builds).toBe(1);
+    expect(result.value.deploys).toBe(1);
+
+    const rows = await database()
+      .db.select()
+      .from(apps)
+      .where(eq(apps.id, seeded.app.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  test('an App with nothing deployed reviews as an empty act', async () => {
+    await seedApp('never-deployed');
+    const { registry } = fakes();
+
+    const result = await deleteApp(
+      { name: 'never-deployed', confirm: false },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stranded).toEqual([]);
+    expect(result.value.builds).toBe(0);
+    expect(result.value.deploys).toBe(0);
+    expect(result.value.detachedDatastores).toEqual([]);
+  });
+});
+
+describe('confirm deletes', () => {
+  test('an undeployed App and its Component are gone', async () => {
+    const seeded = await seedApp('throwaway');
+    const { registry } = fakes();
+
+    const result = await deleteApp(
+      { name: 'throwaway', confirm: true },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    const db = database().db;
+    expect(
+      await db.select().from(apps).where(eq(apps.id, seeded.app.id)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(components)
+        .where(eq(components.id, seeded.component.id)),
+    ).toHaveLength(0);
+  });
+
+  test('the restrict-referenced Build and Deploy go with it', async () => {
+    // Without the ordered deletes this is the test that fails, and it fails as
+    // a foreign-key violation from Postgres rather than as a wrong row count.
+    const target = await seedTarget('folly');
+    const seeded = await seedApp('has-history', {
+      targetId: target.id,
+      phase: 'FAILED',
+    });
+    const { registry } = fakes();
+
+    const result = await deleteApp(
+      { name: 'has-history', confirm: true },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    const db = database().db;
+    expect(
+      await db.select().from(builds).where(eq(builds.id, seeded.build!.id)),
+    ).toHaveLength(0);
+    expect(
+      await db.select().from(deploys).where(eq(deploys.id, seeded.deploy!.id)),
+    ).toHaveLength(0);
+    expect(
+      await db
+        .select()
+        .from(componentTargetDesired)
+        .where(eq(componentTargetDesired.componentId, seeded.component.id)),
+    ).toHaveLength(0);
+    // The Target is not a casualty of deleting an App placed on it.
+    expect(
+      await db.select().from(targets).where(eq(targets.id, target.id)),
+    ).toHaveLength(1);
+  });
+});
+
+describe('a live workload is named and left running', () => {
+  test('the review names it, and confirming never calls destroy', async () => {
+    const target = await seedTarget('folly');
+    const seeded = await seedApp('is-live', { targetId: target.id });
+    const { registry, built } = fakes();
+
+    const review = await deleteApp(
+      { name: 'is-live', confirm: false },
+      context(registry),
+    );
+    expect(review.ok).toBe(true);
+    if (!review.ok) return;
+    expect(review.value.stranded).toEqual([
+      {
+        deployId: String(seeded.deploy!.id),
+        component: 'web',
+        target: 'folly',
+        url: 'web.example.test',
+      },
+    ]);
+
+    const result = await deleteApp(
+      { name: 'is-live', confirm: true },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Named again after the fact: the rows are gone, so this is the only record
+    // that the workload is still there.
+    expect(result.value.stranded).toHaveLength(1);
+    // §13's rule, verbatim: no adapter was ever constructed, so nothing was
+    // torn down.
+    expect(built().size).toBe(0);
+  });
+});
+
+describe('a Datastore survives the App it was attached to', () => {
+  test('it is detached, not deleted (§11)', async () => {
+    const target = await seedTarget('folly');
+    const seeded = await seedApp('has-a-database');
+    const db = database().db;
+    const [datastore] = await db
+      .insert(datastores)
+      .values({
+        name: 'primary',
+        engine: 'postgres',
+        provenance: 'managed',
+        appId: seeded.app.id,
+        targetId: target.id,
+      })
+      .returning();
+    const { registry } = fakes();
+
+    const result = await deleteApp(
+      { name: 'has-a-database', confirm: true },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.detachedDatastores).toEqual(['primary']);
+
+    const [survivor] = await db
+      .select()
+      .from(datastores)
+      .where(eq(datastores.id, datastore!.id));
+    expect(survivor).toBeDefined();
+    expect(survivor?.appId).toBeNull();
+  });
+});
+
+describe('what it refuses', () => {
+  test('a name no App answers to', async () => {
+    const { registry } = fakes();
+    const result = await deleteApp(
+      { name: 'nothing', confirm: false },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+  });
+
+  test('a name two Apps answer to, rather than guessing', async () => {
+    const first = await seedApp('twice');
+    const second = await seedApp('twice');
+    const { registry } = fakes();
+
+    const result = await deleteApp(
+      { name: 'twice', confirm: true },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+    expect(result.failure.message).toContain(first.app.id);
+    expect(result.failure.message).toContain(second.app.id);
+    // Neither was touched.
+    expect(await database().db.select().from(apps)).toHaveLength(2);
+  });
+
+  test('by id, the ambiguity is resolvable', async () => {
+    const first = await seedApp('twice');
+    await seedApp('twice');
+    const { registry } = fakes();
+
+    const result = await deleteApp(
+      { name: first.app.id, confirm: true },
+      context(registry),
+    );
+
+    expect(result.ok).toBe(true);
+    const remaining = await database().db.select().from(apps);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.id).not.toBe(first.app.id);
+  });
+});


### PR DESCRIPTION
## Summary

Apps can be deleted from the UI — from a row in the App list (the case that
matters most: the ones nothing was ever deployed from) or from the workspace
header. `deleteApp` is review-then-confirm, the grammar `replaceConfig` already
uses: the first call writes nothing and answers with what the delete would do,
the second one does it.

## Changes

- `feat(spindrift): add the deleteApp command`
- `feat(spindrift): delete an App from the list row or the workspace`
- `docs(spindrift): describe App deletion in the README`

### Three decisions worth a reviewer's attention

- **It never calls the deploy adapter.** That is `disconnectTarget`'s rule
  (§13), and it binds harder here: once the rows are gone, the stranded list is
  the only record those workloads exist, so it is returned again *after* the
  delete rather than only before it, and the dialog does not close on its own
  when there is one. Deleting a deployed App still leaves a manual cleanup on
  the Target — wiring `destroy` in is a separate decision, because the
  partial-failure semantics (rows gone / workload up, or the reverse) need
  settling first.
- **The deletes are ordered, not left to the cascade.** `deploys.build_id` and
  `component_target_desired.desired_*` are `restrict`, which Postgres enforces
  the moment the referenced row is deleted — including when the referencing row
  is going in the same cascade. A plain `DELETE FROM apps` on an App with
  history fails as a foreign-key violation; there is a test that would catch a
  regression to that.
- **§10 store items are reaped** with the App at retention zero, since a pin
  whose row is gone is unreachable rather than merely unmanaged. Scopes resolve
  before the rows go and the destroys run after; a key the store refuses is
  named in `retainedSecrets` rather than failing a delete that already happened.

`datastores.app_id` still goes null on its own — §11's detachment is the
schema's job, and the command only names what it detached.

## Test Plan

- [x] `bun test` — 1002 pass / 0 fail, including 9 new in
      `test/commands/delete-app.test.ts` (review writes nothing, the restrict-FK
      case, `destroy` never called, datastore detachment, ambiguous-name refusal)
- [x] `bun run typecheck` and `bun run lint` clean; `mise run ts:check` green
- [x] `bun run build` bundles the client
- [ ] In the UI: delete an App that was never deployed (one dialog, one click),
      then one with a live Deploy — the confirmation should name the workload
      and the post-delete panel should name it again
