### PR TITLE
fix(ci): template the charts, not just the kustomizations

### DIFF
--- a/.agents/skills/validate-build/SKILL.md
+++ b/.agents/skills/validate-build/SKILL.md
@@ -21,7 +21,7 @@ Validate by change area — running everything is slow and usually unnecessary.
 | Changed | Run |
 | --- | --- |
 | `terraform/**`, `clusters/*/bootstrap/**` | `mise run tf:validate`, `mise run tf:fmt` |
-| `clusters/**` | `mise run k8s:render-apps` (what CI runs), or `kubectl kustomize clusters/<site>/<category>` |
+| `clusters/**`, `packages/charts/**` | `mise run k8s:render-apps` (what CI runs), or `kubectl kustomize clusters/<site>/<category>` |
 | `nix/**`, `flake.nix` | `mise run nix:check`; `HOST=<host> mise run nix:build` for one closure |
 | `docs/**`, `apps/wiki/**` | `mise run docs:build`, then `mise run docs:check` |
 | TypeScript under `apps/`, `packages/` | `mise run ts:check` |
@@ -32,6 +32,11 @@ Validate by change area — running everything is slow and usually unnecessary.
   particular the OpenTofu binary is `tofu`, never `terraform`.
 - For `clusters/base/` changes, render **both** clusters — they are not
   symmetric and a base change can render on folly and fail on offsite.
+- `k8s:render-apps` also runs `helm template` over every in-repo chart a
+  rendered HelmRelease names, with that release's `.spec.values`. A chart guard
+  or template error is a failed task here rather than a failed Flux reconcile,
+  so run it for a chart edit as well as a manifest edit. Charts from a
+  HelmRepository or OCIRepository are named and skipped, not silently passed.
 - `nix flake check` evaluates every host and is slow. When iterating on one
   host, build just that closure.
 - `mise run docs:check` enforces the docs contract: every wikilink resolves,

--- a/.github/scripts/render-cluster-apps.sh
+++ b/.github/scripts/render-cluster-apps.sh
@@ -1,12 +1,126 @@
 #!/usr/bin/env bash
-# Renders the shared app seams for both cluster adapters without touching live state.
+# Renders the shared app seams for both cluster adapters without touching live
+# state, then templates every in-repo chart the rendered HelmReleases name,
+# using the values those HelmReleases set.
+#
+# Rendering the kustomizations alone proves the overlays compose; it says
+# nothing about whether the charts they point at can render. A chart guard
+# (`{{ fail }}`) or any other template error only surfaced at Flux reconcile
+# time, which is downtime rather than a red check. The values are the input
+# that matters: a chart templated with its own `values.yaml` defaults would
+# miss a key that only a cluster's HelmRelease declares.
 set -euo pipefail
 
