### PR TITLE
fix(ci): keep cosign on the line that can sign without a log

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -120,6 +120,26 @@
   ],
   packageRules: [
     // ============================================================
+    // cosign is pinned to 2.x deliberately, and must stay there
+    // ============================================================
+    {
+      description: 'cosign: 2.x is a deliberate floor, not a stale pin',
+      matchManagers:    ['github-actions'],
+      matchDepNames:    ['sigstore/cosign'],
+      // Cosign 3 refuses `--tlog-upload=false` outright — signing is configured
+      // through a signing config that names a transparency log, and there is no
+      // transparency log in this trust model: the signer is a KMS key whose
+      // public half `spindrift-verify-images` pins, and that policy says the
+      // same thing from its own side with `ctlog.ignoreTlog`. 2.x is also the
+      // keyed-signature format Kyverno 1.18 reads.
+      //
+      // Renovate bumped this to 3.1.2 and automerged it three minutes after the
+      // pin landed, and the next build failed on the flag again. Moving off 2.x
+      // means writing a signing config and re-checking what Kyverno accepts —
+      // tracked as its own piece of work, not a version bump.
+      enabled: false,
+    },
+    // ============================================================
     // Terraform providers — group by kind, not by stack
     // Keep major+minor together so we don't get PR-per-update-type
     // ============================================================

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -262,7 +262,7 @@ jobs:
         if: steps.request.outputs.signer != ''
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          cosign-release: v3.1.2
+          cosign-release: v2.6.4
 
       - name: Sign the artifact
         if: steps.request.outputs.signer != ''


### PR DESCRIPTION
## What happened

```
d56aa609  02:06:50  fix(spindrift): pin cosign to the line that can sign without a log
9bb0d21a  02:10:32  ci(github-action)!: Update action sigstore/cosign ( v2.6.4 → v3.1.2 )  (#1558, renovate[bot], automerged)
```

Three and a half minutes. The next build failed on exactly the flag the pin exists to avoid:

```
Error: --tlog-upload=false is not supported with --signing-config or --use-signing-config.
```

## Why 2.x is a floor and not a stale pin

Cosign 3 configures signing through a signing config that names a transparency log by default. There is no transparency log in this trust model — the signer is a KMS key whose public half `spindrift-verify-images` pins, and that policy already says the same thing from its own side with `ctlog.ignoreTlog`. 2.x is also the keyed-signature format Kyverno 1.18 reads.

## The change

Pin restored, and a Renovate rule disables updates for `sigstore/cosign` with the reason written next to the rule rather than in a commit message nobody will find again.

Moving off 2.x means writing a signing config and re-checking what Kyverno accepts. That is its own piece of work, not a version bump — which is the whole argument for `enabled: false` rather than a wider range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg