### PR TITLE
fix(spindrift): emit a real SLSA statement from the hosted build route

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -211,6 +211,23 @@ jobs:
       # The one line Spindrift reads. Base64 because this stdout goes through
       # the host's log processing on the way back, and a folded or decorated
       # payload is a payload core cannot decode.
+      #
+      # **`statement` is a SLSA v1 provenance document, not a note.** Core does
+      # not treat it as opaque: `supply-chain/verify.ts` hands it to
+      # `spindrift-verifier`, which reads `predicate.runDetails.builder.id`
+      # against the route's `provenanceBuilderId` and `subject[0].digest.sha256`
+      # against the admitted artifact — and core then reads
+      # `predicate.buildDefinition.externalParameters.bundleDigest` back out of
+      # the verified envelope for §16's join. A statement missing any of those
+      # is refused *after* the image is pushed, which reads as a green run whose
+      # Build failed with nothing to deploy.
+      #
+      # It is still the runner's own account of itself, exactly as `route.ts`
+      # says — the builder id here is asserted, not attested. Shaping it
+      # correctly does not make it evidence; it makes it checkable. The builder
+      # id is spelled out because it must equal `GitHubActionsBuildRoute`'s
+      # constant, and `test/adapters/build-report-statement.test.ts` runs this
+      # jq to assert the two still agree.
       - name: Report what was built
         env:
           BUNDLE_DIGEST: ${{ steps.request.outputs.bundleDigest }}
@@ -229,6 +246,7 @@ jobs:
           report="$(jq -nc \
             --arg bundleDigest "$BUNDLE_DIGEST" \
             --arg digest "$DIGEST" \
+            --arg destination "$DESTINATION" \
             --arg ref "${DESTINATION}@${DIGEST}" \
             --arg base "$base" \
             --arg run "${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
@@ -239,5 +257,25 @@ jobs:
               baseDigest: (if $base == "" then null else $base end),
               buildkitProvenanceRef: $ref,
               sbomRef: $ref,
-              statement: {run: $run, workflow: $workflow}}')"
+              statement: {
+                _type: "https://in-toto.io/Statement/v1",
+                subject: [{
+                  name: $destination,
+                  digest: {sha256: ($digest | ltrimstr("sha256:"))}
+                }],
+                predicateType: "https://slsa.dev/provenance/v1",
+                predicate: {
+                  buildDefinition: {
+                    buildType: "https://spindrift.dev/buildtypes/github-actions/v1",
+                    externalParameters: {
+                      bundleDigest: $bundleDigest,
+                      workflow: $workflow
+                    }
+                  },
+                  runDetails: {
+                    builder: {id: "https://github.com/actions/runner/github-hosted"},
+                    metadata: {invocationId: $run}
+                  }
+                }
+              }}')"
           echo "spindrift-result $(printf '%s' "$report" | base64 | tr -d '\n')"

