### PR TITLE
Record a dispatch refusal the operator can see

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -247,6 +247,22 @@ One half is still missing from the Target surface:
 `targets.min_build_level` is read but nothing sets it, and there is no ordered
 per-Target route list — both belong to the Target model and the connect act.
 
+Every refusal `dispatchBuild` makes happens *before* the claim, so it is
+returned to `runBuildPass` — which is `if (result.ok) dispatched += 1` and drops
+everything else. That makes writing the refusal down the only way it reaches
+anybody, and `refuseDispatch` splits them on one question: can a later tick
+clear this? A fact about the row — a location no route can fetch, a name no
+registry will accept, a bundle never staged — closes the Build out with §6's
+reason, because retrying it once a second forever is the only alternative. A
+fact about the installation — no federation, no such route, a threshold no
+configured route meets — leaves the Build `PENDING`, so that configuring the
+thing makes the next tick work without anybody pressing Deploy again, and
+records what is being waited on. The build loop runs at 1Hz, so the sentence is
+written once and suppressed against `builds.dispatch_waiting_on` until it
+changes; the claim clears the column. `runBuildPass` writes the one refusal of
+that class made before dispatch is reached — a Target no configured route can
+serve — through the same function.
+
 Core's supply-chain gate is verify → sign → record. It joins the source receipt
 and backend envelope on the bundle digest, invokes the pinned verifier against
 an immutable artifact reference, caps the achieved level by the route's

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -30,6 +30,7 @@ import type {
   BuildSource,
   BuildSpec,
 } from '../../adapters/build/contract.ts';
+import type { FailureReason } from '../../adapters/deploy/contract.ts';
 import {
   apps,
   builds,
@@ -42,7 +43,10 @@ import {
   artifactTags,
   componentRepository,
 } from '../../domain/artifact-name.ts';
-import { recordBuildEvent } from '../../domain/attempt-log.ts';
+import {
+  type BuildAttemptRef,
+  recordBuildEvent,
+} from '../../domain/attempt-log.ts';
 import {
   buildRouteCandidates,
   DEFAULT_MINIMUM_BUILD_LEVEL,
@@ -54,6 +58,7 @@ import { parseGcsLocation, signedObjectUrl } from '../../storage/signed-url.ts';
 import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
 import {
   type CommandContext,
+  type CommandFailureCode,
   type CommandResult,
   failed,
   ok,
@@ -245,6 +250,114 @@ async function fetchableBundleLocation(
   }
 }
 
+/**
+ * How a dispatch refusal is recorded, and why there are exactly two ways.
+ *
+ * Everything below the Build row's own existence is refused *before* the claim
+ * transaction, which means the refusal is returned to `runBuildPass` — and
+ * `runBuildPass` is `if (result.ok) dispatched += 1`. It keeps the successes and
+ * drops everything else. A refusal that only returns therefore reaches nobody,
+ * and the Build sits PENDING being refused again every second in silence.
+ *
+ * What separates the two arms is not severity, it is **whether a later tick can
+ * clear it**:
+ *
+ * - `closes` — the refusal is a fact about this row. A location no route can
+ *   fetch, a name no registry will accept, a bundle that was never staged: no
+ *   tick makes any of those legal, so the Build is failed with §6's reason and
+ *   the sentence goes on the attempt log. Retrying it once a second forever is
+ *   the alternative, and it is not one.
+ * - `waits` — the refusal is a fact about the *installation*. Federation that
+ *   is not configured, a route this installation does not have, a Target
+ *   threshold no configured route meets: configuring the thing is a thing an
+ *   operator can do, and the next tick should then work without anybody
+ *   pressing Deploy again. So the Build stays PENDING — and says what it is
+ *   waiting on, which is the half that was missing.
+ *
+ * That gap cost real time. Build 13 sat PENDING for two hours over a missing
+ * `roles/iam.serviceAccountTokenCreator` binding while
+ * {@link fetchableBundleLocation} composed the true sentence once a second and
+ * threw it away every time; it was finally named by reading Terraform, not by
+ * anything Spindrift said. The sentence existed. Nobody could see it.
+ *
+ * Repeat suppression is what makes the `waits` arm bearable at 1Hz, and it is
+ * keyed on `builds.dispatchWaitingOn` — the row is already in hand, so an
+ * unchanged refusal costs no query and writes nothing. A *changed* one writes,
+ * because a refusal that has changed is news.
+ */
+type RefusalDisposition =
+  | { readonly kind: 'closes'; readonly reason: FailureReason }
+  | { readonly kind: 'waits' };
+
+/** Everything {@link refuseDispatch} needs to know about the Build it is refusing. */
+export interface RefusalSubject {
+  readonly attempt: BuildAttemptRef;
+  /** `builds.dispatchWaitingOn` as it stands, for suppressing a repeat. */
+  readonly waitingOn: string | null;
+}
+
+async function refuseDispatch<Output>(
+  context: Pick<BuildDispatchContext, 'db'>,
+  subject: RefusalSubject,
+  code: CommandFailureCode,
+  sentence: string,
+  disposition: RefusalDisposition,
+): Promise<CommandResult<Output>> {
+  if (disposition.kind === 'closes') {
+    await recordBuildEvent(context.db, subject.attempt, {
+      type: 'log',
+      line: sentence,
+      resource: 'dispatch',
+    });
+    await recordBuildEvent(context.db, subject.attempt, {
+      type: 'status',
+      phase: 'FAILED',
+      reason: disposition.reason,
+    });
+    await context.db
+      .update(builds)
+      // Cleared with the same statement that ends the wait: a FAILED Build is
+      // not waiting on anything, and leaving the sentence behind would read as
+      // though it were.
+      .set({ status: 'FAILED', dispatchWaitingOn: null })
+      .where(eq(builds.id, subject.attempt.buildId));
+    return failed(code, sentence);
+  }
+
+  await recordDispatchWait(context, subject, sentence);
+  return failed(code, sentence);
+}
+
+/**
+ * Say once, on the attempt log, what a PENDING Build is waiting for.
+ *
+ * Exported because one refusal of this class is made before `dispatchBuild` is
+ * ever called: `runBuildPass` selects a route for the Target and skips the
+ * Build when there is none, so the sentence has to be written from there. It is
+ * the same disposition and the same suppression, which is why it is the same
+ * function rather than a second one that drifts.
+ *
+ * No status event is written: the Build has not failed and its phase has not
+ * moved. It is PENDING, which is what it was, and the log now says why it
+ * still is.
+ */
+export async function recordDispatchWait(
+  context: Pick<BuildDispatchContext, 'db'>,
+  subject: RefusalSubject,
+  sentence: string,
+): Promise<void> {
+  if (subject.waitingOn === sentence) return;
+  await recordBuildEvent(context.db, subject.attempt, {
+    type: 'log',
+    line: sentence,
+    resource: 'dispatch',
+  });
+  await context.db
+    .update(builds)
+    .set({ dispatchWaitingOn: sentence })
+    .where(eq(builds.id, subject.attempt.buildId));
+}
+
 export const dispatchBuild = async (
   input: DispatchBuildInput,
   context: BuildDispatchContext,
@@ -300,21 +413,46 @@ export const dispatchBuild = async (
     });
   }
 
+  // Everything from here down can refuse, and every refusal below is made
+  // before the claim — so every one of them is dropped by `runBuildPass` unless
+  // it is written somewhere first. See {@link refuseDispatch}: the App and the
+  // Component are known by now, which is all an attempt reference needs, so the
+  // subject is assembled once and each refusal only has to say which of the two
+  // dispositions it is.
+  const subject: RefusalSubject = {
+    attempt: {
+      appId: app.id,
+      componentId: component.id,
+      buildId: build.id,
+    },
+    waitingOn: build.dispatchWaitingOn,
+  };
+
   if (build.bundleDigest === null) {
     // §16: "the bundle digest must be a build parameter on every route, or the
     // correlation between a source receipt and a provenance document has no
-    // join." A Build without one cannot be dispatched at all.
-    return failed(
+    // join." A Build without one cannot be dispatched at all — and no tick
+    // stages one, because staging happens where the Build is created.
+    return refuseDispatch(
+      context,
+      subject,
       'NOT_BUILDABLE',
       `Build ${build.id} has no staged bundle, so no route can be given one`,
+      { kind: 'closes', reason: 'ARTIFACT_UNAVAILABLE' },
     );
   }
 
   const adapter = context.adapters.build(input.route);
   if (adapter === null) {
-    return failed(
+    // The route set is §4's installation configuration, so this names a
+    // prerequisite rather than a defect: an operator who configures the route
+    // gets this Build dispatched on the next tick.
+    return refuseDispatch(
+      context,
+      subject,
       'NOT_FOUND',
-      `this installation has no build route named ${input.route}`,
+      `this installation has no build route named ${input.route}, so nothing can run this Build until one is configured`,
+      { kind: 'waits' },
     );
   }
 
@@ -331,18 +469,28 @@ export const dispatchBuild = async (
       placements.length > 0 &&
       !placements.some((p) => p.targetId === effectiveTargetId)
     ) {
-      return failed(
+      // Placements are rows an operator edits, so this is `waits` for the same
+      // reason a missing route is: it is not reachable from the loop at all
+      // (the loop dispatches the placement it read), and where it does arrive
+      // the remedy is a placement, not a rebuild.
+      return refuseDispatch(
+        context,
+        subject,
         'NOT_BUILDABLE',
         `Target ${effectiveTargetId} is not a placement target for Component ${component.id}`,
+        { kind: 'waits' },
       );
     }
   } else {
     if (placements.length === 1) {
       effectiveTargetId = placements[0]!.targetId;
     } else if (placements.length > 1) {
-      return failed(
+      return refuseDispatch(
+        context,
+        subject,
         'NOT_BUILDABLE',
         `Component ${component.id} has multiple target placements, so dispatch must name an explicit placementTargetId`,
+        { kind: 'waits' },
       );
     }
   }
@@ -351,18 +499,29 @@ export const dispatchBuild = async (
   // is the Target's, so it is only checkable where a placement is named — and
   // where one is, a route below it is refused here rather than producing an
   // artifact the Target would refuse to admit anyway.
+  //
+  // `waits`, because both halves of the comparison are configuration: the
+  // Target's threshold and the set of routes this installation offers. Lowering
+  // one or adding a better route makes the next tick work.
   const targetPolicy = await targetBuildPolicy(context, effectiveTargetId);
   const refusal = routeRefusedByTarget(targetPolicy, adapter);
-  if (refusal !== null) return failed('NOT_BUILDABLE', refusal);
+  if (refusal !== null) {
+    return refuseDispatch(context, subject, 'NOT_BUILDABLE', refusal, {
+      kind: 'waits',
+    });
+  }
 
   // The staged bundle's own columns, not the artifact's. §15 stages a bundle for
   // either builder — a repo commit and an upload alike — and a Build that has
   // not run has no artifact refs to borrow an address from, so a missing
   // location is what would otherwise reach a route as an empty URL.
   if (build.bundleLocation === null) {
-    return failed(
+    return refuseDispatch(
+      context,
+      subject,
       'NOT_BUILDABLE',
       `Build ${build.id} has no staged bundle location, so no route can fetch it`,
+      { kind: 'closes', reason: 'ARTIFACT_UNAVAILABLE' },
     );
   }
 
@@ -371,11 +530,7 @@ export const dispatchBuild = async (
   // dispatch is what keeps it out of the Build row, out of the attempt log, and
   // out of any window between staging and running. What is persisted is the
   // `gs://` object; what a route is handed is a URL that resolves.
-  const attempt = {
-    appId: app.id,
-    componentId: component.id,
-    buildId: build.id,
-  };
+  const attempt = subject.attempt;
 
   /**
    * §16 names one registry per installation — "every artifact is pushed to and
@@ -406,24 +561,13 @@ export const dispatchBuild = async (
       `App "${app.name}" / Component "${component.name}" cannot name a ` +
       `repository under ${context.manifest.supplyChain.registry}: a registry ` +
       `path segment is lowercase alphanumerics separated by "-", "_" or "."`;
-    await recordBuildEvent(context.db, attempt, {
-      type: 'log',
-      line: sentence,
-      resource: 'bundle',
-    });
-    await recordBuildEvent(context.db, attempt, {
-      // §6's table covers "invalid spec" here, which is what a name no registry
-      // will accept is — and it blames the developer, who is the one who can
-      // rename the thing.
-      type: 'status',
-      phase: 'FAILED',
+    // §6's table covers "invalid spec" here, which is what a name no registry
+    // will accept is — and it blames the developer, who is the one who can
+    // rename the thing.
+    return refuseDispatch(context, subject, 'NOT_BUILDABLE', sentence, {
+      kind: 'closes',
       reason: 'REJECTED',
     });
-    await context.db
-      .update(builds)
-      .set({ status: 'FAILED' })
-      .where(eq(builds.id, build.id));
-    return failed('NOT_BUILDABLE', sentence);
   }
 
   const fetchable = await fetchableBundleLocation(
@@ -432,34 +576,25 @@ export const dispatchBuild = async (
     build.bundleLocation,
   );
   if (!fetchable.ok) {
-    // A refusal returned to `runBuildPass` reaches nobody — the loop keeps the
-    // successes and drops the rest — so a Build refused here would sit PENDING
-    // and be refused again every tick, silently. Where the location itself is
-    // the problem, the sentence goes on the attempt log the operator is already
-    // reading and the Build is closed out: the location is a column on this row
-    // and no later tick makes it fetchable. §6's `ARTIFACT_UNAVAILABLE` is the
-    // platform-blamed reason for an object that is not there to be fetched.
+    // Both dispositions come out of this one function, and which one is decided
+    // by the location rather than by the error. Where the location itself is
+    // the problem it is a column on this row and no later tick makes it
+    // fetchable, so the Build is closed out — §6's `ARTIFACT_UNAVAILABLE` is
+    // the platform-blamed reason for an object that is not there to be fetched.
     //
-    // The other refusals from that function are about this installation's
-    // federation rather than about this row, so they stay PENDING — configuring
-    // federation is a thing an operator can do that makes the next tick work.
-    if (!isFetchableBundleLocation(build.bundleLocation)) {
-      await recordBuildEvent(context.db, attempt, {
-        type: 'log',
-        line: fetchable.failure.message,
-        resource: 'bundle',
-      });
-      await recordBuildEvent(context.db, attempt, {
-        type: 'status',
-        phase: 'FAILED',
-        reason: 'ARTIFACT_UNAVAILABLE',
-      });
-      await context.db
-        .update(builds)
-        .set({ status: 'FAILED' })
-        .where(eq(builds.id, build.id));
-    }
-    return fetchable;
+    // The other refusals are about this installation's federation rather than
+    // about this row, so they wait: configuring federation is a thing an
+    // operator can do that makes the next tick work. **This is the arm that
+    // recorded nothing at all**, and it is the one build 13 sat two hours in.
+    return refuseDispatch(
+      context,
+      subject,
+      'NOT_BUILDABLE',
+      fetchable.failure.message,
+      isFetchableBundleLocation(build.bundleLocation)
+        ? { kind: 'waits' }
+        : { kind: 'closes', reason: 'ARTIFACT_UNAVAILABLE' },
+    );
   }
 
   const source: Source =
@@ -546,6 +681,11 @@ export const dispatchBuild = async (
         logFidelity: adapter.logFidelity,
         dispatchId,
         leasedAt: now,
+        // The wait is over, so what it was waiting on stops being true. Cleared
+        // here rather than left to age out, so that a Build whose lease expires
+        // and is refused again reports it again instead of being suppressed
+        // against a sentence from a previous attempt.
+        dispatchWaitingOn: null,
       })
       .where(
         and(
@@ -574,9 +714,17 @@ export const dispatchBuild = async (
   });
 
   if (claimResult.type === 'CONCURRENCY_EXCEEDED') {
-    return failed(
+    // `waits`, and the one refusal in this file that clears itself: the
+    // prerequisite is a free slot, which a running sibling gives up on its own.
+    // Recorded anyway, because "PENDING and not moving" looks identical to the
+    // developer whether the cause is a queue or a missing IAM binding, and the
+    // difference is the whole of what they want to know.
+    return refuseDispatch(
+      context,
+      subject,
       'NOT_BUILDABLE',
       `${app.name} already has ${claimResult.count} builds running, which is this installation's limit`,
+      { kind: 'waits' },
     );
   }
 
@@ -608,6 +756,10 @@ export const dispatchBuild = async (
         dispatchId: current.dispatchId ?? dispatchId,
       });
     }
+    // Deliberately not recorded. Losing the claim is not a refusal to report to
+    // anybody: another replica won the same row and is writing that Build's log
+    // right now, so a line here would say "not dispatched" underneath the events
+    // of the dispatch that did happen.
     return failed(
       'NOT_BUILDABLE',
       `Build ${build.id} is already running on ${current?.runner ?? adapter.name}`,

--- a/apps/spindrift/src/db/migrations/0017_build_dispatch_waiting_on.sql
+++ b/apps/spindrift/src/db/migrations/0017_build_dispatch_waiting_on.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "builds" ADD COLUMN "dispatch_waiting_on" text;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1785374380760,
       "tag": "0016_jsonb_documents",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1785374380761,
+      "tag": "0017_build_dispatch_waiting_on",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -515,6 +515,27 @@ export const builds = pgTable(
      * an in-cluster build and not a missing value to paper over.
      */
     runUrl: text('run_url'),
+    /**
+     * The sentence dispatch last refused this Build with, while it is still
+     * PENDING.
+     *
+     * A refusal an operator can clear — no federation, no route, a Target
+     * threshold no configured route meets — leaves the Build PENDING on
+     * purpose, so that configuring the thing makes the next tick work without
+     * anybody pressing Deploy again. The build loop runs once a second, so the
+     * refusal recurs at that rate, and the sentence belongs on the attempt log
+     * exactly once rather than once per tick.
+     *
+     * This column is what makes "exactly once" free. The Build row is already
+     * selected at the top of every dispatch, so comparing against it costs no
+     * query, and a refusal that has not changed writes nothing at all. It is a
+     * ledger of what was last said, not the place it was said: the operator
+     * reads the attempt log.
+     *
+     * Null whenever the Build is not waiting — never dispatched, claimed, or
+     * closed out.
+     */
+    dispatchWaitingOn: text('dispatch_waiting_on'),
     /** §4: durable identity for the dispatch attempt running or that ran this build. */
     dispatchId: text('dispatch_id'),
     /** Timestamp when the current runner claimed the dispatch lease. */

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -9,6 +9,7 @@ import { asc, eq } from 'drizzle-orm';
 import {
   type BuildDispatchContext,
   dispatchBuild,
+  recordDispatchWait,
 } from '../commands/builds/dispatch.ts';
 import { routeForTarget } from '../commands/builds/route.ts';
 import {
@@ -40,6 +41,11 @@ export async function runBuildPass(
     .select({
       buildId: builds.id,
       targetId: componentTargetDesired.targetId,
+      // Carried for the refusal below, which needs an attempt reference and
+      // cannot get one from `dispatchBuild` — it never reaches it.
+      appId: components.appId,
+      componentId: components.id,
+      waitingOn: builds.dispatchWaitingOn,
     })
     .from(builds)
     .innerJoin(components, eq(builds.componentId, components.id))
@@ -57,7 +63,26 @@ export async function runBuildPass(
     if (visited.has(row.buildId)) continue;
     visited.add(row.buildId);
     const route = await routeForTarget(row.targetId, context);
-    if (route === null) continue;
+    if (route === null) {
+      // A Target whose policy no configured route satisfies. Skipping silently
+      // is what `dispatchBuild`'s own refusals used to do, with the same result:
+      // a Build PENDING forever and nothing anywhere saying why. Configuring a
+      // route is an operator act that makes the next tick work, so the Build
+      // stays PENDING — and now says so, once.
+      await recordDispatchWait(
+        context,
+        {
+          attempt: {
+            appId: row.appId,
+            componentId: row.componentId,
+            buildId: row.buildId,
+          },
+          waitingOn: row.waitingOn,
+        },
+        'no build route this installation configures meets the policy of the Target this Build is placed on, so nothing can run it',
+      );
+      continue;
+    }
     const result = await dispatchBuild(
       {
         buildId: row.buildId,

--- a/apps/spindrift/test/commands/build-dispatch-refusal.test.ts
+++ b/apps/spindrift/test/commands/build-dispatch-refusal.test.ts
@@ -1,0 +1,439 @@
+/**
+ * What a refused dispatch tells the operator (ticket 25).
+ *
+ * `runBuildPass` is `if (result.ok) dispatched += 1`: it keeps the successes and
+ * drops everything else. So a refusal made before the claim reaches nobody
+ * unless dispatch writes it down first, and the Build sits PENDING being refused
+ * again once a second in silence.
+ *
+ * That is not hypothetical. Build 13 sat PENDING for two hours over a missing
+ * `roles/iam.serviceAccountTokenCreator` binding while the true sentence was
+ * composed once a second and thrown away every time; it was named in the end by
+ * reading Terraform, not by anything Spindrift said.
+ *
+ * Two dispositions, separated by whether a later tick can clear the refusal —
+ * and a suppression rule, because the honest fix to a silent 1Hz loop is a
+ * chatty one.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { asc, desc, eq } from 'drizzle-orm';
+import { dispatchBuild } from '../../src/commands/builds/dispatch.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+  componentTargetDesired,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { runBuildPass } from '../../src/reconciler/build-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const baseManifest = await fixtureManifest();
+
+const BUNDLE_DIGEST =
+  'sha256:3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03';
+const DEPOT_LOCATION = `gs://bluenose-spindrift-source/${BUNDLE_DIGEST.slice(7)}.tgz`;
+
+/** Federation that impersonates but cannot sign — build 13's 403, verbatim in shape. */
+function cloudThatCannotSign() {
+  return async (request: Request): Promise<Response> => {
+    if (request.url.includes(':signBlob')) {
+      return Response.json(
+        {
+          error: {
+            code: 403,
+            message:
+              'Permission iam.serviceAccounts.signBlob denied on resource',
+          },
+        },
+        { status: 403 },
+      );
+    }
+    return Response.json({ access_token: 'federated', expires_in: 3600 });
+  };
+}
+
+const FEDERATION = {
+  audience: '//iam.googleapis.com/projects/1/locations/global/x/y',
+  tokenUrl: 'https://sts.googleapis.test/v1/token',
+  tokenPath: '/var/run/secrets/spindrift/gcp-token',
+  impersonationUrl:
+    'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+  readToken: async () => 'projected-jwt',
+};
+
+describe('a dispatch refusal the operator can see', () => {
+  let ctx: CommandContext;
+  let route: FakeBuildAdapter;
+  let targetId: string;
+
+  async function seedBuild(
+    overrides: {
+      readonly location?: string | null;
+      readonly digest?: string | null;
+      readonly appName?: string;
+      readonly componentName?: string;
+    } = {},
+  ) {
+    const [app] = await ctx.db
+      .insert(apps)
+      .values({
+        name: overrides.appName ?? `app-${crypto.randomUUID().slice(0, 8)}`,
+        sourceKind: 'repo',
+        sourceRepoUrl: 'jonpulsifer/infra',
+        sourceRepoSubpath: 'apps/spindrift-demo/plain',
+      })
+      .returning();
+    const [component] = await ctx.db
+      .insert(components)
+      .values({
+        appId: app!.id,
+        name: overrides.componentName ?? 'web',
+        kind: 'service',
+      })
+      .returning();
+    await ctx.db
+      .insert(componentTargetDesired)
+      .values({ componentId: component!.id, targetId });
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: component!.id,
+        commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+        targetShape: 'image',
+        artifactType: 'image',
+        bundleDigest:
+          overrides.digest === undefined ? BUNDLE_DIGEST : overrides.digest,
+        bundleLocation:
+          overrides.location === undefined
+            ? DEPOT_LOCATION
+            : overrides.location,
+      })
+      .returning();
+    return build!;
+  }
+
+  function withFederation(federation: unknown): CommandContext {
+    return {
+      ...ctx,
+      manifest: {
+        ...baseManifest,
+        cloud: { ...baseManifest.cloud, federation },
+      },
+    } as CommandContext;
+  }
+
+  /** Every log line written against one Build, oldest first. */
+  async function linesFor(
+    context: CommandContext,
+    buildId: number,
+  ): Promise<string[]> {
+    const rows = await context.db
+      .select()
+      .from(attemptEvents)
+      .where(eq(attemptEvents.buildId, buildId))
+      .orderBy(asc(attemptEvents.id));
+    return rows
+      .filter((row) => row.eventType === 'log')
+      .map((row) => row.line ?? '');
+  }
+
+  async function buildRow(context: CommandContext, buildId: number) {
+    const [row] = await context.db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, buildId));
+    return row!;
+  }
+
+  beforeEach(async () => {
+    const { client, db } = database();
+    await db.delete(attemptEvents);
+    await db.delete(componentTargetDesired);
+    await db.delete(builds);
+    await db.delete(components);
+    await db.delete(apps);
+    await db.delete(targets);
+    await db.delete(users);
+
+    const [operator] = await db
+      .insert(users)
+      .values({ displayName: 'Operator' })
+      .returning();
+    const [target] = await db
+      .insert(targets)
+      .values(targetValues({ name: 'target-a', rank: 1 }))
+      .returning();
+    targetId = target!.id;
+
+    route = new FakeBuildAdapter();
+    const adapters: AdapterRegistry = {
+      deploy: () => null,
+      build: (name) => (name === 'hosted' ? route : null),
+      store: () => new FakeSecretStore(),
+      supplyChain: () => new SupplyChainHarness(),
+      repository: () => null,
+    };
+
+    ctx = {
+      client,
+      db,
+      adapters,
+      clock: { now: () => new Date('2026-08-01T12:00:00.000Z') },
+      manifest: baseManifest,
+      operatorId: operator!.id,
+      principal: {
+        type: 'user',
+        id: operator!.id,
+        displayName: 'Operator',
+      },
+    } as CommandContext;
+  });
+
+  describe('a refusal no later tick can clear', () => {
+    test('closes the Build out rather than retrying it forever', async () => {
+      // A Build with no staged bundle location. Nothing about a later tick
+      // stages one — staging happens where the Build is created — so leaving it
+      // PENDING would be a row refused once a second until the table is dropped.
+      const context = withFederation(FEDERATION);
+      const build = await seedBuild({ location: null });
+
+      const result = await dispatchBuild(
+        { buildId: build.id, route: 'hosted' },
+        context,
+      );
+
+      expect(result.ok).toBe(false);
+      const row = await buildRow(context, build.id);
+      expect(row.status).toBe('FAILED');
+      expect(row.dispatchWaitingOn).toBeNull();
+      expect(await linesFor(context, build.id)).toEqual([
+        `Build ${build.id} has no staged bundle location, so no route can fetch it`,
+      ]);
+    });
+
+    test('carries §6 reason and blame, so the screen can say who is at fault', async () => {
+      const context = withFederation(FEDERATION);
+      const build = await seedBuild({ digest: null });
+
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+
+      const [status] = await context.db
+        .select()
+        .from(attemptEvents)
+        .where(eq(attemptEvents.buildId, build.id))
+        .orderBy(desc(attemptEvents.id))
+        .limit(1);
+      expect(status?.eventType).toBe('status');
+      expect(status?.phase).toBe('FAILED');
+      // Spindrift held the bundle. Nothing the developer wrote caused this.
+      expect(status?.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(status?.blame).toBe('platform');
+    });
+  });
+
+  describe('a refusal a later tick can clear', () => {
+    test('leaves the Build PENDING and records what it is waiting on', async () => {
+      // The mirror of the case above, and the one that cost the hours: nothing
+      // is wrong with this row, so an operator who configures federation gets
+      // it dispatched without pressing anything again.
+      const context = withFederation(null);
+      const build = await seedBuild();
+
+      const result = await dispatchBuild(
+        { buildId: build.id, route: 'hosted' },
+        context,
+      );
+
+      expect(result.ok).toBe(false);
+      const row = await buildRow(context, build.id);
+      expect(row.status).toBe('PENDING');
+      expect(row.dispatchWaitingOn).toContain('federation');
+      expect(await linesFor(context, build.id)).toEqual([
+        row.dispatchWaitingOn ?? '',
+      ]);
+    });
+
+    test('writes no status event, because the Build has not failed', async () => {
+      const context = withFederation(null);
+      const build = await seedBuild();
+
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+
+      const rows = await context.db
+        .select()
+        .from(attemptEvents)
+        .where(eq(attemptEvents.buildId, build.id));
+      expect(rows.every((row) => row.eventType === 'log')).toBe(true);
+    });
+
+    test('records the signing failure build 13 sat two hours in', async () => {
+      // Federation is configured and impersonation works; `signBlob` is the one
+      // call that is refused, because `workloadIdentityUser` carries
+      // `getAccessToken` and not `iam.serviceAccounts.signBlob`. The location is
+      // a good one, so this is a fact about the installation and not the row.
+      const context = withFederation({
+        ...FEDERATION,
+        fetch: cloudThatCannotSign(),
+      });
+      const build = await seedBuild();
+
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+
+      const row = await buildRow(context, build.id);
+      expect(row.status).toBe('PENDING');
+      const [line] = await linesFor(context, build.id);
+      expect(line).toContain('could not mint a signed URL');
+      // The object, so an operator can go look it up. Never the signed URL.
+      expect(line).toContain(DEPOT_LOCATION);
+      expect(line).not.toContain('X-Goog-Signature');
+    });
+  });
+
+  describe('the sentence names the missing prerequisite', () => {
+    test('a route this installation does not have says to configure one', async () => {
+      const context = withFederation(FEDERATION);
+      const build = await seedBuild();
+
+      const result = await dispatchBuild(
+        { buildId: build.id, route: 'managed' },
+        context,
+      );
+
+      expect(result.ok).toBe(false);
+      const [line] = await linesFor(context, build.id);
+      expect(line).toContain('managed');
+      expect(line).toContain('configured');
+      expect((await buildRow(context, build.id)).status).toBe('PENDING');
+    });
+
+    test('a Target threshold no route meets names the Target and the route', async () => {
+      // §16: "the level is a threshold, then admin rank wins." Both halves are
+      // configuration, so this waits rather than closing out.
+      await ctx.db
+        .update(targets)
+        .set({ minBuildLevel: 3 })
+        .where(eq(targets.id, targetId));
+      const context = withFederation(FEDERATION);
+      const build = await seedBuild();
+
+      await dispatchBuild(
+        { buildId: build.id, route: 'hosted', placementTargetId: targetId },
+        context,
+      );
+
+      const [line] = await linesFor(context, build.id);
+      expect(line).toContain('target-a');
+      expect(line).toContain('fake');
+      expect((await buildRow(context, build.id)).status).toBe('PENDING');
+    });
+
+    test('a Target no configured route can serve is recorded by the loop itself', async () => {
+      // `runBuildPass` selects the route and skips the Build when there is
+      // none, so this refusal never reaches `dispatchBuild` at all. Skipping
+      // silently is the same disease with a different call site.
+      const context = {
+        ...withFederation(FEDERATION),
+        adapters: { ...ctx.adapters, build: () => null },
+      } as CommandContext;
+      const build = await seedBuild();
+
+      expect(await runBuildPass(context)).toBe(0);
+
+      const row = await buildRow(context, build.id);
+      expect(row.status).toBe('PENDING');
+      const [line] = await linesFor(context, build.id);
+      expect(line).toContain('no build route');
+      expect(line).toContain('Target');
+    });
+  });
+
+  describe('repeat suppression', () => {
+    test('a Build refused every tick is written down once', async () => {
+      // The loop runs at 1Hz and the refusal is durable, so the naive fix is a
+      // log line a second. An operator wants to know a Build is waiting and
+      // what on — not to read it several thousand times.
+      const context = withFederation(null);
+      const build = await seedBuild();
+
+      for (let tick = 0; tick < 5; tick += 1) {
+        await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
+      }
+
+      expect(await linesFor(context, build.id)).toHaveLength(1);
+    });
+
+    test('through the loop as well, which is where the ticks actually come from', async () => {
+      const context = withFederation(null);
+      const build = await seedBuild();
+
+      for (let tick = 0; tick < 5; tick += 1) {
+        expect(await runBuildPass(context)).toBe(0);
+      }
+
+      expect(await linesFor(context, build.id)).toHaveLength(1);
+    });
+
+    test('a refusal that changes is news, and is written again', async () => {
+      // Suppression is per sentence, not per Build: an operator who configures
+      // federation and then hits the signing gap has been told two different
+      // true things, and the second one is the one they need.
+      const build = await seedBuild();
+      const unconfigured = withFederation(null);
+      const unsigned = withFederation({
+        ...FEDERATION,
+        fetch: cloudThatCannotSign(),
+      });
+
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, unconfigured);
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, unconfigured);
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, unsigned);
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, unsigned);
+
+      const lines = await linesFor(unsigned, build.id);
+      expect(lines).toHaveLength(2);
+      expect(lines[0]).toContain('no federation');
+      expect(lines[1]).toContain('could not mint a signed URL');
+    });
+
+    test('a Build that dispatches stops waiting, so a later refusal reports again', async () => {
+      // The claim clears the sentence. Without that, a Build whose lease expires
+      // and is refused a second time would be suppressed against a sentence from
+      // an attempt that is over.
+      const build = await seedBuild();
+      const unconfigured = withFederation(null);
+      const configured = withFederation({
+        ...FEDERATION,
+        fetch: async (request: Request) =>
+          request.url.includes(':signBlob')
+            ? Response.json({ signedBlob: btoa('\x01\x02') })
+            : Response.json({ access_token: 'federated', expires_in: 3600 }),
+      });
+
+      await dispatchBuild({ buildId: build.id, route: 'hosted' }, unconfigured);
+      expect(
+        (await buildRow(unconfigured, build.id)).dispatchWaitingOn,
+      ).not.toBeNull();
+
+      const dispatched = await dispatchBuild(
+        { buildId: build.id, route: 'hosted' },
+        configured,
+      );
+      expect(dispatched.ok).toBe(true);
+      expect(
+        (await buildRow(configured, build.id)).dispatchWaitingOn,
+      ).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes ticket 25.

Every refusal `dispatchBuild` makes happens **before** the claim, so it is returned to `runBuildPass` — which is `if (result.ok) dispatched += 1` and drops everything else. A refusal that only returns reaches nobody: the Build sits `PENDING` being refused again once a second, in silence.

That is not hypothetical. Build 13 sat `PENDING` for two hours over a missing `roles/iam.serviceAccountTokenCreator` binding while `fetchableBundleLocation` composed the true sentence every tick and threw it away every tick. Two agent sessions went into naming it, and it was named in the end by reading Terraform — not by anything Spindrift said. The sentence existed. Nobody could see it.

## What changed

`refuseDispatch` splits every pre-claim refusal on one question: **can a later tick clear this?**

- **`closes`** — a fact about the row (a location no route can fetch, a name no registry will accept, a bundle never staged). The Build is failed with §6's reason and the sentence goes on the attempt log, as the unfetchable-scheme arm already did. Retrying once a second forever is the only alternative.
- **`waits`** — a fact about the installation (no federation, no such route, a Target threshold no configured route meets). The Build stays `PENDING`, because configuring the thing should make the next tick work without anybody pressing Deploy again — and it now records what is being waited on.

The design that produced the gap was deliberate and the reasoning held; only the second class recorded *nothing at all*.

**Repeat suppression.** The loop runs at 1Hz and the refusal is durable, so the naive fix writes a line a second. The sentence is suppressed against a new `builds.dispatch_waiting_on` column, which costs no query — the Build row is already selected at the top of every dispatch, so an unchanged refusal writes nothing. A *changed* refusal writes, because that is news. The claim clears the column, so a Build whose lease expires and is refused again reports again.

`runBuildPass` writes the one refusal of that class made before `dispatchBuild` is reached — a Target no configured route can serve — through the same function, instead of `continue`.

## Verification

12 new tests, in `test/commands/build-dispatch-refusal.test.ts`. Confirmed non-vacuous: with `dispatch.ts` and `build-loop.ts` reverted and the column left in place, **11 of the 12 fail** (the 12th is a guard paired with a line-exists assertion).

The signing case is exercised with a fake cloud that impersonates but answers `403` on `:signBlob` — build 13's failure in shape — and asserts the Build stays `PENDING`, the line names the object rather than the signed URL, and it is written once across five ticks.

```
1084 pass, 0 fail (1072 before, 12 added)
bun run typecheck   clean
bun run lint        clean
mise run ts:check   clean
mise run check      clean
```

Migration `0016_build_dispatch_waiting_on` adds one nullable column; the test harness replays it for every test in the suite.

Not verified live: no build has been dispatched from this branch. The behaviour is verified against the fakes and against a reproduction of build 13's refusal shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)