### PR TITLE
fix(spindrift): grant the signing permission a signed URL actually needs

### DIFF
--- a/apps/spindrift/src/storage/signed-url.ts
+++ b/apps/spindrift/src/storage/signed-url.ts
@@ -17,12 +17,20 @@
  * **There is no private key here, and that is the whole point of §13.** V4
  * signing normally means a service-account key file; instead the string-to-sign
  * goes to IAM's `signBlob`, authorized by the *federated* token — the one from
- * before impersonation. That is deliberate: the workload-identity principal
- * already holds `roles/iam.serviceAccountTokenCreator` on the impersonated
- * service account, or `impersonationUrl` could not work at all, and that role
- * is precisely what `signBlob` checks. Signing as the impersonated token would
- * instead require the service account to hold that role on *itself*, which is a
+ * before impersonation. Signing as the impersonated token would instead require
+ * the service account to hold a token-creator role on *itself*, which is a
  * separate grant nothing else in this installation needs.
+ *
+ * **That costs a grant, and it is not the one impersonation needs.** `signBlob`
+ * checks `iam.serviceAccounts.signBlob`, which lives in
+ * `roles/iam.serviceAccountTokenCreator`. Impersonation checks
+ * `iam.serviceAccounts.getAccessToken`, which `roles/iam.workloadIdentityUser`
+ * also carries. So an installation whose federated principal holds only
+ * `workloadIdentityUser` reaches every other cloud API and is refused here
+ * alone — deploys work, and builds from a `gs://` bundle never dispatch. The
+ * principal needs `roles/iam.serviceAccountTokenCreator` on the impersonated
+ * service account; `terraform/gcp/projects/bluenose/iam.tf` is where this
+ * installation grants it.
  */
 import {
   FederationError,

--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -18,6 +18,20 @@ resource "google_service_account_iam_member" "spindrift_controller_workload_iden
   member             = local.spindrift_principal
 }
 
+# Signing a V4 storage URL is a separate permission from impersonating.
+# Spindrift mints one for every `gs://` source bundle it hands a hosted build
+# route, and signs it through IAM's `signBlob` as the federated principal —
+# before impersonation — so the string-to-sign never needs a private key.
+# `roles/iam.workloadIdentityUser` carries `iam.serviceAccounts.getAccessToken`
+# but not `iam.serviceAccounts.signBlob`, so impersonation succeeds while every
+# signature is refused. `roles/iam.serviceAccountTokenCreator` is the role that
+# carries both.
+resource "google_service_account_iam_member" "spindrift_controller_token_creator" {
+  service_account_id = google_service_account.spindrift_controller.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = local.spindrift_principal
+}
+
 resource "google_service_account_iam_member" "spindrift_act_as_runtime" {
   service_account_id = google_service_account.spindrift_runtime.name
   role               = "roles/iam.serviceAccountUser"


### PR DESCRIPTION
## What

Grants `roles/iam.serviceAccountTokenCreator` to Spindrift's federated principal on `spindrift-controller@bluenose`, alongside the existing `roles/iam.workloadIdentityUser`.

## Why

Every Build staged at a `gs://` location is refused before it is claimed, silently, forever.

`dispatchBuild` turns the durable bundle address into something a hosted runner can `curl` by minting a V4 signed URL (`fetchableBundleLocation` → `signedObjectUrl`). There is deliberately no private key: the string-to-sign goes to IAM's `signBlob`, authorized by the federated token from *before* impersonation.

`signBlob` checks `iam.serviceAccounts.signBlob`. `roles/iam.workloadIdentityUser` carries `getAccessToken`/`getOpenIdToken`/`implicitDelegation` — **not** `signBlob`. So impersonation succeeds, every other cloud API is reachable, and signing is the single refused call. It is also the only one on the dispatch path before the claim transaction.

## Evidence

Build 13 is the first build created after ticket 24's re-staging fix, and the first to carry a `gs://` location. It has not moved:

```text
 id | status  |         leased_at          | dispatch_id |                   loc
----+---------+----------------------------+-------------+------------------------------------------
 13 | PENDING |                            |             | gs://bluenose-spindrift-source/3f5cbbc2…
 12 | FAILED  | 2026-08-01 08:57:01.443+00 | 3ea8afaa-…  | upload://3f5cbbc2…
```

Null `dispatch_id`, null `leased_at`, and zero attempt events — so it is refused *before* the claim transaction, and the reconciler only logs `build loop processed event` on a loop.

Builds 12 and 13 share a Component, route, placement and Target policy, and both carry a bundle digest and location:

```text
 id | status  | no_digest | no_loc | artifact_type |             component_id
----+---------+-----------+--------+---------------+--------------------------------------
 13 | PENDING | f         | f      | image         | 9bc98ab3-de6b-441e-bff2-981e3136b98e
 12 | FAILED  | f         | f      | image         | 9bc98ab3-de6b-441e-bff2-981e3136b98e
```

12 dispatched and reached the runner; 13 does not. The only code path that treats them differently is `fetchableBundleLocation`, and for a `gs://` location its only failure modes are "no federation configured" or a throw out of `signedObjectUrl`.

Federation *is* configured, with an impersonation URL, so `signingServiceAccount` resolves and the call reaches `signBlob`:

```text
"federation":{"audience":"//iam.googleapis.com/projects/629296473058/…/providers/offsite",
 "tokenUrl":"https://sts.googleapis.com/v1/token",
 "tokenPath":"/var/run/secrets/spindrift/gcp-token",
 "impersonationUrl":"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken"}
```

And the grant `signBlob` checks is not in the project. `grep -rn 'serviceAccountTokenCreator' terraform/` matches only `lolcorp` and `homelab-ng`; `bluenose` binds the principal to `roles/iam.workloadIdentityUser` alone.

`spindrift-controller` already holds `roles/storage.admin` on the source bucket, so a URL signed as it resolves once it can be signed.

**Stated limit:** the literal 403 body is not captured here. `gcloud` in this environment needs an interactive reauth, and exercising the signing path inside the running pod is not inspection I should route around. The chain above is from live state, the stored manifest, and the declared IAM.

## Also

The header comment on `signed-url.ts` asserted the principal "already holds `roles/iam.serviceAccountTokenCreator` … or `impersonationUrl` could not work at all". Impersonation works fine without it — that false premise is why the gap survived review. Corrected, and pointed at the root that grants it.

## Checks

`bun test` 1049 pass / 0 fail, `bun run typecheck`, `bun run lint`, `mise run ts:check` all clean. `tofu validate` and `tofu fmt -check` clean on `terraform/gcp/projects/bluenose`.

Needs an `atlantis apply` — no local apply was run.

## Ticket

Unblocks `08 — Stream live status and logs`, which cannot close until a build reaches `SUCCEEDED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJ5PL1Xb72NzEg9uW54jPC