### PR TITLE
fix(spindrift): declare only what the chart does not render

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -102,16 +102,13 @@ spec:
         # build that no digest covers.
         zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
       cloud:
-        federation:
-          audience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
-          tokenUrl: https://sts.googleapis.com/v1/token
-          tokenPath: /var/run/secrets/spindrift/gcp-token
-          impersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
+        # No `federation` here. It is read from the `external_account`
+        # credential this chart renders, from the two serviceAccount.token
+        # values above — declaring it a second time is what the chart refuses.
         artifactsProject: trusted-builds
         homeVesselProject: bluenose
       charts:
         app: packages/charts/spindrift-app
-        installer: packages/charts/spindrift
       github:
         clientId: Iv1.918d699f36ee7afc
         apiBaseUrl: https://api.github.com


### PR DESCRIPTION
## main does not render, and Flux has been failing since #1503 merged

#1500 made `cloud.federation` and `charts.installer` facts the chart owns, and added `{{ fail }}` guards so a declaration cannot restate them. #1504 declared a manifest for offsite carrying both. They merged in that order, so no combination of them was ever rendered before landing.

Live, right now:

```
$ kubectl -n spindrift get helmrelease spindrift
spindrift  READY=False
Helm upgrade failed for release spindrift/spindrift with chart spindrift@0.1.1+6cee62d50ca6:
execution error at (spindrift/templates/manifest.yaml:23:4):
manifest.cloud.federation is not a manifest key: federation is read from the
external_account credential this chart renders.

lastAttemptedRevision: 0.1.1+6cee62d50ca6      # current main
```

Reproduced locally against the real HelmRelease values before and after this change:

```
before   federation present: true    charts.installer: packages/charts/spindrift   -> RENDER FAILED
after    federation present: false   charts.installer: undefined                   -> RENDER OK
```

## Nothing is lost

`serviceAccount.token.gcpAudience` and `gcpImpersonationUrl` are already set on this release, and the credential the chart renders from them carries all four facts the declaration was restating:

```json
{
  "type": "external_account",
  "audience": "//iam.googleapis.com/.../providers/offsite",
  "token_url": "https://sts.googleapis.com/v1/token",
  "service_account_impersonation_url": ".../spindrift-controller@bluenose...:generateAccessToken",
  "credential_source": { "file": "/var/run/secrets/spindrift/gcp-token" }
}
```

Field for field, that matches what the stored `installation.manifest` row already holds — so the derived credential is the same credential. `charts.installer` named this chart and nothing in `src/` reads it.

## Why CI missed it

`mise run k8s:render-apps` renders kustomizations; it never templates a Helm chart, so neither PR's checks evaluated the new guard against these values. It passes on the broken tree. Worth a follow-up: the guards #1500 added are only enforced at Flux reconcile time, which is the one place where being wrong costs an outage.

Checks: `mise run k8s:render-apps` clean, chart tests 22 pass / 0 fail, `helm template` with the real offsite values renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)