### PR TITLE
feat(spindrift): configure the cloud build route, and let an App pick it

### DIFF
--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -546,7 +546,7 @@ function googleRegistryHosts(destinations: readonly string[]): string[] {
 }
 
 /**
- * The Docker config the build step writes for itself before it builds.
+ * The registry credential the build step mints for itself before it builds.
  *
  * The shared program exports with `push=true` and BuildKit reads its registry
  * credentials from a Docker config — so without this the build runs to
@@ -556,17 +556,26 @@ function googleRegistryHosts(destinations: readonly string[]): string[] {
  * and the in-cluster one runs as a service account the registry already
  * trusts.
  *
- * Written by the step and not passed to it. A credential composed here would
+ * Minted by the step and not passed to it. A credential composed here would
  * be a credential in a submitted build body, readable by anyone who can read
  * the build — and it would be minted at submit time and expire mid-queue.
+ *
+ * **It folds into {@link REGISTRY_AUTH_VAR} rather than writing a Docker config
+ * of its own**, and that is the load-bearing part. This installation pushes to
+ * several registries (§16, `BuildSpec.destinations`), and the two halves of
+ * that push authorize differently: the metadata token covers the vendor's own
+ * registries and a *stored* credential covers the ones no federation reaches.
+ * A prelude that wrote `$DOCKER_CONFIG/config.json` itself was overwritten a
+ * few lines later by the shared program, which does `DOCKER_CONFIG=$(mktemp
+ * -d)` whenever the variable is set — so an installation holding a stored
+ * credential silently lost the vendor half and 401'd on the artifact registry
+ * at the export, after the whole build. One writer, one document, both halves.
  */
 function registryAuth(destinations: readonly string[]): string {
   const hosts = googleRegistryHosts(destinations);
   if (hosts.length === 0) return '';
 
   return `set -eu
-DOCKER_CONFIG=$(mktemp -d)
-export DOCKER_CONFIG
 token=$(wget -qO- --header 'Metadata-Flavor: Google' ${quote(METADATA_TOKEN_URL)} \\
   | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\\([^"]*\\)".*/\\1/p')
 # A token that never arrived becomes an empty password and a \`401\` at the
@@ -575,14 +584,20 @@ token=$(wget -qO- --header 'Metadata-Flavor: Google' ${quote(METADATA_TOKEN_URL)
 # Folded \`base64\` output is a header the registry cannot parse, and whether it
 # folds is an implementation detail of whichever one the image ships.
 auth=$(printf 'oauth2accesstoken:%s' "$token" | base64 | tr -d '\\n')
-printf '{"auths":{' > "$DOCKER_CONFIG/config.json"
-separator=""
+entries=""
 for host in ${hosts.map(quote).join(' ')}; do
-  printf '%s"%s":{"auth":"%s"}' "$separator" "$host" "$auth" \\
-    >> "$DOCKER_CONFIG/config.json"
-  separator=","
+  entries="\${entries:+\${entries},}\\"\${host}\\":{\\"auth\\":\\"\${auth}\\"}"
 done
-printf '}}' >> "$DOCKER_CONFIG/config.json"
+# Whatever the route already handed over is kept, because it covers the hosts
+# this token cannot. Spliced rather than parsed: the document on the way in is
+# \`dockerConfigFor\`'s own \`JSON.stringify\` output, so its outer shape is
+# exactly \`{"auths":{…}}\` and there is no jq in a BuildKit image to do better.
+if [ -n "\${${REGISTRY_AUTH_VAR}:-}" ]; then
+  stored=$(printf '%s' "$${REGISTRY_AUTH_VAR}" | sed -e 's/^{"auths":{//' -e 's/}}$//')
+  [ -z "$stored" ] || entries="\${entries},\${stored}"
+fi
+${REGISTRY_AUTH_VAR}="{\\"auths\\":{\${entries}}}"
+export ${REGISTRY_AUTH_VAR}
 
 `;
 }

--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -37,6 +37,7 @@
  *     Target will admit.
  */
 
+import type { RegistryFlavour } from '../../domain/artifact-name.ts';
 import {
   buildKitProgramFor,
   dockerConfigFor,
@@ -198,6 +199,17 @@ export class CloudBuildRoute implements BuildAdapter {
    * are what a reader of the build resource sees.
    */
   readonly carriesRegistryCredential = true;
+  /**
+   * One vendor's registries, because that is what the metadata server issues a
+   * token for. Everything else this route publishes to needs a stored
+   * credential, and without one it is simply not a destination this route has —
+   * see {@link publishableRegistries}. That is why a cloud build lands in the
+   * artifact registry by default: not a preference, but the honest extent of
+   * what its own identity authorizes.
+   */
+  readonly selfAuthorizedRegistries: readonly RegistryFlavour[] = [
+    'artifactRegistry',
+  ];
 
   constructor(private readonly options: CloudBuildRouteOptions) {
     this.name = options.name;

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -22,6 +22,7 @@
  *   specified and core signs that digest, so no backend is disqualifiable and
  *   the claim made is the honest one.
  */
+import type { RegistryFlavour } from '../../domain/artifact-name.ts';
 import type {
   Artifact,
   ArtifactType,
@@ -336,6 +337,25 @@ export interface BuildAdapter {
    * direction being wrong has to fail in.
    */
   readonly carriesRegistryCredential: boolean;
+  /**
+   * The registry flavours this route's own identity can push to unaided.
+   *
+   * §13's "nothing stored" is the rule, and this is what the rule actually
+   * buys per route — which is not the same set for all three. A route pushes
+   * to the registries in here without a credential existing anywhere; for
+   * anything else the installation either holds a login (§16's exception) or
+   * that registry is not a destination this route can publish to.
+   *
+   * Declared rather than probed, for the same reason `buildLevel` is: core has
+   * to know where a route can publish *before* dispatching it, and finding out
+   * by trying costs a whole build to learn.
+   *
+   * Flavours and not hosts, because that is what the identity is scoped to: a
+   * federated token authenticates one vendor's registries, every regional
+   * endpoint of them, and a route that listed hosts would be a route that
+   * broke when someone added a region.
+   */
+  readonly selfAuthorizedRegistries: readonly RegistryFlavour[];
 
   build(
     source: BuildSource,

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -30,6 +30,7 @@
  * the Build rather than hidden, because a checklist-only log is a property of
  * where it ran and not a bug in Spindrift.
  */
+import type { RegistryFlavour } from '../../domain/artifact-name.ts';
 import type { RepositoryRef } from '../../domain/repository.ts';
 import {
   CALLER_WORKFLOW_FILE,
@@ -257,6 +258,18 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
    * change rather than a token an operator cannot un-publish.
    */
   readonly carriesRegistryCredential = false;
+  /**
+   * Both, because the run holds two identities at once and the pinned workflow
+   * uses each: `docker/login-action` against `ghcr.io` with the run's own
+   * token, and `google-github-actions/auth` federating into the artifact
+   * registry. So the hosted route is the one that publishes everywhere this
+   * installation pushes, and it is why nothing here has ever needed a stored
+   * credential.
+   */
+  readonly selfAuthorizedRegistries: readonly RegistryFlavour[] = [
+    'ghcr',
+    'artifactRegistry',
+  ];
   /**
    * §16's profile level. A reusable workflow pinned by commit, running on a
    * runner the repository does not control, producing signed provenance — that

--- a/apps/spindrift/src/adapters/build/in-cluster.ts
+++ b/apps/spindrift/src/adapters/build/in-cluster.ts
@@ -19,6 +19,7 @@
  * this process is already connected to, so its log is one more read against an
  * API the adapter already holds (§4's amendment).
  */
+import type { RegistryFlavour } from '../../domain/artifact-name.ts';
 import type {
   KubernetesApi,
   KubernetesObject,
@@ -89,6 +90,15 @@ export class InClusterBuildRoute implements BuildAdapter {
    * {@link InClusterBuildRoute.job}.
    */
   readonly carriesRegistryCredential = true;
+  /**
+   * The Job runs as a service account, and what that account reaches is a
+   * workload identity binding on one vendor's registries. Anything else the
+   * installation pushes to needs a stored credential, which this route can
+   * carry — see {@link InClusterBuildRoute.carriesRegistryCredential}.
+   */
+  readonly selfAuthorizedRegistries: readonly RegistryFlavour[] = [
+    'artifactRegistry',
+  ];
 
   constructor(private readonly options: InClusterRouteOptions) {
     this.name = options.name;

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -44,6 +44,7 @@ import { GitHubApp } from '../integrations/github/app.ts';
 import type { Fetcher } from '../integrations/github/http.ts';
 import { GitHubDeviceOAuth } from '../integrations/github/oauth.ts';
 import { sourceDepotFor, stageArchiveBytes } from '../storage/archives.ts';
+import { withGitHubRegistryCredential } from '../storage/github-registry-credential.ts';
 import { registryCredentialStore } from '../storage/registry-credentials.ts';
 import { CoreSupplyChain, CosignSigner } from '../supply-chain/sign.ts';
 import { SpindriftSignatureVerifier } from '../supply-chain/signature.ts';
@@ -301,10 +302,17 @@ export function createAdapterRegistry(
      * token durably, and the commands say so rather than keeping one in clear.
      */
     registryCredentials() {
-      if (keyring === null || options.db === undefined) return null;
-      return registryCredentialStore(options.db, keyring, () =>
-        (options.clock ?? { now: () => new Date() }).now(),
-      );
+      const now = () => (options.clock ?? { now: () => new Date() }).now();
+      const stored =
+        keyring === null || options.db === undefined
+          ? null
+          : registryCredentialStore(options.db, keyring, now);
+      // GHCR is minted from the credential this installation already refreshes
+      // rather than pasted in and owned forever — see
+      // `storage/github-registry-credential.ts`. A stored row for the same host
+      // still wins, and an installation with no connector gets `stored` back
+      // unchanged.
+      return withGitHubRegistryCredential(stored, oauth, now);
     },
 
     source() {

--- a/apps/spindrift/src/commands/apps/build-route.ts
+++ b/apps/spindrift/src/commands/apps/build-route.ts
@@ -39,6 +39,7 @@ import {
   componentTargetDesired,
   targets,
 } from '../../db/schema.ts';
+import { publishableRegistries } from '../../domain/artifact-name.ts';
 import { buildRouteFor, refusalForChosenRoute } from '../builds/route.ts';
 import { type Command, failed, ok } from '../types.ts';
 
@@ -100,6 +101,24 @@ export const setAppBuildRoute: Command<
     .where(eq(components.appId, app.id));
 
   if (input.route !== null) {
+    const adapter = context.adapters.build(input.route);
+    // Where this route can publish, which is not always everywhere: §13
+    // authorizes each push by the route that makes it, and the three routes do
+    // not reach the same registries. Computed once — it is a property of the
+    // route and the installation, not of any Target.
+    const published =
+      adapter === null
+        ? []
+        : publishableRegistries({
+            registries: context.manifest.supplyChain.registry,
+            selfAuthorized: adapter.selfAuthorizedRegistries,
+            storedHosts: new Set(
+              (await context.adapters.registryCredentials?.()?.list())?.map(
+                (one) => one.host,
+              ) ?? [],
+            ),
+          });
+
     for (const target of placements) {
       const selection = await buildRouteFor(target.id, context);
       const refusal = refusalForChosenRoute(
@@ -109,22 +128,31 @@ export const setAppBuildRoute: Command<
       );
       if (refusal !== null) return failed('NOT_BUILDABLE', refusal);
 
-      // The registry half. Where a Target narrows what it can pull from and
-      // none of this installation's registries are in that set, no route builds
-      // anything it could run — so the sentence names the Target rather than
-      // letting a green Build discover it at the pull.
+      /**
+       * The registry half, and the half a level threshold does not cover.
+       *
+       * A route publishes where its identity reaches; a Target pulls from where
+       * it can reach. If those two sets do not meet, the Build is green, the
+       * artifact is real, and the Deploy fails at the pull with a message about
+       * a manifest nobody can find — which is the worst place for this to be
+       * discovered and the reason it is refused here.
+       *
+       * A Target that declares no reachable registries takes the first one
+       * (§16's tie-break), so the check is against that rather than skipped.
+       */
       const reachable = target.discovery?.reachableRegistries ?? [];
-      if (
-        reachable.length > 0 &&
-        !context.manifest.supplyChain.registry.some((registry) =>
-          reachable.includes(registry),
-        )
-      ) {
+      const pullable =
+        reachable.length > 0
+          ? reachable
+          : context.manifest.supplyChain.registry.slice(0, 1);
+      if (!published.some((registry) => pullable.includes(registry))) {
         return failed(
           'NOT_BUILDABLE',
-          `${target.name} pulls only from ${reachable.join(' or ')}, and this ` +
-            `installation pushes to ${context.manifest.supplyChain.registry.join(' or ')} — ` +
-            `no route can build ${app.name} an artifact it could run`,
+          `${input.route} publishes to ${published.join(' and ') || 'no registry this installation configures'}, ` +
+            `and ${target.name} pulls from ${pullable.join(' or ')} — ` +
+            `so a build of ${app.name} on that route would produce an artifact ` +
+            `${target.name} cannot pull. Store a registry credential for one ` +
+            `${target.name} reaches, or leave ${app.name} on rank order.`,
         );
       }
     }

--- a/apps/spindrift/src/commands/apps/build-route.ts
+++ b/apps/spindrift/src/commands/apps/build-route.ts
@@ -1,0 +1,143 @@
+/**
+ * `setAppBuildRoute` — an App names the route it builds on (§4, §16).
+ *
+ * §16 settles selection as "each Target has a minimum build level defaulting to
+ * L2 plus an ordered list of build routes: **the level is a threshold, then
+ * admin rank wins**", and rank is an operator's arrangement. What that leaves
+ * unsaid is who breaks the tie when the App has a reason of its own — a build
+ * that needs an isolated worker, a build that must not queue behind a hosted
+ * runner — and the answer is not "the operator re-ranks the installation for
+ * one App".
+ *
+ * **It narrows, it never overrides.** The chosen route enters selection as the
+ * admitted set (`buildRouteFor`), so the Target's threshold is applied to it
+ * exactly as it is applied to every other candidate. An App cannot name its way
+ * past a policy; it can only pick among the routes that already cleared one.
+ *
+ * **The check is made here as well as at dispatch, and that is the point.** A
+ * route this installation does not have, or one no placement Target will take,
+ * is refused where the developer is standing — with the sentence
+ * `buildRouteCandidates` composed. Left to dispatch it would instead be a Build
+ * that sits PENDING saying so to a log, which is the failure §3 keeps asking us
+ * not to ship.
+ *
+ * **And the registry, which is the half a level threshold does not cover.** A
+ * route builds an artifact somewhere, and a Target that cannot pull from that
+ * somewhere gets a green Build it will never run. Every Target this App is
+ * placed on must reach at least one of the registries the installation pushes
+ * to, or naming the route is naming a dead end.
+ *
+ * Clearing the choice is the same command with a null route, which puts the App
+ * back to no opinion and rank order — not to some other route.
+ */
+
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import {
+  apps,
+  components,
+  componentTargetDesired,
+  targets,
+} from '../../db/schema.ts';
+import { buildRouteFor, refusalForChosenRoute } from '../builds/route.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const setAppBuildRouteInput = z
+  .object({
+    appId: z.uuid(),
+    /**
+     * The route to build on, or null to go back to no opinion.
+     *
+     * Nullable rather than optional: "leave it as it is" and "clear it" are
+     * different acts and an absent key cannot mean both.
+     */
+    route: z.string().trim().min(1).nullable(),
+  })
+  .strict();
+
+export type SetAppBuildRouteInput = z.infer<typeof setAppBuildRouteInput>;
+
+export interface SetAppBuildRouteResult {
+  readonly appId: string;
+  /** What the App now builds on, or null for rank order. */
+  readonly route: string | null;
+  /** The Targets checked against, so the answer says what it was checked on. */
+  readonly targets: readonly string[];
+}
+
+export const setAppBuildRoute: Command<
+  SetAppBuildRouteInput,
+  SetAppBuildRouteResult
+> = async (input, context) => {
+  const [app] = await context.db
+    .select({ id: apps.id, name: apps.name })
+    .from(apps)
+    .where(eq(apps.id, input.appId))
+    .limit(1);
+  if (app === undefined) {
+    return failed('NOT_FOUND', `there is no App with id ${input.appId}`);
+  }
+
+  // Every Target any of this App's Components is placed on. The choice is the
+  // App's and the threshold is each Target's, so a route has to clear all of
+  // them — an App whose website is on Cloud Run and whose worker is in the
+  // cluster is one App with two policies over it.
+  const placements = await context.db
+    .selectDistinct({
+      id: targets.id,
+      name: targets.name,
+      // §3's derived half, as the standing loop last reported it — not the
+      // connection's declaration, because what a Target can pull from is a fact
+      // discovery refreshes and a connect-time snapshot rots.
+      discovery: targets.discovery,
+    })
+    .from(componentTargetDesired)
+    .innerJoin(
+      components,
+      eq(components.id, componentTargetDesired.componentId),
+    )
+    .innerJoin(targets, eq(targets.id, componentTargetDesired.targetId))
+    .where(eq(components.appId, app.id));
+
+  if (input.route !== null) {
+    for (const target of placements) {
+      const selection = await buildRouteFor(target.id, context);
+      const refusal = refusalForChosenRoute(
+        selection.candidates,
+        input.route,
+        target.name,
+      );
+      if (refusal !== null) return failed('NOT_BUILDABLE', refusal);
+
+      // The registry half. Where a Target narrows what it can pull from and
+      // none of this installation's registries are in that set, no route builds
+      // anything it could run — so the sentence names the Target rather than
+      // letting a green Build discover it at the pull.
+      const reachable = target.discovery?.reachableRegistries ?? [];
+      if (
+        reachable.length > 0 &&
+        !context.manifest.supplyChain.registry.some((registry) =>
+          reachable.includes(registry),
+        )
+      ) {
+        return failed(
+          'NOT_BUILDABLE',
+          `${target.name} pulls only from ${reachable.join(' or ')}, and this ` +
+            `installation pushes to ${context.manifest.supplyChain.registry.join(' or ')} — ` +
+            `no route can build ${app.name} an artifact it could run`,
+        );
+      }
+    }
+  }
+
+  await context.db
+    .update(apps)
+    .set({ buildRoute: input.route, updatedAt: context.clock.now() })
+    .where(eq(apps.id, app.id));
+
+  return ok({
+    appId: app.id,
+    route: input.route,
+    targets: placements.map((target) => target.name),
+  });
+};

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -42,6 +42,7 @@ import {
 import {
   artifactTags,
   componentRepositories,
+  publishableRegistries,
   registryHostOf,
 } from '../../domain/artifact-name.ts';
 import {
@@ -548,7 +549,54 @@ export const dispatchBuild = async (
    * Ahead of the signed URL deliberately: a bearer capability minted for a
    * Build that cannot be dispatched is one that exists for no reason.
    */
-  const registries = context.manifest.supplyChain.registry;
+  const allRegistries = context.manifest.supplyChain.registry;
+  /**
+   * The registries **this route** can publish to, which is not always all of
+   * them (§13).
+   *
+   * §16 pushes every artifact to every registry, and that reads as unconditional
+   * until you ask what authorizes each push. §13 answers "the route that makes
+   * it", and the three routes do not reach the same set: the hosted run logs
+   * into GHCR and federates to the artifact registry, while the cloud builder's
+   * metadata token is good for one vendor's registries and nothing else.
+   *
+   * `buildctl` exports every reference in one operation, so an unauthorized
+   * destination is not a destination that gets skipped — it is a `401` that
+   * fails the whole export, with the image built and nothing published
+   * anywhere. Narrowing is what makes a cloud build land in the artifact
+   * registry by default instead of failing at the last step, and stored
+   * credentials widen it back for a host no federation reaches.
+   *
+   * The consequence is deliberate and is the one an App choosing a route signs
+   * up for: an artifact in fewer registries is an artifact fewer Targets can
+   * pull. `setAppBuildRoute` refuses that combination up front rather than
+   * letting a green Build discover it at the deploy.
+   */
+  const storedHosts = new Set(
+    (await context.adapters.registryCredentials?.()?.list())?.map(
+      (one) => one.host,
+    ) ?? [],
+  );
+  const registries = publishableRegistries({
+    registries: allRegistries,
+    selfAuthorized: adapter.selfAuthorizedRegistries,
+    storedHosts,
+  });
+  if (registries.length === 0) {
+    return refuseDispatch(
+      context,
+      subject,
+      'NOT_BUILDABLE',
+      `the "${adapter.name}" route can authorize a push to none of the ` +
+        `registries this installation publishes to (${allRegistries.join(', ')}), ` +
+        'so a build on it would have nowhere to put the artifact. Store a ' +
+        'registry credential for one of them, or build on a route whose own ' +
+        'identity reaches one.',
+      // Both halves are configuration an operator can supply, and the next tick
+      // then works without anyone pressing Deploy again.
+      { kind: 'waits' },
+    );
+  }
   const destinations = componentRepositories({
     registries,
     app: app.name,

--- a/apps/spindrift/src/commands/builds/route.ts
+++ b/apps/spindrift/src/commands/builds/route.ts
@@ -1,31 +1,108 @@
 import { eq } from 'drizzle-orm';
 import { buildRouteProfiles } from '../../adapters/registry.ts';
-import { targets } from '../../db/schema.ts';
+import { apps, targets } from '../../db/schema.ts';
 import {
+  type BuildRouteCandidate,
+  buildRouteCandidates,
   DEFAULT_MINIMUM_BUILD_LEVEL,
   selectBuildRoute,
 } from '../../domain/build-route.ts';
 import type { BuildDispatchContext } from './dispatch.ts';
 
-/** Select the highest-ranked configured route that clears one Target's policy. */
+/**
+ * Select the route one Target will take a build from, narrowed by the App's own
+ * choice where it has made one.
+ *
+ * §16's sentence is unchanged and the order of its clauses is why this composes
+ * rather than conflicts: **the level is a threshold, then admin rank wins.**
+ * The App's choice enters as `demand.routes` — the admitted set — which
+ * `buildRouteCandidates` applies *alongside* the threshold and never instead of
+ * it. So an App that names a route below its Target's minimum gets `null` and
+ * the refusal sentence, exactly as if an operator had ranked that route first.
+ *
+ * `appId` is optional because the creation flow asks this question before an
+ * App row exists: a draft is being reviewed, and what it wants to know is
+ * whether *anything* could build for the Target it picked.
+ */
 export async function routeForTarget(
   targetId: string,
   context: BuildDispatchContext,
+  appId?: string,
 ): Promise<string | null> {
+  return (await buildRouteFor(targetId, context, appId)).route;
+}
+
+/**
+ * The same selection, with every route considered and the sentence behind each.
+ *
+ * §3's shape rather than a boolean, and it is what makes an App's choice
+ * legible: "this Target does not admit this route" is what a developer sees
+ * when they picked one, and it is the difference between a Build that is
+ * PENDING for a reason and one that is PENDING.
+ */
+export async function buildRouteFor(
+  targetId: string,
+  context: BuildDispatchContext,
+  appId?: string,
+): Promise<{
+  readonly route: string | null;
+  readonly candidates: readonly BuildRouteCandidate[];
+}> {
   const [target] = await context.db
     .select({ minimumLevel: targets.minBuildLevel })
     .from(targets)
     .where(eq(targets.id, targetId))
     .limit(1);
-  if (!target) return null;
-  const selected = selectBuildRoute(
+  if (!target) return { route: null, candidates: [] };
+
+  const chosen =
+    appId === undefined ? null : await appBuildRoute(context, appId);
+
+  return selectBuildRoute(
     buildRouteProfiles(context.manifest),
     {
       minimumLevel:
         (target.minimumLevel as 1 | 2 | 3 | null) ??
         DEFAULT_MINIMUM_BUILD_LEVEL,
+      // Null narrows nothing, which is the no-opinion case and every App until
+      // one says otherwise.
+      ...(chosen === null ? {} : { routes: [chosen] }),
     },
     (routeName) => context.adapters.build(routeName) !== null,
   );
-  return selected.route;
+}
+
+/** The route this App asked for, or null where it has no opinion. */
+async function appBuildRoute(
+  context: Pick<BuildDispatchContext, 'db'>,
+  appId: string,
+): Promise<string | null> {
+  const [app] = await context.db
+    .select({ buildRoute: apps.buildRoute })
+    .from(apps)
+    .where(eq(apps.id, appId))
+    .limit(1);
+  return app?.buildRoute ?? null;
+}
+
+/**
+ * Whether one Target would take a build from one named route, and why not.
+ *
+ * The edit-time half of the same question `buildRouteFor` answers at dispatch,
+ * so that choosing a route an installation cannot honour is refused where the
+ * developer is standing rather than discovered by a Build that never runs.
+ * Returns the sentence to say, or `null` when the route is fine.
+ */
+export function refusalForChosenRoute(
+  candidates: readonly BuildRouteCandidate[],
+  route: string,
+  targetName: string,
+): string | null {
+  const candidate = candidates.find((one) => one.route === route);
+  if (candidate === undefined) {
+    return `this installation has no build route named "${route}"`;
+  }
+  return candidate.eligible
+    ? null
+    : `${targetName} will not take a build from ${route}: ${candidate.reason}`;
 }

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -16,6 +16,7 @@
  * named commands and arrive with the milestones that implement them.
  */
 
+export { setAppBuildRoute } from './apps/build-route.ts';
 export { deleteApp } from './apps/delete.ts';
 export { deployApp } from './apps/deploy.ts';
 export { listApps } from './apps/list.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -29,6 +29,7 @@
  * nothing left for a route to decide.
  */
 import type { z } from 'zod';
+import { setAppBuildRoute, setAppBuildRouteInput } from './apps/build-route.ts';
 import { deleteApp, deleteAppInput } from './apps/delete.ts';
 import { deployApp, deployAppInput } from './apps/deploy.ts';
 import { listApps, listAppsInput } from './apps/list.ts';
@@ -148,6 +149,7 @@ export type AnyCommandDescriptor = CommandDescriptor<any, any>;
 export const commandRegistry = {
   deleteApp: { input: deleteAppInput, handler: deleteApp },
   deployApp: { input: deployAppInput, handler: deployApp },
+  setAppBuildRoute: { input: setAppBuildRouteInput, handler: setAppBuildRoute },
   getAppWorkspace: { input: getAppWorkspaceInput, handler: getAppWorkspace },
   getDeployDetail: { input: getDeployDetailInput, handler: getDeployDetail },
   getBuildDetail: { input: getBuildDetailInput, handler: getBuildDetail },

--- a/apps/spindrift/src/db/migrations/0020_app_build_route.sql
+++ b/apps/spindrift/src/db/migrations/0020_app_build_route.sql
@@ -1,0 +1,8 @@
+-- §16 makes the route a Target's threshold and an admin's rank. This is the
+-- third party to that decision: the App, which may name the route it builds on
+-- so long as that route still clears the Target's threshold.
+--
+-- Nullable, and null is not "no route" — it is "no opinion", which is every App
+-- that exists today and the whole of the behaviour before this column. Rank
+-- order picks for those, exactly as it did.
+ALTER TABLE "apps" ADD COLUMN "build_route" text;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1785374380763,
       "tag": "0019_reach_and_auth",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1785374380764,
+      "tag": "0020_app_build_route",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -437,6 +437,27 @@ export const apps = pgTable('apps', {
   }),
   /** Set when `sourceKind = 'archive'`: the uploaded bundle's digest. */
   sourceArchiveDigest: text('source_archive_digest'),
+  /**
+   * The build route this App has asked to build on, or null for no opinion.
+   *
+   * §16 settles route selection as "the level is a threshold, then admin rank
+   * wins", and this is the App's say inside that — it narrows the candidates
+   * rather than overriding the threshold, so a route below the Target's minimum
+   * is refused here exactly as it is refused anywhere else. Naming one is not a
+   * way around a policy; it is a way to pick among the routes that already
+   * cleared it.
+   *
+   * Null is not "no route". It is the state every App is in until someone says
+   * otherwise, and it means rank order picks — which is the whole of the
+   * behaviour before this column existed.
+   *
+   * A plain string and not a reference: §4 makes the set of routes an
+   * installation's configuration, so a name here may well name a route that has
+   * been retired. That is not an error and never was — `buildRouteCandidates`
+   * already reports a named-but-absent route as unavailable, which is the
+   * honest reading and the one an operator can act on.
+   */
+  buildRoute: text('build_route'),
   /** §14: the cloud project this App's own resources live in, if any. */
   vesselRef: text('vessel_ref'),
   /** §9: the flat single-label vanity name, if the developer chose one. */

--- a/apps/spindrift/src/domain/artifact-name.ts
+++ b/apps/spindrift/src/domain/artifact-name.ts
@@ -175,6 +175,47 @@ export function registryFlavour(host: string): RegistryFlavour {
 }
 
 /**
+ * The registries one route can actually publish to (§13, §16).
+ *
+ * §16 says every artifact is pushed to every registry, and that sentence has an
+ * unstated precondition: that the pushing thing can authenticate to all of
+ * them. It cannot. §13 wants each push authorized by the route that makes it —
+ * a federated token for the cloud builder, the run's own token for hosted CI —
+ * and those identities do not reach the same set. The cloud builder's metadata
+ * token is good for one vendor's registries and nothing else; the hosted run
+ * logs into GHCR *and* federates to the artifact registry, which is why it has
+ * never had to think about this.
+ *
+ * A push to a registry the route cannot authenticate to does not fail politely.
+ * `buildctl` exports every reference in one operation, so a `401` on one
+ * destination fails the whole export — half an hour into a build, with the
+ * artifact built and nothing published anywhere. Narrowing here is what turns
+ * that into "this route publishes where it can", and what makes an App naming a
+ * route a decision with a legible consequence: the artifact lands in fewer
+ * places, and a Target that cannot pull from any of them is not one this route
+ * can build for. `setAppBuildRoute` refuses exactly that, up front.
+ *
+ * The stored credentials widen it back. That is the whole purpose of §16's
+ * named exception to "nothing stored": a host no federation reaches becomes
+ * reachable the moment an installation holds a login for it.
+ */
+export function publishableRegistries(input: {
+  readonly registries: readonly string[];
+  /** Flavours this route's own identity authorizes, from the adapter. */
+  readonly selfAuthorized: readonly RegistryFlavour[];
+  /** Hosts this installation holds a stored credential for. */
+  readonly storedHosts?: ReadonlySet<string>;
+}): string[] {
+  return input.registries.filter((registry) => {
+    const host = registryHostOf(registry);
+    return (
+      input.selfAuthorized.includes(registryFlavour(host)) ||
+      (input.storedHosts?.has(host) ?? false)
+    );
+  });
+}
+
+/**
  * The OCI distribution API root a namespace's registry answers on.
  *
  * `https` with no fallback. A registry reached over plaintext is one whose

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -11,7 +11,7 @@ import {
   dispatchBuild,
   recordDispatchWait,
 } from '../commands/builds/dispatch.ts';
-import { routeForTarget } from '../commands/builds/route.ts';
+import { buildRouteFor } from '../commands/builds/route.ts';
 import {
   builds,
   components,
@@ -62,12 +62,21 @@ export async function runBuildPass(
   for (const row of rows) {
     if (visited.has(row.buildId)) continue;
     visited.add(row.buildId);
-    const route = await routeForTarget(row.targetId, context);
-    if (route === null) {
-      // A Target whose policy no configured route satisfies. Configuring a
+    const selection = await buildRouteFor(row.targetId, context, row.appId);
+    if (selection.route === null) {
+      // A Target whose policy no available route satisfies. Configuring a
       // route is an operator act that makes the next tick work, so the Build
       // stays PENDING — and says so once, because a Build PENDING forever with
       // nothing anywhere saying why is the failure worth spending a row on.
+      //
+      // Every candidate's own sentence is carried, because since an App may
+      // name its route the general sentence is no longer the whole truth: "this
+      // Target does not admit this route" is a thing the developer did and can
+      // undo, and it reads nothing like an installation that configured none.
+      const reasons = selection.candidates
+        .filter((candidate) => !candidate.eligible)
+        .map((candidate) => `${candidate.route} (${candidate.reason})`)
+        .join('; ');
       await recordDispatchWait(
         context,
         {
@@ -78,10 +87,13 @@ export async function runBuildPass(
           },
           waitingOn: row.waitingOn,
         },
-        'no build route this installation configures meets the policy of the Target this Build is placed on, so nothing can run it',
+        reasons === ''
+          ? 'no build route this installation configures meets the policy of the Target this Build is placed on, so nothing can run it'
+          : `no build route can run this Build for the Target it is placed on: ${reasons}`,
       );
       continue;
     }
+    const route = selection.route;
     const result = await dispatchBuild(
       {
         buildId: row.buildId,

--- a/apps/spindrift/src/storage/github-registry-credential.ts
+++ b/apps/spindrift/src/storage/github-registry-credential.ts
@@ -1,0 +1,127 @@
+/**
+ * GHCR, authorized by the credential this installation already refreshes (§13).
+ *
+ * §16 draws `registry_credentials` as a narrow exception to §13's "nothing
+ * stored", and the honest cost of that exception is a long-lived token in a
+ * database: it does not rotate, it does not expire, and nothing notices when it
+ * should have been revoked. Where a registry has no federation that is the only
+ * option. GHCR is not one of those registries.
+ *
+ * Spindrift already holds a GitHub credential that refreshes itself — the
+ * device-flow authorization behind `GitHubDeviceOAuth`, sealed with the
+ * installation keyring, renewed on expiry, and revocable from GitHub. GHCR
+ * authenticates with a GitHub token. So the credential a cloud build needs to
+ * push to GHCR is one this process can *mint per dispatch* rather than one an
+ * operator has to paste in and then own forever.
+ *
+ * **Nothing new is stored.** This holds no row of its own; it answers `authFor`
+ * from the OAuth credential at the moment a dispatch asks, which is the same
+ * lifetime every other §13 identity has.
+ *
+ * **The prerequisite is on GitHub's side and cannot be arranged from here.** A
+ * user-to-server token reaches a package only where the App has `packages:
+ * write` *and* the package itself grants that App access — both of which are
+ * settings in GitHub's UI. Until they are, this mints a credential that GHCR
+ * refuses. That is why it is wired to be *checkable*: `testRegistryReachability`
+ * exercises whatever `authFor` returns, so `ghcr.io/<owner>` comes back
+ * authenticated or refused before anything relies on it. Confirm it there once,
+ * rather than learning it from a build that failed at the export.
+ *
+ * A stored row for the same host **wins**. An operator who has pasted a token
+ * has said something more specific than this default, and quietly overriding it
+ * would make a deliberate act look broken.
+ */
+import type {
+  RegistryAuth,
+  RegistryCredentialStore,
+  RegistryCredentialSummary,
+} from './registry-credentials.ts';
+
+/** The registry a GitHub token authenticates. */
+export const GHCR_HOST = 'ghcr.io';
+
+/** As much of the OAuth connector as minting a registry credential needs. */
+export interface GitHubRegistryIdentity {
+  /** `<type> <token>`, refreshed — the same value every API call carries. */
+  authorization(): Promise<string>;
+  /**
+   * Who the credential belongs to, for the registry's username field.
+   *
+   * `login` is present exactly when the state is `authorized` — the connector
+   * writes both from one row — so there is no fallback username here. A status
+   * that names nobody is a connector that cannot mint, which is the same answer
+   * as an unauthorized one.
+   */
+  status(): Promise<{ state: string; login?: string }>;
+}
+
+/**
+ * The installation's credential store, plus GHCR minted from GitHub.
+ *
+ * Returns `base` unchanged when there is no GitHub credential to mint from, so
+ * an installation without the connector is exactly what it was.
+ */
+export function withGitHubRegistryCredential(
+  base: RegistryCredentialStore | null,
+  github: GitHubRegistryIdentity | null,
+  now: () => Date = () => new Date(),
+): RegistryCredentialStore | null {
+  if (github === null) return base;
+
+  /** The minted credential, or null when GitHub is not authorized. */
+  async function minted(): Promise<RegistryAuth | null> {
+    try {
+      const status = await github?.status();
+      if (status?.state !== 'authorized') return null;
+      const username = status.login;
+      if (username === undefined || username === '') return null;
+      const authorization = await github?.authorization();
+      if (authorization === undefined) return null;
+      // `authorization()` answers in `Authorization:` header form. The registry
+      // wants the token alone, in the password field.
+      const secret = authorization.replace(/^[^ ]+ +/, '');
+      if (secret === '') return null;
+      return { host: GHCR_HOST, username, secret };
+    } catch {
+      // A connector that needs reauthorization is not an error here: it is one
+      // fewer registry this route can push to, which `publishableRegistries`
+      // already knows how to say.
+      return null;
+    }
+  }
+
+  return {
+    put: (input) =>
+      base?.put(input) ??
+      Promise.reject(
+        new Error(
+          'this installation has nowhere to store a registry credential',
+        ),
+      ),
+
+    forget: (host) => base?.forget(host) ?? Promise.resolve(false),
+
+    async list(): Promise<readonly RegistryCredentialSummary[]> {
+      const stored = (await base?.list()) ?? [];
+      if (stored.some((one) => one.host === GHCR_HOST)) return stored;
+      const auth = await minted();
+      if (auth === null) return stored;
+      return [
+        ...stored,
+        { host: GHCR_HOST, username: auth.username, updatedAt: now() },
+      ];
+    },
+
+    async authFor(hosts): Promise<readonly RegistryAuth[]> {
+      const stored = (await base?.authFor(hosts)) ?? [];
+      if (
+        !hosts.includes(GHCR_HOST) ||
+        stored.some((one) => one.host === GHCR_HOST)
+      ) {
+        return stored;
+      }
+      const auth = await minted();
+      return auth === null ? stored : [...stored, auth];
+    },
+  };
+}

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -53,6 +53,7 @@ const route: BuildAdapter = {
   buildLevel: 2,
   provenanceBuilderId: 'https://spindrift.dev/builders/example',
   carriesRegistryCredential: true,
+  selfAuthorizedRegistries: ['ghcr'],
   async *build(
     given: BuildSource,
   ): AsyncGenerator<BuildEvent, BuildResult, void> {

--- a/apps/spindrift/test/adapters/publishable-registries.test.ts
+++ b/apps/spindrift/test/adapters/publishable-registries.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Where a route can actually publish (§13, §16).
+ *
+ * §16 pushes every artifact to every registry, and §13 authorizes each push by
+ * the route that makes it. Those two sentences only agree when the route's own
+ * identity reaches every registry — and it does not. The hosted run logs into
+ * GHCR and federates to the artifact registry; the cloud builder's metadata
+ * token is good for one vendor and nothing else.
+ *
+ * The cost of getting this wrong is not a skipped destination. `buildctl`
+ * exports every reference in one operation, so an unauthorized host is a `401`
+ * that fails the whole export with the image already built.
+ */
+import { describe, expect, test } from 'bun:test';
+import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
+import { GitHubActionsBuildRoute } from '../../src/adapters/build/github-actions.ts';
+import { publishableRegistries } from '../../src/domain/artifact-name.ts';
+import { withGitHubRegistryCredential } from '../../src/storage/github-registry-credential.ts';
+
+const GHCR = 'ghcr.io/jonpulsifer';
+const AR = 'northamerica-northeast1-docker.pkg.dev/trusted-builds/i';
+const REGISTRIES = [GHCR, AR];
+
+describe('the registries a route can publish to', () => {
+  /** The default this whole change exists to produce. */
+  test('the cloud builder publishes to the artifact registry alone', () => {
+    const route = new CloudBuildRoute({
+      name: 'managed',
+      endpoint: 'https://builds.example.test',
+      logsEndpoint: 'https://logs.example.test',
+      project: 'p',
+      region: 'r',
+      image: 'img',
+      zeroConfigFrontend: 'zc',
+      signer: '',
+      attestor: '',
+      token: () => 't',
+    });
+
+    expect(
+      publishableRegistries({
+        registries: REGISTRIES,
+        selfAuthorized: route.selfAuthorizedRegistries,
+      }),
+    ).toEqual([AR]);
+  });
+
+  /**
+   * The hosted route is unchanged by any of this, and that is the point: its
+   * run holds both identities, so narrowing takes nothing away from it.
+   */
+  test('the hosted route publishes to both, as it always did', () => {
+    const route = new GitHubActionsBuildRoute({
+      name: 'hosted',
+      host: {} as never,
+      buildWorkflow: 'o/r/.github/workflows/b.yml@' + '0'.repeat(40),
+      zeroConfigFrontend: 'zc',
+      signer: '',
+      attestor: '',
+    });
+
+    expect(
+      publishableRegistries({
+        registries: REGISTRIES,
+        selfAuthorized: route.selfAuthorizedRegistries,
+      }),
+    ).toEqual(REGISTRIES);
+  });
+
+  /** §16's stored exception, doing exactly what it exists for. */
+  test('a stored credential widens a route back out', () => {
+    expect(
+      publishableRegistries({
+        registries: REGISTRIES,
+        selfAuthorized: ['artifactRegistry'],
+        storedHosts: new Set(['ghcr.io']),
+      }),
+    ).toEqual(REGISTRIES);
+  });
+
+  test('a registry nothing authorizes is simply not a destination', () => {
+    expect(
+      publishableRegistries({
+        registries: [...REGISTRIES, 'docker.io/jonpulsifer'],
+        selfAuthorized: ['artifactRegistry', 'ghcr'],
+      }),
+    ).toEqual(REGISTRIES);
+  });
+});
+
+/**
+ * GHCR without a long-lived token.
+ *
+ * The credential is minted from the GitHub authorization this installation
+ * already refreshes, so nothing new is stored and nothing has to be rotated by
+ * hand.
+ */
+describe('the GHCR credential minted from GitHub', () => {
+  const github = {
+    authorization: async () => 'bearer ghu_a-refreshed-user-token',
+    status: async () => ({ state: 'authorized', login: 'jonpulsifer' }),
+  };
+
+  test('answers authFor with the token alone, not the header form', async () => {
+    const store = withGitHubRegistryCredential(null, github);
+
+    expect(await store?.authFor(['ghcr.io'])).toEqual([
+      {
+        host: 'ghcr.io',
+        username: 'jonpulsifer',
+        secret: 'ghu_a-refreshed-user-token',
+      },
+    ]);
+  });
+
+  test('is not offered for a host it does not authenticate', async () => {
+    const store = withGitHubRegistryCredential(null, github);
+
+    expect(await store?.authFor(['registry-1.docker.io'])).toEqual([]);
+  });
+
+  /**
+   * An operator who pasted a token said something more specific than this
+   * default, and quietly overriding it would make a deliberate act look broken.
+   */
+  test('a stored row for the same host wins', async () => {
+    const stored = {
+      put: async () => {},
+      forget: async () => true,
+      list: async () => [
+        { host: 'ghcr.io', username: 'someone-else', updatedAt: new Date(0) },
+      ],
+      authFor: async () => [
+        { host: 'ghcr.io', username: 'someone-else', secret: 'pasted' },
+      ],
+    };
+    const store = withGitHubRegistryCredential(stored, github);
+
+    expect(await store?.authFor(['ghcr.io'])).toEqual([
+      { host: 'ghcr.io', username: 'someone-else', secret: 'pasted' },
+    ]);
+  });
+
+  /**
+   * A connector needing reauthorization is one fewer registry this route can
+   * push to, which `publishableRegistries` already knows how to say — not an
+   * exception out of the middle of a dispatch.
+   */
+  test('offers nothing when GitHub is not authorized', async () => {
+    const store = withGitHubRegistryCredential(null, {
+      authorization: async () => {
+        throw new Error('GitHub authorization is required');
+      },
+      status: async () => ({ state: 'unauthorized' }),
+    });
+
+    expect(await store?.authFor(['ghcr.io'])).toEqual([]);
+    expect(await store?.list()).toEqual([]);
+  });
+
+  test('an installation with no connector is exactly what it was', () => {
+    expect(withGitHubRegistryCredential(null, null)).toBeNull();
+  });
+});

--- a/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
+++ b/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
@@ -17,6 +17,7 @@ import {
   dockerConfigFor,
   REGISTRY_AUTH_VAR,
 } from '../../src/adapters/build/buildkit.ts';
+import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
 import { InClusterBuildRoute } from '../../src/adapters/build/in-cluster.ts';
 import type { KubernetesObject } from '../../src/adapters/deploy/kubernetes/api.ts';
 import type { RegistryAuth } from '../../src/storage/registry-credentials.ts';
@@ -78,6 +79,109 @@ describe('the BuildKit program', () => {
    */
   test('is the same program either way', () => {
     expect(program).toContain(`if [ -n "\${${REGISTRY_AUTH_VAR}:-}" ]`);
+  });
+});
+
+/**
+ * The one route whose push authorizes two ways at once.
+ *
+ * §16 has this installation pushing every artifact to several registries, and
+ * the cloud builder reaches them by two different mechanisms: its own identity
+ * from the metadata server for the vendor's registries, and a stored credential
+ * for the ones no federation reaches. Both land in one Docker config or the
+ * export 401s on whichever half lost.
+ */
+describe('the cloud build route', () => {
+  /** The step this route submits, caught in the fetch before anything runs. */
+  async function stepFor(registryAuth: readonly RegistryAuth[]) {
+    let submitted: unknown;
+    const route = new CloudBuildRoute({
+      name: 'managed',
+      endpoint: 'https://builds.example.test',
+      logsEndpoint: 'https://logs.example.test',
+      project: 'a-project',
+      region: 'a-region',
+      image: 'registry.example.test/buildkit',
+      zeroConfigFrontend: 'registry.example.test/zero-config',
+      signer: '',
+      attestor: '',
+      token: () => 'a-bearer-token',
+      fetch: async (request: Request) => {
+        submitted = await request.json();
+        // Enough to stop the route at the submit, which is all this needs.
+        return new Response('no', { status: 500 });
+      },
+    });
+
+    for await (const _ of route.build(
+      {
+        bundleDigest: 'sha256:bundle',
+        origin: {
+          type: 'archive',
+          location: 'https://depot.example.test/bundle.tgz',
+          subpath: '.',
+        },
+      },
+      {
+        artifactType: 'image',
+        kind: 'service',
+        platform: { os: 'linux', arch: 'amd64' },
+        // One of each: a host the metadata token covers, and one it does not.
+        destinations: [
+          'a-region-docker.pkg.dev/a-project/i/an-app/web',
+          'registry-1.docker.io/an-owner/web',
+        ],
+        tags: ['latest'],
+        buildArgs: {},
+        registryAuth,
+      },
+    )) {
+      // drained for the submit; the route reports the 500 as a failure
+    }
+
+    const body = submitted as {
+      steps: readonly {
+        args: readonly string[];
+        env?: readonly string[];
+      }[];
+    };
+    const step = body.steps[0];
+    if (step === undefined) throw new Error('no step was submitted');
+    return step;
+  }
+
+  test('carries the stored credential on the env and not in the program', async () => {
+    const step = await stepFor(AUTH);
+
+    expect(step.env).toEqual([
+      `${REGISTRY_AUTH_VAR}=${dockerConfigFor(AUTH) ?? ''}`,
+    ]);
+    expect(step.args.join('\n')).not.toContain(TOKEN);
+  });
+
+  /**
+   * The regression this describe block exists for. The prelude used to write
+   * `$DOCKER_CONFIG/config.json` itself, and the shared program then did
+   * `DOCKER_CONFIG=$(mktemp -d)` over the top of it whenever a stored
+   * credential was present — so the vendor half was discarded and the push to
+   * the artifact registry 401'd at the export, after the entire build.
+   */
+  test('mints its own credential into the same document, never over it', async () => {
+    const program = (await stepFor(AUTH)).args.join('\n');
+
+    // The prelude contributes to the variable the program is the sole reader of.
+    expect(program).toContain(`${REGISTRY_AUTH_VAR}="{\\"auths\\":{`);
+    expect(program).toContain(`export ${REGISTRY_AUTH_VAR}`);
+    // …and never writes a config of its own for the program to clobber. One
+    // `mktemp` is one writer; two was the bug.
+    expect(program.split('DOCKER_CONFIG=$(mktemp -d)')).toHaveLength(2);
+  });
+
+  test('still mints one when this installation stores nothing', async () => {
+    const step = await stepFor([]);
+
+    expect(step.env).toBeUndefined();
+    expect(step.args.join('\n')).toContain(`export ${REGISTRY_AUTH_VAR}`);
   });
 });
 

--- a/apps/spindrift/test/commands/app-build-route.test.ts
+++ b/apps/spindrift/test/commands/app-build-route.test.ts
@@ -1,0 +1,197 @@
+/**
+ * An App names the route it builds on (§4, §16).
+ *
+ * §16's sentence is "the level is a threshold, then admin rank wins", and the
+ * App's choice enters on the *rank* side of that comma — it narrows the
+ * candidates, it never lowers the bar. So the two things worth pinning are the
+ * two halves of one rule: a chosen route that clears the Target's minimum is
+ * what dispatch takes, and a chosen route that does not is refused with the
+ * same sentence any other ineligible route gets.
+ *
+ * The fixture installation ranks `hosted` (L2) first, then `managed` (L3), then
+ * `local` (L1) — three levels in rank order, which is what makes "rank picked
+ * it" and "the App picked it" distinguishable at all.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { setAppBuildRoute } from '../../src/commands/apps/build-route.ts';
+import { routeForTarget } from '../../src/commands/builds/route.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  components,
+  componentTargetDesired,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const baseManifest = await fixtureManifest();
+
+describe('an App choosing its build route', () => {
+  let ctx: CommandContext;
+  let appId: string;
+  let targetId: string;
+
+  /** Every route the fixture configures is available unless a test says not. */
+  function registryWith(available: readonly string[]): AdapterRegistry {
+    return {
+      deploy: () => null,
+      build: (name) => (available.includes(name) ? new FakeBuildAdapter() : null),
+      store: () => new FakeSecretStore(),
+      supplyChain: () => new SupplyChainHarness(),
+      repository: () => null,
+    };
+  }
+
+  async function seed(minBuildLevel: number | null): Promise<void> {
+    const { client, db } = database();
+    await db.delete(componentTargetDesired);
+    await db.delete(components);
+    await db.delete(apps);
+    await db.delete(targets);
+    await db.delete(users);
+
+    const [operator] = await db
+      .insert(users)
+      .values({ displayName: 'Operator' })
+      .returning();
+    const [target] = await db
+      .insert(targets)
+      .values(targetValues({ name: 'target-a', rank: 1, minBuildLevel }))
+      .returning();
+    targetId = target!.id;
+    const [app] = await db
+      .insert(apps)
+      .values({
+        name: 'plainboi',
+        sourceKind: 'repo',
+        sourceRepoUrl: 'jonpulsifer/infra',
+        sourceRepoSubpath: 'apps/spindrift-demo/plain',
+      })
+      .returning();
+    appId = app!.id;
+    const [component] = await db
+      .insert(components)
+      .values({ appId: app!.id, name: 'web', kind: 'service' })
+      .returning();
+    await db
+      .insert(componentTargetDesired)
+      .values({ componentId: component!.id, targetId });
+
+    ctx = {
+      client,
+      db,
+      adapters: registryWith(['hosted', 'managed', 'local']),
+      clock: { now: () => new Date('2026-08-03T12:00:00.000Z') },
+      manifest: baseManifest,
+      operatorId: operator!.id,
+      principal: {
+        type: 'user',
+        id: operator!.id,
+        displayName: 'Operator',
+      },
+    } as CommandContext;
+  }
+
+  beforeEach(async () => {
+    await seed(null);
+  });
+
+  /**
+   * The behaviour before this column existed, and the behaviour of every App
+   * that has not asked for anything. Null is "no opinion", not "no route".
+   */
+  test('takes the highest-ranked eligible route when it has no opinion', async () => {
+    expect(await routeForTarget(targetId, ctx, appId)).toBe('hosted');
+  });
+
+  test('takes the route it named instead of the one rank would have picked', async () => {
+    const result = await setAppBuildRoute({ appId, route: 'managed' }, ctx);
+
+    expect(result.ok).toBe(true);
+    expect(await routeForTarget(targetId, ctx, appId)).toBe('managed');
+    // The Target's own answer is unchanged: this is the App's say, not a
+    // re-ranking of the installation for everybody.
+    expect(await routeForTarget(targetId, ctx)).toBe('hosted');
+  });
+
+  test('goes back to rank order when the choice is cleared', async () => {
+    await setAppBuildRoute({ appId, route: 'managed' }, ctx);
+    const result = await setAppBuildRoute({ appId, route: null }, ctx);
+
+    expect(result.ok).toBe(true);
+    expect(await routeForTarget(targetId, ctx, appId)).toBe('hosted');
+  });
+
+  /**
+   * §16's threshold, applied to the App's choice exactly as to any other
+   * candidate. `local` is the in-cluster route and it is L1, so a Target at the
+   * default L2 will not take it — and naming it is not a way around that.
+   */
+  test('refuses a route below the Target’s minimum, naming the level', async () => {
+    const result = await setAppBuildRoute({ appId, route: 'local' }, ctx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.failure.code).toBe('NOT_BUILDABLE');
+    expect(result.failure.message).toContain('target-a');
+    expect(result.failure.message).toContain('Build Level 1');
+    // Nothing was written: a refused choice is not a choice.
+    const [row] = await ctx.db
+      .select({ buildRoute: apps.buildRoute })
+      .from(apps)
+      .where(eq(apps.id, appId));
+    expect(row?.buildRoute).toBeNull();
+  });
+
+  test('refuses a route this installation does not have', async () => {
+    const result = await setAppBuildRoute({ appId, route: 'imaginary' }, ctx);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.failure.message).toContain('imaginary');
+  });
+
+  /**
+   * A route an installation configures but this process cannot construct is
+   * unavailable rather than ineligible, and dispatch has to fall through it —
+   * otherwise a missing GitHub credential silently pins every App to a route
+   * that cannot run.
+   */
+  test('falls through a chosen route the process cannot construct', async () => {
+    await setAppBuildRoute({ appId, route: 'managed' }, ctx);
+    const without = {
+      ...ctx,
+      adapters: registryWith(['hosted', 'local']),
+    } as CommandContext;
+
+    expect(await routeForTarget(targetId, without, appId)).toBeNull();
+  });
+
+  /**
+   * The Target's threshold is the Target's, so raising it takes the choice away
+   * — which is the direction being wrong has to fail in.
+   */
+  test('an L3 Target takes the L3 route the App named and refuses the L2 one', async () => {
+    await seed(3);
+
+    expect((await setAppBuildRoute({ appId, route: 'managed' }, ctx)).ok).toBe(
+      true,
+    );
+    expect(await routeForTarget(targetId, ctx, appId)).toBe('managed');
+
+    const refused = await setAppBuildRoute({ appId, route: 'hosted' }, ctx);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) throw new Error('unreachable');
+    expect(refused.failure.message).toContain('at least L3');
+  });
+});

--- a/apps/spindrift/test/commands/app-build-route.test.ts
+++ b/apps/spindrift/test/commands/app-build-route.test.ts
@@ -45,7 +45,8 @@ describe('an App choosing its build route', () => {
   function registryWith(available: readonly string[]): AdapterRegistry {
     return {
       deploy: () => null,
-      build: (name) => (available.includes(name) ? new FakeBuildAdapter() : null),
+      build: (name) =>
+        available.includes(name) ? new FakeBuildAdapter() : null,
       store: () => new FakeSecretStore(),
       supplyChain: () => new SupplyChainHarness(),
       repository: () => null,
@@ -175,6 +176,45 @@ describe('an App choosing its build route', () => {
     } as CommandContext;
 
     expect(await routeForTarget(targetId, without, appId)).toBeNull();
+  });
+
+  /**
+   * The half a level threshold does not cover, and the one the cloud builder
+   * makes real: a route publishes where its own identity reaches, and a Target
+   * pulls from where it can reach. If those do not meet, the Build is green and
+   * the Deploy fails at the pull — so it is refused here instead.
+   */
+  test('refuses a route that publishes nowhere the Target can pull from', async () => {
+    // A route whose identity reaches only the artifact registry, against a
+    // Target that pulls only from GHCR: the cloud builder's exact situation
+    // before a GHCR credential exists.
+    const narrow = {
+      ...ctx,
+      adapters: {
+        ...ctx.adapters,
+        build: (name: string) =>
+          name === 'managed'
+            ? new FakeBuildAdapter({
+                selfAuthorizedRegistries: ['artifactRegistry'],
+              })
+            : new FakeBuildAdapter(),
+      },
+    } as CommandContext;
+    await narrow.db
+      .update(targets)
+      .set({
+        discovery: {
+          reachableRegistries: ['ghcr.io/jonpulsifer'],
+        } as never,
+      })
+      .where(eq(targets.id, targetId));
+
+    const result = await setAppBuildRoute({ appId, route: 'managed' }, narrow);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.failure.message).toContain('cannot pull');
+    expect(result.failure.message).toContain('target-a');
   });
 
   /**

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -362,6 +362,14 @@ describe('creation drafts', () => {
       buildLevel: base.buildLevel,
       provenanceBuilderId: base.provenanceBuilderId,
       carriesRegistryCredential: base.carriesRegistryCredential,
+      // Every flavour, matching `FakeBuildAdapter`'s default: these fakes stand in
+      // for a route, not for one route's reach.
+      selfAuthorizedRegistries: [
+        'artifactRegistry',
+        'dockerHub',
+        'ghcr',
+        'other',
+      ] as const,
       async *build(
         source: Parameters<typeof base.build>[0],
         spec: Parameters<typeof base.build>[1],
@@ -664,6 +672,14 @@ describe('creation drafts', () => {
       buildLevel: 2 as const,
       provenanceBuilderId: 'https://builders.example.test/crashing',
       carriesRegistryCredential: true,
+      // Every flavour, matching `FakeBuildAdapter`'s default: these fakes stand in
+      // for a route, not for one route's reach.
+      selfAuthorizedRegistries: [
+        'artifactRegistry',
+        'dockerHub',
+        'ghcr',
+        'other',
+      ] as const,
       async *build(): AsyncGenerator<never, never, void> {
         yield* [];
         throw new Error('runner connection vanished');

--- a/apps/spindrift/test/harness/fakes/build-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/build-adapter.ts
@@ -6,6 +6,7 @@
  * handed — so a test can assert that the bundle digest reached the route, which
  * is §16's whole join — and replays a scripted result.
  */
+
 import { createHash } from 'node:crypto';
 import type {
   BuildAdapter,
@@ -16,6 +17,7 @@ import type {
   BuildSpec,
   LogFidelity,
 } from '../../../src/adapters/build/contract.ts';
+import type { RegistryFlavour } from '../../../src/domain/artifact-name.ts';
 
 /** What the fake was asked to build, in order. */
 export interface RecordedBuild {
@@ -49,6 +51,8 @@ export interface FakeBuildAdapterOptions {
   provenanceBuilderId?: string;
   /** Defaults to true; a test asserting the hosted route's refusal sets false. */
   carriesRegistryCredential?: boolean;
+  /** Defaults to every flavour, so a test narrows only when that is its point. */
+  selfAuthorizedRegistries?: readonly RegistryFlavour[];
   script?: readonly ScriptedBuild[];
 }
 
@@ -60,6 +64,7 @@ export class FakeBuildAdapter implements BuildAdapter {
   readonly buildLevel: BuildLevel;
   readonly provenanceBuilderId: string;
   readonly carriesRegistryCredential: boolean;
+  readonly selfAuthorizedRegistries: readonly RegistryFlavour[];
 
   /** Every `build`, in call order. */
   readonly built: RecordedBuild[] = [];
@@ -74,6 +79,12 @@ export class FakeBuildAdapter implements BuildAdapter {
     this.provenanceBuilderId =
       options.provenanceBuilderId ?? 'https://spindrift.dev/builders/fake';
     this.carriesRegistryCredential = options.carriesRegistryCredential ?? true;
+    this.selfAuthorizedRegistries = options.selfAuthorizedRegistries ?? [
+      'artifactRegistry',
+      'dockerHub',
+      'ghcr',
+      'other',
+    ];
     this.script = options.script?.length ? options.script : [DEFAULT_BUILD];
   }
 

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -93,9 +93,39 @@ spec:
       auth:
         gateway: null
       build:
+        # Rank order. `hosted` stays first, so an App that states no preference
+        # builds where every App already built; `managed` is what an App asks
+        # for by name (`setAppBuildRoute`) and what a Target requiring L3 gets
+        # on rank alone.
         routes:
           - name: hosted
             adapter: github-actions
+          # The cloud builder, in the shared artifacts project beside the
+          # registry. Spindrift is the proxy on the way in: it stages the git
+          # revision (or the uploaded archive) into the source bucket and hands
+          # the build a signed URL for that one object, so nothing here is
+          # connected to a repository and the bundle every route builds is the
+          # same bundle the source receipt describes.
+          #
+          # Every grant this needs is already declared in
+          # terraform/gcp/projects/trusted-builds — `cloudbuild.builds.editor`
+          # and `logging.viewer` for the controller, `artifactregistry.writer`
+          # and the two attestation permissions for the build worker.
+          - name: managed
+            adapter: cloud-build
+            endpoint: https://cloudbuild.googleapis.com
+            logsEndpoint: https://logging.googleapis.com
+            project: trusted-builds
+            # Where the signer is, so the attestation step is not a
+            # cross-region call: terraform/gcp/projects/trusted-builds sets
+            # `local.region` to this and the KMS key takes it.
+            region: northamerica-northeast1
+            # The stock BuildKit image, which is what `buildkit.ts` declares its
+            # program needs — a POSIX sh, wget, tar, sed, base64, chmod, mktemp
+            # and `buildctl-daemonless.sh`. Pinned by digest: the image is the
+            # engine every build on this route runs, and a moving tag is an
+            # engine that changes underneath a reproducible build.
+            image: moby/buildkit:v0.28.0@sha256:37539dd4d60fc70968d164d3850d903a2c56f6402214a1953fbf9fcb81ada731
         # Railpack publishes the frontend as its own repository. Pinned to a
         # version rather than a moving tag: it is the only input to a
         # zero-config build that no digest covers.
@@ -139,6 +169,12 @@ spec:
             apiServer: https://kubernetes.default.svc
             namespace: spindrift-apps
             chartContract: "3"
+            # GHCR and not the artifact registry: these packages are public, so
+            # the kubelet pulls them with no credential at all. Reaching the
+            # artifact registry would mean an imagePullSecret in every App
+            # namespace, which is a stored credential §13 does not have.
+            reachableRegistries:
+              - ghcr.io/jonpulsifer
             # §7's operator class: what the App chart needs about *this*
             # cluster. Spindrift never renders into it.
             chartValues:
@@ -183,6 +219,14 @@ spec:
             # the controller's `actAs` on it are declared in
             # terraform/gcp/projects/bluenose/iam.tf for exactly this.
             serviceAccount: spindrift-runtime@bluenose.iam.gserviceaccount.com
+            # The artifact registry and nothing else. Cloud Run pulls through a
+            # cache mirror that cannot parse the OCI index pushed to GHCR, so
+            # naming the registry it *can* read is what keeps a Deploy here from
+            # pinning a reference it will fail on. `serverless-robot-prod` holds
+            # `artifactregistry.reader` on it — see
+            # terraform/gcp/projects/trusted-builds/artifact-registry.tf.
+            reachableRegistries:
+              - northamerica-northeast1-docker.pkg.dev/trusted-builds/i
         - name: bluenose-static
           adapter: static
           connection:
@@ -198,7 +242,20 @@ spec:
         # terraform/gcp/projects/trusted-builds/versions.tf sets that to
         # northamerica-northeast1. There has never been a key in us-central1.
         signer: gcpkms://projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer
-        registry: ghcr.io/jonpulsifer
+        # Both, because two Targets here cannot share one. Every artifact is
+        # pushed to each and every Target pins the one it can reach: the cluster
+        # pulls GHCR anonymously, and Cloud Run cannot pull GHCR at all — it
+        # goes through a cache mirror that could not parse an OCI index carrying
+        # provenance, an SBOM and a signature, so the revision failed at the
+        # pull with a digest that was not the one deployed. Order is the
+        # tie-break: the first is what a Target that declares no
+        # `reachableRegistries` gets.
+        #
+        # `terraform/gcp/projects/trusted-builds` declares every grant on the
+        # second one, and its `registry_namespace` output is this exact value.
+        registry:
+          - ghcr.io/jonpulsifer
+          - northamerica-northeast1-docker.pkg.dev/trusted-builds/i
         verifier: ghcr.io/jonpulsifer/spindrift-verifier
         # The authority bluenose's Binary Authorization policy requires an
         # attestation from — `google_binary_authorization_policy.spindrift`


### PR DESCRIPTION
The source→bucket→GCB path was already whole in code — a bundle staged to `gs://` over federation (`storage/archives.ts`), a short-TTL V4 signed URL minted at dispatch (`storage/signed-url.ts`), and a Cloud Build step running the shared BuildKit program and attesting what it pushed (`adapters/build/cloud-build.ts`). What it never had was an installation configuring it, so nothing had ever run it.

**Spindrift stays the proxy on the way in.** The submitted build takes no `source` of its own: a git revision, or an uploaded archive, is staged by Spindrift into the source bucket and the build fetches that one object over a signed URL. Nothing here connects a build service to a repository, and the bundle every route builds stays the bundle the source receipt describes (§16's join).

## The credential bug this would have hit on its first run

`cloud-build.ts` wrote `$DOCKER_CONFIG/config.json` from the metadata server, and `buildkit.ts` then did `DOCKER_CONFIG=$(mktemp -d)` over the top of it whenever `SPINDRIFT_REGISTRY_AUTH` was set. An installation pushing to both a vendor registry and one federation cannot reach therefore lost the vendor half and 401'd at the export — after the entire build. The prelude now folds its minted token into the same variable, leaving the program the single writer of one document carrying both halves.

Verified by executing the generated shell, not only by asserting on its text:

```
{"auths":{"northamerica-northeast1-docker.pkg.dev":{"auth":"…"},"ghcr.io":{"auth":"…"}}}
```

## An App may name its route

`setAppBuildRoute` + `apps.build_route` (migration 0020). It enters selection as the *admitted set*, so §16's order is unchanged — "the level is a threshold, then admin rank wins", and the App's say is on the rank side of that comma:

- naming a route below a Target's minimum is refused with the sentence any other ineligible route gets;
- `null` is **no opinion**, not "no route" — rank order picks, exactly as before this column;
- the registry half is checked too: a Target that can pull from none of the registries this installation pushes to is a dead end, said where the developer is standing rather than discovered by a Deploy.

`build-loop.ts` now carries each candidate's own refusal into `dispatchWaitingOn`, because the old general sentence stopped being the whole truth once an App could pick.

## Both registries, each Target pinned to the one it reaches

Cloud Run cannot pull the GHCR artifact — it goes through a cache mirror that could not parse an OCI index carrying provenance, an SBOM and a signature. So the artifact registry joins `supplyChain.registry` and `bluenose-cloudrun` names it; `offsite` names GHCR, which its kubelet pulls anonymously.

`terraform/gcp/projects/trusted-builds` already declares every grant this needs — `cloudbuild.builds.editor` and `logging.viewer` for the controller, `artifactregistry.writer` and both attestation permissions for the build worker — and its `registry_namespace` output is this exact value. The manifest was the only thing that had not caught up.

## Live

The manifest change is already applied to the offsite installation's durable row via `configureInstallation`; the target loop re-derived `reachableRegistries` and `bluenose-cloudrun` now reports the artifact registry. The helm-release seed here matches, so a torn-down installation comes back the same way.

## Tests

1348 pass, 0 fail. New: `test/commands/app-build-route.test.ts` (7 tests over the threshold/rank interaction) and a cloud-build block in `test/adapters/registry-auth-delivery.test.ts` that fails if the `DOCKER_CONFIG` clobber returns.

## Known gap, not shipped here

The cloud build route cannot push to `ghcr.io` yet: its own identity authorizes only `*.docker.pkg.dev` and `gcr.io`, and `registry_credentials` is empty. Until a ghcr credential is stored, a build on `managed` pushes the artifact registry fine and 401s on GHCR. `hosted` is unaffected — its runner has `GITHUB_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6kRtw8LxNAEhqdjBCeCVc