### PR TITLE
fix(k8s): pull the runner image from ghcr, where CI actually pushes it

### DIFF
--- a/clusters/base/apps/arc/infra.yaml
+++ b/clusters/base/apps/arc/infra.yaml
@@ -41,6 +41,6 @@ spec:
       spec:
         containers:
           - name: runner
-            image: jonpulsifer/actions-runner:latest@sha256:7ce612cba1211d56ff4dd4051a60dd6059191df553ddd4255c84baed6bbd1012
+            image: ghcr.io/jonpulsifer/actions-runner:latest@sha256:d33ff525b16c24d58424c2884acf91aa7d422afa5e8fd5cf9c9c620b6129947f
             command: ["/home/runner/run.sh"]
 


### PR DESCRIPTION
#1592 and #1594 both built and pushed correctly, and **neither could ever reach the cluster**. Here is why.

## The bug

`containers.yml` pushes to `ghcr.io/jonpulsifer/actions-runner` (line 77). This manifest asked for:

```yaml
image: jonpulsifer/actions-runner:latest@sha256:...
```

No registry prefix — so containerd resolves it against **docker.io**. Different image. Nothing in CI has ever pushed to Docker Hub (no `docker.io` reference, no Hub credentials anywhere in `.github/workflows/`).

The selective-CD step in `containers.yml` only rewrites the digest:

```bash
sed -i -E "s|@sha256:[0-9a-f]{64}|@${DIGEST}|g" "$manifest"
```

It never touches the registry. So it has been stamping **GHCR digests onto a Docker Hub reference**.

## Evidence from the live clusters

Both clusters, after a full reconcile to `492a4a9e`:

```
spec     sha256:7ce612cba121
imageID  docker.io/jonpulsifer/actions-runner@sha256:1d998da13bb6
```

The pods never even converged on the pinned digest — they run a stale cached docker.io image. `kubectl exec` into the live runner on both `folly` and `offsite`:

```
node: error while loading shared libraries: libatomic.so.1
libatomic1 pkg:   (not installed)
libatomic files: 0
```

That is the *original* breakage, still present after both fixes merged.

## Registry convention across the repo

| Manifest | Ref | Registry |
| --- | --- | --- |
| `spindrift/helm-release.yaml` | `ghcr.io/jonpulsifer/spindrift` | GHCR ✅ |
| `hub/helm-release.yaml` | `ghcr.io/jonpulsifer/hub` | GHCR ✅ |
| `arc/infra.yaml` | `jonpulsifer/actions-runner` | Docker Hub ❌ |
| `iperf3/iperf3-daemonset.yaml` | `jonpulsifer/netbench` | Docker Hub ❌ |

## The digest

`d33ff525` is the image #1594 built and pushed (commit `7cb86012`, `n lts` → v24.18.1 with the `node --version` assertion passing in the build log).

Verified before pinning it:
- anonymous GHCR pull of that digest returns **HTTP 200**, so the package is public
- `hub` and `spindrift` already pull from GHCR with no `imagePullSecret`, and none is declared here — so none is needed

## Not fixed here

`iperf3-daemonset.yaml` has the identical missing prefix for `netbench`. Left alone deliberately — it deserves the same GHCR-existence check against its own package rather than a blind sweep. Happy to do it as a follow-up.

## Secondary bug worth a separate look

#1594's build was **cancelled** ([run 30771021223](https://github.com/jonpulsifer/infra/actions/runs/30771021223)) by `concurrency: containers-${{ github.ref }}` with `cancel-in-progress: true`, when #1595 merged right behind it. The cancel landed *after* `Build and push` succeeded but *before* `Update manifest digest`:

```
success    Build and push actions-runner
cancelled  Scan actions-runner image with Trivy
skipped    Update manifest digest for selective continuous delivery
```

So GHCR got the new image and the manifest never learned about it. Rapid merges to `main` can silently decouple the two. Cancelling in-progress runs on a *shared* ref like `main` is the root of that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)