### PR TITLE
fix(spindrift): resolve placement against the App being created, not a default

### DIFF
--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import { KINDS_BY_ADAPTER } from '../../domain/capabilities.ts';
+import { auth, componentKind, reach } from '../../domain/creation-draft.ts';
 import type { ComponentKind } from '../../domain/desired-state.ts';
 import {
   DEFAULT_PLATFORM,
@@ -14,7 +16,21 @@ import type {
 } from '../../web/model.ts';
 import { type Command, ok } from '../types.ts';
 
-export const listTargetsInput = z.object({});
+/**
+ * The three requirements placement is derived from (§3).
+ *
+ * Optional, and their absence is not a default: a caller that does not say what
+ * it is placing gets no `options` at all. The alternative — resolving against a
+ * plausible-looking workload — is what made this command answer for a
+ * `service`/`private`/`proxy` App no matter what the caller was actually
+ * creating, so a `website` was offered Targets that were candidates for
+ * something else.
+ */
+export const listTargetsInput = z.object({
+  kind: componentKind.optional(),
+  reach: reach.optional(),
+  auth: auth.optional(),
+});
 export type ListTargetsInput = z.infer<typeof listTargetsInput>;
 
 export interface ListTargetsResult {
@@ -25,19 +41,25 @@ export interface ListTargetsResult {
 }
 
 export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
-  _input,
+  input,
   context,
 ) => {
   const allTargets = await context.db.query.targets.findMany({
     orderBy: (targets, { asc }) => [asc(targets.rank)],
   });
 
+  const requirements =
+    input.kind === undefined ||
+    input.reach === undefined ||
+    input.auth === undefined
+      ? null
+      : { kind: input.kind, reach: input.reach, auth: input.auth };
+
   const targetsList: TargetListItem[] = [];
   const optionsList: TargetOptionView[] = [];
 
   for (const target of allTargets) {
-    const kinds: ComponentKind[] =
-      target.adapter === 'static' ? ['website'] : ['service', 'website', 'job'];
+    const kinds: ComponentKind[] = [...KINDS_BY_ADAPTER[target.adapter]];
 
     const canonical = (target.connection as { canonicalSuffix?: string })
       ?.canonicalSuffix
@@ -73,7 +95,11 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
     const isConnected = target.status === 'connected';
     const isHealthy = target.health === 'healthy';
 
-    if (isConnected && isHealthy) {
+    if (requirements === null) {
+      // Nothing to place, so nothing to say about placement. The Targets screen
+      // reads `targets` and never `options`, which is why this is silence
+      // rather than a guess.
+    } else if (isConnected && isHealthy) {
       const placementTarget = placementTargetOf(target, {
         artifactTypes:
           context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
@@ -81,9 +107,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
       });
 
       const placement = resolvePlacement([placementTarget], {
-        kind: 'service',
-        reach: 'private',
-        auth: 'proxy',
+        ...requirements,
         platform: DEFAULT_PLATFORM,
         registries: context.manifest.supplyChain.registry,
         resources: {},

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -49,9 +49,12 @@ export const DECISIONS = [
   'Review',
 ] as const;
 
-const componentKind = z.enum(['service', 'website', 'job']);
-const reach = z.enum(['none', 'private', 'public']);
-const auth = z.enum(['none', 'proxy']);
+// Exported because §3's requirements are derived from exactly these three, so
+// any command that resolves placement validates them against the same words the
+// draft does.
+export const componentKind = z.enum(['service', 'website', 'job']);
+export const reach = z.enum(['none', 'private', 'public']);
+export const auth = z.enum(['none', 'proxy']);
 const entry = z.enum(['service', 'website', 'upload', 'repo', 'discover']);
 const appName = z
   .string()

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -1266,38 +1266,47 @@ function NewAppScreen({
       draftId === null
         ? command('startCreationDraft', { id: startId })
         : command('getCreationDraft', { id: draftId });
-    Promise.all([
-      command('listTargets', {}),
-      command('listRepositories', {}),
-      draftRequest,
-    ])
-      .then(([targetRes, repoRes, draftRes]) => {
-        if (!live) return;
-        if (!targetRes.ok) {
-          setState({ type: 'error', message: targetRes.failure.message });
-        } else if (!repoRes.ok) {
-          setState({ type: 'error', message: repoRes.failure.message });
-        } else if (!draftRes.ok) {
-          setState({ type: 'error', message: draftRes.failure.message });
-        } else {
-          setState({
-            type: 'success',
-            targetOptions: targetRes.value.options,
-            repoOptions: repoRes.value.options,
-            draft: draftRes.value,
-          });
-          if (draftId === null) {
-            onNavigate(`/apps/new/${draftRes.value.id}`);
-          }
-        }
-      })
-      .catch((e: unknown) => {
-        if (!live) return;
-        setState({
-          type: 'error',
-          message: e instanceof Error ? e.message : 'Server failure',
-        });
+    // The Targets read follows the draft rather than racing it: placement is
+    // derived from what is being created (§3), so asking before the draft
+    // exists is asking about a different workload. Repositories still load
+    // alongside it — that read depends on nothing.
+    (async () => {
+      const draftRes = await draftRequest;
+      if (!live) return;
+      if (!draftRes.ok) {
+        setState({ type: 'error', message: draftRes.failure.message });
+        return;
+      }
+      const { kind, reach, auth } = draftRes.value.draft;
+      const [targetRes, repoRes] = await Promise.all([
+        command('listTargets', { kind, reach, auth }),
+        command('listRepositories', {}),
+      ]);
+      if (!live) return;
+      if (!targetRes.ok) {
+        setState({ type: 'error', message: targetRes.failure.message });
+        return;
+      }
+      if (!repoRes.ok) {
+        setState({ type: 'error', message: repoRes.failure.message });
+        return;
+      }
+      setState({
+        type: 'success',
+        targetOptions: targetRes.value.options,
+        repoOptions: repoRes.value.options,
+        draft: draftRes.value,
       });
+      if (draftId === null) {
+        onNavigate(`/apps/new/${draftRes.value.id}`);
+      }
+    })().catch((e: unknown) => {
+      if (!live) return;
+      setState({
+        type: 'error',
+        message: e instanceof Error ? e.message : 'Server failure',
+      });
+    });
     return () => {
       live = false;
     };

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -53,7 +53,7 @@ import {
 
 export function NewApp({
   initial,
-  targets,
+  targets: initialTargets,
   repos,
   onCreated,
 }: {
@@ -63,6 +63,11 @@ export function NewApp({
   onCreated?: (app: { readonly id: string; readonly name: string }) => void;
 }) {
   const [draft, setDraft] = useState(initial.draft);
+  // Placement is derived from kind, reach and auth (§3), so the options are
+  // only true for the draft they were resolved against. Correcting any of the
+  // three re-resolves them; leaving them stale is how a `website` ends up
+  // offered the candidates for a `service`.
+  const [targets, setTargets] = useState(initialTargets);
   const [serverBlockers, setServerBlockers] = useState(initial.blockers);
   const [refusal, setRefusal] = useState<TransportFailure | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -88,9 +93,29 @@ export function NewApp({
   const target = targets.find((option) => option.targetId === draft.targetId);
 
   const dispatch: Dispatch<DraftAction> = (action) => {
-    const next = draftReducer(draftRef.current, action);
+    const previous = draftRef.current;
+    const next = draftReducer(previous, action);
     draftRef.current = next;
     setDraft(next);
+    // Compared rather than keyed off the action type: `entry` and `detect`
+    // change the kind too, and an enumeration here would drift the first time a
+    // new action moves one of the three.
+    if (
+      next.kind !== previous.kind ||
+      next.reach !== previous.reach ||
+      next.auth !== previous.auth
+    ) {
+      void command('listTargets', {
+        kind: next.kind,
+        reach: next.reach,
+        auth: next.auth,
+      }).then((result) => {
+        // Only the newest answer counts: a slower earlier read must not
+        // overwrite the options for the draft as it stands now.
+        if (result.ok && draftRef.current === next)
+          setTargets(result.value.options);
+      });
+    }
     pendingSaves.current += 1;
     setSaving(true);
     saves.current = saves.current

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -507,7 +507,10 @@ describe('listTargets', () => {
       context(registry),
     );
 
-    const result = await listTargets({}, context(registry));
+    const result = await listTargets(
+      { kind: 'service', reach: 'private', auth: 'proxy' },
+      context(registry),
+    );
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.targets).toHaveLength(3); // 1 k8s + 2 cloud (cloudrun, static)
@@ -516,6 +519,52 @@ describe('listTargets', () => {
       expect(result.value.options.length).toBeGreaterThan(0);
       const option = result.value.options.find((o) => o.name === 'folly-k8s');
       expect(option?.candidate).toBe(true);
+    }
+  });
+
+  test('resolves placement against the requirements it was given, not a default', async () => {
+    const { registry } = fakes();
+    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
+    await connectTarget(
+      cloudInput({ name: 'cloudrun-app' }),
+      context(registry),
+    );
+
+    // The static Target serves `website` and nothing else, so it is a candidate
+    // for one of these two calls and a non-candidate for the other. Resolving
+    // both against the same hardcoded workload is the defect this pins.
+    const asWebsite = await listTargets(
+      { kind: 'website', reach: 'public', auth: 'none' },
+      context(registry),
+    );
+    const asJob = await listTargets(
+      { kind: 'job', reach: 'none', auth: 'none' },
+      context(registry),
+    );
+    expect(asWebsite.ok && asJob.ok).toBe(true);
+    if (!asWebsite.ok || !asJob.ok) return;
+
+    const staticAsWebsite = asWebsite.value.options.find(
+      (o) => o.adapter === 'static',
+    );
+    const staticAsJob = asJob.value.options.find((o) => o.adapter === 'static');
+    expect(staticAsWebsite?.candidate).toBe(true);
+    expect(staticAsJob?.candidate).toBe(false);
+    expect(staticAsJob?.reasons).toContain('KIND_UNSUPPORTED');
+  });
+
+  test('says nothing about placement when it is not told what is being placed', async () => {
+    const { registry } = fakes();
+    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
+
+    // A partial triple is not a partial answer: placement needs all three, and
+    // filling the gaps with plausible values is what made this command answer
+    // for a workload the caller was not creating.
+    const result = await listTargets({ kind: 'website' }, context(registry));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.targets.length).toBeGreaterThan(0);
+      expect(result.value.options).toHaveLength(0);
     }
   });
 });

--- a/apps/spindrift/test/web/target-repo-routes.test.ts
+++ b/apps/spindrift/test/web/target-repo-routes.test.ts
@@ -94,8 +94,14 @@ describe('listTargets and listRepositories over route boundary', () => {
     await connectTarget(clusterInput({ name: 'folly-cluster' }), ctx);
 
     const routes = serve(ctx, true);
+    // The requirements travel in the payload, so options over the route
+    // boundary is only exercised when the caller states what it is placing.
     const res = await routes[pathFor('listTargets')]!(
-      post(pathFor('listTargets'), {}),
+      post(pathFor('listTargets'), {
+        kind: 'service',
+        reach: 'private',
+        auth: 'proxy',
+      }),
     );
     expect(res.status).toBe(200);
 


### PR DESCRIPTION
## The defect

`listTargets` resolved placement against three literals:

```ts
const placement = resolvePlacement([placementTarget], {
  kind: 'service', reach: 'private', auth: 'proxy',
```

Those are `initialCreationDraft`'s defaults, so the answer was right only until
the developer corrected any of the three. After that, every exclusion —
`KIND_UNSUPPORTED`, `REACH_UNSUPPORTED`, `NO_GATEWAY` — was evaluated against a
workload nobody was creating.

Observed live: an operator creating a `website` was offered, and took,
`bluenose-cloudrun`. `website` is served by `kubernetes`, `cloudrun` **and**
`static`, so a cloud Target sailed through a filter that was never asked the
right question, and an App meant for the cluster was placed on Cloud Run.

## The fix

The requirements travel in the input now, validated by the same three zod enums
the draft uses (exported from `domain/creation-draft.ts` rather than
duplicated). All three supplied → placement resolved against that. None
supplied → `options: []`, silence rather than a guess. The Targets screen never
read `options`, so it is unaffected.

That alone would not have been enough: `NewAppScreen` fired `listTargets` in the
same `Promise.all` that *created* the draft, so it had nothing to send. The read
now follows the draft, with repositories still loading alongside it. And `NewApp`
re-resolves options whenever kind, reach or auth changes — compared before and
after the reducer rather than keyed off the action type, since `entry` and
`detect` move the kind too and an enumeration would drift.

`kinds` comes from `KINDS_BY_ADAPTER` for the same reason it should always have:
re-deriving it here gave `cloudrun` a `job` it does not serve.

## Verification

```text
$ mise run ts:check
 4 successful, 4 total

$ bun test
 1376 pass  0 fail  across 99 files
```

Two new tests pin the contract: placement resolved against the given
requirements (`static` is a candidate for a `website`, and a non-candidate with
`KIND_UNSUPPORTED` for a `job`), and a partial triple yielding no options.

## Scope

Closes the placement half of the "use real Targets and repositories" ticket in
the private tracker. The canonical-hostname half of that ticket — reading
`canonical` from `manifest.dns.apexZone` instead of the
`*.{name}.apps.internal` pattern — is deliberately not in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mkx5y2ZQiGuarodBpdeXke