--- a/apps/spindrift/test/adapters/build-report-statement.test.ts
+++ b/apps/spindrift/test/adapters/build-report-statement.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The hosted route's report step, run as the file actually ships it.
+ *
+ * Every other test in this tree stands a fake in front of the runner, and the
+ * fake (`test/harness/fakes/build-adapter.ts`) composes a well-formed SLSA
+ * statement — so a workflow emitting `{run, workflow}` instead passed the whole
+ * suite and refused every real build at admission, after the image was pushed.
+ * A fixture cannot catch that. Running the step's own `run:` script can.
+ *
+ * `docker buildx imagetools inspect` is not on the box here; the step guards
+ * that lookup with `|| true` and reports `baseDigest: null`, which is the same
+ * answer §16 wants from a builder that cannot read its own base.
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { GitHubActionsBuildRoute } from '../../src/adapters/build/github-actions.ts';
+import { parseBuildReport } from '../../src/adapters/build/report.ts';
+
+const WORKFLOW = join(
+  import.meta.dir,
+  '../../../../.github/workflows/spindrift-build.yml',
+);
+const REPORT_STEP = 'Report what was built';
+
+const BUNDLE_DIGEST = `sha256:${'b'.repeat(64)}`;
+const IMAGE_DIGEST = `sha256:${'a'.repeat(64)}`;
+const DESTINATION = 'ghcr.io/jonpulsifer/spindrift/demo/web';
+
+/** The `run:` script of the named step, straight out of the shipped file. */
+async function reportScript(): Promise<string> {
+  const document = Bun.YAML.parse(await Bun.file(WORKFLOW).text()) as {
+    jobs: { build: { steps: { name?: string; run?: string }[] } };
+  };
+  const step = document.jobs.build.steps.find((s) => s.name === REPORT_STEP);
+  if (step?.run === undefined) {
+    throw new Error(`${WORKFLOW} has no “${REPORT_STEP}” step with a script`);
+  }
+  return step.run;
+}
+
+/** Run that script the way a runner does, and read what it printed. */
+async function runReportStep() {
+  const directory = await mkdtemp(join(tmpdir(), 'spindrift-report-'));
+  try {
+    const script = join(directory, 'report.sh');
+    await writeFile(script, await reportScript());
+    const child = Bun.spawn(['sh', script], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        PATH: Bun.env.PATH ?? '',
+        BUNDLE_DIGEST,
+        DESTINATION,
+        DIGEST: IMAGE_DIGEST,
+        GITHUB_REPOSITORY: 'jonpulsifer/infra',
+        GITHUB_RUN_ID: '12345',
+        GITHUB_WORKFLOW_REF:
+          'jonpulsifer/infra/.github/workflows/spindrift-build.yml@refs/heads/main',
+      },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    return { stdout, stderr, exitCode };
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}
+
+describe('the hosted route reports a statement admission can read', () => {
+  test('the step prints a report core can parse', async () => {
+    // Only the exit code is asserted: the base-digest probe is `|| true` and
+    // whatever it writes to stderr on a box with no registry is noise the step
+    // is designed to survive.
+    const { stdout, exitCode } = await runReportStep();
+    expect(exitCode).toBe(0);
+
+    const report = parseBuildReport(stdout);
+    expect(report).not.toBeNull();
+    expect(report?.bundleDigest).toBe(BUNDLE_DIGEST);
+    expect(report?.digest).toBe(IMAGE_DIGEST);
+    expect(report?.refs).toEqual([`${DESTINATION}@${IMAGE_DIGEST}`]);
+    expect(report?.baseDigest).toBeNull();
+  });
+
+  /**
+   * The three facts admission reads, and the one that was missing: without
+   * `externalParameters.bundleDigest` the verified envelope carries no join to
+   * the source receipt and `verify.ts` refuses with "does not bind the source
+   * bundle digest" — on a build whose blobs are already in the registry.
+   */
+  test('the statement binds the bundle, the artifact, and the builder', async () => {
+    const { stdout } = await runReportStep();
+    const statement = parseBuildReport(stdout)?.statement as {
+      subject: { digest: { sha256: string } }[];
+      predicateType: string;
+      predicate: {
+        buildDefinition: { externalParameters: { bundleDigest: string } };
+        runDetails: { builder: { id: string } };
+      };
+    };
+
+    expect(
+      statement.predicate.buildDefinition.externalParameters.bundleDigest,
+    ).toBe(BUNDLE_DIGEST);
+    // Bare hex, which is what in-toto says and what the verifier re-prefixes
+    // before comparing it to the digest it pulled off the immutable reference.
+    expect(statement.subject[0]?.digest.sha256).toBe(
+      IMAGE_DIGEST.replace('sha256:', ''),
+    );
+    expect(statement.predicateType).toBe('https://slsa.dev/provenance/v1');
+
+    // The expectation is the route profile's, passed to the verifier as
+    // `--builder-id`; a workflow naming anything else is refused as a builder
+    // mismatch. These two constants live in different languages and must agree.
+    const route = new GitHubActionsBuildRoute({
+      name: 'hosted',
+      host: {} as never,
+      buildWorkflow:
+        'jonpulsifer/infra/.github/workflows/spindrift-build.yml@abc',
+      zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
+    });
+    expect(statement.predicate.runDetails.builder.id).toBe(
+      route.provenanceBuilderId,
+    );
+  });
+});

--- a/apps/spindrift/test/adapters/build-report-statement.test.ts
+++ b/apps/spindrift/test/adapters/build-report-statement.test.ts
@@ -46,7 +46,13 @@ async function runReportStep() {
   try {
     const script = join(directory, 'report.sh');
     await writeFile(script, await reportScript());
-    const child = Bun.spawn(['sh', script], {
+    // `bash`, not `sh`: a GitHub Actions `run:` block runs under
+    // `bash --noprofile --norc -e -o pipefail` on a Linux runner, and this step
+    // opens with `set -euo pipefail`. Under a POSIX `sh` — dash on the runner
+    // this test itself runs on — `set -o pipefail` is not a legal option, `-e`
+    // takes the failure, and the step exits before printing anything. Testing
+    // it under the wrong shell is testing a script production never executes.
+    const child = Bun.spawn(['bash', script], {
       stdout: 'pipe',
       stderr: 'pipe',
       env: {


### PR DESCRIPTION
## The failure

```
supply-chain admission failed: hosted verified provenance does not bind the source bundle digest
```

…on builds whose blobs demonstrably reached the registry, followed by deploys that say the App has no artifact.

## Root cause

`.github/workflows/spindrift-build.yml`'s *Report what was built* step emitted:

```json
"statement": {"run": "...", "workflow": "..."}
```

Core does **not** treat that field as opaque. `SlsaVerifier.verify` (`apps/spindrift/src/supply-chain/verify.ts:196`) reads `predicate.buildDefinition.externalParameters.bundleDigest` back out of the verified envelope for §16's join between the source receipt and the provenance document. The placeholder has no `predicate` at all, so `bundleDigestOf` returns `null` and admission refuses at `verify.ts:203`.

The Go verifier waves it through on the way in — `verify-image` never sets `Expectations.BundleDigest`, and `extractBuilderID`/`extractSubjectDigest` both return `""` on a statement with no predicate, so every check that would have caught it is skipped. It exits 0, prints the placeholder back, and the TS side is the one that refuses.

`dispatch.ts:832-853` then marks the Build `FAILED` with `artifactDigest: null` — **after** `docker/build-push-action` has pushed. Hence the shape of the report: green run, blobs uploaded, failed build, and `deploys/create.ts:317` saying there is no artifact to place.

## Fix

The step emits an in-toto / SLSA v1 statement carrying the three facts admission actually reads:

| Field | Read by |
| --- | --- |
| `predicate.buildDefinition.externalParameters.bundleDigest` | `verify.ts:267` (the refusal above) and `verify.go:241` |
| `subject[0].digest.sha256` | `verify.go:153` — must equal the admitted artifact |
| `predicate.runDetails.builder.id` | `verify.go:76` — must equal `GitHubActionsBuildRoute.provenanceBuilderId` |

It remains the runner's own account of itself, exactly as `route.ts` documents. Shaping it correctly makes it *checkable*; it does not make it attested.

## Why no test caught this

Every test in the tree stands `test/harness/fakes/build-adapter.ts` in front of the runner, and that fake composes a well-formed statement (`build-adapter.ts:180-184`). The suite passed green against a workflow that refused every real build.

`test/adapters/build-report-statement.test.ts` closes that: it reads the step's own `run:` script out of the shipped YAML, executes it, parses the marker line with the real `parseBuildReport`, and asserts the builder id against a constructed `GitHubActionsBuildRoute`. Red on the old workflow, green on the new.

## Follow-ups, deliberately not in this PR

- **The `buildWorkflow` pin.** This repo's own caller uses `uses: ./…`, so archive and in-repo builds pick the fix up on merge. Connected repositories pin `manifest.github.buildWorkflow` by SHA (`clusters/offsite/apps/spindrift/helm-release.yaml:112`, `src/config/manifest.ts:118`), and that SHA does not exist until this merges. Needs a follow-up bump.
- **`slsaVersionOf` cannot parse a correct predicateType.** `/slsa[^/]*\/v(\d+)/` does not match `https://slsa.dev/provenance/v1`, so this records `slsaVersion: "unknown"` (TS) / `"1.2"` (Go). Cosmetic — nothing gates on it — but wrong in both languages.
- **The other two routes report no statement at all.** `buildKitProgram` (`adapters/build/buildkit.ts:208`) omits the field entirely, so `cloud-build` and `in-cluster` would fail `PROVENANCE_MISSING`. Neither is configured on any cluster today, and composing JSON in that container means no `jq`.

## Verification

- `bun test test/adapters test/supply-chain` — 243 pass
- `bun run typecheck` clean; `bun run lint` shows one pre-existing warning in `test/config/`
- New test confirmed red against the previous workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)