### PR TITLE
fix(images): install node from the LTS line, and assert it starts

### DIFF
--- a/images/actions-runner/Dockerfile
+++ b/images/actions-runner/Dockerfile
@@ -8,8 +8,15 @@ RUN apt-get update && apt-get -qqy upgrade &&\
       libatomic1 \
       unzip \
       wget \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s current
+    && rm -rf /var/lib/apt/lists/*
+# Install node on the LTS line. `n current` tracked the newest release of all, so
+# the version moved on every rebuild with nothing asserting the result still ran.
+# `lts` still moves — it rolls to Node 26 in October — which is why libatomic1
+# above stays: Node 26 links it and this slim base does not carry it otherwise.
+# `node --version` is the assertion, so a node that cannot start fails the build
+# here rather than at `bun install` in CI.
+RUN curl -fsSL https://raw.githubusercontent.com/tj/n/master/bin/n | bash -s lts \
+    && node --version
 # Install kubectl
 RUN curl -fsSL "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl


### PR DESCRIPTION
Follow-up to #1592, which fixed the symptom. This fixes what let it happen.

## The actual root cause

The image installed node with `n current` — the newest release of all, **v26.5.1** today. Nothing pinned it and nothing checked it, so the node version moved on every rebuild. A green image could start failing with no Dockerfile change, and the failure surfaced at the far end of CI as `bun install` dying:

```
node: error while loading shared libraries: libatomic.so.1
```

## Change

`n current` → `n lts`, which resolves to **v24.18.1 (Krypton)** today.

`libatomic1` from #1592 **stays**. `lts` is still a moving target — it rolls to Node 26 when that line goes LTS in October — and Node 26 is precisely what links libatomic. Reverting it would just re-arm the same trap on a timer.

## The check the image never had

`node --version` now runs at build time. An image whose node cannot start fails the build here instead of in a consuming workflow.

`arc-smoke.yml` could never have caught this — it proves the runner reaches a Docker daemon and that a `services:` container answers on the job's localhost, and installs no toolchain. Verified it is green on offsite ([run 30770492942](https://github.com/jonpulsifer/infra/actions/runs/30770492942)); the dind path was always fine.

## Verified

- `n --lts` → `24.18.1`
- node 24.18.1 links `libc, libdl, libgcc_s, libm, libpthread, libstdc++` — no libatomic
- bun 1.3.14 links no libatomic either

## Still open

Moving `typescript.yml`'s `validate` to `runs-on: offsite`, which is what surfaced all this. `Test` is 196s of that job's ~300s, and offsite's `retrofit` is 8 cores to GitHub's 4. Blocked until this image rolls: merge here → `containers` builds → CD opens the digest bump against `clusters/base/apps/arc/infra.yaml` → Flux rolls the scale sets → then the `runs-on:` switch is one word.

Worth knowing when that happens: the runner pod declares no resource requests, so nothing keeps it off `oldschool` (4 cores). Flat numbers would point there first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)