### PR TITLE
fix(spindrift): cut the client bundle's value-edge into the command layer

### DIFF
--- a/apps/spindrift/src/web/client.ts
+++ b/apps/spindrift/src/web/client.ts
@@ -13,7 +13,7 @@
  */
 import type { commandRegistry } from '../commands/registry.ts';
 import type { CommandResult } from '../commands/types.ts';
-import { pathFor, type TransportFailureCode } from './dispatch.ts';
+import { pathFor, type TransportFailureCode } from './command-path.ts';
 
 type Registry = typeof commandRegistry;
 

--- a/apps/spindrift/src/web/command-path.ts
+++ b/apps/spindrift/src/web/command-path.ts
@@ -1,0 +1,62 @@
+/**
+ * The client-safe edge of the command dispatch boundary.
+ *
+ * `dispatch.ts` is the server-side transport, and behind `commands/registry.ts`
+ * sits every command handler — drizzle queries, adapter imports, server-only
+ * modules. None of that has business in the browser. But the browser still
+ * needs to know the route a command is reached at, and the shape of a
+ * transport-produced refusal, so those three things — `pathFor`,
+ * `COMMAND_PATH_PREFIX`, and `TransportFailureCode` — live in their own module
+ * rather than in `dispatch.ts`.
+ *
+ * The load-bearing line is the import below: `CommandName` comes in with
+ * `import type`, which TypeScript erases at compile time, so Bun never turns
+ * it into a module edge. That is what keeps the registry — and the entire
+ * command layer behind it — out of `client.ts`'s reachable graph.
+ * `test/web/client-bundle.test.ts` builds the client and asserts this holds.
+ *
+ * `dispatch.ts` re-exports from here rather than this module importing from
+ * `dispatch.ts`, so the server side is unchanged and there is exactly one
+ * definition of each of these three things.
+ */
+import type { CommandName } from '../commands/registry.ts';
+import type { CommandFailureCode } from '../commands/types.ts';
+
+/**
+ * Unversioned, and named so that nobody has to be told twice. §21 permits a
+ * purpose-specific integration protocol for the browser; this is that and
+ * nothing more.
+ */
+export const COMMAND_PATH_PREFIX = '/internal/commands';
+
+/**
+ * The route a command is reached at, and the one place the path is composed.
+ *
+ * It takes a {@link CommandName} rather than a string on purpose: this file's
+ * whole claim is that a path with no command behind it cannot be written, and a
+ * `string` parameter here would be the one place somebody could write one.
+ */
+export function pathFor(name: CommandName): string {
+  return `${COMMAND_PATH_PREFIX}/${name}`;
+}
+
+/**
+ * Why a request was refused before, or instead of, a command running.
+ *
+ * The command layer's codes plus the two only a transport can produce. Both
+ * additions are genuinely not the command layer's business: a request with no
+ * session never reaches a command, and neither does one whose body is not JSON,
+ * so neither could be a `CommandFailureCode` without inventing a failure the
+ * command layer cannot cause.
+ *
+ * Keeping them in one union is what makes `dispatch.ts`'s `STATUS` total.
+ * `client.ts` imports this rather than widening to `string`, so a browser
+ * switching on a refusal is switching over a closed set.
+ */
+export type TransportFailureCode =
+  | CommandFailureCode
+  | 'UNAUTHENTICATED'
+  | 'FORBIDDEN'
+  | 'METHOD_NOT_ALLOWED'
+  | 'MALFORMED_REQUEST'
+  | 'INTERNAL';

--- a/apps/spindrift/src/web/dispatch.ts
+++ b/apps/spindrift/src/web/dispatch.ts
@@ -24,6 +24,13 @@
  * What is left is transport: decode JSON, find a principal, call `dispatch`,
  * and choose a status code. Every decision about the act itself was already
  * made by the command.
+ *
+ * `pathFor`, `COMMAND_PATH_PREFIX`, and `TransportFailureCode` live in
+ * `./command-path.ts` and are re-exported below rather than defined here,
+ * because those three are the only edge `client.ts` needs into this file —
+ * everything else pulls in `commands/registry.ts` as a value, which drags the
+ * whole server-only command layer into the browser bundle.
+ * `test/web/client-bundle.test.ts` guards against that edge coming back.
  */
 
 import type { RequestAuthentication } from '../auth/types.ts';
@@ -32,29 +39,15 @@ import {
   commandNames,
   dispatch,
 } from '../commands/registry.ts';
-import type {
-  CommandContext,
-  CommandFailureCode,
-  Principal,
-} from '../commands/types.ts';
+import type { CommandContext, Principal } from '../commands/types.ts';
+import {
+  COMMAND_PATH_PREFIX,
+  pathFor,
+  type TransportFailureCode,
+} from './command-path.ts';
 
-/**
- * Unversioned, and named so that nobody has to be told twice. §21 permits a
- * purpose-specific integration protocol for the browser; this is that and
- * nothing more.
- */
-export const COMMAND_PATH_PREFIX = '/internal/commands';
-
-/**
- * The route a command is reached at, and the one place the path is composed.
- *
- * It takes a {@link CommandName} rather than a string on purpose: this file's
- * whole claim is that a path with no command behind it cannot be written, and a
- * `string` parameter here would be the one place somebody could write one.
- */
-export function pathFor(name: CommandName): string {
-  return `${COMMAND_PATH_PREFIX}/${name}`;
-}
+export type { TransportFailureCode };
+export { COMMAND_PATH_PREFIX, pathFor };
 
 export interface DispatchDeps {
   /**
@@ -80,27 +73,6 @@ export interface DispatchDeps {
    */
   context(principal: Principal): CommandContext | Promise<CommandContext>;
 }
-
-/**
- * Why a request was refused before, or instead of, a command running.
- *
- * The command layer's codes plus the two only a transport can produce. Both
- * additions are genuinely not the command layer's business: a request with no
- * session never reaches a command, and neither does one whose body is not JSON,
- * so neither could be a `CommandFailureCode` without inventing a failure the
- * command layer cannot cause.
- *
- * Keeping them in one union is what makes {@link STATUS} total. `client.ts`
- * imports this rather than widening to `string`, so a browser switching on a
- * refusal is switching over a closed set.
- */
-export type TransportFailureCode =
-  | CommandFailureCode
-  | 'UNAUTHENTICATED'
-  | 'FORBIDDEN'
-  | 'METHOD_NOT_ALLOWED'
-  | 'MALFORMED_REQUEST'
-  | 'INTERNAL';
 
 /**
  * The HTTP status a refusal reads as.

--- a/apps/spindrift/test/web/client-bundle.test.ts
+++ b/apps/spindrift/test/web/client-bundle.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The client bundle's only edge into the command layer, and the ceiling that
+ * keeps it from growing back.
+ *
+ * `.agent/plans/spindrift/issues/32-onboard-an-installation-without-a-manifest.md`
+ * (2026-08-01 comment) names the landmine: `client.ts` value-imported
+ * `pathFor` from `dispatch.ts`, and `dispatch.ts` value-imported `dispatch`
+ * and `commandNames` from `commands/registry.ts` — the registry that wires
+ * every command handler to its drizzle queries and adapters. Bun resolves
+ * imports before tree-shaking, so an export nothing calls is still a build
+ * error, and PR #1492's CI proved it: a change nowhere near the browser broke
+ * the client build, because `configureInstallation` importing
+ * `config/manifest-store.ts` was the first command handler to reach for a
+ * server-only Node polyfill the browser build does not carry.
+ *
+ * The fix moved `pathFor`, `COMMAND_PATH_PREFIX`, and `TransportFailureCode`
+ * into `src/web/command-path.ts`, which takes `CommandName` as `import type`
+ * only — erased at compile time, so Bun never turns it into a module edge.
+ * `dispatch.ts` re-exports the three from there rather than defining them
+ * itself, so the server side is unchanged.
+ *
+ * This runs `build.ts` itself, as a real subprocess — the same command the
+ * Dockerfile's `builder` stage runs (`bun run build --filter=spindrift`,
+ * which resolves to `bun run build.ts` in this package) — rather than calling
+ * `Bun.build` in-process. A nested `Bun.build` invoked from inside the
+ * `bun test` runtime fails to resolve this app's own `../`-relative imports
+ * (a `bun test`-specific resolver quirk, reproduced against a minimal
+ * fixture independently of this change); shelling out sidesteps it and is
+ * more honest besides, since it is the literal command CI and the image run.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const APP = join(import.meta.dir, '../..');
+
+async function buildClient(): Promise<{ readonly stdout: string }> {
+  const proc = Bun.spawn(['bun', 'run', 'build.ts'], {
+    cwd: APP,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`bun run build.ts exited ${exitCode}\n${stderr}`);
+  }
+  return { stdout };
+}
+
+const built = await buildClient();
+const DIST = join(APP, 'dist');
+
+describe('the client bundle', () => {
+  test('carries no fingerprint of the command layer it used to pull in', async () => {
+    const files = await readdir(DIST);
+    const entry = files.find((file) => file.endsWith('.js'));
+    expect(entry).toBeDefined();
+    const text = await Bun.file(join(DIST, entry!)).text();
+
+    // Bun's unminified output keeps a `// path/to/module.ts` comment ahead of
+    // each bundled module — the same shape PR #1492's CI failure named a file
+    // by (`src/config/manifest-store.ts:8:10`). If `commands/registry.ts`
+    // does not appear here, none of the handlers it wires are in the bundle
+    // either, which is the property this whole fix rests on.
+    expect(text).not.toContain('commands/registry.ts');
+    // The handler whose server-only import broke #1492's build, named
+    // directly rather than only through the registry it is reached from.
+    expect(text).not.toContain('config/manifest-store.ts');
+  });
+
+  test('stays within the ceiling cutting that edge bought back', async () => {
+    const files = await readdir(DIST);
+    const sizes = await Promise.all(
+      files.map(async (file) => (await stat(join(DIST, file))).size),
+    );
+    const bytes = sizes.reduce((total, size) => total + size, 0);
+
+    // `build.ts` prints its own total; keeping this test's math and its
+    // console line honest against each other.
+    expect(built.stdout).toContain(`${files.length} files`);
+
+    // Measured on this branch: ~5.4 MiB for this exact build, once the
+    // registry stopped being reachable. Before the fix, with the whole
+    // command layer pulled in through `client.ts` -> `dispatch.ts` ->
+    // `registry.ts`, the same build was ~8.7 MiB (the number
+    // `2026-08-01`'s ticket comment records). The ceiling below sits at
+    // 6 MiB: comfortably above today's measured size — headroom for
+    // ordinary UI growth — and comfortably below what reintroducing the
+    // registry edge would cost (+~3 MiB), so that regression trips this
+    // rather than shipping unnoticed the way it did the first time.
+    const CEILING_BYTES = 6 * 1024 * 1024;
+    expect(bytes).toBeLessThan(CEILING_BYTES);
+  });
+});


### PR DESCRIPTION
## Summary

- `src/web/client.ts` value-imported `pathFor` from `dispatch.ts`, and `dispatch.ts` value-imported `dispatch`/`commandNames` from `commands/registry.ts` — the registry that wires every command handler to its drizzle queries and adapters. Bun resolves imports before tree-shaking, so the entire server-only command layer rode along into the browser bundle. This already broke PR #1492's CI on a file it never touched (`node:util`'s `isDeepStrictEqual` has no browser polyfill export), patched narrowly there; this PR fixes the general problem, diagnosed in the 2026-08-01 comment on `.agent/plans/spindrift/issues/32-onboard-an-installation-without-a-manifest.md`.
- `pathFor`, `COMMAND_PATH_PREFIX`, and `TransportFailureCode` — the three things the client actually needs — move into a new `src/web/command-path.ts`, which takes `CommandName` as `import type` only. TypeScript erases type-only imports, so Bun never turns it into a module edge. `dispatch.ts` re-exports from there rather than duplicating, so the server side is unchanged.
- Added `test/web/client-bundle.test.ts`, which shells out to the real `bun run build.ts` (the same command the Dockerfile's `builder` stage runs), asserts the compiled client no longer names `commands/registry.ts` or `config/manifest-store.ts` (the file that broke #1492), and holds the total bundle under a 6 MiB ceiling.

## Evidence — before/after, same build command (`bun run build.ts`, no `NODE_ENV=production`, matching the Dockerfile's builder stage)

Before (stashed this fix):
```
spindrift client → dist/ (4 files, 8681.1 KiB)
$ grep -c "commands/registry.ts" dist/chunk-*.js
1
$ grep -c "config/manifest-store.ts" dist/chunk-*.js
1
```

After:
```
spindrift client → dist/ (4 files, 5429.6 KiB)
$ grep -c "commands/registry.ts" dist/chunk-*.js
0
$ grep -c "config/manifest-store.ts" dist/chunk-*.js
0
```

**8681.1 KiB → 5429.6 KiB** (≈37% smaller), and the command layer's fingerprint is gone from the compiled output.

### Import graph

Before: `client.ts` --(value)--> `dispatch.ts` --(value)--> `commands/registry.ts` --(value)--> every command handler (drizzle queries, adapters, `config/manifest-store.ts`, ...).

After: `client.ts` --(value)--> `command-path.ts` --(type only, erased)--> `commands/registry.ts`. `dispatch.ts` is no longer in the client's reachable graph at all.

## Known related issue found, out of scope here

While tracing the graph I found `src/web/app.tsx` -> `stream-client.ts` -> `streams.ts` value-imports `drizzle-orm` directly, so `drizzle-orm` is still present in the post-fix client bundle through an unrelated path. `streams.ts` and `app.tsx` are outside this PR's scope fence (other agents are live on `src/web/views/**` and `src/config/**`); flagging for a follow-up ticket.

## Test plan

- [x] `bun test` — 1099 pass, 0 fail (with `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift`)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [x] `mise run ts:check` — clean (workspace-wide)
- [x] Before/after bundle size and fingerprint check captured above

🤖 Generated with [Claude Code](https://claude.com/claude-code)