### PR TITLE
fix(images): give the runner image libatomic1 so node can start

### DIFF
--- a/images/actions-runner/Dockerfile
+++ b/images/actions-runner/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get -qqy upgrade &&\
       curl \
       git \
       jq \
+      libatomic1 \
       unzip \
       wget \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
## What broke

Flipping `typescript.yml`'s `validate` job to `runs-on: offsite` fails at `bun install --frozen-lockfile` ([run 30770538235](https://github.com/jonpulsifer/infra/actions/runs/30770538235)):

```
node: error while loading shared libraries: libatomic.so.1: cannot open shared object file
error: postinstall script from "bun" exited with 127
```

`bun` is a real dependency in `bun.lock` (`bun@1.3.14`) and its postinstall shells out to node.

## Why it works on ubuntu-latest and not here

| Environment | `libatomic.so.1` | Why |
| --- | --- | --- |
| `ubuntu-latest` | present | GitHub's image preinstalls gcc/build-essential; `libatomic1` comes along with them |
| NixOS hosts | present at runtime | `nix-ld`, already enabled fleet-wide at `nix/system/nixos.nix:59`. `ldd` reports it missing, but `NIX_LD_LIBRARY_PATH` resolves it — this is the mise-shaped breakage nix-ld exists to absorb |
| this image | **absent** | slim Ubuntu base, no compilers, and no Nix for nix-ld to hook into |

The Dockerfile installs node via `n current`, which is Node **v26.5.1** today — and that binary links `libatomic`.

## Fix

One package in the apt list. `libatomic1`.

## Why ARC Smoke missed it

`arc-smoke.yml` proves the two things that were broken before: the runner reaches a Docker daemon, and a `services:` container answers on the job's own localhost. It never installs a toolchain, so nothing exercised node. Confirmed the smoke test itself is green on offsite ([run 30770492942](https://github.com/jonpulsifer/infra/actions/runs/30770492942)) — the dind path is fine, this was purely the image.

## Sequencing

This PR is the image fix alone. The digest CD in `containers.yml` only fires on push to `main`, so the runner switch cannot go green until the rebuilt image rolls:

1. merge this → `containers` builds and pushes `actions-runner`
2. CD opens `cd/update-actions-runner-digest` against `clusters/base/apps/arc/infra.yaml`
3. merge that → Flux rolls the scale sets
4. **then** flip `validate` to `runs-on: offsite` (one word)

`validate` is skipped on this PR because only `images/` changed, which is not in its `detect` path list.

## Follow-up, not in scope

`n current` is unpinned, so the node version moves on every image rebuild. That is how a working image can start failing with no Dockerfile change. Worth pinning separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)