### PR TITLE
fix(spindrift): name the signing key that exists

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -156,7 +156,11 @@ spec:
         endpoint: http://onepassword-connect.external-secrets.svc.cluster.local:8080
         container: homelab
       supplyChain:
-        signer: gcpkms://projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer
+        # northamerica-northeast1, which is where the key is:
+        # `google_kms_crypto_key.signer` takes `local.region`, and
+        # terraform/gcp/projects/trusted-builds/versions.tf sets that to
+        # northamerica-northeast1. There has never been a key in us-central1.
+        signer: gcpkms://projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer
         registry: ghcr.io/jonpulsifer
         verifier: ghcr.io/jonpulsifer/spindrift-verifier
         # The authority bluenose's Binary Authorization policy requires an


### PR DESCRIPTION
## The bug

```yaml
# declared
signer: gcpkms://projects/trusted-builds/locations/us-central1/keyRings/keys/cryptoKeys/signer

# where the key actually is, from the Atlantis apply that just touched it
projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer
```

`google_kms_crypto_key.signer` takes `local.region`, and `terraform/gcp/projects/trusted-builds/versions.tf` sets that to `northamerica-northeast1`. There has never been a key at the declared path.

## Why nothing caught it

Nothing had ever called KMS with it. `spindrift-verifier`'s `gcpkms://` arm derives an Ed25519 key from a sha256 of the URI and never opens a connection:

```go
if strings.HasPrefix(path, kmsPrefix) {
    ...
    seed := sha256.Sum256([]byte(path))
    return ed25519.NewKeyFromSeed(seed[:]), nil
}
```

So core's signing "worked" against a reference pointing at nothing, for as long as it has existed.

The first caller to actually use the key was cosign, and GCP answers both cases in one sentence:

```
Permission 'cloudkms.cryptoKeys.get' denied on resource
'projects/trusted-builds/locations/us-central1/…/signer' (or it may not exist).
```

It did not exist. Two IAM grants (#1553, #1557) were made chasing the first half of that sentence before the second half was read. Both were correct on their own terms and both landed on the real key, in the other region — the apply output is what gave it away:

```
Creation complete after 5s [id=projects/trusted-builds/locations/northamerica-northeast1/…]
```

## Blast radius

**A recorded signature will not re-verify across this change.** The derived key is seeded from the URI string, so every `CoreSignature` written before this is bound to the old one. Only superseded Builds carry one, so nothing live is affected — and it is one more reason the derived-key arm is a placeholder rather than a signer.

The stored manifest has already been corrected through `configureInstallation`; this fixes the declaration so a re-seed does not reintroduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg