### PR TITLE
feat(spindrift): make releases navigable, listed, and honest about builds

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -94,14 +94,19 @@ stamps `data-theme` on the root, and its absence means "follow the OS".
 Four screens, each implementing rules §18 and identity settled rather than choices made
 while building them:
 
-- **Deploy** (`views/apps/deploy-detail.tsx`) — App-first, not attempt-first.
-  State and URL, then diagnosis, then a dense resource list, then the log. No
-  stage rail. `blame` gets a chip, the build log opens only when the *build* is
-  what failed, and **the red screen says the previous release is still serving**.
+- **Attempt** (`views/apps/deploy-detail.tsx`) — App-first, not attempt-first.
+  State and URL, then diagnosis, then what the release is made of, then a dense
+  resource list, then the logs. No stage rail. `blame` gets a chip, the build
+  log opens only when the *build* is what failed, and **the red screen says the
+  previous release is still serving**. It serves two routes, because pressing
+  Deploy has two outcomes: `/deploys/:id` for an intent, and `/builds/:id` for a
+  Build that has not produced one yet — same screen with a null release id,
+  handing over to the deploy the moment an intent names that Build.
 - **Workspace** (`views/apps/workspace.tsx`) — live state and URL lead; Target
   and the immutable vessel are visible; Components and Datastores are peer
-  sections. A website states that it has no runtime instead of showing an empty
-  log.
+  sections; every release is listed and every activity entry opens the attempt
+  it came from. A website states that it has no runtime instead of showing an
+  empty log.
 - **Create** (`views/apps/new/`) — Source → Component → Place → Configure →
   Review, defaults carrying every step, preflight folded into Review. The
   server-owned draft survives refresh and rejects stale concurrent edits. An
@@ -110,6 +115,13 @@ while building them:
 - **Authentication Settings** (`views/auth/settings.tsx`) — additive passkeys
   and the optional Gateway binding. Every mutation requires a fresh passkey
   assertion, and the final account-root passkey cannot be removed.
