### PR TITLE
fix(nix): run docker only where it's used, and stop its socket failing on switch

### DIFF
--- a/.github/workflows/arc-smoke.yml
+++ b/.github/workflows/arc-smoke.yml
@@ -1,0 +1,55 @@
+name: ARC Smoke
+
+# The self-hosted scale sets run, but no workflow targets them, so nothing
+# proves they can carry a job. This is that proof, on demand.
+#
+# Two things worth proving, because they are the two that were broken:
+#   - the runner reaches a Docker daemon at all (containerMode: dind)
+#   - a `services:` container is reachable on the job's own localhost, which
+#     is what typescript.yml's postgres needs and what a node-level Docker
+#     socket could never deliver
+#
+# `services:` failing to come up fails the job before any step runs, so the
+# service block is itself half the assertion.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cluster:
+        description: Which cluster's scale set to run on
+        type: choice
+        options:
+          - folly
+          - offsite
+        default: folly
+
+permissions:
+  contents: read
+
+jobs:
+  dind:
+    runs-on: ${{ inputs.cluster }}
+    timeout-minutes: 10
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: smoke
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Runner reaches the dind daemon
+        run: docker version
+
+      - name: Service container answers on the job's localhost
+        run: |
+          timeout 30 bash -c \
+            'until (echo > /dev/tcp/localhost/5432) 2>/dev/null; do sleep 1; done'
+          echo "postgres reachable on localhost:5432"

--- a/clusters/base/apps/arc/infra.yaml
+++ b/clusters/base/apps/arc/infra.yaml
@@ -31,17 +31,8 @@ spec:
     minRunners: 1
     template:
       spec:
-        securityContext:
-          supplementalGroups: [123]
         containers:
           - name: runner
             image: jonpulsifer/actions-runner:latest@sha256:1d998da13bb6d6dcce7f1869920d6a7049696d6e6ff049c4472939c185660298
             command: ["/home/runner/run.sh"]
-            volumeMounts:
-              - name: dsock
-                mountPath: /var/run/docker.sock
-        volumes:
-          - name: dsock
-            hostPath:
-              path: /var/run/docker.sock
 

--- a/clusters/base/apps/arc/infra.yaml
+++ b/clusters/base/apps/arc/infra.yaml
@@ -29,6 +29,14 @@ spec:
     githubConfigUrl: https://github.com/jonpulsifer/infra
     githubConfigSecret: arc
     minRunners: 1
+    # A workflow's `services:` and `container:` need a Docker daemon the runner
+    # can reach. dind puts one in the runner's own pod, so a published port
+    # lands on the pod's network namespace and the job's localhost:PORT
+    # resolves to it — the reason a node-level socket cannot serve this.
+    # The chart injects the sidecar, wires DOCKER_HOST, and adds the work and
+    # dind-sock volumes; the runner container below is merged into that.
+    containerMode:
+      type: dind
     template:
       spec:
         containers:

--- a/images/actions-runner/Dockerfile
+++ b/images/actions-runner/Dockerfile
@@ -3,7 +3,6 @@ USER root
 RUN apt-get update && apt-get -qqy upgrade &&\
     apt-get install -qqy --no-install-recommends \
       curl \
-      docker.io \
       git \
       jq \
       unzip \
@@ -18,5 +17,4 @@ RUN curl -fsSL -o /usr/local/bin/argocd "https://github.com/argoproj/argo-cd/rel
     && chmod +x /usr/local/bin/argocd
 # Install helm (often needed for ArgoCD app diffs)
 RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-# uid=1001(runner) gid=1001(runner) groups=1001(runner),27(sudo),123(docker)
 USER 1001:1001

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -1,5 +1,5 @@
 # oldschool: offsite worker node that also carries the site's odd jobs —
-# docker, a GitHub runner, yarr, and the offsite harmonia binary cache.
+# yarr and the offsite harmonia binary cache.
 { ... }:
 {
   imports = [
@@ -12,7 +12,7 @@
 
   homelab.disko.device = "/dev/sda";
   # 200G root (default is 100G) — leaves headroom for the harmonia
-  # binary cache + remote-builder role on top of docker/runner/yarr.
+  # binary cache + remote-builder role on top of yarr.
   homelab.disko.rootSize = "200G";
 
   sops.defaultSopsFile = ../secrets/oldschool.sops.yaml;

--- a/nix/profiles/fleet.nix
+++ b/nix/profiles/fleet.nix
@@ -68,6 +68,18 @@
     ];
   };
 
+  # The docker package ships its own docker.socket with
+  # ListenStream=/run/docker.sock, and virtualisation.docker layers a NixOS
+  # drop-in on top that sets ListenStream again. systemd treats ListenStream as
+  # a list, so the drop-in appends instead of replacing: two listeners on one
+  # path, and the second bind fails with EADDRINUSE. The leading "" is
+  # systemd's list-reset — the same idiom the module already uses for
+  # docker.service's ExecStart.
+  virtualisation.docker.listenOptions = [
+    ""
+    "/run/docker.sock"
+  ];
+
   programs.zsh.enable = lib.mkDefault true;
 
   security.sudo = {

--- a/nix/profiles/k8s-node.nix
+++ b/nix/profiles/k8s-node.nix
@@ -40,9 +40,6 @@ in
     nfs-utils
   ];
 
-  virtualisation.docker.enable = true;
-  users.groups.docker.gid = lib.mkForce 123;
-
   services.k8s = {
     enable = true;
     inherit network;


### PR DESCRIPTION
## Summary

`docker.socket` fails on `nixos-rebuild switch` across the fleet, and the investigation found the daemon it guards has no consumer on the k8s nodes. Fixes the socket for the one host that genuinely needs docker (`forge`), and removes it everywhere else.

## The socket bug

The docker package ships its own `docker.socket` with `ListenStream=/run/docker.sock`, pulled in via the module's `systemd.packages`. `virtualisation.docker` then layers a NixOS drop-in that sets `ListenStream` again. systemd treats `ListenStream` as a list, so the drop-in **appends rather than replaces**:

```
Listen: /run/docker.sock (Stream)
        /run/docker.sock (Stream)
```

Latent at boot, fatal on switch — the second bind hits `EADDRINUSE` and takes `docker.service` down with it:

```
docker.socket: Failed to create listening socket (/run/docker.sock): Address already in use
docker.socket: Failed with result 'resources'.
```

Every docker host in the fleet carried the duplicate. `riptide`, `shale` and `retrofit` were already failed; `optiplex`, `oldschool` and `forge` were live only because they hadn't switched yet.

The fix is systemd's list-reset — the same idiom the module already uses for `docker.service`'s `ExecStart`, just missing on the socket.

## Why the k8s nodes lose docker

It was added so ARC runners could bind-mount the node's docker socket. Nothing schedules onto that scale set — every `runs-on:` in `.github/workflows` is a GitHub-hosted runner — and the daemons show it:

| host | evidence |
| --- | --- |
| riptide | `/var/lib/docker` = one empty `containers/`, no images, no `docker0` |
| oldschool | two orphan images, **zero** containers; its `yarr` is native transmission |
| all | no `docker0` bridge anywhere |

The socket mount also wouldn't have carried its intended load. A service container started through the node's daemon lands in the *node's* network namespace, so a workflow's `localhost:PORT` never reaches it from inside the runner pod — which is exactly what `typescript.yml`'s `services: postgres` needs. ARC's `containerMode` handles `services:`/`container:` with a pod-local dind sidecar and no host daemon; that's the door to open when a workflow actually moves onto these runners.

`forge` keeps docker for its `ociBuilder` role — native arm64 OCI builds are a real consumer. It's now the only host in the fleet running it.

## Changes

- `fix(nix): stop docker.socket colliding with itself on switch`
- `refactor(k8s): drop the docker daemon nothing on the k8s nodes used`

## Test Plan

- [x] `forge` renders `ListenStream=` (reset) + `ListenStream=/run/docker.sock` — single listener
- [x] `virtualisation.docker.enable` is `false` on riptide/shale/retrofit/optiplex/oldschool/weatherpi4/homepi4, `true` only on forge
- [x] all eight host configs evaluate
- [x] `kustomize build clusters/base/apps/arc` renders
- [x] `mise run nix:fmt` clean
- [ ] after merge: the three failed hosts come back with docker gone entirely; `forge` rebinds its socket once on switch

## Follow-ups (not in this PR)

- `/var/lib/docker` stays behind on the five nodes after they rebuild — `rm -rf` reclaims it
- `docker.io` is dropped from `images/actions-runner/Dockerfile`; if ARC dind mode lands later, that CLI comes back
- commit 0194364c also dropped `ACTIONS_RUNNER_PRINT_LOG_TO_STDOUT` from the runner spec — unrelated collateral, left alone


---

## Update: dind + a smoke test

Third commit adds `containerMode: {type: dind}` to the scale set and a dispatchable `arc-smoke.yml` to prove the runners can actually carry a job.

Rendered `AutoscalingRunnerSet` (chart 0.14.2, verified with `helm template`):

- `init-dind-externals` init container
- `dind` native sidecar (`restartPolicy: Always`, `startupProbe: docker info`), `privileged: true`, `DOCKER_GROUP_GID: "123"`
- runner gains `DOCKER_HOST=unix:///var/run/docker.sock`, `RUNNER_WAIT_FOR_DOCKER_IN_SECONDS=120`, and the `work` + `dind-sock` mounts

That `DOCKER_GROUP_GID: "123"` is where the `supplementalGroups: [123]` and `users.groups.docker.gid = 123` in 0194364c came from — it's the chart's dind convention, being applied to the wrong daemon.

**`docker.io` stays removed.** Verified against the pinned base image rather than assumed — `ghcr.io/actions/actions-runner:2.336.0` already ships `/usr/bin/docker`, `dockerd`, `docker-init`, `docker-proxy`, and the buildx plugin. The apt package was redundant from the start, and apt's `docker.io` drags in a daemon + containerd that dind makes pointless.

**Privileged admission:** the `arc` namespace sets `pod-security audit`/`warn: restricted` with `enforce` commented out (`clusters/base/platform/arc-system/namespace.yaml:12`), so the sidecar is admitted. Expect restricted *warnings* on runner pods, not rejections.

### Verifying after merge

`gh workflow run arc-smoke.yml -f cluster=folly` — the job fails before any step if the service container can't start, then asserts the daemon is reachable and `localhost:5432` answers.

Nothing is moved onto the self-hosted runners in this PR. `typescript.yml` stays on `ubuntu-latest`; the smoke test is what decides whether moving it is worth doing.
