### PR TITLE
fix(spindrift): stop restating the deployment in the manifest

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -421,18 +421,27 @@ the projected service account token.
 **A cloud Target needs no variable at all**, and that is §13's one auth mode
 arriving where the spec wanted it: "native OIDC federation, nothing stored".
 `src/adapters/deploy/cloud/federation.ts` reads a projected token, exchanges it
-at the pool's STS endpoint, and optionally impersonates a service account —
-`cloud.federation` in the manifest is that `external_account` credential
-document, field for field, so an operator who has one copies it.
+at the pool's STS endpoint, and optionally impersonates a service account.
+
+**Nobody configures any of that.** The installer chart already renders an
+`external_account` credential document from the workload-identity audience and
+mount path a release names, and points `GOOGLE_APPLICATION_CREDENTIALS` at it.
+`src/config/federation-credential.ts` reads the four facts back out of that
+document, and `resolveManifest` joins them onto the manifest every reader gets —
+so there is no `cloud.federation` key to author, and nothing that could disagree
+with the pod it is running in. An installation whose deployment mounts no
+credential resolves `null`, which is exactly what an installation with no cloud
+Targets honestly has.
 
 The mistake it exists to prevent is worth naming, because it is the convenient
 one: **the default service account token is the wrong token.** It is minted for
 this cluster's own API server, and a cloud API refuses it — the symptom would be
-a `401` on every cloud deploy, blamed on the Target. So `tokenPath` is required
-configuration naming the *separately* projected volume whose audience is the
-pool, with no default that could quietly be the wrong one. An installation that
-configured no federation gets a provider that refuses with that sentence, rather
-than a Target that silently cannot be assessed.
+a `401` on every cloud deploy, blamed on the Target. So the token path is read
+from the credential's `credential_source.file`, which the chart renders from the
+*separately* projected volume whose audience is the pool, with no default that
+could quietly be the wrong one. An installation with no federation gets a
+provider that refuses with that sentence, rather than a Target that silently
+cannot be assessed.
 
 ## The three deploy backends
 

--- a/apps/spindrift/src/commands/installation/configure.ts
+++ b/apps/spindrift/src/commands/installation/configure.ts
@@ -26,7 +26,7 @@
  */
 import { z } from 'zod';
 import {
-  type InstallationManifest,
+  type AuthoredManifest,
   installationManifestSchema,
 } from '../../config/manifest.schema.ts';
 import { ManifestError, validateManifest } from '../../config/manifest.ts';
@@ -67,7 +67,7 @@ export const configureInstallation: Command<
   ConfigureInstallationInput,
   ConfigureInstallationResult
 > = async (input, context) => {
-  let manifest: InstallationManifest;
+  let manifest: AuthoredManifest;
   try {
     manifest = validateManifest(input.manifest, 'the submitted manifest');
   } catch (cause) {

--- a/apps/spindrift/src/config/federation-credential.ts
+++ b/apps/spindrift/src/config/federation-credential.ts
@@ -1,0 +1,138 @@
+/**
+ * §13's federation, read from the credential this deployment mounts.
+ *
+ * The installer chart writes an `external_account` credential document from the
+ * workload-identity audience and mount path a release names, and points
+ * `GOOGLE_APPLICATION_CREDENTIALS` at it. Every fact federation needs is
+ * already in that document: the pool provider this cluster's tokens are trusted
+ * by, where a projected token is exchanged, where that token is read from, and
+ * which service account is impersonated with the result.
+ *
+ * **So the manifest does not ask for them a second time.** §20's rule is
+ * "everything naming this installation is a value in the installation manifest;
+ * a literal outside it is a bug", and the rule is enforced as a grep — which a
+ * value living in *both* the chart and the manifest satisfies while still being
+ * able to disagree with itself. When it disagreed, the failure surfaced as an
+ * `iam.serviceAccounts.signBlob` refusal that read as a code defect for a whole
+ * session. There is one copy now, and it is the one the pod is holding.
+ *
+ * `null` — no credential mounted — stays a supported installation, for exactly
+ * the reason `cloud.federation` was nullable when it was authored: an
+ * installation with no cloud Targets has no honest value here, and a
+ * placeholder would be a configuration that looks complete and fails on the
+ * first deploy. Null means cloud Targets cannot be reached, and nothing else
+ * changes.
+ *
+ * Read on every resolution rather than captured once, for the same reason
+ * `federation.ts` re-reads the projected token: the file is a projected volume
+ * the kubelet owns, and a value captured at boot is a value that stops being
+ * true the moment the credential is re-rendered.
+ */
+import { z } from 'zod';
+import type { FederationConfig } from '../adapters/deploy/cloud/federation.ts';
+
+/**
+ * Where the credential document is. The name is Google's own ADC variable, not
+ * this software's: it names no installation, and the chart sets it beside the
+ * mount so that any client in the process — this one included — finds the same
+ * credential.
+ */
+export const GCP_CREDENTIALS_VAR = 'GOOGLE_APPLICATION_CREDENTIALS';
+
+/** Raised when a mounted credential is present and unusable. */
+export class FederationCredentialError extends Error {
+  override readonly name = 'FederationCredentialError';
+}
+
+/**
+ * An `external_account` credential document, as far as federation reads it.
+ *
+ * Not `.strict()`: this is a third party's format and a document carrying a
+ * field this code does not read is a valid credential, not a broken one.
+ * `type` is checked because a *service account key* file would parse against
+ * everything else and is the one thing §13 forbids being here at all.
+ */
+const externalAccountSchema = z.object({
+  type: z.literal('external_account'),
+  audience: z.string().trim().min(1),
+  token_url: z.url(),
+  credential_source: z.object({
+    file: z
+      .string()
+      .trim()
+      .regex(/^\//, 'must be an absolute path inside the pod'),
+  }),
+  service_account_impersonation_url: z.url().optional(),
+});
+
+type Env = Record<string, string | undefined>;
+
+/**
+ * The federation this deployment declares, or `null` when it declares none.
+ *
+ * A credential named and absent is an error rather than a `null`, the same
+ * distinction {@link loadManifestIfPresent} draws for a mounted manifest: a
+ * broken mount is not the same state as no cloud at all, and silently becoming
+ * an installation with no cloud Targets is how a deploy fails for a reason
+ * nobody can act on.
+ */
+export async function loadDeploymentFederation(
+  env: Env = Bun.env,
+): Promise<FederationConfig | null> {
+  const path = env[GCP_CREDENTIALS_VAR]?.trim();
+  if (!path) return null;
+
+  const file = Bun.file(path);
+  if (!(await file.exists())) {
+    throw new FederationCredentialError(
+      `${GCP_CREDENTIALS_VAR}=${path}: no such file, so this installation declares a cloud credential it does not mount`,
+    );
+  }
+
+  return parseFederationCredential(await file.text(), path);
+}
+
+/** Parse one credential document. Exported so a test needs no file on disk. */
+export function parseFederationCredential(
+  document: string,
+  source: string,
+): FederationConfig {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(document);
+  } catch (cause) {
+    throw new FederationCredentialError(
+      `${source}: not valid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  const result = externalAccountSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => {
+        const path = issue.path.join('.');
+        return `  ${path === '' ? '(root)' : path}: ${issue.message}`;
+      })
+      .join('\n');
+    throw new FederationCredentialError(
+      `${source}: not a usable external_account credential\n${issues}`,
+    );
+  }
+
+  const credential = result.data;
+  return {
+    audience: credential.audience,
+    tokenUrl: credential.token_url,
+    // The document's `credential_source.file` is the separately projected
+    // volume whose audience is the pool — never the default service account
+    // token, which is minted for this cluster's own API server and which a
+    // cloud API refuses. The chart projects both and names this one here.
+    tokenPath: credential.credential_source.file,
+    // Absent is a supported configuration rather than an omission: direct
+    // resource access grants the federated identity roles on its own, which is
+    // one fewer identity to reason about where the cloud resources allow it.
+    impersonationUrl: credential.service_account_impersonation_url ?? null,
+  };
+}
+
+export type { FederationConfig };

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -10,11 +10,16 @@ import type { Database } from '../db/client.ts';
 import { installation, targets } from '../db/schema.ts';
 import { unreachablePrerequisites } from '../domain/capabilities.ts';
 import type { TargetConnection } from '../domain/target.ts';
-import type { InstallationManifest, TargetSeed } from './manifest.schema.ts';
+import type {
+  AuthoredManifest,
+  InstallationManifest,
+  TargetSeed,
+} from './manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
   loadManifestIfPresent,
   ManifestError,
+  resolveManifest,
   validateManifest,
 } from './manifest.ts';
 
@@ -33,6 +38,11 @@ type Env = Record<string, string | undefined>;
  * The cost is that editing a declaration does nothing to an installation that
  * already has a row, so an ignored declaration says so at startup rather than
  * being quietly skipped. Re-seeding is deliberate: discard the row.
+ *
+ * What is written is the authored document; what is returned has the
+ * deployment's own facts resolved onto it. The row therefore never holds a
+ * second copy of something the deployment declares — which is the whole of why
+ * the two types are different.
  */
 export async function loadStoredManifest(
   db: Database,
@@ -47,7 +57,7 @@ export async function loadStoredManifest(
   }
   const declared = stored ?? declaration ?? DEFAULT_PLACEHOLDER_MANIFEST;
   await writeStoredManifest(db, declared);
-  return declared;
+  return resolveManifest(declared, env);
 }
 
 /**
@@ -65,7 +75,7 @@ export async function loadStoredManifest(
  */
 export async function writeStoredManifest(
   db: Database,
-  manifest: InstallationManifest,
+  manifest: AuthoredManifest,
 ): Promise<void> {
   await db.transaction(async (tx) => {
     await tx.insert(installation).values({ manifest }).onConflictDoUpdate({
@@ -86,8 +96,10 @@ export async function writeStoredManifest(
  */
 export async function currentStoredManifest(
   db: Database,
+  env: Env = Bun.env,
 ): Promise<InstallationManifest | null> {
-  return readStoredManifest(db);
+  const stored = await readStoredManifest(db);
+  return stored === null ? null : resolveManifest(stored, env);
 }
 
 /**
@@ -104,7 +116,7 @@ export async function currentStoredManifest(
  */
 async function reconcileManifestTargets(
   db: Pick<Database, 'insert' | 'query'>,
-  manifest: InstallationManifest,
+  manifest: AuthoredManifest,
 ): Promise<void> {
   for (const [rank, target] of manifest.targets.entries()) {
     const { name, adapter } = target;
@@ -180,7 +192,7 @@ function connectionFromSeed(target: TargetSeed): TargetConnection | null {
 
 async function readStoredManifest(
   db: Database,
-): Promise<InstallationManifest | null> {
+): Promise<AuthoredManifest | null> {
   const [stored] = await db
     .select({ manifest: installation.manifest })
     .from(installation)

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -10,8 +10,17 @@
  *
  * There are no defaults. A missing key fails the boot rather than falling back
  * to whatever the first operator happened to use.
+ *
+ * **What names the installation and what names its deployment are not the same
+ * set.** A value the installer chart already renders is read from the
+ * deployment, never asked for here as well: a fact carried in both places
+ * satisfies §20's grep and can still disagree with itself, and a disagreement
+ * surfaces somewhere else entirely — once as an `iam.serviceAccounts.signBlob`
+ * refusal that read as a code defect. Every removal is recorded at the block it
+ * left, so the reason survives the key.
  */
 import { z } from 'zod';
+import type { FederationConfig } from '../adapters/deploy/cloud/federation.ts';
 
 /** A non-empty string with no surrounding whitespace. */
 const nonEmptyString = z.string().trim().min(1);
@@ -253,6 +262,27 @@ export const installationManifestSchema = z
          * It is not derived from `dns.apexZone`: the control plane is a
          * platform workload (§19) and never one of its own Apps, so it does not
          * live in the zone Apps are named in.
+         *
+         * **Kept when `cloud.federation` and `charts.installer` were derived
+         * away, and here is the justification.** The installer chart has a
+         * `hostname` value that renders the Gateway and the HTTPRoute, which
+         * looks like the same fact restated — and it is not, for two reasons.
+         *
+         * The chart's `hostname` may be empty, and the chart says so: an
+         * installation that renders no Gateway and no HTTPRoute, reachable only
+         * in-cluster, is supported. That installation still needs a relying
+         * party id, so the chart is not a total source for this and deriving it
+         * would make a supported installation unconfigurable.
+         *
+         * And the relying party is bound once, at boot, on purpose — a passkey
+         * ceremony is scoped to the origin it began at, so re-resolving this
+         * mid-session invalidates credentials rather than updating them.
+         * Moving where it resolves from changes which origin ceremonies are
+         * accepted, and the only honest proof of that change is a real
+         * enrolment, not an argument. So the chart refuses instead: a release
+         * that declares a manifest whose `controlPlane.hostname` disagrees with
+         * its own `hostname` fails to render, which is the earliest moment the
+         * two can be compared and the only one where being wrong costs nothing.
          */
         hostname: zone,
       })
@@ -311,46 +341,22 @@ export const installationManifestSchema = z
          */
         homeVesselProject: nonEmptyString,
         /**
-         * How this installation reaches a cloud Target, with nothing stored
-         * (§13's one auth mode).
+         * **No `federation` key, and that is the point.**
          *
-         * The shape is an `external_account` credential document's, field for
-         * field, because an operator configuring this has one already and
-         * copying it should be the whole of the work.
+         * §13's one auth mode — "native OIDC federation, nothing stored" — is
+         * an `external_account` credential document, and the installer chart
+         * already writes one from the workload-identity audience and mount path
+         * a release names. Asking for the same four facts here made a second
+         * copy, by hand, in a document the chart does not render; the two could
+         * disagree, they did, and the failure arrived as a `signBlob` refusal
+         * that read as a code defect.
          *
-         * Nullable, stated the way `auth.gateway` and `github.buildWorkflow`
-         * are: an installation with no cloud Targets has no honest value to put
-         * here, and a placeholder would be a configuration that looks complete
-         * and fails on the first deploy. Null means cloud Targets cannot be
-         * reached, and nothing else changes.
+         * It is now resolved from the mounted credential —
+         * `federation-credential.ts` — and appears on {@link
+         * InstallationManifest} without ever being authored. Nullable exactly
+         * as before, and for the same reason: an installation with no cloud
+         * Targets mounts no credential and has no honest value here.
          */
-        federation: z
-          .object({
-            /** The workload-identity pool provider this cluster is trusted by. */
-            audience: nonEmptyString,
-            /** Where a projected token is exchanged for a federated one. */
-            tokenUrl: z.url(),
-            /**
-             * Where the projected token is read from.
-             *
-             * No default, and deliberately so: the convenient path — the
-             * default service account token — is minted for this cluster's own
-             * API server and a cloud API refuses it. Requiring the operator to
-             * name the volume they projected keeps the wrong token from being
-             * the easy one.
-             */
-            tokenPath: nonEmptyString.regex(
-              /^\//,
-              'must be an absolute path inside the pod',
-            ),
-            /**
-             * The service account to impersonate, as a `generateAccessToken`
-             * url, or null to use the federated identity's own grants.
-             */
-            impersonationUrl: z.url().nullable(),
-          })
-          .strict()
-          .nullable(),
       })
       .strict(),
 
@@ -359,13 +365,21 @@ export const installationManifestSchema = z
         /**
          * Reference to the App chart (§7) — the chart every deployed Component
          * renders through.
+         *
+         * Authored, unlike the two keys derived away around it, because no
+         * deployment renders it: the installer chart names itself and its own
+         * release, never the chart an App is deployed through, so there is no
+         * second copy for this one to disagree with. It is also a real
+         * installation choice — §7 wants the App chart pinned per Target, and
+         * an OCI reference is where that ends up.
          */
         app: nonEmptyString,
         /**
-         * Reference to the installer chart (§19) — the chart this installation
-         * itself was installed from.
+         * **No `installer` key.** It named the chart this installation was
+         * installed from — the release restating itself into a document the
+         * release does not render — and nothing in the process ever read it.
+         * A value that can only be wrong is not configuration.
          */
-        installer: nonEmptyString,
       })
       .strict(),
 
@@ -554,4 +568,27 @@ export type BuildRouteAdapter = z.infer<typeof buildRouteAdapterSchema>;
 export type BuildRouteConfig = z.infer<typeof buildRouteSchema>;
 export type TargetSeed = z.infer<typeof targetSeedSchema>;
 export type GatewayAuthConfig = z.infer<typeof gatewayAuthSchema>;
-export type InstallationManifest = z.infer<typeof installationManifestSchema>;
+
+/**
+ * The manifest as it is authored, stored and edited — exactly the schema above.
+ *
+ * This is what a declaration carries, what the durable row holds, and what
+ * `configureInstallation` accepts. It carries no derived key, so a write can
+ * never persist a copy of something the deployment already declares.
+ */
+export type AuthoredManifest = z.infer<typeof installationManifestSchema>;
+
+/**
+ * The authored document plus the deployment facts resolved around it.
+ *
+ * What every reader in the process is given. The split exists so that "what an
+ * operator may write" and "what the software may read" are different types: a
+ * derived value is present for readers and unreachable from any write path,
+ * which is what makes disagreement impossible rather than merely discouraged.
+ */
+export type InstallationManifest = Omit<AuthoredManifest, 'cloud'> & {
+  readonly cloud: AuthoredManifest['cloud'] & {
+    /** Resolved from the credential the deployment mounts, never authored. */
+    readonly federation: FederationConfig | null;
+  };
+};

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -10,7 +10,9 @@
  * workload.
  */
 
+import { loadDeploymentFederation } from './federation-credential.ts';
 import {
+  type AuthoredManifest,
   type InstallationManifest,
   installationManifestSchema,
 } from './manifest.schema.ts';
@@ -42,7 +44,7 @@ type Env = Record<string, string | undefined>;
 export function parseManifest(
   document: string,
   source: string,
-): InstallationManifest {
+): AuthoredManifest {
   let parsed: unknown;
   try {
     parsed = Bun.YAML.parse(document);
@@ -55,12 +57,72 @@ export function parseManifest(
   return validateManifest(parsed, source);
 }
 
+/**
+ * Keys the schema no longer has, and where the fact went instead.
+ *
+ * Read as `[block, key, why]`. Every one of them was a copy of something the
+ * deployment already declares, so a document still carrying one is describing
+ * a fact it does not own.
+ */
+const DERIVED_AWAY: readonly (readonly [string, string, string])[] = [
+  [
+    'cloud',
+    'federation',
+    'it is read from the credential the deployment mounts',
+  ],
+  ['charts', 'installer', 'nothing reads it'],
+];
+
+/**
+ * Drop the keys that were derived away, before the strict schema sees them.
+ *
+ * Dropped rather than refused, and the difference matters: an installation
+ * seeded before the removal has one of these in its durable row, and a
+ * refusal would be a control plane that will not boot until someone edits
+ * Postgres by hand. The row is rewritten from what this returns, so it
+ * self-heals on the first start and the warning fires once.
+ *
+ * This is also what makes the removal complete. A key that is merely absent
+ * from the schema can be written back by any caller holding an older document;
+ * a key that is stripped on the way in cannot reach storage from any path.
+ */
+function withoutDerivedKeys(manifest: unknown, source: string): unknown {
+  if (
+    typeof manifest !== 'object' ||
+    manifest === null ||
+    Array.isArray(manifest)
+  ) {
+    return manifest;
+  }
+
+  let document = manifest as Record<string, unknown>;
+  for (const [blockName, key, why] of DERIVED_AWAY) {
+    const block = document[blockName];
+    if (
+      typeof block !== 'object' ||
+      block === null ||
+      Array.isArray(block) ||
+      !(key in block)
+    ) {
+      continue;
+    }
+    const { [key]: _dropped, ...rest } = block as Record<string, unknown>;
+    document = { ...document, [blockName]: rest };
+    console.warn(
+      `${source}: ${blockName}.${key} is no longer an installation manifest key — ${why}, so the value in this document is being discarded`,
+    );
+  }
+  return document;
+}
+
 /** Validate a parsed or stored manifest and report every bad field together. */
 export function validateManifest(
   manifest: unknown,
   source: string,
-): InstallationManifest {
-  const result = installationManifestSchema.safeParse(manifest);
+): AuthoredManifest {
+  const result = installationManifestSchema.safeParse(
+    withoutDerivedKeys(manifest, source),
+  );
   if (!result.success) {
     const issues = result.error.issues
       .map((issue) => {
@@ -79,7 +141,7 @@ export function validateManifest(
 export const DEFAULT_MANIFEST_PATH = '/etc/spindrift/manifest.yaml';
 
 /** High-trust default placeholder manifest used when initializing an unseeded installation. */
-export const DEFAULT_PLACEHOLDER_MANIFEST: InstallationManifest = {
+export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
   installation: 'default',
   controlPlane: {
     hostname: 'spindrift.example.com',
@@ -98,18 +160,9 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: InstallationManifest = {
   cloud: {
     artifactsProject: 'spindrift-artifacts',
     homeVesselProject: 'spindrift-vessel',
-    federation: {
-      audience:
-        '//iam.googleapis.com/projects/1234567890/locations/global/workloadIdentityPools/spindrift-pool/providers/spindrift-provider',
-      tokenUrl: 'https://sts.googleapis.com/v1/token',
-      tokenPath: '/var/run/secrets/spindrift/gcp-token',
-      impersonationUrl:
-        'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@spindrift-vessel.iam.gserviceaccount.com:generateAccessToken',
-    },
   },
   charts: {
     app: 'packages/charts/spindrift-app',
-    installer: 'packages/charts/spindrift',
   },
   supplyChain: {
     registry: 'ghcr.io/spindrift',
@@ -190,7 +243,7 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: InstallationManifest = {
  */
 export async function loadManifest(
   env: Env = Bun.env,
-): Promise<InstallationManifest> {
+): Promise<AuthoredManifest> {
   const manifest = await loadManifestIfPresent(env);
   if (manifest !== null) return manifest;
 
@@ -208,7 +261,7 @@ export async function loadManifest(
  */
 export async function loadManifestIfPresent(
   env: Env = Bun.env,
-): Promise<InstallationManifest | null> {
+): Promise<AuthoredManifest | null> {
   const explicitPath = env[MANIFEST_PATH_VAR]?.trim();
   const path = explicitPath || DEFAULT_MANIFEST_PATH;
 
@@ -231,6 +284,32 @@ export async function loadManifestIfPresent(
 }
 
 /**
+ * Attach the deployment facts an authored document deliberately omits.
+ *
+ * The one place the two halves meet, and the only place they may: everything
+ * upstream of this — parsing, validation, the durable write — handles an
+ * {@link AuthoredManifest} with no derived key on it, and everything downstream
+ * reads an {@link InstallationManifest} it cannot write back. That is what
+ * makes a second copy unrepresentable rather than merely discouraged.
+ *
+ * Resolved on every read rather than once at boot, because the credential is a
+ * projected volume the kubelet owns and a value captured at start is a value
+ * that stops being true when the deployment re-renders it.
+ */
+export async function resolveManifest(
+  manifest: AuthoredManifest,
+  env: Env = Bun.env,
+): Promise<InstallationManifest> {
+  return {
+    ...manifest,
+    cloud: {
+      ...manifest.cloud,
+      federation: await loadDeploymentFederation(env),
+    },
+  };
+}
+
+/**
  * Refuse to enable header authentication without its non-bypassable boundary.
  *
  * The process cannot observe a Kubernetes NetworkPolicy from inside its own
@@ -238,7 +317,7 @@ export async function loadManifestIfPresent(
  * a manifest copied into an unrestricted deployment fails closed at boot.
  */
 export function assertTrustedGatewayBoundary(
-  manifest: InstallationManifest,
+  manifest: Pick<InstallationManifest, 'auth'>,
   env: Env = Bun.env,
 ): void {
   if (
@@ -252,6 +331,7 @@ export function assertTrustedGatewayBoundary(
 }
 
 export type {
+  AuthoredManifest,
   GatewayAuthConfig,
   InstallationManifest,
 } from './manifest.schema.ts';

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -43,7 +43,7 @@ import {
   DEPLOY_PHASES,
   FAILURE_REASONS,
 } from '../adapters/deploy/contract.ts';
-import type { InstallationManifest } from '../config/manifest.schema.ts';
+import type { AuthoredManifest } from '../config/manifest.schema.ts';
 import type {
   PrerequisiteResult,
   TargetDiscovery,
@@ -253,12 +253,17 @@ export const webauthnPurpose = pgEnum('webauthn_purpose', [
  * Postgres its durable store. A deployment declaration reconciles into this
  * row at process start; without one, every process can recover the same last
  * validated value from the database.
+ *
+ * The **authored** document, never the resolved one. What the deployment
+ * already declares — its federation credential — is read from the deployment on
+ * every load and is not representable here, so this row cannot hold a copy that
+ * disagrees with the pod it is running in.
  */
 export const installation = pgTable(
   'installation',
   {
     id: integer('id').primaryKey().default(1),
-    manifest: jsonbDocument('manifest').$type<InstallationManifest>().notNull(),
+    manifest: jsonbDocument('manifest').$type<AuthoredManifest>().notNull(),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/spindrift/test/adapters/registry.test.ts
+++ b/apps/spindrift/test/adapters/registry.test.ts
@@ -12,7 +12,7 @@ import {
   IDENTITY_TOKEN_PATH_VAR,
   installationServiceAccountToken,
 } from '../../src/adapters/registry.ts';
-import { parseManifest } from '../../src/config/manifest.ts';
+import { parseManifest, resolveManifest } from '../../src/config/manifest.ts';
 
 test('the installation token provider follows the projected path', async () => {
   const path = join('/tmp', `spindrift-identity-token-${crypto.randomUUID()}`);
@@ -35,7 +35,7 @@ test('source adapter returns null when no GitHub App or custom stager is configu
   const yaml = await Bun.file(
     join(import.meta.dir, '../fixtures/installation.example.yaml'),
   ).text();
-  const manifest = parseManifest(yaml, 'test');
+  const manifest = await resolveManifest(parseManifest(yaml, 'test'), {});
   const registry = createAdapterRegistry({ manifest, env: {} });
 
   expect(registry.source?.()).toBeNull();
@@ -45,7 +45,7 @@ test('source adapter returns explicitly passed source stager when provided', asy
   const yaml = await Bun.file(
     join(import.meta.dir, '../fixtures/installation.example.yaml'),
   ).text();
-  const manifest = parseManifest(yaml, 'test');
+  const manifest = await resolveManifest(parseManifest(yaml, 'test'), {});
   const customStager = {
     async stageRepository() {
       return {

--- a/apps/spindrift/test/commands/installation-configure.test.ts
+++ b/apps/spindrift/test/commands/installation-configure.test.ts
@@ -14,7 +14,10 @@
 import { describe, expect, test } from 'bun:test';
 import { configureInstallation } from '../../src/commands/index.ts';
 import type { Clock, CommandContext } from '../../src/commands/types.ts';
-import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
+import type {
+  AuthoredManifest,
+  InstallationManifest,
+} from '../../src/config/manifest.schema.ts';
 import { loadStoredManifest } from '../../src/config/manifest-store.ts';
 import { installation } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
@@ -46,7 +49,7 @@ function context(): CommandContext {
   };
 }
 
-async function storedManifest(): Promise<InstallationManifest | undefined> {
+async function storedManifest(): Promise<AuthoredManifest | undefined> {
   const [row] = await database().db.select().from(installation);
   return row?.manifest;
 }

--- a/apps/spindrift/test/config/federation-credential.test.ts
+++ b/apps/spindrift/test/config/federation-credential.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Federation is read from the deployment, not restated in the manifest.
+ *
+ * The claim under test is the one the ticket is named for: there is exactly one
+ * copy of §13's federation facts, it is the `external_account` document the
+ * installer chart renders, and no manifest key exists that could disagree with
+ * it. So these tests read the *chart's own rendered output* wherever they can —
+ * a test that asserted against a hand-written credential would be a second copy
+ * of the thing being removed.
+ */
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  FederationCredentialError,
+  GCP_CREDENTIALS_VAR,
+  loadDeploymentFederation,
+  parseFederationCredential,
+} from '../../src/config/federation-credential.ts';
+import { installationManifestSchema } from '../../src/config/manifest.schema.ts';
+import { parseManifest, resolveManifest } from '../../src/config/manifest.ts';
+
+const FIXTURE = join(import.meta.dir, '../fixtures/installation.example.yaml');
+const CREDENTIAL = join(import.meta.dir, '../fixtures/gcp-credentials.json');
+
+describe('the credential the deployment mounts', () => {
+  test('is the whole of the federation, field for field', async () => {
+    const federation = await loadDeploymentFederation({
+      [GCP_CREDENTIALS_VAR]: CREDENTIAL,
+    });
+
+    expect(federation).toEqual({
+      audience:
+        '//iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster',
+      tokenUrl: 'https://sts.example.test/v1/token',
+      tokenPath: '/var/run/secrets/cloud/token',
+      impersonationUrl:
+        'https://iamcredentials.example.test/v1/projects/-/serviceAccounts/spindrift@example-home.example.test:generateAccessToken',
+    });
+  });
+
+  test('leaves an installation with no cloud Targets honestly null', async () => {
+    // The nullability `cloud.federation` had is preserved and is now
+    // structural: a deployment that mounts no credential has none, rather than
+    // an operator having remembered to write `null`.
+    expect(await loadDeploymentFederation({})).toBeNull();
+  });
+
+  test('impersonation is optional, because direct grants are a real posture', () => {
+    const direct = parseFederationCredential(
+      JSON.stringify({
+        type: 'external_account',
+        audience: '//iam.example.test/pools/direct',
+        token_url: 'https://sts.example.test/v1/token',
+        credential_source: { file: '/var/run/secrets/cloud/token' },
+      }),
+      'direct',
+    );
+    expect(direct.impersonationUrl).toBeNull();
+  });
+
+  test('a named credential that is not mounted is an error, not an absence', async () => {
+    // Silently becoming an installation with no cloud is how a deploy fails for
+    // a reason nobody can act on. A broken mount says so.
+    await expect(
+      loadDeploymentFederation({
+        [GCP_CREDENTIALS_VAR]: '/var/run/secrets/spindrift/absent.json',
+      }),
+    ).rejects.toThrow(FederationCredentialError);
+  });
+
+  test('refuses a service account key file wearing the same shape', () => {
+    // §13 stores nothing. A key file would parse against every other field, so
+    // `type` is the check that keeps the one forbidden credential out.
+    expect(() =>
+      parseFederationCredential(
+        JSON.stringify({
+          type: 'service_account',
+          audience: '//iam.example.test/pools/wrong',
+          token_url: 'https://sts.example.test/v1/token',
+          credential_source: { file: '/var/run/secrets/cloud/token' },
+          private_key: '-----BEGIN PRIVATE KEY-----',
+        }),
+        'a key file',
+      ),
+    ).toThrow(FederationCredentialError);
+  });
+
+  test('refuses a relative token path', () => {
+    expect(() =>
+      parseFederationCredential(
+        JSON.stringify({
+          type: 'external_account',
+          audience: '//iam.example.test/pools/relative',
+          token_url: 'https://sts.example.test/v1/token',
+          credential_source: { file: 'gcp-token' },
+        }),
+        'a relative path',
+      ),
+    ).toThrow(/absolute path/);
+  });
+});
+
+describe('the manifest cannot restate it', () => {
+  test('there is no key to write it into', () => {
+    const cloud = installationManifestSchema.shape.cloud;
+    expect(Object.keys(cloud.shape).sort()).toEqual([
+      'artifactsProject',
+      'homeVesselProject',
+    ]);
+    expect(Object.keys(installationManifestSchema.shape.charts.shape)).toEqual([
+      'app',
+    ]);
+  });
+
+  test('a document that carries one anyway loses it before it is stored', async () => {
+    // Dropped rather than refused, and that is deliberate: an installation
+    // seeded before the removal has one of these in its durable row, and a
+    // refusal would be a control plane that will not boot until someone edits
+    // Postgres by hand. Stripping on the way in also means no write path can
+    // put it back, which is what makes the removal complete.
+    const document = Bun.YAML.parse(await Bun.file(FIXTURE).text()) as Record<
+      string,
+      unknown
+    >;
+    const restated = {
+      ...document,
+      cloud: {
+        ...(document.cloud as Record<string, unknown>),
+        federation: {
+          audience: '//iam.stale.test/pools/stale',
+          tokenUrl: 'https://sts.stale.test/v1/token',
+          tokenPath: '/var/run/secrets/stale/token',
+          impersonationUrl: null,
+        },
+      },
+      charts: {
+        ...(document.charts as Record<string, unknown>),
+        installer: 'example/spindrift',
+      },
+    };
+
+    const authored = parseManifest(
+      JSON.stringify(restated),
+      'a stale document',
+    );
+    expect(authored.cloud).not.toHaveProperty('federation');
+    expect(authored.charts).not.toHaveProperty('installer');
+  });
+
+  test('what readers get is the deployment’s copy, joined on at resolve', async () => {
+    const authored = parseManifest(await Bun.file(FIXTURE).text(), FIXTURE);
+    const resolved = await resolveManifest(authored, {
+      [GCP_CREDENTIALS_VAR]: CREDENTIAL,
+    });
+
+    expect(resolved.cloud.federation?.tokenPath).toBe(
+      '/var/run/secrets/cloud/token',
+    );
+    // And the authored document is untouched by the join, so a write path
+    // holding one cannot round-trip a derived value back into the row.
+    expect(authored.cloud).not.toHaveProperty('federation');
+  });
+});

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
-import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
+import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
   MANIFEST_INLINE_VAR,
@@ -10,6 +10,7 @@ import { loadStoredManifest } from '../../src/config/manifest-store.ts';
 import { createDb } from '../../src/db/client.ts';
 import { installation, targets } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
+import { FIXTURE_DEPLOYMENT_ENV } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const FIXTURE = new URL(
@@ -17,7 +18,7 @@ const FIXTURE = new URL(
   import.meta.url,
 );
 const fixtureText = await Bun.file(FIXTURE).text();
-const fixtureManifest = Bun.YAML.parse(fixtureText) as InstallationManifest;
+const fixtureManifest = Bun.YAML.parse(fixtureText) as AuthoredManifest;
 const connectedManifest = {
   ...fixtureManifest,
   targets: [
@@ -53,7 +54,7 @@ const connectedManifest = {
       },
     },
   ],
-} satisfies InstallationManifest;
+} satisfies AuthoredManifest;
 
 describe('the stored installation manifest', () => {
   test('stores declared configuration, then boots from the database alone', async () => {
@@ -185,7 +186,7 @@ describe('the stored installation manifest', () => {
             }
           : target,
       ),
-    } satisfies InstallationManifest;
+    } satisfies AuthoredManifest;
 
     // Configuration is the UI's to drive, so the trigger for reconciliation is
     // the stored manifest changing — which is what a settings write is.
@@ -328,7 +329,7 @@ describe('the stored installation manifest', () => {
         { name: 'cluster', adapter: 'kubernetes' },
         { name: 'cloud-cloudrun', adapter: 'kubernetes' },
       ],
-    } satisfies InstallationManifest;
+    } satisfies AuthoredManifest;
 
     await expect(
       loadStoredManifest(database().db, {
@@ -405,6 +406,49 @@ describe('the stored installation manifest', () => {
 
   test('seeds default placeholder manifest when the database is empty and no bootstrap exists', async () => {
     const loaded = await loadStoredManifest(database().db, {});
-    expect(loaded).toEqual(DEFAULT_PLACEHOLDER_MANIFEST);
+    // The placeholder as authored, plus the deployment facts resolved onto it.
+    // A deployment that mounts no cloud credential resolves `null`, which is
+    // what an installation with no cloud Targets honestly has.
+    expect(loaded).toEqual({
+      ...DEFAULT_PLACEHOLDER_MANIFEST,
+      cloud: { ...DEFAULT_PLACEHOLDER_MANIFEST.cloud, federation: null },
+    });
+  });
+
+  test('the stored row never holds a fact the deployment declares', async () => {
+    // The keys derived away are dropped on the way in, not merely absent from
+    // the schema — an installation seeded before the removal has them in its
+    // row, and refusing would be a control plane that will not boot.
+    await database().client`
+      INSERT INTO installation (manifest)
+      VALUES (${JSON.stringify({
+        ...fixtureManifest,
+        cloud: {
+          ...fixtureManifest.cloud,
+          federation: {
+            audience: '//iam.stale.test/pools/stale',
+            tokenUrl: 'https://sts.stale.test/v1/token',
+            tokenPath: '/var/run/secrets/stale/token',
+            impersonationUrl: null,
+          },
+        },
+        charts: { ...fixtureManifest.charts, installer: 'example/spindrift' },
+      })}::jsonb)
+    `;
+
+    // The deployment's credential wins outright, because it is the only copy
+    // left: the row's stale audience reaches no reader.
+    const loaded = await loadStoredManifest(
+      database().db,
+      FIXTURE_DEPLOYMENT_ENV,
+    );
+    expect(loaded.cloud.federation?.audience).toBe(
+      '//iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster',
+    );
+    expect(loaded.charts).not.toHaveProperty('installer');
+
+    const [row] = await database().db.select().from(installation).limit(1);
+    expect(row?.manifest.cloud).not.toHaveProperty('federation');
+    expect(row?.manifest.charts).not.toHaveProperty('installer');
   });
 });

--- a/apps/spindrift/test/conformance/second-target-admission.test.ts
+++ b/apps/spindrift/test/conformance/second-target-admission.test.ts
@@ -254,11 +254,12 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
   });
 
   test('Installer and App chart distribution use independently pinned, extractable artifacts', async () => {
-    // Check that manifest declares pinned chart references
+    // The App chart is a pinned reference an installation declares. The
+    // installer chart is not one of these: it named the release this process is
+    // already running from, nothing read it, and it has been removed.
     expect(manifest.charts.app).toBeDefined();
-    expect(manifest.charts.installer).toBeDefined();
     expect(typeof manifest.charts.app).toBe('string');
-    expect(typeof manifest.charts.installer).toBe('string');
+    expect(manifest.charts).not.toHaveProperty('installer');
   });
 
   test('Status, diagnosis, and logs identify the second Target while preserving App-first product view', async () => {

--- a/apps/spindrift/test/fixtures/gcp-credentials.json
+++ b/apps/spindrift/test/fixtures/gcp-credentials.json
@@ -1,0 +1,10 @@
+{
+  "type": "external_account",
+  "audience": "//iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.example.test/v1/token",
+  "service_account_impersonation_url": "https://iamcredentials.example.test/v1/projects/-/serviceAccounts/spindrift@example-home.example.test:generateAccessToken",
+  "credential_source": {
+    "file": "/var/run/secrets/cloud/token"
+  }
+}

--- a/apps/spindrift/test/fixtures/installation.dev.yaml
+++ b/apps/spindrift/test/fixtures/installation.dev.yaml
@@ -14,15 +14,12 @@ dns:
 cloud:
   artifactsProject: example-artifacts
   homeVesselProject: example-home
-  federation:
-    audience: //iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster
-    tokenUrl: https://sts.example.test/v1/token
-    tokenPath: /var/run/secrets/cloud/token
-    impersonationUrl: https://iamcredentials.example.test/v1/projects/-/serviceAccounts/spindrift@example-home.example.test:generateAccessToken
+  # Federation comes from the external_account credential the deployment mounts,
+  # named by GOOGLE_APPLICATION_CREDENTIALS. A local run that sets neither has
+  # no cloud Targets, which is a supported installation.
 
 charts:
   app: example/spindrift-app
-  installer: example/spindrift
 
 supplyChain:
   registry: registry.example.test/artifacts

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -28,19 +28,13 @@ sources:
 cloud:
   artifactsProject: example-artifacts
   homeVesselProject: example-home
-  # §13's one auth mode: the pod projects a token, the token is exchanged, and
-  # nothing is stored. The path is a *separately* projected volume whose
-  # audience is the pool below — not the default service account token, which is
-  # minted for this cluster's own API server and which a cloud API refuses.
-  federation:
-    audience: //iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster
-    tokenUrl: https://sts.example.test/v1/token
-    tokenPath: /var/run/secrets/cloud/token
-    impersonationUrl: https://iamcredentials.example.test/v1/projects/-/serviceAccounts/spindrift@example-home.example.test:generateAccessToken
+  # No `federation` block. §13's one auth mode is an external_account credential
+  # the installer chart renders, and the process reads it from there — see
+  # gcp-credentials.json beside this file, which is the fixture deployment's
+  # copy. A second one here could disagree with the pod it runs in.
 
 charts:
   app: example/spindrift-app
-  installer: example/spindrift
 
 supplyChain:
   registry: registry.example.test/artifacts

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -16,22 +16,43 @@
 import { join } from 'node:path';
 import { VALUES_CONTRACT } from '../../src/adapters/deploy/kubernetes/values.ts';
 import type { ConnectTargetInput } from '../../src/commands/targets/connect.ts';
+import { GCP_CREDENTIALS_VAR } from '../../src/config/federation-credential.ts';
 import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
 import {
   type InstallationManifest,
   parseManifest,
+  resolveManifest,
 } from '../../src/config/manifest.ts';
 import type { NewTarget } from '../../src/db/schema.ts';
 import type { TargetConnection } from '../../src/domain/target.ts';
 
 const FIXTURE = join(import.meta.dir, '../fixtures/installation.example.yaml');
 
+/**
+ * The fixture deployment's own credential.
+ *
+ * §13's federation is not in the manifest — it is read from the
+ * `external_account` document the installer chart renders — so a test
+ * installation needs a deployment as well as a document. This is that
+ * deployment, and pointing the real resolver at it is what makes every test
+ * context carry federation the same way a pod does.
+ */
+export const FIXTURE_DEPLOYMENT_ENV: Record<string, string> = {
+  [GCP_CREDENTIALS_VAR]: join(
+    import.meta.dir,
+    '../fixtures/gcp-credentials.json',
+  ),
+};
+
 let cached: InstallationManifest | null = null;
 
-/** The fixture installation, parsed through the real loader. */
+/** The fixture installation, parsed and resolved through the real loader. */
 export async function fixtureManifest(): Promise<InstallationManifest> {
   if (cached === null) {
-    cached = parseManifest(await Bun.file(FIXTURE).text(), FIXTURE);
+    cached = await resolveManifest(
+      parseManifest(await Bun.file(FIXTURE).text(), FIXTURE),
+      FIXTURE_DEPLOYMENT_ENV,
+    );
   }
   return cached;
 }

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -30,7 +30,11 @@ import {
 import { startReconciler } from '../../src/reconciler/start.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  FIXTURE_DEPLOYMENT_ENV,
+  fixtureManifest,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -243,7 +247,13 @@ async function reconcilePendingDeploy(platform: FakeDeployAdapter) {
     signal: shutdown.signal,
     client: database().connect(),
     clock,
-    env: { [MANIFEST_INLINE_VAR]: JSON.stringify(manifest) },
+    // The declaration and the deployment's own credential, which is how a pod
+    // starts: the manifest names the installation, the mounted external_account
+    // document names the federation, and the boot manifest is the two joined.
+    env: {
+      ...FIXTURE_DEPLOYMENT_ENV,
+      [MANIFEST_INLINE_VAR]: JSON.stringify(manifest),
+    },
     createAdapters(storedManifest) {
       bootManifest = storedManifest;
       return adaptersFor(platform);

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -35,9 +35,20 @@ spec:
     # The Secret carries only the one-time enrolment token and optional
     # integration credentials.
     envFromSecret: spindrift-env
+    # The whole of §13's federation. These two values render the pod's
+    # `external_account` credential, and the process reads its federation out of
+    # that file — so this is the only place the facts are stated.
+    #
+    # The pool principal holds `roles/iam.workloadIdentityUser` and
+    # `roles/iam.serviceAccountTokenCreator` on this one service account and
+    # nothing else; every project role, the source bucket and the signer hang
+    # off the account. Impersonating it is therefore the only thing the
+    # federated identity can do, which is why the url is not optional here.
+    # Declared in terraform/gcp/projects/bluenose/iam.tf.
     serviceAccount:
       token:
         gcpAudience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
+        gcpImpersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
     ingress:
       enabled: true
     # §19's own database, including the installation manifest singleton.

--- a/packages/charts/spindrift/templates/federated-identity.yaml
+++ b/packages/charts/spindrift/templates/federated-identity.yaml
@@ -1,3 +1,17 @@
+{{/*
+The whole of §13's federation, in one document, in one place.
+
+This is the only copy. The installation manifest used to restate `audience`,
+`token_url`, the token path and the impersonation url by hand, in a document
+this chart does not render — so the two could disagree, and when they did the
+failure arrived as an `iam.serviceAccounts.signBlob` refusal that read as a code
+defect. The process now reads its federation from this file, through
+`GOOGLE_APPLICATION_CREDENTIALS`, which the deployment already sets beside the
+mount.
+
+An ordinary ADC `external_account` document, so any client in the process finds
+the same credential rather than a Spindrift-shaped one only Spindrift reads.
+*/}}
 {{- if .Values.serviceAccount.token.gcpAudience }}
 ---
 apiVersion: v1
@@ -14,6 +28,9 @@ data:
       "audience": {{ .Values.serviceAccount.token.gcpAudience | quote }},
       "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
       "token_url": "https://sts.googleapis.com/v1/token",
+      {{- with .Values.serviceAccount.token.gcpImpersonationUrl }}
+      "service_account_impersonation_url": {{ . | quote }},
+      {{- end }}
       "credential_source": {
         "file": {{ printf "%s/gcp-token" .Values.serviceAccount.token.mountPath | quote }}
       }

--- a/packages/charts/spindrift/templates/manifest.yaml
+++ b/packages/charts/spindrift/templates/manifest.yaml
@@ -10,8 +10,25 @@ under ordinary review — a manifest change is a pull request.
 
 Empty declares nothing, which stays a valid installation: the process falls back
 to the durable row exactly as it does today.
+
+**A declaration may not restate what this chart already renders.** The three
+refusals below are the mechanical half of that rule: a release whose manifest
+carries a fact this chart owns fails to render, which is the earliest moment the
+two copies can be compared and the only one where being wrong costs nothing. The
+alternative is a value that agrees today, drifts on the next edit, and surfaces
+as a refusal somewhere else entirely.
 */}}
 {{- if .Values.manifest }}
+{{- if dig "cloud" "federation" nil .Values.manifest }}
+{{- fail "manifest.cloud.federation is not a manifest key: federation is read from the external_account credential this chart renders. Set serviceAccount.token.gcpAudience and serviceAccount.token.gcpImpersonationUrl instead." }}
+{{- end }}
+{{- if dig "charts" "installer" nil .Values.manifest }}
+{{- fail "manifest.charts.installer is not a manifest key: it named this chart, and nothing reads it. Remove it." }}
+{{- end }}
+{{- $declaredHostname := dig "controlPlane" "hostname" "" .Values.manifest }}
+{{- if and .Values.hostname $declaredHostname (ne $declaredHostname .Values.hostname) }}
+{{- fail (printf "manifest.controlPlane.hostname is %q but this release serves the control plane at %q. It is the passkey relying-party id, so the disagreement would enrol nobody: a ceremony is scoped to the origin it began at, and the origin is the one the HTTPRoute answers on." $declaredHostname .Values.hostname) }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -371,3 +371,133 @@ describe('authenticated Gateway trust', () => {
     ).rejects.toThrow('gatewayAuth.from must name at least one');
   });
 });
+
+describe('the credential is the only copy of the federation', () => {
+  const audience =
+    '//iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster';
+  const impersonation =
+    'https://iamcredentials.example.test/v1/projects/-/serviceAccounts/spindrift@example-home.example.test:generateAccessToken';
+
+  test('renders a complete external_account document the process reads back', async () => {
+    const objects = await render({
+      serviceAccount: {
+        token: { gcpAudience: audience, gcpImpersonationUrl: impersonation },
+      },
+    });
+    const credential = one(
+      objects,
+      'ConfigMap',
+      'spindrift-federated-identity',
+    );
+    // Every fact `cloud.federation` used to ask for by hand, rendered once,
+    // from values a release already sets. The manifest has no key for any of
+    // them, so nothing is left that could disagree.
+    expect(JSON.parse(credential.data?.['gcp-credentials.json'] ?? '')).toEqual(
+      {
+        type: 'external_account',
+        audience,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:jwt',
+        token_url: 'https://sts.googleapis.com/v1/token',
+        service_account_impersonation_url: impersonation,
+        credential_source: { file: '/var/run/secrets/spindrift/gcp-token' },
+      },
+    );
+
+    // And the deployment points ADC at exactly that file, which is how the
+    // process finds it without being told a second time.
+    const web = one(objects, 'Deployment', 'spindrift-web');
+    expect(web.spec.template.spec.containers[0].env).toContainEqual({
+      name: 'GOOGLE_APPLICATION_CREDENTIALS',
+      value: '/var/run/secrets/spindrift/gcp-credentials.json',
+    });
+  });
+
+  test('omits impersonation when the identity holds its own grants', async () => {
+    const objects = await render({
+      serviceAccount: { token: { gcpAudience: audience } },
+    });
+    const credential = JSON.parse(
+      one(objects, 'ConfigMap', 'spindrift-federated-identity').data?.[
+        'gcp-credentials.json'
+      ] ?? '',
+    );
+    expect(credential).not.toHaveProperty('service_account_impersonation_url');
+  });
+
+  test('refuses a declaration that restates the federation', async () => {
+    await expect(
+      render({
+        manifest: {
+          installation: 'declared',
+          cloud: { federation: { audience: '//iam.stale.test/pools/stale' } },
+        },
+      }),
+    ).rejects.toThrow('manifest.cloud.federation is not a manifest key');
+  });
+
+  test('refuses a declaration that names the chart it was installed from', async () => {
+    await expect(
+      render({
+        manifest: {
+          installation: 'declared',
+          charts: { app: 'example/spindrift-app', installer: 'example/x' },
+        },
+      }),
+    ).rejects.toThrow('manifest.charts.installer is not a manifest key');
+  });
+});
+
+describe('the relying party and the front door cannot disagree', () => {
+  test('refuses a declaration whose hostname is not the one served', async () => {
+    // `controlPlane.hostname` is kept rather than derived — it is the passkey
+    // relying-party id, bound at boot on purpose, and an installation with no
+    // Gateway still needs one. What is not kept is the ability for the two to
+    // differ, which would enrol nobody.
+    await expect(
+      render({
+        hostname: 'spindrift.example.test',
+        manifest: {
+          installation: 'declared',
+          controlPlane: { hostname: 'stale.example.test' },
+        },
+      }),
+    ).rejects.toThrow(
+      /manifest.controlPlane.hostname is "stale.example.test" but this release serves the control plane at "spindrift.example.test"/,
+    );
+  });
+
+  test('renders when they agree', async () => {
+    const objects = await render({
+      hostname: 'spindrift.example.test',
+      manifest: {
+        installation: 'declared',
+        controlPlane: { hostname: 'spindrift.example.test' },
+      },
+    });
+    expect(
+      one(objects, 'HTTPRoute', 'spindrift-http-route').spec.hostnames,
+    ).toEqual(['spindrift.example.test']);
+  });
+
+  test('leaves an in-cluster-only installation free to name its own relying party', async () => {
+    // The chart's `hostname` may be empty — no Gateway, no HTTPRoute, still a
+    // valid installation. That installation has no deployment fact to derive a
+    // relying party from, which is the structural reason the key stays.
+    const objects = await render({
+      manifest: {
+        installation: 'declared',
+        controlPlane: { hostname: 'spindrift.internal.example.test' },
+      },
+    });
+    expect(objects.some((object) => object.kind === 'HTTPRoute')).toBe(false);
+    expect(
+      Bun.YAML.parse(
+        one(objects, 'ConfigMap', 'spindrift-manifest').data?.[
+          'manifest.yaml'
+        ] ?? '',
+      ),
+    ).toMatchObject({
+      controlPlane: { hostname: 'spindrift.internal.example.test' },
+    });
+  });
+});

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -34,7 +34,22 @@ serviceAccount:
     # Optional GCP workload identity provider audience. When set, both
     # processes receive a second projected token and an ADC-compatible
     # external-account credential file.
+    #
+    # This is the only place the audience is named. The installation manifest
+    # no longer carries a `cloud.federation` block; the process reads its
+    # federation out of the credential rendered from these two values, so there
+    # is nothing for it to disagree with.
     gcpAudience: ""
+    # The service account the federated identity impersonates, as a
+    # `generateAccessToken` url. Empty uses the federated identity's own grants
+    # directly, which is a supported installation rather than an omission —
+    # where the cloud resources grant the principal itself, that is one fewer
+    # identity to reason about.
+    #
+    # Set it when the roles live on a service account, which is the usual shape:
+    # the pool principal is granted `roles/iam.serviceAccountTokenCreator` on
+    # that account and every project role hangs off the account, not the pool.
+    gcpImpersonationUrl: ""
     expirationSeconds: 3600
     mountPath: /var/run/secrets/spindrift
 


### PR DESCRIPTION
Ticket 33 — the values a deployment already declares are read from the deployment, not asked for a second time in the installation manifest.

§20's rule is enforced as a grep, and a value living in **both** the chart and the manifest satisfies the grep while still being able to disagree with itself. When it disagreed, the failure surfaced somewhere else entirely: ticket 08 lost a session to a `signBlob` refusal that read as a code defect and was a federation fact that did not match its deployment.

## `cloud.federation` — derived

The installer chart already writes an `external_account` credential document from `serviceAccount.token.gcpAudience` and `serviceAccount.token.mountPath`, and the Deployment already sets `GOOGLE_APPLICATION_CREDENTIALS` beside the mount. `src/config/federation-credential.ts` reads the four facts back out of that document; `resolveManifest` joins them onto the manifest every reader gets. There is no key left to author.

The chart now also renders `service_account_impersonation_url`, so the credential is complete rather than three quarters of one. The offsite release names the service account its pool principal is the only one able to impersonate — `terraform/gcp/projects/bluenose/iam.tf` grants `spindrift_principal` `roles/iam.workloadIdentityUser` and `roles/iam.serviceAccountTokenCreator` on `spindrift-controller@bluenose`, and nothing else, so that url is the only value that can work.

Chart output, rendered with this release's values, fed to the process's real reader:

```
$ helm template … --set serviceAccount.token.gcpAudience=… \
    --set serviceAccount.token.gcpImpersonationUrl=… -s templates/federated-identity.yaml
      "type": "external_account",
      "audience": "//iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite",
      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
      "token_url": "https://sts.googleapis.com/v1/token",
      "service_account_impersonation_url": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken",
      "credential_source": { "file": "/var/run/secrets/spindrift/gcp-token" }

$ bun run roundtrip.ts cm.yaml   # parseFederationCredential over that exact document
{
  "audience": "//iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite",
  "tokenUrl": "https://sts.googleapis.com/v1/token",
  "tokenPath": "/var/run/secrets/spindrift/gcp-token",
  "impersonationUrl": "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken"
}
```

Nullability is preserved and is now structural: a deployment that mounts no credential resolves `null`, rather than an operator having remembered to write it.

## The split is a type

`AuthoredManifest` is what a declaration carries, what the durable row holds, and what `configureInstallation` accepts. `InstallationManifest` is that plus the resolved deployment facts. No write path can reach the derived half, which is what makes a second copy unrepresentable rather than merely discouraged.

A document arriving with a retired key loses it before the strict schema sees it. Dropped rather than refused on purpose: this installation's row was seeded with `cloud.federation` and `charts.installer`, and a refusal would be a control plane that will not boot until someone edits Postgres by hand. The row is rewritten from the stripped document, so it self-heals on the first start.

## `charts.installer` — removed

It named the chart this installation was already running from — the release restating itself into a document the release does not render — and nothing in `src/` ever read it.

## `charts.app` — kept, justified

No deployment renders it. The installer chart names itself and its own release, never the chart an App is deployed through, so there is no second copy for it to disagree with. It is also a real installation choice: §7 wants the App chart pinned per Target, and an OCI reference is where that ends up.

## `controlPlane.hostname` — kept, justified, and made unable to disagree

It is the passkey relying-party id. Two reasons it stays, both written at the field in `manifest.schema.ts`:

1. The chart's `hostname` **may be empty**, and the chart says so — an installation that renders no Gateway and no HTTPRoute, reachable only in-cluster, is supported. That installation still needs a relying party id, so the chart is not a total source and deriving it would make a supported installation unconfigurable.
2. The relying party is bound once at boot on purpose (#1492): a ceremony is scoped to the origin it began at. Moving where it resolves from changes which origin ceremonies are accepted, and the only honest proof of that change is a real enrolment — not an argument. Getting it wrong enrols nobody.

What is removed is the **ability for the two to differ**. `templates/manifest.yaml` refuses to render a declaration whose `controlPlane.hostname` is not the hostname the release serves — the earliest moment the two copies can be compared and the only one where being wrong costs nothing. It also refuses a declaration that restates the federation or names the installer chart.

## Checks

```
$ bun test                     1107 pass, 0 fail (1069 before; 78 files)
$ bun run typecheck            clean
$ bun run lint                 Checked 283 files. No fixes applied.
$ mise run ts:check            4 successful, 4 total
$ mise run k8s:render-apps     rendered clusters/folly/apps, clusters/offsite/apps (+ arc)
$ bun test (packages/charts)   22 pass, 0 fail
```

Scope: `src/config/**`, `packages/charts/spindrift/**` and their tests, plus the `installation.manifest` column type, the offsite release, and the README paragraph that described the removed key. `src/web/**` and `test/auth/**` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
