### PR TITLE
spindrift: the App list and the red deploy screen stop lying

### DIFF
--- a/apps/spindrift/src/commands/apps/list.ts
+++ b/apps/spindrift/src/commands/apps/list.ts
@@ -50,6 +50,7 @@ export const listApps: Command<
     const target = deploy?.target;
 
     return {
+      id: app.id,
       name: app.name,
       vessel: app.vesselRef ?? '',
       source,

--- a/apps/spindrift/src/commands/deploys/get-detail.ts
+++ b/apps/spindrift/src/commands/deploys/get-detail.ts
@@ -16,6 +16,30 @@ export const getDeployDetailInput = z.object({
 });
 export type GetDeployDetailInput = z.infer<typeof getDeployDetailInput>;
 
+/**
+ * §6's raw `debug` payload as a screen can read it, or `null` where core
+ * recorded nothing.
+ *
+ * `debug` is nullable and usually null: a Deploy that goes red on something
+ * core decided for itself — an artifact with no address to pull it by — never
+ * reaches a platform that could hand back events to persist. Serialising that
+ * absence yields `"{}"`, which is not evidence, is not what any runner emitted,
+ * and is truthy enough to be mistaken for both by everything downstream. So
+ * nothing is reported as nothing, and the views that already know how to say
+ * "there is nothing here" get to say it.
+ */
+function evidenceOf(debug: unknown): string | null {
+  if (debug === null || debug === undefined) return null;
+  if (typeof debug === 'string') return debug.trim() === '' ? null : debug;
+  const serialised = JSON.stringify(debug);
+  // An empty document is the same absence wearing braces — a red Deploy whose
+  // adapter opened a payload and put nothing in it saw nothing either.
+  if (serialised === undefined || serialised === '{}' || serialised === '[]') {
+    return null;
+  }
+  return serialised;
+}
+
 export const getDeployDetail: Command<
   GetDeployDetailInput,
   { deploy: DeployView }
@@ -89,10 +113,7 @@ export const getDeployDetail: Command<
       reason: deploy.reason as FailureReason,
       blame: (deploy.blame ?? null) as Blame | null,
       detail: deploy.detail ?? 'Deploy failed',
-      evidence:
-        typeof deploy.debug === 'string'
-          ? deploy.debug
-          : JSON.stringify(deploy.debug ?? {}),
+      evidence: evidenceOf(deploy.debug),
     };
   }
 
@@ -142,6 +163,10 @@ export const getDeployDetail: Command<
       text: event.line!,
       tone: event.reason ? ('error' as const) : undefined,
     }));
