### PR TITLE
feat(spindrift): reach configureInstallation from the browser

### DIFF
--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -40,6 +40,7 @@ export { getDeployDetail } from './deploys/get-detail.ts';
 export { listDeploys } from './deploys/list.ts';
 export { rollbackDeploy } from './deploys/rollback.ts';
 export { configureInstallation } from './installation/configure.ts';
+export { getInstallationManifest } from './installation/get.ts';
 export {
   beginRepositoryAuthorization,
   pollRepositoryAuthorization,

--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -1,0 +1,40 @@
+/**
+ * `getInstallationManifest` — read what {@link configureInstallation} writes.
+ *
+ * An editing surface has to start from the document it is about to replace,
+ * and `configureInstallation` takes the whole document rather than a patch, so
+ * a form that guessed at the keys it did not render would delete them. This is
+ * the read half of that pair, and the two are deliberately symmetric: what this
+ * answers is exactly what that accepts.
+ *
+ * **It reads the context, not the database.** `CommandContext.manifest` is
+ * resolved per dispatch — that is the whole reason the context factory is
+ * async — so the row is already the source of this answer, and querying it a
+ * second time would only add a way for the two to disagree. It also keeps this
+ * command free of any server-only import, which matters more than it looks:
+ * the command registry is reachable from the browser bundle, so a read command
+ * that reached for the store would put the store in the client build.
+ *
+ * **Nothing here is secret.** §13 keeps credentials out of the manifest by
+ * construction — every adapter's access path is resolved per request, and no
+ * variant of any route or connection carries key material — so the document is
+ * platform configuration, and the surface is session-authenticated regardless.
+ */
+import { z } from 'zod';
+import type { InstallationManifest } from '../../config/manifest.schema.ts';
+import { type Command, ok } from '../types.ts';
+
+export const getInstallationManifestInput = z.object({}).strict();
+
+export type GetInstallationManifestInput = z.infer<
+  typeof getInstallationManifestInput
+>;
+
+export interface GetInstallationManifestResult {
+  readonly manifest: InstallationManifest;
+}
+
+export const getInstallationManifest: Command<
+  GetInstallationManifestInput,
+  GetInstallationManifestResult
+> = async (_input, context) => ok({ manifest: context.manifest });

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -66,6 +66,10 @@ import {
   configureInstallationInput,
 } from './installation/configure.ts';
 import {
+  getInstallationManifest,
+  getInstallationManifestInput,
+} from './installation/get.ts';
+import {
   beginRepositoryAuthorization,
   beginRepositoryAuthorizationInput,
   pollRepositoryAuthorization,
@@ -159,6 +163,10 @@ export const commandRegistry = {
   configureInstallation: {
     input: configureInstallationInput,
     handler: configureInstallation,
+  },
+  getInstallationManifest: {
+    input: getInstallationManifestInput,
+    handler: getInstallationManifest,
   },
   replaceConfig: { input: replaceConfigInput, handler: replaceConfig },
   uploadArchive: { input: uploadArchiveInput, handler: uploadArchive },

--- a/apps/spindrift/src/web/forms/document.ts
+++ b/apps/spindrift/src/web/forms/document.ts
@@ -1,0 +1,172 @@
+/**
+ * Editing a JSON document by path, without a form library.
+ *
+ * The manifest is one document that is valid or is not — `configureInstallation`
+ * takes the whole thing for that reason — so the editing model here is a
+ * document and a cursor into it, never a bag of per-field states. Two properties
+ * follow that are worth having on purpose:
+ *
+ * 1. **What is submitted is what was read, plus edits.** A key this build's
+ *    schema does not render is carried through untouched rather than dropped,
+ *    so an older UI cannot silently delete a key a newer server requires. The
+ *    schema decides what is *editable*; it does not decide what is *kept*.
+ * 2. **Every edit is a whole new document.** React re-renders on identity, and
+ *    a mutation in place is the bug where a field types and nothing moves.
+ *
+ * Absence and `null` are different states and both are reachable: a manifest key
+ * may be optional, nullable, or neither, and flattening the two would make
+ * "this installation has no Gateway" indistinguishable from "this build of the
+ * form did not know about Gateways".
+ */
+import type { FormNode, FormVariant } from './schema.ts';
+
+/** Where a value sits: object keys and array indices, outermost first. */
+export type Path = readonly (string | number)[];
+
+/** A path rendered for an input's `name`, and for keying an error to a field. */
+export function pathKey(path: Path): string {
+  return path.map(String).join('.');
+}
+
+/** The value at a path, or `undefined` where nothing is there. */
+export function valueAt(document: unknown, path: Path): unknown {
+  let current = document;
+  for (const step of path) {
+    if (current === null || typeof current !== 'object') return undefined;
+    current = (current as Record<string | number, unknown>)[step];
+  }
+  return current;
+}
+
+/** The document with `value` at `path`, and every container along it replaced. */
+export function withValueAt(
+  document: unknown,
+  path: Path,
+  value: unknown,
+): unknown {
+  if (path.length === 0) return value;
+  const [step, ...rest] = path as [string | number, ...Path];
+  if (typeof step === 'number') {
+    const list = Array.isArray(document) ? document : [];
+    const next = list.slice();
+    next[step] = withValueAt(list[step], rest, value);
+    return next;
+  }
+  const object =
+    document !== null &&
+    typeof document === 'object' &&
+    !Array.isArray(document)
+      ? (document as Record<string, unknown>)
+      : {};
+  return { ...object, [step]: withValueAt(object[step], rest, value) };
+}
+
+/** The document with whatever is at `path` removed — a key, or an array item. */
+export function withoutValueAt(document: unknown, path: Path): unknown {
+  if (path.length === 0) return undefined;
+  const [step, ...rest] = path as [string | number, ...Path];
+  if (rest.length > 0) {
+    const inner = withoutValueAt(valueAt(document, [step]), rest);
+    return withValueAt(document, [step], inner);
+  }
+  if (typeof step === 'number') {
+    const list = Array.isArray(document) ? document : [];
+    return list.filter((_, index) => index !== step);
+  }
+  if (document === null || typeof document !== 'object') return document;
+  const { [step]: _removed, ...kept } = document as Record<string, unknown>;
+  return kept;
+}
+
+/**
+ * A value of the right shape, with nothing filled in.
+ *
+ * What "nothing" means is the schema's answer, not a convention: an enum's
+ * first member, a literal's only legal value, an object carrying exactly its
+ * required keys. Optional keys are left out, because a blank optional key is a
+ * value the operator did not choose and the schema does not require.
+ *
+ * Blank strings are what make the form's own validation say something useful:
+ * an empty required string fails `min(1)` and is reported against its own path,
+ * which is a better sentence than a missing key's.
+ */
+export function blankValue(node: FormNode): unknown {
+  switch (node.kind) {
+    case 'string':
+      return '';
+    case 'number':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'enum':
+      return node.values[0] ?? '';
+    case 'literal':
+      return node.value;
+    case 'array':
+      return [];
+    case 'object': {
+      const value: Record<string, unknown> = {};
+      for (const field of node.fields) {
+        if (field.optional) continue;
+        value[field.key] = field.nullable ? null : blankValue(field.node);
+      }
+      return value;
+    }
+    case 'union': {
+      const [first] = node.variants;
+      return first === undefined ? null : blankValue(first.node);
+    }
+    case 'unsupported':
+      return null;
+  }
+}
+
+/**
+ * Which arm of a discriminated union a value is currently in.
+ *
+ * By the discriminator's value rather than by trial parse: a half-edited object
+ * matches no arm cleanly, and a form that lost track of which variant it was
+ * showing every time the value was momentarily invalid would be unusable.
+ */
+export function variantOf(
+  variants: readonly FormVariant[],
+  discriminator: string | null,
+  value: unknown,
+): FormVariant | undefined {
+  if (discriminator === null) return variants[0];
+  const tag = (value as Record<string, unknown> | null)?.[discriminator];
+  return variants.find((variant) => variant.tag === tag);
+}
+
+/**
+ * Move a value to another arm of a union, keeping what both arms declare.
+ *
+ * The rule is the schema's, not a list of field names: a key the new arm also
+ * has keeps its value unless it is the discriminator or a literal, both of
+ * which the arm itself decides. So changing a Target from one adapter to
+ * another keeps its name and discards the connection facts that only meant
+ * something to the old adapter — without this module knowing that Targets have
+ * names.
+ */
+export function switchVariant(value: unknown, to: FormVariant): unknown {
+  const blank = blankValue(to.node);
+  if (
+    to.node.kind !== 'object' ||
+    blank === null ||
+    typeof blank !== 'object' ||
+    value === null ||
+    typeof value !== 'object'
+  ) {
+    return blank;
+  }
+  const carried: Record<string, unknown> = {
+    ...(blank as Record<string, unknown>),
+  };
+  const previous = value as Record<string, unknown>;
+  for (const field of to.node.fields) {
+    if (field.node.kind === 'literal') continue;
+    if (!Object.hasOwn(previous, field.key)) continue;
+    carried[field.key] = previous[field.key];
+  }
+  return carried;
+}

--- a/apps/spindrift/src/web/forms/manifest.ts
+++ b/apps/spindrift/src/web/forms/manifest.ts
@@ -1,0 +1,53 @@
+/**
+ * The installation manifest, as a form.
+ *
+ * One module, two functions, and the reason both exist is that they must read
+ * the **same schema the command validates against**. `configureInstallation`
+ * re-exports `installationManifestSchema` for exactly this: a screen that
+ * described the document from a copy could offer a field the server refuses, or
+ * refuse one the server takes, and neither would show up until an operator hit
+ * it.
+ *
+ * Nothing here lists a key. Both functions are the schema applied to something.
+ */
+import { installationManifestSchema } from '../../config/manifest.schema.ts';
+import type { FieldErrors } from './render.tsx';
+import { describeObject, type FormField } from './schema.ts';
+
+/**
+ * The manifest's top-level keys, as fields, in the order the schema declares
+ * them.
+ *
+ * Computed once: the schema does not change while the process runs, and a
+ * re-derivation per render would make every keystroke walk the document type.
+ */
+const FIELDS: readonly FormField[] = describeObject(installationManifestSchema);
+
+export function manifestFields(): readonly FormField[] {
+  return FIELDS;
+}
+
+/**
+ * What is wrong with a document, keyed by the path of the value that is wrong.
+ *
+ * Empty when the document is valid. The keying is what lets a Zod issue be
+ * rendered against the control that produced it rather than in a list at the
+ * bottom of the screen — `dns.apexZone` names one input, and `targets.1.name`
+ * names one row of one array.
+ */
+export function manifestIssues(document: unknown): FieldErrors {
+  const result = installationManifestSchema.safeParse(document);
+  if (result.success) return new Map();
+
+  const errors = new Map<string, string[]>();
+  for (const issue of result.error.issues) {
+    const path = issue.path.map(String).join('.');
+    const existing = errors.get(path);
+    if (existing === undefined) {
+      errors.set(path, [issue.message]);
+    } else {
+      existing.push(issue.message);
+    }
+  }
+  return errors;
+}

--- a/apps/spindrift/src/web/forms/render.tsx
+++ b/apps/spindrift/src/web/forms/render.tsx
@@ -1,0 +1,395 @@
+/**
+ * Rendering a {@link FormNode} tree as controls.
+ *
+ * The whole of this file is a fold over the shape `schema.ts` derived. It knows
+ * about strings, enums, objects, arrays and unions; it knows nothing about
+ * manifests, installations, registries or Targets. That is the point — the
+ * screen that does know is one component, and everything a field needs in order
+ * to be edited comes from the schema rather than from a list somebody maintains.
+ *
+ * Errors arrive keyed by path and are rendered against the control at that
+ * path, so the sentence a Zod issue carries is shown where the value that
+ * caused it is typed rather than collected into a summary at the bottom.
+ */
+import { CircleAlert, Plus, Trash2 } from 'lucide-react';
+import { Button } from '../ui/button.tsx';
+import { Input, Label } from '../ui/field.tsx';
+import { cn } from '../ui/utils.ts';
+import {
+  blankValue,
+  type Path,
+  pathKey,
+  switchVariant,
+  valueAt,
+  variantOf,
+  withoutValueAt,
+  withValueAt,
+} from './document.ts';
+import type { FormField, FormNode } from './schema.ts';
+
+/** One thing wrong with one path, as `configureInstallation` reports it. */
+export type FieldErrors = ReadonlyMap<string, readonly string[]>;
+
+export interface FormProps {
+  /** The whole document being edited; every control reads its own path from it. */
+  readonly document: unknown;
+  readonly errors: FieldErrors;
+  readonly disabled: boolean;
+  onChange(document: unknown): void;
+}
+
+/** Every key of an object schema, in the order the schema declares them. */
+export function SchemaFields({
+  fields,
+  at,
+  form,
+}: {
+  readonly fields: readonly FormField[];
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  return (
+    <div className="flex flex-col gap-4">
+      {fields.map((field) => (
+        <SchemaFieldControl
+          key={field.key}
+          field={field}
+          at={[...at, field.key]}
+          form={form}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * One key, with whatever its optionality permits.
+ *
+ * A key that may be absent or `null` gets a checkbox before its control,
+ * because "this installation has no Gateway" is a configuration an operator
+ * chooses and an empty text box is not a way to say it.
+ */
+function SchemaFieldControl({
+  field,
+  at,
+  form,
+}: {
+  readonly field: FormField;
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  const value = valueAt(form.document, at);
+  const present = value !== undefined && value !== null;
+  const togglable = field.optional || field.nullable;
+  const id = pathKey(at);
+
+  const toggle = (on: boolean) => {
+    if (on) {
+      form.onChange(withValueAt(form.document, at, blankValue(field.node)));
+    } else if (field.nullable) {
+      form.onChange(withValueAt(form.document, at, null));
+    } else {
+      form.onChange(withoutValueAt(form.document, at));
+    }
+  };
+
+  const nested = field.node.kind === 'object' || field.node.kind === 'array';
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1.5',
+        nested && 'rounded-md border border-border/70 p-3',
+      )}
+    >
+      <div className="flex items-center gap-2">
+        {togglable ? (
+          <input
+            type="checkbox"
+            id={`${id}--present`}
+            name={`${id}--present`}
+            checked={present}
+            disabled={form.disabled}
+            onChange={(event) => toggle(event.currentTarget.checked)}
+            className="size-3.5 accent-accent"
+            aria-label={`Configure ${field.label}`}
+          />
+        ) : null}
+        <Label htmlFor={id}>{field.label}</Label>
+      </div>
+      {field.description ? (
+        <p className="text-xs text-muted-foreground">{field.description}</p>
+      ) : null}
+      {present ? (
+        <SchemaControl node={field.node} at={at} form={form} />
+      ) : (
+        <p className="font-mono text-xs text-muted-foreground">
+          {field.nullable && value === null ? 'null' : 'not configured'}
+        </p>
+      )}
+      <IssueList at={at} errors={form.errors} />
+    </div>
+  );
+}
+
+/** The control a node's kind calls for. */
+export function SchemaControl({
+  node,
+  at,
+  form,
+}: {
+  readonly node: FormNode;
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  const value = valueAt(form.document, at);
+  const id = pathKey(at);
+  const set = (next: unknown) =>
+    form.onChange(withValueAt(form.document, at, next));
+
+  switch (node.kind) {
+    case 'string':
+      return (
+        <Input
+          id={id}
+          name={id}
+          type={node.format === 'url' ? 'url' : 'text'}
+          value={typeof value === 'string' ? value : ''}
+          disabled={form.disabled}
+          onChange={(event) => set(event.currentTarget.value)}
+        />
+      );
+    case 'number':
+      return (
+        <Input
+          id={id}
+          name={id}
+          type="number"
+          step={node.integer ? 1 : 'any'}
+          value={typeof value === 'number' ? String(value) : ''}
+          disabled={form.disabled}
+          onChange={(event) => {
+            const parsed = Number(event.currentTarget.value);
+            set(event.currentTarget.value === '' ? undefined : parsed);
+          }}
+        />
+      );
+    case 'boolean':
+      return (
+        <input
+          type="checkbox"
+          id={id}
+          name={id}
+          checked={value === true}
+          disabled={form.disabled}
+          onChange={(event) => set(event.currentTarget.checked)}
+          className="size-4 accent-accent"
+        />
+      );
+    case 'enum':
+      return (
+        <Select
+          id={id}
+          value={typeof value === 'string' ? value : ''}
+          disabled={form.disabled}
+          onChange={set}
+          options={node.values.map((each) => ({ value: each, label: each }))}
+        />
+      );
+    case 'literal':
+      // Not editable, and shown rather than hidden: it is the answer to "which
+      // kind of thing is this", and the union's own selector is what changes it.
+      return (
+        <p className="font-mono text-sm text-muted-foreground">{node.value}</p>
+      );
+    case 'object':
+      return <SchemaFields fields={node.fields} at={at} form={form} />;
+    case 'array':
+      return <ArrayControl node={node} at={at} form={form} />;
+    case 'union':
+      return <UnionControl node={node} at={at} form={form} />;
+    case 'unsupported':
+      return (
+        <p className="flex items-center gap-1.5 text-xs text-terminal-destructive">
+          <CircleAlert aria-hidden="true" className="size-3.5" />
+          This build of the form cannot edit a {node.type} field. Its current
+          value is submitted unchanged.
+        </p>
+      );
+  }
+}
+
+function ArrayControl({
+  node,
+  at,
+  form,
+}: {
+  readonly node: FormNode & { kind: 'array' };
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  const value = valueAt(form.document, at);
+  const items = Array.isArray(value) ? value : [];
+
+  return (
+    <div className="flex flex-col gap-3">
+      {items.map((_, index) => (
+        <div
+          // The index is the identity: these rows have no id of their own, and
+          // the order is meaningful — §16 makes array order the admin rank.
+          key={`${pathKey(at)}.${index}`}
+          className="flex items-start gap-2 rounded-md border border-border/70 p-3"
+        >
+          <div className="min-w-0 flex-1">
+            <SchemaControl
+              node={node.element}
+              at={[...at, index]}
+              form={form}
+            />
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            disabled={form.disabled}
+            aria-label={`Remove item ${index + 1}`}
+            onClick={() =>
+              form.onChange(withoutValueAt(form.document, [...at, index]))
+            }
+          >
+            <Trash2 aria-hidden="true" />
+          </Button>
+        </div>
+      ))}
+      <Button
+        type="button"
+        size="sm"
+        variant="outline"
+        className="self-start"
+        disabled={form.disabled}
+        onClick={() =>
+          form.onChange(
+            withValueAt(form.document, at, [
+              ...items,
+              blankValue(node.element),
+            ]),
+          )
+        }
+      >
+        <Plus aria-hidden="true" />
+        Add
+      </Button>
+    </div>
+  );
+}
+
+function UnionControl({
+  node,
+  at,
+  form,
+}: {
+  readonly node: FormNode & { kind: 'union' };
+  readonly at: Path;
+  readonly form: FormProps;
+}) {
+  const value = valueAt(form.document, at);
+  const active = variantOf(node.variants, node.discriminator, value);
+  const id = pathKey(at);
+
+  return (
+    <div className="flex flex-col gap-3">
+      {node.discriminator === null ? null : (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor={`${id}--variant`}>
+            {node.discriminator.charAt(0).toUpperCase()}
+            {node.discriminator.slice(1)}
+          </Label>
+          <Select
+            id={`${id}--variant`}
+            value={active?.tag ?? ''}
+            disabled={form.disabled}
+            onChange={(next) => {
+              const chosen = node.variants.find((each) => each.tag === next);
+              if (chosen === undefined) return;
+              form.onChange(
+                withValueAt(form.document, at, switchVariant(value, chosen)),
+              );
+            }}
+            options={node.variants.map((variant) => ({
+              value: variant.tag ?? '',
+              label: variant.label,
+            }))}
+          />
+        </div>
+      )}
+      {active === undefined || active.node.kind !== 'object' ? null : (
+        <SchemaFields
+          // The discriminator is chosen above; repeating it as a read-only
+          // literal below would be the same fact twice.
+          fields={active.node.fields.filter(
+            (field) => field.key !== node.discriminator,
+          )}
+          at={at}
+          form={form}
+        />
+      )}
+    </div>
+  );
+}
+
+/** A `<select>` styled like {@link Input}, so the two do not diverge. */
+function Select({
+  id,
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  readonly id: string;
+  readonly value: string;
+  readonly options: readonly { value: string; label: string }[];
+  readonly disabled: boolean;
+  onChange(value: string): void;
+}) {
+  return (
+    <select
+      id={id}
+      name={id}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.currentTarget.value)}
+      className={cn(
+        'h-9 w-full rounded-md border border-input bg-background px-3',
+        'font-mono text-sm text-foreground',
+        'disabled:cursor-not-allowed disabled:opacity-60',
+      )}
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/** Whatever the server or the schema said about this exact path. */
+function IssueList({
+  at,
+  errors,
+}: {
+  readonly at: Path;
+  readonly errors: FieldErrors;
+}) {
+  const issues = errors.get(pathKey(at));
+  if (issues === undefined || issues.length === 0) return null;
+  return (
+    <ul className="flex flex-col gap-0.5">
+      {issues.map((issue) => (
+        <li key={issue} className="text-xs text-terminal-destructive">
+          {issue}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/spindrift/src/web/forms/schema.ts
+++ b/apps/spindrift/src/web/forms/schema.ts
@@ -1,0 +1,258 @@
+/**
+ * What a Zod schema looks like to a form, as data.
+ *
+ * The installation manifest is edited in the browser, and the reason this
+ * module exists rather than a screen listing the fields is that **the schema
+ * moves**. Deployment facts are being taken out of the manifest and derived
+ * from the chart; discovery will take more out after that. A hand-listed form
+ * survives none of those changes by failing — it survives them by silently
+ * editing a key that no longer exists, or by never offering one that appeared.
+ * Neither is visible until an installation is misconfigured.
+ *
+ * So the form is a projection of {@link describeSchema}. A key removed from the
+ * schema stops being rendered on the next build, a key added starts being
+ * rendered, and no screen has an opinion about which keys there are.
+ *
+ * **Deliberately a small vocabulary.** This describes the shapes the manifest
+ * actually uses — objects, arrays, discriminated unions, enums, literals,
+ * strings, numbers, booleans — and answers `unsupported` for anything else,
+ * naming the Zod type it could not read. A general Zod-to-UI compiler would be
+ * a much larger thing with no more coverage of this document, and an
+ * `unsupported` node is rendered as a visible refusal rather than a silently
+ * missing field, so the failure mode of meeting a new shape is a form that says
+ * so.
+ *
+ * Zod 4 exposes `.def` on every schema; that is the whole of the reflection
+ * used here, and it is read in one place so a Zod upgrade has one site to fix.
+ */
+import type { z } from 'zod';
+
+/** A field's kind, and whatever rendering it needs beyond a label. */
+export type FormNode =
+  | { readonly kind: 'string'; readonly format: StringFormat }
+  | { readonly kind: 'number'; readonly integer: boolean }
+  | { readonly kind: 'boolean' }
+  | { readonly kind: 'enum'; readonly values: readonly string[] }
+  | { readonly kind: 'literal'; readonly value: string }
+  | { readonly kind: 'object'; readonly fields: readonly FormField[] }
+  | { readonly kind: 'array'; readonly element: FormNode }
+  | {
+      readonly kind: 'union';
+      /** The key whose value picks a variant, for a discriminated union. */
+      readonly discriminator: string | null;
+      readonly variants: readonly FormVariant[];
+    }
+  | { readonly kind: 'unsupported'; readonly type: string };
+
+/**
+ * How a string is entered. `url` gets a URL input so a browser validates it
+ * without this module restating the rule; everything else is text, because a
+ * regex is the schema's to enforce and paraphrasing it in the UI is how the two
+ * drift apart.
+ */
+export type StringFormat = 'text' | 'url';
+
+/** One key of an object, with what may be done to it. */
+export interface FormField {
+  readonly key: string;
+  /** The key, spaced and capitalized — `apexZone` reads as `Apex zone`. */
+  readonly label: string;
+  readonly node: FormNode;
+  /** The key may be absent entirely. */
+  readonly optional: boolean;
+  /** The key may be present and `null`. */
+  readonly nullable: boolean;
+  /** The schema's own `.describe()` text, where it has one. */
+  readonly description: string | null;
+}
+
+/** One arm of a union, named by its discriminator value where it has one. */
+export interface FormVariant {
+  readonly label: string;
+  /** The discriminator value that selects this arm, or `null` if untagged. */
+  readonly tag: string | null;
+  readonly node: FormNode;
+}
+
+/** Zod 4's definition object, read structurally so no internal type is imported. */
+interface Definition {
+  readonly type: string;
+  readonly shape?: Record<string, unknown>;
+  readonly element?: unknown;
+  readonly innerType?: unknown;
+  readonly options?: readonly unknown[];
+  readonly discriminator?: string;
+  readonly entries?: Record<string, string | number>;
+  readonly values?: readonly unknown[];
+  readonly format?: string;
+  readonly checks?: readonly unknown[];
+}
+
+/** The wrappers that say a value may be missing, null, or defaulted. */
+interface Wrapping {
+  readonly optional: boolean;
+  readonly nullable: boolean;
+  readonly schema: unknown;
+}
+
+function definitionOf(schema: unknown): Definition | null {
+  const def = (schema as { def?: unknown } | null)?.def;
+  return def !== null && typeof def === 'object' ? (def as Definition) : null;
+}
+
+function descriptionOf(schema: unknown): string | null {
+  const described = (schema as { description?: unknown }).description;
+  return typeof described === 'string' ? described : null;
+}
+
+/**
+ * Peel `optional`, `nullable`, `default`, `readonly` and `nonoptional` off a
+ * schema, remembering what they permit.
+ *
+ * A loop rather than recursion because the wrappers compose in any order and
+ * the answer is the same either way — what matters to a form is only whether
+ * absence and `null` are legal, never how many layers said so.
+ */
+function unwrap(schema: unknown): Wrapping {
+  let optional = false;
+  let nullable = false;
+  let current = schema;
+  for (;;) {
+    const def = definitionOf(current);
+    if (def === null) return { optional, nullable, schema: current };
+    switch (def.type) {
+      case 'optional':
+      case 'default':
+      case 'prefault':
+        optional = true;
+        break;
+      case 'nullable':
+        nullable = true;
+        break;
+      case 'nonoptional':
+        optional = false;
+        break;
+      case 'readonly':
+        break;
+      default:
+        return { optional, nullable, schema: current };
+    }
+    if (def.innerType === undefined) {
+      return { optional, nullable, schema: current };
+    }
+    current = def.innerType;
+  }
+}
+
+/** `apexZone` → `Apex zone`; `zeroConfigFrontend` → `Zero config frontend`. */
+export function humanize(key: string): string {
+  const spaced = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[-_]+/g, ' ')
+    .toLowerCase()
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Describe a schema as a form node.
+ *
+ * Pure and total: every input answers something, and a shape this module does
+ * not read answers `unsupported` with the Zod type name rather than throwing.
+ * A form is not a place to discover that reflection failed.
+ */
+export function describeSchema(schema: unknown): FormNode {
+  const def = definitionOf(schema);
+  if (def === null) return { kind: 'unsupported', type: 'unknown' };
+
+  switch (def.type) {
+    case 'string':
+      return { kind: 'string', format: stringFormat(def) };
+    case 'number':
+    case 'int':
+      return { kind: 'number', integer: def.type === 'int' };
+    case 'boolean':
+      return { kind: 'boolean' };
+    case 'enum':
+      return { kind: 'enum', values: Object.keys(def.entries ?? {}) };
+    case 'literal': {
+      const [value] = def.values ?? [];
+      return { kind: 'literal', value: String(value ?? '') };
+    }
+    case 'object':
+      return { kind: 'object', fields: fieldsOf(def.shape ?? {}) };
+    case 'array':
+      return { kind: 'array', element: describeSchema(def.element) };
+    case 'union':
+      return unionNode(def);
+    default:
+      return { kind: 'unsupported', type: def.type };
+  }
+}
+
+/**
+ * Whether a string is a URL, asked both ways Zod can answer it.
+ *
+ * `z.url()` puts the format on the definition; `z.string().url()` puts the same
+ * fact in a check. The manifest schema uses both spellings, and a form that
+ * read only one of them would offer a plain text box for half its URLs.
+ */
+function stringFormat(def: Definition): StringFormat {
+  if (def.format === 'url') return 'url';
+  for (const check of def.checks ?? []) {
+    const inner = (check as { _zod?: { def?: { format?: string } } })._zod?.def;
+    if (inner?.format === 'url') return 'url';
+  }
+  return 'text';
+}
+
+function fieldsOf(shape: Record<string, unknown>): readonly FormField[] {
+  return Object.entries(shape).map(([key, value]) => {
+    const { optional, nullable, schema } = unwrap(value);
+    return {
+      key,
+      label: humanize(key),
+      node: describeSchema(schema),
+      optional,
+      nullable,
+      description: descriptionOf(value) ?? descriptionOf(schema),
+    };
+  });
+}
+
+function unionNode(def: Definition): FormNode {
+  const discriminator = def.discriminator ?? null;
+  const variants = (def.options ?? []).map((option, index): FormVariant => {
+    const node = describeSchema(option);
+    const tag =
+      discriminator === null ? null : tagOf(node, discriminator, index);
+    return {
+      tag,
+      label: tag === null ? `Option ${index + 1}` : humanize(tag),
+      node,
+    };
+  });
+  return { kind: 'union', discriminator, variants };
+}
+
+/** The literal value an arm pins its discriminator to. */
+function tagOf(
+  node: FormNode,
+  discriminator: string,
+  index: number,
+): string | null {
+  if (node.kind !== 'object') return null;
+  const field = node.fields.find((each) => each.key === discriminator);
+  return field?.node.kind === 'literal' ? field.node.value : String(index);
+}
+
+/**
+ * The fields of an object schema, or an empty list for anything else.
+ *
+ * A convenience for the one caller that starts from the manifest's own root and
+ * wants sections rather than a single nested control.
+ */
+export function describeObject(schema: z.ZodType): readonly FormField[] {
+  const node = describeSchema(schema);
+  return node.kind === 'object' ? node.fields : [];
+}

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -1,0 +1,380 @@
+/**
+ * The installation manifest, edited in the product (§20, ticket 32 slice 1).
+ *
+ * §20 makes the manifest the place everything naming an installation lives, and
+ * `manifest-store.ts` has always said the point of storing it durably is "so
+ * the UI can drive all configuration dynamically". `configureInstallation`
+ * built the write; this is the hand that reaches it. Until both exist, a value
+ * seeded wrong stays wrong for the life of the installation — a declaration
+ * only seeds an empty row, so re-declaring it changes nothing once a row is
+ * there.
+ *
+ * **Rendered from the schema, not from a list of fields.** The keys, their
+ * kinds, their optionality and their order all come from
+ * `installationManifestSchema` through `forms/schema.ts`. That is a correctness
+ * requirement rather than a preference: the manifest is losing keys to the
+ * chart and gaining discovery, and a hand-listed form absorbs neither — it
+ * would keep offering a key that no longer exists and quietly never offer one
+ * that appeared. Nothing in this file names a manifest key.
+ *
+ * **Refusals are not flattened.** `configureInstallation` can refuse in three
+ * different ways and they mean three different things, so they read three
+ * different ways here:
+ *
+ * - `INVALID_INPUT` — the document is wrong, and there is a field to fix. The
+ *   issues land against the paths that caused them.
+ * - `NOT_DEPLOYABLE` — the document is well formed and this installation cannot
+ *   take it, because reconciling the Targets it declares meets the ones that
+ *   already exist. Nothing was written and no field is wrong; telling an
+ *   operator to correct a key here would be a lie.
+ * - anything else — a transport or session refusal, which is about the request
+ *   rather than the manifest.
+ *
+ * **The concurrent-edit cost, carried not compounded.** There is no revision
+ * column on `installation`, so two operators saving at once lose one edit
+ * whole; `STALE_EDIT` exists for that shape and stays unused while this is the
+ * one editing surface. This screen does not add a second: it reads once, edits
+ * a document, saves it whole, and re-reads what was stored afterwards, so the
+ * next edit starts from the row rather than from a stale copy. Reload discards
+ * local edits for the same reason.
+ */
+import { CircleAlert, CircleCheck, RotateCcw, Sliders } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import type { TransportFailure } from '../../client.ts';
+import { command } from '../../client.ts';
+import { manifestFields, manifestIssues } from '../../forms/manifest.ts';
+import type { FieldErrors } from '../../forms/render.tsx';
+import { SchemaFields } from '../../forms/render.tsx';
+import type { FormField } from '../../forms/schema.ts';
+import { Button } from '../../ui/button.tsx';
+import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
+
+/** What the last save attempt produced. */
+export type SaveOutcome =
+  | { readonly kind: 'saved'; readonly targets: readonly string[] }
+  /** The document is wrong, and the issues say where. */
+  | { readonly kind: 'invalid'; readonly message: string }
+  /** A fact about this installation, not a field to correct. */
+  | { readonly kind: 'refused'; readonly message: string }
+  /** The request itself did not get to be an answer about the manifest. */
+  | { readonly kind: 'failed'; readonly message: string };
+
+export function InstallationSettings() {
+  const [document, setDocument] = useState<unknown>(undefined);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [errors, setErrors] = useState<FieldErrors>(new Map());
+  const [outcome, setOutcome] = useState<SaveOutcome | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const load = useCallback(async () => {
+    const result = await command('getInstallationManifest', {});
+    if (result.ok) {
+      setDocument(result.value.manifest);
+      setLoadError(null);
+    } else {
+      setLoadError(result.failure.message);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load().catch((cause: unknown) =>
+      setLoadError(
+        cause instanceof Error
+          ? cause.message
+          : 'This installation could not be read.',
+      ),
+    );
+  }, [load]);
+
+  const save = async () => {
+    // Checked here first so the issues can be shown against the fields that
+    // caused them: `configureInstallation` reports every offending key at once
+    // in one sentence, which is the right shape for a log and the wrong shape
+    // for a form. The command validates again regardless — it is the authority,
+    // and this is only the earlier of two identical checks against the same
+    // schema module.
+    const issues = manifestIssues(document);
+    if (issues.size > 0) {
+      setErrors(issues);
+      setOutcome({
+        kind: 'invalid',
+        message: 'This manifest is not valid, so nothing was written.',
+      });
+      return;
+    }
+
+    setSaving(true);
+    setErrors(new Map());
+    try {
+      const result = await command('configureInstallation', {
+        manifest: document,
+      });
+      if (result.ok) {
+        setOutcome({ kind: 'saved', targets: result.value.targets });
+        // What the row now holds, rather than what was sent: the two are the
+        // same document only when nothing else wrote in between, and this
+        // screen has no revision to notice that with.
+        await load();
+      } else {
+        setOutcome(refusalOf(result.failure));
+        if (result.failure.code === 'INVALID_INPUT') {
+          setErrors(issuesOf(result.failure));
+        }
+      }
+    } catch (cause) {
+      setOutcome({
+        kind: 'failed',
+        message:
+          cause instanceof Error ? cause.message : 'The save did not complete.',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loadError !== null) {
+    return (
+      <Card>
+        <CardContent>
+          <p className="text-sm text-terminal-destructive">{loadError}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (document === undefined) {
+    return (
+      <Card>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            Loading this installation…
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <InstallationSettingsView
+      fields={manifestFields()}
+      document={document}
+      errors={errors}
+      outcome={outcome}
+      saving={saving}
+      onChange={(next) => {
+        setDocument(next);
+        setOutcome(null);
+      }}
+      onSave={() => void save()}
+      onReload={() => {
+        setErrors(new Map());
+        setOutcome(null);
+        void load();
+      }}
+    />
+  );
+}
+
+/** A refusal, kept in the three kinds the command actually draws. */
+function refusalOf(failure: TransportFailure): SaveOutcome {
+  switch (failure.code) {
+    case 'INVALID_INPUT':
+      return { kind: 'invalid', message: failure.message };
+    case 'NOT_DEPLOYABLE':
+      return { kind: 'refused', message: failure.message };
+    default:
+      return { kind: 'failed', message: failure.message };
+  }
+}
+
+/** Server-reported issues, keyed the way the form keys its controls. */
+function issuesOf(failure: TransportFailure): FieldErrors {
+  const errors = new Map<string, string[]>();
+  for (const issue of failure.issues ?? []) {
+    // The dispatch layer paths an issue from the command's *input*, whose one
+    // key is the document. The form's paths are into the document itself.
+    const path = issue.path.replace(/^manifest\.?/, '');
+    const existing = errors.get(path);
+    if (existing === undefined) {
+      errors.set(path, [issue.message]);
+    } else {
+      existing.push(issue.message);
+    }
+  }
+  return errors;
+}
+
+export function InstallationSettingsView({
+  fields,
+  document,
+  errors,
+  outcome,
+  saving,
+  onChange,
+  onSave,
+  onReload,
+}: {
+  readonly fields: readonly FormField[];
+  readonly document: unknown;
+  readonly errors: FieldErrors;
+  readonly outcome: SaveOutcome | null;
+  readonly saving: boolean;
+  onChange(document: unknown): void;
+  onSave(): void;
+  onReload(): void;
+}) {
+  const form = { document, errors, disabled: saving, onChange };
+  // Sections are whichever keys have structure. Derived rather than listed, so
+  // a key that changes shape moves itself between the two halves.
+  const nested = fields.filter(
+    (field) => field.node.kind === 'object' || field.node.kind === 'array',
+  );
+  const plain = fields.filter((field) => !nested.includes(field));
+
+  return (
+    <form
+      className="flex flex-col gap-6"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSave();
+      }}
+    >
+      <Card>
+        <CardHeader>
+          <Sliders aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+          <div>
+            <CardTitle>Installation manifest</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Everything that names this installation. Saving writes the whole
+              document and reconciles the Targets it declares.
+            </p>
+          </div>
+        </CardHeader>
+        {plain.length === 0 ? null : (
+          <CardContent>
+            <SchemaFields fields={plain} at={[]} form={form} />
+          </CardContent>
+        )}
+      </Card>
+
+      {nested.map((field) => (
+        <Card key={field.key}>
+          <CardHeader>
+            <div>
+              <CardTitle>{field.label}</CardTitle>
+              {field.description ? (
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {field.description}
+                </p>
+              ) : null}
+            </div>
+          </CardHeader>
+          <CardContent>
+            {field.node.kind === 'object' &&
+            !field.optional &&
+            !field.nullable ? (
+              // A required object is its keys — the card's own title already
+              // names it, and repeating the label inside would be the same
+              // word twice. A key that may be absent keeps its wrapper,
+              // because the wrapper is where "not configured" is said.
+              <SchemaFields
+                fields={field.node.fields}
+                at={[field.key]}
+                form={form}
+              />
+            ) : (
+              <SchemaFields fields={[field]} at={[]} form={form} />
+            )}
+          </CardContent>
+        </Card>
+      ))}
+
+      <Outcome outcome={outcome} />
+
+      <div className="flex items-center gap-3">
+        <Button type="submit" disabled={saving}>
+          {saving ? 'Saving…' : 'Save this installation'}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          disabled={saving}
+          onClick={onReload}
+        >
+          <RotateCcw aria-hidden="true" />
+          Discard edits and re-read
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/**
+ * What the last attempt did, in the grammar the refusal came in.
+ *
+ * The `refused` arm is the one that earns its own shape. §3's
+ * disabled-with-reasons grammar is that a caller is told a fact about the
+ * world, not asked to fix a field, and `NOT_DEPLOYABLE` is that code — a
+ * message about a Target that already exists with a different adapter is not
+ * something re-typing a value in this form can resolve.
+ */
+function Outcome({ outcome }: { readonly outcome: SaveOutcome | null }) {
+  if (outcome === null) return null;
+
+  if (outcome.kind === 'saved') {
+    return (
+      <div
+        role="status"
+        className="flex items-start gap-2 rounded-md border border-good/40 bg-good/10 p-3 text-sm text-good"
+      >
+        <CircleCheck aria-hidden="true" className="mt-0.5 size-4" />
+        <div>
+          <p className="font-medium">This installation was configured.</p>
+          <p className="mt-0.5">
+            {outcome.targets.length === 0
+              ? 'It declares no Targets.'
+              : `Targets reconciled, in rank order: ${outcome.targets.join(', ')}.`}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (outcome.kind === 'refused') {
+    return (
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground"
+      >
+        <CircleAlert aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+        <div>
+          <p className="font-medium">
+            This installation cannot take that manifest.
+          </p>
+          <p className="mt-0.5">{outcome.message}</p>
+          <p className="mt-1 text-muted-foreground">
+            Nothing was written. This is a fact about the installation, not a
+            field to correct.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-terminal-destructive"
+    >
+      <CircleAlert aria-hidden="true" className="mt-0.5 size-4" />
+      <div>
+        <p className="font-medium">
+          {outcome.kind === 'invalid'
+            ? 'This manifest was refused.'
+            : 'That save did not happen.'}
+        </p>
+        <p className="mt-0.5 whitespace-pre-wrap">{outcome.message}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/views/auth/settings.tsx
+++ b/apps/spindrift/src/web/views/auth/settings.tsx
@@ -1,12 +1,4 @@
-import {
-  CheckCircle2,
-  KeyRound,
-  Link,
-  Link2Off,
-  Sliders,
-  Sparkles,
-  Trash2,
-} from 'lucide-react';
+import { KeyRound, Link, Link2Off, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import type { CredentialSettings } from '../../../auth/credential-admin.ts';
 import {
@@ -19,7 +11,7 @@ import {
 } from '../../auth-client.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
-import { Field } from '../../ui/field.tsx';
+import { InstallationSettings } from './installation.tsx';
 
 type CredentialAction =
   | { readonly kind: 'add' }
@@ -76,19 +68,22 @@ export function Settings() {
   }
 
   return (
-    <CredentialSettingsView
-      settings={settings}
-      error={error}
-      running={running}
-      onAdd={() => change({ kind: 'add' }, addPasskey)}
-      onRemove={(credentialId) =>
-        change({ kind: 'remove', credentialId }, () =>
-          removePasskey(credentialId),
-        )
-      }
-      onLink={() => change({ kind: 'gateway' }, linkGateway)}
-      onUnlink={() => change({ kind: 'gateway' }, unlinkGateway)}
-    />
+    <main className="mx-auto flex w-full max-w-[760px] flex-col gap-6 px-5 py-8">
+      <InstallationSettings />
+      <CredentialSettingsView
+        settings={settings}
+        error={error}
+        running={running}
+        onAdd={() => change({ kind: 'add' }, addPasskey)}
+        onRemove={(credentialId) =>
+          change({ kind: 'remove', credentialId }, () =>
+            removePasskey(credentialId),
+          )
+        }
+        onLink={() => change({ kind: 'gateway' }, linkGateway)}
+        onUnlink={() => change({ kind: 'gateway' }, unlinkGateway)}
+      />
+    </main>
   );
 }
 
@@ -109,49 +104,15 @@ export function CredentialSettingsView({
   readonly onLink: () => void;
   readonly onUnlink: () => void;
 }) {
-  const [manifestSaved, setManifestSaved] = useState(false);
-  const [installationName, setInstallationName] = useState('default');
-  const [controlPlaneHost, setControlPlaneHost] = useState(
-    'spindrift.example.com',
-  );
-  const [apexZone, setApexZone] = useState('example.com');
-  const [vanityZone, setVanityZone] = useState('example.com');
-  const [secretStore, setSecretStore] = useState<
-    'onepassword' | 'gcp-secret-manager'
-  >('onepassword');
-  const [targetAdapter, setTargetAdapter] = useState<
-    'kubernetes' | 'cloudrun' | 'static'
-  >('kubernetes');
-  const [buildAdapter, setBuildAdapter] = useState<
-    'github-actions' | 'cloud-build' | 'in-cluster'
-  >('github-actions');
-  const [githubClientId, setGithubClientId] = useState('Iv1.918d699f36ee7afc');
-  const [artifactRegistry, setArtifactRegistry] = useState('ghcr.io/spindrift');
-  const [kmsSigner, setKmsSigner] = useState(
-    'gcpkms://projects/spindrift-artifacts/locations/us-central1/keyRings/keys/cryptoKeys/signer',
-  );
-
-  const handleSaveManifest = (e: React.FormEvent) => {
-    e.preventDefault();
-    setManifestSaved(true);
-    setTimeout(() => setManifestSaved(false), 4000);
-  };
-
   return (
-    <main className="mx-auto flex w-full max-w-[760px] flex-col gap-6 px-5 py-8">
+    <section className="flex flex-col gap-6">
       <div className="flex flex-col gap-1">
-        <div className="flex items-center gap-2">
-          <h1 className="text-2xl font-bold tracking-tight text-foreground">
-            Platform Settings
-          </h1>
-          <span className="rounded-full bg-accent/10 border border-accent/30 px-2.5 py-0.5 text-xs font-semibold text-accent">
-            UI Manifest Driver
-          </span>
-        </div>
+        <h2 className="text-2xl font-bold tracking-tight text-foreground">
+          Operator credentials
+        </h2>
         <p className="text-sm text-muted-foreground">
-          Manage Passkey root identity, Gateway assertions, and UI-driven
-          manifest configurations. Every change requires a fresh assertion from
-          an enrolled passkey.
+          Passkey root identity and Gateway assertions. Every change requires a
+          fresh assertion from an enrolled passkey.
         </p>
       </div>
 
@@ -160,167 +121,6 @@ export function CredentialSettingsView({
           {error}
         </p>
       )}
-
-      {/* Platform & Installation Manifest Control Panel */}
-      <Card className="glass-card border-accent/30">
-        <CardHeader>
-          <Sliders aria-hidden="true" className="mt-0.5 size-5 text-accent" />
-          <div>
-            <CardTitle className="text-base font-semibold text-foreground">
-              Installation Manifest &amp; Control Panel
-            </CardTitle>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Drive platform manifest declarations directly from the UI.
-              Pre-filled with Helm chart placeholders.
-            </p>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSaveManifest} className="flex flex-col gap-4">
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field
-                name="installationName"
-                label="Installation Identifier"
-                type="text"
-                value={installationName}
-                placeholder="e.g. default"
-                onChange={(e) => setInstallationName(e.currentTarget.value)}
-              />
-              <Field
-                name="controlPlaneHost"
-                label="Control Plane Hostname"
-                type="text"
-                value={controlPlaneHost}
-                placeholder="e.g. spindrift.example.com"
-                onChange={(e) => setControlPlaneHost(e.currentTarget.value)}
-              />
-            </div>
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field
-                name="apexZone"
-                label="DNS Apex Zone"
-                type="text"
-                value={apexZone}
-                placeholder="e.g. example.com"
-                onChange={(e) => setApexZone(e.currentTarget.value)}
-              />
-              <Field
-                name="vanityZone"
-                label="DNS Vanity Zone"
-                type="text"
-                value={vanityZone}
-                placeholder="e.g. example.com"
-                onChange={(e) => setVanityZone(e.currentTarget.value)}
-              />
-            </div>
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-              <div className="flex flex-col gap-1.5">
-                <label
-                  htmlFor="secretStoreSelect"
-                  className="text-xs font-medium text-foreground"
-                >
-                  Secret Store Adapter
-                </label>
-                <select
-                  id="secretStoreSelect"
-                  value={secretStore}
-                  onChange={(e) => setSecretStore(e.target.value as any)}
-                  className="h-9 w-full rounded-md border border-border bg-card px-3 text-xs font-mono text-foreground focus:border-accent focus:outline-none"
-                >
-                  <option value="onepassword">1Password Connect</option>
-                  <option value="gcp-secret-manager">GCP Secret Manager</option>
-                </select>
-              </div>
-
-              <div className="flex flex-col gap-1.5">
-                <label
-                  htmlFor="targetAdapterSelect"
-                  className="text-xs font-medium text-foreground"
-                >
-                  Default Target Adapter
-                </label>
-                <select
-                  id="targetAdapterSelect"
-                  value={targetAdapter}
-                  onChange={(e) => setTargetAdapter(e.target.value as any)}
-                  className="h-9 w-full rounded-md border border-border bg-card px-3 text-xs font-mono text-foreground focus:border-accent focus:outline-none"
-                >
-                  <option value="kubernetes">Kubernetes</option>
-                  <option value="cloudrun">Google Cloud Run</option>
-                  <option value="static">Static Hosting</option>
-                </select>
-              </div>
-
-              <div className="flex flex-col gap-1.5">
-                <label
-                  htmlFor="buildAdapterSelect"
-                  className="text-xs font-medium text-foreground"
-                >
-                  Build Route Adapter
-                </label>
-                <select
-                  id="buildAdapterSelect"
-                  value={buildAdapter}
-                  onChange={(e) => setBuildAdapter(e.target.value as any)}
-                  className="h-9 w-full rounded-md border border-border bg-card px-3 text-xs font-mono text-foreground focus:border-accent focus:outline-none"
-                >
-                  <option value="github-actions">
-                    GitHub Actions (Hosted)
-                  </option>
-                  <option value="cloud-build">Cloud Build (Managed)</option>
-                  <option value="in-cluster">In-Cluster BuildKit</option>
-                </select>
-              </div>
-            </div>
-
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <Field
-                name="githubClientId"
-                label="GitHub App Client ID"
-                type="text"
-                value={githubClientId}
-                placeholder="e.g. Iv1.918d699f36ee7afc"
-                onChange={(e) => setGithubClientId(e.currentTarget.value)}
-              />
-              <Field
-                name="artifactRegistry"
-                label="Supply Chain Registry"
-                type="text"
-                value={artifactRegistry}
-                placeholder="e.g. ghcr.io/spindrift"
-                onChange={(e) => setArtifactRegistry(e.currentTarget.value)}
-              />
-            </div>
-
-            <Field
-              name="kmsSigner"
-              label="Supply Chain KMS Signer URI"
-              type="text"
-              value={kmsSigner}
-              placeholder="e.g. gcpkms://projects/spindrift-artifacts/locations/us-central1/keyRings/keys/cryptoKeys/signer"
-              onChange={(e) => setKmsSigner(e.currentTarget.value)}
-            />
-
-            <div className="flex items-center justify-between pt-2">
-              <Button
-                type="submit"
-                className="gap-2 bg-accent text-accent-foreground hover:bg-accent/90"
-              >
-                <Sparkles aria-hidden="true" className="size-4" />
-                Save &amp; Reconcile Manifest
-              </Button>
-              {manifestSaved && (
-                <div className="inline-flex items-center gap-1.5 rounded-md bg-good/15 border border-good/40 px-3 py-1 text-xs font-medium text-good">
-                  <CheckCircle2 className="size-3.5" />
-                  Manifest Updated &amp; Reconciled to Store
-                </div>
-              )}
-            </div>
-          </form>
-        </CardContent>
-      </Card>
 
       {/* Account Passkeys */}
       <Card>
@@ -430,7 +230,7 @@ export function CredentialSettingsView({
           )}
         </CardContent>
       </Card>
-    </main>
+    </section>
   );
 }
 

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * The settings screen ticket 32 slice 1 exists to build.
+ *
+ * Rendered to static markup, which is the right depth for what is claimed:
+ * every rule below is a statement about **what is on the screen in a given
+ * state**, and none is about interaction.
+ *
+ * Two things are being asserted, and they are not the same thing:
+ *
+ * 1. **A control exists for every manifest value**, derived from the schema, so
+ *    a key an operator has to correct is reachable. This is the half seven
+ *    tickets are waiting on — the live installation pins a zero-config frontend
+ *    that resolves nowhere, a declaration only seeds an empty row, and until
+ *    this screen there was no hand to change it with.
+ * 2. **The three refusals read as three different things.**
+ *    `configureInstallation` distinguishes "your document is wrong" from "this
+ *    installation cannot take it", and flattening the second into a form error
+ *    would tell an operator to fix a field that is not wrong.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { manifestFields } from '../../src/web/forms/manifest.ts';
+import type { FieldErrors } from '../../src/web/forms/render.tsx';
+import type { SaveOutcome } from '../../src/web/views/auth/installation.tsx';
+import { InstallationSettingsView } from '../../src/web/views/auth/installation.tsx';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const manifest = await fixtureManifest();
+
+function screen({
+  document = manifest as unknown,
+  errors = new Map() as FieldErrors,
+  outcome = null as SaveOutcome | null,
+  saving = false,
+} = {}): string {
+  return renderToStaticMarkup(
+    <InstallationSettingsView
+      fields={manifestFields()}
+      document={document}
+      errors={errors}
+      outcome={outcome}
+      saving={saving}
+      onChange={() => undefined}
+      onSave={() => undefined}
+      onReload={() => undefined}
+    />,
+  );
+}
+
+describe('every manifest value is reachable', () => {
+  const markup = screen();
+
+  test('a control exists for each key the schema declares', () => {
+    // By the schema's keys rather than a list here, for the same reason the
+    // screen renders by them: a list in a test rots exactly as fast as a list
+    // in a component.
+    for (const field of manifestFields()) {
+      expect(markup).toContain(`name="${field.key}`);
+    }
+  });
+
+  test('a nested key is reached by its own path', () => {
+    // Dotted paths are what let a Zod issue be rendered against the input that
+    // caused it. `targets.0.name` names one row of one array.
+    expect(markup).toContain('name="dns.apexZone"');
+    expect(markup).toContain('name="targets.0.name"');
+  });
+
+  test('the pinned zero-config frontend is one of them', () => {
+    // The specific value that cannot be corrected any other way: a declaration
+    // seeds only an empty row, and an installation with a row keeps it. This
+    // input is the whole of the hand ticket 29's second item was missing.
+    expect(markup).toContain('name="build.zeroConfigFrontend"');
+    expect(markup).toContain(manifest.build.zeroConfigFrontend);
+  });
+
+  test('a value the schema calls a url is entered as one', () => {
+    expect(markup).toContain('type="url"');
+  });
+
+  test('a nullable key can be said to be absent', () => {
+    // `auth.gateway` is null in the fixture — passkeys are the only path — and
+    // the screen has to be able to render that as a chosen configuration
+    // rather than as an empty box.
+    expect(markup).toContain('name="auth.gateway--present"');
+    expect(markup).toContain('not configured');
+  });
+
+  test('a discriminated union offers its arms', () => {
+    expect(markup).toContain('name="targets.0--variant"');
+    for (const target of manifest.targets) {
+      expect(markup).toContain(`value="${target.adapter}"`);
+    }
+  });
+
+  test('saving disables the form rather than letting a second save start', () => {
+    expect(screen({ saving: true })).toContain('disabled=""');
+  });
+});
+
+describe('a refusal reads as what it is', () => {
+  test('an invalid document is reported against the field that is wrong', () => {
+    const markup = screen({
+      errors: new Map([['dns.apexZone', ['must be a lowercase DNS name']]]),
+      outcome: {
+        kind: 'invalid',
+        message: 'This manifest is not valid, so nothing was written.',
+      },
+    });
+    expect(markup).toContain('must be a lowercase DNS name');
+    expect(markup).toContain('This manifest was refused.');
+  });
+
+  test('NOT_DEPLOYABLE is a fact about the installation, not a field to fix', () => {
+    // §3's disabled-with-reasons grammar: the caller is told something about
+    // the world. A Target that already exists with a different adapter is not
+    // something re-typing a value in this form resolves, and a form error
+    // saying "fix this" would be false.
+    const markup = screen({
+      outcome: {
+        kind: 'refused',
+        message:
+          'manifest Target cluster uses cloudrun, but the stored Target uses kubernetes',
+      },
+    });
+    expect(markup).toContain('This installation cannot take that manifest.');
+    expect(markup).toContain('not a field to correct');
+    expect(markup).not.toContain('This manifest was refused.');
+  });
+
+  test('a transport refusal is about the request, not the manifest', () => {
+    const markup = screen({
+      outcome: {
+        kind: 'failed',
+        message: 'this surface is reachable only with a session',
+      },
+    });
+    expect(markup).toContain('That save did not happen.');
+    expect(markup).not.toContain('This manifest was refused.');
+    expect(markup).not.toContain(
+      'This installation cannot take that manifest.',
+    );
+  });
+
+  test('a success names the Targets the write reconciled', () => {
+    // Writing a manifest is the one act that creates a Target without anybody
+    // naming one, so a confirmation that did not say so would hide it.
+    const markup = screen({
+      outcome: { kind: 'saved', targets: ['cluster', 'cloud-cloudrun'] },
+    });
+    expect(markup).toContain('This installation was configured.');
+    expect(markup).toContain('cluster, cloud-cloudrun');
+  });
+});

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Ticket 32 slice 1's two acceptance criteria, over the surface an operator
+ * actually reaches.
+ *
+ * `test/commands/installation-configure.test.ts` already proves the command.
+ * What it cannot prove is the sentence the ticket is written in — "onboarding
+ * writes the installation row **through a session-authenticated command**, and
+ * Target reconciliation runs on that write" — because a command called directly
+ * from a test has no session and no route. So this file drives the browser's
+ * own route table: `commandRoutes` is what `Bun.serve` is handed, `pathFor` is
+ * the path the typed client posts to, and the request goes through the same
+ * authentication check every other command does.
+ *
+ * The document is edited with `forms/document.ts` — the module the form edits
+ * through — rather than by spreading an object here, so what is submitted is
+ * what the screen would submit.
+ *
+ * The context resolves the manifest per dispatch, exactly as `serve.ts` does,
+ * because that is what makes the read-after-write in these tests mean anything:
+ * a process-lifetime copy would answer a `getInstallationManifest` with what
+ * the row held at boot.
+ */
+import { describe, expect, test } from 'bun:test';
+import type { CommandContext, Principal } from '../../src/commands/types.ts';
+import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
+import {
+  currentStoredManifest,
+  loadStoredManifest,
+} from '../../src/config/manifest-store.ts';
+import { installation } from '../../src/db/schema.ts';
+import {
+  commandRoutes,
+  type DispatchDeps,
+  pathFor,
+} from '../../src/web/dispatch.ts';
+import { valueAt, withValueAt } from '../../src/web/forms/document.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const fixture = await fixtureManifest();
+
+const OPERATOR: Principal = {
+  id: crypto.randomUUID(),
+  displayName: 'Operator',
+};
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+
+/** A context whose manifest is the row, resolved per dispatch. */
+async function context(): Promise<CommandContext> {
+  const stored = await currentStoredManifest(database().db);
+  return {
+    principal: OPERATOR,
+    clock: { now: () => FROZEN },
+    db: database().db,
+    manifest: stored ?? fixture,
+    adapters: {
+      deploy: () => null,
+      build: () => null,
+      store: () => null,
+      repository: () => null,
+      supplyChain: () => {
+        throw new Error('configuring an installation reached the supply chain');
+      },
+    } as unknown as CommandContext['adapters'],
+  };
+}
+
+const authenticated: DispatchDeps = {
+  authenticate: async () => ({ kind: 'authenticated', principal: OPERATOR }),
+  context,
+};
+
+const anonymous: DispatchDeps = {
+  authenticate: async () => ({ kind: 'anonymous' }),
+  context: () => {
+    throw new Error('an unauthenticated request built a request context');
+  },
+};
+
+/** Post to a command's own route, the way `client.ts` does. */
+async function post(
+  deps: DispatchDeps,
+  name: Parameters<typeof pathFor>[0],
+  body: unknown,
+): Promise<Response> {
+  const route = commandRoutes(deps)[pathFor(name)];
+  if (route === undefined) throw new Error(`${name} has no route`);
+  return route(
+    new Request(`https://spindrift.example.test${pathFor(name)}`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+async function seed(): Promise<void> {
+  await loadStoredManifest(database().db, {
+    SPINDRIFT_MANIFEST: JSON.stringify(fixture),
+  });
+}
+
+async function storedManifest(): Promise<InstallationManifest | undefined> {
+  const [row] = await database().db.select().from(installation);
+  return row?.manifest;
+}
+
+describe('reading this installation from the browser', () => {
+  test('answers the stored document, whole', async () => {
+    await seed();
+    const response = await post(authenticated, 'getInstallationManifest', {});
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      ok: boolean;
+      value: { manifest: InstallationManifest };
+    };
+    expect(body.ok).toBe(true);
+    // Whole, because `configureInstallation` takes the whole document: a read
+    // that returned a subset would make the form delete every key it did not
+    // ask for.
+    const stored = await storedManifest();
+    expect(stored).toBeDefined();
+    expect(body.value.manifest).toEqual(stored as InstallationManifest);
+  });
+
+  test('is refused without a session', async () => {
+    await seed();
+    const response = await post(anonymous, 'getInstallationManifest', {});
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('configuring this installation from the browser', () => {
+  test('is refused without a session, and writes nothing', async () => {
+    await seed();
+    const before = await storedManifest();
+    const response = await post(anonymous, 'configureInstallation', {
+      manifest: fixture,
+    });
+    expect(response.status).toBe(401);
+    expect(await storedManifest()).toEqual(before);
+  });
+
+  test('writes a value that no declaration can reach', async () => {
+    // The act ticket 29's second item has no other path to: a declaration only
+    // seeds an empty row, and an installation with a row keeps it. The edit is
+    // made through the form's own document module.
+    await seed();
+    const read = await post(authenticated, 'getInstallationManifest', {});
+    const { value } = (await read.json()) as {
+      value: { manifest: InstallationManifest };
+    };
+
+    const edited = withValueAt(
+      value.manifest,
+      ['build', 'zeroConfigFrontend'],
+      'registry.example.test/zero-config:corrected',
+    );
+
+    const saved = await post(authenticated, 'configureInstallation', {
+      manifest: edited,
+    });
+    expect(saved.status).toBe(200);
+    expect((await storedManifest())?.build.zeroConfigFrontend).toBe(
+      'registry.example.test/zero-config:corrected',
+    );
+  });
+
+  test('a configured installation reads back what it just wrote', async () => {
+    // Criterion 2. The value has to survive the round trip through the row,
+    // not just through this process — `context.manifest` is resolved per
+    // dispatch for exactly that reason.
+    await seed();
+    const edited = withValueAt(
+      fixture,
+      ['supplyChain', 'registry'],
+      'registry.example.test/second',
+    );
+    await post(authenticated, 'configureInstallation', { manifest: edited });
+
+    const read = await post(authenticated, 'getInstallationManifest', {});
+    const { value } = (await read.json()) as {
+      value: { manifest: InstallationManifest };
+    };
+    expect(valueAt(value.manifest, ['supplyChain', 'registry'])).toBe(
+      'registry.example.test/second',
+    );
+  });
+
+  test('reconciles the Targets the written document declares', async () => {
+    // Criterion 1's second half, and the one a form is most likely to break:
+    // reconciliation runs inside the write's transaction, so a surface that
+    // reached a different writer would leave a Target declared in the document
+    // and absent from the table.
+    await seed();
+    const declared = [
+      ...fixture.targets,
+      { name: 'spare', adapter: 'kubernetes' },
+    ];
+    const edited = withValueAt(fixture, ['targets'], declared);
+
+    const saved = await post(authenticated, 'configureInstallation', {
+      manifest: edited,
+    });
+    expect(saved.status).toBe(200);
+
+    const rows = await database().db.query.targets.findMany({
+      orderBy: (targets, { asc }) => [asc(targets.rank)],
+    });
+    expect(rows.map((row) => row.name)).toEqual(
+      declared.map((target) => target.name),
+    );
+    // A Target nobody named through the product exists because the manifest
+    // said so, which is the whole reason the write and the reconcile are one
+    // transaction.
+    expect(rows.some((row) => row.name === 'spare')).toBe(true);
+  });
+
+  test('an invalid document is a 422 naming every offending key', async () => {
+    await seed();
+    const before = await storedManifest();
+    const broken = withValueAt(
+      withValueAt(fixture, ['installation'], ''),
+      ['dns', 'apexZone'],
+      '',
+    );
+
+    const response = await post(authenticated, 'configureInstallation', {
+      manifest: broken,
+    });
+    expect(response.status).toBe(422);
+    const body = (await response.json()) as {
+      failure: { code: string; message: string };
+    };
+    expect(body.failure.code).toBe('INVALID_INPUT');
+    expect(body.failure.message).toContain('apexZone');
+    expect(await storedManifest()).toEqual(before);
+  });
+
+  test('a document this installation cannot take is a 409, not a field error', async () => {
+    // The distinction the screen renders. 409 rather than 422 because the
+    // request is well formed and the caller has nothing to fix in it — §3's
+    // disabled-with-reasons grammar, over HTTP.
+    await seed();
+    const swapped = withValueAt(
+      fixture,
+      ['targets'],
+      [
+        { name: 'cluster', adapter: 'kubernetes' },
+        { name: 'cloud-cloudrun', adapter: 'kubernetes' },
+      ],
+    );
+
+    const response = await post(authenticated, 'configureInstallation', {
+      manifest: swapped,
+    });
+    expect(response.status).toBe(409);
+    const body = (await response.json()) as { failure: { code: string } };
+    expect(body.failure.code).toBe('NOT_DEPLOYABLE');
+  });
+});

--- a/apps/spindrift/test/web/schema-form.test.ts
+++ b/apps/spindrift/test/web/schema-form.test.ts
@@ -1,0 +1,252 @@
+/**
+ * The property the settings form is built on (ticket 32 slice 1).
+ *
+ * The claim is not "this renders nicely". It is that **the set of editable keys
+ * is the schema's set, derived, and never a list somebody maintains** — because
+ * the manifest is actively losing keys to the chart and will gain others from
+ * discovery, and a hand-listed form absorbs neither of those by failing. It
+ * absorbs them by editing a key that no longer exists, or by never offering one
+ * that appeared, and nothing notices until an installation is misconfigured.
+ *
+ * So the assertions here are equalities against
+ * `installationManifestSchema` itself, plus the same equality over synthetic
+ * schemas that gain and lose a key — which is the shape of the change that is
+ * happening to the real one right now.
+ */
+import { describe, expect, test } from 'bun:test';
+import { z } from 'zod';
+import { installationManifestSchema } from '../../src/config/manifest.schema.ts';
+import {
+  blankValue,
+  pathKey,
+  switchVariant,
+  valueAt,
+  variantOf,
+  withoutValueAt,
+  withValueAt,
+} from '../../src/web/forms/document.ts';
+import { manifestFields } from '../../src/web/forms/manifest.ts';
+import {
+  describeObject,
+  describeSchema,
+  type FormField,
+  type FormNode,
+  humanize,
+} from '../../src/web/forms/schema.ts';
+
+/** The keys the schema itself declares, read the way a parser would. */
+function schemaKeys(schema: z.ZodType): string[] {
+  const shape = (
+    schema as unknown as { def: { shape: Record<string, unknown> } }
+  ).def.shape;
+  return Object.keys(shape);
+}
+
+function field(fields: readonly FormField[], key: string): FormField {
+  const found = fields.find((each) => each.key === key);
+  if (found === undefined) throw new Error(`no field named ${key}`);
+  return found;
+}
+
+describe('the form is the schema', () => {
+  test('offers exactly the keys the manifest schema declares', () => {
+    // Set equality in one assertion, not two subset checks: a key the form
+    // offers that the schema does not have and a key the schema has that the
+    // form does not offer are the same drift seen from two sides.
+    expect(manifestFields().map((each) => each.key)).toEqual(
+      schemaKeys(installationManifestSchema),
+    );
+  });
+
+  test('offers them in the schema’s own order', () => {
+    // §16 makes array order meaningful in this document, and an operator
+    // reading a form expects the order the manifest is written in.
+    const [first] = manifestFields();
+    expect(first?.key).toBe(schemaKeys(installationManifestSchema)[0]);
+  });
+
+  test('drops a key the schema drops, with no edit here', () => {
+    // Ticket 33 is removing deployment facts from the manifest as this lands.
+    // This is that change, in miniature: the same derivation over a schema
+    // with a key and without it.
+    const before = z.object({ kept: z.string(), leaving: z.string() });
+    const after = z.object({ kept: z.string() });
+
+    expect(describeObject(before).map((each) => each.key)).toEqual([
+      'kept',
+      'leaving',
+    ]);
+    expect(describeObject(after).map((each) => each.key)).toEqual(['kept']);
+  });
+
+  test('offers a key the schema gains, with no edit here', () => {
+    const grown = z.object({ kept: z.string(), arrived: z.string() });
+    expect(describeObject(grown).map((each) => each.key)).toContain('arrived');
+  });
+});
+
+describe('what a field knows about itself', () => {
+  const fields = manifestFields();
+
+  test('a nested object becomes a group of its own keys', () => {
+    const dns = field(fields, 'dns').node;
+    expect(dns.kind).toBe('object');
+    if (dns.kind !== 'object') return;
+    expect(dns.fields.map((each) => each.key).sort()).toEqual(
+      schemaKeys(
+        (
+          installationManifestSchema as unknown as {
+            def: { shape: Record<string, z.ZodType> };
+          }
+        ).def.shape.dns as z.ZodType,
+      ).sort(),
+    );
+  });
+
+  test('a nullable key is togglable and a required one is not', () => {
+    const auth = field(fields, 'auth').node;
+    expect(auth.kind).toBe('object');
+    if (auth.kind !== 'object') return;
+    // `auth.gateway` is `null` when passkeys are the only path — a
+    // configuration an operator chooses, so the form has to be able to say it.
+    expect(field(auth.fields, 'gateway').nullable).toBe(true);
+    expect(field(fields, 'installation').nullable).toBe(false);
+    expect(field(fields, 'installation').optional).toBe(false);
+  });
+
+  test('an optional key is marked optional', () => {
+    const sources = field(fields, 'sources').node;
+    if (sources.kind !== 'object') throw new Error('sources is not an object');
+    expect(field(sources.fields, 'defaultBucket').optional).toBe(true);
+  });
+
+  test('an enum becomes its own members, read from the schema', () => {
+    const store = field(fields, 'secretStore').node;
+    if (store.kind !== 'object')
+      throw new Error('secretStore is not an object');
+    const adapter = field(store.fields, 'adapter').node;
+    expect(adapter.kind).toBe('enum');
+    if (adapter.kind !== 'enum') return;
+    expect(adapter.values.length).toBeGreaterThan(1);
+  });
+
+  test('a discriminated union becomes a choice plus the arm’s own keys', () => {
+    const targets = field(fields, 'targets').node;
+    expect(targets.kind).toBe('array');
+    if (targets.kind !== 'array') return;
+    const element = targets.element;
+    expect(element.kind).toBe('union');
+    if (element.kind !== 'union') return;
+    expect(element.discriminator).toBe('adapter');
+    // Every arm names itself with the literal it pins, so the selector reads
+    // as the vocabulary rather than as "Option 2".
+    expect(element.variants.every((variant) => variant.tag !== null)).toBe(
+      true,
+    );
+  });
+
+  test('a url string is entered as a url', () => {
+    const store = field(fields, 'secretStore').node;
+    if (store.kind !== 'object')
+      throw new Error('secretStore is not an object');
+    const endpoint = field(store.fields, 'endpoint').node;
+    expect(endpoint).toEqual({ kind: 'string', format: 'url' });
+  });
+
+  test('a url is a url in either spelling the schema uses', () => {
+    // `z.url()` states the format on the definition; `z.string().url()` states
+    // it in a check. The manifest schema uses both, and reading only one of
+    // them offers a plain text box for half the URLs in the document.
+    expect(describeSchema(z.url())).toEqual({ kind: 'string', format: 'url' });
+    expect(describeSchema(z.string().url())).toEqual({
+      kind: 'string',
+      format: 'url',
+    });
+  });
+
+  test('a shape this module cannot read says so rather than disappearing', () => {
+    // The failure mode that matters. A reflection miss must be visible, because
+    // a field that silently vanished is a key an operator cannot configure and
+    // has no way to notice.
+    const node = describeSchema(z.map(z.string(), z.string()));
+    expect(node.kind).toBe('unsupported');
+  });
+
+  test('a key reads as a sentence, not as an identifier', () => {
+    expect(humanize('zeroConfigFrontend')).toBe('Zero config frontend');
+    expect(humanize('apexZone')).toBe('Apex zone');
+  });
+});
+
+describe('editing the document', () => {
+  const node: FormNode = describeSchema(
+    z.object({
+      name: z.string(),
+      note: z.string().optional(),
+      list: z.array(z.string()),
+    }),
+  );
+
+  test('a set replaces the document rather than mutating it', () => {
+    const before = { a: { b: 'one' } };
+    const after = withValueAt(before, ['a', 'b'], 'two');
+    expect(before.a.b).toBe('one');
+    expect(valueAt(after, ['a', 'b'])).toBe('two');
+  });
+
+  test('a key this build does not render survives the edit', () => {
+    // The property that makes an older UI safe against a newer server: the
+    // schema decides what is editable, never what is kept.
+    const before = { known: 'one', unknown: 'kept' };
+    const after = withValueAt(before, ['known'], 'two');
+    expect(valueAt(after, ['unknown'])).toBe('kept');
+  });
+
+  test('removing a key and removing an array item are different acts', () => {
+    expect(withoutValueAt({ a: 1, b: 2 }, ['b'])).toEqual({ a: 1 });
+    expect(withoutValueAt({ list: [1, 2, 3] }, ['list', 1])).toEqual({
+      list: [1, 3],
+    });
+  });
+
+  test('a blank value carries the required keys and omits the optional ones', () => {
+    expect(blankValue(node)).toEqual({ name: '', list: [] });
+  });
+
+  test('a path keys a control and an error the same way', () => {
+    expect(pathKey(['targets', 1, 'name'])).toBe('targets.1.name');
+  });
+});
+
+describe('changing which kind of thing a value is', () => {
+  const union = describeSchema(
+    z.discriminatedUnion('adapter', [
+      z.object({
+        name: z.string(),
+        adapter: z.literal('one'),
+        only: z.string(),
+      }),
+      z.object({ name: z.string(), adapter: z.literal('two') }),
+    ]),
+  );
+
+  test('finds the arm by its discriminator, not by trial parse', () => {
+    if (union.kind !== 'union') throw new Error('not a union');
+    const arm = variantOf(union.variants, 'adapter', {
+      adapter: 'two',
+      name: 'x',
+    });
+    expect(arm?.tag).toBe('two');
+  });
+
+  test('keeps what both arms declare and drops what only the old one did', () => {
+    if (union.kind !== 'union') throw new Error('not a union');
+    const two = union.variants.find((variant) => variant.tag === 'two');
+    if (two === undefined) throw new Error('no second arm');
+    const moved = switchVariant(
+      { adapter: 'one', name: 'keep me', only: 'drop me' },
+      two,
+    );
+    expect(moved).toEqual({ adapter: 'two', name: 'keep me' });
+  });
+});


### PR DESCRIPTION
Slice 1 of ticket 32 had a command and no hand. #1492 built `configureInstallation`, tested it, and nothing in the UI called it — so the one act it exists for still had no path. This is that surface, plus the read half it needs.

## What changed

- **`getInstallationManifest`** (`src/commands/installation/get.ts`) — the read half of the pair. It answers `context.manifest`, which is resolved per dispatch, so the row is already the source and querying it twice would only add a way for the two to disagree. It also keeps the command free of any server-only import.
- **`src/web/forms/`** — a Zod schema, described as form nodes (`schema.ts`), a JSON document edited by path (`document.ts`), a renderer that folds one over the other (`render.tsx`), and the manifest's own application of both (`manifest.ts`).
- **`src/web/views/auth/installation.tsx`** — the screen. Reads, edits, saves the whole document, re-reads.
- **`src/web/views/auth/settings.tsx`** — the placeholder manifest panel is gone. It was hardcoded state and a save handler that set a flag for four seconds; it was the shape of this screen with none of its behaviour.

## Rendered from the schema, deliberately

Nothing in the view names a manifest key. The keys, kinds, optionality and order all come from `installationManifestSchema`.

This is a correctness requirement rather than a style preference. Deployment facts are being taken out of the manifest by ticket 33 while this lands, and discovery will take more out after that. A hand-listed form absorbs none of those changes by failing — it absorbs them by editing a key that no longer exists, or by never offering one that appeared, and nothing notices until an installation is misconfigured. `test/web/schema-form.test.ts` asserts the set equality against the schema itself, and asserts the same derivation over synthetic schemas that gain and lose a key.

A shape the reflection cannot read renders as a visible refusal naming the Zod type, not as a missing field. A field that silently vanished is a key an operator cannot configure and has no way to notice.

## The three refusals stay three things

`configureInstallation` distinguishes them and this screen keeps the distinction:

- `INVALID_INPUT` — issues land against the paths that caused them.
- `NOT_DEPLOYABLE` — rendered as a fact about the installation, with an explicit "this is not a field to correct". §3's disabled-with-reasons grammar; flattening it into a form error would tell an operator to fix a key that is not wrong.
- anything else — about the request, not the manifest.

## The carried cost

No revision column, so concurrent edits still lose one, and `STALE_EDIT` stays unused. This adds no second editing surface: it reads once, edits a document, saves it whole, and re-reads the row after a successful save so the next edit starts from what was stored. "Discard edits and re-read" is the manual recovery.

## Evidence

`test/web/installation-surface.test.ts` drives `commandRoutes` — the table `Bun.serve` is handed — through the same authentication check every command gets, with a context that resolves the manifest per dispatch exactly as `serve.ts` does. The document is edited with `forms/document.ts`, the module the form edits through, so what is submitted is what the screen submits.

```text
$ DATABASE_URL=… bun test test/web/installation-surface.test.ts
bun test v1.3.14 (0d9b296a)

 8 pass
 0 fail
 18 expect() calls
Ran 8 tests across 1 file. [1.56s]
```

Full suite, typecheck, lint, workspace check and the client build:

```text
$ bun test
 1140 pass
 0 fail
 3286 expect() calls
Ran 1140 tests across 81 files. [84.08s]

$ bun run typecheck && bun run lint
$ tsc --noEmit
$ biome check .
Checked 291 files in 75ms. No fixes applied.

$ bun run build
spindrift client → dist/ (4 files, 5524.4 KiB)
```

1097 tests before, 1140 after — 39 added here, the rest from #1496 landing in between. The client build is on top of #1496's cut edge and is unaffected by it.

## What this does not close

Ticket 32 items 3 and 4 — the unconfigured-install wizard and cloud discovery — are later slices and are not in this PR. Ticket 29's item 2 has a hand now; using it is an operator's act in a browser with a passkey session, and no test can stand in for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
