### PR TITLE
fix(spindrift): name the identity a Cloud Run revision runs as

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -191,6 +191,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     const document = cloudRunService(desired, {
       project: connection.project,
       image,
+      serviceAccount: connection.serviceAccount ?? null,
     });
     const applied = await http.json<unknown>({
       method: 'PATCH',

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -44,6 +44,18 @@ export interface CloudRunRenderContext {
   readonly project: string;
   /** The image the revision pulls, pinned by digest where the artifact has one. */
   readonly image: string;
+  /**
+   * The identity the revision runs as (§14), or `null` to let the runtime pick.
+   *
+   * Letting it pick is what the absent case *means*, and it is worth naming
+   * because it does not fail where it is chosen: the runtime substitutes the
+   * project's default compute account, and the apply is then refused for
+   * missing `iam.serviceAccounts.actAs` on an account nobody named. So this is
+   * rendered when the Target supplies one and omitted when it does not, rather
+   * than defaulted here — an adapter that invented an identity would be
+   * choosing what the workload may reach.
+   */
+  readonly serviceAccount: string | null;
 }
 
 /**
@@ -95,6 +107,9 @@ export function cloudRunService(
     ingress: ingressFor(desired.exposure),
     template: {
       labels: { ...labels, 'spindrift-deploy': desired.deploy },
+      ...(context.serviceAccount === null
+        ? {}
+        : { serviceAccount: context.serviceAccount }),
       containers: [
         {
           image: context.image,

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -215,6 +215,8 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
           region: nonEmptyString,
           endpoint: z.url(),
           policyEndpoint: z.url().optional(),
+          /** The identity a revision runs as. See `CloudRunConnection`. */
+          serviceAccount: nonEmptyString.optional(),
           servedHosts: z.array(nonEmptyString).optional(),
           reachableRegistries: z.array(nonEmptyString).optional(),
           logHistorySeconds: z.number().int().nonnegative().optional(),

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -81,6 +81,23 @@ export interface CloudRunConnection {
    * claim about verification has to fail in.
    */
   policyEndpoint?: string;
+  /**
+   * The identity a revision runs as (§13, §14).
+   *
+   * Connection material rather than a manifest-wide value, for the same reason
+   * `project` is: it is a fact about this Target's project, and two connected
+   * projects have different ones.
+   *
+   * **Absent is a footgun rather than a default**, and the reason it is still
+   * optional is that only the runtime can supply the alternative. Omit it and
+   * Cloud Run runs the revision as the project's default compute account —
+   * which the controller has no `iam.serviceAccounts.actAs` on, because nobody
+   * granted it any, so the apply is refused with an IAM sentence naming an
+   * account the operator never chose. Naming the account here is what turns
+   * that into a deliberate choice; `bluenose` already has a `spindrift-runtime`
+   * account and the `actAs` grant for exactly this.
+   */
+  serviceAccount?: string;
   /** §33's static reachability input, stated by the operator (§3). */
   servedHosts?: readonly string[];
   reachableRegistries?: readonly string[];

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -539,6 +539,7 @@ describe('§10: config crosses as a pinned reference and never as a value', () =
       {
         project: 'example-vessel',
         image: 'registry.example.test/shop@sha256:abc',
+        serviceAccount: null,
       },
     );
     const template = document.template as {
@@ -557,6 +558,34 @@ describe('§10: config crosses as a pinned reference and never as a value', () =
   });
 });
 
+describe('the identity a revision runs as', () => {
+  test('is the Target’s, on the revision template', () => {
+    const document = cloudRunService(desired({}), {
+      project: 'example-vessel',
+      image: 'registry.example.test/shop@sha256:abc',
+      serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
+    });
+    const template = document.template as { serviceAccount?: string };
+    expect(template.serviceAccount).toBe(
+      'runtime@example-vessel.iam.gserviceaccount.com',
+    );
+  });
+
+  test('is absent rather than invented where the Target names none', () => {
+    // Not a default composed here: an adapter that picked an identity would be
+    // choosing what the workload may reach. The runtime substitutes the
+    // project's default compute account, and refuses the apply for missing
+    // `iam.serviceAccounts.actAs` on an account nobody named — which is the
+    // failure this field exists to turn into a deliberate choice.
+    const document = cloudRunService(desired({}), {
+      project: 'example-vessel',
+      image: 'registry.example.test/shop@sha256:abc',
+      serviceAccount: null,
+    });
+    expect(document.template as object).not.toHaveProperty('serviceAccount');
+  });
+});
+
 describe('the exposure a Target rejects is a state, not a crash', () => {
   test('every exposure state produces a document', () => {
     const states: Exposure[] = ['internal', 'private', 'public'];
@@ -564,6 +593,7 @@ describe('the exposure a Target rejects is a state, not a crash', () => {
       const document = cloudRunService(desired({ exposure }), {
         project: 'example-vessel',
         image: 'registry.example.test/shop@sha256:abc',
+        serviceAccount: null,
       });
       expect(document.ingress).toBe(ingressFor(exposure));
     }

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -133,6 +133,13 @@ spec:
             region: northamerica-northeast1
             project: bluenose
             endpoint: https://run.googleapis.com
+            # The identity a revision runs as. Named because omitting it is not
+            # a default: Cloud Run substitutes the project's default compute
+            # account, which the controller has no `actAs` on, and the apply is
+            # refused naming an account nobody chose. `spindrift-runtime` and
+            # the controller's `actAs` on it are declared in
+            # terraform/gcp/projects/bluenose/iam.tf for exactly this.
+            serviceAccount: spindrift-runtime@bluenose.iam.gserviceaccount.com
         - name: bluenose-static
           adapter: static
           connection:


### PR DESCRIPTION
## The failure

The first Deploy ever placed on the Cloud Run Target (deploy 6, offsite, build 25):

```
TARGET_UNREACHABLE | Permission 'iam.serviceAccounts.actAs' denied on service
account 558198215187-compute@developer.gserviceaccount.com (or it may not exist).
```

Nobody chose that account. `cloudRunService` (`adapters/deploy/cloudrun/service.ts:96`) renders no `serviceAccount` on the revision template, so the runtime substitutes the project's default compute account — and the controller has no `actAs` on it, because nobody granted it any.

## The fix

`bluenose` already declares the right account and the right grant:

```hcl
# terraform/gcp/projects/bluenose/iam.tf
resource "google_service_account" "spindrift_runtime" { account_id = "spindrift-runtime" }

resource "google_service_account_iam_member" "spindrift_act_as_runtime" {
  service_account_id = google_service_account.spindrift_runtime.name
  role               = "roles/iam.serviceAccountUser"
  member             = google_service_account.spindrift_controller.member
}
```

Nothing was naming it. `serviceAccount` becomes Cloud Run connection material beside `project`, for the same reason `project` is: it is a fact about this Target's project, and two connected projects have different ones. No terraform change is needed.

**Rendered when supplied, omitted when not — never defaulted here.** An adapter that invented an identity would be choosing what the workload may reach. The absent case is documented as the footgun it is rather than as a default.

## Sequencing

The offsite declaration now names `spindrift-runtime@bluenose`. The stored manifest wins over the declaration once an installation is seeded, so it gets updated through `configureInstallation` **after** this image rolls out — the schema is `.strict()` and the running controller would refuse a key it does not know.

## Tests

- `is the Target's, on the revision template` — new.
- `is absent rather than invented where the Target names none` — new; pins the omission so a later default cannot creep in silently.
- `bun test` 1175 pass / 0 fail; `bun run typecheck` clean; `bun run lint` shows the one pre-existing warning in `test/config/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg