### PR TITLE
feat(spindrift): a declaration seeds an installation, and the database survives an uninstall

### DIFF
--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -22,21 +22,31 @@ import {
 type Env = Record<string, string | undefined>;
 
 /**
- * Reconcile declared configuration into the durable singleton, then load it.
+ * Load the durable singleton, seeding it from a declaration when it is empty.
  *
- * A mounted file or inline env declaration is reconciled first. Without a
- * file/env declaration, Spindrift reads the stored manifest from Postgres.
- * If the Postgres store is unseeded, Spindrift seeds the high-trust default
- * placeholder manifest so the UI can drive all configuration dynamically.
+ * **A declaration seeds; it does not govern.** The stored row wins whenever one
+ * exists, because configuration is the UI's to drive and a rollout must not
+ * revert what an operator just configured. A mounted file or inline env
+ * document is therefore consulted only for an unseeded installation, ahead of
+ * the high-trust placeholder — which is what makes a torn-down installation
+ * come back configured without anyone opening a browser.
+ *
+ * The cost is that editing a declaration does nothing to an installation that
+ * already has a row, so an ignored declaration says so at startup rather than
+ * being quietly skipped. Re-seeding is deliberate: discard the row.
  */
 export async function loadStoredManifest(
   db: Database,
   env: Env = Bun.env,
 ): Promise<InstallationManifest> {
-  const declared =
-    (await loadManifestIfPresent(env)) ??
-    (await readStoredManifest(db)) ??
-    DEFAULT_PLACEHOLDER_MANIFEST;
+  const stored = await readStoredManifest(db);
+  const declaration = await loadManifestIfPresent(env);
+  if (stored !== null && declaration !== null) {
+    console.warn(
+      'installation manifest: a declaration is mounted but this installation is already seeded, so the stored manifest is being used and the declaration is ignored — discard the row to re-seed from it',
+    );
+  }
+  const declared = stored ?? declaration ?? DEFAULT_PLACEHOLDER_MANIFEST;
 
   await db.transaction(async (tx) => {
     await tx

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -163,7 +163,7 @@ describe('the stored installation manifest', () => {
     ]);
   });
 
-  test('a changed declared connection resets its assessment and timestamp', async () => {
+  test('a changed Target connection resets its assessment and timestamp', async () => {
     await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
     });
@@ -187,9 +187,10 @@ describe('the stored installation manifest', () => {
       ),
     } satisfies InstallationManifest;
 
-    await loadStoredManifest(database().db, {
-      [MANIFEST_INLINE_VAR]: JSON.stringify(changed),
-    });
+    // Configuration is the UI's to drive, so the trigger for reconciliation is
+    // the stored manifest changing — which is what a settings write is.
+    await database().db.update(installation).set({ manifest: changed });
+    await loadStoredManifest(database().db, {});
 
     const cluster = await database().db.query.targets.findFirst({
       where: (targets, { eq }) => eq(targets.name, 'cluster'),
@@ -202,8 +203,27 @@ describe('the stored installation manifest', () => {
     expect(cluster?.updatedAt.getTime()).toBeGreaterThan(old.getTime());
   });
 
-  test('changed declared configuration updates the durable manifest', async () => {
+  test('a declaration seeds an empty installation and never governs a seeded one', async () => {
     const first = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    expect(first.installation).toBe('example');
+    const changed = fixtureText.replace(
+      'installation: example',
+      'installation: replacement',
+    );
+
+    // A rollout must not revert what an operator just configured, so the row
+    // wins over the declaration that seeded it.
+    const later = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: changed,
+    });
+    expect(later).toEqual(first);
+    expect(later.installation).toBe('example');
+  });
+
+  test('discarding the row re-seeds from the declaration', async () => {
+    await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,
     });
     const changed = fixtureText.replace(
@@ -211,12 +231,16 @@ describe('the stored installation manifest', () => {
       'installation: replacement',
     );
 
-    const later = await loadStoredManifest(database().db, {
+    // The deliberate act that makes a declaration apply again. It is also the
+    // whole of the tear-down-and-redeploy loop: an installation that lost its
+    // database comes back configured without anyone opening a browser.
+    await database().db.delete(installation);
+
+    const reseeded = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: changed,
     });
-    expect(later).not.toEqual(first);
-    expect(later.installation).toBe('replacement');
-    expect(await loadStoredManifest(database().db, {})).toEqual(later);
+    expect(reseeded.installation).toBe('replacement');
+    expect(await loadStoredManifest(database().db, {})).toEqual(reseeded);
   });
 
   test('updating declared configuration preserves connected Target state', async () => {
@@ -294,6 +318,9 @@ describe('the stored installation manifest', () => {
       .db.update(targets)
       .set({ rank: 99 })
       .where(eq(targets.name, 'cluster'));
+    // Re-seeding is where a declaration can still meet Target rows it did not
+    // create: discarding the installation row leaves the Targets behind.
+    await database().db.delete(installation);
     const incompatible = {
       ...fixtureManifest,
       installation: 'incompatible',
@@ -309,8 +336,9 @@ describe('the stored installation manifest', () => {
       }),
     ).rejects.toThrow(/stored Target uses cloudrun/);
 
-    const [stored] = await database().db.select().from(installation);
-    expect(stored?.manifest).toEqual(fixtureManifest);
+    // The whole seed is one transaction, so a refused Target leaves no
+    // half-seeded installation behind and no rank change from the attempt.
+    expect(await database().db.select().from(installation)).toEqual([]);
     const cluster = await database().db.query.targets.findFirst({
       where: (targets, { eq }) => eq(targets.name, 'cluster'),
     });

--- a/packages/charts/spindrift/templates/database.yaml
+++ b/packages/charts/spindrift/templates/database.yaml
@@ -18,6 +18,14 @@ metadata:
   namespace: {{ include "spindrift.namespace" . }}
   labels:
     {{- include "spindrift.labels" . | nindent 4 }}
+  {{- if .Values.database.keepOnDelete }}
+  annotations:
+    # The keep policy the comment above describes. CNPG owns the data PVC
+    # through the Cluster, so an uninstall that removes the Cluster garbage
+    # collects the volume with it whatever the storage class reclaims — keeping
+    # the Cluster is what keeps the data.
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   instances: {{ .Values.database.instances }}
   enableSuperuserAccess: false

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -24,6 +24,28 @@ describe('process topology', () => {
   });
 });
 
+describe('the database keep policy', () => {
+  test('keeps the Cluster on uninstall by default, because the PVC dies with it', async () => {
+    const objects = await render({ database: { enabled: true } });
+    expect(
+      one(objects, 'Cluster', 'spindrift-db').metadata.annotations?.[
+        'helm.sh/resource-policy'
+      ],
+    ).toBe('keep');
+  });
+
+  test('lets a release opt into a real teardown', async () => {
+    const objects = await render({
+      database: { enabled: true, keepOnDelete: false },
+    });
+    expect(
+      one(objects, 'Cluster', 'spindrift-db').metadata.annotations?.[
+        'helm.sh/resource-policy'
+      ],
+    ).toBeUndefined();
+  });
+});
+
 describe('declarative schema ordering', () => {
   test('renders the database, migration Job, and both gated healthy processes', async () => {
     const objects = await render({

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -99,6 +99,15 @@ database:
   size: 2Gi
   name: spindrift
   storageClass: local-path
+  # §19's keep policy. The data PVC is owned by the CNPG Cluster, so removing
+  # the Cluster discards the desired-state rows, the attempt log, and the config
+  # version pins — none of which are in any source, because §12 ships no backups
+  # and the loss story is reconcile-from-sources.
+  #
+  # Turn it off to make an uninstall a real teardown. That is the loop for
+  # working on onboarding itself: every redeploy is then a fresh installation,
+  # which is the only way to exercise seeding and the wizard repeatedly.
+  keepOnDelete: true
   # The Job is part of an installation that owns its database. Its default
   # command is compatible with images that expose applyMigrations before the
   # executable entrypoint exists.


### PR DESCRIPTION
Follow-up to #1487, which merged with the precedence the declaration path was
born with. Both changes here come from a settled decision: **onboarding is the
UI's job**, and a declaration exists so a torn-down installation comes back
without anyone opening a browser.

## A declaration seeds; it does not govern

#1487 made the declaration overwrite the row on **every process start**. That is
backwards for a control plane whose configuration is meant to be UI-driven —
`manifest-store.ts`'s own doc comment says *"so the UI can drive all
configuration dynamically"* — because an installation wizard's output would be
reverted by the next rollout.

```
before:  declaration? -> overwrite row on every start
after:   row exists?  -> use the row      (the UI is authoritative)
         row empty?   -> seed from the declaration, else the placeholder
```

The cost is that editing a declaration does nothing to an installation that
already has a row — which is exactly the silent-no-op failure ticket 29 is
about, so it warns at startup and names the remedy. Re-seeding is deliberate:
discard the row.

Target reconciliation keeps its meaning and changes its trigger: it used to fire
when a declaration changed, and now fires when the **stored** manifest changes,
which is what a settings write is. Its test moves with it. The
incompatible-Target test moves to re-seed time — the case that still exists,
since discarding the installation row leaves Target rows behind — and now also
pins that a refused seed is atomic.

## The database keep policy §19 requires

`database.yaml`'s comment claims *"the PVC outlives the Cluster"* and §19
requires *"its own database cluster with a keep policy, overridable"*. Neither
was implemented:

```text
NAME             SC           OWNER
spindrift-db-1   local-path   Cluster     ← PVC garbage-collected with the Cluster

NAME         RECLAIM   DEFAULT
local-path   Delete    true               ← and the class reclaims by deleting
```

An uninstall therefore discards the desired-state rows, the attempt log, and the
config version pins — the three things §12 ships no backups for on the reasoning
that the loss story is reconcile-from-sources. None of them are in any source.

The storage class cannot fix this: CNPG owns the PVC through the Cluster, so the
volume goes when the Cluster goes whatever the class reclaims. Keeping the
Cluster is what keeps the data.

`keepOnDelete` (default `true`) is the overridable half, and it is not
hypothetical — turning it off is the loop for working on onboarding itself,
where every redeploy should be a fresh installation so seeding and the wizard
get exercised rather than described.

## Checks

1069 spindrift tests pass (1068 before), 15 chart render tests pass (13 before),
`bun run typecheck`, `bun run lint`, `mise run ts:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)