### PR TITLE
feat(spindrift): give Targets and source storage a way in

### DIFF
--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -50,6 +50,7 @@ export { inspectRepository } from './repositories/inspect.ts';
 export { listRepositories } from './repositories/list.ts';
 export { listSourceBuckets } from './storage/list-buckets.ts';
 export { testBucketPermissions } from './storage/test-bucket.ts';
+export { useSourceBucket } from './storage/use-bucket.ts';
 export { connectTarget } from './targets/connect.ts';
 export { disconnectTarget } from './targets/disconnect.ts';
 export { listTargets } from './targets/list.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -95,6 +95,7 @@ import {
   testBucketPermissions,
   testBucketPermissionsInput,
 } from './storage/test-bucket.ts';
+import { useSourceBucket, useSourceBucketInput } from './storage/use-bucket.ts';
 import { connectTarget, connectTargetInput } from './targets/connect.ts';
 import {
   disconnectTarget,
@@ -201,6 +202,10 @@ export const commandRegistry = {
   testBucketPermissions: {
     input: testBucketPermissionsInput,
     handler: testBucketPermissions,
+  },
+  useSourceBucket: {
+    input: useSourceBucketInput,
+    handler: useSourceBucket,
   },
 } as const satisfies Readonly<Record<string, AnyCommandDescriptor>>;
 

--- a/apps/spindrift/src/commands/storage/list-buckets.ts
+++ b/apps/spindrift/src/commands/storage/list-buckets.ts
@@ -11,6 +11,15 @@ export type ListSourceBucketsInput = z.infer<typeof listSourceBucketsInput>;
 export interface ListSourceBucketsResult {
   readonly buckets: readonly string[];
   readonly defaultBucket: string;
+  /**
+   * Whether this installation can reach a bucket to check one at all (§13).
+   *
+   * Stated rather than discovered by a failed check: without Workload Identity
+   * Federation there is no identity to ask Cloud Storage about, so a Verify
+   * button would be a button that can only ever report the same configuration
+   * fact. The screen says it once, up front, instead.
+   */
+  readonly canVerify: boolean;
 }
 
 export const listSourceBuckets: Command<
@@ -21,5 +30,6 @@ export const listSourceBuckets: Command<
   return ok({
     buckets,
     defaultBucket: defaultBucket ?? buckets[0] ?? '',
+    canVerify: context.manifest.cloud.federation !== null,
   });
 };

--- a/apps/spindrift/src/commands/storage/use-bucket.ts
+++ b/apps/spindrift/src/commands/storage/use-bucket.ts
@@ -1,0 +1,153 @@
+/**
+ * `useSourceBucket` — stage sources to this bucket, and optionally to it first.
+ *
+ * §4 stages an uploaded archive and a repository's source in a first-party
+ * bucket before any builder can fetch it, and §20 puts the list of those
+ * buckets in the installation manifest. Between those two facts there was no
+ * act: the creation flow rendered `sources.buckets` as a `<select>` with a
+ * "Custom bucket…" option, which let a developer type a bucket that was not
+ * declared anywhere and stage a build into it. That is configuration entered
+ * on a deploy form, which is the shape §20 exists to prevent.
+ *
+ * So adding a bucket is its own act, and it is one act rather than two:
+ * *stage to this bucket*, and optionally *stage to it first*. Naming an
+ * already-declared bucket with `makeDefault` is how the default moves, which
+ * is why this is not called `addSourceBucket` — the add is idempotent and the
+ * interesting half is often the other one.
+ *
+ * **It verifies before it writes.** A bucket the controller cannot write to is
+ * not a configuration mistake that shows up in configuration; it is a build
+ * that dies at staging, minutes later, with a message about a signed URL. The
+ * check is the same `testBucketPermissions` runs, and refusing here costs the
+ * operator one sentence instead of one failed deploy.
+ *
+ * **Named cost, inherited from `configureInstallation`:** the manifest has no
+ * revision column, so this read-modify-write loses a concurrent edit whole.
+ * That comment is not copied here to be waved at — it is the reason this
+ * command changes exactly two keys and validates the whole document on the way
+ * back out, so the edit it might lose is always somebody else's *other* key
+ * rather than a document this act half-rewrote.
+ */
+import { z } from 'zod';
+import type { AuthoredManifest } from '../../config/manifest.schema.ts';
+import { ManifestError, validateManifest } from '../../config/manifest.ts';
+import {
+  readStoredManifest,
+  writeStoredManifest,
+} from '../../config/manifest-store.ts';
+import { testGcsBucketPermissions } from '../../storage/cloud.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const useSourceBucketInput = z
+  .object({
+    /**
+     * A Cloud Storage bucket name, in Cloud Storage's own terms.
+     *
+     * Checked here rather than left to the far side because the far side's
+     * refusal for a malformed name is a `404` that reads identically to a
+     * bucket somebody else owns, and those two want different sentences.
+     */
+    bucketName: z
+      .string()
+      .trim()
+      .min(3)
+      .max(222)
+      .regex(
+        /^[a-z0-9][a-z0-9._-]*[a-z0-9]$/,
+        'must be a Cloud Storage bucket name: lowercase letters, digits, dots, hyphens and underscores',
+      ),
+    /** Whether this becomes the bucket a new staging picks by default. */
+    makeDefault: z.boolean().default(false),
+  })
+  .strict();
+
+export type UseSourceBucketInput = z.infer<typeof useSourceBucketInput>;
+
+export interface UseSourceBucketResult {
+  readonly buckets: readonly string[];
+  readonly defaultBucket: string;
+  /** Where the bucket lives, as the far side reported it. */
+  readonly location: string;
+  /** What the controller's federated identity may do there. */
+  readonly permissions: readonly string[];
+}
+
+export const useSourceBucket: Command<
+  UseSourceBucketInput,
+  UseSourceBucketResult
+> = async (input, context) => {
+  const federation = context.manifest.cloud.federation;
+  if (!federation) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'Workload Identity Federation is not configured for this installation, so Spindrift cannot reach a bucket to check it',
+    );
+  }
+
+  let verified: Awaited<ReturnType<typeof testGcsBucketPermissions>>;
+  try {
+    verified = await testGcsBucketPermissions({
+      bucketName: input.bucketName,
+      federation,
+    });
+  } catch (cause) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      `Spindrift cannot stage sources to ${input.bucketName}: ${
+        cause instanceof Error ? cause.message : 'the permission check failed'
+      }`,
+    );
+  }
+
+  if (!verified.accessible) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      `Spindrift reached ${input.bucketName} but cannot write to it. Grant the controller's federated identity object create and read on the bucket.`,
+    );
+  }
+
+  const stored = await readStoredManifest(context.db);
+  if (stored === null) {
+    return failed(
+      'NOT_FOUND',
+      'this installation has no stored manifest to add a bucket to',
+    );
+  }
+
+  const buckets = stored.sources.buckets.includes(input.bucketName)
+    ? stored.sources.buckets
+    : [...stored.sources.buckets, input.bucketName];
+  const defaultBucket = input.makeDefault
+    ? input.bucketName
+    : (stored.sources.defaultBucket ?? buckets[0]);
+
+  const next: AuthoredManifest = {
+    ...stored,
+    sources: { ...stored.sources, buckets, defaultBucket },
+  };
+
+  try {
+    // Validated on the way out even though only two keys moved: the document
+    // that gets written is the one that has to be valid, and a stored manifest
+    // that was already drifting from the schema must not be made durable again
+    // by an act that never looked at the rest of it.
+    await writeStoredManifest(
+      context.db,
+      validateManifest(next, 'the updated manifest'),
+    );
+  } catch (cause) {
+    if (cause instanceof ManifestError) {
+      return failed('NOT_DEPLOYABLE', cause.message);
+    }
+    throw cause;
+  }
+
+  return ok({
+    buckets,
+    // Non-null by construction: `sources.buckets` has a minimum of one, and the
+    // bucket just verified is in it.
+    defaultBucket: defaultBucket ?? input.bucketName,
+    location: verified.location,
+    permissions: verified.permissions,
+  });
+};

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -6,7 +6,12 @@ import {
   placementTargetOf,
   resolvePlacement,
 } from '../../domain/placement.ts';
-import type { TargetListItem, TargetOptionView } from '../../web/model.ts';
+import { pendingConnections } from '../../domain/target-onboarding.ts';
+import type {
+  PendingTargetConnection,
+  TargetListItem,
+  TargetOptionView,
+} from '../../web/model.ts';
 import { type Command, ok } from '../types.ts';
 
 export const listTargetsInput = z.object({});
@@ -15,6 +20,8 @@ export type ListTargetsInput = z.infer<typeof listTargetsInput>;
 export interface ListTargetsResult {
   readonly targets: readonly TargetListItem[];
   readonly options: readonly TargetOptionView[];
+  /** Connect acts this installation is waiting on — the onboarding surface. */
+  readonly pending: readonly PendingTargetConnection[];
 }
 
 export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
@@ -42,6 +49,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
       .map((p) => p.detail!);
 
     targetsList.push({
+      id: target.id,
       name: target.name,
       adapter: target.adapter,
       rank: target.rank,
@@ -50,8 +58,16 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
         prereqFailures && prereqFailures.length > 0
           ? prereqFailures
           : undefined,
+      prerequisites: (target.prerequisites ?? []).map((item) => ({
+        name: item.name,
+        met: item.met,
+        ...(item.detail === undefined ? {} : { detail: item.detail }),
+      })),
       kinds,
       canonical,
+      status: target.status,
+      configured: target.connection !== null,
+      inspectedAt: target.inspectedAt?.toISOString() ?? null,
     });
 
     const isConnected = target.status === 'connected';
@@ -139,5 +155,6 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
   return ok({
     targets: targetsList,
     options: optionsList,
+    pending: pendingConnections(allTargets),
   });
 };

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -231,7 +231,16 @@ function connectionFromSeed(target: TargetSeed): TargetConnection | null {
   }
 }
 
