### PR TITLE
fix(spindrift): pin a current frontend, and give the manifest a way to be declared

### DIFF
--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -132,11 +132,14 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: InstallationManifest = {
      * §5's ladder pulls it whenever a scope has no Dockerfile, so a
      * stand-in here is a build that cannot fall through.
      *
-     * Railpack publishes the frontend as its own repository with version tags —
-     * `railwayapp/railpack` is not a repository that serves, and there is no
-     * `latest` here to track, so the pin names a version.
+     * Railpack publishes the frontend as its own repository,
+     * `railwayapp/railpack-frontend` — `railwayapp/railpack` is one GHCR
+     * refuses to serve at all. The frontend repository does carry a `latest`,
+     * and the pin names a version anyway: rebuilding one bundle digest should
+     * not silently change what built it, and this is the only input to a
+     * zero-config build that no digest covers.
      */
-    zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.0.33',
+    zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
   },
   secretStore: {
     adapter: 'onepassword',

--- a/packages/charts/spindrift/templates/deployment.yaml
+++ b/packages/charts/spindrift/templates/deployment.yaml
@@ -46,6 +46,14 @@ spec:
       {{- include "spindrift.selectorLabels" (dict "Release" $top.Release "Values" $top.Values "Chart" $top.Chart "component" $process.name) | nindent 6 }}
   template:
     metadata:
+      {{- if $top.Values.manifest }}
+      annotations:
+        # Both processes read the manifest once, at start. Without this the
+        # ConfigMap would change and the running processes would keep the
+        # declaration they booted with — a declared change that does nothing is
+        # the failure this document exists to end.
+        checksum/manifest: {{ toYaml $top.Values.manifest | sha256sum }}
+      {{- end }}
       labels:
         {{- include "spindrift.labels" $top | nindent 8 }}
         app.kubernetes.io/component: {{ $process.name }}
@@ -124,6 +132,13 @@ spec:
               value: {{ printf "%s/gcp-credentials.json" $top.Values.serviceAccount.token.mountPath | quote }}
             {{- end }}
             {{- end }}
+            {{- if $top.Values.manifest }}
+            # Named explicitly rather than left to the default path, so a
+            # declaration that fails to mount is fatal instead of falling back
+            # to the durable row and serving the value it was meant to replace.
+            - name: SPINDRIFT_MANIFEST_PATH
+              value: /etc/spindrift/manifest.yaml
+            {{- end }}
             {{- if $top.Values.gatewayAuth.enabled }}
             # Rendered only beside the NetworkPolicy in gateway-auth.yaml.
             - name: SPINDRIFT_TRUSTED_GATEWAY_BOUNDARY
@@ -159,6 +174,11 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
+            {{- if $top.Values.manifest }}
+            - name: manifest
+              mountPath: /etc/spindrift
+              readOnly: true
+            {{- end }}
             {{- if $process.federates }}
             - name: federated-identity
               mountPath: {{ $top.Values.serviceAccount.token.mountPath }}
@@ -179,6 +199,11 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
+        {{- if $top.Values.manifest }}
+        - name: manifest
+          configMap:
+            name: {{ include "spindrift.fullname" $top }}-manifest
+        {{- end }}
         {{- if $process.federates }}
         - name: federated-identity
           projected:

--- a/packages/charts/spindrift/templates/manifest.yaml
+++ b/packages/charts/spindrift/templates/manifest.yaml
@@ -1,0 +1,28 @@
+{{/*
+§20's installation manifest, declared by the release.
+
+Without this the durable row is the only copy, and it can only ever be seeded:
+`loadStoredManifest` writes a declaration when one is present and otherwise
+reads the row back, and no command writes that row. A value corrected in code
+therefore cannot reach an installation that already has one, and a value nothing
+seeds correctly stays wrong forever. Declaring the document here puts it back
+under ordinary review — a manifest change is a pull request.
+
+Empty declares nothing, which stays a valid installation: the process falls back
+to the durable row exactly as it does today.
+*/}}
+{{- if .Values.manifest }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "spindrift.fullname" . }}-manifest
+  namespace: {{ include "spindrift.namespace" . }}
+  labels:
+    {{- include "spindrift.labels" . | nindent 4 }}
+data:
+  # The filename the process looks for. It is mounted at the directory so the
+  # key lands at the path `DEFAULT_MANIFEST_PATH` names.
+  manifest.yaml: |-
+    {{- toYaml .Values.manifest | nindent 4 }}
+{{- end }}

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -224,6 +224,76 @@ describe('ui-driven installation configuration', () => {
       ).toBe(false);
     }
   });
+
+  test('renders no manifest ConfigMap when the release declares none', async () => {
+    const objects = await render({ reconciler: { enabled: true } });
+    expect(
+      objects.some((object) => object.metadata.name === 'spindrift-manifest'),
+    ).toBe(false);
+    for (const deployment of objects.filter(
+      (object) => object.kind === 'Deployment',
+    )) {
+      const pod = deployment.spec.template.spec;
+      expect(
+        pod.volumes.some(
+          (volume: { name: string }) => volume.name === 'manifest',
+        ),
+      ).toBe(false);
+    }
+  });
+
+  test('mounts a declared manifest at the path both processes read', async () => {
+    const manifest = { installation: 'declared', build: { routes: [] } };
+    const objects = await render({ manifest, reconciler: { enabled: true } });
+
+    const configMap = one(objects, 'ConfigMap', 'spindrift-manifest');
+    expect(Bun.YAML.parse(configMap.data?.['manifest.yaml'] ?? '')).toEqual(
+      manifest,
+    );
+
+    const deployments = objects.filter(
+      (object) => object.kind === 'Deployment',
+    );
+    expect(deployments).toHaveLength(2);
+    for (const deployment of deployments) {
+      const pod = deployment.spec.template.spec;
+      // The declaration is named, not left to the default path, so a mount that
+      // never lands is fatal rather than a silent fall back to the stored row.
+      expect(pod.containers[0].env).toContainEqual({
+        name: 'SPINDRIFT_MANIFEST_PATH',
+        value: '/etc/spindrift/manifest.yaml',
+      });
+      expect(pod.containers[0].volumeMounts).toContainEqual({
+        name: 'manifest',
+        mountPath: '/etc/spindrift',
+        readOnly: true,
+      });
+      expect(pod.volumes).toContainEqual({
+        name: 'manifest',
+        configMap: { name: 'spindrift-manifest' },
+      });
+    }
+  });
+
+  test('rolls both processes when the declared manifest changes', async () => {
+    const checksums = async (manifest: Record<string, unknown>) =>
+      (await render({ manifest, reconciler: { enabled: true } }))
+        .filter((object) => object.kind === 'Deployment')
+        .map(
+          (object) =>
+            object.spec.template.metadata.annotations?.['checksum/manifest'],
+        );
+
+    const before = await checksums({ installation: 'declared' });
+    const after = await checksums({ installation: 'retuned' });
+
+    expect(before).toHaveLength(2);
+    for (const checksum of before) expect(checksum).toBeString();
+    // Both processes read the manifest once at start, so a ConfigMap change
+    // that does not restart them is a declaration that does nothing.
+    expect(after[0]).not.toBe(before[0]);
+    expect(after[1]).not.toBe(before[1]);
+  });
 });
 
 describe('authenticated Gateway trust', () => {

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -13,6 +13,16 @@
 
 image: ""
 
+# The installation manifest document. Empty declares nothing and leaves the
+# durable row in charge, which is what every installation did before this key
+# existed and remains a valid way to run.
+#
+# Declaring it is how a manifest value gets corrected. The row is written from a
+# declaration when one is present and otherwise from itself, and no product
+# command writes it — so an installation whose row is already seeded has no
+# other hand to change it with.
+manifest: {}
+
 # One named identity for the control plane. Kubernetes never automounts its
 # default API credential: both processes receive projected, audience-scoped
 # credentials because the reconciler deploys and the web process tails logs.


### PR DESCRIPTION
Ticket 29 — *Pin a zero-config frontend that exists*.

## The pin was corrected to a stale version, for a reason that is not true

#1485 got the repository right and the rest from one page of a paginated tag
list. GHCR pages `tags/list` at 100; the full list is 396 tags:

```text
$ …/v2/railwayapp/railpack-frontend/tags/list?n=1000
total tags: 396
'latest' present: True
newest plain version tags: ['v0.31.1', 'v0.31.2', 'v0.32.0', 'v0.33.0', 'v0.34.0', 'v0.35.0']
```

```text
latest    sha256:bc73534934e7929ab3dc41765fb7e25c8c69d9be98c43ef8792fea51f65317bd
v0.35.0   sha256:bc73534934e7929ab3dc41765fb7e25c8c69d9be98c43ef8792fea51f65317bd
v0.0.33   sha256:0864b2ee91df6c25ace4ab1f1aac3baa28bcb957179473427a0ce7ecbc25f4a8
```

`latest` exists and is `v0.35.0`, so the pin was 35 minor versions behind and
the comment justifying it ("there is no `latest` here to track") was wrong.
Both tags resolve as complete `linux/amd64` + `linux/arm64` indexes — `v0.0.33`
was old, not broken. Pinning is still right, and the comment now says why:
a floating tag is the one input to a zero-config build that no digest covers.

## Correcting code cannot reach this installation, and that is the real defect

The chart's `values.yaml` says a release "supplies the manifest document" and
that it "is mounted from a ConfigMap". There is no ConfigMap template, and the
live pods have no manifest volume and no manifest env:

```text
$ kubectl -n spindrift get cm
cnpg-default-monitoring / kube-root-ca.crt / spindrift-federated-identity
```
```text
env:     TMPDIR HOME PORT SPINDRIFT_IDENTITY_TOKEN_PATH NODE_EXTRA_CA_CERTS
         GOOGLE_APPLICATION_CREDENTIALS DATABASE_URL
volumes: tmp federated-identity
```

`manifest-store.ts:43` is the only writer of the `installation` row, and it
writes a declaration when one exists and otherwise the row's own contents back.
No product command writes it either. With no declaration wired, **a seeded row
is permanent** — which is why this installation still builds against the
reference #1485 corrected, read straight off build 16's runner:

```text
"zeroConfigFrontend":"ghcr.io/railwayapp/railpack:railpack-frontend"
##[error]failed to resolve source metadata for
ghcr.io/railwayapp/railpack:railpack-frontend: not found
```

So this renders the ConfigMap the chart already documents, mounts it where
`DEFAULT_MANIFEST_PATH` points, and puts a manifest change back under ordinary
review.

- `SPINDRIFT_MANIFEST_PATH` is set explicitly, not left to the default path.
  `loadManifestIfPresent` throws for a missing explicit path and returns `null`
  for a missing default — so a declaration that fails to mount is fatal rather
  than a silent fall back to the value it was meant to replace.
- The checksum annotation is load-bearing. Both processes read the manifest
  once at start; without a rollout the ConfigMap changes and the running
  processes keep the declaration they booted with.

## This changes nothing live until someone declares a manifest

Empty declares nothing and remains valid. Rendering offsite's actual values
before and after is byte-identical:

```text
$ diff before.yaml after.yaml && echo IDENTICAL
IDENTICAL
```

Deliberately **not** included: the offsite HelmRelease declaration itself. A
declaration overwrites the durable row, and reading that row is blocked in this
environment — authoring one from guesses would clobber live configuration and
reset Target connection state. That edit is the operator's, and ticket 29's
item 2 stays open until it happens.

## Checks

1068 spindrift tests pass (1067 before), 13 chart render tests pass (10 before,
3 added), `bun run typecheck`, `bun run lint`, `mise run ts:check` and
`mise run k8s:render-apps` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)