+
+**A release has a source and only sometimes a build.** §4's supplied-artifact
+arm records an uploaded bundle as-is with no builder, so `DeployView` carries a
+source always and a build that may be null — the screen states that no builder
+was involved rather than naming one that never ran. **Rolling back deploys an
+older release and rebuilds nothing** (§6: an ordinary deploy naming an older
+Build), and the affordance appears only where that comparison would be accepted.
 
 **Deleting an App is review-then-confirm**, from the App list row or the
 workspace header (`components/delete-app.tsx`). `deleteApp` called without

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { elapsedSince } from '../../domain/elapsed.ts';
 import type {
   ActivityEntry,
   ComponentView,
@@ -7,6 +8,7 @@ import type {
   Runtime,
   WorkspaceView,
 } from '../../web/model.ts';
+import { releasesOf } from '../deploys/list.ts';
 import { type Command, failed, ok } from '../types.ts';
 
 export const getAppWorkspaceInput = z.object({
@@ -122,6 +124,12 @@ export const getAppWorkspace: Command<
     limit: 20,
   });
 
+  const now = context.clock.now();
+
+  // Every event belongs to exactly one attempt — the `attempt_events` check
+  // constraint is what guarantees it — so every entry carries the id of the
+  // screen it came from and the timeline becomes a way into the system rather
+  // than a wall of past tense.
   const activity: ActivityEntry[] = [];
   if (events.length > 0) {
     for (const ev of events) {
@@ -136,23 +144,32 @@ export const getAppWorkspace: Command<
       activity.push({
         title,
         detail,
-        when: 'recently',
+        when: elapsedSince(ev.createdAt, now),
         status: ev.reason ? 'failed' : ev.phase === 'LIVE' ? 'ok' : 'info',
+        deployId: ev.deployId,
+        buildId: ev.buildId,
       });
     }
   } else if (latestDeploy) {
     activity.push({
       title: `Deploy ${latestDeploy.id} ${latestDeploy.phase.toLowerCase()}`,
       detail: latestDeploy.detail ?? `Target: ${latestTarget?.name ?? 'none'}`,
-      when: 'recently',
+      when: elapsedSince(latestDeploy.createdAt, now),
       status:
         latestDeploy.phase === 'LIVE'
           ? 'ok'
           : latestDeploy.phase === 'FAILED'
             ? 'failed'
             : 'info',
+      deployId: latestDeploy.id,
+      buildId: latestDeploy.buildId,
     });
   }
+
+  const releases = await releasesOf(
+    context,
+    app.components.map((component) => component.id),
+  );
 
   let runtime: Runtime;
   if (
@@ -207,6 +224,7 @@ export const getAppWorkspace: Command<
     components,
     datastores: Array.from(datastoresMap.values()),
     activity,
+    deploys: releases,
     runtime,
   };
 

--- a/apps/spindrift/src/commands/builds/get-detail.ts
+++ b/apps/spindrift/src/commands/builds/get-detail.ts
@@ -1,0 +1,185 @@
+/**
+ * `getBuildDetail` — the attempt screen for a Build that has no Deploy yet.
+ *
+ * §4: "a build records an artifact rather than deploying one", so pressing
+ * Deploy on an App with nothing deployable starts a Build and writes no intent
+ * (`deployApp` returns `deployId: null`). Before this command existed there was
+ * nowhere for that press to land: the operator stayed on the workspace and the
+ * act they had just taken had no screen. A Build is an attempt with a durable
+ * id and a live event stream, which is everything an attempt screen needs — the
+ * only thing it lacks is the intent row, and that absence is what
+ * {@link DeployView.id} being `null` says.
+ *
+ * The result also carries {@link GetBuildDetailResult.deployId}. A Build that
+ * has since been deployed has a better screen than this one, and the client
+ * follows that id rather than leaving a reader on an attempt page that has been
+ * superseded by a release.
+ */
+import { z } from 'zod';
+import { elapsedSince } from '../../domain/elapsed.ts';
+import type { DeployPhase, DeployView } from '../../web/model.ts';
+import { type Command, failed, ok } from '../types.ts';
+import { buildViewOf, sourceViewOf } from './view.ts';
+
+export const getBuildDetailInput = z.object({
+  id: z.union([z.number(), z.string()]),
+});
+export type GetBuildDetailInput = z.infer<typeof getBuildDetailInput>;
+
+export interface GetBuildDetailResult {
+  /** The Build as an attempt, with `id: null` — no intent has been written. */
+  readonly attempt: DeployView;
+  /**
+   * The newest Deploy naming this Build, once one exists.
+   *
+   * Not folded into `attempt.id`: that field says what *this* view is, and this
+   * view is a Build. A caller that wants the release goes and reads it.
+   */
+  readonly deployId: number | null;
+}
+
+export const getBuildDetail: Command<
+  GetBuildDetailInput,
+  GetBuildDetailResult
+> = async (input, context) => {
+  const numericId =
+    typeof input.id === 'number' ? input.id : Number.parseInt(input.id, 10);
+
+  if (Number.isNaN(numericId)) {
+    return failed('NOT_FOUND', `Build '${input.id}' not found`);
+  }
+
+  const build = await context.db.query.builds.findFirst({
+    where: (builds, { eq }) => eq(builds.id, numericId),
+    with: {
+      component: {
+        with: {
+          app: true,
+          desiredTargets: { limit: 1, with: { target: true } },
+        },
+      },
+      deploys: {
+        orderBy: (deploys, { desc }) => [desc(deploys.id)],
+        limit: 1,
+      },
+    },
+  });
+
+  if (!build) {
+    return failed('NOT_FOUND', `Build '${numericId}' not found`);
+  }
+
+  const { view: buildView } = await buildViewOf(context, build);
+  const target = build.component.desiredTargets[0]?.target ?? null;
+
+  // Where this Build is headed, resolved the same way `deployApp` resolves it:
+  // the desired row is what says which Target a Component belongs on before any
+  // intent has named one.
+  const previousLive = target
+    ? await context.db.query.deploys.findFirst({
+        where: (deploys, { eq, and }) =>
+          and(
+            eq(deploys.componentId, build.componentId),
+            eq(deploys.targetId, target.id),
+            eq(deploys.phase, 'LIVE'),
+          ),
+        orderBy: (deploys, { desc }) => [desc(deploys.id)],
+      })
+    : null;
+
+  const attempt: DeployView = {
+    id: null,
+    buildId: build.id,
+    componentId: build.component.id,
+    targetId: target?.id ?? '',
+    appId: build.component.app.id,
+    app: build.component.app.name,
+    component: build.component.name,
+    target: target?.name ?? 'not placed',
+    commit: build.commit,
+    phase: PHASE[build.status],
+    phaseWord: buildView === null ? 'Extracted' : PHASE_WORD[build.status],
+    headline: headlineFor(
+      build.status,
+      buildView?.runner ?? null,
+      target?.name ?? null,
+    ),
+    url: build.component.app.vanityDomain ?? '',
+    // A Build never serves anything: §6's exposure is only ever changed by an
+    // intent, and there is no intent here.
+    urlLive: false,
+    previousReleaseServing: previousLive !== null,
+    // §6 persists a diagnosis on a Deploy going red. A Build that failed says
+    // so in its own log, and inventing a `Diagnosis` here would put a reason
+    // from the closed deploy-failure set on something that never deployed.
+    diagnosis: null,
+    // Nothing has been placed, so there is nothing to check off. An empty list
+    // renders no section at all, which is the honest shape.
+    resources: [],
+    source: sourceViewOf(build.component.app, build),
+    build: buildView,
+    deployLog: null,
+    when: elapsedSince(build.createdAt, context.clock.now()),
+    at: build.createdAt.toISOString(),
+    current: false,
+    configVersion: null,
+    artifactDigest: build.artifactDigest,
+    previousDeployId: previousLive?.id ?? null,
+    // There is no intent to roll back to. Rollback names a Deploy's Build, and
+    // this attempt has no Deploy.
+    rollbackable: false,
+  };
+
+  return ok({ attempt, deployId: build.deploys[0]?.id ?? null });
+};
+
+/**
+ * A Build's status in the phase vocabulary the screen renders.
+ *
+ * The mapping is a projection, not a claim that the two are the same thing:
+ * `WAITING` for a succeeded Build says exactly what is true — the artifact
+ * exists and nothing has placed it yet.
+ */
+const PHASE = {
+  PENDING: 'PENDING',
+  RUNNING: 'APPLYING',
+  SUCCEEDED: 'WAITING',
+  FAILED: 'FAILED',
+} as const satisfies Record<string, DeployPhase>;
+
+const PHASE_WORD = {
+  PENDING: 'Queued',
+  RUNNING: 'Building',
+  SUCCEEDED: 'Built',
+  FAILED: 'Build failed',
+} as const;
+
+/**
+ * The sentence under the phase.
+ *
+ * A `null` runner is §4's supplied artifact: nothing ran, so "built" is the
+ * wrong verb for it and the headline says what did happen instead.
+ */
+function headlineFor(
+  status: keyof typeof PHASE,
+  runner: string | null,
+  target: string | null,
+): string {
+  const ready =
+    target === null
+      ? 'this Component has no Target placement yet'
+      : `ready to deploy to ${target}`;
+
+  switch (status) {
+    case 'PENDING':
+      return 'Queued — waiting for a runner to claim it';
+    case 'RUNNING':
+      return `Building on ${runner ?? 'a runner'}`;
+    case 'SUCCEEDED':
+      return runner === null
+        ? `Uploaded output recorded as-is — ${ready}`
+        : `Built — ${ready}`;
+    case 'FAILED':
+      return 'Build failed — nothing was placed';
+  }
+}

--- a/apps/spindrift/src/commands/builds/view.ts
+++ b/apps/spindrift/src/commands/builds/view.ts
@@ -1,0 +1,167 @@
+/**
+ * The source and build halves of an attempt, projected once for both screens.
+ *
+ * `/deploys/:id` and `/builds/:id` render the same drawers, and they have to
+ * agree about what they say: a build that reads "5 steps, 42s, LIVE_STATUS" on
+ * one screen and "1 step, no duration" on the other is one screen lying.
+ * Projecting here is what makes that a structural guarantee rather than two
+ * copies somebody keeps in step.
+ *
+ * The asymmetry between the two exports is §4's, not a convenience: **every
+ * attempt has a source, and only some have a build.** An archive of finished
+ * output is "a supplied artifact, digested over the uploaded bundle" — recorded
+ * with no adapter looked up — so {@link buildViewOf} answers `null` for it,
+ * while {@link sourceViewOf} always answers.
+ */
+import type { App, AttemptEvent, Build } from '../../db/schema.ts';
+import type {
+  BuildView,
+  ChecklistItem,
+  LogFidelity,
+  LogLine,
+  SourceView,
+  StepStatus,
+} from '../../web/model.ts';
+import type { CommandContext } from '../types.ts';
+
+/** How a Build's status reads as a checklist status. */
+export function buildStepStatus(status: Build['status']): StepStatus {
+  if (status === 'SUCCEEDED') return 'done';
+  if (status === 'FAILED') return 'failed';
+  if (status === 'PENDING') return 'waiting';
+  return 'running';
+}
+
+/**
+ * Whether this Build row records finished output rather than something built.
+ *
+ * The two facts checked are exactly the two `uploadArchive` writes on its
+ * supplied arm: the artifact digest **is** the bundle digest — core digested
+ * what was uploaded rather than something a builder emitted — and no runner
+ * ever claimed it. A source archive gets a runner and an artifact digest of its
+ * own, so the pair is what separates "extracted" from "built" without a column
+ * saying which.
+ */
+export function isSuppliedArtifact(build: Build): boolean {
+  return (
+    build.runner === null &&
+    build.artifactDigest !== null &&
+    build.artifactDigest === build.bundleDigest
+  );
+}
+
+/**
+ * Where this release's bytes came from (§4, §5).
+ *
+ * Read off the App's declared source kind rather than guessed from the Build:
+ * §2 puts the origin on the App — "immutable vessel reference, domain, config"
+ * — and the Build carries only what staging produced from it.
+ */
+export function sourceViewOf(app: App, build: Build): SourceView {
+  const subpath = build.bundleSubpath ?? app.sourceRepoSubpath ?? '.';
+
+  if (app.sourceKind === 'repo') {
+    return {
+      kind: 'repo',
+      repo: app.sourceRepoUrl ?? 'unknown repository',
+      // §2 keys a Build on the commit, so the Build is the authority on which
+      // one this release delivers — the App only says where commits come from.
+      commit: build.commit,
+      subpath,
+    };
+  }
+
+  return {
+    kind: 'archive',
+    // `commitOf` puts the bundle digest in the commit column for an upload, so
+    // either column answers; `bundleDigest` is the one that means it.
+    digest: build.bundleDigest ?? build.commit,
+    location: build.bundleLocation,
+    subpath,
+    extracted: isSuppliedArtifact(build),
+  };
+}
+
+/**
+ * One Build, plus whatever its runner has said so far — or `null` where no
+ * builder ran at all (§4).
+ *
+ * The events are read here rather than passed in because the two callers reach
+ * this from different directions — one holds a Deploy, the other a Build — and
+ * the query is the same either way.
+ */
+export async function buildViewOf(
+  context: CommandContext,
+  build: Build,
+): Promise<{ view: BuildView | null; events: readonly AttemptEvent[] }> {
+  if (isSuppliedArtifact(build)) {
+    // Nothing ran, so there is nothing to project. Returning an empty
+    // `BuildView` here would put a checklist and a fidelity on a release that
+    // never had either, which is the fiction the null exists to refuse.
+    return { view: null, events: [] };
+  }
+
+  const events = await context.db.query.attemptEvents.findMany({
+    where: (rows, { eq }) => eq(rows.buildId, build.id),
+    orderBy: (rows, { asc }) => [asc(rows.id)],
+  });
+
+  const status = buildStepStatus(build.status);
+
+  const log: LogLine[] = events
+    .filter((event) => event.eventType === 'log' && event.line)
+    .map((event) => ({
+      text: event.line!,
+      tone: event.reason ? ('error' as const) : undefined,
+    }));
+
+  const steps: ChecklistItem[] = events
+    .filter((event) => event.resource)
+    .map((event) => ({
+      name: event.resource!,
+      status: event.reason ? ('failed' as const) : ('done' as const),
+      detail: event.line ?? undefined,
+    }));
+
+  return {
+    view: {
+      status,
+      duration: durationOf(context, build, events),
+      fidelity: (build.logFidelity ?? 'LIVE_TEXT') as LogFidelity,
+      // A Build with no step events is still a Build doing one thing, and
+      // saying so beats an empty checklist that reads as a broken stream.
+      steps: steps.length > 0 ? steps : [{ name: 'build artifact', status }],
+      // Null rather than `[]`: §4's `logFidelity` distinguishes "the runner has
+      // released nothing yet" from "the runner printed nothing", and the screen
+      // states the first rather than rendering the second as an empty pane.
+      log: log.length > 0 ? log : null,
+      runner: build.runner ?? 'hosted runner',
+    },
+    events,
+  };
+}
+
+/**
+ * How long the build has been going, or went.
+ *
+ * The last event is the end marker because no column records one: `builds` has
+ * `createdAt` and a status, and the runner's final line is the closest thing to
+ * a finish time that is actually written down. A build still in flight is
+ * measured against the clock instead, so the number moves while it runs.
+ */
+function durationOf(
+  context: CommandContext,
+  build: Build,
+  events: readonly AttemptEvent[],
+): string | undefined {
+  const running = build.status === 'RUNNING';
+  const last = events.at(-1);
+  if (!(running || last)) return undefined;
+
+  const end = running ? context.clock.now() : last!.createdAt;
+  const seconds = Math.max(
+    0,
+    Math.round((end.getTime() - build.createdAt.getTime()) / 1000),
+  );
+  return `${seconds}s`;
+}

--- a/apps/spindrift/src/commands/deploys/get-detail.ts
+++ b/apps/spindrift/src/commands/deploys/get-detail.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import type { Blame, FailureReason } from '../../adapters/deploy/contract.ts';
+import { elapsedSince } from '../../domain/elapsed.ts';
 import type {
-  BuildView,
   ChecklistItem,
   DeployPhase,
   DeployView,
   Diagnosis,
-  LogFidelity,
   LogLine,
 } from '../../web/model.ts';
+import { buildViewOf, sourceViewOf } from '../builds/view.ts';
 import { type Command, failed, ok } from '../types.ts';
 
 export const getDeployDetailInput = z.object({
@@ -59,6 +59,30 @@ export const getDeployDetail: Command<
     previousLiveDeploy && deploy.phase !== 'LIVE',
   );
 
+  // The release before this one here, whatever it did. `previousLiveDeploy`
+  // above answers a different question — "is anything still serving" — and a
+  // reader stepping back through the history wants the row that came before,
+  // including the one that failed.
+  const previousDeploy = await context.db.query.deploys.findFirst({
+    where: (deploys, { eq, and, lt }) =>
+      and(
+        eq(deploys.componentId, deploy.componentId),
+        eq(deploys.targetId, deploy.targetId),
+        lt(deploys.id, deploy.id),
+      ),
+    orderBy: (deploys, { desc }) => [desc(deploys.id)],
+  });
+
+  // §6's desired row is the only thing that knows which release *should* be
+  // running: a LIVE Deploy that a newer intent superseded is still LIVE.
+  const desired = await context.db.query.componentTargetDesired.findFirst({
+    where: (rows, { eq, and }) =>
+      and(
+        eq(rows.componentId, deploy.componentId),
+        eq(rows.targetId, deploy.targetId),
+      ),
+  });
+
   let diagnosis: Diagnosis | null = null;
   if (deploy.phase === 'FAILED' && deploy.reason) {
     diagnosis = {
@@ -105,17 +129,9 @@ export const getDeployDetail: Command<
     );
   }
 
-  const buildLogEvents = await context.db.query.attemptEvents.findMany({
-    where: (events, { eq }) => eq(events.buildId, deploy.build.id),
-    orderBy: (events, { asc }) => [asc(events.id)],
-  });
+  const { view: build } = await buildViewOf(context, deploy.build);
+  const source = sourceViewOf(deploy.component.app, deploy.build);
 
-  const buildLogs: LogLine[] = buildLogEvents
-    .filter((e) => e.eventType === 'log' && e.line)
-    .map((e) => ({
-      text: e.line!,
-      tone: e.reason ? ('error' as const) : undefined,
-    }));
   const deployLogEvents = await context.db.query.attemptEvents.findMany({
     where: (events, { eq }) => eq(events.deployId, deploy.id),
     orderBy: (events, { asc }) => [asc(events.id)],
@@ -135,45 +151,10 @@ export const getDeployDetail: Command<
     );
   }
 
-  const buildSteps: ChecklistItem[] = buildLogEvents
-    .filter((e) => e.resource)
-    .map((e) => ({
-      name: e.resource!,
-      status: e.reason ? 'failed' : 'done',
-      detail: e.line ?? undefined,
-    }));
-
-  const buildStatus =
-    deploy.build.status === 'SUCCEEDED'
-      ? 'done'
-      : deploy.build.status === 'FAILED'
-        ? 'failed'
-        : 'running';
-
-  let duration: string | undefined;
-  if (deploy.build.createdAt && deploy.createdAt) {
-    const elapsedSeconds = Math.max(
-      1,
-      Math.round(
-        (deploy.createdAt.getTime() - deploy.build.createdAt.getTime()) / 1000,
-      ),
-    );
-    duration = `${elapsedSeconds}s`;
-  }
-
-  const build: BuildView = {
-    status: buildStatus,
-    duration,
-    fidelity: (deploy.build.logFidelity ?? 'LIVE_TEXT') as LogFidelity,
-    steps:
-      buildSteps.length > 0
-        ? buildSteps
-        : [{ name: 'build artifact', status: buildStatus }],
-    log: buildLogs.length > 0 ? buildLogs : null,
-    runner: deploy.build.runner ?? 'hosted runner',
-  };
-
-  let phaseWord = 'Building';
+  // "Building" is only honest while something is building. A release whose
+  // artifact was uploaded rather than built (§4) is releasing, not building,
+  // and a screen that said otherwise would name a step that never ran.
+  let phaseWord = build === null ? 'Releasing' : 'Building';
   if (deploy.phase === 'LIVE') phaseWord = 'Live';
   else if (deploy.phase === 'FAILED') {
     phaseWord =
@@ -207,8 +188,24 @@ export const getDeployDetail: Command<
     previousReleaseServing,
     diagnosis,
     resources,
+    source,
     build,
     deployLog: deployLogs.length > 0 ? deployLogs : null,
+    when: elapsedSince(deploy.createdAt, context.clock.now()),
+    at: deploy.createdAt.toISOString(),
+    current: desired?.desiredDeployId === deploy.id,
+    configVersion: deploy.configVersion,
+    artifactDigest: deploy.build.artifactDigest,
+    previousDeployId: previousDeploy?.id ?? null,
+    // The same comparison `rollbackDeploy` makes under the lock. It can still
+    // refuse for a reason this projection cannot see — a disconnected Target, a
+    // signature that stopped verifying — and that refusal is a sentence the
+    // operator reads rather than something to pre-empt by hiding the button.
+    rollbackable:
+      desired?.desiredDeployId !== deploy.id &&
+      desired?.desiredBuildId != null &&
+      deploy.buildId < desired.desiredBuildId &&
+      deploy.build.artifactDigest !== null,
   };
 
   return ok({ deploy: view });

--- a/apps/spindrift/src/commands/deploys/list.ts
+++ b/apps/spindrift/src/commands/deploys/list.ts
@@ -1,0 +1,128 @@
+/**
+ * `listDeploys` — the releases of one App, newest first (§2, §6).
+ *
+ * §2 makes "one Build → many Deploys" the thing that "makes rollback-without-
+ * rebuild possible", and §6 makes a rollback "an ordinary deploy — a newer
+ * intent row pointing at an older Build". Both sentences are about a *set* of
+ * releases, and neither is reachable from a screen that shows only the newest
+ * one: choosing the older Build means reading the release that named it.
+ *
+ * Each row is atomic in the sense that matters here — a Deploy row is written
+ * once and never edited into a different release. Its Build, its commit, and
+ * the config document it pinned (§10) are what it delivered, so a row is a
+ * durable answer to "what was live then" rather than a view of what is live
+ * now. `current` is the one field that is *not* on the row: which release
+ * should be running is the desired row's answer (§6), and a LIVE Deploy that a
+ * newer intent superseded is still LIVE.
+ */
+import { inArray } from 'drizzle-orm';
+import { z } from 'zod';
+import { elapsedSince } from '../../domain/elapsed.ts';
+import type { DeployListItem, DeployPhase } from '../../web/model.ts';
+import { type Command, type CommandContext, failed, ok } from '../types.ts';
+
+/** How many releases a list answers with before it is a data-export problem. */
+export const RELEASE_PAGE = 25;
+
+export const listDeploysInput = z
+  .object({
+    /** The App's id, or its name where that names exactly one App. */
+    app: z.string().trim().min(1),
+    limit: z.number().int().positive().max(RELEASE_PAGE).optional(),
+  })
+  .strict();
+
+export type ListDeploysInput = z.infer<typeof listDeploysInput>;
+
+export interface ListDeploysResult {
+  readonly deploys: readonly DeployListItem[];
+}
+
+export const listDeploys: Command<ListDeploysInput, ListDeploysResult> = async (
+  input,
+  context,
+) => {
+  const isUuid = z.uuid().safeParse(input.app).success;
+  const app = await context.db.query.apps.findFirst({
+    where: (apps, { eq, or }) =>
+      isUuid
+        ? or(eq(apps.name, input.app), eq(apps.id, input.app))
+        : eq(apps.name, input.app),
+    with: { components: true },
+  });
+
+  if (!app) return failed('NOT_FOUND', `App '${input.app}' not found`);
+
+  return ok({
+    deploys: await releasesOf(
+      context,
+      app.components.map((component) => component.id),
+      input.limit ?? RELEASE_PAGE,
+    ),
+  });
+};
+
+/**
+ * The releases across a set of Components, newest first.
+ *
+ * Exported because the workspace shows the same list without a second round
+ * trip, and two projections of one concept is how the two screens start
+ * disagreeing about which release is current.
+ */
+export async function releasesOf(
+  context: CommandContext,
+  componentIds: readonly string[],
+  limit: number = RELEASE_PAGE,
+): Promise<readonly DeployListItem[]> {
+  if (componentIds.length === 0) return [];
+
+  const rows = await context.db.query.deploys.findMany({
+    where: (deploys) => inArray(deploys.componentId, [...componentIds]),
+    orderBy: (deploys, { desc }) => [desc(deploys.id)],
+    limit,
+    with: { component: true, target: true, build: true },
+  });
+
+  if (rows.length === 0) return [];
+
+  // One read of every desired row these releases touch. `current` and
+  // `rollbackable` are both questions about §6's check-and-set, and asking the
+  // database once per release would be the same answer fetched N times.
+  const desiredRows = await context.db.query.componentTargetDesired.findMany({
+    where: (rowsTable) => inArray(rowsTable.componentId, [...componentIds]),
+  });
+  const desired = new Map(
+    desiredRows.map((row) => [`${row.componentId}@${row.targetId}`, row]),
+  );
+
+  const now = context.clock.now();
+
+  return rows.map((row) => {
+    const here = desired.get(`${row.componentId}@${row.targetId}`);
+    const current = here?.desiredDeployId === row.id;
+    return {
+      id: row.id,
+      buildId: row.buildId,
+      componentId: row.componentId,
+      targetId: row.targetId,
+      component: row.component.name,
+      target: row.target.name,
+      commit: row.build.commit,
+      phase: row.phase as DeployPhase,
+      when: elapsedSince(row.createdAt, now),
+      at: row.createdAt.toISOString(),
+      current,
+      configVersion: row.configVersion,
+      // The same comparison `rollbackDeploy` makes under the lock, so the
+      // affordance appears only where the act would be accepted. It can still
+      // refuse for a reason this list cannot see — a disconnected Target, a
+      // signature that no longer verifies — and that refusal is a sentence the
+      // operator reads, not something to pre-empt by hiding the button.
+      rollbackable:
+        !current &&
+        here?.desiredBuildId != null &&
+        row.buildId < here.desiredBuildId &&
+        row.build.artifactDigest !== null,
+    };
+  });
+}

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -23,6 +23,7 @@ export { resolveComponentPlacement } from './apps/resolve-placement.ts';
 export { uploadArchive } from './apps/upload-archive.ts';
 export { getAppWorkspace } from './apps/workspace.ts';
 export { dispatchBuild } from './builds/dispatch.ts';
+export { getBuildDetail } from './builds/get-detail.ts';
 export { createComponent } from './components/create.ts';
 export { placeComponent } from './components/place.ts';
 export { replaceConfig } from './config/replace.ts';
@@ -36,6 +37,7 @@ export {
 } from './creation-drafts/lifecycle.ts';
 export { createDeploy } from './deploys/create.ts';
 export { getDeployDetail } from './deploys/get-detail.ts';
+export { listDeploys } from './deploys/list.ts';
 export { rollbackDeploy } from './deploys/rollback.ts';
 export {
   beginRepositoryAuthorization,

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -39,6 +39,7 @@ import {
 import { uploadArchive, uploadArchiveInput } from './apps/upload-archive.ts';
 import { getAppWorkspace, getAppWorkspaceInput } from './apps/workspace.ts';
 import { dispatchBuild, dispatchBuildInput } from './builds/dispatch.ts';
+import { getBuildDetail, getBuildDetailInput } from './builds/get-detail.ts';
 import { createComponent, createComponentInput } from './components/create.ts';
 import { placeComponent, placeComponentInput } from './components/place.ts';
 import { replaceConfig, replaceConfigInput } from './config/replace.ts';
@@ -57,6 +58,7 @@ import {
 } from './creation-drafts/lifecycle.ts';
 import { createDeploy, createDeployInput } from './deploys/create.ts';
 import { getDeployDetail, getDeployDetailInput } from './deploys/get-detail.ts';
+import { listDeploys, listDeploysInput } from './deploys/list.ts';
 import { rollbackDeploy, rollbackDeployInput } from './deploys/rollback.ts';
 import type * as commands from './index.ts';
 import {
@@ -111,7 +113,9 @@ export const commandRegistry = {
   deployApp: { input: deployAppInput, handler: deployApp },
   getAppWorkspace: { input: getAppWorkspaceInput, handler: getAppWorkspace },
   getDeployDetail: { input: getDeployDetailInput, handler: getDeployDetail },
+  getBuildDetail: { input: getBuildDetailInput, handler: getBuildDetail },
   listApps: { input: listAppsInput, handler: listApps },
+  listDeploys: { input: listDeploysInput, handler: listDeploys },
   listTargets: { input: listTargetsInput, handler: listTargets },
   listRepositories: {
     input: listRepositoriesInput,

--- a/apps/spindrift/src/domain/elapsed.ts
+++ b/apps/spindrift/src/domain/elapsed.ts
@@ -1,0 +1,32 @@
+/**
+ * How long ago something happened, in the words a screen uses.
+ *
+ * It lives in the domain rather than in a view because the views are rendered
+ * from immutable read models projected by commands (`src/web/model.ts`), and a
+ * relative time computed in the browser would be computed against the browser's
+ * clock. Every command already carries a {@link Clock}; this is what turns it
+ * into the one string a timeline entry needs.
+ *
+ * The scale stops at days. A release from last March is not more legible as
+ * "142d ago" than as its date, and the screens that need the exact instant
+ * carry the ISO timestamp beside the word.
+ */
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * `when` relative to `now` — "just now", "8m ago", "2h ago", "3d ago".
+ *
+ * A future instant reads as "just now" rather than negative: clock skew between
+ * a database default and a command's clock is ordinary, and "in -2s" would say
+ * the machine is broken when only the two clocks disagree.
+ */
+export function elapsedSince(when: Date, now: Date): string {
+  const delta = now.getTime() - when.getTime();
+  if (delta < MINUTE) return 'just now';
+  if (delta < HOUR) return `${Math.floor(delta / MINUTE)}m ago`;
+  if (delta < DAY) return `${Math.floor(delta / HOUR)}h ago`;
+  return `${Math.floor(delta / DAY)}d ago`;
+}

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -12,6 +12,7 @@ import { command, type InputOf } from './client.ts';
 import { DeleteAppDialog, useAppDeletion } from './components/delete-app.tsx';
 import type {
   AppListItem,
+  DeployListItem,
   DeployView,
   LinkedRepoView,
   RepositoryConnectorView,
@@ -138,6 +139,13 @@ function Screen({
     const deployId = path.replace(/^\/deploys\/?/, '');
     return <DeployScreen deployId={deployId} onNavigate={onNavigate} />;
   }
+  // §4: pressing Deploy with nothing deployable starts a Build and writes no
+  // intent, so the act has a durable id but no release. This is where that
+  // press lands until an intent exists.
+  if (path.startsWith('/builds')) {
+    const buildId = path.replace(/^\/builds\/?/, '');
+    return <BuildScreen buildId={buildId} onNavigate={onNavigate} />;
+  }
   if (path === '/apps' || path === '')
     return <AppsScreen onNavigate={onNavigate} />;
   if (path.startsWith('/apps/')) {
@@ -234,11 +242,8 @@ function WorkspaceScreen({
   >({ type: 'loading' });
   const [deploying, setDeploying] = useState(false);
   const [deployError, setDeployError] = useState<string | null>(null);
-  /**
-   * Bumped when the button started a Build rather than a Deploy. There is no
-   * deploy screen to send the operator to in that case, so the workspace they
-   * are already on re-reads itself and the new Build shows up in its activity.
-   */
+  const [rollingBack, setRollingBack] = useState<number | null>(null);
+  /** Bumped when an act changed state the workspace has already read. */
   const [reloadToken, setReloadToken] = useState(0);
 
   // There is no workspace left to stand on once the App is gone.
@@ -376,13 +381,16 @@ function WorkspaceScreen({
         name: state.workspace.appId ?? appName,
       });
       if (result.ok) {
-        if (result.value.deployId === null) {
-          // A Build was started, so there is no deploy screen yet. Re-read the
-          // workspace rather than navigating somewhere that does not exist.
-          setReloadToken((token) => token + 1);
-        } else {
-          onNavigate(`/deploys/${result.value.deployId}`);
-        }
+        // Both arms navigate. §4 makes "a Build started" a different act from
+        // "an intent was written", not a lesser one — it has a durable id and a
+        // live event stream — so the press lands on the attempt it started
+        // rather than leaving the operator on the screen they pressed from,
+        // wondering whether anything happened.
+        onNavigate(
+          result.value.deployId === null
+            ? `/builds/${result.value.buildId}`
+            : `/deploys/${result.value.deployId}`,
+        );
       } else {
         // The sentence the command refused with, unedited — a disconnected
         // Target, a signature that did not verify. Nothing is retried behind it.
@@ -392,6 +400,26 @@ function WorkspaceScreen({
       setDeployError(e instanceof Error ? e.message : 'Deploy failed');
     } finally {
       setDeploying(false);
+    }
+  };
+
+  const handleRollback = async (release: DeployListItem) => {
+    setRollingBack(release.id);
+    setDeployError(null);
+    try {
+      const result = await rollback({
+        componentId: release.componentId,
+        targetId: release.targetId,
+        buildId: release.buildId,
+      });
+      if (result.ok) {
+        onNavigate(`/deploys/${result.deployId}`);
+      } else {
+        setDeployError(result.message);
+        setReloadToken((token) => token + 1);
+      }
+    } finally {
+      setRollingBack(null);
     }
   };
 
@@ -420,10 +448,36 @@ function WorkspaceScreen({
         deploying={deploying}
         onNavigate={onNavigate}
         deletion={deletion}
+        onRollback={handleRollback}
+        rollingBack={rollingBack}
       />
       <DeleteAppDialog deletion={deletion} />
     </>
   );
+}
+
+/**
+ * Make an older release live again (§6).
+ *
+ * Shared by the workspace and the attempt screen because a rollback is one act
+ * with one refusal: §6 gives it no special path, and two call sites that
+ * phrased its failures differently would be inventing the second admission
+ * policy `rollbackDeploy` exists to avoid.
+ */
+async function rollback(
+  target: InputOf<'rollbackDeploy'>,
+): Promise<{ ok: true; deployId: number } | { ok: false; message: string }> {
+  try {
+    const result = await command('rollbackDeploy', target);
+    return result.ok
+      ? { ok: true, deployId: result.value.deployId }
+      : { ok: false, message: result.failure.message };
+  } catch (cause) {
+    return {
+      ok: false,
+      message: cause instanceof Error ? cause.message : 'Rollback failed',
+    };
+  }
 }
 
 function DeployScreen({
@@ -440,7 +494,7 @@ function DeployScreen({
     | { type: 'success'; deploy: DeployView }
   >({ type: 'loading' });
 
-  const [redeploying, setRedeploying] = useState(false);
+  const [busy, setBusy] = useState<'redeploy' | 'rollback' | null>(null);
   const [redeployError, setRedeployError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -466,7 +520,9 @@ function DeployScreen({
           stopStream = subscribeAttempt(
             {
               buildId: result.value.deploy.buildId,
-              deployId: result.value.deploy.id,
+              // Non-null on this screen by construction: `getDeployDetail`
+              // answers about a Deploy, so its view always carries that id.
+              deployId: result.value.deploy.id ?? parsedId,
             },
             () => {
               void command('getDeployDetail', { id: parsedId }).then(
@@ -504,21 +560,18 @@ function DeployScreen({
 
   const handleRedeploy = async () => {
     if (state.type !== 'success') return;
-    setRedeploying(true);
+    setBusy('redeploy');
     setRedeployError(null);
     try {
       // The App's id, not its name: `apps` has no unique constraint on `name`,
       // so redeploying by name would act on whichever row shares it.
       const result = await command('deployApp', { name: state.deploy.appId });
       if (result.ok) {
-        if (result.value.deployId === null) {
-          // Nothing was deployable, so a Build started instead. The workspace is
-          // where a Build in flight is visible; this screen belongs to a deploy
-          // that does not exist yet.
-          onNavigate(`/apps/${state.deploy.appId}`);
-        } else {
-          onNavigate(`/deploys/${result.value.deployId}`);
-        }
+        onNavigate(
+          result.value.deployId === null
+            ? `/builds/${result.value.buildId}`
+            : `/deploys/${result.value.deployId}`,
+        );
       } else {
         // Surfaced verbatim and acted on no further: a refused redeploy is a
         // fact about this artifact and this Target, not a cue to build another.
@@ -527,7 +580,28 @@ function DeployScreen({
     } catch (e: unknown) {
       setRedeployError(e instanceof Error ? e.message : 'Redeploy failed');
     } finally {
-      setRedeploying(false);
+      setBusy(null);
+    }
+  };
+
+  const handleRollback = async () => {
+    if (state.type !== 'success') return;
+    const view = state.deploy;
+    setBusy('rollback');
+    setRedeployError(null);
+    try {
+      const result = await rollback({
+        componentId: view.componentId,
+        targetId: view.targetId,
+        buildId: view.buildId,
+      });
+      if (result.ok) {
+        onNavigate(`/deploys/${result.deployId}`);
+      } else {
+        setRedeployError(result.message);
+      }
+    } finally {
+      setBusy(null);
     }
   };
 
@@ -577,7 +651,7 @@ function DeployScreen({
         <div className="mx-auto mt-4 w-full max-w-[1040px] px-5">
           <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium">Redeploy failed</p>
+              <p className="text-sm font-medium">That act was refused</p>
               <p className="text-sm mt-0.5">{redeployError}</p>
             </div>
             <Button
@@ -592,8 +666,187 @@ function DeployScreen({
       ) : null}
       <DeployDetail
         view={state.deploy}
-        onRedeploy={handleRedeploy}
-        redeploying={redeploying}
+        actions={{
+          onRedeploy: handleRedeploy,
+          onRollback: handleRollback,
+          busy,
+        }}
+        onNavigate={onNavigate}
+      />
+    </>
+  );
+}
+
+/**
+ * The attempt screen for a Build that has no Deploy (§4).
+ *
+ * It exists because the Deploy button has two outcomes and only one of them
+ * used to have a screen: "nothing was deployable, so a Build started" is a real
+ * act with a durable id and a live event stream, and leaving the operator on
+ * the workspace made it look like the press did nothing.
+ *
+ * The screen resolves itself. A Build that reaches an intent has a better page
+ * than this one, so when `getBuildDetail` reports a Deploy naming this Build
+ * the screen hands over to `/deploys/:id` rather than continuing to render the
+ * half of the story it can see.
+ */
+function BuildScreen({
+  buildId,
+  onNavigate,
+}: {
+  buildId: string;
+  onNavigate: (path: string) => void;
+}) {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'not-found'; message: string }
+    | { type: 'error'; message: string }
+    | { type: 'success'; attempt: DeployView }
+  >({ type: 'loading' });
+  const [busy, setBusy] = useState<'redeploy' | 'deploy' | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    let stopStream: (() => void) | null = null;
+    const parsedId = Number.parseInt(buildId, 10);
+    if (!buildId || Number.isNaN(parsedId)) {
+      setState({ type: 'not-found', message: `Invalid Build ID '${buildId}'` });
+      return;
+    }
+
+    const read = async () => {
+      const result = await command('getBuildDetail', { id: parsedId });
+      if (!live) return;
+      if (!result.ok) {
+        setState({
+          type: result.failure.code === 'NOT_FOUND' ? 'not-found' : 'error',
+          message: result.failure.message,
+        });
+        return;
+      }
+      if (result.value.deployId !== null) {
+        onNavigate(`/deploys/${result.value.deployId}`);
+        return;
+      }
+      setState({ type: 'success', attempt: result.value.attempt });
+    };
+
+    read()
+      .then(() => {
+        if (!live) return;
+        // The same authenticated stream the deploy screen uses, subscribed with
+        // no `deployId` because there is not one yet.
+        stopStream = subscribeAttempt({ buildId: parsedId }, () => {
+          void read();
+        });
+      })
+      .catch((cause: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: cause instanceof Error ? cause.message : 'Server failure',
+        });
+      });
+
+    return () => {
+      live = false;
+      stopStream?.();
+    };
+  }, [buildId, onNavigate]);
+
+  const act = async (kind: 'redeploy' | 'deploy') => {
+    if (state.type !== 'success') return;
+    setBusy(kind);
+    setActionError(null);
+    try {
+      // One command for both, because §4 gives the workspace button one
+      // meaning: deploy the newest artifact, or start the Build that would
+      // produce one. Pressing "Deploy this build" on a finished Build takes the
+      // first arm; pressing "Build again" on a failed one takes the second.
+      const result = await command('deployApp', { name: state.attempt.appId });
+      if (result.ok) {
+        onNavigate(
+          result.value.deployId === null
+            ? `/builds/${result.value.buildId}`
+            : `/deploys/${result.value.deployId}`,
+        );
+      } else {
+        setActionError(result.failure.message);
+      }
+    } catch (cause) {
+      setActionError(cause instanceof Error ? cause.message : 'Deploy failed');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (state.type === 'loading') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Loading build...
+        </p>
+      </div>
+    );
+  }
+
+  if (state.type === 'not-found') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-border bg-card p-6 text-center">
+          <Eyebrow>Build Not Found</Eyebrow>
+          <h1 className="mt-2 text-xl font-semibold">
+            Build #{buildId} not found
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
+          <div className="mt-4 flex justify-center">
+            <Button variant="outline" onClick={() => onNavigate('/apps')}>
+              Back to Apps
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.type === 'error') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm font-medium">Failed to load build</p>
+          <p className="text-sm mt-1">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {actionError ? (
+        <div className="mx-auto mt-4 w-full max-w-[1040px] px-5">
+          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium">That act was refused</p>
+              <p className="text-sm mt-0.5">{actionError}</p>
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setActionError(null)}
+            >
+              Dismiss
+            </Button>
+          </div>
+        </div>
+      ) : null}
+      <DeployDetail
+        view={state.attempt}
+        actions={{
+          onDeployBuild: () => void act('deploy'),
+          onRedeploy: () => void act('redeploy'),
+          busy,
+        }}
         onNavigate={onNavigate}
       />
     </>

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -90,7 +90,7 @@ export interface Diagnosis {
   readonly evidence: string;
 }
 
-/** The build half of an attempt. */
+/** The build half of an attempt, present only when a builder actually ran. */
 export interface BuildView {
   readonly status: StepStatus;
   readonly duration?: string;
@@ -106,6 +106,45 @@ export interface BuildView {
 }
 
 /**
+ * Where a release's bytes came from (§4, §5).
+ *
+ * Every attempt has one of these; not every attempt has a {@link BuildView}.
+ * §4: "Repo and archive share **one pipeline** — unpack, detect, build. An
+ * archive of *finished output* is a supplied artifact, digested over the
+ * uploaded bundle; an archive of *source* builds normally." So the origin is
+ * the constant and the build is the variable, and a screen that led with the
+ * build would have nothing to say about the release that was only ever
+ * extracted.
+ *
+ * `subpath` is on both arms because §5's scope "is named, never searched" — the
+ * bytes that were staged are the bytes under that path, and a reader comparing
+ * two releases of a monorepo needs it as much as the commit.
+ */
+export type SourceView =
+  | {
+      readonly kind: 'repo';
+      /** The repository, as the App names it. */
+      readonly repo: string;
+      /** The exact commit staged (§15). */
+      readonly commit: string;
+      readonly subpath: string;
+    }
+  | {
+      readonly kind: 'archive';
+      /** §16's join: the digest over the staged bundle, on both arms. */
+      readonly digest: string;
+      /** Where the staged bundle is fetched from, when it is recorded. */
+      readonly location: string | null;
+      readonly subpath: string;
+      /**
+       * Whether this upload was finished output rather than code — recorded and
+       * extracted, never built (§4). It is the case that makes a release with no
+       * Build a normal state instead of a missing one.
+       */
+      readonly extracted: boolean;
+    };
+
+/**
  * The deploy screen's whole state (Task 39).
  *
  * `previousReleaseUrl` is the field §18 singles out: **the red screen says the
@@ -115,7 +154,17 @@ export interface BuildView {
  * of something.
  */
 export interface DeployView {
-  readonly id: number;
+  /**
+   * The Deploy this attempt is, or `null` while it is still only a Build.
+   *
+   * §4: "a build records an artifact rather than deploying one", so a Build in
+   * flight has no intent row and therefore no id — and §6 will not let one be
+   * invented, because an intent naming a Build that has not succeeded could not
+   * pass `checkDeployable`. The screen is addressable either way: `/builds/:id`
+   * renders the same view with this null, and swaps itself for `/deploys/:id`
+   * the moment an intent exists.
+   */
+  readonly id: number | null;
   readonly buildId: number;
   readonly componentId: string;
   readonly targetId: string;
@@ -145,17 +194,97 @@ export interface DeployView {
   readonly previousReleaseServing: boolean;
   readonly diagnosis: Diagnosis | null;
   readonly resources: readonly ChecklistItem[];
-  readonly build: BuildView;
+  /** Where this release's bytes came from. Always present (§4). */
+  readonly source: SourceView;
+  /**
+   * The build that produced the artifact, or `null` when none ran.
+   *
+   * §4's supplied-artifact arm ends at a Build row that was born `SUCCEEDED`
+   * with "no build adapter looked up, let alone invoked" — `runner` and
+   * `logFidelity` are null on that row precisely because "saying so is more
+   * useful than naming a runner that never ran". This field carries that
+   * sentence into the UI rather than letting a screen invent a builder.
+   */
+  readonly build: BuildView | null;
   /** Controller and platform output for the deploy leg of this attempt. */
   readonly deployLog: readonly LogLine[] | null;
+  /** How long ago this attempt was written — "8m ago". */
+  readonly when: string;
+  /** The instant behind {@link when}, for the title a reader hovers. */
+  readonly at: string;
+  /**
+   * Whether this release is the one currently desired at its Component@Target.
+   *
+   * Read from the desired row rather than from the phase: a LIVE Deploy that a
+   * newer intent has superseded is still LIVE — it is just no longer what
+   * should be running — and only the desired row knows the difference.
+   */
+  readonly current: boolean;
+  /** §10's hash over what this release pinned. Never the config itself. */
+  readonly configVersion: string | null;
+  /** The artifact this release delivers, as the Build recorded it. */
+  readonly artifactDigest: string | null;
+  /** The release immediately before this one here, for stepping back. */
+  readonly previousDeployId: number | null;
+  /**
+   * Whether `rollbackDeploy` would take this release's Build (§6).
+   *
+   * Computed rather than inferred from `current`: §6 refuses a "rollback" to a
+   * Build that is not older than what is desired, so the affordance appears
+   * only where the act would be accepted.
+   */
+  readonly rollbackable: boolean;
 }
 
-/** One activity-timeline entry on the App workspace. */
+/**
+ * One Deploy as a releases list presents it (§2, §6).
+ *
+ * A list rather than a rolled-up "current release" because §2's "one Build →
+ * many Deploys" only pays for itself if the many are visible: a rollback is an
+ * ordinary deploy naming an older Build, and choosing which older Build means
+ * reading the releases that named them.
+ */
+export interface DeployListItem {
+  readonly id: number;
+  readonly buildId: number;
+  readonly componentId: string;
+  readonly targetId: string;
+  readonly component: string;
+  readonly target: string;
+  readonly commit: string;
+  readonly phase: DeployPhase;
+  readonly when: string;
+  readonly at: string;
+  /** Whether this release is what the desired row currently names. */
+  readonly current: boolean;
+  /** §10's pinned-config hash, which is what makes rollback reproducible. */
+  readonly configVersion: string | null;
+  /**
+   * Whether `rollbackDeploy` would take this release's Build.
+   *
+   * §6 refuses a "rollback" to a Build that is not older than what is desired —
+   * a roll-forward somebody typed the wrong word for. The list computes the
+   * same comparison so it can offer the act only where it would be accepted,
+   * rather than offering it everywhere and refusing half the presses.
+   */
+  readonly rollbackable: boolean;
+}
+
+/**
+ * One activity-timeline entry on the App workspace.
+ *
+ * The two ids are what make the timeline a way *into* the system rather than a
+ * wall of past tense: every event belongs to exactly one attempt (the
+ * `attempt_events` check constraint enforces it), so every entry has somewhere
+ * to go — `/deploys/:id` or `/builds/:id`.
+ */
 export interface ActivityEntry {
   readonly title: string;
   readonly detail: string;
   readonly when: string;
   readonly status: 'ok' | 'failed' | 'info';
+  readonly deployId: number | null;
+  readonly buildId: number | null;
 }
 
 /**
@@ -246,6 +375,14 @@ export interface WorkspaceView {
   readonly components: readonly ComponentView[];
   readonly datastores: readonly DatastoreView[];
   readonly activity: readonly ActivityEntry[];
+  /**
+   * The releases of this App, newest first (§2).
+   *
+   * On the workspace rather than behind a link because "what is live" and "what
+   * was live before it" are the same question asked twice, and a workspace that
+   * showed only the first makes the second an archaeology exercise.
+   */
+  readonly deploys: readonly DeployListItem[];
   /**
    * The Component's output surface (§17) — one of three, never a nullable log.
    * A `website` on a static Target is the case that forced the union: §17 gives

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -1,11 +1,24 @@
 /**
- * The deploy screen (Task 39, §18).
+ * The attempt screen (Task 39, §18).
  *
  * **App-first, not attempt-first.** The order down the page is state and URL,
- * then diagnosis, then resources, then the log — and that order is the whole
- * design. §18 rejects the stage rail every CI tool reaches for, because here
- * the running App is the product and the pipeline is only how it got there. A
- * rail puts the pipeline first and makes a green deploy a screen about a build.
+ * then diagnosis, then what this release *is*, then resources, then the logs —
+ * and that order is the whole design. §18 rejects the stage rail every CI tool
+ * reaches for, because here the running App is the product and the pipeline is
+ * only how it got there. A rail puts the pipeline first and makes a green
+ * deploy a screen about a build.
+ *
+ * **A release has a source, and only sometimes a build.** §4: "Repo and archive
+ * share one pipeline — unpack, detect, build. An archive of *finished output* is
+ * a supplied artifact, digested over the uploaded bundle." That release was
+ * extracted, never built, and `uploadArchive` records it with a null runner
+ * because "saying so is more useful than naming a runner that never ran". So
+ * Source is a section that is always there and Build is a drawer that is not.
+ *
+ * **The same screen renders a Build with no Deploy.** Pressing Deploy on an App
+ * with nothing deployable starts a Build and writes no intent (§4, §6), and that
+ * press still has to land somewhere. `view.id === null` is that state: same
+ * identity, same source, same log, no release — and the actions change to match.
  *
  * Four rules this file implements literally, each from §18:
  *
@@ -21,13 +34,13 @@
  * takes one immutable view; its controller replaces that view as authenticated
  * attempt events arrive.
  */
-import { RefreshCw } from 'lucide-react';
+import { ArrowLeft, RefreshCw, Rocket, Undo2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Checklist } from '../../components/checklist.tsx';
 import { DiagnosisPanel } from '../../components/diagnosis.tsx';
 import { LogPane, Notice } from '../../components/log-pane.tsx';
 import { PhasePill, StepGlyph, statusWord } from '../../components/status.tsx';
-import type { DeployView } from '../../model.ts';
+import type { DeployView, SourceView } from '../../model.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, Eyebrow } from '../../ui/card.tsx';
 import {
@@ -37,21 +50,37 @@ import {
 } from '../../ui/collapsible.tsx';
 import { cn } from '../../ui/utils.ts';
 
+/**
+ * What the operator can do from here, and which one is running.
+ *
+ * One object rather than three pairs of props: the actions are mutually
+ * exclusive in practice — a release is either current, older, or not a release
+ * yet — and `busy` naming which one is in flight keeps two buttons from both
+ * claiming to be working.
+ */
+export interface AttemptActions {
+  /** Deploy the App's newest artifact again, or rebuild it if there is none. */
+  readonly onRedeploy?: () => void;
+  /** Make this older release live again (§6: an ordinary deploy). */
+  readonly onRollback?: () => void;
+  /** Place the artifact this finished Build produced. */
+  readonly onDeployBuild?: () => void;
+  readonly busy?: 'redeploy' | 'rollback' | 'deploy' | null;
+}
+
 export function DeployDetail({
   view,
-  onRedeploy,
-  redeploying = false,
+  actions = {},
   onNavigate,
 }: {
   view: DeployView;
-  onRedeploy?: () => void;
-  redeploying?: boolean;
+  actions?: AttemptActions;
   onNavigate?: (path: string) => void;
 }) {
   return (
     <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-4 px-5 py-6">
       <Chrome view={view} onNavigate={onNavigate} />
-      <Hero view={view} onRedeploy={onRedeploy} redeploying={redeploying} />
+      <Hero view={view} actions={actions} />
 
       {view.diagnosis ? (
         <DiagnosisPanel
@@ -60,6 +89,8 @@ export function DeployDetail({
           url={view.url}
         />
       ) : null}
+
+      <Provenance view={view} onNavigate={onNavigate} />
 
       {view.resources.length > 0 ? (
         <section className="flex flex-col gap-2">
@@ -73,14 +104,16 @@ export function DeployDetail({
       ) : null}
 
       <BuildDrawer view={view} />
-      {view.build.status === 'done' ? <DeployDrawer view={view} /> : null}
+      {view.id !== null && view.build?.status === 'done' ? (
+        <DeployDrawer view={view} />
+      ) : null}
     </div>
   );
 }
 
 /**
- * What this attempt is, in one line: which Component, from which commit, on
- * which Target, built by which runner.
+ * What this attempt is, in one line: which Component, from which source, on
+ * which Target, built by which runner — if one ran.
  *
  * It sits above the state rather than inside it because it is the same for
  * every phase — identity, not status. The runner carries its `logFidelity`
@@ -99,7 +132,7 @@ function Chrome({
         {onNavigate ? (
           <button
             type="button"
-            onClick={() => onNavigate(`/apps/${view.app}`)}
+            onClick={() => onNavigate(`/apps/${view.appId}`)}
             className="font-semibold hover:underline"
           >
             {view.app}
@@ -109,17 +142,41 @@ function Chrome({
         )}
         <span className="mx-1.5 text-muted-foreground">/</span>
         <span className="text-subtle">{view.component}</span>
+        <span className="mx-1.5 text-muted-foreground">/</span>
+        <span className="text-subtle">{attemptName(view)}</span>
       </p>
       <dl className="ml-auto flex flex-wrap gap-x-6 gap-y-1">
-        <Meta label="Commit" value={view.commit} />
+        <Meta label="Source" value={sourceRef(view.source)} />
         <Meta label="Target" value={view.target} />
         <Meta
-          label="Runner"
-          value={`${view.build.runner} · ${view.build.fidelity}`}
+          label="Build"
+          value={
+            view.build === null
+              ? 'none · extracted'
+              : `${view.build.runner} · ${view.build.fidelity}`
+          }
         />
       </dl>
     </div>
   );
+}
+
+/** What to call this attempt: a release has a number, a Build has its own. */
+function attemptName(view: DeployView): string {
+  return view.id === null ? `build ${view.buildId}` : `deploy ${view.id}`;
+}
+
+/** The short form of a source, for a one-line header. */
+function sourceRef(source: SourceView): string {
+  return source.kind === 'repo'
+    ? shorten(source.commit)
+    : `archive ${shorten(source.digest)}`;
+}
+
+/** A digest or commit, cut to the length a human compares by eye. */
+function shorten(ref: string): string {
+  const bare = ref.startsWith('sha256:') ? ref.slice('sha256:'.length) : ref;
+  return bare.length > 12 ? bare.slice(0, 12) : bare;
 }
 
 function Meta({ label, value }: { label: string; value: string }) {
@@ -141,39 +198,107 @@ function Meta({ label, value }: { label: string; value: string }) {
  */
 function Hero({
   view,
-  onRedeploy,
-  redeploying = false,
+  actions,
 }: {
   view: DeployView;
-  onRedeploy?: () => void;
-  redeploying?: boolean;
+  actions: AttemptActions;
 }) {
   return (
     <Card className="flex flex-wrap items-center gap-4 px-5 py-5">
       <div className="flex flex-col gap-2">
-        <PhasePill phase={view.phase}>{view.phaseWord}</PhasePill>
+        <div className="flex flex-wrap items-center gap-2">
+          <PhasePill phase={view.phase}>{view.phaseWord}</PhasePill>
+          <Eyebrow>{view.when}</Eyebrow>
+          {view.current ? <Eyebrow>· current release</Eyebrow> : null}
+        </div>
         <h1 className="text-[27px] font-semibold leading-tight tracking-[-0.02em]">
           {view.headline}
         </h1>
-        {onRedeploy ? (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onRedeploy}
-            disabled={redeploying}
-            className="self-start"
-          >
-            <RefreshCw
-              aria-hidden="true"
-              className={cn('size-3.5', redeploying && 'animate-spin')}
-            />
-            {redeploying ? 'Deploying…' : 'Redeploy'}
-          </Button>
-        ) : null}
+        <Actions view={view} actions={actions} />
       </div>
       <UrlBlock view={view} />
     </Card>
   );
+}
+
+/**
+ * The acts this attempt admits, and no others.
+ *
+ * The branching is the point. A Build that finished is deployable and is not
+ * redeployable, because there is no release to repeat; an older release is
+ * rollable-back and a current one is not, because §6 refuses a "rollback" to
+ * something that is not older. Rendering every button always and letting the
+ * command refuse would teach the operator that half the buttons lie.
+ */
+function Actions({
+  view,
+  actions,
+}: {
+  view: DeployView;
+  actions: AttemptActions;
+}) {
+  const { onRedeploy, onRollback, onDeployBuild, busy } = actions;
+  const buttons = [];
+
+  if (view.id === null && onDeployBuild && view.build?.status !== 'failed') {
+    buttons.push(
+      <Button
+        key="deploy"
+        size="sm"
+        onClick={onDeployBuild}
+        disabled={busy !== null && busy !== undefined}
+        // A Build still running has nothing to place yet. It is shown disabled
+        // rather than hidden so the next act is visible while you wait for it.
+        title={
+          view.build !== null && view.build.status !== 'done'
+            ? 'Available once the build finishes'
+            : undefined
+        }
+      >
+        <Rocket aria-hidden="true" className="size-3.5" />
+        {busy === 'deploy' ? 'Deploying…' : 'Deploy this build'}
+      </Button>,
+    );
+  }
+
+  if (view.rollbackable && onRollback) {
+    buttons.push(
+      <Button
+        key="rollback"
+        size="sm"
+        onClick={onRollback}
+        disabled={busy !== null && busy !== undefined}
+      >
+        <Undo2 aria-hidden="true" className="size-3.5" />
+        {busy === 'rollback' ? 'Rolling back…' : 'Roll back to this release'}
+      </Button>,
+    );
+  }
+
+  if (onRedeploy) {
+    buttons.push(
+      <Button
+        key="redeploy"
+        variant="outline"
+        size="sm"
+        onClick={onRedeploy}
+        disabled={busy !== null && busy !== undefined}
+      >
+        <RefreshCw
+          aria-hidden="true"
+          className={cn('size-3.5', busy === 'redeploy' && 'animate-spin')}
+        />
+        {busy === 'redeploy'
+          ? 'Working…'
+          : view.build?.status === 'failed'
+            ? 'Build again'
+            : 'Redeploy'}
+      </Button>,
+    );
+  }
+
+  if (buttons.length === 0) return null;
+  return <div className="flex flex-wrap gap-2 self-start">{buttons}</div>;
 }
 
 /**
@@ -209,7 +334,106 @@ function UrlBlock({ view }: { view: DeployView }) {
 }
 
 /**
- * The build, collapsed on green.
+ * What this release is made of, and what it pinned.
+ *
+ * A Deploy row is written once and never edited into a different release: its
+ * Build, its source, and the config document it captured (§10) are what it
+ * delivered, which is what makes "roll back to this" a reproducible act rather
+ * than a hopeful one. This section is where those facts are legible — and where
+ * §10's version hash appears, because a release whose config you cannot name is
+ * one you cannot claim to be able to reproduce.
+ */
+function Provenance({
+  view,
+  onNavigate,
+}: {
+  view: DeployView;
+  onNavigate?: (path: string) => void;
+}) {
+  const source = view.source;
+
+  return (
+    <section className="flex flex-col gap-2">
+      <Eyebrow>What this {view.id === null ? 'build' : 'release'} is</Eyebrow>
+      <Card>
+        <CardContent className="grid gap-x-6 gap-y-3 py-3 sm:grid-cols-2">
+          {source.kind === 'repo' ? (
+            <>
+              <Fact label="Repository" value={source.repo} />
+              <Fact label="Commit" value={source.commit} />
+            </>
+          ) : (
+            <>
+              <Fact
+                label="Uploaded archive"
+                value={source.digest}
+                note={
+                  source.extracted
+                    ? 'finished output — recorded as-is, never built'
+                    : 'source — built through the same pipeline as a repo'
+                }
+              />
+              <Fact label="Bundle location" value={source.location} />
+            </>
+          )}
+          <Fact label="Scope" value={source.subpath} />
+          <Fact label="Artifact" value={view.artifactDigest} />
+          <Fact label="Config version" value={view.configVersion} />
+          <Fact label="Created" value={view.at} />
+        </CardContent>
+      </Card>
+      {view.previousDeployId !== null && onNavigate ? (
+        <button
+          type="button"
+          onClick={() => onNavigate(`/deploys/${view.previousDeployId}`)}
+          className="flex items-center gap-1.5 self-start text-xs text-subtle hover:text-foreground"
+        >
+          <ArrowLeft aria-hidden="true" className="size-3.5" />
+          Deploy {view.previousDeployId} — the release before this one
+        </button>
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * One recorded fact, or the statement that it was never recorded.
+ *
+ * The em dash is not a placeholder for a value that is loading. §10 pins config
+ * on the Deploy row when the intent is written, so a release with no version
+ * is one that pinned nothing — and "—" says that, where an empty cell would
+ * read as a rendering bug.
+ */
+function Fact({
+  label,
+  value,
+  note,
+}: {
+  label: string;
+  value: string | null;
+  note?: string;
+}) {
+  return (
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <Eyebrow>{label}</Eyebrow>
+      <span
+        className={cn(
+          'truncate font-mono text-xs',
+          value === null ? 'text-muted-foreground' : 'text-subtle',
+        )}
+        title={value ?? undefined}
+      >
+        {value ?? '—'}
+      </span>
+      {note ? (
+        <span className="text-[11px] text-muted-foreground">{note}</span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The build, collapsed on green — and absent entirely when none ran.
  *
  * §18's "auto-opens on red or running" keys on **the build's** status, not on
  * the screen's. The distinction is load-bearing on exactly the case that
@@ -225,28 +449,41 @@ function UrlBlock({ view }: { view: DeployView }) {
  * the data, and React cannot take back an uncontrolled `open`.
  */
 function BuildDrawer({ view }: { view: DeployView }) {
-  const autoOpen =
-    view.build.status === 'failed' || view.build.status === 'running';
+  const build = view.build;
+  const autoOpen = build?.status === 'failed' || build?.status === 'running';
   const [open, setOpen] = useState(autoOpen);
-  const priorStatus = useRef(view.build.status);
+  const priorStatus = useRef(build?.status ?? null);
 
   useEffect(() => {
-    if (priorStatus.current === view.build.status) return;
-    priorStatus.current = view.build.status;
-    setOpen(view.build.status !== 'done');
-  }, [view.build.status]);
+    const status = build?.status ?? null;
+    if (priorStatus.current === status) return;
+    priorStatus.current = status;
+    setOpen(status !== null && status !== 'done');
+  }, [build?.status]);
+
+  // §4's supplied artifact: nothing ran, so there is no drawer to open. The
+  // sentence replaces it rather than an empty log pane, which would read as a
+  // build whose output went missing.
+  if (build === null) {
+    return (
+      <Notice label="NO BUILD">
+        This release delivers uploaded output, digested over the bundle exactly
+        as it arrived. No builder was involved, so there is no build log.
+      </Notice>
+    );
+  }
 
   return (
     <Collapsible open={open} onOpenChange={setOpen} asChild>
       <Card>
         <CollapsibleTrigger className="flex w-full items-center gap-2.5 px-3.5 py-3 text-left text-xs font-semibold uppercase tracking-[0.07em] text-subtle hover:text-foreground">
-          <StepGlyph status={view.build.status} />
-          Build log · {statusWord(view.build.status)}
-          {view.build.duration ? ` · ${view.build.duration}` : ''}
+          <StepGlyph status={build.status} />
+          Build log · {statusWord(build.status)}
+          {build.duration ? ` · ${build.duration}` : ''}
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="flex flex-col gap-3 px-3.5 pb-3.5">
-            <Checklist items={view.build.steps} />
+            <Checklist items={build.steps} />
             <BuildOutput view={view} />
           </div>
         </CollapsibleContent>
@@ -264,20 +501,22 @@ function BuildDrawer({ view }: { view: DeployView }) {
  * as a broken stream rather than a known limit of that runner.
  */
 function BuildOutput({ view }: { view: DeployView }) {
-  if (view.build.log !== null) return <LogPane lines={view.build.log} />;
+  const build = view.build;
+  if (build === null) return null;
+  if (build.log !== null) return <LogPane lines={build.log} />;
 
-  if (view.build.fidelity === 'LIVE_STATUS') {
+  if (build.fidelity === 'LIVE_STATUS') {
     return (
       <Notice label="LIVE_STATUS">
-        {view.build.runner} reports step status live, but its log text only
-        arrives when the build finishes. The checklist above is the live view.
+        {build.runner} reports step status live, but its log text only arrives
+        when the build finishes. The checklist above is the live view.
       </Notice>
     );
   }
 
   return (
-    <Notice label={view.build.fidelity}>
-      {view.build.runner} releases its log when the build finishes.
+    <Notice label={build.fidelity}>
+      {build.runner} releases its log when the build finishes.
     </Notice>
   );
 }

--- a/apps/spindrift/src/web/views/apps/releases.tsx
+++ b/apps/spindrift/src/web/views/apps/releases.tsx
@@ -1,0 +1,138 @@
+/**
+ * The releases list (§2, §6).
+ *
+ * §2 makes "one Build → many Deploys" the thing that "makes rollback-without-
+ * rebuild possible", and §6 makes a rollback "an ordinary deploy — a newer
+ * intent row pointing at an older Build". Neither sentence is reachable from a
+ * screen that shows only what is live now: choosing the older Build means
+ * reading the release that named it.
+ *
+ * Every row is one immutable answer to "what was live then" — its Build, its
+ * commit, and the config it pinned are what it delivered, and nothing edits a
+ * Deploy row into a different release. So a row is addressable, and clicking
+ * one opens that release rather than a filtered view of the current one.
+ *
+ * **`current` is not the same as `LIVE`.** A LIVE Deploy that a newer intent
+ * superseded is still LIVE — what changed is that it is no longer what should
+ * be running — and only §6's desired row knows the difference. The list marks
+ * the current one explicitly rather than letting the phase imply it.
+ */
+import { ChevronRight, Undo2 } from 'lucide-react';
+import { EmptyState } from '../../components/log-pane.tsx';
+import type { DeployListItem, DeployPhase } from '../../model.ts';
+import { Badge } from '../../ui/badge.tsx';
+import { Button } from '../../ui/button.tsx';
+import { cn } from '../../ui/utils.ts';
+
+function phaseTone(
+  phase: DeployPhase,
+): 'success' | 'warning' | 'destructive' | 'idle' {
+  if (phase === 'LIVE') return 'success';
+  if (phase === 'FAILED') return 'destructive';
+  return 'warning';
+}
+
+export function Releases({
+  deploys,
+  onNavigate,
+  onRollback,
+  rollingBack = null,
+}: {
+  deploys: readonly DeployListItem[];
+  onNavigate?: (path: string) => void;
+  onRollback?: (release: DeployListItem) => void;
+  /** The release id a rollback is in flight for, if any. */
+  rollingBack?: number | null;
+}) {
+  if (deploys.length === 0) {
+    return (
+      <EmptyState title="No releases yet.">
+        Every deploy writes one immutable release here — its Build, its commit,
+        and the configuration it pinned.
+      </EmptyState>
+    );
+  }
+
+  return (
+    <div className="flex max-h-[420px] flex-col overflow-y-auto">
+      {deploys.map((release) => (
+        <Row
+          key={release.id}
+          release={release}
+          onNavigate={onNavigate}
+          onRollback={onRollback}
+          rollingBack={rollingBack}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Row({
+  release,
+  onNavigate,
+  onRollback,
+  rollingBack,
+}: {
+  release: DeployListItem;
+  onNavigate?: (path: string) => void;
+  onRollback?: (release: DeployListItem) => void;
+  rollingBack: number | null;
+}) {
+  const detail = [
+    release.target,
+    release.when,
+    release.configVersion
+      ? `config ${release.configVersion.slice(0, 8)}`
+      : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <div className="flex items-center gap-3 border-b border-border-soft py-2.5 last:border-b-0">
+      <Badge tone={phaseTone(release.phase)}>{release.phase}</Badge>
+      <button
+        type="button"
+        onClick={() => onNavigate?.(`/deploys/${release.id}`)}
+        disabled={!onNavigate}
+        className="min-w-0 flex-1 text-left disabled:cursor-default"
+      >
+        <p className="truncate text-sm font-medium">
+          Deploy {release.id}
+          <span className="ml-2 font-mono text-xs text-muted-foreground">
+            {release.commit.slice(0, 12)}
+          </span>
+          {release.current ? (
+            <span
+              className={cn(
+                'ml-2 rounded-sm border px-1.5 py-0.5',
+                'text-[10px] font-semibold uppercase tracking-[0.07em]',
+                'text-accent-foreground',
+              )}
+            >
+              current
+            </span>
+          ) : null}
+        </p>
+        <p className="truncate text-xs text-muted-foreground">{detail}</p>
+      </button>
+      {release.rollbackable && onRollback ? (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => onRollback(release)}
+          disabled={rollingBack !== null}
+        >
+          <Undo2 aria-hidden="true" className="size-3.5" />
+          {rollingBack === release.id ? 'Rolling back…' : 'Roll back'}
+        </Button>
+      ) : (
+        <ChevronRight
+          aria-hidden="true"
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -27,12 +27,14 @@ import type {
   ActivityEntry,
   ComponentView,
   DatastoreView,
+  DeployListItem,
   WorkspaceView,
 } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, Eyebrow } from '../../ui/card.tsx';
 import { cn } from '../../ui/utils.ts';
+import { Releases } from './releases.tsx';
 
 export function Workspace({
   view,
@@ -40,6 +42,8 @@ export function Workspace({
   deploying = false,
   onNavigate,
   deletion,
+  onRollback,
+  rollingBack = null,
 }: {
   view: WorkspaceView;
   onDeploy?: () => void;
@@ -51,6 +55,8 @@ export function Workspace({
    * question does not offer the act.
    */
   deletion?: AppDeletionControls;
+  onRollback?: (release: DeployListItem) => void;
+  rollingBack?: number | null;
 }) {
   const primary = view.components[0];
 
@@ -82,15 +88,22 @@ export function Workspace({
         </div>
       </header>
 
-      <Hero view={view} />
+      <Hero view={view} onNavigate={onNavigate} />
 
       <div className="grid gap-4 md:grid-cols-2">
         <Components components={view.components} />
         <Datastores datastores={view.datastores} />
       </div>
 
+      <ReleaseHistory
+        deploys={view.deploys}
+        onNavigate={onNavigate}
+        onRollback={onRollback}
+        rollingBack={rollingBack}
+      />
+
       <div className="grid gap-4 md:grid-cols-2">
-        <Activity entries={view.activity} />
+        <Activity entries={view.activity} onNavigate={onNavigate} />
         <Runtime view={view} onNavigate={onNavigate} />
       </div>
     </div>
@@ -98,7 +111,13 @@ export function Workspace({
 }
 
 /** Live state and URL on the left; placement on the right. */
-function Hero({ view }: { view: WorkspaceView }) {
+function Hero({
+  view,
+  onNavigate,
+}: {
+  view: WorkspaceView;
+  onNavigate?: (path: string) => void;
+}) {
   return (
     <Card className="flex flex-wrap items-start gap-6 px-5 py-5">
       <div className="flex flex-col gap-2">
@@ -119,6 +138,22 @@ function Hero({ view }: { view: WorkspaceView }) {
         >
           {view.url}
         </a>
+        {/*
+          The release is a link because it is a thing, not a label: §2's Deploy
+          is Heroku's Release, and the attempt that produced what is running is
+          one press away from the screen that says how it went.
+        */}
+        {view.latestDeployId !== undefined && onNavigate ? (
+          <button
+            type="button"
+            onClick={() => onNavigate(`/deploys/${view.latestDeployId}`)}
+            className="self-start text-xs text-subtle hover:text-foreground"
+          >
+            {view.release} →
+          </button>
+        ) : (
+          <Eyebrow>{view.release}</Eyebrow>
+        )}
       </div>
 
       <div className="ml-auto flex flex-col gap-1 text-right">
@@ -137,6 +172,13 @@ function Hero({ view }: { view: WorkspaceView }) {
   );
 }
 
+/**
+ * A section's label, and its one action where it has one.
+ *
+ * `action` is optional because not every section does something: the timeline
+ * is read by clicking its own entries, and a "View all" beside it would be a
+ * button whose absence of a destination the reader discovers by pressing it.
+ */
 function SectionHeader({
   eyebrow,
   title,
@@ -145,7 +187,7 @@ function SectionHeader({
 }: {
   eyebrow: string;
   title: string;
-  action: string;
+  action?: string;
   onAction?: () => void;
 }) {
   return (
@@ -154,14 +196,16 @@ function SectionHeader({
         <Eyebrow>{eyebrow}</Eyebrow>
         <h2 className="text-base font-semibold tracking-tight">{title}</h2>
       </div>
-      <Button
-        variant="outline"
-        size="sm"
-        className="ml-auto"
-        onClick={onAction}
-      >
-        {action}
-      </Button>
+      {action ? (
+        <Button
+          variant="outline"
+          size="sm"
+          className="ml-auto"
+          onClick={onAction}
+        >
+          {action}
+        </Button>
+      ) : null}
     </CardHeader>
   );
 }
@@ -266,37 +310,136 @@ function Datastores({ datastores }: { datastores: readonly DatastoreView[] }) {
   );
 }
 
+/**
+ * Every release of this App, newest first (§2).
+ *
+ * A full-width section rather than a card in the two-column grid: it is the
+ * history of the thing the whole screen is about, and §2's "one Build → many
+ * Deploys" is only legible when the many are listed.
+ */
+function ReleaseHistory({
+  deploys,
+  onNavigate,
+  onRollback,
+  rollingBack,
+}: {
+  deploys: readonly DeployListItem[];
+  onNavigate?: (path: string) => void;
+  onRollback?: (release: DeployListItem) => void;
+  rollingBack: number | null;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <div>
+          <Eyebrow>Deploy history</Eyebrow>
+          <h2 className="text-base font-semibold tracking-tight">Releases</h2>
+        </div>
+        <p className="ml-auto max-w-[46ch] text-right text-xs text-muted-foreground">
+          Each release is immutable — its Build, its commit, and the
+          configuration it pinned. Rolling back deploys an older one; it never
+          rebuilds.
+        </p>
+      </CardHeader>
+      <CardContent className="pt-0">
+        <Releases
+          deploys={deploys}
+          onNavigate={onNavigate}
+          onRollback={onRollback}
+          rollingBack={rollingBack}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
 const ACTIVITY_TONE = {
   ok: 'border-l-success',
   failed: 'border-l-destructive',
   info: 'border-l-border',
 } as const satisfies Record<ActivityEntry['status'], string>;
 
-function Activity({ entries }: { entries: readonly ActivityEntry[] }) {
+/**
+ * The timeline, and a way in from every line of it.
+ *
+ * `attempt_events` constrains every row to exactly one attempt, so every entry
+ * has somewhere to go — `/deploys/:id` or `/builds/:id`. An entry that led
+ * nowhere would be the one thing on this screen a reader could not act on.
+ */
+function Activity({
+  entries,
+  onNavigate,
+}: {
+  entries: readonly ActivityEntry[];
+  onNavigate?: (path: string) => void;
+}) {
   return (
     <Card>
-      <SectionHeader
-        eyebrow="Recent activity"
-        title="What happened"
-        action="View all"
-      />
+      <SectionHeader eyebrow="Recent activity" title="What happened" />
       <CardContent className="flex flex-col gap-2.5 pt-0">
-        {entries.map((entry) => (
-          <div
-            key={`${entry.title}-${entry.when}`}
-            className={cn('border-l-2 pl-3', ACTIVITY_TONE[entry.status])}
-          >
-            <div className="flex items-baseline gap-2">
-              <p className="text-sm font-medium">{entry.title}</p>
-              <span className="ml-auto font-mono text-xs text-muted-foreground">
-                {entry.when}
-              </span>
-            </div>
-            <p className="text-xs text-muted-foreground">{entry.detail}</p>
-          </div>
-        ))}
+        {entries.length === 0 ? (
+          <EmptyState title="Nothing has happened yet.">
+            Build and deploy events land here as they arrive.
+          </EmptyState>
+        ) : (
+          entries.map((entry) => (
+            <ActivityRow
+              key={`${entry.title}-${entry.when}-${entry.deployId ?? entry.buildId}`}
+              entry={entry}
+              onNavigate={onNavigate}
+            />
+          ))
+        )}
       </CardContent>
     </Card>
+  );
+}
+
+function ActivityRow({
+  entry,
+  onNavigate,
+}: {
+  entry: ActivityEntry;
+  onNavigate?: (path: string) => void;
+}) {
+  const path =
+    entry.deployId !== null
+      ? `/deploys/${entry.deployId}`
+      : entry.buildId !== null
+        ? `/builds/${entry.buildId}`
+        : null;
+
+  const body = (
+    <>
+      <div className="flex items-baseline gap-2">
+        <p className="text-sm font-medium">{entry.title}</p>
+        <span className="ml-auto font-mono text-xs text-muted-foreground">
+          {entry.when}
+        </span>
+      </div>
+      <p className="text-xs text-muted-foreground">{entry.detail}</p>
+    </>
+  );
+
+  if (path === null || !onNavigate) {
+    return (
+      <div className={cn('border-l-2 pl-3', ACTIVITY_TONE[entry.status])}>
+        {body}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigate(path)}
+      className={cn(
+        'border-l-2 pl-3 text-left hover:bg-secondary/50',
+        ACTIVITY_TONE[entry.status],
+      )}
+    >
+      {body}
+    </button>
   );
 }
 

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -5,7 +5,10 @@ import {
   createComponent,
   deployApp,
   getAppWorkspace,
+  getBuildDetail,
   getDeployDetail,
+  listDeploys,
+  uploadArchive,
 } from '../../src/commands/index.ts';
 import type {
   AdapterRegistry,
@@ -13,6 +16,7 @@ import type {
   CommandContext,
 } from '../../src/commands/types.ts';
 import {
+  attemptEvents,
   builds,
   componentTargetDesired,
   deploys,
@@ -52,6 +56,330 @@ function context(clock: Clock = frozenClock): CommandContext {
     manifest,
   };
 }
+
+/**
+ * One App, one Component, one placed Target — the shape every screen below
+ * reads. Written once because none of these tests is about authoring.
+ */
+async function scaffold(
+  ctx: CommandContext,
+  options: {
+    readonly prefix: string;
+    readonly kind?: 'service' | 'website';
+    readonly adapter?: 'kubernetes' | 'static';
+    readonly sourceKind?: 'repo' | 'archive';
+  },
+) {
+  const name = `${options.prefix}-${crypto.randomUUID().slice(0, 8)}`;
+  const app = await createApp(
+    options.sourceKind === 'archive'
+      ? {
+          name,
+          sourceKind: 'archive',
+          archiveDigest: `sha256:${'e'.repeat(64)}`,
+          vesselRef: 'driftwood',
+        }
+      : {
+          name,
+          sourceKind: 'repo',
+          repoUrl: 'https://vcs.example/acme/thing.git',
+          vesselRef: 'driftwood',
+        },
+    ctx,
+  );
+  if (!app.ok) throw new Error(app.failure.message);
+
+  const component = await createComponent(
+    options.kind === 'website'
+      ? {
+          appId: app.value.appId,
+          name: 'web',
+          kind: 'website',
+          exposure: 'public',
+        }
+      : {
+          appId: app.value.appId,
+          name: 'web',
+          kind: 'service',
+          expose: true,
+          exposure: 'private',
+        },
+    ctx,
+  );
+  if (!component.ok) throw new Error(component.failure.message);
+
+  const [target] = await ctx.db
+    .insert(targets)
+    .values(targetValues({ adapter: options.adapter ?? 'kubernetes' }))
+    .returning();
+
+  await ctx.db.insert(componentTargetDesired).values({
+    componentId: component.value.componentId,
+    targetId: target!.id,
+  });
+
+  return {
+    appName: name,
+    appId: app.value.appId,
+    componentId: component.value.componentId,
+    target: target!,
+  };
+}
+
+describe('getBuildDetail command', () => {
+  test('projects a Build with no Deploy as an attempt with a null id', async () => {
+    // §4: pressing Deploy with nothing deployable "writes a PENDING Build for
+    // the build loop to dispatch, and that is the whole act". The press still
+    // has to land somewhere, and this is what it lands on.
+    const ctx = context();
+    const { componentId, target, appName } = await scaffold(ctx, {
+      prefix: 'queued',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'aaa1111',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'RUNNING',
+        runner: 'hosted runner',
+      })
+      .returning();
+
+    const result = await getBuildDetail({ id: build!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { attempt, deployId } = result.value;
+    expect(attempt.id).toBeNull();
+    expect(deployId).toBeNull();
+    expect(attempt.buildId).toBe(build!.id);
+    expect(attempt.app).toBe(appName);
+    // The desired row is what says where a Component belongs before any intent
+    // has named a Target.
+    expect(attempt.target).toBe(target.name);
+    expect(attempt.headline).toContain('Building on hosted runner');
+    // No intent means nothing was placed and nothing can be rolled back to.
+    expect(attempt.resources).toEqual([]);
+    expect(attempt.rollbackable).toBe(false);
+  });
+
+  test('hands over to the Deploy once an intent names this Build', async () => {
+    // A Build that reached an intent has a better screen than the build page,
+    // and the client follows this id rather than rendering half the story.
+    const ctx = context();
+    const { componentId, target } = await scaffold(ctx, { prefix: 'handover' });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'bbb2222',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'a'.repeat(64)}`,
+        status: 'SUCCEEDED',
+        runner: 'hosted runner',
+      })
+      .returning();
+
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'LIVE',
+      })
+      .returning();
+
+    const result = await getBuildDetail({ id: build!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.deployId).toBe(deploy!.id);
+  });
+
+  test('an uploaded artifact has a source and no build', async () => {
+    // §4: "An archive of *finished output* is a supplied artifact, digested
+    // over the uploaded bundle" — recorded, never built. `uploadArchive` writes
+    // that row with a null runner because "saying so is more useful than naming
+    // a runner that never ran", and the projection has to carry that through.
+    const ctx = context();
+    const { componentId, target } = await scaffold(ctx, {
+      prefix: 'extracted',
+      kind: 'website',
+      adapter: 'static',
+      sourceKind: 'archive',
+    });
+
+    const digest = `sha256:${'b'.repeat(64)}`;
+    const uploaded = await uploadArchive(
+      {
+        componentId,
+        targetId: target.id,
+        bundleDigest: digest,
+        location: 'gs://bundles.example/site.tar.zst',
+        contents: 'artifact',
+        subpath: '.',
+      },
+      ctx,
+    );
+    expect(uploaded.ok).toBe(true);
+    if (!uploaded.ok) return;
+    expect(uploaded.value.status).toBe('SUCCEEDED');
+
+    const result = await getBuildDetail({ id: uploaded.value.buildId }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { attempt } = result.value;
+    expect(attempt.build).toBeNull();
+    expect(attempt.source.kind).toBe('archive');
+    if (attempt.source.kind === 'archive') {
+      expect(attempt.source.extracted).toBe(true);
+      expect(attempt.source.digest).toBe(digest);
+      expect(attempt.source.location).toBe('gs://bundles.example/site.tar.zst');
+    }
+    expect(attempt.headline).toContain('Uploaded output recorded as-is');
+  });
+
+  test('returns NOT_FOUND for an unknown build id', async () => {
+    const result = await getBuildDetail({ id: 999999 }, context());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+  });
+});
+
+describe('listDeploys command', () => {
+  test('lists releases newest first and marks the current one', async () => {
+    // §2: "one Build → many Deploys — this is what makes rollback-without-
+    // rebuild possible." `current` is the desired row's answer, not the phase's:
+    // a LIVE Deploy a newer intent superseded is still LIVE.
+    const ctx = context();
+    const { appName, componentId, target } = await scaffold(ctx, {
+      prefix: 'releases',
+    });
+
+    const written = [];
+    for (const commit of ['c111', 'c222', 'c333']) {
+      const [build] = await ctx.db
+        .insert(builds)
+        .values({
+          componentId,
+          commit,
+          targetShape: 'image',
+          artifactType: 'image',
+          artifactDigest: `sha256:${commit.repeat(16)}`,
+          status: 'SUCCEEDED',
+          runner: 'hosted runner',
+        })
+        .returning();
+      const [deploy] = await ctx.db
+        .insert(deploys)
+        .values({
+          componentId,
+          targetId: target.id,
+          buildId: build!.id,
+          phase: 'LIVE',
+          configVersion: `sha256:${'f'.repeat(64)}`,
+        })
+        .returning();
+      written.push({ build: build!, deploy: deploy! });
+    }
+
+    // The middle release is what is desired — a rollback, which is exactly the
+    // state that makes `current` disagree with `phase` on the newest row.
+    const desired = written[1]!;
+    await ctx.db
+      .update(componentTargetDesired)
+      .set({
+        desiredBuildId: desired.build.id,
+        desiredDeployId: desired.deploy.id,
+      })
+      .where(eq(componentTargetDesired.componentId, componentId));
+
+    const result = await listDeploys({ app: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { deploys: releases } = result.value;
+    expect(releases.map((release) => release.id)).toEqual([
+      written[2]!.deploy.id,
+      written[1]!.deploy.id,
+      written[0]!.deploy.id,
+    ]);
+    expect(releases.filter((release) => release.current)).toHaveLength(1);
+    expect(releases.find((release) => release.current)?.id).toBe(
+      desired.deploy.id,
+    );
+    expect(releases[0]?.configVersion).toBeTruthy();
+    expect(releases[0]?.commit).toBe('c333');
+  });
+
+  test('offers rollback only for a release older than what is desired', async () => {
+    // §6 refuses a "rollback" to a Build that is not older — a roll-forward
+    // somebody typed the wrong word for. The list makes the same comparison so
+    // the affordance appears only where the act would be accepted.
+    const ctx = context();
+    const { appName, componentId, target } = await scaffold(ctx, {
+      prefix: 'rollbackable',
+    });
+
+    const written = [];
+    for (const commit of ['d111', 'd222']) {
+      const [build] = await ctx.db
+        .insert(builds)
+        .values({
+          componentId,
+          commit,
+          targetShape: 'image',
+          artifactType: 'image',
+          artifactDigest: `sha256:${commit.repeat(16)}`,
+          status: 'SUCCEEDED',
+        })
+        .returning();
+      const [deploy] = await ctx.db
+        .insert(deploys)
+        .values({
+          componentId,
+          targetId: target.id,
+          buildId: build!.id,
+          phase: 'LIVE',
+        })
+        .returning();
+      written.push({ build: build!, deploy: deploy! });
+    }
+
+    const newest = written[1]!;
+    await ctx.db
+      .update(componentTargetDesired)
+      .set({
+        desiredBuildId: newest.build.id,
+        desiredDeployId: newest.deploy.id,
+      })
+      .where(eq(componentTargetDesired.componentId, componentId));
+
+    const result = await listDeploys({ app: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const byId = new Map(
+      result.value.deploys.map((release) => [release.id, release]),
+    );
+    expect(byId.get(newest.deploy.id)?.rollbackable).toBe(false);
+    expect(byId.get(written[0]!.deploy.id)?.rollbackable).toBe(true);
+  });
+
+  test('returns NOT_FOUND for an unknown app', async () => {
+    const result = await listDeploys({ app: 'no-such-app' }, context());
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+  });
+});
 
 describe('getAppWorkspace command', () => {
   test('returns NOT_FOUND for an unknown app name', async () => {
@@ -244,7 +572,132 @@ describe('getAppWorkspace command', () => {
   });
 });
 
+describe('the workspace as a way into the system', () => {
+  test('lists releases and gives every activity entry an attempt to open', async () => {
+    // `attempt_events` constrains every row to exactly one attempt, so every
+    // entry has somewhere to go. An entry that led nowhere would be the one
+    // thing on the screen a reader could not act on.
+    const ctx = context();
+    const { appName, appId, componentId, target } = await scaffold(ctx, {
+      prefix: 'navigable',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'e111222',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'c'.repeat(64)}`,
+        status: 'SUCCEEDED',
+        runner: 'hosted runner',
+      })
+      .returning();
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'LIVE',
+      })
+      .returning();
+
+    await ctx.db.insert(attemptEvents).values([
+      {
+        appId,
+        componentId,
+        attemptKind: 'build',
+        buildId: build!.id,
+        eventType: 'log',
+        line: 'exporting to image',
+      },
+      {
+        appId,
+        componentId,
+        attemptKind: 'deploy',
+        deployId: deploy!.id,
+        eventType: 'status',
+        phase: 'LIVE',
+      },
+    ]);
+
+    const result = await getAppWorkspace({ name: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { workspace } = result.value;
+    expect(workspace.activity.length).toBe(2);
+    for (const entry of workspace.activity) {
+      expect(entry.deployId ?? entry.buildId).not.toBeNull();
+      // The clock is frozen at the same instant the rows were written, so the
+      // relative time is a real one rather than the "recently" it used to be.
+      expect(entry.when).not.toBe('recently');
+    }
+    expect(workspace.deploys.map((release) => release.id)).toEqual([
+      deploy!.id,
+    ]);
+  });
+});
+
 describe('getDeployDetail command', () => {
+  test('carries the source, the pinned config, and whether it is current', async () => {
+    // A Deploy row is written once and never edited into a different release:
+    // its Build, its source, and the config document it pinned (§10) are what
+    // it delivered, which is what makes "roll back to this" reproducible.
+    const ctx = context();
+    const { componentId, target } = await scaffold(ctx, { prefix: 'atomic' });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'f7a9b2c',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'d'.repeat(64)}`,
+        bundleDigest: `sha256:${'9'.repeat(64)}`,
+        status: 'SUCCEEDED',
+        runner: 'hosted runner',
+      })
+      .returning();
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'LIVE',
+        configVersion: `sha256:${'7'.repeat(64)}`,
+      })
+      .returning();
+    await ctx.db
+      .update(componentTargetDesired)
+      .set({ desiredBuildId: build!.id, desiredDeployId: deploy!.id })
+      .where(eq(componentTargetDesired.componentId, componentId));
+
+    const result = await getDeployDetail({ id: deploy!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { deploy: view } = result.value;
+    expect(view.source.kind).toBe('repo');
+    if (view.source.kind === 'repo') {
+      expect(view.source.commit).toBe('f7a9b2c');
+      expect(view.source.repo).toContain('acme/thing');
+    }
+    // A repo App builds, so there is a build to show — the other half of §4.
+    expect(view.build).not.toBeNull();
+    expect(view.build?.runner).toBe('hosted runner');
+    expect(view.configVersion).toBe(`sha256:${'7'.repeat(64)}`);
+    expect(view.artifactDigest).toBe(`sha256:${'d'.repeat(64)}`);
+    expect(view.current).toBe(true);
+    // Nothing to roll back to: this release is what is desired.
+    expect(view.rollbackable).toBe(false);
+    expect(view.previousDeployId).toBeNull();
+  });
+
   test('returns NOT_FOUND for an unknown deploy id', async () => {
     const ctx = context();
     const result = await getDeployDetail({ id: 999999 }, ctx);

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -87,6 +87,19 @@ const BASE = {
     { text: 'controller accepted the deploy', tone: 'muted' },
     { text: 'platform reconciliation reached a terminal state' },
   ],
+  source: {
+    kind: 'repo',
+    repo: 'https://vcs.example/example/almanac',
+    commit: 'dd9b103',
+    subpath: 'apps/web',
+  },
+  when: '40s ago',
+  at: '2026-07-29T10:00:00.000Z',
+  current: true,
+  configVersion: 'sha256:5c1f9e2a44b7',
+  artifactDigest: 'sha256:9f2c1a7e30b4',
+  previousDeployId: 40,
+  rollbackable: false,
 } as const;
 
 const BUILT = {
@@ -240,6 +253,35 @@ export const DEPLOY_SCENARIOS = {
     build: BUILT,
   },
 
+  /**
+   * §4's other arm: an archive of *finished output* is "a supplied artifact,
+   * digested over the uploaded bundle", recorded with no build adapter looked
+   * up. `uploadArchive` writes that row with a null runner precisely because
+   * "saying so is more useful than naming a runner that never ran" — so the
+   * screen has no build to show, and says which fact that is.
+   */
+  extracted: {
+    ...BASE,
+    source: {
+      kind: 'archive',
+      digest: `sha256:${'b1'.repeat(32)}`,
+      location: 'gs://bundles.example/almanac/b119.tar.zst',
+      subpath: '.',
+      extracted: true,
+    },
+    commit: `sha256:${'b1'.repeat(32)}`,
+    phase: 'LIVE',
+    phaseWord: 'Live',
+    headline: 'Uploaded output released to Static hosting',
+    target: 'Static hosting',
+    urlLive: true,
+    previousReleaseServing: false,
+    diagnosis: null,
+    resources: RESOURCES_OK.slice(2),
+    build: null,
+    artifactDigest: `sha256:${'b1'.repeat(32)}`,
+  },
+
   neverReady: {
     ...BASE,
     phase: 'FAILED',
@@ -264,6 +306,33 @@ export const DEPLOY_SCENARIOS = {
     build: BUILT,
   },
 } as const satisfies Record<string, DeployView>;
+
+/**
+ * The state `/builds/:id` renders: an attempt with no release.
+ *
+ * §4 makes this a normal outcome of pressing Deploy — "there is nothing
+ * deployable yet, so a PENDING Build is written and that is the whole act" —
+ * and §6 will not let an intent be invented for it, because one naming a Build
+ * that has not succeeded could not pass `checkDeployable`. So `id` is null, the
+ * deploy drawer is absent, and the action is to place what the Build produces.
+ */
+export const BUILD_ATTEMPT: DeployView = {
+  ...BASE,
+  id: null,
+  phase: 'WAITING',
+  phaseWord: 'Built',
+  headline: 'Built — ready to deploy to Metal',
+  urlLive: false,
+  previousReleaseServing: true,
+  diagnosis: null,
+  resources: [],
+  deployLog: null,
+  current: false,
+  configVersion: null,
+  previousDeployId: null,
+  rollbackable: false,
+  build: BUILT,
+};
 
 export type DeployScenarioName = keyof typeof DEPLOY_SCENARIOS;
 
@@ -320,18 +389,58 @@ export const WORKSPACE_SCENARIOS = {
         detail: 'Artifact reconciled on Metal; all resources healthy.',
         when: '8m ago',
         status: 'ok',
+        deployId: 42,
+        buildId: null,
       },
       {
         title: 'Build passed',
         detail: 'main · 7f3d2c1 · hosted runner',
         when: '9m ago',
         status: 'ok',
+        deployId: null,
+        buildId: 41,
       },
       {
         title: 'Deploy 40 failed',
         detail: 'STARTUP_FAILED · developer · DATABASE_URL missing',
         when: '1d ago',
         status: 'failed',
+        deployId: 40,
+        buildId: null,
+      },
+    ],
+    deploys: [
+      {
+        id: 42,
+        buildId: 41,
+        componentId: '00000000-0000-4000-8000-000000000041',
+        targetId: '00000000-0000-4000-8000-000000000042',
+        component: 'web',
+        target: 'Metal',
+        commit: '7f3d2c1',
+        phase: 'LIVE',
+        when: '8m ago',
+        at: '2026-07-29T09:52:00.000Z',
+        current: true,
+        configVersion: 'sha256:5c1f9e2a44b7',
+        rollbackable: false,
+      },
+      {
+        id: 40,
+        buildId: 39,
+        componentId: '00000000-0000-4000-8000-000000000041',
+        targetId: '00000000-0000-4000-8000-000000000042',
+        component: 'web',
+        target: 'Metal',
+        commit: '91dc4ab',
+        phase: 'FAILED',
+        when: '1d ago',
+        at: '2026-07-28T10:00:00.000Z',
+        current: false,
+        configVersion: 'sha256:5c1f9e2a44b7',
+        // Older than what is desired and carrying an artifact — §6 would take
+        // it, so the affordance is offered.
+        rollbackable: true,
       },
     ],
     runtime: {
@@ -376,12 +485,33 @@ export const WORKSPACE_SCENARIOS = {
         detail: 'Files released to static hosting.',
         when: '2h ago',
         status: 'ok',
+        deployId: 17,
+        buildId: null,
       },
       {
         title: 'Build passed',
         detail: 'main · 91dc4ab · hosted runner',
         when: '2h ago',
         status: 'ok',
+        deployId: null,
+        buildId: 16,
+      },
+    ],
+    deploys: [
+      {
+        id: 17,
+        buildId: 16,
+        componentId: '00000000-0000-4000-8000-000000000051',
+        targetId: '00000000-0000-4000-8000-000000000052',
+        component: 'web',
+        target: 'Static hosting',
+        commit: '91dc4ab',
+        phase: 'LIVE',
+        when: '2h ago',
+        at: '2026-07-29T08:00:00.000Z',
+        current: true,
+        configVersion: null,
+        rollbackable: false,
       },
     ],
     runtime: {
@@ -424,12 +554,33 @@ export const WORKSPACE_SCENARIOS = {
         detail: '02:14 · 1,284 objects copied',
         when: '8m ago',
         status: 'ok',
+        deployId: 118,
+        buildId: null,
       },
       {
         title: 'Execution 116 failed',
         detail: 'exit 1 · bucket unavailable',
         when: '1d ago',
         status: 'failed',
+        deployId: 116,
+        buildId: null,
+      },
+    ],
+    deploys: [
+      {
+        id: 118,
+        buildId: 90,
+        componentId: '00000000-0000-4000-8000-000000000061',
+        targetId: '00000000-0000-4000-8000-000000000062',
+        component: 'nightly',
+        target: 'Cloud Run',
+        commit: '7cc2198',
+        phase: 'LIVE',
+        when: '8m ago',
+        at: '2026-07-29T09:52:00.000Z',
+        current: true,
+        configVersion: 'sha256:aa41c0d29e15',
+        rollbackable: false,
       },
     ],
     // §17: a job is a list of executions, not a stream. The depth is achieved

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -20,6 +20,7 @@ import { Gate } from '../../src/web/views/auth/gate.tsx';
 import { CredentialSettingsView } from '../../src/web/views/auth/settings.tsx';
 import { RepositoryList } from '../../src/web/views/repos/list.tsx';
 import {
+  BUILD_ATTEMPT,
   DEPLOY_SCENARIOS,
   WORKSPACE_SCENARIOS,
 } from '../fixtures/scenarios.ts';
@@ -204,9 +205,14 @@ describe('the deploy screen, on red', () => {
       //
       // Radix leaves closed content unmounted, so the step list appearing at
       // all is what distinguishes the two.
-      const opened = deploy(view).includes(view.build.steps[0]!.name);
+      //
+      // Every red scenario built something — §4's supplied-artifact arm has no
+      // build to open, and no failure mode that would want one opened.
+      expect(view.build).not.toBeNull();
+      const build = view.build!;
+      const opened = deploy(view).includes(build.steps[0]!.name);
       expect(opened).toBe(
-        view.build.status === 'failed' || view.build.status === 'running',
+        build.status === 'failed' || build.status === 'running',
       );
     });
   }
@@ -215,7 +221,7 @@ describe('the deploy screen, on red', () => {
     // The case that makes the rule above worth having: the build succeeded and
     // the cluster could not pull what it produced.
     const view = DEPLOY_SCENARIOS.imageUnpullable;
-    expect(view.build.status).toBe('done');
+    expect(view.build?.status).toBe('done');
 
     const markup = deploy(view);
     expect(markup).toContain('ARTIFACT_UNAVAILABLE');
@@ -274,7 +280,135 @@ describe('a runner that withholds log text', () => {
   });
 });
 
+describe('a release that was extracted rather than built', () => {
+  // §4: "An archive of *finished output* is a supplied artifact, digested over
+  // the uploaded bundle" — recorded with no build adapter looked up.
+  // `uploadArchive` writes that row with a null runner precisely because
+  // "saying so is more useful than naming a runner that never ran", and the
+  // screen has to carry that sentence rather than invent a builder.
+  const view = DEPLOY_SCENARIOS.extracted;
+  const markup = deploy(view);
+
+  test('has no build at all', () => {
+    expect(view.build).toBeNull();
+  });
+
+  test('says no builder was involved instead of showing an empty log', () => {
+    expect(markup).toContain('NO BUILD');
+    expect(markup).toContain('No builder was involved');
+    expect(markup).not.toContain('Build log');
+  });
+
+  test('leads with the source, which every release has', () => {
+    expect(view.source.kind).toBe('archive');
+    expect(markup).toContain('Uploaded archive');
+    expect(markup).toContain('recorded as-is, never built');
+    if (view.source.kind === 'archive') {
+      expect(markup).toContain(view.source.digest);
+    }
+  });
+
+  test('still names the artifact it delivers', () => {
+    // The digest is over the uploaded bundle on both arms (§16), which is what
+    // keeps the supply-chain join intact whether or not a build happened.
+    expect(markup).toContain('Artifact');
+    expect(markup).toContain(view.artifactDigest!);
+  });
+});
+
+describe('an attempt that is only a Build', () => {
+  // §4: pressing Deploy with nothing deployable "writes a PENDING Build for the
+  // build loop to dispatch, and that is the whole act". The press still has to
+  // land somewhere, and this is the screen it lands on.
+  const markup = renderToStaticMarkup(
+    <DeployDetail
+      view={BUILD_ATTEMPT}
+      actions={{ onDeployBuild: () => undefined }}
+    />,
+  );
+
+  test('has no release id, because no intent was written', () => {
+    expect(BUILD_ATTEMPT.id).toBeNull();
+  });
+
+  test('names itself a build rather than a deploy', () => {
+    expect(markup).toContain(`build ${BUILD_ATTEMPT.buildId}`);
+  });
+
+  test('offers to place what the Build produced', () => {
+    expect(markup).toContain('Deploy this build');
+  });
+
+  test('shows no deploy log, because nothing was applied', () => {
+    // §6 gives the deploy leg its own drawer. There is no deploy leg here, and
+    // rendering an empty one would say the platform was asked and said nothing.
+    expect(markup).not.toContain('Deploy log');
+  });
+});
+
+describe('the releases list', () => {
+  const view = WORKSPACE_SCENARIOS.service;
+  const markup = renderToStaticMarkup(
+    <Workspace view={view} onNavigate={() => undefined} />,
+  );
+
+  test('lists every release, not only the one that is live', () => {
+    // §2: "one Build → many Deploys — this is what makes rollback-without-
+    // rebuild possible." The many have to be visible for that to be reachable.
+    expect(view.deploys.length).toBeGreaterThan(1);
+    for (const release of view.deploys) {
+      expect(markup).toContain(`Deploy ${release.id}`);
+    }
+  });
+
+  test('marks which release is current, separately from its phase', () => {
+    // A LIVE Deploy that a newer intent superseded is still LIVE. Only §6's
+    // desired row knows which one should be running.
+    expect(markup).toContain('current');
+    expect(view.deploys.filter((release) => release.current)).toHaveLength(1);
+  });
+
+  test('states that a release is immutable and that rollback rebuilds nothing', () => {
+    expect(markup).toContain('Each release is immutable');
+    expect(markup).toContain('it never');
+  });
+
+  test('offers rollback only where §6 would accept it', () => {
+    const rollbackable = view.deploys.filter((release) => release.rollbackable);
+    expect(rollbackable.length).toBeGreaterThan(0);
+    const withAction = renderToStaticMarkup(
+      <Workspace
+        view={view}
+        onNavigate={() => undefined}
+        onRollback={() => undefined}
+      />,
+    );
+    expect(withAction).toContain('Roll back');
+    // Without a handler there is no button at all, rather than one that refuses.
+    expect(markup).not.toContain('Roll back');
+  });
+});
+
 describe('the App workspace', () => {
+  test('every activity entry leads to the attempt it came from', () => {
+    // `attempt_events` constrains every row to exactly one attempt, so every
+    // entry has somewhere to go. An entry that led nowhere would be the one
+    // thing on this screen a reader could not act on.
+    const view = WORKSPACE_SCENARIOS.service;
+    const markup = renderToStaticMarkup(
+      <Workspace view={view} onNavigate={() => undefined} />,
+    );
+
+    for (const entry of view.activity) {
+      expect(entry.deployId ?? entry.buildId).not.toBeNull();
+      expect(markup).toContain(entry.title);
+    }
+    // Rendered as buttons rather than static rows — one per entry, plus the
+    // release link in the hero and the rows of the releases list.
+    const buttons = markup.split('<button').length - 1;
+    expect(buttons).toBeGreaterThanOrEqual(view.activity.length);
+  });
+
   test('a website states that it has no runtime', () => {
     // §17: the `static` adapter gets an honest empty state, and §18 puts it one
     // level down rather than disabling a tab. `kind: 'none'` carries the reason


### PR DESCRIPTION
## Summary

Pressing Deploy now lands you on the attempt it started, every release is listed and addressable, and the screen stops inventing a builder for releases that were only extracted.

## Changes

**A release has a source, and only sometimes a build.** §4's supplied-artifact arm records an uploaded bundle as-is with no builder — `uploadArchive` writes that row with a null runner precisely because "saying so is more useful than naming a runner that never ran" — and the UI was contradicting it, defaulting to `'hosted runner'`. `DeployView` now carries `source` always (repo with commit+subpath, or archive with digest+location+`extracted`) and `build: BuildView | null`. A release with no build states that no builder was involved instead of rendering an empty log drawer.

**Both outcomes of Deploy have a screen.** With nothing deployable, `deployApp` starts a Build and writes no intent (§6 will not let one be invented for a Build that could not pass `checkDeployable`) — and the operator was left on the workspace wondering whether anything happened. New `getBuildDetail` projects a Build as an attempt with a null release id, `/builds/:id` renders it on the same screen, subscribes to the same attempt stream, and hands over to `/deploys/:id` the moment an intent names that Build.

**Releases are listed, atomic, and reachable.** New `listDeploys` plus a `releasesOf` projection shared with the workspace, so the two cannot disagree. Each row carries its Build, commit, and pinned config version (§10). `current` is read from §6's desired row rather than from the phase, because a LIVE Deploy a newer intent superseded is still LIVE. Rollback reaches the UI for the first time, offered only where §6's comparison would accept it.

**The timeline is a way in.** Every activity entry carries the attempt it came from and opens it, and `when` is a real elapsed time rather than the hardcoded `'recently'` every row used to show.

The attempt screen also gained a "what this release is" block (source, artifact, config version, scope, created), a link to the previous release, and actions that branch on state rather than rendering buttons that refuse.

## Test Plan

- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (biome)
- [x] `bun test` — 1040 pass, 0 fail
- [x] `bun run build` — client bundles
- [ ] Press Deploy on an App with no succeeded Build → lands on `/builds/:id`; when the Build finishes, "Deploy this build" places it and the page follows to `/deploys/:id`
- [ ] Press Deploy on an App with a succeeded artifact → lands on `/deploys/:id` directly
- [ ] Upload finished output (`contents: 'artifact'`) → the attempt screen shows the archive source and "no builder was involved", with no build log drawer
- [ ] Workspace lists every release, marks exactly one `current`, and clicking any row opens it
- [ ] Roll back to an older release → new intent, no rebuild; a refusal surfaces the command's own sentence

## Notes

Two things deliberately left alone:

- **No auto-deploy when a build succeeds.** Pressing Deploy on a stale App starts a Build; you still press "Deploy this build" afterwards. Chaining it client-side would lose the deploy if the tab closes, and the correct home — the deploy loop writing an intent when the desired row asked for one — is a reconciler semantics change beyond this PR.
- **"Add Component" / "Attach Datastore"** on the workspace stay inert; no commands back them yet. Activity's "View all" was dropped, since its entries are now individually navigable and it had no destination.
