### PR TITLE
fix(oauth2-proxy): give each cluster its own GitHub OAuth App

### DIFF
--- a/clusters/base/apps/oauth2-proxy/external-secret.yaml
+++ b/clusters/base/apps/oauth2-proxy/external-secret.yaml
@@ -1,4 +1,8 @@
 ---
+# The credential is per-cluster, so the item id is. A GitHub OAuth App registers
+# exactly one Authorization callback URL — one host — and the two clusters
+# authenticate on different apexes, so they cannot share an App and cannot share
+# the item holding it. Each cluster names its own in `cluster-settings`.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -14,13 +18,13 @@ spec:
   data:
     - secretKey: client-id
       remoteRef:
-        key: 46xuydwpk5vbw2gld2pzn5o4pq
+        key: ${OAUTH2_PROXY_ITEM}
         property: client-id
     - secretKey: client-secret
       remoteRef:
-        key: 46xuydwpk5vbw2gld2pzn5o4pq
+        key: ${OAUTH2_PROXY_ITEM}
         property: client-secret
     - secretKey: cookie-secret
       remoteRef:
-        key: 46xuydwpk5vbw2gld2pzn5o4pq
+        key: ${OAUTH2_PROXY_ITEM}
         property: cookie-secret

--- a/clusters/folly/config/cluster-settings.yaml
+++ b/clusters/folly/config/cluster-settings.yaml
@@ -1,0 +1,12 @@
+---
+# Patched onto clusters/base/cluster-settings.yaml. Only what folly does not
+# share with offsite belongs here.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-settings
+  namespace: flux-system
+data:
+  # 1Password "oauth2-proxy: folly" — the App whose callback is on
+  # oauth2.${SECRET_DOMAIN}.
+  OAUTH2_PROXY_ITEM: iy4vkwkvbfhvm4kd2g6slnxlca

--- a/clusters/folly/config/kustomization.yaml
+++ b/clusters/folly/config/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - cluster-topology.json
   - cluster-secrets.sops.yaml
+patches:
+  - path: cluster-settings.yaml

--- a/clusters/offsite/config/cluster-settings.yaml
+++ b/clusters/offsite/config/cluster-settings.yaml
@@ -6,3 +6,6 @@ metadata:
   namespace: flux-system
 data:
   SPINDRIFT_DOMAIN: lolwtf.dev
+  # 1Password "oauth2-proxy: offsite" — the App whose callback is on
+  # oauth2.${SPINDRIFT_DOMAIN}.
+  OAUTH2_PROXY_ITEM: 46xuydwpk5vbw2gld2pzn5o4pq


### PR DESCRIPTION
Ticket 48, found by ticket 42 (#1576).

## Why

A GitHub **OAuth App** registers exactly one *Authorization callback URL* — one host, not a list. Multiple callbacks are a GitHub *App* feature. Both clusters read one App out of one 1Password item, so `oauth2.lolwtf.ca` and `oauth2.lolwtf.dev` were competing for the same field, and registering the second silently replaced the first.

That is not theoretical — it happened while diagnosing this, and folly stopped completing sign-ins until the callback went back.

## What changed

The item id moves out of the shared `ExternalSecret` into each cluster's `cluster-settings`, where per-cluster facts already live. folly gains the patch file offsite already had. Nothing else moves — the ExternalSecret, HelmRelease and ReferenceGrant stay shared in `clusters/base/`.

| Cluster | 1Password item | OAuth App | Callback |
| --- | --- | --- | --- |
| folly | `oauth2-proxy: folly` | `Ov23liWfALJh4T0yhDSN` | `https://oauth2.lolwtf.ca/oauth2/callback` |
| offsite | `oauth2-proxy: offsite` | `Ov23liiy3JFf06AgUiMH` | `https://oauth2.lolwtf.dev/oauth2/callback` |

Distinct `cookie-secret` per item, so a session cookie minted on one apex does not validate on the other.

## Verified

GitHub's *authorize* endpoint cannot show this — it validates `redirect_uri` only after login, so registered and unregistered hosts both 302 to `/login`. The *token* endpoint validates immediately, so a deliberately-invalid code separates them: `bad_verification_code` means the `redirect_uri` was accepted, `redirect_uri_mismatch` means it was not.

```text
offsite app + https://oauth2.lolwtf.dev/oauth2/callback   {"error":"bad_verification_code"}
folly   app + https://oauth2.lolwtf.ca/oauth2/callback    {"error":"bad_verification_code"}
offsite app + https://example.invalid/cb                  {"error":"redirect_uri_mismatch"}   ← control
```

The control is what makes the first two readings mean anything.

```text
$ kustomize build clusters/folly/config   | grep OAUTH2_PROXY_ITEM
  OAUTH2_PROXY_ITEM: iy4vkwkvbfhvm4kd2g6slnxlca
$ kustomize build clusters/offsite/config | grep OAUTH2_PROXY_ITEM
  OAUTH2_PROXY_ITEM: 46xuydwpk5vbw2gld2pzn5o4pq
```

Both `oauth2-proxy` overlays render, and `mise run k8s:render-apps` is clean.

## Merge promptly

`refreshInterval: 1h`. Until this lands, folly's ExternalSecret still points at the item that now holds **offsite's** App, so folly breaks on its next refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)