### PR TITLE
feat(spindrift): give the Apps their own gateway

### DIFF
--- a/clusters/offsite/apps/oauth2-proxy/helm-release-patch.yaml
+++ b/clusters/offsite/apps/oauth2-proxy/helm-release-patch.yaml
@@ -7,9 +7,15 @@ spec:
   values:
     extraArgs:
       redirect-url: https://oauth2.${SPINDRIFT_DOMAIN}/oauth2/callback
-      # No cookie-domain: the session cookie is host-only, for whatever
-      # x-forwarded-host the filter passed. A zone-wide cookie would be sent to
-      # an `auth: none` App on this same zone — handing the token that unlocks
-      # every authenticated App to the one workload deliberately exposed.
+      # The session cookie is host-only, for whatever x-forwarded-host the
+      # filter passed. A zone-wide cookie would be sent to an `auth: none` App
+      # on this same zone — handing the token that unlocks every authenticated
+      # App to the one workload deliberately exposed.
+      #
+      # Explicitly null rather than absent. `extraArgs` is a map, so a strategic
+      # merge that simply omits the key merges the base's value straight through:
+      # this overlay read as "no cookie-domain" and shipped `.${SECRET_DOMAIN}`,
+      # the *other* cluster's apex, on every session cookie offsite issued.
+      cookie-domain: null
       # whitelist-domain still permits the return trip after sign-in.
       whitelist-domain: .${SPINDRIFT_DOMAIN}

--- a/clusters/offsite/apps/oauth2-proxy/httproute.yaml
+++ b/clusters/offsite/apps/oauth2-proxy/httproute.yaml
@@ -1,16 +1,27 @@
 ---
+# The authenticated edge, on the same gateway and the same wildcard listener as
+# the Apps it stands in front of.
+#
+# No `sectionName`: the route has to attach to **both** listeners. The tunnel
+# reaches this gateway over plain HTTP, and `oauth2.${SPINDRIFT_DOMAIN}` also
+# resolves straight to the gateway's own address for anything already on the
+# operator's network — pinning the route to one listener leaves the other
+# answering 404 to a redirect the filter has just issued.
+#
+# The name publishes like any other in this zone: external-dns reads this route
+# and writes an A record to the gateway, unproxied. That is the same boundary
+# `reach: private` rests on — an RFC1918 address is not reachable from the
+# internet whatever is or is not attached to it — so there is nothing here to
+# hold back from DNS.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
   name: oauth2-proxy
   namespace: oauth2-proxy
-  annotations:
-    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   parentRefs:
-    - name: cluster-gateway
-      namespace: default
-      sectionName: http-gateway
+    - name: spindrift-apps
+      namespace: spindrift-apps
   hostnames:
     - "oauth2.${SPINDRIFT_DOMAIN}"
   rules:

--- a/clusters/offsite/apps/spindrift/gateway.yaml
+++ b/clusters/offsite/apps/spindrift/gateway.yaml
@@ -1,0 +1,88 @@
+---
+# The edge Spindrift's Apps are served on, separate from `cluster-gateway` and
+# from the control plane's own `spindrift-gateway`.
+#
+# Its own Gateway rather than a listener on a shared one. App traffic is
+# developer-controlled and arrives from the internet through the tunnel, so it
+# gets its own Envoy listener set and its own load-balancer address: an App
+# cannot crowd the media stack's edge, and it cannot crowd the operator UI that
+# is supposed to still answer when an App is melting down.
+#
+# It lives in `spindrift-apps`, beside the workloads it serves. That costs
+# nothing the App chart's NetworkPolicy was buying: same-namespace siblings are
+# already an unconditional exception there, because a release's own pods are the
+# one caller that cannot be named ahead of time.
+#
+# It is a vessel resource all the same — the App chart renders a route and
+# nothing else, so no release owns the gateway, the certificate, or the address,
+# and a `destroy()` cannot take them with it.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: spindrift-apps
+  namespace: spindrift-apps
+  annotations:
+    cert-manager.io/cluster-issuer: ${CERT_CLUSTER_ISSUER}
+spec:
+  gatewayClassName: cilium
+  # Pinned, because the Target's `platform.dns.privateAddress` is the literal
+  # address every `reach: private` App publishes an A record to. An address the
+  # pool reassigns on a rebuild would silently point a whole zone at nothing.
+  #
+  # If the implementation will not honour the request it is required to report
+  # `Programmed=False` with reason `AddressNotAssigned` and assign nothing —
+  # so this fails as a gateway that does not come up, which is visible, rather
+  # than as a zone pointed at an address serving somebody else.
+  addresses:
+    - type: IPAddress
+      value: 10.89.0.69
+  listeners:
+    # The tunnel's origin, and so the only leg `reach: public` travels. Plain
+    # HTTP is correct here: the leg is inside the cluster and Cloudflare
+    # terminates TLS at the edge.
+    - name: http-gateway
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - spindrift-apps
+                  - oauth2-proxy
+        kinds:
+          - kind: HTTPRoute
+    # One wildcard for every App name Spindrift mints, rather than a listener
+    # per App: the App chart renders a route and nothing else, so there is no
+    # release that could own a listener or a certificate. cert-manager's
+    # gateway-shim issues it by DNS-01 from the annotation at the top of this
+    # Gateway. A wildcard binds exactly one label, which is why App names are
+    # flat — `plainboi-web` is covered, `web.plainboi` is not.
+    #
+    # `oauth2-proxy` is admitted alongside the Apps because the authenticated
+    # edge answers on a name in this same zone. A `reach: private` App's record
+    # points here, and the sign-in it redirects to has to be served by the same
+    # listener or the redirect lands on a 404.
+    - name: spindrift-apps-tls
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${SPINDRIFT_DOMAIN}"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: wildcard-${SPINDRIFT_DOMAIN}
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - spindrift-apps
+                  - oauth2-proxy
+        kinds:
+          - kind: HTTPRoute

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -143,26 +143,29 @@ spec:
             # cluster. Spindrift never renders into it.
             chartValues:
               platform:
