### PR TITLE
fix(spindrift): push where each Target can pull from

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -63,7 +63,21 @@ jobs:
             printf 'bundleDigest=%s\n' "$(read_key '.bundleDigest')"
             printf 'location=%s\n'     "$(read_key '.origin.location')"
             printf 'subpath=%s\n'      "$(read_key '.origin.subpath')"
-            printf 'destination=%s\n'  "$(read_key '.destination')"
+            # `.destinations` with `.destination` behind it, because this file
+            # and the controller ship on different clocks — the same reason
+            # `tags` carries a default. A caller pins this workflow by a local
+            # reference resolving to the default branch, so a merge here reaches
+            # the next dispatch immediately while the controller image waits on
+            # a Flux rollout. Every spec composed in that window still names one
+            # destination.
+            printf 'destinations<<SPINDRIFT_EOF\n'
+            read_key '(.destinations // [.destination])[]'
+            printf 'SPINDRIFT_EOF\n'
+            # The first, for the one-per-build documents: the provenance and the
+            # SBOM describe a build, not a registry, and the report names one
+            # subject. The signature and the attestation are per destination and
+            # are composed from the list above.
+            printf 'destination=%s\n'  "$(read_key '(.destinations // [.destination])[0]')"
             printf 'frontend=%s\n'     "$(read_key '.zeroConfigFrontend')"
             # `// ""` for the same reason `tags` has a default: a spec composed
             # by a controller that predates this field must still build. Empty
@@ -73,7 +87,21 @@ jobs:
             # signature is the thing that says so.
             printf 'signer=%s\n'       "$(read_key '.signer // ""')"
             printf 'attestor=%s\n'     "$(read_key '.attestor // ""')"
-            printf 'registry=%s\n'     "$(read_key '.destination | split("/")[0]')"
+            # One login per distinct registry host. The GitHub token below only
+            # authenticates to GHCR; anything else is a cloud registry the
+            # `Authenticate to Google Cloud` step already federates for, so the
+            # hosts are split rather than looped over with one credential.
+            printf 'registry=%s\n'     "$(read_key '(.destinations // [.destination])[0] | split("/")[0]')"
+            hosts() {
+              read_key "[(.destinations // [.destination])[] | split(\"/\")[0]] | unique | map(select($1))"
+            }
+            # Two kinds, spelled out rather than abstracted: GHCR takes the run's
+            # own token, and Google Artifact Registry takes the federated
+            # identity the signing steps already establish. A host that is
+            # neither is not silently skipped — it reaches `docker push` with no
+            # credential and fails there, naming itself.
+            printf 'ghcrHosts=%s\n'   "$(hosts '. == "ghcr.io"' | jq -r 'join(",")')"
+            printf 'googleHosts=%s\n' "$(hosts 'endswith("docker.pkg.dev") or . == "gcr.io"' | jq -r 'join(",")')"
             # §12 counts tags, so core sends every tag this push must carry and
             # the runner composes none of its own. Full references, because that
             # is what build-push-action's newline list takes.
@@ -87,8 +115,14 @@ jobs:
             # the bare destination meant to the reader of this file before it
             # did. Absent the default, every dispatch in that window dies here,
             # at the step before anything is recorded.
+            #
+            # Every tag under every destination. One buildx invocation pushes
+            # the same manifest to each — one build, one digest, N registries —
+            # which is what lets a Deploy pin whichever reference its own Target
+            # can pull without anything being built twice.
             printf 'tags<<SPINDRIFT_EOF\n'
