### PR TITLE
feat(spindrift): separate the build and deploy stages, and stop dumping logs

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -118,10 +118,19 @@ export const getAppWorkspace: Command<
     }
   }
 
+  // Status events only — the checkpoints, not the transcript.
+  //
+  // Every log line an adapter emits lands in `attempt_events` too, and reading
+  // the table raw made the timeline the last twenty lines of whatever ran most
+  // recently: three screens of BuildKit chatter where a reader wanted "built,
+  // deployed, went red". A checkpoint is a status event by definition — §6's
+  // `{phase, resource?, reason?}` — so the filter is the whole selection, and
+  // the text stays where it belongs, on the attempt screen each entry links to.
   const events = await context.db.query.attemptEvents.findMany({
-    where: (ev, { eq }) => eq(ev.appId, app.id),
+    where: (ev, { eq, and }) =>
+      and(eq(ev.appId, app.id), eq(ev.eventType, 'status')),
     orderBy: (ev, { desc }) => [desc(ev.id)],
-    limit: 20,
+    limit: 12,
   });
 
   const now = context.clock.now();
@@ -133,17 +142,15 @@ export const getAppWorkspace: Command<
   const activity: ActivityEntry[] = [];
   if (events.length > 0) {
     for (const ev of events) {
-      const title = ev.phase
-        ? `${ev.attemptKind} ${ev.phase.toLowerCase()}`
-        : ev.resource
-          ? ev.resource
-          : `${ev.attemptKind} event`;
-      const detail = ev.resource
-        ? `${ev.resource}${ev.line ? `: ${ev.line}` : ''}`
-        : (ev.line ?? ev.reason ?? '');
       activity.push({
-        title,
-        detail,
+        kind: ev.attemptKind,
+        title: checkpointTitle(
+          ev.attemptKind,
+          ev.phase,
+          ev.deployId,
+          ev.buildId,
+        ),
+        detail: ev.resource ?? ev.reason ?? '',
         when: elapsedSince(ev.createdAt, now),
         status: ev.reason ? 'failed' : ev.phase === 'LIVE' ? 'ok' : 'info',
         deployId: ev.deployId,
@@ -152,6 +159,7 @@ export const getAppWorkspace: Command<
     }
   } else if (latestDeploy) {
     activity.push({
+      kind: 'deploy',
       title: `Deploy ${latestDeploy.id} ${latestDeploy.phase.toLowerCase()}`,
       detail: latestDeploy.detail ?? `Target: ${latestTarget?.name ?? 'none'}`,
       when: elapsedSince(latestDeploy.createdAt, now),
@@ -230,6 +238,31 @@ export const getAppWorkspace: Command<
 
   return ok({ workspace });
 };
+
+/**
+ * What a checkpoint is called on the timeline.
+ *
+ * Named by its attempt — "Build 41", "Deploy 42" — because the two stages are
+ * separate and a reader scanning the column has to be able to tell which one a
+ * line is about. `${kind} ${phase}` alone could not: "failed" appeared on both
+ * legs and read as one pipeline that fell over somewhere.
+ *
+ * A build's step transitions come through here as their own phases (`RUNNING`,
+ * `SUCCEEDED`), which is why the word is lowercased rather than mapped — the
+ * vocabularies differ per §6 and inventing a shared one would mean guessing at
+ * a step name the runner already chose.
+ */
+function checkpointTitle(
+  kind: 'build' | 'deploy',
+  phase: string | null,
+  deployId: number | null,
+  buildId: number | null,
+): string {
+  const id = kind === 'deploy' ? deployId : buildId;
+  const noun = kind === 'deploy' ? 'Deploy' : 'Build';
+  const subject = id === null ? noun : `${noun} ${id}`;
+  return phase ? `${subject} ${phase.toLowerCase()}` : subject;
+}
 
 function phaseFor(
   deploy: DeployPhase | undefined,

--- a/apps/spindrift/src/commands/builds/view.ts
+++ b/apps/spindrift/src/commands/builds/view.ts
@@ -115,13 +115,7 @@ export async function buildViewOf(
       tone: event.reason ? ('error' as const) : undefined,
     }));
 
-  const steps: ChecklistItem[] = events
-    .filter((event) => event.resource)
-    .map((event) => ({
-      name: event.resource!,
-      status: event.reason ? ('failed' as const) : ('done' as const),
-      detail: event.line ?? undefined,
-    }));
+  const steps = checkpointsOf(events);
 
   return {
     view: {
@@ -134,12 +128,116 @@ export async function buildViewOf(
       // Null rather than `[]`: §4's `logFidelity` distinguishes "the runner has
       // released nothing yet" from "the runner printed nothing", and the screen
       // states the first rather than rendering the second as an empty pane.
-      log: log.length > 0 ? log : null,
+      log: log.length > 0 ? log.slice(-LOG_TAIL) : null,
+      logTotal: log.length,
       runner: build.runner ?? 'hosted runner',
       runUrl: build.runUrl ?? null,
     },
     events,
   };
+}
+
+/**
+ * How much of the runner's transcript the drawer carries.
+ *
+ * A build prints thousands of lines and the screen is not a terminal — the
+ * checkpoints above it are what says how the build went, and the text is the
+ * evidence for the last thing that happened. The tail is the part that holds
+ * that evidence: a failure is at the end of the log, never in the middle. The
+ * whole transcript stays one click away on the runner's own page, which is what
+ * `runUrl` is for, and `logTotal` says how much was left there.
+ */
+const LOG_TAIL = 60;
+
+/** A step's reported state in the checklist's words. */
+function stepStatusOf(phase: string | null, failed: boolean): StepStatus {
+  if (failed || phase === 'FAILED') return 'failed';
+  if (phase === 'SUCCEEDED') return 'done';
+  if (phase === 'RUNNING') return 'running';
+  return 'waiting';
+}
+
+/**
+ * The named checkpoints of a build, in the order the runner reached them.
+ *
+ * A step is not one event — a route reports `RUNNING` and then a verdict for
+ * the same name (`stepEvents` in the GitHub Actions route emits exactly that
+ * pair), and log lines arrive under it in between. Folding them by name is what
+ * turns a flat event list into a checklist that says what each step *is doing*
+ * rather than marking everything done because it was mentioned. The latest
+ * status event for a name wins; the pair of timestamps around it gives the step
+ * a duration, which is the whole reason a reader scans this list.
+ *
+ * A name carried only by log lines — `dispatch`, `provenance` — never gets a
+ * status event, so it keeps its sentence as its detail instead of a duration.
+ * That is the one thing it has to say, and dropping it would leave a bare word.
+ */
+function checkpointsOf(events: readonly AttemptEvent[]): ChecklistItem[] {
+  interface Checkpoint {
+    status: StepStatus;
+    from: Date;
+    to: Date | null;
+    line: string | null;
+  }
+  const seen = new Map<string, Checkpoint>();
+
+  for (const event of events) {
+    const name = event.resource;
+    if (!name) continue;
+    const isLog = event.eventType === 'log';
+    const prior = seen.get(name);
+
+    if (!prior) {
+      seen.set(name, {
+        status: isLog
+          ? 'running'
+          : stepStatusOf(event.phase, event.reason !== null),
+        from: event.createdAt,
+        to: null,
+        line: isLog ? event.line : null,
+      });
+      continue;
+    }
+
+    if (isLog) {
+      if (event.line) prior.line = event.line;
+      continue;
+    }
+    prior.status = stepStatusOf(event.phase, event.reason !== null);
+    prior.to = prior.status === 'running' ? null : event.createdAt;
+  }
+
+  return Array.from(seen, ([name, checkpoint]) => ({
+    name,
+    status: checkpoint.status,
+    ...detailOf(checkpoint),
+  }));
+}
+
+function detailOf(checkpoint: {
+  from: Date;
+  to: Date | null;
+  line: string | null;
+}): { detail?: string } {
+  if (checkpoint.to !== null) {
+    const seconds = Math.max(
+      0,
+      (checkpoint.to.getTime() - checkpoint.from.getTime()) / 1000,
+    );
+    return { detail: `${seconds.toFixed(1)}s` };
+  }
+  // Cut rather than wrapped: the detail sits at the end of a one-line row (§18
+  // — "per-resource detail is one line, no tree"), and a paragraph there would
+  // push the step name it belongs to off the screen.
+  if (checkpoint.line !== null) {
+    return {
+      detail:
+        checkpoint.line.length > 64
+          ? `${checkpoint.line.slice(0, 63)}…`
+          : checkpoint.line,
+    };
+  }
+  return {};
 }
 
 /**

--- a/apps/spindrift/src/commands/deploys/get-detail.ts
+++ b/apps/spindrift/src/commands/deploys/get-detail.ts
@@ -182,8 +182,17 @@ export const getDeployDetail: Command<
   let phaseWord = build === null ? 'Releasing' : 'Building';
   if (deploy.phase === 'LIVE') phaseWord = 'Live';
   else if (deploy.phase === 'FAILED') {
+    // The deploy's own verdict outranks the Build row, and the order is the
+    // fix. A Deploy that recorded a reason failed *here* — it was applied, the
+    // platform answered, and §6 persisted what it said. Reading the Build
+    // first meant that reason lost to a FAILED Build row, which is exactly the
+    // pairing supply-chain admission produces: the runner pushed an image, the
+    // artifact was refused, and the screen blamed a build that had already
+    // done its job. A build is only the failure when nothing after it spoke.
     phaseWord =
-      deploy.build.status === 'FAILED' ? 'Build failed' : 'Deploy failed';
+      deploy.reason === null && deploy.build.status === 'FAILED'
+        ? 'Build failed'
+        : 'Deploy failed';
   } else if (deploy.phase === 'APPLYING') phaseWord = 'Applying';
 
   let headline = `Deployed to ${deploy.target.name}`;

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -110,6 +110,16 @@ export interface BuildView {
    * to state, not an empty pane to show.
    */
   readonly log: readonly LogLine[] | null;
+  /**
+   * How many lines the runner actually produced, of which {@link log} is the
+   * tail.
+   *
+   * Carried rather than inferred from `log.length`, because those two numbers
+   * disagreeing is the whole point: a screen that shows sixty lines of eight
+   * hundred and says nothing has silently edited the evidence. The count is
+   * what lets it say so, and say where the rest is.
+   */
+  readonly logTotal: number;
   /** The runner that produced it, for the header. */
   readonly runner: string;
   /**
@@ -297,6 +307,15 @@ export interface DeployListItem {
  * to go — `/deploys/:id` or `/builds/:id`.
  */
 export interface ActivityEntry {
+  /**
+   * Which stage this checkpoint belongs to.
+   *
+   * Build and Deploy are two stages, not one pipeline with a tail, and the
+   * timeline is where that is most easily lost: a column of "failed" lines
+   * cannot say whether the image or its placement is the problem. The lane a
+   * row sits in answers that before the words do.
+   */
+  readonly kind: 'build' | 'deploy';
   readonly title: string;
   readonly detail: string;
   readonly when: string;

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -36,6 +36,7 @@
  */
 import {
   ArrowLeft,
+  ChevronRight,
   ExternalLink,
   RefreshCw,
   Rocket,
@@ -110,9 +111,16 @@ export function DeployDetail({
       ) : null}
 
       <BuildDrawer view={view} />
-      {view.id !== null && view.build?.status === 'done' ? (
-        <DeployDrawer view={view} />
-      ) : null}
+      {/*
+        Every release has a deploy leg, so every release gets the drawer. It
+        used to be gated on a green build, which hid the log on precisely the
+        screen that needed it: a Deploy over a Build the supply chain refused
+        is red *at the deploy*, and gating on the build meant the only thing on
+        screen was a build log, saying the failure was somewhere it was not.
+        A Build with no intent (`id === null`) still has no deploy leg — that
+        one is an absence, not a hidden pane.
+      */}
+      {view.id !== null ? <DeployDrawer view={view} /> : null}
     </div>
   );
 }
@@ -246,20 +254,26 @@ function Actions({
   const { onRedeploy, onRollback, onDeployBuild, busy } = actions;
   const buttons = [];
 
-  if (view.id === null && onDeployBuild && view.build?.status !== 'failed') {
+  // An artifact that exists is deployable, and the button keys on the artifact
+  // rather than on the Build's status. Those two disagree on the case that
+  // matters: a Build the supply chain refused is FAILED with an image in the
+  // registry, and hiding the act there says the artifact cannot be placed when
+  // it can. Only a Build that ended having produced nothing has nothing to
+  // offer — and that one gets Rebuild, below.
+  const nothingToPlace =
+    view.artifactDigest === null && view.build?.status === 'failed';
+
+  if (view.id === null && onDeployBuild && !nothingToPlace) {
+    const placeable = view.artifactDigest !== null;
     buttons.push(
       <Button
         key="deploy"
         size="sm"
         onClick={onDeployBuild}
-        disabled={busy !== null && busy !== undefined}
+        disabled={!placeable || (busy !== null && busy !== undefined)}
         // A Build still running has nothing to place yet. It is shown disabled
         // rather than hidden so the next act is visible while you wait for it.
-        title={
-          view.build !== null && view.build.status !== 'done'
-            ? 'Available once the build finishes'
-            : undefined
-        }
+        title={placeable ? undefined : 'Available once an artifact exists'}
       >
         <Rocket aria-hidden="true" className="size-3.5" />
         {busy === 'deploy' ? 'Deploying…' : 'Deploy this build'}
@@ -480,18 +494,76 @@ function BuildDrawer({ view }: { view: DeployView }) {
   }
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen} asChild>
+    <Stage
+      ordinal="1"
+      name="Build"
+      status={build.status}
+      word={statusWord(build.status)}
+      note={build.duration ?? null}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      <Checklist items={build.steps} />
+      <BuildOutput view={view} />
+    </Stage>
+  );
+}
+
+/**
+ * One leg of the pipeline, as a card that looks exactly like the other one.
+ *
+ * Build and Deploy are **two stages, not one story with a tail**: a Build
+ * records an artifact, a Deploy places one, and either can go red while the
+ * other is fine. The screen has to be able to say that, and it can only say it
+ * if the two read as peers — same header, same glyph, its own verdict on each.
+ * A layout that made Deploy a section *inside* Build could not express "the
+ * image is fine, the placement failed", which is the most common red there is.
+ *
+ * The ordinal is what makes the pairing legible at a glance: two numbered
+ * stages, and the reader can see which one stopped.
+ */
+function Stage({
+  ordinal,
+  name,
+  status,
+  word,
+  note,
+  open,
+  onOpenChange,
+  children,
+}: {
+  ordinal: string;
+  name: string;
+  status: 'done' | 'running' | 'failed' | 'waiting';
+  word: string;
+  note: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Collapsible open={open} onOpenChange={onOpenChange} asChild>
       <Card>
         <CollapsibleTrigger className="flex w-full items-center gap-2.5 px-3.5 py-3 text-left text-xs font-semibold uppercase tracking-[0.07em] text-subtle hover:text-foreground">
-          <StepGlyph status={build.status} />
-          Build log · {statusWord(build.status)}
-          {build.duration ? ` · ${build.duration}` : ''}
+          <span className="font-mono text-[11px] text-muted-foreground">
+            {ordinal}
+          </span>
+          <StepGlyph status={status} />
+          <span className="text-foreground">{name}</span>
+          <span>· {word}</span>
+          {note ? (
+            <span className="text-muted-foreground">· {note}</span>
+          ) : null}
+          <ChevronRight
+            aria-hidden="true"
+            className={cn(
+              'ml-auto size-4 transition-transform',
+              open && 'rotate-90',
+            )}
+          />
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="flex flex-col gap-3 px-3.5 pb-3.5">
-            <Checklist items={build.steps} />
-            <BuildOutput view={view} />
-          </div>
+          <div className="flex flex-col gap-3 px-3.5 pb-3.5">{children}</div>
         </CollapsibleContent>
       </Card>
     </Collapsible>
@@ -515,12 +587,7 @@ function BuildOutput({ view }: { view: DeployView }) {
   const build = view.build;
   if (build === null) return null;
   if (build.log !== null) {
-    return (
-      <div className="flex flex-col gap-2">
-        <LogPane lines={build.log} />
-        <RunLink url={build.runUrl} />
-      </div>
-    );
+    return <Transcript build={build} />;
   }
 
   if (build.fidelity === 'LIVE_STATUS') {
@@ -556,6 +623,54 @@ function BuildOutput({ view }: { view: DeployView }) {
 }
 
 /**
+ * The runner's raw text, behind one more click and never the whole of it.
+ *
+ * The checkpoints above are the build. This is the evidence for them, and a
+ * drawer that opened straight onto a thousand lines of BuildKit chatter buried
+ * the seven lines that said what happened. So it stays shut on green — nobody
+ * reads a successful build's transcript — and springs open on red, where the
+ * last lines are the answer.
+ *
+ * `logTotal` is stated whenever it exceeds what is here. A tail presented as
+ * the log is the UI editing evidence; a tail that says how much it is a tail
+ * of, and where the rest lives, is not.
+ */
+function Transcript({ build }: { build: NonNullable<DeployView['build']> }) {
+  const lines = build.log ?? [];
+  const [open, setOpen] = useState(build.status === 'failed');
+  const clipped = build.logTotal > lines.length;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="flex flex-col">
+      <CollapsibleTrigger className="flex items-center gap-2 self-start text-[12.5px] text-subtle hover:text-foreground">
+        <ChevronRight
+          aria-hidden="true"
+          className={cn('size-3.5 transition-transform', open && 'rotate-90')}
+        />
+        {open ? 'Hide' : 'Show'} {build.runner} output
+        <span className="text-muted-foreground">
+          {clipped
+            ? `· last ${lines.length} of ${build.logTotal} lines`
+            : `· ${build.logTotal} lines`}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <div className="flex flex-col gap-2 pt-2">
+          <LogPane lines={lines} />
+          {clipped ? (
+            <p className="text-[11.5px] text-muted-foreground">
+              Only the tail is kept here — a failure is at the end of a log, and
+              the full transcript stays on the runner.
+            </p>
+          ) : null}
+          <RunLink url={build.runUrl} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+/**
  * A way out to the runner's own view of this run.
  *
  * Rendered only from a URL the backend reported. Nothing here composes one out
@@ -581,7 +696,15 @@ function RunLink({ url, inline }: { url: string | null; inline?: boolean }) {
   );
 }
 
-/** The deploy leg is separate from build output and opens on deploy red. */
+/**
+ * The deploy leg — stage 2, and never a consequence of stage 1.
+ *
+ * It reads its own phase and nothing else. The Build above it may be green,
+ * red, or still going; what this stage says is what the platform said when the
+ * artifact was placed. That independence is the point: an artifact that exists
+ * is deployable to any supported Target, so a red Build is a fact about an
+ * older artifact and not a reason to stop describing this placement.
+ */
 function DeployDrawer({ view }: { view: DeployView }) {
   const autoOpen = view.phase !== 'LIVE';
   const [open, setOpen] = useState(autoOpen);
@@ -594,33 +717,29 @@ function DeployDrawer({ view }: { view: DeployView }) {
   }, [view.phase]);
 
   return (
-    <Collapsible open={open} onOpenChange={setOpen} asChild>
-      <Card>
-        <CollapsibleTrigger className="flex w-full items-center gap-2.5 px-3.5 py-3 text-left text-xs font-semibold uppercase tracking-[0.07em] text-subtle hover:text-foreground">
-          <StepGlyph
-            status={
-              view.phase === 'LIVE'
-                ? 'done'
-                : view.phase === 'FAILED'
-                  ? 'failed'
-                  : 'running'
-            }
-          />
-          Deploy log · {view.phase.toLowerCase()}
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="px-3.5 pb-3.5">
-            {view.deployLog === null ? (
-              <Notice label="LIVE_STATUS">
-                The controller reports deploy status live; no text line has
-                arrived yet.
-              </Notice>
-            ) : (
-              <LogPane lines={view.deployLog} />
-            )}
-          </div>
-        </CollapsibleContent>
-      </Card>
-    </Collapsible>
+    <Stage
+      ordinal="2"
+      name="Deploy"
+      status={
+        view.phase === 'LIVE'
+          ? 'done'
+          : view.phase === 'FAILED'
+            ? 'failed'
+            : 'running'
+      }
+      word={view.phase.toLowerCase()}
+      note={view.target}
+      open={open}
+      onOpenChange={setOpen}
+    >
+      {view.deployLog === null ? (
+        <Notice label="LIVE_STATUS">
+          The controller reports deploy status live; no text line has arrived
+          yet.
+        </Notice>
+      ) : (
+        <LogPane lines={view.deployLog} />
+      )}
+    </Stage>
   );
 }

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -377,18 +377,27 @@ function ReleaseHistory({
   );
 }
 
-const ACTIVITY_TONE = {
-  ok: 'border-l-success',
-  failed: 'border-l-destructive',
-  info: 'border-l-border',
+const MARKER_TONE = {
+  ok: 'border-success bg-success',
+  failed: 'border-destructive bg-destructive',
+  info: 'border-border bg-card',
 } as const satisfies Record<ActivityEntry['status'], string>;
 
 /**
  * The timeline, and a way in from every line of it.
  *
- * `attempt_events` constrains every row to exactly one attempt, so every entry
- * has somewhere to go — `/deploys/:id` or `/builds/:id`. An entry that led
- * nowhere would be the one thing on this screen a reader could not act on.
+ * A **timeline, not a list** — the rows are joined by a rule the markers sit
+ * on, because these entries are one sequence and stacked cards said they were
+ * unrelated events that happened to be near each other. The connector is what
+ * carries the reading down the column, and the newest checkpoint is at the top
+ * where the last thing that happened belongs.
+ *
+ * The stage each row belongs to is on the row, and it is load-bearing rather
+ * than decorative: **Build and Deploy are separate stages**, so a column of red
+ * has to say which of the two went red. `attempt_events` constrains every row
+ * to exactly one attempt, so the lane is always knowable and every entry has
+ * somewhere to go — `/deploys/:id` or `/builds/:id`. An entry that led nowhere
+ * would be the one thing on this screen a reader could not act on.
  */
 function Activity({
   entries,
@@ -399,20 +408,31 @@ function Activity({
 }) {
   return (
     <Card>
-      <SectionHeader eyebrow="Recent activity" title="What happened" />
-      <CardContent className="flex flex-col gap-2.5 pt-0">
+      <SectionHeader eyebrow="Timeline" title="What happened" />
+      <CardContent className="pt-0">
         {entries.length === 0 ? (
           <EmptyState title="Nothing has happened yet.">
-            Build and deploy events land here as they arrive.
+            Build and deploy checkpoints land here as they arrive.
           </EmptyState>
         ) : (
-          entries.map((entry) => (
-            <ActivityRow
-              key={`${entry.title}-${entry.when}-${entry.deployId ?? entry.buildId}`}
-              entry={entry}
-              onNavigate={onNavigate}
+          <ol className="relative flex flex-col">
+            {/*
+              One rule behind every marker, stopped short at both ends so the
+              sequence reads as bounded rather than continuing off the card
+              into checkpoints that are not shown.
+            */}
+            <span
+              aria-hidden="true"
+              className="absolute left-[5px] top-3 bottom-3 w-px bg-border-soft"
             />
-          ))
+            {entries.map((entry) => (
+              <ActivityRow
+                key={`${entry.title}-${entry.when}-${entry.deployId ?? entry.buildId}`}
+                entry={entry}
+                onNavigate={onNavigate}
+              />
+            ))}
+          </ol>
         )}
       </CardContent>
     </Card>
@@ -435,35 +455,53 @@ function ActivityRow({
 
   const body = (
     <>
-      <div className="flex items-baseline gap-2">
-        <p className="text-sm font-medium">{entry.title}</p>
-        <span className="ml-auto font-mono text-xs text-muted-foreground">
-          {entry.when}
-        </span>
+      {/*
+        The marker sits on the rule rather than beside it — `bg-card` on an
+        `info` dot is what punches it through the line, so a checkpoint reads
+        as a point on the sequence instead of a bullet next to one.
+      */}
+      <span
+        aria-hidden="true"
+        className={cn(
+          'relative z-10 mt-[7px] size-[11px] shrink-0 rounded-full border-2',
+          MARKER_TONE[entry.status],
+        )}
+      />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <Badge tone={entry.kind === 'deploy' ? 'accent' : 'idle'}>
+            {entry.kind}
+          </Badge>
+          <p className="truncate text-sm font-medium">{entry.title}</p>
+          <span className="ml-auto shrink-0 font-mono text-xs text-muted-foreground">
+            {entry.when}
+          </span>
+        </div>
+        {entry.detail ? (
+          <p className="truncate text-xs text-muted-foreground">
+            {entry.detail}
+          </p>
+        ) : null}
       </div>
-      <p className="text-xs text-muted-foreground">{entry.detail}</p>
     </>
   );
 
-  if (path === null || !onNavigate) {
-    return (
-      <div className={cn('border-l-2 pl-3', ACTIVITY_TONE[entry.status])}>
-        {body}
-      </div>
-    );
-  }
+  const shape = 'flex w-full items-start gap-2.5 py-2 text-left';
 
   return (
-    <button
-      type="button"
-      onClick={() => onNavigate(path)}
-      className={cn(
-        'border-l-2 pl-3 text-left hover:bg-secondary/50',
-        ACTIVITY_TONE[entry.status],
+    <li className="relative">
+      {path === null || !onNavigate ? (
+        <div className={shape}>{body}</div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => onNavigate(path)}
+          className={cn(shape, 'rounded-md hover:bg-secondary/50')}
+        >
+          {body}
+        </button>
       )}
-    >
-      {body}
-    </button>
+    </li>
   );
 }
 

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -616,6 +616,14 @@ describe('the workspace as a way into the system', () => {
       {
         appId,
         componentId,
+        attemptKind: 'build',
+        buildId: build!.id,
+        eventType: 'status',
+        phase: 'SUCCEEDED',
+      },
+      {
+        appId,
+        componentId,
         attemptKind: 'deploy',
         deployId: deploy!.id,
         eventType: 'status',
@@ -628,9 +636,21 @@ describe('the workspace as a way into the system', () => {
     if (!result.ok) return;
 
     const { workspace } = result.value;
+    // Two checkpoints, not three rows. Every log line an adapter emits lands in
+    // the same table, and reading it raw made the timeline the last twenty
+    // lines of whatever ran most recently — the transcript belongs on the
+    // attempt screen each entry links to, not on the workspace.
     expect(workspace.activity.length).toBe(2);
+    expect(workspace.activity.map((entry) => entry.title)).toEqual([
+      `Deploy ${deploy!.id} live`,
+      `Build ${build!.id} succeeded`,
+    ]);
     for (const entry of workspace.activity) {
       expect(entry.deployId ?? entry.buildId).not.toBeNull();
+      // The stage a checkpoint belongs to is on the entry: Build and Deploy are
+      // two stages, and a timeline that could not say which one a red row came
+      // from cannot say whether the image or its placement is the problem.
+      expect(entry.kind).toBe(entry.deployId === null ? 'build' : 'deploy');
       // The clock is frozen at the same instant the rows were written, so the
       // relative time is a real one rather than a "recently" placeholder.
       expect(entry.when).not.toBe('recently');
@@ -992,6 +1012,147 @@ describe('getDeployDetail command', () => {
     // And nothing was manufactured from it: `null` is what the deploy-log card
     // reads to render its own LIVE_STATUS notice.
     expect(deploy.deployLog).toBeNull();
+  });
+
+  test('blames the deploy, not the build, when the build produced an image', async () => {
+    // The pairing supply-chain admission produces: the runner pushed an image
+    // and the artifact was refused, so the Build row is FAILED while the Deploy
+    // over it went red for a reason of its own. Reading the Build first meant
+    // that reason lost, and the screen said "Build failed" about a build that
+    // had already done its job.
+    const ctx = context();
+    const { componentId, target } = await scaffold(ctx, {
+      prefix: 'misblamed',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'ddd4444',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'d'.repeat(64)}`,
+        status: 'FAILED',
+        runner: 'hosted runner',
+      })
+      .returning();
+
+    const [failed] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'FAILED',
+        reason: 'ARTIFACT_UNAVAILABLE',
+        blame: 'platform',
+        detail: "the cluster can't pull the image",
+      })
+      .returning();
+
+    const result = await getDeployDetail({ id: failed!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.deploy.phaseWord).toBe('Deploy failed');
+  });
+
+  test('still says Build failed when nothing after the build spoke', async () => {
+    // The other side of the same rule. A Deploy that recorded no reason of its
+    // own never got an answer from the platform, and the Build row is the only
+    // thing that knows anything.
+    const ctx = context();
+    const { componentId, target } = await scaffold(ctx, { prefix: 'redbuild' });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'eee5555',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'FAILED',
+        runner: 'hosted runner',
+      })
+      .returning();
+
+    const [failed] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'FAILED',
+      })
+      .returning();
+
+    const result = await getDeployDetail({ id: failed!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.deploy.phaseWord).toBe('Build failed');
+  });
+
+  test('folds a step’s events into one checkpoint with a duration', async () => {
+    // A route reports `RUNNING` and then a verdict for the same step name, with
+    // log lines under it in between. Projecting each row as its own checklist
+    // line marked everything done because it had been mentioned; folding by
+    // name is what makes the list say what each step is *doing*, and gives it
+    // the duration a reader scans the column for.
+    const ctx = context();
+    const { componentId, appId, target } = await scaffold(ctx, {
+      prefix: 'folded',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'fff6666',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'f'.repeat(64)}`,
+        status: 'FAILED',
+        runner: 'hosted runner',
+      })
+      .returning();
+
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'FAILED',
+      })
+      .returning();
+
+    const at = (offsetSeconds: number) =>
+      new Date(FROZEN.getTime() + offsetSeconds * 1000);
+    const step = (phase: string, seconds: number, reason?: 'BUILD_FAILED') => ({
+      appId,
+      componentId,
+      attemptKind: 'build' as const,
+      buildId: build!.id,
+      eventType: 'status' as const,
+      resource: 'build / run build',
+      phase,
+      ...(reason ? { reason } : {}),
+      createdAt: at(seconds),
+    });
+
+    await ctx.db
+      .insert(attemptEvents)
+      .values([step('RUNNING', 0), step('FAILED', 3, 'BUILD_FAILED')]);
+
+    const result = await getDeployDetail({ id: deploy!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.deploy.build?.steps).toEqual([
+      { name: 'build / run build', status: 'failed', detail: '3.0s' },
+    ]);
   });
 });
 

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -108,6 +108,11 @@ const BUILT = {
   fidelity: 'LIVE_TEXT',
   steps: BUILD_STEPS_OK,
   log: LOG_OK,
+  // A real build prints far more than the tail the drawer carries, and the
+  // fixture says so — the "showing the last N of M" sentence only appears when
+  // the two numbers disagree, so a fixture where they agreed would never
+  // exercise it.
+  logTotal: 812,
   runner: 'hosted runner',
   runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
 } as const;
@@ -153,6 +158,7 @@ export const DEPLOY_SCENARIOS = {
         { name: 'push registry', status: 'waiting' },
       ],
       log: null,
+      logTotal: 0,
       runner: 'hosted runner',
       runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
     },
@@ -200,6 +206,10 @@ export const DEPLOY_SCENARIOS = {
         { text: '#9 > 14 |   return <Hello name={viewer.sesion.name} />;' },
         { text: '#9 ERROR: exited with code 1', tone: 'error' },
       ],
+      // The whole of it: a build that failed in eight lines has no tail to cut,
+      // and this is the scenario that proves the sentence stays away when
+      // nothing was left behind.
+      logTotal: 8,
       runner: 'hosted runner',
       runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
     },
@@ -388,6 +398,7 @@ export const WORKSPACE_SCENARIOS = {
     ],
     activity: [
       {
+        kind: 'deploy',
         title: 'Deploy 42 live',
         detail: 'Artifact reconciled on Metal; all resources healthy.',
         when: '8m ago',
@@ -396,6 +407,7 @@ export const WORKSPACE_SCENARIOS = {
         buildId: null,
       },
       {
+        kind: 'build',
         title: 'Build passed',
         detail: 'main · 7f3d2c1 · hosted runner',
         when: '9m ago',
@@ -404,6 +416,7 @@ export const WORKSPACE_SCENARIOS = {
         buildId: 41,
       },
       {
+        kind: 'deploy',
         title: 'Deploy 40 failed',
         detail: 'STARTUP_FAILED · developer · DATABASE_URL missing',
         when: '1d ago',
@@ -484,6 +497,7 @@ export const WORKSPACE_SCENARIOS = {
     datastores: [],
     activity: [
       {
+        kind: 'deploy',
         title: 'Deploy 17 live',
         detail: 'Files released to static hosting.',
         when: '2h ago',
@@ -492,6 +506,7 @@ export const WORKSPACE_SCENARIOS = {
         buildId: null,
       },
       {
+        kind: 'build',
         title: 'Build passed',
         detail: 'main · 91dc4ab · hosted runner',
         when: '2h ago',
@@ -553,6 +568,7 @@ export const WORKSPACE_SCENARIOS = {
     ],
     activity: [
       {
+        kind: 'deploy',
         title: 'Execution 118 passed',
         detail: '02:14 · 1,284 objects copied',
         when: '8m ago',
@@ -561,6 +577,7 @@ export const WORKSPACE_SCENARIOS = {
         buildId: null,
       },
       {
+        kind: 'deploy',
         title: 'Execution 116 failed',
         detail: 'exit 1 · bucket unavailable',
         when: '1d ago',

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -33,6 +33,21 @@ const deploy = (view: DeployView) =>
 const workspace = (view: WorkspaceView) =>
   renderToStaticMarkup(<Workspace view={view} />);
 
+/**
+ * The rendered words, with the tags taken out.
+ *
+ * A stage header is assembled from several spans — an ordinal, a glyph, a name,
+ * a verdict — so a claim about the sentence it reads as cannot be made against
+ * raw markup without pinning the element boundaries, which is testing the
+ * layout rather than the sentence. Collapsing to text asserts what a person
+ * sees and survives the next time the header is restyled.
+ */
+const words = (markup: string) =>
+  markup
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&#x27;/g, "'")
+    .replace(/\s+/g, ' ');
+
 const RED = Object.entries(DEPLOY_SCENARIOS).filter(
   ([, view]) => view.phase === 'FAILED',
 );
@@ -246,8 +261,35 @@ describe('the deploy screen, on red', () => {
     expect(markup).toContain('ARTIFACT_UNAVAILABLE');
     expect(markup).toContain('platform');
     expect(markup).not.toContain('compiled successfully');
-    expect(markup).toContain('Deploy log · failed');
+    expect(words(markup)).toContain('Deploy · failed');
     expect(markup).toContain('controller accepted the deploy');
+  });
+
+  test('names the two stages separately and marks only the one that failed', () => {
+    // The whole point of the pair. An artifact that exists is deployable to any
+    // supported Target, so a red placement says nothing about the image — and
+    // the screen has to be able to hold both facts at once rather than
+    // collapsing them into one verdict about "the pipeline".
+    const view = DEPLOY_SCENARIOS.imageUnpullable;
+    const text = words(deploy(view));
+
+    expect(text).toContain('1 Build · done');
+    expect(text).toContain('2 Deploy · failed');
+  });
+
+  test('shows the deploy stage even when the Build row is red', () => {
+    // Supply-chain admission produces exactly this pairing: the runner pushed
+    // an image, the artifact was refused, and the Deploy over it went red on
+    // its own. Gating the deploy stage on a green build hid the log on the one
+    // screen that needed it and left a build log claiming the whole failure.
+    const view: DeployView = {
+      ...DEPLOY_SCENARIOS.imageUnpullable,
+      build: { ...DEPLOY_SCENARIOS.buildFailed.build, status: 'failed' },
+    };
+    const text = words(deploy(view));
+
+    expect(text).toContain('2 Deploy · failed');
+    expect(deploy(view)).toContain('controller accepted the deploy');
   });
 
   test('but not when nothing is serving', () => {
@@ -293,6 +335,47 @@ describe('a red deploy that recorded nothing', () => {
   test('says the deploy log is live status rather than inventing a line', () => {
     expect(markup).toContain('no text line has arrived yet');
     expect(markup).not.toContain('{}');
+  });
+});
+
+describe('the build stage, on the transcript it carries', () => {
+  // The drawer is the checkpoints. The runner's text is evidence behind one
+  // more click, and only ever the tail of it — a drawer that opened onto a
+  // thousand lines of BuildKit chatter buried the seven that said what
+  // happened.
+  test('leads with checkpoints rather than the runner output', () => {
+    const text = words(deploy(DEPLOY_SCENARIOS.buildFailed));
+
+    for (const step of DEPLOY_SCENARIOS.buildFailed.build.steps) {
+      expect(text).toContain(step.name);
+    }
+  });
+
+  test('opens the runner output on red, where the last lines are the answer', () => {
+    expect(deploy(DEPLOY_SCENARIOS.buildFailed)).toContain(
+      'Failed to compile.',
+    );
+  });
+
+  test('says how much of the log it is showing, and how much it is not', () => {
+    // A tail presented as the log is the UI editing evidence. `imageUnpullable`
+    // is the green build, whose drawer is shut — so the claim is made on the
+    // red one, where the reader is actually looking.
+    const clipped: DeployView = {
+      ...DEPLOY_SCENARIOS.buildFailed,
+      build: { ...DEPLOY_SCENARIOS.buildFailed.build, logTotal: 812 },
+    };
+    const text = words(deploy(clipped));
+
+    expect(text).toContain('last 8 of 812 lines');
+    expect(text).toContain('the full transcript stays on the runner');
+  });
+
+  test('claims no tail when it is showing the whole thing', () => {
+    const text = words(deploy(DEPLOY_SCENARIOS.buildFailed));
+
+    expect(text).toContain('8 lines');
+    expect(text).not.toContain('the full transcript stays on the runner');
   });
 });
 
@@ -373,7 +456,7 @@ describe('a release that was extracted rather than built', () => {
   test('says no builder was involved instead of showing an empty log', () => {
     expect(markup).toContain('NO BUILD');
     expect(markup).toContain('No builder was involved');
-    expect(markup).not.toContain('Build log');
+    expect(words(markup)).not.toContain('1 Build ·');
   });
 
   test('leads with the source, which every release has', () => {
@@ -419,7 +502,7 @@ describe('an attempt that is only a Build', () => {
   test('shows no deploy log, because nothing was applied', () => {
     // §6 gives the deploy leg its own drawer. There is no deploy leg here, and
     // rendering an empty one would say the platform was asked and said nothing.
-    expect(markup).not.toContain('Deploy log');
+    expect(words(markup)).not.toContain('2 Deploy ·');
   });
 });
 
@@ -568,6 +651,30 @@ describe('the App workspace', () => {
     // that exists but is not attached still exists.
     const markup = workspace(WORKSPACE_SCENARIOS.service);
     expect(markup).toContain('unattached');
+  });
+
+  describe('the timeline', () => {
+    const view = WORKSPACE_SCENARIOS.service;
+    const markup = workspace(view);
+
+    test('is a sequence, joined by a rule its markers sit on', () => {
+      // Stacked rows said these were unrelated events that happened to be near
+      // each other. The connector is what carries the reading down the column,
+      // and it is the difference between a list and a timeline.
+      expect(markup).toContain('Timeline');
+      expect(markup).toContain('<ol');
+    });
+
+    test('says which stage every checkpoint belongs to', () => {
+      // A column of red cannot say whether the image or its placement is the
+      // problem unless each row carries its lane. Build and Deploy are two
+      // stages, and this is where that is easiest to lose.
+      const text = words(markup);
+      for (const entry of view.activity) {
+        expect(text).toContain(entry.kind);
+        expect(text).toContain(entry.title);
+      }
+    });
   });
 });
 


### PR DESCRIPTION
Three complaints, one root: the attempt screen treated the pipeline as one story about a build, so a failure anywhere read as a build failure, and every log line an adapter emitted got rendered somewhere.

## Build and Deploy are two stages

Both drawers render as numbered peers — same header, own glyph, own verdict — and the deploy stage is no longer gated on a green build.

That gate hid the deploy log on exactly the screen that needed it. Supply-chain admission (`dispatch.ts`) marks a Build `FAILED` with an image already pushed to the registry; a Deploy over it that then goes red for a reason of its own had nothing on screen but a build log, claiming the whole failure. `getDeployDetail` now reads the deploy's own `reason` **before** the Build row — a build is only the failure when nothing after it spoke.

`Deploy this build` keys on `artifactDigest` rather than the Build's status, so an artifact that exists stays placeable on any supported Target.

## The build drawer leads with checkpoints

`buildViewOf` folded each event into its own checklist line and marked it `done` because it had been mentioned. Step events are now folded by name — the latest state wins, and the pair of timestamps around it gives the step a duration. A name carried only by log lines (`dispatch`, `provenance`) keeps its sentence.

The runner's transcript moves behind a disclosure, capped to the last 60 lines, stating how many of how many it shows and pointing at `runUrl` for the rest. Shut on green, open on red.

## Recent activity becomes a Timeline

It read `attempt_events` raw, so it was the last twenty log lines of whatever ran most recently. It now selects status events — the checkpoints — and renders them as a connected sequence with the stage on each row.

## Checks

- `bun run typecheck` clean
- `bun test` — 1262 pass, 0 fail (against a local Postgres)
- `bun run lint` — only a pre-existing warning in `test/config/`, untouched here
- `bun run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)