### PR TITLE
fix(spindrift): pin an image whose schema reads the declaration

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -26,7 +26,14 @@ spec:
   values:
     # Renovate pins the digest on this line. Flux picks up the change
     # and rolls out the new image automatically.
-    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:be1a95161fe8b85d7bd63d212620425a959e7fed43594d49fa3ba9f360690b6a
+    #
+    # It must be an image whose schema agrees with the chart about which keys a
+    # declaration may carry. `be1a951` was pinned two minutes before #1500
+    # derived `cloud.federation` and `charts.installer` away, so it required the
+    # two keys the chart had begun refusing — the declaration could satisfy the
+    # chart or the process, never both, and the pods crashlooped on a manifest
+    # the chart would not have rendered had it carried them.
+    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:201b68bfeefcb394c3acf6459b7f00d9cb4753ee1566afdf4718931489485d6b
     # Substituted by the apps Kustomization from the cluster-secrets Secret, so
     # the zone is read rather than restated. external-dns publishes the record
     # from the HTTPRoute and cert-manager issues the certificate, so this line


### PR DESCRIPTION
**This is what is actually stopping the declared manifest from landing.** Caught live before a rollback erased it:

```
ManifestError: /etc/spindrift/manifest.yaml: invalid installation manifest
  cloud.federation: Invalid input: expected object, received undefined
  charts.installer: Invalid input: expected string, received undefined
    at loadStoredManifest (manifest-store.ts:42)
    at startReconciler (reconciler/start.ts:50)
```

That is the exact inverse of the guard in `templates/manifest.yaml`. The chart **refuses** a declaration carrying those two keys; the running image **requires** them. A declaration could satisfy one or the other, never both.

## How the two ended up disagreeing

| | when |
|---|---|
| renovate pinned `be1a951` (#1501) | 18:20:00 |
| #1500 derived `cloud.federation` and `charts.installer` away | 18:22:47 |

Two minutes and forty-seven seconds. The pinned image was built from a commit whose schema still required both keys, and #1500 changed the chart and the schema together — but not the pin that decides which schema actually runs.

So the declaration went in, Helm rendered it, both processes died at boot, readiness never passed, Helm hit its 5m timeout and rolled back. The rollback deleted the ConfigMap and reverted the image, which is why each cycle left no trace and why `spindrift-manifest` kept reading NotFound.

## The fix

`201b68bf` is built from `6cee62d5`, which has #1500 in it.

Verified rather than assumed:

- `git merge-base --is-ancestor f0e51eae 6cee62d5` → **yes**, the image includes #1500.
- `git diff 6cee62d5 origin/main -- apps/spindrift/src/config/` → **empty**, so the image's schema is byte-identical to main's.
- Ran main's declared document through that schema: **passes**, with `cloud` carrying only `artifactsProject, homeVesselProject` and `charts` only `app` — exactly what the chart's guards permit.
- `helm template` renders, `kustomize build` exits 0.

The image digest is renovate's line; this bump only moves it to the newest published `:latest`, which renovate would have reached on its own schedule. Nothing else changes.

## Impact

The rollbacks kept the installation serving throughout — the old chart and old image stayed up. This is a stuck upgrade, not an outage. But until it merges the row keeps the frontend nobody can pull, so **builds stay broken**.

## After merge

Flux reconciles, the ConfigMap lands, and both processes read the declaration at start instead of dying on it. The check is `kubectl get cm spindrift-manifest -n spindrift` — if it survives more than five minutes, the upgrade held.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
