### PR TITLE
fix(trusted-builds): let the signer read the key it signs with

### DIFF
--- a/terraform/gcp/projects/trusted-builds/kms.tf
+++ b/terraform/gcp/projects/trusted-builds/kms.tf
@@ -36,3 +36,25 @@ resource "google_kms_crypto_key_iam_binding" "signer" {
   role          = "roles/cloudkms.signerVerifier"
   members       = local.attester_principals
 }
+
+# The third permission signing needs, and the last one: `cloudkms.cryptoKeys.
+# get`.
+#
+# Before it can sign anything, cosign reads the key itself to learn its default
+# hash function — the key is `RSA_SIGN_PKCS1_4096_SHA512`, and nothing on the
+# command line says so. `signerVerifier` grants use of the *versions* and sight
+# of their public halves, and not `get` on the key they hang off, so signing
+# stopped one call short of the one that matters:
+#
+#     signing digest: getting fetching default hash function: rpc error:
+#     code = PermissionDenied desc = Permission 'cloudkms.cryptoKeys.get' denied
+#
+# `roles/cloudkms.viewer` is metadata only — get and list on the key and its
+# versions, no use of either — so this adds reading and no capability. It also
+# makes `cryptoKeyVersions.list` answer, which is how the attestation step finds
+# the enabled version rather than falling back to assuming the first.
+resource "google_kms_crypto_key_iam_binding" "signer_metadata" {
+  crypto_key_id = google_kms_crypto_key.signer.id
+  role          = "roles/cloudkms.viewer"
+  members       = local.attester_principals
+}


### PR DESCRIPTION
## The failure

Third run of the signing step, with the cosign version pinned and `signerVerifier` applied:

```
Error: signing [ghcr.io/jonpulsifer/plainboi/web@sha256:39cfbd55…]:
  signing digest: getting fetching default hash function:
  rpc error: code = PermissionDenied
  desc = Permission 'cloudkms.cryptoKeys.get' denied on resource
         'projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer'
```

Before it signs anything, cosign reads the key itself to learn its default hash function — the key is `RSA_SIGN_PKCS1_4096_SHA512` and nothing on the command line says so.

`roles/cloudkms.signerVerifier` grants use of the *versions* and sight of their public halves, and not `get` on the key those versions hang off. So signing stopped one call short of the one that matters.

## The change

A second binding on the same key: `roles/cloudkms.viewer`. Metadata only — get and list on the key and its versions, no use of either — so this adds reading and no capability.

It also makes `cryptoKeyVersions.list` answer, which is how the attestation step finds the enabled key version instead of falling back to assuming the first one.

## The chain, for the record

| Call | Permission | Role |
| --- | --- | --- |
| `GetCryptoKey` (hash function) | `cryptoKeys.get` | `cloudkms.viewer` ← this PR |
| `GetPublicKey` | `cryptoKeyVersions.viewPublicKey` | `cloudkms.signerVerifier` (#1553) |
| `AsymmetricSign` | `cryptoKeyVersions.useToSign` | `cloudkms.signer`, kept by `signerVerifier` |

`tofu validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg