### PR TITLE
fix(spindrift): let an operator rebuild, and let a saved manifest reach the reconciler

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -22,6 +22,16 @@
  *   {@link sourceForRerun}'s subject and §15's "stage an immutable source
  *   bundle" read as being about a Build rather than about an App.
  *
+ * `rebuild` is the operator asking for the second act where the first was
+ * available — the one question the button above cannot express, because its
+ * whole design is to answer the deployable case with a Deploy. Without it an
+ * App whose newest Build succeeded has **no path to a new Build at all**: the
+ * branch below is the only caller of {@link sourceForRerun}, and reaching it
+ * meant writing `status = 'FAILED'` onto a Build that genuinely succeeded. It
+ * changes which act runs and nothing else — the same staging, the same row, the
+ * same refusals — and the result still says which of the two happened, so the
+ * substitution this command forbids stays forbidden in both directions.
+ *
  * **This command writes no `deploys` row of its own**, on either branch. That
  * is the point rather than an omission: §6's check-and-set is only a
  * correctness argument if every intent is written through the one pair that
@@ -55,6 +65,14 @@ export const deployAppInput = z
   .object({
     /** The App's id, or its name where that names exactly one App. */
     name: z.string().trim().min(1),
+    /**
+     * Build again rather than deploy what is already built.
+     *
+     * Absent is the one-button decision unchanged, so every existing caller
+     * keeps its behaviour by saying nothing. Set only where the operator asked
+     * for a Build in as many words.
+     */
+    rebuild: z.boolean().optional(),
   })
   .strict();
 