-                # The gateway the tunnel already forwards to, which already
-                # admits routes from spindrift-apps.
+                # The Apps' own gateway (`gateway.yaml`), not the cluster's
+                # shared one: the tunnel forwards this zone to it and it carries
+                # the wildcard listener every minted name is served on.
                 gateway:
-                  name: cluster-gateway
-                  namespace: default
+                  name: spindrift-apps
+                  namespace: spindrift-apps
                 externalAuth:
                   name: oauth2-proxy
                   namespace: oauth2-proxy
                   port: 80
                 dns:
-                  # The gateway's LoadBalancer address. RFC1918, so publishing
-                  # it is the private boundary rather than a hole in one.
-                  privateAddress: 10.89.0.67
+                  # That gateway's pinned LoadBalancer address. RFC1918, so
+                  # publishing it is the private boundary rather than a hole in
+                  # one.
+                  privateAddress: 10.89.0.69
                   tunnelHostname: 9d53c07a-8bde-4466-9f99-3a69d06a6325.cfargotunnel.com
                 networkPolicy:
                   # The chart's ingress is default-deny for every Component, so
                   # a correctly attached route still reaches nothing until the
-                  # gateway's namespace is named here.
+                  # caller's namespace is named here. The gateway's own
+                  # namespace is not in the list because it is `spindrift-apps`
+                  # itself, which the chart always admits as a sibling.
                   allowedNamespaces:
-                    - default
                     - oauth2-proxy
         - name: bluenose-cloudrun
           adapter: cloudrun

--- a/clusters/offsite/apps/spindrift/kustomization.yaml
+++ b/clusters/offsite/apps/spindrift/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - gateway.yaml
   - secret.sops.yaml
   - helm-release.yaml
   - target-rbac.yaml

--- a/clusters/offsite/networking/gateway-api/cluster-gateway.yaml
+++ b/clusters/offsite/networking/gateway-api/cluster-gateway.yaml
@@ -20,8 +20,6 @@ spec:
                 operator: In
                 values:
                   - agents-sandbox
-                  - oauth2-proxy
-                  - spindrift-apps
         kinds:
           - kind: HTTPRoute
     - name: dave-tls
@@ -80,25 +78,3 @@ spec:
         certificateRefs:
           - kind: Secret
             name: *hostname
-    # One wildcard for every App name Spindrift mints, rather than a listener
-    # per App: the App chart renders a route and nothing else, so there is no
-    # release that could own a listener or a certificate. cert-manager's
-    # gateway-shim issues it by DNS-01 from the annotation at the top of this
-    # Gateway. A wildcard binds exactly one label, which is why App names are
-    # flat — `plainboi-web` is covered, `web.plainboi` is not.
-    - name: spindrift-apps-tls
-      protocol: HTTPS
-      port: 443
-      hostname: "*.${SPINDRIFT_DOMAIN}"
-      tls:
-        certificateRefs:
-          - kind: Secret
-            name: wildcard-${SPINDRIFT_DOMAIN}
-      allowedRoutes:
-        namespaces:
-          from: Selector
-          selector:
-            matchLabels:
-              kubernetes.io/metadata.name: spindrift-apps
-        kinds:
-          - kind: HTTPRoute

