### PR TITLE
fix(spindrift): build a spec written before tags existed

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -66,8 +66,18 @@ jobs:
             # §12 counts tags, so core sends every tag this push must carry and
             # the runner composes none of its own. Full references, because that
             # is what build-push-action's newline list takes.
+            #
+            # `// ["latest"]` because this file and the controller ship on
+            # different clocks: the caller pins with `uses: ./…`, a local
+            # reference resolving to the default branch's own commit, so a merge
+            # here reaches the next dispatch immediately while the controller
+            # image waits on a Flux rollout. A spec written before `tags`
+            # existed must therefore still build — and `:latest` is exactly what
+            # the bare destination meant to the reader of this file before it
+            # did. Absent the default, every dispatch in that window dies here,
+            # at the step before anything is recorded.
             printf 'tags<<SPINDRIFT_EOF\n'
-            read_key '.destination + ":" + .tags[]'
+            read_key '.destination + ":" + (.tags // ["latest"])[]'
             printf 'SPINDRIFT_EOF\n'
             printf 'buildArgs<<SPINDRIFT_EOF\n'
             read_key '.buildArgs | to_entries[] | "\(.key)=\(.value)"'


### PR DESCRIPTION
Fixes the regression #1479 introduced. The first real dispatch after it merged died at `Read the build request`:

```text
jq: error (at <stdin>:0): Cannot iterate over null (null)
Error: Process completed with exit code 5.
Error: Unable to process file command 'output' successfully.
Error: Invalid value. Matching delimiter not found 'SPINDRIFT_EOF'
```

The spec it received carries no `tags` key at all:

```json
"destination":"ghcr.io/jonpulsifer","buildArgs":{},"zeroConfigFrontend":"…"
```

## Why

The two halves of #1479 ship on different clocks, and I did not account for it.

| half | ships when |
| --- | --- |
| this workflow | on merge to `main`, immediately |
| the controller that composes the spec | on a Flux rollout of a new image |

The caller pins with `uses: ./.github/workflows/spindrift-build.yml` — a local reference resolving to the default branch's own commit — so a merge here reaches the very next dispatch, while the controller is still the pre-#1479 image sending the old spec shape. Ticket 08's notes already recorded that asymmetry; #1479 nonetheless made the workflow hard-require a field the controller might not send.

It is the worst place to fail: before the registry login, before the build, at the step that writes `$GITHUB_OUTPUT` — so the run records nothing an operator can read, and it repeats on every dispatch until the rollout lands.

## The fix

Default to `["latest"]`, which is exactly what the bare destination meant to this file before `tags` existed. An old spec now behaves as it did before #1479: if it fails it fails at `Build and push`, with the registry's own sentence, rather than on a jq iteration error that eats the output file.

Replaying the failing run's spec through the fixed step:

```text
destination=ghcr.io/jonpulsifer
registry=ghcr.io
tags<<SPINDRIFT_EOF
ghcr.io/jonpulsifer:latest
SPINDRIFT_EOF
buildArgs<<SPINDRIFT_EOF
SPINDRIFT_EOF
EXIT=0
```

and a current spec is unchanged:

```text
ghcr.io/jonpulsifer/infra/demo:sha256-abc
ghcr.io/jonpulsifer/infra/demo:latest
```

`actionlint` clean. The reverse skew — old workflow, new controller — was already safe: it ignores `tags` and uses the destination, which is now a tagless repository and so pushes `:latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015imhxsNqh7kWuhhnWxhkKm