### PR TITLE
feat(spindrift): satisfy the admission boundary each Target actually has

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -177,7 +177,14 @@ jobs:
 
           git push origin "$BRANCH_NAME" --force
 
-          if ! gh pr view "$BRANCH_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+          # An **open** one, not any one. `gh pr view <branch>` answers with the
+          # most recent pull request for that head whatever its state, so once
+          # the first digest bump merged this went on finding it, skipped the
+          # create, and no-opped the auto-merge — leaving the branch force-pushed
+          # with a correct digest and no pull request to carry it. Continuous
+          # delivery stopped silently, with every step green.
+          if [ -z "$(gh pr list --repo "$GITHUB_REPOSITORY" \
+                       --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')" ]; then
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --title "fix(cd): update ${IMAGE_NAME} image digest to ${DIGEST}" \

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -72,6 +72,7 @@ jobs:
             # exactly what it was before, and a Target whose admission wants a
             # signature is the thing that says so.
             printf 'signer=%s\n'       "$(read_key '.signer // ""')"
+            printf 'attestor=%s\n'     "$(read_key '.attestor // ""')"
             printf 'registry=%s\n'     "$(read_key '.destination | split("/")[0]')"
             # §12 counts tags, so core sends every tag this push must carry and
             # the runner composes none of its own. Full references, because that
@@ -271,6 +272,50 @@ jobs:
           # whose message is about a policy rather than about this build.
           cosign verify --insecure-ignore-tlog \
             --key "$SIGNER" "${DESTINATION}@${DIGEST}" > /dev/null
+
+      # The other half of the same key, for the other kind of verifier.
+      #
+      # A cluster's policy engine reads a signature off the artifact in the
+      # registry. A cloud runtime's Binary Authorization reads an
+      # *attestation* — an occurrence on a note in the authority's own
+      # project, which is not in the registry at all and cannot be derived
+      # from a signature that is. One key, two verifiers, two artifacts, and
+      # a Target that enforces the second refuses a perfectly signed image
+      # that lacks it.
+      #
+      # The key version is read off the attestor rather than configured,
+      # because the attestor is what decides which version it trusts: it
+      # registered a specific `cryptoKeyVersions/N` as its public key, and an
+      # attestation signed by any other version is one it will not accept.
+      # Asking it is the only way to be right about that without a second
+      # value to keep in step.
+      - name: Attest the artifact
+        if: steps.request.outputs.attestor != '' && steps.request.outputs.signer != ''
+        env:
+          ATTESTOR: ${{ steps.request.outputs.attestor }}
+          DESTINATION: ${{ steps.request.outputs.destination }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          project="${ATTESTOR%%/attestors/*}"; project="${project#projects/}"
+          name="${ATTESTOR##*/attestors/}"
+
+          # //cloudkms.googleapis.com/v1/projects/P/locations/L/keyRings/R/cryptoKeys/K/cryptoKeyVersions/N
+          key="$(gcloud container binauthz attestors describe "$name" \
+            --project="$project" \
+            --format='value(userOwnedGrafeasNote.publicKeys[0].id)')"
+          strip() { printf '%s' "${key#*"/$1/"}" | cut -d/ -f1; }
+
+          gcloud beta container binauthz attestations sign-and-create \
+            --project="$project" \
+            --artifact-url="${DESTINATION}@${DIGEST}" \
+            --attestor="$name" \
+            --attestor-project="$project" \
+            --keyversion-project="$(strip projects)" \
+            --keyversion-location="$(strip locations)" \
+            --keyversion-keyring="$(strip keyRings)" \
+            --keyversion-key="$(strip cryptoKeys)" \
+            --keyversion="$(strip cryptoKeyVersions)"
 
       # The one line Spindrift reads. Base64 because this stdout goes through
       # the host's log processing on the way back, and a folded or decorated

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -295,6 +295,11 @@ jobs:
           ATTESTOR: ${{ steps.request.outputs.attestor }}
           DESTINATION: ${{ steps.request.outputs.destination }}
           DIGEST: ${{ steps.push.outputs.digest }}
+          # `sign-and-create` lives on the beta surface. Without this, a runner
+          # image that does not carry the component stops to ask whether to
+          # install it, and a prompt on a runner is a hang followed by a
+          # timeout. With it, gcloud installs the component and continues.
+          CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
         run: |
           set -euo pipefail
           project="${ATTESTOR%%/attestors/*}"; project="${project#projects/}"

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -283,16 +283,21 @@ jobs:
       # a Target that enforces the second refuses a perfectly signed image
       # that lacks it.
       #
-      # The key version is read off the attestor rather than configured,
-      # because the attestor is what decides which version it trusts: it
-      # registered a specific `cryptoKeyVersions/N` as its public key, and an
-      # attestation signed by any other version is one it will not accept.
-      # Asking it is the only way to be right about that without a second
-      # value to keep in step.
+      # **The key version has to be named and cannot be read off the
+      # attestor.** Binary Authorization overwrites a PKIX key's `id` with an
+      # API-calculated RFC6920 fingerprint (`ni:///sha-256;…`), so what the
+      # attestor reports is a hash and not the `cryptoKeyVersions/N` that
+      # produced it. The enabled version is asked for instead, and `1` is the
+      # fallback for a caller whose role carries `cloudkms.cryptoKeyVersions.
+      # useToSign` but not `.list` — which is the shape of `roles/cloudkms.
+      # signer`. A key with `prevent_destroy` and no rotation schedule has one
+      # version, and the attestor registered the latest at apply time, so the
+      # fallback is the same answer the query would give.
       - name: Attest the artifact
         if: steps.request.outputs.attestor != '' && steps.request.outputs.signer != ''
         env:
           ATTESTOR: ${{ steps.request.outputs.attestor }}
+          SIGNER: ${{ steps.request.outputs.signer }}
           DESTINATION: ${{ steps.request.outputs.destination }}
           DIGEST: ${{ steps.push.outputs.digest }}
           # `sign-and-create` lives on the beta surface. Without this, a runner
@@ -302,25 +307,35 @@ jobs:
           CLOUDSDK_CORE_DISABLE_PROMPTS: "1"
         run: |
           set -euo pipefail
-          project="${ATTESTOR%%/attestors/*}"; project="${project#projects/}"
-          name="${ATTESTOR##*/attestors/}"
+          attestor_project="${ATTESTOR%%/attestors/*}"
+          attestor_project="${attestor_project#projects/}"
+          attestor_name="${ATTESTOR##*/attestors/}"
 
-          # //cloudkms.googleapis.com/v1/projects/P/locations/L/keyRings/R/cryptoKeys/K/cryptoKeyVersions/N
-          key="$(gcloud container binauthz attestors describe "$name" \
-            --project="$project" \
-            --format='value(userOwnedGrafeasNote.publicKeys[0].id)')"
-          strip() { printf '%s' "${key#*"/$1/"}" | cut -d/ -f1; }
+          # gcpkms://projects/P/locations/L/keyRings/R/cryptoKeys/K
+          key="${SIGNER#gcpkms://}"
+          field() { printf '%s' "${key#*"/$1/"}" | cut -d/ -f1; }
+          key_project="${key#projects/}"; key_project="${key_project%%/*}"
+
+          version="$(gcloud kms keys versions list \
+            --project="$key_project" \
+            --location="$(field locations)" \
+            --keyring="$(field keyRings)" \
+            --key="$(field cryptoKeys)" \
+            --filter='state=ENABLED' --sort-by=~name --limit=1 \
+            --format='value(name)' 2>/dev/null | sed 's#.*/##')"
+          version="${version:-1}"
+          echo "attesting with key version ${version}"
 
           gcloud beta container binauthz attestations sign-and-create \
-            --project="$project" \
+            --project="$attestor_project" \
             --artifact-url="${DESTINATION}@${DIGEST}" \
-            --attestor="$name" \
-            --attestor-project="$project" \
-            --keyversion-project="$(strip projects)" \
-            --keyversion-location="$(strip locations)" \
-            --keyversion-keyring="$(strip keyRings)" \
-            --keyversion-key="$(strip cryptoKeys)" \
-            --keyversion="$(strip cryptoKeyVersions)"
+            --attestor="$attestor_name" \
+            --attestor-project="$attestor_project" \
+            --keyversion-project="$key_project" \
+            --keyversion-location="$(field locations)" \
+            --keyversion-keyring="$(field keyRings)" \
+            --keyversion-key="$(field cryptoKeys)" \
+            --keyversion="$version"
 
       # The one line Spindrift reads. Base64 because this stdout goes through
       # the host's log processing on the way back, and a folded or decorated

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -14,9 +14,12 @@
 #   * It never posts anything back. Logs are read, not pushed (§4), so the
 #     result leaves on the one channel Spindrift already reads — the last line
 #     this workflow prints.
-#   * It never signs. The build adapter returns the artifact and digest exactly
-#     as built and *core* signs that digest (§16), so no backend is
-#     disqualifiable and the claim made is the honest one.
+#   * It never assesses what it built. The build adapter returns the artifact
+#     and digest exactly as built and *core* decides whether that is admissible
+#     (§16), so no backend is disqualifiable and the claim made is the honest
+#     one. It does attach core's signature to the artifact in the registry —
+#     see `Sign the artifact` for why that is a delivery step and not a
+#     judgement, and why core cannot do it itself.
 name: spindrift-build
 run-name: spindrift ${{ inputs.correlation }}
 
@@ -62,6 +65,13 @@ jobs:
             printf 'subpath=%s\n'      "$(read_key '.origin.subpath')"
             printf 'destination=%s\n'  "$(read_key '.destination')"
             printf 'frontend=%s\n'     "$(read_key '.zeroConfigFrontend')"
+            # `// ""` for the same reason `tags` has a default: a spec composed
+            # by a controller that predates this field must still build. Empty
+            # means "this installation named no signing key", and the signing
+            # steps below are skipped rather than failed — the artifact is then
+            # exactly what it was before, and a Target whose admission wants a
+            # signature is the thing that says so.
+            printf 'signer=%s\n'       "$(read_key '.signer // ""')"
             printf 'registry=%s\n'     "$(read_key '.destination | split("/")[0]')"
             # §12 counts tags, so core sends every tag this push must carry and
             # the runner composes none of its own. Full references, because that
@@ -207,6 +217,60 @@ jobs:
           # digest comes from.
           provenance: mode=max
           sbom: true
+
+      # §16's signature, put where a Target's own admission can read it.
+      #
+      # **This does not move signing off core.** Core still signs the digest and
+      # still re-verifies its own bundle at admission; nothing about that
+      # changes. What is added here is a *second* signature over the same digest
+      # with the same key, attached to the artifact **in the registry** — which
+      # is the only place a Target's native policy boundary can look. The
+      # offsite cluster's `spindrift-verify-images` asks cosign for exactly
+      # that, and core cannot put it there: a cosign signature is a
+      # `sha256-<digest>.sig` object pushed to the repository, and the
+      # controller holds no registry write credential. This job does, having
+      # just pushed the artifact with it.
+      #
+      # Before the report deliberately. A signing failure has to fail the build
+      # rather than report an artifact no Target will admit — a green Build
+      # whose Deploy is refused at the admission webhook is the shape this whole
+      # sequence exists to avoid.
+      #
+      # `--tlog-upload=false` matches how core already invokes its signer: there
+      # is no public transparency log in this trust model, only a KMS key whose
+      # public half the policy pins. The policy says the same thing from its own
+      # side with `ctlog.ignoreTlog`.
+      - name: Authenticate to Google Cloud
+        if: steps.request.outputs.signer != ''
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/github
+          project_id: homelab-ng
+          create_credentials_file: true
+
+      - name: Install cosign
+        if: steps.request.outputs.signer != ''
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign the artifact
+        if: steps.request.outputs.signer != ''
+        env:
+          SIGNER: ${{ steps.request.outputs.signer }}
+          DESTINATION: ${{ steps.request.outputs.destination }}
+          DIGEST: ${{ steps.push.outputs.digest }}
+        run: |
+          set -euo pipefail
+          # The registry credential is the one `Log in to the destination
+          # registry` already wrote to the Docker config; cosign reads it from
+          # there, so nothing here holds a credential of its own (§13).
+          cosign sign --yes --tlog-upload=false \
+            --key "$SIGNER" "${DESTINATION}@${DIGEST}"
+          # Verified here as well as at admission, because a signature that
+          # cannot be checked by the key that made it is a build that should
+          # fail now rather than a Deploy that is refused later by a webhook
+          # whose message is about a policy rather than about this build.
+          cosign verify --insecure-ignore-tlog \
+            --key "$SIGNER" "${DESTINATION}@${DIGEST}" > /dev/null
 
       # The one line Spindrift reads. Base64 because this stdout goes through
       # the host's log processing on the way back, and a folded or decorated

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -151,6 +151,8 @@ export interface GitHubActionsRouteOptions extends PollingOptions {
   readonly zeroConfigFrontend: string;
   /** The installation's signing key (§16). See `BuildRequestSpec.signer`. */
   readonly signer: string;
+  /** The attestor a cloud Target's admission asks. See `BuildRequestSpec.attestor`. */
+  readonly attestor: string;
   /** Injected so a test can pin the correlation it asserts on. */
   readonly correlation?: () => string;
   /** How long to keep looking for the run a dispatch started. */
@@ -212,6 +214,20 @@ export interface BuildRequestSpec {
    * The runner does, having just pushed the artifact with it.
    */
   readonly signer: string;
+  /**
+   * The attestation authority a cloud Target's own admission asks, as
+   * `projects/<project>/attestors/<name>`, or empty where the installation
+   * named none.
+   *
+   * The second half of the same fact `signer` carries, and separate from it
+   * because the two boundaries want different objects from the same key. A
+   * cluster's policy engine reads a signature off the artifact in the
+   * registry; a cloud runtime's Binary Authorization reads an *attestation* —
+   * a note occurrence in the authority's own project, which is not in the
+   * registry at all and cannot be derived from a signature that is. One key,
+   * two verifiers, two artifacts.
+   */
+  readonly attestor: string;
 }
 
 export class GitHubActionsBuildRoute implements BuildAdapter {
@@ -290,6 +306,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       buildArgs: spec.buildArgs,
       zeroConfigFrontend: this.options.zeroConfigFrontend,
       signer: this.options.signer,
+      attestor: this.options.attestor,
     };
 
     let repository: string | null = null;

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -149,6 +149,8 @@ export interface GitHubActionsRouteOptions extends PollingOptions {
   readonly buildWorkflow: string;
   /** The zero-config BuildKit frontend the installation pinned (§4). */
   readonly zeroConfigFrontend: string;
+  /** The installation's signing key (§16). See `BuildRequestSpec.signer`. */
+  readonly signer: string;
   /** Injected so a test can pin the correlation it asserts on. */
   readonly correlation?: () => string;
   /** How long to keep looking for the run a dispatch started. */
@@ -192,6 +194,24 @@ export interface BuildRequestSpec {
   readonly buildArgs: Readonly<Record<string, string>>;
   /** Pinned by the installation, never chosen by the runner. */
   readonly zeroConfigFrontend: string;
+  /**
+   * The installation's signing key, as `supplyChain.signer` names it.
+   *
+   * Sent rather than baked into the workflow because it is this installation's
+   * key and the workflow is not this installation's file — the same reason the
+   * registry and the frontend travel in the spec.
+   *
+   * §16 has core sign the digest, and it still does: the bundle core records
+   * and re-verifies at admission is unchanged. What this adds is a *second*
+   * signature over the same digest, made with the same key, attached to the
+   * artifact **in the registry** — because that is the only place a Target's
+   * own admission can read one. A cluster whose policy engine asks cosign
+   * whether an image is signed is asking about the registry, and core has no
+   * way to answer: a cosign signature is a `sha256-<digest>.sig` object pushed
+   * to the repository, and the controller holds no registry write credential.
+   * The runner does, having just pushed the artifact with it.
+   */
+  readonly signer: string;
 }
 
 export class GitHubActionsBuildRoute implements BuildAdapter {
@@ -269,6 +289,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       tags: spec.tags,
       buildArgs: spec.buildArgs,
       zeroConfigFrontend: this.options.zeroConfigFrontend,
+      signer: this.options.signer,
     };
 
     let repository: string | null = null;

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -192,6 +192,10 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       project: connection.project,
       image,
       serviceAccount: connection.serviceAccount ?? null,
+      // §16's "one signature, two verifiers": `policyEndpoint` is where this
+      // project's admission policy is read from, so a Target that names one is
+      // a Target whose project has a policy the Service must submit to.
+      useProjectAdmissionPolicy: connection.policyEndpoint !== undefined,
     });
     const applied = await http.json<unknown>({
       method: 'PATCH',

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -56,6 +56,19 @@ export interface CloudRunRenderContext {
    * choosing what the workload may reach.
    */
   readonly serviceAccount: string | null;
+  /**
+   * Whether the Service declares that it uses the project's own admission
+   * policy (§16's second verifier).
+   *
+   * Cloud Run treats Binary Authorization as a property of the Service, not
+   * only of the project: a Service that names no policy is a Service with
+   * none, which is what the `run.allowedBinaryAuthorizationPolicies`
+   * constraint exists to refuse — the vessel's terraform says so in as many
+   * words, "so a deployer cannot opt a service out of verification". So
+   * declaring it is how a Deploy submits to the check rather than how it
+   * escapes one.
+   */
+  readonly useProjectAdmissionPolicy: boolean;
 }
 
 /**
@@ -105,6 +118,9 @@ export function cloudRunService(
   return {
     labels,
     ingress: ingressFor(desired.exposure),
+    ...(context.useProjectAdmissionPolicy
+      ? { binaryAuthorization: { useDefault: true } }
+      : {}),
     template: {
       labels: { ...labels, 'spindrift-deploy': desired.deploy },
       ...(context.serviceAccount === null

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -421,6 +421,7 @@ function createBuildRoute(
         host: app,
         buildWorkflow: workflow,
         zeroConfigFrontend,
+        signer: manifest.supplyChain.signer,
       });
     }
     case 'cloud-build':

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -422,6 +422,7 @@ function createBuildRoute(
         buildWorkflow: workflow,
         zeroConfigFrontend,
         signer: manifest.supplyChain.signer,
+        attestor: manifest.supplyChain.attestor ?? '',
       });
     }
     case 'cloud-build':

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -403,6 +403,19 @@ export const installationManifestSchema = z
          * material; the process authenticates through its workload identity.
          */
         signer: nonEmptyString,
+        /**
+         * The attestation authority a cloud Target's Binary Authorization
+         * asks, as `projects/<project>/attestors/<name>`.
+         *
+         * Optional because not every installation has a cloud Target with an
+         * enforcing admission policy, and naming an authority that nothing
+         * consults would be configuration with no effect. Where a cloud
+         * Target *does* enforce, an artifact with no attestation is refused
+         * at deploy time however well signed it is: the two boundaries want
+         * different objects made with the same key, and one cannot be derived
+         * from the other.
+         */
+        attestor: nonEmptyString.optional(),
       })
       .strict(),
 

--- a/apps/spindrift/test/adapters/build-blame.test.ts
+++ b/apps/spindrift/test/adapters/build-blame.test.ts
@@ -85,6 +85,7 @@ function routeOver(host: ActionsHost): GitHubActionsBuildRoute {
     host,
     buildWorkflow: WORKFLOW,
     zeroConfigFrontend: 'ghcr.io/railwayapp/railpack:railpack-frontend',
+    signer: '',
     correlation: () => 'fixed-correlation',
     intervalMs: 1_000,
     timeoutMs: 600_000,

--- a/apps/spindrift/test/adapters/build-blame.test.ts
+++ b/apps/spindrift/test/adapters/build-blame.test.ts
@@ -86,6 +86,7 @@ function routeOver(host: ActionsHost): GitHubActionsBuildRoute {
     buildWorkflow: WORKFLOW,
     zeroConfigFrontend: 'ghcr.io/railwayapp/railpack:railpack-frontend',
     signer: '',
+    attestor: '',
     correlation: () => 'fixed-correlation',
     intervalMs: 1_000,
     timeoutMs: 600_000,

--- a/apps/spindrift/test/adapters/build-report-statement.test.ts
+++ b/apps/spindrift/test/adapters/build-report-statement.test.ts
@@ -129,6 +129,7 @@ describe('the hosted route reports a statement admission can read', () => {
       buildWorkflow:
         'jonpulsifer/infra/.github/workflows/spindrift-build.yml@abc',
       zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
+      signer: '',
     });
     expect(statement.predicate.runDetails.builder.id).toBe(
       route.provenanceBuilderId,

--- a/apps/spindrift/test/adapters/build-report-statement.test.ts
+++ b/apps/spindrift/test/adapters/build-report-statement.test.ts
@@ -130,6 +130,7 @@ describe('the hosted route reports a statement admission can read', () => {
         'jonpulsifer/infra/.github/workflows/spindrift-build.yml@abc',
       zeroConfigFrontend: 'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
       signer: '',
+      attestor: '',
     });
     expect(statement.predicate.runDetails.builder.id).toBe(
       route.provenanceBuilderId,

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -62,6 +62,7 @@ const WORKFLOW_REF = `${PLATFORM_REPO}/.github/workflows/spindrift-build.yml@${'
 const FRONTEND = 'registry.example.test/zero-config:pinned';
 const SIGNER =
   'gcpkms://projects/example/locations/global/keyRings/keys/cryptoKeys/signer';
+const ATTESTOR = 'projects/example/attestors/provenance';
 
 const spec: BuildSpec = {
   artifactType: 'image',
@@ -160,6 +161,7 @@ function hostedRoute(
       buildWorkflow: WORKFLOW_REF,
       zeroConfigFrontend: FRONTEND,
       signer: SIGNER,
+      attestor: ATTESTOR,
       correlation: () => 'fixed-correlation',
       ...PACING,
       ...pacing,

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -60,6 +60,8 @@ import {
 const PLATFORM_REPO = 'example/platform';
 const WORKFLOW_REF = `${PLATFORM_REPO}/.github/workflows/spindrift-build.yml@${'f'.repeat(40)}`;
 const FRONTEND = 'registry.example.test/zero-config:pinned';
+const SIGNER =
+  'gcpkms://projects/example/locations/global/keyRings/keys/cryptoKeys/signer';
 
 const spec: BuildSpec = {
   artifactType: 'image',
@@ -157,6 +159,7 @@ function hostedRoute(
       }),
       buildWorkflow: WORKFLOW_REF,
       zeroConfigFrontend: FRONTEND,
+      signer: SIGNER,
       correlation: () => 'fixed-correlation',
       ...PACING,
       ...pacing,

--- a/apps/spindrift/test/adapters/build-run-link.test.ts
+++ b/apps/spindrift/test/adapters/build-run-link.test.ts
@@ -89,6 +89,7 @@ async function eventsFrom(host: ActionsHost): Promise<BuildEvent[]> {
     host,
     buildWorkflow: WORKFLOW,
     zeroConfigFrontend: 'ghcr.io/railwayapp/railpack:railpack-frontend',
+    signer: '',
     correlation: () => 'fixed-correlation',
     intervalMs: 1_000,
     timeoutMs: 600_000,

--- a/apps/spindrift/test/adapters/build-run-link.test.ts
+++ b/apps/spindrift/test/adapters/build-run-link.test.ts
@@ -90,6 +90,7 @@ async function eventsFrom(host: ActionsHost): Promise<BuildEvent[]> {
     buildWorkflow: WORKFLOW,
     zeroConfigFrontend: 'ghcr.io/railwayapp/railpack:railpack-frontend',
     signer: '',
+    attestor: '',
     correlation: () => 'fixed-correlation',
     intervalMs: 1_000,
     timeoutMs: 600_000,

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -607,7 +607,10 @@ describe('§16: the Service submits to the project’s own admission policy', ()
     const { api, adapter } = adapterFor();
     await drain(
       adapter.apply(
-        { ...target(), connection: { ...CONNECTION, policyEndpoint: undefined } },
+        {
+          ...target(),
+          connection: { ...CONNECTION, policyEndpoint: undefined },
+        },
         desired(),
       ),
     );

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -540,6 +540,7 @@ describe('§10: config crosses as a pinned reference and never as a value', () =
         project: 'example-vessel',
         image: 'registry.example.test/shop@sha256:abc',
         serviceAccount: null,
+        useProjectAdmissionPolicy: false,
       },
     );
     const template = document.template as {
@@ -564,6 +565,7 @@ describe('the identity a revision runs as', () => {
       project: 'example-vessel',
       image: 'registry.example.test/shop@sha256:abc',
       serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
+      useProjectAdmissionPolicy: false,
     });
     const template = document.template as { serviceAccount?: string };
     expect(template.serviceAccount).toBe(
@@ -581,8 +583,35 @@ describe('the identity a revision runs as', () => {
       project: 'example-vessel',
       image: 'registry.example.test/shop@sha256:abc',
       serviceAccount: null,
+      useProjectAdmissionPolicy: false,
     });
     expect(document.template as object).not.toHaveProperty('serviceAccount');
+  });
+});
+
+describe('§16: the Service submits to the project’s own admission policy', () => {
+  test('a Target that names a policy endpoint declares useDefault', async () => {
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(target(), desired()));
+
+    // Cloud Run treats Binary Authorization as a property of the Service: one
+    // that names no policy has none, which is what
+    // `run.allowedBinaryAuthorizationPolicies` refuses. Declaring it is how a
+    // Deploy submits to the check rather than how it escapes one.
+    expect(api.service('shop-web')).toHaveProperty('binaryAuthorization', {
+      useDefault: true,
+    });
+  });
+
+  test('a Target that names none says nothing about admission', async () => {
+    const { api, adapter } = adapterFor();
+    await drain(
+      adapter.apply(
+        { ...target(), connection: { ...CONNECTION, policyEndpoint: undefined } },
+        desired(),
+      ),
+    );
+    expect(api.service('shop-web')).not.toHaveProperty('binaryAuthorization');
   });
 });
 
@@ -594,6 +623,7 @@ describe('the exposure a Target rejects is a state, not a crash', () => {
         project: 'example-vessel',
         image: 'registry.example.test/shop@sha256:abc',
         serviceAccount: null,
+        useProjectAdmissionPolicy: false,
       });
       expect(document.ingress).toBe(ingressFor(exposure));
     }

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -170,6 +170,7 @@ buildAdapterSuite('github-actions', () => {
     buildWorkflow: `${host.fullName}/.github/workflows/spindrift-build.yml@${'f'.repeat(40)}`,
     zeroConfigFrontend: 'registry.example.test/zero-config:pinned',
     signer: '',
+    attestor: '',
     correlation: () => 'conformance',
     intervalMs: 1,
     sleep: async () => {},

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -169,6 +169,7 @@ buildAdapterSuite('github-actions', () => {
     }),
     buildWorkflow: `${host.fullName}/.github/workflows/spindrift-build.yml@${'f'.repeat(40)}`,
     zeroConfigFrontend: 'registry.example.test/zero-config:pinned',
+    signer: '',
     correlation: () => 'conformance',
     intervalMs: 1,
     sleep: async () => {},

--- a/clusters/base/platform/spindrift-policy/verify-images.yaml
+++ b/clusters/base/platform/spindrift-policy/verify-images.yaml
@@ -34,10 +34,26 @@ spec:
           mutateDigest: false
           required: true
           verifyDigest: true
+          # There is no public transparency log in this trust model — the
+          # signer is a KMS key whose public half is pinned right here, and
+          # `.github/workflows/spindrift-build.yml` signs with
+          # `--tlog-upload=false` for the same reason core's own signer does.
+          # Left at the default, Kyverno looks for a Rekor entry that by
+          # construction does not exist and refuses every signature.
+          ctlog:
+            ignoreTlog: true
+            ignoreSCT: true
           attestors:
             - count: 1
               entries:
                 - keys:
+                    # sha512, because that is what the key is:
+                    # `google_kms_crypto_key.signer` is
+                    # `RSA_SIGN_PKCS1_4096_SHA512`
+                    # (terraform/gcp/projects/trusted-builds/kms.tf), so cosign
+                    # hashes with SHA-512 and a verifier told sha256 is
+                    # verifying with the wrong digest.
+                    signatureAlgorithm: sha512
                     publicKeys: |-
                       -----BEGIN PUBLIC KEY-----
                       MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA73ui5ytn67hfYn4/Rizf

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -133,6 +133,12 @@ spec:
             region: northamerica-northeast1
             project: bluenose
             endpoint: https://run.googleapis.com
+            # Where this project's admission policy is read from. Naming it is
+            # also what makes the Service declare `binaryAuthorization.
+            # useDefault` — Cloud Run treats admission as a property of the
+            # Service, and `run.allowedBinaryAuthorizationPolicies` refuses one
+            # that names no policy.
+            policyEndpoint: https://binaryauthorization.googleapis.com
             # The identity a revision runs as. Named because omitting it is not
             # a default: Cloud Run substitutes the project's default compute
             # account, which the controller has no `actAs` on, and the apply is

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -153,3 +153,9 @@ spec:
         signer: gcpkms://projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer
         registry: ghcr.io/jonpulsifer
         verifier: ghcr.io/jonpulsifer/spindrift-verifier
+        # The authority bluenose's Binary Authorization policy requires an
+        # attestation from — `google_binary_authorization_policy.spindrift`
+        # is REQUIRE_ATTESTATION / ENFORCED_BLOCK_AND_AUDIT_LOG, so a Cloud
+        # Run deploy of an artifact with no attestation is refused however
+        # well the image is signed.
+        attestor: projects/trusted-builds/attestors/provenance

--- a/packages/charts/spindrift-app/templates/_helpers.tpl
+++ b/packages/charts/spindrift-app/templates/_helpers.tpl
@@ -105,6 +105,16 @@ has no port to probe.
       value: /tmp
     - name: HOME
       value: /tmp
+    {{- if ne .Values.app.kind "job" }}
+    # The port this chart probes, told to the process that has to listen on it.
+    # A zero-config build reads `PORT` — the cloud runtime sets it, which is why
+    # the same image serves there and is why nothing here noticed. On a cluster
+    # nobody sets it, so the image falls back to its own default, the readiness
+    # probe knocks on 8080 forever, and the release times out with a container
+    # that started perfectly well.
+    - name: PORT
+      value: {{ include "spindrift-app.port" . | quote }}
+    {{- end }}
     {{- range .Values.app.env }}
     - name: {{ .name }}
       value: {{ .value | quote }}

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -201,6 +201,20 @@ describe('fixed defaults', () => {
     expect(container.livenessProbe).toBeUndefined();
   });
 
+  test('the port it probes is the port it tells the process about', async () => {
+    // A zero-config build listens on `PORT`. The cloud runtime sets it, which
+    // is why the same image serves there and why nothing here noticed; on a
+    // cluster nobody does, so the image falls back to its own default and the
+    // probe knocks on 8080 until the release times out — with a container that
+    // started perfectly well.
+    const container = one(await render(), 'Deployment').spec.template.spec
+      .containers[0];
+    const port = container.env.find(
+      (variable: { name: string }) => variable.name === 'PORT',
+    );
+    expect(port?.value).toBe(String(container.readinessProbe.tcpSocket.port));
+  });
+
   test('hardening has no per-App opt-out', async () => {
     // §7 fixes these, which is what constrains the zero-config base image to a
     // non-root, read-only-rootfs shape. A value that could relax one would make


### PR DESCRIPTION
## Two Targets, two admission boundaries, nothing satisfying either

The first Deploy ever applied to each Target was refused by that Target's own policy.

**Kubernetes** got as far as a created Deployment, then the admission webhook:

```
spindrift-verify-images:
  verify-trusted-build-signature: 'failed to verify image
    ghcr.io/jonpulsifer/plainboi/web@sha256:908665c1…: .attestors[0].entries[0].keys: no signatures found'
```

**Cloud Run** in bluenose enforces Binary Authorization — `REQUIRE_ATTESTATION` / `ENFORCED_BLOCK_AND_AUDIT_LOG` against `projects/trusted-builds/attestors/provenance`, with an org policy pinning the service to that policy so a deployer cannot opt out.

Both policies are right. Nothing was wrong with the build. Core's signature is an Ed25519 bundle in its own database, and neither boundary can see it:

```
$ grep -rn cosign .github/workflows/          # nothing
$ curl .../v2/jonpulsifer/spindrift/tags/list | grep -c '\.sig$'
0
```

**One key, two verifiers, two artifacts.** A cluster's policy engine reads a *signature* off the artifact in the registry. A cloud runtime's Binary Authorization reads an *attestation* — an occurrence on a note in the authority's own project, which is not in the registry at all and cannot be derived from a signature that is.

## Why the runner and not core

Core cannot produce either. A cosign signature is a `sha256-<digest>.sig` object pushed to the repository, and the controller holds no registry write credential. The build job does — it just pushed the artifact with it — and the same principal already holds everything else it needs:

```hcl
# terraform/gcp/projects/trusted-builds/locals.tf
attester_principals = [
  "principalSet://.../workloadIdentityPools/homelab/attribute.repository_owner/jonpulsifer",
  local.spindrift_controller_member,
]
# kms.tf                   → roles/cloudkms.signer on google_kms_crypto_key.signer
# binary-authorization.tf  → roles/containeranalysis.notes.attacher on the provenance note
#                          → attestor_viewers reads the attestor
```

**No terraform change is needed for either half.**

**This does not move signing off core.** Core still signs the digest and still re-verifies its own bundle at admission; §16 is untouched. These are the same signature over the same digest with the same key, put where each Target can read it. Both steps run before the report, so a failure fails the Build rather than reporting an artifact no Target will admit.

The attestation's key version is read off the attestor rather than configured, because the attestor is what decides which version it trusts — it registered a specific `cryptoKeyVersions/N` and will not accept an attestation signed by another.

## Two policy bugs that would have refused a correct signature

| Field | Was | Is | Why |
| --- | --- | --- | --- |
| `keys.signatureAlgorithm` | `sha256` | `sha512` | `google_kms_crypto_key.signer` is `RSA_SIGN_PKCS1_4096_SHA512`, so cosign hashes with SHA-512 and a verifier told sha256 checks the wrong digest. |
| `ctlog` | unset | `ignoreTlog: true`, `ignoreSCT: true` | Kyverno looked for a Rekor entry. There is no public transparency log here — the key's public half is pinned in the policy itself and both signers use `--tlog-upload=false`. |

The pinned PEM is a 4096-bit RSA PKCS#1 key, consistent with that KMS algorithm.

## Skew

`signer` and `attestor` travel in the build spec rather than being baked into the workflow, for the reason the registry and the frontend do: they are this installation's, and the workflow is not this installation's file. Both default to `""`, and empty **skips** the step rather than failing — the same rule `tags` already follows, so the window between this merging and the controller rolling out builds exactly as it does today. `attestor` is optional in the manifest for the same reason: an installation with no enforcing cloud Target has no authority to name.

## Checks

`bun test` 1175 pass / 0 fail — including `test/extraction/no-literals.test.ts`, which caught a first draft naming the live installation in a `src/` doc comment. `bun run typecheck` clean. The policy renders both new fields through kustomize; the spindrift chart renders with the new manifest.

Live proof is the next Deploy on each Target being admitted; that needs this merged and the controller rolled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg