### PR TITLE
fix(spindrift): declare the installation manifest offsite runs on

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -58,3 +58,87 @@ spec:
         limits:
           memory: 768Mi
           cpu: 1000m
+    # §20's installation manifest, declared rather than seeded.
+    #
+    # The durable row is written from this document at process start and
+    # otherwise from itself, so an undeclared installation can only ever be
+    # seeded — and a value seeded wrong stays wrong. `zeroConfigFrontend` was
+    # exactly that: `ghcr.io/railwayapp/railpack:railpack-frontend` came in with
+    # the row, GHCR does not serve that repository at all, and two later
+    # corrections to the code default could not reach an installation that
+    # already had one. Declaring the document is what puts a manifest change
+    # back under ordinary review.
+    #
+    # Both zones are substituted by the apps Kustomization — `SPINDRIFT_DOMAIN`
+    # from cluster-settings, `SECRET_DOMAIN` from cluster-secrets — so the zone
+    # is read rather than restated, the same way `hostname` above reads it.
+    manifest:
+      installation: offsite
+      controlPlane:
+        hostname: spindrift.${SECRET_DOMAIN}
+      dns:
+        apexZone: ${SPINDRIFT_DOMAIN}
+        vanityZone: ${SPINDRIFT_DOMAIN}
+      auth:
+        gateway: null
+      build:
+        routes:
+          - name: hosted
+            adapter: github-actions
+        # Railpack publishes the frontend as its own repository. The tag is a
+        # version because rebuilding one bundle digest should not silently
+        # change what built it, and this is the only input to a zero-config
+        # build that no digest covers.
+        zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
+      cloud:
+        federation:
+          audience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
+          tokenUrl: https://sts.googleapis.com/v1/token
+          tokenPath: /var/run/secrets/spindrift/gcp-token
+          impersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
+        artifactsProject: trusted-builds
+        homeVesselProject: bluenose
+      charts:
+        app: packages/charts/spindrift-app
+        installer: packages/charts/spindrift
+      github:
+        clientId: Iv1.918d699f36ee7afc
+        apiBaseUrl: https://api.github.com
+        oauthBaseUrl: https://github.com
+        buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
+      sources:
+        buckets:
+          - bluenose-spindrift-source
+        defaultBucket: bluenose-spindrift-source
+      targets:
+        - name: offsite
+          adapter: kubernetes
+          connection:
+            delivery:
+              flavour: flux-helmrelease
+              namespace: spindrift-apps
+              sourceRef:
+                name: infra
+                namespace: flux-system
+            apiServer: https://kubernetes.default.svc
+            namespace: spindrift-apps
+            chartContract: "2"
+        - name: bluenose-cloudrun
+          adapter: cloudrun
+          connection:
+            region: northamerica-northeast1
+            project: bluenose
+            endpoint: https://run.googleapis.com
+        - name: bluenose-static
+          adapter: static
+          connection:
+            project: bluenose
+            endpoint: https://firebasehosting.googleapis.com
+      secretStore:
+        adapter: onepassword
+        endpoint: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+        container: homelab
+      supplyChain:
+        signer: gcpkms://projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer
+        registry: ghcr.io/jonpulsifer
+        verifier: ghcr.io/jonpulsifer/spindrift-verifier


### PR DESCRIPTION
**This is the change that turns the failing builds green.** #1499 fixes the mechanism that made the failure unreadable; this fixes the value that caused it.

## What was wrong

The live installation ran with:

```
"zeroConfigFrontend": "ghcr.io/railwayapp/railpack:railpack-frontend"
```

GHCR does not serve `railwayapp/railpack` at all — its tags API answers **403**, where `railwayapp/railpack-frontend` answers **200** with 396 tags including the pinned `v0.35.0`. Every zero-config build died on it.

## Why git could not already fix it

The value arrived with the row. `f220e080` seeded it; `d62caba4` and `19e403d6` later corrected the code default — and neither could reach this installation, because `loadStoredManifest` writes the row from a declaration when one is present and **otherwise from itself**. An undeclared installation can only ever be seeded, so the row was the only copy and no code change could touch it.

That is exactly the trap `d3ed7e2c` added `configureInstallation` for, and the trap the chart's `manifest:` value exists to close. This installation had neither a declaration nor a UI to drive the command with, so the row had no other hand to change it.

## What this does

Declares the document, which puts a manifest change back under ordinary review. Both zones read their zone rather than restating it — `SPINDRIFT_DOMAIN` from cluster-settings, `SECRET_DOMAIN` from cluster-secrets, the same substitution `hostname` already uses two lines up.

Nothing in the document is credential material: a GCP KMS key *reference*, a projected-token *path*, a cluster-internal endpoint, and a public GitHub App client id. The chart says as much — "public identifiers such as a GitHub App id do not make the document a credential."

## Verification

Read the live row, built the declaration from it, and checked the whole way down:

- **Semantic diff against the live row, keys normalised** — one line differs:
  ```
  -   "zeroConfigFrontend": "ghcr.io/railwayapp/railpack:railpack-frontend"
  +   "zeroConfigFrontend": "ghcr.io/railwayapp/railpack-frontend:v0.35.0"
  ```
- **Schema**: substituted the two variables as the apps Kustomization does, then ran the real `validateManifest` — passes.
- **Chart render**: `helm template` produces the `spindrift-manifest` ConfigMap, mounts it into both web and reconciler, and sets `SPINDRIFT_MANIFEST_PATH=/etc/spindrift/manifest.yaml`.
- **Rendered bytes**: parsed `manifest.yaml` out of the rendered ConfigMap and ran it through `parseManifest` — passes, and resolves to the live values:
  ```
  installation: offsite   controlPlane: spindrift.lolwtf.ca
  dns.apexZone: lolwtf.dev
  targets: offsite, bluenose-cloudrun, bluenose-static
  ```
- `kustomize build clusters/offsite/apps/spindrift` exits 0.

A validation failure here is fatal at process start, which is why it was checked against the real schema rather than by eye.

## Rollout

The chart annotates both Deployments with `checksum/manifest`, so merging rolls both processes and they read the declaration at start — no manual restart.

## Ordering

Independent of #1499, and either order is safe. This one alone turns builds green: with the frontend corrected, even the old download path resolves `v0.35.0` to a release that exists. #1499 alone does not — it would fail at image pull instead of at a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
