### PR TITLE
feat(arc): enable host Docker access for ARC runners on Kubernetes nodes

### DIFF
--- a/clusters/base/apps/arc/infra.yaml
+++ b/clusters/base/apps/arc/infra.yaml
@@ -31,10 +31,17 @@ spec:
     minRunners: 1
     template:
       spec:
+        securityContext:
+          supplementalGroups: [123]
         containers:
           - name: runner
             image: jonpulsifer/actions-runner:latest@sha256:1d998da13bb6d6dcce7f1869920d6a7049696d6e6ff049c4472939c185660298
             command: ["/home/runner/run.sh"]
-            env:
-              - name: ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT
-                value: "false"
+            volumeMounts:
+              - name: dsock
+                mountPath: /var/run/docker.sock
+        volumes:
+          - name: dsock
+            hostPath:
+              path: /var/run/docker.sock
+

--- a/images/actions-runner/Dockerfile
+++ b/images/actions-runner/Dockerfile
@@ -3,6 +3,7 @@ USER root
 RUN apt-get update && apt-get -qqy upgrade &&\
     apt-get install -qqy --no-install-recommends \
       curl \
+      docker.io \
       git \
       jq \
       unzip \

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -10,8 +10,6 @@
     ../system/tailscale-disable.nix
   ];
 
-  virtualisation.docker.enable = true;
-
   homelab.disko.device = "/dev/sda";
   # 200G root (default is 100G) — leaves headroom for the harmonia
   # binary cache + remote-builder role on top of docker/runner/yarr.

--- a/nix/profiles/k8s-node.nix
+++ b/nix/profiles/k8s-node.nix
@@ -40,6 +40,9 @@ in
     nfs-utils
   ];
 
+  virtualisation.docker.enable = true;
+  users.groups.docker.gid = lib.mkForce 123;
+
   services.k8s = {
     enable = true;
     inherit network;


### PR DESCRIPTION
## Summary
Enable Docker daemon across Kubernetes host nodes (via NixOS profile) with a fixed docker group GID (123), mounting host Docker socket into ARC runner pods using `supplementalGroups: [123]` without requiring `privileged: true`.

## Changes
- `nix/profiles/k8s-node.nix`: Enable Docker (`virtualisation.docker.enable = true;`) and set fixed `users.groups.docker.gid = lib.mkForce 123;` across all Kubernetes host nodes (`oldschool`, `retrofit`, etc.).
- `nix/hosts/oldschool.nix`: Remove redundant host-level Docker setting.
- `clusters/base/apps/arc/infra.yaml`: Mount host `/var/run/docker.sock` and configure `securityContext.supplementalGroups: [123]` in ARC runner scale set template (no container `privileged: true` needed).
- `images/actions-runner/Dockerfile`: Add `docker.io` package to install `docker` CLI in runner container image.

## Test Plan
- [x] Verified system closure build for `oldschool` (`HOST=oldschool mise run nix:build`).
- [x] Verified system closure build for `retrofit` (`HOST=retrofit mise run nix:build`).
- [x] Verified Kubernetes app overlays render cleanly (`mise run k8s:render-apps`).
- [x] Verified Logseq wiki & docs contract (`mise run docs:check`).
- [x] Formatted codebase (`mise run fmt`).
