### PR TITLE
fix(spindrift): build a Dockerfile against the bundle root, not the scope

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -157,10 +157,13 @@ jobs:
           printf 'root=%s\n' "$root" >> "$GITHUB_OUTPUT"
 
       # §5's ladder, and the only decision made here: a Dockerfile settles how
-      # to build and never what the thing is. Where there is none, the same
-      # directory is handed to the pinned zero-config frontend — which is what
-      # makes "one engine, two frontends" true rather than two build systems to
-      # operate (§4).
+      # to build and never what the thing is. Where there is none, the scope is
+      # handed to the pinned zero-config frontend — which is what makes "one
+      # engine, two frontends" true rather than two build systems to operate
+      # (§4).
+      #
+      # The two arms disagree about the context on purpose, and each arm says
+      # why below.
       #
       # The zero-config arm does **not** write a `#syntax=` stub. The railpack
       # frontend reads the file it is given as its *build plan*, so a stub comes
@@ -190,9 +193,21 @@ jobs:
           set -euo pipefail
           scope="${ROOT}/${SUBPATH}"
 
+          # The scope names the Dockerfile; the bundle root is what it builds.
+          # A monorepo App is one subpath of a tree it shares a lockfile,
+          # workspace and sibling packages with, and its Dockerfile is written
+          # against the root that `docker build -f apps/x/Dockerfile .` gives
+          # it — `COPY . .` then a path *into* the app. Handing that file the
+          # subpath as its context is the one arrangement under which every
+          # such Dockerfile fails, and fails deep inside the build with a
+          # missing directory rather than here with a reason.
+          #
+          # Only this arm. The zero-config arm below keeps the scope, because
+          # railpack detects a single app and a plan built against the root
+          # would describe the wrong one.
           if [ -f "${scope}/Dockerfile" ]; then
             {
-              printf 'context=%s\n' "$scope"
+              printf 'context=%s\n' "$ROOT"
               printf 'file=%s\n' "${scope}/Dockerfile"
               printf 'buildArgs=\n'
             } >> "$GITHUB_OUTPUT"

--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -148,7 +148,7 @@ function zeroConfigArm(input: BuildKitProgramInput): string {
   chmod +x "$bin/railpack"
   "$bin"/railpack prepare . --plan-out "$plan/railpack-plan.json"
   set -- --frontend gateway.v0 --opt source=${frontend} \\
-    --local dockerfile="$plan"`;
+    --local dockerfile="$plan" --local context=.`;
 }
 
 /**
@@ -191,14 +191,27 @@ cd "$root"/${quote(input.subpath)}
 # local — that is the mount name the frontend reads, and \`railpack-plan.json\`
 # is the filename it defaults to. It is not a Dockerfile and it carries no
 # syntax directive: the frontend parses this file as JSON.
+#
+# The two arms carry their own \`context\` local rather than sharing one below,
+# because they do not agree on it and the disagreement is the point.
+#
+# The scope names the Dockerfile; the bundle root is what it builds. A monorepo
+# App is one subpath of a tree it shares a lockfile, workspace and sibling
+# packages with, and its Dockerfile is written against the root that
+# \`docker build -f apps/x/Dockerfile .\` gives it — \`COPY . .\` then a path
+# *into* the app. Handing that file the subpath as its context is the one
+# arrangement under which every such Dockerfile fails, and fails deep inside
+# the build with a missing directory rather than here with a reason.
+#
+# The zero-config arm keeps the scope, because railpack detects a single app
+# and a plan built against the root would describe the wrong one.
 if [ -f Dockerfile ]; then
-  set -- --frontend dockerfile.v0 --local dockerfile=.
+  set -- --frontend dockerfile.v0 --local dockerfile=. --local context="$root"
 else
 ${zeroConfigArm(input)}
 fi
 
 buildctl-daemonless.sh build "$@" \\
-  --local context=. \\
 ${args}
   --attest=type=provenance,mode=max \\
   --attest=type=sbom \\

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -906,6 +906,21 @@ describe('the BuildKit program', () => {
     expect(program).toContain(`--opt source='${FRONTEND}'`);
   });
 
+  test('builds a Dockerfile against the bundle root, not the scope', () => {
+    // The scope names the Dockerfile; the root is what it builds. A monorepo
+    // App shares a lockfile and sibling packages with the tree above it, and
+    // its Dockerfile is written against the root `docker build -f
+    // apps/web/Dockerfile .` gives it — `COPY . .` then a path *into* the app.
+    // Handed the scope, every such Dockerfile fails deep inside the build on a
+    // missing directory instead of here with a reason.
+    expect(program).toContain(
+      '--frontend dockerfile.v0 --local dockerfile=. --local context="$root"',
+    );
+    // And the two arms disagree on purpose, so neither may share one context
+    // local on the `buildctl` line below them.
+    expect(program).not.toContain('build "$@" \\\n  --local context=.');
+  });
+
   test('hands the zero-config frontend a plan, never a `#syntax=` stub', () => {
     // The railpack frontend reads its input as a build plan: a stub comes back
     // as `invalid character '#' looking for beginning of value`, at every


### PR DESCRIPTION
## What broke

Dispatching a build for `apps/spindrift-demo` fails inside the container build, not at the step that made the decision:

```
#20 [builder 3/3] RUN cd apps/spindrift-demo && … bun run build.ts
#20 0.062 /bin/sh: cd: line 0: can't cd to apps/spindrift-demo: No such file or directory
```

([run 30771465039](https://github.com/jonpulsifer/infra/actions/runs/30771465039))

`Choose the frontend` sets `context = ${ROOT}/${SUBPATH}` — the App's own directory. But a monorepo App is one subpath of a tree it shares a lockfile, a workspace and sibling packages with, and its Dockerfile is written against the root that `docker build -f apps/x/Dockerfile .` gives it: `COPY . .` and then a path *into* the app.

It is not a narrow case. Every image this repo builds declares the same thing:

| `build.json` | context | file |
| --- | --- | --- |
| slingshot, spindrift, spindrift-demo, agent-web, hub | `.` | `apps/*/Dockerfile` |

5/5 — so connecting any App here to Spindrift reproduces it.

## What changed

The Dockerfile arm builds against the bundle root and names the Dockerfile at the scope. Both routes, so they cannot disagree about the same source:

| | context | dockerfile |
| --- | --- | --- |
| `spindrift-build.yml`, Dockerfile arm | `$ROOT` | `$scope/Dockerfile` |
| `buildkit.ts`, Dockerfile arm | `$root` | `.` |
| both, zero-config arm | scope, unchanged | generated plan |

The zero-config arm keeps the scope: `railpack prepare` detects a single app from the directory it is given, and a plan built against the root would describe the wrong one. So the two arms now carry their own `context` local instead of sharing one on the `buildctl` line, and each says why.

One test covers the arm and the fact that the shared local is gone.

## Not in scope

- **A configurable context.** `spindrift.yaml`'s `build` union already carries `frontend: dockerfile, file: <path>`, but that field is dead — it stops at `DetectionProposal` and never reaches a `BuildRequest`, because both builders re-run the ladder themselves with `[ -f Dockerfile ]`. A `context` knob means threading detection → app row → build spec → two builders → a migration, and would want `file` fixed in the same pass. Today no App wants the non-root context.
- **The `create_credentials_file` warning** on the Google auth step. It is cosmetic — it fires, then writes `gha-creds-*.json`, and gcloud and cosign use it. Silencing it with `actions/checkout` would clone a second tree at the default branch, which is what "the bundle, not the repository" exists to prevent.

## Verification

`bun test test/adapters/build-routes.test.ts` → 52 pass. Biome clean, workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)