-async function readStoredManifest(
+/**
+ * The stored document **as authored**, before environment resolution.
+ *
+ * Exported for the one shape of act that changes a single value and writes the
+ * document back. {@link currentStoredManifest} is the wrong input for that: it
+ * has already substituted whatever the environment supplied, so writing its
+ * result would bake this pod's environment into the durable document and make
+ * the next pod's environment stop mattering.
+ */
+export async function readStoredManifest(
   db: Database,
 ): Promise<AuthoredManifest | null> {
   const [stored] = await db

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -1,0 +1,179 @@
+/**
+ * What is left to connect, and what to propose for it (§13).
+ *
+ * The manifest seeds Target **identities**: a name, an adapter, and a rank,
+ * with connection facts optional. A seed with no connection produces a row
+ * whose checklist reads "Target connection has not been configured" and whose
+ * `connection` column is null — a real, visible, half-ready state, exactly as
+ * §13 intends. What did not exist was any way to finish it from the product:
+ * `connectTarget` has always been a command with no screen.
+ *
+ * This module is the small amount of domain reasoning that screen needs, and
+ * it is here rather than in the view for the usual reason — the browser would
+ * otherwise be deriving it from connection blobs it has no business holding.
+ *
+ * Two jobs:
+ *
+ * 1. **Group Targets back into acts.** Connecting a cloud project registers
+ *    both of its Targets (§13), so two unconfigured rows named
+ *    `<project>-cloudrun` and `<project>-static` are *one* thing to do, named
+ *    `<project>`. A screen listing two cards would reintroduce the second noun
+ *    §13 removed.
+ * 2. **Propose what can honestly be proposed.** See
+ *    {@link TargetConnectionProposal} — carried from a working Target of the
+ *    same adapter, never from a literal, and never for a value that is
+ *    per-instance.
+ */
+import type { TargetAdapter } from '../config/manifest.schema.ts';
+import type {
+  PendingTargetConnection,
+  TargetConnectionProposal,
+} from '../web/model.ts';
+import { CLOUD_ADAPTERS, type TargetConnection } from './target.ts';
+
+/** The columns this reasoning reads, without importing the table. */
+export interface OnboardingTargetRow {
+  readonly name: string;
+  readonly adapter: TargetAdapter;
+  readonly connection: TargetConnection | null;
+  readonly health: 'healthy' | 'unhealthy';
+}
+
+/** The project name behind one of a cloud project's two derived Target names. */
+function cloudProjectOf(name: string, adapter: TargetAdapter): string | null {
+  const suffix = `-${adapter}`;
+  return name.endsWith(suffix) ? name.slice(0, -suffix.length) : null;
+}
+
+/**
+ * The Target a proposal is carried from.
+ *
+ * Prefers a healthy one. A configured-but-unhealthy Target's connection facts
+ * are the facts of something that does not work, and copying them forward is
+ * the fastest way to make one broken Target into two.
+ */
+function donor(
+  rows: readonly OnboardingTargetRow[],
+  adapter: TargetAdapter,
+): OnboardingTargetRow | undefined {
+  const configured = rows.filter(
+    (row) => row.adapter === adapter && row.connection !== null,
+  );
+  return configured.find((row) => row.health === 'healthy') ?? configured[0];
+}
+
+function kubernetesProposal(
+  rows: readonly OnboardingTargetRow[],
+): TargetConnectionProposal {
+  const from = donor(rows, 'kubernetes');
+  const connection = from?.connection;
+  if (connection === undefined || connection?.adapter !== 'kubernetes') {
+    return { carriedFrom: null };
+  }
+  // `apiServer` is deliberately absent. It is the one field here that names a
+  // particular cluster, and a second cluster prefilled with the first one's
+  // address — `https://kubernetes.default.svc` on an in-cluster install —
+  // would read as correct and deploy somewhere else.
+  return {
+    carriedFrom: from?.name ?? null,
+    namespace: connection.namespace,
+    deliveryFlavour: connection.delivery.flavour,
+    ...(connection.delivery.flavour === 'flux-helmrelease'
+      ? { sourceRef: connection.delivery.sourceRef }
+      : {}),
+    ...(connection.chartContract === undefined
+      ? {}
+      : { chartContract: connection.chartContract }),
+  };
+}
+
+function cloudProposal(
+  rows: readonly OnboardingTargetRow[],
+): TargetConnectionProposal {
+  const run = donor(rows, 'cloudrun');
+  const runConnection =
+    run?.connection?.adapter === 'cloudrun' ? run.connection : null;
+  const hosting = donor(rows, 'static');
+  const hostingConnection =
+    hosting?.connection?.adapter === 'static' ? hosting.connection : null;
+
+  if (runConnection === null && hostingConnection === null) {
+    return { carriedFrom: null };
+  }
+  // `project` is absent for the same reason `apiServer` is: connecting a second
+  // cloud project and being handed the first project's id is the one mistake
+  // this screen could make that nobody would catch by reading.
+  return {
+    carriedFrom: run?.name ?? hosting?.name ?? null,
+    ...(runConnection === null
+      ? {}
+      : {
+          region: runConnection.region,
+          runEndpoint: runConnection.endpoint,
+          ...(runConnection.policyEndpoint === undefined
+            ? {}
+            : { policyEndpoint: runConnection.policyEndpoint }),
+        }),
+    ...(hostingConnection === null
+      ? {}
+      : { hostingEndpoint: hostingConnection.endpoint }),
+  };
+}
+
+/** What a screen would propose for a fresh connect of this shape. */
+export function connectionProposal(
+  rows: readonly OnboardingTargetRow[],
+  kind: 'kubernetes' | 'cloud',
+): TargetConnectionProposal {
+  return kind === 'kubernetes' ? kubernetesProposal(rows) : cloudProposal(rows);
+}
+
+/**
+ * Every connect act this installation is waiting on.
+ *
+ * A Target with a connection is not here however unhealthy it is — an unmet
+ * checklist item is something to fix on the Target, not a connection to
+ * supply, and §13 keeps those apart on purpose. Only `connection === null`,
+ * the state nothing but a manifest seed produces, is an act that is still
+ * owed.
+ */
+export function pendingConnections(
+  rows: readonly OnboardingTargetRow[],
+): readonly PendingTargetConnection[] {
+  const unconfigured = rows.filter((row) => row.connection === null);
+  const pending: PendingTargetConnection[] = [];
+  const cloudProjects = new Set<string>();
+
+  for (const row of unconfigured) {
+    if (row.adapter === 'kubernetes') {
+      pending.push({
+        kind: 'kubernetes',
+        name: row.name,
+        targets: [row.name],
+        proposal: connectionProposal(rows, 'kubernetes'),
+      });
+      continue;
+    }
+    // A cloud Target whose name does not carry its adapter's suffix cannot be
+    // reached by `connectTarget`, which derives both names from one project
+    // name. Listing it as connectable would offer a button that registers two
+    // Targets neither of which is this row.
+    const project = cloudProjectOf(row.name, row.adapter);
+    if (project === null) continue;
+    cloudProjects.add(project);
+  }
+
+  for (const project of cloudProjects) {
+    pending.push({
+      kind: 'cloud',
+      name: project,
+      // Both names the act will write, whether or not both are unconfigured
+      // today: connecting re-registers the pair, and saying so is what stops
+      // the confirmation from under-reporting what it is about to touch.
+      targets: CLOUD_ADAPTERS.map((adapter) => `${project}-${adapter}`),
+      proposal: connectionProposal(rows, 'cloud'),
+    });
+  }
+
+  return pending;
+}

--- a/apps/spindrift/src/storage/archives.ts
+++ b/apps/spindrift/src/storage/archives.ts
@@ -54,13 +54,21 @@ export const ARTIFACTS_BUCKET_VAR = 'SPINDRIFT_ARTIFACTS_BUCKET';
  * installation with no bucket or no federation is a configuration fact callers
  * report — as a refusal, or by falling back to local disk — rather than an
  * exception thrown from inside staging.
+ *
+ * **It takes no per-request override, and that is a rule rather than a
+ * simplification.** The upload route used to pass one straight through from a
+ * request header, so any authenticated caller could stage bytes into any
+ * bucket name they liked — declared in this installation's manifest or not.
+ * §20 puts the set of buckets in the manifest precisely so that the answer to
+ * "where did this get staged" is a value somebody wrote down;
+ * `useSourceBucket` is how that set grows, after checking the bucket is
+ * writable. The environment variable stays, because it is the operator running
+ * this process outside its chart rather than a caller of it.
  */
 export function sourceDepotFor(
   manifest: Pick<InstallationManifest, 'sources' | 'cloud'> | null | undefined,
-  bucketOverride?: string | null,
 ): SourceDepot | null {
   const bucket =
-    bucketOverride?.trim() ||
     process.env[ARTIFACTS_BUCKET_VAR]?.trim() ||
     manifest?.sources?.defaultBucket?.trim() ||
     manifest?.sources?.buckets?.[0]?.trim();

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -15,6 +15,7 @@ import type {
   DeployListItem,
   DeployView,
   LinkedRepoView,
+  PendingTargetConnection,
   RepositoryConnectorView,
   RepositoryOptionView,
   TargetListItem,
@@ -37,12 +38,17 @@ import {
   type RepositoryAuthorizationView,
   RepositoryList,
 } from './views/repos/list.tsx';
+import {
+  SourceStorage,
+  type SourceStorageView,
+} from './views/storage/list.tsx';
 import { TargetList } from './views/targets/list.tsx';
 
 const NAV = [
   { path: '/apps', label: 'Apps' },
   { path: '/targets', label: 'Targets' },
   { path: '/repos', label: 'Repos' },
+  { path: '/storage', label: 'Storage' },
   { path: '/apps/new', label: 'New App' },
   { path: '/settings', label: 'Settings' },
 ] as const;
@@ -135,6 +141,7 @@ function Screen({
   }
   if (path.startsWith('/targets')) return <TargetsScreen />;
   if (path.startsWith('/repos')) return <RepositoriesScreen />;
+  if (path.startsWith('/storage')) return <StorageScreen />;
   if (path.startsWith('/deploys')) {
     const deployId = path.replace(/^\/deploys\/?/, '');
     return <DeployScreen deployId={deployId} onNavigate={onNavigate} />;
@@ -867,8 +874,16 @@ function TargetsScreen() {
   const [state, setState] = useState<
     | { type: 'loading' }
     | { type: 'error'; message: string }
-    | { type: 'success'; targets: readonly TargetListItem[] }
+    | {
+        type: 'success';
+        targets: readonly TargetListItem[];
+        pending: readonly PendingTargetConnection[];
+      }
   >({ type: 'loading' });
+  const [connecting, setConnecting] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  /** Bumped after a connect, because the checklist it produced is the answer. */
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -876,7 +891,11 @@ function TargetsScreen() {
       .then((result) => {
         if (!live) return;
         if (result.ok) {
-          setState({ type: 'success', targets: result.value.targets });
+          setState({
+            type: 'success',
+            targets: result.value.targets,
+            pending: result.value.pending,
+          });
         } else {
           setState({ type: 'error', message: result.failure.message });
         }
@@ -891,7 +910,29 @@ function TargetsScreen() {
     return () => {
       live = false;
     };
-  }, []);
+  }, [reloadToken]);
+
+  const connect = async (input: InputOf<'connectTarget'>) => {
+    setConnecting(true);
+    setActionError(null);
+    try {
+      const result = await command('connectTarget', input);
+      if (!result.ok) {
+        setActionError(result.failure.message);
+        return;
+      }
+      // §13: connect always succeeds, and what it produced is a checklist. The
+      // list is re-read rather than patched because that checklist is the whole
+      // outcome of the act and it came from a pass of the inspection loop.
+      setReloadToken((token) => token + 1);
+    } catch (cause) {
+      setActionError(
+        cause instanceof Error ? cause.message : 'Connecting the Target failed',
+      );
+    } finally {
+      setConnecting(false);
+    }
+  };
 
   if (state.type === 'loading') {
     return (
@@ -914,7 +955,75 @@ function TargetsScreen() {
     );
   }
 
-  return <TargetList targets={state.targets} />;
+  return (
+    <TargetList
+      targets={state.targets}
+      pending={state.pending}
+      connecting={connecting}
+      error={actionError}
+      onConnect={connect}
+    />
+  );
+}
+
+function StorageScreen() {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'error'; message: string }
+    | { type: 'success'; view: SourceStorageView }
+  >({ type: 'loading' });
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let live = true;
+    command('listSourceBuckets', {})
+      .then((result) => {
+        if (!live) return;
+        setState(
+          result.ok
+            ? { type: 'success', view: result.value }
+            : { type: 'error', message: result.failure.message },
+        );
+      })
+      .catch((cause: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: cause instanceof Error ? cause.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, [reloadToken]);
+
+  if (state.type === 'loading') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <p className="text-sm text-muted-foreground animate-pulse">
+          Loading source storage...
+        </p>
+      </div>
+    );
+  }
+
+  if (state.type === 'error') {
+    return (
+      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+          <p className="text-sm font-medium">Failed to load source storage</p>
+          <p className="text-sm mt-1">{state.message}</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <SourceStorage
+      view={state.view}
+      onChanged={() => setReloadToken((token) => token + 1)}
+    />
+  );
 }
 
 function RepositoriesScreen() {

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -514,14 +514,91 @@ export interface AppListItem {
 
 /** A Target as the targets management view lists it. */
 export interface TargetListItem {
+  readonly id: string;
   readonly name: string;
   readonly adapter: string;
   readonly rank: number;
   readonly health: 'healthy' | 'unhealthy';
   /** Prerequisite failure details when target is unhealthy. */
   readonly prerequisiteFailures?: readonly string[];
+  /**
+   * The whole standing checklist, met items included (§13).
+   *
+   * Not only the failures: §13 makes health "a standing prerequisite
+   * checklist", and a list that showed only what is broken cannot answer *what
+   * was checked* — which is the question an operator staring at a healthy
+   * Target that will not take their app is actually asking.
+   */
+  readonly prerequisites: readonly {
+    readonly name: string;
+    readonly met: boolean;
+    readonly detail?: string;
+  }[];
   /** Supported component kinds on this target. */
   readonly kinds: readonly ComponentKind[];
   /** The canonical hostname prefix for apps on this target. */
   readonly canonical: string;
+  /** `disconnected` keeps serving; it strands Deploys rather than ending them. */
+  readonly status: 'connected' | 'disconnected';
+  /**
+   * Whether anything has ever supplied this Target's connection facts.
+   *
+   * False is the manifest-seeded state: an identity and a rank exist and
+   * nothing else does. It is a different state from a Target an operator
+   * deliberately disconnected, and the two want opposite words on a button.
+   */
+  readonly configured: boolean;
+  /** When the standing checklist last ran, ISO-8601, or null if never. */
+  readonly inspectedAt: string | null;
+}
+
+/**
+ * A connect act this installation is waiting on (§13).
+ *
+ * One entry per *act*, not per Target: connecting a cloud project registers
+ * both of its Targets, so `bluenose-cloudrun` and `bluenose-static` are one
+ * pending connection named `bluenose`. §13 is explicit that the split is "a
+ * consequence of the model, not a decision", and an onboarding screen that
+ * listed two cards would be making the operator learn the second noun that
+ * decision exists to avoid.
+ */
+export interface PendingTargetConnection {
+  /** What `connectTarget` takes as its `kind`. */
+  readonly kind: 'kubernetes' | 'cloud';
+  /** What `connectTarget` takes as its `name`. */
+  readonly name: string;
+  /** Every Target name this one act would configure. */
+  readonly targets: readonly string[];
+  readonly proposal: TargetConnectionProposal;
+}
+
+/**
+ * Values proposed for a connect, and where each came from.
+ *
+ * Carried from a Target of the same adapter this installation has **already**
+ * configured, never from a literal in this repository. §20 puts every value
+ * naming a far side in the manifest, and a default compiled into `src/` would
+ * be that contract broken quietly — so the only thing that can teach Spindrift
+ * what a Cloud Run endpoint looks like here is a Cloud Run Target that is
+ * already working here.
+ *
+ * What is **not** carried matters as much: an `apiServer`, a `project`, and a
+ * Target's name are per-instance facts, and a plausible wrong default for one
+ * of those is worse than an empty field. A second cluster prefilled with the
+ * first one's in-cluster address would look right and be wrong.
+ */
+export interface TargetConnectionProposal {
+  /** The Target these values were read off, or null when there was none. */
+  readonly carriedFrom: string | null;
+  readonly namespace?: string;
+  readonly deliveryFlavour?: 'flux-helmrelease' | 'argo-application';
+  readonly sourceRef?: {
+    readonly name: string;
+    readonly namespace: string;
+  };
+  readonly chartContract?: string;
+  readonly region?: string;
+  readonly runEndpoint?: string;
+  readonly hostingEndpoint?: string;
+  readonly policyEndpoint?: string;
 }

--- a/apps/spindrift/src/web/upload.ts
+++ b/apps/spindrift/src/web/upload.ts
@@ -109,11 +109,13 @@ export async function handleUpload(
     // One staging call, to one place, so the returned location describes where
     // the bytes actually are. A depot failure is a `500` that says so, because
     // a staged bundle nobody can retrieve is not a staged bundle.
+    //
+    // The place is the installation's, not the request's. This route used to
+    // honour an `x-bucket` header, which made "which bucket" a thing a caller
+    // asserted rather than a thing the manifest declares — see
+    // `sourceDepotFor`.
     const context = await deps.context(authentication.principal);
-    const depot = sourceDepotFor(
-      context.manifest,
-      request.headers.get('x-bucket'),
-    );
+    const depot = sourceDepotFor(context.manifest);
 
     let staged: StagedArchive;
     try {

--- a/apps/spindrift/src/web/views/apps/new/steps.tsx
+++ b/apps/spindrift/src/web/views/apps/new/steps.tsx
@@ -112,57 +112,19 @@ export function StepSource({
 }: StepProps & { repos: readonly RepositoryOptionView[] }) {
   const [uploading, setUploading] = useState(false);
   const [uploadError, setUploadError] = useState<string | null>(null);
-  const [bucketName, setBucketName] = useState<string | null>(null);
-  const [buckets, setBuckets] = useState<readonly string[] | null>(null);
   const [defaultBucket, setDefaultBucket] = useState<string | null>(null);
-  const [customBucket, setCustomBucket] = useState('');
-  const [useCustom, setUseCustom] = useState(false);
-  const [bucketLoadError, setBucketLoadError] = useState(false);
-  const [testingWif, setTestingWif] = useState(false);
-  const [wifStatus, setWifStatus] = useState<string | null>(null);
 
-  const bucketsLoading = buckets === null && !bucketLoadError;
-  const activeBucketName = bucketName ?? '';
-
+  // Read to be *shown*, not to be chosen. Which bucket sources stage to is
+  // installation configuration (§20) and now lives on the Storage screen; a
+  // picker here was how an undeclared bucket could be typed onto a deploy form
+  // and then staged into.
   useEffect(() => {
     command('listSourceBuckets', {})
       .then((res) => {
-        if (res.ok) {
-          setBuckets(res.value.buckets);
-          setDefaultBucket(res.value.defaultBucket ?? null);
-          const selected =
-            res.value.defaultBucket || res.value.buckets[0] || null;
-          setBucketName(selected);
-        } else {
-          setBucketLoadError(true);
-          setBuckets([]);
-        }
+        if (res.ok) setDefaultBucket(res.value.defaultBucket || null);
       })
-      .catch(() => {
-        setBucketLoadError(true);
-        setBuckets([]);
-      });
+      .catch(() => setDefaultBucket(null));
   }, []);
-
-  async function handleTestWif() {
-    if (!activeBucketName.trim()) return;
-    setTestingWif(true);
-    setWifStatus(null);
-    try {
-      const res = await command('testBucketPermissions', {
-        bucketName: activeBucketName.trim(),
-      });
-      if (res.ok) {
-        setWifStatus(`✓ WIF permissions verified for ${res.value.location}`);
-      } else {
-        setWifStatus(`✗ WIF check failed: ${res.failure.message}`);
-      }
-    } catch {
-      setWifStatus('Network error testing bucket permissions');
-    } finally {
-      setTestingWif(false);
-    }
-  }
 
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
@@ -175,14 +137,11 @@ export function StepSource({
       const formData = new FormData();
       formData.append('file', file);
 
-      const headers: Record<string, string> = {};
-      if (activeBucketName.trim()) {
-        headers['x-bucket'] = activeBucketName.trim();
-      }
-
+      // No `x-bucket` header. The upload route resolves the installation's
+      // default itself, which is the only bucket this flow was ever entitled
+      // to name.
       const response = await fetch('/internal/upload', {
         method: 'POST',
-        headers,
         body: formData,
       });
 
@@ -291,95 +250,14 @@ export function StepSource({
         </Card>
       )}
 
-      <div className="mt-4 flex flex-col gap-3 rounded border bg-muted/40 p-3">
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-semibold text-foreground">
-            First-Party Storage Bucket (Source & Artifact Staging)
-          </span>
-          <Badge tone="accent">first-party</Badge>
-        </div>
-        <p className="text-[11.5px] text-muted-foreground">
-          Select from configured first-party Cloud Storage buckets or enter a
-          custom bucket name.
-        </p>
-        {bucketLoadError ? (
-          <p className="text-[11px] text-amber-600 dark:text-amber-400">
-            Could not load configured buckets — showing default. Enter a bucket
-            name manually if needed.
-          </p>
-        ) : null}
-
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="source-bucket-select"
-            className="text-xs font-medium text-muted-foreground"
-          >
-            Bucket
-          </label>
-          <select
-            id="source-bucket-select"
-            disabled={bucketsLoading}
-            value={useCustom ? 'custom' : activeBucketName}
-            onChange={(e) => {
-              if (e.target.value === 'custom') {
-                setUseCustom(true);
-                setBucketName(customBucket);
-              } else {
-                setUseCustom(false);
-                setBucketName(e.target.value);
-              }
-            }}
-            className="rounded border bg-background px-2.5 py-1.5 font-mono text-xs text-foreground disabled:opacity-50"
-          >
-            {bucketsLoading ? (
-              <option value="">Loading…</option>
-            ) : (
-              <>
-                {(buckets ?? []).map((b) => (
-                  <option key={b} value={b}>
-                    {b} {b === defaultBucket ? '(default · infra repo)' : ''}
-                  </option>
-                ))}
-                <option value="custom">Custom bucket...</option>
-              </>
-            )}
-          </select>
-
-          {useCustom ? (
-            <input
-              type="text"
-              placeholder="e.g. custom-spindrift-bucket"
-              value={customBucket}
-              onChange={(e) => {
-                setCustomBucket(e.target.value);
-                setBucketName(e.target.value);
-              }}
-              className="rounded border bg-background px-2.5 py-1.5 font-mono text-xs text-foreground"
-            />
-          ) : null}
-        </div>
-
-        <div className="mt-1 flex items-center gap-2">
-          <button
-            type="button"
-            disabled={!activeBucketName.trim() || testingWif}
-            onClick={handleTestWif}
-            className="rounded bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90 disabled:opacity-50"
-          >
-            {testingWif ? 'Testing WIF…' : 'Test WIF Permissions'}
-          </button>
-        </div>
-        {wifStatus ? (
-          <p className="text-xs font-medium text-muted-foreground">
-            {wifStatus}
-          </p>
-        ) : (
-          <p className="text-[11px] text-muted-foreground">
-            Uses credential-less Workload Identity Federation (WIF) token
-            exchange with spindrift-controller service account impersonation.
-          </p>
-        )}
-      </div>
+      <p className="mt-4 text-xs text-muted-foreground">
+        Staged to{' '}
+        <span className="font-mono">
+          {defaultBucket ?? 'this installation’s source bucket'}
+        </span>
+        . Which bucket that is, and whether Spindrift can write to it, lives on
+        the Storage screen.
+      </p>
     </>
   );
 }

--- a/apps/spindrift/src/web/views/storage/list.tsx
+++ b/apps/spindrift/src/web/views/storage/list.tsx
@@ -1,0 +1,328 @@
+/**
+ * Source storage — where an archive or a repository's source is staged (§4).
+ *
+ * This existed as three controls buried in step one of the creation flow: a
+ * `<select>` of the manifest's buckets, a "Custom bucket…" option that let a
+ * developer type an undeclared bucket and stage a build into it, and a "Test
+ * WIF Permissions" button whose result was a sentence nobody kept. All three
+ * were configuration wearing the costume of a deploy form.
+ *
+ * They are one screen now, and the creation flow shows the default as a fact.
+ * The move is not only tidying: a bucket that is typed on a deploy form is a
+ * bucket that is never declared, and §20 puts every value naming this
+ * installation in the manifest — which `useSourceBucket` writes to, after
+ * verifying that the controller can actually write there.
+ *
+ * The default bucket verifies itself on arrival. Every other bucket verifies
+ * on request, because a screen that made N calls to Cloud Storage on load
+ * would be a screen that is slow in proportion to how much storage you have,
+ * and the default is the one whose health actually decides whether the next
+ * deploy works.
+ */
+import {
+  AlertTriangle,
+  Check,
+  Database,
+  Loader2,
+  Plus,
+  Star,
+  X,
+} from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { command, type OutputOf } from '../../client.ts';
+import { Badge } from '../../ui/badge.tsx';
+import { Button } from '../../ui/button.tsx';
+import { Card, CardContent, Eyebrow } from '../../ui/card.tsx';
+import { Field } from '../../ui/field.tsx';
+import { cn } from '../../ui/utils.ts';
+
+type Verification = OutputOf<'testBucketPermissions'>;
+
+/** What is known about one bucket's reachability, right now. */
+type Reachability =
+  | { readonly state: 'unchecked' }
+  | { readonly state: 'checking' }
+  | { readonly state: 'reachable'; readonly result: Verification }
+  | { readonly state: 'unreachable'; readonly message: string };
+
+export interface SourceStorageView {
+  readonly buckets: readonly string[];
+  readonly defaultBucket: string;
+  readonly canVerify: boolean;
+}
+
+export function SourceStorage({
+  view,
+  onChanged,
+}: {
+  view: SourceStorageView;
+  /** Re-read after the manifest moved: this screen does not own that state. */
+  onChanged: () => void;
+}) {
+  const [checks, setChecks] = useState<Record<string, Reachability>>({});
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const verify = async (bucket: string) => {
+    setChecks((current) => ({ ...current, [bucket]: { state: 'checking' } }));
+    try {
+      const result = await command('testBucketPermissions', {
+        bucketName: bucket,
+      });
+      setChecks((current) => ({
+        ...current,
+        [bucket]: result.ok
+          ? { state: 'reachable', result: result.value }
+          : { state: 'unreachable', message: result.failure.message },
+      }));
+    } catch (cause) {
+      setChecks((current) => ({
+        ...current,
+        [bucket]: {
+          state: 'unreachable',
+          message:
+            cause instanceof Error ? cause.message : 'the check did not answer',
+        },
+      }));
+    }
+  };
+
+  // The default only. See the module note: N buckets should not mean N calls.
+  useEffect(() => {
+    if (!view.canVerify || view.defaultBucket === '') return;
+    void verify(view.defaultBucket);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [view.defaultBucket, view.canVerify]);
+
+  const use = async (bucketName: string, makeDefault: boolean) => {
+    setBusy(true);
+    setError(null);
+    try {
+      const result = await command('useSourceBucket', {
+        bucketName,
+        makeDefault,
+      });
+      if (!result.ok) {
+        setError(result.failure.message);
+        return;
+      }
+      setChecks((current) => ({
+        ...current,
+        [bucketName]: {
+          state: 'reachable',
+          result: {
+            bucketName,
+            accessible: true,
+            location: result.value.location,
+            permissions: result.value.permissions,
+          },
+        },
+      }));
+      setAdding(false);
+      setName('');
+      onChanged();
+    } catch (cause) {
+      setError(
+        cause instanceof Error ? cause.message : 'the bucket could not be used',
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
+      <header className="flex flex-wrap items-end gap-4">
+        <div>
+          <Eyebrow>Storage</Eyebrow>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+            Source storage
+          </h1>
+          <p className="mt-1 max-w-prose text-sm text-muted-foreground">
+            Where an uploaded archive and a repository's source are staged
+            before a builder can fetch them. The default is what a new deploy
+            uses; the creation flow shows it and does not ask.
+          </p>
+        </div>
+        {view.canVerify ? (
+          <Button
+            variant="outline"
+            className="ml-auto"
+            onClick={() => setAdding((open) => !open)}
+          >
+            <Plus aria-hidden="true" /> Add a bucket
+          </Button>
+        ) : null}
+      </header>
+
+      {!view.canVerify ? (
+        <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning-soft px-3 py-2.5">
+          <AlertTriangle
+            aria-hidden="true"
+            className="mt-0.5 size-4 shrink-0 text-warning"
+          />
+          <p className="text-sm">
+            Workload Identity Federation is not configured, so Spindrift has no
+            identity to check a bucket with. Buckets below are what the manifest
+            declares and nothing here has confirmed them.
+          </p>
+        </div>
+      ) : null}
+
+      {error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      {adding ? (
+        <Card>
+          <CardContent className="flex flex-col gap-3">
+            <Field
+              name="bucket"
+              label="Bucket name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="spindrift-sources"
+              hint="Checked before it is added — a bucket the controller cannot write to is a build that dies at staging."
+            />
+            <div className="flex flex-wrap gap-2">
+              <Button
+                disabled={busy || name.trim() === ''}
+                onClick={() => use(name.trim(), false)}
+              >
+                {busy ? 'Checking…' : 'Verify and add'}
+              </Button>
+              <Button
+                variant="outline"
+                disabled={busy || name.trim() === ''}
+                onClick={() => use(name.trim(), true)}
+              >
+                Add as default
+              </Button>
+              <Button variant="ghost" onClick={() => setAdding(false)}>
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : null}
+
+      <Card className="divide-y divide-border">
+        {view.buckets.map((bucket) => (
+          <BucketRow
+            key={bucket}
+            bucket={bucket}
+            isDefault={bucket === view.defaultBucket}
+            check={checks[bucket] ?? { state: 'unchecked' }}
+            canVerify={view.canVerify}
+            busy={busy}
+            onVerify={() => void verify(bucket)}
+            onMakeDefault={() => use(bucket, true)}
+          />
+        ))}
+      </Card>
+    </div>
+  );
+}
+
+function BucketRow({
+  bucket,
+  isDefault,
+  check,
+  canVerify,
+  busy,
+  onVerify,
+  onMakeDefault,
+}: {
+  bucket: string;
+  isDefault: boolean;
+  check: Reachability;
+  canVerify: boolean;
+  busy: boolean;
+  onVerify: () => void;
+  onMakeDefault: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 px-4 py-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <Database
+          aria-hidden="true"
+          className="size-4 shrink-0 text-muted-foreground"
+        />
+        <span className="font-mono text-sm font-medium">{bucket}</span>
+        {isDefault ? (
+          <Badge tone="accent">
+            <Star aria-hidden="true" className="size-3" />
+            default
+          </Badge>
+        ) : null}
+        <CheckBadge check={check} />
+        <div className="ml-auto flex gap-2">
+          {!isDefault ? (
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={busy || !canVerify}
+              onClick={onMakeDefault}
+            >
+              Make default
+            </Button>
+          ) : null}
+          {canVerify ? (
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={check.state === 'checking'}
+              onClick={onVerify}
+            >
+              {check.state === 'checking' ? 'Checking…' : 'Verify'}
+            </Button>
+          ) : null}
+        </div>
+      </div>
+
+      {check.state === 'reachable' ? (
+        <div className="flex flex-wrap gap-x-4 gap-y-0.5 pl-6 text-[11px] text-subtle">
+          <span className="font-mono">{check.result.location}</span>
+          <span className="font-mono">
+            {check.result.permissions.join(' · ')}
+          </span>
+        </div>
+      ) : null}
+      {check.state === 'unreachable' ? (
+        <p className="pl-6 text-xs text-destructive">{check.message}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function CheckBadge({ check }: { check: Reachability }) {
+  switch (check.state) {
+    case 'checking':
+      return (
+        <Badge tone="idle">
+          <Loader2 aria-hidden="true" className={cn('size-3 animate-spin')} />
+          checking
+        </Badge>
+      );
+    case 'reachable':
+      return (
+        <Badge tone="success">
+          <Check aria-hidden="true" className="size-3" />
+          writable
+        </Badge>
+      );
+    case 'unreachable':
+      return (
+        <Badge tone="destructive">
+          <X aria-hidden="true" className="size-3" />
+          unreachable
+        </Badge>
+      );
+    default:
+      return null;
+  }
+}

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -1,0 +1,262 @@
+/**
+ * Finishing a Target's connection (§13).
+ *
+ * `connectTarget` has existed since Task 13 with no screen in front of it, so
+ * every Target this installation has was declared in the manifest or created
+ * by a test. This is the screen.
+ *
+ * Three things keep it short, and all three come out of §13 rather than out of
+ * a preference for short forms:
+ *
+ * - **The adapter is not a question.** A pending connection is a manifest seed,
+ *   and a seed names its adapter. Nothing here asks what kind of thing this is;
+ *   it asks the two or three facts that seed did not carry.
+ * - **A cloud project is one act.** Connecting `bluenose` registers both
+ *   `bluenose-cloudrun` and `bluenose-static`. The form says so and asks once.
+ * - **Connect always succeeds, so there is no test button.** A reachability
+ *   gate would be a second opinion about health, and §13 has exactly one: the
+ *   standing checklist, which this act runs a pass of on its way through. Press
+ *   the button and read the checklist — that *is* the test, and unlike a
+ *   preflight it keeps being true tomorrow.
+ */
+import { Layers, Server } from 'lucide-react';
+import { useState } from 'react';
+import type { InputOf } from '../../client.ts';
+import type { TargetConnectionProposal } from '../../model.ts';
+import { Badge } from '../../ui/badge.tsx';
+import { Button } from '../../ui/button.tsx';
+import { Field, Label } from '../../ui/field.tsx';
+
+type ConnectTargetInput = InputOf<'connectTarget'>;
+
+/**
+ * The `sourceRef` a Flux delivery needs, defaulted from the proposal.
+ *
+ * Split out because it is the one nested value on the form, and because an
+ * `argo-application` delivery does not have one — a shape the discriminated
+ * union in `connectTarget` already refuses, and which this mirrors rather than
+ * restates.
+ */
+function fluxDelivery(
+  namespace: string,
+  sourceName: string,
+  sourceNamespace: string,
+) {
+  return {
+    flavour: 'flux-helmrelease' as const,
+    namespace,
+    sourceRef: { name: sourceName, namespace: sourceNamespace },
+  };
+}
+
+export function ConnectTargetForm({
+  kind,
+  name,
+  targets,
+  proposal,
+  connecting,
+  onConnect,
+  onCancel,
+}: {
+  kind: 'kubernetes' | 'cloud';
+  name: string;
+  targets: readonly string[];
+  proposal: TargetConnectionProposal;
+  connecting: boolean;
+  onConnect: (input: ConnectTargetInput) => void;
+  onCancel: () => void;
+}) {
+  // Per-instance, so never proposed: see `TargetConnectionProposal`.
+  const [apiServer, setApiServer] = useState('');
+  const [project, setProject] = useState('');
+  // Carried where a working Target of the same adapter taught us the value.
+  const [namespace, setNamespace] = useState(proposal.namespace ?? '');
+  const [sourceName, setSourceName] = useState(proposal.sourceRef?.name ?? '');
+  const [sourceNamespace, setSourceNamespace] = useState(
+    proposal.sourceRef?.namespace ?? '',
+  );
+  const [region, setRegion] = useState(proposal.region ?? '');
+  const [runEndpoint, setRunEndpoint] = useState(proposal.runEndpoint ?? '');
+  const [hostingEndpoint, setHostingEndpoint] = useState(
+    proposal.hostingEndpoint ?? '',
+  );
+
+  const carried = proposal.carriedFrom;
+  // ponytail: the form writes a Flux delivery and only that. Argo is a real
+  // `connectTarget` shape with five more fields and nothing in this
+  // installation uses it, so rather than render a branch nobody exercises the
+  // screen refuses and points at the manifest, which can express both. Add the
+  // branch when a second delivery flavour actually shows up.
+  const unsupportedDelivery = proposal.deliveryFlavour === 'argo-application';
+  const ready =
+    kind === 'kubernetes'
+      ? apiServer.trim() !== '' &&
+        namespace.trim() !== '' &&
+        sourceName.trim() !== '' &&
+        sourceNamespace.trim() !== ''
+      : project.trim() !== '' &&
+        region.trim() !== '' &&
+        runEndpoint.trim() !== '' &&
+        hostingEndpoint.trim() !== '';
+
+  const submit = () => {
+    onConnect(
+      kind === 'kubernetes'
+        ? {
+            kind: 'kubernetes',
+            name,
+            apiServer: apiServer.trim(),
+            namespace: namespace.trim(),
+            delivery: fluxDelivery(
+              namespace.trim(),
+              sourceName.trim(),
+              sourceNamespace.trim(),
+            ),
+            ...(proposal.chartContract === undefined
+              ? {}
+              : { chartContract: proposal.chartContract }),
+          }
+        : {
+            kind: 'cloud',
+            name,
+            project: project.trim(),
+            region: region.trim(),
+            runEndpoint: runEndpoint.trim(),
+            hostingEndpoint: hostingEndpoint.trim(),
+            ...(proposal.policyEndpoint === undefined
+              ? {}
+              : { policyEndpoint: proposal.policyEndpoint }),
+          },
+    );
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        {kind === 'kubernetes' ? (
+          <Server aria-hidden="true" className="size-4 text-muted-foreground" />
+        ) : (
+          <Layers aria-hidden="true" className="size-4 text-muted-foreground" />
+        )}
+        <span className="font-mono text-sm font-semibold">{name}</span>
+        <Badge tone="idle">
+          {kind === 'kubernetes' ? 'cluster' : 'cloud project'}
+        </Badge>
+        {carried !== null ? (
+          <span className="ml-auto text-xs text-muted-foreground">
+            defaults carried from <span className="font-mono">{carried}</span>
+          </span>
+        ) : null}
+      </div>
+
+      {targets.length > 1 ? (
+        <p className="text-xs text-muted-foreground">
+          Registers{' '}
+          {targets.map((target, index) => (
+            <span key={target}>
+              {index > 0 ? ' and ' : ''}
+              <span className="font-mono">{target}</span>
+            </span>
+          ))}{' '}
+          — one project, both of its Targets.
+        </p>
+      ) : null}
+
+      <div className="grid gap-4 md:grid-cols-2">
+        {kind === 'kubernetes' ? (
+          <>
+            <Field
+              name="api-server"
+              label="API server"
+              value={apiServer}
+              onChange={(event) => setApiServer(event.target.value)}
+              placeholder="https://kubernetes.default.svc"
+              hint="Not carried from another cluster — this one names this cluster."
+            />
+            <Field
+              name="namespace"
+              label="Namespace"
+              value={namespace}
+              onChange={(event) => setNamespace(event.target.value)}
+              hint="Where App workloads land. Spindrift never creates it."
+            />
+            <Field
+              name="source-name"
+              label="Flux GitRepository"
+              value={sourceName}
+              onChange={(event) => setSourceName(event.target.value)}
+              hint="The source the App chart is fetched from."
+            />
+            <Field
+              name="source-namespace"
+              label="GitRepository namespace"
+              value={sourceNamespace}
+              onChange={(event) => setSourceNamespace(event.target.value)}
+            />
+          </>
+        ) : (
+          <>
+            <Field
+              name="project"
+              label="Project"
+              value={project}
+              onChange={(event) => setProject(event.target.value)}
+              hint="Not carried — a second project prefilled with the first one's id would read as correct."
+            />
+            <Field
+              name="region"
+              label="Region"
+              value={region}
+              onChange={(event) => setRegion(event.target.value)}
+            />
+            <Field
+              name="run-endpoint"
+              label="Cloud Run API"
+              value={runEndpoint}
+              onChange={(event) => setRunEndpoint(event.target.value)}
+            />
+            <Field
+              name="hosting-endpoint"
+              label="Hosting API"
+              value={hostingEndpoint}
+              onChange={(event) => setHostingEndpoint(event.target.value)}
+            />
+          </>
+        )}
+      </div>
+
+      {kind === 'kubernetes' ? (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="delivery">Delivery</Label>
+          <p className="text-xs text-muted-foreground">
+            Flux <span className="font-mono">HelmRelease</span>.
+          </p>
+        </div>
+      ) : null}
+
+      {unsupportedDelivery ? (
+        <div className="rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
+          The cluster this installation already runs delivers through Argo. This
+          form writes a Flux delivery and would not match it — declare this
+          Target's connection in the installation manifest instead.
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          disabled={!ready || connecting || unsupportedDelivery}
+          onClick={submit}
+        >
+          {connecting ? 'Connecting…' : 'Connect'}
+        </Button>
+        <Button variant="ghost" onClick={onCancel} disabled={connecting}>
+          Cancel
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Connecting always succeeds. What it finds shows up as the checklist
+          below.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -1,21 +1,54 @@
 /**
- * The Targets list (§18).
+ * The Targets surface (§13, §18).
  *
- * Shows every deployment Target the control plane knows about, its adapter
- * type, rank, health, supported kinds, and canonical hostname pattern. This
- * is an admin view — Target identities and rank come from the manifest (§7),
- * while connection facts come from `connectTarget` (§14), not from this UI.
+ * It used to be a read-only list whose own header said Targets "are connected
+ * by an operator" — true, and there was no way to be that operator here.
+ * `connectTarget` existed as a command with no screen, so an installation with
+ * a manifest-seeded Target and no connection had a permanently unhealthy row
+ * and nothing to press.
  *
- * The view exists because §18 names **Apps / Datastores / Targets** as the
- * global navigation, and a Target's health, rank, and canonical pattern are
- * the context a developer needs when choosing where to deploy.
+ * So this screen is two things at once, in the order they matter:
+ *
+ * 1. **What is left to do.** A Target whose `connection` is null is a manifest
+ *    seed nobody finished, and it sits at the top with the form that finishes
+ *    it. Cloud projects are grouped back into one act, because that is what
+ *    §13 makes them.
+ * 2. **What is running, and what was checked.** Each Target carries its whole
+ *    standing checklist behind a disclosure, met rows included. §13's
+ *    "an unmet item makes the Target a non-candidate with a stated reason" only
+ *    helps if the reason is somewhere a person looks, and "why can I not deploy
+ *    here" should be answered on the Target rather than in a deploy failure.
+ *
+ * The checklist is collapsed on healthy and open on unhealthy, which is §18's
+ * rule for the build log applied to the same question: the one time it says
+ * something other than "fine" is the time it should not need a click.
  */
-import { Activity, Globe, Server, Zap } from 'lucide-react';
+import {
+  Activity,
+  AlertTriangle,
+  Check,
+  ChevronRight,
+  Globe,
+  Server,
+  X,
+  Zap,
+} from 'lucide-react';
+import { useState } from 'react';
 import type { ComponentKind } from '../../../domain/desired-state.ts';
-import type { TargetListItem } from '../../model.ts';
-import { Badge } from '../../ui/badge.tsx';
+import type { InputOf } from '../../client.ts';
+import type { PendingTargetConnection, TargetListItem } from '../../model.ts';
+import { Badge, Dot } from '../../ui/badge.tsx';
+import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, Eyebrow } from '../../ui/card.tsx';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../../ui/collapsible.tsx';
 import { cn } from '../../ui/utils.ts';
+import { ConnectTargetForm } from './connect.tsx';
+
+type ConnectTargetInput = InputOf<'connectTarget'>;
 
 function kindIcon(kind: ComponentKind) {
   switch (kind) {
@@ -30,9 +63,19 @@ function kindIcon(kind: ComponentKind) {
 
 export function TargetList({
   targets,
+  pending,
+  connecting,
+  error,
+  onConnect,
 }: {
   targets: readonly TargetListItem[];
+  pending: readonly PendingTargetConnection[];
+  connecting: boolean;
+  error: string | null;
+  onConnect: (input: ConnectTargetInput) => void;
 }) {
+  const configured = targets.filter((target) => target.configured);
+
   return (
     <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
       <header>
@@ -41,13 +84,27 @@ export function TargetList({
           Deployment targets
         </h1>
         <p className="mt-1 max-w-prose text-sm text-muted-foreground">
-          Where Spindrift can deploy apps. Targets are declared in the manifest
-          and connected by an operator — this surface shows their current health
-          and capabilities.
+          Where Spindrift can deploy apps. Identities and rank come from the
+          installation manifest; connecting one is what fills in how to reach
+          it, and health is the standing checklist afterwards.
         </p>
       </header>
 
-      {targets.length === 0 ? (
+      {error ? (
+        <div className="rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-sm text-destructive">
+          {error}
+        </div>
+      ) : null}
+
+      {pending.length > 0 ? (
+        <PendingConnections
+          pending={pending}
+          connecting={connecting}
+          onConnect={onConnect}
+        />
+      ) : null}
+
+      {configured.length === 0 && pending.length === 0 ? (
         <Card>
           <CardContent className="py-12 text-center">
             <p className="text-sm text-muted-foreground">
@@ -57,71 +114,186 @@ export function TargetList({
         </Card>
       ) : (
         <div className="flex flex-col gap-3">
-          {targets.map((target) => (
-            <Card key={target.name}>
-              <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-                <div className="flex items-center gap-3">
-                  <Activity
-                    aria-hidden="true"
-                    className={cn(
-                      'size-5',
-                      target.health === 'healthy'
-                        ? 'text-green-600 dark:text-green-400'
-                        : 'text-red-500 dark:text-red-400',
-                    )}
-                  />
-                  <div className="min-w-0">
-                    <div className="flex flex-wrap items-center gap-2">
-                      <span className="text-sm font-semibold">
-                        {target.name}
-                      </span>
-                      <Badge
-                        tone={
-                          target.health === 'healthy'
-                            ? 'success'
-                            : 'destructive'
-                        }
-                      >
-                        {target.health}
-                      </Badge>
-                      <Badge tone="idle">{target.adapter}</Badge>
-                    </div>
-                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
-                      <span className="font-mono text-xs text-muted-foreground">
-                        {target.canonical}
-                      </span>
-                      <span className="text-xs text-subtle">
-                        rank {target.rank}
-                      </span>
-                    </div>
-                    {target.health === 'unhealthy' &&
-                      target.prerequisiteFailures &&
-                      target.prerequisiteFailures.length > 0 && (
-                        <div className="mt-2 flex flex-col gap-1 text-xs text-red-600 dark:text-red-400">
-                          {target.prerequisiteFailures.map((failure, idx) => (
-                            <p key={idx}>{failure}</p>
-                          ))}
-                        </div>
-                      )}
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap gap-1.5 sm:ml-auto">
-                  {target.kinds.map((kind) => (
-                    <span
-                      key={kind}
-                      className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground"
-                    >
-                      {kindIcon(kind)}
-                      {kind}
-                    </span>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
+          {configured.map((target) => (
+            <TargetCard key={target.id} target={target} />
           ))}
         </div>
       )}
     </div>
+  );
+}
+
+/** The unfinished half, at the top, with the form that finishes it. */
+function PendingConnections({
+  pending,
+  connecting,
+  onConnect,
+}: {
+  pending: readonly PendingTargetConnection[];
+  connecting: boolean;
+  onConnect: (input: ConnectTargetInput) => void;
+}) {
+  const [open, setOpen] = useState<string | null>(null);
+
+  return (
+    <section className="flex flex-col gap-2">
+      <Eyebrow>Waiting to be connected</Eyebrow>
+      <Card className="divide-y divide-border border-warning/40">
+        {pending.map((entry) => (
+          <div key={entry.name}>
+            <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+              <AlertTriangle
+                aria-hidden="true"
+                className="size-4 shrink-0 text-warning"
+              />
+              <span className="font-mono text-sm font-medium">
+                {entry.name}
+              </span>
+              <Badge tone="idle">
+                {entry.kind === 'kubernetes' ? 'cluster' : 'cloud project'}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                declared in the manifest, never connected
+              </span>
+              <Button
+                size="sm"
+                variant={open === entry.name ? 'ghost' : 'default'}
+                className="ml-auto"
+                onClick={() =>
+                  setOpen((current) =>
+                    current === entry.name ? null : entry.name,
+                  )
+                }
+              >
+                {open === entry.name ? 'Cancel' : 'Finish setup'}
+              </Button>
+            </div>
+            {open === entry.name ? (
+              <div className="border-t border-border-soft bg-secondary/40 px-4 py-4">
+                <ConnectTargetForm
+                  kind={entry.kind}
+                  name={entry.name}
+                  targets={entry.targets}
+                  proposal={entry.proposal}
+                  connecting={connecting}
+                  onConnect={onConnect}
+                  onCancel={() => setOpen(null)}
+                />
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </Card>
+    </section>
+  );
+}
+
+function TargetCard({ target }: { target: TargetListItem }) {
+  const unhealthy = target.health !== 'healthy';
+  const [checklistOpen, setChecklistOpen] = useState(unhealthy);
+  const met = target.prerequisites.filter((item) => item.met).length;
+
+  return (
+    <Card className={cn(unhealthy && 'border-destructive/40')}>
+      <CardContent className="flex flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+          <div className="flex items-center gap-3">
+            <Activity
+              aria-hidden="true"
+              className={cn(
+                'size-5',
+                target.health === 'healthy'
+                  ? 'text-success'
+                  : 'text-destructive',
+              )}
+            />
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm font-semibold">{target.name}</span>
+                <Badge tone={unhealthy ? 'destructive' : 'success'}>
+                  <Dot />
+                  {target.health}
+                </Badge>
+                <Badge tone="idle">{target.adapter}</Badge>
+                {target.status === 'disconnected' ? (
+                  <Badge tone="warning">disconnected</Badge>
+                ) : null}
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
+                <span className="font-mono text-xs text-muted-foreground">
+                  {target.canonical}
+                </span>
+                <span className="text-xs text-subtle">rank {target.rank}</span>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-1.5 sm:ml-auto">
+            {target.kinds.map((kind) => (
+              <span
+                key={kind}
+                className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground"
+              >
+                {kindIcon(kind)}
+                {kind}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        {target.prerequisites.length > 0 ? (
+          <Collapsible open={checklistOpen} onOpenChange={setChecklistOpen}>
+            <CollapsibleTrigger className="group flex w-full items-center gap-1.5 border-t border-border-soft pt-3 text-xs text-muted-foreground hover:text-foreground">
+              <ChevronRight
+                aria-hidden="true"
+                className="size-3.5 transition-transform group-data-[state=open]:rotate-90"
+              />
+              Checklist
+              <span className="ml-auto font-mono">
+                {met}/{target.prerequisites.length}
+              </span>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-2 flex flex-col gap-1">
+              {target.prerequisites.map((item) => (
+                <div
+                  key={item.name}
+                  className="flex items-start gap-2 rounded-md px-2 py-1.5 text-xs"
+                >
+                  {item.met ? (
+                    <Check
+                      aria-hidden="true"
+                      className="mt-0.5 size-3.5 shrink-0 text-success"
+                    />
+                  ) : (
+                    <X
+                      aria-hidden="true"
+                      className="mt-0.5 size-3.5 shrink-0 text-destructive"
+                    />
+                  )}
+                  <span className="font-mono">{item.name}</span>
+                  {item.detail ? (
+                    <span className="text-muted-foreground">
+                      — {item.detail}
+                    </span>
+                  ) : null}
+                </div>
+              ))}
+              {/*
+                Labelled as of-a-moment on purpose. §18 makes "the live
+                checklist must be labelled as the live view" load-bearing, and
+                the inverse is the same rule: this one is a snapshot from the
+                last pass of the loop, and saying when stops it from being read
+                as now.
+              */}
+              <p className="mt-1 text-[11px] text-subtle">
+                {target.inspectedAt === null
+                  ? 'never inspected'
+                  : `last checked ${new Date(target.inspectedAt).toLocaleString()}`}
+              </p>
+            </CollapsibleContent>
+          </Collapsible>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 }

--- a/apps/spindrift/test/commands/source-buckets.test.ts
+++ b/apps/spindrift/test/commands/source-buckets.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Declaring the bucket sources are staged to (§4, §20).
+ *
+ * The behaviour that matters is the order of two steps: **check, then write**.
+ * A bucket the controller cannot write to is not a configuration mistake that
+ * shows up in configuration — it is a build that dies minutes later at
+ * staging, with a message about a signed URL. So a refused check must leave
+ * the manifest exactly as it was, and that is what most of this file asserts.
+ */
+import { describe, expect, test } from 'bun:test';
+import { listSourceBuckets } from '../../src/commands/storage/list-buckets.ts';
+import { useSourceBucket } from '../../src/commands/storage/use-bucket.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  readStoredManifest,
+  writeStoredManifest,
+} from '../../src/config/manifest-store.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { authoredFixture, fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+
+const NOW = new Date('2026-08-02T12:00:00.000Z');
+
+/**
+ * A far side that answers the two-step token exchange, then the bucket read.
+ *
+ * The two steps answer in different shapes and that is not incidental: STS
+ * speaks OAuth's `access_token`, and `iamcredentials` speaks its own
+ * `accessToken`. A fake that answered one shape to both would pass a client
+ * that reads the wrong field.
+ */
+function cloud(bucketStatus: number): typeof fetch {
+  return (async (input: Request | string) => {
+    const url = typeof input === 'string' ? input : input.url;
+    if (url.includes('generateAccessToken')) {
+      return Response.json({
+        accessToken: 'impersonated',
+        expireTime: '2099-01-01T00:00:00Z',
+      });
+    }
+    if (url.includes('sts.')) {
+      return Response.json({ access_token: 'federated', expires_in: 3600 });
+    }
+    if (url.includes('storage.googleapis.com')) {
+      return bucketStatus === 200
+        ? Response.json({ name: 'a bucket' })
+        : new Response('no', { status: bucketStatus });
+    }
+    throw new Error(`the test far side was asked for ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+const adapters: AdapterRegistry = {
+  deploy: () => null,
+  build: () => null,
+  store: () => null,
+  repository: () => null,
+  supplyChain: () => {
+    throw new Error('declaring a bucket reached the supply chain');
+  },
+};
+
+async function context(bucketStatus = 200): Promise<CommandContext> {
+  const base = await fixtureManifest();
+  const manifest = {
+    ...base,
+    cloud: {
+      ...base.cloud,
+      federation: {
+        audience: '//iam.example/pool',
+        tokenUrl: 'https://sts.example/v1/token',
+        tokenPath: '/var/run/secrets/token',
+        impersonationUrl:
+          'https://iamcredentials.example/v1/projects/-/serviceAccounts/c@p.iam.gserviceaccount.com:generateAccessToken',
+        fetch: cloud(bucketStatus),
+        // The projected volume a pod would have. Injected rather than written
+        // to a real path, for the same reason the transport is.
+        readToken: async () => 'a-projected-token',
+      },
+    },
+  } as CommandContext['manifest'];
+
+  // Stored as *authored*, not as resolved: the deployment's federation is
+  // joined onto the context's copy and the schema refuses it in the document.
+  // This command reads the durable one precisely so it never writes the
+  // resolved one back — storing the resolved one here would test the opposite.
+  await writeStoredManifest(database().db, await authoredFixture());
+
+  return {
+    principal: { id: 'user-1', displayName: 'Operator' },
+    clock: { now: () => NOW },
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+async function storedBuckets() {
+  const stored = await readStoredManifest(database().db);
+  return stored?.sources;
+}
+
+describe('declaring a source bucket', () => {
+  test('checks the bucket, then declares it', async () => {
+    const result = await useSourceBucket(
+      { bucketName: 'a-second-bucket', makeDefault: false },
+      await context(),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.buckets).toContain('a-second-bucket');
+    expect(await storedBuckets()).toMatchObject({
+      buckets: ['example-source-bucket', 'a-second-bucket'],
+      // Not made default, because nobody asked for that.
+      defaultBucket: 'example-source-bucket',
+    });
+  });
+
+  test('makes it the default when asked, in the same act', async () => {
+    const result = await useSourceBucket(
+      { bucketName: 'a-second-bucket', makeDefault: true },
+      await context(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(await storedBuckets()).toMatchObject({
+      defaultBucket: 'a-second-bucket',
+    });
+  });
+
+  test('moves the default onto a bucket already declared, without duplicating it', async () => {
+    const ctx = await context();
+    await useSourceBucket(
+      { bucketName: 'a-second-bucket', makeDefault: true },
+      ctx,
+    );
+    await useSourceBucket(
+      { bucketName: 'example-source-bucket', makeDefault: true },
+      ctx,
+    );
+
+    expect(await storedBuckets()).toMatchObject({
+      buckets: ['example-source-bucket', 'a-second-bucket'],
+      defaultBucket: 'example-source-bucket',
+    });
+  });
+
+  test('writes nothing when the bucket cannot be reached', async () => {
+    const result = await useSourceBucket(
+      { bucketName: 'not-ours', makeDefault: true },
+      await context(403),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('not-ours');
+    // The whole point: a refused check leaves the manifest as it was.
+    expect(await storedBuckets()).toMatchObject({
+      buckets: ['example-source-bucket'],
+      defaultBucket: 'example-source-bucket',
+    });
+  });
+
+  test('refuses when there is no federated identity to check with', async () => {
+    const base = await context();
+    const result = await useSourceBucket(
+      { bucketName: 'a-second-bucket', makeDefault: false },
+      {
+        ...base,
+        manifest: {
+          ...base.manifest,
+          cloud: { ...base.manifest.cloud, federation: null },
+        } as CommandContext['manifest'],
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.message).toContain('Workload Identity Federation');
+  });
+
+  test('the list says whether anything here can be checked at all', async () => {
+    const base = await context();
+
+    const withFederation = await listSourceBuckets({}, base);
+    expect(withFederation.ok && withFederation.value.canVerify).toBe(true);
+
+    const without = await listSourceBuckets(
+      {},
+      {
+        ...base,
+        manifest: {
+          ...base.manifest,
+          cloud: { ...base.manifest.cloud, federation: null },
+        } as CommandContext['manifest'],
+      },
+    );
+    expect(without.ok && without.value.canVerify).toBe(false);
+  });
+});

--- a/apps/spindrift/test/domain/target-onboarding.test.ts
+++ b/apps/spindrift/test/domain/target-onboarding.test.ts
@@ -1,0 +1,180 @@
+/**
+ * What is left to connect, and what may honestly be proposed for it (§13).
+ *
+ * The two claims worth a test are the two that are easy to get subtly wrong:
+ * a cloud project is **one** act and not two, and a proposal carries only the
+ * values that are not per-instance. The second one is a correctness property,
+ * not a nicety — a second cluster prefilled with the first one's in-cluster
+ * API server reads as correct and points somewhere else.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  connectionProposal,
+  type OnboardingTargetRow,
+  pendingConnections,
+} from '../../src/domain/target-onboarding.ts';
+
+const CLUSTER: OnboardingTargetRow = {
+  name: 'offsite',
+  adapter: 'kubernetes',
+  health: 'healthy',
+  connection: {
+    adapter: 'kubernetes',
+    apiServer: 'https://kubernetes.default.svc',
+    namespace: 'spindrift-apps',
+    delivery: {
+      flavour: 'flux-helmrelease',
+      namespace: 'spindrift-apps',
+      sourceRef: { name: 'infra', namespace: 'flux-system' },
+    },
+    chartContract: '2',
+  },
+};
+
+const CLOUD_RUN: OnboardingTargetRow = {
+  name: 'bluenose-cloudrun',
+  adapter: 'cloudrun',
+  health: 'healthy',
+  connection: {
+    adapter: 'cloudrun',
+    project: 'bluenose',
+    region: 'northamerica-northeast1',
+    endpoint: 'https://run.googleapis.example',
+    policyEndpoint: 'https://binaryauthorization.googleapis.example',
+  },
+};
+
+const CLOUD_STATIC: OnboardingTargetRow = {
+  name: 'bluenose-static',
+  adapter: 'static',
+  health: 'healthy',
+  connection: {
+    adapter: 'static',
+    project: 'bluenose',
+    endpoint: 'https://firebasehosting.googleapis.example',
+  },
+};
+
+function unconfigured(
+  name: string,
+  adapter: OnboardingTargetRow['adapter'],
+): OnboardingTargetRow {
+  return { name, adapter, health: 'unhealthy', connection: null };
+}
+
+describe('what is still waiting to be connected', () => {
+  test('a fully configured installation is waiting on nothing', () => {
+    expect(pendingConnections([CLUSTER, CLOUD_RUN, CLOUD_STATIC])).toEqual([]);
+  });
+
+  test('an unhealthy Target is not a pending connection', () => {
+    // An unmet checklist item is something to fix on the Target. Offering a
+    // connect form for it would be offering to re-supply facts that are
+    // already right and are not what is broken.
+    const broken = { ...CLUSTER, health: 'unhealthy' as const };
+    expect(pendingConnections([broken])).toEqual([]);
+  });
+
+  test('a cloud project is one act naming both of its Targets', () => {
+    const pending = pendingConnections([
+      unconfigured('bluenose-cloudrun', 'cloudrun'),
+      unconfigured('bluenose-static', 'static'),
+    ]);
+
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      kind: 'cloud',
+      name: 'bluenose',
+      targets: ['bluenose-cloudrun', 'bluenose-static'],
+    });
+  });
+
+  test('half a cloud project still names both Targets the act would write', () => {
+    const pending = pendingConnections([
+      CLOUD_RUN,
+      unconfigured('bluenose-static', 'static'),
+    ]);
+
+    // Connecting re-registers the pair. Listing only the unconfigured half
+    // would under-report what the button is about to touch.
+    expect(pending[0]?.targets).toEqual([
+      'bluenose-cloudrun',
+      'bluenose-static',
+    ]);
+  });
+
+  test('a cloud Target whose name carries no adapter suffix is not offered', () => {
+    // `connectTarget` derives both names from one project name, so there is no
+    // input that would produce this row. A button for it would register two
+    // Targets, neither of them this one.
+    expect(pendingConnections([unconfigured('bluenose', 'cloudrun')])).toEqual(
+      [],
+    );
+  });
+
+  test('a cluster is one act named exactly as the manifest seeded it', () => {
+    expect(pendingConnections([unconfigured('folly', 'kubernetes')])).toEqual([
+      {
+        kind: 'kubernetes',
+        name: 'folly',
+        targets: ['folly'],
+        proposal: { carriedFrom: null },
+      },
+    ]);
+  });
+});
+
+describe('what a connect may be prefilled with', () => {
+  test('nothing, when this installation has nothing to learn from', () => {
+    expect(connectionProposal([], 'kubernetes')).toEqual({ carriedFrom: null });
+    expect(connectionProposal([], 'cloud')).toEqual({ carriedFrom: null });
+  });
+
+  test('a cluster carries its delivery and namespace, never its API server', () => {
+    const proposal = connectionProposal([CLUSTER], 'kubernetes');
+
+    expect(proposal).toEqual({
+      carriedFrom: 'offsite',
+      namespace: 'spindrift-apps',
+      deliveryFlavour: 'flux-helmrelease',
+      sourceRef: { name: 'infra', namespace: 'flux-system' },
+      chartContract: '2',
+    });
+    // The one field that names a particular cluster.
+    expect(proposal).not.toHaveProperty('apiServer');
+  });
+
+  test('a cloud project carries its endpoints and region, never its project id', () => {
+    const proposal = connectionProposal([CLOUD_RUN, CLOUD_STATIC], 'cloud');
+
+    expect(proposal).toEqual({
+      carriedFrom: 'bluenose-cloudrun',
+      region: 'northamerica-northeast1',
+      runEndpoint: 'https://run.googleapis.example',
+      policyEndpoint: 'https://binaryauthorization.googleapis.example',
+      hostingEndpoint: 'https://firebasehosting.googleapis.example',
+    });
+    expect(proposal).not.toHaveProperty('project');
+  });
+
+  test('it prefers a healthy Target to copy from', () => {
+    const broken: OnboardingTargetRow = {
+      ...CLUSTER,
+      name: 'broken',
+      health: 'unhealthy',
+    };
+
+    // Copying a Target that does not work forward is the fastest way to turn
+    // one broken Target into two.
+    expect(connectionProposal([broken, CLUSTER], 'kubernetes')).toMatchObject({
+      carriedFrom: 'offsite',
+    });
+  });
+
+  test('it falls back to an unhealthy Target rather than proposing nothing', () => {
+    const broken: OnboardingTargetRow = { ...CLUSTER, health: 'unhealthy' };
+    expect(connectionProposal([broken], 'kubernetes')).toMatchObject({
+      carriedFrom: 'offsite',
+    });
+  });
+});

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -831,38 +831,85 @@ export const APP_LIST: readonly AppListItem[] = [
   },
 ];
 
+const CLUSTER_CHECKLIST = [
+  { name: 'DELIVERY_OPERATOR', met: true },
+  { name: 'CHART_SOURCE', met: true },
+  { name: 'WRITABLE_STORE', met: true },
+  { name: 'OIDC_FEDERATION', met: true },
+  { name: 'VESSEL', met: true },
+  { name: 'CHART_CONTRACT', met: true },
+] as const;
+
+const CLOUD_CHECKLIST = [
+  { name: 'PLATFORM_API', met: true },
+  { name: 'OIDC_FEDERATION', met: true },
+  { name: 'VESSEL', met: true },
+] as const;
+
 /** Target list demo data. */
 export const TARGET_LIST: readonly TargetListItem[] = [
   {
+    id: 'target-primary',
     name: 'Primary',
     adapter: 'kubernetes',
     rank: 1,
     health: 'healthy',
+    prerequisites: [...CLUSTER_CHECKLIST],
     kinds: ['service', 'website', 'job'],
     canonical: '*.primary.apps.example',
+    status: 'connected',
+    configured: true,
+    inspectedAt: '2026-08-02T12:00:00.000Z',
   },
   {
+    id: 'target-cloudrun',
     name: 'Cloud Run · vessel-a',
     adapter: 'cloudrun',
     rank: 2,
     health: 'healthy',
+    prerequisites: [...CLOUD_CHECKLIST],
     kinds: ['service', 'website', 'job'],
     canonical: '*.northamerica-northeast1.run.app',
+    status: 'connected',
+    configured: true,
+    inspectedAt: '2026-08-02T12:00:00.000Z',
   },
   {
+    id: 'target-static',
     name: 'Firebase · vessel-a',
     adapter: 'static',
     rank: 3,
     health: 'healthy',
+    prerequisites: [...CLOUD_CHECKLIST],
     kinds: ['website'],
     canonical: '*.web.app',
+    status: 'connected',
+    configured: true,
+    inspectedAt: '2026-08-02T12:00:00.000Z',
   },
   {
+    id: 'target-secondary',
     name: 'Secondary',
     adapter: 'kubernetes',
     rank: 4,
     health: 'unhealthy',
+    prerequisiteFailures: ['no Flux controller answers in this cluster'],
+    prerequisites: [
+      {
+        name: 'DELIVERY_OPERATOR',
+        met: false,
+        detail: 'no Flux controller answers in this cluster',
+      },
+      { name: 'CHART_SOURCE', met: true },
+      { name: 'WRITABLE_STORE', met: true },
+      { name: 'OIDC_FEDERATION', met: true },
+      { name: 'VESSEL', met: true },
+      { name: 'CHART_CONTRACT', met: true },
+    ],
     kinds: ['service', 'website', 'job'],
     canonical: '*.secondary.apps.example',
+    status: 'connected',
+    configured: true,
+    inspectedAt: '2026-08-02T12:00:00.000Z',
   },
 ];

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -19,9 +19,11 @@ import { Workspace } from '../../src/web/views/apps/workspace.tsx';
 import { Gate } from '../../src/web/views/auth/gate.tsx';
 import { CredentialSettingsView } from '../../src/web/views/auth/settings.tsx';
 import { RepositoryList } from '../../src/web/views/repos/list.tsx';
+import { TargetList } from '../../src/web/views/targets/list.tsx';
 import {
   BUILD_ATTEMPT,
   DEPLOY_SCENARIOS,
+  TARGET_LIST,
   WORKSPACE_SCENARIOS,
 } from '../fixtures/scenarios.ts';
 
@@ -566,5 +568,67 @@ describe('the App workspace', () => {
     // that exists but is not attached still exists.
     const markup = workspace(WORKSPACE_SCENARIOS.service);
     expect(markup).toContain('unattached');
+  });
+});
+
+/**
+ * The Targets surface (§13).
+ *
+ * Two claims, and the second is the one that used to have no screen at all:
+ * a Target says what was *checked*, not only what is broken, and a Target the
+ * manifest seeded but nobody connected is something an operator can finish
+ * here rather than only in Git.
+ */
+describe('the Targets surface', () => {
+  const targets = (pending: Parameters<typeof TargetList>[0]['pending'] = []) =>
+    renderToStaticMarkup(
+      <TargetList
+        targets={TARGET_LIST}
+        pending={pending}
+        connecting={false}
+        error={null}
+        onConnect={() => undefined}
+      />,
+    );
+
+  test('shows the whole checklist, met rows included', () => {
+    const markup = targets();
+    // Every prerequisite a cluster is assessed against, not only the failures:
+    // "why can I not deploy here" is answered by what was checked.
+    for (const item of [
+      'DELIVERY_OPERATOR',
+      'CHART_SOURCE',
+      'WRITABLE_STORE',
+      'OIDC_FEDERATION',
+      'VESSEL',
+      'CHART_CONTRACT',
+    ]) {
+      expect(markup).toContain(item);
+    }
+    expect(markup).toContain('no Flux controller answers in this cluster');
+  });
+
+  test('offers to finish a Target the manifest seeded and nobody connected', () => {
+    const markup = targets([
+      {
+        kind: 'cloud',
+        name: 'a-project',
+        targets: ['a-project-cloudrun', 'a-project-static'],
+        proposal: {
+          carriedFrom: 'other-cloudrun',
+          region: 'somewhere',
+          runEndpoint: 'https://run.example.test',
+          hostingEndpoint: 'https://hosting.example.test',
+        },
+      },
+    ]);
+
+    expect(markup).toContain('Waiting to be connected');
+    expect(markup).toContain('a-project');
+    expect(markup).toContain('Finish setup');
+  });
+
+  test('says nothing about connecting when there is nothing left to connect', () => {
+    expect(targets()).not.toContain('Waiting to be connected');
   });
 });


### PR DESCRIPTION
Two operator surfaces that had commands and no screens.

## Targets

`connectTarget` has existed since Task 13 with nothing in front of it, so the Targets page said Targets "are connected by an operator" and offered no way to be one. A manifest seed with no `connection` block produces a row with a null connection and a checklist reading "Target connection has not been configured" (`manifest-store.ts:196`) — a permanently unhealthy Target and nothing to press.

Those rows now sit at the top of the page with the form that finishes them, **grouped back into acts**: two unconfigured rows named `<project>-cloudrun` and `<project>-static` are *one* pending connection named `<project>`. §13 makes that split a consequence of the model rather than a decision, and two cards would reintroduce the noun it removed.

The form asks two or three things, because the seed already named the adapter and the rest is **carried from a Target of the same adapter this installation already runs** — delivery flavour, GitRepository, namespace, cloud endpoints, region. Never from a literal in `src/`: §20 puts far-side values in the manifest, so the only thing that can teach Spindrift what a Cloud Run endpoint looks like *here* is a Cloud Run Target that already works here.

What is deliberately **not** carried is the point. An `apiServer` and a `project` name one particular instance; a second cluster prefilled with the first one's `https://kubernetes.default.svc` reads as correct and deploys somewhere else. Those fields stay empty and say why.

**No Test Connection button.** §13 already has one opinion about health and it is the standing checklist. Connect always succeeds and runs a pass of the inspection loop, so the checklist *is* the test — and unlike a preflight it keeps being true tomorrow. Every Target now carries its whole checklist, met rows included, open on unhealthy and collapsed on healthy (§18's build-log rule, same question).

## Source storage

The bucket was a `<select>` in step one of the creation flow, with a "Custom bucket…" free-text option and a "Test WIF Permissions" button whose result nobody kept. Worse, the upload route honoured an `x-bucket` request header and passed it straight into `sourceDepotFor` — so any authenticated caller could stage bytes into any bucket name they liked, declared or not, and "where did this get staged" had no answer anybody had written down.

`useSourceBucket` is the act that adds one: **check the bucket is writable, then declare it in the manifest.** That order is the whole design — a bucket the controller cannot write to is not a configuration mistake that shows up in configuration, it is a build that dies at staging minutes later with a message about a signed URL.

`sourceDepotFor` no longer takes a per-request override and the upload route no longer passes one. The creation flow states the default as a fact instead of asking.

## Checks

`bun test` 1242 pass / 0 fail · `bun run typecheck` clean · `bun run lint` clean (one pre-existing warning in `test/web/installation-surface.test.ts`, untouched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)