### PR TITLE
fix(spindrift): push the artifact to a repository, under tags §12 can count

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -63,6 +63,12 @@ jobs:
             printf 'destination=%s\n'  "$(read_key '.destination')"
             printf 'frontend=%s\n'     "$(read_key '.zeroConfigFrontend')"
             printf 'registry=%s\n'     "$(read_key '.destination | split("/")[0]')"
+            # §12 counts tags, so core sends every tag this push must carry and
+            # the runner composes none of its own. Full references, because that
+            # is what build-push-action's newline list takes.
+            printf 'tags<<SPINDRIFT_EOF\n'
+            read_key '.destination + ":" + .tags[]'
+            printf 'SPINDRIFT_EOF\n'
             printf 'buildArgs<<SPINDRIFT_EOF\n'
             read_key '.buildArgs | to_entries[] | "\(.key)=\(.value)"'
             printf 'SPINDRIFT_EOF\n'
@@ -137,7 +143,7 @@ jobs:
           file: ${{ steps.frontend.outputs.file }}
           build-args: ${{ steps.request.outputs.buildArgs }}
           push: true
-          tags: ${{ steps.request.outputs.destination }}
+          tags: ${{ steps.request.outputs.tags }}
           cache-from: |
             type=gha,scope=spindrift-build
             type=gha,scope=spindrift-push

--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -35,8 +35,13 @@ export interface BuildKitProgramInput {
   readonly bundleDigest: string;
   /** The scope inside the bundle, after §5's unwrap. */
   readonly subpath: string;
-  /** Where the artifact is pushed. Core chose it; the route never does (§4). */
+  /**
+   * The repository the artifact is pushed to, without a tag. Core chose it; the
+   * route never does (§4).
+   */
   readonly destination: string;
+  /** The tags to push it under (§12). Core chose these too. */
+  readonly tags: readonly string[];
   /** The zero-config frontend the installation pinned. */
   readonly zeroConfigFrontend: string;
   /** §4: ordinary rows, never fetched from a store. */
@@ -68,6 +73,7 @@ export function buildKitProgramFor(
     bundleDigest: source.bundleDigest,
     subpath: source.origin.subpath,
     destination: spec.destination,
+    tags: spec.tags,
     zeroConfigFrontend,
     buildArgs: spec.buildArgs,
   });
