### PR TITLE
feat(spindrift): build without a merged setup PR

### DIFF
--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -223,12 +223,30 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     const logs = { backend: this.name, fidelity: this.logFidelity } as const;
     const { host } = this.options;
 
-    // A repo App builds where its source lives, on its own minutes (§15); an
-    // archive has no repository, so it builds where the workflow does.
-    const repository =
-      source.origin.type === 'repo'
-        ? source.origin.repository
-        : this.platformRepository;
+    // Where the run happens, in preference order.
+    //
+    // §15 puts a repo App's build on its own repository's minutes, and an
+    // archive has no repository at all so it runs where the reusable workflow
+    // lives. The second entry is the same place for a third reason: a connected
+    // repository that does not carry the caller yet.
+    //
+    // **The fallback is sound because the runner never reads the source
+    // repository.** §15 stages one immutable bundle and the workflow fetches it
+    // by URL — `Fetch the staged bundle` is a `curl`, not a checkout — so the
+    // build is byte-identical wherever it runs. What differs is only whose
+    // Actions minutes pay for it, which is a billing preference and not a
+    // correctness one.
+    //
+    // Without this, connecting a repository and creating an App on it were one
+    // act: the configuration PR had to be merged before the first Build could
+    // be dispatched, so the operator had to name every scope up front and wait
+    // on a merge to find out whether the thing built at all. Connecting grants
+    // access; Apps are created on it afterwards, and the first one builds.
+    const candidates =
+      source.origin.type === 'repo' &&
+      source.origin.repository !== this.platformRepository
+        ? [source.origin.repository, this.platformRepository]
+        : [this.platformRepository];
     // Always a caller, never the reusable workflow itself — a dispatch names a
     // branch, so dispatching the reusable workflow directly would discard the
     // commit §15 pins. The connected repository runs the caller the
@@ -253,28 +271,45 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       zeroConfigFrontend: this.options.zeroConfigFrontend,
     };
 
-    let ref: RepositoryRef;
-    let branch: string;
-    try {
-      ref = await host.installationFor(repository);
-      branch = (await host.repository(ref, repository)).defaultBranch;
-      await host.dispatchWorkflow(ref, repository, {
-        workflow,
-        branch,
-        inputs: { spec: JSON.stringify(request), correlation },
-      });
-    } catch (error) {
-      // §4 story 48: a failure *before* the build step — dispatch refused, the
-      // runner never came up — must be visible as text rather than as an empty
-      // log and a spinner. So it is yielded onto the attempt log first and
-      // becomes the verdict second.
-      const detail = error instanceof Error ? error.message : String(error);
-      yield { type: 'log', at: now(), line: `dispatch failed: ${detail}` };
+    let repository: string | null = null;
+    let ref: RepositoryRef | null = null;
+    let branch = '';
+    let detail = '';
+    for (const candidate of candidates) {
+      try {
+        const candidateRef = await host.installationFor(candidate);
+        const candidateBranch = (await host.repository(candidateRef, candidate))
+          .defaultBranch;
+        await host.dispatchWorkflow(candidateRef, candidate, {
+          workflow,
+          branch: candidateBranch,
+          inputs: { spec: JSON.stringify(request), correlation },
+        });
+        repository = candidate;
+        ref = candidateRef;
+        branch = candidateBranch;
+        break;
+      } catch (error) {
+        // §4 story 48: a failure *before* the build step — dispatch refused,
+        // the runner never came up — must be visible as text rather than as an
+        // empty log and a spinner. Every attempt is yielded, including the one
+        // that is about to be retried elsewhere, because "we tried your
+        // repository and it has no caller" is the sentence that explains why
+        // the run appears somewhere the operator did not expect.
+        detail = error instanceof Error ? error.message : String(error);
+        yield {
+          type: 'log',
+          at: now(),
+          line: `could not dispatch ${workflow} in ${candidate}: ${detail}`,
+        };
+      }
+    }
+    if (ref === null || repository === null) {
       return buildFailed(
         logs,
         'TARGET_UNREACHABLE',
-        `could not dispatch ${workflow} in ${repository}: ${detail}`,
-        { repository, workflow },
+        `could not dispatch ${workflow} in ${candidates.join(' or ')}: ${detail}`,
+        { repositories: candidates, workflow },
       );
     }
 

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -181,6 +181,27 @@ describe('the hosted build route', () => {
     expect(host.dispatches[0]?.branch).toBe('main');
   });
 
+  test('a repo with no caller falls back to where the workflow lives', async () => {
+    // Connecting a repository grants access; it does not have to also merge a
+    // configuration PR before the first App on it can build. The runner fetches
+    // the staged bundle by URL and never checks the source repository out, so
+    // the build is the same build wherever it runs — only whose minutes pay
+    // for it differs. Without the fallback this is `TARGET_UNREACHABLE` and
+    // the operator is sent to merge a PR to find out whether the thing builds.
+    const { host, route } = hostedRoute({ fullName: PLATFORM_REPO });
+    const { events, result } = await run(
+      route.build(repoSource('someone/never-connected'), spec),
+    );
+
+    expect(result.status).toBe('SUCCEEDED');
+    expect(host.dispatches).toHaveLength(1);
+    expect(host.dispatches[0]?.workflow).toBe('spindrift.yml');
+    // The refused attempt is on the log rather than swallowed: it is what
+    // explains why the run appears somewhere other than the App's own
+    // repository.
+    expect(text(events)).toContain('someone/never-connected');
+  });
+
   test('an archive builds where the workflow lives, having no repository', async () => {
     const { host, route } = hostedRoute();
     const { result } = await run(route.build(archiveSource(), spec));
@@ -227,7 +248,10 @@ describe('the hosted build route', () => {
     if (result.status === 'FAILED') {
       expect(result.reason).toBe('TARGET_UNREACHABLE');
     }
-    expect(text(events)).toContain('dispatch failed');
+    // The sentence names the repository the dispatch was refused in, because
+    // the route now has more than one place it may try.
+    expect(text(events)).toContain('could not dispatch');
+    expect(text(events)).toContain('example/platform');
     expect(text(events).length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
## The gate

Connecting a repository and creating an App on it were one act. The hosted route dispatched `spindrift.yml` into the App's own repository and nowhere else:

```ts
const repository = source.origin.type === 'repo'
  ? source.origin.repository
  : this.platformRepository;
```

A connected repository that does not carry that caller answers `404`, and the Build closes `TARGET_UNREACHABLE`. Live today — `jonpulsifer/wishlist` is `connected`, has `ci.yml` and nothing else, and no App on it can build until a configuration PR is merged there. So the operator has to name every scope up front, open a PR, and wait on a merge to find out whether the thing builds at all.

## The fix

Try the App's own repository first, fall back to the platform repository — where the reusable workflow lives, and where an uploaded archive already builds.

**Sound because the runner never reads the source repository.** §15 stages one immutable bundle and the workflow's *Fetch the staged bundle* step is a `curl` against a signed URL, not a checkout. The build is byte-identical wherever it runs. What differs is only whose Actions minutes pay for it — a billing preference, not a correctness one — and §15's preference is preserved by trying the connected repository first.

The refused attempt stays on the attempt log rather than being swallowed. It is the sentence that explains why the run appeared somewhere other than the App's own repository.

## Tests

- `a repo with no caller falls back to where the workflow lives` — new; red without the change (`TARGET_UNREACHABLE`).
- `a dispatch that is refused is a failure with the reason in the log` — updated: the sentence now names the repository, because the route has more than one place it may try.
- `bun test` — 1171 pass, 0 fail. `bun run typecheck` clean. `bun run lint` shows the one pre-existing warning in `test/config/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg