### PR TITLE
fix(spindrift): answer the settings form what it is allowed to send

### DIFF
--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -7,6 +7,14 @@
  * the read half of that pair, and the two are deliberately symmetric: what this
  * answers is exactly what that accepts.
  *
+ * That symmetry is why the context manifest is projected through
+ * {@link toAuthoredManifest} rather than answered as it is. A reader is given
+ * the resolved document — the authored one plus the deployment facts joined
+ * around it — and the write half takes only what may be authored. Answering the
+ * resolved document made the form refuse its own round trip with
+ * `cloud: Unrecognized key: "federation"` on a field it never rendered, which
+ * is the shape of bug this pair exists to make impossible.
+ *
  * **It reads the context, not the database.** `CommandContext.manifest` is
  * resolved per dispatch — that is the whole reason the context factory is
  * async — so the row is already the source of this answer, and querying it a
@@ -21,7 +29,10 @@
  * platform configuration, and the surface is session-authenticated regardless.
  */
 import { z } from 'zod';
-import type { InstallationManifest } from '../../config/manifest.schema.ts';
+import {
+  type AuthoredManifest,
+  toAuthoredManifest,
+} from '../../config/manifest.schema.ts';
 import { type Command, ok } from '../types.ts';
 
 export const getInstallationManifestInput = z.object({}).strict();
@@ -31,10 +42,11 @@ export type GetInstallationManifestInput = z.infer<
 >;
 
 export interface GetInstallationManifestResult {
-  readonly manifest: InstallationManifest;
+  readonly manifest: AuthoredManifest;
 }
 
 export const getInstallationManifest: Command<
   GetInstallationManifestInput,
   GetInstallationManifestResult
-> = async (_input, context) => ok({ manifest: context.manifest });
+> = async (_input, context) =>
+  ok({ manifest: toAuthoredManifest(context.manifest) });

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -592,3 +592,24 @@ export type InstallationManifest = Omit<AuthoredManifest, 'cloud'> & {
     readonly federation: FederationConfig | null;
   };
 };
+
+/**
+ * Project a resolved manifest back down to the document an operator may write.
+ *
+ * The inverse of the join `resolveManifest` performs, and it exists because an
+ * editing surface reads before it writes. `getInstallationManifest` answers
+ * what a reader holds and `configureInstallation` accepts only what may be
+ * authored; if those are different documents the round trip refuses itself on
+ * a key the operator can neither see nor correct — the schema is `.strict()`,
+ * so a derived key coming back in is an `Unrecognized key` on a form the
+ * operator never touched.
+ *
+ * Lives here rather than beside the join because it is a fact about the two
+ * types, and because the read command must stay free of server-only imports.
+ */
+export function toAuthoredManifest(
+  manifest: InstallationManifest,
+): AuthoredManifest {
+  const { federation: _derived, ...cloud } = manifest.cloud;
+  return { ...manifest, cloud };
+}