-for overlay in \
-  clusters/folly/apps \
-  clusters/offsite/apps \
-  clusters/folly/apps/arc \
-  clusters/offsite/apps/arc; do
-  kubectl kustomize "$overlay" >/dev/null
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+OVERLAYS=(
+  clusters/folly/apps
+  clusters/offsite/apps
+  clusters/folly/apps/arc
+  clusters/offsite/apps/arc
+)
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# ns/name of every HelmRelease this run actually templated, so the coverage
+# check below can name the ones it never reached.
+covered="$WORK/covered"
+: >"$covered"
+
+failures=0
+
+# Extracts one field from one document of a rendered stream.
+field() {
+  yq eval-all "select(documentIndex == $2) | $3" "$1"
+}
+
+template_releases() {
+  local rendered="$1" overlay="$2"
+  local idx ns name chart source release target values
+  local list="$WORK/releases-${overlay//\//_}.tsv"
+
+  yq eval-all '
+    select(.kind == "HelmRelease")
+    | [[ documentIndex,
+         (.metadata.namespace // "default"),
+         .metadata.name,
+         (.spec.chart.spec.chart // "-"),
+         (.spec.chart.spec.sourceRef.kind // .spec.chartRef.kind // "unknown source") ]]
+    | @tsv
+  ' "$rendered" >"$list"
+
+  while IFS=$'\t' read -r idx ns name chart source; do
+    [ -n "${idx:-}" ] || continue
+
+    if [ "$chart" = "-" ]; then
+      printf '  skipped %s/%s — chartRef (%s), chart not in this repo\n' \
+        "$ns" "$name" "$source"
+      continue
+    fi
+
+    if [ ! -f "$chart/Chart.yaml" ]; then
+      printf '  skipped %s/%s — chart %q from %s, not in this repo\n' \
+        "$ns" "$name" "$chart" "$source"
+      continue
+    fi
+
+    release="$(field "$rendered" "$idx" '.spec.releaseName // .metadata.name')"
+    target="$(field "$rendered" "$idx" '.spec.targetNamespace // .metadata.namespace // "default"')"
+    values="$WORK/values-$ns-$name.yaml"
+    field "$rendered" "$idx" '.spec.values // {}' >"$values"
+
+    printf '%s/%s\n' "$ns" "$name" >>"$covered"
+
+    # Flux substitutes ${VAR} postbuild variables from cluster ConfigMaps and
+    # Secrets. Helm does not interpret ${...}, so an unsubstituted value is an
+    # ordinary string here and renders fine — the guards this check exists to
+    # catch are about which keys are declared, not what they expand to.
+    if helm template "$release" "$chart" \
+      --namespace "$target" \
+      --values "$values" \
+      </dev/null >/dev/null 2>"$WORK/helm.err"; then
+      printf '  templated %s/%s with %s (values from %s)\n' \
+        "$ns" "$name" "$chart" "$overlay"
+    else
+      printf '  FAILED %s/%s with %s (values from %s)\n' \
+        "$ns" "$name" "$chart" "$overlay"
+      sed 's/^/    /' "$WORK/helm.err"
+      failures=$((failures + 1))
+    fi
+  done <"$list"
+}
+
+for overlay in "${OVERLAYS[@]}"; do
+  rendered="$WORK/${overlay//\//_}.yaml"
+  kubectl kustomize "$overlay" >"$rendered"
   printf 'rendered %s\n' "$overlay"
+  template_releases "$rendered" "$overlay"
 done
+
+# A HelmRelease that names an in-repo chart but lives outside the overlays above
+# is exactly the gap this script closes, so it is an error rather than silence:
+# either the overlay belongs in OVERLAYS, or the chart is no longer reachable.
+declared="$WORK/declared"
+: >"$declared"
+while IFS= read -r file; do
+  yq eval-all '
+    select(.kind == "HelmRelease")
+    | select(.spec.chart.spec.chart // "" | test("^packages/charts/"))
+    | (.metadata.namespace // "default") + "/" + .metadata.name
+  ' "$file" 2>/dev/null >>"$declared" || true
+done < <(grep -rl --include='*.yaml' 'packages/charts/' clusters/ || true)
+
+uncovered="$(comm -23 <(sort -u "$declared") <(sort -u "$covered") || true)"
+if [ -n "$uncovered" ]; then
+  printf '\nHelmReleases naming an in-repo chart that no rendered overlay reached:\n'
+  printf '%s\n' "$uncovered" | sed 's/^/  /'
+  printf 'Add the overlay that carries them to OVERLAYS in %s.\n' "${BASH_SOURCE[0]}"
+  failures=$((failures + 1))
+fi
+
+if [ "$failures" -gt 0 ]; then
+  printf '\n%d chart render check(s) failed\n' "$failures" >&2
+  exit 1
+fi

--- a/.github/workflows/kustomize.yml
+++ b/.github/workflows/kustomize.yml
@@ -6,6 +6,7 @@ on:
       - 'clusters/base/**'
       - 'clusters/folly/apps/**'
       - 'clusters/offsite/apps/**'
+      - 'packages/charts/**'
       - '.github/scripts/render-cluster-apps.sh'
       - '.github/workflows/kustomize.yml'
   pull_request:
@@ -13,6 +14,7 @@ on:
       - 'clusters/base/**'
       - 'clusters/folly/apps/**'
       - 'clusters/offsite/apps/**'
+      - 'packages/charts/**'
       - '.github/scripts/render-cluster-apps.sh'
       - '.github/workflows/kustomize.yml'
 jobs:
@@ -20,4 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # helm templates the in-repo charts the rendered HelmReleases name; yq
+      # pulls each release's values back out of the rendered stream.
+      - uses: jdx/mise-action@9e7f7633ff6f6d6048a9418a68d48f288f50eb14 # v4.2.3
+        with:
+          install_args: helm kubectl yq
       - run: bash .github/scripts/render-cluster-apps.sh

--- a/docs/pages/Runbooks___Validate Infra Changes.md
+++ b/docs/pages/Runbooks___Validate Infra Changes.md
@@ -27,6 +27,11 @@ tags:: runbook, validation
 	  kubectl kustomize clusters/folly/<category>
 	  kubectl kustomize clusters/offsite/<category>
 	  ```
+	- Run what CI runs, which renders both app overlays and then templates every in-repo chart their HelmReleases name, with that release's `.spec.values`:
+	- ```bash
+	  mise run k8s:render-apps
+	  ```
+	- A chart guard or template error is a failed task here rather than a failed Flux reconcile, so run it for a `packages/charts/` edit as well as a manifest edit. Charts served from a HelmRepository or OCIRepository are named and skipped.
 	- See [[Runbooks/Kubernetes GitOps Change]] and [[Runbooks/Add Shared Kubernetes Resource]].
 - # Terraform
 	- The binary is **OpenTofu** (`tofu`), not `terraform`. Validate every root the same way CI does:

--- a/mise.toml
+++ b/mise.toml
@@ -21,6 +21,7 @@ kustomize = "latest"
 shellcheck = "latest"
 shfmt = "latest"
 sops = "latest"
+yq = "latest"
 # tofu is the apply-path binary (Atlantis runs ATLANTIS_DEFAULT_TF_DISTRIBUTION=opentofu);
 # terraform stays installed for anything not yet migrated.
 opentofu = "1.12.5"
@@ -52,7 +53,7 @@ description = "Test validation-impact routing"
 run = "bash .github/scripts/validation-impact_test.sh"
 
 [tasks."k8s:render-apps"]
-description = "Render shared folly and offsite app overlays"
+description = "Render shared folly and offsite app overlays, then template the in-repo charts their HelmReleases name"
 run = "bash .github/scripts/render-cluster-apps.sh"
 
 [tasks."tf:init"]


### PR DESCRIPTION
## The gap

`mise run k8s:render-apps` (`.github/scripts/render-cluster-apps.sh`) rendered
four kustomize overlays and never templated a Helm chart. Every guard a chart
declares was therefore enforced only at Flux reconcile time — the one place
where being wrong is downtime instead of a red check.

That is what took the offsite control plane down tonight. #1500 taught
`packages/charts/spindrift/templates/manifest.yaml` to refuse a declaration
restating `manifest.cloud.federation` or `manifest.charts.installer`; #1504
declared an offsite manifest carrying both. Neither PR is wrong alone, no
combination of them was ever rendered before landing, both went green, and main
rendered no spindrift chart at all:

```text
Helm upgrade failed for release spindrift/spindrift with chart
spindrift@0.1.1+6cee62d50ca6: execution error at
(spindrift/templates/manifest.yaml:23:4): manifest.cloud.federation is not a
manifest key…
```

#1505 fixed the declaration. This fixes the check.

## What the check does

The script writes each rendered overlay out instead of to `/dev/null`, pulls
every `HelmRelease` back out of the rendered stream with `yq`, and for each one
whose chart resolves to a `Chart.yaml` in this repo runs `helm template` with
that release's own `.spec.values`, `.spec.releaseName` and namespace.

Reading the values off the **rendered** overlay rather than the source file is
load-bearing twice over: the release's values are what the guard sees (a chart
templated with its `values.yaml` defaults would not have caught this, because
the offending keys live only in `clusters/offsite/apps/spindrift/helm-release.yaml`),
and rendering first applies the overlay's HelmRelease patches.

Three details worth review:

- **Charts that are not in this repo are named and skipped**, never silently
  passed — `chartRef` OCIRepository releases and every HelmRepository chart get
  a `skipped …, not in this repo` line.
- **A HelmRelease naming an in-repo chart that no rendered overlay reaches is
  an error.** That is this same gap in a different overlay, so it fails with the
  releases it could not reach rather than passing quietly.
- **Flux's `${VAR}` postbuild substitutions need no placeholder.** Helm does not
  interpret `${...}`, so `spindrift.${SECRET_DOMAIN}` and `${SPINDRIFT_DOMAIN}`
  render as ordinary strings. Confirmed by the passing run below, which
  templates the real offsite release unmodified. The guards this exists to catch
  are about which keys are declared, not what they expand to.

`yq` is added to `[tools]` and the workflow gains a `mise-action` step for
`helm kubectl yq`; `packages/charts/**` joins the workflow's trigger paths,
since a chart edit can now break this check.

## Proof it catches the real bug

Reconstructing #1504's declaration in a worktree — the exact hunk `da7061bf`
removed — reproduces the live failure, at the same template line, with the same
message:

```text
$ mise run k8s:render-apps
rendered clusters/offsite/apps
  templated agents-sandbox/dave with packages/charts/ai-agent (values from clusters/offsite/apps)
  skipped atlantis/atlantis — chart atlantis from HelmRepository, not in this repo
  skipped cloudnative-pg/cloudnative-pg — chart cloudnative-pg from HelmRepository, not in this repo
  skipped descheduler/descheduler — chart descheduler from HelmRepository, not in this repo
  templated hub/hub with packages/charts/app (values from clusters/offsite/apps)
  skipped reloader/reloader — chartRef (OCIRepository), chart not in this repo
  FAILED spindrift/spindrift with packages/charts/spindrift (values from clusters/offsite/apps)
    Error: execution error at (spindrift/templates/manifest.yaml:23:4): manifest.cloud.federation is not a manifest key: federation is read from the external_account credential this chart renders. Set serviceAccount.token.gcpAudience and serviceAccount.token.gcpImpersonationUrl instead.

    Use --debug flag to render out invalid YAML

1 chart render check(s) failed
[k8s:render-apps] ERROR task failed
exit=1
```

The second guard fires on its own too, with `charts.installer` left in and
`cloud.federation` removed:

```text
  FAILED spindrift/spindrift with packages/charts/spindrift (values from clusters/offsite/apps)
    Error: execution error at (spindrift/templates/manifest.yaml:26:4): manifest.charts.installer is not a manifest key: it named this chart, and nothing reads it. Remove it.
```

Restored, on the tree this PR ships:

```text
$ mise run k8s:render-apps
rendered clusters/folly/apps
  templated agents-sandbox/hermes with packages/charts/ai-agent (values from clusters/folly/apps)
  skipped argo/argo — chart argo-cd from HelmRepository, not in this repo
  skipped cloudnative-pg/cloudnative-pg — chart cloudnative-pg from HelmRepository, not in this repo
  skipped default/hajimari — chart hajimari from HelmRepository, not in this repo
  skipped default/podinfo — chart podinfo from HelmRepository, not in this repo
  skipped descheduler/descheduler — chart descheduler from HelmRepository, not in this repo
  skipped falco/falco — chart falco from HelmRepository, not in this repo
  skipped k6/k6 — chart k6-operator from HelmRepository, not in this repo
  skipped open-webui/open-webui — chart open-webui from HelmRepository, not in this repo
  skipped reloader/reloader — chartRef (OCIRepository), chart not in this repo
  skipped vault/vault — chart openbao from HelmRepository, not in this repo
rendered clusters/offsite/apps
  templated agents-sandbox/dave with packages/charts/ai-agent (values from clusters/offsite/apps)
  skipped atlantis/atlantis — chart atlantis from HelmRepository, not in this repo
  skipped cloudnative-pg/cloudnative-pg — chart cloudnative-pg from HelmRepository, not in this repo
  skipped descheduler/descheduler — chart descheduler from HelmRepository, not in this repo
  templated hub/hub with packages/charts/app (values from clusters/offsite/apps)
  skipped reloader/reloader — chartRef (OCIRepository), chart not in this repo
  templated spindrift/spindrift with packages/charts/spindrift (values from clusters/offsite/apps)
rendered clusters/folly/apps/arc
  skipped arc/infra — chartRef (OCIRepository), chart not in this repo
rendered clusters/offsite/apps/arc
  skipped arc/infra — chartRef (OCIRepository), chart not in this repo
exit=0
```

Three in-repo charts are now covered where zero were: `spindrift`, `app` and
`ai-agent`.

## Checks

```text
$ mise run k8s:render-apps                                    exit 0
$ mise run docs:check                                         wikilinks ok / repo paths ok / archaeology ok
$ shellcheck .github/scripts/render-cluster-apps.sh           clean
$ shfmt -d -i 2 -ci -bn .github/scripts/render-cluster-apps.sh clean
$ actionlint .github/workflows/kustomize.yml                  clean
```

No manifest, chart template or `apps/spindrift/` file is touched — the fix is
the check. `clusters/offsite/apps/spindrift/helm-release.yaml` is byte-identical
to main; the break above existed only in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
