### PR TITLE
fix(spindrift): let the telemetry wrapper carry a WebSocket upgrade

### DIFF
--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -50,11 +50,23 @@ import {
   tracer,
 } from '../telemetry/index.ts';
 
-function instrumentRoutes<T extends Record<string, any>>(routes: T): T {
+/**
+ * Wrap every handler in a span and the two HTTP metrics.
+ *
+ * Two things it must not change about a handler, both of which the WebSocket
+ * upgrades depend on: `Bun.serve` calls a route with `(request, server)` and the
+ * upgrade handlers need that second argument, and a handler that upgraded
+ * returns `undefined` rather than a `Response` because Bun has taken the socket.
+ * Dropping either turns every stream into a 500.
+ */
+export function instrumentRoutes<T extends Record<string, any>>(routes: T): T {
   const instrumented: Record<string, any> = {};
   for (const [path, handler] of Object.entries(routes)) {
     if (typeof handler === 'function') {
-      instrumented[path] = async (req: Request) => {
+      instrumented[path] = async (
+        req: Request,
+        server: Bun.Server<StreamSocketData>,
+      ) => {
         const startTime = Date.now();
         return tracer.startActiveSpan(
           `HTTP ${req.method} ${path}`,
@@ -64,10 +76,16 @@ function instrumentRoutes<T extends Record<string, any>>(routes: T): T {
 
             try {
               const res = await (
-                handler as (r: Request) => Promise<Response> | Response
-              )(req);
+                handler as (
+                  r: Request,
+                  s: Bun.Server<StreamSocketData>,
+                ) => Promise<Response | undefined> | Response | undefined
+              )(req, server);
               const durationSec = (Date.now() - startTime) / 1000;
-              const status = res.status ?? 200;
+              // An upgraded WebSocket has no Response to report on. 101 is what
+              // it is, and it keeps the metric honest rather than counting a
+              // successful upgrade as a 200 that never went out.
+              const status = res?.status ?? 101;
 
               httpRequestCounter.add(1, { path, status: String(status) });
               httpRequestDuration.record(durationSec, {

--- a/apps/spindrift/test/web/instrumented-upgrade.test.ts
+++ b/apps/spindrift/test/web/instrumented-upgrade.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The telemetry wrapper must stay transparent to a WebSocket upgrade.
+ *
+ * It sits between `Bun.serve` and every route, including the two stream
+ * upgrades in `src/web/streams.ts`. Those need the `server` argument Bun passes
+ * second, and they return `undefined` once Bun owns the socket. A wrapper that
+ * forwards only the request, or that reads `.status` off the result, answers 500
+ * to every stream — which is a build log page that never updates.
+ */
+import { expect, test } from 'bun:test';
+import { instrumentRoutes } from '../../src/web/serve.ts';
+
+test('an instrumented route can still upgrade a WebSocket', async () => {
+  const routes = instrumentRoutes({
+    '/ws': (request: Request, server: Bun.Server<undefined>) =>
+      server.upgrade(request, { data: undefined })
+        ? undefined
+        : new Response('no upgrade', { status: 400 }),
+  });
+
+  const server = Bun.serve<undefined>({
+    port: 0,
+    routes,
+    websocket: {
+      open: (socket) => {
+        socket.send('open');
+      },
+      message: () => {},
+    },
+  });
+
+  try {
+    const socket = new WebSocket(`ws://localhost:${server.port}/ws`);
+    const first = await new Promise<string>((resolve) => {
+      const timer = setTimeout(() => resolve('timeout'), 5_000);
+      socket.onmessage = (event) => {
+        clearTimeout(timer);
+        resolve(String(event.data));
+      };
+      socket.onclose = () => {
+        clearTimeout(timer);
+        resolve('closed');
+      };
+    });
+    socket.close();
+    expect(first).toBe('open');
+  } finally {
+    server.stop(true);
+  }
+});


### PR DESCRIPTION
## Symptom

Two, which turned out to be one bug:

- Landing on a build page and watching it sit there — no log updates, ever.
- The "deploy seam" appearing dead after a build completed.

## Root cause

`instrumentRoutes` (`src/web/serve.ts`, added with the OpenTelemetry work in 736f16f6) wraps every route handler. It broke both WebSocket upgrades in two ways at once:

1. It forwarded only `req`. `Bun.serve` calls a route with `(request, server)`, and `upgradeAttempt`/`upgradeRuntime` need that second argument.
2. It read `res.status` unconditionally. A handler that upgraded returns `undefined`, because Bun has taken the socket.

Every stream connection answered 500. From the running `spindrift-web` pod on offsite:

```
src/web/streams.ts:153
  const upgraded = server.upgrade(request, {
                   ^
TypeError: undefined is not an object (evaluating 'server.upgrade')
```

`stream-client.ts` reconnects on close, so the browser retried into that 500 every 500ms indefinitely.

The deploy half falls out of the same failure. `BuildScreen` re-reads `getBuildDetail` **only** on a stream message. With no message ever arriving, a Build that reached `SUCCEEDED` never refreshed the screen, so the `Deploy this build` button (`deploy-detail.tsx:249`, gated on `view.id === null && build.status !== 'failed'`) was never rendered. Nothing was wrong below the seam — the reconciler's deploy loop was idling at its 5-minute converged cadence because no `PENDING` deploy row had ever been written.

## Fix

Forward `server`, and treat a missing `Response` as the 101 it is rather than counting a successful upgrade as a 200 that never went out.

## Test

`test/web/instrumented-upgrade.test.ts` opens a real socket through the wrapper. It fails on the previous code with the same `server.upgrade` TypeError.

## Verification

- `bun test` — 1170 pass, 0 fail
- `bun run typecheck` — clean
- `biome check` — clean

## Not in scope

The GitHub Actions route is `LIVE_STATUS` fidelity: during a run it yields step transitions (the checklist ticks live), and the log *text* arrives only once the run concludes. That is the adapter's stated design, not part of this bug. Live mid-run text would be a change to `adapters/build/github-actions.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)