### PR TITLE
fix(spindrift): a reachable registry is a namespace, not a host

### DIFF
--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -66,14 +66,34 @@ export function immutableImageRef(artifact: Artifact): string | null {
  * all; {@link import('./placement.ts')} makes that a non-candidate before a
  * Build is ever dispatched, and `null` here is the backstop for the case that
  * gets past it.
+ *
+ * **A `reachableRegistries` entry is a namespace, not a host**, and getting that
+ * wrong is how this function returned `null` for an artifact that was sitting in
+ * the very registry the Target had named. The vocabulary is `supplyChain.
+ * registry`'s — `ghcr.io/owner`, `<region>-docker.pkg.dev/<project>/<repo>` —
+ * because that is what an operator copies from the manifest into a Target's
+ * connection, and it is what discovery reports back. Comparing it to
+ * `registryHostOf(ref)` compares a namespace to a host and never matches.
+ *
+ * A bare host is still honoured, because it is a legitimate thing to write when
+ * a Target reaches every namespace on one registry and nobody should have to
+ * enumerate them.
  */
 export function artifactAddress(
   artifact: Artifact,
   reachable: readonly string[] = [],
 ): string | null {
   if (reachable.length === 0) return artifact.refs[0] ?? null;
-  return (
-    artifact.refs.find((ref) => reachable.includes(registryHostOf(ref))) ?? null
+  return artifact.refs.find((ref) => pullableFrom(ref, reachable)) ?? null;
+}
+
+/** Whether one reference sits under any of the registries a Target named. */
+function pullableFrom(ref: string, reachable: readonly string[]): boolean {
+  return reachable.some(
+    (registry) =>
+      // The namespace spelling, which is the ordinary one. The trailing slash
+      // is what stops `…/i` from claiming a reference in `…/images`.
+      ref.startsWith(`${registry}/`) || registryHostOf(ref) === registry,
   );
 }
 

--- a/apps/spindrift/test/domain/artifact-address.test.ts
+++ b/apps/spindrift/test/domain/artifact-address.test.ts
@@ -42,6 +42,38 @@ describe('the address a Target pulls an artifact by', () => {
     expect(artifactAddress(PUSHED, ['ghcr.io'])).toBe(`${GHCR}@${DIGEST}`);
   });
 
+  /**
+   * The spelling every real value uses, and the one this file did not have.
+   *
+   * Every case above passes a bare host, so the comparison could be
+   * `reachable.includes(registryHostOf(ref))` and still come up green — while a
+   * live Target, whose `reachableRegistries` is copied from
+   * `supplyChain.registry` and reported back by discovery, holds
+   * `ghcr.io/jonpulsifer`. That never equals `ghcr.io`, so the artifact was
+   * refused with "carries no address this Target can pull it by" while sitting
+   * in the exact registry the Target had named.
+   */
+  test('matches the namespace spelling an operator actually writes', () => {
+    expect(
+      artifactAddress(PUSHED, [
+        'northamerica-northeast1-docker.pkg.dev/trusted-builds/i',
+      ]),
+    ).toBe(`${AR}@${DIGEST}`);
+    expect(artifactAddress(PUSHED, ['ghcr.io/jonpulsifer'])).toBe(
+      `${GHCR}@${DIGEST}`,
+    );
+  });
+
+  /** The trailing slash, which is the whole of why this is a prefix and not one. */
+  test('does not let one namespace claim a longer one beside it', () => {
+    expect(
+      artifactAddress(PUSHED, [
+        'northamerica-northeast1-docker.pkg.dev/trusted-builds/im',
+      ]),
+    ).toBeNull();
+    expect(artifactAddress(PUSHED, ['ghcr.io/jonpulsifer-two'])).toBeNull();
+  });
+
   test('falls back to the first where a Target declares no restriction', () => {
     // Empty is "nothing was said", not "reaches nothing" — which is every
     // Target on this installation until an operator says otherwise, and is why

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -173,8 +173,12 @@ spec:
             # the kubelet pulls them with no credential at all. Reaching the
             # artifact registry would mean an imagePullSecret in every App
             # namespace, which is a stored credential §13 does not have.
+            #
+            # The host rather than the `ghcr.io/jonpulsifer` namespace, because
+            # the kubelet's anonymous pull is a property of the registry and not
+            # of one owner's packages. `artifactAddress` accepts either.
             reachableRegistries:
-              - ghcr.io/jonpulsifer
+              - ghcr.io
             # §7's operator class: what the App chart needs about *this*
             # cluster. Spindrift never renders into it.
             chartValues:
@@ -298,8 +302,13 @@ spec:
             # pinning a reference it will fail on. `serverless-robot-prod` holds
             # `artifactregistry.reader` on it — see
             # terraform/gcp/projects/trusted-builds/artifact-registry.tf.
+            #
+            # The host, which names this installation's one artifact registry
+            # namespace unambiguously. `artifactAddress` takes the fuller
+            # `…/trusted-builds/i` spelling too, and would need it if a second
+            # namespace on this host were ever added to `supplyChain.registry`.
             reachableRegistries:
-              - northamerica-northeast1-docker.pkg.dev/trusted-builds/i
+              - northamerica-northeast1-docker.pkg.dev
         - name: bluenose-static
           adapter: static
           connection:


### PR DESCRIPTION
`artifactAddress` picked the reference a Target can pull by comparing its
`reachableRegistries` against `registryHostOf(ref)` — a namespace against a
host, which never matches. A Target naming `ghcr.io/jonpulsifer` was told the
artifact "carries no address this Target can pull it by" while the artifact sat
in exactly that registry.

It survived because every case in `artifact-address.test.ts` passed a bare host
and every live Target declared nothing at all, so the `reachable.length === 0`
arm answered for all of them. Populating `reachableRegistries` on the offsite
installation is what ran the comparison for the first time, and both Targets
failed at once.

The vocabulary is `supplyChain.registry`'s — that is what an operator copies
into a Target's connection and what discovery reports back — so the match is a
namespace prefix, with the trailing slash that stops `…/i` claiming a reference
in `…/images`. A bare host still works, because it is a legitimate thing to
write when a Target reaches every namespace on one registry.

The manifest declares hosts for both Targets: unambiguous against this
installation's registry list, and the spelling the currently deployed image
understands, so Cloud Run resolves its artifact-registry reference before this
fix has rolled out.

Split out of #1609, which merged the other two commits from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6kRtw8LxNAEhqdjBCeCVc
