### PR TITLE
fix(k8s): let the managed CA bundle reach the trust store

### DIFF
--- a/nix/services/k8s/default.nix
+++ b/nix/services/k8s/default.nix
@@ -146,6 +146,13 @@ in
 
     systemd.tmpfiles.rules = lib.mkIf cfg.clusterCa.enable (
       [
+        # kube-certmgr-bootstrap mkdir's the secrets dir as root inside
+        # kubernetes-owned /var/lib/kubernetes. systemd-tmpfiles calls that
+        # ownership change an unsafe path transition and silently skips every
+        # rule underneath it, so the ca.pem link below never lands and the node
+        # keeps trusting whichever CA was there first. Own the dir to match its
+        # parent to keep the transition safe.
+        "d /var/lib/kubernetes/secrets 0755 kubernetes kubernetes -"
         "L+ /var/lib/kubernetes/secrets/ca.pem - - - - ${fmlClusterCaBundle}"
       ]
       ++ lib.optional (cfg.role == "control-plane") "L+ ${cfsslCaPrefix}.pem - - - - ${fmlClusterCaCert}"


### PR DESCRIPTION
## What broke

folly's apiserver could not reach etcd — the cluster was hard down (`10.3.0.10:6443` refusing connections).

```
etcd:      rejected connection on client endpoint … remote error: tls: bad certificate
apiserver: handshake failed: x509: certificate signed by unknown authority
```

## Root cause

`f5da2abc` rotated folly onto the Terraform-managed FML CA using two tmpfiles rules. Only one of them ever applied:

| Rule | Parent dir owner | Result |
| --- | --- | --- |
| `L+ /var/lib/cfssl/ca.pem → folly-ca.pem` | `/var/lib` — root | applied |
| `L+ /var/lib/kubernetes/secrets/ca.pem → folly-ca-bundle.pem` | `/var/lib/kubernetes` — **kubernetes** | silently skipped |

```
systemd-tmpfiles[564]: Detected unsafe path transition /var/lib/kubernetes (owned by
  kubernetes) → /var/lib/kubernetes/secrets (owned by root) during canonicalization
```

nixpkgs' `kube-certmgr-bootstrap` `mkdir -p`s the secrets dir as root inside the kubernetes-owned dataDir. systemd-tmpfiles refuses to follow a path where a non-root-owned directory hands off to a differently-owned child, and drops every rule underneath it — no error, no failed unit.

So cfssl got the new CA while the trust store kept the old one. When certmgr renewed the leaf certs on Aug 2 04:31, apiserver and etcd began presenting new-CA certs that every node still rejected.

## Fix

Own the secrets dir to match its parent so the transition is safe and the existing link rule applies. `folly-ca-bundle.pem` carries both the previous and current CA, so nodes converge without a flag day.

Tradeoff: the `kubernetes` user now owns that directory, so apiserver could rewrite certs in it. It already reads every key there, and the CA private key stays in cfssl's own dir — marginal.

Rejected alternative: redirecting `services.kubernetes.caFile` at the store path. nixpkgs derives the CA path as `${secretsPath}/ca.pem` for seven other consumers (`etcd.trustedCaFile`, `apiserver.etcd.caFile`, `clientCaFile`, `kubeletClientCaFile`, `controllerManager.rootCaFile`, …), so that only fixes the kubeconfigs.

## Deployed and verified

Already switched onto all three folly nodes ahead of this PR to end the outage. **Merge before the 03:37 auto-upgrade or the deploy reverts.**

- `ca.pem` is now a symlink to the bundle on optiplex, riptide and shale
- etcd, kube-apiserver and both kubelets restarted; zero `unknown authority` / `bad certificate` since
- `kubectl --context folly get nodes` — all three `Ready`

Unrelated pre-existing issue spotted on shale: `/run/docker.sock` is a **directory** (created Jun 23), so `docker.socket` fails to bind with `Address already in use`. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)