### PR TITLE
feat(spindrift): connect a repository by reading it, not by asking

### DIFF
--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -46,6 +46,7 @@ export {
   pollRepositoryAuthorization,
 } from './repositories/authorize.ts';
 export { connectRepository } from './repositories/connect.ts';
+export { inspectRepository } from './repositories/inspect.ts';
 export { listRepositories } from './repositories/list.ts';
 export { listSourceBuckets } from './storage/list-buckets.ts';
 export { testBucketPermissions } from './storage/test-bucket.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -80,6 +80,10 @@ import {
   connectRepositoryInput,
 } from './repositories/connect.ts';
 import {
+  inspectRepository,
+  inspectRepositoryInput,
+} from './repositories/inspect.ts';
+import {
   listRepositories,
   listRepositoriesInput,
 } from './repositories/list.ts';
@@ -176,6 +180,10 @@ export const commandRegistry = {
   connectRepository: {
     input: connectRepositoryInput,
     handler: connectRepository,
+  },
+  inspectRepository: {
+    input: inspectRepositoryInput,
+    handler: inspectRepository,
   },
   connectTarget: { input: connectTargetInput, handler: connectTarget },
   disconnectTarget: {

--- a/apps/spindrift/src/commands/repositories/connect.ts
+++ b/apps/spindrift/src/commands/repositories/connect.ts
@@ -19,7 +19,14 @@
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { repositories } from '../../db/schema.ts';
-import type { repositoryRefOf } from '../../domain/repository.ts';
+import { declaredPlanner } from '../../domain/detection/declared.ts';
+import { scanRepository } from '../../domain/detection/discover.ts';
+import { gitHubTree } from '../../domain/detection/tree.ts';
+import type {
+  RepositoryHost,
+  RepositoryRef,
+  repositoryRefOf,
+} from '../../domain/repository.ts';
 import {
   type ConfigurationScope,
   configurationTransaction,
@@ -66,8 +73,30 @@ const operatorBuild = z.discriminatedUnion('frontend', [
 export const connectRepositoryInput = z
   .object({
     fullName,
-    /** One entry per App subpath the transaction will carry (§5, §15). */
-    scopes: z
+    /**
+     * Which directories the transaction covers, and nothing about them.
+     *
+     * §5's ladder is what turns a directory into a proposal, and it runs
+     * **here**, against the commit this connect resolves — not in the browser.
+     * The screen has already shown the operator what detection found; sending
+     * that answer back to be written would make the browser the author of
+     * domain state and would write whatever was on screen when the tab was
+     * opened, which is not necessarily what is on the default branch now.
+     *
+     * Omitted entirely means the same thing `inspectRepository` means by it:
+     * the root, or what is below it when the root is not itself an App.
+     */
+    scopes: z.array(scopePath).min(1).max(24).optional(),
+    /**
+     * The escape hatch (story 32): assert the proposal instead of detecting it.
+     *
+     * Kept separate from `scopes` rather than making every field optional on
+     * one shape, because these two are different acts. One says "connect what
+     * you found"; the other says "I know better than the detector, and here is
+     * what to write". A half-filled mixture of the two is not a third act, and
+     * the schema declines to represent it.
+     */
+    overrides: z
       .array(
         z.object({
           scope: scopePath,
@@ -76,7 +105,8 @@ export const connectRepositoryInput = z
           watchPaths: z.array(scopePath).min(1),
         }),
       )
-      .min(1, 'a configuration pull request needs at least one scope'),
+      .min(1)
+      .optional(),
   })
   .strict();
 
@@ -90,6 +120,80 @@ export interface ConnectRepositoryResult {
   readonly pullRequest: number | null;
   /** Always null: nothing is authoritative before that merge (§15). */
   readonly authoritativeCommit: null;
+}
+
+/**
+ * What the transaction will carry: detection's answer, or the operator's.
+ *
+ * The two arms are the two acts the input schema separates. An override is
+ * written exactly as asserted and marked `operator`, so the pull request's
+ * "proposed by" column tells a reviewer that a human, not the detector, chose
+ * this — which is the difference that matters when the review is about whether
+ * to trust it.
+ *
+ * Unsupported scopes are dropped rather than refused. A monorepo with nine
+ * directories and two Apps is the ordinary case, and failing the connect
+ * because seven of them are libraries would make discovery useless. The caller
+ * refuses only when *nothing* survived.
+ */
+async function configurationScopes(
+  input: ConnectRepositoryInput,
+  host: RepositoryHost,
+  ref: RepositoryRef,
+  defaultBranch: string,
+): Promise<{
+  readonly scopes: ConfigurationScope[];
+  /** The revision detection read, or null when nothing needed reading. */
+  readonly commit: string | null;
+}> {
+  if (input.overrides !== undefined) {
+    // No commit is resolved on this path, and that is not an optimization: an
+    // asserted proposal is a statement about what the operator wants written,
+    // not about what is currently on the branch. Reading the repository to
+    // write it would add a way for this act to fail that has nothing to do
+    // with what it does.
+    return {
+      commit: null,
+      scopes: input.overrides.map(({ scope, kind, build, watchPaths }) => ({
+        scope,
+        proposal: {
+          source: 'operator' as const,
+          kind,
+          reason: `an operator asserted this scope is a ${kind}`,
+          kinds: (['service', 'website', 'job'] as const).map((candidate) =>
+            candidate === kind
+              ? { kind: candidate, available: true as const }
+              : {
+                  kind: candidate,
+                  available: false as const,
+                  reason: 'the operator selected another kind',
+                },
+          ),
+          build,
+          watchPaths,
+        },
+      })),
+    };
+  }
+
+  // Resolved here rather than taken as a parameter, because it is what
+  // detection reads and what the pull request will be a statement about. A
+  // repository that moved between the operator seeing the inspection and
+  // pressing the button is connected against what is on the branch **now**.
+  const commit = await host.branchHead(ref, input.fullName, defaultBranch);
+  const found = await scanRepository(
+    gitHubTree(host, ref, input.fullName, commit),
+    declaredPlanner(),
+    input.scopes,
+  );
+  return {
+    commit,
+    scopes: found.flatMap((result) =>
+      result.outcome === 'detected'
+        ? [{ scope: result.scope, proposal: result.proposal }]
+        : [],
+    ),
+  };
 }
 
 export const connectRepository: Command<
@@ -152,6 +256,43 @@ export const connectRepository: Command<
     );
   }
 
+  let scopes: ConfigurationScope[];
+  let commit: string | null;
+  try {
+    ({ scopes, commit } = await configurationScopes(
+      input,
+      host,
+      ref,
+      defaultBranch,
+    ));
+  } catch (cause) {
+    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
+      return failed(
+        'NOT_FOUND',
+        `Spindrift lost access to ${input.fullName} while reading it`,
+      );
+    }
+    return failed(
+      'NOT_DEPLOYABLE',
+      `Spindrift could not read ${input.fullName}: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+  }
+
+  if (scopes.length === 0) {
+    // Nothing is written, deliberately. A `repositories` row with no scope is a
+    // connection to nothing: the repo loop would adopt it, find no App, and
+    // reconcile forever over a repository that cannot produce a Build. §5 makes
+    // "I do not know how to build this" an outcome to state, and this is where
+    // it gets stated — before a row exists rather than after.
+    const at = commit === null ? '' : ` at ${commit.slice(0, 7)}`;
+    return failed(
+      'NOT_DEPLOYABLE',
+      `Spindrift found nothing it knows how to build in ${input.fullName}${at}. Add a spindrift.yaml or a Dockerfile to the directory you want deployed, then connect it again.`,
+    );
+  }
+
   const now = context.clock.now();
   const [row] = await context.db
     .insert(repositories)
@@ -174,26 +315,6 @@ export const connectRepository: Command<
 
   let pullRequest: number | null = null;
   if (buildWorkflow !== null) {
-    const scopes: ConfigurationScope[] = input.scopes.map(
-      ({ scope, kind, build, watchPaths }) => ({
-        scope,
-        proposal: {
-          source: 'operator',
-          kind,
-          kinds: (['service', 'website', 'job'] as const).map((candidate) =>
-            candidate === kind
-              ? { kind: candidate, available: true }
-              : {
-                  kind: candidate,
-                  available: false,
-                  reason: 'the operator selected another kind',
-                },
-          ),
-          build,
-          watchPaths,
-        },
-      }),
-    );
     const transaction = configurationTransaction({
       scopes,
       buildWorkflow,

--- a/apps/spindrift/src/commands/repositories/inspect.ts
+++ b/apps/spindrift/src/commands/repositories/inspect.ts
@@ -1,0 +1,199 @@
+/**
+ * `inspectRepository` — read a repository and say what is deployable in it.
+ *
+ * This command writes nothing. It exists so that connecting a repository can be
+ * a thing a developer *reads and confirms* rather than a form they fill in:
+ * §5's ladder already knows how to turn one directory into one Component
+ * proposal, and until now the only caller that could have asked it was a test.
+ *
+ * Two properties make it safe to run on a keystroke:
+ *
+ * - **It is pinned to a commit.** The default branch's head is resolved once and
+ *   every read is against that sha, so what the screen shows and what
+ *   `connectRepository` later writes are statements about the same code — even
+ *   if somebody pushes in between, in which case the connect re-resolves and
+ *   re-detects rather than writing a stale answer.
+ * - **It is one tree read plus a handful of blobs.** No clone, no checkout, no
+ *   builder. `gitHubTree` caches both, so inspecting five scopes in a monorepo
+ *   costs one listing, not five.
+ *
+ * The unhappy path is a first-class result rather than an error: §5 makes "I do
+ * not know how to build this" an outcome, and a repository where nothing is
+ * recognized answers with an empty `scopes` and the reason each candidate was
+ * passed over.
+ */
+import { z } from 'zod';
+import type { ComponentKind } from '../../domain/desired-state.ts';
+import { declaredPlanner } from '../../domain/detection/declared.ts';
+import { scanRepository } from '../../domain/detection/discover.ts';
+import type { DetectionProposal } from '../../domain/detection/ladder.ts';
+import { gitHubTree } from '../../domain/detection/tree.ts';
+import { GitHubAccessError } from '../../integrations/github/http.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+/** `owner/name` — the only handle the repository API takes. */
+const fullName = z
+  .string()
+  .trim()
+  .regex(/^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/, 'must be owner/name');
+
+/** §5's named scope: a repo-relative directory, `.` for the root. */
+const scopePath = z
+  .string()
+  .trim()
+  .min(1)
+  .refine(
+    (value) => !value.startsWith('/') && !value.split(/[\\/]/).includes('..'),
+    'must stay inside the repository',
+  );
+
+export const inspectRepositoryInput = z
+  .object({
+    fullName,
+    /**
+     * Directories to inspect. Omitted means: look at the root, and if the root
+     * is not itself an App, discover what is below it.
+     */
+    scopes: z.array(scopePath).max(24).optional(),
+  })
+  .strict();
+
+export type InspectRepositoryInput = z.infer<typeof inspectRepositoryInput>;
+
+/** What one directory turned out to be. */
+export type InspectedScope =
+  | {
+      readonly scope: string;
+      readonly outcome: 'detected';
+      readonly kind: ComponentKind;
+      /** Why detection says so, in words a person reads on the screen. */
+      readonly reason: string;
+      readonly frontend: 'railpack' | 'dockerfile';
+      /** Set only for the `dockerfile` frontend. */
+      readonly dockerfile: string | null;
+      /** Where a static rendering would lift files from, when there is one. */
+      readonly outputDirectory: string | null;
+      readonly watchPaths: readonly string[];
+      /** True when an in-repo `spindrift.yaml` already settled this (§5). */
+      readonly configured: boolean;
+    }
+  | {
+      readonly scope: string;
+      readonly outcome: 'unsupported';
+      readonly detail: string;
+    };
+
+export interface InspectRepositoryResult {
+  readonly fullName: string;
+  readonly defaultBranch: string;
+  /** The exact revision every answer below is about. */
+  readonly commit: string;
+  readonly scopes: readonly InspectedScope[];
+  /**
+   * Whether this installation can open the configuration PR at all.
+   *
+   * §15 makes the pinned reusable workflow part of the transaction, so an
+   * installation without one has nothing to connect a repository *to*. Said
+   * here, on the screen that is about to offer the button, rather than
+   * discovered by the button not working.
+   */
+  readonly canConnect: boolean;
+}
+
+function viewOf(scope: string, proposal: DetectionProposal): InspectedScope {
+  return {
+    scope,
+    outcome: 'detected',
+    kind: proposal.kind,
+    reason: proposal.reason,
+    frontend: proposal.build.frontend,
+    dockerfile:
+      proposal.build.frontend === 'dockerfile'
+        ? proposal.build.dockerfile
+        : null,
+    outputDirectory:
+      proposal.build.frontend === 'railpack'
+        ? proposal.build.outputDirectory
+        : null,
+    watchPaths: proposal.watchPaths,
+    configured: proposal.source === 'spindrift-file',
+  };
+}
+
+export const inspectRepository: Command<
+  InspectRepositoryInput,
+  InspectRepositoryResult
+> = async (input, context) => {
+  const host = context.adapters.repository();
+  if (host === null) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this installation has no repository integration, so nothing can be read from one',
+    );
+  }
+  if (host.installationFor === undefined) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this repository integration cannot discover installations, so nothing new can be inspected',
+    );
+  }
+
+  let ref: Awaited<ReturnType<NonNullable<typeof host.installationFor>>>;
+  let defaultBranch: string;
+  let commit: string;
+  try {
+    ref = await host.installationFor(input.fullName);
+    ({ defaultBranch } = await host.repository(ref, input.fullName));
+    commit = await host.branchHead(ref, input.fullName, defaultBranch);
+  } catch (cause) {
+    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
+      return failed(
+        'NOT_FOUND',
+        `Spindrift cannot reach ${input.fullName}: authorize GitHub and check that the App installation selects it`,
+      );
+    }
+    return failed(
+      'NOT_FOUND',
+      `Spindrift cannot reach ${input.fullName}: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+  }
+
+  let scopes: readonly InspectedScope[];
+  try {
+    const found = await scanRepository(
+      gitHubTree(host, ref, input.fullName, commit),
+      declaredPlanner(),
+      input.scopes,
+    );
+    scopes = found.map((result) =>
+      result.outcome === 'detected'
+        ? viewOf(result.scope, result.proposal)
+        : {
+            scope: result.scope,
+            outcome: 'unsupported' as const,
+            detail: result.detail,
+          },
+    );
+  } catch (cause) {
+    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
+      return failed(
+        'NOT_FOUND',
+        `Spindrift lost access to ${input.fullName} while reading it`,
+      );
+    }
+    return failed(
+      'NOT_DEPLOYABLE',
+      `Spindrift could not read ${input.fullName} at ${commit.slice(0, 7)}: ${
+        cause instanceof Error ? cause.message : String(cause)
+      }`,
+    );
+  }
+
+  return ok({
+    fullName: input.fullName,
+    defaultBranch,
+    commit,
+    scopes,
+    canConnect: (context.manifest.github?.buildWorkflow ?? null) !== null,
+  });
+};

--- a/apps/spindrift/src/domain/detection/declared.ts
+++ b/apps/spindrift/src/domain/detection/declared.ts
@@ -1,0 +1,293 @@
+/**
+ * The plan a project's *declared* dependencies imply (§5).
+ *
+ * §5 gives language and framework detection to "the zero-config builder", and
+ * that builder is Railpack — which runs inside the BuildKit build, days of
+ * wall-clock after the moment a developer is looking at a connect screen
+ * waiting to be told what their repository is. So there are two questions here
+ * wearing one name, and this module answers only the first:
+ *
+ * - **What is this?** — a `kind`, and for a website the directory its build
+ *   leaves files in. Answered here, at connect time, from what the project
+ *   declares about itself. Spindrift needs it before any build exists, because
+ *   `kind` decides placement and placement decides the artifact's shape (§3).
+ * - **How is it built?** — the command, the toolchain, the base image. Left to
+ *   Railpack, which is why {@link declaredPlanner} always proposes a null
+ *   `buildCommand`. Guessing one here would be a worse answer than the one the
+ *   builder produces from the same files, and it would be the answer that wins.
+ *
+ * `outputDirectory` is the exception that proves it, and it is not Railpack's
+ * to know: it is where *Spindrift* lifts files from when a website is placed on
+ * a static Target (§3, story 42). No builder is asked that question, so it is
+ * asked here.
+ *
+ * **Foreign build config is not read** (§5). `next.config.js` can turn Next.js
+ * into a static export and this module will not know it — reading it means
+ * evaluating somebody's JavaScript, and the surface past that is unbounded. A
+ * project that exports statically says so by editing its `spindrift.yaml`,
+ * which is the override §5 gives it and which wins permanently.
+ */
+import type { ComponentKind } from '../desired-state.ts';
+import type {
+  InferredComponentKind,
+  KindOption,
+  ZeroConfigPlan,
+  ZeroConfigPlanner,
+} from './ladder.ts';
+import { exists, type SourceTree } from './tree.ts';
+
+/**
+ * One recognizable way of declaring what a project is.
+ *
+ * `outputDirectory: null` means "this renders a server, not a directory of
+ * files" — it is not "unknown". A website whose output directory is null is
+ * placeable as a server image and not as static files, and the placement
+ * screen says so in those words rather than failing at build time.
+ */
+interface Preset {
+  /** What a human calls it. Shown on the connect screen. */
+  readonly label: string;
+  /** The dependency whose presence proves it. */
+  readonly dependency: string;
+  readonly kind: InferredComponentKind;
+  readonly outputDirectory: string | null;
+}
+
+/**
+ * Ordered, most specific first: a SvelteKit app depends on `vite`, a Gatsby
+ * app on `react`, and the first match wins. Reordering this changes answers.
+ */
+const PRESETS: readonly Preset[] = [
+  {
+    label: 'Next.js',
+    dependency: 'next',
+    kind: 'website',
+    outputDirectory: null,
+  },
+  { label: 'Nuxt', dependency: 'nuxt', kind: 'website', outputDirectory: null },
+  {
+    label: 'Remix',
+    dependency: '@remix-run/dev',
+    kind: 'website',
+    outputDirectory: null,
+  },
+  {
+    label: 'SvelteKit',
+    dependency: '@sveltejs/kit',
+    kind: 'website',
+    outputDirectory: null,
+  },
+  {
+    label: 'Docusaurus',
+    dependency: '@docusaurus/core',
+    kind: 'website',
+    outputDirectory: 'build',
+  },
+  {
+    label: 'Gatsby',
+    dependency: 'gatsby',
+    kind: 'website',
+    outputDirectory: 'public',
+  },
+  {
+    label: 'Astro',
+    dependency: 'astro',
+    kind: 'website',
+    outputDirectory: 'dist',
+  },
+  {
+    label: 'Angular',
+    dependency: '@angular/cli',
+    kind: 'website',
+    outputDirectory: 'dist',
+  },
+  {
+    label: 'Create React App',
+    dependency: 'react-scripts',
+    kind: 'website',
+    outputDirectory: 'build',
+  },
+  {
+    label: 'Vue CLI',
+    dependency: '@vue/cli-service',
+    kind: 'website',
+    outputDirectory: 'dist',
+  },
+  {
+    label: 'Vite',
+    dependency: 'vite',
+    kind: 'website',
+    outputDirectory: 'dist',
+  },
+  {
+    label: 'Parcel',
+    dependency: 'parcel',
+    kind: 'website',
+    outputDirectory: 'dist',
+  },
+];
+
+/**
+ * The dependency each preset is recognized by.
+ *
+ * Exported because it is vocabulary rather than configuration — the package
+ * that means "this is a Next.js app" is the same package in every installation
+ * — and the literal scanner reads this list rather than carrying its own copy,
+ * so adding a preset does not break a test somewhere else.
+ */
+export const PRESET_DEPENDENCIES: readonly string[] = PRESETS.map(
+  (preset) => preset.dependency,
+);
+
+/** A manifest file whose mere existence names a long-running process. */
+const SERVICE_MANIFESTS: readonly {
+  readonly file: string;
+  readonly label: string;
+}[] = [
+  { file: 'go.mod', label: 'Go' },
+  { file: 'Cargo.toml', label: 'Rust' },
+  { file: 'pyproject.toml', label: 'Python' },
+  { file: 'requirements.txt', label: 'Python' },
+  { file: 'Gemfile', label: 'Ruby' },
+];
+
+interface PackageManifest {
+  readonly dependencies?: Readonly<Record<string, string>>;
+  readonly devDependencies?: Readonly<Record<string, string>>;
+  readonly optionalDependencies?: Readonly<Record<string, string>>;
+  readonly peerDependencies?: Readonly<Record<string, string>>;
+  readonly scripts?: Readonly<Record<string, string>>;
+}
+
+function declaredDependencies(manifest: PackageManifest): ReadonlySet<string> {
+  return new Set([
+    ...Object.keys(manifest.dependencies ?? {}),
+    ...Object.keys(manifest.devDependencies ?? {}),
+    ...Object.keys(manifest.optionalDependencies ?? {}),
+    ...Object.keys(manifest.peerDependencies ?? {}),
+  ]);
+}
+
+/**
+ * The disabled-with-reasons grammar (§3, §5), for one settled kind.
+ *
+ * Every kind stays on the list wearing why it was not chosen, because "nowhere
+ * fits" and "not what I meant" are both corrections a developer makes by
+ * reading rather than by guessing.
+ */
+function kindOptions(
+  chosen: InferredComponentKind,
+  because: string,
+): readonly KindOption[] {
+  const unavailable: Record<ComponentKind, string> = {
+    service: because,
+    website: because,
+    job: 'jobs are asserted, never inferred',
+  };
+  return (['service', 'website', 'job'] as const).map((kind) =>
+    kind === chosen
+      ? { kind, available: true as const }
+      : { kind, available: false as const, reason: unavailable[kind] },
+  );
+}
+
+function joinPath(scope: string, file: string): string {
+  return scope === '.' ? file : `${scope}/${file}`;
+}
+
+async function readPackageManifest(
+  tree: SourceTree,
+  scope: string,
+): Promise<PackageManifest | null> {
+  const document = await tree.readText(joinPath(scope, 'package.json'));
+  if (document === null) return null;
+  try {
+    return JSON.parse(document) as PackageManifest;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Plan one scope from what it declares.
+ *
+ * The order is: a recognized framework, then a language manifest, then a
+ * package that at least starts something, then the honest unknown §5 insists
+ * on — "I do not know how to build this" is a first-class outcome and never a
+ * silent fallback to `service`.
+ */
+export async function planFromDeclarations(
+  tree: SourceTree,
+  scope: string,
+): Promise<ZeroConfigPlan> {
+  const manifest = await readPackageManifest(tree, scope);
+
+  if (manifest !== null) {
+    const dependencies = declaredDependencies(manifest);
+    const preset = PRESETS.find((candidate) =>
+      dependencies.has(candidate.dependency),
+    );
+    if (preset !== undefined) {
+      return {
+        outcome: 'detected',
+        kind: preset.kind,
+        reason: `${preset.label} — \`${preset.dependency}\` is a dependency in package.json`,
+        kinds: kindOptions(
+          preset.kind,
+          preset.outputDirectory === null
+            ? `${preset.label} renders a server, not a directory of files`
+            : `${preset.label} builds files into ${preset.outputDirectory}`,
+        ),
+        buildCommand: null,
+        outputDirectory: preset.outputDirectory,
+      };
+    }
+
+    if (manifest.scripts?.start !== undefined) {
+      return {
+        outcome: 'detected',
+        kind: 'service',
+        reason: 'package.json declares a start script and no known frontend',
+        kinds: kindOptions(
+          'service',
+          'nothing here builds a directory of files to serve',
+        ),
+        buildCommand: null,
+        outputDirectory: null,
+      };
+    }
+
+    return {
+      outcome: 'unsupported',
+      detail:
+        'package.json declares no framework Spindrift recognizes and no start script. Add a `spindrift.yaml` naming the kind, or a Dockerfile.',
+    };
+  }
+
+  for (const { file, label } of SERVICE_MANIFESTS) {
+    if (await exists(tree, joinPath(scope, file))) {
+      return {
+        outcome: 'detected',
+        kind: 'service',
+        reason: `${label} — ${file} is in this directory`,
+        kinds: kindOptions(
+          'service',
+          `${label} projects build a program, not a directory of files`,
+        ),
+        buildCommand: null,
+        outputDirectory: null,
+      };
+    }
+  }
+
+  return {
+    outcome: 'unsupported',
+    detail:
+      'no package.json, go.mod, Cargo.toml, pyproject.toml, requirements.txt or Gemfile in this directory.',
+  };
+}
+
+/** {@link planFromDeclarations}, as the seam the ladder takes. */
+export function declaredPlanner(): ZeroConfigPlanner {
+  return { plan: planFromDeclarations };
+}

--- a/apps/spindrift/src/domain/detection/discover.ts
+++ b/apps/spindrift/src/domain/detection/discover.ts
@@ -1,0 +1,148 @@
+/**
+ * The "discover" branch (§5, story 23).
+ *
+ * §5 is emphatic that **the scope is named, never searched** — an App is a repo
+ * plus a subpath, and detection is one algorithm over one directory. This
+ * module does not weaken that. It answers a different question, the one story
+ * 23 puts on the front page beside *service*, *website*, *upload* and *link a
+ * repo*: **what is in here?**
+ *
+ * The distinction is where the answer goes. Discovery proposes a list of
+ * candidate directories for a human to choose from; whatever they choose
+ * becomes a named scope, and detection runs over that one directory exactly as
+ * it would have if the name had been typed. Nothing here reaches an App, a
+ * Component, or a `spindrift.yaml`. It reaches a screen.
+ *
+ * It exists because the alternative is a text field. A developer connecting a
+ * monorepo knows where their app is and should not have to spell it, and a
+ * developer connecting a single-app repository should never see the question at
+ * all.
+ */
+import {
+  type DetectionResult,
+  detectScope,
+  type ZeroConfigPlanner,
+} from './ladder.ts';
+import type { SourceTree } from './tree.ts';
+import { workspaceDirectories } from './watch-paths.ts';
+
+/**
+ * Directories whose contents are never somebody's app.
+ *
+ * Checked as a path segment anywhere in the path, not as a prefix: a
+ * `node_modules` six levels down is as uninteresting as one at the root, and a
+ * vendored tree can hold thousands of manifests that would otherwise each
+ * become a candidate.
+ */
+const IGNORED_SEGMENTS = new Set([
+  'node_modules',
+  'vendor',
+  'third_party',
+  'testdata',
+  'fixtures',
+  '.git',
+  '.next',
+  '.output',
+  '.venv',
+  'dist',
+  'build',
+  'target',
+  'out',
+]);
+
+/** A file whose presence in a directory makes that directory a candidate. */
+const CANDIDATE_MANIFESTS = new Set([
+  'package.json',
+  'go.mod',
+  'Cargo.toml',
+  'pyproject.toml',
+  'requirements.txt',
+  'Gemfile',
+  'Dockerfile',
+]);
+
+/**
+ * How deep a candidate may sit below the root.
+ *
+ * ponytail: fixed at 2, which covers `apps/web` and `services/api` and every
+ * other two-level convention, and stops a deep tree from turning discovery into
+ * a hundred tiles. Raise it, or replace it with a real project-graph read, if a
+ * repository shows up that genuinely nests deeper.
+ */
+const MAX_DEPTH = 2;
+
+/** How many candidates are worth showing before the list stops being a choice. */
+const MAX_CANDIDATES = 24;
+
+function ignored(path: string): boolean {
+  return path.split('/').some((segment) => IGNORED_SEGMENTS.has(segment));
+}
+
+/**
+ * Candidate directories, in the order a screen should list them.
+ *
+ * Workspace membership wins when the repository declares it: a Bun, npm, yarn
+ * or pnpm workspace has already said where its packages are, and guessing past
+ * a declaration would be inventing an answer somebody wrote down. Everything
+ * else falls back to a bounded walk for a directory carrying a manifest.
+ *
+ * The root is **not** included. The caller has already asked about it — that is
+ * the first question detection answers — and discovery is what happens when the
+ * root did not turn out to be the whole story.
+ */
+export async function discoverScopes(
+  tree: SourceTree,
+): Promise<readonly string[]> {
+  const declared = (await workspaceDirectories(tree)).filter(
+    (directory) => !ignored(directory),
+  );
+  if (declared.length > 0) return declared.slice(0, MAX_CANDIDATES);
+
+  const candidates = new Set<string>();
+  for (const path of await tree.paths()) {
+    if (ignored(path)) continue;
+    const segments = path.split('/');
+    const file = segments.pop();
+    if (file === undefined || !CANDIDATE_MANIFESTS.has(file)) continue;
+    if (segments.length === 0 || segments.length > MAX_DEPTH) continue;
+    candidates.add(segments.join('/'));
+  }
+  return [...candidates].sort().slice(0, MAX_CANDIDATES);
+}
+
+/**
+ * Everything one repository has to say about itself, in one pass.
+ *
+ * The shape of the answer is the whole point and it is not a list of Apps: it
+ * is a list of {@link DetectionResult}, unsupported outcomes included. A
+ * directory Spindrift could not make sense of stays on the list wearing its
+ * reason (§3's grammar), because the screen this feeds has to be able to say
+ * *why not here* as readily as *here*.
+ *
+ * Named scopes are honoured exactly as given — that is §5's "named, never
+ * searched". Discovery only happens when nobody named anything **and** the root
+ * turned out not to be an App on its own, which is the one case where the
+ * alternative is asking a developer to type a path they should not have to.
+ *
+ * Shared by `inspectRepository` and `connectRepository` so the screen and the
+ * pull request cannot disagree about what is in the repository. They still each
+ * run it, against their own resolved commit: showing one answer and writing
+ * another is the failure this is shaped to prevent, not the round trip.
+ */
+export async function scanRepository(
+  tree: SourceTree,
+  planner: ZeroConfigPlanner,
+  scopes?: readonly string[],
+): Promise<readonly DetectionResult[]> {
+  const inspect = (scope: string) =>
+    detectScope({ tree, source: { kind: 'repo', subpath: scope }, planner });
+
+  if (scopes !== undefined) return Promise.all(scopes.map(inspect));
+
+  const root = await inspect('.');
+  if (root.outcome === 'detected') return [root];
+  return [
+    root,
+    ...(await Promise.all((await discoverScopes(tree)).map(inspect))),
+  ];
+}

--- a/apps/spindrift/src/domain/detection/ladder.ts
+++ b/apps/spindrift/src/domain/detection/ladder.ts
@@ -5,16 +5,22 @@
  * normalized plan instead of duplicating those heuristics, then selects the
  * build frontend independently: a Dockerfile changes how code is built, never
  * what kind of Component it is.
+ *
+ * The ladder reads through a {@link SourceTree}, not a path. That is what lets
+ * the same algorithm answer for an unpacked archive on a disk and for a
+ * repository that has never been checked out — §5 says detection is one
+ * algorithm, and one algorithm that only ran against one of its two sources
+ * was one algorithm in name only.
  */
-import { access } from 'node:fs/promises';
-import { join } from 'node:path';
 import type { ComponentKind } from '../desired-state.ts';
 import type { DetectionSource } from './scope.ts';
 import { resolveDetectionScope } from './scope.ts';
-import { loadSpindriftFile } from './spindrift-file.ts';
+import { parseSpindriftFile } from './spindrift-file.ts';
+import { exists, type SourceTree } from './tree.ts';
 import { deriveWatchPaths } from './watch-paths.ts';
 
 export type { DetectionSource } from './scope.ts';
+export type { SourceTree } from './tree.ts';
 
 export type InferredComponentKind = Exclude<ComponentKind, 'job'>;
 
@@ -35,6 +41,8 @@ export type ZeroConfigPlan =
       readonly outcome: 'detected';
       readonly kind: InferredComponentKind;
       readonly kinds: readonly KindOption[];
+      /** One sentence naming what produced this, in a human's words. */
+      readonly reason: string;
       readonly buildCommand: string | null;
       readonly outputDirectory: string | null;
     }
@@ -44,17 +52,27 @@ export type ZeroConfigPlan =
     };
 
 /**
- * The Railpack-facing seam. A concrete process adapter belongs beside the build
- * routes; the detection ladder depends only on the stable facts it needs.
+ * The planner seam. A concrete implementation belongs beside the thing that
+ * plans; the ladder depends only on the stable facts it needs.
  */
 export interface ZeroConfigPlanner {
-  plan(directory: string): Promise<ZeroConfigPlan>;
+  plan(tree: SourceTree, scope: string): Promise<ZeroConfigPlan>;
 }
 
 export interface DetectionProposal {
-  readonly source: 'railpack' | 'spindrift-file' | 'operator';
+  readonly source: 'detection' | 'spindrift-file' | 'operator';
   readonly kind: ComponentKind;
   readonly kinds: readonly KindOption[];
+  /**
+   * Why this proposal says what it says.
+   *
+   * Not serialized into `spindrift.yaml`, for the same reason `kinds` is not
+   * (see `serializeSpindriftFile`): it is a statement about how the answer was
+   * reached, not about what this scope is, and writing it into the repository
+   * would turn a sentence somebody read once into a value the next run has to
+   * honour.
+   */
+  readonly reason: string;
   readonly build:
     | { readonly frontend: 'dockerfile'; readonly dockerfile: string }
     | {
@@ -80,42 +98,41 @@ export type DetectionResult =
     };
 
 export interface DetectScopeInput {
-  readonly repositoryRoot: string;
+  readonly tree: SourceTree;
   readonly source: DetectionSource;
   readonly planner: ZeroConfigPlanner;
 }
 
-async function exists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
+/** The Spindrift file's name inside each scope (§5). */
+const SPINDRIFT_FILE = 'spindrift.yaml';
+
+function joinPath(scope: string, file: string): string {
+  return scope === '.' ? file : `${scope}/${file}`;
 }
 
 export async function detectScope(
   input: DetectScopeInput,
 ): Promise<DetectionResult> {
-  const { scope, directory } = await resolveDetectionScope(
-    input.repositoryRoot,
-    input.source,
-  );
+  const { tree, source, planner } = input;
+  const { scope, prefix } = await resolveDetectionScope(tree, source);
 
-  const spindriftFile = join(directory, 'spindrift.yaml');
-  if (input.source.kind === 'repo' && (await exists(spindriftFile))) {
-    return {
-      outcome: 'detected',
-      scope,
-      proposal: await loadSpindriftFile(spindriftFile),
-    };
+  if (source.kind === 'repo') {
+    const document = await tree.readText(joinPath(prefix, SPINDRIFT_FILE));
+    if (document !== null) {
+      return {
+        outcome: 'detected',
+        scope,
+        proposal: parseSpindriftFile(
+          document,
+          joinPath(prefix, SPINDRIFT_FILE),
+        ),
+      };
+    }
   }
 
   const watchPaths =
-    input.source.kind === 'repo'
-      ? await deriveWatchPaths(input.repositoryRoot, scope)
-      : [];
-  const plan = await input.planner.plan(directory);
+    source.kind === 'repo' ? await deriveWatchPaths(tree, scope) : [];
+  const plan = await planner.plan(tree, prefix);
 
   if (plan.outcome === 'unsupported') {
     return {
@@ -127,14 +144,17 @@ export async function detectScope(
     };
   }
 
-  const dockerfile = await exists(join(directory, 'Dockerfile'));
+  const dockerfile = await exists(tree, joinPath(prefix, 'Dockerfile'));
   return {
     outcome: 'detected',
     scope,
     proposal: {
-      source: 'railpack',
+      source: 'detection',
       kind: plan.kind,
       kinds: plan.kinds,
+      reason: dockerfile
+        ? `${plan.reason}; built from the Dockerfile in this directory`
+        : plan.reason,
       build: dockerfile
         ? { frontend: 'dockerfile', dockerfile: 'Dockerfile' }
         : {

--- a/apps/spindrift/src/domain/detection/scope.ts
+++ b/apps/spindrift/src/domain/detection/scope.ts
@@ -1,80 +1,81 @@
 /**
  * Resolve the one directory detection is allowed to inspect (§5).
  *
- * Repo scopes are caller-named and may not escape through either traversal or
- * a symlink. Archives have no named scope and unwrap exactly one lone directory.
+ * Repo scopes are caller-named and may not escape the root. Archives have no
+ * named scope and unwrap exactly one lone directory — the shape every `zip -r`
+ * and every `git archive` produces, which a developer dropping output from a
+ * coding agent (story 28) should not have to know about.
+ *
+ * This is pure string work over a {@link SourceTree}'s listing. It used to
+ * resolve real paths and follow symlinks, and that job did not disappear — it
+ * moved into `diskTree`, which is the only implementation that has symlinks to
+ * be lied to by. A git tree has none, and putting the check where the risk is
+ * means scope resolution is now testable without a filesystem.
  */
-import { readdir, realpath } from 'node:fs/promises';
-import { isAbsolute, join, relative, resolve, sep } from 'node:path';
+import type { SourceTree } from './tree.ts';
+import { within } from './tree.ts';
 
 export type DetectionSource =
   | { readonly kind: 'repo'; readonly subpath: string }
   | { readonly kind: 'archive' };
 
 export interface ResolvedDetectionScope {
+  /**
+   * What this scope is *called* — repo-relative, `.` for the root.
+   *
+   * This is the value that reaches `spindrift.yaml`'s path and the App's
+   * `sourceRepoSubpath`, so it is always relative to the repository, never to
+   * whatever wrapper directory an archive happened to arrive in.
+   */
   readonly scope: string;
-  readonly directory: string;
+  /**
+   * Where to *read* from, as a prefix on tree paths.
+   *
+   * The same as `scope` for a repository. For an archive it is the unwrapped
+   * lone directory, which is exactly the difference between the two.
+   */
+  readonly prefix: string;
 }
 
-function isWithin(parent: string, child: string): boolean {
-  const path = relative(parent, child);
-  return path !== '..' && !path.startsWith(`..${sep}`) && !isAbsolute(path);
-}
-
-function assertWithin(parent: string, child: string): void {
-  if (!isWithin(parent, child)) {
+/** Normalize a caller-named repo scope, or refuse it. */
+function repoScope(subpath: string): ResolvedDetectionScope {
+  const requested = subpath.replaceAll('\\', '/').replace(/\/+$/, '');
+  if (requested === '' || requested === '.') {
+    return { scope: '.', prefix: '.' };
+  }
+  if (!within(requested)) {
     throw new RangeError('scope must stay inside the repository root');
   }
+  const scope = requested.replace(/^\.\//, '');
+  return { scope, prefix: scope };
 }
 
-async function repoScope(
-  repositoryRoot: string,
-  requestedScope: string,
-): Promise<ResolvedDetectionScope> {
-  const requested = requestedScope.replaceAll('\\', '/');
-  if (
-    requested.length === 0 ||
-    isAbsolute(requested) ||
-    /^[A-Za-z]:\//.test(requested)
-  ) {
-    throw new RangeError('scope must stay inside the repository root');
+/**
+ * Unwrap a lone top-level directory, if that is what the archive is.
+ *
+ * "Lone" means every entry shares one first segment *and* that segment is a
+ * directory rather than a single file at the root — an archive of one file is
+ * not a wrapper to unwrap.
+ */
+async function archiveScope(tree: SourceTree): Promise<ResolvedDetectionScope> {
+  const paths = await tree.paths();
+  if (paths.length === 0) return { scope: '.', prefix: '.' };
+
+  const first = new Set(paths.map((path) => path.split('/')[0]));
+  if (first.size !== 1) return { scope: '.', prefix: '.' };
+
+  const [only] = first;
+  if (only === undefined || paths.includes(only)) {
+    return { scope: '.', prefix: '.' };
   }
-
-  const root = resolve(repositoryRoot);
-  const directory = resolve(root, requested);
-  assertWithin(root, directory);
-
-  const [realRoot, realDirectory] = await Promise.all([
-    realpath(root),
-    realpath(directory),
-  ]);
-  assertWithin(realRoot, realDirectory);
-
-  const scope = relative(root, directory);
-  return {
-    scope: scope.length === 0 ? '.' : scope.split(sep).join('/'),
-    directory: realDirectory,
-  };
-}
-
-async function archiveScope(
-  directory: string,
-): Promise<ResolvedDetectionScope> {
-  const entries = await readdir(directory, { withFileTypes: true });
-  return {
-    scope: '.',
-    directory:
-      entries.length === 1 && entries[0]?.isDirectory()
-        ? join(directory, entries[0].name)
-        : directory,
-  };
+  return { scope: '.', prefix: only };
 }
 
 export function resolveDetectionScope(
-  repositoryRoot: string,
+  tree: SourceTree,
   source: DetectionSource,
 ): Promise<ResolvedDetectionScope> {
   return source.kind === 'repo'
-    ? repoScope(repositoryRoot, source.subpath)
-    : archiveScope(repositoryRoot);
+    ? Promise.resolve(repoScope(source.subpath))
+    : archiveScope(tree);
 }

--- a/apps/spindrift/src/domain/detection/spindrift-file.ts
+++ b/apps/spindrift/src/domain/detection/spindrift-file.ts
@@ -78,6 +78,7 @@ export function parseSpindriftFile(
   return {
     source: 'spindrift-file',
     kind: component.kind,
+    reason: `${source} asserts this scope is a ${component.kind}`,
     kinds: [
       {
         kind: component.kind,
@@ -95,10 +96,4 @@ export function parseSpindriftFile(
           },
     watchPaths,
   };
-}
-
-export async function loadSpindriftFile(
-  path: string,
-): Promise<DetectionProposal> {
-  return parseSpindriftFile(await Bun.file(path).text(), path);
 }

--- a/apps/spindrift/src/domain/detection/tree.ts
+++ b/apps/spindrift/src/domain/detection/tree.ts
@@ -1,0 +1,160 @@
+/**
+ * The file surface detection is allowed to see (§5).
+ *
+ * Detection is "one algorithm over one directory", and until now *directory*
+ * meant a path on a disk. That is why the ladder never ran outside a test: the
+ * one moment a developer wants an answer — connecting a repository — is a
+ * moment when nothing has been checked out, and cloning to answer a question
+ * about a directory listing is a build the operator did not ask for.
+ *
+ * So the ladder reads through this instead. Two methods, because two are what
+ * the ladder actually uses: the set of paths, and one file's text. A git tree
+ * and an unpacked archive can both answer those, and neither can answer more
+ * without becoming a filesystem.
+ *
+ * **Paths are root-relative, `/`-separated, and name files only.** Directories
+ * are implied by the files inside them, which is how git's own tree reads and
+ * is the only shape both sides can produce without inventing entries.
+ */
+
+import { realpath } from 'node:fs/promises';
+import { isAbsolute, relative, resolve, sep } from 'node:path';
+import type { RepositoryRef } from '../repository.ts';
+
+export interface SourceTree {
+  /**
+   * Every file, root-relative. Implementations cache: the ladder asks more
+   * than once and a second walk would answer a question already answered.
+   */
+  paths(): Promise<readonly string[]>;
+  /** One file's text, or `null` when it is not there. */
+  readText(path: string): Promise<string | null>;
+}
+
+/** Whether a path names a file that is in the tree. */
+export async function exists(tree: SourceTree, path: string): Promise<boolean> {
+  return (await tree.paths()).includes(path);
+}
+
+/**
+ * Whether a path stays inside the root it is relative to.
+ *
+ * Pure string work, and deliberately so. A git tree has no `..` to resolve and
+ * no symlink to follow — every entry is already root-relative — so the only
+ * place a real filesystem check is owed is {@link diskTree}, which does it.
+ */
+export function within(path: string): boolean {
+  const normalized = path.replaceAll('\\', '/');
+  return (
+    normalized.length > 0 &&
+    !normalized.startsWith('/') &&
+    !/^[A-Za-z]:\//.test(normalized) &&
+    !normalized.split('/').includes('..')
+  );
+}
+
+/** A tree over a directory on disk — an unpacked archive, or a checkout. */
+export function diskTree(root: string): SourceTree {
+  const absoluteRoot = resolve(root);
+  let listing: Promise<readonly string[]> | null = null;
+
+  /**
+   * Refuse a read that leaves the root, by real path.
+   *
+   * The string check above is not enough here and is the one place it is not:
+   * an unpacked archive is attacker-supplied bytes, and a symlink inside one
+   * can point anywhere. `Bun.file().text()` would follow it.
+   */
+  async function resolveWithin(path: string): Promise<string | null> {
+    if (!within(path)) return null;
+    const absolute = resolve(absoluteRoot, path);
+    const [realRoot, real] = await Promise.all([
+      realpath(absoluteRoot).catch(() => null),
+      realpath(absolute).catch(() => null),
+    ]);
+    if (realRoot === null || real === null) return null;
+    const inside = relative(realRoot, real);
+    return inside !== '..' &&
+      !inside.startsWith(`..${sep}`) &&
+      !isAbsolute(inside)
+      ? real
+      : null;
+  }
+
+  return {
+    paths() {
+      listing ??= Array.fromAsync(
+        new Bun.Glob('**/*').scan({
+          cwd: absoluteRoot,
+          onlyFiles: true,
+          dot: true,
+          followSymlinks: false,
+        }),
+      ).then((found) => found.map((path) => path.split(sep).join('/')).sort());
+      return listing;
+    },
+    async readText(path) {
+      const absolute = await resolveWithin(path);
+      if (absolute === null) return null;
+      return Bun.file(absolute)
+        .text()
+        .catch(() => null);
+    },
+  };
+}
+
+/** What {@link gitHubTree} reads through — a narrowing of `RepositoryReader`. */
+export interface TreeReader {
+  /** Every blob path at one exact commit, root-relative. */
+  treePaths(
+    ref: RepositoryRef,
+    fullName: string,
+    commit: string,
+  ): Promise<readonly string[]>;
+  /** One file at one exact commit, or `null` when it is not there. */
+  readFile(
+    ref: RepositoryRef,
+    fullName: string,
+    commit: string,
+    path: string,
+  ): Promise<string | null>;
+}
+
+/**
+ * A tree over one commit of a repository, read through the host.
+ *
+ * No clone, no checkout, no temporary directory: the listing is one recursive
+ * tree call and each file is one blob read. That is what makes detection
+ * something the connect screen can do while the operator is still looking at
+ * it.
+ *
+ * Pinned to a commit rather than a branch, because everything downstream — the
+ * proposal shown, the `spindrift.yaml` written into the configuration PR — is a
+ * statement about one revision, and a branch that moved mid-flow would make
+ * those two statements about different code.
+ */
+export function gitHubTree(
+  reader: TreeReader,
+  ref: RepositoryRef,
+  fullName: string,
+  commit: string,
+): SourceTree {
+  let listing: Promise<readonly string[]> | null = null;
+  const files = new Map<string, Promise<string | null>>();
+
+  return {
+    paths() {
+      listing ??= reader.treePaths(ref, fullName, commit);
+      return listing;
+    },
+    readText(path) {
+      if (!within(path)) return Promise.resolve(null);
+      let file = files.get(path);
+      if (file === undefined) {
+        file = reader.readFile(ref, fullName, commit, path);
+        files.set(path, file);
+      }
+      return file;
+    },
+  };
+}

--- a/apps/spindrift/src/domain/detection/watch-paths.ts
+++ b/apps/spindrift/src/domain/detection/watch-paths.ts
@@ -5,9 +5,15 @@
  * Other ecosystems degrade honestly to the named scope plus the root manifests
  * and lockfiles that exist, which is still conservative: it can overbuild but
  * cannot silently miss a root toolchain change.
+ *
+ * Reads through a {@link SourceTree} rather than the filesystem, so the same
+ * derivation answers for a repository nobody has checked out. The workspace
+ * walk that used to `scan()` the disk now matches glob patterns against the
+ * tree's listing — the same `Bun.Glob`, asked whether a string matches instead
+ * of asked what is on a disk.
  */
-import { access } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
+import type { SourceTree } from './tree.ts';
 
 const ROOT_WATCH_FILES = [
   'package.json',
@@ -44,21 +50,18 @@ interface WorkspacePackage {
   readonly manifest: PackageManifest;
 }
 
-async function exists(path: string): Promise<boolean> {
-  try {
-    await access(path);
-    return true;
-  } catch {
-    return false;
-  }
+function joinPath(scope: string, file: string): string {
+  return scope === '.' ? file : `${scope}/${file}`;
 }
 
 async function readPackageManifest(
+  tree: SourceTree,
   path: string,
 ): Promise<PackageManifest | null> {
-  if (!(await exists(path))) return null;
+  const document = await tree.readText(path);
+  if (document === null) return null;
   try {
-    return (await Bun.file(path).json()) as PackageManifest;
+    return JSON.parse(document) as PackageManifest;
   } catch {
     return null;
   }
@@ -76,18 +79,16 @@ function packageWorkspacePatterns(
 }
 
 async function pnpmWorkspacePatterns(
-  repositoryRoot: string,
+  tree: SourceTree,
 ): Promise<readonly string[]> {
-  const path = join(repositoryRoot, 'pnpm-workspace.yaml');
-  if (!(await exists(path))) return [];
+  const document = await tree.readText('pnpm-workspace.yaml');
+  if (document === null) return [];
 
   try {
-    const document = Bun.YAML.parse(await Bun.file(path).text()) as {
-      packages?: unknown;
-    };
-    return Array.isArray(document?.packages) &&
-      document.packages.every((entry) => typeof entry === 'string')
-      ? document.packages
+    const parsed = Bun.YAML.parse(document) as { packages?: unknown };
+    return Array.isArray(parsed?.packages) &&
+      parsed.packages.every((entry) => typeof entry === 'string')
+      ? parsed.packages
       : [];
   } catch {
     return [];
@@ -104,49 +105,67 @@ function dependencyNames(manifest: PackageManifest): string[] {
 }
 
 async function workspacePackages(
-  repositoryRoot: string,
+  tree: SourceTree,
   rootManifest: PackageManifest,
 ): Promise<Map<string, WorkspacePackage>> {
-  const packages = new Map<string, WorkspacePackage>();
   const patterns = new Set([
     ...packageWorkspacePatterns(rootManifest),
-    ...(await pnpmWorkspacePatterns(repositoryRoot)),
+    ...(await pnpmWorkspacePatterns(tree)),
   ]);
+  if (patterns.size === 0) return new Map();
+
+  const manifestPaths = (await tree.paths()).filter((path) =>
+    path.endsWith('package.json'),
+  );
+  const packages = new Map<string, WorkspacePackage>();
   for (const pattern of patterns) {
-    const manifests = new Bun.Glob(
-      `${pattern.replace(/\/+$/, '')}/package.json`,
-    );
-    for await (const path of manifests.scan({
-      cwd: repositoryRoot,
-      onlyFiles: true,
-    })) {
-      const manifest = await readPackageManifest(join(repositoryRoot, path));
+    const glob = new Bun.Glob(`${pattern.replace(/\/+$/, '')}/package.json`);
+    for (const path of manifestPaths) {
+      if (!glob.match(path)) continue;
+      const manifest = await readPackageManifest(tree, path);
       if (manifest?.name) {
-        packages.set(manifest.name, {
-          directory: dirname(path),
-          manifest,
-        });
+        packages.set(manifest.name, { directory: dirname(path), manifest });
       }
     }
   }
   return packages;
 }
 
+/**
+ * Every directory the root manifest declares as a workspace package.
+ *
+ * Exported for discovery (§5's "discover" branch), which needs the same answer
+ * for a different reason: watch paths ask *which packages does this one depend
+ * on*, discovery asks *which packages are there at all*. Both are the workspace
+ * glob walk, and running two of them would be two ways to disagree about what a
+ * monorepo contains.
+ */
+export async function workspaceDirectories(
+  tree: SourceTree,
+): Promise<readonly string[]> {
+  const rootManifest = await readPackageManifest(tree, 'package.json');
+  if (rootManifest === null) return [];
+  const packages = await workspacePackages(tree, rootManifest);
+  return [...packages.values()]
+    .map((entry) => entry.directory)
+    .filter((directory) => directory !== '.')
+    .sort();
+}
+
 async function workspaceDependencyPaths(
-  repositoryRoot: string,
+  tree: SourceTree,
   scope: string,
 ): Promise<string[]> {
   if (scope === '.') return [];
 
-  const rootManifest = await readPackageManifest(
-    join(repositoryRoot, 'package.json'),
-  );
+  const rootManifest = await readPackageManifest(tree, 'package.json');
   const scopeManifest = await readPackageManifest(
-    join(repositoryRoot, scope, 'package.json'),
+    tree,
+    joinPath(scope, 'package.json'),
   );
   if (!rootManifest || !scopeManifest) return [];
 
-  const packages = await workspacePackages(repositoryRoot, rootManifest);
+  const packages = await workspacePackages(tree, rootManifest);
   const paths: string[] = [];
   const queued = dependencyNames(scopeManifest);
   const seen = new Set<string>();
@@ -166,15 +185,13 @@ async function workspaceDependencyPaths(
 }
 
 export async function deriveWatchPaths(
-  repositoryRoot: string,
+  tree: SourceTree,
   scope: string,
 ): Promise<string[]> {
-  const paths = [
-    scope,
-    ...(await workspaceDependencyPaths(repositoryRoot, scope)),
-  ];
+  const paths = [scope, ...(await workspaceDependencyPaths(tree, scope))];
+  const listing = new Set(await tree.paths());
   for (const path of ROOT_WATCH_FILES) {
-    if (await exists(join(repositoryRoot, path))) paths.push(path);
+    if (listing.has(path)) paths.push(path);
   }
   return paths;
 }

--- a/apps/spindrift/src/domain/repository.ts
+++ b/apps/spindrift/src/domain/repository.ts
@@ -112,6 +112,19 @@ export interface RepositoryReader {
     commit: string,
     path: string,
   ): Promise<string | null>;
+  /**
+   * Every file at one exact commit, root-relative.
+   *
+   * Detection needs to know what is in a directory before anything has been
+   * checked out (§5), and this is the one call that answers it. Files only:
+   * a tree's directories are implied by the paths inside them, and core has no
+   * use for an entry that names a container rather than content.
+   */
+  treePaths(
+    ref: RepositoryRef,
+    fullName: string,
+    commit: string,
+  ): Promise<readonly string[]>;
 }
 
 /**

--- a/apps/spindrift/src/integrations/github/app.ts
+++ b/apps/spindrift/src/integrations/github/app.ts
@@ -176,6 +176,47 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
     return response === null ? null : await response.text();
   }
 
+  /**
+   * Every blob path at one exact commit.
+   *
+   * One recursive call, which is what makes connect-time detection something
+   * that happens while an operator is looking at the screen rather than a
+   * clone they wait for. GitHub caps the response and says so in `truncated`;
+   * a truncated listing is refused rather than returned, because detection
+   * reading a partial tree would answer "no package.json here" about a
+   * repository that has one, and a wrong answer written into a configuration
+   * pull request is worse than an error the operator can see.
+   *
+   * `tree` entries with a `blob` type are files. Directories (`tree`) and
+   * submodules (`commit`) are dropped: `SourceTree` names content, and a
+   * submodule's content is in another repository this installation may not
+   * even be able to see.
+   */
+  async treePaths(
+    ref: InstallationRef,
+    fullName: string,
+    commit: string,
+  ): Promise<readonly string[]> {
+    const tree = await this.http(ref).json<{
+      truncated?: boolean;
+      tree: readonly { path: string; type: string }[];
+    }>({
+      method: 'GET',
+      path: `/repos/${fullName}/git/trees/${encodeURIComponent(commit)}?recursive=1`,
+    });
+    if (tree === null) {
+      throw new TypeError('the tree endpoint tolerates no status');
+    }
+    if (tree.truncated === true) {
+      throw new Error(
+        `${fullName} has more files at ${commit.slice(0, 7)} than one tree response carries, so detection cannot see all of it`,
+      );
+    }
+    return tree.tree
+      .filter((entry) => entry.type === 'blob')
+      .map((entry) => entry.path);
+  }
+
   // --- The Git data API, which the configuration PR is written through -----
   //
   // These six exist so `openConfigurationPullRequest` can put the whole file

--- a/apps/spindrift/src/web/views/repos/list.tsx
+++ b/apps/spindrift/src/web/views/repos/list.tsx
@@ -1,29 +1,59 @@
 /**
- * Repository authorization, connection, and durable connection health.
+ * Connecting a repository: one button, and what Spindrift found behind it.
  *
- * GitHub authorization is installation-level; connecting a repository is a
- * second, reviewed act that opens the configuration PR. Keeping those two
- * states visually separate prevents “GitHub can list it” from reading as
- * “Spindrift has adopted it”.
+ * This screen used to ask for seven things — a scope, a kind, a build
+ * frontend, a Dockerfile path, a build command, an output directory, and a
+ * newline-separated list of watch paths — before it would open a pull request.
+ * Every one of those is something §5's detector can read out of the repository,
+ * and asking a person to type them made connecting a repo a form about how
+ * deployment works rather than a decision about their code.
+ *
+ * So the shape is: **press Connect, read what it found, confirm.** The scan is
+ * `inspectRepository`, which writes nothing; the confirm is
+ * `connectRepository`, which detects again against the branch as it is at that
+ * moment and opens the pull request. Nothing detection proposes travels through
+ * the browser on its way into the repository.
+ *
+ * Two things stay visible that a shorter screen would have dropped, both §3's
+ * disabled-with-reasons grammar:
+ *
+ * - **A directory Spindrift could not make sense of is listed anyway**, wearing
+ *   the sentence saying why. "Nothing here" and "nine things here, seven of
+ *   them libraries" are different answers and the screen says which.
+ * - **The override is still reachable**, behind a disclosure, because story 32
+ *   asks for progressive disclosure rather than for the escape hatch to be
+ *   removed.
  */
 import {
   AlertTriangle,
+  Check,
   CheckCircle2,
+  ChevronRight,
   ExternalLink,
+  FileCode,
   GitBranch,
+  Globe,
+  Loader2,
   RefreshCw,
+  Server,
+  Timer,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
-import type { InputOf } from '../../client.ts';
+import { useState } from 'react';
+import type { ComponentKind } from '../../../domain/desired-state.ts';
+import { command, type InputOf, type OutputOf } from '../../client.ts';
 import type {
   LinkedRepoView,
   RepositoryConnectorView,
   RepositoryOptionView,
 } from '../../model.ts';
-import { Badge } from '../../ui/badge.tsx';
+import { Badge, Dot } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, Eyebrow } from '../../ui/card.tsx';
-import { Field, Label } from '../../ui/field.tsx';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../../ui/collapsible.tsx';
 import { cn } from '../../ui/utils.ts';
 
 export interface RepositoryAuthorizationView {
@@ -38,7 +68,15 @@ export interface OpenedRepositoryPullRequest {
   readonly number: number;
 }
 
+type Inspection = OutputOf<'inspectRepository'>;
+type InspectedScope = Inspection['scopes'][number];
 type ConnectRepositoryInput = InputOf<'connectRepository'>;
+
+/** What the panel under one repository row is doing. */
+type Scan =
+  | { readonly state: 'reading' }
+  | { readonly state: 'read'; readonly inspection: Inspection }
+  | { readonly state: 'failed'; readonly message: string };
 
 export function RepositoryList({
   repos,
@@ -74,8 +112,9 @@ export function RepositoryList({
             GitHub repositories
           </h1>
           <p className="mt-1 max-w-prose text-sm text-muted-foreground">
-            Authorize GitHub, select an installed repository, then review the
-            configuration pull request Spindrift opens.
+            Pick a repository. Spindrift reads it, writes the configuration it
+            implies, and opens one pull request — merging that is what connects
+            it.
           </p>
         </div>
         <div className="ml-auto flex gap-2">
@@ -102,37 +141,55 @@ export function RepositoryList({
       <ConnectorCard
         connector={connector}
         authorization={authorization}
-        options={options}
-        connecting={connecting}
-        error={error}
-        openedPullRequest={openedPullRequest}
         onAuthorize={onAuthorize}
-        onConnect={onConnect}
+        error={error}
       />
+
+      {connector.state === 'authorized' ? (
+        <AvailableRepositories
+          options={options}
+          connecting={connecting}
+          onConnect={onConnect}
+        />
+      ) : null}
+
+      {openedPullRequest ? (
+        <div className="rounded-md border border-success/40 bg-success-soft px-3 py-2.5 text-sm">
+          Configuration PR opened:{' '}
+          <a
+            className="font-semibold underline underline-offset-2"
+            href={`https://github.com/${openedPullRequest.fullName}/pull/${openedPullRequest.number}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {openedPullRequest.fullName}#{openedPullRequest.number}
+          </a>
+          . Nothing becomes authoritative until it merges.
+        </div>
+      ) : null}
 
       <ConnectedRepositories repos={repos} />
     </div>
   );
 }
 
+/**
+ * Authorization, which is a different act from connecting anything.
+ *
+ * Once authorized this collapses to one line. It is a prerequisite, not a
+ * destination, and a card that stayed the size of the ceremony would keep
+ * spending the top of the screen on a thing that is already done.
+ */
 function ConnectorCard({
   connector,
   authorization,
-  options,
-  connecting,
-  error,
-  openedPullRequest,
   onAuthorize,
-  onConnect,
+  error,
 }: {
   connector: RepositoryConnectorView;
   authorization: RepositoryAuthorizationView | null;
-  options: readonly RepositoryOptionView[];
-  connecting: boolean;
-  error: string | null;
-  openedPullRequest: OpenedRepositoryPullRequest | null;
   onAuthorize: () => void;
-  onConnect: (input: ConnectRepositoryInput) => void;
+  error: string | null;
 }) {
   if (connector.state === 'unavailable') {
     return (
@@ -185,13 +242,14 @@ function ConnectorCard({
 
   return (
     <Card>
-      <CardContent className="flex flex-col gap-5">
+      <CardContent className="flex flex-col gap-3">
         <div className="flex flex-wrap items-center gap-2">
-          <CheckCircle2 aria-hidden="true" className="size-5 text-success" />
-          <p className="font-semibold">Authorized as @{connector.login}</p>
-          <Badge tone="success">GitHub connected</Badge>
+          <CheckCircle2 aria-hidden="true" className="size-4 text-success" />
+          <p className="text-sm font-semibold">
+            Authorized as @{connector.login}
+          </p>
           <Button
-            variant="outline"
+            variant="ghost"
             size="sm"
             className="ml-auto"
             onClick={onAuthorize}
@@ -201,25 +259,6 @@ function ConnectorCard({
         </div>
         {authorization !== null ? (
           <DeviceAuthorization authorization={authorization} />
-        ) : null}
-        <RepositoryConnectionForm
-          options={options}
-          connecting={connecting}
-          onConnect={onConnect}
-        />
-        {openedPullRequest ? (
-          <div className="rounded-md border border-success/40 bg-success-soft px-3 py-2.5 text-sm">
-            Configuration PR opened:{' '}
-            <a
-              className="font-semibold underline underline-offset-2"
-              href={`https://github.com/${openedPullRequest.fullName}/pull/${openedPullRequest.number}`}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {openedPullRequest.fullName}#{openedPullRequest.number}
-            </a>
-            . Nothing becomes authoritative until it merges.
-          </div>
         ) : null}
         {error ? <ErrorMessage message={error} /> : null}
       </CardContent>
@@ -268,7 +307,8 @@ function DeviceAuthorization({
   );
 }
 
-function RepositoryConnectionForm({
+/** Everything the installation grants, each one row and one button. */
+function AvailableRepositories({
   options,
   connecting,
   onConnect,
@@ -277,158 +317,278 @@ function RepositoryConnectionForm({
   connecting: boolean;
   onConnect: (input: ConnectRepositoryInput) => void;
 }) {
-  const [repository, setRepository] = useState(options[0]?.fullName ?? '');
-  const [scope, setScope] = useState('.');
-  const [kind, setKind] =
-    useState<ConnectRepositoryInput['scopes'][number]['kind']>('service');
-  const [frontend, setFrontend] = useState<'railpack' | 'dockerfile'>(
-    'railpack',
-  );
-  const [dockerfile, setDockerfile] = useState('Dockerfile');
-  const [buildCommand, setBuildCommand] = useState('');
-  const [outputDirectory, setOutputDirectory] = useState('');
-  const [watchPaths, setWatchPaths] = useState('.');
-
-  useEffect(() => {
-    if (!options.some((option) => option.fullName === repository)) {
-      setRepository(options[0]?.fullName ?? '');
-    }
-  }, [options, repository]);
-
-  const submit = () => {
-    const watched = watchPaths
-      .split(/[\n,]/)
-      .map((path) => path.trim())
-      .filter(Boolean);
-    const build: ConnectRepositoryInput['scopes'][number]['build'] =
-      frontend === 'dockerfile'
-        ? { frontend, dockerfile }
-        : {
-            frontend,
-            buildCommand: buildCommand.trim() || null,
-            outputDirectory: outputDirectory.trim() || null,
-          };
-    onConnect({
-      fullName: repository,
-      scopes: [
-        {
-          scope,
-          kind,
-          build,
-          watchPaths: watched.length > 0 ? watched : [scope],
-        },
-      ],
-    });
-  };
+  const [open, setOpen] = useState<string | null>(null);
 
   if (options.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground">
-        This App installation exposes no repositories. Select one in GitHub,
-        then refresh.
-      </p>
+      <Card>
+        <CardContent className="py-8 text-center">
+          <p className="text-sm text-muted-foreground">
+            This App installation exposes no repositories. Select one in GitHub,
+            then refresh.
+          </p>
+        </CardContent>
+      </Card>
     );
   }
 
   return (
-    <div className="grid gap-4">
-      <div className="grid gap-4 md:grid-cols-2">
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="repository">Repository</Label>
-          <select
-            id="repository"
-            value={repository}
-            onChange={(event) => setRepository(event.target.value)}
-            className="h-9 rounded-md border border-input bg-background px-3 font-mono text-sm"
-          >
-            {options.map((option) => (
-              <option key={option.repositoryId} value={option.fullName}>
-                {option.fullName}
-                {option.connected ? ' (connected)' : ''}
-              </option>
-            ))}
-          </select>
-        </div>
-        <Field
-          name="scope"
-          label="Scope"
-          value={scope}
-          onChange={(event) => setScope(event.target.value)}
-          hint="Repository-relative directory; use . for the root."
-        />
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="kind">Component kind</Label>
-          <select
-            id="kind"
-            value={kind}
-            onChange={(event) => setKind(event.target.value as typeof kind)}
-            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-          >
-            <option value="service">service</option>
-            <option value="website">website</option>
-            <option value="job">job</option>
-          </select>
-        </div>
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="frontend">Build frontend</Label>
-          <select
-            id="frontend"
-            value={frontend}
-            onChange={(event) =>
-              setFrontend(event.target.value as typeof frontend)
+    <section className="flex flex-col gap-2">
+      <Eyebrow>Available on this installation</Eyebrow>
+      <Card className="divide-y divide-border">
+        {options.map((option) => (
+          <RepositoryRow
+            key={option.repositoryId}
+            option={option}
+            open={open === option.fullName}
+            connecting={connecting}
+            onToggle={() =>
+              setOpen((current) =>
+                current === option.fullName ? null : option.fullName,
+              )
             }
-            className="h-9 rounded-md border border-input bg-background px-3 text-sm"
-          >
-            <option value="railpack">Railpack</option>
-            <option value="dockerfile">Dockerfile</option>
-          </select>
-        </div>
-        {frontend === 'dockerfile' ? (
-          <Field
-            name="dockerfile"
-            label="Dockerfile"
-            value={dockerfile}
-            onChange={(event) => setDockerfile(event.target.value)}
+            onConnect={onConnect}
           />
-        ) : (
-          <>
-            <Field
-              name="build-command"
-              label="Build command"
-              value={buildCommand}
-              onChange={(event) => setBuildCommand(event.target.value)}
-              placeholder="Let Railpack choose"
-            />
-            <Field
-              name="output-directory"
-              label="Output directory"
-              value={outputDirectory}
-              onChange={(event) => setOutputDirectory(event.target.value)}
-              placeholder="Not set"
-            />
-          </>
-        )}
-      </div>
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor="watch-paths">Watch paths</Label>
-        <textarea
-          id="watch-paths"
-          value={watchPaths}
-          onChange={(event) => setWatchPaths(event.target.value)}
-          rows={3}
-          className="rounded-md border border-input bg-background px-3 py-2 font-mono text-sm"
+        ))}
+      </Card>
+    </section>
+  );
+}
+
+/**
+ * One repository, and the scan that opens under it.
+ *
+ * The scan starts when the row opens rather than on a second press. A screen
+ * that made you click Connect and then click Scan would be a screen with two
+ * buttons for one intention, and the read is free — nothing is written until
+ * the confirm at the bottom of the panel.
+ */
+function RepositoryRow({
+  option,
+  open,
+  connecting,
+  onToggle,
+  onConnect,
+}: {
+  option: RepositoryOptionView;
+  open: boolean;
+  connecting: boolean;
+  onToggle: () => void;
+  onConnect: (input: ConnectRepositoryInput) => void;
+}) {
+  const [scan, setScan] = useState<Scan | null>(null);
+
+  const toggle = () => {
+    onToggle();
+    if (!open && scan === null) {
+      setScan({ state: 'reading' });
+      command('inspectRepository', { fullName: option.fullName })
+        .then((result) => {
+          setScan(
+            result.ok
+              ? { state: 'read', inspection: result.value }
+              : { state: 'failed', message: result.failure.message },
+          );
+        })
+        .catch((cause: unknown) => {
+          setScan({
+            state: 'failed',
+            message: cause instanceof Error ? cause.message : 'the read failed',
+          });
+        });
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+        <GitBranch
+          aria-hidden="true"
+          className="size-4 shrink-0 text-muted-foreground"
         />
+        <span className="font-mono text-sm font-medium">{option.fullName}</span>
+        <span className="font-mono text-xs text-muted-foreground">
+          {option.defaultBranch}
+        </span>
+        {option.connected ? <Badge tone="success">connected</Badge> : null}
+        <Button
+          size="sm"
+          variant={open ? 'ghost' : 'outline'}
+          className="ml-auto"
+          onClick={toggle}
+        >
+          {open ? 'Cancel' : option.connected ? 'Reconnect' : 'Connect'}
+        </Button>
+      </div>
+
+      {open ? (
+        <div className="border-t border-border-soft bg-secondary/40 px-4 py-4">
+          <ScanPanel
+            scan={scan}
+            fullName={option.fullName}
+            connecting={connecting}
+            onConnect={onConnect}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ScanPanel({
+  scan,
+  fullName,
+  connecting,
+  onConnect,
+}: {
+  scan: Scan | null;
+  fullName: string;
+  connecting: boolean;
+  onConnect: (input: ConnectRepositoryInput) => void;
+}) {
+  if (scan === null || scan.state === 'reading') {
+    return (
+      <p className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+        Reading {fullName}…
+      </p>
+    );
+  }
+
+  if (scan.state === 'failed') return <ErrorMessage message={scan.message} />;
+
+  const { inspection } = scan;
+  const deployable = inspection.scopes.filter(
+    (scope) => scope.outcome === 'detected',
+  );
+  const passedOver = inspection.scopes.filter(
+    (scope) => scope.outcome === 'unsupported',
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span className="font-mono">{inspection.defaultBranch}</span>
+        <span className="font-mono">{inspection.commit.slice(0, 7)}</span>
+        <span>
+          {deployable.length === 0
+            ? 'nothing deployable found'
+            : deployable.length === 1
+              ? '1 deployable directory'
+              : `${deployable.length} deployable directories`}
+        </span>
+      </div>
+
+      {deployable.length > 0 ? (
+        <ul className="flex flex-col gap-2">
+          {deployable.map((scope) => (
+            <li key={scope.scope}>
+              <DetectedScope scope={scope} />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {passedOver.length > 0 ? (
+        <Collapsible>
+          <CollapsibleTrigger className="group flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+            <ChevronRight
+              aria-hidden="true"
+              className="size-3.5 transition-transform group-data-[state=open]:rotate-90"
+            />
+            {passedOver.length} directory passed over
+            {passedOver.length === 1 ? '' : 's'}
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
+            {passedOver.map((scope) =>
+              scope.outcome === 'unsupported' ? (
+                <div
+                  key={scope.scope}
+                  className="rounded-md border border-border px-3 py-2"
+                >
+                  <p className="font-mono text-xs font-medium">{scope.scope}</p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">
+                    {scope.detail}
+                  </p>
+                </div>
+              ) : null,
+            )}
+          </CollapsibleContent>
+        </Collapsible>
+      ) : null}
+
+      {!inspection.canConnect ? (
+        <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning-soft px-3 py-2">
+          <AlertTriangle
+            aria-hidden="true"
+            className="mt-0.5 size-4 shrink-0 text-warning"
+          />
+          <p className="text-xs">
+            This installation has published no build workflow, so connecting
+            writes a repository row but opens no configuration pull request.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          disabled={connecting || deployable.length === 0}
+          onClick={() => onConnect({ fullName })}
+        >
+          {connecting ? 'Opening pull request…' : 'Connect repository'}
+        </Button>
         <p className="text-xs text-muted-foreground">
-          One repository-relative path per line or comma.
+          {deployable.length === 0
+            ? 'Add a spindrift.yaml or a Dockerfile to the directory you want deployed.'
+            : 'Opens one pull request. Nothing takes effect until it merges.'}
         </p>
       </div>
-      <Button
-        className="justify-self-start"
-        disabled={connecting || repository === '' || scope.trim() === ''}
-        onClick={submit}
-      >
-        {connecting ? 'Opening pull request…' : 'Open configuration PR'}
-      </Button>
+    </div>
+  );
+}
+
+const KIND_ICON = {
+  website: Globe,
+  service: Server,
+  job: Timer,
+} as const satisfies Record<ComponentKind, typeof Globe>;
+
+/** One directory Spindrift knows what to do with, and how it knows. */
+function DetectedScope({ scope }: { scope: InspectedScope }) {
+  if (scope.outcome !== 'detected') return null;
+  const Icon = KIND_ICON[scope.kind];
+
+  return (
+    <div className="rounded-md border border-border bg-card px-3 py-2.5">
+      <div className="flex flex-wrap items-center gap-2">
+        <Check aria-hidden="true" className="size-3.5 text-success" />
+        <span className="font-mono text-sm font-medium">{scope.scope}</span>
+        <Badge tone="accent">
+          <Icon aria-hidden="true" className="size-3" />
+          {scope.kind}
+        </Badge>
+        {scope.configured ? (
+          <Badge tone="idle">
+            <FileCode aria-hidden="true" className="size-3" />
+            spindrift.yaml
+          </Badge>
+        ) : null}
+        <span className="ml-auto font-mono text-[11px] text-muted-foreground">
+          {scope.frontend === 'dockerfile' ? scope.dockerfile : 'railpack'}
+        </span>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">{scope.reason}</p>
+      <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-0.5 text-[11px] text-subtle">
+        <span>
+          {scope.outputDirectory === null
+            ? 'served by a running process'
+            : `static files from ${scope.outputDirectory}`}
+        </span>
+        <span>
+          rebuilds on {scope.watchPaths.length}{' '}
+          {scope.watchPaths.length === 1 ? 'path' : 'paths'}
+        </span>
+      </div>
     </div>
   );
 }
@@ -438,73 +598,70 @@ function ConnectedRepositories({
 }: {
   repos: readonly LinkedRepoView[];
 }) {
-  if (repos.length === 0) {
-    return (
-      <Card>
-        <CardContent className="py-10 text-center">
-          <p className="text-sm text-muted-foreground">
-            No repositories connected yet.
-          </p>
-        </CardContent>
-      </Card>
-    );
-  }
+  if (repos.length === 0) return null;
+
   return (
-    <div className="flex flex-col gap-3">
-      {repos.map((repo) => (
-        <Card
-          key={repo.repositoryId}
-          className={cn(
-            repo.health === 'connection_lost' && 'border-destructive/40',
-          )}
-        >
-          <CardContent className="flex flex-col gap-3">
-            <div className="flex flex-wrap items-center gap-3">
-              <GitBranch aria-hidden="true" className="size-4" />
-              <span className="font-mono text-sm font-semibold">
-                {repo.fullName}
-              </span>
-              <Badge tone="idle">{repo.defaultBranch}</Badge>
-              <Badge
-                tone={repo.health === 'connected' ? 'success' : 'destructive'}
-              >
-                {repo.health === 'connected' ? 'connected' : 'connection lost'}
-              </Badge>
-              {repo.lastReconciledSha ? (
-                <span className="ml-auto font-mono text-xs text-muted-foreground">
-                  last reconciled {repo.lastReconciledSha}
-                </span>
-              ) : null}
-            </div>
-            {repo.health === 'connection_lost' && repo.error ? (
-              <div className="flex items-start gap-2 rounded-md border border-destructive bg-destructive-soft px-3 py-2">
-                <AlertTriangle
-                  aria-hidden="true"
-                  className="mt-0.5 size-4 text-destructive"
-                />
-                <p className="text-sm">{repo.error}</p>
-              </div>
-            ) : null}
-            {repo.appSubpaths.length > 0 ? (
-              <div className="flex flex-wrap gap-1.5">
-                {repo.appSubpaths.map((subpath) => (
-                  <span
-                    key={subpath}
-                    className="rounded-md border bg-secondary px-2 py-1 font-mono text-xs"
-                  >
-                    {subpath}
-                  </span>
-                ))}
-              </div>
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                Awaiting the configuration PR merge.
-              </p>
+    <section className="flex flex-col gap-2">
+      <Eyebrow>Connected</Eyebrow>
+      <div className="flex flex-col gap-3">
+        {repos.map((repo) => (
+          <Card
+            key={repo.repositoryId}
+            className={cn(
+              repo.health === 'connection_lost' && 'border-destructive/40',
             )}
-          </CardContent>
-        </Card>
-      ))}
-    </div>
+          >
+            <CardContent className="flex flex-col gap-3">
+              <div className="flex flex-wrap items-center gap-3">
+                <GitBranch aria-hidden="true" className="size-4" />
+                <span className="font-mono text-sm font-semibold">
+                  {repo.fullName}
+                </span>
+                <Badge tone="idle">{repo.defaultBranch}</Badge>
+                <Badge
+                  tone={repo.health === 'connected' ? 'success' : 'destructive'}
+                >
+                  <Dot />
+                  {repo.health === 'connected'
+                    ? 'connected'
+                    : 'connection lost'}
+                </Badge>
+                {repo.lastReconciledSha ? (
+                  <span className="ml-auto font-mono text-xs text-muted-foreground">
+                    {repo.lastReconciledSha.slice(0, 7)}
+                  </span>
+                ) : null}
+              </div>
+              {repo.health === 'connection_lost' && repo.error ? (
+                <div className="flex items-start gap-2 rounded-md border border-destructive bg-destructive-soft px-3 py-2">
+                  <AlertTriangle
+                    aria-hidden="true"
+                    className="mt-0.5 size-4 text-destructive"
+                  />
+                  <p className="text-sm">{repo.error}</p>
+                </div>
+              ) : null}
+              {repo.appSubpaths.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5">
+                  {repo.appSubpaths.map((subpath) => (
+                    <span
+                      key={subpath}
+                      className="rounded-md border bg-secondary px-2 py-1 font-mono text-xs"
+                    >
+                      {subpath}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Awaiting the configuration PR merge.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
 import { dispatch } from '../../src/commands/registry.ts';
 import { connectRepository } from '../../src/commands/repositories/connect.ts';
+import { inspectRepository } from '../../src/commands/repositories/inspect.ts';
 import { listRepositories } from '../../src/commands/repositories/list.ts';
 import type {
   AdapterRegistry,
@@ -34,8 +35,9 @@ const database = withIsolatedDatabase();
 const NOW = new Date('2026-07-28T12:00:00.000Z');
 
 const proposal: DetectionProposal = {
-  source: 'railpack',
+  source: 'detection',
   kind: 'service',
+  reason: 'a fixture',
   kinds: [{ kind: 'service', available: true }],
   build: {
     frontend: 'railpack',
@@ -43,6 +45,12 @@ const proposal: DetectionProposal = {
     outputDirectory: null,
   },
   watchPaths: ['services/api'],
+};
+
+/** A repository whose root is a Go service and nothing else. */
+const GO_SERVICE = {
+  'README.md': 'unconnected',
+  'go.mod': 'module example.com/app\n',
 };
 
 async function context(
@@ -79,9 +87,16 @@ async function context(
   };
 }
 
+/**
+ * The escape hatch, as an input: an operator asserting the proposal.
+ *
+ * Most tests here are about the transaction rather than about detection, and
+ * an override is the way to hold detection still while asserting on what the
+ * pull request wrote. The detection path has its own tests below.
+ */
 const input = (fake: FakeGitHub) => ({
   fullName: fake.fullName,
-  scopes: [
+  overrides: [
     {
       scope: 'services/api',
       kind: proposal.kind,
@@ -219,7 +234,7 @@ describe('connecting a repository', () => {
     const result = await connectRepository(
       {
         fullName: 'example/app',
-        scopes: [
+        overrides: [
           {
             scope: 'services/api',
             kind: proposal.kind,
@@ -258,6 +273,281 @@ describe('connecting a repository', () => {
 
     const accepted = await dispatch('connectRepository', input(fake), loop);
     expect(accepted.ok).toBe(true);
+  });
+});
+
+/**
+ * Connecting with nothing but a name (§5, story 25).
+ *
+ * The point of these is that the *command* detects. A browser that sent back
+ * what a screen showed it would be authoring domain state and would write
+ * whatever was on screen when the tab was opened; the connect resolves the
+ * default branch again and reads the repository at that commit, so the file it
+ * writes is a statement about the code that is there now.
+ */
+describe('connecting a repository without being told what is in it', () => {
+  test('detects the root and writes the Spindrift file it implies', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', GO_SERVICE);
+
+    const result = await connectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pullRequest).toBe(1);
+
+    const written = fake.filesAt(fake.head(CONFIG_BRANCH) ?? '');
+    expect(Object.keys(written).sort()).toEqual(
+      ['README.md', 'go.mod', WORKFLOW_PATH, SPINDRIFT_FILE].sort(),
+    );
+    expect(written[SPINDRIFT_FILE]).toContain('kind: service');
+    // The pull request names the detector, not a person, so a reviewer can tell
+    // which of the two proposed it.
+    expect(fake.pulls[0]?.body).toContain('detection');
+  });
+
+  test('a monorepo yields one pull request carrying every scope it found', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'package.json': JSON.stringify({
+        name: 'root',
+        workspaces: ['apps/*'],
+      }),
+      'apps/web/package.json': JSON.stringify({
+        name: 'web',
+        dependencies: { astro: '^5.0.0' },
+      }),
+      'apps/api/go.mod': 'module api\n',
+      'apps/lib/package.json': JSON.stringify({ name: 'lib' }),
+    });
+
+    const result = await connectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(true);
+    const written = fake.filesAt(fake.head(CONFIG_BRANCH) ?? '');
+    // `apps/lib` is a library. It is passed over rather than connected, and
+    // passing over seven of nine directories is the ordinary monorepo case —
+    // refusing the whole connect over them would make discovery useless.
+    expect(
+      Object.keys(written)
+        .filter((path) => path.endsWith(SPINDRIFT_FILE))
+        .sort(),
+    ).toEqual([`apps/web/${SPINDRIFT_FILE}`]);
+  });
+
+  test('an in-repo spindrift.yaml is what gets written back, unchanged', async () => {
+    const fake = new FakeGitHub();
+    const authored = [
+      'version: 1',
+      'component:',
+      '  kind: job',
+      'build:',
+      '  frontend: railpack',
+      '  command: bun run nightly',
+      '  outputDirectory: null',
+      'watchPaths:',
+      '  - .',
+      '',
+    ].join('\n');
+    fake.commitFiles('main', {
+      'go.mod': 'module example.com/app\n',
+      [SPINDRIFT_FILE]: authored,
+    });
+
+    await connectRepository({ fullName: fake.fullName }, await context(fake));
+
+    const written = fake.filesAt(fake.head(CONFIG_BRANCH) ?? '');
+    // Detection would have said `service`. The file says `job` and the file
+    // wins (§5) — including here, where Spindrift is writing the file back.
+    expect(written[SPINDRIFT_FILE]).toContain('kind: job');
+  });
+
+  test('refuses, and writes no row, when nothing in the repository is buildable', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'just prose' });
+
+    const result = await connectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('nothing it knows how to build');
+    // A row with no scope is a connection to nothing: the repo loop would
+    // reconcile it forever and never find an App.
+    expect(await database().db.select().from(repositories)).toEqual([]);
+    expect(fake.pulls).toEqual([]);
+  });
+
+  test('a named scope is connected exactly, with no discovery', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'package.json': JSON.stringify({ name: 'root', workspaces: ['apps/*'] }),
+      'apps/web/package.json': JSON.stringify({
+        name: 'web',
+        dependencies: { astro: '^5.0.0' },
+      }),
+      'apps/api/go.mod': 'module api\n',
+    });
+
+    await connectRepository(
+      { fullName: fake.fullName, scopes: ['apps/api'] },
+      await context(fake),
+    );
+
+    const written = fake.filesAt(fake.head(CONFIG_BRANCH) ?? '');
+    expect(
+      Object.keys(written)
+        .filter((path) => path.endsWith(SPINDRIFT_FILE))
+        .sort(),
+    ).toEqual([`apps/api/${SPINDRIFT_FILE}`]);
+  });
+});
+
+describe('inspecting a repository before connecting it', () => {
+  test('reads the repository and writes nothing', async () => {
+    const fake = new FakeGitHub();
+    const head = fake.commitFiles('main', GO_SERVICE);
+
+    const result = await inspectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value).toMatchObject({
+      fullName: fake.fullName,
+      defaultBranch: 'main',
+      commit: head,
+      canConnect: true,
+    });
+    expect(result.value.scopes).toEqual([
+      {
+        scope: '.',
+        outcome: 'detected',
+        kind: 'service',
+        reason: 'Go — go.mod is in this directory',
+        frontend: 'railpack',
+        dockerfile: null,
+        outputDirectory: null,
+        watchPaths: ['.', 'go.mod'],
+        configured: false,
+      },
+    ]);
+    // Read-only: no branch was cut, no pull request opened, no row written.
+    expect(fake.head(CONFIG_BRANCH)).toBeUndefined();
+    expect(fake.pulls).toEqual([]);
+    expect(await database().db.select().from(repositories)).toEqual([]);
+  });
+
+  test('a Dockerfile settles how to build and not what the thing is', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'package.json': JSON.stringify({
+        name: 'site',
+        dependencies: { astro: '^5.0.0' },
+      }),
+      Dockerfile: 'FROM nginx\n',
+    });
+
+    const result = await inspectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scopes[0]).toMatchObject({
+      outcome: 'detected',
+      // Still a website. An nginx-plus-files image that lost its static
+      // rendering is the exact failure §5 names.
+      kind: 'website',
+      frontend: 'dockerfile',
+      dockerfile: 'Dockerfile',
+    });
+  });
+
+  test('says what it could not make sense of, rather than answering empty', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'just prose' });
+
+    const result = await inspectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.scopes).toEqual([
+      {
+        scope: '.',
+        outcome: 'unsupported',
+        detail:
+          'no package.json, go.mod, Cargo.toml, pyproject.toml, requirements.txt or Gemfile in this directory.',
+      },
+    ]);
+  });
+
+  test('warns that this installation cannot open a configuration PR at all', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', GO_SERVICE);
+    const base = await context(fake);
+
+    const result = await inspectRepository(
+      { fullName: fake.fullName },
+      {
+        ...base,
+        manifest: {
+          ...base.manifest,
+          github: { ...base.manifest.github, buildWorkflow: null },
+        },
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.canConnect).toBe(false);
+  });
+
+  test('refuses a repository the App installation cannot see', async () => {
+    const fake = new FakeGitHub();
+    fake.accessLost = true;
+
+    const result = await inspectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+  });
+
+  test('reads the tree once however many scopes it inspects', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', {
+      'package.json': JSON.stringify({ name: 'root', workspaces: ['apps/*'] }),
+      'apps/one/go.mod': 'module one\n',
+      'apps/two/go.mod': 'module two\n',
+      'apps/three/go.mod': 'module three\n',
+    });
+
+    await inspectRepository({ fullName: fake.fullName }, await context(fake));
+
+    // One recursive listing for the whole scan, not one per scope: this is
+    // what makes inspection something a screen can do while somebody watches.
+    expect(
+      fake.requests.filter((request) => request.path.includes('/git/trees/')),
+    ).toHaveLength(1);
   });
 });
 

--- a/apps/spindrift/test/domain/detection.test.ts
+++ b/apps/spindrift/test/domain/detection.test.ts
@@ -1,22 +1,33 @@
 /**
  * Detection is one algorithm over one named directory (§5).
  *
- * The public seam is `detectScope`: a caller supplies the directory and the
- * zero-config builder's normalized plan, then receives either one Component
- * proposal or an honest unknown outcome. Tests stay above the filesystem and
- * planner boundaries; none reaches into the ladder's helpers.
+ * The public seam is `detectScope`: a caller supplies a {@link SourceTree} and
+ * the zero-config builder's normalized plan, then receives either one Component
+ * proposal or an honest unknown outcome. Tests stay above the tree and planner
+ * boundaries; none reaches into the ladder's helpers.
+ *
+ * Every case below runs twice where it can — once over a real directory and
+ * once over an in-memory tree — because "one algorithm over both sources" is
+ * the claim the seam exists to make, and a claim tested against one source is
+ * the claim that was already false.
  */
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
 import {
   detectScope,
   type InferredComponentKind,
+  type SourceTree,
   type ZeroConfigPlanner,
 } from '../../src/domain/detection/ladder.ts';
+import { diskTree } from '../../src/domain/detection/tree.ts';
 
 const FIXTURES = join(import.meta.dir, '../fixtures/detection');
 
 type Assert<T extends true> = T;
+
+function fixture(name: string): SourceTree {
+  return diskTree(join(FIXTURES, name));
+}
 
 function planner(
   plan: Awaited<ReturnType<ZeroConfigPlanner['plan']>>,
@@ -37,11 +48,12 @@ describe('the detection ladder', () => {
 
   test('a Dockerfile-wrapped static site is still a website', async () => {
     const result = await detectScope({
-      repositoryRoot: join(FIXTURES, 'dockerfile-website'),
+      tree: fixture('dockerfile-website'),
       source: { kind: 'repo', subpath: '.' },
       planner: planner({
         outcome: 'detected',
         kind: 'website',
+        reason: 'a static site generator',
         kinds: [
           { kind: 'website', available: true },
           {
@@ -78,7 +90,7 @@ describe('the detection ladder', () => {
   test('spindrift.yaml is authoritative and stops the ladder', async () => {
     let plannerCalls = 0;
     const result = await detectScope({
-      repositoryRoot: join(FIXTURES, 'authoritative-file'),
+      tree: fixture('authoritative-file'),
       source: { kind: 'repo', subpath: '.' },
       planner: {
         async plan() {
@@ -86,6 +98,7 @@ describe('the detection ladder', () => {
           return {
             outcome: 'detected',
             kind: 'website',
+            reason: 'must not run',
             kinds: [{ kind: 'website', available: true }],
             buildCommand: 'bun run build',
             outputDirectory: 'dist',
@@ -101,6 +114,7 @@ describe('the detection ladder', () => {
       proposal: {
         source: 'spindrift-file',
         kind: 'job',
+        reason: 'spindrift.yaml asserts this scope is a job',
         kinds: [
           {
             kind: 'job',
@@ -119,13 +133,13 @@ describe('the detection ladder', () => {
   });
 
   test('classifies only the named monorepo scope', async () => {
-    const plannedDirectories: string[] = [];
+    const planned: string[] = [];
     const result = await detectScope({
-      repositoryRoot: join(FIXTURES, 'named-scope'),
+      tree: fixture('named-scope'),
       source: { kind: 'repo', subpath: 'apps/unknown' },
       planner: {
-        async plan(directory) {
-          plannedDirectories.push(directory);
+        async plan(_tree, scope) {
+          planned.push(scope);
           return {
             outcome: 'unsupported',
             detail:
@@ -135,9 +149,7 @@ describe('the detection ladder', () => {
       },
     });
 
-    expect(plannedDirectories).toEqual([
-      join(FIXTURES, 'named-scope/apps/unknown'),
-    ]);
+    expect(planned).toEqual(['apps/unknown']);
     expect(result).toEqual({
       outcome: 'unknown',
       scope: 'apps/unknown',
@@ -150,11 +162,12 @@ describe('the detection ladder', () => {
 
   test('derives transitive workspace watch paths from manifests', async () => {
     const result = await detectScope({
-      repositoryRoot: join(FIXTURES, 'workspace-watch'),
+      tree: fixture('workspace-watch'),
       source: { kind: 'repo', subpath: 'apps/web' },
       planner: planner({
         outcome: 'detected',
         kind: 'service',
+        reason: 'a start command',
         kinds: [
           { kind: 'service', available: true },
           {
@@ -181,16 +194,17 @@ describe('the detection ladder', () => {
   });
 
   test('unwraps an archive once and runs the same classifier without repo state', async () => {
-    const plannedDirectories: string[] = [];
+    const planned: string[] = [];
     const result = await detectScope({
-      repositoryRoot: join(FIXTURES, 'wrapped-archive'),
+      tree: fixture('wrapped-archive'),
       source: { kind: 'archive' },
       planner: {
-        async plan(directory) {
-          plannedDirectories.push(directory);
+        async plan(_tree, scope) {
+          planned.push(scope);
           return {
             outcome: 'detected',
             kind: 'website',
+            reason: 'files to serve',
             kinds: [{ kind: 'website', available: true }],
             buildCommand: null,
             outputDirectory: '.',
@@ -199,15 +213,14 @@ describe('the detection ladder', () => {
       },
     });
 
-    expect(plannedDirectories).toEqual([
-      join(FIXTURES, 'wrapped-archive/site'),
-    ]);
+    expect(planned).toEqual(['site']);
     expect(result).toEqual({
       outcome: 'detected',
       scope: '.',
       proposal: {
-        source: 'railpack',
+        source: 'detection',
         kind: 'website',
+        reason: 'files to serve',
         kinds: [{ kind: 'website', available: true }],
         build: {
           frontend: 'railpack',
@@ -221,7 +234,7 @@ describe('the detection ladder', () => {
 
   test('returns unknown instead of reading foreign build configuration', async () => {
     const result = await detectScope({
-      repositoryRoot: join(FIXTURES, 'foreign-config'),
+      tree: fixture('foreign-config'),
       source: { kind: 'repo', subpath: '.' },
       planner: planner({
         outcome: 'unsupported',
@@ -241,15 +254,12 @@ describe('the detection ladder', () => {
   test('rejects a named scope outside the repository root', async () => {
     let plannerCalls = 0;
     const detection = detectScope({
-      repositoryRoot: join(FIXTURES, 'named-scope'),
+      tree: fixture('named-scope'),
       source: { kind: 'repo', subpath: '../outside' },
       planner: {
         async plan() {
           plannerCalls += 1;
-          return {
-            outcome: 'unsupported',
-            detail: 'must not run',
-          };
+          return { outcome: 'unsupported', detail: 'must not run' };
         },
       },
     });
@@ -263,15 +273,12 @@ describe('the detection ladder', () => {
   test('an invalid authoritative file fails instead of falling through', async () => {
     let plannerCalls = 0;
     const detection = detectScope({
-      repositoryRoot: join(FIXTURES, 'invalid-authority'),
+      tree: fixture('invalid-authority'),
       source: { kind: 'repo', subpath: '.' },
       planner: {
         async plan() {
           plannerCalls += 1;
-          return {
-            outcome: 'unsupported',
-            detail: 'must not run',
-          };
+          return { outcome: 'unsupported', detail: 'must not run' };
         },
       },
     });

--- a/apps/spindrift/test/domain/repository-scan.test.ts
+++ b/apps/spindrift/test/domain/repository-scan.test.ts
@@ -1,0 +1,255 @@
+/**
+ * What a repository turns out to be, read without checking it out (§5).
+ *
+ * Two claims are under test and they are different claims:
+ *
+ * 1. **The planner answers from what a project declares.** A `package.json`
+ *    with `next` in it is a website; a `go.mod` is a service; a library that
+ *    declares neither a framework nor a start script is the honest unknown §5
+ *    insists on, never a silent fallback to `service`.
+ * 2. **The ladder does not care where the bytes came from.** Every case here
+ *    runs over an in-memory tree — no disk, no clone — and `detection.test.ts`
+ *    runs the same ladder over real directories. One algorithm, two sources,
+ *    which is the whole reason `SourceTree` exists.
+ */
+import { describe, expect, test } from 'bun:test';
+import { declaredPlanner } from '../../src/domain/detection/declared.ts';
+import {
+  discoverScopes,
+  scanRepository,
+} from '../../src/domain/detection/discover.ts';
+import type { SourceTree } from '../../src/domain/detection/tree.ts';
+
+/** A tree that is a literal, so a test states the repository it means. */
+function memoryTree(files: Record<string, string>): SourceTree {
+  const paths = Object.keys(files).sort();
+  return {
+    paths: async () => paths,
+    readText: async (path) => files[path] ?? null,
+  };
+}
+
+const PACKAGE = (extra: Record<string, unknown>) =>
+  JSON.stringify({ name: 'thing', ...extra });
+
+describe('planning from what a project declares', () => {
+  const plan = (files: Record<string, string>, scope = '.') =>
+    declaredPlanner().plan(memoryTree(files), scope);
+
+  test('a framework dependency names the kind and where its files land', async () => {
+    const result = await plan({
+      'package.json': PACKAGE({ dependencies: { astro: '^5.0.0' } }),
+    });
+
+    expect(result).toEqual({
+      outcome: 'detected',
+      kind: 'website',
+      reason: 'Astro — `astro` is a dependency in package.json',
+      kinds: [
+        {
+          kind: 'service',
+          available: false,
+          reason: 'Astro builds files into dist',
+        },
+        { kind: 'website', available: true },
+        {
+          kind: 'job',
+          available: false,
+          reason: 'jobs are asserted, never inferred',
+        },
+      ],
+      buildCommand: null,
+      outputDirectory: 'dist',
+    });
+  });
+
+  test('a server-rendering framework has no static output directory', async () => {
+    const result = await plan({
+      'package.json': PACKAGE({ dependencies: { next: '15.0.0' } }),
+    });
+
+    expect(result).toMatchObject({
+      outcome: 'detected',
+      kind: 'website',
+      outputDirectory: null,
+    });
+  });
+
+  test('the more specific framework wins over the bundler it is built on', async () => {
+    const result = await plan({
+      'package.json': PACKAGE({
+        dependencies: { '@sveltejs/kit': '^2.0.0' },
+        devDependencies: { vite: '^6.0.0' },
+      }),
+    });
+
+    expect(result).toMatchObject({
+      reason: expect.stringContaining('SvelteKit'),
+    });
+  });
+
+  test('a language manifest with no package.json is a service', async () => {
+    expect(
+      await plan({ 'go.mod': 'module example.com/thing\n' }),
+    ).toMatchObject({
+      outcome: 'detected',
+      kind: 'service',
+      reason: 'Go — go.mod is in this directory',
+    });
+  });
+
+  test('the build command is left to the builder that owns it', async () => {
+    const result = await plan({
+      'package.json': PACKAGE({
+        dependencies: { vite: '^6.0.0' },
+        scripts: { build: 'vite build --mode production' },
+      }),
+    });
+
+    // Railpack reads the same package.json at build time and is better at this
+    // than a table here would be. Proposing a command would be proposing the
+    // answer that then wins over the builder's.
+    expect(result).toMatchObject({ buildCommand: null });
+  });
+
+  test('a library is unsupported rather than quietly a service', async () => {
+    const result = await plan({
+      'package.json': PACKAGE({ dependencies: { zod: '^4.0.0' } }),
+    });
+
+    expect(result.outcome).toBe('unsupported');
+  });
+
+  test('a start script with no framework is a service', async () => {
+    expect(
+      await plan({
+        'package.json': PACKAGE({ scripts: { start: 'node server.js' } }),
+      }),
+    ).toMatchObject({ outcome: 'detected', kind: 'service' });
+  });
+
+  test('an unparseable package.json does not throw', async () => {
+    expect(await plan({ 'package.json': '{ not json' })).toMatchObject({
+      outcome: 'unsupported',
+    });
+  });
+
+  test('it plans the named scope, not the root', async () => {
+    const result = await plan(
+      {
+        'package.json': PACKAGE({ workspaces: ['apps/*'] }),
+        'apps/site/package.json': PACKAGE({ dependencies: { gatsby: '^5' } }),
+      },
+      'apps/site',
+    );
+
+    expect(result).toMatchObject({
+      kind: 'website',
+      outputDirectory: 'public',
+    });
+  });
+});
+
+describe('discovering what is in a repository', () => {
+  test('a repository whose root is an App is not walked any further', async () => {
+    const found = await scanRepository(
+      memoryTree({
+        'package.json': PACKAGE({ dependencies: { next: '15.0.0' } }),
+        'apps/ignored/package.json': PACKAGE({ dependencies: { vite: '^6' } }),
+      }),
+      declaredPlanner(),
+    );
+
+    expect(found).toHaveLength(1);
+    expect(found[0]).toMatchObject({ outcome: 'detected', scope: '.' });
+  });
+
+  test('a workspace root offers its declared packages', async () => {
+    const found = await scanRepository(
+      memoryTree({
+        'package.json': PACKAGE({ workspaces: ['apps/*', 'packages/*'] }),
+        'apps/web/package.json': PACKAGE({
+          name: 'web',
+          dependencies: { next: '15.0.0' },
+        }),
+        'apps/api/package.json': PACKAGE({
+          name: 'api',
+          scripts: { start: 'bun run index.ts' },
+        }),
+        'packages/ui/package.json': PACKAGE({ name: 'ui' }),
+      }),
+      declaredPlanner(),
+    );
+
+    // The root stays on the list wearing its reason (§3): "why not here" is as
+    // much an answer as "here", and a screen that dropped it would be a screen
+    // that silently decided.
+    expect(
+      found.map((result) => [
+        result.scope,
+        result.outcome,
+        result.outcome === 'detected' ? result.proposal.kind : null,
+      ]),
+    ).toEqual([
+      ['.', 'unknown', null],
+      ['apps/api', 'detected', 'service'],
+      ['apps/web', 'detected', 'website'],
+      ['packages/ui', 'unknown', null],
+    ]);
+  });
+
+  test('a repository with no workspace declaration is walked, but not deeply', async () => {
+    const found = await discoverScopes(
+      memoryTree({
+        'README.md': '',
+        'services/api/go.mod': 'module api\n',
+        'services/api/vendor/dep/go.mod': 'module dep\n',
+        'deep/one/two/three/package.json': PACKAGE({}),
+        'node_modules/left-pad/package.json': PACKAGE({}),
+      }),
+    );
+
+    // `services/api` is two deep and kept. The vendored module and the
+    // `node_modules` entry are somebody else's code; `deep/one/two/three` is
+    // past the depth ceiling and is reachable by naming it.
+    expect(found).toEqual(['services/api']);
+  });
+
+  test('a named scope is honoured exactly, with no discovery at all', async () => {
+    const found = await scanRepository(
+      memoryTree({
+        'package.json': PACKAGE({ dependencies: { next: '15.0.0' } }),
+        'apps/api/go.mod': 'module api\n',
+      }),
+      declaredPlanner(),
+      ['apps/api'],
+    );
+
+    expect(found.map((result) => result.scope)).toEqual(['apps/api']);
+  });
+
+  test('an in-repo spindrift.yaml wins over anything detection would say', async () => {
+    const found = await scanRepository(
+      memoryTree({
+        'package.json': PACKAGE({ dependencies: { next: '15.0.0' } }),
+        'spindrift.yaml': [
+          'version: 1',
+          'component:',
+          '  kind: job',
+          'build:',
+          '  frontend: railpack',
+          '  command: bun run nightly',
+          '  outputDirectory: null',
+          'watchPaths:',
+          '  - .',
+        ].join('\n'),
+      }),
+      declaredPlanner(),
+    );
+
+    expect(found[0]).toMatchObject({
+      outcome: 'detected',
+      proposal: { source: 'spindrift-file', kind: 'job' },
+    });
+  });
+});

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -23,6 +23,7 @@ import {
   targetAdapterSchema,
 } from '../../src/config/manifest.schema.ts';
 import { BUILD_ROUTE_REFUSALS } from '../../src/domain/build-route.ts';
+import { PRESET_DEPENDENCIES } from '../../src/domain/detection/declared.ts';
 import { KUBERNETES_DELIVERY_FLAVOURS } from '../../src/domain/target.ts';
 
 const APP = join(import.meta.dir, '../..');
@@ -72,6 +73,10 @@ const PROJECT_ID_ALLOWLIST = new Set<string>([
   // Why a build route is not usable for a Target — vocabulary again, read from
   // the domain rather than restated, so adding one does not break a test here.
   ...BUILD_ROUTE_REFUSALS,
+  // The package that proves a project uses a given framework. `react-scripts`
+  // wears the project-id shape and names no installation: it is the same
+  // package on npm for everybody, which is exactly why detection can key on it.
+  ...PRESET_DEPENDENCIES,
   // An encoding, a digest algorithm, and a key in a workflow file. None of the
   // three names anything; all wear the shape because they are lowercase words
   // carrying a digit or a hyphen, which is the whole of what this scanner can

--- a/apps/spindrift/test/harness/fakes/github-api.ts
+++ b/apps/spindrift/test/harness/fakes/github-api.ts
@@ -445,6 +445,33 @@ export class FakeGitHub {
         : this.json({ object: { sha: commit } });
     }
 
+    // Trees answer for a tree id *or* a commit id, exactly as the real
+    // endpoint does, and only `recursive=1` flattens. A client that forgot the
+    // flag gets the top level here too, so "why is my monorepo one entry" is a
+    // question this fake can be asked rather than one production answers.
+    const gitTree = rest.match(/^\/git\/trees\/(.+)$/);
+    if (gitTree) {
+      const requested = decodeURIComponent(gitTree[1] ?? '');
+      const treeId = this.commits.get(requested)?.tree ?? requested;
+      const tree = this.trees.get(treeId);
+      if (tree === undefined) return this.notFound();
+      const recursive = url.searchParams.get('recursive') !== null;
+      const entries = recursive
+        ? [...tree.keys()].map((path) => ({ path, type: 'blob' }))
+        : [
+            ...new Map(
+              [...tree.keys()].map((path) => {
+                const [head = path, ...rest] = path.split('/');
+                return [
+                  head,
+                  { path: head, type: rest.length === 0 ? 'blob' : 'tree' },
+                ] as const;
+              }),
+            ).values(),
+          ];
+      return this.json({ sha: treeId, truncated: false, tree: entries });
+    }
+
     const gitCommit = rest.match(/^\/git\/commits\/(.+)$/);
     if (gitCommit) {
       const stored = this.commits.get(gitCommit[1] ?? '');

--- a/apps/spindrift/test/integrations/github/config-pr.test.ts
+++ b/apps/spindrift/test/integrations/github/config-pr.test.ts
@@ -32,8 +32,9 @@ const BUILD_WORKFLOW =
   'example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809';
 
 const railpack: DetectionProposal = {
-  source: 'railpack',
+  source: 'detection',
   kind: 'website',
+  reason: 'a fixture',
   kinds: [{ kind: 'website', available: true }],
   build: {
     frontend: 'railpack',
@@ -44,8 +45,9 @@ const railpack: DetectionProposal = {
 };
 
 const dockerfile: DetectionProposal = {
-  source: 'railpack',
+  source: 'detection',
   kind: 'service',
+  reason: 'a fixture',
   kinds: [{ kind: 'service', available: true }],
   build: { frontend: 'dockerfile', dockerfile: 'Dockerfile' },
   watchPaths: ['services/api'],

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -335,6 +335,7 @@ function unusedRepositoryHost(): RepositoryHost {
     repository: unused,
     branchHead: unused,
     readFile: unused,
+    treePaths: unused,
     commitTree: unused,
     createBlob: unused,
     createTree: unused,

--- a/apps/spindrift/test/reconciler/repo-loop.test.ts
+++ b/apps/spindrift/test/reconciler/repo-loop.test.ts
@@ -53,8 +53,9 @@ const NOW = new Date('2026-07-28T12:00:00.000Z');
 const clock = { now: () => NOW };
 
 const proposal: DetectionProposal = {
-  source: 'railpack',
+  source: 'detection',
   kind: 'service',
+  reason: 'a fixture',
   kinds: [{ kind: 'service', available: true }],
   build: {
     frontend: 'railpack',
@@ -178,6 +179,9 @@ describe('adopting the default branch', () => {
         proposal: {
           ...proposal,
           source: 'spindrift-file',
+          // The file that settled it, named — this is what the workspace shows
+          // when it says where a Component's kind came from.
+          reason: 'services/api/spindrift.yaml asserts this scope is a service',
           kinds: [
             {
               kind: 'service',

--- a/apps/spindrift/test/web/target-repo-routes.test.ts
+++ b/apps/spindrift/test/web/target-repo-routes.test.ts
@@ -153,7 +153,7 @@ describe('listTargets and listRepositories over route boundary', () => {
     await connectRepository(
       {
         fullName: fake.fullName,
-        scopes: [
+        overrides: [
           {
             scope: 'app',
             kind: 'service',
@@ -194,7 +194,7 @@ describe('listTargets and listRepositories over route boundary', () => {
     await connectRepository(
       {
         fullName: fake.fullName,
-        scopes: [
+        overrides: [
           {
             scope: 'app',
             kind: 'service',

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -140,7 +140,16 @@ describe('the GitHub repository connector', () => {
     expect(markup).not.toContain('device-code-secret');
   });
 
-  test('collects reviewed scope configuration after authorization', () => {
+  /**
+   * The whole point of the rebuild, asserted as an absence.
+   *
+   * Connecting a repository asks for nothing. Every field this screen used to
+   * collect — the scope, the kind, the build frontend, the Dockerfile, the
+   * build command, the output directory, the watch paths — is something §5's
+   * detector reads out of the repository, and a regression here would be the
+   * form growing back one field at a time.
+   */
+  test('offers a repository to connect and asks for nothing', () => {
     const markup = renderToStaticMarkup(
       <RepositoryList
         repos={[]}
@@ -166,10 +175,18 @@ describe('the GitHub repository connector', () => {
     );
     expect(markup).toContain('Authorized as @operator');
     expect(markup).toContain('example/app');
-    expect(markup).toContain('Component kind');
-    expect(markup).toContain('Build frontend');
-    expect(markup).toContain('Watch paths');
-    expect(markup).toContain('Open configuration PR');
+    expect(markup).toContain('>Connect<');
+    for (const field of [
+      'Component kind',
+      'Build frontend',
+      'Watch paths',
+      'Output directory',
+      'Build command',
+      '<select',
+      '<textarea',
+    ]) {
+      expect(markup).not.toContain(field);
+    }
   });
 });
 


### PR DESCRIPTION
Connecting a repository asked for seven fields before it would open a pull request — scope, kind, build frontend, Dockerfile path, build command, output directory, and a newline-separated watch-path textarea. All seven are things §5's detection ladder can read out of the repository.

The ladder had never run in production. It took a `repositoryRoot`, and the one moment somebody wants an answer is a moment when nothing is checked out.

## What changed

**`SourceTree`** — the ladder reads through `paths()` + `readText()` instead of a path. Implemented over a directory on disk (archives, fixtures) and over a GitHub tree at one commit (`git/trees?recursive=1` + blob reads, both cached). Scope resolution loses its filesystem and becomes string work; the symlink-escape check moves into `diskTree`, the only implementation with symlinks to be lied to by.

**`declared.ts`** — `ZeroConfigPlanner` had no production implementation either, because Railpack runs *inside* the BuildKit build (`buildkit.ts:147`). This planner answers the half a connect screen needs — *what is this* — from what a project declares, and leaves *how is it built* to the builder. Hence the always-null `buildCommand`. `outputDirectory` is the exception and is not Railpack's to know: it is where Spindrift lifts files from when a website is placed on a static Target.

**Two commands.** `inspectRepository` reads and writes nothing, pinned to a commit. `connectRepository` now takes `scopes?` (names only) and detects against the branch as it is at that moment — nothing detection proposes travels through the browser on its way into the repository. `overrides` is the escape hatch, a separate field because asserting a proposal and accepting one are different acts.

**Discovery** is story 23's "discover" branch, not a weakening of "the scope is named, never searched": it proposes candidates for a human to pick, and what they pick becomes a named scope. Workspace declarations win where a repo has them; otherwise a depth-2 walk. A root that is itself an App ends the question.

## The screen

Pick a repository → it reads → you see what it found → Connect. A directory it could not make sense of stays listed wearing its reason (§3), because "nothing here" and "nine directories, seven of them libraries" are different answers.

## Behaviour worth calling out

- A repository where nothing is buildable is **refused before a row exists**. A `repositories` row with no scope is a connection to nothing, which the repo loop would reconcile forever.
- An in-repo `spindrift.yaml` still wins, including when Spindrift is writing the file back.
- `DetectionProposal.source` renames `railpack` → `detection` and gains `reason`. Both are user-visible — that value is the "proposed by" column of a human-reviewed PR, and a tree-reading detector calling itself Railpack would be a lie in it.

## Checks

`bun test` 1206 pass / 0 fail · `bun run typecheck` clean · `bun run lint` clean (one pre-existing warning in `test/web/installation-surface.test.ts`, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)