### PR TITLE
docs(spindrift): a declaration seeds, it does not govern

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -68,9 +68,14 @@ spec:
         limits:
           memory: 768Mi
           cpu: 1000m
-    # The installation manifest, declared rather than seeded: the durable row is
-    # written from this document at process start, which is what puts a manifest
-    # change under ordinary review.
+    # The installation manifest. **A declaration seeds; it does not govern.**
+    # The durable row wins whenever one exists, so editing this document does
+    # nothing to an installation that already has one — the process says so at
+    # startup rather than skipping it quietly. Configuration is driven through
+    # the UI; re-seeding from here means discarding the row first.
+    #
+    # What this document is for is bringing a torn-down installation back
+    # configured without anyone opening a browser.
     #
     # Both zones are substituted by the apps Kustomization — `SPINDRIFT_DOMAIN`
     # from cluster-settings, `SECRET_DOMAIN` from cluster-secrets — so the zone

--- a/packages/charts/spindrift/templates/manifest.yaml
+++ b/packages/charts/spindrift/templates/manifest.yaml
@@ -1,7 +1,9 @@
 {{/*
-The installation manifest, declared by the release. `loadStoredManifest` writes
-this document to the durable row at process start, so a manifest change is a
-pull request. Empty declares nothing and the process reads the row back.
+The installation manifest, declared by the release.
+
+**A declaration seeds; it does not govern.** `loadStoredManifest` takes the
+stored row whenever one exists and this document only when none does, so
+editing it does nothing to a seeded installation. Empty declares nothing.
 
 **A declaration may not restate what this chart already renders.** The refusals
 below reject a manifest carrying a fact this chart owns, at render time — the

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -2,9 +2,10 @@
 
 image: ""
 
-# The installation manifest document, mounted as a ConfigMap and reconciled into
-# the durable database at process start. Empty leaves the durable row in charge.
-# Declaring it is the only hand that can correct a manifest value.
+# The installation manifest document, mounted as a ConfigMap. It seeds an
+# installation that has no durable row yet and is ignored once one exists, so
+# it brings a torn-down installation back configured rather than driving a
+# running one. Correcting a value on a seeded installation is the UI's job.
 manifest: {}
 
 # One named identity for the control plane. Both processes receive projected,


### PR DESCRIPTION
## Summary

Corrects an error I introduced in #1527. Three comments there were compressed
into the claim that the durable manifest row is written from the release's
declaration at process start. It is not.

`loadStoredManifest` is `stored ?? declaration ?? DEFAULT_PLACEHOLDER_MANIFEST` —
**a declaration seeds; it does not govern.** The stored row wins whenever one
exists, and the process logs a warning at startup saying the mounted declaration
is being ignored. Discarding the row is the only way to re-seed from it.

This matters operationally: the old wording invites someone to edit
`manifest:` in the HelmRelease, merge it, and get no effect. What a declaration
is for is bringing a torn-down installation back configured without anyone
opening a browser; correcting a value on a live installation is the UI's job
(`configureInstallation`).

I hit the warning in the process's own log while running a command against the
live installation, which is what surfaced it.

## Changes

- `clusters/offsite/apps/spindrift/helm-release.yaml`
- `packages/charts/spindrift/templates/manifest.yaml`
- `packages/charts/spindrift/values.yaml`

Comments only — no template, value, or code change.

## Note on #1540

#1540's body carried the same wrong claim as part of its risk argument. Its
conclusion still holds, but for a narrower reason than stated: removing
`DERIVED_AWAY` is safe because the offsite row is verified clean **and** no
write path can dirty it (the strict schema now refuses those keys on both the
seed and `configureInstallation` paths) — not because the row self-heals from
the declaration. It does not self-heal; a bad row would have to be discarded.

## Test Plan

- [x] `bun test` in `packages/charts/spindrift` — 22/22
- [x] `mise run k8s:render-apps` — offsite spindrift release templates
- [x] Behaviour verified against the running process: `loadStoredManifest` in
      `src/config/manifest-store.ts` takes `stored` first, and the live pod logs
      the ignored-declaration warning on every start
