### PR TITLE
fix(spindrift): unwrap the staged bundle before applying the subpath

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -72,6 +72,7 @@ jobs:
       # stages one immutable bundle for either builder — cloning again here
       # would build a second tree the source receipt does not describe.
       - name: Fetch the staged bundle
+        id: bundle
         env:
           LOCATION: ${{ steps.request.outputs.location }}
         run: |
@@ -79,6 +80,20 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/bundle"
           curl --fail --silent --show-error --location "$LOCATION" \
             | tar -xz -C "${RUNNER_TEMP}/bundle"
+          # §5's unwrap, which is what makes the subpath below resolve. Core
+          # records a scope relative to the source root, and a bundle's root is
+          # not always that: a repository tarball wraps the whole tree in one
+          # `{owner}-{repo}-{sha}` directory. The rule is the shape rather than
+          # the source — exactly one entry and it a directory — because an
+          # uploaded archive may arrive either way, and it is the same rule
+          # `archiveScope` applies to the copy core detects against.
+          root="${RUNNER_TEMP}/bundle"
+          shopt -s dotglob nullglob
+          entries=("$root"/*)
+          if [ "${#entries[@]}" -eq 1 ] && [ -d "${entries[0]}" ]; then
+            root="${entries[0]}"
+          fi
+          printf 'root=%s\n' "$root" >> "$GITHUB_OUTPUT"
 
       # §5's ladder, and the only decision made here: a Dockerfile settles how
       # to build and never what the thing is. Where there is none, a one-line
@@ -88,11 +103,12 @@ jobs:
       - name: Choose the frontend
         id: frontend
         env:
+          ROOT: ${{ steps.bundle.outputs.root }}
           SUBPATH: ${{ steps.request.outputs.subpath }}
           FRONTEND: ${{ steps.request.outputs.frontend }}
         run: |
           set -euo pipefail
-          scope="${RUNNER_TEMP}/bundle/${SUBPATH}"
+          scope="${ROOT}/${SUBPATH}"
           if [ -f "${scope}/Dockerfile" ]; then
             printf 'context=%s\nfile=%s\n' "$scope" "${scope}/Dockerfile"
           else

--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -101,7 +101,21 @@ export function buildKitProgram(input: BuildKitProgramInput): string {
   return `set -eu
 workspace=$(mktemp -d)
 wget -qO- ${quote(input.bundleUrl)} | tar -xz -C "$workspace"
-cd "$workspace"/${quote(input.subpath)}
+
+# §5's unwrap. The subpath is relative to the source root, and a bundle's root
+# is not always that — a repository tarball wraps the tree in one directory.
+# The rule is the shape rather than the source: exactly one entry and it a
+# directory, which is what \`archiveScope\` applies to the copy core detects
+# against. \`ls -A\` counts dotfiles, because a lone directory beside a stray
+# \`.gitignore\` is two entries and unwrapping it would lose the file.
+root="$workspace"
+if [ "$(ls -A "$workspace" | wc -l)" -eq 1 ]; then
+  only="$workspace/$(ls -A "$workspace")"
+  if [ -d "$only" ]; then
+    root="$only"
+  fi
+fi
+cd "$root"/${quote(input.subpath)}
 
 # §5's ladder, and the only decision this script makes: a Dockerfile settles
 # how to build. What the thing *is* was decided before the build was dispatched.

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -771,6 +771,18 @@ describe('the BuildKit program', () => {
     expect(program).toContain(`--opt source='${FRONTEND}'`);
   });
 
+  test('applies §5’s unwrap before it applies the subpath', () => {
+    // The subpath is relative to the source root, and a repository tarball
+    // wraps the tree in one directory — so entering the subpath straight off
+    // the extraction root is what makes every repo build miss its Dockerfile.
+    expect(program).toContain('root="$workspace"');
+    expect(program).toContain(`cd "$root"/'apps/web'`);
+    expect(program).not.toContain(`cd "$workspace"/'apps/web'`);
+    // The same rule `archiveScope` applies: exactly one entry, and a directory.
+    expect(program).toContain('ls -A "$workspace" | wc -l');
+    expect(program).toContain('if [ -d "$only" ]');
+  });
+
   test('passes build arguments as build arguments', () => {
     expect(program).toContain(
       `--opt 'build-arg:PUBLIC_URL=https://app.example.test'`,


### PR DESCRIPTION
## What

Both build routes now unwrap a lone top-level directory before applying the subpath — the rule core already declares and already implements in `archiveScope`.

## Why

With #1473 applied, build 13 became the first build ever to fetch its staged bundle successfully. It failed four seconds later:

```text
 status | SUCCEEDED | build / build / Fetch the staged bundle
 status | FAILED    | build / build / Choose the frontend
```

```text
/home/runner/work/_temp/a1db2e59-….sh: line 6: /home/runner/work/_temp/bundle/apps/spindrift-demo/plain/Dockerfile.spindrift: No such file or directory
```

A repository tarball (`GET /repos/{repo}/tarball/{sha}`, `app.ts:650`) wraps the whole tree in one `{owner}-{repo}-{sha}` directory. Core records a subpath relative to the *source* root — `apps/spindrift-demo/plain` — and the workflow joined it onto the *extraction* root, which is one level too high.

The invariant was never in doubt; it is stated in six places and implemented once:

- `schema.ts:522` — "after a lone top-level directory has been unwrapped"
- `contract.ts:62`, `source.ts:66`, `creation-draft.ts:70`, `upload-archive.ts:60`
- `buildkit.ts:36` — "The scope inside the bundle, after §5's unwrap"
- `detection/scope.ts` — `archiveScope`, the one place that actually did it

Neither build route did. `buildkit.ts` carried the sentence in a doc comment directly above a program that entered `"$workspace"/$subpath`.

## The rule

Exactly one entry, and it a directory — matching `archiveScope`'s `readdir` semantics, dotfiles included. It is keyed on the bundle's shape rather than the source kind on purpose: an uploaded archive arrives either way, and core applies this same rule to it, so keying on shape is what keeps the two sides agreeing.

Verified both implementations against three fixtures — a GitHub-style wrapped tarball, a flat one, and a lone directory beside a dotfile:

```text
bash (hosted)                          sh (buildkit)
wrapped: root=bundle/jonpulsifer-…     wrapped: root=/jonpulsifer-infra-be796d6
  -> Dockerfile FOUND
flat:    root=bundle/apps              flat:    root=/apps
dotfile: root=bundle                   dotfile: root=
```

Identical on all three, and the wrapped case — the live failure — resolves.

Note the `flat` row: a bundle whose root holds exactly one directory unwraps into it. That is inherent to the lone-directory rule and is why the rule has to be applied *consistently* rather than cleverly — core's `archiveScope` makes the same call, so a recorded subpath and a runner scope agree. It cannot bite a repo source, whose tarball always carries exactly one wrapper.

## Why the workflow edit takes effect

`.github/workflows/spindrift.yml` in this repo pins the reusable workflow with `uses: ./.github/workflows/spindrift-build.yml` — a local reference resolving to the same commit as the caller. So builds of apps in this repository run the reviewed file on merge; the manifest's SHA pin (`github.buildWorkflow`) governs *connected* repositories' callers, not this one.

## Checks

`bun test` 1050 pass / 0 fail (1049 before, 1 added), `bun run typecheck`, `bun run lint`, `mise run ts:check`, `mise run check`, and `actionlint` on the changed workflow all clean.

## Ticket

Next blocker on `08 — Stream live status and logs`, which cannot close until a build reaches `SUCCEEDED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BJ5PL1Xb72NzEg9uW54jPC