### PR TITLE
fix(spindrift): put ignoreTlog where Kyverno's schema has it

### DIFF
--- a/clusters/base/platform/spindrift-policy/verify-images.yaml
+++ b/clusters/base/platform/spindrift-policy/verify-images.yaml
@@ -34,15 +34,6 @@ spec:
           mutateDigest: false
           required: true
           verifyDigest: true
-          # There is no public transparency log in this trust model — the
-          # signer is a KMS key whose public half is pinned right here, and
-          # `.github/workflows/spindrift-build.yml` signs with
-          # `--tlog-upload=false` for the same reason core's own signer does.
-          # Left at the default, Kyverno looks for a Rekor entry that by
-          # construction does not exist and refuses every signature.
-          ctlog:
-            ignoreTlog: true
-            ignoreSCT: true
           attestors:
             - count: 1
               entries:
@@ -54,6 +45,19 @@ spec:
                     # hashes with SHA-512 and a verifier told sha256 is
                     # verifying with the wrong digest.
                     signatureAlgorithm: sha512
+                    # There is no public transparency log in this trust model —
+                    # the signer is a KMS key whose public half is pinned right
+                    # below, and the build workflow signs with
+                    # `--tlog-upload=false` for the same reason core's own
+                    # signer does. Left at the default, Kyverno looks for a
+                    # Rekor entry that by construction does not exist and
+                    # refuses every signature.
+                    #
+                    # Under `rekor`, and `ctlog` is a different thing: `ctlog`
+                    # carries `ignoreSCT` for certificate timestamps, which a
+                    # keyed signature has none of.
+                    rekor:
+                      ignoreTlog: true
                     publicKeys: |-
                       -----BEGIN PUBLIC KEY-----
                       MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA73ui5ytn67hfYn4/Rizf


### PR DESCRIPTION
## What broke

The policy correction never reached the cluster. Flux refused the whole Kustomization:

```
ClusterPolicy/spindrift-verify-images dry-run failed:
  .spec.rules[0].verifyImages[0].ctlog: field not declared in schema
```

`spindrift-policy` sat at the previous revision with `Ready=False`, so the live policy still had `signatureAlgorithm: sha256` and no tlog exemption — and the `sha512` half, which was correct, never landed either. **A Kustomization is refused whole.**

## What was wrong

Two things, both from guessing at the shape:

- `ctlog` is not a field of `verifyImages`. It belongs inside `keys`, beside `publicKeys`.
- `ctlog` is not the right field regardless. It carries `ignoreSCT`, for certificate timestamps — which a keyed signature has none of. What skips the transparency log is **`rekor.ignoreTlog`**.

Read off the cluster's own CRD this time:

```
$ kubectl get crd clusterpolicies.kyverno.io -o json | jq '… .keys.properties.rekor.properties'
ignoreTlog: IgnoreTlog skips transparency log verification
```

## Checked before pushing

```
$ kubectl kustomize clusters/base/platform/spindrift-policy | kubectl apply --dry-run=server -f -
clusterpolicy.kyverno.io/spindrift-verify-images configured (server dry run)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HqgkRMbnmVCUehG2ChgSHg