### PR TITLE
feat(spindrift): link the build run where its log is still being written

### DIFF
--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -141,10 +141,21 @@ export const BUILD_STATES = ['RUNNING', 'SUCCEEDED', 'FAILED'] as const;
 
 export type BuildState = (typeof BUILD_STATES)[number];
 
-/** What a route yields while it runs, at whatever fidelity it declared. */
+/**
+ * What a route yields while it runs, at whatever fidelity it declared.
+ *
+ * `runner` is not a log line, and the distinction is the point. A route that
+ * can be watched somewhere else says so **once, as a fact about the run**, and
+ * core records it on the Build rather than appending it to the stream. Putting
+ * it in the log would file it under exactly the thing it compensates for: at
+ * `LIVE_STATUS` the log is empty until the run ends, so a link inside it would
+ * arrive too late to be worth following. Emitted as soon as the backend knows
+ * where the run is, which is what makes it useful while the run is going.
+ */
 export type BuildEvent =
   | { type: 'log'; at: Date; line: string; step?: string }
-  | { type: 'step'; at: Date; step: string; state: BuildState };
+  | { type: 'step'; at: Date; step: string; state: BuildState }
+  | { type: 'runner'; at: Date; url: string };
 
 /**
  * SLSA Build Level. A Target has a minimum defaulting to L2 and an ordered list

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -59,6 +59,15 @@ export interface ActionsRun {
   readonly name: string | null;
   readonly status: string;
   readonly conclusion: string | null;
+  /**
+   * The run's page on the host, where its log can be watched live.
+   *
+   * Nullable because it is the host's to report and this route does not
+   * compose one from the run id — a URL this module invented would be a guess
+   * about a layout GitHub owns, and a wrong guess is a dead link offered as
+   * the remedy for an empty log.
+   */
+  readonly htmlUrl: string | null;
 }
 
 /** One job of a run, and the steps inside it. */
@@ -299,6 +308,18 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     }
 
     yield { type: 'log', at: now(), line: `run ${run.id} started` };
+
+    // Announced the moment the run is correlated, because this route is
+    // `LIVE_STATUS`: the checklist is the only live thing Spindrift can show,
+    // and this is where the live *text* is. Emitting it here rather than with
+    // the result is what makes it usable during the run instead of after it.
+    //
+    // Truthiness rather than a null check: a host that omits the field entirely
+    // is saying the same thing as one that reports it empty, and an event
+    // carrying `undefined` would reach the Build row as a link to nowhere.
+    if (run.htmlUrl) {
+      yield { type: 'runner', at: now(), url: run.htmlUrl };
+    }
 
     const budget = deadlineFrom(this.options);
     const seen = new Set<string>();

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -571,6 +571,18 @@ export const dispatchBuild = async (
     let next = await stream.next();
     while (!next.done) {
       const event = next.value;
+      // Where the run can be watched is a fact about the Build, not a line in
+      // its log — and it is written as soon as the route reports it so the
+      // screen can offer it *during* the run, which is the whole of its value
+      // on a `LIVE_STATUS` route whose text arrives only at the end.
+      if (event.type === 'runner') {
+        await context.db
+          .update(builds)
+          .set({ runUrl: event.url })
+          .where(eq(builds.id, build.id));
+        next = await stream.next();
+        continue;
+      }
       // §6's one attempt-scoped log: build events and deploy events land on the
       // same stream for the same attempt, so the UI subscribes once.
       await recordBuildEvent(

--- a/apps/spindrift/src/commands/builds/view.ts
+++ b/apps/spindrift/src/commands/builds/view.ts
@@ -136,6 +136,7 @@ export async function buildViewOf(
       // states the first rather than rendering the second as an empty pane.
       log: log.length > 0 ? log : null,
       runner: build.runner ?? 'hosted runner',
+      runUrl: build.runUrl ?? null,
     },
     events,
   };

--- a/apps/spindrift/src/db/migrations/0015_build_run_url.sql
+++ b/apps/spindrift/src/db/migrations/0015_build_run_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "builds" ADD COLUMN "run_url" text;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1785374380758,
       "tag": "0014_build_dispatch_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1785374380759,
+      "tag": "0015_build_run_url",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -464,6 +464,20 @@ export const builds = pgTable(
     /** §4: "The build backend and its fidelity are visible on the Build." */
     runner: text('runner'),
     logFidelity: logFidelity('log_fidelity'),
+    /**
+     * Where this build can be watched on the backend that is running it.
+     *
+     * A column rather than a log line because of *when* it is needed. §4's
+     * `LIVE_STATUS` means the text does not arrive until the run is over, so
+     * the log is empty during the exact window a developer wants to go look —
+     * a link inside it would land with the thing it was meant to substitute
+     * for. Written when the run is discovered, it is readable for the whole of
+     * the run.
+     *
+     * Null for a route that has no such place, which is the honest answer for
+     * an in-cluster build and not a missing value to paper over.
+     */
+    runUrl: text('run_url'),
     /** §4: durable identity for the dispatch attempt running or that ran this build. */
     dispatchId: text('dispatch_id'),
     /** Timestamp when the current runner claimed the dispatch lease. */

--- a/apps/spindrift/src/integrations/github/app.ts
+++ b/apps/spindrift/src/integrations/github/app.ts
@@ -486,6 +486,7 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
       readonly name: string | null;
       readonly status: string;
       readonly conclusion: string | null;
+      readonly htmlUrl: string | null;
     }[]
   > {
     const runs = await this.http(ref).json<{
@@ -494,6 +495,7 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
         name?: string | null;
         status: string;
         conclusion: string | null;
+        html_url?: string | null;
       }[];
     }>({
       method: 'GET',
@@ -509,6 +511,10 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
       name: run.name ?? null,
       status: run.status,
       conclusion: run.conclusion,
+      // The page a human opens, served by the host rather than composed here:
+      // the API knows its own web address and a hand-built one would be this
+      // module guessing at a URL layout it does not own.
+      htmlUrl: run.html_url ?? null,
     }));
   }
 

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -103,6 +103,15 @@ export interface BuildView {
   readonly log: readonly LogLine[] | null;
   /** The runner that produced it, for the header. */
   readonly runner: string;
+  /**
+   * Where this build can be watched on the runner's own surface, or `null`
+   * where the runner has none.
+   *
+   * It exists for the fidelity gap: a `LIVE_STATUS` route withholds its text
+   * until the run ends, and the honest thing to do with a reader who wants it
+   * now is send them where it is rather than ask them to wait at an empty pane.
+   */
+  readonly runUrl: string | null;
 }
 
 /**

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -34,7 +34,13 @@
  * takes one immutable view; its controller replaces that view as authenticated
  * attempt events arrive.
  */
-import { ArrowLeft, RefreshCw, Rocket, Undo2 } from 'lucide-react';
+import {
+  ArrowLeft,
+  ExternalLink,
+  RefreshCw,
+  Rocket,
+  Undo2,
+} from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Checklist } from '../../components/checklist.tsx';
 import { DiagnosisPanel } from '../../components/diagnosis.tsx';
@@ -499,17 +505,38 @@ function BuildDrawer({ view }: { view: DeployView }) {
  * leaves the checklist above as the only live view. §18 makes saying so
  * mandatory — the alternative renders an empty pane and a spinner, which reads
  * as a broken stream rather than a known limit of that runner.
+ *
+ * **Stating the limit is necessary but not sufficient**: the text exists, it is
+ * live, and it is simply somewhere Spindrift cannot read from yet. So where the
+ * runner reports a page of its own, the sentence carries a way to go read it
+ * instead of only apologising for not having it.
  */
 function BuildOutput({ view }: { view: DeployView }) {
   const build = view.build;
   if (build === null) return null;
-  if (build.log !== null) return <LogPane lines={build.log} />;
+  if (build.log !== null) {
+    return (
+      <div className="flex flex-col gap-2">
+        <LogPane lines={build.log} />
+        <RunLink url={build.runUrl} />
+      </div>
+    );
+  }
 
   if (build.fidelity === 'LIVE_STATUS') {
     return (
       <Notice label="LIVE_STATUS">
         {build.runner} reports step status live, but its log text only arrives
-        when the build finishes. The checklist above is the live view.
+        when the build finishes. The checklist above is the live view
+        {build.runUrl === null ? (
+          '.'
+        ) : (
+          <>
+            {' — '}
+            <RunLink url={build.runUrl} inline />
+            {' for the text as it is written.'}
+          </>
+        )}
       </Notice>
     );
   }
@@ -517,7 +544,40 @@ function BuildOutput({ view }: { view: DeployView }) {
   return (
     <Notice label={build.fidelity}>
       {build.runner} releases its log when the build finishes.
+      {build.runUrl === null ? null : (
+        <>
+          {' '}
+          <RunLink url={build.runUrl} inline />
+          {' to watch it there.'}
+        </>
+      )}
     </Notice>
+  );
+}
+
+/**
+ * A way out to the runner's own view of this run.
+ *
+ * Rendered only from a URL the backend reported. Nothing here composes one out
+ * of a run id and a host name: a guessed link that 404s is worse than no link,
+ * because it is offered at the moment the reader has already been told the log
+ * is elsewhere.
+ */
+function RunLink({ url, inline }: { url: string | null; inline?: boolean }) {
+  if (url === null) return null;
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={cn(
+        'inline-flex items-center gap-1 font-medium text-accent-foreground hover:underline',
+        inline ? '' : 'self-start text-[12.5px]',
+      )}
+    >
+      Open the run
+      <ExternalLink aria-hidden className="size-3" />
+    </a>
   );
 }
 

--- a/apps/spindrift/test/adapters/build-run-link.test.ts
+++ b/apps/spindrift/test/adapters/build-run-link.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Where a `LIVE_STATUS` run can be watched while it is still running.
+ *
+ * §4 makes the fidelity visible rather than worked around, and this route's
+ * fidelity means the log text does not exist on this side until the run is
+ * over. The run's own page is where that text is being written, so the route
+ * reports it — as a fact about the run, not as a line in a log that is by
+ * definition still empty when a reader wants it.
+ */
+import { describe, expect, test } from 'bun:test';
+import type {
+  BuildEvent,
+  BuildSource,
+  BuildSpec,
+} from '../../src/adapters/build/contract.ts';
+import {
+  type ActionsHost,
+  GitHubActionsBuildRoute,
+} from '../../src/adapters/build/github-actions.ts';
+
+const WORKFLOW =
+  'acme/platform/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6';
+
+const RUN_URL = 'https://vcs.example/acme/widgets/actions/runs/9';
+
+const source: BuildSource = {
+  bundleDigest: 'sha256:bundle',
+  origin: {
+    type: 'repo',
+    repository: 'acme/widgets',
+    commit: 'c0ffee',
+    subpath: '.',
+    location: 'https://storage.example/depot/bundle.tgz?signed',
+  },
+};
+
+const spec: BuildSpec = {
+  artifactType: 'image',
+  kind: 'service',
+  platform: { os: 'linux', arch: 'amd64' },
+  destination: 'registry.example.test/app',
+  buildArgs: {},
+};
+
+/** A host whose run goes green, reporting whatever web address a test names. */
+function hostReporting(htmlUrl: string | null | undefined): ActionsHost {
+  return {
+    installationFor: async () => ({ installationId: '1' }),
+    repository: async () => ({ defaultBranch: 'main' }),
+    dispatchWorkflow: async () => {},
+    workflowRuns: async () => [
+      {
+        id: 9,
+        name: 'spindrift fixed-correlation',
+        status: 'completed',
+        conclusion: 'success',
+        htmlUrl,
+      },
+    ],
+    workflowRun: async () => ({
+      id: 9,
+      status: 'completed',
+      conclusion: 'success',
+    }),
+    runJobs: async () => [
+      {
+        id: 91,
+        name: 'build',
+        status: 'completed',
+        conclusion: 'success',
+        steps: [
+          {
+            name: 'Build and push',
+            status: 'completed',
+            conclusion: 'success',
+          },
+        ],
+      },
+    ],
+    jobLog: async () => 'built\n',
+  } as unknown as ActionsHost;
+}
+
+async function eventsFrom(host: ActionsHost): Promise<BuildEvent[]> {
+  let elapsed = 0;
+  const route = new GitHubActionsBuildRoute({
+    name: 'hosted',
+    host,
+    buildWorkflow: WORKFLOW,
+    zeroConfigFrontend: 'ghcr.io/railwayapp/railpack:railpack-frontend',
+    correlation: () => 'fixed-correlation',
+    intervalMs: 1_000,
+    timeoutMs: 600_000,
+    now: () => new Date(elapsed),
+    sleep: async (ms: number) => {
+      elapsed += ms;
+    },
+  });
+
+  const stream = route.build(source, spec);
+  const events: BuildEvent[] = [];
+  let step = await stream.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return events;
+}
+
+describe('the run link a hosted build reports', () => {
+  test('the run’s own page is announced as soon as the run is correlated', async () => {
+    const events = await eventsFrom(hostReporting(RUN_URL));
+
+    const runner = events.filter((event) => event.type === 'runner');
+    expect(runner).toHaveLength(1);
+    expect(runner[0]).toMatchObject({ url: RUN_URL });
+  });
+
+  test('it arrives before any log text, which is the whole of its value', async () => {
+    // `LIVE_STATUS` releases text only at the end. A link that landed with the
+    // text would arrive with the thing it exists to substitute for.
+    const events = await eventsFrom(hostReporting(RUN_URL));
+
+    const link = events.findIndex((event) => event.type === 'runner');
+    const firstJobLogLine = events.findIndex(
+      (event) => event.type === 'log' && event.line === 'built',
+    );
+
+    expect(link).toBeGreaterThanOrEqual(0);
+    expect(firstJobLogLine).toBeGreaterThan(link);
+  });
+
+  test('a host that reports no web address produces no event', async () => {
+    // Rather than an event carrying nothing, which reaches the screen as a link
+    // to nowhere offered at the moment the reader was told to go elsewhere.
+    for (const absent of [null, undefined]) {
+      const events = await eventsFrom(hostReporting(absent));
+      expect(events.filter((event) => event.type === 'runner')).toHaveLength(0);
+    }
+  });
+});

--- a/apps/spindrift/test/commands/build-run-url.test.ts
+++ b/apps/spindrift/test/commands/build-run-url.test.ts
@@ -1,0 +1,207 @@
+/**
+ * What dispatch does with a route's report of where its run can be watched.
+ *
+ * The event is not a log line and must not become one. §4's `LIVE_STATUS`
+ * means the attempt log is empty for the whole of the run, so a link recorded
+ * there would be invisible exactly when it is wanted; recorded on the Build it
+ * is readable from the first poll onwards.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { dispatchBuild } from '../../src/commands/builds/dispatch.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+  componentTargetDesired,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const baseManifest = await fixtureManifest();
+
+const BUNDLE_DIGEST = 'sha256:0e6a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c';
+const BUNDLE_LOCATION = 'https://depot.example/bundles/site.tgz';
+const RUN_URL = 'https://vcs.example/acme/widgets/actions/runs/9';
+
+describe('the run link dispatch records', () => {
+  let ctx: CommandContext;
+
+  async function seedBuild() {
+    const [app] = await ctx.db
+      .insert(apps)
+      .values({
+        name: 'almanac',
+        sourceKind: 'repo',
+        sourceRepoUrl: 'acme/widgets',
+        sourceRepoSubpath: 'apps/web',
+      })
+      .returning();
+    const [component] = await ctx.db
+      .insert(components)
+      .values({ appId: app!.id, name: 'web', kind: 'service' })
+      .returning();
+    const [target] = await ctx.db.select().from(targets).limit(1);
+    await ctx.db
+      .insert(componentTargetDesired)
+      .values({ componentId: component!.id, targetId: target!.id });
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: component!.id,
+        commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: BUNDLE_DIGEST,
+        bundleLocation: BUNDLE_LOCATION,
+      })
+      .returning();
+    return build!;
+  }
+
+  /** The same context, routing `hosted` to a scripted stream a test names. */
+  function routing(route: FakeBuildAdapter): CommandContext {
+    return {
+      ...ctx,
+      adapters: {
+        deploy: () => null,
+        build: (name: string) => (name === 'hosted' ? route : null),
+        store: () => new FakeSecretStore(),
+        supplyChain: () => new SupplyChainHarness(),
+        repository: () => null,
+      } as AdapterRegistry,
+    } as CommandContext;
+  }
+
+  beforeEach(async () => {
+    const { client, db } = database();
+    await db.delete(attemptEvents);
+    await db.delete(componentTargetDesired);
+    await db.delete(builds);
+    await db.delete(components);
+    await db.delete(apps);
+    await db.delete(targets);
+    await db.delete(users);
+
+    const [operator] = await db
+      .insert(users)
+      .values({ displayName: 'Operator' })
+      .returning();
+    await db
+      .insert(targets)
+      .values(targetValues({ name: 'target-a', rank: 1 }));
+
+    ctx = {
+      client,
+      db,
+      adapters: {} as AdapterRegistry,
+      clock: { now: () => new Date('2026-08-01T12:00:00.000Z') },
+      manifest: baseManifest,
+      operatorId: operator!.id,
+      principal: {
+        type: 'user',
+        id: operator!.id,
+        displayName: 'Operator',
+      },
+    } as CommandContext;
+  });
+
+  test('a runner event lands on the Build, not in the attempt log', async () => {
+    const context = routing(
+      new FakeBuildAdapter({
+        name: 'hosted',
+        logFidelity: 'LIVE_STATUS',
+        script: [
+          {
+            events: [
+              { type: 'runner', at: new Date(0), url: RUN_URL },
+              { type: 'log', at: new Date(1), line: 'run 9 started' },
+            ],
+            result: { status: 'SUCCEEDED' },
+          },
+        ],
+      }),
+    );
+    const build = await seedBuild();
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+    expect(result.ok).toBe(true);
+
+    const [stored] = await ctx.db
+      .select({ runUrl: builds.runUrl })
+      .from(builds)
+      .where(eq(builds.id, build.id));
+    expect(stored?.runUrl).toBe(RUN_URL);
+
+    // The log is the operator-visible stream, and this is not a log line. If it
+    // leaked into one, the URL would also be the thing a reader has to scroll a
+    // finished transcript to find.
+    const events = await ctx.db
+      .select({ line: attemptEvents.line })
+      .from(attemptEvents)
+      .where(eq(attemptEvents.buildId, build.id));
+    expect(events.some((event) => event.line?.includes(RUN_URL))).toBe(false);
+  });
+
+  test('a route that reports no run link leaves the column null', async () => {
+    const context = routing(
+      new FakeBuildAdapter({
+        name: 'hosted',
+        script: [
+          {
+            events: [{ type: 'log', at: new Date(0), line: 'building' }],
+            result: { status: 'SUCCEEDED' },
+          },
+        ],
+      }),
+    );
+    const build = await seedBuild();
+
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+
+    const [stored] = await ctx.db
+      .select({ runUrl: builds.runUrl })
+      .from(builds)
+      .where(eq(builds.id, build.id));
+    expect(stored?.runUrl).toBeNull();
+  });
+
+  test('a failed build keeps its run link, which is when it is most wanted', async () => {
+    const context = routing(
+      new FakeBuildAdapter({
+        name: 'hosted',
+        logFidelity: 'LIVE_STATUS',
+        script: [
+          {
+            events: [{ type: 'runner', at: new Date(0), url: RUN_URL }],
+            result: { status: 'FAILED', reason: 'BUILD_FAILED' },
+          },
+        ],
+      }),
+    );
+    const build = await seedBuild();
+
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+
+    const [stored] = await ctx.db
+      .select({ status: builds.status, runUrl: builds.runUrl })
+      .from(builds)
+      .where(eq(builds.id, build.id));
+    expect(stored?.status).toBe('FAILED');
+    expect(stored?.runUrl).toBe(RUN_URL);
+  });
+});

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -109,6 +109,7 @@ const BUILT = {
   steps: BUILD_STEPS_OK,
   log: LOG_OK,
   runner: 'hosted runner',
+  runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
 } as const;
 
 /**
@@ -153,6 +154,7 @@ export const DEPLOY_SCENARIOS = {
       ],
       log: null,
       runner: 'hosted runner',
+      runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
     },
   },
 
@@ -199,6 +201,7 @@ export const DEPLOY_SCENARIOS = {
         { text: '#9 ERROR: exited with code 1', tone: 'error' },
       ],
       runner: 'hosted runner',
+      runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
     },
   },
 

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -278,6 +278,32 @@ describe('a runner that withholds log text', () => {
   test('shows the checklist it just called live', () => {
     expect(markup).toContain('export image');
   });
+
+  test('sends the reader where the text is actually being written', () => {
+    // Stating the limit is necessary but not sufficient. The log exists and is
+    // live; it is only somewhere Spindrift cannot read from until the run ends,
+    // so the sentence that admits that carries the way to go read it.
+    const url = DEPLOY_SCENARIOS.building.build.runUrl;
+    expect(url).not.toBeNull();
+    expect(markup).toContain(`href="${url}"`);
+    expect(markup).toContain('Open the run');
+  });
+
+  test('opens it away from the app, and without handing over the referrer', () => {
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noreferrer noopener"');
+  });
+
+  test('offers no link where the runner reported none', () => {
+    // A guessed URL that 404s is worse than no link, because it is offered at
+    // the moment the reader has already been told the log is elsewhere.
+    const withoutLink = deploy({
+      ...DEPLOY_SCENARIOS.building,
+      build: { ...DEPLOY_SCENARIOS.building.build, runUrl: null },
+    } as DeployView);
+    expect(withoutLink).toContain('the live view');
+    expect(withoutLink).not.toContain('Open the run');
+  });
 });
 
 describe('a release that was extracted rather than built', () => {


### PR DESCRIPTION
## Why

A hosted build is `LIVE_STATUS` (§4): step transitions are readable while the run goes, the text is not released until it ends. The deploy screen has always *stated* that — §18 makes the sentence mandatory, and without it the screen reads as a broken stream rather than a known limit of the runner.

But stating the limit was the whole of it. The log the reader wants **does** exist and **is** live; it is on the runner's own page, which Spindrift cannot read from until the run finishes. So the sentence that admits the limit now carries a way to go read it.

Confirmed against the live installation — build 12's attempt log shows step statuses arriving live (`Set up job` → `Read the build request` → `Fetch the staged bundle`) and every line of log text landing in one burst *after* the run concluded.

## What

- **`BuildEvent` gains a `runner` variant** — deliberately not a log line. At `LIVE_STATUS` the attempt log is empty for the whole of the run, so a link recorded there would arrive with the very thing it substitutes for.
- **`builds.run_url`** (migration `0015`) is where dispatch persists it. The deploy screen re-reads the full view on every attempt event, so the link appears within one event of the run being correlated — no page refresh.
- **The URL is the host's to report.** Nothing composes one from a run id: a guessed link that 404s is worse than no link, because it is offered at the moment the reader has already been told the log is elsewhere. A route reporting none renders none.
- The link also sits under a landed log, since red is exactly when you want the runner's own view.

## Checks

```
bun test        1049 pass, 0 fail (9 added)
bun run typecheck   clean
bun run lint        clean
mise run ts:check   4 successful, 4 total
```

Ticket: `.agent/plans/spindrift/issues/08-stream-live-status-and-logs.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShS4a1SSDvB7XL9dB3NkDx