@@ -292,6 +310,7 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
   const latestBuild = primaryComponent.builds[0];
 
   if (
+    !input.rebuild &&
     latestBuild &&
     latestBuild.status === 'SUCCEEDED' &&
     latestBuild.artifactDigest !== null

--- a/apps/spindrift/src/reconciler/process.ts
+++ b/apps/spindrift/src/reconciler/process.ts
@@ -5,6 +5,7 @@
  * shared lifecycle: start them together, isolate failures, retry a failed loop
  * with bounded backoff, and stop every loop from one signal.
  */
+import type { SecretStore } from '../adapters/store/contract.ts';
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
@@ -19,7 +20,8 @@ export type ReconcilerLoopName =
   | 'repository'
   | 'config'
   | 'build'
-  | 'deploy';
+  | 'deploy'
+  | 'manifest';
 
 /** One independently supervised process loop. */
 interface SupervisedLoop {
@@ -52,16 +54,44 @@ interface SupervisorOptions {
   readonly onFailure?: (failure: LoopFailure) => void;
 }
 
-/** Everything the long-running process needs after production bootstraps it. */
+/**
+ * Everything the long-running process needs after production bootstraps it.
+ *
+ * `manifest` and `adapters` are **read per pass, never captured**. Production
+ * supplies them as getters over a value {@link ReconcilerContext.refresh}
+ * replaces, so a loop that holds this context for the life of the process still
+ * acts on the configuration as it is now. Every loop below already passes this
+ * object into its per-pass function rather than destructuring it at startup,
+ * which is what makes that work without touching any of them.
+ */
 export interface ReconcilerContext {
   readonly db: Database;
   readonly adapters: AdapterRegistry;
   readonly clock: Clock;
   readonly manifest: InstallationManifest;
+  /**
+   * Re-read the stored manifest and rebuild whatever was assembled from it.
+   *
+   * Absent leaves the context frozen, which is what a test that supplies its
+   * own manifest wants. Production supplies it, because `configureInstallation`
+   * writes the row this process would otherwise never re-read — the
+   * declared-change-that-does-nothing failure §20's authoring path exists to
+   * remove. The web process solves the same problem per request; this process
+   * has no request to hang a read on, so it hangs it on a loop.
+   */
+  readonly refresh?: () => Promise<void>;
 }
 
 const DEFAULT_TARGET_INTERVAL_MS = 5 * 60_000;
 const DEFAULT_REPOSITORY_INTERVAL_MS = 5 * 60_000;
+/**
+ * How soon a saved manifest reaches the loops.
+ *
+ * Far below the loops it feeds, because the operator who just pressed save is
+ * watching. One `select` against a row this process already reads at startup,
+ * and no adapter is rebuilt unless the document actually changed.
+ */
+const DEFAULT_MANIFEST_INTERVAL_MS = 30_000;
 
 /** Observable process events for production logging and lifecycle tests. */
 export type ReconcilerProcessEvent =
@@ -79,6 +109,11 @@ export type ReconcilerProcessEvent =
 export interface ReconcilerOptions {
   readonly signal: AbortSignal;
   readonly retry?: RetryBackoff;
+  /**
+   * How often {@link ReconcilerContext.refresh} runs, for a test that cannot
+   * wait {@link DEFAULT_MANIFEST_INTERVAL_MS} to watch a change arrive.
+   */
+  readonly manifestIntervalMs?: number;
   readonly onEvent?: (event: ReconcilerProcessEvent) => void;
 }
 
@@ -110,12 +145,10 @@ export async function runReconciler(
 ): Promise<void> {
   if (options.signal.aborted) return;
 
-  const store = context.adapters.store(context.manifest.secretStore.adapter);
-  if (store === null) {
-    throw new Error(
-      `the installation has no ${context.manifest.secretStore.adapter} store adapter for config retention`,
-    );
-  }
+  // Once here so an installation that cannot retain config says so at startup
+  // rather than on the config loop's first pass, and again per pass below so
+  // the store is the one the current manifest names.
+  storeFor(context);
 
   const passed = (loop: ReconcilerLoopName): void =>
     options.onEvent?.({ type: 'pass', loop });
@@ -134,7 +167,15 @@ export async function runReconciler(
       name: 'config',
       run: (signal) =>
         runConfigLoop(
-          { db: context.db, store },
+          {
+            db: context.db,
+            // A getter, not the value resolved above: `runConfigPass` reads
+            // this per pass, and a store captured at startup would be the one
+            // the process booted with even after the manifest named another.
+            get store() {
+              return storeFor(context);
+            },
+          },
           {
             intervalMs: DEFAULT_REAP_INTERVAL_MS,
             signal,
@@ -161,6 +202,26 @@ export async function runReconciler(
         }),
     },
   ];
+
+  const refresh = context.refresh;
+  if (refresh !== undefined) {
+    // Supervised like any other loop rather than raced alongside them: a
+    // database blip while re-reading the row is a transient this process
+    // already knows how to back off from, not a reason to stop reconciling.
+    loops.push({
+      name: 'manifest',
+      run: async (signal) => {
+        const interval =
+          options.manifestIntervalMs ?? DEFAULT_MANIFEST_INTERVAL_MS;
+        while (!signal.aborted) {
+          await refresh();
+          if (signal.aborted) return;
+          passed('manifest');
+          await abortableSleep(interval, signal);
+        }
+      },
+    });
+  }
 
   const repository = context.adapters.repository();
   if (repository === null) {
@@ -189,6 +250,17 @@ export async function runReconciler(
     ...(options.retry ? { retry: options.retry } : {}),
     onFailure: (failure) => options.onEvent?.({ type: 'failure', ...failure }),
   });
+}
+
+/** §10's store of record, as the manifest names it *now*. */
+function storeFor(context: ReconcilerContext): SecretStore {
+  const store = context.adapters.store(context.manifest.secretStore.adapter);
+  if (store === null) {
+    throw new Error(
+      `the installation has no ${context.manifest.secretStore.adapter} store adapter for config retention`,
+    );
+  }
+  return store;
 }
 
 async function superviseLoop(

--- a/apps/spindrift/src/reconciler/start.ts
+++ b/apps/spindrift/src/reconciler/start.ts
@@ -9,7 +9,10 @@ import { createAdapterRegistry } from '../adapters/registry.ts';
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import { systemClock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
-import { loadStoredManifest } from '../config/manifest-store.ts';
+import {
+  currentStoredManifest,
+  loadStoredManifest,
+} from '../config/manifest-store.ts';
 import { createClient, createDb } from '../db/client.ts';
 import { type ReconcilerProcessEvent, runReconciler } from './process.ts';
 import { restoreDeclaredTargetConnections } from './target-loop.ts';
@@ -29,6 +32,8 @@ export interface StartReconcilerOptions {
   readonly createAdapters?: (manifest: InstallationManifest) => AdapterRegistry;
   readonly onStarted?: (manifest: InstallationManifest) => void;
   readonly onEvent?: (event: ReconcilerProcessEvent) => void;
+  /** Forwarded to the manifest loop; production takes its default. */
+  readonly manifestIntervalMs?: number;
 }
 
 import { initTelemetry } from '../telemetry/index.ts';
@@ -47,24 +52,61 @@ export async function startReconciler(
 
   try {
     const db = createDb(client);
-    const manifest = await loadStoredManifest(db, env);
     const clock = options.clock ?? systemClock;
-    const adapters =
-      options.createAdapters?.(manifest) ??
-      createAdapterRegistry({ manifest, env, db, clock });
-    await restoreDeclaredTargetConnections({ db, adapters, clock }, manifest);
-    options.onStarted?.(manifest);
+    const assemble = (manifest: InstallationManifest) => ({
+      manifest,
+      adapters:
+        options.createAdapters?.(manifest) ??
+        createAdapterRegistry({ manifest, env, db, clock }),
+    });
+
+    /**
+     * The configuration the loops run against, current as of the last refresh.
+     *
+     * `loadStoredManifest` seeds and reconciles, so it runs once at startup;
+     * every read after it is `currentStoredManifest`, which the manifest store
+     * exports for exactly this — asking whether configuration changed without
+     * paying for a transaction to answer.
+     */
+    let current = assemble(await loadStoredManifest(db, env));
+
+    await restoreDeclaredTargetConnections(
+      { db, adapters: current.adapters, clock },
+      current.manifest,
+    );
+    options.onStarted?.(current.manifest);
 
     await runReconciler(
       {
         db,
-        adapters,
         clock,
-        manifest,
+        // Getters, so a loop holding this object for the life of the process
+        // reads what `refresh` last put in `current` rather than what the
+        // process booted with. The adapters are the half that matters: the
+        // build route bakes in `supplyChain.signer` and `attestor` at
+        // assembly, which is how a Build went out naming an attestor added to
+        // the manifest minutes earlier and skipped the step on the empty value.
+        get manifest() {
+          return current.manifest;
+        },
+        get adapters() {
+          return current.adapters;
+        },
+        refresh: async () => {
+          const stored = await currentStoredManifest(db, env);
+          // Rebuilt only where the document actually changed, so an unchanged
+          // installation costs one `select` per tick and nothing else.
+          if (stored === null || Bun.deepEquals(stored, current.manifest, true))
+            return;
+          current = assemble(stored);
+        },
       },
       {
         signal: options.signal,
         ...(options.onEvent ? { onEvent: options.onEvent } : {}),
+        ...(options.manifestIntervalMs === undefined
+          ? {}
+          : { manifestIntervalMs: options.manifestIntervalMs }),
       },
     );
   } finally {

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -375,7 +375,10 @@ function WorkspaceScreen({
     );
   }
 
-  const handleDeploy = async () => {
+  // `rebuild` is passed explicitly rather than defaulted from a bare click
+  // handler: a click hands its event to the first parameter, and an event is
+  // truthy, so `onClick={handleDeploy}` would silently rebuild every press.
+  const handleDeploy = async (rebuild: boolean) => {
     if (state.type !== 'success') return;
     setDeploying(true);
     setDeployError(null);
@@ -384,6 +387,7 @@ function WorkspaceScreen({
       // and the command refuses a name two Apps answer to rather than guessing.
       const result = await command('deployApp', {
         name: state.workspace.appId ?? appName,
+        rebuild,
       });
       if (result.ok) {
         // Both arms navigate. §4 makes "a Build started" a different act from
@@ -449,7 +453,8 @@ function WorkspaceScreen({
       ) : null}
       <Workspace
         view={state.workspace}
-        onDeploy={handleDeploy}
+        onDeploy={() => handleDeploy(false)}
+        onRebuild={() => handleDeploy(true)}
         deploying={deploying}
         onNavigate={onNavigate}
         deletion={deletion}

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -39,6 +39,7 @@ import { Releases } from './releases.tsx';
 export function Workspace({
   view,
   onDeploy,
+  onRebuild,
   deploying = false,
   onNavigate,
   deletion,
@@ -47,6 +48,16 @@ export function Workspace({
 }: {
   view: WorkspaceView;
   onDeploy?: () => void;
+  /**
+   * Ask for a Build outright.
+   *
+   * Its own control rather than a mode on the one above, because that button's
+   * whole job is to decide — and a decision an operator can silently flip is
+   * the substitution `deployApp` refuses to make. Always offered, never
+   * conditional on what is built: "Rebuild" does exactly one thing whatever
+   * the state, which is what makes it safe to press next to one that does not.
+   */
+  onRebuild?: () => void;
   deploying?: boolean;
   onNavigate?: (path: string) => void;
   /**
@@ -86,6 +97,11 @@ export function Workspace({
               Open app <ExternalLink aria-hidden="true" />
             </a>
           </Button>
+          {onRebuild ? (
+            <Button variant="outline" onClick={onRebuild} disabled={deploying}>
+              Rebuild
+            </Button>
+          ) : null}
           <Button onClick={onDeploy} disabled={deploying}>
             {deploying
               ? 'Deploying...'

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -76,11 +76,17 @@ describe('the bundle a rerun stages', () => {
   /**
    * An App whose only Build failed carrying `location`, placed on a Target —
    * the shape the deploy button acts on, and offsite's shape today.
+   *
+   * `status` and `artifactDigest` default to that shape. Ticket 36 is the one
+   * caller that overrides them, because the act it asks for is only reachable
+   * on the Build the defaults exclude.
    */
   async function seedFailedBuild(options: {
     location: string | null;
     sourceKind?: 'repo' | 'archive';
     connectRepository?: boolean;
+    status?: 'FAILED' | 'SUCCEEDED';
+    artifactDigest?: string;
   }) {
     const name = `rerun-${crypto.randomUUID().slice(0, 8)}`;
     const [repository] = options.connectRepository
@@ -125,7 +131,10 @@ describe('the bundle a rerun stages', () => {
         bundleDigest:
           'sha256:3f5cbbc2ced964573220535fc887677dcb768b9d56b4931c415db44402440b03',
         bundleLocation: options.location,
-        status: 'FAILED',
+        status: options.status ?? 'FAILED',
+        ...(options.artifactDigest === undefined
+          ? {}
+          : { artifactDigest: options.artifactDigest }),
       })
       .returning();
     return { app: app!, component: component!, build: build! };
@@ -295,5 +304,73 @@ describe('the bundle a rerun stages', () => {
     if (!result.ok) return;
     expect(result.value.phase).toBe('BUILDING');
     expect(stager.staged).toHaveLength(0);
+  });
+
+  /**
+   * Ticket 36 — an App whose newest Build succeeded had no path to a new one.
+   * The branch above is the only caller of `sourceForRerun`, and reaching it
+   * meant writing `status = 'FAILED'` onto a Build that genuinely succeeded.
+   */
+  describe('a rebuild asked for against a succeeded Build', () => {
+    const seedSucceeded = () =>
+      seedFailedBuild({
+        location: DURABLE_LOCATION,
+        connectRepository: true,
+        status: 'SUCCEEDED',
+        artifactDigest: `sha256:${'b'.repeat(64)}`,
+      });
+
+    test('writes a new PENDING Build and leaves the succeeded one alone', async () => {
+      const seeded = await seedSucceeded();
+
+      const result = await deployApp(
+        { name: seeded.app.name, rebuild: true },
+        ctx,
+      );
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      // The act says which of the two it did: a Build was started, so there is
+      // no intent to navigate to.
+      expect(result.value.phase).toBe('BUILDING');
+      expect(result.value.deployId).toBeNull();
+      expect(result.value.buildId).not.toBe(seeded.build.id);
+
+      const rows = await ctx.db
+        .select()
+        .from(builds)
+        .where(eq(builds.componentId, seeded.component.id));
+      expect(rows).toHaveLength(2);
+
+      const rerun = rows.find((row) => row.id === result.value.buildId);
+      expect(rerun?.status).toBe('PENDING');
+      // Staged for it, not carried from the Build being rerun — the same rule
+      // the failed-Build path follows, and the reason a durable bundle is
+      // inherited rather than fetched twice.
+      expect(rerun?.bundleLocation).toBe(DURABLE_LOCATION);
+      expect(stager.staged).toHaveLength(0);
+
+      // The row edit this ticket exists to end: the succeeded Build still says
+      // it succeeded, and still names what it produced.
+      const succeeded = rows.find((row) => row.id === seeded.build.id);
+      expect(succeeded?.status).toBe('SUCCEEDED');
+      expect(succeeded?.artifactDigest).toBe(`sha256:${'b'.repeat(64)}`);
+    });
+
+    test('is the only thing that reaches it — the button still deploys', async () => {
+      const seeded = await seedSucceeded();
+
+      // Same App, same Build, no `rebuild`. The Target is not connected, so
+      // `createDeploy` refuses — which is the point: the deploy branch was
+      // taken, and it refused with its own sentence rather than building.
+      const result = await deployApp({ name: seeded.app.name }, ctx);
+      expect(result.ok).toBe(false);
+
+      const rows = await ctx.db
+        .select()
+        .from(builds)
+        .where(eq(builds.componentId, seeded.component.id));
+      expect(rows).toHaveLength(1);
+    });
   });
 });

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -13,8 +13,10 @@ import {
   type Clock,
   systemClock,
 } from '../../src/commands/types.ts';
+import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
 import { toAuthoredManifest } from '../../src/config/manifest.schema.ts';
 import { MANIFEST_INLINE_VAR } from '../../src/config/manifest.ts';
+import { writeStoredManifest } from '../../src/config/manifest-store.ts';
 import {
   apps,
   builds,
@@ -188,6 +190,116 @@ describe('reconciler loop composition', () => {
   });
 });
 
+/**
+ * Ticket 38 — the reconciler read the manifest once, at boot.
+ *
+ * `supplyChain.attestor` is the field that caught it: it was added through the
+ * product's own authoring path, and the next Build still dispatched with the
+ * empty value the process had booted with, so the attestation step skipped
+ * itself and the artifact went out unattested with every step green. The row
+ * is the seam — `configureInstallation` writes it and this asserts the
+ * reconciler reads it again — so the write here is the store function that
+ * command calls, without assembling a whole command context to reach it.
+ */
+describe('a manifest saved after boot', () => {
+  test('reaches the loops without restarting the process', async () => {
+    await pendingBuildNoRouteSatisfies();
+    const shutdown = new AbortController();
+    /** Every manifest handed to adapter assembly, in order. */
+    const assembled: InstallationManifest[] = [];
+    /** Which generation of adapters each build pass routed through. */
+    const routedThrough: number[] = [];
+    const ATTESTOR = 'projects/trusted-builds/attestors/spindrift';
+
+    let written = false;
+    await startReconciler({
+      signal: shutdown.signal,
+      client: database().connect(),
+      clock,
+      // Far below the 30s default so the change arrives inside a test.
+      manifestIntervalMs: 5,
+      env: {
+        ...FIXTURE_DEPLOYMENT_ENV,
+        [MANIFEST_INLINE_VAR]: JSON.stringify(toAuthoredManifest(manifest)),
+      },
+      createAdapters(storedManifest) {
+        const generation = assembled.push(storedManifest);
+        return {
+          ...adaptersFor(new FakeDeployAdapter()),
+          // `routeForTarget` asks this per pending Build, per pass, so which
+          // generation answers says which manifest that pass ran against.
+          // Answering `null` leaves the Build PENDING, which is what keeps
+          // the build loop looking at it every idle interval.
+          build: () => {
+            routedThrough.push(generation);
+            return null;
+          },
+        };
+      },
+      async onEvent(event) {
+        if (event.type !== 'pass') return;
+
+        if (event.loop === 'manifest' && !written) {
+          written = true;
+          const authored = toAuthoredManifest(manifest);
+          // The row `configureInstallation` writes, written the way it
+          // writes it — without assembling a command context to reach it.
+          await writeStoredManifest(database().db, {
+            ...authored,
+            supplyChain: { ...authored.supplyChain, attestor: ATTESTOR },
+          });
+          return;
+        }
+
+        // Stop once a build pass has routed through the rebuilt adapters —
+        // the point being that a loop acted on the new manifest, not merely
+        // that the row was re-read.
+        if (routedThrough.includes(2)) shutdown.abort();
+      },
+    });
+
+    // Assembled twice: once at boot, once when the document changed.
+    expect(assembled).toHaveLength(2);
+    expect(assembled[0]?.supplyChain.attestor).toBeUndefined();
+    expect(assembled[1]?.supplyChain.attestor).toBe(ATTESTOR);
+    // And a loop is running against the second one, with no restart between.
+    expect(routedThrough).toContain(2);
+    // Two build-loop idle intervals plus the change between them.
+  }, 20_000);
+
+  test('an unchanged document rebuilds nothing', async () => {
+    const platform = new FakeDeployAdapter();
+    const shutdown = new AbortController();
+    const assembled: InstallationManifest[] = [];
+    let manifestPasses = 0;
+
+    await startReconciler({
+      signal: shutdown.signal,
+      client: database().connect(),
+      clock,
+      manifestIntervalMs: 5,
+      env: {
+        ...FIXTURE_DEPLOYMENT_ENV,
+        [MANIFEST_INLINE_VAR]: JSON.stringify(toAuthoredManifest(manifest)),
+      },
+      createAdapters(storedManifest) {
+        assembled.push(storedManifest);
+        return adaptersFor(platform);
+      },
+      onEvent(event) {
+        if (event.type !== 'pass' || event.loop !== 'manifest') return;
+        manifestPasses += 1;
+        if (manifestPasses >= 3) shutdown.abort();
+      },
+    });
+
+    // Three re-reads, one assembly: the deep comparison is what keeps polling
+    // affordable enough to do every 30 seconds.
+    expect(manifestPasses).toBeGreaterThanOrEqual(3);
+    expect(assembled).toHaveLength(1);
+  });
+});
+
 describe('Deploy convergence through process startup', () => {
   test('polling takes a pending Deploy to the platform’s successful verdict', async () => {
     const platform = new FakeDeployAdapter();
@@ -271,6 +383,45 @@ async function reconcilePendingDeploy(platform: FakeDeployAdapter) {
 }
 
 /** An App, Component, Target, Build, and one PENDING Deploy intent. */
+/**
+ * A PENDING Build placed on a Target, for a registry whose `build()` answers
+ * `null`.
+ *
+ * No route clears the Target's policy, so `runBuildPass` leaves it PENDING and
+ * looks at it again every idle interval — which is what makes the build loop
+ * observable more than once inside a test.
+ */
+async function pendingBuildNoRouteSatisfies() {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: `app-${crypto.randomUUID()}`, sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind: 'service' })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: `cluster-${crypto.randomUUID()}`,
+        adapter: 'kubernetes',
+      }),
+    )
+    .returning();
+  await db
+    .insert(componentTargetDesired)
+    .values({ componentId: component!.id, targetId: target!.id });
+  await db.insert(builds).values({
+    componentId: component!.id,
+    commit: 'abcdef0',
+    targetShape: 'image',
+    artifactType: 'image',
+    status: 'PENDING',
+  });
+}
+
 async function pendingDeploy() {
   const db = database().db;
   const [app] = await db


### PR DESCRIPTION
Closes tickets **36** and **38** from the Spindrift v1 closure plan. Both are friction the last session hit for real while getting the first Deploy to `LIVE`; both were worked around by hand, and the workarounds are the reason they are tickets.

## 36 — Let an operator ask for a rebuild

`deployApp` has one button and decides between two acts. That default is right, and it stays. What was missing is the *other* question: an App whose newest Build succeeded had no path to a new Build at all. The rerun branch is the only caller of `sourceForRerun`, and the only way to reach it was

```sql
update builds set status = 'FAILED' where id = 25;
```

which says something false about a Build that genuinely succeeded.

`rebuild` is an optional input, absent by default, so every existing caller keeps today's behaviour by saying nothing. The workspace gets its own **Rebuild** control next to Deploy — deliberately unconditional, because "Rebuild" does exactly one thing whatever the state, which is what makes it safe to press next to a button that decides.

## 38 — Let a configuration change reach the reconciler

`startReconciler` read the manifest once and handed that value to every loop *and* to the adapter registry. A manifest written after boot was invisible until the process restarted, and deleting the pod was the whole workaround.

Not theoretical — this is build 27:

```json
"signer":"gcpkms://projects/trusted-builds/…/signer","attestor":""
```

The signer from the manifest the reconciler booted with, and an empty attestor because that key did not exist yet when it booted. The build ran, the image was pushed, and the attestation step skipped itself on the empty value with every step green.

The adapter registry is the half that matters — `registry.ts` bakes `supplyChain.signer` and `attestor` in at assembly — so a getter over the manifest alone would not have fixed it. `manifest` and `adapters` are now getters over a value a supervised `manifest` loop refreshes every 30s, rebuilding adapters only where the stored document actually changed. That is the same read `serve.ts` already does per request; this process has no request to hang it on, so it hangs it on a loop.

The config loop's store moved to a per-pass getter for the same reason: it was resolved once at startup.

## Checks

```
bun test        1183 pass, 0 fail
bun run typecheck
bun run lint    (1 pre-existing warning, unrelated file)
```

Three new tests: a rebuild against a succeeded Build, the same App without `rebuild` still taking the deploy branch, and a manifest change reaching the build loop with no restart (plus one asserting an unchanged document rebuilds nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)