### PR TITLE
fix(spindrift): store a jsonb document as a document

### DIFF
--- a/apps/spindrift/src/db/migrations/0016_jsonb_documents.sql
+++ b/apps/spindrift/src/db/migrations/0016_jsonb_documents.sql
@@ -1,0 +1,56 @@
+-- Unwrap the double-encoded jsonb documents written before `jsonbDocument`.
+--
+-- Every jsonb column was written as `JSON.stringify(JSON.stringify(doc))` — a
+-- scalar — so `jsonb_typeof` is 'string' and no `->>` can read inside one. This
+-- rewrites those rows to the document they always meant.
+--
+-- Guarded three ways, because this runs at startup and a failure here is an
+-- installation that will not boot:
+--   * `jsonb_typeof(...) = 'string'` makes it idempotent and safe on a table
+--     that is half-migrated — rows already stored as an object or array are not
+--     touched, and re-running changes nothing.
+--   * `pg_input_is_valid(..., 'jsonb')` (Postgres 16+) skips a string that is
+--     not parseable JSON rather than aborting the transaction on the cast. Such
+--     a row would stay double-encoded and readable — the decoder still parses a
+--     string — rather than taking the process down.
+--   * SQL NULL is never a 'string', so nullable columns are left alone.
+
+UPDATE "installation" SET "manifest" = ("manifest" #>> '{}')::jsonb
+WHERE jsonb_typeof("manifest") = 'string'
+  AND pg_input_is_valid("manifest" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "creation_drafts" SET "draft" = ("draft" #>> '{}')::jsonb
+WHERE jsonb_typeof("draft") = 'string'
+  AND pg_input_is_valid("draft" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "targets" SET "connection" = ("connection" #>> '{}')::jsonb
+WHERE jsonb_typeof("connection") = 'string'
+  AND pg_input_is_valid("connection" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "targets" SET "prerequisites" = ("prerequisites" #>> '{}')::jsonb
+WHERE jsonb_typeof("prerequisites") = 'string'
+  AND pg_input_is_valid("prerequisites" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "targets" SET "discovery" = ("discovery" #>> '{}')::jsonb
+WHERE jsonb_typeof("discovery") = 'string'
+  AND pg_input_is_valid("discovery" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "builds" SET "artifact_refs" = ("artifact_refs" #>> '{}')::jsonb
+WHERE jsonb_typeof("artifact_refs") = 'string'
+  AND pg_input_is_valid("artifact_refs" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "builds" SET "provenance" = ("provenance" #>> '{}')::jsonb
+WHERE jsonb_typeof("provenance") = 'string'
+  AND pg_input_is_valid("provenance" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "builds" SET "signature" = ("signature" #>> '{}')::jsonb
+WHERE jsonb_typeof("signature") = 'string'
+  AND pg_input_is_valid("signature" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "deploys" SET "config_document" = ("config_document" #>> '{}')::jsonb
+WHERE jsonb_typeof("config_document") = 'string'
+  AND pg_input_is_valid("config_document" #>> '{}', 'jsonb');
+--> statement-breakpoint
+UPDATE "deploys" SET "debug" = ("debug" #>> '{}')::jsonb
+WHERE jsonb_typeof("debug") = 'string'
+  AND pg_input_is_valid("debug" #>> '{}', 'jsonb');

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1785374380759,
       "tag": "0015_build_run_url",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1785374380760,
+      "tag": "0016_jsonb_documents",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -28,8 +28,8 @@ import {
   bigserial,
   boolean,
   check,
+  customType,
   integer,
-  jsonb,
   pgEnum,
   pgTable,
   text,
@@ -53,6 +53,43 @@ import type { ConfigEntry } from '../domain/desired-state.ts';
 import type { TargetConnection } from '../domain/target.ts';
 import type { CoreSignature } from '../supply-chain/sign.ts';
 import type { BackendProvenanceAssessment } from '../supply-chain/verify.ts';
+
+/**
+ * A `jsonb` column that stores a JSON **document**, not a JSON string.
+ *
+ * Drizzle's own `jsonb` encoder hands the driver `JSON.stringify(value)`, and
+ * Bun's SQL client serialises a JS string bound to a `jsonb` parameter *as a
+ * JSON string*. The document is therefore encoded twice, and the column holds a
+ * scalar: `jsonb_typeof(...)` is `'string'` and `draft->>'appName'` is `NULL`.
+ *
+ * Nothing caught it because the read path is symmetric — Bun parses the `jsonb`
+ * back to a JS string and the decoder parses that — so the application always
+ * got its object back. What it costs is every SQL-side use of the document: a
+ * predicate, a GIN index, a generated column, or a data migration reading inside
+ * one of these columns matches nothing rather than erroring.
+ *
+ * Passing the value through untouched is the fix; Bun binds objects and arrays
+ * to `jsonb` correctly on its own. `null` never reaches {@link toDriver} —
+ * Drizzle emits SQL `NULL` for it — so a nullable column still stores SQL `NULL`
+ * rather than a JSON `null`, and `IS NULL` keeps meaning what it meant.
+ *
+ * {@link fromDriver} still parses a string so that rows written before
+ * `0016_jsonb_documents` read correctly during a rollout, when the new image and
+ * the un-migrated rows overlap. It is the same decode Drizzle already did. The
+ * one thing it forbids is a column whose document is legitimately a JSON string;
+ * none is, and a scalar in a `jsonb` column here would be a modelling mistake.
+ */
+const jsonbDocument = customType<{ data: unknown; driverData: unknown }>({
+  dataType() {
+    return 'jsonb';
+  },
+  toDriver(value) {
+    return value;
+  },
+  fromDriver(value) {
+    return typeof value === 'string' ? JSON.parse(value) : value;
+  },
+});
 
 // --- Enums -----------------------------------------------------------------
 //
@@ -221,7 +258,7 @@ export const installation = pgTable(
   'installation',
   {
     id: integer('id').primaryKey().default(1),
-    manifest: jsonb('manifest').$type<InstallationManifest>().notNull(),
+    manifest: jsonbDocument('manifest').$type<InstallationManifest>().notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -457,7 +494,7 @@ export const builds = pgTable(
     artifactType: artifactType('artifact_type').notNull(),
     /** Set once the build produces a digestible artifact. */
     artifactDigest: text('artifact_digest'),
-    artifactRefs: jsonb('artifact_refs').$type<string[]>(),
+    artifactRefs: jsonbDocument('artifact_refs').$type<string[]>(),
     status: buildStatus('status').notNull().default('PENDING'),
     /** §4: the base image digest this build started from, for provenance. */
     baseDigest: text('base_digest'),
@@ -483,7 +520,8 @@ export const builds = pgTable(
     /** Timestamp when the current runner claimed the dispatch lease. */
     leasedAt: timestamp('leased_at', { withTimezone: true }),
     /** §16: the backend envelope plus the facts core verified from it. */
-    provenance: jsonb('provenance').$type<BackendProvenanceAssessment>(),
+    provenance:
+      jsonbDocument('provenance').$type<BackendProvenanceAssessment>(),
     /**
      * The concrete achieved level, normalized for policy queries.
      *
@@ -493,7 +531,7 @@ export const builds = pgTable(
      */
     verifiedBuildLevel: integer('verified_build_level'),
     /** Core's one cosign record, written only after provenance passes (§16). */
-    signature: jsonb('signature').$type<CoreSignature>(),
+    signature: jsonbDocument('signature').$type<CoreSignature>(),
     /**
      * The unsigned BuildKit materials document attached to the artifact.
      *
@@ -565,7 +603,7 @@ export const deploys = pgTable('deploys', {
   /** §6: "`FAILED` carries a closed reason set plus free-text `detail`." */
   detail: text('detail'),
   /** §6: "and a raw `debug` payload." */
-  debug: jsonb('debug'),
+  debug: jsonbDocument('debug'),
   /**
    * §6: the adapter's own handle on what `apply` placed — "opaque to core,
    * which stores it and hands it back to `observe` and `destroy`." This column
@@ -590,7 +628,8 @@ export const deploys = pgTable('deploys', {
    * database that cannot produce a credential is a database whose disclosure
    * does not produce one either.
    */
-  configDocument: jsonb('config_document').$type<readonly ConfigEntry[]>(),
+  configDocument:
+    jsonbDocument('config_document').$type<readonly ConfigEntry[]>(),
   exposure: exposureState('exposure'),
   /**
    * §13: "Disconnect always works: live Deploys go `orphaned`, workloads keep
@@ -735,14 +774,14 @@ export const targets = pgTable(
      * Null means the manifest has established the Target's identity and rank,
      * but neither desired state nor an operator has supplied connection facts.
      */
-    connection: jsonb('connection').$type<TargetConnection>(),
+    connection: jsonbDocument('connection').$type<TargetConnection>(),
     /** §13: the standing checklist's last verdict. */
     health: targetHealth('health').notNull(),
     /** One `PrerequisiteResult` per item, with the sentence behind each. */
     prerequisites:
-      jsonb('prerequisites').$type<readonly PrerequisiteResult[]>(),
+      jsonbDocument('prerequisites').$type<readonly PrerequisiteResult[]>(),
     /** §3's discovered half, as the adapter last reported it. */
-    discovery: jsonb('discovery').$type<TargetDiscovery>(),
+    discovery: jsonbDocument('discovery').$type<TargetDiscovery>(),
     /** When the one loop (§13) last ran against this Target. */
     inspectedAt: timestamp('inspected_at', { withTimezone: true }),
     /**
@@ -804,7 +843,7 @@ export const creationDrafts = pgTable('creation_drafts', {
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),
   revision: integer('revision').notNull().default(0),
-  draft: jsonb('draft').$type<Draft>().notNull(),
+  draft: jsonbDocument('draft').$type<Draft>().notNull(),
   completedAppId: uuid('completed_app_id').references(() => apps.id, {
     onDelete: 'set null',
   }),

--- a/apps/spindrift/test/db/jsonb-documents.test.ts
+++ b/apps/spindrift/test/db/jsonb-documents.test.ts
@@ -1,0 +1,168 @@
+/**
+ * A `jsonb` column holds a document, not a string (ticket 30).
+ *
+ * The defect this guards against is invisible from the application: Drizzle's
+ * stock `jsonb` encoder stringified, Bun's SQL client stringified that string
+ * again, and the decode was symmetric — so a JS round trip returned the object
+ * every time while the column held a scalar and `->>` read nothing. A test that
+ * writes a document and reads it back through Drizzle passes under both the bug
+ * and the fix, which is exactly how this survived to production.
+ *
+ * So every assertion here is made **in SQL**, against the stored shape.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { eq } from 'drizzle-orm';
+import { creationDrafts, targets, users } from '../../src/db/schema.ts';
+import { initialCreationDraft } from '../../src/domain/creation-draft.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+
+const MIGRATION = join(
+  import.meta.dir,
+  '../../src/db/migrations/0016_jsonb_documents.sql',
+);
+
+const draftValues = () =>
+  initialCreationDraft({
+    repository: 'jonpulsifer/infra',
+    targetId: crypto.randomUUID(),
+    vessel: 'bluenose',
+  });
+
+/** A draft needs an owner; `creation_drafts.user_id` is a cascading FK. */
+async function seedOperator() {
+  const [user] = await database()
+    .db.insert(users)
+    .values({ displayName: 'Operator' })
+    .returning();
+  return user!;
+}
+
+/** The committed migration, exactly as it ships, as its own statements. */
+async function migrationStatements() {
+  const sql = await readFile(MIGRATION, 'utf8');
+  return sql
+    .split('--> statement-breakpoint')
+    .map((statement) => statement.trim())
+    .filter((statement) => statement.length > 0);
+}
+
+describe('jsonb columns store documents', () => {
+  test('an object written through Drizzle is readable field by field in SQL', async () => {
+    const user = await seedOperator();
+    const draft = draftValues();
+    const [row] = await database()
+      .db.insert(creationDrafts)
+      .values({ id: crypto.randomUUID(), userId: user.id, draft })
+      .returning();
+
+    const [stored] = await database().client`
+      SELECT jsonb_typeof(draft) AS shape,
+             draft->>'appName' AS app_name,
+             draft->'source'->>'repo' AS repo
+      FROM creation_drafts WHERE id = ${row!.id}`;
+
+    expect(stored.shape).toBe('object');
+    expect(stored.app_name).toBe(draft.appName);
+    expect(stored.repo).toBe('jonpulsifer/infra');
+  });
+
+  test('an array column is a jsonb array, not a scalar and not a Postgres array', async () => {
+    const [row] = await database()
+      .db.insert(targets)
+      .values(targetValues({ prerequisites: [{ name: 'VESSEL', met: true }] }))
+      .returning();
+
+    const [stored] = await database().client`
+      SELECT jsonb_typeof(connection) AS connection_shape,
+             jsonb_typeof(prerequisites) AS prerequisites_shape,
+             jsonb_array_length(prerequisites) AS prerequisites_length,
+             prerequisites->0->>'name' AS first_prerequisite
+      FROM targets WHERE id = ${row!.id}`;
+
+    expect(stored.connection_shape).toBe('object');
+    expect(stored.prerequisites_shape).toBe('array');
+    expect(stored.prerequisites_length).toBe(1);
+    expect(stored.first_prerequisite).toBe('VESSEL');
+  });
+
+  test('an absent document is SQL NULL rather than a JSON null', async () => {
+    const [row] = await database()
+      .db.insert(targets)
+      .values(targetValues())
+      .returning();
+
+    const [stored] = await database().client`
+      SELECT discovery IS NULL AS sql_null, jsonb_typeof(discovery) AS shape
+      FROM targets WHERE id = ${row!.id}`;
+
+    // A JSON null would make `IS NULL` false and `jsonb_typeof` 'null', which
+    // would silently break every `IS NULL` predicate over these columns.
+    expect(stored.sql_null).toBe(true);
+    expect(stored.shape).toBeNull();
+    expect(row!.discovery).toBeNull();
+  });
+});
+
+describe('migration 0016 unwraps what the old encoder wrote', () => {
+  test('a double-encoded row becomes a document and still reads the same', async () => {
+    const user = await seedOperator();
+    const draft = draftValues();
+    const id = crypto.randomUUID();
+
+    // Exactly what the stock Drizzle encoder produced: the document, stringified,
+    // handed to Bun as a string, which serialised it as a JSON string again.
+    await database().client`
+      INSERT INTO creation_drafts (id, user_id, draft)
+      VALUES (${id}, ${user.id}, ${JSON.stringify(draft)})`;
+
+    const [before] = await database().client`
+      SELECT jsonb_typeof(draft) AS shape, draft->>'appName' AS app_name
+      FROM creation_drafts WHERE id = ${id}`;
+    expect(before.shape).toBe('string');
+    expect(before.app_name).toBeNull();
+
+    for (const statement of await migrationStatements()) {
+      await database().client.unsafe(statement);
+    }
+
+    const [after] = await database().client`
+      SELECT jsonb_typeof(draft) AS shape, draft->>'appName' AS app_name
+      FROM creation_drafts WHERE id = ${id}`;
+    expect(after.shape).toBe('object');
+    expect(after.app_name).toBe(draft.appName);
+
+    // The document itself is unchanged — this migrates the encoding, not the data.
+    const [read] = await database()
+      .db.select()
+      .from(creationDrafts)
+      .where(eq(creationDrafts.id, id));
+    expect(read!.draft).toEqual(draft);
+  });
+
+  test('it is idempotent, and leaves an already-correct row alone', async () => {
+    const user = await seedOperator();
+    const draft = draftValues();
+    const [row] = await database()
+      .db.insert(creationDrafts)
+      .values({ id: crypto.randomUUID(), userId: user.id, draft })
+      .returning();
+
+    // Runs at startup on every boot, so it meets migrated rows every time.
+    for (const pass of [1, 2]) {
+      for (const statement of await migrationStatements()) {
+        await database().client.unsafe(statement);
+      }
+      const [stored] = await database().client`
+        SELECT jsonb_typeof(draft) AS shape, draft->>'appName' AS app_name
+        FROM creation_drafts WHERE id = ${row!.id}`;
+      expect(`pass ${pass}: ${stored.shape}`).toBe(`pass ${pass}: object`);
+      expect(stored.app_name).toBe(draft.appName);
+    }
+  });
+});


### PR DESCRIPTION
Every `jsonb` column in Spindrift is written twice-encoded, so the column holds a
JSON *string* rather than a document and no SQL can read inside one.

Found by the evidence audit of ticket 04. Live on offsite right now:

```text
$ select jsonb_typeof(draft), count(*) from creation_drafts group by 1
 stored_type | count
-------------+-------
 string      |    23

$ select count(*) from creation_drafts where draft->>'appName' is not null
 rows_where_appname_is_readable
--------------------------------
                              0
```

The same is true of `installation.manifest`, `targets.connection`, and
`targets.prerequisites`. `builds.artifact_refs` is NULL on all 16 rows, so it
carries no evidence either way.

## Why it went unnoticed

Drizzle's stock `jsonb` encoder hands the driver `JSON.stringify(value)`, and
Bun's SQL client serialises a JS string bound to a `jsonb` parameter *as a JSON
string*. The decode is symmetric — Bun parses the `jsonb` back to a JS string and
the decoder parses that — so the application always got its object back.

Three writes into one `jsonb` column isolate it. `bun-obj` is the control:

```text
--- how each write lands in the column ---
bun-obj  stored_type=object  doc->>'appName'=hello     # raw Bun SQL, object param
bun-str  stored_type=string  doc->>'appName'=NULL      # raw Bun SQL, JSON.stringify'd param
drizzle  stored_type=string  doc->>'appName'=NULL      # db.insert(...).values({doc: {...}})

--- what Drizzle reads back ---
drizzle  typeof=object appName=hello
bun-obj  typeof=object appName=hello
bun-str  typeof=object appName=hello
```

This is **latent, not broken**: nothing in `src/` reads inside a `jsonb` column in
SQL today (`grep -rn -e "->>" -e "jsonb_" -e "@>" apps/spindrift/src/` is empty).
It is worth fixing for how it would surface — the first predicate, GIN index,
generated column, or data migration over one of these fields would match nothing
rather than error.

## The fix

`jsonbDocument` passes the value through; Bun binds objects and arrays to `jsonb`
correctly on its own. Two things I checked rather than assumed, because both
would have been silent regressions:

- **`null` still becomes SQL `NULL`.** Drizzle short-circuits null before
  `toDriver`, so nullable columns do not start storing a JSON `null` — `IS NULL`
  keeps meaning what it meant. A JSON `null` would have quietly broken every
  `IS NULL` predicate over these columns.
- **Arrays land as jsonb arrays, not Postgres arrays.** Three of the ten columns
  hold arrays.

`fromDriver` still parses a string, so rows written before `0016` read correctly
during the rollout window when the new image and un-migrated rows overlap. It is
the same decode Drizzle already did.

## The migration

`0016_jsonb_documents` unwraps the existing rows across all ten columns. It runs
at startup, where a failure is an installation that will not boot, so it is
guarded three ways:

- `jsonb_typeof(...) = 'string'` — idempotent, and safe on a half-migrated table.
  Re-running changes nothing.
- `pg_input_is_valid(..., 'jsonb')` (PG16+; offsite is 18.3, test is 16.14) skips
  an unparseable string rather than aborting the transaction on the cast. Such a
  row stays double-encoded and readable rather than taking the process down.
- SQL `NULL` is never a `'string'`, so nullable columns are untouched.

## Verification

The new test asserts the stored shape **in SQL**, not the JS round trip — the
round trip passes under both the bug and the fix, which is how this survived.
Confirmed it actually detects the defect by restoring the old encoder:

```text
--- with toDriver returning JSON.stringify(value) ---
(fail) an object written through Drizzle is readable field by field in SQL
(fail) an array column is a jsonb array, not a scalar and not a Postgres array
 3 pass  2 fail

--- with the fix ---
 5 pass  0 fail
```

`test/db/migrate.test.ts` already exercises the rollout path — it applies the
journal minus its last entry, then applies only the pending migration, which is
now `0016`.

```text
$ bun test
 1073 pass  0 fail  (1068 before, 5 added)  across 75 files

$ bun run typecheck && bun run lint && mise run ts:check
clean
```

Not verified against live data: applying it is Flux's job on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