+  // Evidence stands in for a deploy log only when there is evidence. Where
+  // there is none, `deployLog` stays null and the card renders its own
+  // `LIVE_STATUS` notice — the true sentence about a controller that reports
+  // status without text.
   if (deployLogs.length === 0 && diagnosis?.evidence) {
     deployLogs.push(
       ...diagnosis.evidence.split('\n').map((text) => ({

--- a/apps/spindrift/src/web/components/delete-app.tsx
+++ b/apps/spindrift/src/web/components/delete-app.tsx
@@ -17,9 +17,14 @@
  * - **Retained secrets.** §10's store items are reaped with the App; the ones a
  *   store refused are named, because nothing will reach them again.
  *
- * The confirm call goes by `appId`, never by the name that was typed: the review
- * already resolved which App this is, and re-resolving a name that a second App
- * has since taken would delete the wrong one.
+ * Both calls go by `appId`, never by the name on the button: `apps` has no
+ * unique constraint on `name`, so a name is a label rather than an identifier.
+ * The review refuses `INVALID_INPUT` on a name two Apps answer to — correctly,
+ * because guessing which of two to delete is not recoverable — and a screen
+ * that could only offer the name would dead-end there, never reaching the
+ * confirmation that carries the id. The name is still carried alongside,
+ * because every sentence in the dialog before the review lands is about the App
+ * the operator pointed at, and a uuid is not what they pointed at.
  */
 import { AlertTriangle, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -31,17 +36,27 @@ import { command } from '../client.ts';
 import { Button } from '../ui/button.tsx';
 import { Eyebrow } from '../ui/card.tsx';
 
+/** Which App this is, and what the operator calls it. */
+export interface AppIdentity {
+  /** What both `deleteApp` calls resolve on. */
+  readonly id: string;
+  /** What the dialog says while it is still talking about a pending act. */
+  readonly name: string;
+}
+
 export type AppDeletion =
   | { readonly kind: 'idle' }
   /** The review call is in flight. */
-  | { readonly kind: 'reviewing'; readonly name: string }
+  | { readonly kind: 'reviewing'; readonly id: string; readonly name: string }
   | {
       readonly kind: 'confirming';
+      readonly id: string;
       readonly name: string;
       readonly effects: DeleteAppEffects;
     }
   | {
       readonly kind: 'deleting';
+      readonly id: string;
       readonly name: string;
       readonly effects: DeleteAppEffects;
     }
@@ -61,7 +76,7 @@ export type AppDeletion =
 export interface AppDeletionControls {
   readonly state: AppDeletion;
   /** Ask what deleting this App would do. Nothing is written. */
-  review(name: string): void;
+  review(app: AppIdentity): void;
   /** Do it. Only meaningful from `confirming`. */
   confirm(): void;
   /** Back out, or acknowledge the aftermath. */
@@ -85,15 +100,17 @@ export function useAppDeletion(
   const deleted = useRef(onDeleted);
   deleted.current = onDeleted;
 
-  const review = useCallback((name: string) => {
-    setState({ kind: 'reviewing', name });
-    command('deleteApp', { name, confirm: false })
+  const review = useCallback(({ id, name }: AppIdentity) => {
+    setState({ kind: 'reviewing', id, name });
+    // `deleteApp` takes the id in the field it names `name`, precisely so a
+    // caller holding one does not have to go back through a name.
+    command('deleteApp', { name: id, confirm: false })
       .then((result) => {
         if (!result.ok) {
           setState({ kind: 'failed', name, message: result.failure.message });
           return;
         }
-        setState({ kind: 'confirming', name, effects: result.value });
+        setState({ kind: 'confirming', id, name, effects: result.value });
       })
       .catch((error: unknown) => {
         setState({
@@ -110,7 +127,7 @@ export function useAppDeletion(
   const confirm = useCallback(() => {
     setState((current) => {
       if (current.kind !== 'confirming') return current;
-      const { name, effects } = current;
+      const { id, name, effects } = current;
 
       command('deleteApp', { name: effects.appId, confirm: true })
         .then((result) => {
@@ -143,7 +160,7 @@ export function useAppDeletion(
           });
         });
 
-      return { kind: 'deleting', name, effects };
+      return { kind: 'deleting', id, name, effects };
     });
   }, []);
 
@@ -159,12 +176,20 @@ export function useAppDeletion(
   return { state, review, confirm, dismiss };
 }
 
-/** The trash affordance, so no screen writes its own. */
+/**
+ * The trash affordance, so no screen writes its own.
+ *
+ * It takes the id as well as the name because the name is what the operator
+ * reads and the id is what the command acts on — a button offered per row has
+ * to be able to say which row, and two rows can share a name.
+ */
 export function DeleteAppButton({
+  appId,
   name,
   deletion,
   label = false,
 }: {
+  appId: string;
   name: string;
   deletion: AppDeletionControls;
   /** Show the word beside the icon — the workspace has room, a list row does not. */
@@ -180,7 +205,7 @@ export function DeleteAppButton({
       onClick={(event) => {
         // A list row is a link to the workspace; deleting is not navigating.
         event.stopPropagation();
-        deletion.review(name);
+        deletion.review({ id: appId, name });
       }}
     >
       <Trash2 aria-hidden="true" />

--- a/apps/spindrift/src/web/components/diagnosis.tsx
+++ b/apps/spindrift/src/web/components/diagnosis.tsx
@@ -13,9 +13,13 @@
  *    says the previous release is still serving", and that "changed the feel of
  *    failure more than anything else". §6 guarantees it is true — exposure is
  *    never mutated by a failed deploy.
- * 4. **The evidence, collapsed.** §6 reads pods and events once on red and
- *    persists what it found, because the platform will not keep it. It is
- *    behind a disclosure because it is the second question, never the first.
+ * 4. **The evidence, collapsed** — and only when there is some. §6 reads pods
+ *    and events once on red and persists what it found, because the platform
+ *    will not keep it. It is behind a disclosure because it is the second
+ *    question, never the first. A failure core decided for itself never reached
+ *    a platform to read, so `evidence` is null and the disclosure is absent:
+ *    offering "show what Spindrift found" over an empty pane promises an answer
+ *    that was never recorded.
  */
 import { useState } from 'react';
 import { reasonCovers } from '../../adapters/deploy/contract.ts';
@@ -61,16 +65,18 @@ export function DiagnosisPanel({
           </Notice>
         ) : null}
 
-        <Collapsible open={open} onOpenChange={setOpen}>
-          <CollapsibleTrigger className="text-[11.5px] font-semibold uppercase tracking-[0.05em] text-muted-foreground hover:text-foreground">
-            {open ? 'Hide' : 'Show'} what Spindrift found
-          </CollapsibleTrigger>
-          <CollapsibleContent className="pt-2">
-            <LogPane
-              lines={diagnosis.evidence.split('\n').map((text) => ({ text }))}
-            />
-          </CollapsibleContent>
-        </Collapsible>
+        {diagnosis.evidence === null ? null : (
+          <Collapsible open={open} onOpenChange={setOpen}>
+            <CollapsibleTrigger className="text-[11.5px] font-semibold uppercase tracking-[0.05em] text-muted-foreground hover:text-foreground">
+              {open ? 'Hide' : 'Show'} what Spindrift found
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-2">
+              <LogPane
+                lines={diagnosis.evidence.split('\n').map((text) => ({ text }))}
+              />
+            </CollapsibleContent>
+          </Collapsible>
+        )}
       </div>
     </section>
   );

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -86,8 +86,17 @@ export interface Diagnosis {
   readonly blame: Blame | null;
   /** The sentence the developer reads. */
   readonly detail: string;
-  /** What core actually saw — events, exit codes, probe results. */
-  readonly evidence: string;
+  /**
+   * What core actually saw — events, exit codes, probe results — or `null`
+   * where it recorded nothing.
+   *
+   * Nullable for the same reason `BuildView.log` is: a Deploy that went red
+   * before anything observable happened has no evidence, and the honest
+   * rendering of that is no pane at all. Rendering `"{}"` — a serialised
+   * absence — puts a line on the screen no runner ever emitted, which is the
+   * fabrication §6 exists to refuse.
+   */
+  readonly evidence: string | null;
 }
 
 /** The build half of an attempt, present only when a builder actually ran. */
@@ -479,6 +488,17 @@ export interface LinkedRepoView {
  * one navigates to the workspace.
  */
 export interface AppListItem {
+  /**
+   * The App's id, and the only thing on this row that identifies it.
+   *
+   * `apps` carries no unique constraint on `name` — §2's Components and Targets
+   * do, `apps` does not — so two rows can wear one name. A list that keyed,
+   * linked, and deleted by name would hand both of them the same React key, the
+   * same workspace, and a delete `deleteApp` refuses as ambiguous. Every
+   * consumer already takes an id in the field it takes a name in
+   * (`getAppWorkspace`, `deleteApp`), so the id travels with the row.
+   */
+  readonly id: string;
   readonly name: string;
   readonly phase: DeployPhase;
   readonly target: string;

--- a/apps/spindrift/src/web/views/apps/list.tsx
+++ b/apps/spindrift/src/web/views/apps/list.tsx
@@ -15,6 +15,12 @@
  * making the operator open a workspace to throw one away is what leaves a fresh
  * install's failed first attempts on the screen forever. What it opens is a
  * review, not a delete — `components/delete-app.tsx` owns that whole flow.
+ *
+ * **A row stands for an App, not for a name.** `apps` has no unique constraint
+ * on `name`, so the key, the link, and the delete all go by `AppListItem.id`.
+ * By name, two Apps called the same thing share one React key, one workspace,
+ * and one refused delete — which leaves the second one persisted and with no
+ * route to it at all.
  */
 import { ExternalLink, Globe, Plus, Server, Zap } from 'lucide-react';
 import {
@@ -107,7 +113,7 @@ export function AppList({
             // button: an interactive control inside a `<button>` is neither
             // valid HTML nor reachable by keyboard.
             <div
-              key={app.name}
+              key={app.id}
               className={cn(
                 'group flex items-center gap-2 rounded-lg border border-border bg-card pr-2 transition-colors',
                 'focus-within:border-primary hover:border-primary hover:bg-secondary/60',
@@ -115,7 +121,7 @@ export function AppList({
             >
               <button
                 type="button"
-                onClick={() => onNavigate(`/apps/${app.name}`)}
+                onClick={() => onNavigate(`/apps/${app.id}`)}
                 className="flex min-w-0 flex-1 items-center gap-4 px-4 py-3.5 text-left"
               >
                 {kindIcon(app.kind)}
@@ -152,7 +158,11 @@ export function AppList({
                 ) : null}
               </button>
 
-              <DeleteAppButton name={app.name} deletion={deletion} />
+              <DeleteAppButton
+                appId={app.id}
+                name={app.name}
+                deletion={deletion}
+              />
             </div>
           ))}
         </div>

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -70,8 +70,16 @@ export function Workspace({
           <h1 className="text-2xl font-semibold tracking-tight">{view.app}</h1>
         </div>
         <div className="ml-auto flex gap-2">
-          {deletion ? (
-            <DeleteAppButton name={view.app} deletion={deletion} label />
+          {/* And the id, because a name is not one: `deleteApp` resolves on the
+              id, and a workspace that only knew what this App is called could
+              not tell it apart from another App called the same thing. */}
+          {deletion && view.appId ? (
+            <DeleteAppButton
+              appId={view.appId}
+              name={view.app}
+              deletion={deletion}
+              label
+            />
           ) : null}
           <Button variant="outline" asChild>
             <a href={`https://${view.url}`}>

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -904,6 +904,94 @@ describe('getDeployDetail command', () => {
     expect(deploy.diagnosis?.reason).toBe('BUILD_FAILED');
     expect(deploy.diagnosis?.blame).toBe('developer');
     expect(deploy.diagnosis?.detail).toContain('Type error');
+    // The recorded payload is the evidence, and with no `log` event to show it
+    // is what the deploy-log card falls back to. That fallback is the reason
+    // the null case below matters: it only reads as evidence when there is any.
+    expect(deploy.diagnosis?.evidence).toBe('{"exitCode":1}');
+    expect(deploy.deployLog).toEqual([
+      { text: '{"exitCode":1}', tone: 'error' },
+    ]);
+  });
+
+  test('a failed deploy that recorded nothing shows nothing', async () => {
+    // The shape every failed Deploy on a real installation has. Core decides an
+    // `INTERNAL` failure by itself — it never reaches a platform that could
+    // hand back events to persist — so `debug` stays null. `?? {}` turned that
+    // absence into `"{}"`, which is truthy, which the deploy-log fallback then
+    // adopted as a log line. The result was one red line reading `{}` on every
+    // red screen, attributed to a runner that never emitted it.
+    const ctx = context();
+    const { componentId, appId, target } = await scaffold(ctx, {
+      prefix: 'silent',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'ccc3333',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'SUCCEEDED',
+      })
+      .returning();
+
+    const [failed] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'FAILED',
+        reason: 'INTERNAL',
+        blame: 'platform',
+        detail: 'the artifact carries no address to pull it by',
+        // `debug` is deliberately unset. Seeding a payload here is what let
+        // this reach production.
+      })
+      .returning();
+
+    // Status rows and nothing else, as the reconciler wrote them: no `log`
+    // event exists, so the deploy log is empty before the fallback runs.
+    await ctx.db.insert(attemptEvents).values([
+      {
+        appId,
+        componentId,
+        attemptKind: 'deploy',
+        deployId: failed!.id,
+        eventType: 'status',
+        phase: 'FAILED',
+        reason: 'INTERNAL',
+      },
+      {
+        appId,
+        componentId,
+        attemptKind: 'deploy',
+        deployId: failed!.id,
+        eventType: 'status',
+        phase: 'FAILED',
+        reason: 'INTERNAL',
+      },
+    ]);
+
+    const result = await getDeployDetail({ id: failed!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const { deploy } = result.value;
+    // The diagnosis is still made — the reason, the blame and the sentence are
+    // all there. It is only the evidence that is absent, and it says so.
+    expect(deploy.diagnosis).not.toBeNull();
+    expect(deploy.diagnosis?.reason).toBe('INTERNAL');
+    expect(deploy.diagnosis?.blame).toBe('platform');
+    expect(deploy.diagnosis?.detail).toBe(
+      'the artifact carries no address to pull it by',
+    );
+    expect(deploy.diagnosis?.evidence).toBeNull();
+
+    // And nothing was manufactured from it: `null` is what the deploy-log card
+    // reads to render its own LIVE_STATUS notice.
+    expect(deploy.deployLog).toBeNull();
   });
 });
 

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -782,6 +782,7 @@ export const LINKED_REPOS: readonly LinkedRepoView[] = [
 /** App list demo data. */
 export const APP_LIST: readonly AppListItem[] = [
   {
+    id: '00000000-0000-4000-8000-0000000000a1',
     name: 'hub',
     phase: 'LIVE',
     target: 'Primary',
@@ -793,6 +794,7 @@ export const APP_LIST: readonly AppListItem[] = [
     release: 'Deploy #14 · a1b2c3d',
   },
   {
+    id: '00000000-0000-4000-8000-0000000000a2',
     name: 'api',
     phase: 'LIVE',
     target: 'Primary',
@@ -804,6 +806,7 @@ export const APP_LIST: readonly AppListItem[] = [
     release: 'Deploy #8 · m3n4o5p',
   },
   {
+    id: '00000000-0000-4000-8000-0000000000a3',
     name: 'wiki',
     phase: 'FAILED',
     target: 'Cloud Run · vessel-a',
@@ -815,6 +818,7 @@ export const APP_LIST: readonly AppListItem[] = [
     release: 'Deploy #3 · q6r7s8t',
   },
   {
+    id: '00000000-0000-4000-8000-0000000000a4',
     name: 'weather-card',
     phase: 'APPLYING',
     target: 'Firebase · vessel-a',

--- a/apps/spindrift/test/web/app-list-identity.test.tsx
+++ b/apps/spindrift/test/web/app-list-identity.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * A row in the App list stands for one App (§18, and §2's identity rules).
+ *
+ * `apps` carries no unique constraint on `name` — `components` has
+ * `unique(appId, name)` and `targets` has `unique(name)`, `apps` has neither —
+ * so two Apps can wear one name, and a real installation does. `deployApp` and
+ * `deleteApp` already refuse to guess between them. The list was the surface
+ * that could not ask a better question: it dropped the id before the view ran,
+ * so both rows keyed the same, linked the same, and offered a delete the
+ * command was right to refuse.
+ *
+ * Both halves are proved here against **two genuinely different Apps sharing
+ * one name**, because one App checked twice is the shape that made this look
+ * fine for as long as it did:
+ *
+ * - the far side hands out an identity — `listApps` carries the id, and each id
+ *   opens its own workspace and reviews for its own deletion;
+ * - the near side uses it — the row's key, its link, and its trash button are
+ *   all the id.
+ *
+ * The view half calls the components as functions and reads the tree they
+ * return, rather than rendering to markup: what is under test is *which value*
+ * a handler is closed over, and that is not something markup can show.
+ */
+import { describe, expect, test } from 'bun:test';
+import { isValidElement, type ReactElement, type ReactNode } from 'react';
+import { listApps } from '../../src/commands/apps/list.ts';
+import { getAppWorkspace } from '../../src/commands/apps/workspace.ts';
+import { createApp } from '../../src/commands/create-app.ts';
+import { createComponent, deleteApp } from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  type AppDeletion,
+  type AppDeletionControls,
+  DeleteAppButton,
+} from '../../src/web/components/delete-app.tsx';
+import type { AppListItem } from '../../src/web/model.ts';
+import { AppList } from '../../src/web/views/apps/list.tsx';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const manifest = await fixtureManifest();
+const database = withIsolatedDatabase();
+
+const FROZEN = new Date('2026-08-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+const noAdapters: AdapterRegistry = {
+  deploy: () => null,
+  build: () => null,
+  store: () => {
+    throw new Error('no store adapter is configured for this test');
+  },
+  repository: () => null,
+  supplyChain: () => {
+    throw new Error('the App list reached the supply chain');
+  },
+};
+
+function context(): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters: noAdapters,
+    manifest,
+  };
+}
+
+/**
+ * Two Apps that answer to one name and are not each other: one a `service`, one
+ * a `website`, which is the pair a real installation ended up with.
+ */
+async function seedTwins(ctx: CommandContext, name: string) {
+  const made: { id: string; kind: 'service' | 'website' }[] = [];
+  for (const kind of ['service', 'website'] as const) {
+    const app = await createApp(
+      {
+        name,
+        sourceKind: 'repo',
+        repoUrl: 'https://vcs.example/acme/twins.git',
+        subpath: kind,
+      },
+      ctx,
+    );
+    if (!app.ok) throw new Error(app.failure.message);
+
+    const component = await createComponent(
+      kind === 'website'
+        ? {
+            appId: app.value.appId,
+            name: 'web',
+            kind: 'website',
+            exposure: 'public',
+          }
+        : {
+            appId: app.value.appId,
+            name: 'web',
+            kind: 'service',
+            expose: true,
+            exposure: 'private',
+          },
+      ctx,
+    );
+    if (!component.ok) throw new Error(component.failure.message);
+
+    made.push({ id: app.value.appId, kind });
+  }
+  return made;
+}
+
+describe('two Apps answer to one name', () => {
+  test('the list carries an id for each, and the ids differ', async () => {
+    const ctx = context();
+    const name = `twins-${crypto.randomUUID().slice(0, 8)}`;
+    const twins = await seedTwins(ctx, name);
+
+    const listed = await listApps({}, ctx);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+
+    const rows = listed.value.apps.filter((app) => app.name === name);
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((row) => row.id)).size).toBe(2);
+    // And the ids are the Apps', not something the projection invented.
+    expect(rows.map((row) => row.id).sort()).toEqual(
+      twins.map((twin) => twin.id).sort(),
+    );
+  });
+
+  test('each id opens its own workspace', async () => {
+    const ctx = context();
+    const name = `twins-${crypto.randomUUID().slice(0, 8)}`;
+    await seedTwins(ctx, name);
+
+    const listed = await listApps({}, ctx);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    const rows = listed.value.apps.filter((app) => app.name === name);
+    expect(rows).toHaveLength(2);
+
+    // The row says which kind it is; the workspace it links to must agree, or
+    // one of the two rows is a link to the other one's App.
+    for (const row of rows) {
+      const workspace = await getAppWorkspace({ name: row.id }, ctx);
+      expect(workspace.ok).toBe(true);
+      if (!workspace.ok) continue;
+      expect(workspace.value.workspace.appId).toBe(row.id);
+      expect(workspace.value.workspace.components[0]?.kind).toBe(row.kind);
+    }
+
+    // By name, both rows land on the same App — the reason the id is carried.
+    const byName = await getAppWorkspace({ name }, ctx);
+    expect(byName.ok).toBe(true);
+    if (!byName.ok) return;
+    const resolved = byName.value.workspace.appId ?? '';
+    expect(rows.map((row) => row.id)).toContain(resolved);
+  });
+
+  test('each can be reviewed for deletion independently', async () => {
+    const ctx = context();
+    const name = `twins-${crypto.randomUUID().slice(0, 8)}`;
+    await seedTwins(ctx, name);
+
+    const listed = await listApps({}, ctx);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    const rows = listed.value.apps.filter((app) => app.name === name);
+    expect(rows).toHaveLength(2);
+
+    for (const row of rows) {
+      const review = await deleteApp({ name: row.id, confirm: false }, ctx);
+      expect(review.ok).toBe(true);
+      if (!review.ok) continue;
+      expect(review.value.deleted).toBe(false);
+      // The id the confirm call will go by is this row's, not the other's.
+      expect(review.value.appId).toBe(row.id);
+    }
+
+    // The review the list used to be able to make, and the refusal that left
+    // both Apps undeletable.
+    const ambiguous = await deleteApp({ name, confirm: false }, ctx);
+    expect(ambiguous.ok).toBe(false);
+    if (ambiguous.ok) return;
+    expect(ambiguous.failure.code).toBe('INVALID_INPUT');
+  });
+
+  test('and deleting one by id leaves the other', async () => {
+    const ctx = context();
+    const name = `twins-${crypto.randomUUID().slice(0, 8)}`;
+    await seedTwins(ctx, name);
+
+    const listed = await listApps({}, ctx);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    const rows = listed.value.apps.filter((app) => app.name === name);
+    expect(rows).toHaveLength(2);
+
+    const gone = rows[0]!;
+    const kept = rows[1]!;
+    const deleted = await deleteApp({ name: gone.id, confirm: true }, ctx);
+    expect(deleted.ok).toBe(true);
+
+    const after = await listApps({}, ctx);
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    const remaining = after.value.apps.filter((app) => app.name === name);
+    expect(remaining.map((app) => app.id)).toEqual([kept.id]);
+  });
+});
+
+/** Every element in a tree, depth first — the tree as returned, not rendered. */
+function* elements(node: ReactNode): Generator<ReactElement> {
+  if (Array.isArray(node)) {
+    for (const child of node) yield* elements(child as ReactNode);
+    return;
+  }
+  if (!isValidElement(node)) return;
+  yield node;
+  yield* elements((node.props as { children?: ReactNode }).children);
+}
+
+/** A pair of rows sharing a name, as the browser contract now delivers them. */
+const TWIN_ROWS: readonly AppListItem[] = [
+  {
+    id: '00000000-0000-4000-8000-0000000000b1',
+    name: 'twins',
+    phase: 'PENDING',
+    target: 'none',
+    vessel: 'driftwood',
+    url: '',
+    urlLive: false,
+    kind: 'service',
+    source: 'acme/twins',
+    release: 'latest',
+  },
+  {
+    id: '00000000-0000-4000-8000-0000000000b2',
+    name: 'twins',
+    phase: 'FAILED',
+    target: 'Metal',
+    vessel: 'driftwood',
+    url: 'twins.apps.example',
+    urlLive: false,
+    kind: 'website',
+    source: 'acme/twins',
+    release: 'Deploy 4',
+  },
+];
+
+const IDS = TWIN_ROWS.map((row) => row.id);
+
+const idleDeletion: AppDeletionControls = {
+  state: { kind: 'idle' } as AppDeletion,
+  review: () => undefined,
+  confirm: () => undefined,
+  dismiss: () => undefined,
+};
+
+describe('the list renders two same-named rows as two Apps', () => {
+  const tree = AppList({
+    apps: TWIN_ROWS,
+    onNavigate: () => undefined,
+    deletion: idleDeletion,
+  });
+  const rows = [...elements(tree)].filter((element) => element.key !== null);
+
+  test('there are two rows, keyed by id rather than by name', () => {
+    // Keyed by name, React sees one key twice and reconciles two Apps into one
+    // row — before any of the rest of this can even be asked.
+    expect(rows.map((row) => row.key)).toEqual([...IDS]);
+  });
+
+  test('each row navigates to its own App', () => {
+    const visited: string[] = [];
+    const navigating = AppList({
+      apps: TWIN_ROWS,
+      onNavigate: (path) => visited.push(path),
+      deletion: idleDeletion,
+    });
+    for (const element of elements(navigating)) {
+      if (element.key === null) continue;
+      for (const inner of elements(element)) {
+        const props = inner.props as { onClick?: () => void };
+        if (inner.type === 'button' && props.onClick) {
+          props.onClick();
+          break;
+        }
+      }
+    }
+    expect(visited).toEqual(IDS.map((id) => `/apps/${id}`));
+  });
+
+  test('each row hands its own id to the trash affordance', () => {
+    const targets = rows.map((row) => {
+      for (const inner of elements(row)) {
+        if (inner.type === DeleteAppButton) {
+          return inner.props as { appId: string; name: string };
+        }
+      }
+      throw new Error('a row offered no delete');
+    });
+    expect(targets.map((target) => target.appId)).toEqual([...IDS]);
+    // The name still travels, because it is what the confirmation says out
+    // loud. It is simply not what the command acts on.
+    expect(targets.map((target) => target.name)).toEqual(['twins', 'twins']);
+  });
+
+  test('and the trash affordance reviews by that id', () => {
+    const reviewed: { id: string; name: string }[] = [];
+    const button = DeleteAppButton({
+      appId: IDS[1]!,
+      name: 'twins',
+      deletion: { ...idleDeletion, review: (app) => reviewed.push(app) },
+    });
+    for (const element of elements(button)) {
+      const props = element.props as {
+        onClick?: (event: { stopPropagation(): void }) => void;
+      };
+      if (props.onClick) {
+        props.onClick({ stopPropagation: () => undefined });
+        break;
+      }
+    }
+    expect(reviewed).toEqual([{ id: IDS[1]!, name: 'twins' }]);
+  });
+});

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -245,6 +245,38 @@ describe('the deploy screen, on red', () => {
   });
 });
 
+describe('a red deploy that recorded nothing', () => {
+  // The shape every failed Deploy on a real installation has: `debug` null, no
+  // `log` event, so `getDeployDetail` projects a diagnosis with no evidence and
+  // a null deploy log. The screen has an honest sentence for exactly this and
+  // never used to reach it, because `"{}"` arrived where the null belonged.
+  const silent: DeployView = {
+    ...DEPLOY_SCENARIOS.imageUnpullable,
+    diagnosis: {
+      ...DEPLOY_SCENARIOS.imageUnpullable.diagnosis!,
+      evidence: null,
+    },
+    deployLog: null,
+  };
+  const markup = deploy(silent);
+
+  test('still names the failure it does know', () => {
+    expect(markup).toContain('ARTIFACT_UNAVAILABLE');
+    expect(markup).toContain('platform');
+  });
+
+  test('offers no disclosure over evidence it does not have', () => {
+    // The trigger promises an answer. Opening it onto an empty pane is the
+    // promise broken, and there is nothing to put behind it.
+    expect(markup).not.toContain('what Spindrift found');
+  });
+
+  test('says the deploy log is live status rather than inventing a line', () => {
+    expect(markup).toContain('no text line has arrived yet');
+    expect(markup).not.toContain('{}');
+  });
+});
+
 describe('the deploy screen, on green', () => {
   const markup = deploy(DEPLOY_SCENARIOS.live);
 


### PR DESCRIPTION
Closes tickets 26 and 28 of the Spindrift v1 closure plan. They ship together
because both edit `src/web/model.ts`, and because they are one story: two view
surfaces projecting something the row does not say.

## 26 — the App list had no identity

`AppListItem` carried no id, so the browser contract dropped the identifier
before the view ran and every use of a row fell back to the name — `key`, the
workspace link, and the delete review. `apps` has no unique constraint on
`name`, and this installation holds two Apps called `infra`: one React key for
two rows, both links resolving to whichever row Postgres returns first, and a
delete `deleteApp` correctly refuses as `INVALID_INPUT`. The confirm path needs
`effects.appId`, which the refused review never produced, so the flow dead-ended
before it could offer the id it was designed to use.

The refusal is right. The list had no way to ask a better question:

- `listApps` carries `apps.id` and `AppListItem` has an `id`.
- The row keys by it, links to `/apps/<id>`, and hands it to the trash button.
- `DeleteAppButton` takes the id alongside the name — the name is what the
  confirmation reads aloud, the id is what the command acts on.
- The workspace's own delete button takes `view.appId` for the same reason.

Both consumers already accepted an id in the field they accept a name in
(`workspace.ts:23` `isUuid`, `deleteApp`'s `name`), so nothing on the far side
changed.

No `unique(apps.name)` migration — ticket 14 settled that it cannot apply while
the live database holds the duplicates. This is what lets an operator clear them
through the UI first, which is the precondition 14 named.

## 28 — the red screen invented a log line

`getDeployDetail` built the diagnosis with `JSON.stringify(deploy.debug ?? {})`,
so a null `debug` became `"{}"`. That string is truthy, and the deploy-log
fallback twenty lines below adopted it as the log. Every failed Deploy on this
installation has `debug` null, so every one of them rendered one red line
reading `{}` that no runner emitted — and none of them ever reached the honest
`LIVE_STATUS` notice `deploy-detail.tsx:613-620` already has for exactly this
state, because that notice fires only on `deployLog === null`.

- `Diagnosis.evidence` is `string | null`, and `evidenceOf` reports nothing as
  nothing.
- `deployLog` stays null, so the card renders its own notice.
- The diagnosis card drops its "show what Spindrift found" disclosure rather
  than opening onto an empty pane.

## Tests

Both boxes are proved against the shape that was untested:

- **26** — two genuinely different Apps sharing one name (a `service` and a
  `website`, the pair live), not one App checked twice. Nine assertions across
  the far side (distinct ids, each id opens its own workspace, each reviews
  independently, deleting one by id leaves the other) and the near side (two
  rows keyed by id, each navigating to its own App, each handing its own id to
  the trash button, and the button reviewing by that id).
- **28** — a failed Deploy seeded with `debug` **unset** and status-only
  `attempt_events`, matching every row on the installation. The existing
  coverage seeds `debug: { exitCode: 1 }`, which is exactly why this reached
  production; that test now also asserts the evidence and the fallback it still
  produces, so the null case is the difference under test.

Verified red before green: with `src/` stashed, the nine new #26 assertions fail
and `getDeployDetail` returns `evidence: "{}"`.

## Known residual

`app.tsx` drops a deleted row optimistically by filtering on the name
(`apps.filter((app) => app.name !== name)`). With two same-named Apps, deleting
one hides both rows until the next load — the App is still there, and a reload
shows it. Fixing it means `useAppDeletion`'s `onDeleted` handing back the id,
which is a change to `app.tsx`; that file is owned by another lane right now, so
it is left for whoever lands there next. It is strictly better than the current
state, where neither App can be deleted at all.

## Checks

```
$ bun test          → 1162 pass, 0 fail (3349 expect calls, 83 files)
$ bun run typecheck → clean
$ bun run lint      → Checked 295 files. No fixes applied.
$ mise run ts:check → 5 typecheck + 4 lint tasks successful
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