--- a/apps/spindrift/test/commands/installation-round-trip.test.ts
+++ b/apps/spindrift/test/commands/installation-round-trip.test.ts
@@ -1,0 +1,128 @@
+/**
+ * The settings surface's read/write pair round-trips (§20, ticket 32).
+ *
+ * `getInstallationManifest` and `configureInstallation` are halves of one act:
+ * an editing surface reads the document it is about to replace, and
+ * `configureInstallation` takes the whole document rather than a patch. So what
+ * the read answers must be something the write accepts — and, before that,
+ * something the *form* accepts, because the form validates client-side against
+ * the same strict schema and refuses without ever dispatching.
+ *
+ * That is the bug this file pins. A reader is handed the resolved manifest —
+ * the authored document plus the deployment facts joined around it — and the
+ * schema is `.strict()`, so answering it unprojected made the form refuse its
+ * own round trip with `cloud: Unrecognized key: "federation"` on a field it
+ * never rendered. Live, the operator saw "This manifest is not valid, so
+ * nothing was written" and the only way to correct a value was to edit Postgres
+ * by hand, which is the exact act ticket 32 exists to abolish.
+ *
+ * The assertions go through `manifestIssues` rather than the schema directly:
+ * that is the function the screen actually calls, so a fix that satisfied the
+ * schema but not the form would still fail here.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  configureInstallation,
+  getInstallationManifest,
+} from '../../src/commands/index.ts';
+import type { Clock, CommandContext } from '../../src/commands/types.ts';
+import { installationManifestSchema } from '../../src/config/manifest.schema.ts';
+import { installation } from '../../src/db/schema.ts';
+import { manifestIssues } from '../../src/web/forms/manifest.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+function context(): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    manifest,
+    adapters: {
+      deploy: () => null,
+      build: () => null,
+      store: () => {
+        throw new Error('reading the manifest reached the store');
+      },
+      repository: () => null,
+      supplyChain: () => {
+        throw new Error('reading the manifest reached the supply chain');
+      },
+    } as unknown as CommandContext['adapters'],
+  };
+}
+
+async function seed(): Promise<void> {
+  const { federation: _derived, ...cloud } = manifest.cloud;
+  await database()
+    .db.insert(installation)
+    .values({ id: 1, manifest: { ...manifest, cloud } })
+    .onConflictDoNothing();
+}
+
+describe('the installation settings round trip', () => {
+  test('the context manifest carries the derived key this guards against', () => {
+    // If federation ever stops being joined onto a reader's manifest, this test
+    // would pass vacuously and guard nothing. Assert the precondition.
+    expect(manifest.cloud.federation).not.toBeUndefined();
+  });
+
+  test('what the read answers is what the form accepts', async () => {
+    await seed();
+
+    const result = await getInstallationManifest({}, context());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const issues = manifestIssues(result.value.manifest);
+    expect([...issues.entries()]).toEqual([]);
+    expect(
+      installationManifestSchema.safeParse(result.value.manifest).success,
+    ).toBe(true);
+  });
+
+  test('the answered document carries no derived key', async () => {
+    await seed();
+
+    const result = await getInstallationManifest({}, context());
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect('federation' in result.value.manifest.cloud).toBe(false);
+  });
+
+  test('a value edited on what the read answers writes back', async () => {
+    await seed();
+
+    const read = await getInstallationManifest({}, context());
+    expect(read.ok).toBe(true);
+    if (!read.ok) return;
+
+    // Exactly what the screen does: take the answered document, change one
+    // field, submit the whole thing.
+    const edited = {
+      ...read.value.manifest,
+      build: {
+        ...read.value.manifest.build,
+        zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
+      },
+    };
+
+    const written = await configureInstallation(
+      { manifest: edited },
+      context(),
+    );
+    expect(written.ok).toBe(true);
+
+    const [row] = await database().db.select().from(installation);
+    expect(row?.manifest.build.zeroConfigFrontend).toBe(
+      'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
+    );
+  });
+});

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -118,7 +118,7 @@ describe('reading this installation from the browser', () => {
     expect(response.status).toBe(200);
     const body = (await response.json()) as {
       ok: boolean;
-      value: { manifest: InstallationManifest };
+      value: { manifest: AuthoredManifest };
     };
     expect(body.ok).toBe(true);
     // Whole, because `configureInstallation` takes the whole document: a read
@@ -126,13 +126,15 @@ describe('reading this installation from the browser', () => {
     // ask for.
     const stored = await storedManifest();
     expect(stored).toBeDefined();
-    // The row holds the *authored* document; the read answers that document
-    // with the deployment facts attached, which is the one place the two halves
-    // meet. Comparing against the row itself would assert the read had never
-    // resolved anything.
-    expect(body.value.manifest).toEqual(
-      await resolveManifest(stored as AuthoredManifest),
-    );
+    // And *authored*, which is the row exactly. This assertion used to compare
+    // against `resolveManifest(stored)`, on the reasoning that anything else
+    // would prove the read had never resolved. That reasoning is what broke
+    // this surface: a reader is handed the resolved document, the schema is
+    // `.strict()`, and the form validates client-side before it dispatches — so
+    // answering the resolved shape made the screen refuse its own round trip
+    // with `cloud: Unrecognized key: "federation"` on a field it never
+    // rendered. The read half answers what the write half accepts.
+    expect(body.value.manifest).toEqual(stored as AuthoredManifest);
   });
 
   test('is refused without a session', async () => {


### PR DESCRIPTION
## The settings surface refused every save

Reported by the operator: *"This manifest was refused. This manifest is not valid, so nothing was written."* With no working save, the only way left to correct a manifest value was hand-editing Postgres — the exact act ticket 32 exists to abolish, and the thing blocking `build.zeroConfigFrontend` and therefore seven downstream tickets.

## Cause

`getInstallationManifest` answered `context.manifest`, the **resolved** document: authored + the deployment facts #1500 derived away and joins back on for readers. `configureInstallation` accepts only the **authored** document, the schema is `.strict()`, and the form validates client-side via `manifestIssues` *before* dispatching.

Reproduced against the real live row:

```
CLIENT: manifestIssues(resolved)   → 1 issue: cloud -> Unrecognized key: "federation"
CLIENT: manifestIssues(authored)   → 0 issues
SERVER: validateManifest(resolved) → strips it, SERVER ACCEPTS
```

The server half was already right — which is exactly why no test of the write path caught it.

`get.ts`'s doc comment promised "the two are deliberately symmetric: what this answers is exactly what that accepts." #1500 and #1503 landed hours apart and made that sentence false without either being wrong on its own. Same merge-order collision shape as #1505.

## Fix

`toAuthoredManifest` projects the resolved document back down to the authored one. It lives in `manifest.schema.ts` because it is a fact about the relationship between those two types, and because `get.ts` must stay free of server-only imports (its own comment explains why).

## Corrected test

`installation-surface.test.ts` asserted the resolved shape **deliberately**, reasoning that comparing against the row "would assert the read had never resolved anything." That reasoning is the defect. It now asserts the row, with the reason recorded in place.

## Evidence

New `test/commands/installation-round-trip.test.ts` drives the real read → form-validate → write chain, asserting through `manifestIssues` (the function the screen actually calls) rather than the schema, so a fix satisfying the schema but not the form would still fail. It includes a precondition test so it cannot pass vacuously if federation ever stops being joined on.

Verified it catches the bug — reverting the fix:

```
2 pass / 2 fail
(fail) the installation settings round trip > the answered document carries no derived key
(fail) the installation settings round trip > what the read answers is what the form accepts
```

Restored: `4 pass / 0 fail`.

Full suite `1154 pass / 0 fail`, `bun run typecheck`, `bun run lint`, `mise run ts:check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)