### PR TITLE
fix(atlantis): update image repository to ghcr.io

### DIFF
--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -14,7 +14,7 @@ spec:
         name: atlantis
   values:
     image:
-      repository: jonpulsifer/atlantis
+      repository: ghcr.io/jonpulsifer/atlantis
       tag: latest@sha256:65fa654907df7a3fecefe0d28309269ca22c53671e2b9a3e78f41568ba5d4d66
     orgAllowlist: github.com/jonpulsifer/*
     environment:


### PR DESCRIPTION
## Summary
Fixes `ImagePullBackOff` on the `atlantis-0` pod by updating the image repository in the `atlantis` HelmRelease from `jonpulsifer/atlantis` to `ghcr.io/jonpulsifer/atlantis`.

## Root Cause
The continuous delivery workflow (`.github/workflows/containers.yml`) builds the Atlantis container image from `images/atlantis/Dockerfile` and pushes it to GHCR (`ghcr.io/jonpulsifer/atlantis`), then updates the digest pin in `clusters/offsite/apps/atlantis/helm-release.yaml`. Because the HelmRelease repository field was set to `jonpulsifer/atlantis` (Docker Hub), Kubernetes attempted to pull the newly built GHCR digest from Docker Hub, causing `ImagePullBackOff`.

## Verification
- Validated application rendering with `mise run k8s:render-apps`.