-            read_key '.destination + ":" + (.tags // ["latest"])[]'
+            read_key '(.destinations // [.destination])[] as $d
+                      | (.tags // ["latest"])[] | $d + ":" + .'
             printf 'SPINDRIFT_EOF\n'
             printf 'buildArgs<<SPINDRIFT_EOF\n'
             read_key '.buildArgs | to_entries[] | "\(.key)=\(.value)"'
@@ -185,15 +219,41 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
+      # Federation before the push, not just before the signing.
+      #
+      # It used to sit below `Build and push`, because the only thing that
+      # needed a cloud identity was cosign. An installation whose Targets cannot
+      # share one registry pushes to Artifact Registry as well, and that push
+      # needs the same identity — so the step moves up and now runs whenever
+      # *either* wants it.
+      - name: Authenticate to Google Cloud
+        if: >-
+          steps.request.outputs.signer != '' ||
+          steps.request.outputs.googleHosts != ''
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/github
+          project_id: homelab-ng
+          create_credentials_file: true
+
       # The run's own token, which is the only credential this job can hold
-      # without one being stored somewhere (§13). An installation whose registry
-      # does not accept it uses the cloud route, which federates instead.
-      - name: Log in to the destination registry
+      # without one being stored somewhere (§13).
+      - name: Log in to GitHub Container Registry
+        if: steps.request.outputs.ghcrHosts != ''
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
-          registry: ${{ steps.request.outputs.registry }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
+
+      # The federated identity, written to the same Docker config the step above
+      # writes to — which is what lets one `docker buildx build --push` reach
+      # both registries, and lets cosign find a credential for either.
+      - name: Log in to Artifact Registry
+        if: steps.request.outputs.googleHosts != ''
+        env:
+          HOSTS: ${{ steps.request.outputs.googleHosts }}
+        run: gcloud auth configure-docker --quiet "$HOSTS"
 
       - name: Build and push
         id: push
@@ -241,14 +301,6 @@ jobs:
       # is no public transparency log in this trust model, only a KMS key whose
       # public half the policy pins. The policy says the same thing from its own
       # side with `ctlog.ignoreTlog`.
-      - name: Authenticate to Google Cloud
-        if: steps.request.outputs.signer != ''
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/github
-          project_id: homelab-ng
-          create_credentials_file: true
-
       # Pinned to the 2.x line, and the pin is the point. Cosign 3 refuses
       # `--tlog-upload=false` outright — "not supported with --signing-config or
       # --use-signing-config", because signing is configured through a signing
@@ -264,25 +316,34 @@ jobs:
         with:
           cosign-release: v2.6.4
 
+      # Once per destination. A cosign signature is a `sha256-<digest>.sig`
+      # object pushed to **the repository the artifact is in**, so a signature
+      # made against one registry is not there to be found by a Target pulling
+      # from another — and that Target's admission would refuse a signed
+      # artifact for the one reason that is not true of it.
       - name: Sign the artifact
         if: steps.request.outputs.signer != ''
         env:
           SIGNER: ${{ steps.request.outputs.signer }}
-          DESTINATION: ${{ steps.request.outputs.destination }}
+          DESTINATIONS: ${{ steps.request.outputs.destinations }}
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           set -euo pipefail
-          # The registry credential is the one `Log in to the destination
-          # registry` already wrote to the Docker config; cosign reads it from
-          # there, so nothing here holds a credential of its own (§13).
-          cosign sign --yes --tlog-upload=false \
-            --key "$SIGNER" "${DESTINATION}@${DIGEST}"
-          # Verified here as well as at admission, because a signature that
-          # cannot be checked by the key that made it is a build that should
-          # fail now rather than a Deploy that is refused later by a webhook
-          # whose message is about a policy rather than about this build.
-          cosign verify --insecure-ignore-tlog \
-            --key "$SIGNER" "${DESTINATION}@${DIGEST}" > /dev/null
+          # The registry credentials are the ones the login steps already wrote
+          # to the Docker config; cosign reads them from there, so nothing here
+          # holds a credential of its own (§13).
+          while IFS= read -r destination; do
+            [ -n "$destination" ] || continue
+            echo "signing ${destination}@${DIGEST}"
+            cosign sign --yes --tlog-upload=false \
+              --key "$SIGNER" "${destination}@${DIGEST}"
+            # Verified here as well as at admission, because a signature that
+            # cannot be checked by the key that made it is a build that should
+            # fail now rather than a Deploy that is refused later by a webhook
+            # whose message is about a policy rather than about this build.
+            cosign verify --insecure-ignore-tlog \
+              --key "$SIGNER" "${destination}@${DIGEST}" > /dev/null
+          done <<< "$DESTINATIONS"
 
       # The other half of the same key, for the other kind of verifier.
       #
@@ -309,7 +370,7 @@ jobs:
         env:
           ATTESTOR: ${{ steps.request.outputs.attestor }}
           SIGNER: ${{ steps.request.outputs.signer }}
-          DESTINATION: ${{ steps.request.outputs.destination }}
+          DESTINATIONS: ${{ steps.request.outputs.destinations }}
           DIGEST: ${{ steps.push.outputs.digest }}
           # `sign-and-create` lives on the beta surface. Without this, a runner
           # image that does not carry the component stops to ask whether to
@@ -337,16 +398,26 @@ jobs:
           version="${version:-1}"
           echo "attesting with key version ${version}"
 
-          gcloud beta container binauthz attestations sign-and-create \
-            --project="$attestor_project" \
-            --artifact-url="${DESTINATION}@${DIGEST}" \
-            --attestor="$attestor_name" \
-            --attestor-project="$attestor_project" \
-            --keyversion-project="$key_project" \
-            --keyversion-location="$(field locations)" \
-            --keyversion-keyring="$(field keyRings)" \
-            --keyversion-key="$(field cryptoKeys)" \
-            --keyversion="$version"
+          # Once per destination, and for a sharper reason than the signature:
+          # an attestation is an occurrence bound to an **`--artifact-url`**, so
+          # one made against `ghcr.io/…` says nothing about the same digest at
+          # `…-docker.pkg.dev/…`. Binary Authorization would refuse the exact
+          # image it had already attested, because the URL it was asked about is
+          # not the URL it was told about.
+          while IFS= read -r destination; do
+            [ -n "$destination" ] || continue
+            echo "attesting ${destination}@${DIGEST}"
+            gcloud beta container binauthz attestations sign-and-create \
+              --project="$attestor_project" \
+              --artifact-url="${destination}@${DIGEST}" \
+              --attestor="$attestor_name" \
+              --attestor-project="$attestor_project" \
+              --keyversion-project="$key_project" \
+              --keyversion-location="$(field locations)" \
+              --keyversion-keyring="$(field keyRings)" \
+              --keyversion-key="$(field cryptoKeys)" \
+              --keyversion="$version"
+          done <<< "$DESTINATIONS"
 
       # The one line Spindrift reads. Base64 because this stdout goes through
       # the host's log processing on the way back, and a folded or decorated
@@ -372,9 +443,16 @@ jobs:
         env:
           BUNDLE_DIGEST: ${{ steps.request.outputs.bundleDigest }}
           DESTINATION: ${{ steps.request.outputs.destination }}
+          DESTINATIONS: ${{ steps.request.outputs.destinations }}
           DIGEST: ${{ steps.push.outputs.digest }}
         run: |
           set -euo pipefail
+          # One reference per destination, in the order core sent them — which
+          # is the manifest's order, and is what makes `refs[0]` still the
+          # registry a Target with no declared reachability gets.
+          refs="$(printf '%s' "$DESTINATIONS" \
+            | jq -R -s -c --arg digest "$DIGEST" \
+                'split("\n") | map(select(length > 0) | . + "@" + $digest)')"
           # Best effort, and null when it is not there: a base is fresh only at
           # build time, so §16 surfaces a stale one and never corrects it — but
           # a builder that cannot report one says so rather than guessing.
@@ -388,12 +466,13 @@ jobs:
             --arg digest "$DIGEST" \
             --arg destination "$DESTINATION" \
             --arg ref "${DESTINATION}@${DIGEST}" \
+            --argjson refs "$refs" \
             --arg base "$base" \
             --arg run "${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
             --arg workflow "$GITHUB_WORKFLOW_REF" \
             '{bundleDigest: $bundleDigest,
               digest: $digest,
-              refs: [$ref],
+              refs: $refs,
               baseDigest: (if $base == "" then null else $base end),
               buildkitProvenanceRef: $ref,
               sbomRef: $ref,

--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -37,10 +37,10 @@ export interface BuildKitProgramInput {
   /** The scope inside the bundle, after §5's unwrap. */
   readonly subpath: string;
   /**
-   * The repository the artifact is pushed to, without a tag. Core chose it; the
-   * route never does (§4).
+   * The repositories the artifact is pushed to, without tags. Core chose them;
+   * the route never does (§4). One build, one digest, every destination.
    */
-  readonly destination: string;
+  readonly destinations: readonly string[];
   /** The tags to push it under (§12). Core chose these too. */
   readonly tags: readonly string[];
   /** The zero-config frontend the installation pinned. */
@@ -73,7 +73,7 @@ export function buildKitProgramFor(
     bundleUrl: source.origin.location,
     bundleDigest: source.bundleDigest,
     subpath: source.origin.subpath,
-    destination: spec.destination,
+    destinations: spec.destinations,
     tags: spec.tags,
     zeroConfigFrontend,
     buildArgs: spec.buildArgs,
@@ -101,7 +101,9 @@ function quote(value: string): string {
  * are needed and neither substitutes for the other.
  */
 function imageNames(input: BuildKitProgramInput): string {
-  const refs = input.tags.map((tag) => `${input.destination}:${tag}`).join(',');
+  const refs = input.destinations
+    .flatMap((destination) => input.tags.map((tag) => `${destination}:${tag}`))
+    .join(',');
   return `"name=${refs}"`;
 }
 
@@ -204,9 +206,17 @@ ${args}
   --metadata-file "$workspace/metadata.json"
 
 digest=$(sed -n 's/.*"containerimage.digest"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p' "$workspace/metadata.json")
-ref=${quote(input.destination)}@"$digest"
-report=$(printf '{"bundleDigest":"%s","digest":"%s","refs":["%s"],"baseDigest":null,"buildkitProvenanceRef":"%s","sbomRef":"%s"}' \\
-  ${quote(input.bundleDigest)} "$digest" "$ref" "$ref" "$ref")
+# One digest, one reference per destination — the same manifest was pushed to
+# each, so the only thing that differs is the repository in front of the "@".
+# The first is what the provenance and SBOM are reported against, because those
+# are one document about one build rather than one per registry.
+refs=""
+for destination in ${input.destinations.map(quote).join(' ')}; do
+  refs="\${refs:+$refs,}\\"\${destination}@\${digest}\\""
+done
+ref=${quote(input.destinations[0] ?? '')}@"$digest"
+report=$(printf '{"bundleDigest":"%s","digest":"%s","refs":[%s],"baseDigest":null,"buildkitProvenanceRef":"%s","sbomRef":"%s"}' \\
+  ${quote(input.bundleDigest)} "$digest" "$refs" "$ref" "$ref")
 echo "${BUILD_REPORT_MARKER} $(printf '%s' "$report" | base64 | tr -d '\\n')"
 `;
 }

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -101,15 +101,27 @@ export interface BuildSpec {
   /** What the artifact must run on (§3). */
   platform: Platform;
   /**
-   * The **repository** the artifact is published to, without a tag. Core picks
-   * it from the Target's `reachableRegistries` (§3); an adapter never chooses
-   * its own destination.
+   * The **repositories** the artifact is published to, without tags. Core
+   * composes them from the installation's registries (§16); an adapter never
+   * chooses its own destination.
    *
-   * A repository and not the installation's registry namespace: the namespace
+   * Repositories and not the installation's registry namespaces: a namespace
    * is a prefix, and a registry answers `NAME_INVALID` to a single-segment
-   * path. `componentRepository` composes it.
+   * path. `componentRepositories` composes them.
+   *
+   * **Several, and every one is pushed to.** Two Targets on one installation
+   * cannot always share a registry — the cluster pulls anonymously from GitHub
+   * Container Registry, while Cloud Run pulls through a cache mirror that
+   * could not parse the OCI index pushed there. One build, one digest, N
+   * destinations: the runner pushes the same manifest to each and reports a
+   * reference per registry, and each Target pins the one it can reach.
+   *
+   * Order is the manifest's, and it is the order `refs` comes back in — so the
+   * first stays what a Target with no declared `reachableRegistries` gets.
+   *
+   * Never empty: a build with nowhere to push is refused at dispatch.
    */
-  destination: string;
+  destinations: readonly string[];
   /**
    * The tags to push it under, most specific first (§12).
    *

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -189,8 +189,17 @@ export interface BuildRequestSpec {
   readonly artifactType: BuildSpec['artifactType'];
   readonly kind: BuildSpec['kind'];
   readonly platform: BuildSpec['platform'];
-  /** The repository, without a tag. */
-  readonly destination: string;
+  /**
+   * The repositories, without tags — one per registry the installation names.
+   *
+   * `destination` (singular) is what every spec carried before two Targets on
+   * one installation turned out not to share a registry. The workflow reads
+   * this and falls back to that, because the caller pins this file by a local
+   * reference that resolves to the default branch while the controller image
+   * waits on a Flux rollout: for the length of that window a spec composed by
+   * the old controller reaches the new workflow.
+   */
+  readonly destinations: readonly string[];
   /** What to push it as (§12); the workflow tags with these and no others. */
   readonly tags: readonly string[];
   readonly buildArgs: Readonly<Record<string, string>>;
@@ -301,7 +310,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       artifactType: spec.artifactType,
       kind: spec.kind,
       platform: spec.platform,
-      destination: spec.destination,
+      destinations: spec.destinations,
       tags: spec.tags,
       buildArgs: spec.buildArgs,
       zeroConfigFrontend: this.options.zeroConfigFrontend,

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -155,10 +155,15 @@ export class CloudRunDeployAdapter implements DeployAdapter {
         `cloudrun does not accept a ${desired.artifact.type} artifact`,
       );
     }
-    const image = artifactAddress(desired.artifact);
+    const image = artifactAddress(
+      desired.artifact,
+      connection.reachableRegistries ?? [],
+    );
     if (image === null) {
       yield this.status('FAILED', { reason: 'INTERNAL' });
-      return this.internal('the artifact carries no address to pull it by');
+      return this.internal(
+        'the artifact carries no address this Target can pull it by',
+      );
     }
 
     const id = serviceId(desired);

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -161,7 +161,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
         `kubernetes does not accept a ${desired.artifact.type} artifact`,
       );
     }
-    const image = imageReference(desired);
+    const image = imageReference(desired, connection.reachableRegistries ?? []);
     if (image === null) {
       yield this.status('FAILED', { reason: 'INTERNAL' });
       return this.internal('the artifact carries no address to pull it by');

--- a/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/values.ts
@@ -142,8 +142,11 @@ export function configSecretName(desired: DesiredState): string {
  * immutable. An artifact with no address is a core bug — the adapter says so as
  * `INTERNAL` rather than rendering a release that cannot pull.
  */
-export function imageReference(desired: DesiredState): string | null {
-  return artifactAddress(desired.artifact);
+export function imageReference(
+  desired: DesiredState,
+  reachable: readonly string[] = [],
+): string | null {
+  return artifactAddress(desired.artifact, reachable);
 }
 
 /**

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -149,6 +149,9 @@ export class StaticDeployAdapter implements DeployAdapter {
         `static hosting serves Public only, and this Component is ${desired.exposure} (§9)`,
       );
     }
+    // No registry filter: a static Target serves `files`, and the reachability
+    // §3 models over registries is about pulling an image. Its discovery says
+    // so itself — `reachableRegistries: []`.
     const location = artifactAddress(desired.artifact);
     if (location === null) {
       yield this.status('FAILED', { reason: 'INTERNAL' });

--- a/apps/spindrift/src/commands/apps/resolve-placement.ts
+++ b/apps/spindrift/src/commands/apps/resolve-placement.ts
@@ -166,6 +166,7 @@ function derive(
     kind,
     exposure,
     platform: DEFAULT_PLATFORM,
+    registries: context.manifest.supplyChain.registry,
     resources: {},
     gpu: false,
     persistence: false,

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -41,7 +41,7 @@ import {
 } from '../../db/schema.ts';
 import {
   artifactTags,
-  componentRepository,
+  componentRepositories,
 } from '../../domain/artifact-name.ts';
 import {
   type BuildAttemptRef,
@@ -547,15 +547,16 @@ export const dispatchBuild = async (
    * Ahead of the signed URL deliberately: a bearer capability minted for a
    * Build that cannot be dispatched is one that exists for no reason.
    */
-  const destination = componentRepository({
-    registry: context.manifest.supplyChain.registry,
+  const registries = context.manifest.supplyChain.registry;
+  const destinations = componentRepositories({
+    registries,
     app: app.name,
     component: component.name,
   });
-  if (destination === null) {
+  if (destinations === null) {
     const sentence =
       `App "${app.name}" / Component "${component.name}" cannot name a ` +
-      `repository under ${context.manifest.supplyChain.registry}: a registry ` +
+      `repository under ${registries.join(' or ')}: a registry ` +
       `path segment is lowercase alphanumerics separated by "-", "_" or "."`;
     // §6's table covers "invalid spec" here, which is what a name no registry
     // will accept is — and it blames the developer, who is the one who can
@@ -621,7 +622,7 @@ export const dispatchBuild = async (
     artifactType: build.artifactType,
     kind: component.kind,
     platform: DEFAULT_PLATFORM,
-    destination,
+    destinations,
     /**
      * §12 counts tags, so a push that carried only the implicit `:latest` would
      * leave retention nothing to act on and a rollback depth of one.

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -609,6 +609,7 @@ async function revalidate(
       kind: draft.kind,
       exposure: draft.exposure,
       platform: DEFAULT_PLATFORM,
+      registries: context.manifest.supplyChain.registry,
       resources: {},
       gpu: false,
       persistence: false,

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -68,6 +68,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
         kind: 'service',
         exposure: 'private',
         platform: DEFAULT_PLATFORM,
+        registries: context.manifest.supplyChain.registry,
         resources: {},
         gpu: false,
         persistence: false,

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -387,12 +387,29 @@ export const installationManifestSchema = z
     supplyChain: z
       .object({
         /**
-         * Registry every artifact is pushed to and pulled from (§16). Named
-         * here rather than derived from the artifacts project because a
-         * mirror in front of it is a legitimate installation choice, and
-         * `offlineDeploy` (§3, §33) is derived from which host this names.
+         * The registries every artifact is pushed to and pulled from (§16).
+         * Named here rather than derived from the artifacts project because a
+         * mirror in front of one is a legitimate installation choice, and
+         * `offlineDeploy` (§3, §33) is derived from which host the first names.
+         *
+         * **Several, because two Targets on one installation cannot always
+         * share one.** §16 named a single registry and a placement filter over
+         * it, which has no answer for an installation whose cluster pulls
+         * anonymously from GitHub Container Registry while its Cloud Run
+         * Target pulls through a cache mirror that cannot parse what was
+         * pushed there. Each is pushed to; each Target pins the one it can
+         * reach (`artifactAddress`).
+         *
+         * A bare string is the same document as a one-element list and stays
+         * legal, so an installation with one registry says one thing and no
+         * stored manifest needs rewriting to keep parsing. Order is meaningful
+         * only as a tie-break: the first is what a Target with no declared
+         * `reachableRegistries` gets, which is every Target until an operator
+         * says otherwise.
          */
-        registry: nonEmptyString,
+        registry: z
+          .union([nonEmptyString, z.array(nonEmptyString).min(1)])
+          .transform((value) => (typeof value === 'string' ? [value] : value)),
         /**
          * Where signature verification fetches its material (§16) — the third
          * of the deploy path's references `offlineDeploy` is checked over.

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -105,7 +105,7 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
     app: 'packages/charts/spindrift-app',
   },
   supplyChain: {
-    registry: 'ghcr.io/spindrift',
+    registry: ['ghcr.io/spindrift'],
     verifier: 'ghcr.io/spindrift/spindrift-verifier',
     signer:
       'gcpkms://projects/spindrift-artifacts/locations/us-central1/keyRings/keys/cryptoKeys/signer',

--- a/apps/spindrift/src/domain/artifact-name.ts
+++ b/apps/spindrift/src/domain/artifact-name.ts
@@ -1,12 +1,16 @@
 /**
  * Where a Component's artifact is published, and under what tags.
  *
- * §16 names one registry per installation — "every artifact is pushed to and
- * pulled from" it — and that value is a **namespace**. A namespace is not a
- * place an image can be pushed: a registry host followed by one path segment is
- * not a repository, and every registry rejects it as a name before
- * authentication is relevant. Something has to append the rest, and this is
- * that place.
+ * §16 names the registries an installation pushes to — "every artifact is
+ * pushed to and pulled from" them — and each value is a **namespace**. A
+ * namespace is not a place an image can be pushed: a registry host followed by
+ * one path segment is not a repository, and every registry rejects it as a name
+ * before authentication is relevant. Something has to append the rest, and this
+ * is that place.
+ *
+ * **Several registries, one repository path under each.** Two Targets on one
+ * installation cannot always share a registry, so the same Component resolves
+ * to one repository per registry and the same digest is pushed to all of them.
  *
  * This is not a DNS name and `naming.ts` is not its home, for the same reason
  * {@link import('./workload-name.ts')} is not there: §9's names are what a user
@@ -47,26 +51,42 @@ export function isPathComponent(value: string): boolean {
 
 /** What a repository name is assembled from. */
 export interface ArtifactRepositoryParts {
-  /** The installation's registry namespace (§16) — a host and a namespace. */
-  readonly registry: string;
+  /** The installation's registry namespaces (§16) — a host and a namespace each. */
+  readonly registries: readonly string[];
   readonly app: string;
   readonly component: string;
 }
 
 /**
- * The repository one Component's artifacts are pushed to.
+ * The repositories one Component's artifacts are pushed to, one per registry.
  *
  * Returns `null` when either half cannot be a path component, so the caller
  * refuses with the offending name rather than handing a registry something it
  * will answer `NAME_INVALID` to — which is the failure this module exists to
  * end, and which cost a build every step up to `Build and push` to discover.
+ *
+ * All or none, because the App and Component names are what a registry rejects
+ * and they are the same names under every registry. A partial answer would push
+ * to one destination and silently not to another, which reads as "Cloud Run
+ * cannot pull an artifact the cluster is already running".
+ *
+ * Order is the manifest's order, and it is the order `refs` is recorded in — so
+ * `refs[0]` remains the first registry, which is what a Target that declares no
+ * `reachableRegistries` still gets.
  */
-export function componentRepository(
+export function componentRepositories(
   parts: ArtifactRepositoryParts,
-): string | null {
+): readonly string[] | null {
   if (!isPathComponent(parts.app)) return null;
   if (!isPathComponent(parts.component)) return null;
-  return `${parts.registry}/${parts.app}/${parts.component}`;
+  return parts.registries.map(
+    (registry) => `${registry}/${parts.app}/${parts.component}`,
+  );
+}
+
+/** The registry host a reference is pulled from — everything before the first `/`. */
+export function registryHostOf(reference: string): string {
+  return reference.split('/')[0] ?? '';
 }
 
 /**

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -202,8 +202,17 @@ export interface TargetInspection {
 export interface DeployPathReferences {
   /** The App chart every Component renders through (§7). */
   chart: string;
-  /** Where the artifact is pulled from (§16). */
-  image: string;
+  /**
+   * Where the artifact is pulled from (§16) — one entry per registry the
+   * installation pushes to.
+   *
+   * Plural because an installation whose Targets cannot share a registry pushes
+   * to each, and a Target only ever pulls from **one** of them. `offlineDeploy`
+   * is therefore satisfied when any one is served rather than when all are:
+   * requiring every registry would make a Target that mirrors the one it
+   * actually uses report that it cannot deploy offline.
+   */
+  images: readonly string[];
   /** Where signature verification fetches its material (§16). */
   verifier: string;
 }
@@ -214,7 +223,7 @@ export function deployPathReferences(
 ): DeployPathReferences {
   return {
     chart: manifest.charts.app,
-    image: manifest.supplyChain.registry,
+    images: manifest.supplyChain.registry,
     verifier: manifest.supplyChain.verifier,
   };
 }
@@ -307,8 +316,10 @@ export function deriveOfflineDeploy(
   servedHosts: readonly string[],
 ): boolean {
   const served = new Set(servedHosts.map(hostOf));
-  return [references.chart, references.image, references.verifier].every(
-    (reference) => served.has(hostOf(reference)),
+  return (
+    [references.chart, references.verifier].every((reference) =>
+      served.has(hostOf(reference)),
+    ) && references.images.some((reference) => served.has(hostOf(reference)))
   );
 }
 

--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -11,6 +11,7 @@
  * The shape is §6's, field for field. A field this file does not name is a field
  * core does not get to describe.
  */
+import { registryHostOf } from './artifact-name.ts';
 
 /**
  * What a Component is (§3, §5). `website` is not a chart branch — §7 renders it
@@ -47,19 +48,33 @@ export function immutableImageRef(artifact: Artifact): string | null {
 }
 
 /**
- * The address an adapter pulls the artifact by, or `null` when it has none.
+ * The address a Target pulls the artifact by, or `null` when it has none.
  *
- * §4 lets a Build report several — the same digest is reachable at a mirror as
- * well as at the registry it was pushed to — and every backend needs exactly
- * one. The first is taken rather than a preferred one selected, because
- * preference would need a cost model, and §3 declines to have one.
+ * §4 lets a Build report several — the same digest is pushed to every registry
+ * the installation names — and every backend needs exactly one. Which one is
+ * **not** a preference and needs no cost model: it is the one this Target can
+ * actually reach, which §3 already models as `reachableRegistries`.
  *
- * `null` is a real answer, and every adapter treats it as `INTERNAL`: an
- * artifact with no address is a Build that recorded a digest and nowhere to get
- * it, which is core's bug rather than the backend's.
+ * Taking the first instead is what put a `ghcr.io` reference on a Cloud Run
+ * revision that failed at the pull, several layers past IAM and Binary
+ * Authorization, with an artifact that was signed, attested and admitted.
+ *
+ * `reachable` empty means **no declared restriction**, not "reaches nothing" —
+ * which is every Target until an operator says otherwise, and is why the
+ * fallback is the first reference rather than none. A Target that declares
+ * registries and matches none of them is a Deploy that must not be written at
+ * all; {@link import('./placement.ts')} makes that a non-candidate before a
+ * Build is ever dispatched, and `null` here is the backstop for the case that
+ * gets past it.
  */
-export function artifactAddress(artifact: Artifact): string | null {
-  return artifact.refs[0] ?? null;
+export function artifactAddress(
+  artifact: Artifact,
+  reachable: readonly string[] = [],
+): string | null {
+  if (reachable.length === 0) return artifact.refs[0] ?? null;
+  return (
+    artifact.refs.find((ref) => reachable.includes(registryHostOf(ref))) ?? null
+  );
 }
 
 /**

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -31,6 +31,7 @@ import type {
 } from '../config/manifest.schema.ts';
 import {
   capabilitiesOfRow,
+  hostOf,
   type TargetCapabilities,
   type TargetDiscovery,
 } from './capabilities.ts';
@@ -69,6 +70,7 @@ export const EXCLUSIONS = [
   'DATASTORE_ENGINE_MISSING',
   'DATASTORE_IS_CLUSTER_LOCAL',
   'STORE_UNREACHABLE',
+  'REGISTRY_UNREACHABLE',
   'QUOTA_EXHAUSTED',
   'NO_ADAPTER',
 ] as const;
@@ -110,6 +112,15 @@ export interface DerivedRequirements {
   readonly datastores: readonly RequiredDatastore[];
   /** §10's reach rule: the store must be reachable by the Target chosen. */
   readonly secretStore: TargetCapabilities['reachableSecretStores'][number];
+  /**
+   * The registries this installation pushes every artifact to (§16).
+   *
+   * Here because §3 filters on reachability *before* a Build is dispatched, and
+   * a Target that can pull from none of them is a non-candidate rather than a
+   * failed revision hours later — which is what a `ghcr.io` reference on a
+   * Cloud Run service was, several layers past IAM and Binary Authorization.
+   */
+  readonly registries: readonly string[];
 }
 
 /** One attached Datastore, as a requirement. */
@@ -244,6 +255,8 @@ function sentence(
       return 'an attached datastore is cluster-local and lives elsewhere';
     case 'STORE_UNREACHABLE':
       return 'this Target cannot reach the secret store this App is configured through';
+    case 'REGISTRY_UNREACHABLE':
+      return 'this Target cannot pull from any registry this installation publishes to';
     case 'QUOTA_EXHAUSTED':
       return 'this Target has no quota left';
     case 'NO_ADAPTER':
@@ -366,6 +379,24 @@ export function exclusionsFor(
     !can.reachableSecretStores.includes(requirements.secretStore)
   ) {
     reasons.push('STORE_UNREACHABLE');
+  }
+
+  // Only where an image is what gets pulled: a `files` artifact is fetched from
+  // the depot, and a static Target's discovery says `reachableRegistries: []`
+  // for exactly that reason — reading it as "reaches nothing" would exclude the
+  // one Target the rule does not apply to.
+  //
+  // An empty list is **no declared restriction**, not "reaches nothing", which
+  // is every Target until an operator says otherwise. So this only bites where
+  // a Target names registries and none of them is one an artifact is pushed to.
+  if (
+    artifactTypeFor(requirements.kind, target) === 'image' &&
+    can.reachableRegistries.length > 0 &&
+    !requirements.registries.some((registry) =>
+      can.reachableRegistries.includes(hostOf(registry)),
+    )
+  ) {
+    reasons.push('REGISTRY_UNREACHABLE');
   }
 
   if (target.quotaExhausted === true) reasons.push('QUOTA_EXHAUSTED');

--- a/apps/spindrift/test/adapters/build-blame.test.ts
+++ b/apps/spindrift/test/adapters/build-blame.test.ts
@@ -40,7 +40,7 @@ const spec: BuildSpec = {
   artifactType: 'image',
   kind: 'service',
   platform: { os: 'linux', arch: 'amd64' },
-  destination: 'registry.example.test/app',
+  destinations: ['registry.example.test/app'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -29,7 +29,7 @@ const spec: BuildSpec = {
   artifactType: 'image',
   kind: 'service',
   platform: { os: 'linux', arch: 'arm64' },
-  destination: 'registry.example.test/apps',
+  destinations: ['registry.example.test/apps'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };
@@ -191,7 +191,7 @@ describe('the fake route reports what the product would accept', () => {
     if (result.status !== 'SUCCEEDED' || result.artifact === null) return;
     expect(result.artifact.digest).toBe(digest);
     expect(digestPinnedRef(result.artifact)).toBe(
-      `${spec.destination}@${digest}`,
+      `${spec.destinations[0]}@${digest}`,
     );
   });
 

--- a/apps/spindrift/test/adapters/build-report-statement.test.ts
+++ b/apps/spindrift/test/adapters/build-report-statement.test.ts
@@ -27,6 +27,16 @@ const REPORT_STEP = 'Report what was built';
 const BUNDLE_DIGEST = `sha256:${'b'.repeat(64)}`;
 const IMAGE_DIGEST = `sha256:${'a'.repeat(64)}`;
 const DESTINATION = 'ghcr.io/jonpulsifer/spindrift/demo/web';
+/**
+ * Two, because an installation whose Targets cannot share a registry pushes to
+ * each and the report has to carry a reference per registry (ticket 39). One
+ * build, one digest, N references — the cluster pulls the first and Cloud Run
+ * the second, and a report that carried only one is a Deploy that pins an
+ * address its Target cannot reach.
+ */
+const AR_DESTINATION =
+  'northamerica-northeast1-docker.pkg.dev/trusted-builds/i/demo/web';
+const DESTINATIONS = [DESTINATION, AR_DESTINATION];
 
 /** The `run:` script of the named step, straight out of the shipped file. */
 async function reportScript(): Promise<string> {
@@ -59,6 +69,7 @@ async function runReportStep() {
         PATH: Bun.env.PATH ?? '',
         BUNDLE_DIGEST,
         DESTINATION,
+        DESTINATIONS: DESTINATIONS.join('\n'),
         DIGEST: IMAGE_DIGEST,
         GITHUB_REPOSITORY: 'jonpulsifer/infra',
         GITHUB_RUN_ID: '12345',
@@ -89,7 +100,12 @@ describe('the hosted route reports a statement admission can read', () => {
     expect(report).not.toBeNull();
     expect(report?.bundleDigest).toBe(BUNDLE_DIGEST);
     expect(report?.digest).toBe(IMAGE_DIGEST);
-    expect(report?.refs).toEqual([`${DESTINATION}@${IMAGE_DIGEST}`]);
+    // One per destination, in the order core sent them — so `refs[0]` is still
+    // the first registry, which is what a Target that declares no reachable
+    // registries gets.
+    expect(report?.refs).toEqual(
+      DESTINATIONS.map((destination) => `${destination}@${IMAGE_DIGEST}`),
+    );
     expect(report?.baseDigest).toBeNull();
   });
 

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -68,7 +68,7 @@ const spec: BuildSpec = {
   artifactType: 'image',
   kind: 'service',
   platform: { os: 'linux', arch: 'amd64' },
-  destination: 'registry.example.test/app',
+  destinations: ['registry.example.test/app'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };
@@ -238,7 +238,7 @@ describe('the hosted build route', () => {
     const request = JSON.parse(host.dispatches[0]?.inputs.spec ?? '{}');
     expect(request.bundleDigest).toBe('sha256:bundle');
     expect(request.zeroConfigFrontend).toBe(FRONTEND);
-    expect(request.destination).toBe(spec.destination);
+    expect(request.destinations[0]).toBe(spec.destinations[0]);
   });
 
   test('a dispatch that is refused is a failure with the reason in the log', async () => {
@@ -790,7 +790,7 @@ describe('the BuildKit program', () => {
     bundleUrl: 'staged://bundle',
     bundleDigest: 'sha256:bundle',
     subpath: 'apps/web',
-    destination: 'registry.example.test/app',
+    destinations: ['registry.example.test/app'],
     tags: ['sha256-bundle', 'latest'],
     zeroConfigFrontend: FRONTEND,
     buildArgs: { PUBLIC_URL: 'https://app.example.test' },
@@ -850,7 +850,7 @@ describe('the BuildKit program', () => {
       bundleUrl: 'staged://bundle',
       bundleDigest: 'sha256:bundle',
       subpath: '.',
-      destination: 'registry.example.test/app',
+      destinations: ['registry.example.test/app'],
       tags: ['latest'],
       zeroConfigFrontend: 'registry.example.test/zero-config',
       buildArgs: {},
@@ -910,7 +910,7 @@ describe('the BuildKit program', () => {
       bundleUrl: "staged://bundle'; rm -rf /; echo '",
       bundleDigest: 'sha256:bundle',
       subpath: '.',
-      destination: 'registry.example.test/app',
+      destinations: ['registry.example.test/app'],
       tags: ['sha256-bundle', 'latest'],
       zeroConfigFrontend: FRONTEND,
       buildArgs: { EVIL: "'; rm -rf /; echo '" },

--- a/apps/spindrift/test/adapters/build-run-link.test.ts
+++ b/apps/spindrift/test/adapters/build-run-link.test.ts
@@ -38,7 +38,7 @@ const spec: BuildSpec = {
   artifactType: 'image',
   kind: 'service',
   platform: { os: 'linux', arch: 'amd64' },
-  destination: 'registry.example.test/app',
+  destinations: ['registry.example.test/app'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
 };

--- a/apps/spindrift/test/commands/build-destination.test.ts
+++ b/apps/spindrift/test/commands/build-destination.test.ts
@@ -136,8 +136,8 @@ describe('the destination dispatch hands a route', () => {
     // The bug, stated as an assertion: `ghcr.io/jonpulsifer` reached a runner
     // verbatim and GHCR answered `NAME_INVALID` before authentication was
     // relevant, so `Build and push` could not succeed whatever the App built.
-    expect(route.built[0]?.spec.destination).not.toBe(REGISTRY);
-    expect(route.built[0]?.spec.destination).toBe(
+    expect(route.built[0]?.spec.destinations[0]).not.toBe(REGISTRY);
+    expect(route.built[0]?.spec.destinations[0]).toBe(
       `${REGISTRY}/infra/spindrift-demo`,
     );
   });
@@ -155,8 +155,8 @@ describe('the destination dispatch hands a route', () => {
     await dispatchBuild({ buildId: build.id, route: 'hosted' }, context);
 
     expect(route.built).toHaveLength(2);
-    expect(route.built[0]?.spec.destination).toBe(
-      route.built[1]?.spec.destination,
+    expect(route.built[0]?.spec.destinations[0]).toBe(
+      route.built[1]?.spec.destinations[0],
     );
   });
 
@@ -171,8 +171,10 @@ describe('the destination dispatch hands a route', () => {
     const worker = await seedBuild({ app: 'shop2', component: 'worker' });
     await dispatchBuild({ buildId: worker.id, route: 'hosted' }, context);
 
-    expect(route.built[0]?.spec.destination).toBe(`${REGISTRY}/shop/web`);
-    expect(route.built[1]?.spec.destination).toBe(`${REGISTRY}/shop2/worker`);
+    expect(route.built[0]?.spec.destinations[0]).toBe(`${REGISTRY}/shop/web`);
+    expect(route.built[1]?.spec.destinations[0]).toBe(
+      `${REGISTRY}/shop2/worker`,
+    );
   });
 
   test('carries the tags §12 counts, not only an implicit latest', async () => {

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -246,7 +246,7 @@ export function buildAdapterSuite(
       artifactType: 'image',
       kind: 'service',
       platform: { os: 'linux', arch: 'amd64' },
-      destination: 'registry.example.test/app',
+      destinations: ['registry.example.test/app'],
       tags: ['sha256-bundle', 'latest'],
       buildArgs: {},
     } as const;

--- a/apps/spindrift/test/conformance/second-target-admission.test.ts
+++ b/apps/spindrift/test/conformance/second-target-admission.test.ts
@@ -171,6 +171,7 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
       gpu: false,
       persistence: false,
       datastores: [],
+      registries: ['registry.example.test'],
       secretStore: 'onepassword',
     });
 

--- a/apps/spindrift/test/domain/artifact-address.test.ts
+++ b/apps/spindrift/test/domain/artifact-address.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Which reference a Target pulls the artifact by (ticket 39).
+ *
+ * §16 named one registry per installation, and `artifactAddress` took `refs[0]`
+ * because "preference would need a cost model, and §3 declines to have one".
+ * Which registry a Target can reach is not a preference and needs no cost
+ * model — §3 already models it as `reachableRegistries` — and taking the first
+ * instead is what put a `ghcr.io` reference on a Cloud Run revision that failed
+ * at the *pull*, several layers past IAM and Binary Authorization, on an
+ * artifact that was signed, attested and admitted:
+ *
+ * ```text
+ * Revision 'plainboi-web-00001-vcw' is not ready and cannot serve traffic.
+ * Image 'cache.us-docker.pkg.dev/ghcr.io/jonpulsifer/plainboi/web@sha256:e6bbf889…'
+ * parsing failed.
+ * ```
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  type Artifact,
+  artifactAddress,
+} from '../../src/domain/desired-state.ts';
+
+const DIGEST = `sha256:${'a'.repeat(64)}`;
+const GHCR = 'ghcr.io/jonpulsifer/plainboi/web';
+const AR =
+  'northamerica-northeast1-docker.pkg.dev/trusted-builds/i/plainboi/web';
+
+const PUSHED: Artifact = {
+  type: 'image',
+  digest: DIGEST,
+  refs: [`${GHCR}@${DIGEST}`, `${AR}@${DIGEST}`],
+};
+
+describe('the address a Target pulls an artifact by', () => {
+  test('is the one its registry reachability names, not the first', () => {
+    // The whole ticket in one assertion: same artifact, same digest, two
+    // Targets, two addresses.
+    expect(
+      artifactAddress(PUSHED, ['northamerica-northeast1-docker.pkg.dev']),
+    ).toBe(`${AR}@${DIGEST}`);
+    expect(artifactAddress(PUSHED, ['ghcr.io'])).toBe(`${GHCR}@${DIGEST}`);
+  });
+
+  test('falls back to the first where a Target declares no restriction', () => {
+    // Empty is "nothing was said", not "reaches nothing" — which is every
+    // Target on this installation until an operator says otherwise, and is why
+    // this cannot be `null`.
+    expect(artifactAddress(PUSHED)).toBe(`${GHCR}@${DIGEST}`);
+    expect(artifactAddress(PUSHED, [])).toBe(`${GHCR}@${DIGEST}`);
+  });
+
+  test('is null where a Target reaches none of the registries pushed to', () => {
+    // The backstop. Placement makes this Target a non-candidate before a Build
+    // is dispatched; an adapter reaching here anyway renders no workload rather
+    // than one that cannot pull.
+    expect(artifactAddress(PUSHED, ['registry.internal.example'])).toBeNull();
+  });
+
+  test('is null for an artifact with no address at all', () => {
+    expect(
+      artifactAddress({ type: 'image', digest: DIGEST, refs: [] }),
+    ).toBeNull();
+  });
+});

--- a/apps/spindrift/test/domain/artifact-name.test.ts
+++ b/apps/spindrift/test/domain/artifact-name.test.ts
@@ -11,7 +11,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   artifactTags,
   bundleTag,
-  componentRepository,
+  componentRepositories,
   isPathComponent,
   MOVING_TAG,
 } from '../../src/domain/artifact-name.ts';
@@ -23,66 +23,101 @@ const DIGEST =
 describe('a Component’s repository', () => {
   test('nests the App and the Component under the registry', () => {
     expect(
-      componentRepository({
-        registry: REGISTRY,
+      componentRepositories({
+        registries: [REGISTRY],
         app: 'infra',
         component: 'spindrift-demo',
       }),
-    ).toBe('ghcr.io/jonpulsifer/infra/spindrift-demo');
+    ).toEqual(['ghcr.io/jonpulsifer/infra/spindrift-demo']);
   });
 
   test('is a repository and never the bare namespace', () => {
-    const repository = componentRepository({
-      registry: REGISTRY,
+    const repository = componentRepositories({
+      registries: [REGISTRY],
       app: 'infra',
       component: 'web',
     });
     // The defect verbatim: GHCR answers `NAME_INVALID` to a single-segment
     // path, which is what the registry alone is.
-    expect(repository).not.toBe(REGISTRY);
-    expect(repository?.slice(REGISTRY.length)).toBe('/infra/web');
+    expect(repository).not.toContain(REGISTRY);
+    expect(repository?.[0]?.slice(REGISTRY.length)).toBe('/infra/web');
   });
 
   test('is stable — the same Component composes the same name twice', () => {
-    const parts = { registry: REGISTRY, app: 'infra', component: 'web' };
-    expect(componentRepository(parts)).toBe(componentRepository(parts));
+    const parts = { registries: [REGISTRY], app: 'infra', component: 'web' };
+    expect(componentRepositories(parts)).toEqual(componentRepositories(parts));
   });
 
   test('nests rather than joining, so a hyphen in either half is unambiguous', () => {
     // `naming.ts` states the reason for canonical names and it holds here:
     // flattened, these two would both be `my-app-web-api`.
-    const first = componentRepository({
-      registry: REGISTRY,
+    const first = componentRepositories({
+      registries: [REGISTRY],
       app: 'my-app',
       component: 'web-api',
     });
-    const second = componentRepository({
-      registry: REGISTRY,
+    const second = componentRepositories({
+      registries: [REGISTRY],
       app: 'my-app-web',
       component: 'api',
     });
-    expect(first).not.toBe(second);
+    expect(first).not.toEqual(second);
   });
 
   test('refuses a name no registry would accept rather than projecting it', () => {
     // Projecting would push two Components to one repository, which is the
     // quiet failure: the second build overwrites the first's tag.
     expect(
-      componentRepository({
-        registry: REGISTRY,
+      componentRepositories({
+        registries: [REGISTRY],
         app: 'My App',
         component: 'web',
       }),
     ).toBeNull();
     expect(
-      componentRepository({
-        registry: REGISTRY,
+      componentRepositories({
+        registries: [REGISTRY],
         app: 'infra',
         component: 'Web',
       }),
     ).toBeNull();
     expect(
-      componentRepository({ registry: REGISTRY, app: '', component: 'web' }),
+      componentRepositories({
+        registries: [REGISTRY],
+        app: '',
+        component: 'web',
+      }),
+    ).toBeNull();
+  });
+
+  test('composes one repository per registry, in the manifest’s order', () => {
+    // Ticket 39: two Targets on one installation cannot always share a
+    // registry, so the same digest is pushed to each. `refs[0]` stays the
+    // first, which is what a Target declaring no reachability gets.
+    expect(
+      componentRepositories({
+        registries: [
+          REGISTRY,
+          'northamerica-northeast1-docker.pkg.dev/trusted-builds/i',
+        ],
+        app: 'infra',
+        component: 'web',
+      }),
+    ).toEqual([
+      'ghcr.io/jonpulsifer/infra/web',
+      'northamerica-northeast1-docker.pkg.dev/trusted-builds/i/infra/web',
+    ]);
+  });
+
+  test('refuses every registry or none — never a partial push', () => {
+    // A partial answer would push to one destination and silently not to the
+    // other, which reads as "Cloud Run cannot pull what the cluster is running".
+    expect(
+      componentRepositories({
+        registries: [REGISTRY, 'other.example.test/ns'],
+        app: 'My App',
+        component: 'web',
+      }),
     ).toBeNull();
   });
 });

--- a/apps/spindrift/test/domain/capabilities.test.ts
+++ b/apps/spindrift/test/domain/capabilities.test.ts
@@ -30,7 +30,7 @@ import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
 /** A deploy path served entirely by the Target itself. */
 const LOCAL_PATH = {
   chart: 'oci://registry.cluster.test/charts/app:1.0.0',
-  image: 'registry.cluster.test/artifacts',
+  images: ['registry.cluster.test/artifacts'],
   verifier: 'https://verifier.cluster.test/keys',
 };
 
@@ -117,7 +117,7 @@ describe('offlineDeploy is a static check over three references', () => {
   test('an unparseable reference fails closed', () => {
     // The claim is that a deploy needs nothing off-Target. A reference nobody
     // can read is not evidence for that claim.
-    expect(deriveOfflineDeploy({ ...LOCAL_PATH, image: '' }, SERVED)).toBe(
+    expect(deriveOfflineDeploy({ ...LOCAL_PATH, images: [''] }, SERVED)).toBe(
       false,
     );
   });

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -25,7 +25,7 @@ import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
 
 const DEPLOY_PATH = {
   chart: 'oci://registry.cluster.test/charts/app:1.0.0',
-  image: 'registry.cluster.test/artifacts',
+  images: ['registry.cluster.test/artifacts'],
   verifier: 'https://verifier.cluster.test/keys',
 };
 
@@ -81,6 +81,7 @@ function requirements(
     gpu: false,
     persistence: false,
     datastores: [],
+    registries: ['registry.example.test'],
     secretStore: 'gcp-secret-manager',
     ...overrides,
   };
@@ -268,6 +269,55 @@ describe('an attached datastore constrains where its App can go', () => {
       }),
     );
     expect(reasons).toEqual(['DATASTORE_ENGINE_MISSING']);
+  });
+});
+
+/**
+ * Ticket 39's third criterion — a Target that can reach none of the registries
+ * an artifact is pushed to is a non-candidate **before the build**, rather than
+ * a failed revision after it.
+ */
+describe('registry reachability at Place', () => {
+  test('a Target reaching none of them is excluded, with a reason', () => {
+    const excluded = exclusionsFor(
+      target({ discovery: { reachableRegistries: ['registry.internal'] } }),
+      requirements({ registries: ['registry.example.test/ns'] }),
+    );
+    expect(excluded).toEqual(['REGISTRY_UNREACHABLE']);
+  });
+
+  test('a Target reaching any one of them is a candidate', () => {
+    // Any, not all: an artifact is pulled once, from one registry.
+    expect(
+      exclusionsFor(
+        target({ discovery: { reachableRegistries: ['ghcr.io'] } }),
+        requirements({
+          registries: ['ghcr.io/ns', 'registry.internal/ns'],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  test('declaring nothing is no restriction, not "reaches nothing"', () => {
+    // Every Target on this installation, until an operator says otherwise —
+    // reading an empty list as a refusal would exclude all of them.
+    expect(
+      exclusionsFor(
+        target({ discovery: { reachableRegistries: [] } }),
+        requirements({ registries: ['registry.example.test/ns'] }),
+      ),
+    ).toEqual([]);
+  });
+
+  test('a static Target is not asked the question', () => {
+    // It serves `files`, fetched from the depot, and its discovery reports
+    // `reachableRegistries: []` for that reason rather than as a refusal.
+    expect(
+      exclusionsFor(
+        target({ adapter: 'static', discovery: { reachableRegistries: [] } }),
+        requirements({ kind: 'website', exposure: 'public' }),
+      ),
+    ).toEqual([]);
   });
 });
 

--- a/apps/spindrift/test/harness/fakes/build-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/build-adapter.ts
@@ -108,7 +108,7 @@ export class FakeBuildAdapter implements BuildAdapter {
       artifact: {
         type: spec.artifactType,
         digest,
-        refs: [`${spec.destination}@${digest}`],
+        refs: [`${spec.destinations[0]}@${digest}`],
       },
       logs,
       provenance: {
@@ -118,13 +118,13 @@ export class FakeBuildAdapter implements BuildAdapter {
         statement: fakeStatement({
           builderId: this.provenanceBuilderId,
           bundleDigest: source.bundleDigest,
-          destination: spec.destination,
+          destination: spec.destinations[0] ?? '',
           digest,
         }),
       },
       baseDigest: scripted.result.baseDigest ?? null,
-      buildkitProvenanceRef: `${spec.destination}@${digest}#buildkit`,
-      sbomRef: `${spec.destination}@${digest}#spdx`,
+      buildkitProvenanceRef: `${spec.destinations[0]}@${digest}#buildkit`,
+      sbomRef: `${spec.destinations[0]}@${digest}#spdx`,
     };
   }
 

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -199,9 +199,13 @@ describe('configuring this installation from the browser', () => {
     const { value } = (await read.json()) as {
       value: { manifest: InstallationManifest };
     };
-    expect(valueAt(value.manifest, ['supplyChain', 'registry'])).toBe(
+    // A list, from a document that wrote a bare string: an installation whose
+    // Targets cannot share a registry names several, and one is the same
+    // document as a one-element list (ticket 39). Nothing stored has to be
+    // rewritten to keep parsing.
+    expect(valueAt(value.manifest, ['supplyChain', 'registry'])).toEqual([
       'registry.example.test/second',
-    );
+    ]);
   });
 
   test('reconciles the Targets the written document declares', async () => {

--- a/terraform/gcp/projects/trusted-builds/artifact-registry.tf
+++ b/terraform/gcp/projects/trusted-builds/artifact-registry.tf
@@ -41,6 +41,30 @@ resource "google_artifact_registry_repository_iam_member" "reader_spindrift" {
   member     = each.key
 }
 
+# The hosted build route pushes here as well as to GHCR.
+#
+# Cloud Run cannot pull the GHCR artifact: it goes through a cache mirror that
+# could not parse an OCI index carrying provenance, an SBOM and a signature, and
+# the revision failed at the pull with a digest that was not the one deployed.
+# Every reader below was already granted; nothing wrote. This is the writer.
+#
+# The same principalSet the attestation steps federate as, so the job holds one
+# identity for signing, attesting and pushing rather than a registry credential
+# stored somewhere.
+resource "google_artifact_registry_repository_iam_member" "writer_builds" {
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.writer"
+  member     = "principalSet://iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/homelab/attribute.repository_owner/jonpulsifer"
+}
+
+# What an operator puts in `supplyChain.registry` alongside the GHCR namespace.
+# A namespace and not a repository: core appends `{app}/{component}`.
+output "registry_namespace" {
+  description = "Artifact Registry namespace Spindrift publishes to."
+  value       = "${local.region}-docker.pkg.dev/${local.project}/${google_artifact_registry_repository.images.repository_id}"
+}
+
 resource "google_artifact_registry_repository_iam_binding" "admins" {
   location   = google_artifact_registry_repository.images.location
   repository = google_artifact_registry_repository.images.name


### PR DESCRIPTION
Closes ticket **39**. Stacked conceptually behind #1568 but touches no file it does.

## The failure

Deploy 8 reached a Cloud Run revision — **past IAM, past Binary Authorization**, on an artifact that was signed, attested, and admitted by BinAuthz's own attestor — and failed at the *pull*:

```text
Revision 'plainboi-web-00001-vcw' is not ready and cannot serve traffic.
Image 'cache.us-docker.pkg.dev/ghcr.io/jonpulsifer/plainboi/web@sha256:e6bbf889…'
parsing failed.
```

Note the digest: `e6bbf889…`, not the `c11fb666…` that was deployed. Cloud Run pulls public GHCR images through a cache mirror, and what the mirror holds is not what was pushed — the pushed artifact is an OCI index with `provenance: mode=max`, an SPDX SBOM and a cosign signature hanging off it, several manifests whose platform is `unknown/unknown`.

The offsite cluster is fine: `ghcr.io/jonpulsifer/plainboi/web` is anonymously pullable and the cluster holds no pull secret. **Two connected Targets on this installation cannot both pull from one registry**, and §16's model — one registry, with `reachableRegistries` as a filter over it — has no answer for that.

## The shape

Push to each, and let each Target pin the reference it can pull.

| Layer | Change |
|---|---|
| Manifest | `supplyChain.registry` takes a string **or** a list. A bare string is the same document as a one-element list, so no stored manifest needs rewriting and there is no crash-loop window on the live installation. |
| Core | `BuildSpec.destination` → `destinations`. One buildx invocation, one digest, N registries — nothing is built twice. |
| Core | `artifactAddress(artifact, reachable)` picks the reference the Target can reach. Empty stays *no declared restriction*, so every Target keeps today's behaviour. |
| Core | Placement gains `REGISTRY_UNREACHABLE` — a non-candidate **before** the build, in §3's existing grammar. |
| Workflow | Auth to Google Cloud moves above the push; GHCR and Artifact Registry each get a login; tags span every destination. |
| Workflow | **Signature and attestation are made per destination.** |
| Terraform | `roles/artifactregistry.writer` for the build's WIF principalSet. |

### Why sign and attest per destination

This is the part that would have failed silently.

A cosign signature is a `sha256-<digest>.sig` object pushed **to the repository the artifact is in** — a signature made against `ghcr.io/…` is not there to be found by a Target pulling from `…-docker.pkg.dev/…`. An attestation is worse: it is an occurrence bound to an `--artifact-url`, so Binary Authorization would refuse the exact image it had already attested, because the URL it is asked about is not the URL it was told about.

Both loop over destinations now.

### The terraform half was already there

`terraform/gcp/projects/trusted-builds/artifact-registry.tf` already declares repository `i` and already grants `roles/artifactregistry.reader` to the bluenose Cloud Run service agent, the BinAuthz service agent, and the controller. **Nothing wrote.** This adds the one missing grant, to the same principalSet the signing steps already federate as — so the job holds one identity for pushing, signing and attesting rather than a stored registry credential.

Needs an `atlantis apply`.

## Checks

```
bun test        1193 pass, 0 fail
bun run typecheck
bun run lint    (1 pre-existing warning, unrelated file)
tofu validate   Success! The configuration is valid.
```

Ten new tests. The one worth naming is in `test/adapters/build-report-statement.test.ts`, which extracts the report step's `run:` script **out of the shipped YAML** and executes it — so "the workflow emits one ref per registry" is asserted against the file that actually runs, not a fixture.

## Operator steps after merge

1. `atlantis apply` the terraform, granting the writer.
2. Add the Artifact Registry namespace to `supplyChain.registry` through the installation form (the `registry_namespace` output names it).
3. Declare `reachableRegistries` on the two Targets so each pins its own reference.
4. Rebuild — which #1568 makes possible without editing a `builds` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)