### PR TITLE
fix(gcp): drop allowed_audiences from the Vercel WIF provider

### DIFF
--- a/terraform/gcp/projects/homelab-ng/workload-identity.tf
+++ b/terraform/gcp/projects/homelab-ng/workload-identity.tf
@@ -60,9 +60,11 @@ resource "google_iam_workload_identity_pool_provider" "vercel" {
   }
 
   attribute_condition = "assertion.sub.startsWith('owner:jonpulsifer:project:')"
+  # No allowed_audiences: the Vercel project mints its OIDC token with this
+  # provider's full resource name as `aud`, which is exactly what GCP accepts
+  # by default. Setting allowed_audiences replaces that default and rejects it.
   oidc {
-    allowed_audiences = ["https://vercel.com/jonpulsifer"]
-    issuer_uri        = "https://oidc.vercel.com/jonpulsifer"
+    issuer_uri = "https://oidc.vercel.com/jonpulsifer"
   }
 
   depends_on = [time_sleep.workload_identity_org_policy_propagation]


### PR DESCRIPTION
## Problem

slingshot fails to reach Firestore on Vercel:

```
invalid_grant: The audience in ID Token [//iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/vercel] does not match the expected audience.
```

The Vercel project mints its OIDC token with the WIF provider's full
resource name as `aud` — exactly what GCP accepts by default. Setting
`allowed_audiences = ["https://vercel.com/jonpulsifer"]` *replaces* that
default set, so the real token is rejected.

## Fix

Remove `allowed_audiences` so the default (provider resource name, both
`//iam.googleapis.com/...` and `https://iam.googleapis.com/...` forms) applies.
Issuer stays pinned to `https://oidc.vercel.com/jonpulsifer` and the
`assertion.sub.startsWith('owner:jonpulsifer:project:')` condition is unchanged,
so trust is not widened.

`tofu validate` passes. No app change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)