### PR TITLE
fix(spindrift): forge signatures by mutating decoded bytes, not the encoded string

### DIFF
--- a/apps/spindrift/test/auth/credential-admin.test.ts
+++ b/apps/spindrift/test/auth/credential-admin.test.ts
@@ -6,6 +6,7 @@
  * linked Gateway session cannot accidentally become an account root.
  */
 import { describe, expect, test } from 'bun:test';
+import { base64urlDecode, base64urlEncode } from '../../src/auth/bytes.ts';
 import {
   beginAddPasskey,
   beginCredentialChange,
@@ -76,6 +77,28 @@ async function enrolled(): Promise<{
 async function fresh(principal: Principal, root: Authenticator) {
   const begun = await beginCredentialChange(deps(), principal);
   return root.assert(begun.challenge);
+}
+
+/**
+ * Flip a byte inside the DER-encoded signature payload so the assertion
+ * decodes to different bytes and fails cryptographic verification.
+ *
+ * The signature is `base64urlEncode(derEncode(r || s))`
+ * (`test/harness/authenticator.ts`), and a DER-encoded ECDSA signature is
+ * usually not a multiple of three bytes — so editing the *encoded string*
+ * (e.g. overwriting its last character) can land in slack bits that decode
+ * back to the original bytes about one run in eight. Decoding, XOR-ing the
+ * final byte of the DER blob — which is always the low byte of the `s`
+ * integer, never the tag/length framing `derToRawEcdsa` reads structurally —
+ * and re-encoding guarantees both a different decoded value on every run and
+ * a signature that genuinely fails `crypto.subtle.verify`.
+ */
+function forgeSignature(signature: string): string {
+  const bytes = base64urlDecode(signature);
+  if (!bytes) throw new Error('signature did not decode');
+  const mutated = new Uint8Array(bytes);
+  mutated[mutated.length - 1] = mutated[mutated.length - 1]! ^ 0xff;
+  return base64urlEncode(mutated);
 }
 
 describe('adding a passkey', () => {
@@ -194,7 +217,7 @@ describe('the Gateway binding', () => {
     const assertion = await fresh(principal, root);
     const forged = {
       ...assertion,
-      signature: `${assertion.signature.slice(0, -1)}x`,
+      signature: forgeSignature(assertion.signature),
     };
 
     const result = await linkGatewayIdentity(


### PR DESCRIPTION
## Summary

Closes ticket `32-forge-a-signature-that-is-always-a-forgery`.

- `test/auth/credential-admin.test.ts:192` ("does not link when the fresh assertion is invalid") forged a signature by overwriting the last base64url character: `` `${assertion.signature.slice(0, -1)}x` ``. A DER-encoded ECDSA signature is usually not a multiple of three bytes, so the final base64url character carries only 2-4 bits of real payload — overwriting it produced a *different string* that decoded to the *same bytes* ~12% of the time, so the negative test flaked by legitimately verifying a valid signature.
- Fixed by decoding the signature, XOR-ing the **last byte of the DER blob** — always the low byte of the `s` integer, never the tag/length framing `derToRawEcdsa` reads structurally — and re-encoding. This mutates real signature bytes, so the forgery decodes to different bytes on every run and genuinely fails `crypto.subtle.verify`, not just a string comparison.
- Swept the rest of the test tree for sibling negative cases built by string-mutating an encoded value (base64url/hex/DER/JWT). The only other close candidates were `test/supply-chain/finalize.test.ts` ("a tampered signature is refused", which decodes then reverses the actual byte buffer) and `test/integrations/github/credential-crypto.test.ts` ("detects ciphertext tampering", which flips the *middle* character of a full base64 quantum, never the slack-bit-bearing tail) — both already mutate at the byte level or fall outside any slack-bit position, so no changes were needed there.

## Test plan

- [x] `bun test` (apps/spindrift) — 1097 pass, 0 fail
- [x] `bun run typecheck` (apps/spindrift) — clean
- [x] `bun run lint` (apps/spindrift) — clean
- [x] `mise run ts:check` (workspace) — clean
- [x] Target test run 250x via `bun test ... --rerun-each=250` — 250 pass, 0 fail
- [x] Verification-removal check: neutered `verifySignature` in `src/auth/webauthn.ts` to `return true`, confirmed the test fails (`Expected: false, Received: true`), then restored the source (`git diff` on that file is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)