--- a/terraform/network/cloudflare/spindrift.tf
+++ b/terraform/network/cloudflare/spindrift.tf
@@ -1,6 +1,7 @@
-# Spindrift's generated App names resolve only through this tunnel. The origin
-# is the offsite cluster's internal Gateway service, so no public DNS record
-# exposes its load-balancer address as an alternate path.
+# How a `reach: public` App name arrives at the cluster. The origin is the
+# Apps' own Gateway service, not the cluster's shared one: App traffic gets its
+# own Envoy listener set and its own load-balancer address, so a public App
+# cannot crowd the edge the media stack or the operator UI answer on.
 module "tunnel_spindrift" {
   source     = "./modules/tunnel"
   account_id = local.fml_account_id
@@ -10,7 +11,7 @@ module "tunnel_spindrift" {
     ingress = [
       {
         hostname = "*.${cloudflare_zone.lolwtf_dev.name}"
-        service  = "http://cilium-gateway-cluster-gateway.default.svc.cluster.local"
+        service  = "http://cilium-gateway-spindrift-apps.spindrift-apps.svc.cluster.local"
       },
       {
         service = "http_status:404"


### PR DESCRIPTION
The App zone was a listener bolted onto `cluster-gateway`, the media stack's edge in `default`. Its address is what every `reach: private` App publishes an A record to, so a zone's worth of developer-controlled traffic landed on the same Envoy the operator UI and the media stack answer on. It gets its own Gateway, its own listener set, and its own pinned address.

It goes in `spindrift-apps`, beside the workloads. That costs nothing the App chart's NetworkPolicy was buying: same-namespace siblings are already an unconditional exception there, so naming that namespace in `allowedNamespaces` would have been a no-op. The list drops to `oauth2-proxy` alone.

## Two live breakages go with it

Both were caused by #1602 opening the zone, and both were found by verifying that PR against offsite rather than reading it.

**`oauth2.lolwtf.dev` has been answering 404.** Adding `lolwtf.dev` to external-dns' domain filter did exactly what it was meant to, and also published a record nobody planned for:

```
time="2026-08-02T23:54:08Z" level=info msg="Changing record." action=CREATE record=oauth2.lolwtf.dev ttl=1 type=A zone=0c35b6bf…
```

The name stopped travelling through the tunnel and started arriving on the wildcard TLS listener, where `sectionName: http-gateway` meant the route could not serve it:

```
$ curl -sS -o /dev/null -w 'ip=%{remote_ip} http=%{http_code}\n' https://oauth2.lolwtf.dev/oauth2/start
ip=10.89.0.67 http=404
```

The `external-dns.alpha.kubernetes.io/exclude: "true"` that was supposed to prevent the record **is not an external-dns annotation** and never did anything — the record simply could not exist while the zone was outside the domain filter. Publishing it is correct under `reach: private`, so the fix is the route attaching to both listeners rather than the record going away.

**The session cookie was never host-only.** The overlay says so in a comment and does not do it:

```
$ kubectl --context offsite get deploy oauth2-proxy -n oauth2-proxy -o json \
    | jq -r '.spec.template.spec.containers[].args[]' | grep cookie-domain
--cookie-domain=.lolwtf.ca
```

`extraArgs` is a map, so an overlay that omits the key merges the base's value straight through. offsite has been stamping **folly's apex** onto every session cookie it issues. `cookie-domain: null` deletes it; the render confirms the key is gone rather than overridden.

## Check first after merge

The gateway's address is pinned because `platform.dns.privateAddress` is a literal an entire zone points at. **Cilium's static-address support could not be probed from here** — the operator image is distroless, no shell. Gateway API requires an implementation that will not honour the request to report `Programmed=False`/`AddressNotAssigned` and assign nothing, so the failure mode is a gateway that does not come up rather than a zone aimed at a stranger, but it wants confirming:

```
kubectl --context offsite get gateway spindrift-apps -n spindrift-apps \
  -o jsonpath='{.status.addresses[*].value} {range .status.conditions[*]}{.type}={.status} {end}'
```

## Notes

- The tunnel origin moves, so this needs an Atlantis apply alongside the Flux reconcile.
- `plainboi-web`'s HelmRelease is wedged on pre-#1602 values and this PR does not touch it. The reconciler writes values on deploy rather than on every pass, so it has not self-healed in 21 hours and will not; a redeploy rewrites it.
- Tracked privately as ticket 49; unblocks the live observation 45 and 47 are waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)