### PR TITLE
chore(spindrift): drop historical commentary and the shims it justified

### DIFF
--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -119,13 +119,8 @@ function imageNames(input: BuildKitProgramInput): string {
  * railpack-frontend` is the whole railpack binary at `/railpack` with
  * `ENTRYPOINT ["/railpack", "frontend"]` — `frontend` is one subcommand of the
  * CLI that also carries `prepare`. So the release that reads the plan is
- * extracted from the image already pinned to read it, and "same release" stops
- * being a thing to arrange: there is one artifact, and it cannot disagree with
- * itself. What used to be here — deriving a version from the image tag to fetch
- * a second copy of that binary from GitHub releases — could disagree, and did:
- * a tag that was not a version (`railpack:railpack-frontend`) resolved to a
- * release URL that 404'd, in a step whose error named a download rather than the
- * misconfigured field.
+ * extracted from the image already pinned to read it, so "same release" is not a
+ * thing to arrange: there is one artifact, and it cannot disagree with itself.
  *
  * A named context is how a file leaves an image without a registry client: the
  * dockerfile frontend resolves `docker-image://` itself, so this needs nothing

--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -86,13 +86,11 @@ interface RerunSource {
 /**
  * Stage the bundle the new Build will be dispatched from (§15).
  *
- * **A Build inherits a bundle only while that bundle is still fetchable.** The
- * rule sounds like a detail and is the whole ticket: this command used to copy
- * the previous Build's `bundleLocation` forward unconditionally, so a handle
- * staged before there was a depot to stage into outlived the release that
- * retired it. Build 10 was Build 9's `upload://` handle, one row later and
- * three weeks of fixes down the line, and it died at `curl` for exactly the
- * reason Build 9 had.
+ * **A Build inherits a bundle only while that bundle is still fetchable.**
+ * Copying the previous Build's `bundleLocation` forward unconditionally would
+ * carry an unfetchable handle — an `upload://` from an installation with no
+ * depot — into a Build that then dies at `curl` naming a download rather than
+ * the staging that never happened.
  *
  * **Why here and not at dispatch.** §15 has Spindrift "fetch the exact commit
  * *once* and stage an immutable source bundle for either builder", and the

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -193,21 +193,17 @@ function routeRefusedByTarget(
  * builder §15 stages for is, because the hosted route's runner is a machine on
  * the public internet. So it is exchanged here for a short-TTL V4 signed URL.
  *
- * **A failure to mint one is a refusal, not a warning.** Dispatching anyway is
- * what produced this function: a route handed an address it could not resolve
- * ran a workflow that failed at its first step, and the developer was sent to
- * debug a Dockerfile over a location Spindrift itself had made unusable. A
- * refusal costs one dispatch and says the true thing.
+ * **A failure to mint one is a refusal, not a warning.** Dispatching anyway
+ * hands a route an address it cannot resolve, so the workflow fails at its first
+ * step and sends the developer to debug a Dockerfile over a location Spindrift
+ * itself made unusable. A refusal costs one dispatch and says the true thing.
  *
  * An `https://` location is already fetchable and passes through untouched.
- * **Anything else is refused here rather than forwarded.** It used to be
- * forwarded, on the reasoning that an `upload://` handle is honest about being
- * unfetchable and could be left to fail where it fails. Where it failed was
- * `curl: (1) Protocol "upload" not supported or disabled in libcurl`, on a
- * hosted runner, after a workflow had been dispatched — a failure the operator
- * reads out of a CI log for a refusal this function could have made for free.
- * A location no route can resolve is exactly what this function exists to
- * catch, so it catches it.
+ * **Anything else is refused here rather than forwarded.** An `upload://` handle
+ * is honest about being unfetchable, but forwarding it means the honesty arrives
+ * as `curl: (1) Protocol "upload" not supported or disabled in libcurl` on a
+ * hosted runner, after a dispatch — a CI log the operator has to read for a
+ * refusal this function makes for free.
  */
 async function fetchableBundleLocation(
   context: Pick<BuildDispatchContext, 'manifest'>,

--- a/apps/spindrift/src/commands/builds/get-detail.ts
+++ b/apps/spindrift/src/commands/builds/get-detail.ts
@@ -3,12 +3,10 @@
  *
  * §4: "a build records an artifact rather than deploying one", so pressing
  * Deploy on an App with nothing deployable starts a Build and writes no intent
- * (`deployApp` returns `deployId: null`). Before this command existed there was
- * nowhere for that press to land: the operator stayed on the workspace and the
- * act they had just taken had no screen. A Build is an attempt with a durable
- * id and a live event stream, which is everything an attempt screen needs — the
- * only thing it lacks is the intent row, and that absence is what
- * {@link DeployView.id} being `null` says.
+ * (`deployApp` returns `deployId: null`). This is where that press lands. A
+ * Build is an attempt with a durable id and a live event stream, which is
+ * everything an attempt screen needs — the only thing it lacks is the intent
+ * row, and that absence is what {@link DeployView.id} being `null` says.
  *
  * The result also carries {@link GetBuildDetailResult.deployId}. A Build that
  * has since been deployed has a better screen than this one, and the client

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -58,11 +58,10 @@ export function parseManifest(
 }
 
 /**
- * Keys the schema no longer has, and where the fact went instead.
+ * Keys the schema does not have, and where the fact lives instead.
  *
- * Read as `[block, key, why]`. Every one of them was a copy of something the
- * deployment already declares, so a document still carrying one is describing
- * a fact it does not own.
+ * Read as `[block, key, why]`. Each is a copy of something the deployment
+ * declares, so a document carrying one is describing a fact it does not own.
  */
 const DERIVED_AWAY: readonly (readonly [string, string, string])[] = [
   [
@@ -74,17 +73,15 @@ const DERIVED_AWAY: readonly (readonly [string, string, string])[] = [
 ];
 
 /**
- * Drop the keys that were derived away, before the strict schema sees them.
+ * Drop the derived-away keys before the strict schema sees them.
  *
- * Dropped rather than refused, and the difference matters: an installation
- * seeded before the removal has one of these in its durable row, and a
- * refusal would be a control plane that will not boot until someone edits
- * Postgres by hand. The row is rewritten from what this returns, so it
- * self-heals on the first start and the warning fires once.
+ * Dropped rather than refused: a durable row holding one of these would
+ * otherwise be a control plane that will not boot until someone edits Postgres
+ * by hand. The row is rewritten from what this returns, so it self-heals on the
+ * first start and the warning fires once.
  *
- * This is also what makes the removal complete. A key that is merely absent
- * from the schema can be written back by any caller holding an older document;
- * a key that is stripped on the way in cannot reach storage from any path.
+ * Stripping on the way in is also what keeps a key out of storage from every
+ * path, which mere absence from the schema does not.
  */
 function withoutDerivedKeys(manifest: unknown, source: string): unknown {
   if (

--- a/apps/spindrift/src/domain/artifact-name.ts
+++ b/apps/spindrift/src/domain/artifact-name.ts
@@ -24,9 +24,9 @@
  * **It is unique per (App name, Component name), which is not the same as per
  * Component.** Where two Apps share a name their Components share a repository.
  * That is live today and it is not this module's to fix: `apps.name` carries no
- * unique constraint, which is the defect tracked as ticket 26. Encoding the
- * App's id here would dodge it at the cost of a registry listing no one can
- * read, and would leave the identity bug in place everywhere else.
+ * unique constraint. Encoding the App's id here would dodge it at the cost of a
+ * registry listing no one can read, and would leave the identity gap in place
+ * everywhere else.
  */
 
 /**

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -64,11 +64,10 @@ export async function runBuildPass(
     visited.add(row.buildId);
     const route = await routeForTarget(row.targetId, context);
     if (route === null) {
-      // A Target whose policy no configured route satisfies. Skipping silently
-      // is what `dispatchBuild`'s own refusals used to do, with the same result:
-      // a Build PENDING forever and nothing anywhere saying why. Configuring a
+      // A Target whose policy no configured route satisfies. Configuring a
       // route is an operator act that makes the next tick work, so the Build
-      // stays PENDING — and now says so, once.
+      // stays PENDING — and says so once, because a Build PENDING forever with
+      // nothing anywhere saying why is the failure worth spending a row on.
       await recordDispatchWait(
         context,
         {

--- a/apps/spindrift/src/storage/archives.ts
+++ b/apps/spindrift/src/storage/archives.ts
@@ -8,12 +8,11 @@
  * to the installation's **source depot** — the GCS bucket the manifest names —
  * so that both builders §15 stages for can fetch it.
  *
- * **The pod's own disk is not a depot.** It used to be one, and it could not
- * work: a bundle written to `tmpdir()` is not shared with the reconciler, not
- * shared with a second replica, and gone on the next restart, so no builder
- * anywhere could fetch it under any scheme. The local directory survives here
- * only as the fallback for an installation with no depot configured — a
- * developer running the process on a laptop — and it announces itself as such
+ * **The pod's own disk is not a depot.** A bundle written to `tmpdir()` is not
+ * shared with the reconciler, not shared with a second replica, and gone on the
+ * next restart, so no builder could fetch it under any scheme. The local
+ * directory is only the fallback for an installation with no depot configured —
+ * a developer running the process on a laptop — and it announces itself as such
  * by keeping the `upload://` handle, which is deliberately not a URL. A
  * location that cannot be fetched should not be spelled like one that can.
  */

--- a/apps/spindrift/src/storage/signed-url.ts
+++ b/apps/spindrift/src/storage/signed-url.ts
@@ -52,8 +52,7 @@ const SCOPE_SUFFIX = 'auto/storage/goog4_request';
  *
  * Fifteen minutes is ample for a runner to pull a source bundle and short
  * enough that a URL leaked through a workflow run's outputs is a capability
- * that has already expired by the time anyone reads it. The ticket that settled
- * the signed-URL design named this number; it is not a tuning knob.
+ * that has already expired by the time anyone reads it. Not a tuning knob.
  */
 export const SIGNED_URL_TTL_SECONDS = 900;
 

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -685,10 +685,10 @@ function DeployScreen({
 /**
  * The attempt screen for a Build that has no Deploy (§4).
  *
- * It exists because the Deploy button has two outcomes and only one of them
- * used to have a screen: "nothing was deployable, so a Build started" is a real
- * act with a durable id and a live event stream, and leaving the operator on
- * the workspace made it look like the press did nothing.
+ * The Deploy button has two outcomes and this is the screen for the second one:
+ * "nothing was deployable, so a Build started" is a real act with a durable id
+ * and a live event stream. Leaving the operator on the workspace would make the
+ * press look like it did nothing.
  *
  * The screen resolves itself. A Build that reaches an intent has a better page
  * than this one, so when `getBuildDetail` reports a Deploy naming this Build

--- a/apps/spindrift/src/web/upload.ts
+++ b/apps/spindrift/src/web/upload.ts
@@ -106,12 +106,9 @@ export async function handleUpload(
       bytes = new Uint8Array(buffer);
     }
 
-    // One staging call, to one place. It used to be two — local disk first,
-    // then the bucket on top — which meant the bytes were written twice and the
-    // location came back describing whichever step happened to run, so a depot
-    // that was configured but unreachable still answered with a pod-local
-    // handle no builder could fetch. A depot failure is now a `500` that says
-    // so, because a staged bundle nobody can retrieve is not a staged bundle.
+    // One staging call, to one place, so the returned location describes where
+    // the bytes actually are. A depot failure is a `500` that says so, because
+    // a staged bundle nobody can retrieve is not a staged bundle.
     const context = await deps.context(authentication.principal);
     const depot = sourceDepotFor(
       context.manifest,

--- a/apps/spindrift/test/commands/build-bundle-location.test.ts
+++ b/apps/spindrift/test/commands/build-bundle-location.test.ts
@@ -4,8 +4,8 @@
  * §15 stages one immutable bundle "for either builder", and the durable address
  * of that bundle is a `gs://` object nothing without a Google credential can
  * resolve. Turning it into something the builder can fetch is `dispatchBuild`'s
- * job, and getting it wrong is what produced a build that died at `curl` and
- * blamed the developer for it.
+ * job; getting it wrong is a build that dies at `curl` and blames the developer
+ * for it.
  */
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
@@ -149,10 +149,9 @@ describe('the bundle location a route is dispatched with', () => {
   });
 
   test('a depot address reaches the route as a URL curl can follow', async () => {
-    // The defect verbatim: the route used to receive the stored location, and
-    // the stored location was not a URL. `curl` answered
-    // "Protocol upload not supported or disabled in libcurl" and the build died
-    // before it read a line of the App's code.
+    // Handing the route the stored location verbatim is what this rules out: it
+    // is not always a URL, and `curl` answers "Protocol upload not supported or
+    // disabled in libcurl" before the build reads a line of the App's code.
     const context = withFederation(signable);
     const build = await seedBuild(DEPOT_LOCATION);
 

--- a/apps/spindrift/test/commands/build-destination.test.ts
+++ b/apps/spindrift/test/commands/build-destination.test.ts
@@ -1,12 +1,11 @@
 /**
  * What dispatch tells a route to push, and where.
  *
- * This is the layer the defect lived at. `dispatch.ts` handed the installation's
- * registry through unchanged — a namespace, which no registry accepts as a
- * repository — and every adapter-level fixture supplied an already-correct
- * value, so the routes were tested against the shape they expect and the caller
- * that produced the wrong one was tested against nothing. These assert on the
- * spec the route was actually handed.
+ * These assert on the spec the route is handed, which is the seam an
+ * adapter-level fixture cannot cover: a fixture supplies an already-correct
+ * value, so it tests the shape a route expects and not whether `dispatch.ts`
+ * produces it. The installation's registry is a namespace, and no registry
+ * accepts a namespace as a repository.
  */
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';

--- a/apps/spindrift/test/commands/build-dispatch-followups.test.ts
+++ b/apps/spindrift/test/commands/build-dispatch-followups.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for PR #1364 build dispatch follow-ups:
+ * Build dispatch:
  * 1. Durable dispatch identity and lease timeout
  * 2. Explicit Target binding when a Component has multiple placements
  * 3. Atomic per-App concurrency limit across reconciler replicas

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -2,10 +2,9 @@
  * What bundle a rerun's Build is created with (ticket 24).
  *
  * §15 has Spindrift stage an immutable source bundle for either builder, and
- * the thing it is staged *for* is a Build. `deployApp` used to copy the
- * previous Build's `bundleLocation` forward instead, so a handle staged before
- * the depot existed survived every release that fixed staging: build 10 was
- * build 9's `upload://3f5cbbc2…`, and it died at `curl` for build 9's reason.
+ * the thing it is staged *for* is a Build. Copying the previous Build's
+ * `bundleLocation` forward instead would carry an unfetchable `upload://`
+ * handle into build 10 that dies at `curl` for build 9's reason.
  */
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -632,7 +632,7 @@ describe('the workspace as a way into the system', () => {
     for (const entry of workspace.activity) {
       expect(entry.deployId ?? entry.buildId).not.toBeNull();
       // The clock is frozen at the same instant the rows were written, so the
-      // relative time is a real one rather than the "recently" it used to be.
+      // relative time is a real one rather than a "recently" placeholder.
       expect(entry.when).not.toBe('recently');
     }
     expect(workspace.deploys.map((release) => release.id)).toEqual([

--- a/apps/spindrift/test/harness/fakes/supply-chain.ts
+++ b/apps/spindrift/test/harness/fakes/supply-chain.ts
@@ -411,9 +411,9 @@ class RecordingSigner implements ArtifactSigner {
 /**
  * Records each admission check, then runs the real one.
  *
- * The default answer used to be `{ ok: true }`, so every deploy test passed
- * §16's signature gate for free. It now runs the pinned verifier over the
- * bundle the signer actually wrote.
+ * The default answer is the pinned verifier's, over the bundle the signer
+ * actually wrote — a stub `{ ok: true }` would pass §16's signature gate for
+ * free in every deploy test.
  */
 export class RecordingSignatureVerifier implements SignatureVerifier {
   readonly admissions: VerifySignatureInput[] = [];

--- a/apps/spindrift/test/web/app-list-identity.test.tsx
+++ b/apps/spindrift/test/web/app-list-identity.test.tsx
@@ -181,8 +181,8 @@ describe('two Apps answer to one name', () => {
       expect(review.value.appId).toBe(row.id);
     }
 
-    // The review the list used to be able to make, and the refusal that left
-    // both Apps undeletable.
+    // A review by name alone is ambiguous across the two rows, and the refusal
+    // is what keeps either from being deleted by accident.
     const ambiguous = await deleteApp({ name, confirm: false }, ctx);
     expect(ambiguous.ok).toBe(false);
     if (ambiguous.ok) return;

--- a/apps/spindrift/test/web/auth-routes.test.ts
+++ b/apps/spindrift/test/web/auth-routes.test.ts
@@ -174,7 +174,7 @@ describe('enrolling over the route table', () => {
   });
 
   test('and the session it mints reaches a command', async () => {
-    // The whole point. Before this, every command route answered 401.
+    // The whole point of enrolment: without it every command route answers 401.
     const { routes } = serve();
     const cookie = cookieFrom(await enrolOverHttp(routes));
     expect(cookie).not.toBeNull();

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -1,13 +1,11 @@
 ---
-# Spindrift is a **platform workload, never one of its own Apps** (§19). The
-# bootstrap circularity — a deploy layer that would otherwise have to deploy
-# itself — resolves by classification, not machinery: Flux owns this namespace
-# exactly as it owns Atlantis's and hub's.
+# Spindrift is a **platform workload, never one of its own Apps**: Flux owns
+# this namespace exactly as it owns Atlantis's and hub's, which is what resolves
+# a deploy layer that would otherwise have to deploy itself.
 #
-# The chart is sourced from GitRepository/infra rather than OCI, which is the
-# plan's stated deferral. It costs the per-Target chart pinning §7 wants and
-# leaves the extraction path unexercised; reversing it is one workflow plus a
-# source swap, and it must happen before extraction is claimed.
+# The chart is sourced from GitRepository/infra rather than OCI. That costs the
+# per-Target chart pinning and leaves the extraction path unexercised; reversing
+# it is one workflow plus a source swap, and must happen before extraction.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
@@ -24,15 +22,9 @@ spec:
         name: infra
         namespace: flux-system
   values:
-    # Renovate pins the digest on this line. Flux picks up the change
-    # and rolls out the new image automatically.
-    #
-    # It must be an image whose schema agrees with the chart about which keys a
-    # declaration may carry. `be1a951` was pinned two minutes before #1500
-    # derived `cloud.federation` and `charts.installer` away, so it required the
-    # two keys the chart had begun refusing — the declaration could satisfy the
-    # chart or the process, never both, and the pods crashlooped on a manifest
-    # the chart would not have rendered had it carried them.
+    # Renovate pins the digest on this line and Flux rolls it out. The image's
+    # manifest schema and the chart must agree on which keys a declaration may
+    # carry — the manifest below has to satisfy both.
     image: ghcr.io/jonpulsifer/spindrift:latest@sha256:07ff8fa911dd199ef8399979793ee129963a6374ca927a5e75c5531673424131
     # Substituted by the apps Kustomization from the cluster-secrets Secret, so
     # the zone is read rather than restated. external-dns publishes the record
@@ -42,15 +34,15 @@ spec:
     # The Secret carries only the one-time enrolment token and optional
     # integration credentials.
     envFromSecret: spindrift-env
-    # The whole of §13's federation. These two values render the pod's
-    # `external_account` credential, and the process reads its federation out of
-    # that file — so this is the only place the facts are stated.
+    # The whole of the federation. These two values render the pod's
+    # `external_account` credential and the process reads its federation out of
+    # that file, so this is the only place the facts are stated.
     #
     # The pool principal holds `roles/iam.workloadIdentityUser` and
     # `roles/iam.serviceAccountTokenCreator` on this one service account and
-    # nothing else; every project role, the source bucket and the signer hang
-    # off the account. Impersonating it is therefore the only thing the
-    # federated identity can do, which is why the url is not optional here.
+    # nothing else; every project role, the source bucket, and the signer hang
+    # off the account. Impersonating it is the only thing the federated identity
+    # can do, so the url is not optional here.
     # Declared in terraform/gcp/projects/bluenose/iam.tf.
     serviceAccount:
       token:
@@ -58,14 +50,14 @@ spec:
         gcpImpersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
     ingress:
       enabled: true
-    # §19's own database, including the installation manifest singleton.
+    # The control plane's own database, including the installation manifest
+    # singleton. Both processes wait for the image's committed migration journal
+    # before becoming Ready.
     database:
       enabled: true
       size: 2Gi
       migration:
         enabled: true
-    # Both processes wait for the image's committed migration journal before
-    # becoming Ready.
     reconciler:
       enabled: true
     web:
@@ -76,16 +68,9 @@ spec:
         limits:
           memory: 768Mi
           cpu: 1000m
-    # §20's installation manifest, declared rather than seeded.
-    #
-    # The durable row is written from this document at process start and
-    # otherwise from itself, so an undeclared installation can only ever be
-    # seeded — and a value seeded wrong stays wrong. `zeroConfigFrontend` was
-    # exactly that: `ghcr.io/railwayapp/railpack:railpack-frontend` came in with
-    # the row, GHCR does not serve that repository at all, and two later
-    # corrections to the code default could not reach an installation that
-    # already had one. Declaring the document is what puts a manifest change
-    # back under ordinary review.
+    # The installation manifest, declared rather than seeded: the durable row is
+    # written from this document at process start, which is what puts a manifest
+    # change under ordinary review.
     #
     # Both zones are substituted by the apps Kustomization — `SPINDRIFT_DOMAIN`
     # from cluster-settings, `SECRET_DOMAIN` from cluster-secrets — so the zone
@@ -103,15 +88,14 @@ spec:
         routes:
           - name: hosted
             adapter: github-actions
-        # Railpack publishes the frontend as its own repository. The tag is a
-        # version because rebuilding one bundle digest should not silently
-        # change what built it, and this is the only input to a zero-config
-        # build that no digest covers.
+        # Railpack publishes the frontend as its own repository. Pinned to a
+        # version rather than a moving tag: it is the only input to a
+        # zero-config build that no digest covers.
         zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
       cloud:
-        # No `federation` here. It is read from the `external_account`
-        # credential this chart renders, from the two serviceAccount.token
-        # values above — declaring it a second time is what the chart refuses.
+        # Federation is not a manifest key: it is read from the
+        # `external_account` credential the chart renders from the two
+        # serviceAccount.token values above.
         artifactsProject: trusted-builds
         homeVesselProject: bluenose
       charts:

--- a/packages/charts/spindrift-app/Chart.yaml
+++ b/packages/charts/spindrift-app/Chart.yaml
@@ -5,9 +5,8 @@ type: application
 version: 0.2.0
 appVersion: "1"
 annotations:
-  # The chart declares its own value contract and version, read at pin time
-  # (§7). Helm ignores unknown values silently, so a Target pinned to a chart
-  # whose contract has moved would apply cleanly, report green, and run without
-  # the config it was handed. Core reads this annotation when a Target is
-  # pinned and turns skew into a prerequisite failure rather than a mystery.
+  # The value contract this chart speaks, read when a Target is pinned. Helm
+  # ignores unknown values silently, so a Target pinned to a chart whose
+  # contract has moved would apply cleanly, report green, and run without the
+  # config it was handed. Core turns that skew into a prerequisite failure.
   spindrift.dev/values-contract: "2"

--- a/packages/charts/spindrift-app/templates/_helpers.tpl
+++ b/packages/charts/spindrift-app/templates/_helpers.tpl
@@ -1,10 +1,8 @@
 {{/*
 The release's object name: one App's one Component.
 
-Names are already DNS labels by the time Spindrift writes them (§9 mints the
-canonical hostname from the same two), so this composes rather than sanitizes —
-a value that needed sanitizing here would be a value that could not be a
-hostname either.
+Both names are already DNS labels — the canonical hostname is minted from the
+same two — so this composes rather than sanitizes.
 */}}
 {{- define "spindrift-app.fullname" -}}
 {{- printf "%s-%s" .Values.app.name .Values.app.component | trunc 63 | trimSuffix "-" }}
@@ -13,10 +11,8 @@ hostname either.
 {{/*
 Selector labels: what a Deployment's selector and a Service's selector match on.
 
-**Immutable by construction.** Nothing that changes deploy to deploy is here —
-the deploy label lives on the pod template only (§7), because a selector cannot
-be edited on an existing Deployment and putting a per-deploy value in one would
-brick every upgrade after the first.
+**Immutable by construction.** A selector cannot be edited on an existing
+Deployment, so nothing that changes deploy to deploy belongs here.
 */}}
 {{- define "spindrift-app.selectorLabels" -}}
 app.kubernetes.io/name: {{ .Values.app.component }}
@@ -36,9 +32,8 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{/*
 Pod template labels: the common set plus the one label that moves per deploy.
 
-§7: "a deploy label goes on the pod template and **never** in the selector",
-because both delivery flavours enumerate applied objects and neither covers
-pods — the label is how a pod is traced back to the Deploy that placed it.
+Neither delivery flavour's applied-object enumeration covers pods, so this
+label is how a pod is traced back to the Deploy that placed it.
 */}}
 {{- define "spindrift-app.podLabels" -}}
 {{ include "spindrift-app.labels" . }}
@@ -51,31 +46,25 @@ spindrift.dev/deploy: {{ . | quote }}
 {{- end }}
 
 {{/*
-The value-contract version the chart declares, read back onto every object.
-
-The pin-time read is of `Chart.yaml`; this puts the same number on what was
-rendered, so an object in a cluster can be traced to the contract it was
-rendered under without holding the chart that did it.
+The value-contract version from `Chart.yaml`, stamped onto every object, so an
+object in a cluster can be traced to the contract it was rendered under without
+holding the chart that did it.
 */}}
 {{- define "spindrift-app.contractAnnotations" -}}
 spindrift.dev/values-contract: {{ index .Chart.Annotations "spindrift.dev/values-contract" | quote }}
 {{- end }}
 
 {{/*
-The port this Component serves on.
-
-A website is already normalized to a service with a fixed port in values (§7),
-so this helper never needs to know which non-job kind it rendered.
+The port this Component serves on. A website arrives normalized to a service
+with a fixed port, so this never needs to know which non-job kind it rendered.
 */}}
 {{- define "spindrift-app.port" -}}
 {{- .Values.app.port }}
 {{- end }}
 
 {{/*
-Whether this Component serves traffic at all.
-
-`expose` is a field on a service; website normalization has already forced it
-on (§2, §7). A job is the only workload branch and never serves.
+Whether this Component serves traffic at all. A job is the only workload branch
+and never serves.
 */}}
 {{- define "spindrift-app.serving" -}}
 {{- if and (ne .Values.app.kind "job") .Values.app.expose }}true{{ end }}
@@ -84,10 +73,9 @@ on (§2, §7). A job is the only workload branch and never serves.
 {{/*
 The container: identical between the Deployment and the CronJob.
 
-Hardening is fixed with no per-App opt-out (§7), which is why every security
-field here is a literal rather than a value. The readiness probe is the other
-half of that rule — **readiness on the port, no liveness probe** — and it is
-absent for a job, which has no port to probe.
+Hardening is fixed with no per-App opt-out, so every security field here is a
+literal rather than a value. Readiness on the port, no liveness probe; a job
+has no port to probe.
 */}}
 {{- define "spindrift-app.container" -}}
 - name: app

--- a/packages/charts/spindrift-app/templates/cronjob.yaml
+++ b/packages/charts/spindrift-app/templates/cronjob.yaml
@@ -1,11 +1,10 @@
 {{/*
-A job **always** renders a CronJob, suspended when unscheduled (§7).
+A job **always** renders a CronJob, suspended when unscheduled.
 
-Two facts force it: a Job's template is immutable, so a chart rendering one
-cannot be upgraded — and Helm then prunes the old Job on the next upgrade,
-which would silently cut an N-deep execution history to one. A CronJob owns its
-executions, so a scheduled run and a manual run are the same object with a
-field flipped, and `apply` for a job becomes two acts rather than two objects.
+A Job's template is immutable, so a chart rendering one cannot be upgraded, and
+Helm prunes the old Job on the next upgrade — cutting an N-deep execution
+history to one. A CronJob owns its executions, so a scheduled run and a manual
+run are the same object with a field flipped.
 */}}
 {{- if eq .Values.app.kind "job" }}
 apiVersion: batch/v1

--- a/packages/charts/spindrift-app/templates/deployment.yaml
+++ b/packages/charts/spindrift-app/templates/deployment.yaml
@@ -1,7 +1,6 @@
 {{/*
-A service and a website are one object. §7: "`kind` branches; **`website` is
-not a branch**" — every difference between the two is a value, so this template
-never asks which of the two it is rendering.
+A service and a website are one object: every difference between the two is a
+value, so this template never asks which of them it is rendering.
 */}}
 {{- if ne .Values.app.kind "job" }}
 apiVersion: apps/v1

--- a/packages/charts/spindrift-app/templates/externalsecret.yaml
+++ b/packages/charts/spindrift-app/templates/externalsecret.yaml
@@ -1,31 +1,27 @@
 {{/*
 The one object that turns pinned references into a running process's
-environment (§10).
+environment: one store per Target, per-key, pinned, delivered by the platform's
+own secret operator.
 
-§10: config is "**one store per Target, per-key, pinned, delivered by the
-platform's own secret operator**". Every clause is visible below. Spindrift
-writes values into the store of record and renders *references* here; the
-operator on the far side is what reads them. Nothing in this release carries a
-value, which is why a `helm get values` on a Component shows its whole
-configuration and discloses none of it.
+Spindrift writes values into the store of record and renders *references* here.
+Nothing in this release carries a value, so a `helm get values` on a Component
+shows its whole configuration and discloses none of it.
 
-**One Secret, one key per variable.** §10's "one secret per variable, not a
-blob" is about the store of record — a blob has no cloud-runtime equivalent —
-not about how many Kubernetes objects the values land in. The container reads
-`secretKeyRef`s out of this one Secret, and each of them was fetched
-individually from its own pinned item.
+**One Secret, one key per variable.** One secret per variable, not a blob, is a
+rule about the store of record — a blob has no cloud-runtime equivalent — not
+about how many Kubernetes objects the values land in. The container reads
+`secretKeyRef`s out of this one Secret, each fetched from its own pinned item.
 
-**`refreshInterval: 0` because the references are pinned.** A periodic refresh
-would re-fetch the exact version it fetched last time, since a config change
-produces a new Deploy and a new Deploy re-renders this object. Polling for a
-change that can only arrive by re-render is cost with no outcome.
+**`refreshInterval: 0` because the references are pinned.** A config change
+produces a new Deploy, which re-renders this object; polling would re-fetch the
+exact version it fetched last time.
 
-**A store whose provider addresses a version some other way is a gap, stated.**
-`remoteRef.key` plus `remoteRef.version` is the pinned pair Spindrift's store
-contract mints and is what a Secret Manager provider takes. A store that pins by
-minting an immutable item per version has to mint a `key` that is itself unique
-per version for this to address it, and 1Password Connect's item id is not its
-title — closing that is the store adapter's work, not the chart's.
+**A store whose provider addresses a version some other way is a gap.**
+`remoteRef.key` plus `remoteRef.version` is the pinned pair the store contract
+mints and what a Secret Manager provider takes. A store that pins by minting an
+immutable item per version has to mint a `key` unique per version for this to
+address it, and 1Password Connect's item id is not its title — closing that is
+the store adapter's work, not the chart's.
 */}}
 {{- if .Values.app.secretEnv }}
 apiVersion: external-secrets.io/v1
@@ -44,7 +40,7 @@ spec:
     # Required rather than defaulted: a wrong store name fails visibly here,
     # while an empty one would render an ExternalSecret that never syncs and a
     # workload that waits forever for a Secret nobody is creating.
-    name: {{ required "platform.secretStore.name is unset, so this Target cannot deliver config (§10)" .Values.platform.secretStore.name }}
+    name: {{ required "platform.secretStore.name is unset, so this Target cannot deliver config" .Values.platform.secretStore.name }}
   target:
     name: {{ include "spindrift-app.fullname" . }}
     creationPolicy: Owner

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -1,15 +1,14 @@
 {{/*
-The route onto the shared gateway's **existing HTTP listener** (§9).
+The route onto the shared gateway's **existing HTTP listener**.
 
-Three things this deliberately is not: it is not a Gateway, not a certificate,
-and not a cross-namespace grant — all three are vessel, and §7 excludes them
-from the release because a `destroy()` that could take the gateway with it is
-not a `destroy()` anybody can run. Private routes delegate authentication to
-the vessel's shared proxy; public routes have no authentication filter.
+Not a Gateway, not a certificate, not a cross-namespace grant: all three are
+vessel resources, kept out of the release so a `destroy()` cannot take the
+gateway with it. Private routes delegate authentication to the vessel's shared
+proxy; public routes have no authentication filter.
 
-An `internal` Component has no route at all. §9 makes internal Target-private,
-authenticated at the workload boundary, and a route onto the shared gateway is
-exactly the alternate origin a non-public state may not leave open.
+An `internal` Component has no route at all — it is Target-private and
+authenticated at the workload boundary, and a route onto the shared gateway
+would be exactly the alternate origin that state may not leave open.
 */}}
 {{- if and (include "spindrift-app.serving" .) (ne .Values.app.exposure "internal") }}
 apiVersion: gateway.networking.k8s.io/v1

--- a/packages/charts/spindrift-app/templates/networkpolicy.yaml
+++ b/packages/charts/spindrift-app/templates/networkpolicy.yaml
@@ -1,20 +1,19 @@
 {{/*
-Ingress is default-deny with a fixed exception list (§8).
+Ingress is default-deny with a fixed exception list.
 
-"**Internal is a workload boundary, not a network location.**" Without this,
-any pod in any namespace could reach an Internal Component directly and skip
-the authenticated gateway — so the policy is on for every Component, whatever
-its exposure, and there is no per-App opt-out.
+**Internal is a workload boundary, not a network location.** Without this, any
+pod in any namespace could reach an internal Component directly and skip the
+authenticated gateway — so the policy is on for every Component, whatever its
+exposure, with no per-App opt-out.
 
 **The shape is fixed; the names are Target configuration.** Same-namespace
-siblings are always allowed because a release's own pods are the one caller
-that cannot be named ahead of time; everything else arrives as a namespace name
-an operator set on the Target.
+siblings are always allowed, because a release's own pods are the one caller
+that cannot be named ahead of time; everything else is a namespace name an
+operator set on the Target.
 
-Egress is not here. §8 wants an FQDN allowlist rather than an IP blocklist, and
-a portable NetworkPolicy cannot express one — which is why egress filtering is
-a *discovered capability* rather than a prerequisite (§8), and why the ingress
-half is the half that ships in a portable chart.
+Egress is not here: it wants an FQDN allowlist, which a portable NetworkPolicy
+cannot express, so egress filtering is a discovered capability of a Target
+rather than something a portable chart ships.
 */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/packages/charts/spindrift-app/values.yaml
+++ b/packages/charts/spindrift-app/values.yaml
@@ -1,17 +1,12 @@
-# The App chart's values (§7).
+# One App Component, as values.
 #
-# Three value classes, not two: some keys are written by both the operator and
-# Spindrift, so a disjointness rule would reject a correct config. The classes
-# are the three top-level keys below, and the boundary between them is enforced
-# where a Target's chart-values are saved — not here, because a chart cannot
-# know who set a value.
+# Three value classes, by who writes them. The boundary is enforced where a
+# Target's chart-values are saved, not here — a chart cannot know who set a
+# value.
 #
 #   app.*       Spindrift writes. Never an operator's to set.
 #   platform.*  The operator writes, per Target. Spindrift never renders into it.
 #   shared.*    Either may write. Spindrift's value wins where both do.
-#
-# Everything a Component is, is a value. `website` is not a template branch —
-# it is a service with `expose` forced and a fixed port (§7).
 
 # --- Spindrift's class ------------------------------------------------------
 app:
@@ -21,51 +16,50 @@ app:
   component: ""
 
   # service | website | job. `job` is the one branch: it renders a CronJob
-  # rather than a Deployment (§7).
+  # rather than a Deployment. A website is a service with `expose` forced and a
+  # fixed port.
   kind: service
 
-  # Digest-pinned image reference. §16 correlates on digest everywhere, so a
-  # tag here would break the join between what was signed and what runs.
+  # Digest-pinned image reference. The supply chain correlates on digest, so a
+  # tag would break the join between what was signed and what runs.
   image: ""
 
-  # The port this non-job Component listens on. Spindrift supplies the fixed
-  # website port as this value, leaving `job` as the only chart branch.
+  # The port this non-job Component listens on.
   port: 8080
 
-  # Whether this non-job Component serves traffic. Spindrift forces this on
-  # when it normalizes a website; an unexposed service is a queue worker (§2).
+  # Whether this non-job Component serves traffic. An unexposed service is a
+  # queue worker.
   expose: true
 
-  # internal | private | public (§9). The chart renders a route for a Component
-  # that is exposed and not `internal`; a private route delegates authentication
-  # to the Target's shared proxy while a public route is filter-free.
+  # internal | private | public. A route renders for a Component that is exposed
+  # and not `internal`; a private route delegates authentication to the Target's
+  # shared proxy, a public route is filter-free.
   exposure: private
 
-  # Job only. Empty renders a suspended CronJob — a job always renders one, so
-  # a manual run and a scheduled run are one object with a field flipped (§7).
+  # Job only. Empty renders a suspended CronJob, so a manual run and a scheduled
+  # run are one object with a field flipped.
   schedule: ""
 
   # The Deploy this release came from. Rendered onto the pod template and
-  # **never** into a selector, which is immutable and would brick every
-  # upgrade (§7).
+  # **never** into a selector, which is immutable.
   deployId: ""
 
-  # What is running here, as a digest. Kept on the delivery object so observe
-  # can report drift against core's desired state (§6).
+  # What is running here, as a digest, so observe can report drift against
+  # core's desired state.
   artifactDigest: ""
 
   # Hostnames the route answers on: the canonical name first, the vanity name
-  # after it where one exists (§9).
+  # after it where one exists.
   hostnames: []
 
-  # Plain environment. §10 keeps no secret/non-secret classification; a value
-  # that is a secret arrives through `secretEnv` as a reference, never here.
+  # Plain environment. A value that is a secret arrives through `secretEnv` as a
+  # reference, never here.
   env: []
   # [{ name, secretName, remote: { key, version } }] — one secret per variable,
-  # not a blob (§10). `name` is both the variable and the key inside the
-  # materialized Secret; `remote` is the **pinned** reference in the store of
-  # record, never a floating latest. The chart renders one ExternalSecret from
-  # these and the platform's own secret operator materializes it.
+  # not a blob. `name` is both the variable and the key inside the materialized
+  # Secret; `remote` is the **pinned** reference in the store of record, never a
+  # floating latest. The chart renders one ExternalSecret from these and the
+  # platform's secret operator materializes it.
   secretEnv: []
 
   # Entrypoint overrides. Empty means the image's own.
@@ -74,13 +68,13 @@ app:
 
 # --- The operator's class ---------------------------------------------------
 platform:
-  # Sandbox runtime class, defaulting to unset (§7).
+  # Sandbox runtime class.
   runtimeClassName: ""
 
   imagePullSecrets: []
 
-  # The shared gateway routes attach to. No Gateway and no certificate are
-  # rendered here — routes attach to the existing HTTP listener (§7, §9).
+  # The shared gateway routes attach to, on its existing HTTP listener. This
+  # chart renders no Gateway and no certificate.
   gateway:
     name: ""
     namespace: ""
@@ -92,25 +86,23 @@ platform:
     namespace: ""
     port: 80
 
-  # The ClusterSecretStore config is fetched through. A Target property: §10
-  # gives a Kubernetes Target an admin-chosen store, and the operator is the
-  # one who knows what theirs is called. Rendering config without it is refused
-  # rather than guessed — see templates/externalsecret.yaml.
+  # The ClusterSecretStore config is fetched through — an admin-chosen Target
+  # property. Rendering config without it is refused rather than guessed; see
+  # templates/externalsecret.yaml.
   secretStore:
     kind: ClusterSecretStore
     name: ""
 
   networkPolicy:
-    # Ingress is default-deny with a fixed exception list whose **names are
-    # Target configuration while the shape is fixed** (§8). Same-namespace
-    # siblings are always allowed; these are the namespaces outside it.
+    # Ingress is default-deny with a fixed exception shape whose **names are
+    # Target configuration**. Same-namespace siblings are always allowed; these
+    # are the namespaces outside it.
     allowedNamespaces: []
 
 # --- Written by both --------------------------------------------------------
 shared:
   # The operator sets a Target's defaults; Spindrift overrides them per
-  # Component. Both are legitimate authors of the same key, which is the whole
-  # reason this class exists.
+  # Component.
   resources:
     requests:
       cpu: 50m

--- a/packages/charts/spindrift/templates/_helpers.tpl
+++ b/packages/charts/spindrift/templates/_helpers.tpl
@@ -1,7 +1,6 @@
 {{/*
 The release's base name. Every object is derived from it, and the namespace is
-assumed to match — Flux creates the Namespace alongside this release rather than
-the chart rendering one, the same split `packages/charts/app` uses.
+assumed to match — Flux creates the Namespace alongside this release.
 */}}
 {{- define "spindrift.fullname" -}}
 {{- default .Release.Name .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
@@ -23,11 +22,8 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end }}
 
 {{/*
-Selector labels for one process.
-
-§19 makes this two Deployments off one image, so the selector has to separate
-them — `app.kubernetes.io/component` is what the Service targets, and getting it
-wrong would point the route at the reconciler.
+Selector labels for one process. `app.kubernetes.io/component` is what
+separates the two Deployments and what the Service targets.
 */}}
 {{- define "spindrift.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "spindrift.fullname" . }}
@@ -39,12 +35,12 @@ app.kubernetes.io/component: {{ .component }}
 {{- end }}
 
 {{/*
-The migration Job's name carries a digest of every operator-controlled input to
-its immutable pod template. A changed migration becomes a new Job; an unrelated
-chart revision leaves the completed Job alone.
+The migration Job's name carries a digest of every input to its immutable pod
+template. New migrations arrive with a new image and become a new Job; an
+unrelated chart revision leaves the completed Job alone.
 */}}
 {{- define "spindrift.migrationName" -}}
-{{- $inputs := dict "image" .Values.image "command" .Values.database.migration.command "sandbox" .Values.sandbox "envFromSecret" .Values.envFromSecret -}}
+{{- $inputs := dict "image" .Values.image "sandbox" .Values.sandbox "envFromSecret" .Values.envFromSecret -}}
 {{- $digest := toJson $inputs | sha256sum | trunc 20 -}}
 {{ include "spindrift.fullname" . }}-migrate-{{ $digest }}
 {{- end }}

--- a/packages/charts/spindrift/templates/database.yaml
+++ b/packages/charts/spindrift/templates/database.yaml
@@ -1,14 +1,8 @@
 {{/*
-§19: "Its chart renders **its own database cluster with a keep policy,
-overridable** — the orphan-tracking objection does not bind at one instance, and
-this is not the refused escape hatch, since it undermines no guarantee about
-Apps."
-
-The keep policy is the load-bearing half. §12 ships no backups deliberately and
-the loss story is reconcile-from-sources — but the desired-state rows, the
-attempt log, and the config version pins are not in any source. So the PVC
-outlives the Cluster: deleting the release must not be the thing that discards
-them.
+The control plane's own database. There are no backups: the loss story is
+reconcile-from-sources, and the desired-state rows, the attempt log, and the
+config version pins are the part of it no source holds. So the PVC outlives the
+Cluster — deleting the release must not be what discards them.
 */}}
 {{- if .Values.database.enabled }}
 apiVersion: postgresql.cnpg.io/v1
@@ -20,10 +14,9 @@ metadata:
     {{- include "spindrift.labels" . | nindent 4 }}
   {{- if .Values.database.keepOnDelete }}
   annotations:
-    # The keep policy the comment above describes. CNPG owns the data PVC
-    # through the Cluster, so an uninstall that removes the Cluster garbage
-    # collects the volume with it whatever the storage class reclaims — keeping
-    # the Cluster is what keeps the data.
+    # CNPG owns the data PVC through the Cluster, so an uninstall that removes
+    # the Cluster collects the volume with it whatever the storage class
+    # reclaims. Keeping the Cluster is what keeps the data.
     helm.sh/resource-policy: keep
   {{- end }}
 spec:

--- a/packages/charts/spindrift/templates/deployment.yaml
+++ b/packages/charts/spindrift/templates/deployment.yaml
@@ -1,22 +1,15 @@
 {{/*
-§19: "One image, two Deployments — `web` (UI, webhooks, log WebSockets) and
-`reconciler` — forced, because the transactional desired-state row assumes a
-loop that owns its own lifecycle."
+Two Deployments off one image — `web` (UI, webhooks, log WebSockets) and
+`reconciler` — rendered from one template so they cannot drift apart in the
+image, the database credential, the manifest bootstrap, or the security context.
 
-They are rendered from one template with one difference each — the command and
-the component label — so the two processes cannot drift apart in the things
-that must not differ: the image, the database credential, the manifest
-bootstrap, and the security context.
-
-The reconciler serves nothing and is therefore given no port and no probe. A
-loop that claims work with `SELECT … FOR UPDATE SKIP LOCKED` has no readiness to
-report, and inventing an endpoint so it could would be inventing the surface §21
-declined to declare.
+The reconciler serves nothing, so it gets no port and no probe: a loop that
+claims work with `SELECT … FOR UPDATE SKIP LOCKED` has no readiness to report.
 */}}
 {{- $top := . -}}
-{{- $processes := list (dict "name" "web" "command" .Values.command "replicas" .Values.web.replicas "resources" .Values.web.resources "serves" true "federates" true) -}}
+{{- $processes := list (dict "name" "web" "command" "src/web/server.ts" "replicas" .Values.web.replicas "resources" .Values.web.resources "serves" true "federates" true) -}}
 {{- if .Values.reconciler.enabled -}}
-{{- $processes = append $processes (dict "name" "reconciler" "command" .Values.reconciler.command "replicas" .Values.reconciler.replicas "resources" .Values.reconciler.resources "serves" false "federates" true) -}}
+{{- $processes = append $processes (dict "name" "reconciler" "command" "src/reconciler/main.ts" "replicas" .Values.reconciler.replicas "resources" .Values.reconciler.resources "serves" false "federates" true) -}}
 {{- end -}}
 {{- range $process := $processes }}
 ---
@@ -34,8 +27,8 @@ metadata:
     app.kubernetes.io/database: {{ include "spindrift.databaseName" $top }}
     {{- end }}
     {{- with $top.Values.envFromSecret }}
-    # Recovery is token rotation. Reloader turns that desired-state Secret
-    # change into the restart needed for the process to read the new value.
+    # A rotated token is a Secret change; Reloader turns it into the restart the
+    # process needs to read the new value.
     secret.reloader.stakater.com/reload: {{ . | quote }}
     {{- end }}
   {{- end }}
@@ -48,10 +41,8 @@ spec:
     metadata:
       {{- if $top.Values.manifest }}
       annotations:
-        # Both processes read the manifest once, at start. Without this the
-        # ConfigMap would change and the running processes would keep the
-        # declaration they booted with — a declared change that does nothing is
-        # the failure this document exists to end.
+        # Both processes read the manifest once, at start, so a ConfigMap change
+        # has to become a rollout.
         checksum/manifest: {{ toYaml $top.Values.manifest | sha256sum }}
       {{- end }}
       labels:
@@ -72,10 +63,7 @@ spec:
         - name: wait-for-schema
           image: {{ $top.Values.image }}
           imagePullPolicy: IfNotPresent
-          command:
-            - sh
-            - -c
-            - {{ $top.Values.database.migration.waitCommand | quote }}
+          command: ["bun", "run", "src/db/wait-for-schema.ts"]
           env:
             - name: TMPDIR
               value: /tmp
@@ -104,10 +92,7 @@ spec:
         - name: {{ $process.name }}
           image: {{ $top.Values.image }}
           imagePullPolicy: IfNotPresent
-          command:
-            - sh
-            - -c
-            - {{ $process.command | quote }}
+          command: ["bun", "run", {{ $process.command | quote }}]
           {{- if $process.serves }}
           ports:
             - containerPort: {{ $top.Values.port }}
@@ -133,9 +118,8 @@ spec:
             {{- end }}
             {{- end }}
             {{- if $top.Values.manifest }}
-            # Named explicitly rather than left to the default path, so a
-            # declaration that fails to mount is fatal instead of falling back
-            # to the durable row and serving the value it was meant to replace.
+            # Named explicitly, so a declaration that fails to mount is fatal
+            # rather than falling back to the durable row.
             - name: SPINDRIFT_MANIFEST_PATH
               value: /etc/spindrift/manifest.yaml
             {{- end }}
@@ -161,8 +145,7 @@ spec:
                 name: {{ . }}
           {{- end }}
           {{- if $process.serves }}
-          # No liveness probe, deliberately — the same rule §7 fixes for App
-          # workloads. A liveness probe on a process whose slow path is a
+          # Readiness only. A liveness probe on a process whose slow path is a
           # database query restarts it exactly when it is least able to recover.
           readinessProbe:
             httpGet:

--- a/packages/charts/spindrift/templates/federated-identity.yaml
+++ b/packages/charts/spindrift/templates/federated-identity.yaml
@@ -1,13 +1,8 @@
 {{/*
-The whole of §13's federation, in one document, in one place.
-
-This is the only copy. The installation manifest used to restate `audience`,
-`token_url`, the token path and the impersonation url by hand, in a document
-this chart does not render — so the two could disagree, and when they did the
-failure arrived as an `iam.serviceAccounts.signBlob` refusal that read as a code
-defect. The process now reads its federation from this file, through
-`GOOGLE_APPLICATION_CREDENTIALS`, which the deployment already sets beside the
-mount.
+The whole of the process's GCP federation, in one document, in one place — the
+audience, the token url, the impersonation url, and the projected token's path.
+The process reads it through `GOOGLE_APPLICATION_CREDENTIALS`, which the
+deployment sets beside the mount.
 
 An ordinary ADC `external_account` document, so any client in the process finds
 the same credential rather than a Spindrift-shaped one only Spindrift reads.

--- a/packages/charts/spindrift/templates/gateway.yaml
+++ b/packages/charts/spindrift/templates/gateway.yaml
@@ -1,11 +1,10 @@
 {{/*
 The control plane's own edge.
 
-cert-manager issues the certificate from the annotation, and external-dns
-publishes the record from the HTTPRoute beside this (its `gateway-httproute`
-source) — so a hostname is the whole of what a release supplies to be reachable
-on the internet with TLS. Nothing here writes a DNS record or holds a
-Cloudflare credential, which is the same rule §9 fixes for Apps.
+cert-manager issues the certificate from the annotation and external-dns
+publishes the record from the HTTPRoute beside this, so a hostname is the whole
+of what a release supplies to be reachable on the internet with TLS. Nothing
+here writes a DNS record or holds a Cloudflare credential.
 */}}
 {{- if and .Values.ingress.enabled .Values.hostname }}
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/packages/charts/spindrift/templates/httproute.yaml
+++ b/packages/charts/spindrift/templates/httproute.yaml
@@ -2,10 +2,8 @@
 One route, and the client owns everything below it.
 
 `src/web/routes.ts` serves one HTML document, a health probe, and the generated
-command surface; navigation is a hash router. So there is no path matching here
-and there is nothing for a second rule to route to — a path split at the edge
-would be the first place the browser's protocol grew a shape the server does
-not have.
+command surface; navigation is a hash router. There is nothing for a second
+rule to route to, so the edge does no path matching.
 */}}
 {{- if and .Values.ingress.enabled .Values.hostname }}
 apiVersion: gateway.networking.k8s.io/v1beta1

--- a/packages/charts/spindrift/templates/manifest.yaml
+++ b/packages/charts/spindrift/templates/manifest.yaml
@@ -1,29 +1,18 @@
 {{/*
-§20's installation manifest, declared by the release.
+The installation manifest, declared by the release. `loadStoredManifest` writes
+this document to the durable row at process start, so a manifest change is a
+pull request. Empty declares nothing and the process reads the row back.
 
-Without this the durable row is the only copy, and it can only ever be seeded:
-`loadStoredManifest` writes a declaration when one is present and otherwise
-reads the row back, and no command writes that row. A value corrected in code
-therefore cannot reach an installation that already has one, and a value nothing
-seeds correctly stays wrong forever. Declaring the document here puts it back
-under ordinary review — a manifest change is a pull request.
-
-Empty declares nothing, which stays a valid installation: the process falls back
-to the durable row exactly as it does today.
-
-**A declaration may not restate what this chart already renders.** The three
-refusals below are the mechanical half of that rule: a release whose manifest
-carries a fact this chart owns fails to render, which is the earliest moment the
-two copies can be compared and the only one where being wrong costs nothing. The
-alternative is a value that agrees today, drifts on the next edit, and surfaces
-as a refusal somewhere else entirely.
+**A declaration may not restate what this chart already renders.** The refusals
+below reject a manifest carrying a fact this chart owns, at render time — the
+earliest the two copies can be compared and the only place being wrong is free.
 */}}
 {{- if .Values.manifest }}
 {{- if dig "cloud" "federation" nil .Values.manifest }}
 {{- fail "manifest.cloud.federation is not a manifest key: federation is read from the external_account credential this chart renders. Set serviceAccount.token.gcpAudience and serviceAccount.token.gcpImpersonationUrl instead." }}
 {{- end }}
 {{- if dig "charts" "installer" nil .Values.manifest }}
-{{- fail "manifest.charts.installer is not a manifest key: it named this chart, and nothing reads it. Remove it." }}
+{{- fail "manifest.charts.installer is not a manifest key: nothing reads it. Remove it." }}
 {{- end }}
 {{- $declaredHostname := dig "controlPlane" "hostname" "" .Values.manifest }}
 {{- if and .Values.hostname $declaredHostname (ne $declaredHostname .Values.hostname) }}

--- a/packages/charts/spindrift/templates/migration.yaml
+++ b/packages/charts/spindrift/templates/migration.yaml
@@ -1,10 +1,8 @@
 {{/*
-The database owner applies committed migrations with a retryable Job. Its name
-contains a digest of the execution inputs, so an unchanged release reuses the
-completed Job and changed migration inputs create a fresh attempt. The pod
-template excludes revision-varying chart labels because Jobs are immutable.
-Process init containers independently hold web and reconciler below Ready until
-that image's journal is present.
+Applies the image's committed migrations. The Job name digests its execution
+inputs, so an unchanged release reuses the completed Job and a new image creates
+a fresh attempt. The pod template excludes revision-varying chart labels because
+Jobs are immutable.
 */}}
 {{- if and .Values.database.enabled .Values.database.migration.enabled }}
 apiVersion: batch/v1
@@ -16,9 +14,9 @@ metadata:
     {{- include "spindrift.labels" . | nindent 4 }}
     app.kubernetes.io/component: migration
 spec:
-  # Database startup and network readiness are eventually consistent. Keep
-  # retrying this image-scoped, idempotent act until it succeeds; a finite
-  # backoff would leave the same declared release permanently failed.
+  # Database startup and network readiness are eventually consistent. Retry this
+  # idempotent act until it succeeds; a finite backoff would leave the same
+  # declared release permanently failed.
   backoffLimit: 2147483647
   template:
     metadata:
@@ -37,10 +35,7 @@ spec:
       containers:
         - name: migrate
           image: {{ .Values.image }}
-          command:
-            - sh
-            - -c
-            - {{ .Values.database.migration.command | quote }}
+          command: ["bun", "run", "src/db/migrate.ts"]
           env:
             - name: TMPDIR
               value: /tmp

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -15,11 +15,11 @@ describe('process topology', () => {
       .template.spec.containers[0];
 
     expect(reconciler.image).toBe(web.image);
-    expect(web.command).toEqual(['sh', '-c', 'bun run src/web/server.ts']);
+    expect(web.command).toEqual(['bun', 'run', 'src/web/server.ts']);
     expect(reconciler.command).toEqual([
-      'sh',
-      '-c',
-      'bun run src/reconciler/main.ts',
+      'bun',
+      'run',
+      'src/reconciler/main.ts',
     ]);
   });
 });
@@ -60,18 +60,18 @@ describe('declarative schema ordering', () => {
     expect(migration.spec.backoffLimit).toBe(2147483647);
     expect(migration.spec.ttlSecondsAfterFinished).toBeUndefined();
     expect(migration.spec.template.spec.containers[0].command).toEqual([
-      'sh',
-      '-c',
-      expect.stringContaining('applyMigrations'),
+      'bun',
+      'run',
+      'src/db/migrate.ts',
     ]);
 
     for (const name of ['spindrift-web', 'spindrift-reconciler']) {
       const deployment = one(objects, 'Deployment', name);
-      const waitCommand =
-        deployment.spec.template.spec.initContainers[0].command;
-      expect(waitCommand.slice(0, 2)).toEqual(['sh', '-c']);
-      expect(waitCommand[2]).toContain('wait-for-schema.ts');
-      expect(waitCommand[2]).toContain('drizzle.__drizzle_migrations');
+      expect(deployment.spec.template.spec.initContainers[0].command).toEqual([
+        'bun',
+        'run',
+        'src/db/wait-for-schema.ts',
+      ]);
       expect(
         deployment.spec.template.spec.initContainers[0].env,
       ).toContainEqual({
@@ -183,13 +183,7 @@ describe('Secret-backed authentication configuration', () => {
 });
 
 describe('migration Job identity', () => {
-  const database = {
-    enabled: true,
-    migration: {
-      enabled: true,
-      command: 'bun run migrate',
-    },
-  };
+  const database = { enabled: true, migration: { enabled: true } };
 
   test('is stable for the same execution inputs and excludes chart revision labels', async () => {
     const first = one(await render({ database }), 'Job');
@@ -206,15 +200,7 @@ describe('migration Job identity', () => {
   test('changes when an immutable execution input changes', async () => {
     const first = one(await render({ database }), 'Job');
     const changed = one(
-      await render({
-        database: {
-          ...database,
-          migration: {
-            enabled: true,
-            command: 'bun run migrate --strict',
-          },
-        },
-      }),
+      await render({ database, image: 'ghcr.io/jonpulsifer/spindrift:next' }),
       'Job',
     );
 

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -1,66 +1,33 @@
-# The installer chart's values (Task 41, §19, §20).
-#
-# §20 line 3: "everything naming this installation is a value in the
-# installation manifest; a literal outside it is a bug." This file holds no
-# installation name at all — not a zone, not a project, not a cluster. A
-# release supplies the manifest document plus `hostname`, which is where this
-# control plane is served; both are empty here.
-#
-# The installation manifest is ordinary configuration. It is mounted from a
-# ConfigMap and reconciled into Spindrift's durable database when each process
-# starts. Public identifiers such as a GitHub App id do not make the document a
-# credential.
+# The Spindrift control plane: one image, two processes, its own database.
 
 image: ""
 
-# The installation manifest document. Empty declares nothing and leaves the
-# durable row in charge, which is what every installation did before this key
-# existed and remains a valid way to run.
-#
-# Declaring it is how a manifest value gets corrected. The row is written from a
-# declaration when one is present and otherwise from itself, and no product
-# command writes it — so an installation whose row is already seeded has no
-# other hand to change it with.
+# The installation manifest document, mounted as a ConfigMap and reconciled into
+# the durable database at process start. Empty leaves the durable row in charge.
+# Declaring it is the only hand that can correct a manifest value.
 manifest: {}
 
-# One named identity for the control plane. Kubernetes never automounts its
-# default API credential: both processes receive projected, audience-scoped
-# credentials because the reconciler deploys and the web process tails logs.
+# One named identity for the control plane. Both processes receive projected,
+# audience-scoped credentials; the default API credential is never automounted.
 serviceAccount:
   create: true
   name: ""
   token:
     audience: api
-    # Optional GCP workload identity provider audience. When set, both
-    # processes receive a second projected token and an ADC-compatible
-    # external-account credential file.
-    #
-    # This is the only place the audience is named. The installation manifest
-    # no longer carries a `cloud.federation` block; the process reads its
-    # federation out of the credential rendered from these two values, so there
-    # is nothing for it to disagree with.
+    # GCP workload identity provider audience. When set, both processes receive
+    # a second projected token and an ADC-compatible external-account
+    # credential file, and the process reads its federation out of that file.
     gcpAudience: ""
     # The service account the federated identity impersonates, as a
-    # `generateAccessToken` url. Empty uses the federated identity's own grants
-    # directly, which is a supported installation rather than an omission —
-    # where the cloud resources grant the principal itself, that is one fewer
-    # identity to reason about.
-    #
-    # Set it when the roles live on a service account, which is the usual shape:
-    # the pool principal is granted `roles/iam.serviceAccountTokenCreator` on
-    # that account and every project role hangs off the account, not the pool.
+    # `generateAccessToken` url. Empty uses the federated identity's own grants.
     gcpImpersonationUrl: ""
     expirationSeconds: 3600
     mountPath: /var/run/secrets/spindrift
 
 # Where the control plane's own UI is served. Empty renders no Gateway and no
-# HTTPRoute, which is a valid installation — the UI is then reachable only
-# in-cluster.
+# HTTPRoute, leaving the UI reachable only in-cluster.
 hostname: ""
 
-# §19: "One image, two Deployments." The reconciler is the second entrypoint off
-# the same image. It remains opt-in so an installation can validate and roll out
-# the process independently of the web Deployment.
 web:
   replicas: 1
   resources:
@@ -71,10 +38,11 @@ web:
       memory: 512Mi
       cpu: 500m
 
+# The second process off the same image. Opt-in, so it can be rolled out
+# independently of the web Deployment.
 reconciler:
   enabled: false
   replicas: 1
-  command: "bun run src/reconciler/main.ts"
   resources:
     requests:
       memory: 256Mi
@@ -84,75 +52,39 @@ reconciler:
       cpu: 500m
 
 port: 3000
-command: "bun run src/web/server.ts"
 
-# gVisor is available on some nodes and not others; a release that wants it says
-# so rather than the chart assuming a runtime class exists.
+# Run every pod under gVisor. Only some nodes offer the runtime class.
 sandbox: false
 
-# The Secret carrying `SPINDRIFT_ENROLMENT_TOKEN` and repository credentials
-# when those integrations are configured. It contains credentials only.
+# Secret carrying `SPINDRIFT_ENROLMENT_TOKEN` and repository credentials.
 envFromSecret: ""
 
-# Header authentication is safe only behind a Gateway that strips and replaces
+# Header authentication, safe only behind a Gateway that strips and replaces
 # identity headers and is the sole network path to the web pod. Enabling this
-# renders a default-deny ingress NetworkPolicy, admits exactly these peers, and
-# attests that boundary to the process. `from` is a list of Kubernetes
-# NetworkPolicyPeer objects and must be non-empty when enabled.
+# renders a default-deny ingress NetworkPolicy admitting exactly `from`, and
+# attests that boundary to the process. `from` is a list of NetworkPolicyPeer
+# and must be non-empty when enabled.
 gatewayAuth:
   enabled: false
   from: []
 
 env: []
 
-# §19: "Its chart renders its own database cluster with a keep policy,
-# overridable." Off by default so the chart can be installed without CNPG; the
-# offsite release turns it on.
 database:
   enabled: false
   instances: 1
   size: 2Gi
   name: spindrift
   storageClass: local-path
-  # §19's keep policy. The data PVC is owned by the CNPG Cluster, so removing
-  # the Cluster discards the desired-state rows, the attempt log, and the config
-  # version pins — none of which are in any source, because §12 ships no backups
-  # and the loss story is reconcile-from-sources.
-  #
-  # Turn it off to make an uninstall a real teardown. That is the loop for
-  # working on onboarding itself: every redeploy is then a fresh installation,
-  # which is the only way to exercise seeding and the wizard repeatedly.
+  # CNPG owns the data PVC through the Cluster, so keeping the Cluster is what
+  # keeps the desired-state rows, the attempt log, and the config version pins.
+  # Turn it off to make an uninstall a real teardown, which is the loop for
+  # working on seeding and the onboarding wizard.
   keepOnDelete: true
-  # The Job is part of an installation that owns its database. Its default
-  # command is compatible with images that expose applyMigrations before the
-  # executable entrypoint exists.
+  # Apply the image's committed migrations with a Job, and hold both processes
+  # below Ready until its journal is present.
   migration:
     enabled: true
-    command: >-
-      bun -e 'import { createClient } from "./src/db/client.ts";
-      import { applyMigrations } from "./src/db/migrate.ts";
-      const client = createClient();
-      try { await applyMigrations(client); } finally { await client.close(); }'
-    # The fallback lets a chart revision safely precede its matching image
-    # digest. Both paths read the migration journal embedded in that image.
-    waitCommand: >-
-      if [ -f src/db/wait-for-schema.ts ]; then
-      bun run src/db/wait-for-schema.ts;
-      else bun -e 'import journal from "./src/db/migrations/meta/_journal.json";
-      import { createClient } from "./src/db/client.ts";
-      const expected = Math.max(0, ...journal.entries.map((entry) => entry.when));
-      const client = createClient();
-      const deadline = Date.now() + 600000;
-      while (Date.now() < deadline) {
-      try {
-      const rows = await client.unsafe("SELECT max(created_at)::bigint AS latest FROM drizzle.__drizzle_migrations");
-      if (Number(rows[0]?.latest ?? 0) >= expected) { await client.close(); process.exit(0); }
-      } catch {}
-      await Bun.sleep(1000);
-      }
-      await client.close();
-      throw new Error(`database schema did not reach migration ${expected}`);
-      '; fi
 
 ingress:
   enabled: true


### PR DESCRIPTION
## Summary

Spindrift's charts, manifests, and app source had accumulated commentary that
explains the present by narrating the past — "it used to be two", "before this
command existed", a pinned digest's incident timeline, a `zeroConfigFrontend`
postmortem. The code is the documentation; git history is the archaeology
record. This removes the narration and the back-compat shims it was there to
justify.

## Changes

- `refactor(spindrift): inline chart entrypoints, drop the migration shim`
  - `database.migration.waitCommand` was a 17-line inline bun script guarded by
    `if [ -f src/db/wait-for-schema.ts ]`, a fallback for images predating that
    file. It ships in the image, so the fallback goes — with
    `database.migration.command`, `command`, and `reconciler.command`. All four
    are properties of the image, not of an installation, so the templates name
    them directly and the `sh -c` wrapper goes too.
  - The migration Job's name digested `migration.command`; it now digests
    `image`, which is what actually changes when the committed migrations do.
  - `packages/charts/spindrift/values.yaml`: 160 lines to 85.
- `docs(spindrift): the code is the documentation`
  - Comment-only across `apps/spindrift` (verified: no non-comment line in the
    `apps/` diff).
  - The HelmRelease keeps every value and loses the stories about how they got
    there.

## Deliberately left in place

`DERIVED_AWAY` in `apps/spindrift/src/config/manifest.ts` is a real migration
shim rather than commentary: it strips removed keys from a durable manifest row
on read, and an installation whose row still carries them fails to boot without
it. The prose is present-tensed; the mechanism stays until we can confirm no row
needs it.

## Test Plan

- [x] `bun test` in `packages/charts/spindrift` — 22/22
- [x] `mise run k8s:render-apps` — offsite spindrift release templates
- [x] `helm lint` both charts — 0 failed
- [x] `bun run lint` and `bun run typecheck` at the workspace root
- [x] `mise run docs:check`
- [ ] `apps/spindrift`'s DB-backed tests — need Postgres on `:15432`, not run
      locally; CI covers them
- [ ] Flux reconciles the offsite release onto the new chart without a rollout
      surprise (entrypoints changed shape, same processes)
