### PR TITLE
chore(renovate): raise concurrent PR/branch limits to 15

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,11 +16,11 @@
   ],
   dependencyDashboardTitle: 'Renovate Dashboard',
   dependencyDashboard: true,
-  // Keep the repository-wide dependency queue small. This also limits
-  // concurrent branches, so workspace updates do not pile up against shared
-  // lockfiles. Vulnerability alerts bypass these limits by design.
-  prConcurrentLimit: 3,
-  branchConcurrentLimit: 3,
+  // Bound the repository-wide dependency queue. This also limits concurrent
+  // branches, so workspace updates do not pile up against shared lockfiles.
+  // Vulnerability alerts bypass these limits by design.
+  prConcurrentLimit: 15,
+  branchConcurrentLimit: 15,
   lockFileMaintenance: {
     enabled: true,
     automerge: true,


### PR DESCRIPTION
## Summary
Renovate PRs trickle out too slowly. `prHourlyLimit` was already unlimited (`:disableRateLimiting`); the real throttle was `prConcurrentLimit`/`branchConcurrentLimit` at 3.

## Changes
- `prConcurrentLimit` / `branchConcurrentLimit`: 3 → 15

## Test Plan
- [ ] Renovate Dashboard shows more than 3 open PRs on the next run
- [ ] No sustained rebase churn on `bun.lock` from concurrent workspace PRs

Not set to `0` (unlimited): every bun-workspace PR touches the same `bun.lock`, so unbounded concurrency means constant lockfile-conflict rebases.
