### PR TITLE
fix(spindrift): drop the deleted row by id, not by its name

### DIFF
--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -164,12 +164,17 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
 
   // The row goes when the App does. Re-reading the list instead would be a
   // second round trip to learn something this screen was just told.
-  const deletion = useAppDeletion((name) => {
+  //
+  // By id, because `apps` has no unique constraint on `name`: filtering on the
+  // name drops every row sharing it, so deleting one of two same-named Apps
+  // would hide the other until a reload — and reaching the other one is the
+  // whole point of giving this list an identity.
+  const deletion = useAppDeletion(({ id }) => {
     setState((current) =>
       current.type === 'success'
         ? {
             type: 'success',
-            apps: current.apps.filter((app) => app.name !== name),
+            apps: current.apps.filter((app) => app.id !== id),
           }
         : current,
     );

--- a/apps/spindrift/src/web/components/delete-app.tsx
+++ b/apps/spindrift/src/web/components/delete-app.tsx
@@ -63,6 +63,8 @@ export type AppDeletion =
   /** Done, and something outlived it that somebody has to go and deal with. */
   | {
       readonly kind: 'aftermath';
+      /** Carried so `dismiss` can report *which* App went, not just its label. */
+      readonly id: string;
       readonly name: string;
       readonly stranded: readonly StrandedWorkload[];
       readonly retainedSecrets: readonly string[];
@@ -89,9 +91,15 @@ export interface AppDeletionControls {
  * `onDeleted` fires once per completed delete, after the operator has seen any
  * aftermath — so a caller can navigate away or drop a row without racing the
  * one screen that still names what was stranded.
+ *
+ * It reports the whole {@link AppIdentity} rather than the name, for the reason
+ * this module already gives about `deleteApp`'s own arguments: `apps` has no
+ * unique constraint on `name`. A list that dropped its row by name would hide
+ * every App sharing it, which is precisely the pair this flow exists to let an
+ * operator take apart.
  */
 export function useAppDeletion(
-  onDeleted: (name: string) => void,
+  onDeleted: (app: AppIdentity) => void,
 ): AppDeletionControls {
   const [state, setState] = useState<AppDeletion>({ kind: 'idle' });
 
@@ -139,11 +147,12 @@ export function useAppDeletion(
           const retained = value.deleted ? value.retainedSecrets : [];
           if (value.stranded.length === 0 && retained.length === 0) {
             setState({ kind: 'idle' });
-            deleted.current(name);
+            deleted.current({ id, name });
             return;
           }
           setState({
             kind: 'aftermath',
+            id,
             name,
             stranded: value.stranded,
             retainedSecrets: retained,
@@ -168,7 +177,8 @@ export function useAppDeletion(
     setState((current) => {
       // The App is already gone by then; the caller has to hear about it even
       // though what closed the panel was a dismissal rather than a success.
-      if (current.kind === 'aftermath') deleted.current(current.name);
+      if (current.kind === 'aftermath')
+        deleted.current({ id: current.id, name: current.name });
       return { kind: 'idle' };
     });
   }, []);

--- a/apps/spindrift/test/web/app-list-identity.test.tsx
+++ b/apps/spindrift/test/web/app-list-identity.test.tsx
@@ -329,3 +329,29 @@ describe('the list renders two same-named rows as two Apps', () => {
     expect(reviewed).toEqual([{ id: IDS[1]!, name: 'twins' }]);
   });
 });
+
+/**
+ * The optimistic drop, which is the last place a name was still standing in for
+ * an identity.
+ *
+ * `app.tsx` removes the row itself rather than re-reading the list, so the
+ * predicate it filters on decides what an operator sees the instant a delete
+ * completes. Filtering on the name hid *both* twins until a reload — the App
+ * that survived being exactly the one this ticket exists to keep reachable.
+ *
+ * The wiring is additionally guarded by the type system: `onDeleted` now takes
+ * an `AppIdentity`, so the old `app.name !== name` predicate is a compile error
+ * rather than a silent behaviour, and `bun run typecheck` fails if it returns.
+ */
+describe('deleting one twin leaves the other on screen', () => {
+  test('dropping the row by id keeps its same-named sibling', () => {
+    const remaining = TWIN_ROWS.filter((app) => app.id !== IDS[0]);
+    expect(remaining.map((app) => app.id)).toEqual([IDS[1]!]);
+  });
+
+  test('dropping the row by name would have taken both', () => {
+    const byName = TWIN_ROWS[0]!.name;
+    expect(TWIN_ROWS.every((app) => app.name === byName)).toBe(true);
+    expect(TWIN_ROWS.filter((app) => app.name !== byName)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The last place a name was still standing in for an identity

#1515 closed ticket 26 — the list carries `apps.id`, keys by it, navigates by it, and deletes by it. Every step but one. The optimistic row drop in `app.tsx` still filtered on the name:

```ts
apps: current.apps.filter((app) => app.name !== name)
```

Live, this installation holds **two Apps named `infra`** — that pair is the entire reason ticket 26 exists. Deleting either removed both rows until a reload, so the App that survived the delete was the one the ticket set out to make reachable, and the flow ended by hiding it.

This was self-reported by the implementing session as a known residual, out of its file fence at the time. `app.tsx` is free now.

## The fix

`useAppDeletion`'s `onDeleted` reports the whole `AppIdentity` instead of the name — for the reason `delete-app.tsx` already states about `deleteApp`'s own arguments: `apps` has no unique constraint on `name`. The `aftermath` state gains the id so the dismissal path can say *which* App went rather than just what it was called.

## The signature change is the guard

Restoring the old predicate is now a compile error, verified by putting it back:

```
src/web/app.tsx(177,48): error TS2367: This comparison appears to be unintentional
because the types 'string' and 'AppIdentity' have no overlap.
```

So `bun run typecheck` fails if this returns — which is a better guard than a test asserting a filter.

Two tests added alongside, pinning that dropping by id keeps the sibling and that dropping by name would have taken both.

## Checks

`bun test` 1169 pass / 0 fail (1162 before, 7 added across this and the round-trip fix), `bun run typecheck`, `bun run lint`, `mise run ts:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)