### PR TITLE
fix(spindrift): compare the installation read against what it answers

### DIFF
--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -26,6 +26,7 @@ import type {
   AuthoredManifest,
   InstallationManifest,
 } from '../../src/config/manifest.schema.ts';
+import { resolveManifest } from '../../src/config/manifest.ts';
 import {
   currentStoredManifest,
   loadStoredManifest,
@@ -125,7 +126,13 @@ describe('reading this installation from the browser', () => {
     // ask for.
     const stored = await storedManifest();
     expect(stored).toBeDefined();
-    expect(body.value.manifest).toEqual(stored as InstallationManifest);
+    // The row holds the *authored* document; the read answers that document
+    // with the deployment facts attached, which is the one place the two halves
+    // meet. Comparing against the row itself would assert the read had never
+    // resolved anything.
+    expect(body.value.manifest).toEqual(
+      await resolveManifest(stored as AuthoredManifest),
+    );
   });
 
   test('is refused without a session', async () => {

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -22,7 +22,10 @@
  */
 import { describe, expect, test } from 'bun:test';
 import type { CommandContext, Principal } from '../../src/commands/types.ts';
-import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
+import type {
+  AuthoredManifest,
+  InstallationManifest,
+} from '../../src/config/manifest.schema.ts';
 import {
   currentStoredManifest,
   loadStoredManifest,
@@ -102,7 +105,7 @@ async function seed(): Promise<void> {
   });
 }
 
-async function storedManifest(): Promise<InstallationManifest | undefined> {
+async function storedManifest(): Promise<AuthoredManifest | undefined> {
   const [row] = await database().db.select().from(installation);
   return row?.manifest;
 }

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -101,17 +101,16 @@ spec:
         # change what built it, and this is the only input to a zero-config
         # build that no digest covers.
         zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
+      # No `federation` key: §13's one auth mode is the `external_account`
+      # credential this chart renders from `serviceAccount.token` above, and the
+      # process reads its federation out of that file. Restating it here is a
+      # second copy to drift, which the chart refuses to render.
       cloud:
-        federation:
-          audience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
-          tokenUrl: https://sts.googleapis.com/v1/token
-          tokenPath: /var/run/secrets/spindrift/gcp-token
-          impersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
         artifactsProject: trusted-builds
         homeVesselProject: bluenose
+      # No `installer` key: it named this chart, and nothing reads it.
       charts:
         app: packages/charts/spindrift-app
-        installer: packages/charts/spindrift
       github:
         clientId: Iv1.918d699f36ee7afc
         apiBaseUrl: https://api.github.com

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -101,14 +101,12 @@ spec:
         # change what built it, and this is the only input to a zero-config
         # build that no digest covers.
         zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
-      # No `federation` key: §13's one auth mode is the `external_account`
-      # credential this chart renders from `serviceAccount.token` above, and the
-      # process reads its federation out of that file. Restating it here is a
-      # second copy to drift, which the chart refuses to render.
       cloud:
+        # No `federation` here. It is read from the `external_account`
+        # credential this chart renders, from the two serviceAccount.token
+        # values above — declaring it a second time is what the chart refuses.
         artifactsProject: trusted-builds
         homeVesselProject: bluenose
-      # No `installer` key: it named this chart, and nothing reads it.
       charts:
         app: packages/charts/spindrift-app
       github:


### PR DESCRIPTION
Fixes the two ways `installation-surface.test.ts` disagreed with what #1500 made true. Main has been red since #1503.

**This branch no longer touches the HelmRelease.** #1505 landed that fix first; what was left here was a second phrasing of its comments and no behaviour, so it has gone back to the wording on main.

## Typecheck

`storedManifest` claimed `InstallationManifest` — the *resolved* type carrying the federation the process derives from its credential file. The column is `$type<AuthoredManifest>()`, which has had no federation key since #1500 derived it away.

## The failing assertion

```
error: expect(received).toEqual(expected)
+     "federation": null,
  at installation-surface.test.ts:128
```

`answers the stored document, whole` compared the API's answer against the raw row. The row holds the authored document; the read answers that document with the deployment facts attached, which `resolveManifest` documents as "the one place the two halves meet". So the assertion differed by exactly the derived key and, read literally, asserted that the read had never resolved anything.

Comparing against `resolveManifest(stored)` keeps what the test is actually for. "Whole" is about the read not returning a *subset*, so a form cannot delete the keys it did not render — it was never about the read being byte-identical to storage.

I checked whether the round-trip was genuinely broken before changing the test, since the handler's own docstring promises "what this answers is exactly what that accepts". It is not: `configureInstallation` warns and discards a submitted `cloud.federation` rather than refusing it, so read → edit → submit still works. The test was comparing the wrong two things, not catching a product bug.

## Verification

- `mise run ts:check`: 5/5 and 4/4 tasks pass.
- The test itself needs Postgres and I have none locally (WSL), so **CI is the verification for the assertion change** — the typecheck half I confirmed locally.

## Worth noting

#1505 identified why CI never caught the original collision: `k8s:render-apps` renders kustomizations and never templates a Helm chart, so no check evaluates the chart's `fail` guards against real release values. That gap is still open — it is what let a HelmRelease that cannot render reach main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
