### PR TITLE
fix(spindrift): an ignored declaration cannot take the boot down

### DIFF
--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -49,7 +49,7 @@ export async function loadStoredManifest(
   env: Env = Bun.env,
 ): Promise<InstallationManifest> {
   const stored = await readStoredManifest(db);
-  const declaration = await loadManifestIfPresent(env);
+  const declaration = await declaredManifest(stored !== null, env);
   if (stored !== null && declaration !== null) {
     console.warn(
       'installation manifest: a declaration is mounted but this installation is already seeded, so the stored manifest is being used and the declaration is ignored — discard the row to re-seed from it',
@@ -58,6 +58,47 @@ export async function loadStoredManifest(
   const declared = stored ?? declaration ?? DEFAULT_PLACEHOLDER_MANIFEST;
   await writeStoredManifest(db, declared);
   return resolveManifest(declared, env);
+}
+
+/**
+ * The mounted declaration, and `null` for one a **seeded** installation cannot
+ * parse.
+ *
+ * A declaration seeds and does not govern, so on an installation that already
+ * has a row it is read, announced as ignored, and thrown away. Validating it
+ * strictly on that path meant a document this build could not parse took the
+ * process down — over a value it had already decided not to use.
+ *
+ * That is not hypothetical. A manifest key added to the declaration ahead of
+ * the image that understands it is the ordinary shape of a rollout: the
+ * declaration lands with the merge and the image lands with the digest bump,
+ * and between them every replica crash-loops on
+ * `Unrecognized key` for a field the stored row does not have and no reader
+ * would have consulted. Nothing about the running installation was wrong.
+ *
+ * **Unseeded is still fatal**, and has to be: there the declaration is the
+ * whole configuration, and continuing would boot the placeholder manifest as
+ * though the operator had declared nothing.
+ *
+ * The cost, stated: a declaration that has been broken for a while is a
+ * warning nobody reads until a torn-down installation fails to come back
+ * configured. That is the smaller failure. Crashing a healthy installation to
+ * report a document it is ignoring is the larger one.
+ */
+async function declaredManifest(
+  seeded: boolean,
+  env: Env,
+): Promise<AuthoredManifest | null> {
+  try {
+    return await loadManifestIfPresent(env);
+  } catch (cause) {
+    if (!seeded) throw cause;
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    console.warn(
+      `installation manifest: the mounted declaration is not valid for this build and is being ignored, which is what a declaration already is for a seeded installation — re-seeding from it would fail until it is corrected: ${detail}`,
+    );
+    return null;
+  }
 }
 
 /**

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -302,13 +302,52 @@ describe('the stored installation manifest', () => {
       'installation: ""',
     );
 
-    await expect(
-      loadStoredManifest(database().db, {
+    // Ignored rather than fatal: a declaration does not govern a seeded
+    // installation, so this document was never going to be read. The row is
+    // what boots, unchanged.
+    expect(
+      await loadStoredManifest(database().db, {
         [MANIFEST_INLINE_VAR]: malformed,
       }),
-    ).rejects.toThrow(ManifestError);
+    ).toEqual(first);
 
     expect(await loadStoredManifest(database().db, {})).toEqual(first);
+  });
+
+  test('a declaration this build cannot parse does not stop a seeded boot', async () => {
+    // The ordinary shape of a rollout: a manifest key lands in the declaration
+    // with the merge and in the image with the digest bump, and between them
+    // every replica reads a document carrying a field it has no schema for.
+    // Crashing there takes a healthy control plane down over a value it had
+    // already decided not to use — the same controller/declaration skew the
+    // build workflow's `tags` default exists to absorb.
+    const first = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    const fromTheFuture = fixtureText.replace(
+      'installation: example',
+      'installation: example\nsomethingThisBuildHasNeverHeardOf: true',
+    );
+
+    expect(
+      await loadStoredManifest(database().db, {
+        [MANIFEST_INLINE_VAR]: fromTheFuture,
+      }),
+    ).toEqual(first);
+  });
+
+  test('an unseeded installation still refuses to boot on a bad declaration', async () => {
+    // The other half, and it has to stay fatal: with no row the declaration is
+    // the whole configuration, and continuing would boot the placeholder as
+    // though the operator had declared nothing at all.
+    await expect(
+      loadStoredManifest(database().db, {
+        [MANIFEST_INLINE_VAR]: fixtureText.replace(
+          'installation: example',
+          'installation: ""',
+        ),
+      }),
+    ).rejects.toThrow(ManifestError);
   });
 
   test('an incompatible Target declaration rolls back manifest and rank changes', async () => {


### PR DESCRIPTION
## What happened

Merging a manifest key ahead of the image that understands it crash-looped every replica:

```
ManifestError: /etc/spindrift/manifest.yaml: invalid installation manifest
  targets.1.connection: Unrecognized key: "serviceAccount"
      at validateManifest (config/manifest.ts:73:11)
      at async loadStoredManifest (config/manifest-store.ts:52:29)
      at async startReconciler (reconciler/start.ts:50:28)
```

```
spindrift-reconciler-6bd446c755-8pgg2   0/1   Error   2 (16s ago)
spindrift-web-6b574d65d4-gl2rl          0/1   Error   2 (18s ago)
```

Nothing about the running installation was wrong. The stored row does not have that field and no reader would have consulted it — `loadStoredManifest` reads the declaration, announces that it is **ignored**, and throws it away. It just validated it strictly first.

Flux's rollback is the only reason it came back, and it came back to the same failure on the next reconcile.

## Why this is the general case, not my sequencing mistake

The declaration ships on merge; the image ships on the digest bump. That window always exists. The repository already found this on the other surface and wrote the rule down in `spindrift-build.yml`:

> a change to this workflow may add a field the controller sends, but may never *require* one, because there is always a window in which the controller has not caught up

Nothing had applied it to the manifest, where the asymmetry is identical.

## The change

On a **seeded** installation a declaration that does not parse is warned about and ignored — which is what a declaration already is there.

**Unseeded stays fatal**, and has to: with no row the declaration is the whole configuration, and continuing would boot the placeholder manifest as though the operator had declared nothing.

## Cost, stated rather than hidden

A declaration that has been broken for a while is now a warning nobody reads until a torn-down installation fails to come back configured. That is the smaller failure. Crashing a healthy control plane to report a document it is ignoring is the larger one.

## Tests

- `an invalid declaration does not overwrite durable configuration` — kept, retargeted from "throws" to "the row is what boots, unchanged". Its name was always about the guarantee, not the mechanism.
- `a declaration this build cannot parse does not stop a seeded boot` — new; the exact shape above.
- `an unseeded installation still refuses to boot on a bad declaration` — new; pins the half that must stay fatal.

`bun test` 1179 pass / 0 fail. `bun run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg