### PR TITLE
fix(spindrift): stop refusing a build over a credential the route never needed

### DIFF
--- a/.agents/skills/kubernetes-gitops/SKILL.md
+++ b/.agents/skills/kubernetes-gitops/SKILL.md
@@ -46,4 +46,14 @@ only the agent-specific guidance.
 - SOPS encrypts only `data` and `stringData` in files matching
   `clusters/.*\.sops\.ya?ml`. **Never** put decrypted values in docs, PR
   comments, logs, or commit messages.
+- Postgres is CloudNativePG. Reach one with the plugin, which resolves the
+  primary — an `exec` against `<cluster>-1` names a pod that is only the primary
+  until the next failover:
+  ```bash
+  kubectl --context <site> cnpg psql <cluster> -n <namespace>
+  kubectl --context <site> cnpg status <cluster> -n <namespace>
+  ```
+  Prefer the native tool generally (`kubectl cnpg`, `flux`, `talosctl`) over
+  reassembling what it does out of `kubectl`. Procedure:
+  `docs/pages/Runbooks___Managed Postgres.md`.
 - For changes to `clusters/base/`, also use the `multi-cluster` skill.

--- a/apps/spindrift/src/auth/routes.ts
+++ b/apps/spindrift/src/auth/routes.ts
@@ -26,9 +26,25 @@
  * The pre-session members are the only acts in the application reachable
  * without a principal. Credential-administration members authenticate again at
  * this boundary, and `test/web/routes.test.ts` protects the closed route set.
+ *
+ * `AUTH_PATH_PREFIX`, `AUTH_ACTS`, `AuthAct`, and `authPathFor` live in
+ * `src/web/auth-path.ts` and are re-exported below rather than defined here,
+ * because those four are the only edge `auth-client.ts` needs into this
+ * file — everything else here pulls in `session.ts`, which value-imports
+ * `credentials`, `sessions`, and `users` from `db/schema.ts`, which drags the
+ * whole database layer into the browser bundle
+ * (`.agent/plans/spindrift/issues/34-keep-the-server-out-of-the-browser-bundle.md`,
+ * edge 3). `test/web/client-bundle.test.ts` guards against that edge coming
+ * back.
  */
 import { z } from 'zod';
 import type { Principal } from '../commands/types.ts';
+import {
+  AUTH_ACTS,
+  AUTH_PATH_PREFIX,
+  type AuthAct,
+  authPathFor,
+} from '../web/auth-path.ts';
 import {
   beginAddPasskey,
   beginCredentialChange,
@@ -58,37 +74,8 @@ import {
 } from './session.ts';
 import { type AuthFailureCode, type AuthResult, authOk } from './types.ts';
 
-/** Unversioned, and named so nobody has to be told it is not an API. */
-export const AUTH_PATH_PREFIX = '/internal/auth';
-
-/**
- * Every act on this surface.
- *
- * A tuple rather than a set of function declarations, so the route table is
- * `Object.fromEntries` over it and there is nowhere to write another path
- * without another member here.
- */
-export const AUTH_ACTS = [
-  'enrol/begin',
-  'enrol/complete',
-  'signin/begin',
-  'signin/complete',
-  'signout',
-  'session',
-  'credentials',
-  'credentials/verify/begin',
-  'passkeys/add/begin',
-  'passkeys/add/complete',
-  'passkeys/remove',
-  'gateway/link',
-  'gateway/unlink',
-] as const;
-
-export type AuthAct = (typeof AUTH_ACTS)[number];
-
-export function authPathFor(act: AuthAct): string {
-  return `${AUTH_PATH_PREFIX}/${act}`;
-}
+export type { AuthAct };
+export { AUTH_ACTS, AUTH_PATH_PREFIX, authPathFor };
 
 /**
  * The HTTP status a refusal reads as. Total over the closed set, so a new code

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -43,6 +43,7 @@ import {
   artifactTags,
   componentRepositories,
   publishableRegistries,
+  registryFlavour,
   registryHostOf,
 } from '../../domain/artifact-name.ts';
 import {
@@ -682,10 +683,28 @@ export const dispatchBuild = async (
    * is composed from one.
    */
   const credentials = context.adapters.registryCredentials?.() ?? null;
-  const registryAuth =
-    (await credentials?.authFor([
-      ...new Set(destinations.map(registryHostOf)),
-    ])) ?? [];
+  /**
+   * **Only the hosts this route cannot authorize on its own.** The same
+   * `selfAuthorizedRegistries` that chose the destinations above decides this,
+   * because they are the same question asked twice: a flavour the route's own
+   * identity reaches needs no credential handed to it, and asking for one
+   * anyway produces a credential that is unnecessary, unused, and — on a route
+   * that cannot carry one — fatal.
+   *
+   * That was not hypothetical. GHCR's credential is *minted per dispatch* from
+   * the GitHub OAuth the installation already holds
+   * (`storage/github-registry-credential.ts`), so it answers whenever the
+   * connector is authorized. Asking about every destination therefore always
+   * produced one for `ghcr.io`, and the refusal below fired on every single
+   * build on the hosted route — the route whose own workflow logs into GHCR
+   * with the run's token and needs nothing from here.
+   */
+  const unauthorizedHosts = [
+    ...new Set(destinations.map(registryHostOf)),
+  ].filter(
+    (host) => !adapter.selfAuthorizedRegistries.includes(registryFlavour(host)),
+  );
+  const registryAuth = (await credentials?.authFor(unauthorizedHosts)) ?? [];
 
   // A route that cannot carry one is refused **before** the claim, so nothing
   // is dispatched that would fail at the push — or, worse, put the credential

--- a/apps/spindrift/src/commands/builds/get-detail.ts
+++ b/apps/spindrift/src/commands/builds/get-detail.ts
@@ -111,6 +111,9 @@ export const getBuildDetail: Command<
     // so in its own log, and inventing a `Diagnosis` here would put a reason
     // from the closed deploy-failure set on something that never deployed.
     diagnosis: null,
+    // Drift is a `LIVE` release the platform stopped agreeing with. A Build has
+    // placed nothing, so there is nothing for a platform to disagree with.
+    drift: null,
     // Nothing has been placed, so there is nothing to check off. An empty list
     // renders no section at all, which is the honest shape.
     resources: [],

--- a/apps/spindrift/src/commands/deploys/get-detail.ts
+++ b/apps/spindrift/src/commands/deploys/get-detail.ts
@@ -221,6 +221,15 @@ export const getDeployDetail: Command<
     urlLive: deploy.phase === 'LIVE',
     previousReleaseServing,
     diagnosis,
+    drift:
+      deploy.driftedAt === null
+        ? null
+        : {
+            since: elapsedSince(deploy.driftedAt, context.clock.now()),
+            at: deploy.driftedAt.toISOString(),
+            observedDigest: deploy.observedDigest,
+            detail: deploy.driftDetail,
+          },
     resources,
     source,
     build,

--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -27,6 +27,17 @@
  * construction — every adapter's access path is resolved per request, and no
  * variant of any route or connection carries key material — so the document is
  * platform configuration, and the surface is session-authenticated regardless.
+ *
+ * **`manifestDivergence` rides along for the same reason `manifest` does.**
+ * `loadStoredManifest` already detects a mounted declaration that disagrees
+ * with the stored row and says so — once, in a pod log, at boot. §6: "drift is
+ * detected and surfaced, never silently corrected" does not stop at the log;
+ * an operator who opens this screen weeks after the rollout that caused the
+ * disagreement is exactly who needed to see it and exactly who cannot. It is
+ * read off `context.manifestDivergence` rather than recomputed here for the
+ * same reason `manifest` is: recomputing it would mean reading the mounted
+ * declaration a second time, which needs `Bun.file` and puts this command back
+ * in the shape it exists to avoid.
  */
 import { z } from 'zod';
 import {
@@ -43,10 +54,20 @@ export type GetInstallationManifestInput = z.infer<
 
 export interface GetInstallationManifestResult {
   readonly manifest: AuthoredManifest;
+  /**
+   * Dotted paths where a mounted declaration disagrees with the manifest
+   * above, or `[]` when nothing is mounted or the two agree. Paths only —
+   * see `manifest-store.ts`'s `diffManifestPaths` for why a value never rides
+   * along with one.
+   */
+  readonly manifestDivergence: readonly string[];
 }
 
 export const getInstallationManifest: Command<
   GetInstallationManifestInput,
   GetInstallationManifestResult
 > = async (_input, context) =>
-  ok({ manifest: toAuthoredManifest(context.manifest) });
+  ok({
+    manifest: toAuthoredManifest(context.manifest),
+    manifestDivergence: context.manifestDivergence ?? [],
+  });

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
+import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import { KINDS_BY_ADAPTER } from '../../domain/capabilities.ts';
 import { auth, componentKind, reach } from '../../domain/creation-draft.ts';
 import type { ComponentKind } from '../../domain/desired-state.ts';
+import { coreMintsCanonical, type DnsZones } from '../../domain/naming.ts';
 import {
   DEFAULT_PLATFORM,
   type Exclusion,
@@ -33,6 +35,39 @@ export const listTargetsInput = z.object({
 });
 export type ListTargetsInput = z.infer<typeof listTargetsInput>;
 
+/**
+ * The naming boundary a Target's canonical names would live under (§9).
+ *
+ * Not a minted name — neither call site here has an App or a Component yet,
+ * so there is nothing to run `hostnameFor` on. This states the zone the mint
+ * would land in, which is the honest thing the Targets screen and the Place
+ * step can say before that: `<app>-<component>` is not known, but the zone it
+ * would be joined to is.
+ *
+ * `null` is not "unknown" — it is the correct answer for `cloudrun` and
+ * `static`. `coreMintsCanonical` is false for both: the platform mints its
+ * own workload address, and inventing a Spindrift-owned suffix beside it
+ * would show a naming pattern no Deploy on that Target will ever use. Every
+ * caller must render `null` as "the platform names its own" rather than
+ * fall back to a suffix — a fallback here is exactly the bug this replaced
+ * (`*.<target>.apps.internal`, a zone that appeared nowhere else in the
+ * repo).
+ */
+function canonicalBoundary(
+  adapter: TargetAdapter,
+  zones: DnsZones,
+): string | null {
+  if (!coreMintsCanonical(adapter)) return null;
+  // One zone per reach (§9's `DnsZones`): an installation may point both at
+  // the same name, so collapsing to one pattern is both honest and the common
+  // case; an installation that split them gets both, because a Target minting
+  // into `public` as readily as `private` is not represented by naming only
+  // one.
+  return zones.private === zones.public
+    ? `*.${zones.private}`
+    : `*.${zones.private} (private) · *.${zones.public} (public)`;
+}
+
 export interface ListTargetsResult {
   readonly targets: readonly TargetListItem[];
   readonly options: readonly TargetOptionView[];
@@ -61,10 +96,10 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
   for (const target of allTargets) {
     const kinds: ComponentKind[] = [...KINDS_BY_ADAPTER[target.adapter]];
 
-    const canonical = (target.connection as { canonicalSuffix?: string })
-      ?.canonicalSuffix
-      ? `*.${(target.connection as { canonicalSuffix?: string }).canonicalSuffix}`
-      : `*.${target.name.toLowerCase().replace(/[^a-z0-9]/g, '')}.apps.internal`;
+    const canonical = canonicalBoundary(
+      target.adapter,
+      context.manifest.dns.zones,
+    );
 
     const prereqFailures = target.prerequisites
       ?.filter((p) => !p.met && p.detail)

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -164,6 +164,27 @@ export interface CommandContext {
    * to exist, and a test can run two installations in one process.
    */
   readonly manifest: InstallationManifest;
+  /**
+   * Dotted paths where a mounted declaration disagrees with `manifest`, from
+   * {@link diffManifestPaths}. `undefined` where a caller has not computed
+   * one — every production context does; a test context that does not care is
+   * not required to.
+   *
+   * §6: "drift is detected and surfaced, never silently corrected" applies to
+   * the manifest itself, not only to what it deploys. `loadStoredManifest`
+   * already says this once, in a pod log nobody is watching at the moment a
+   * rollout quietly stops matching what is running; this is the same fact
+   * reachable from a screen an operator actually opens. `getInstallationManifest`
+   * is the one command that answers it — carried on the context, not
+   * recomputed by that command, because it has no server-only import to
+   * recompute it with (`src/commands/installation/get.ts` says why).
+   *
+   * **Paths only, exactly as {@link diffManifestPaths} promises — never a
+   * value.** A command that reads this must not append a value onto a path
+   * before handing it back; doing so would defeat the one property this
+   * field exists to keep.
+   */
+  readonly manifestDivergence?: readonly string[];
 }
 
 /**

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -73,13 +73,83 @@ export async function loadStoredManifest(
       `installation manifest: the stored manifest is not valid for this build, so this installation is being re-seeded from the mounted declaration — anything configured through the UI that the declaration does not carry is lost: ${unreadable.message}`,
     );
   } else if (stored !== null && declaration !== null) {
+    // The generic half of this warning has existed since the rule did — "a
+    // declaration is mounted and ignored" — and it is not enough. Proven live:
+    // a rollout moved a Target's gateway in the declaration; the stored row
+    // never moved because the row wins by design; and this line gave nobody a
+    // reason to go look, right up until the listener that rollout deleted took
+    // the Target's gateway with it. §6: "drift is detected and surfaced, never
+    // silently corrected" — naming the paths is that rule applied to the
+    // manifest itself, not just to what it deploys.
+    const divergentPaths = diffManifestPaths(declaration, stored);
     console.warn(
-      'installation manifest: a declaration is mounted but this installation is already seeded, so the stored manifest is being used and the declaration is ignored — discard the row to re-seed from it',
+      divergentPaths.length === 0
+        ? 'installation manifest: a declaration is mounted but this installation is already seeded, so the stored manifest is being used and the declaration is ignored — discard the row to re-seed from it'
+        : `installation manifest: a declaration is mounted but this installation is already seeded, so the stored manifest is being used and the declaration is ignored — discard the row to re-seed from it. It now disagrees with the stored row at: ${divergentPaths.join(', ')}`,
     );
   }
   const declared = stored ?? declaration ?? DEFAULT_PLACEHOLDER_MANIFEST;
   await writeStoredManifest(db, declared);
   return resolveManifest(declared, env);
+}
+
+/**
+ * Every dotted path where two manifest documents disagree.
+ *
+ * **Paths only, never a value — deliberately, not just today.** §13 keeps
+ * every `TargetConnection` variant credential-free by construction, so
+ * nothing in this schema is secret right now. This walk does not lean on
+ * that: it is generic over whatever the schema is next asked to carry, and a
+ * diff utility that prints what it finds is exactly the code a later
+ * secret-bearing field walks straight through unnoticed. Naming where two
+ * documents disagree costs nothing extra over naming what they disagree
+ * about; only one of the two stays safe if that promise ever slips.
+ *
+ * Recurses through plain objects and arrays and stops at the first point two
+ * branches stop being the same *shape* — a leaf value differs, or a key exists
+ * on one side and not the other — reporting the path to that node rather than
+ * descending further: there is nothing under an absent key to compare, and a
+ * Target that moved from index 2 to index 0 should read as `targets.0`, not
+ * as a page of noise about every field underneath it.
+ */
+export function diffManifestPaths(
+  a: unknown,
+  b: unknown,
+  path: readonly string[] = [],
+): string[] {
+  if (Bun.deepEquals(a, b, true)) return [];
+
+  const left = containerEntries(a);
+  const right = containerEntries(b);
+  if (left === null || right === null) {
+    return [path.length === 0 ? '(root)' : path.join('.')];
+  }
+
+  const leftByKey = new Map(left);
+  const rightByKey = new Map(right);
+  const diffs: string[] = [];
+  for (const key of new Set([...leftByKey.keys(), ...rightByKey.keys()])) {
+    diffs.push(
+      ...diffManifestPaths(leftByKey.get(key), rightByKey.get(key), [
+        ...path,
+        key,
+      ]),
+    );
+  }
+  return diffs;
+}
+
+/** `[key, value]` pairs for a plain object or an array; `null` for anything else. */
+function containerEntries(value: unknown): [string, unknown][] | null {
+  if (Array.isArray(value)) {
+    return value.map(
+      (item, index) => [String(index), item] as [string, unknown],
+    );
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.entries(value as Record<string, unknown>);
+  }
+  return null;
 }
 
 /**

--- a/apps/spindrift/src/db/migrations/0021_drift_detail.sql
+++ b/apps/spindrift/src/db/migrations/0021_drift_detail.sql
@@ -1,0 +1,9 @@
+-- §6's drift is "detected and surfaced, never silently corrected", and the
+-- surfacing was a flag plus the digest running instead. That pair cannot
+-- describe the case this column exists for: a delivery object failing every
+-- reconcile while the previous release keeps serving the digest that was asked
+-- for. Nothing is running instead — nothing new is running at all.
+--
+-- Separate from `detail`, which belongs to a `FAILED` verdict. A Deploy in this
+-- state reached `LIVE`; what changed is that the platform stopped agreeing.
+ALTER TABLE "deploys" ADD COLUMN "drift_detail" text;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1785374380764,
       "tag": "0020_app_build_route",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1785374380765,
+      "tag": "0021_drift_detail",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -726,6 +726,20 @@ export const deploys = pgTable('deploys', {
    * ask, the answer is one poll interval old at best.
    */
   observedDigest: text('observed_digest'),
+  /**
+   * Why the platform will not converge on this release, in its own words.
+   *
+   * The digest answers "what is running instead"; this answers the case where
+   * the digest is not the question. A delivery object can fail every reconcile
+   * while the last good release keeps serving the desired digest — a chart
+   * whose contract moved out from under stored values does exactly that — and
+   * a drift flag with no sentence beside it tells an operator that something
+   * is wrong without telling them it is unfixable by waiting.
+   *
+   * Not `detail`, which §6 reserves for a `FAILED` verdict. This Deploy did not
+   * fail: it reached `LIVE` and the platform has since stopped agreeing.
+   */
+  driftDetail: text('drift_detail'),
   createdAt: timestamp('created_at', { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/apps/spindrift/src/domain/diagnosis.ts
+++ b/apps/spindrift/src/domain/diagnosis.ts
@@ -93,6 +93,13 @@ export function failureColumns(diagnosis: Diagnosis): {
  *
  * Drift is only meaningful for a Deploy that reached `LIVE`. A Deploy still
  * converging has not drifted; it has not arrived.
+ *
+ * **The digest is not the only way to disagree.** A delivery object the platform
+ * is refusing to apply has drifted even while it still serves the digest that
+ * was asked for: the previous release is what is answering, and every reconcile
+ * is failing behind it. Comparing digests alone reads that as converged, which
+ * is how a release whose chart contract moved sat wedged for a day with a green
+ * row in front of it.
  */
 export function hasDrifted(args: {
   readonly phase: DeployPhase;
@@ -100,8 +107,16 @@ export function hasDrifted(args: {
   readonly desiredDigest: string;
   /** The digest `observe` says is actually serving, or `null` when nothing is. */
   readonly observedDigest: string | null;
+  /**
+   * The phase the delivery object itself reports, when the adapter read one.
+   *
+   * Distinct from `phase` above, which is what this Deploy's own attempt ended
+   * on. They agreed when the attempt finished and are free to diverge after.
+   */
+  readonly observedPhase?: DeployPhase;
 }): boolean {
   if (args.phase !== 'LIVE') return false;
   if (args.observedDigest === null) return true;
+  if (args.observedPhase === 'FAILED') return true;
   return args.observedDigest !== args.desiredDigest;
 }

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -41,6 +41,7 @@ import type {
   DeployEvent,
   DeployPhase,
   DeployVerdict,
+  ObservedState,
 } from '../adapters/deploy/contract.ts';
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
@@ -484,6 +485,8 @@ export interface DriftReport {
   readonly deployId: number;
   readonly drifted: boolean;
   readonly observedDigest: string | null;
+  /** Why the platform will not converge, when that is what drifted. */
+  readonly driftDetail: string | null;
 }
 
 /**
@@ -510,25 +513,33 @@ export async function observeConverged(
     const subject = await subjectOf(context, deploy);
     if (subject === null) continue;
 
-    let observed: string | null = null;
+    let state: ObservedState | null = null;
     try {
-      const state = await subject.adapter.observe(
+      state = await subject.adapter.observe(
         deployTargetOf(subject.target),
         deploy.ref,
       );
-      observed = state?.artifactDigest ?? null;
     } catch {
       // A Target that cannot be reached is not a Target that has drifted. Saying
       // "drifted" here would turn every uplink blip into a false alarm about
       // something a developer did.
       continue;
     }
+    const observed = state?.artifactDigest ?? null;
 
     const drifted = hasDrifted({
       phase: deploy.phase,
       desiredDigest: subject.build.artifactDigest ?? '',
       observedDigest: observed,
+      ...(state === null ? {} : { observedPhase: state.phase }),
     });
+
+    // The platform's own sentence, kept only while it is the reason. §12's
+    // argument for storing a diagnosis applies here for the same cause: a
+    // Helm error naming the value that no longer renders is not recoverable
+    // from anywhere once the object is reconciled again.
+    const driftDetail =
+      drifted && state?.phase === 'FAILED' ? (state.detail ?? null) : null;
 
     // §6 wants drift to be "a visible state", and visible means a row: the UI
     // reads rows, so a finding that lived only for the length of this pass
@@ -536,19 +547,26 @@ export async function observeConverged(
     // somebody fixed out of band stops being reported without a dismissal.
     if (
       drifted !== (deploy.driftedAt !== null) ||
-      observed !== deploy.observedDigest
+      observed !== deploy.observedDigest ||
+      driftDetail !== deploy.driftDetail
     ) {
       await context.db
         .update(deploys)
         .set({
           driftedAt: drifted ? now : null,
           observedDigest: observed,
+          driftDetail,
           updatedAt: now,
         })
         .where(eq(deploys.id, deploy.id));
     }
 
-    reports.push({ deployId: deploy.id, drifted, observedDigest: observed });
+    reports.push({
+      deployId: deploy.id,
+      drifted,
+      observedDigest: observed,
+      driftDetail,
+    });
   }
   return reports;
 }

--- a/apps/spindrift/src/web/auth-client.ts
+++ b/apps/spindrift/src/web/auth-client.ts
@@ -26,9 +26,9 @@ import type {
   AddPasskeyChallenge,
   CredentialSettings,
 } from '../auth/credential-admin.ts';
-import { AUTH_PATH_PREFIX, type AuthAct } from '../auth/routes.ts';
 import type { AuthFailure } from '../auth/types.ts';
 import type { Principal } from '../commands/types.ts';
+import { AUTH_PATH_PREFIX, type AuthAct } from './auth-path.ts';
 
 export type AuthClientResult<Value> =
   | { readonly ok: true; readonly value: Value }

--- a/apps/spindrift/src/web/auth-path.ts
+++ b/apps/spindrift/src/web/auth-path.ts
@@ -1,0 +1,56 @@
+/**
+ * The client-safe edge of the auth boundary (Task 37).
+ *
+ * `.agent/plans/spindrift/issues/34-keep-the-server-out-of-the-browser-bundle.md`
+ * names this as edge 3, found while verifying edge 2: `auth-client.ts`
+ * value-imported `AUTH_PATH_PREFIX` and `AuthAct` from `src/auth/routes.ts`,
+ * which value-imports `session.ts`, which value-imports `credentials`,
+ * `sessions`, and `users` from `db/schema.ts`. `db/schema.ts` is one module
+ * declaring every table, so any live edge into it — regardless of which table
+ * the importer actually wanted — drags the whole file and the whole
+ * `drizzle-orm` surface into the browser bundle. That is why cutting edge 2
+ * (the streaming transport) left the bundle's `drizzle-orm` count unchanged:
+ * this edge was still open.
+ *
+ * `AUTH_PATH_PREFIX`, `AUTH_ACTS`, `AuthAct`, and `authPathFor` are the only
+ * things `auth-client.ts` needs from `src/auth/routes.ts`, and none of them
+ * touch the database — they are a route prefix, a closed tuple of act names,
+ * and a function that concatenates the two. So, the same move as
+ * `command-path.ts` (edge 1) and `stream-path.ts` (edge 2): they live here,
+ * in a leaf module with no imports of their own, and `routes.ts` re-exports
+ * them rather than defining them, so the server side is unchanged and there
+ * is exactly one definition of each. `test/web/client-bundle.test.ts` builds
+ * the client and asserts `db/schema.ts` and `drizzle-orm` are unreachable.
+ */
+
+/** Unversioned, and named so nobody has to be told it is not an API. */
+export const AUTH_PATH_PREFIX = '/internal/auth';
+
+/**
+ * Every act on this surface.
+ *
+ * A tuple rather than a set of function declarations, so the route table is
+ * `Object.fromEntries` over it and there is nowhere to write another path
+ * without another member here.
+ */
+export const AUTH_ACTS = [
+  'enrol/begin',
+  'enrol/complete',
+  'signin/begin',
+  'signin/complete',
+  'signout',
+  'session',
+  'credentials',
+  'credentials/verify/begin',
+  'passkeys/add/begin',
+  'passkeys/add/complete',
+  'passkeys/remove',
+  'gateway/link',
+  'gateway/unlink',
+] as const;
+
+export type AuthAct = (typeof AUTH_ACTS)[number];
+
+export function authPathFor(act: AuthAct): string {
+  return `${AUTH_PATH_PREFIX}/${act}`;
+}

--- a/apps/spindrift/src/web/components/diagnosis.tsx
+++ b/apps/spindrift/src/web/components/diagnosis.tsx
@@ -23,7 +23,8 @@
  */
 import { useState } from 'react';
 import { reasonCovers } from '../../adapters/deploy/contract.ts';
-import type { Diagnosis } from '../model.ts';
+import type { Diagnosis, DriftView } from '../model.ts';
+import { Button } from '../ui/button.tsx';
 import {
   Collapsible,
   CollapsibleContent,
@@ -76,6 +77,108 @@ export function DiagnosisPanel({
               />
             </CollapsibleContent>
           </Collapsible>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * The amber block: a release that succeeded and no longer agrees with reality.
+ *
+ * Deliberately not the red one. §6 calls drift "information, not an alarm", and
+ * on this screen the distinction is load-bearing — a red panel over a release
+ * that is still serving traffic would say an outage that is not happening.
+ *
+ * The two arms it renders are the two ways a converged release stops being
+ * converged, and they want opposite first sentences. A digest mismatch means
+ * **something else is serving**: somebody applied around Spindrift, and the
+ * question is which artifact won. A refusal means **nothing new can serve at
+ * all**: the delivery object is failing every reconcile behind a previous
+ * release that is still up, so the App looks fine and has been frozen since.
+ * That second arm is the one nothing surfaced before — it has no digest to
+ * report, because no new digest ever landed — and it is the reason `detail`
+ * carries the platform's own sentence rather than a phrase composed here. The
+ * sentence names the value the chart rejected; a paraphrase would not.
+ *
+ * The button is §6's "one-click re-converge", and it is the same redeploy act
+ * as everywhere else — drift is never corrected on Spindrift's own initiative,
+ * so the affordance is a person pressing the ordinary path.
+ */
+export function DriftPanel({
+  drift,
+  url,
+  onRedeploy,
+  busy,
+}: {
+  drift: DriftView;
+  url: string;
+  onRedeploy?: () => void;
+  busy?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const refused = drift.detail !== null;
+
+  return (
+    <section className="overflow-hidden rounded-lg border border-warning/40">
+      <header className="flex flex-wrap items-center gap-2.5 bg-warning-soft px-3.5 py-3">
+        <span className="font-mono text-[13px] font-semibold text-warning">
+          DRIFTED
+        </span>
+        <span className="text-[12.5px] text-subtle">
+          {refused
+            ? 'the platform is refusing to apply this release'
+            : 'what is running is not what this release asked for'}
+        </span>
+        <span className="ml-auto text-[12.5px] text-subtle" title={drift.at}>
+          since {drift.since}
+        </span>
+      </header>
+
+      <div className="flex flex-col gap-3 bg-card px-3.5 py-3.5">
+        <p className="text-sm text-foreground">
+          {refused ? (
+            <>
+              This release reached Live and the platform has stopped accepting
+              it since. Every reconcile is failing, so nothing new can roll out
+              here until it is resolved — the last release that applied cleanly
+              is what {url ? <code>{url}</code> : 'this Component'} is still
+              serving.
+            </>
+          ) : (
+            <>
+              Something other than this release is serving{' '}
+              {url ? <code>{url}</code> : 'this Component'}. Spindrift does not
+              correct drift on its own; deploying again re-converges it.
+            </>
+          )}
+        </p>
+
+        {drift.observedDigest === null ? null : (
+          <Notice label="Serving">
+            <code>{drift.observedDigest}</code>
+          </Notice>
+        )}
+
+        {drift.detail === null ? null : (
+          <Collapsible open={open} onOpenChange={setOpen}>
+            <CollapsibleTrigger className="text-[11.5px] font-semibold uppercase tracking-[0.05em] text-muted-foreground hover:text-foreground">
+              {open ? 'Hide' : 'Show'} what the platform said
+            </CollapsibleTrigger>
+            <CollapsibleContent className="pt-2">
+              <LogPane
+                lines={drift.detail.split('\n').map((text) => ({ text }))}
+              />
+            </CollapsibleContent>
+          </Collapsible>
+        )}
+
+        {onRedeploy === undefined ? null : (
+          <div>
+            <Button variant="outline" onClick={onRedeploy} disabled={busy}>
+              {busy ? 'Deploying…' : 'Deploy again to re-converge'}
+            </Button>
+          </div>
         )}
       </div>
     </section>

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -182,6 +182,32 @@ export type SourceView =
  * still up, so the view never has to infer "nothing went down" from the absence
  * of something.
  */
+/**
+ * A `LIVE` release the platform has since stopped agreeing with (§6).
+ *
+ * Two shapes reach this one type, because a reader's next move is the same for
+ * both — press re-converge — and the difference is only what to say first:
+ * something else is serving (`observedDigest` differs), or nothing new can
+ * serve at all (`detail` carries the platform's refusal).
+ */
+export interface DriftView {
+  /** When the loop first saw the disagreement, in words — "2h ago". */
+  readonly since: string;
+  /** The instant behind {@link since}, for the title a reader hovers. */
+  readonly at: string;
+  /** The digest actually serving, when that is what differs. */
+  readonly observedDigest: string | null;
+  /**
+   * Why the platform will not converge, in its own words.
+   *
+   * Present for a release whose delivery object is failing every reconcile —
+   * stored values the current chart no longer accepts is the case this exists
+   * for. `null` when the drift is an ordinary digest mismatch, which
+   * {@link observedDigest} already explains.
+   */
+  readonly detail: string | null;
+}
+
 export interface DeployView {
   /**
    * The Deploy this attempt is, or `null` while it is still only a Build.
@@ -222,6 +248,15 @@ export interface DeployView {
    */
   readonly previousReleaseServing: boolean;
   readonly diagnosis: Diagnosis | null;
+  /**
+   * What the platform stopped agreeing with, once this release was `LIVE` (§6).
+   *
+   * Separate from {@link diagnosis}, which belongs to an attempt that failed.
+   * A drifted release succeeded; the disagreement started afterwards, and §6
+   * wants it "a visible state with a one-click re-converge" — so it has to
+   * reach a screen. `null` is the ordinary case: converged.
+   */
+  readonly drift: DriftView | null;
   readonly resources: readonly ChecklistItem[];
   /** Where this release's bytes came from. Always present (§4). */
   readonly source: SourceView;
@@ -446,8 +481,14 @@ export interface TargetOptionView {
   readonly rank: number;
   readonly candidate: boolean;
   readonly artifactType: ArtifactType | null;
-  /** The name this Component would answer on here (§9). */
-  readonly canonical: string;
+  /**
+   * The zone core would mint this Component's canonical name into here (§9),
+   * as `*.<zone>` — not the minted name itself; nothing has been named yet at
+   * Place. `null` on a Target whose adapter names its own workloads
+   * (`coreMintsCanonical` false), which must be rendered as that fact, never
+   * defaulted back to a suffix.
+   */
+  readonly canonical: string | null;
   readonly reasons: readonly Exclusion[];
   readonly detail: readonly string[];
 }
@@ -557,8 +598,13 @@ export interface TargetListItem {
   }[];
   /** Supported component kinds on this target. */
   readonly kinds: readonly ComponentKind[];
-  /** The canonical hostname prefix for apps on this target. */
-  readonly canonical: string;
+  /**
+   * The zone core mints canonical names into on this Target (§9), as
+   * `*.<zone>`. `null` when the adapter names its own workloads instead
+   * (`coreMintsCanonical` false, e.g. `cloudrun`, `static`) — the screen must
+   * say that rather than show a suffix core will never mint.
+   */
+  readonly canonical: string | null;
   /** `disconnected` keeps serving; it strands Deploys rather than ending them. */
   readonly status: 'connected' | 'disconnected';
   /**

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -22,9 +22,14 @@ import { createAdapterRegistry } from '../adapters/registry.ts';
 import type { EnrolmentDeps } from '../auth/enrol.ts';
 import { authenticateRequest, type GatewayDeps } from '../auth/gateway.ts';
 import { systemClock } from '../commands/types.ts';
-import { assertTrustedGatewayBoundary } from '../config/manifest.ts';
+import { toAuthoredManifest } from '../config/manifest.schema.ts';
+import {
+  assertTrustedGatewayBoundary,
+  loadManifestIfPresent,
+} from '../config/manifest.ts';
 import {
   currentStoredManifest,
+  diffManifestPaths,
   loadStoredManifest,
 } from '../config/manifest-store.ts';
 import { createDb } from '../db/client.ts';
@@ -138,6 +143,22 @@ export async function start(
   });
 
   /**
+   * The mounted declaration, read once and held for the life of the process.
+   *
+   * `loadStoredManifest` already read this file at boot to decide whether to
+   * seed from it, and already logs when it disagrees with what got stored —
+   * this is a second, best-effort read of the same file so `manifestDivergence`
+   * below can answer the same question on demand rather than only once, to a
+   * log line, at the moment nobody was watching. `null` for "unreadable" as
+   * well as "absent": an invalid declaration is already reported by that boot
+   * warning, and this is a display concern, not a second place to be fatal
+   * about it. Not re-read per request — the ConfigMap volume it lives on does
+   * not change without a pod restart in the ordinary case, which is the same
+   * reasoning `relyingParty` below rests on.
+   */
+  const declaration = await loadManifestIfPresent().catch(() => null);
+
+  /**
    * The configuration a command runs against, current as of this request.
    *
    * `configureInstallation` writes the row, so a process-lifetime copy would
@@ -145,14 +166,24 @@ export async function start(
    * is one `select` per command; the adapters are rebuilt only when the
    * document actually changed, which is what makes doing this per request
    * affordable — `createAdapterRegistry` is pure assembly whose credentials are
-   * providers called per request, so rebuilding opens nothing.
+   * providers called per request, so rebuilding opens nothing. `manifestDivergence`
+   * is recomputed on that same change, against the one-time `declaration`
+   * above — cheap, because `diffManifestPaths` is a pure walk over two
+   * documents already in memory.
    *
    * Deliberately **not** current: `auth` below. `controlPlane.hostname` is the
    * passkey relying-party id, and a ceremony is scoped to the origin it began
    * at — re-reading it mid-session would invalidate credentials rather than
    * update them. Changing where an installation is served is a restart.
    */
-  let current = { manifest, adapters };
+  let current = {
+    manifest,
+    adapters,
+    manifestDivergence:
+      declaration === null
+        ? []
+        : diffManifestPaths(declaration, toAuthoredManifest(manifest)),
+  };
   const installationNow = async () => {
     const stored = await currentStoredManifest(db);
     if (stored === null || Bun.deepEquals(stored, current.manifest, true)) {
@@ -165,6 +196,10 @@ export async function start(
         db,
         clock: systemClock,
       }),
+      manifestDivergence:
+        declaration === null
+          ? []
+          : diffManifestPaths(declaration, toAuthoredManifest(stored)),
     };
     return current;
   };
@@ -193,6 +228,7 @@ export async function start(
           db,
           adapters: installation.adapters,
           manifest: installation.manifest,
+          manifestDivergence: installation.manifestDivergence,
         };
       },
     },

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -44,7 +44,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Checklist } from '../../components/checklist.tsx';
-import { DiagnosisPanel } from '../../components/diagnosis.tsx';
+import { DiagnosisPanel, DriftPanel } from '../../components/diagnosis.tsx';
 import { LogPane, Notice } from '../../components/log-pane.tsx';
 import { PhasePill, StepGlyph, statusWord } from '../../components/status.tsx';
 import type { DeployView, SourceView } from '../../model.ts';
@@ -94,6 +94,23 @@ export function DeployDetail({
           diagnosis={view.diagnosis}
           previousReleaseServing={view.previousReleaseServing}
           url={view.url}
+        />
+      ) : null}
+
+      {/*
+        Below the diagnosis, and never instead of it. The two can both be
+        absent, and only drift can be present on a green release — but a red
+        release that has also drifted leads with why it failed, because that is
+        the older and more actionable fact.
+      */}
+      {view.drift ? (
+        <DriftPanel
+          drift={view.drift}
+          url={view.url}
+          {...(actions.onRedeploy === undefined
+            ? {}
+            : { onRedeploy: actions.onRedeploy })}
+          busy={actions.busy === 'redeploy'}
         />
       ) : null}
 
@@ -634,10 +651,26 @@ function BuildOutput({ view }: { view: DeployView }) {
  * `logTotal` is stated whenever it exceeds what is here. A tail presented as
  * the log is the UI editing evidence; a tail that says how much it is a tail
  * of, and where the rest lives, is not.
+ *
+ * The initial `open` is only half the contract — a `LIVE_TEXT` runner (§4)
+ * releases text as it's written, so `BuildOutput` can hand this a non-null
+ * `log` while the build is still `running`, well before red is known at
+ * mount. Without re-deriving `open` on a status change, React keeps whatever
+ * it picked at that early mount forever, and a running→failed transition
+ * lands on a drawer that never sprang open. Same shape as `BuildDrawer`'s
+ * prior-status effect above, for the same reason.
  */
 function Transcript({ build }: { build: NonNullable<DeployView['build']> }) {
   const lines = build.log ?? [];
   const [open, setOpen] = useState(build.status === 'failed');
+  const priorStatus = useRef(build.status);
+
+  useEffect(() => {
+    if (priorStatus.current === build.status) return;
+    priorStatus.current = build.status;
+    setOpen(build.status === 'failed');
+  }, [build.status]);
+
   const clipped = build.logTotal > lines.length;
 
   return (

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -343,8 +343,17 @@ export function NewApp({
                   </span>
                 </div>
                 {option.candidate ? (
-                  <span className="font-mono text-xs text-muted-foreground">
-                    {option.canonical}
+                  <span
+                    className={
+                      option.canonical === null
+                        ? 'text-xs text-subtle'
+                        : 'font-mono text-xs text-muted-foreground'
+                    }
+                  >
+                    {/* §9: `null` means this adapter names its own workloads
+                        — say so rather than showing a suffix core will never
+                        mint. */}
+                    {option.canonical ?? 'platform names its own'}
                   </span>
                 ) : (
                   <ul className="flex flex-col gap-0.5">
@@ -365,7 +374,17 @@ export function NewApp({
           </div>
         </Row>
 
-        <Row label="URL" value={target?.canonical ?? 'pending a Target'} />
+        <Row
+          label="URL"
+          value={
+            target === undefined
+              ? 'pending a Target'
+              : // §9: `null` is not "pending" — it is `cloudrun`/`static`
+                // reporting their own address back after deploy, which this
+                // step cannot show early because nothing has deployed yet.
+                (target.canonical ?? 'platform names its own')
+          }
+        />
 
         <Row label="Reach" value={draft.reach} why={REACH_NOTE[draft.reach]}>
           <div className="grid gap-2 sm:grid-cols-3">

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -65,11 +65,13 @@ export function InstallationSettings() {
   const [errors, setErrors] = useState<FieldErrors>(new Map());
   const [outcome, setOutcome] = useState<SaveOutcome | null>(null);
   const [saving, setSaving] = useState(false);
+  const [divergence, setDivergence] = useState<readonly string[]>([]);
 
   const load = useCallback(async () => {
     const result = await command('getInstallationManifest', {});
     if (result.ok) {
       setDocument(result.value.manifest);
+      setDivergence(result.value.manifestDivergence);
       setLoadError(null);
     } else {
       setLoadError(result.failure.message);
@@ -161,6 +163,7 @@ export function InstallationSettings() {
       errors={errors}
       outcome={outcome}
       saving={saving}
+      divergence={divergence}
       onChange={(next) => {
         setDocument(next);
         setOutcome(null);
@@ -210,6 +213,7 @@ export function InstallationSettingsView({
   errors,
   outcome,
   saving,
+  divergence = [],
   onChange,
   onSave,
   onReload,
@@ -219,6 +223,14 @@ export function InstallationSettingsView({
   readonly errors: FieldErrors;
   readonly outcome: SaveOutcome | null;
   readonly saving: boolean;
+  /**
+   * Dotted paths where the mounted declaration disagrees with what is shown
+   * below, from `getInstallationManifest`. Optional, and defaulted to `[]`
+   * rather than required, so a test rendering this view for the ordinary case
+   * — no declaration mounted, or nothing seeded yet — states nothing about a
+   * fact it is not exercising.
+   */
+  readonly divergence?: readonly string[];
   onChange(document: unknown): void;
   onSave(): void;
   onReload(): void;
@@ -239,6 +251,8 @@ export function InstallationSettingsView({
         onSave();
       }}
     >
+      <ManifestDivergenceNotice paths={divergence} />
+
       <Card>
         <CardHeader>
           <Sliders aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
@@ -306,6 +320,57 @@ export function InstallationSettingsView({
         </Button>
       </div>
     </form>
+  );
+}
+
+/**
+ * The one thing this screen says that is not about the last save: the
+ * mounted declaration and the document below no longer agree.
+ *
+ * `loadStoredManifest` seeds from a declaration and, once seeded, ignores
+ * it — deliberately, so a rollout can never revert what an operator just
+ * configured here. The cost of that rule is that a declaration can drift for
+ * a long time with nothing but a boot-time pod log to say so, which is how
+ * PR #1607 moved a Target's gateway in the declaration while the row this
+ * screen edits kept pointing at the one that PR deleted. This notice is that
+ * same fact, read where an operator actually looks rather than where a
+ * rollout happened to leave it.
+ *
+ * Not a refusal — nothing failed, and nothing here is wrong to fix — so it
+ * renders beside `Outcome` rather than as one of its arms, and it is present
+ * whenever `divergence` is non-empty rather than only after a save.
+ *
+ * **Paths only**, exactly as `getInstallationManifest` answers them: the list
+ * says where the two documents disagree, never what either one says at that
+ * path.
+ */
+function ManifestDivergenceNotice({
+  paths,
+}: {
+  readonly paths: readonly string[];
+}) {
+  if (paths.length === 0) return null;
+
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground"
+    >
+      <CircleAlert aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+      <div>
+        <p className="font-medium">
+          The mounted declaration no longer matches this installation.
+        </p>
+        <p className="mt-0.5">
+          Configuration is this screen's to drive, so what is stored below is
+          what is running — the declaration was only ever the seed. Discard the
+          row to re-seed from it instead of editing here.
+        </p>
+        <p className="mt-1 text-muted-foreground">
+          Differs at: {paths.join(', ')}.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -268,9 +268,18 @@ function TargetCard({ target }: { target: TargetListItem }) {
                 ) : null}
               </div>
               <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1">
-                <span className="font-mono text-xs text-muted-foreground">
-                  {target.canonical}
-                </span>
+                {target.canonical === null ? (
+                  // §9: `cloudrun` and `static` name their own workloads —
+                  // core mints nothing here, so the honest boundary is this
+                  // sentence, not a suffix core will never produce.
+                  <span className="text-xs text-subtle">
+                    platform names its own
+                  </span>
+                ) : (
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {target.canonical}
+                  </span>
+                )}
                 <span className="text-xs text-subtle">rank {target.rank}</span>
               </div>
             </div>

--- a/apps/spindrift/test/commands/build-registry-auth.test.ts
+++ b/apps/spindrift/test/commands/build-registry-auth.test.ts
@@ -31,6 +31,7 @@ import {
   targets,
   users,
 } from '../../src/db/schema.ts';
+import type { RegistryFlavour } from '../../src/domain/artifact-name.ts';
 import type {
   RegistryAuth,
   RegistryCredentialStore,
@@ -111,13 +112,29 @@ describe('a build whose destination needs a stored credential', () => {
     return build!;
   }
 
-  /** The context, with a credential store and a route of a given disposition. */
+  /**
+   * The context, with a credential store and a route of a given disposition.
+   *
+   * `selfAuthorized` omits `other` — the flavour of the fixture's registry —
+   * because that is what this whole block is about. A destination only *needs*
+   * a stored credential where the route's own identity cannot reach it, so a
+   * route that self-authorized this host would make every case below vacuous.
+   * The `selfAuthorized` block at the end is the other half of that statement.
+   */
   function withCredentials(
     held: readonly RegistryAuth[],
     carries = true,
+    selfAuthorized: readonly RegistryFlavour[] = [
+      'artifactRegistry',
+      'dockerHub',
+      'ghcr',
+    ],
   ): { context: CommandContext; asked: string[][] } {
     const { store, asked } = credentialStore(held);
-    route = new FakeBuildAdapter({ carriesRegistryCredential: carries });
+    route = new FakeBuildAdapter({
+      carriesRegistryCredential: carries,
+      selfAuthorizedRegistries: selfAuthorized,
+    });
     return {
       asked,
       context: {
@@ -191,7 +208,15 @@ describe('a build whose destination needs a stored credential', () => {
   });
 
   test('hands over nothing when none is held', async () => {
-    const { context } = withCredentials([]);
+    // Self-authorized here, because with nothing held and nothing the route can
+    // reach on its own there is no publishable registry at all — that is a
+    // different refusal, tested elsewhere.
+    const { context } = withCredentials([], true, [
+      'artifactRegistry',
+      'dockerHub',
+      'ghcr',
+      'other',
+    ]);
     const build = await seedBuild();
 
     const result = await dispatchBuild(
@@ -251,5 +276,57 @@ describe('a build whose destination needs a stored credential', () => {
       .from(builds)
       .where(eq(builds.id, build.id));
     expect(JSON.stringify(row)).not.toContain(HELD.secret);
+  });
+
+  /**
+   * The regression that stopped every build on the hosted route.
+   *
+   * GHCR's credential is *minted per dispatch* from the GitHub OAuth the
+   * installation already holds, so the store answers for `ghcr.io` whenever the
+   * connector is authorized — there is no row to delete and no way to "not hold
+   * one". Dispatch asked about every destination host, got that credential
+   * back, and refused, on the one route whose own workflow logs into GHCR with
+   * the run's token and needs nothing from here.
+   *
+   * The fix is that a host the route self-authorizes is never asked about, so
+   * the store's willingness to answer stops being what decides.
+   */
+  test('never asks about a host the route authorizes itself', async () => {
+    const { context, asked } = withCredentials([HELD], false, [
+      'artifactRegistry',
+      'dockerHub',
+      'ghcr',
+      'other',
+    ]);
+    const build = await seedBuild();
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+
+    // Dispatched, on a route that cannot carry a credential, while the store
+    // holds one for exactly this host. Before the fix this was the refusal.
+    expect(result.ok).toBe(true);
+    expect(asked).toEqual([[]]);
+    expect(route.built[0]?.spec.registryAuth).toEqual([]);
+  });
+
+  /** A route that self-authorizes *some* flavours still needs the others. */
+  test('asks only about the hosts it cannot reach on its own', async () => {
+    const { context, asked } = withCredentials([HELD], true, [
+      'artifactRegistry',
+      'ghcr',
+    ]);
+    const build = await seedBuild();
+
+    const result = await dispatchBuild(
+      { buildId: build.id, route: 'hosted' },
+      context,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(asked).toEqual([[HELD.host]]);
+    expect(route.built[0]?.spec.registryAuth).toEqual([HELD]);
   });
 });

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -567,4 +567,67 @@ describe('listTargets', () => {
       expect(result.value.options).toHaveLength(0);
     }
   });
+
+  test('states the real naming boundary, never a fabricated domain', async () => {
+    const { registry } = fakes();
+    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
+    await connectTarget(cloudInput({ name: 'vessel' }), context(registry));
+
+    const result = await listTargets(
+      { kind: 'website', reach: 'public', auth: 'none' },
+      context(registry),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    // §9: core mints only where the platform will not, and `kubernetes` is
+    // the one Target here that mints. The boundary is the fixture's real
+    // zones — never `*.<target>.apps.internal`, a domain that appeared
+    // nowhere in the repo, which is the defect this pins.
+    const k8s = result.value.targets.find((t) => t.adapter === 'kubernetes');
+    expect(k8s?.canonical).toBe(
+      `*.${manifest.dns.zones.private} (private) · *.${manifest.dns.zones.public} (public)`,
+    );
+    expect(k8s?.canonical).not.toContain('apps.internal');
+
+    // `cloudrun` and `static` name their own workloads (`coreMintsCanonical`
+    // is false for both) — core mints nothing, so the screen must say that
+    // rather than show a suffix no Deploy on either Target will ever use.
+    const cloudrun = result.value.targets.find((t) => t.adapter === 'cloudrun');
+    const staticTarget = result.value.targets.find(
+      (t) => t.adapter === 'static',
+    );
+    expect(cloudrun?.canonical).toBeNull();
+    expect(staticTarget?.canonical).toBeNull();
+
+    // The same fact carries onto the Place step's options: a caller placing a
+    // Component is told the same boundary about the same Target.
+    const cloudrunOption = result.value.options.find(
+      (o) => o.adapter === 'cloudrun',
+    );
+    expect(cloudrunOption?.canonical).toBeNull();
+  });
+
+  test('collapses the boundary to one zone when private and public agree', async () => {
+    // The common, and live, shape (§9's `DnsZones`): an installation may
+    // point both reaches at the same zone. Two identical clauses joined by
+    // " · " would be true but unreadable, so this pins the collapse.
+    const { registry } = fakes();
+    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
+
+    const oneZoneManifest = {
+      ...manifest,
+      dns: {
+        zones: { private: 'apps.example.test', public: 'apps.example.test' },
+      },
+    };
+    const result = await listTargets(
+      {},
+      { ...context(registry), manifest: oneZoneManifest },
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const k8s = result.value.targets.find((t) => t.adapter === 'kubernetes');
+    expect(k8s?.canonical).toBe('*.apps.example.test');
+  });
 });

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -6,7 +6,10 @@ import {
   MANIFEST_INLINE_VAR,
   ManifestError,
 } from '../../src/config/manifest.ts';
-import { loadStoredManifest } from '../../src/config/manifest-store.ts';
+import {
+  diffManifestPaths,
+  loadStoredManifest,
+} from '../../src/config/manifest-store.ts';
 import { createDb } from '../../src/db/client.ts';
 import { installation, targets } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
@@ -501,5 +504,122 @@ describe('the stored installation manifest', () => {
     expect(
       loadStoredManifest(database().db, FIXTURE_DEPLOYMENT_ENV),
     ).rejects.toThrow(/installer/);
+  });
+});
+
+describe('naming where a declaration disagrees with the stored row', () => {
+  test('an identical declaration reports no divergence', () => {
+    expect(diffManifestPaths(connectedManifest, connectedManifest)).toEqual([]);
+  });
+
+  test('names the dotted paths that differ, and only those', () => {
+    // Mirrors the live bug this guards against: PR #1607 moved the offsite
+    // Target's gateway — a value nested inside one Target's connection — in
+    // the declaration, while the row it seeded and every other field of
+    // every other Target stayed exactly where they were.
+    const withGateway = (name: string, namespace: string) => ({
+      ...connectedManifest,
+      targets: connectedManifest.targets.map((target) =>
+        target.adapter === 'kubernetes'
+          ? {
+              ...target,
+              connection: {
+                ...target.connection,
+                chartValues: { platform: { gateway: { name, namespace } } },
+              },
+            }
+          : target,
+      ),
+    });
+    const declared = withGateway(
+      'spindrift-apps',
+      'spindrift-apps',
+    ) satisfies AuthoredManifest;
+    const stored = withGateway(
+      'cluster-gateway',
+      'cluster-gateway',
+    ) satisfies AuthoredManifest;
+
+    expect(diffManifestPaths(declared, stored)).toEqual([
+      'targets.0.connection.chartValues.platform.gateway.name',
+      'targets.0.connection.chartValues.platform.gateway.namespace',
+    ]);
+  });
+
+  test('the report carries the path that differs, never the values', () => {
+    const stored = {
+      ...connectedManifest,
+      targets: connectedManifest.targets.map((target) =>
+        target.adapter === 'kubernetes'
+          ? {
+              ...target,
+              connection: {
+                ...target.connection,
+                apiServer: 'https://replacement.example.test',
+              },
+            }
+          : target,
+      ),
+    } satisfies AuthoredManifest;
+
+    const paths = diffManifestPaths(connectedManifest, stored);
+    expect(paths).toEqual(['targets.0.connection.apiServer']);
+    // Neither the declared value nor the stored value appears anywhere in
+    // what was returned — a path names *where* the two documents disagree,
+    // never *what* they disagree about. That is what keeps a value the
+    // schema has not been written yet — a credential on some future Target
+    // connection — off a startup log line, without this function needing to
+    // know which paths are sensitive.
+    const rendered = JSON.stringify(paths);
+    expect(rendered).not.toContain('cluster.example.test');
+    expect(rendered).not.toContain('replacement.example.test');
+  });
+
+  test('the startup warning names the differing path, and still no value', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
+    });
+    const declared = {
+      ...connectedManifest,
+      targets: connectedManifest.targets.map((target) =>
+        target.adapter === 'kubernetes'
+          ? {
+              ...target,
+              connection: {
+                ...target.connection,
+                apiServer: 'https://declared-elsewhere.example.test',
+              },
+            }
+          : target,
+      ),
+    } satisfies AuthoredManifest;
+
+    // `bun:test`'s `spyOn` does not intercept `console.warn` — verified against
+    // a two-line reproduction outside this suite — so this captures it the
+    // plain way: swap the method out, put it back in `finally`.
+    const original = console.warn;
+    const calls: unknown[][] = [];
+    console.warn = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    try {
+      // A declaration seeds and does not govern (see above), so this write is
+      // ignored — the point here is only what the warning it produces says.
+      await loadStoredManifest(database().db, {
+        [MANIFEST_INLINE_VAR]: JSON.stringify(declared),
+      });
+    } finally {
+      console.warn = original;
+    }
+
+    const messages = calls.map((call) => String(call[0]));
+    expect(
+      messages.some((message) =>
+        message.includes('targets.0.connection.apiServer'),
+      ),
+    ).toBe(true);
+    expect(
+      messages.some((message) => message.includes('declared-elsewhere')),
+    ).toBe(false);
   });
 });

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -96,6 +96,8 @@ const BASE = {
   },
   when: '40s ago',
   at: '2026-07-29T10:00:00.000Z',
+  // Converged. The `drifted` scenario below is the one that is not.
+  drift: null,
   current: true,
   configVersion: 'sha256:5c1f9e2a44b7',
   artifactDigest: 'sha256:9f2c1a7e30b4',
@@ -317,6 +319,58 @@ export const DEPLOY_SCENARIOS = {
       ].join('\n'),
     },
     resources: resourcesFailingWith('0/2 ready — readiness probe failing'),
+    build: BUILT,
+  },
+
+  /**
+   * Green, and frozen. The release reached Live, the chart's value contract
+   * moved underneath its stored values, and every reconcile since has failed
+   * behind a previous release that is still serving — so the phase, the URL and
+   * the checklist all read healthy. Nothing but the drift panel says otherwise,
+   * which is exactly the state that went unnoticed for a day in the real
+   * installation this fixture is drawn from.
+   */
+  wedged: {
+    ...BASE,
+    phase: 'LIVE',
+    phaseWord: 'Live',
+    headline: 'Deployed 21 hours ago',
+    urlLive: true,
+    previousReleaseServing: false,
+    diagnosis: null,
+    drift: {
+      since: '21h ago',
+      at: '2026-07-28T13:00:00.000Z',
+      // No digest to report: the platform never applied anything new, so there
+      // is no "running instead" — the previous release is the running one.
+      observedDigest: null,
+      detail: [
+        'Helm upgrade failed for release spindrift-apps/almanac-web with chart',
+        'spindrift-app@0.2.0: execution error at (spindrift-app/templates/httproute.yaml:26:4):',
+        'platform.gateway.name is required for a Component whose reach is not none:',
+        'a route with no gateway attaches to nothing',
+      ].join('\n'),
+    },
+    resources: RESOURCES_OK,
+    build: BUILT,
+  },
+
+  /** The other arm: something else is serving, and it can say what. */
+  drifted: {
+    ...BASE,
+    phase: 'LIVE',
+    phaseWord: 'Live',
+    headline: 'Deployed 3 days ago',
+    urlLive: true,
+    previousReleaseServing: false,
+    diagnosis: null,
+    drift: {
+      since: '2h ago',
+      at: '2026-07-29T08:00:00.000Z',
+      observedDigest: 'sha256:1b8e44c07af2',
+      detail: null,
+    },
+    resources: RESOURCES_OK,
     build: BUILT,
   },
 } as const satisfies Record<string, DeployView>;

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -538,6 +538,100 @@ describe('drift is surfaced, never corrected (§6)', () => {
     expect(row?.observedDigest).toBe(`sha256:${'b'.repeat(64)}`);
   });
 
+  test('a release the platform will not apply has drifted, digest or not', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'hr/apps/web' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    // The shape that went unnoticed for a day in the live installation: the
+    // chart's value contract moved, the stored values no longer render, and
+    // every reconcile fails behind a previous release that keeps serving. The
+    // digest still matches, so comparing digests alone reads this as converged.
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'FAILED',
+      artifactDigest: DIGEST,
+      reason: 'INTERNAL',
+      detail:
+        'execution error at (spindrift-app/templates/httproute.yaml:26:4): platform.gateway.name is required',
+    });
+
+    const pass = await runDeployPass(context(adapter));
+    const report = pass.drift.find((entry) => entry.deployId === deploy.id);
+    expect(report?.drifted).toBe(true);
+
+    // Still surfaced and still not corrected: the re-converge stays a click.
+    expect(adapter.applied).toHaveLength(1);
+
+    const row = await deployRow(deploy.id);
+    // The Deploy did not fail — it reached LIVE and the platform stopped
+    // agreeing afterwards. §9's "exposure never mutates on red" is the same
+    // argument: the previous release is up, and calling this FAILED would say
+    // an outage that is not happening.
+    expect(row?.phase).toBe('LIVE');
+    expect(row?.driftedAt).toEqual(FROZEN);
+    // The platform's own sentence, which is the only thing that names the value
+    // the chart rejected. A drift flag without it says something is wrong
+    // without saying that waiting will not fix it.
+    expect(row?.driftDetail).toContain('platform.gateway.name is required');
+  });
+
+  test('an ordinary digest mismatch records no refusal detail', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'hr/apps/web' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'LIVE',
+      artifactDigest: `sha256:${'b'.repeat(64)}`,
+    });
+    await runDeployPass(context(adapter));
+
+    // Nothing refused anything here — something else is simply serving, which
+    // `observedDigest` already explains. A detail invented for this case would
+    // be the screen claiming the platform said something it did not.
+    const row = await deployRow(deploy.id);
+    expect(row?.driftedAt).toEqual(FROZEN);
+    expect(row?.driftDetail).toBeNull();
+  });
+
+  test('a refusal that is resolved clears its detail with the flag', async () => {
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'hr/apps/web' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'FAILED',
+      artifactDigest: DIGEST,
+      reason: 'INTERNAL',
+      detail: 'values rejected by the chart',
+    });
+    await runDeployPass(context(adapter));
+    expect((await deployRow(deploy.id))?.driftDetail).not.toBeNull();
+
+    // A redeploy rewrote the values and the object applies again. The sentence
+    // has to go with the flag: a stale refusal left on the row would keep
+    // explaining a state that no longer exists.
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'LIVE',
+      artifactDigest: DIGEST,
+    });
+    await runDeployPass(context(adapter));
+
+    const row = await deployRow(deploy.id);
+    expect(row?.driftedAt).toBeNull();
+    expect(row?.driftDetail).toBeNull();
+  });
+
   test('drift fixed out of band stops being reported, with no dismissal', async () => {
     const { deploy } = await pendingDeploy();
     const adapter = new FakeDeployAdapter({

--- a/apps/spindrift/test/web/client-bundle.test.ts
+++ b/apps/spindrift/test/web/client-bundle.test.ts
@@ -1,6 +1,7 @@
 /**
- * The client bundle's only two edges into the server — command dispatch and
- * streaming — and the ceiling that keeps either from growing back.
+ * The client bundle's three edges into the server — command dispatch,
+ * streaming, and auth — and the ceiling that keeps any of them from growing
+ * back.
  *
  * `.agent/plans/spindrift/issues/32-onboard-an-installation-without-a-manifest.md`
  * (2026-08-01 comment) names the landmine: `client.ts` value-imported
@@ -29,6 +30,19 @@
  * takes `AttemptLogCursor`/`AttemptLogEntry` (from `domain/attempt-log.ts`)
  * and `RuntimeLogPage` (from `adapters/deploy/contract.ts`) as `import type`
  * only. `streams.ts` re-exports from there rather than defining them itself.
+ *
+ * The same ticket's edge 3, found while verifying edge 2: cutting the
+ * streaming edge left the bundle's `drizzle-orm` count unchanged, because
+ * `app.tsx` value-imported `auth-client.ts`, which value-imported
+ * `AUTH_PATH_PREFIX` and `AuthAct` from `src/auth/routes.ts` — and
+ * `routes.ts` value-imports `session.ts`, which value-imports `credentials`,
+ * `sessions`, and `users` from `db/schema.ts`. `db/schema.ts` is one module
+ * declaring every table, so that one edge dragged the whole file, and with it
+ * the whole `drizzle-orm` surface, regardless of which table the importer
+ * wanted. The fix is the same move a third time: `AUTH_PATH_PREFIX`,
+ * `AUTH_ACTS`, `AuthAct`, and `authPathFor` now live in
+ * `src/web/auth-path.ts`, a leaf module with no imports of its own, and
+ * `routes.ts` re-exports from there rather than defining them itself.
  *
  * This runs `build.ts` itself, as a real subprocess — the same command the
  * Dockerfile's `builder` stage runs (`bun run build --filter=spindrift`,
@@ -98,6 +112,27 @@ describe('the client bundle', () => {
     // dependencies) is holding.
     expect(text).not.toContain('web/streams.ts');
     expect(text).not.toContain('db/notify.ts');
+  });
+
+  test('carries no fingerprint of the database layer the auth client used to pull in', async () => {
+    const files = await readdir(DIST);
+    const entry = files.find((file) => file.endsWith('.js'));
+    expect(entry).toBeDefined();
+    const text = await Bun.file(join(DIST, entry!)).text();
+
+    // Ticket 34, edge 3: `auth-client.ts` used to value-import
+    // `AUTH_PATH_PREFIX` and `AuthAct` directly from `src/auth/routes.ts`,
+    // which value-imports `session.ts`, which value-imports `credentials`,
+    // `sessions`, and `users` from `db/schema.ts` — one module declaring
+    // every table, so that edge dragged the whole file, and with it the
+    // whole `drizzle-orm` surface, into the bundle. This is the edge item 2
+    // of the ticket's checklist found unmoved: cutting the streaming edge
+    // left `grep -c "drizzle-orm" dist/chunk-*.js` at 57, because this edge
+    // was still open. Asserting on the literal string rather than a count is
+    // the stronger claim and the one the ticket asks for: zero occurrences,
+    // not merely fewer.
+    expect(text).not.toContain('db/schema.ts');
+    expect(text).not.toContain('drizzle-orm');
   });
 
   test('stays within the ceiling cutting that edge bought back', async () => {

--- a/apps/spindrift/test/web/deploy-detail-transcript.test.tsx
+++ b/apps/spindrift/test/web/deploy-detail-transcript.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * The one assertion `views.test.tsx` cannot make (ticket 08, criterion 3).
+ *
+ * That file's own header explains why it renders through
+ * `renderToStaticMarkup`: every rule it checks is a statement about what a
+ * given state looks like, and SSR is the right depth for that. The bug this
+ * file exists for is not that shape — it is React **preserving** `Transcript`'s
+ * `open` state across a running→failed transition of the *same mounted
+ * instance*, and `renderToStaticMarkup` cannot even observe that class of bug:
+ * it never keeps a fiber tree alive between calls (no reconciliation happens)
+ * and it never runs `useEffect` at all (SSR effects are a no-op by design).
+ * Proving the fix means mounting once and re-rendering with a changed prop,
+ * which needs a live `react-dom/client` root — and that needs *something*
+ * DOM-shaped to render into.
+ *
+ * The repo has no jsdom/happy-dom (checked: absent from `package.json`,
+ * absent from `bun.lock`, no DOM global in the Bun runtime itself), and
+ * adding one is out of scope for a single regression test. What follows is a
+ * few dozen lines of the smallest object graph `react-dom/client`'s host
+ * config and the `@radix-ui/react-collapsible` tree actually call —
+ * `appendChild`/`insertBefore`/`removeChild`, `setAttribute`/`getAttribute`
+ * (Radix reports `data-state` and `hidden` through these, never through a
+ * direct IDL property, which is what makes them a reliable read here),
+ * `style` as a plain object, a no-op `addEventListener` (nothing here
+ * simulates a click), and a `getBoundingClientRect` that satisfies
+ * `CollapsibleContent`'s layout-effect without a real layout. It is not a DOM
+ * implementation; it is the subset this one component tree touches.
+ */
+import { afterAll, describe, expect, test } from 'bun:test';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { DeployView } from '../../src/web/model.ts';
+import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
+import { DEPLOY_SCENARIOS } from '../fixtures/scenarios.ts';
+
+const ELEMENT_NODE = 1;
+const TEXT_NODE = 3;
+
+/**
+ * `CollapsibleContentImpl` sets a `--radix-collapsible-content-height`
+ * custom property alongside ordinary style keys. React DOM routes any
+ * `--`-prefixed style key through `style.setProperty` rather than a direct
+ * assignment (that split exists for real CSSStyleDeclarations, where custom
+ * properties aren't reflected as JS properties) — a plain object supports
+ * neither, so this is a plain object plus that one method.
+ */
+class FakeStyle {
+  [key: string]: unknown;
+  setProperty(name: string, value: string): void {
+    this[name] = value;
+  }
+  removeProperty(name: string): void {
+    delete this[name];
+  }
+}
+
+class FakeNode {
+  readonly nodeType: number;
+  readonly ownerDocument: FakeDocument;
+  readonly namespaceURI?: string;
+  parentNode: FakeNode | null = null;
+  childNodes: FakeNode[] = [];
+  readonly style = new FakeStyle();
+  readonly tagName: string;
+  private readonly attrs = new Map<string, string>();
+  private text: string;
+
+  constructor(
+    nodeType: number,
+    ownerDocument: FakeDocument,
+    text = '',
+    namespaceURI?: string,
+    tag = '',
+  ) {
+    this.nodeType = nodeType;
+    this.ownerDocument = ownerDocument;
+    this.text = text;
+    this.namespaceURI = namespaceURI;
+    // `getRootHostContext` reads the container's `tagName` (uppercase, per
+    // DOM convention) to seed the SVG/HTML namespace switch; every other
+    // fake node just carries it for parity.
+    this.tagName = tag.toUpperCase();
+  }
+
+  appendChild(child: FakeNode): FakeNode {
+    return this.insertBefore(child, null);
+  }
+
+  insertBefore(child: FakeNode, ref: FakeNode | null): FakeNode {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    const index = ref ? this.childNodes.indexOf(ref) : -1;
+    if (ref && index === -1) {
+      this.childNodes.push(child);
+    } else if (ref) {
+      this.childNodes.splice(index, 0, child);
+    } else {
+      this.childNodes.push(child);
+    }
+    child.parentNode = this;
+    return child;
+  }
+
+  removeChild(child: FakeNode): FakeNode {
+    const index = this.childNodes.indexOf(child);
+    if (index !== -1) this.childNodes.splice(index, 1);
+    child.parentNode = null;
+    return child;
+  }
+
+  contains(node: FakeNode): boolean {
+    for (let n: FakeNode | null = node; n; n = n.parentNode) {
+      if (n === this) return true;
+    }
+    return false;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attrs.set(name, String(value));
+  }
+  getAttribute(name: string): string | null {
+    return this.attrs.has(name) ? (this.attrs.get(name) ?? null) : null;
+  }
+  removeAttribute(name: string): void {
+    this.attrs.delete(name);
+  }
+  hasAttribute(name: string): boolean {
+    return this.attrs.has(name);
+  }
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+
+  getBoundingClientRect() {
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    };
+  }
+
+  get nodeValue(): string | null {
+    return this.nodeType === TEXT_NODE ? this.text : null;
+  }
+  set nodeValue(value: string) {
+    this.text = value;
+  }
+
+  get textContent(): string {
+    return this.nodeType === TEXT_NODE
+      ? this.text
+      : this.childNodes.map((c) => c.textContent).join('');
+  }
+  set textContent(value: string) {
+    this.childNodes = [];
+    if (value)
+      this.appendChild(new FakeNode(TEXT_NODE, this.ownerDocument, value));
+  }
+}
+
+class FakeDocument {
+  readonly nodeType = 9;
+  // Set to `globalThis` once the test installs it as the global `window` —
+  // `commitBeforeMutationEffects` reads focus through
+  // `container.ownerDocument.defaultView.document`, so `defaultView` has to
+  // be the same object as `globalThis.document`'s owner, not a lookalike.
+  defaultView: typeof globalThis | undefined;
+  // Read by `getActiveElement`; there is no focus in this shim, and `null`
+  // says so instead of leaving the property (and the `|| doc.body` fallback
+  // it feeds) undefined.
+  readonly activeElement: null = null;
+  readonly body: null = null;
+
+  // React registers a handful of document-level listeners (selection,
+  // composition) alongside the per-root ones. Nothing here simulates input,
+  // so these only need to not throw.
+  addEventListener(): void {}
+  removeEventListener(): void {}
+
+  createElement(tag: string): FakeNode {
+    return new FakeNode(ELEMENT_NODE, this, '', undefined, tag);
+  }
+  createElementNS(ns: string, tag: string): FakeNode {
+    return new FakeNode(ELEMENT_NODE, this, '', ns, tag);
+  }
+  createTextNode(text: string): FakeNode {
+    return new FakeNode(TEXT_NODE, this, text);
+  }
+  createComment(text: string): FakeNode {
+    return new FakeNode(8, this, text);
+  }
+}
+
+/** Depth-first search for the first element whose text passes `match`. */
+function findButton(
+  root: FakeNode,
+  match: (text: string) => boolean,
+): FakeNode | null {
+  if (root.nodeType === ELEMENT_NODE && match(root.textContent)) {
+    // Only descend into leaves once no deeper element also matches, so the
+    // button itself (not some ancestor `div`) is what's returned.
+    const child = root.childNodes.find(
+      (c) => c.nodeType === ELEMENT_NODE && match(c.textContent),
+    );
+    if (!child) return root;
+  }
+  for (const child of root.childNodes) {
+    const found = findButton(child, match);
+    if (found) return found;
+  }
+  return null;
+}
+
+describe('Transcript re-derives open on a build status change', () => {
+  const fakeDocument = new FakeDocument();
+  const previousDocument = (globalThis as { document?: unknown }).document;
+  const previousWindow = (globalThis as { window?: unknown }).window;
+  const previousGetComputedStyle = (
+    globalThis as { getComputedStyle?: unknown }
+  ).getComputedStyle;
+  const previousRaf = (globalThis as { requestAnimationFrame?: unknown })
+    .requestAnimationFrame;
+  const previousCancelRaf = (globalThis as { cancelAnimationFrame?: unknown })
+    .cancelAnimationFrame;
+  const previousActEnv = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: unknown })
+    .IS_REACT_ACT_ENVIRONMENT;
+  const previousHTMLIFrameElement = (
+    globalThis as { HTMLIFrameElement?: unknown }
+  ).HTMLIFrameElement;
+
+  Object.assign(globalThis, {
+    document: fakeDocument,
+    // `@radix-ui/react-primitive` does a bare `typeof window !== 'undefined'`
+    // feature-check on every mount, and react-dom's own focus-restoration
+    // pass reads `container.ownerDocument.defaultView.document` — both need
+    // `window` to be the same object `document` was installed on.
+    window: globalThis,
+    // `@radix-ui/react-presence` reads this to decide whether an open/close
+    // transition is mid CSS-animation. Nothing here has a stylesheet, so
+    // reporting no `animationName` is correct, not a stub of convenience.
+    getComputedStyle: (node: FakeNode) => node.style,
+    requestAnimationFrame: (cb: () => void) => setTimeout(cb, 0),
+    cancelAnimationFrame: (id: number) => clearTimeout(id),
+    IS_REACT_ACT_ENVIRONMENT: true,
+    // react-dom's focus restoration walks into iframes via
+    // `element instanceof window.HTMLIFrameElement`; nothing here ever is
+    // one, but the right-hand side still has to be a real constructor.
+    HTMLIFrameElement: class {},
+  });
+  fakeDocument.defaultView = globalThis;
+
+  afterAll(() => {
+    Object.assign(globalThis, {
+      document: previousDocument,
+      window: previousWindow,
+      getComputedStyle: previousGetComputedStyle,
+      requestAnimationFrame: previousRaf,
+      cancelAnimationFrame: previousCancelRaf,
+      IS_REACT_ACT_ENVIRONMENT: previousActEnv,
+      HTMLIFrameElement: previousHTMLIFrameElement,
+    });
+  });
+
+  test('a running LIVE_TEXT build that turns failed springs the transcript open', () => {
+    // The exact case §4/§18 create: a LIVE_TEXT runner (`buildFailed`'s
+    // fixture) has already released log lines while `status` is still
+    // `running` — `BuildOutput` renders `Transcript` the moment `log` is
+    // non-null, which is before the build is known to be red or green.
+    const runningView: DeployView = {
+      ...DEPLOY_SCENARIOS.building,
+      build: { ...DEPLOY_SCENARIOS.buildFailed.build, status: 'running' },
+    };
+    const failedView: DeployView = DEPLOY_SCENARIOS.buildFailed;
+
+    const container = fakeDocument.createElement('div');
+    let root!: Root;
+    act(() => {
+      root = createRoot(container as unknown as Element);
+      root.render(<DeployDetail view={runningView} />);
+    });
+
+    const runnerName = failedView.build?.runner ?? '';
+    const trigger = () =>
+      findButton(container, (text) => text.includes(`${runnerName} output`));
+
+    // Mounted mid-build: `Transcript`'s own contract (deploy-detail.tsx
+    // ~642-653) is "shut on green, open on red" — `running` is neither, so it
+    // starts collapsed. This is the state that used to persist forever.
+    expect(trigger()?.getAttribute('data-state')).toBe('closed');
+
+    act(() => {
+      root.render(<DeployDetail view={failedView} />);
+    });
+
+    // Same mounted instance, `build.status` now `failed`. Without the
+    // prior-status effect this stays `closed` — React does not re-run a
+    // `useState` initializer on an update, so the collapsed trigger from the
+    // first render is exactly what a reader would find on the terminal red
+    // screen. With the effect, the trigger flips to `open`.
+    expect(trigger()?.getAttribute('data-state')).toBe('open');
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});

--- a/docs/pages/Runbooks.md
+++ b/docs/pages/Runbooks.md
@@ -5,6 +5,7 @@ icon:: 🚒
 	- [[Runbooks/Deploy a NixOS Host]] — build, deploy, verify, and roll back NixOS hosts
 	- [[Runbooks/Terraform Change]] — Atlantis-first OpenTofu workflow and local validation
 	- [[Runbooks/Kubernetes GitOps Change]] — inspect Flux, reconcile resources, and handle SOPS safely
+	- [[Runbooks/Managed Postgres]] — reach a CloudNativePG database through `kubectl cnpg`, and check whether it has a backup
 	- [[Runbooks/OpenBao Bootstrap]] — initialize and verify the folly OpenBao instance
 	- [[Runbooks/Add Shared Kubernetes Resource]] — use the `clusters/base/` pattern for both clusters
 	- [[Runbooks/Validate Infra Changes]] — validation commands by change area

--- a/docs/pages/Runbooks___Kubernetes GitOps Change.md
+++ b/docs/pages/Runbooks___Kubernetes GitOps Change.md
@@ -40,6 +40,8 @@ tags:: runbook, kubernetes, gitops
 	  sops -e -i clusters/<cluster>/<path>/<secret>.sops.yaml
 	  ```
 	- Never paste decrypted values into this wiki, issues, PR comments, or logs.
+- # Managed Postgres
+	- Databases are CloudNativePG `Cluster` objects and have their own tooling — reach one with `kubectl cnpg psql`, not `kubectl exec` against an instance pod. See [[Runbooks/Managed Postgres]].
 - # HelmRelease source pattern
 	- Keep `HelmRepository`, `GitRepository`, or `OCIRepository` sources colocated with the resource that consumes them.
 	- Do not centralize sources unless the local pattern changes across the repo.

--- a/docs/pages/Runbooks___Managed Postgres.md
+++ b/docs/pages/Runbooks___Managed Postgres.md
@@ -1,0 +1,62 @@
+tags:: runbook, kubernetes, postgres, cnpg
+
+- Every Postgres in the fleet is a CloudNativePG `Cluster`. Use the operator's own `kubectl cnpg` plugin rather than reconstructing what it does out of `kubectl exec`. The GitOps rules on [[Runbooks/Kubernetes GitOps Change]] apply here too: desired state is authored in git, and everything below is inspection.
+- # The rule
+	- **Reach a database through `kubectl cnpg`, never through a pod name.**
+	- ```bash
+	  kubectl --context offsite cnpg psql spindrift-db -n spindrift
+	  ```
+	- The plugin resolves the primary itself. A hand-written `exec <cluster>-1` names a pod that is only the primary *until the next failover*, so it is right until the moment it matters most. It also needs `-c postgres` to skip the bootstrap init container, which is the kind of detail the plugin exists to know.
+	- Same rule for the rest of the verbs — prefer the native tool over an equivalent assembled by hand.
+- # Where the databases are
+	- The operator is declared per cluster under `clusters/<cluster>/apps/cloudnative-pg/`. The `Cluster` objects themselves live with the app that owns them, in `clusters/` or in a chart under `packages/charts/`.
+	- ```bash
+	  kubectl --context offsite cnpg status spindrift-db -n spindrift
+	  kubectl --context folly   get cluster.postgresql.cnpg.io -A
+	  ```
+- # Inspect
+	- Health, topology, replication lag, and recent operator activity in one screen:
+	- ```bash
+	  kubectl --context <cluster> cnpg status <name> -n <namespace>
+	  kubectl --context <cluster> cnpg status <name> -n <namespace> --verbose
+	  ```
+	- Logs for every instance, without picking a pod:
+	- ```bash
+	  kubectl --context <cluster> cnpg logs cluster <name> -n <namespace>
+	  ```
+- # Open a psql session
+	- ```bash
+	  kubectl --context <cluster> cnpg psql <name> -n <namespace>
+	  ```
+	- Add `--replica` to land on a standby instead — the right choice for a read-only look at a busy primary.
+	- Non-interactive, for one statement:
+	- ```bash
+	  kubectl --context <cluster> cnpg psql <name> -n <namespace> -- -At -c 'select 1'
+	  ```
+	- Everything after `--` goes to `psql`, so its own flags work unchanged.
+- # Restart and failover
+	- Both are inspection-adjacent acts on a managed object, not edits to desired state:
+	- ```bash
+	  kubectl --context <cluster> cnpg restart <name> -n <namespace>
+	  kubectl --context <cluster> cnpg promote <name> <name>-<n> -n <namespace>
+	  ```
+	- Changing instance count, storage, or Postgres version is a manifest change that ships through git — see [[Runbooks/Kubernetes GitOps Change]].
+- # Backups are not universal
+	- **Do not assume a database has a backup.** Each `Cluster` decides, and at least one deliberately has none: the Spindrift control plane's own database (`packages/charts/spindrift/templates/database.yaml`) states its loss story is reconcile-from-sources, with the desired-state rows, the attempt log, and the config version pins as the part no source holds. Its PVC therefore outlives the `Cluster` on purpose, so deleting the release does not discard them.
+	- Check what a given cluster actually has before relying on one:
+	- ```bash
+	  kubectl --context <cluster> get cluster.postgresql.cnpg.io <name> -n <namespace> \
+	    -o jsonpath='{.spec.backup}{"\n"}'
+	  kubectl --context <cluster> get backup.postgresql.cnpg.io -n <namespace>
+	  ```
+	- Where a cluster does define one, take an on-demand backup with:
+	- ```bash
+	  kubectl --context <cluster> cnpg backup <name> -n <namespace>
+	  ```
+- # If psql cannot connect
+	- Confirm the cluster is healthy and has a primary at all — `cnpg status` names it. A `Cluster` with no primary is a cluster mid-failover or mid-bootstrap, and the answer is to wait and read `cnpg logs cluster`, not to exec into an instance.
+	- Confirm the plugin is present. It ships with the `kubectl` tooling in the dev shell:
+	- ```bash
+	  kubectl cnpg version
+	  ```
+	- Credentials live in a Secret the operator generates and rotates; read them from the `Cluster`'s app secret rather than from a chart's values. `cnpg psql` needs none of this, which is the main reason to prefer it.


### PR DESCRIPTION
**Nothing has been building.** Every dispatch on the `hosted` route refuses with:

> this installation holds a registry credential for ghcr.io, and the "hosted" route cannot carry one — its dispatch inputs are readable by anyone who can see the run. Admit a route that runs the build in a container of its own, or remove the credential if that registry does not need one.

## Why neither of the two suggested fixes was available

The refusal is correct in principle — a token in a `workflow_dispatch` input is published to everyone who can see the run. But its second escape hatch, "remove the credential", **cannot be taken**: GHCR's credential is *minted per dispatch* from the GitHub OAuth the installation already holds (`src/storage/github-registry-credential.ts`), precisely so nobody has to paste and own a long-lived token. There is no row to delete. `authFor` answers for `ghcr.io` whenever the connector is authorized, so the refusal fires forever.

And the first, "admit a route that runs the build in a container of its own", would trade away the attestation the hosted route exists to produce — for a registry that needs no credential at all.

## The actual defect

The workflow already authenticates both registries itself:

```yaml
# .github/workflows/spindrift-build.yml
# Two kinds, spelled out rather than abstracted: GHCR takes the run's own
# token, and Google Artifact Registry takes the federated identity the
# signing steps already establish.
```

and the adapter says so — `selfAuthorizedRegistries = ['ghcr', 'artifactRegistry']`. `publishableRegistries` already uses exactly that to choose destinations. Only the `authFor` call a hundred lines later disagreed, asking the store about **every** destination host including the ones the route authorizes itself.

One filter, using the vocabulary that was already there:

```ts
const unauthorizedHosts = [...new Set(destinations.map(registryHostOf))]
  .filter((host) => !adapter.selfAuthorizedRegistries.includes(registryFlavour(host)));
```

This makes the code match the contract **its own test file already claimed**:

> It opens the credential for the destinations being pushed to, and only those. *Nothing is handed over for a registry the route's own identity already reaches.*

The refusal survives for the case it was written for: a Docker Hub destination on a route that cannot carry a token still refuses, still before the claim, still `waits` so the next tick works once an operator admits a different route.

## The tests were encoding the old model

Their fake self-authorized all four flavours while asserting a credential was needed — which the fix correctly makes vacuous. They now describe a route that genuinely cannot reach the destination, plus two new cases: the regression itself, and a route that self-authorizes *some* flavours and still needs a credential for the rest.

Proven by reverting the fix:

```
(fail) a build whose destination needs a stored credential > never asks about a host the route authorizes itself
```

`1391 pass, 0 fail`. typecheck and biome clean.

## Also: a Managed Postgres runbook

`docs/pages/Runbooks___Managed Postgres.md` — reach a CloudNativePG database with `kubectl cnpg psql <cluster>`, which resolves the primary itself, rather than `kubectl exec` against `<cluster>-1`: a pod that is only the primary *until the next failover*, and which also needs `-c postgres` to dodge the bootstrap init container. Records that backups are per-`Cluster` and that the Spindrift control plane's own database deliberately has none — its loss story is reconcile-from-sources, which is why its PVC outlives the Cluster.

Linked from `Runbooks.md` and the `kubernetes-gitops` skill. `mise run docs:check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)