### PR TITLE
fix(spindrift): pin cosign to the line that can sign without a log

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -249,9 +249,20 @@ jobs:
           project_id: homelab-ng
           create_credentials_file: true
 
+      # Pinned to the 2.x line, and the pin is the point. Cosign 3 refuses
+      # `--tlog-upload=false` outright — "not supported with --signing-config or
+      # --use-signing-config", because signing is configured through a signing
+      # config that names a transparency log by default. There is no
+      # transparency log in this trust model: the signer is a KMS key whose
+      # public half the admission policy pins, and the policy says the same
+      # thing from its own side with `ctlog.ignoreTlog`. Cosign 2 is also the
+      # keyed-signature format Kyverno 1.18 reads, so the pin holds two things
+      # at once and should not move without checking both.
       - name: Install cosign
         if: steps.request.outputs.signer != ''
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: v2.6.4
 
       - name: Sign the artifact
         if: steps.request.outputs.signer != ''


### PR DESCRIPTION
## The failure

First run of the new signing step (build 26, run 30728211741):

```
Error: --tlog-upload=false is not supported with --signing-config or --use-signing-config.
  Provide a signing config with --signing-config without a transparency log service…
```

The installer was unpinned and took cosign `v3.0.6`. Cosign 3 configures signing through a signing config that names a transparency log by default, and refuses the flag rather than ignoring it.

There is no transparency log in this trust model. The signer is a KMS key whose public half the admission policy pins, and the policy already says the same thing from its own side with `ctlog.ignoreTlog`.

## The fix

`cosign-release: v2.6.4`. That is also the keyed-signature format Kyverno 1.18 reads, so the pin holds two things at once — a comment on the step says so, because moving it means checking both.

## What already worked

Everything ahead of it, on the very first run:

```
6. Log in to the destination registry: success
7. Build and push:                     success
8. Authenticate to Google Cloud:       success   ← WIF federation
9. Install cosign:                     success
10. Sign the artifact:                 failure   ← the flag
```

So the federation, the IAM from #1553, and the registry credential are all confirmed good. Only the flag was wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg