### PR TITLE
feat(spindrift): connect a Target by reading it, and give folly its own gateway

### DIFF
--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -21,7 +21,10 @@
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import type { TargetInspection } from '../../domain/capabilities.ts';
 import type { ArtifactType, DesiredState } from '../../domain/desired-state.ts';
-import type { TargetConnection } from '../../domain/target.ts';
+import type {
+  KubernetesDeliveryFlavour,
+  TargetConnection,
+} from '../../domain/target.ts';
 
 /**
  * What the verbs need to name a Target. The Target model (§13) carries
@@ -290,6 +293,48 @@ export type RuntimeLogPage =
     };
 
 /**
+ * What a cluster says about itself **before** it is a Target (§13).
+ *
+ * `inspect` cannot answer this: it takes a `DeployTarget`, and a `DeployTarget`
+ * carries the very connection facts — namespace, delivery flavour, chart source
+ * — an operator is here to choose. So a probe is the read that runs one step
+ * earlier, against nothing but an address, and everything it returns is a
+ * **list to pick from** rather than a verdict.
+ *
+ * Every field degrades to empty rather than throwing. A cluster that answers
+ * some reads and refuses others is the ordinary state of a cluster whose
+ * `spindrift-target` RBAC has not been merged yet, and a probe that gave up on
+ * the first `403` would report nothing about a cluster that is nearly ready.
+ * The screen says what was found; what was not found is the operator's to type.
+ */
+export interface ClusterProbe {
+  /** False when the address did not answer at all — the one hard failure. */
+  readonly reachable: boolean;
+  /** Why it did not answer. Present exactly when `reachable` is false. */
+  readonly because?: string;
+  /** Delivery flavours this cluster serves a CRD for (§6). */
+  readonly deliveryFlavours: readonly KubernetesDeliveryFlavour[];
+  /** Namespaces that exist. Spindrift never creates one (§7). */
+  readonly namespaces: readonly string[];
+  /** Sources the App chart could be fetched from — Flux `GitRepository`s. */
+  readonly chartSources: readonly { name: string; namespace: string }[];
+  /** `ClusterSecretStore`s config could be delivered through (§10). */
+  readonly secretStores: readonly string[];
+  /**
+   * Gateways routes could attach to, with the address each answers on.
+   *
+   * The address is the same fact `platform.dns.privateAddress` needs, which is
+   * why it is read here rather than asked for: an operator who picks a gateway
+   * has already said where private traffic lands.
+   */
+  readonly gateways: readonly {
+    name: string;
+    namespace: string;
+    address: string | null;
+  }[];
+}
+
+/**
  * One backend, one artifact shape family, three verbs.
  *
  * `apply` is written as a generator because §6's contract is literally a stream
@@ -350,4 +395,16 @@ export interface DeployAdapter {
    * this, not by asking every adapter to.
    */
   inspect(target: DeployTarget): Promise<TargetInspection>;
+
+  /**
+   * Read a backend that is not a Target yet, so a connect can offer choices.
+   *
+   * Optional, and absent is the honest answer for two of the three adapters: a
+   * cloud project's connection facts are a project id and two API roots, none
+   * of which the project can be asked for before it is named. Only a cluster
+   * has a discovery API to enumerate itself with, so only the cluster adapter
+   * implements this — and an optional method with one implementation is
+   * smaller than a second registry that could only ever hold the same one.
+   */
+  probe?(apiServer: string): Promise<ClusterProbe>;
 }

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -43,6 +43,7 @@ import type {
 } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
 import type {
+  ClusterProbe,
   DeployAdapter,
   DeployEvent,
   DeployPhase,
@@ -136,6 +137,18 @@ const SECRET_STORE = {
   apiVersion: 'external-secrets.io/v1',
   kind: 'ClusterSecretStore',
   plural: 'clustersecretstores',
+} as const;
+
+/**
+ * What a route attaches to. Read only by {@link KubernetesDeployAdapter.probe}
+ * — the App chart renders an `HTTPRoute` and never a `Gateway`, so this
+ * adapter's only interest in one is telling an operator which exist and where
+ * each answers.
+ */
+const GATEWAY = {
+  apiVersion: 'gateway.networking.k8s.io/v1',
+  kind: 'Gateway',
+  plural: 'gateways',
 } as const;
 
 export class KubernetesDeployAdapter implements DeployAdapter {
@@ -329,6 +342,85 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       this.discover(api, connection),
     ]);
     return { prerequisites, discovery };
+  }
+
+  /**
+   * Read a cluster that is not a Target yet (§13's connect, one step earlier).
+   *
+   * Every read is independently caught. §13's "connect always succeeds" has a
+   * mirror here: **probing always answers**, and a cluster that serves Flux but
+   * refuses to list its namespaces produces a screen with one field to pick
+   * from and one to type, rather than an error page about a cluster that is
+   * nearly ready. The one thing that is fatal is the address not answering at
+   * all, because then nothing on the screen would mean anything.
+   */
+  async probe(apiServer: string): Promise<ClusterProbe> {
+    const api = new KubernetesApi({
+      apiServer,
+      token: this.options.token,
+      ...(this.options.fetch === undefined
+        ? {}
+        : { fetch: this.options.fetch }),
+    });
+
+    // The liveness read, and the first half of the delivery answer. `servesKind`
+    // reads the discovery API, which every authenticated identity may read, so
+    // a failure here is the address rather than the permissions.
+    let flux: boolean;
+    try {
+      flux = await api.servesKind(HELM_RELEASE.apiVersion, HELM_RELEASE.kind);
+    } catch (cause) {
+      return {
+        reachable: false,
+        because: cause instanceof Error ? cause.message : String(cause),
+        deliveryFlavours: [],
+        namespaces: [],
+        chartSources: [],
+        secretStores: [],
+        gateways: [],
+      };
+    }
+
+    const [argo, namespaces, sources, stores, gateways] = await Promise.all([
+      api
+        .servesKind(APPLICATION.apiVersion, APPLICATION.kind)
+        .catch(() => false),
+      api.list({ apiVersion: 'v1', plural: 'namespaces' }).catch(() => null),
+      api
+        .list({
+          apiVersion: GIT_REPOSITORY.apiVersion,
+          plural: GIT_REPOSITORY.plural,
+        })
+        .catch(() => null),
+      api
+        .list({
+          apiVersion: SECRET_STORE.apiVersion,
+          plural: SECRET_STORE.plural,
+        })
+        .catch(() => null),
+      api
+        .list({ apiVersion: GATEWAY.apiVersion, plural: GATEWAY.plural })
+        .catch(() => null),
+    ]);
+
+    return {
+      reachable: true,
+      deliveryFlavours: [
+        ...(flux ? (['flux-helmrelease'] as const) : []),
+        ...(argo ? (['argo-application'] as const) : []),
+      ],
+      namespaces: (namespaces ?? []).map((item) => item.metadata.name),
+      chartSources: (sources ?? []).map((item) => ({
+        name: item.metadata.name,
+        namespace: item.metadata.namespace ?? '',
+      })),
+      secretStores: (stores ?? []).map((item) => item.metadata.name),
+      gateways: (gateways ?? []).map((item) => ({
+        name: item.metadata.name,
+        namespace: item.metadata.namespace ?? '',
+        address: gatewayAddress(item),
+      })),
+    };
   }
 
   // --- apply's second half -------------------------------------------------
@@ -950,6 +1042,25 @@ function writeFailure(
     reason: 'TARGET_UNREACHABLE',
     detail: cause instanceof Error ? cause.message : String(cause),
   };
+}
+
+/**
+ * The address a Gateway answers on, or null while it has none.
+ *
+ * The first `IPAddress` entry, and deliberately not a `Hostname` one: what
+ * reads this is `platform.dns.privateAddress`, which the App chart publishes as
+ * an A record. A gateway whose only address is a name has nothing to put there,
+ * and saying so leaves the field for the operator rather than filling it with
+ * something the record cannot hold.
+ */
+function gatewayAddress(gateway: KubernetesObject): string | null {
+  const status = gateway.status as
+    | { addresses?: { type?: string; value?: string }[] }
+    | undefined;
+  const address = (status?.addresses ?? []).find(
+    (entry) => entry.type !== 'Hostname' && (entry.value ?? '') !== '',
+  );
+  return address?.value ?? null;
 }
 
 /** What the nodes say this Target can run (§3's discovered half). */

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -61,3 +61,4 @@ export { useArtifactRegistry } from './storage/use-registry.ts';
 export { connectTarget } from './targets/connect.ts';
 export { disconnectTarget } from './targets/disconnect.ts';
 export { listTargets } from './targets/list.ts';
+export { probeCluster } from './targets/probe.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -127,6 +127,7 @@ import {
   disconnectTargetInput,
 } from './targets/disconnect.ts';
 import { listTargets, listTargetsInput } from './targets/list.ts';
+import { probeCluster, probeClusterInput } from './targets/probe.ts';
 import {
   type Command,
   type CommandContext,
@@ -212,6 +213,7 @@ export const commandRegistry = {
     input: inspectRepositoryInput,
     handler: inspectRepository,
   },
+  probeCluster: { input: probeClusterInput, handler: probeCluster },
   connectTarget: { input: connectTargetInput, handler: connectTarget },
   disconnectTarget: {
     input: disconnectTargetInput,

--- a/apps/spindrift/src/commands/targets/probe.ts
+++ b/apps/spindrift/src/commands/targets/probe.ts
@@ -1,0 +1,81 @@
+/**
+ * `probeCluster` — read a cluster before it is a Target (§13).
+ *
+ * The repository screen settled this shape already: "press Connect, read what
+ * it found, confirm." Connecting a repository stopped being a form about how
+ * deployment works the moment detection did the reading, and a Target's connect
+ * form has the same problem in the same place — an operator was being asked to
+ * type a namespace, a `GitRepository` name, a gateway, and a load-balancer
+ * address, every one of which the cluster can be asked for.
+ *
+ * So this is the Target-side `inspectRepository`: **it writes nothing**, it
+ * answers with lists rather than with a verdict, and what comes back is what a
+ * screen offers as choices. The act that follows it is `connectTarget`, exactly
+ * as `connectRepository` follows the repository scan.
+ *
+ * Two things it deliberately is not:
+ *
+ * - **Not a reachability gate.** §13's connect always succeeds and its health
+ *   is a standing checklist; a probe that could refuse would be the second
+ *   opinion §13 does not have. A cluster that answers nothing still connects,
+ *   and the checklist afterwards says why it is unhealthy.
+ * - **Not a source of defaults.** Everything here was read off *this* cluster.
+ *   What is carried from another Target arrives beside it as a
+ *   {@link TargetConnectionProposal}, kept separate so a screen can say which
+ *   of the two a value came from — §3's grammar, applied to a form field.
+ */
+import { z } from 'zod';
+import type { ClusterProbe } from '../../adapters/deploy/contract.ts';
+import { VALUES_CONTRACT } from '../../adapters/deploy/kubernetes/values.ts';
+import { connectionProposal } from '../../domain/target-onboarding.ts';
+import type { TargetConnectionProposal } from '../../web/model.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const probeClusterInput = z
+  .object({
+    /** The only fact a probe needs. No Target row exists yet to read one from. */
+    apiServer: z.url(),
+  })
+  .strict();
+
+export type ProbeClusterInput = z.infer<typeof probeClusterInput>;
+
+export interface ProbeClusterResult {
+  /** What this cluster said about itself. */
+  readonly probe: ClusterProbe;
+  /** What a Target this installation already has would lend (§13). */
+  readonly proposal: TargetConnectionProposal;
+  /**
+   * The value contract this build renders (§7).
+   *
+   * Offered as the default for `chartContract` because until the OCI swap every
+   * Target fetches the App chart from a branch of the same repository, so a
+   * second cluster's chart is this repository's chart. The field stays editable:
+   * the moment a Target pins something else, stating it is what turns skew into
+   * a checklist failure instead of a deploy that renders the wrong values.
+   */
+  readonly rendersContract: string;
+}
+
+export const probeCluster: Command<
+  ProbeClusterInput,
+  ProbeClusterResult
+> = async (input, context) => {
+  const adapter = context.adapters.deploy('kubernetes');
+  if (adapter?.probe === undefined) {
+    // §3's disabled-with-reasons grammar rather than a new failure code: an
+    // installation without the cluster adapter cannot deploy to a cluster, and
+    // that is the fact the operator is being told.
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this installation has no Kubernetes adapter to read a cluster with',
+    );
+  }
+
+  const rows = await context.db.query.targets.findMany();
+  return ok({
+    probe: await adapter.probe(input.apiServer),
+    proposal: connectionProposal(rows, 'kubernetes'),
+    rendersContract: VALUES_CONTRACT,
+  });
+};

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -268,10 +268,14 @@ export interface ClusterConnectPlan {
  *   and the claim is not this function's to make. **ponytail:** widening it is a
  *   manifest edit today; give it a control when an installation runs an edge
  *   whose policy actually holds publicly.
- * - **`networkPolicy.allowedNamespaces`** is exactly the namespaces of the
- *   components that were included. The chart's ingress is default-deny, so a
- *   route attached to a gateway in a namespace nobody listed reaches nothing —
- *   which is the failure this derivation exists to make impossible.
+ * - **`networkPolicy.allowedNamespaces`** is the namespaces of the components
+ *   that were included, less the one the workloads are in. The chart's ingress
+ *   is default-deny, so a route attached to a gateway in a namespace nobody
+ *   listed reaches nothing — which is the failure this derivation exists to
+ *   make impossible. Its own namespace is left out because the chart already
+ *   admits same-namespace siblings unconditionally: a gateway beside the
+ *   workloads it serves needs no entry, and writing one would put a name in
+ *   the list that means nothing.
  */
 export function clusterConnectPlan(
   choices: ClusterConnectChoices,
@@ -279,7 +283,8 @@ export function clusterConnectPlan(
   const allowedNamespaces = [
     ...new Set(
       [choices.gateway?.namespace, choices.externalAuth?.namespace].filter(
-        (namespace): namespace is string => (namespace ?? '') !== '',
+        (candidate): candidate is string =>
+          (candidate ?? '') !== '' && candidate !== choices.namespace,
       ),
     ),
   ];

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -84,6 +84,15 @@ function kubernetesProposal(
     ...(connection.chartContract === undefined
       ? {}
       : { chartContract: connection.chartContract }),
+    // Carried whole. What the screen takes out of it is `platform.externalAuth`
+    // and `platform.secretStore`'s kind — the parts `clusters/base` makes the
+    // same on every cluster. What it must not take is `platform.dns`, which
+    // names one cluster's gateway address; the screen reads that off the probe
+    // instead, and the split is stated here rather than performed here so a
+    // second consumer cannot get it the other way round.
+    ...(connection.chartValues === undefined
+      ? {}
+      : { chartValues: connection.chartValues }),
   };
 }
 
@@ -176,4 +185,187 @@ export function pendingConnections(
   }
 
   return pending;
+}
+
+// --- Connecting a cluster, one component at a time --------------------------
+
+/** §3's reach vocabulary, as both the seed and the connect act spell it. */
+type Reach = 'none' | 'private' | 'public';
+
+/**
+ * What an operator picked on the connect screen.
+ *
+ * Three of these are required because a Target without them is not addressable,
+ * and the rest are **components**: each one is a thing this cluster already runs
+ * that an App's release can be made to blend into, and each is `null` when the
+ * operator left it out. Leaving one out is a supported answer everywhere — a
+ * cluster with no gateway serves nothing but in-cluster traffic, which §3 spells
+ * `none` and is a real Target.
+ */
+export interface ClusterConnectChoices {
+  readonly name: string;
+  readonly apiServer: string;
+  /** Where App workloads land. Never created by Spindrift (§7). */
+  readonly namespace: string;
+  /** Where the `HelmRelease` object itself is created. */
+  readonly deliveryNamespace: string;
+  /** The `GitRepository` the App chart is fetched from. */
+  readonly sourceRef: { readonly name: string; readonly namespace: string };
+  /** The value contract the App chart pinned here declares (§7). */
+  readonly chartContract: string;
+  /** The gateway routes attach to, and the address it answers on. */
+  readonly gateway: {
+    readonly name: string;
+    readonly namespace: string;
+    readonly privateAddress: string | null;
+  } | null;
+  /** The authenticated edge that stands in front, where there is one. */
+  readonly externalAuth: {
+    readonly name: string;
+    readonly namespace: string;
+    readonly port: number;
+  } | null;
+  /** The `ClusterSecretStore` config is fetched through (§10). */
+  readonly secretStore: string | null;
+  /** The tunnel this Target answers public traffic through, where it has one. */
+  readonly tunnelHostname: string | null;
+}
+
+/** What `connectTarget` takes for a cluster, assembled from the choices. */
+export interface ClusterConnectPlan {
+  readonly kind: 'kubernetes';
+  readonly name: string;
+  readonly apiServer: string;
+  readonly namespace: string;
+  readonly delivery: {
+    readonly flavour: 'flux-helmrelease';
+    readonly namespace: string;
+    readonly sourceRef: { readonly name: string; readonly namespace: string };
+  };
+  readonly chartContract: string;
+  readonly chartValues: Record<string, unknown>;
+  readonly reaches: Reach[];
+  readonly authReaches: Reach[];
+}
+
+/**
+ * Turn the operator's choices into one connect act.
+ *
+ * This is the whole of the screen's reasoning and it is here rather than in the
+ * view for the reason the top of this file gives: three of the values below are
+ * **derived from what was included**, and a browser deriving them is a browser
+ * that can derive them differently from the next screen that needs to.
+ *
+ * The three:
+ *
+ * - **`reaches`** follows from the components. `none` is always true — a
+ *   Component reachable only in-cluster needs nothing. `private` is true exactly
+ *   when a gateway with an address was included, because that address *is* the
+ *   private reach. `public` is true exactly when a tunnel was named.
+ * - **`authReaches`** is `private` and never `public`, whatever the edge could
+ *   technically front. An authenticated proxy admitting one account is honest in
+ *   front of an RFC1918 address and a claim in front of one anybody can reach,
+ *   and the claim is not this function's to make. **ponytail:** widening it is a
+ *   manifest edit today; give it a control when an installation runs an edge
+ *   whose policy actually holds publicly.
+ * - **`networkPolicy.allowedNamespaces`** is exactly the namespaces of the
+ *   components that were included. The chart's ingress is default-deny, so a
+ *   route attached to a gateway in a namespace nobody listed reaches nothing —
+ *   which is the failure this derivation exists to make impossible.
+ */
+export function clusterConnectPlan(
+  choices: ClusterConnectChoices,
+): ClusterConnectPlan {
+  const allowedNamespaces = [
+    ...new Set(
+      [choices.gateway?.namespace, choices.externalAuth?.namespace].filter(
+        (namespace): namespace is string => (namespace ?? '') !== '',
+      ),
+    ),
+  ];
+  const privateAddress = choices.gateway?.privateAddress ?? '';
+  const tunnelHostname = choices.tunnelHostname ?? '';
+
+  const reaches: Reach[] = [
+    'none',
+    ...(privateAddress === '' ? [] : (['private'] as const)),
+    ...(tunnelHostname === '' ? [] : (['public'] as const)),
+  ];
+
+  return {
+    kind: 'kubernetes',
+    name: choices.name,
+    apiServer: choices.apiServer,
+    namespace: choices.namespace,
+    delivery: {
+      flavour: 'flux-helmrelease',
+      namespace: choices.deliveryNamespace,
+      sourceRef: choices.sourceRef,
+    },
+    chartContract: choices.chartContract,
+    // Only `platform`. §7 gives that key to the operator whole and Spindrift
+    // renders `app` and `shared` per deploy, so writing either here would be
+    // saving a value the next deploy overwrites.
+    chartValues: {
+      platform: {
+        ...(choices.gateway === null
+          ? {}
+          : {
+              gateway: {
+                name: choices.gateway.name,
+                namespace: choices.gateway.namespace,
+              },
+            }),
+        ...(choices.externalAuth === null
+          ? {}
+          : { externalAuth: choices.externalAuth }),
+        ...(choices.secretStore === null
+          ? {}
+          : {
+              secretStore: {
+                kind: 'ClusterSecretStore',
+                name: choices.secretStore,
+              },
+            }),
+        dns: { privateAddress, tunnelHostname },
+        networkPolicy: { allowedNamespaces },
+      },
+    },
+    reaches,
+    authReaches:
+      choices.externalAuth === null || !reaches.includes('private')
+        ? []
+        : ['private'],
+  };
+}
+
+/**
+ * The same act, as the installation manifest declares it.
+ *
+ * §13's connect and `targets[]` in the manifest are two spellings of one thing,
+ * and this function is the proof — the screen renders what it is about to do as
+ * the document that would do it, so an operator connecting a cluster through the
+ * UI can put the identical connection in Git and a torn-down installation comes
+ * back with it. That is the whole of "connectable both ways": not two code
+ * paths, one shape with two entry points.
+ *
+ * Returned as an object rather than as text. JSON is valid YAML, so a caller
+ * that wants a document has `JSON.stringify` and no emitter to maintain.
+ */
+export function targetSeedOf(
+  plan: ClusterConnectPlan,
+): Record<string, unknown> {
+  return {
+    name: plan.name,
+    adapter: 'kubernetes',
+    ...(plan.reaches.length > 0 ? { reaches: plan.reaches } : {}),
+    ...(plan.authReaches.length > 0 ? { authReaches: plan.authReaches } : {}),
+    connection: {
+      apiServer: plan.apiServer,
+      namespace: plan.namespace,
+      delivery: plan.delivery,
+      chartContract: plan.chartContract,
+      chartValues: plan.chartValues,
+    },
+  };
 }

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -618,6 +618,19 @@ export interface TargetConnectionProposal {
     readonly namespace: string;
   };
   readonly chartContract?: string;
+  /**
+   * §7's operator class, as an already-working cluster states it.
+   *
+   * Carried whole, and then read apart by the screen rather than by anything
+   * here: `platform.externalAuth` names an authenticated edge that
+   * `clusters/base` puts in the same namespace on every cluster, so the value
+   * a working Target holds is the right proposal for the next one — while
+   * `platform.dns.privateAddress` names one gateway's address and is the
+   * opposite, which is why the screen fills that one from the probe and this
+   * one from here. Untyped for the reason `KubernetesConnection.chartValues`
+   * gives: the chart's classes are the adapter's knowledge.
+   */
+  readonly chartValues?: Record<string, unknown>;
   readonly region?: string;
   readonly runEndpoint?: string;
   readonly hostingEndpoint?: string;

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -1,137 +1,114 @@
 /**
- * Finishing a Target's connection (§13).
+ * Connecting a Target (§13).
  *
- * `connectTarget` has existed since Task 13 with no screen in front of it, so
- * every Target this installation has was declared in the manifest or created
- * by a test. This is the screen.
+ * The cluster half of this screen used to be eight text fields — an API server,
+ * a namespace, a `GitRepository` and its namespace, and nothing at all for the
+ * gateway, the authenticated edge, the config store, or the address a route's
+ * DNS record points at, which meant a cluster connected here could never take
+ * an App that had to be reachable. Every one of those is something the cluster
+ * can be asked for, and asking a person to type them made connecting a Target a
+ * form about how Kubernetes delivery works rather than a decision about where
+ * to deploy.
  *
- * Three things keep it short, and all three come out of §13 rather than out of
- * a preference for short forms:
+ * So it is the repository screen's shape, one noun over: **give an address,
+ * read what is there, choose what to blend into, confirm.** `probeCluster` is
+ * the read and it writes nothing; `connectTarget` is the confirm.
  *
- * - **The adapter is not a question.** A pending connection is a manifest seed,
- *   and a seed names its adapter. Nothing here asks what kind of thing this is;
- *   it asks the two or three facts that seed did not carry.
- * - **A cloud project is one act.** Connecting `bluenose` registers both
- *   `bluenose-cloudrun` and `bluenose-static`. The form says so and asks once.
- * - **Connect always succeeds, so there is no test button.** A reachability
- *   gate would be a second opinion about health, and §13 has exactly one: the
- *   standing checklist, which this act runs a pass of on its way through. Press
- *   the button and read the checklist — that *is* the test, and unlike a
- *   preflight it keeps being true tomorrow.
+ * What that buys, beyond fewer keystrokes:
+ *
+ * - **The components are the form.** A gateway, an authenticated edge, and a
+ *   config store are each a card the operator includes or leaves out, and
+ *   leaving one out is a supported Target rather than a half-filled one. §3's
+ *   reaches fall out of what was included rather than being a fourth question.
+ * - **Nothing is proposed that this cluster did not confirm.** A namespace, a
+ *   chart source, and a gateway address come off the probe. What is carried
+ *   from a working Target is only what `clusters/base` makes identical on every
+ *   cluster, and the card says which of the two a value came from.
+ * - **The declaration is on the screen.** What the button is about to do is
+ *   rendered as the manifest entry that would do the same thing, because §13's
+ *   connect act and the manifest's `targets[]` are one shape with two entry
+ *   points — and an operator who cannot see that has to take it on faith.
+ *
+ * Connect still always succeeds, so there is still no test button. Press it and
+ * read the checklist; that *is* the test, and unlike a preflight it keeps being
+ * true tomorrow.
  */
-import { Layers, Server } from 'lucide-react';
-import { useState } from 'react';
-import type { InputOf } from '../../client.ts';
+import {
+  AlertTriangle,
+  Globe,
+  Layers,
+  Loader2,
+  Lock,
+  Radio,
+  Search,
+  Server,
+  Shield,
+  Waypoints,
+} from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+import {
+  type ClusterConnectChoices,
+  clusterConnectPlan,
+  targetSeedOf,
+} from '../../../domain/target-onboarding.ts';
+import { command, type InputOf, type OutputOf } from '../../client.ts';
 import type { TargetConnectionProposal } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '../../ui/collapsible.tsx';
 import { Field, Label } from '../../ui/field.tsx';
+import { cn } from '../../ui/utils.ts';
 
 type ConnectTargetInput = InputOf<'connectTarget'>;
+type Probed = OutputOf<'probeCluster'>;
 
-/**
- * The `sourceRef` a Flux delivery needs, defaulted from the proposal.
- *
- * Split out because it is the one nested value on the form, and because an
- * `argo-application` delivery does not have one — a shape the discriminated
- * union in `connectTarget` already refuses, and which this mirrors rather than
- * restates.
- */
-function fluxDelivery(
-  namespace: string,
-  sourceName: string,
-  sourceNamespace: string,
-) {
-  return {
-    flavour: 'flux-helmrelease' as const,
-    namespace,
-    sourceRef: { name: sourceName, namespace: sourceNamespace },
-  };
-}
+/** What the panel is doing, in the same three states the repository scan has. */
+type Scan =
+  | { readonly state: 'idle' }
+  | { readonly state: 'reading' }
+  | { readonly state: 'read'; readonly probed: Probed }
+  | { readonly state: 'failed'; readonly message: string };
 
-export function ConnectTargetForm({
-  kind,
-  name,
-  targets,
-  proposal,
-  connecting,
-  onConnect,
-  onCancel,
-}: {
+export function ConnectTargetForm(props: {
   kind: 'kubernetes' | 'cloud';
   name: string;
+  /** True on the "add a Target" path, where no manifest seed named it. */
+  nameEditable?: boolean;
   targets: readonly string[];
   proposal: TargetConnectionProposal;
   connecting: boolean;
   onConnect: (input: ConnectTargetInput) => void;
   onCancel: () => void;
 }) {
-  // Per-instance, so never proposed: see `TargetConnectionProposal`.
-  const [apiServer, setApiServer] = useState('');
-  const [project, setProject] = useState('');
-  // Carried where a working Target of the same adapter taught us the value.
-  const [namespace, setNamespace] = useState(proposal.namespace ?? '');
-  const [sourceName, setSourceName] = useState(proposal.sourceRef?.name ?? '');
-  const [sourceNamespace, setSourceNamespace] = useState(
-    proposal.sourceRef?.namespace ?? '',
-  );
-  const [region, setRegion] = useState(proposal.region ?? '');
-  const [runEndpoint, setRunEndpoint] = useState(proposal.runEndpoint ?? '');
-  const [hostingEndpoint, setHostingEndpoint] = useState(
-    proposal.hostingEndpoint ?? '',
-  );
-
-  const carried = proposal.carriedFrom;
-  // ponytail: the form writes a Flux delivery and only that. Argo is a real
-  // `connectTarget` shape with five more fields and nothing in this
-  // installation uses it, so rather than render a branch nobody exercises the
-  // screen refuses and points at the manifest, which can express both. Add the
-  // branch when a second delivery flavour actually shows up.
-  const unsupportedDelivery = proposal.deliveryFlavour === 'argo-application';
-  const ready =
-    kind === 'kubernetes'
-      ? apiServer.trim() !== '' &&
-        namespace.trim() !== '' &&
-        sourceName.trim() !== '' &&
-        sourceNamespace.trim() !== ''
-      : project.trim() !== '' &&
-        region.trim() !== '' &&
-        runEndpoint.trim() !== '' &&
-        hostingEndpoint.trim() !== '';
-
-  const submit = () => {
-    onConnect(
-      kind === 'kubernetes'
-        ? {
-            kind: 'kubernetes',
-            name,
-            apiServer: apiServer.trim(),
-            namespace: namespace.trim(),
-            delivery: fluxDelivery(
-              namespace.trim(),
-              sourceName.trim(),
-              sourceNamespace.trim(),
-            ),
-            ...(proposal.chartContract === undefined
-              ? {}
-              : { chartContract: proposal.chartContract }),
-          }
-        : {
-            kind: 'cloud',
-            name,
-            project: project.trim(),
-            region: region.trim(),
-            runEndpoint: runEndpoint.trim(),
-            hostingEndpoint: hostingEndpoint.trim(),
-            ...(proposal.policyEndpoint === undefined
-              ? {}
-              : { policyEndpoint: proposal.policyEndpoint }),
-          },
-    );
-  };
-
   return (
     <div className="flex flex-col gap-4">
+      <Heading {...props} />
+      {props.kind === 'kubernetes' ? (
+        <ConnectCluster {...props} />
+      ) : (
+        <ConnectCloud {...props} />
+      )}
+    </div>
+  );
+}
+
+function Heading({
+  kind,
+  name,
+  targets,
+  proposal,
+}: {
+  kind: 'kubernetes' | 'cloud';
+  name: string;
+  targets: readonly string[];
+  proposal: TargetConnectionProposal;
+}) {
+  return (
+    <>
       <div className="flex flex-wrap items-center gap-2">
         {kind === 'kubernetes' ? (
           <Server aria-hidden="true" className="size-4 text-muted-foreground" />
@@ -142,13 +119,13 @@ export function ConnectTargetForm({
         <Badge tone="idle">
           {kind === 'kubernetes' ? 'cluster' : 'cloud project'}
         </Badge>
-        {carried !== null ? (
+        {proposal.carriedFrom !== null ? (
           <span className="ml-auto text-xs text-muted-foreground">
-            defaults carried from <span className="font-mono">{carried}</span>
+            defaults carried from{' '}
+            <span className="font-mono">{proposal.carriedFrom}</span>
           </span>
         ) : null}
       </div>
-
       {targets.length > 1 ? (
         <p className="text-xs text-muted-foreground">
           Registers{' '}
@@ -161,92 +138,449 @@ export function ConnectTargetForm({
           — one project, both of its Targets.
         </p>
       ) : null}
+    </>
+  );
+}
 
+// --- The cluster flow -------------------------------------------------------
+
+function ConnectCluster({
+  name,
+  nameEditable = false,
+  proposal,
+  connecting,
+  onConnect,
+  onCancel,
+}: {
+  name: string;
+  nameEditable?: boolean;
+  proposal: TargetConnectionProposal;
+  connecting: boolean;
+  onConnect: (input: ConnectTargetInput) => void;
+  onCancel: () => void;
+}) {
+  const [targetName, setTargetName] = useState(name);
+  // Per-instance, so never proposed: this is the one field that names *this*
+  // cluster, and a second cluster prefilled with the first one's address would
+  // read as correct and deploy somewhere else.
+  const [apiServer, setApiServer] = useState('');
+  const [scan, setScan] = useState<Scan>({ state: 'idle' });
+  /** Counts reads, so a re-read remounts the panel below on the new answer. */
+  const [reads, setReads] = useState(0);
+
+  const read = async () => {
+    setScan({ state: 'reading' });
+    try {
+      const result = await command('probeCluster', {
+        apiServer: apiServer.trim(),
+      });
+      setReads((count) => count + 1);
+      setScan(
+        result.ok
+          ? { state: 'read', probed: result.value }
+          : { state: 'failed', message: result.failure.message },
+      );
+    } catch (cause) {
+      setScan({
+        state: 'failed',
+        message:
+          cause instanceof Error ? cause.message : 'Reading the cluster failed',
+      });
+    }
+  };
+
+  const addressed = targetName.trim() !== '' && apiServer.trim() !== '';
+
+  return (
+    <div className="flex flex-col gap-4">
       <div className="grid gap-4 md:grid-cols-2">
-        {kind === 'kubernetes' ? (
-          <>
-            <Field
-              name="api-server"
-              label="API server"
-              value={apiServer}
-              onChange={(event) => setApiServer(event.target.value)}
-              placeholder="https://kubernetes.default.svc"
-              hint="Not carried from another cluster — this one names this cluster."
-            />
-            <Field
-              name="namespace"
-              label="Namespace"
-              value={namespace}
-              onChange={(event) => setNamespace(event.target.value)}
-              hint="Where App workloads land. Spindrift never creates it."
-            />
-            <Field
-              name="source-name"
-              label="Flux GitRepository"
-              value={sourceName}
-              onChange={(event) => setSourceName(event.target.value)}
-              hint="The source the App chart is fetched from."
-            />
-            <Field
-              name="source-namespace"
-              label="GitRepository namespace"
-              value={sourceNamespace}
-              onChange={(event) => setSourceNamespace(event.target.value)}
-            />
-          </>
-        ) : (
-          <>
-            <Field
-              name="project"
-              label="Project"
-              value={project}
-              onChange={(event) => setProject(event.target.value)}
-              hint="Not carried — a second project prefilled with the first one's id would read as correct."
-            />
-            <Field
-              name="region"
-              label="Region"
-              value={region}
-              onChange={(event) => setRegion(event.target.value)}
-            />
-            <Field
-              name="run-endpoint"
-              label="Cloud Run API"
-              value={runEndpoint}
-              onChange={(event) => setRunEndpoint(event.target.value)}
-            />
-            <Field
-              name="hosting-endpoint"
-              label="Hosting API"
-              value={hostingEndpoint}
-              onChange={(event) => setHostingEndpoint(event.target.value)}
-            />
-          </>
-        )}
+        {nameEditable ? (
+          <Field
+            name="target-name"
+            label="Target name"
+            value={targetName}
+            onChange={(event) => setTargetName(event.target.value)}
+            hint="What this Target is called here. Placement and rank use it."
+          />
+        ) : null}
+        <Field
+          name="api-server"
+          label="API server"
+          value={apiServer}
+          onChange={(event) => {
+            setApiServer(event.target.value);
+            // The panel below is about the cluster that was read, so editing
+            // the address retires it rather than leaving choices standing that
+            // came from somewhere else.
+            setScan({ state: 'idle' });
+          }}
+          placeholder="https://cluster.example:6443"
+          hint="The only thing needed to read the cluster. Nothing is written."
+        />
       </div>
-
-      {kind === 'kubernetes' ? (
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="delivery">Delivery</Label>
-          <p className="text-xs text-muted-foreground">
-            Flux <span className="font-mono">HelmRelease</span>.
-          </p>
-        </div>
-      ) : null}
-
-      {unsupportedDelivery ? (
-        <div className="rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
-          The cluster this installation already runs delivers through Argo. This
-          form writes a Flux delivery and would not match it — declare this
-          Target's connection in the installation manifest instead.
-        </div>
-      ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
         <Button
-          disabled={!ready || connecting || unsupportedDelivery}
-          onClick={submit}
+          variant={scan.state === 'read' ? 'outline' : 'default'}
+          disabled={!addressed || scan.state === 'reading'}
+          onClick={read}
         >
+          {scan.state === 'reading' ? (
+            <Loader2 aria-hidden="true" className="size-4 animate-spin" />
+          ) : (
+            <Search aria-hidden="true" className="size-4" />
+          )}
+          {scan.state === 'reading'
+            ? 'Reading…'
+            : scan.state === 'read'
+              ? 'Read again'
+              : 'Read this cluster'}
+        </Button>
+        {scan.state === 'idle' ? (
+          <p className="text-xs text-muted-foreground">
+            Spindrift asks the cluster what it runs, and offers what it finds.
+          </p>
+        ) : null}
+        {scan.state === 'idle' || scan.state === 'failed' ? (
+          <Button variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+        ) : null}
+      </div>
+
+      {scan.state === 'failed' ? (
+        <Notice tone="destructive">
+          The cluster could not be read: {scan.message}
+        </Notice>
+      ) : null}
+
+      {scan.state === 'read' ? (
+        <ClusterComponents
+          key={reads}
+          name={targetName.trim()}
+          apiServer={apiServer.trim()}
+          probed={scan.probed}
+          proposal={proposal}
+          connecting={connecting}
+          onConnect={onConnect}
+          onCancel={onCancel}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The components this cluster offers, and the choice about each.
+ *
+ * Mounted fresh per read — the caller keys it on the read count — so re-reading
+ * a cluster after fixing its RBAC re-derives every default rather than leaving
+ * a stale pick that the new probe no longer offers.
+ */
+function ClusterComponents({
+  name,
+  apiServer,
+  probed,
+  proposal,
+  connecting,
+  onConnect,
+  onCancel,
+}: {
+  name: string;
+  apiServer: string;
+  probed: Probed;
+  proposal: TargetConnectionProposal;
+  connecting: boolean;
+  onConnect: (input: ConnectTargetInput) => void;
+  onCancel: () => void;
+}) {
+  const { probe } = probed;
+  const carried = carriedPlatform(proposal);
+
+  const namespaces = probe.namespaces;
+  const [namespace, setNamespace] = useState(
+    pick(namespaces, proposal.namespace),
+  );
+  const [deliveryNamespace, setDeliveryNamespace] = useState(
+    pick(namespaces, proposal.namespace),
+  );
+  const [source, setSource] = useState(
+    refKey(probe.chartSources, proposal.sourceRef),
+  );
+  const [chartContract, setChartContract] = useState(
+    proposal.chartContract ?? probed.rendersContract,
+  );
+
+  const [gatewayName, setGatewayName] = useState(
+    refKey(probe.gateways, undefined),
+  );
+  /**
+   * Read off the Gateway, and still editable.
+   *
+   * Two states need it to be a field rather than a derived value, and both are
+   * ordinary: a Gateway whose load balancer has not been assigned yet reports
+   * no address, and a cluster that would not let its Gateways be listed offers
+   * nothing to read one off. Either way the operator knows the address and the
+   * alternative is a Target that can only reach `none`.
+   */
+  const [privateAddress, setPrivateAddress] = useState(
+    probe.gateways[0]?.address ?? '',
+  );
+  const [gatewayOn, setGatewayOn] = useState(probe.gateways.length > 0);
+  const [authOn, setAuthOn] = useState(carried.externalAuth !== null);
+  const [authName, setAuthName] = useState(carried.externalAuth?.name ?? '');
+  const [authNamespace, setAuthNamespace] = useState(
+    carried.externalAuth?.namespace ?? '',
+  );
+  const [authPort, setAuthPort] = useState(
+    String(carried.externalAuth?.port ?? 80),
+  );
+  const [storeOn, setStoreOn] = useState(probe.secretStores.length > 0);
+  const [store, setStore] = useState(probe.secretStores[0] ?? '');
+  const [tunnelOn, setTunnelOn] = useState(false);
+  const [tunnel, setTunnel] = useState('');
+
+  // Parsed rather than looked up, because {@link Choice} degrades to a text
+  // field on a cluster that would not list the kind — and a form that could
+  // only accept what the probe returned would be unusable on exactly the
+  // cluster whose RBAC has not merged yet, which is every cluster once.
+  const chosenGateway = parseRef(gatewayName);
+  const chosenSource = parseRef(source);
+  const discoveredAddress =
+    probe.gateways.find((entry) => refOf(entry) === gatewayName)?.address ??
+    null;
+
+  const choices: ClusterConnectChoices = {
+    name,
+    apiServer,
+    namespace,
+    deliveryNamespace,
+    sourceRef: chosenSource ?? { name: '', namespace: '' },
+    chartContract: chartContract.trim(),
+    gateway:
+      gatewayOn && chosenGateway !== null
+        ? {
+            name: chosenGateway.name,
+            namespace: chosenGateway.namespace,
+            privateAddress:
+              privateAddress.trim() === '' ? null : privateAddress.trim(),
+          }
+        : null,
+    externalAuth:
+      authOn && authName.trim() !== '' && authNamespace.trim() !== ''
+        ? {
+            name: authName.trim(),
+            namespace: authNamespace.trim(),
+            port: Number(authPort) || 80,
+          }
+        : null,
+    secretStore: storeOn && store !== '' ? store : null,
+    tunnelHostname: tunnelOn && tunnel.trim() !== '' ? tunnel.trim() : null,
+  };
+  const plan = clusterConnectPlan(choices);
+
+  const servesFlux = probe.deliveryFlavours.includes('flux-helmrelease');
+  const ready =
+    name !== '' &&
+    namespace !== '' &&
+    deliveryNamespace !== '' &&
+    chosenSource !== null &&
+    chartContract.trim() !== '';
+
+  return (
+    <div className="flex flex-col gap-3 border-t border-border-soft pt-4">
+      {!servesFlux ? (
+        <Notice tone="warning">
+          This cluster serves no <span className="font-mono">HelmRelease</span>,
+          so a Target here has nothing to deliver through. Connecting still
+          records it — the checklist will say the same thing, and keep saying it
+          until Flux is installed.
+        </Notice>
+      ) : null}
+
+      <Component
+        icon={<Waypoints aria-hidden="true" className="size-4" />}
+        title="Delivery"
+        because="Flux applies the App chart. Spindrift writes the HelmRelease through the API."
+        required
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <Choice
+            name="delivery-namespace"
+            label="HelmRelease namespace"
+            value={deliveryNamespace}
+            onChange={setDeliveryNamespace}
+            options={namespaces}
+            hint="Read off this cluster."
+          />
+          <Choice
+            name="chart-source"
+            label="Chart source"
+            value={source}
+            onChange={setSource}
+            options={probe.chartSources.map(refOf)}
+            hint={
+              probe.chartSources.length === 0
+                ? 'No GitRepository was readable here — the App chart has nowhere to come from.'
+                : 'The GitRepository the App chart is fetched from.'
+            }
+          />
+        </div>
+      </Component>
+
+      <Component
+        icon={<Server aria-hidden="true" className="size-4" />}
+        title="Workloads"
+        because="Where an App's release lands. Spindrift never creates the namespace (§7)."
+        required
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <Choice
+            name="workload-namespace"
+            label="Namespace"
+            value={namespace}
+            onChange={setNamespace}
+            options={namespaces}
+          />
+          <Field
+            name="chart-contract"
+            label="Chart contract"
+            value={chartContract}
+            onChange={(event) => setChartContract(event.target.value)}
+            hint={`What the App chart here declares. This build renders ${probed.rendersContract}.`}
+          />
+        </div>
+      </Component>
+
+      <Component
+        icon={<Radio aria-hidden="true" className="size-4" />}
+        title="Gateway"
+        because="Routes attach to it, and its address is where a private record points."
+        on={gatewayOn}
+        onToggle={setGatewayOn}
+      >
+        <div className="grid gap-4 md:grid-cols-2">
+          <Choice
+            name="gateway"
+            label="Gateway"
+            value={gatewayName}
+            onChange={(value) => {
+              setGatewayName(value);
+              // Follow the pick. An address left behind from the previous
+              // Gateway is the one wrong value here that would look right.
+              setPrivateAddress(
+                probe.gateways.find((entry) => refOf(entry) === value)
+                  ?.address ?? '',
+              );
+            }}
+            options={probe.gateways.map(refOf)}
+            hint={
+              probe.gateways.length === 0
+                ? 'No Gateway was readable here — name one as namespace/name.'
+                : undefined
+            }
+          />
+          <Field
+            name="private-address"
+            label="Private address"
+            value={privateAddress}
+            onChange={(event) => setPrivateAddress(event.target.value)}
+            hint={
+              discoveredAddress === null
+                ? 'This Gateway reports no address, so nothing was read — an empty field means this Target reaches only in-cluster.'
+                : 'Read off the Gateway. Published unproxied, so it is the private boundary.'
+            }
+          />
+        </div>
+      </Component>
+
+      <Component
+        icon={<Shield aria-hidden="true" className="size-4" />}
+        title="Authenticated edge"
+        because="Stands in front of a Component whose auth is proxy."
+        on={authOn}
+        onToggle={setAuthOn}
+        carriedFrom={
+          carried.externalAuth === null ? null : proposal.carriedFrom
+        }
+      >
+        <div className="grid gap-4 md:grid-cols-3">
+          <Field
+            name="auth-namespace"
+            label="Namespace"
+            value={authNamespace}
+            onChange={(event) => setAuthNamespace(event.target.value)}
+          />
+          <Field
+            name="auth-name"
+            label="Service"
+            value={authName}
+            onChange={(event) => setAuthName(event.target.value)}
+          />
+          <Field
+            name="auth-port"
+            label="Port"
+            value={authPort}
+            onChange={(event) => setAuthPort(event.target.value)}
+          />
+        </div>
+      </Component>
+
+      <Component
+        icon={<Lock aria-hidden="true" className="size-4" />}
+        title="Config store"
+        because="Where a Component's pinned secrets are fetched from (§10)."
+        on={storeOn}
+        onToggle={setStoreOn}
+      >
+        <Choice
+          name="secret-store"
+          label="ClusterSecretStore"
+          value={store}
+          onChange={setStore}
+          options={probe.secretStores}
+          hint={
+            probe.secretStores.length === 0
+              ? 'No ClusterSecretStore was readable here. Leaving this out is a Target that can run a Component with no config and refuse one with config, visibly.'
+              : undefined
+          }
+        />
+      </Component>
+
+      <Component
+        icon={<Globe aria-hidden="true" className="size-4" />}
+        title="Public reach"
+        because="A tunnel hostname is what makes a public record something other than a claim."
+        on={tunnelOn}
+        onToggle={setTunnelOn}
+      >
+        <Field
+          name="tunnel-hostname"
+          label="Tunnel hostname"
+          value={tunnel}
+          onChange={(event) => setTunnel(event.target.value)}
+          hint="Not readable from the cluster — the tunnel is registered with the edge provider, not here."
+        />
+      </Component>
+
+      <div className="rounded-md border border-border-soft bg-secondary/40 px-3 py-2 text-xs">
+        <span className="text-muted-foreground">This Target will serve </span>
+        {plan.reaches.map((reach) => (
+          <Badge key={reach} tone="idle" className="mr-1">
+            {reach}
+          </Badge>
+        ))}
+        <span className="text-muted-foreground">
+          {plan.authReaches.length === 0
+            ? ', with no authenticated edge in front of any of it.'
+            : `, authenticated at ${plan.authReaches.join(' and ')}.`}
+        </span>
+      </div>
+
+      <Declaration plan={plan} />
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button disabled={!ready || connecting} onClick={() => onConnect(plan)}>
           {connecting ? 'Connecting…' : 'Connect'}
         </Button>
         <Button variant="ghost" onClick={onCancel} disabled={connecting}>
@@ -259,4 +593,340 @@ export function ConnectTargetForm({
       </div>
     </div>
   );
+}
+
+/** What the button is about to do, as the manifest would declare it. */
+function Declaration({
+  plan,
+}: {
+  plan: ReturnType<typeof clusterConnectPlan>;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex w-full items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+        Declaration
+        <span className="ml-auto font-mono">
+          {open ? 'hide' : 'manifest entry'}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
+        <p className="text-[11px] text-subtle">
+          The same connection, under <span className="font-mono">targets:</span>{' '}
+          in the installation manifest. A declaration seeds an installation that
+          has none; it does not overwrite one that is already configured.
+        </p>
+        {/* JSON, which is valid YAML. An emitter would be a thing to maintain
+            for output nobody parses back. */}
+        <pre className="overflow-x-auto rounded-md border border-border bg-background px-3 py-2 font-mono text-[11px]">
+          {JSON.stringify([targetSeedOf(plan)], null, 2)}
+        </pre>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+// --- The cloud flow, unchanged ---------------------------------------------
+
+/**
+ * A cloud project's two Targets, in one act (§13).
+ *
+ * Still a flat form, and not because nobody got to it: a project has no
+ * discovery API to enumerate itself through before it is named, so there is
+ * nothing here for a probe to read. The two endpoints and the region are
+ * carried from a working cloud Target; the project id never is.
+ */
+function ConnectCloud({
+  name,
+  proposal,
+  connecting,
+  onConnect,
+  onCancel,
+}: {
+  name: string;
+  proposal: TargetConnectionProposal;
+  connecting: boolean;
+  onConnect: (input: ConnectTargetInput) => void;
+  onCancel: () => void;
+}) {
+  const [project, setProject] = useState('');
+  const [region, setRegion] = useState(proposal.region ?? '');
+  const [runEndpoint, setRunEndpoint] = useState(proposal.runEndpoint ?? '');
+  const [hostingEndpoint, setHostingEndpoint] = useState(
+    proposal.hostingEndpoint ?? '',
+  );
+
+  const ready =
+    project.trim() !== '' &&
+    region.trim() !== '' &&
+    runEndpoint.trim() !== '' &&
+    hostingEndpoint.trim() !== '';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field
+          name="project"
+          label="Project"
+          value={project}
+          onChange={(event) => setProject(event.target.value)}
+          hint="Not carried — a second project prefilled with the first one's id would read as correct."
+        />
+        <Field
+          name="region"
+          label="Region"
+          value={region}
+          onChange={(event) => setRegion(event.target.value)}
+        />
+        <Field
+          name="run-endpoint"
+          label="Cloud Run API"
+          value={runEndpoint}
+          onChange={(event) => setRunEndpoint(event.target.value)}
+        />
+        <Field
+          name="hosting-endpoint"
+          label="Hosting API"
+          value={hostingEndpoint}
+          onChange={(event) => setHostingEndpoint(event.target.value)}
+        />
+      </div>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          disabled={!ready || connecting}
+          onClick={() =>
+            onConnect({
+              kind: 'cloud',
+              name,
+              project: project.trim(),
+              region: region.trim(),
+              runEndpoint: runEndpoint.trim(),
+              hostingEndpoint: hostingEndpoint.trim(),
+              ...(proposal.policyEndpoint === undefined
+                ? {}
+                : { policyEndpoint: proposal.policyEndpoint }),
+            })
+          }
+        >
+          {connecting ? 'Connecting…' : 'Connect'}
+        </Button>
+        <Button variant="ghost" onClick={onCancel} disabled={connecting}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- atoms ------------------------------------------------------------------
+
+/**
+ * One thing a Target can blend into, and whether it is included.
+ *
+ * `required` and `on` are the two shapes: a required component has no toggle
+ * because a Target without it is not addressable, and an optional one is a
+ * checkbox whose off state is a supported Target rather than an incomplete
+ * form.
+ *
+ * There is deliberately no disabled state. Nothing here is unavailable because
+ * the probe did not find it — a cluster that would not list its Gateways still
+ * has one, and greying the card out would make a cluster whose RBAC has not
+ * merged yet unconnectable through the product. What the probe did not find
+ * shows up as a field to type with the sentence saying nothing was read, which
+ * is §3's grammar rather than a dead control.
+ */
+function Component({
+  icon,
+  title,
+  because,
+  required = false,
+  on,
+  onToggle,
+  carriedFrom,
+  children,
+}: {
+  icon: ReactNode;
+  title: string;
+  because: string;
+  required?: boolean;
+  on?: boolean;
+  onToggle?: (on: boolean) => void;
+  carriedFrom?: string | null;
+  children: ReactNode;
+}) {
+  const included = required || on === true;
+  return (
+    <div
+      className={cn(
+        'rounded-md border px-3 py-3',
+        included ? 'border-border' : 'border-border-soft opacity-70',
+      )}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-muted-foreground">{icon}</span>
+        <span className="text-sm font-medium">{title}</span>
+        {required ? (
+          <Badge tone="idle">required</Badge>
+        ) : (
+          <label className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+            <input
+              type="checkbox"
+              className="size-3.5 accent-current"
+              checked={on === true}
+              onChange={(event) => onToggle?.(event.target.checked)}
+            />
+            include
+          </label>
+        )}
+        {carriedFrom ? (
+          <span className="text-[11px] text-subtle">
+            carried from <span className="font-mono">{carriedFrom}</span>
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">{because}</p>
+      {included ? <div className="mt-3">{children}</div> : null}
+    </div>
+  );
+}
+
+/** A labelled pick from what the probe found, with a typed escape hatch. */
+function Choice({
+  name,
+  label,
+  value,
+  onChange,
+  options,
+  hint,
+}: {
+  name: string;
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: readonly string[];
+  hint?: string;
+}) {
+  // Nothing was readable, so there is nothing to pick from and the operator
+  // types it. The same field either way — a disabled select would be a dead end
+  // on a cluster whose RBAC is merged but not yet reconciled.
+  if (options.length === 0) {
+    return (
+      <Field
+        name={name}
+        label={label}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        {...(hint === undefined ? {} : { hint })}
+      />
+    );
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={name}>{label}</Label>
+      <select
+        id={name}
+        name={name}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        className="h-9 w-full rounded-md border border-input bg-background px-3 font-mono text-sm text-foreground"
+      >
+        {options.map((option) => (
+          <option key={option} value={option}>
+            {option}
+          </option>
+        ))}
+      </select>
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+function Notice({
+  tone,
+  children,
+}: {
+  tone: 'warning' | 'destructive';
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-md border px-3 py-2 text-xs',
+        tone === 'warning'
+          ? 'border-warning/40 bg-warning-soft'
+          : 'border-destructive/40 bg-destructive-soft text-destructive',
+      )}
+    >
+      <AlertTriangle aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+/** `namespace/name` — the one string a `<select>` can carry a ref in. */
+function refOf(entry: { name: string; namespace: string }): string {
+  return `${entry.namespace}/${entry.name}`;
+}
+
+/** A `namespace/name` back into a ref, or null when it is not one yet. */
+function parseRef(value: string): { name: string; namespace: string } | null {
+  const [namespace, name, ...rest] = value.split('/');
+  if (rest.length > 0) return null;
+  if (!namespace || !name) return null;
+  return { namespace, name };
+}
+
+/** The preferred ref when this cluster has it, otherwise the first one. */
+function refKey(
+  entries: readonly { name: string; namespace: string }[],
+  preferred: { name: string; namespace: string } | undefined,
+): string {
+  const match =
+    preferred === undefined
+      ? undefined
+      : entries.find(
+          (entry) =>
+            entry.name === preferred.name &&
+            entry.namespace === preferred.namespace,
+        );
+  const chosen = match ?? entries[0];
+  return chosen === undefined ? '' : refOf(chosen);
+}
+
+/** The preferred option when this cluster has it, otherwise the first one. */
+function pick(
+  options: readonly string[],
+  preferred: string | undefined,
+): string {
+  if (preferred !== undefined && options.includes(preferred)) return preferred;
+  return options[0] ?? preferred ?? '';
+}
+
+/**
+ * The parts of a working Target's chart-values worth carrying.
+ *
+ * Only `externalAuth`: `clusters/base` installs the authenticated edge in the
+ * same namespace on every cluster, so the value a working Target holds is the
+ * right proposal for the next one. `dns` and `gateway` are pointedly not here —
+ * they name one cluster's address, and the probe read this one's.
+ */
+function carriedPlatform(proposal: TargetConnectionProposal): {
+  externalAuth: { name: string; namespace: string; port: number } | null;
+} {
+  const platform = (
+    proposal.chartValues as { platform?: Record<string, unknown> } | undefined
+  )?.platform;
+  const auth = platform?.externalAuth as
+    | { name?: string; namespace?: string; port?: number }
+    | undefined;
+  if (auth?.name === undefined || auth.namespace === undefined) {
+    return { externalAuth: null };
+  }
+  return {
+    externalAuth: {
+      name: auth.name,
+      namespace: auth.namespace,
+      port: auth.port ?? 80,
+    },
+  };
 }

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -29,6 +29,7 @@ import {
   Check,
   ChevronRight,
   Globe,
+  Plus,
   Server,
   X,
   Zap,
@@ -75,20 +76,64 @@ export function TargetList({
   onConnect: (input: ConnectTargetInput) => void;
 }) {
   const configured = targets.filter((target) => target.configured);
+  const [adding, setAdding] = useState(false);
+  /**
+   * Carried into the add flow from whatever this installation already has.
+   *
+   * The pending entries hold the same proposal — it is derived per adapter kind,
+   * not per Target — so taking the first cluster one is taking the only one
+   * there is. With no pending entry there is nothing seeded either, and an empty
+   * proposal is the honest input: nothing has been learnt to carry.
+   */
+  const clusterProposal = pending.find((entry) => entry.kind === 'kubernetes')
+    ?.proposal ?? { carriedFrom: null };
 
   return (
     <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-      <header>
-        <Eyebrow>Targets</Eyebrow>
-        <h1 className="mt-1 text-2xl font-semibold tracking-tight">
-          Deployment targets
-        </h1>
-        <p className="mt-1 max-w-prose text-sm text-muted-foreground">
-          Where Spindrift can deploy apps. Identities and rank come from the
-          installation manifest; connecting one is what fills in how to reach
-          it, and health is the standing checklist afterwards.
-        </p>
+      <header className="flex flex-wrap items-end gap-4">
+        <div>
+          <Eyebrow>Targets</Eyebrow>
+          <h1 className="mt-1 text-2xl font-semibold tracking-tight">
+            Deployment targets
+          </h1>
+          <p className="mt-1 max-w-prose text-sm text-muted-foreground">
+            Where Spindrift can deploy apps. Give a cluster's address and
+            Spindrift reads what it runs; what you include is what an App's
+            release blends into. The installation manifest declares the same
+            thing, and health is the standing checklist afterwards.
+          </p>
+        </div>
+        <Button
+          className="ml-auto"
+          variant={adding ? 'ghost' : 'default'}
+          onClick={() => setAdding((open) => !open)}
+        >
+          {adding ? (
+            'Cancel'
+          ) : (
+            <>
+              <Plus aria-hidden="true" className="size-4" /> Add a cluster
+            </>
+          )}
+        </Button>
       </header>
+
+      {adding ? (
+        <Card>
+          <CardContent>
+            <ConnectTargetForm
+              kind="kubernetes"
+              name=""
+              nameEditable
+              targets={[]}
+              proposal={clusterProposal}
+              connecting={connecting}
+              onConnect={onConnect}
+              onCancel={() => setAdding(false)}
+            />
+          </CardContent>
+        </Card>
+      ) : null}
 
       {error ? (
         <div className="rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-sm text-destructive">
@@ -108,7 +153,10 @@ export function TargetList({
         <Card>
           <CardContent className="py-12 text-center">
             <p className="text-sm text-muted-foreground">
-              No Targets are configured for this installation.
+              No Targets are configured for this installation. Add a cluster
+              above, or declare one under{' '}
+              <span className="font-mono">targets:</span> in the installation
+              manifest — the two write the same thing.
             </p>
           </CardContent>
         </Card>

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -1045,6 +1045,133 @@ describe('a write is an apply only if it says so', () => {
   });
 });
 
+/**
+ * Reading a cluster that is not a Target yet (§13's connect, one step earlier).
+ *
+ * `inspect` cannot answer this — it takes a connection carrying the very facts
+ * an operator is here to choose — so the probe is the read that runs against
+ * nothing but an address, and everything it returns is a list to pick from.
+ *
+ * The behaviour worth pinning is the degradation. A cluster whose
+ * `spindrift-target` RBAC has not merged yet answers some reads and refuses
+ * others, and that is the *ordinary* state of a cluster somebody is connecting.
+ * A probe that gave up on the first refusal would report nothing about a
+ * cluster that is nearly ready, and the screen would have nothing to offer.
+ */
+describe('probing a cluster before it is a Target', () => {
+  const gateway = (
+    namespace: string,
+    name: string,
+    addresses?: { type: string; value: string }[],
+  ): FakeObject => ({
+    apiVersion: 'gateway.networking.k8s.io/v1',
+    kind: 'Gateway',
+    metadata: { name, namespace },
+    ...(addresses === undefined ? {} : { status: { addresses } }),
+  });
+
+  const namespace = (name: string): FakeObject => ({
+    apiVersion: 'v1',
+    kind: 'Namespace',
+    metadata: { name },
+  });
+
+  const source = (namespace: string, name: string): FakeObject => ({
+    apiVersion: 'source.toolkit.fluxcd.io/v1',
+    kind: 'GitRepository',
+    metadata: { name, namespace },
+  });
+
+  const store = (name: string): FakeObject => ({
+    apiVersion: 'external-secrets.io/v1',
+    kind: 'ClusterSecretStore',
+    metadata: { name },
+  });
+
+  const probed = async (options: FakeKubernetesOptions = {}) => {
+    const { adapter, cluster } = adapterFor({
+      servedKinds: {
+        ...SERVED,
+        'source.toolkit.fluxcd.io/v1': ['GitRepository'],
+        'external-secrets.io/v1': ['ClusterSecretStore'],
+        'gateway.networking.k8s.io/v1': ['Gateway'],
+      },
+      ...options,
+    });
+    return adapter.probe(cluster.apiServer);
+  };
+
+  test('offers what the cluster runs, as lists to choose from', async () => {
+    const probe = await probed({
+      lists: {
+        namespaces: [namespace('apps'), namespace('delivery')],
+        gitrepositories: [source('delivery', 'charts')],
+        clustersecretstores: [store('vault')],
+        gateways: [
+          gateway('edge', 'shared', [{ type: 'IPAddress', value: '10.0.0.9' }]),
+        ],
+      },
+    });
+
+    expect(probe.reachable).toBe(true);
+    expect(probe.deliveryFlavours).toEqual([
+      'flux-helmrelease',
+      'argo-application',
+    ]);
+    expect(probe.namespaces).toEqual(['apps', 'delivery']);
+    expect(probe.chartSources).toEqual([
+      { name: 'charts', namespace: 'delivery' },
+    ]);
+    expect(probe.secretStores).toEqual(['vault']);
+    expect(probe.gateways).toEqual([
+      { name: 'shared', namespace: 'edge', address: '10.0.0.9' },
+    ]);
+  });
+
+  test('a gateway with only a hostname offers no address to publish', async () => {
+    // `platform.dns.privateAddress` is published as an A record, so a name is
+    // not a value it can hold — and filling it with one would be worse than
+    // leaving the field to the operator.
+    const probe = await probed({
+      lists: {
+        gateways: [
+          gateway('edge', 'named', [
+            { type: 'Hostname', value: 'edge.invalid' },
+          ]),
+        ],
+      },
+    });
+
+    expect(probe.gateways).toEqual([
+      { name: 'named', namespace: 'edge', address: null },
+    ]);
+  });
+
+  test('a kind this cluster does not serve is an empty list, not a failure', async () => {
+    const probe = await probed({ servedKinds: {} });
+
+    expect(probe.reachable).toBe(true);
+    expect(probe.deliveryFlavours).toEqual([]);
+    expect(probe.chartSources).toEqual([]);
+    expect(probe.gateways).toEqual([]);
+  });
+
+  test('an address that does not answer is the one hard failure', async () => {
+    const adapter = new KubernetesDeployAdapter({
+      chart: CHART,
+      token: () => 'federated-token',
+      fetch: async () => {
+        throw new Error('connect ECONNREFUSED');
+      },
+    });
+
+    const probe = await adapter.probe('https://nowhere.invalid');
+
+    expect(probe.reachable).toBe(false);
+    expect(probe.because).toContain('ECONNREFUSED');
+  });
+});
+
 function node(arch: string, allocatable: Record<string, string>): FakeObject {
   return {
     apiVersion: 'v1',

--- a/apps/spindrift/test/domain/target-connect-plan.test.ts
+++ b/apps/spindrift/test/domain/target-connect-plan.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Connecting a cluster, component by component (§13, §3, §7).
+ *
+ * The screen's whole job is turning "include this, leave that out" into one
+ * `connectTarget` act, and three of the values it produces are **derived from
+ * what was included** rather than typed. Each one is a wrong-by-default trap if
+ * it is not derived, so each gets a test:
+ *
+ * - A Target that serves a gateway reaches `private`; one that does not reaches
+ *   only `none`. Claiming a reach with no address behind it is how a Component
+ *   gets a DNS record pointing nowhere.
+ * - The chart's ingress is default-deny, so a route attached to a gateway whose
+ *   namespace is not in `allowedNamespaces` renders correctly and reaches
+ *   nothing — the failure that looks like a working deploy.
+ * - `authReaches` never claims `public`, whatever edge was included.
+ *
+ * And the fourth claim, which is the point of the whole screen: **what the UI
+ * writes and what the manifest declares are one shape.** `targetSeedOf` renders
+ * the same act as the document that would perform it, so the test asserts the
+ * declaration round-trips through the manifest's own schema rather than merely
+ * looking plausible.
+ */
+import { describe, expect, test } from 'bun:test';
+import { targetSeedSchema } from '../../src/config/manifest.schema.ts';
+import {
+  type ClusterConnectChoices,
+  clusterConnectPlan,
+  targetSeedOf,
+} from '../../src/domain/target-onboarding.ts';
+
+const BASE: ClusterConnectChoices = {
+  name: 'metal',
+  apiServer: 'https://cluster.invalid:6443',
+  namespace: 'apps',
+  deliveryNamespace: 'apps',
+  sourceRef: { name: 'charts', namespace: 'delivery' },
+  chartContract: '3',
+  gateway: null,
+  externalAuth: null,
+  secretStore: null,
+  tunnelHostname: null,
+};
+
+/** Everything a fully blended cluster offers, as the probe would report it. */
+const BLENDED: ClusterConnectChoices = {
+  ...BASE,
+  gateway: { name: 'shared', namespace: 'edge', privateAddress: '10.0.0.9' },
+  externalAuth: { name: 'proxy', namespace: 'auth', port: 80 },
+  secretStore: 'store',
+  tunnelHostname: 'tunnel.invalid',
+};
+
+describe('a cluster connect plan', () => {
+  test('reaches only in-cluster when nothing was included', () => {
+    const plan = clusterConnectPlan(BASE);
+
+    expect(plan.reaches).toEqual(['none']);
+    expect(plan.authReaches).toEqual([]);
+  });
+
+  test('a gateway with an address is what makes the private reach real', () => {
+    const plan = clusterConnectPlan({ ...BASE, gateway: BLENDED.gateway });
+
+    expect(plan.reaches).toEqual(['none', 'private']);
+    expect(platformOf(plan).dns).toEqual({
+      privateAddress: '10.0.0.9',
+      tunnelHostname: '',
+    });
+  });
+
+  test('a gateway that has no address yet claims no reach', () => {
+    const plan = clusterConnectPlan({
+      ...BASE,
+      gateway: { name: 'shared', namespace: 'edge', privateAddress: null },
+    });
+
+    expect(plan.reaches).toEqual(['none']);
+  });
+
+  test('every included component opens the default-deny ingress', () => {
+    const plan = clusterConnectPlan(BLENDED);
+
+    expect(platformOf(plan).networkPolicy).toEqual({
+      allowedNamespaces: ['edge', 'auth'],
+    });
+  });
+
+  test('a component left out opens nothing on its behalf', () => {
+    const plan = clusterConnectPlan({ ...BASE, gateway: BLENDED.gateway });
+
+    expect(platformOf(plan).networkPolicy).toEqual({
+      allowedNamespaces: ['edge'],
+    });
+    expect(platformOf(plan).externalAuth).toBeUndefined();
+  });
+
+  test('an authenticated edge answers privately and never publicly', () => {
+    const plan = clusterConnectPlan(BLENDED);
+
+    expect(plan.reaches).toEqual(['none', 'private', 'public']);
+    // The proxy fronts the public address just as well; whether its policy is
+    // honest there is a claim nobody made, so the plan does not make it.
+    expect(plan.authReaches).toEqual(['private']);
+  });
+
+  test('an edge with no private reach behind it claims nothing', () => {
+    const plan = clusterConnectPlan({
+      ...BASE,
+      externalAuth: BLENDED.externalAuth,
+    });
+
+    expect(plan.authReaches).toEqual([]);
+  });
+
+  test('writes only the operator’s value class', () => {
+    const plan = clusterConnectPlan(BLENDED);
+
+    // §7: `app` and `shared` are rendered per deploy. Saving either here would
+    // be storing a value the next deploy overwrites.
+    expect(Object.keys(plan.chartValues)).toEqual(['platform']);
+  });
+
+  test('declares the same connection the manifest would', () => {
+    const plan = clusterConnectPlan(BLENDED);
+    const parsed = targetSeedSchema.safeParse(targetSeedOf(plan));
+
+    if (!parsed.success) throw parsed.error;
+    // The discriminant survives, which is what makes this the manifest's own
+    // cluster arm rather than something that merely parsed.
+    if (parsed.data.adapter !== 'kubernetes') {
+      throw new Error(`declared a ${parsed.data.adapter} Target`);
+    }
+    expect(parsed.data.name).toBe('metal');
+    expect(parsed.data.reaches).toEqual(plan.reaches);
+    expect(parsed.data.connection?.apiServer).toBe(BASE.apiServer);
+    expect(parsed.data.connection?.chartValues).toEqual(plan.chartValues);
+  });
+});
+
+/** The operator's class, as the App chart reads it. */
+function platformOf(plan: {
+  chartValues: Record<string, unknown>;
+}): Record<string, unknown> {
+  return plan.chartValues.platform as Record<string, unknown>;
+}

--- a/apps/spindrift/test/domain/target-connect-plan.test.ts
+++ b/apps/spindrift/test/domain/target-connect-plan.test.ts
@@ -85,6 +85,20 @@ describe('a cluster connect plan', () => {
     });
   });
 
+  test('a gateway beside the workloads needs no entry of its own', () => {
+    // The chart admits same-namespace siblings unconditionally, so naming the
+    // workload namespace here would be a line that means nothing — and the
+    // installation's own manifest says so in the same words.
+    const plan = clusterConnectPlan({
+      ...BLENDED,
+      gateway: { name: 'apps', namespace: 'apps', privateAddress: '10.0.0.9' },
+    });
+
+    expect(platformOf(plan).networkPolicy).toEqual({
+      allowedNamespaces: ['auth'],
+    });
+  });
+
   test('a component left out opens nothing on its behalf', () => {
     const plan = clusterConnectPlan({ ...BASE, gateway: BLENDED.gateway });
 

--- a/clusters/base/platform/spindrift-target/rbac.yaml
+++ b/clusters/base/platform/spindrift-target/rbac.yaml
@@ -1,23 +1,54 @@
 ---
+# Two reads, not one. The standing checklist asks about the namespace, the
+# store, and this identity's own permissions on a Target that is already
+# configured; connecting a *new* cluster asks the same API what there is to
+# choose from before any of those facts exist. Both are this role, because both
+# are the same federated identity reading the same cluster — and neither writes.
+#
+# Everything below is list-only and names no Secret. A cluster whose operator
+# does not want to be enumerated simply does not bind this role: the probe
+# degrades to empty lists, and every field it would have filled is one an
+# operator types instead.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: spindrift-target-discovery
 rules:
+  # `list` for the connect screen's namespace pickers; the checklist's `get` on
+  # spindrift-apps is subsumed by it. Naming only that one namespace would make
+  # the screen unable to offer any other, which is the whole of what an operator
+  # connecting a second cluster is choosing.
   - apiGroups:
       - ""
     resources:
       - namespaces
-    resourceNames:
-      - spindrift-apps
     verbs:
       - get
+      - list
   - apiGroups:
       - external-secrets.io
     resources:
       - clustersecretstores
     verbs:
       - get
+      - list
+  # Which sources the App chart could be fetched from. The checklist's `get` on
+  # flux-system/infra stays a Role below: reading one named object is the
+  # narrower grant and is what the standing check actually needs.
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - list
+  # Which Gateways exist and what address each answers on — the input to
+  # `platform.gateway` and to `platform.dns.privateAddress`, which is why an
+  # operator is not asked to type an address the cluster already knows.
+  - apiGroups:
+      - gateway.networking.k8s.io
+    resources:
+      - gateways
+    verbs:
       - list
   - apiGroups:
       - authorization.k8s.io

--- a/clusters/folly/apps/spindrift-target/gateway.yaml
+++ b/clusters/folly/apps/spindrift-target/gateway.yaml
@@ -1,0 +1,92 @@
+---
+# The edge Spindrift's Apps are served on here, separate from `cluster-gateway`.
+#
+# The same shape offsite's `apps/spindrift/gateway.yaml` has, and for the same
+# reason: App traffic is developer-controlled, so it gets its own Envoy listener
+# set and its own load-balancer address rather than sharing the one the media
+# stack answers on. An App cannot crowd `jellyfin` off its edge.
+#
+# It lives in `spindrift-apps`, beside the workloads it serves — which costs
+# nothing the App chart's NetworkPolicy was buying, because same-namespace
+# siblings are already an unconditional exception there. That is why the
+# Target's `allowedNamespaces` names `oauth2-proxy` and not this namespace.
+#
+# It is a vessel resource: the App chart renders a route and nothing else, so no
+# release owns the gateway, the certificate, or the address, and a `destroy()`
+# cannot take them with it. Flux owns this file; Spindrift only attaches to what
+# it finds — which is exactly what the connect screen reads off the cluster.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: Gateway
+metadata:
+  name: spindrift-apps
+  namespace: spindrift-apps
+  annotations:
+    cert-manager.io/cluster-issuer: ${CERT_CLUSTER_ISSUER}
+spec:
+  gatewayClassName: cilium
+  # Pinned, because the Target's `platform.dns.privateAddress` is the literal
+  # address every `reach: private` App on this cluster publishes an A record to.
+  # An address the pool reassigns on a rebuild would point a whole zone at
+  # nothing.
+  #
+  # Free in this cluster's `LB_RANGE` (`cluster-topology.json`). If the
+  # implementation will not honour the request it must report
+  # `Programmed=False`/`AddressNotAssigned` and assign nothing, so this fails as
+  # a gateway that does not come up rather than as a zone aimed at a stranger.
+  addresses:
+    - type: IPAddress
+      value: 10.3.0.80
+  listeners:
+    # Plain HTTP for the in-cluster leg. folly publishes no tunnel of its own to
+    # Spindrift, so nothing arrives here from the internet today and this
+    # listener carries only what the lab net reaches; it is here so that adding
+    # a tunnel is a `dns.tunnelHostname` away rather than a Gateway edit.
+    - name: http-gateway
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - spindrift-apps
+                  - oauth2-proxy
+        kinds:
+          - kind: HTTPRoute
+    # One wildcard for every App name Spindrift mints here, rather than a
+    # listener per App: the chart renders a route and nothing else, so there is
+    # no release that could own a listener or a certificate. cert-manager's
+    # gateway-shim issues it by DNS-01 from the annotation above. Both clusters
+    # serve this zone — `clusters/base/cluster-settings.yaml` says why, and
+    # external-dns only deletes records its own `txtOwnerId` claims.
+    #
+    # `oauth2-proxy` is admitted alongside the Apps to match offsite. It admits
+    # nothing today: this cluster's authenticated edge answers on
+    # `oauth2.${SECRET_DOMAIN}`, whose route attaches to `cluster-gateway`. The
+    # ExternalAuth filter is a backend reference governed by the ReferenceGrant
+    # in `clusters/base/apps/oauth2-proxy` rather than by this list, so a
+    # `reach: private` App here authenticates against that edge and lands on a
+    # name that resolves — one hop off this gateway rather than a 404.
+    - name: spindrift-apps-tls
+      protocol: HTTPS
+      port: 443
+      hostname: "*.${SPINDRIFT_DOMAIN}"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: wildcard-${SPINDRIFT_DOMAIN}
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - spindrift-apps
+                  - oauth2-proxy
+        kinds:
+          - kind: HTTPRoute

--- a/clusters/folly/apps/spindrift-target/kustomization.yaml
+++ b/clusters/folly/apps/spindrift-target/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ../../../base/platform/spindrift-target
   - rbac.yaml
+  - gateway.yaml

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -189,6 +189,12 @@ spec:
                   name: oauth2-proxy
                   namespace: oauth2-proxy
                   port: 80
+                # The chart requires this whenever a Component has config: the
+                # ExternalSecret names the store, and an unset name renders an
+                # object that never syncs behind a workload that waits forever.
+                secretStore:
+                  kind: ClusterSecretStore
+                  name: onepassword-connect
                 dns:
                   # That gateway's pinned LoadBalancer address. RFC1918, so
                   # publishing it is the private boundary rather than a hole in
@@ -202,6 +208,56 @@ spec:
                   # namespace is not in the list because it is `spindrift-apps`
                   # itself, which the chart always admits as a sibling.
                   allowedNamespaces:
+                    - oauth2-proxy
+        # The on-site cluster, reached across the peer OIDC trust rather than
+        # in-cluster: `nix/services/k8s` admits this installation's service
+        # account as `federated:system:serviceaccount:spindrift:spindrift`, and
+        # `clusters/folly/apps/spindrift-target` binds it the discovery,
+        # delivery, and chart-source roles. Nothing here is a credential — the
+        # projected token is minted per request for the `api` audience.
+        - name: folly
+          # No tunnel of its own is named to Spindrift, so this Target serves
+          # what its gateway's RFC1918 address reaches and nothing beyond it.
+          # Adding one is this list plus `dns.tunnelHostname`, either here or on
+          # the connect screen, which reads the same fields.
+          reaches: [none, private]
+          authReaches: [private]
+          adapter: kubernetes
+          connection:
+            delivery:
+              flavour: flux-helmrelease
+              namespace: spindrift-apps
+              sourceRef:
+                name: infra
+                namespace: flux-system
+            apiServer: https://folly.lolwtf.ca:6443
+            namespace: spindrift-apps
+            chartContract: "3"
+            chartValues:
+              platform:
+                # Admits routes from every namespace on both listeners, and
+                # `clusters/base/apps/oauth2-proxy` grants spindrift-apps the
+                # cross-namespace reference to the auth backend.
+                gateway:
+                  name: cluster-gateway
+                  namespace: default
+                externalAuth:
+                  name: oauth2-proxy
+                  namespace: oauth2-proxy
+                  port: 80
+                secretStore:
+                  kind: ClusterSecretStore
+                  name: onepassword-connect
+                dns:
+                  # Assigned to this Gateway from folly's Cilium LB pool. The
+                  # connect screen reads it off the Gateway's status rather than
+                  # asking; this line is the same fact for a torn-down
+                  # installation that has no screen open.
+                  privateAddress: 10.3.0.78
+                  tunnelHostname: ""
+                networkPolicy:
+                  allowedNamespaces:
+                    - default
                     - oauth2-proxy
         - name: bluenose-cloudrun
           adapter: cloudrun

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -233,14 +233,26 @@ spec:
             apiServer: https://folly.lolwtf.ca:6443
             namespace: spindrift-apps
             chartContract: "3"
+            # Public packages, so the kubelet pulls them with no credential —
+            # the same reason offsite names GHCR rather than the artifact
+            # registry.
+            reachableRegistries:
+              - ghcr.io/jonpulsifer
             chartValues:
               platform:
-                # Admits routes from every namespace on both listeners, and
-                # `clusters/base/apps/oauth2-proxy` grants spindrift-apps the
-                # cross-namespace reference to the auth backend.
+                # This cluster's own Apps gateway
+                # (`clusters/folly/apps/spindrift-target/gateway.yaml`), not
+                # `cluster-gateway`: App traffic gets its own listener set here
+                # for the same reason it does offsite.
                 gateway:
-                  name: cluster-gateway
-                  namespace: default
+                  name: spindrift-apps
+                  namespace: spindrift-apps
+                # Answers on `oauth2.${SECRET_DOMAIN}` here rather than in the
+                # App zone, so the sign-in redirect leaves this gateway for
+                # `cluster-gateway`. That is one hop rather than a 404: the
+                # ExternalAuth filter is a backend reference, granted by the
+                # ReferenceGrant in `clusters/base/apps/oauth2-proxy`, and is
+                # not affected by which gateway serves the sign-in name.
                 externalAuth:
                   name: oauth2-proxy
                   namespace: oauth2-proxy
@@ -249,15 +261,17 @@ spec:
                   kind: ClusterSecretStore
                   name: onepassword-connect
                 dns:
-                  # Assigned to this Gateway from folly's Cilium LB pool. The
-                  # connect screen reads it off the Gateway's status rather than
-                  # asking; this line is the same fact for a torn-down
-                  # installation that has no screen open.
-                  privateAddress: 10.3.0.78
+                  # That gateway's pinned address, free in this cluster's
+                  # `LB_RANGE`. The connect screen reads it off the Gateway's
+                  # status rather than asking; this line is the same fact for a
+                  # torn-down installation that has no screen open.
+                  privateAddress: 10.3.0.80
                   tunnelHostname: ""
                 networkPolicy:
+                  # The gateway's own namespace is absent for the reason it is
+                  # absent above: it is `spindrift-apps` itself, which the chart
+                  # always admits as a sibling.
                   allowedNamespaces:
-                    - default
                     - oauth2-proxy
         - name: bluenose-cloudrun
           adapter: cloudrun


### PR DESCRIPTION
## Summary

Connecting a Target was eight text fields, and the only Targets it could reach were manifest seeds. This makes it the repository screen's shape one noun over — **give an address, read what is there, choose what to blend into, confirm** — and adds `folly`, with its own Apps gateway.

`connectTarget` has taken chart values, reaches, and a chart contract since Task 13. The screen in front of it asked for none of them, so a cluster connected through the product had no gateway, no authenticated edge, no config store, and no address for a route's DNS record: a Target that cannot take an App that has to be reachable.

## Changes

- **`probeCluster`** — the Target-side `inspectRepository`. Takes an API server, writes nothing, returns lists: delivery flavours served, namespaces, Flux `GitRepository`s, `ClusterSecretStore`s, and Gateways with the address each answers on. Every read is caught independently, because a cluster whose `spindrift-target` RBAC has not merged answers some and refuses others — which is every cluster once.
- **The connect screen is componentized.** Gateway, authenticated edge, config store, and tunnel are cards you include or leave out; leaving one out is a supported Target rather than a half-filled form. Three values are derived from what was included rather than asked again: `reaches` follows the gateway address and the tunnel, `authReaches` claims `private` and never `public`, and `networkPolicy.allowedNamespaces` is exactly the included namespaces less the workload one.
- **Both entry points, one shape.** A new *Add a cluster* button starts a connect from nothing. A *Declaration* disclosure renders the same act as the manifest `targets:` entry, and a test round-trips it through `targetSeedSchema`.
- **Discovery RBAC** — `clusters/base/platform/spindrift-target` gains cluster-scoped `list` on namespaces, gitrepositories, and gateways. All three answer **no** on folly today, so without this the screen offers nothing on a cluster that is otherwise ready.
- **folly's Apps gateway** — `spindrift-apps/spindrift-apps` pinned to `10.3.0.80`, mirroring #1607. It was declared against `default/cluster-gateway`, which puts developer-controlled App traffic on the Envoy `jellyfin` and `hermes` answer on.
- **Two adjacent fixes.** `allowedNamespaces` no longer writes the workload namespace, which the chart admits as a sibling regardless. And offsite's Target gains `platform.secretStore`, which the App chart `required`s whenever a Component has config — a torn-down offsite would have come back unable to deliver any.

## Notes for review

- **The manifest entries are seeds and change nothing live.** The stored row wins whenever one exists, so connecting folly on the running installation is the connect screen's act. These lines are what bring it back without a browser.
- **Both clusters serve `${SPINDRIFT_DOMAIN}`.** Not new: `clusters/base/cluster-settings.yaml` declares the zone shared, both external-dns instances already filter it, and each deletes only what its own `txtOwnerId` claims.
- **One stated divergence.** folly's authenticated edge answers on `oauth2.${SECRET_DOMAIN}`, whose route attaches to `cluster-gateway`, so a sign-in redirect leaves the Apps gateway. One hop, not a 404 — the ExternalAuth filter is a backend reference governed by the ReferenceGrant in `clusters/base/apps/oauth2-proxy`. Both files say so.
- The Argo delivery flavour still has no branch on this screen, unchanged from before, and the screen points at the manifest for it.

## Test Plan

- [x] `mise run ts:check` — typecheck + lint clean
- [x] `bun test` — 1374 pass, 0 fail (new: 10 for the connect derivation, 4 for the probe against the fake cluster)
- [x] `mise run k8s:render-apps` — both clusters render; folly's overlay carries the new Gateway
- [x] Installation manifest validates against `installationManifestSchema` with substitutions applied
- [x] `10.3.0.80` unclaimed in-repo and on the cluster; inside folly's `LB_RANGE`
- [ ] After merge: folly's Gateway reports `Programmed=True` and takes `10.3.0.80` (it must report `AddressNotAssigned` and take nothing if it will not)
- [ ] After merge: `kubectl auth can-i --as=federated:system:serviceaccount:spindrift:spindrift list namespaces` answers yes on folly (it answers no today)
- [ ] Targets → *Add a cluster* → `https://folly.lolwtf.ca:6443` → the probe fills the namespace, chart source, store, and gateway pickers → Connect → checklist goes healthy
