### PR TITLE
fix(spindrift): pin a zero-config frontend that resolves

### DIFF
--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -126,7 +126,17 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: InstallationManifest = {
   },
   build: {
     routes: [{ name: 'hosted', adapter: 'github-actions' }],
-    zeroConfigFrontend: 'ghcr.io/railwayapp/railpack:railpack-frontend',
+    /**
+     * The one value in this manifest that is not a placeholder, because it
+     * names a third party's image rather than anything about an installation:
+     * §5's ladder pulls it whenever a scope has no Dockerfile, so a
+     * stand-in here is a build that cannot fall through.
+     *
+     * Railpack publishes the frontend as its own repository with version tags —
+     * `railwayapp/railpack` is not a repository that serves, and there is no
+     * `latest` here to track, so the pin names a version.
+     */
+    zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.0.33',
   },
   secretStore: {
     adapter: 'onepassword',


### PR DESCRIPTION
Next blocker after #1484, found by the first build that ever got far enough to hit it. Tracked as ticket 29.

## What happened

Run 30713528509 is the first build to pass `Read the build request` with a signed URL, an unwrapped bundle, and a chosen frontend. It died in `Build and push`:

```text
ERROR: failed to build: failed to solve: failed to resolve source metadata for
ghcr.io/railwayapp/railpack:railpack-frontend:
ghcr.io/railwayapp/railpack:railpack-frontend: not found
```

The reference names repository `railwayapp/railpack`, tag `railpack-frontend`. That repository does not serve:

```text
$ curl -H "Authorization: Bearer $tok" https://ghcr.io/v2/railwayapp/railpack/tags/list
{"errors":[{"code":"DENIED","message":"invalid token"}]}   HTTP 403
```

Railpack publishes the frontend as its **own repository**, with ordinary version tags:

```text
$ curl -H "Authorization: Bearer $tok" https://ghcr.io/v2/railwayapp/railpack-frontend/tags/list
{"count":100,"last":["v0.0.31","v0.0.32-arm64","v0.0.32-amd64","v0.0.32","v0.0.33-arm64"]}
HTTP 200
```

`v0.0.33` is a complete multi-arch index, so it covers this installation's `linux/amd64` builds:

```text
v0.0.32   ["linux/amd64","linux/arm64"]
v0.0.33   ["linux/amd64","linux/arm64"]
```

There is no `latest` tag on that repository, so the pin has to name a version.

## Why this field is not a placeholder

Every other value in `DEFAULT_PLACEHOLDER_MANIFEST` is a stand-in — `example.com`, `ghcr.io/spindrift`, project `1234567890`. This one cannot be: it names a third party's image rather than anything about an installation, and §5's ladder pulls it whenever a scope has no Dockerfile. A stand-in here is a build that cannot fall through. The comment now says so.

## Why nothing caught it

`zeroConfigFrontend` is `nonEmptyString` in the schema and is never resolved by anything until a builder pulls it, so no parse, validation, or test can fail on it. And no build had ever reached the ladder's fallthrough arm — every earlier one died first on an unfetchable `upload://` location, then on signing, then on the subpath unwrap. Only the fallthrough arm is affected; a scope with a Dockerfile never reads this value.

## What this does not do

It does not change the live installation. That value lives in the `installation` row, and §20 makes the manifest an operator's declaration — changing it is not an agent's to do. **The live build stays blocked until the operator updates `build.zeroConfigFrontend` there.** Ticket 29 carries both halves.

1068 tests pass, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015imhxsNqh7kWuhhnWxhkKm