@@ -82,6 +88,20 @@ export function buildKitProgramFor(
  */
 function quote(value: string): string {
   return `'${value.replaceAll("'", `'\\''`)}'`;
+}
+
+/**
+ * The `name=` field of the image exporter, carrying every tag (§12).
+ *
+ * The exporter takes one comma-separated list of full references, and its
+ * options are themselves comma-separated — so the field is wrapped in the
+ * double quotes buildctl's CSV parser reads, which is a different layer from
+ * the single quotes {@link quote} puts around the whole option for `sh`. Both
+ * are needed and neither substitutes for the other.
+ */
+function imageNames(input: BuildKitProgramInput): string {
+  const refs = input.tags.map((tag) => `${input.destination}:${tag}`).join(',');
+  return `"name=${refs}"`;
 }
 
 /**
@@ -130,7 +150,7 @@ buildctl-daemonless.sh build "$@" \\
 ${args}
   --attest=type=provenance,mode=max \\
   --attest=type=sbom \\
-  --output ${quote(`type=image,name=${input.destination},push=true`)} \\
+  --output ${quote(`type=image,${imageNames(input)},push=true`)} \\
   --metadata-file "$workspace/metadata.json"
 
 digest=$(sed -n 's/.*"containerimage.digest"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' "$workspace/metadata.json")

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -101,10 +101,30 @@ export interface BuildSpec {
   /** What the artifact must run on (§3). */
   platform: Platform;
   /**
-   * Where the artifact is published. Core picks it from the Target's
-   * `reachableRegistries` (§3); an adapter never chooses its own destination.
+   * The **repository** the artifact is published to, without a tag. Core picks
+   * it from the Target's `reachableRegistries` (§3); an adapter never chooses
+   * its own destination.
+   *
+   * A repository and not the installation's registry namespace: the namespace
+   * is a prefix, and a registry answers `NAME_INVALID` to a single-segment
+   * path. `componentRepository` composes it.
    */
   destination: string;
+  /**
+   * The tags to push it under, most specific first (§12).
+   *
+   * Separate from {@link destination} rather than folded into it because the
+   * two are read by different things: the destination alone is what an
+   * immutable `repository@digest` reference is built from — which is what the
+   * build report carries and what a Deploy pins — while the tags exist for
+   * §12's retention to count and for a person to type. A destination that
+   * already carried a tag would put one in every digest reference derived from
+   * it.
+   *
+   * Never empty: a build that pushed under no tag would be collected by the
+   * first retention pass that ran.
+   */
+  tags: readonly string[];
   /**
    * Build arguments as ordinary rows, never fetched from a store: whatever a
    * website bakes becomes public anyway, so no builder ever holds a store

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -185,7 +185,10 @@ export interface BuildRequestSpec {
   readonly artifactType: BuildSpec['artifactType'];
   readonly kind: BuildSpec['kind'];
   readonly platform: BuildSpec['platform'];
+  /** The repository, without a tag. */
   readonly destination: string;
+  /** What to push it as (§12); the workflow tags with these and no others. */
+  readonly tags: readonly string[];
   readonly buildArgs: Readonly<Record<string, string>>;
   /** Pinned by the installation, never chosen by the runner. */
   readonly zeroConfigFrontend: string;
@@ -245,6 +248,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       kind: spec.kind,
       platform: spec.platform,
       destination: spec.destination,
+      tags: spec.tags,
       buildArgs: spec.buildArgs,
       zeroConfigFrontend: this.options.zeroConfigFrontend,
     };

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -38,6 +38,10 @@ import {
   repositories,
   targets,
 } from '../../db/schema.ts';
+import {
+  artifactTags,
+  componentRepository,
+} from '../../domain/artifact-name.ts';
 import { recordBuildEvent } from '../../domain/attempt-log.ts';
 import {
   buildRouteCandidates,
@@ -373,6 +377,55 @@ export const dispatchBuild = async (
     buildId: build.id,
   };
 
+  /**
+   * §16 names one registry per installation — "every artifact is pushed to and
+   * pulled from" it — and a Build is keyed on a *shape*, not on a Target (§2),
+   * so there is no Target here to read a reachable registry off. That is the
+   * right way round: whether a Target can reach the registry is a placement
+   * filter (§3's `reachableRegistries`), applied before the build, not a choice
+   * the build makes. An adapter never picks its own destination (§4).
+   *
+   * What §16 names is a **namespace**, so a repository is composed under it
+   * here. Refused rather than projected when a name cannot be a path segment:
+   * the registry would answer `NAME_INVALID` at the last step of the build, and
+   * projecting instead would push two Components to one repository. Recorded
+   * and closed out like an unfetchable location, because a name is a column on
+   * these rows and no later tick makes it legal — an operator renaming the App
+   * or the Component is what clears it.
+   *
+   * Ahead of the signed URL deliberately: a bearer capability minted for a
+   * Build that cannot be dispatched is one that exists for no reason.
+   */
+  const destination = componentRepository({
+    registry: context.manifest.supplyChain.registry,
+    app: app.name,
+    component: component.name,
+  });
+  if (destination === null) {
+    const sentence =
+      `App "${app.name}" / Component "${component.name}" cannot name a ` +
+      `repository under ${context.manifest.supplyChain.registry}: a registry ` +
+      `path segment is lowercase alphanumerics separated by "-", "_" or "."`;
+    await recordBuildEvent(context.db, attempt, {
+      type: 'log',
+      line: sentence,
+      resource: 'bundle',
+    });
+    await recordBuildEvent(context.db, attempt, {
+      // §6's table covers "invalid spec" here, which is what a name no registry
+      // will accept is — and it blames the developer, who is the one who can
+      // rename the thing.
+      type: 'status',
+      phase: 'FAILED',
+      reason: 'REJECTED',
+    });
+    await context.db
+      .update(builds)
+      .set({ status: 'FAILED' })
+      .where(eq(builds.id, build.id));
+    return failed('NOT_BUILDABLE', sentence);
+  }
+
   const fetchable = await fetchableBundleLocation(
     context,
     app,
@@ -437,15 +490,12 @@ export const dispatchBuild = async (
     artifactType: build.artifactType,
     kind: component.kind,
     platform: DEFAULT_PLATFORM,
+    destination,
     /**
-     * §16 names one registry per installation — "every artifact is pushed to and
-     * pulled from" it — and a Build is keyed on a *shape*, not on a Target (§2),
-     * so there is no Target here to read a reachable registry off. That is the
-     * right way round: whether a Target can reach the registry is a placement
-     * filter (§3's `reachableRegistries`), applied before the build, not a
-     * choice the build makes. An adapter never picks its own destination (§4).
+     * §12 counts tags, so a push that carried only the implicit `:latest` would
+     * leave retention nothing to act on and a rollback depth of one.
      */
-    destination: context.manifest.supplyChain.registry,
+    tags: artifactTags(build.bundleDigest),
     /**
      * §4: "a website's build-time config is passed as build arguments as
      * ordinary rows, not fetched from a store — whatever a website bakes

--- a/apps/spindrift/src/domain/artifact-name.ts
+++ b/apps/spindrift/src/domain/artifact-name.ts
@@ -1,0 +1,107 @@
+/**
+ * Where a Component's artifact is published, and under what tags.
+ *
+ * §16 names one registry per installation — "every artifact is pushed to and
+ * pulled from" it — and that value is a **namespace**. A namespace is not a
+ * place an image can be pushed: a registry host followed by one path segment is
+ * not a repository, and every registry rejects it as a name before
+ * authentication is relevant. Something has to append the rest, and this is
+ * that place.
+ *
+ * This is not a DNS name and `naming.ts` is not its home, for the same reason
+ * {@link import('./workload-name.ts')} is not there: §9's names are what a user
+ * types, chosen for how they read and constrained by certificates. A repository
+ * name is a path a registry either accepts or refuses, and the only thing it
+ * owes anyone is being the same one next time.
+ *
+ * **The shape is `{registry}/{app}/{component}`**, settled with the operator
+ * rather than derived. Nesting rather than `{app}-{component}` follows
+ * {@link import('./naming.ts').componentCanonical} and its stated reason: a
+ * hyphen-joined name is ambiguous the moment either half contains a hyphen,
+ * which both are allowed to. GHCR accepts multi-segment package paths, and a
+ * listing that nests is one an operator can read.
+ *
+ * **It is unique per (App name, Component name), which is not the same as per
+ * Component.** Where two Apps share a name their Components share a repository.
+ * That is live today and it is not this module's to fix: `apps.name` carries no
+ * unique constraint, which is the defect tracked as ticket 26. Encoding the
+ * App's id here would dodge it at the cost of a registry listing no one can
+ * read, and would leave the identity bug in place everywhere else.
+ */
+
+/**
+ * One segment of a repository path, per the OCI distribution spec.
+ *
+ * Lowercase alphanumerics, separated by one `.`, one `_`, two `_`, or any run
+ * of `-`. Deliberately not a normalizer: a name that cannot be a path component
+ * is refused at dispatch and named in the refusal, because the alternative is
+ * projecting two distinct names onto one repository and pushing a Component's
+ * image over another Component's.
+ */
+const PATH_COMPONENT = /^[a-z0-9]+(?:(?:[._]|__|-+)[a-z0-9]+)*$/;
+
+/** Whether a name can stand as one segment of a repository path. */
+export function isPathComponent(value: string): boolean {
+  return value.length > 0 && value.length <= 63 && PATH_COMPONENT.test(value);
+}
+
+/** What a repository name is assembled from. */
+export interface ArtifactRepositoryParts {
+  /** The installation's registry namespace (§16) — a host and a namespace. */
+  readonly registry: string;
+  readonly app: string;
+  readonly component: string;
+}
+
+/**
+ * The repository one Component's artifacts are pushed to.
+ *
+ * Returns `null` when either half cannot be a path component, so the caller
+ * refuses with the offending name rather than handing a registry something it
+ * will answer `NAME_INVALID` to — which is the failure this module exists to
+ * end, and which cost a build every step up to `Build and push` to discover.
+ */
+export function componentRepository(
+  parts: ArtifactRepositoryParts,
+): string | null {
+  if (!isPathComponent(parts.app)) return null;
+  if (!isPathComponent(parts.component)) return null;
+  return `${parts.registry}/${parts.app}/${parts.component}`;
+}
+
+/**
+ * The tag that names *what was built*, derived from the bundle digest.
+ *
+ * §12 settles retention as "retain artifacts by **tagging** and let the
+ * registry's own cleanup policy delete", with "N = 10 doubl[ing] as rollback
+ * depth". A push that carries only the implicit `:latest` gives that policy
+ * nothing to count — every build overwrites the one tag and the rollback depth
+ * is one.
+ *
+ * The bundle digest rather than the commit because it is the one identifier
+ * **both** routes have: an upload has no commit, and §16 already makes the
+ * bundle digest "a build parameter on every route" for exactly that reason. It
+ * is also content-addressed, so rebuilding identical source lands on the tag it
+ * landed on last time instead of burning a retention slot.
+ *
+ * `sha256:…` becomes `sha256-…` because a tag may not contain a colon.
+ */
+export function bundleTag(bundleDigest: string): string {
+  return bundleDigest.replace(':', '-');
+}
+
+/** The moving tag, kept so the newest artifact is always one a human can pull. */
+export const MOVING_TAG = 'latest';
+
+/**
+ * Every tag one build pushes, most specific first.
+ *
+ * `latest` moves and the digest tag does not, which is the whole point: the
+ * moving one is for a person typing a pull command, and the immutable one is
+ * what §12 counts and what a rollback names. Nothing in the deploy path reads
+ * either — an artifact is pinned by digest (§16) — so a tag can never be the
+ * reason a Deploy resolves to the wrong image.
+ */
+export function artifactTags(bundleDigest: string): readonly string[] {
+  return [bundleTag(bundleDigest), MOVING_TAG];
+}

--- a/apps/spindrift/test/adapters/build-blame.test.ts
+++ b/apps/spindrift/test/adapters/build-blame.test.ts
@@ -41,6 +41,7 @@ const spec: BuildSpec = {
   kind: 'service',
   platform: { os: 'linux', arch: 'amd64' },
   destination: 'registry.example.test/app',
+  tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };
 

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -30,6 +30,7 @@ const spec: BuildSpec = {
   kind: 'service',
   platform: { os: 'linux', arch: 'arm64' },
   destination: 'registry.example.test/apps',
+  tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };
 

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -66,6 +66,7 @@ const spec: BuildSpec = {
   kind: 'service',
   platform: { os: 'linux', arch: 'amd64' },
   destination: 'registry.example.test/app',
+  tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };
 
@@ -761,6 +762,7 @@ describe('the BuildKit program', () => {
     bundleDigest: 'sha256:bundle',
     subpath: 'apps/web',
     destination: 'registry.example.test/app',
+    tags: ['sha256-bundle', 'latest'],
     zeroConfigFrontend: FRONTEND,
     buildArgs: { PUBLIC_URL: 'https://app.example.test' },
   });
@@ -781,6 +783,23 @@ describe('the BuildKit program', () => {
     // The same rule `archiveScope` applies: exactly one entry, and a directory.
     expect(program).toContain('ls -A "$workspace" | wc -l');
     expect(program).toContain('if [ -d "$only" ]');
+  });
+
+  test('pushes every tag core chose, under the repository core chose', () => {
+    // The exporter takes one comma-separated list of references and its own
+    // options are comma-separated too, so the field carries buildctl's CSV
+    // quotes inside the shell's — two layers, neither substituting for the
+    // other. Written flat, `push=true` would parse as part of the image name.
+    expect(program).toContain(
+      `--output 'type=image,"name=registry.example.test/app:sha256-bundle,registry.example.test/app:latest",push=true'`,
+    );
+  });
+
+  test('builds its immutable reference from the repository, never a tag', () => {
+    // §16 pins an artifact by digest, and `repository:tag@sha256:…` is not what
+    // the report should carry — the tag would ride along into the provenance
+    // and SBOM references derived from it.
+    expect(program).toContain(`ref='registry.example.test/app'@"$digest"`);
   });
 
   test('passes build arguments as build arguments', () => {
@@ -805,6 +824,7 @@ describe('the BuildKit program', () => {
       bundleDigest: 'sha256:bundle',
       subpath: '.',
       destination: 'registry.example.test/app',
+      tags: ['sha256-bundle', 'latest'],
       zeroConfigFrontend: FRONTEND,
       buildArgs: { EVIL: "'; rm -rf /; echo '" },
     });

--- a/apps/spindrift/test/adapters/build-run-link.test.ts
+++ b/apps/spindrift/test/adapters/build-run-link.test.ts
@@ -39,6 +39,7 @@ const spec: BuildSpec = {
   kind: 'service',
   platform: { os: 'linux', arch: 'amd64' },
   destination: 'registry.example.test/app',
+  tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };
 

--- a/apps/spindrift/test/commands/build-destination.test.ts
+++ b/apps/spindrift/test/commands/build-destination.test.ts
@@ -1,0 +1,222 @@
+/**
+ * What dispatch tells a route to push, and where.
+ *
+ * This is the layer the defect lived at. `dispatch.ts` handed the installation's
+ * registry through unchanged — a namespace, which no registry accepts as a
+ * repository — and every adapter-level fixture supplied an already-correct
+ * value, so the routes were tested against the shape they expect and the caller
+ * that produced the wrong one was tested against nothing. These assert on the
+ * spec the route was actually handed.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { dispatchBuild } from '../../src/commands/builds/dispatch.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+  componentTargetDesired,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { artifactTags } from '../../src/domain/artifact-name.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const baseManifest = await fixtureManifest();
+
+/** The fixture installation's §16 registry — a namespace, as §16 says. */
+const REGISTRY = baseManifest.supplyChain.registry;
+const BUNDLE_DIGEST =
+  'sha256:3f5cbbc2a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c';
+const BUNDLE_LOCATION = 'https://depot.example/bundles/site.tgz';
+
+describe('the destination dispatch hands a route', () => {
+  let ctx: CommandContext;
+
+  async function seedBuild(names: { app: string; component: string }) {
+    const [app] = await ctx.db
+      .insert(apps)
+      .values({
+        name: names.app,
+        sourceKind: 'repo',
+        sourceRepoUrl: 'acme/widgets',
+        sourceRepoSubpath: 'apps/web',
+      })
+      .returning();
+    const [component] = await ctx.db
+      .insert(components)
+      .values({ appId: app!.id, name: names.component, kind: 'service' })
+      .returning();
+    const [target] = await ctx.db.select().from(targets).limit(1);
+    await ctx.db
+      .insert(componentTargetDesired)
+      .values({ componentId: component!.id, targetId: target!.id });
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: component!.id,
+        commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest: BUNDLE_DIGEST,
+        bundleLocation: BUNDLE_LOCATION,
+      })
+      .returning();
+    return build!;
+  }
+
+  function routing(route: FakeBuildAdapter): CommandContext {
+    return {
+      ...ctx,
+      adapters: {
+        deploy: () => null,
+        build: (name: string) => (name === 'hosted' ? route : null),
+        store: () => new FakeSecretStore(),
+        supplyChain: () => new SupplyChainHarness(),
+        repository: () => null,
+      } as AdapterRegistry,
+    } as CommandContext;
+  }
+
+  beforeEach(async () => {
+    const { client, db } = database();
+    await db.delete(attemptEvents);
+    await db.delete(componentTargetDesired);
+    await db.delete(builds);
+    await db.delete(components);
+    await db.delete(apps);
+    await db.delete(targets);
+    await db.delete(users);
+
+    const [operator] = await db
+      .insert(users)
+      .values({ displayName: 'Operator' })
+      .returning();
+    await db
+      .insert(targets)
+      .values(targetValues({ name: 'target-a', rank: 1 }));
+
+    ctx = {
+      client,
+      db,
+      adapters: {} as AdapterRegistry,
+      clock: { now: () => new Date('2026-08-01T12:00:00.000Z') },
+      manifest: baseManifest,
+      operatorId: operator!.id,
+      principal: {
+        type: 'user',
+        id: operator!.id,
+        displayName: 'Operator',
+      },
+    } as CommandContext;
+  });
+
+  test('names a repository under the registry, not the registry itself', async () => {
+    const route = new FakeBuildAdapter({ name: 'hosted' });
+    const build = await seedBuild({
+      app: 'infra',
+      component: 'spindrift-demo',
+    });
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      routing(route),
+    );
+    expect(result.ok).toBe(true);
+
+    // The bug, stated as an assertion: `ghcr.io/jonpulsifer` reached a runner
+    // verbatim and GHCR answered `NAME_INVALID` before authentication was
+    // relevant, so `Build and push` could not succeed whatever the App built.
+    expect(route.built[0]?.spec.destination).not.toBe(REGISTRY);
+    expect(route.built[0]?.spec.destination).toBe(
+      `${REGISTRY}/infra/spindrift-demo`,
+    );
+  });
+
+  test('is stable across dispatches of the same Component', async () => {
+    const route = new FakeBuildAdapter({ name: 'hosted' });
+    const context = routing(route);
+    const build = await seedBuild({ app: 'infra', component: 'web' });
+
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+    await ctx.db
+      .update(builds)
+      .set({ status: 'PENDING', leasedAt: null, dispatchId: null })
+      .where(eq(builds.id, build.id));
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+
+    expect(route.built).toHaveLength(2);
+    expect(route.built[0]?.spec.destination).toBe(
+      route.built[1]?.spec.destination,
+    );
+  });
+
+  test('separates two Components of one App', async () => {
+    const route = new FakeBuildAdapter({ name: 'hosted' });
+    const context = routing(route);
+
+    const web = await seedBuild({ app: 'shop', component: 'web' });
+    await dispatchBuild({ buildId: web.id, route: 'hosted' }, context);
+
+    // A second App name, because seeding reuses neither row.
+    const worker = await seedBuild({ app: 'shop2', component: 'worker' });
+    await dispatchBuild({ buildId: worker.id, route: 'hosted' }, context);
+
+    expect(route.built[0]?.spec.destination).toBe(`${REGISTRY}/shop/web`);
+    expect(route.built[1]?.spec.destination).toBe(`${REGISTRY}/shop2/worker`);
+  });
+
+  test('carries the tags §12 counts, not only an implicit latest', async () => {
+    const route = new FakeBuildAdapter({ name: 'hosted' });
+    const build = await seedBuild({ app: 'infra', component: 'web' });
+
+    await dispatchBuild({ buildId: build.id, route: 'hosted' }, routing(route));
+
+    // Retention is "retain by tagging ... N = 10 doubles as rollback depth".
+    // Pushed under `latest` alone, every build overwrites the one tag.
+    expect(route.built[0]?.spec.tags).toEqual(artifactTags(BUNDLE_DIGEST));
+    expect(route.built[0]?.spec.tags).toContain(
+      `sha256-${BUNDLE_DIGEST.slice('sha256:'.length)}`,
+    );
+  });
+
+  test('refuses a name no registry accepts, and says so on the attempt log', async () => {
+    const route = new FakeBuildAdapter({ name: 'hosted' });
+    const build = await seedBuild({ app: 'My App', component: 'web' });
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      routing(route),
+    );
+
+    expect(result.ok).toBe(false);
+    // Nothing was dispatched: a `NAME_INVALID` discovered at the last step of
+    // the build costs a whole run to learn.
+    expect(route.built).toHaveLength(0);
+
+    // A name is a column on these rows and no later tick makes it legal, so the
+    // Build is closed out rather than left to be refused again every second —
+    // which is the silent-`PENDING` shape ticket 25 was filed for.
+    const [stored] = await ctx.db
+      .select({ status: builds.status })
+      .from(builds)
+      .where(eq(builds.id, build.id));
+    expect(stored?.status).toBe('FAILED');
+
+    const events = await ctx.db
+      .select({ line: attemptEvents.line })
+      .from(attemptEvents)
+      .where(eq(attemptEvents.buildId, build.id));
+    expect(events.some((event) => event.line?.includes('My App'))).toBe(true);
+  });
+});

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -247,6 +247,7 @@ export function buildAdapterSuite(
       kind: 'service',
       platform: { os: 'linux', arch: 'amd64' },
       destination: 'registry.example.test/app',
+      tags: ['sha256-bundle', 'latest'],
       buildArgs: {},
     } as const;
 

--- a/apps/spindrift/test/domain/artifact-name.test.ts
+++ b/apps/spindrift/test/domain/artifact-name.test.ts
@@ -1,0 +1,137 @@
+/**
+ * What a Component's artifact is called at the registry.
+ *
+ * The rule these cover is the one a registry enforces and nothing in this
+ * codebase did: a repository is a *path*, and the installation's registry (§16)
+ * is only its prefix. Every fixture in the adapter tests already supplied a
+ * repository-shaped value, so the adapters were tested against the shape they
+ * expect while the one place that produced the wrong shape had no test at all.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  artifactTags,
+  bundleTag,
+  componentRepository,
+  isPathComponent,
+  MOVING_TAG,
+} from '../../src/domain/artifact-name.ts';
+
+const REGISTRY = 'ghcr.io/jonpulsifer';
+const DIGEST =
+  'sha256:3f5cbbc2a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c';
+
+describe('a Component’s repository', () => {
+  test('nests the App and the Component under the registry', () => {
+    expect(
+      componentRepository({
+        registry: REGISTRY,
+        app: 'infra',
+        component: 'spindrift-demo',
+      }),
+    ).toBe('ghcr.io/jonpulsifer/infra/spindrift-demo');
+  });
+
+  test('is a repository and never the bare namespace', () => {
+    const repository = componentRepository({
+      registry: REGISTRY,
+      app: 'infra',
+      component: 'web',
+    });
+    // The defect verbatim: GHCR answers `NAME_INVALID` to a single-segment
+    // path, which is what the registry alone is.
+    expect(repository).not.toBe(REGISTRY);
+    expect(repository?.slice(REGISTRY.length)).toBe('/infra/web');
+  });
+
+  test('is stable — the same Component composes the same name twice', () => {
+    const parts = { registry: REGISTRY, app: 'infra', component: 'web' };
+    expect(componentRepository(parts)).toBe(componentRepository(parts));
+  });
+
+  test('nests rather than joining, so a hyphen in either half is unambiguous', () => {
+    // `naming.ts` states the reason for canonical names and it holds here:
+    // flattened, these two would both be `my-app-web-api`.
+    const first = componentRepository({
+      registry: REGISTRY,
+      app: 'my-app',
+      component: 'web-api',
+    });
+    const second = componentRepository({
+      registry: REGISTRY,
+      app: 'my-app-web',
+      component: 'api',
+    });
+    expect(first).not.toBe(second);
+  });
+
+  test('refuses a name no registry would accept rather than projecting it', () => {
+    // Projecting would push two Components to one repository, which is the
+    // quiet failure: the second build overwrites the first's tag.
+    expect(
+      componentRepository({
+        registry: REGISTRY,
+        app: 'My App',
+        component: 'web',
+      }),
+    ).toBeNull();
+    expect(
+      componentRepository({
+        registry: REGISTRY,
+        app: 'infra',
+        component: 'Web',
+      }),
+    ).toBeNull();
+    expect(
+      componentRepository({ registry: REGISTRY, app: '', component: 'web' }),
+    ).toBeNull();
+  });
+});
+
+describe('what a path segment may be', () => {
+  test('accepts the separators the distribution spec allows', () => {
+    expect(isPathComponent('web')).toBe(true);
+    expect(isPathComponent('spindrift-demo')).toBe(true);
+    expect(isPathComponent('web.api')).toBe(true);
+    expect(isPathComponent('web_api')).toBe(true);
+    expect(isPathComponent('web__api')).toBe(true);
+    expect(isPathComponent('app2')).toBe(true);
+  });
+
+  test('rejects what a registry rejects', () => {
+    expect(isPathComponent('Web')).toBe(false);
+    expect(isPathComponent('my app')).toBe(false);
+    expect(isPathComponent('-web')).toBe(false);
+    expect(isPathComponent('web-')).toBe(false);
+    expect(isPathComponent('web/api')).toBe(false);
+    expect(isPathComponent('')).toBe(false);
+    expect(isPathComponent('a'.repeat(64))).toBe(false);
+  });
+});
+
+describe('the tags one build pushes', () => {
+  test('names what was built, from the digest both routes carry', () => {
+    // A colon is not legal in a tag, and an upload has no commit to use
+    // instead — which is why §16 makes the bundle digest the parameter every
+    // route gets.
+    expect(bundleTag(DIGEST)).toBe(`sha256-${DIGEST.slice('sha256:'.length)}`);
+    expect(bundleTag(DIGEST)).not.toContain(':');
+  });
+
+  test('carries an immutable tag as well as the moving one', () => {
+    const tags = artifactTags(DIGEST);
+    expect(tags).toEqual([bundleTag(DIGEST), MOVING_TAG]);
+    // §12 retains "by tagging" with N = 10 doubling as rollback depth. Only
+    // `latest` and there is nothing to count and nothing to roll back to.
+    expect(tags.filter((tag) => tag !== MOVING_TAG)).toHaveLength(1);
+  });
+
+  test('is content-addressed, so an identical rebuild reuses its tag', () => {
+    expect(artifactTags(DIGEST)).toEqual(artifactTags(DIGEST));
+  });
+
+  test('every tag is legal', () => {
+    for (const tag of artifactTags(DIGEST)) {
+      expect(tag).toMatch(/^[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}$/);
+    }
+  });
+});


### PR DESCRIPTION
Closes the code half of **27 — Push the artifact to a repository that exists**.

`dispatch.ts` handed `supplyChain.registry` through as the build's destination.
That value is a namespace — §16 says so, and the manifest's own example puts a
sibling next to it that is a namespace *plus* a name. A registry rejects a
single-segment path as a repository name before authentication is relevant, so
`Build and push` could not succeed on this installation whatever the App's
Dockerfile did. It is the reason no build has reached `SUCCEEDED`, and the
reason ticket 08's last three criteria have never been provable.

| | before | after |
| --- | --- | --- |
| `destination` | `ghcr.io/jonpulsifer` | `ghcr.io/jonpulsifer/infra/spindrift-demo` |
| tags | implicit `:latest` | `:sha256-3f5cbbc2…` and `:latest` |

## The naming decision

Settled with the operator rather than guessed — ticket 27 records it as a
product decision and previous sessions correctly declined to pick one.
`{registry}/{app}/{component}`, nested rather than `{app}-{component}`, for the
reason `naming.ts` already states about canonical names: a hyphen-joined name is
ambiguous the moment either half contains a hyphen, which both are allowed to.

It is unique per (App name, Component name) and **not** per Component — where
two Apps share a name their Components share a repository. That is live today
and it is ticket 26's defect. Encoding the App's id here would dodge it at the
cost of a registry listing no one can read, and would leave the identity bug in
place everywhere else.

The tag is the bundle digest rather than the commit because it is the
identifier **both** routes have: an upload has no commit, which is why §16
already makes the bundle digest a parameter on every route. It is
content-addressed, so an identical rebuild reuses its tag instead of burning one
of §12's `N = 10`. `ghcr.io/jonpulsifer/spindrift` already carries 72 tags —
full commit SHAs plus `latest` — so "immutable per-build tag plus a moving one"
is the convention this org already uses.

## Three judgment calls

- **A name that cannot be a path segment is refused, not normalized.**
  Projecting `My App` → `my-app` would silently push two Components to one
  repository. Instead the Build is closed out `FAILED` / `REJECTED` with the
  sentence on the attempt log — the same shape as the existing unfetchable
  location arm — because a name is a column on these rows and no later tick
  makes it legal. The check runs **ahead of** the signed URL, so a Build that
  cannot dispatch never mints a bearer capability.
- **`tags` is a separate `BuildSpec` field, not folded into `destination`.** The
  destination alone is what the `repository@digest` reference in the build
  report is built from; a tag folded in would ride along into every provenance
  and SBOM reference derived from it.
- **BuildKit's exporter needs two quoting layers.** The image exporter takes one
  comma-separated list of references and its own options are comma-separated
  too, so the `name=` field carries buildctl's CSV quotes inside the shell's.

## Why no test caught the original defect

Every adapter-level fixture supplied an already-repository-shaped destination —
`registry.example.test/app` and friends — so the routes were tested against the
shape they expect while the one place that produced the wrong shape,
`dispatch.ts`, had no test asserting the value at all. The new
`test/commands/build-destination.test.ts` asserts on the spec the route is
actually handed.

## Checks

1068 spindrift tests pass (1050 before, 18 added), `bun run typecheck`,
`bun run lint`, `mise run ts:check`, and `actionlint` all clean.

## What this does not do

Criterion 4 — "a build reaches `SUCCEEDED` against the live registry" — is
**not** met by this PR and is left unchecked. It needs this merged and then an
operator pressing Deploy in a browser with a passkey session: every path that
creates a Build is a session-authenticated product command, so no agent session
can produce one. Ticket 27 stays `ready-for-agent` for that verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015imhxsNqh7kWuhhnWxhkKm
