### PR TITLE
fix(spindrift): let the strict schema be the only manifest gate

### DIFF
--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -263,10 +263,9 @@ export const installationManifestSchema = z
          * platform workload (§19) and never one of its own Apps, so it does not
          * live in the zone Apps are named in.
          *
-         * **Kept when `cloud.federation` and `charts.installer` were derived
-         * away, and here is the justification.** The installer chart has a
-         * `hostname` value that renders the Gateway and the HTTPRoute, which
-         * looks like the same fact restated — and it is not, for two reasons.
+         * **Authored, even though the installer chart has a `hostname` value
+         * that renders the Gateway and the HTTPRoute.** That looks like the
+         * same fact restated, and it is not, for two reasons.
          *
          * The chart's `hostname` may be empty, and the chart says so: an
          * installation that renders no Gateway and no HTTPRoute, reachable only
@@ -366,19 +365,19 @@ export const installationManifestSchema = z
          * Reference to the App chart (§7) — the chart every deployed Component
          * renders through.
          *
-         * Authored, unlike the two keys derived away around it, because no
-         * deployment renders it: the installer chart names itself and its own
-         * release, never the chart an App is deployed through, so there is no
-         * second copy for this one to disagree with. It is also a real
+         * Authored, because no deployment renders it: the installer chart names
+         * itself and its own release, never the chart an App is deployed
+         * through, so there is no second copy for this one to disagree with.
+         * It is also a real
          * installation choice — §7 wants the App chart pinned per Target, and
          * an OCI reference is where that ends up.
          */
         app: nonEmptyString,
         /**
-         * **No `installer` key.** It named the chart this installation was
+         * **No `installer` key.** It would name the chart this installation is
          * installed from — the release restating itself into a document the
-         * release does not render — and nothing in the process ever read it.
-         * A value that can only be wrong is not configuration.
+         * release does not render — and nothing in the process reads it. A
+         * value that can only be wrong is not configuration.
          */
       })
       .strict(),

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -57,69 +57,12 @@ export function parseManifest(
   return validateManifest(parsed, source);
 }
 
-/**
- * Keys the schema does not have, and where the fact lives instead.
- *
- * Read as `[block, key, why]`. Each is a copy of something the deployment
- * declares, so a document carrying one is describing a fact it does not own.
- */
-const DERIVED_AWAY: readonly (readonly [string, string, string])[] = [
-  [
-    'cloud',
-    'federation',
-    'it is read from the credential the deployment mounts',
-  ],
-  ['charts', 'installer', 'nothing reads it'],
-];
-
-/**
- * Drop the derived-away keys before the strict schema sees them.
- *
- * Dropped rather than refused: a durable row holding one of these would
- * otherwise be a control plane that will not boot until someone edits Postgres
- * by hand. The row is rewritten from what this returns, so it self-heals on the
- * first start and the warning fires once.
- *
- * Stripping on the way in is also what keeps a key out of storage from every
- * path, which mere absence from the schema does not.
- */
-function withoutDerivedKeys(manifest: unknown, source: string): unknown {
-  if (
-    typeof manifest !== 'object' ||
-    manifest === null ||
-    Array.isArray(manifest)
-  ) {
-    return manifest;
-  }
-
-  let document = manifest as Record<string, unknown>;
-  for (const [blockName, key, why] of DERIVED_AWAY) {
-    const block = document[blockName];
-    if (
-      typeof block !== 'object' ||
-      block === null ||
-      Array.isArray(block) ||
-      !(key in block)
-    ) {
-      continue;
-    }
-    const { [key]: _dropped, ...rest } = block as Record<string, unknown>;
-    document = { ...document, [blockName]: rest };
-    console.warn(
-      `${source}: ${blockName}.${key} is no longer an installation manifest key — ${why}, so the value in this document is being discarded`,
-    );
-  }
-  return document;
-}
-
 /** Validate a parsed or stored manifest and report every bad field together. */
 export function validateManifest(
   manifest: unknown,
   source: string,
 ): AuthoredManifest {
-  const result = installationManifestSchema.safeParse(
-    withoutDerivedKeys(manifest, source),
-  );
+  const result = installationManifestSchema.safeParse(manifest);
   if (!result.success) {
     const issues = result.error.issues
       .map((issue) => {

--- a/apps/spindrift/test/commands/installation-configure.test.ts
+++ b/apps/spindrift/test/commands/installation-configure.test.ts
@@ -21,10 +21,12 @@ import type {
 import { loadStoredManifest } from '../../src/config/manifest-store.ts';
 import { installation } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { fixtureManifest } from '../harness/installation.ts';
+import { authoredFixture, fixtureManifest } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
-const manifest = await fixtureManifest();
+// The document an operator writes; `resolved` is what a context carries.
+const manifest = await authoredFixture();
+const resolved = await fixtureManifest();
 
 const FROZEN = new Date('2024-06-01T00:00:00.000Z');
 const clock: Clock = { now: () => FROZEN };
@@ -34,7 +36,7 @@ function context(): CommandContext {
     principal: { id: crypto.randomUUID(), displayName: 'Operator' },
     clock,
     db: database().db,
-    manifest,
+    manifest: resolved,
     adapters: {
       deploy: () => null,
       build: () => null,
@@ -63,7 +65,7 @@ describe('configuring an installation', () => {
         ...manifest.build,
         zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
       },
-    } satisfies InstallationManifest;
+    } satisfies AuthoredManifest;
 
     const result = await configureInstallation(
       { manifest: retuned },

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -29,9 +29,10 @@ import type {
   Clock,
   CommandContext,
 } from '../../src/commands/types.ts';
-import type {
-  InstallationManifest,
-  TargetAdapter,
+import {
+  type InstallationManifest,
+  type TargetAdapter,
+  toAuthoredManifest,
 } from '../../src/config/manifest.schema.ts';
 import { MANIFEST_INLINE_VAR } from '../../src/config/manifest.ts';
 import { loadStoredManifest } from '../../src/config/manifest-store.ts';
@@ -467,7 +468,9 @@ describe('reconnect re-adopts via observe', () => {
     } satisfies InstallationManifest;
 
     await loadStoredManifest(database().db, {
-      [MANIFEST_INLINE_VAR]: JSON.stringify(declared),
+      // Declared as an operator writes it: the federation `declared` carries
+      // is the deployment's, and the schema refuses a document restating it.
+      [MANIFEST_INLINE_VAR]: JSON.stringify(toAuthoredManifest(declared)),
     });
     expect((await targetRow('cluster'))?.status).toBe('disconnected');
 

--- a/apps/spindrift/test/config/federation-credential.test.ts
+++ b/apps/spindrift/test/config/federation-credential.test.ts
@@ -112,12 +112,10 @@ describe('the manifest cannot restate it', () => {
     ]);
   });
 
-  test('a document that carries one anyway loses it before it is stored', async () => {
-    // Dropped rather than refused, and that is deliberate: an installation
-    // seeded before the removal has one of these in its durable row, and a
-    // refusal would be a control plane that will not boot until someone edits
-    // Postgres by hand. Stripping on the way in also means no write path can
-    // put it back, which is what makes the removal complete.
+  test('a document that carries one anyway is refused', async () => {
+    // The schema is strict, so a document restating what the deployment owns
+    // fails to parse rather than being quietly corrected. The installer chart
+    // refuses the same two keys at render, which is where an operator meets it.
     const document = Bun.YAML.parse(await Bun.file(FIXTURE).text()) as Record<
       string,
       unknown
@@ -139,12 +137,9 @@ describe('the manifest cannot restate it', () => {
       },
     };
 
-    const authored = parseManifest(
-      JSON.stringify(restated),
-      'a stale document',
-    );
-    expect(authored.cloud).not.toHaveProperty('federation');
-    expect(authored.charts).not.toHaveProperty('installer');
+    expect(() =>
+      parseManifest(JSON.stringify(restated), 'a stale document'),
+    ).toThrow(/federation/);
   });
 
   test('what readers get is the deployment’s copy, joined on at resolve', async () => {

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -415,40 +415,20 @@ describe('the stored installation manifest', () => {
     });
   });
 
-  test('the stored row never holds a fact the deployment declares', async () => {
-    // The keys derived away are dropped on the way in, not merely absent from
-    // the schema — an installation seeded before the removal has them in its
-    // row, and refusing would be a control plane that will not boot.
+  test('a row restating a fact the deployment declares is refused', async () => {
+    // The schema is strict, so the two keys the deployment owns cannot reach a
+    // reader from storage either. The installer chart refuses them at render,
+    // which is where an operator meets this.
     await database().client`
       INSERT INTO installation (manifest)
       VALUES (${JSON.stringify({
         ...fixtureManifest,
-        cloud: {
-          ...fixtureManifest.cloud,
-          federation: {
-            audience: '//iam.stale.test/pools/stale',
-            tokenUrl: 'https://sts.stale.test/v1/token',
-            tokenPath: '/var/run/secrets/stale/token',
-            impersonationUrl: null,
-          },
-        },
         charts: { ...fixtureManifest.charts, installer: 'example/spindrift' },
       })}::jsonb)
     `;
 
-    // The deployment's credential wins outright, because it is the only copy
-    // left: the row's stale audience reaches no reader.
-    const loaded = await loadStoredManifest(
-      database().db,
-      FIXTURE_DEPLOYMENT_ENV,
-    );
-    expect(loaded.cloud.federation?.audience).toBe(
-      '//iam.example.test/projects/1/locations/global/workloadIdentityPools/example/providers/cluster',
-    );
-    expect(loaded.charts).not.toHaveProperty('installer');
-
-    const [row] = await database().db.select().from(installation).limit(1);
-    expect(row?.manifest.cloud).not.toHaveProperty('federation');
-    expect(row?.manifest.charts).not.toHaveProperty('installer');
+    expect(
+      loadStoredManifest(database().db, FIXTURE_DEPLOYMENT_ENV),
+    ).rejects.toThrow(/installer/);
   });
 });

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -17,7 +17,11 @@ import { join } from 'node:path';
 import { VALUES_CONTRACT } from '../../src/adapters/deploy/kubernetes/values.ts';
 import type { ConnectTargetInput } from '../../src/commands/targets/connect.ts';
 import { GCP_CREDENTIALS_VAR } from '../../src/config/federation-credential.ts';
-import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
+import {
+  type AuthoredManifest,
+  type TargetAdapter,
+  toAuthoredManifest,
+} from '../../src/config/manifest.schema.ts';
 import {
   type InstallationManifest,
   parseManifest,
@@ -55,6 +59,17 @@ export async function fixtureManifest(): Promise<InstallationManifest> {
     );
   }
   return cached;
+}
+
+/**
+ * The same installation as an operator authors it.
+ *
+ * {@link fixtureManifest} is resolved — the deployment's federation is joined
+ * onto it — and the schema refuses that document on the way in. A test writing
+ * a manifest wants this one; a test carrying a context wants the resolved one.
+ */
+export async function authoredFixture(): Promise<AuthoredManifest> {
+  return toAuthoredManifest(await fixtureManifest());
 }
 
 /**

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -13,6 +13,7 @@ import {
   type Clock,
   systemClock,
 } from '../../src/commands/types.ts';
+import { toAuthoredManifest } from '../../src/config/manifest.schema.ts';
 import { MANIFEST_INLINE_VAR } from '../../src/config/manifest.ts';
 import {
   apps,
@@ -252,7 +253,7 @@ async function reconcilePendingDeploy(platform: FakeDeployAdapter) {
     // document names the federation, and the boot manifest is the two joined.
     env: {
       ...FIXTURE_DEPLOYMENT_ENV,
-      [MANIFEST_INLINE_VAR]: JSON.stringify(manifest),
+      [MANIFEST_INLINE_VAR]: JSON.stringify(toAuthoredManifest(manifest)),
     },
     createAdapters(storedManifest) {
       bootManifest = storedManifest;

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -39,10 +39,13 @@ import {
 } from '../../src/web/dispatch.ts';
 import { valueAt, withValueAt } from '../../src/web/forms/document.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { fixtureManifest } from '../harness/installation.ts';
+import { authoredFixture, fixtureManifest } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
-const fixture = await fixtureManifest();
+// The document an operator writes. `resolved` is the same installation with
+// the deployment's federation joined on, which is what a context carries.
+const fixture = await authoredFixture();
+const resolved = await fixtureManifest();
 
 const OPERATOR: Principal = {
   id: crypto.randomUUID(),
@@ -58,7 +61,7 @@ async function context(): Promise<CommandContext> {
     principal: OPERATOR,
     clock: { now: () => FROZEN },
     db: database().db,
-    manifest: stored ?? fixture,
+    manifest: stored ?? resolved,
     adapters: {
       deploy: () => null,
       build: () => null,


### PR DESCRIPTION
## Summary

Follow-up to #1527, which left `DERIVED_AWAY` in place because I could not
confirm the live installation's durable manifest row was clean. It is — checked
directly against the offsite database — so the shim goes and the strict schema
becomes the only gate.

## What the shim did

`DERIVED_AWAY` stripped `cloud.federation` and `charts.installer` out of a
manifest on the way in, so a row seeded before those keys were derived away
would still boot. Both entry paths are closed without it:

- The installer chart `fail`s at render on either key — 1:1 with the two entries.
- The row is rewritten from that chart-validated declaration on every start.

So a document restating what the deployment owns is now a parse error, not a
warning plus a silent correction.

## Changes

- Delete `DERIVED_AWAY` and `withoutDerivedKeys`; `validateManifest` parses the
  document as given.
- Tests that seeded a *resolved* manifest as if it were authored were relying on
  the stripping. They now convert explicitly: `authoredFixture()` in the harness
  for the fixture itself, `toAuthoredManifest` where a test builds its own
  document.
- The two tests that pinned the stripping now pin the refusal.

## Test Plan

- [x] `bun test` in `apps/spindrift` against a real Postgres — **1169 pass, 0
      fail** (the DB-backed suites #1527 could not run; baseline on `main` is
      also 0 fail, so nothing here is pre-existing breakage)
- [x] `bun test` in `packages/charts/spindrift` — 22/22
- [x] `bun run lint` and `bun run typecheck` at the workspace root
- [x] Verified against the live offsite row: `cloud` holds only
      `artifactsProject`/`homeVesselProject`, `charts` only `app`

## Risk

The schema is `.strict()`, so with the shim gone a row carrying either key is a
boot failure rather than a warning. That row is confirmed clean and cannot be
reseeded with those keys while the chart refuses them, but it is the reason this
is a separate PR from #1527.
