### PR TITLE
fix(nix): stop the fleet-evaluates check from building the fleet

### DIFF
--- a/nix/lib/checks.nix
+++ b/nix/lib/checks.nix
@@ -24,9 +24,19 @@ in
   # Every configuration in the registry still evaluates. Naming it as a check
   # makes it something you can run on its own, not just a side effect of
   # `nix flake check` walking nixosConfigurations.
+  #
+  # `unsafeDiscardOutputDependency` is what keeps this a *check* and not a
+  # fleet build. A bare `drvPath` carries a string context that means "build
+  # this derivation and its entire closure", so naming every host's toplevel
+  # here would make the check depend on ~15k derivations across both
+  # architectures — an x86 runner then fails on the first aarch64-only build.
+  # Discarding that context keeps the dependency on the `.drv` file, which
+  # still forces each host to instantiate: exactly the evaluation this asserts.
   fleet-hosts-evaluate = pkgs.runCommand "check-fleet-hosts-evaluate" {
     drvPaths = lib.concatStringsSep "\n" (
-      lib.mapAttrsToList (_: c: c.system.build.toplevel.drvPath) configs
+      lib.mapAttrsToList (
+        _: c: builtins.unsafeDiscardOutputDependency c.system.build.toplevel.drvPath
+      ) configs
     );
   } "touch $out";
 


### PR DESCRIPTION
## Summary

The `check` job in `nix-ci.yaml` has been failing on `main` since `fcf067d4` introduced `nix/lib/checks.nix`. It only surfaces on PRs that touch nix paths, so most runs show it as `skipped` — [#1480](https://github.com/jonpulsifer/infra/pull/1480) is where it bit.

`fleet-hosts-evaluate` names every host's `system.build.toplevel.drvPath` in an env var. A bare `drvPath` carries a `DrvDeep` string context — "build this derivation **and its entire closure**" — so the check depended on the full build closure of all 20 hosts across both architectures.

`nix flake check` therefore built the whole fleet on an x86 runner, spent 22 minutes doing it, and died on the first aarch64-only derivation:

```
error: build of 'icu4c-build-root-76.1.drv^*' failed: platform mismatch
       Required system: 'aarch64-linux'
       Current system: 'x86_64-linux'
```

The file's own comment says these checks "run inside `nix flake check` in seconds and need no builder and no hardware". The code disagreed with the comment.

## Fix

`builtins.unsafeDiscardOutputDependency` drops the output dependency while keeping the dependency on the `.drv` file itself — which still forces every host to instantiate. That is precisely the assertion the check exists to make: a host that fails to evaluate still fails the check.

Measured on the same tree:

| | `inputDrvs` | `nix flake check` |
| --- | --- | --- |
| before | 14,950 | builds the fleet, 22m, platform mismatch |
| after | 2 | `running 1 flake checks…`, passes |

All 20 hosts remain in `inputSrcs` as `.drv` paths.

Real builds stay where they were already declared, in the cachix-backed `nixos`, `spore`, and `images` jobs.

## Test plan

- [x] `nix derivation show` on the check: `inputDrvs` 14950 → 2, 20 host `.drv` files present in `inputSrcs`
- [x] `nix flake check` passes; builds exactly one derivation (`check-fleet-hosts-evaluate`), 1m41s warm
- [x] `nix flake check --no-build` (eval only) 56s
- [x] `mise run nix:fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)