### PR TITLE
feat(spindrift): let a Component change its reach, and let a Target edit stick

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -86,6 +86,7 @@ export const getAppWorkspace: Command<
     }
 
     return {
+      id: comp.id,
       name: comp.name,
       kind: comp.kind,
       phase: phaseFor(deploy?.phase, build?.status),

--- a/apps/spindrift/src/commands/components/create.ts
+++ b/apps/spindrift/src/commands/components/create.ts
@@ -20,7 +20,10 @@
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { apps, components } from '../../db/schema.ts';
-import { AUTH_NEEDS_A_ROUTE } from '../../domain/desired-state.ts';
+import {
+  AUTH_NEEDS_A_ROUTE,
+  authHasARoute,
+} from '../../domain/desired-state.ts';
 import { type Command, failed, ok } from '../types.ts';
 
 /** A DNS-safe label: a Component's name appears in canonical hostnames (§9). */
@@ -89,14 +92,10 @@ export const createComponentInput = z
   ])
   /**
    * §9's rule, at the only moment refusing it is free: a filter needs a route to
-   * sit on. Every other cell of the reach/auth grid is expressible, including
-   * the two the old three-state exposure could not say — an unauthenticated
-   * address on your own network, and an authenticated public one.
+   * sit on. Shared with `setComponentReach` through {@link authHasARoute}, so
+   * the grid an edit may express is the grid a creation may.
    */
-  .refine((input) => !(input.reach === 'none' && input.auth === 'proxy'), {
-    error: AUTH_NEEDS_A_ROUTE,
-    path: ['auth'],
-  });
+  .refine(authHasARoute, { error: AUTH_NEEDS_A_ROUTE, path: ['auth'] });
 
 export type CreateComponentInput = z.infer<typeof createComponentInput>;
 

--- a/apps/spindrift/src/commands/components/reach.ts
+++ b/apps/spindrift/src/commands/components/reach.ts
@@ -1,0 +1,125 @@
+/**
+ * `setComponentReach` — change how an existing Component is reached (§9).
+ *
+ * `reach` and `auth` were settable exactly once, in `createComponent`, so
+ * "make this App reachable" was a re-creation: delete the Component, lose its
+ * Deploy history and its config pins, and say a different answer the second
+ * time. This is the other half of that pair, and it is the whole of it — the
+ * two fields are one decision (§9's grid), so one act sets both.
+ *
+ * **This is a deploy, not a settings toggle.** §9 keeps exposure out of the
+ * mutable-in-place category, and that is a fact about rendering rather than a
+ * preference: the App chart renders the HTTPRoute, the DNS annotations and the
+ * ExternalAuth filter from values written at deploy time
+ * (`src/adapters/deploy/kubernetes/values.ts`), and the canonical hostname is
+ * minted into the zone chosen *per reach* (`zoneForReach`). Nothing that is
+ * already running changes because this row changed. So the act writes the
+ * Component and stops, and {@link SetComponentReachResult.pendingRelease}
+ * names where the released answer is now the older one.
+ *
+ * Deliberately unlike `setConfig`, which ends by writing an intent: §10 says a
+ * config change "produces a new Deploy" because a changed reference nothing
+ * re-applies is a workload still running the old value, and §9 says the
+ * opposite — a tightening that took effect the instant somebody saved a form
+ * would drop a live release's route out from under it with no attempt to read.
+ * Pressing Deploy is the same shape as every other change to what is running.
+ *
+ * The grid rule is the schema's, shared with `createComponent` through
+ * {@link authHasARoute}: `reach: none` with `auth: proxy` is unsayable on both
+ * paths, or it is enforced on neither.
+ */
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { components } from '../../db/schema.ts';
+import {
+  AUTH_NEEDS_A_ROUTE,
+  type Auth,
+  authHasARoute,
+  type Reach,
+} from '../../domain/desired-state.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const setComponentReachInput = z
+  .object({
+    componentId: z.uuid(),
+    /**
+     * Both required, and neither defaulted.
+     *
+     * `createComponent` defaults them because §9 states which state a caller
+     * gets by saying nothing at creation. An edit has no such state to fall
+     * back to: a form that omitted `auth` would silently re-assert `proxy` over
+     * a Component an operator had deliberately left open, and the omission
+     * would read as "leave it alone".
+     */
+    reach: z.enum(['none', 'private', 'public']),
+    auth: z.enum(['none', 'proxy']),
+  })
+  .strict()
+  .refine(authHasARoute, { error: AUTH_NEEDS_A_ROUTE, path: ['auth'] });
+
+export type SetComponentReachInput = z.infer<typeof setComponentReachInput>;
+
+export interface SetComponentReachResult {
+  readonly componentId: string;
+  readonly reach: Reach;
+  readonly auth: Auth;
+  /**
+   * The Targets whose current release still places the previous answer, by
+   * name and sorted.
+   *
+   * Empty means there is nothing to press Deploy for — either this Component
+   * has never been placed, or what is desired already asks for what was just
+   * saved. A non-empty list is the sentence a screen owes the operator, and it
+   * is read off the Deploy's own pinned `reach`/`auth` rather than off the
+   * Component, because those two columns exist precisely so that "what is
+   * running" and "what is now asked for" can be different values.
+   */
+  readonly pendingRelease: readonly string[];
+}
+
+export const setComponentReach: Command<
+  SetComponentReachInput,
+  SetComponentReachResult
+> = async (input, context) => {
+  // Written and read back in one statement: the alternative is a select, a
+  // decision, and an update, which is three chances for the row to be a
+  // different row by the time the last one runs.
+  const [row] = await context.db
+    .update(components)
+    .set({
+      reach: input.reach,
+      auth: input.auth,
+      updatedAt: context.clock.now(),
+    })
+    .where(eq(components.id, input.componentId))
+    .returning();
+  if (row === undefined) {
+    return failed(
+      'NOT_FOUND',
+      `there is no Component with id ${input.componentId}`,
+    );
+  }
+
+  const placed = await context.db.query.componentTargetDesired.findMany({
+    where: (desired, { eq }) => eq(desired.componentId, row.id),
+    with: {
+      target: { columns: { name: true } },
+      desiredDeploy: { columns: { reach: true, auth: true } },
+    },
+  });
+
+  return ok({
+    componentId: row.id,
+    reach: row.reach,
+    auth: row.auth,
+    pendingRelease: placed
+      .filter(
+        ({ desiredDeploy }) =>
+          desiredDeploy !== null &&
+          (desiredDeploy.reach !== input.reach ||
+            desiredDeploy.auth !== input.auth),
+      )
+      .map(({ target }) => target.name)
+      .sort(),
+  });
+};

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -27,6 +27,7 @@ export { dispatchBuild } from './builds/dispatch.ts';
 export { getBuildDetail } from './builds/get-detail.ts';
 export { createComponent } from './components/create.ts';
 export { placeComponent } from './components/place.ts';
+export { setComponentReach } from './components/reach.ts';
 export { replaceConfig } from './config/replace.ts';
 export { setConfig } from './config/set.ts';
 export {

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -43,6 +43,10 @@ import { dispatchBuild, dispatchBuildInput } from './builds/dispatch.ts';
 import { getBuildDetail, getBuildDetailInput } from './builds/get-detail.ts';
 import { createComponent, createComponentInput } from './components/create.ts';
 import { placeComponent, placeComponentInput } from './components/place.ts';
+import {
+  setComponentReach,
+  setComponentReachInput,
+} from './components/reach.ts';
 import { replaceConfig, replaceConfigInput } from './config/replace.ts';
 import { setConfig, setConfigInput } from './config/set.ts';
 import {
@@ -191,6 +195,10 @@ export const commandRegistry = {
   },
   createComponent: { input: createComponentInput, handler: createComponent },
   placeComponent: { input: placeComponentInput, handler: placeComponent },
+  setComponentReach: {
+    input: setComponentReachInput,
+    handler: setComponentReach,
+  },
   setConfig: { input: setConfigInput, handler: setConfig },
   configureInstallation: {
     input: configureInstallationInput,

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
+import { targetConnectionDivergence } from '../../config/manifest-store.ts';
 import { KINDS_BY_ADAPTER } from '../../domain/capabilities.ts';
 import { auth, componentKind, reach } from '../../domain/creation-draft.ts';
 import type { ComponentKind } from '../../domain/desired-state.ts';
@@ -10,7 +11,10 @@ import {
   placementTargetOf,
   resolvePlacement,
 } from '../../domain/placement.ts';
-import { pendingConnections } from '../../domain/target-onboarding.ts';
+import {
+  connectionProposal,
+  pendingConnections,
+} from '../../domain/target-onboarding.ts';
 import type {
   PendingTargetConnection,
   TargetListItem,
@@ -125,6 +129,23 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
       status: target.status,
       configured: target.connection !== null,
       inspectedAt: target.inspectedAt?.toISOString() ?? null,
+      manifestDivergence: targetConnectionDivergence(
+        context.manifest.targets.find((seed) => seed.name === target.name),
+        target.connection,
+      ),
+      // Carried from this Target alone, which is the whole difference between
+      // an edit and a connect: `connectionProposal` prefers a healthy donor of
+      // the same adapter, and given a list of one there is only this row to
+      // read. A donor's values on an edit screen would be the second cluster's
+      // address problem with the Targets the other way round.
+      edit:
+        target.adapter === 'kubernetes' &&
+        target.connection?.adapter === 'kubernetes'
+          ? {
+              apiServer: target.connection.apiServer,
+              proposal: connectionProposal([target], 'kubernetes'),
+            }
+          : null,
     });
 
     const isConnected = target.status === 'connected';

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -89,9 +89,49 @@ export async function loadStoredManifest(
     );
   }
   const declared = stored ?? declaration ?? DEFAULT_PLACEHOLDER_MANIFEST;
-  await writeStoredManifest(db, declared);
+  // `booted` exactly when the document being written is the one the
+  // installation already had — see {@link ManifestWrite}. A stored row this
+  // build could not parse leaves `stored` null, which is right: that boot is
+  // re-seeding from the declaration, and re-seeding is a declaration.
+  await writeStoredManifest(
+    db,
+    declared,
+    stored === null ? 'declared' : 'booted',
+  );
   return resolveManifest(declared, env);
 }
+
+/**
+ * What a write of the stored manifest **is**, which is what decides whether a
+ * declared Target connection lands on the row.
+ *
+ * `declared` is a manifest *becoming* this installation's: the seed path and
+ * `configureInstallation`, which this module already treats as one act. There a
+ * declared connection is desired state — an operator submitted this document —
+ * so it is asserted over the row and resets that Target's assessment.
+ *
+ * `booted` is {@link loadStoredManifest} writing back the document the
+ * installation already had. Nothing became anything, so nothing was declared,
+ * and re-asserting the manifest's copy of a connection there is this module's
+ * own rule broken one noun down: "the stored row wins whenever one exists,
+ * because configuration is the UI's to drive and a rollout must not revert what
+ * an operator just configured" is the rule a declaration loses to, and a Target
+ * an operator corrected through `connectTarget` is that same operator and that
+ * same rollout. It ran on every process start, so a connect-screen edit to a
+ * manifest-declared Target survived exactly until the next pod restarted, with
+ * the screen that accepted it then showing the old values and no reason why.
+ *
+ * The row therefore wins, and the manifest entry it now disagrees with is
+ * reported by {@link targetConnectionDivergence} rather than silently applied —
+ * the same answer 51 gave the same tension one level up: keep the precedence,
+ * report the divergence.
+ *
+ * A boot still materializes and ranks. A Target the document names and the
+ * table lacks is created, and `rank` is repaired from manifest order; both are
+ * facts the document is the only source of, and neither is something an
+ * operator can have edited on the row.
+ */
+export type ManifestWrite = 'declared' | 'booted';
 
 /**
  * Every dotted path where two manifest documents disagree.
@@ -137,6 +177,38 @@ export function diffManifestPaths(
     );
   }
   return diffs;
+}
+
+/**
+ * Every dotted path where one Target's row disagrees with what the manifest
+ * declares for it.
+ *
+ * {@link diffManifestPaths} with one argument each side of the boundary 52 is
+ * about: the row is what every deploy renders from, the manifest entry is what
+ * a `declared` write resets it to, and until now nothing said which was which.
+ * Boot no longer overwrites the row, but `configureInstallation` still asserts
+ * the whole document — so an operator who corrected a Target through the
+ * connect screen has to be able to see that Settings will take it back, on the
+ * Target, rather than discover it by pressing Save.
+ *
+ * Paths, never values, for exactly the reason {@link diffManifestPaths} gives.
+ * Rooted at `connection.` so a path reads as the key it is under in the
+ * document the operator would go and edit, which is the same spelling the
+ * startup warning uses below `targets.N.`.
+ *
+ * `[]` for a seed that declares no connection: §13 lets the manifest seed an
+ * identity and leave the connection to the product, so that Target's connection
+ * is the row's outright and there is nothing for it to disagree with. Same for
+ * a Target the manifest does not name at all — nothing will ever assert over it.
+ */
+export function targetConnectionDivergence(
+  seed: TargetSeed | undefined,
+  connection: TargetConnection | null,
+): readonly string[] {
+  if (seed === undefined) return [];
+  const declared = connectionFromSeed(seed);
+  if (declared === null) return [];
+  return diffManifestPaths(declared, connection, ['connection']);
 }
 
 /** `[key, value]` pairs for a plain object or an array; `null` for anything else. */
@@ -209,13 +281,19 @@ async function declaredManifest(
 export async function writeStoredManifest(
   db: Database,
   manifest: AuthoredManifest,
+  /**
+   * Defaults to `declared`, because every caller but the boot path is an
+   * operator submitting a document — and a new one that forgot to say so
+   * should get the stricter behaviour rather than the quieter one.
+   */
+  write: ManifestWrite = 'declared',
 ): Promise<void> {
   await db.transaction(async (tx) => {
     await tx.insert(installation).values({ manifest }).onConflictDoUpdate({
       target: installation.id,
       set: { manifest },
     });
-    await reconcileManifestTargets(tx, manifest);
+    await reconcileManifestTargets(tx, manifest, write);
   });
 }
 
@@ -240,16 +318,19 @@ export async function currentStoredManifest(
  * connections.
  *
  * An omitted connection leaves existing product-owned connection state alone.
- * A declared connection is desired state: it creates a connected row and
- * resets changed connection facts to an unhealthy, awaiting-inspection
- * checklist. A disconnected row stays disconnected until reconciler startup
- * can inspect and safely re-adopt its Deploys. Keeping this work in the manifest
- * transaction means an incompatible target cannot poison the durable
- * declaration.
+ * A declared connection is desired state **on a `declared` write**: it creates a
+ * connected row and resets changed connection facts to an unhealthy,
+ * awaiting-inspection checklist. On a `booted` write it does not touch an
+ * existing row at all, because nothing was declared — see {@link ManifestWrite}
+ * for why that distinction is the whole of 52. A disconnected row stays
+ * disconnected until reconciler startup can inspect and safely re-adopt its
+ * Deploys. Keeping this work in the manifest transaction means an incompatible
+ * target cannot poison the durable declaration.
  */
 async function reconcileManifestTargets(
   db: Pick<Database, 'insert' | 'query'>,
   manifest: AuthoredManifest,
+  write: ManifestWrite,
 ): Promise<void> {
   for (const [rank, target] of manifest.targets.entries()) {
     const { name, adapter } = target;
@@ -268,6 +349,7 @@ async function reconcileManifestTargets(
       adapter,
     );
     const hasConnectionChange =
+      write === 'declared' &&
       declaredConnection !== null &&
       !Bun.deepEquals(existing?.connection, declaredConnection, true);
 

--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -133,6 +133,27 @@ export const AUTH_NEEDS_A_ROUTE =
   'a Component with no route has nothing to authenticate in front of';
 
 /**
+ * The one cell of the reach/auth grid that is unsayable, as a predicate.
+ *
+ * A function rather than a line repeated in each schema because there are now
+ * two acts that decide a Component's exposure — creating one and editing one —
+ * and the whole value of the rule is that it holds for both. Two copies of the
+ * comparison is two places for the grid to be wrong in one of them, which is
+ * exactly the state 54 found: a rule enforced where a Component is born and
+ * nowhere else.
+ *
+ * Every other cell is expressible, including the two the old three-state
+ * exposure could not say — an unauthenticated address on your own network, and
+ * an authenticated public one.
+ */
+export function authHasARoute(state: {
+  readonly reach: Reach;
+  readonly auth: Auth;
+}): boolean {
+  return !(state.reach === 'none' && state.auth === 'proxy');
+}
+
+/**
  * A pinned reference to one config value in the Target's store (§10).
  *
  * Values are write-only: this is a reference core can render into a delivery

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -31,7 +31,7 @@ import { cn } from './ui/utils.ts';
 import { DeployDetail } from './views/apps/deploy-detail.tsx';
 import { AppList } from './views/apps/list.tsx';
 import { NewApp } from './views/apps/new/index.tsx';
-import { Workspace } from './views/apps/workspace.tsx';
+import { type SetReach, Workspace } from './views/apps/workspace.tsx';
 import { Gate } from './views/auth/gate.tsx';
 import { Settings } from './views/auth/settings.tsx';
 import {
@@ -436,6 +436,23 @@ function WorkspaceScreen({
     }
   };
 
+  // §9: the row is written and the release is not, so the workspace is re-read
+  // rather than patched in place — `Deploy` next to a Component whose reach
+  // just changed has to be reading the same row the next intent will pin.
+  const handleSetReach: SetReach = async (change) => {
+    try {
+      const result = await command('setComponentReach', change);
+      if (!result.ok) return { ok: false, message: result.failure.message };
+      setReloadToken((token) => token + 1);
+      return { ok: true, pendingRelease: result.value.pendingRelease };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message: cause instanceof Error ? cause.message : 'Saving reach failed',
+      };
+    }
+  };
+
   return (
     <>
       {deployError ? (
@@ -464,6 +481,7 @@ function WorkspaceScreen({
         deletion={deletion}
         onRollback={handleRollback}
         rollingBack={rollingBack}
+        onSetReach={handleSetReach}
       />
       <DeleteAppDialog deletion={deletion} />
     </>

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -417,6 +417,14 @@ export interface DatastoreView {
 
 /** One Component as the workspace lists it. */
 export interface ComponentView {
+  /**
+   * The Component's id, and the only thing on this row an act can be aimed at.
+   *
+   * `setComponentReach` resolves on it. A row that carried only a name could
+   * not, because `components` is unique per App and this list is per App — the
+   * name is enough to read and not enough to write.
+   */
+  readonly id: string;
   readonly name: string;
   readonly kind: ComponentKind;
   readonly phase: DeployPhase;
@@ -617,6 +625,37 @@ export interface TargetListItem {
   readonly configured: boolean;
   /** When the standing checklist last ran, ISO-8601, or null if never. */
   readonly inspectedAt: string | null;
+  /**
+   * Dotted paths where this Target's row and the manifest's entry for it
+   * disagree, from `targetConnectionDivergence` — **paths, never values**.
+   *
+   * The row wins: a boot writes the stored manifest back without re-asserting a
+   * declared connection over it, so an operator's correction survives a
+   * restart. `configureInstallation` still writes the whole document, so this
+   * is what a Target owes an operator before they save Settings and take their
+   * own edit back. Empty is the ordinary case — and is also what a Target the
+   * manifest declares no connection for correctly reports.
+   */
+  readonly manifestDivergence: readonly string[];
+  /**
+   * Where an edit of this Target's connection starts, or `null` on an adapter
+   * the product has no edit surface for.
+   *
+   * Editing is `connectTarget` again — idempotent by name, and already the act
+   * that writes these facts (§13). What it needs that a fresh connect does not
+   * is *this* Target's own address: `TargetConnectionProposal` deliberately
+   * omits `apiServer` because a second cluster prefilled with the first one's
+   * would read as correct and deploy somewhere else, and that reasoning is
+   * exactly inverted here — this is the one Target the address does name.
+   *
+   * `null` for `cloudrun` and `static`: `platform` chart values are a cluster's,
+   * and a cloud project has no probe to read itself back through, so the edit
+   * this field exists for has nothing to offer there.
+   */
+  readonly edit: {
+    readonly apiServer: string;
+    readonly proposal: TargetConnectionProposal;
+  } | null;
 }
 
 /**

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -16,7 +16,8 @@
  *   not a disabled tab.
  */
 import { ChevronRight, ExternalLink } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { type ReactNode, useState } from 'react';
+import type { Auth, Reach } from '../../../domain/desired-state.ts';
 import {
   type AppDeletionControls,
   DeleteAppButton,
@@ -34,7 +35,31 @@ import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, Eyebrow } from '../../ui/card.tsx';
 import { cn } from '../../ui/utils.ts';
+import {
+  AUTH_NOTE,
+  AUTHS,
+  Choice,
+  REACH_NOTE,
+  REACHES,
+} from './new/summary.tsx';
 import { Releases } from './releases.tsx';
+
+/**
+ * Saving a Component's reach, as the screen above needs it answered.
+ *
+ * A promise rather than a fire-and-forget callback plus two state props: the
+ * form has exactly one thing to say after the press — the Targets still placing
+ * the old answer, or why it was refused — and threading that back as props
+ * would put this card's transient state on the screen that owns the App.
+ */
+export type SetReach = (change: {
+  readonly componentId: string;
+  readonly reach: Reach;
+  readonly auth: Auth;
+}) => Promise<
+  | { readonly ok: true; readonly pendingRelease: readonly string[] }
+  | { readonly ok: false; readonly message: string }
+>;
 
 export function Workspace({
   view,
@@ -45,6 +70,7 @@ export function Workspace({
   deletion,
   onRollback,
   rollingBack = null,
+  onSetReach,
 }: {
   view: WorkspaceView;
   onDeploy?: () => void;
@@ -68,6 +94,12 @@ export function Workspace({
   deletion?: AppDeletionControls;
   onRollback?: (release: DeployListItem) => void;
   rollingBack?: number | null;
+  /**
+   * Absent where reach is not editable from here — the fixture screens render
+   * this view with no acts wired, and a form whose Save cannot be called is
+   * worse than no form.
+   */
+  onSetReach?: SetReach;
 }) {
   const primary = view.components[0];
 
@@ -115,7 +147,10 @@ export function Workspace({
       <Hero view={view} onNavigate={onNavigate} />
 
       <div className="grid gap-4 md:grid-cols-2">
-        <Components components={view.components} />
+        <Components
+          components={view.components}
+          {...(onSetReach === undefined ? {} : { onSetReach })}
+        />
         <Datastores datastores={view.datastores} />
       </div>
 
@@ -263,7 +298,15 @@ function Row({
   );
 }
 
-function Components({ components }: { components: readonly ComponentView[] }) {
+function Components({
+  components,
+  onSetReach,
+}: {
+  components: readonly ComponentView[];
+  onSetReach?: SetReach;
+}) {
+  const [editing, setEditing] = useState<string | null>(null);
+
   return (
     <Card>
       <SectionHeader
@@ -273,15 +316,160 @@ function Components({ components }: { components: readonly ComponentView[] }) {
       />
       <CardContent className="pt-0">
         {components.map((component) => (
-          <Row
-            key={component.name}
-            badge={<Badge tone="accent">{component.kind}</Badge>}
-            title={component.name}
-            detail={`${component.phase} · ${component.reach}${component.auth === 'proxy' ? ' + auth' : ''} · ${component.artifact}`}
-          />
+          <div key={component.name}>
+            <Row
+              badge={<Badge tone="accent">{component.kind}</Badge>}
+              title={component.name}
+              detail={`${component.phase} · ${component.reach}${component.auth === 'proxy' ? ' + auth' : ''} · ${component.artifact}`}
+              trailing={
+                onSetReach ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() =>
+                      setEditing((current) =>
+                        current === component.id ? null : component.id,
+                      )
+                    }
+                  >
+                    {editing === component.id ? 'Cancel' : 'Reach'}
+                  </Button>
+                ) : undefined
+              }
+            />
+            {onSetReach && editing === component.id ? (
+              <ReachEditor
+                component={component}
+                onSetReach={onSetReach}
+                onDone={() => setEditing(null)}
+              />
+            ) : null}
+          </div>
         ))}
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * Changing how a Component is reached (§9).
+ *
+ * Reach and auth are one decision, so they are one form and one save — the same
+ * shape the creation flow states them in, and literally the same tiles, so a
+ * developer meets the grid once. `auth` disappears at `reach: none` there and
+ * here, which is `AUTH_NEEDS_A_ROUTE` said by not asking rather than by
+ * refusing after the press.
+ *
+ * **What it saves is a Component, not a release.** The chart renders the route,
+ * the DNS annotations and the filter from values written at deploy time, so the
+ * only honest thing this form can do when it succeeds is name the Targets whose
+ * release still places the old answer and point at Deploy. Anything that read
+ * as "done" would be a screen claiming an outcome the platform has not been
+ * asked for yet.
+ *
+ * Exported because it is behind a disclosure: the sentence above is the whole
+ * claim this form makes, and a test that could only reach the button would be
+ * asserting that something opens rather than what it says when it does.
+ */
+export function ReachEditor({
+  component,
+  onSetReach,
+  onDone,
+}: {
+  component: ComponentView;
+  onSetReach: SetReach;
+  onDone: () => void;
+}) {
+  const [reach, setReach] = useState(component.reach);
+  const [auth, setAuth] = useState(component.auth);
+  const [saving, setSaving] = useState(false);
+  const [outcome, setOutcome] = useState<
+    | { readonly kind: 'saved'; readonly pendingRelease: readonly string[] }
+    | { readonly kind: 'refused'; readonly message: string }
+    | null
+  >(null);
+
+  const save = async () => {
+    setSaving(true);
+    setOutcome(null);
+    try {
+      const result = await onSetReach({
+        componentId: component.id,
+        reach,
+        // §9's grid: a Component with no route has nothing to authenticate in
+        // front of, so `none` is not a choice being made for the operator — it
+        // is the only cell that row has.
+        auth: reach === 'none' ? 'none' : auth,
+      });
+      setOutcome(
+        result.ok
+          ? { kind: 'saved', pendingRelease: result.pendingRelease }
+          : { kind: 'refused', message: result.message },
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 border-b border-border-soft py-3 last:border-b-0">
+      <div className="grid gap-2 sm:grid-cols-3">
+        {REACHES.map((option) => (
+          <Choice
+            key={option}
+            selected={reach === option}
+            title={option}
+            note={REACH_NOTE[option]}
+            onClick={() => setReach(option)}
+          />
+        ))}
+      </div>
+      {reach !== 'none' ? (
+        <div className="grid gap-2 sm:grid-cols-2">
+          {AUTHS.map((option) => (
+            <Choice
+              key={option}
+              selected={auth === option}
+              title={option}
+              note={AUTH_NOTE[option]}
+              onClick={() => setAuth(option)}
+            />
+          ))}
+        </div>
+      ) : null}
+
+      {outcome?.kind === 'refused' ? (
+        <p className="rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-xs text-destructive">
+          {outcome.message}
+        </p>
+      ) : null}
+      {outcome?.kind === 'saved' ? (
+        <p className="rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
+          {outcome.pendingRelease.length === 0
+            ? 'Saved. Nothing is placing the previous answer, so the next release carries this one.'
+            : `Saved. ${outcome.pendingRelease.join(' and ')} still ${outcome.pendingRelease.length === 1 ? 'serves' : 'serve'} the previous answer — Deploy to place this one.`}
+        </p>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          disabled={saving}
+          onClick={() => {
+            void save();
+          }}
+        >
+          {saving ? 'Saving…' : 'Save reach'}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onDone} disabled={saving}>
+          {outcome?.kind === 'saved' ? 'Close' : 'Cancel'}
+        </Button>
+        <p className="text-xs text-muted-foreground">
+          Reach is rendered into the release, so this takes effect on the next
+          Deploy rather than on the one that is serving.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -78,6 +78,17 @@ export function ConnectTargetForm(props: {
   name: string;
   /** True on the "add a Target" path, where no manifest seed named it. */
   nameEditable?: boolean;
+  /**
+   * The address to start from, which is only ever *this* Target's own.
+   *
+   * Empty on both connect paths, for the reason {@link TargetConnectionProposal}
+   * gives for having no `apiServer` field: a cluster prefilled with another
+   * cluster's address reads as correct and points somewhere else. Editing a
+   * Target that is already connected is the one case where the address is not
+   * somebody else's, and re-typing it to correct a gateway would be asking the
+   * operator to restate the one fact the row is certain of.
+   */
+  apiServer?: string;
   targets: readonly string[];
   proposal: TargetConnectionProposal;
   connecting: boolean;
@@ -147,6 +158,7 @@ function Heading({
 function ConnectCluster({
   name,
   nameEditable = false,
+  apiServer: knownApiServer = '',
   proposal,
   connecting,
   onConnect,
@@ -154,16 +166,19 @@ function ConnectCluster({
 }: {
   name: string;
   nameEditable?: boolean;
+  apiServer?: string;
   proposal: TargetConnectionProposal;
   connecting: boolean;
   onConnect: (input: ConnectTargetInput) => void;
   onCancel: () => void;
 }) {
   const [targetName, setTargetName] = useState(name);
-  // Per-instance, so never proposed: this is the one field that names *this*
-  // cluster, and a second cluster prefilled with the first one's address would
-  // read as correct and deploy somewhere else.
-  const [apiServer, setApiServer] = useState('');
+  // Per-instance, so never proposed *from another Target*: this is the one field
+  // that names *this* cluster, and a second cluster prefilled with the first
+  // one's address would read as correct and deploy somewhere else. The caller
+  // may still supply the row's own address, which is the same fact rather than
+  // a proposal about it.
+  const [apiServer, setApiServer] = useState(knownApiServer);
   const [scan, setScan] = useState<Scan>({ state: 'idle' });
   /** Counts reads, so a re-read remounts the panel below on the new answer. */
   const [reads, setReads] = useState(0);

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -163,7 +163,12 @@ export function TargetList({
       ) : (
         <div className="flex flex-col gap-3">
           {configured.map((target) => (
-            <TargetCard key={target.id} target={target} />
+            <TargetCard
+              key={target.id}
+              target={target}
+              connecting={connecting}
+              onConnect={onConnect}
+            />
           ))}
         </div>
       )}
@@ -236,9 +241,18 @@ function PendingConnections({
   );
 }
 
-function TargetCard({ target }: { target: TargetListItem }) {
+function TargetCard({
+  target,
+  connecting,
+  onConnect,
+}: {
+  target: TargetListItem;
+  connecting: boolean;
+  onConnect: (input: ConnectTargetInput) => void;
+}) {
   const unhealthy = target.health !== 'healthy';
   const [checklistOpen, setChecklistOpen] = useState(unhealthy);
+  const [editing, setEditing] = useState(false);
   const met = target.prerequisites.filter((item) => item.met).length;
 
   return (
@@ -285,7 +299,7 @@ function TargetCard({ target }: { target: TargetListItem }) {
             </div>
           </div>
 
-          <div className="flex flex-wrap gap-1.5 sm:ml-auto">
+          <div className="flex flex-wrap items-center gap-1.5 sm:ml-auto">
             {target.kinds.map((kind) => (
               <span
                 key={kind}
@@ -295,8 +309,67 @@ function TargetCard({ target }: { target: TargetListItem }) {
                 {kind}
               </span>
             ))}
+            {/*
+              The gateway, the authenticated edge, the config store and the
+              address a record points at are all on this Target's connection,
+              and until this button there was nowhere to correct one: the connect
+              form was reachable only from an unconfigured seed. It is the same
+              form and the same act — §13 makes connect idempotent by name — so
+              the edit is a re-connect rather than a second way to write these.
+            */}
+            {target.edit ? (
+              <Button
+                variant={editing ? 'ghost' : 'outline'}
+                size="sm"
+                onClick={() => setEditing((open) => !open)}
+              >
+                {editing ? 'Cancel' : 'Edit connection'}
+              </Button>
+            ) : null}
           </div>
         </div>
+
+        {/*
+          §6: "drift is detected and surfaced, never silently corrected",
+          applied to the manifest rather than to what it deploys. The row is what
+          every deploy renders from and it wins over the document a boot writes
+          back — but Settings still submits the whole document, so a Target that
+          has been corrected here says which paths a save would take back.
+          Paths, never values: a connection is credential-free today and this
+          line does not lean on it staying that way.
+        */}
+        {target.manifestDivergence.length > 0 ? (
+          <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
+            <AlertTriangle
+              aria-hidden="true"
+              className="mt-0.5 size-3.5 shrink-0 text-warning"
+            />
+            <span>
+              This Target's connection differs from what the installation
+              manifest declares for it, at{' '}
+              <span className="font-mono">
+                {target.manifestDivergence.join(', ')}
+              </span>
+              . The row is what deploys render from and a restart leaves it
+              alone; saving the manifest in Settings replaces it.
+            </span>
+          </div>
+        ) : null}
+
+        {editing && target.edit ? (
+          <div className="rounded-md border border-border-soft bg-secondary/40 px-4 py-4">
+            <ConnectTargetForm
+              kind="kubernetes"
+              name={target.name}
+              apiServer={target.edit.apiServer}
+              targets={[target.name]}
+              proposal={target.edit.proposal}
+              connecting={connecting}
+              onConnect={onConnect}
+              onCancel={() => setEditing(false)}
+            />
+          </div>
+        ) : null}
 
         {target.prerequisites.length > 0 ? (
           <Collapsible open={checklistOpen} onOpenChange={setChecklistOpen}>

--- a/apps/spindrift/test/commands/component-reach.test.ts
+++ b/apps/spindrift/test/commands/component-reach.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Changing a Component's reach (54, §9).
+ *
+ * Three claims, and the middle one is the reason this file exists rather than a
+ * pair of assertions on a row:
+ *
+ * - **The grid rule holds on the edit.** `reach: none` with `auth: proxy` was
+ *   unsayable at creation and sayable nowhere else, because nowhere else could
+ *   say it. It has to stay unsayable now that an edit can.
+ * - **A Component edited between an intent and its attempt does not
+ *   retroactively change what that attempt places.** `deploys.reach` and
+ *   `deploys.auth` were written for this and have never had an edit path to
+ *   defend against; a pin nobody has watched hold is not one.
+ * - **The next release renders the new answer.** Asserted through `appValues` —
+ *   the App chart's own values — because "the edit changed something" is only
+ *   true if the thing it changed is what the chart is applied with.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { appValues } from '../../src/adapters/deploy/kubernetes/values.ts';
+import { createDeploy, setComponentReach } from '../../src/commands/index.ts';
+import { dispatch } from '../../src/commands/registry.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import { AUTH_NEEDS_A_ROUTE } from '../../src/domain/desired-state.ts';
+import {
+  type DeployLoopContext,
+  runDeployPass,
+} from '../../src/reconciler/deploy-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+const DIGEST = `sha256:${'a'.repeat(64)}`;
+
+function registryOf(deployAdapter: FakeDeployAdapter): AdapterRegistry {
+  const chain = new SupplyChainHarness();
+  return {
+    deploy: (adapter) =>
+      adapter === deployAdapter.adapter ? deployAdapter : null,
+    build: () => {
+      throw new Error('a reach edit must not reach a builder');
+    },
+    store: () => {
+      throw new Error('a reach edit must not reach the secret store');
+    },
+    repository: () => null,
+    supplyChain: () => chain,
+  };
+}
+
+function context(adapters: AdapterRegistry): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+function loopContext(adapter: FakeDeployAdapter): DeployLoopContext {
+  return {
+    db: database().db,
+    adapters: { deploy: (name) => (name === adapter.adapter ? adapter : null) },
+    clock,
+    manifest,
+  };
+}
+
+/** An App with one serving Component, a cluster Target, and a Build to place. */
+async function fixture(
+  reach: 'none' | 'private' | 'public' = 'private',
+  auth: 'none' | 'proxy' = 'proxy',
+) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'shop', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({
+      appId: app!.id,
+      name: 'web',
+      kind: 'service',
+      expose: true,
+      reach,
+      auth,
+    })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: `cluster-${crypto.randomUUID()}`,
+        adapter: 'kubernetes',
+        discovery: null,
+      }),
+    )
+    .returning();
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'abcdef0',
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: DIGEST,
+      bundleDigest: DIGEST,
+      bundleLocation: 'https://depot.example.test/bundles/1.zip',
+      status: 'SUCCEEDED',
+      verifiedBuildLevel: 2,
+      signature: testSignature(DIGEST, FROZEN.toISOString()),
+    })
+    .returning();
+  return { app: app!, component: component!, target: target!, build: build! };
+}
+
+async function componentRow(id: string) {
+  const [row] = await database()
+    .db.select()
+    .from(components)
+    .where(eq(components.id, id));
+  return row;
+}
+
+describe('the grid an edit may express is the grid a creation may (§9)', () => {
+  test('a Component with no route has nothing to authenticate in front of', async () => {
+    const { component } = await fixture();
+
+    // Through `dispatch`, because the refusal is the schema's rather than the
+    // handler's: it has to be reachable from the surface a browser calls, and
+    // it has to name the field an operator would go and change.
+    const refused = await dispatch(
+      'setComponentReach',
+      { componentId: component.id, reach: 'none', auth: 'proxy' },
+      context(registryOf(new FakeDeployAdapter())),
+    );
+
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.failure.code).toBe('INVALID_INPUT');
+    expect(refused.failure.issues?.[0]).toEqual({
+      path: 'auth',
+      message: AUTH_NEEDS_A_ROUTE,
+    });
+    // Nothing was written on the way to being refused.
+    const row = await componentRow(component.id);
+    expect(row?.reach).toBe('private');
+    expect(row?.auth).toBe('proxy');
+  });
+
+  test('an unknown Component is a refusal with an identity', async () => {
+    const missing = crypto.randomUUID();
+    const result = await setComponentReach(
+      { componentId: missing, reach: 'public', auth: 'none' },
+      context(registryOf(new FakeDeployAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+    expect(result.failure.message).toContain(missing);
+  });
+});
+
+describe('the edit writes a Component and leaves a Deploy to be pressed', () => {
+  test('a Component that has never been placed has nothing serving the old answer', async () => {
+    const { component } = await fixture();
+
+    const result = await setComponentReach(
+      { componentId: component.id, reach: 'public', auth: 'none' },
+      context(registryOf(new FakeDeployAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pendingRelease).toEqual([]);
+    const row = await componentRow(component.id);
+    expect(row?.reach).toBe('public');
+    expect(row?.auth).toBe('none');
+    expect(row?.updatedAt).toEqual(FROZEN);
+  });
+
+  test('a Target still placing the previous answer is named, and nothing is deployed', async () => {
+    const { component, target, build } = await fixture();
+    const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
+    const adapters = registryOf(adapter);
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    await runDeployPass(loopContext(adapter));
+    expect(adapter.applied).toHaveLength(1);
+
+    const result = await setComponentReach(
+      { componentId: component.id, reach: 'public', auth: 'none' },
+      context(adapters),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pendingRelease).toEqual([target.name]);
+    // §9 keeps exposure out of the mutable-in-place category: the act wrote a
+    // row and asked the platform for nothing. A second `apply` here would be
+    // this command deciding to re-place a live release nobody pressed Deploy
+    // for — which is the whole difference between a settings toggle and this.
+    expect(adapter.applied).toHaveLength(1);
+    const written = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, component.id));
+    expect(written).toHaveLength(1);
+  });
+});
+
+describe('a Component edited mid-attempt does not change what is being placed', () => {
+  test('the attempt renders its own pin, and the next release renders the edit', async () => {
+    const { component, target, build } = await fixture('private', 'proxy');
+    const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
+    const adapters = registryOf(adapter);
+
+    // The intent, pinned at `private` + `proxy` — and then the edit, before
+    // the loop has claimed it. This is the window `deploys.reach` exists for.
+    const first = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    expect(first.ok).toBe(true);
+    const edited = await setComponentReach(
+      { componentId: component.id, reach: 'public', auth: 'none' },
+      context(adapters),
+    );
+    expect(edited.ok).toBe(true);
+
+    await runDeployPass(loopContext(adapter));
+    expect(adapter.applied).toHaveLength(1);
+    const placing = appValues(
+      adapter.applied[0]!.desired,
+      'ghcr.io/x@sha256:1',
+    );
+    expect(placing.reach).toBe('private');
+    expect(placing.auth).toBe('proxy');
+    // The name too, not only the two fields: §9 mints the canonical name into
+    // the zone chosen *per reach*, so an attempt whose reach moved under it
+    // would place a route for a hostname in the wrong zone.
+    expect(placing.hostnames).toContain(
+      `shop-web.${manifest.dns.zones.private}`,
+    );
+
+    // Now press Deploy. The same Build, the same Target, and a release that
+    // renders something else — which is the whole of what "a reach change is a
+    // deploy" means.
+    const second = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    expect(second.ok).toBe(true);
+    await runDeployPass(loopContext(adapter));
+
+    expect(adapter.applied).toHaveLength(2);
+    const placed = appValues(adapter.applied[1]!.desired, 'ghcr.io/x@sha256:1');
+    expect(placed.reach).toBe('public');
+    expect(placed.auth).toBe('none');
+    expect(placed.hostnames).toContain(`shop-web.${manifest.dns.zones.public}`);
+
+    // And the pin is on the row, so a rollback to the first release comes back
+    // up as private rather than as whatever the Component says today.
+    const rows = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, component.id))
+      .orderBy(deploys.id);
+    expect(rows.map(({ reach, auth }) => ({ reach, auth }))).toEqual([
+      { reach: 'private', auth: 'proxy' },
+      { reach: 'public', auth: 'none' },
+    ]);
+  });
+});

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -321,6 +321,125 @@ describe('the act is credential-shaped though the noun is flat', () => {
   });
 });
 
+/**
+ * 52: the correction an operator makes through the product, and the restart.
+ *
+ * `connectTarget` has always written the row. What made it useless on a
+ * manifest-declared Target is that `loadStoredManifest` writes the stored
+ * document back on every boot, and reconciliation used to re-assert the
+ * document's copy of the connection over the row — so an operator who fixed a
+ * gateway here got it reverted by the next rollout, silently, with the screen
+ * that accepted the edit then showing the old values and no reason why.
+ *
+ * The precedence is now the one this module already applies to a mounted
+ * declaration, one noun down: **the row wins and the divergence is reported.**
+ */
+describe('an operator’s Target correction outlives the next boot', () => {
+  /** The manifest as Git declares it, naming whichever gateway it still names. */
+  function declaredWithGateway(gateway: { name: string; namespace: string }) {
+    const input = clusterInput({ name: 'cluster' });
+    const platform = input.chartValues?.platform as Record<string, unknown>;
+    return {
+      ...toAuthoredManifest(manifest),
+      targets: [
+        {
+          name: 'cluster',
+          adapter: 'kubernetes' as const,
+          connection: {
+            apiServer: input.apiServer,
+            namespace: input.namespace,
+            delivery: input.delivery,
+            chartContract: input.chartContract!,
+            chartValues: { platform: { ...platform, gateway } },
+          },
+        },
+      ],
+    };
+  }
+
+  test('the row still holds what was connected, and the manifest entry it now disagrees with is named', async () => {
+    const { registry } = fakes();
+    const declared = declaredWithGateway({
+      name: 'gateway-that-moved',
+      namespace: 'gateway-that-moved',
+    });
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(declared),
+    });
+    expect((await targetRow('cluster'))?.connection).toMatchObject({
+      chartValues: {
+        platform: {
+          gateway: { name: 'gateway-that-moved' },
+        },
+      },
+    });
+
+    // The correction, through the only act there is for it.
+    const connected = await connectTarget(
+      clusterInput({ name: 'cluster' }),
+      context(registry),
+    );
+    expect(connected.ok).toBe(true);
+
+    // The restart. Both pods do this; the reconciler and the web process each
+    // call `loadStoredManifest` once at startup.
+    const booted = await loadStoredManifest(database().db, {});
+
+    const row = await targetRow('cluster');
+    expect(row?.connection).toEqual(connectionFor('kubernetes'));
+    // Not reset to awaiting-inspection either: nothing was declared, so there
+    // is nothing about this Target's assessment for a boot to invalidate.
+    expect(row?.health).toBe('healthy');
+    expect(row?.inspectedAt).not.toBeNull();
+
+    // And the disagreement is on the Target rather than in a pod log: Settings
+    // still writes the whole document, so the operator has to be able to see
+    // which paths saving it would take back — paths, never values.
+    const listed = await listTargets(
+      {},
+      { ...context(registry), manifest: booted },
+    );
+    if (!listed.ok) throw new Error('listTargets refused');
+    const cluster = listed.value.targets.find((t) => t.name === 'cluster');
+    expect(cluster?.manifestDivergence).toEqual([
+      'connection.chartValues.platform.gateway.name',
+      'connection.chartValues.platform.gateway.namespace',
+    ]);
+    expect(JSON.stringify(cluster?.manifestDivergence)).not.toContain(
+      'gateway-that-moved',
+    );
+
+    // The screen that made the correction possible: the edit opens on this
+    // Target's own address, which is the one field a fresh connect refuses to
+    // propose and the one field an edit must not make the operator retype.
+    expect(cluster?.edit?.apiServer).toBe(clusterInput().apiServer);
+    expect(cluster?.edit?.proposal.carriedFrom).toBe('cluster');
+  });
+
+  test('a Target whose row matches its manifest entry reports no divergence', async () => {
+    const { registry } = fakes();
+    // Exactly what `clusterInput` connects, so the two agree.
+    const declared = declaredWithGateway({
+      name: 'cluster-gateway',
+      namespace: 'gateway',
+    });
+    const booted = await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(declared),
+    });
+    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+
+    const listed = await listTargets(
+      {},
+      { ...context(registry), manifest: booted },
+    );
+    if (!listed.ok) throw new Error('listTargets refused');
+    expect(
+      listed.value.targets.find((t) => t.name === 'cluster')
+        ?.manifestDivergence,
+    ).toEqual([]);
+  });
+});
+
 describe('disconnect strands rather than stops', () => {
   test('live Deploys go orphaned and are named, and nothing is destroyed', async () => {
     const { registry, of } = fakes();

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -9,11 +9,16 @@ import {
 import {
   diffManifestPaths,
   loadStoredManifest,
+  targetConnectionDivergence,
+  writeStoredManifest,
 } from '../../src/config/manifest-store.ts';
 import { createDb } from '../../src/db/client.ts';
 import { installation, targets } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { FIXTURE_DEPLOYMENT_ENV } from '../harness/installation.ts';
+import {
+  connectionFor,
+  FIXTURE_DEPLOYMENT_ENV,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const FIXTURE = new URL(
@@ -192,9 +197,13 @@ describe('the stored installation manifest', () => {
     } satisfies AuthoredManifest;
 
     // Configuration is the UI's to drive, so the trigger for reconciliation is
-    // the stored manifest changing — which is what a settings write is.
-    await database().db.update(installation).set({ manifest: changed });
-    await loadStoredManifest(database().db, {});
+    // an operator submitting a document — which is what a settings write is,
+    // and it is `writeStoredManifest` on both the seed path and
+    // `configureInstallation`. Written through that call rather than by
+    // updating the row and rebooting: a boot writes the stored document back
+    // without re-asserting it (see the test below), so the raw-update spelling
+    // was asserting this behaviour through the one path that no longer has it.
+    await writeStoredManifest(database().db, changed);
 
     const cluster = await database().db.query.targets.findFirst({
       where: (targets, { eq }) => eq(targets.name, 'cluster'),
@@ -205,6 +214,85 @@ describe('the stored installation manifest', () => {
     expect(cluster?.health).toBe('unhealthy');
     expect(cluster?.inspectedAt).toBeNull();
     expect(cluster?.updatedAt.getTime()).toBeGreaterThan(old.getTime());
+  });
+
+  test('a boot leaves an operator’s Target connection alone, and says where it diverges', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
+    });
+
+    // What `connectTarget` writes: the row, and only the row. The manifest is
+    // untouched, which is the state 52 is about — the operator corrected a
+    // Target through the product and the document still declares the old one.
+    const corrected = {
+      adapter: 'kubernetes' as const,
+      apiServer: 'https://cluster.example.test',
+      namespace: 'apps',
+      delivery: {
+        flavour: 'flux-helmrelease' as const,
+        namespace: 'apps',
+        sourceRef: { name: 'infra', namespace: 'flux-system' },
+      },
+      chartContract: '2',
+      chartValues: {
+        platform: {
+          gateway: { name: 'spindrift-apps', namespace: 'spindrift-apps' },
+        },
+      },
+    };
+    await database()
+      .db.update(targets)
+      .set({ connection: corrected, health: 'healthy' })
+      .where(eq(targets.name, 'cluster'));
+
+    // The restart. It used to be the whole defect: `loadStoredManifest` writes
+    // the stored document back on every boot, and reconciliation re-asserted
+    // the manifest's copy of the connection over the row — so a connect-screen
+    // edit lasted exactly until the next pod rolled, silently.
+    await loadStoredManifest(database().db, {});
+
+    const cluster = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(cluster?.connection).toEqual(corrected);
+    // Nothing was re-declared, so nothing about the Target's assessment was
+    // invalidated either — a boot that reset this to unhealthy would make every
+    // rollout re-inspect every Target it had not been asked to change.
+    expect(cluster?.health).toBe('healthy');
+
+    // And the divergence is readable rather than silent: the row won, so what
+    // the manifest still declares has to be somewhere an operator can see it
+    // before they submit that document in Settings and take their own edit back.
+    expect(
+      targetConnectionDivergence(
+        connectedManifest.targets[0],
+        cluster?.connection ?? null,
+      ),
+    ).toEqual(['connection.chartValues']);
+  });
+
+  test('a Target the manifest declares no connection for never diverges', async () => {
+    // §13 lets a seed carry an identity and leave the connection to the
+    // product. That Target's connection is the row's outright, so there is
+    // nothing for it to disagree with — reporting one would put a permanent
+    // warning on every Target connected through the screen it belongs to.
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    await database()
+      .db.update(targets)
+      .set({ connection: connectionFor('kubernetes'), status: 'connected' })
+      .where(eq(targets.name, 'cluster'));
+
+    const cluster = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(
+      targetConnectionDivergence(
+        fixtureManifest.targets.find((target) => target.name === 'cluster'),
+        cluster?.connection ?? null,
+      ),
+    ).toEqual([]);
   });
 
   test('a declaration seeds an empty installation and never governs a seeded one', async () => {

--- a/apps/spindrift/test/conformance/archive-to-live.test.ts
+++ b/apps/spindrift/test/conformance/archive-to-live.test.ts
@@ -1,0 +1,591 @@
+/**
+ * Ticket 10, item 7: the archive flow, end to end, on a clean database.
+ *
+ * The ticket's own sentence is the shape of this file — "an authenticated
+ * developer uploads an archive, accepts the suggested real Target, starts the
+ * first Build, and watches the reconciler deliver a working HTTPS App" — and
+ * every one of those clauses is a call here rather than a fixture:
+ *
+ * | the sentence            | what runs                                    |
+ * | ----------------------- | -------------------------------------------- |
+ * | uploads an archive      | `handleUpload` over real bytes → real digest  |
+ * | stages them durably     | `stageArchiveBytes` → GCS through federation  |
+ * | accepts the Target      | `startCreationDraft` → `completeCreationDraft`|
+ * | starts the first Build  | `runBuildPass` → `dispatchBuild`              |
+ * | the reconciler delivers | `runDeployPass` → `runAttempt`                |
+ * | and it stays right      | `observeConverged`                            |
+ *
+ * **Every far side is fake and nothing in between is.** § Testing's rule is
+ * "fake the far side, not our side", and the three far sides this flow has are
+ * the cloud (a `fetch` that answers the token exchange, the object write, and
+ * `signBlob`), the builder ({@link FakeBuildAdapter}), and the cluster
+ * ({@link FakeDeployAdapter}). Between them run the real upload boundary, the
+ * real staging, the real creation draft with its real placement resolution, the
+ * real dispatch with its real signed-URL mint, the real supply chain — which
+ * signs with a real Ed25519 key and re-verifies it at admission — and both real
+ * reconciler passes. Nothing is stubbed on this side of a seam.
+ *
+ * **The assertions are rows.** §6's mechanism is "three rows rather than a
+ * protocol", so a test that asserted only on command return values would be
+ * asserting what the flow *said* rather than what it *wrote* — and what the
+ * next process reads is the row. The single exception is the digest chain,
+ * which is asserted as equality *between* rows: the bytes uploaded here are
+ * what `builds.bundle_digest` names, that is what the route was handed as its
+ * §16 join, and the artifact that came back is what `deploys.observed_digest`
+ * reports at the end.
+ *
+ * A separate second case runs the same chain from a repository source, because
+ * §4 makes the two arms "one pipeline" and a pipeline claimed to be one is a
+ * claim only a test that runs both can make.
+ */
+import { describe, expect, test } from 'bun:test';
+import { asc, eq } from 'drizzle-orm';
+import {
+  completeCreationDraft,
+  reviewCreationDraft,
+  saveCreationDraft,
+  startCreationDraft,
+} from '../../src/commands/creation-drafts/lifecycle.ts';
+import { deployApp } from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+  Principal,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  attemptEvents,
+  builds,
+  components,
+  componentTargetDesired,
+  deploys,
+  repositories,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { runBuildPass } from '../../src/reconciler/build-loop.ts';
+import {
+  type DeployLoopContext,
+  observeConverged,
+  runDeployPass,
+} from '../../src/reconciler/deploy-loop.ts';
+import { handleUpload } from '../../src/web/upload.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import {
+  CAPABLE_DISCOVERY,
+  FakeDeployAdapter,
+} from '../harness/fakes/deploy-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const baseManifest = await fixtureManifest();
+
+const FROZEN = new Date('2026-08-03T12:00:00.000Z');
+
+/** The archive a developer picks in the browser. Real bytes, real digest. */
+const ARCHIVE = new TextEncoder().encode(
+  'PK not a real zip, but real bytes with a real digest\n',
+);
+
+/**
+ * The cloud, as four answers.
+ *
+ * Every call this flow makes to Google is one of these, and each is answered in
+ * that endpoint's own vocabulary rather than with one permissive object: the
+ * STS exchange answers `access_token`, `generateAccessToken` answers
+ * `accessToken`, and `federation.ts` refuses each one that is missing. A fake
+ * that answered both keys at once would pass while the real pairing was wrong.
+ *
+ * The object write is recorded, because "the bytes were staged durably" is a
+ * claim about a request having left for somewhere other than this process's own
+ * disk — the exact thing ticket 23 was filed for.
+ */
+function fakeCloud(): {
+  fetch: (request: Request) => Promise<Response>;
+  readonly writes: string[];
+} {
+  const writes: string[] = [];
+  return {
+    writes,
+    async fetch(request: Request): Promise<Response> {
+      if (request.url.includes(':signBlob')) {
+        return Response.json({ signedBlob: btoa('\x01\x02') });
+      }
+      if (request.url.includes(':generateAccessToken')) {
+        return Response.json({
+          accessToken: 'impersonated',
+          expireTime: '2026-08-03T13:00:00.000Z',
+        });
+      }
+      if (request.url.includes('/upload/storage/v1/b/')) {
+        writes.push(request.url);
+        return Response.json({ name: 'stored' });
+      }
+      return Response.json({ access_token: 'federated', expires_in: 3600 });
+    },
+  };
+}
+
+/** One installation's worth of wiring, assembled per test. */
+async function installation(options: { sourceCommit?: string } = {}) {
+  const db = database().db;
+  const cloud = fakeCloud();
+
+  const [operator] = await db
+    .insert(users)
+    .values({ displayName: 'Operator' })
+    .returning();
+  const principal: Principal = {
+    id: operator!.id,
+    displayName: operator!.displayName,
+  };
+
+  // The Target the draft will suggest. Capable and healthy, because what this
+  // test is about is the chain and not placement's exclusion rules — those have
+  // their own tests, and a Target excluded here would fail this one somewhere
+  // unrelated to why.
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: 'offsite',
+        rank: 0,
+        reaches: ['none', 'private', 'public'],
+        discovery: CAPABLE_DISCOVERY,
+      }),
+    )
+    .returning();
+
+  // Only for the repository arm. Absent otherwise, so `startCreationDraft`
+  // defaults the draft to `upload` exactly as it does for an installation that
+  // has connected no repository at all.
+  const [repository] =
+    options.sourceCommit === undefined
+      ? []
+      : await db
+          .insert(repositories)
+          .values({
+            fullName: 'example/app',
+            installationId: '1',
+            defaultBranch: 'main',
+            authoritativeCommit: options.sourceCommit,
+            access: 'active',
+          })
+          .returning();
+
+  const builder = new FakeBuildAdapter({ name: 'hosted' });
+  const cluster = new FakeDeployAdapter({ adapter: 'kubernetes' });
+  const supplyChain = new SupplyChainHarness();
+
+  const adapters: AdapterRegistry = {
+    deploy: (adapter) => (adapter === cluster.adapter ? cluster : null),
+    build: (route) => (route === builder.name ? builder : null),
+    store: () => null,
+    repository: () => null,
+    source: () => ({
+      // §15 stages the repository bundle where the archive arm's upload
+      // boundary staged the uploaded one — same depot, same address shape, so
+      // dispatch resolves both through the same signed-URL path below.
+      async stageRepository(input) {
+        return {
+          digest: `sha256:${'b'.repeat(64)}`,
+          location: `gs://example-source-bucket/${input.commit}.tgz`,
+          retention: 'ephemeral' as const,
+        };
+      },
+    }),
+    supplyChain: () => supplyChain,
+  };
+
+  const manifest = {
+    ...baseManifest,
+    cloud: {
+      ...baseManifest.cloud,
+      federation: {
+        audience: '//iam.googleapis.com/projects/1/locations/global/x/y',
+        tokenUrl: 'https://sts.googleapis.test/v1/token',
+        tokenPath: '/var/run/secrets/spindrift/gcp-token',
+        impersonationUrl:
+          'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+        fetch: cloud.fetch,
+        readToken: async () => 'projected-jwt',
+      },
+    },
+  } as CommandContext['manifest'];
+
+  const context: CommandContext = {
+    principal,
+    clock: { now: () => FROZEN },
+    db,
+    adapters,
+    manifest,
+  };
+
+  const loop: DeployLoopContext = {
+    db,
+    adapters,
+    clock: context.clock,
+    manifest,
+  };
+
+  return {
+    context,
+    loop,
+    cloud,
+    builder,
+    cluster,
+    supplyChain,
+    target: target!,
+    repository,
+  };
+}
+
+/** The upload route, as the browser reaches it: session, then bytes. */
+async function upload(
+  context: CommandContext,
+  filename: string,
+  bytes: Uint8Array,
+) {
+  const response = await handleUpload(
+    new Request('http://spindrift.example.test/internal/upload', {
+      method: 'POST',
+      headers: { 'x-filename': filename },
+      body: bytes as unknown as BodyInit,
+    }),
+    {
+      authenticate: async () => ({
+        kind: 'authenticated' as const,
+        principal: context.principal,
+      }),
+      context: () => context,
+    },
+  );
+  return {
+    status: response.status,
+    body: (await response.json()) as {
+      ok: boolean;
+      value: { digest: string; location: string; size: number };
+    },
+  };
+}
+
+/**
+ * Walk the creation draft to a completed App.
+ *
+ * The draft is edited through `saveCreationDraft` rather than written to the
+ * table, because the revision guard and the server-side revalidation are what
+ * decide whether the source this test staged is one the installation will
+ * accept — and a row written past them would make a draft ready that the
+ * product would have blocked.
+ */
+async function createThroughDraft(
+  context: CommandContext,
+  edit: (draft: Awaited<ReturnType<typeof startCreationDraft>>) => unknown,
+) {
+  const started = await startCreationDraft({}, context);
+  if (!started.ok) throw new Error(started.failure.message);
+
+  const saved = await saveCreationDraft(
+    {
+      id: started.value.id,
+      revision: started.value.revision,
+      draft: edit(started) as never,
+    },
+    context,
+  );
+  if (!saved.ok) throw new Error(saved.failure.message);
+
+  const reviewed = await reviewCreationDraft(
+    { id: saved.value.id, revision: saved.value.revision },
+    context,
+  );
+  if (!reviewed.ok) throw new Error(reviewed.failure.message);
+  // Read back rather than assumed: a blocker here is the product refusing the
+  // draft, and it names which of §3's conditions this installation failed.
+  expect(reviewed.value.blockers).toEqual([]);
+  expect(reviewed.value.ready).toBe(true);
+
+  const completed = await completeCreationDraft(
+    { id: saved.value.id, revision: saved.value.revision },
+    context,
+  );
+  if (!completed.ok) throw new Error(completed.failure.message);
+  if (completed.value.app === null) {
+    throw new Error('a ready draft completed without creating an App');
+  }
+  return completed.value.app;
+}
+
+describe('Ticket 10 — an archive reaches a live HTTPS App on a clean database', () => {
+  test('upload, build, deploy, and observe, asserting the rows each one wrote', async () => {
+    const { context, loop, cloud, builder, cluster, supplyChain, target } =
+      await installation();
+    const db = context.db;
+
+    // ------------------------------------------------------------------
+    // 1. Upload. Real bytes over the real route, staged to the depot.
+    // ------------------------------------------------------------------
+    const staged = await upload(context, 'bundle.tgz', ARCHIVE);
+    expect(staged.status).toBe(200);
+    expect(staged.body.ok).toBe(true);
+
+    const bundleDigest = staged.body.value.digest;
+    // The digest is over the bytes and nothing else, which is what makes it
+    // §16's join rather than a label: computed independently here, it has to be
+    // the one the route is handed four steps later.
+    expect(bundleDigest).toBe(
+      `sha256:${new Bun.CryptoHasher('sha256').update(ARCHIVE).digest('hex')}`,
+    );
+    expect(staged.body.value.size).toBe(ARCHIVE.byteLength);
+    // Durably: `gs://`, in the bucket the manifest declares, and reached by a
+    // request that actually left. An `upload://` handle here would mean the
+    // pod's own disk, which is the failure ticket 23 was filed for.
+    expect(staged.body.value.location).toBe(
+      `gs://example-source-bucket/${bundleDigest.slice('sha256:'.length)}.tgz`,
+    );
+    expect(cloud.writes).toHaveLength(1);
+    expect(cloud.writes[0]).toContain('/b/example-source-bucket/o');
+
+    // ------------------------------------------------------------------
+    // 2. Creation. The draft suggests the one real Target; the developer
+    //    accepts it and names the archive that was just staged.
+    // ------------------------------------------------------------------
+    const created = await createThroughDraft(context, (started) => {
+      if (!started.ok) throw new Error('unreachable');
+      // The suggestion, taken rather than overridden: this is the "accepts the
+      // suggested real Target" clause, and asserting it here is what makes the
+      // Deploy at the end land somewhere the product chose.
+      expect(started.value.draft.targetId).toBe(target.id);
+      expect(started.value.draft.entry).toBe('upload');
+      return {
+        ...started.value.draft,
+        appName: 'depot',
+        source: {
+          kind: 'archive',
+          filename: 'bundle.tgz',
+          digest: bundleDigest,
+          location: staged.body.value.location,
+          contents: 'source',
+          subpath: '.',
+        },
+      };
+    });
+    expect(created.buildStatus).toBe('PENDING');
+    expect(created.targetId).toBe(target.id);
+
+    const [appRow] = await db
+      .select()
+      .from(apps)
+      .where(eq(apps.id, created.appId));
+    expect(appRow?.sourceKind).toBe('archive');
+    expect(appRow?.sourceArchiveDigest).toBe(bundleDigest);
+
+    // §4's source arm: nothing has been built, so the Build carries the bundle
+    // and no artifact at all.
+    const [pending] = await db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, created.buildId));
+    expect(pending?.status).toBe('PENDING');
+    expect(pending?.bundleDigest).toBe(bundleDigest);
+    expect(pending?.bundleLocation).toBe(staged.body.value.location);
+    expect(pending?.artifactDigest).toBeNull();
+
+    // ------------------------------------------------------------------
+    // 3. Build. The reconciler's own pass, not a direct `dispatchBuild`.
+    // ------------------------------------------------------------------
+    expect(await runBuildPass(context)).toBe(1);
+
+    // What the route was handed. The bundle digest is the join, and the
+    // location has been exchanged for something `curl` can follow — the stored
+    // `gs://` address would have died at the runner's first step.
+    expect(builder.built).toHaveLength(1);
+    expect(builder.built[0]?.source.bundleDigest).toBe(bundleDigest);
+    expect(builder.built[0]?.source.origin.type).toBe('archive');
+    expect(
+      builder.built[0]?.source.origin.location.startsWith(
+        'https://storage.googleapis.com/',
+      ),
+    ).toBe(true);
+
+    const [built] = await db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, created.buildId));
+    expect(built?.status).toBe('SUCCEEDED');
+    expect(built?.runner).toBe('hosted');
+    expect(built?.artifactDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    expect(built?.artifactRefs?.length).toBeGreaterThan(0);
+    // Narrowed only after the shape assertion above, so the rest of the chain
+    // compares against a digest that has already had to be one.
+    const artifactDigest = built?.artifactDigest ?? '';
+    // §16: the artifact is admitted at a level and signed, and both are written
+    // down. A green build with no signature is one no Target would take.
+    expect(built?.verifiedBuildLevel).toBe(2);
+    expect(built?.signature?.artifactDigest).toBe(artifactDigest);
+    expect(supplyChain.signed).toHaveLength(1);
+
+    // ------------------------------------------------------------------
+    // 4. Deploy. The one button an operator presses.
+    // ------------------------------------------------------------------
+    const deployed = await deployApp({ name: created.appId }, context);
+    expect(deployed.ok).toBe(true);
+    if (!deployed.ok) return;
+    // Not `BUILDING`: there is an artifact, so the button means deploy it, and
+    // a second Build here would be the substitution `deployApp` forbids.
+    expect(deployed.value.phase).toBe('PENDING');
+    expect(deployed.value.buildId).toBe(created.buildId);
+    expect(deployed.value.deployId).not.toBeNull();
+    // §16's admission: the recorded signature is re-verified against the
+    // recorded digest before an intent is written, by the same pinned verifier
+    // that wrote it.
+    expect(supplyChain.signatureChecks.admissions).toHaveLength(1);
+    expect(supplyChain.signatureChecks.admissions[0]?.artifactDigest).toBe(
+      artifactDigest,
+    );
+
+    const [intent] = await db
+      .select()
+      .from(deploys)
+      .where(eq(deploys.id, deployed.value.deployId!));
+    expect(intent?.phase).toBe('PENDING');
+    expect(builder.built).toHaveLength(1);
+
+    // ------------------------------------------------------------------
+    // 5. Reconcile. The loop claims the intent and runs it to a verdict.
+    // ------------------------------------------------------------------
+    const pass = await runDeployPass(loop);
+    expect(pass.applied).toEqual([
+      {
+        deployId: deployed.value.deployId!,
+        phase: 'LIVE',
+        // §9: a cluster Target takes core's minted canonical name, and the
+        // developer is shown it over HTTPS.
+        url: 'https://depot-web.apps.example.test',
+      },
+    ]);
+    // Nothing is owed work, which is what the loop reads to slow its cadence.
+    expect(pass.unsettled).toEqual([]);
+
+    const [live] = await db
+      .select()
+      .from(deploys)
+      .where(eq(deploys.id, deployed.value.deployId!));
+    expect(live?.phase).toBe('LIVE');
+    expect(live?.url).toBe('https://depot-web.apps.example.test');
+    expect(live?.buildId).toBe(created.buildId);
+    expect(live?.targetId).toBe(target.id);
+    expect(live?.observedDigest).toBe(artifactDigest);
+    expect(live?.reason).toBeNull();
+    expect(live?.driftedAt).toBeNull();
+
+    // The durable desired row, which is the thing a later deploy check-and-sets
+    // against and the only record of what *should* be live here.
+    const [desired] = await db
+      .select()
+      .from(componentTargetDesired)
+      .where(eq(componentTargetDesired.componentId, created.componentId));
+    expect(desired?.targetId).toBe(target.id);
+    expect(desired?.desiredBuildId).toBe(created.buildId);
+
+    // What the adapter was described, in core's neutral vocabulary — the
+    // artifact it placed is the one the build produced, by digest.
+    expect(cluster.applied).toHaveLength(1);
+    expect(cluster.applied[0]?.desired.artifact.digest).toBe(artifactDigest);
+    expect(cluster.applied[0]?.desired.hostname.canonical).toBe(
+      'depot-web.apps.example.test',
+    );
+
+    // ------------------------------------------------------------------
+    // 6. The read-only post-deployment check: look, and change nothing.
+    // ------------------------------------------------------------------
+    const reports = await observeConverged(loop);
+    expect(reports).toEqual([
+      {
+        deployId: deployed.value.deployId!,
+        drifted: false,
+        observedDigest: artifactDigest,
+        driftDetail: null,
+      },
+    ]);
+    // §6: drift is "detected and surfaced, never silently corrected". Observing
+    // a converged Deploy must not place anything.
+    expect(cluster.applied).toHaveLength(1);
+
+    // §6's one attempt-scoped log carries both halves of the attempt, which is
+    // what the Deploy screen subscribes to.
+    const events = await db
+      .select()
+      .from(attemptEvents)
+      .orderBy(asc(attemptEvents.id));
+    expect(events.some((event) => event.buildId === created.buildId)).toBe(
+      true,
+    );
+    expect(
+      events.some(
+        (event) =>
+          event.deployId === deployed.value.deployId &&
+          event.eventType === 'status' &&
+          event.phase === 'LIVE',
+      ),
+    ).toBe(true);
+  });
+
+  test('a repository source walks the identical pipeline to the identical rows', async () => {
+    // §4: "Repo and archive share **one pipeline** — unpack, detect, build."
+    // Two arms of one pipeline is a claim, and this is the half of it that the
+    // archive case above cannot make on its own.
+    const commit = 'c'.repeat(40);
+    const { context, loop, builder, cluster, target } = await installation({
+      sourceCommit: commit,
+    });
+    const db = context.db;
+
+    const created = await createThroughDraft(context, (started) => {
+      if (!started.ok) throw new Error('unreachable');
+      // A connected repository is what the draft defaults to, so this arm
+      // overrides nothing about the source at all.
+      expect(started.value.draft.entry).toBe('repo');
+      return { ...started.value.draft, appName: 'linked' };
+    });
+
+    expect(await runBuildPass(context)).toBe(1);
+    expect(builder.built[0]?.source.origin.type).toBe('repo');
+    expect(builder.built[0]?.source.bundleDigest).toBe(
+      `sha256:${'b'.repeat(64)}`,
+    );
+
+    const [built] = await db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, created.buildId));
+    expect(built?.status).toBe('SUCCEEDED');
+    expect(built?.commit).toBe(commit);
+    expect(built?.artifactDigest).toMatch(/^sha256:[0-9a-f]{64}$/);
+    const artifactDigest = built?.artifactDigest ?? '';
+    expect(built?.signature?.artifactDigest).toBe(artifactDigest);
+
+    const deployed = await deployApp({ name: created.appId }, context);
+    expect(deployed.ok).toBe(true);
+    if (!deployed.ok) return;
+
+    await runDeployPass(loop);
+    const [live] = await db
+      .select()
+      .from(deploys)
+      .where(eq(deploys.id, deployed.value.deployId!));
+    expect(live?.phase).toBe('LIVE');
+    expect(live?.url).toBe('https://linked-web.apps.example.test');
+    expect(live?.observedDigest).toBe(artifactDigest);
+    expect(cluster.applied).toHaveLength(1);
+
+    const [component] = await db
+      .select()
+      .from(components)
+      .where(eq(components.id, created.componentId));
+    expect(component?.appId).toBe(created.appId);
+    expect(created.targetId).toBe(target.id);
+  });
+});

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -428,6 +428,7 @@ export const WORKSPACE_SCENARIOS = {
     release: 'Deploy 42',
     components: [
       {
+        id: 'component-beacon-web',
         name: 'web',
         kind: 'service',
         phase: 'LIVE',
@@ -542,6 +543,7 @@ export const WORKSPACE_SCENARIOS = {
     release: 'Deploy 17',
     components: [
       {
+        id: 'component-almanac-web',
         name: 'web',
         kind: 'website',
         phase: 'LIVE',
@@ -607,6 +609,7 @@ export const WORKSPACE_SCENARIOS = {
     release: 'Execution 118',
     components: [
       {
+        id: 'component-ledger-nightly',
         name: 'nightly',
         kind: 'job',
         phase: 'LIVE',
@@ -936,6 +939,18 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     status: 'connected',
     configured: true,
     inspectedAt: '2026-08-02T12:00:00.000Z',
+    // The state 52 exists for, as a screen meets it: an operator moved this
+    // cluster's gateway through the connect form and the manifest still
+    // declares the old one. The row is what deploys render from, so the notice
+    // is a warning about Settings rather than about the Target.
+    manifestDivergence: [
+      'connection.chartValues.platform.gateway.name',
+      'connection.chartValues.platform.gateway.namespace',
+    ],
+    edit: {
+      apiServer: 'https://primary.example:6443',
+      proposal: { carriedFrom: 'Primary', namespace: 'apps' },
+    },
   },
   {
     id: 'target-cloudrun',
@@ -949,6 +964,10 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     status: 'connected',
     configured: true,
     inspectedAt: '2026-08-02T12:00:00.000Z',
+    manifestDivergence: [],
+    // A cloud project has no `platform` values and no probe to read itself
+    // back through, so there is nothing here for an edit form to open onto.
+    edit: null,
   },
   {
     id: 'target-static',
@@ -962,6 +981,10 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     status: 'connected',
     configured: true,
     inspectedAt: '2026-08-02T12:00:00.000Z',
+    manifestDivergence: [],
+    // A cloud project has no `platform` values and no probe to read itself
+    // back through, so there is nothing here for an edit form to open onto.
+    edit: null,
   },
   {
     id: 'target-secondary',
@@ -987,5 +1010,10 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     status: 'connected',
     configured: true,
     inspectedAt: '2026-08-02T12:00:00.000Z',
+    manifestDivergence: [],
+    edit: {
+      apiServer: 'https://secondary.example:6443',
+      proposal: { carriedFrom: 'Secondary', namespace: 'apps' },
+    },
   },
 ];

--- a/apps/spindrift/test/web/deploy-detail-transcript.test.tsx
+++ b/apps/spindrift/test/web/deploy-detail-transcript.test.tsx
@@ -1,15 +1,15 @@
 /**
- * The one assertion `views.test.tsx` cannot make (ticket 08, criterion 3).
+ * The assertions `views.test.tsx` cannot make (ticket 08, criterion 3).
  *
  * That file's own header explains why it renders through
  * `renderToStaticMarkup`: every rule it checks is a statement about what a
- * given state looks like, and SSR is the right depth for that. The bug this
- * file exists for is not that shape — it is React **preserving** `Transcript`'s
- * `open` state across a running→failed transition of the *same mounted
- * instance*, and `renderToStaticMarkup` cannot even observe that class of bug:
+ * given state looks like, and SSR is the right depth for that. The bugs this
+ * file exists for are not that shape — they are React **preserving** state
+ * across a transition of the *same mounted instance*, and
+ * `renderToStaticMarkup` cannot even observe that class of bug:
  * it never keeps a fiber tree alive between calls (no reconciliation happens)
  * and it never runs `useEffect` at all (SSR effects are a no-op by design).
- * Proving the fix means mounting once and re-rendering with a changed prop,
+ * Proving either one means mounting once and re-rendering with a changed prop,
  * which needs a live `react-dom/client` root — and that needs *something*
  * DOM-shaped to render into.
  *
@@ -215,56 +215,63 @@ function findButton(
   return null;
 }
 
-describe('Transcript re-derives open on a build status change', () => {
-  const fakeDocument = new FakeDocument();
-  const previousDocument = (globalThis as { document?: unknown }).document;
-  const previousWindow = (globalThis as { window?: unknown }).window;
-  const previousGetComputedStyle = (
-    globalThis as { getComputedStyle?: unknown }
-  ).getComputedStyle;
-  const previousRaf = (globalThis as { requestAnimationFrame?: unknown })
-    .requestAnimationFrame;
-  const previousCancelRaf = (globalThis as { cancelAnimationFrame?: unknown })
-    .cancelAnimationFrame;
-  const previousActEnv = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: unknown })
-    .IS_REACT_ACT_ENVIRONMENT;
-  const previousHTMLIFrameElement = (
-    globalThis as { HTMLIFrameElement?: unknown }
-  ).HTMLIFrameElement;
+/**
+ * The shim is installed for the whole file rather than one `describe`, because
+ * more than one claim needs a mounted tree and installing it twice would leave
+ * the second restore holding the first shim as its "previous". Restoring at all
+ * is what keeps the rest of the suite honest: a `document` left on `globalThis`
+ * flips every `typeof window !== 'undefined'` feature check in the files that
+ * run after this one.
+ */
+const fakeDocument = new FakeDocument();
+const previousDocument = (globalThis as { document?: unknown }).document;
+const previousWindow = (globalThis as { window?: unknown }).window;
+const previousGetComputedStyle = (globalThis as { getComputedStyle?: unknown })
+  .getComputedStyle;
+const previousRaf = (globalThis as { requestAnimationFrame?: unknown })
+  .requestAnimationFrame;
+const previousCancelRaf = (globalThis as { cancelAnimationFrame?: unknown })
+  .cancelAnimationFrame;
+const previousActEnv = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: unknown })
+  .IS_REACT_ACT_ENVIRONMENT;
+const previousHTMLIFrameElement = (
+  globalThis as { HTMLIFrameElement?: unknown }
+).HTMLIFrameElement;
 
+Object.assign(globalThis, {
+  document: fakeDocument,
+  // `@radix-ui/react-primitive` does a bare `typeof window !== 'undefined'`
+  // feature-check on every mount, and react-dom's own focus-restoration
+  // pass reads `container.ownerDocument.defaultView.document` — both need
+  // `window` to be the same object `document` was installed on.
+  window: globalThis,
+  // `@radix-ui/react-presence` reads this to decide whether an open/close
+  // transition is mid CSS-animation. Nothing here has a stylesheet, so
+  // reporting no `animationName` is correct, not a stub of convenience.
+  getComputedStyle: (node: FakeNode) => node.style,
+  requestAnimationFrame: (cb: () => void) => setTimeout(cb, 0),
+  cancelAnimationFrame: (id: number) => clearTimeout(id),
+  IS_REACT_ACT_ENVIRONMENT: true,
+  // react-dom's focus restoration walks into iframes via
+  // `element instanceof window.HTMLIFrameElement`; nothing here ever is
+  // one, but the right-hand side still has to be a real constructor.
+  HTMLIFrameElement: class {},
+});
+fakeDocument.defaultView = globalThis;
+
+afterAll(() => {
   Object.assign(globalThis, {
-    document: fakeDocument,
-    // `@radix-ui/react-primitive` does a bare `typeof window !== 'undefined'`
-    // feature-check on every mount, and react-dom's own focus-restoration
-    // pass reads `container.ownerDocument.defaultView.document` — both need
-    // `window` to be the same object `document` was installed on.
-    window: globalThis,
-    // `@radix-ui/react-presence` reads this to decide whether an open/close
-    // transition is mid CSS-animation. Nothing here has a stylesheet, so
-    // reporting no `animationName` is correct, not a stub of convenience.
-    getComputedStyle: (node: FakeNode) => node.style,
-    requestAnimationFrame: (cb: () => void) => setTimeout(cb, 0),
-    cancelAnimationFrame: (id: number) => clearTimeout(id),
-    IS_REACT_ACT_ENVIRONMENT: true,
-    // react-dom's focus restoration walks into iframes via
-    // `element instanceof window.HTMLIFrameElement`; nothing here ever is
-    // one, but the right-hand side still has to be a real constructor.
-    HTMLIFrameElement: class {},
+    document: previousDocument,
+    window: previousWindow,
+    getComputedStyle: previousGetComputedStyle,
+    requestAnimationFrame: previousRaf,
+    cancelAnimationFrame: previousCancelRaf,
+    IS_REACT_ACT_ENVIRONMENT: previousActEnv,
+    HTMLIFrameElement: previousHTMLIFrameElement,
   });
-  fakeDocument.defaultView = globalThis;
+});
 
-  afterAll(() => {
-    Object.assign(globalThis, {
-      document: previousDocument,
-      window: previousWindow,
-      getComputedStyle: previousGetComputedStyle,
-      requestAnimationFrame: previousRaf,
-      cancelAnimationFrame: previousCancelRaf,
-      IS_REACT_ACT_ENVIRONMENT: previousActEnv,
-      HTMLIFrameElement: previousHTMLIFrameElement,
-    });
-  });
-
+describe('Transcript re-derives open on a build status change', () => {
   test('a running LIVE_TEXT build that turns failed springs the transcript open', () => {
     // The exact case §4/§18 create: a LIVE_TEXT runner (`buildFailed`'s
     // fixture) has already released log lines while `status` is still
@@ -302,6 +309,88 @@ describe('Transcript re-derives open on a build status change', () => {
     // first render is exactly what a reader would find on the terminal red
     // screen. With the effect, the trigger flips to `open`.
     expect(trigger()?.getAttribute('data-state')).toBe('open');
+
+    act(() => {
+      root.unmount();
+    });
+  });
+});
+
+/**
+ * Ticket 08, item 3, as far as a test can carry it.
+ *
+ * The criterion names four presentations — "phase, diagnosis, checklist, and
+ * log presentation" — and one condition, "without a page refresh". The
+ * condition is what makes it awkward to test: nothing here is a page, so what
+ * a test can prove is the half that is a claim about code. `app.tsx`'s
+ * `DeployScreen` re-issues `getDeployDetail` on every attempt event and hands
+ * the result down as a new `view` prop, and the streaming half of that is
+ * already asserted by `streams.test.ts` and `stream-client.test.ts`. What was
+ * never asserted is the other end: that a **mounted** `DeployDetail` handed a
+ * newer view actually replaces all four, rather than showing the state it was
+ * mounted in.
+ *
+ * That is not a re-statement of "React re-renders on new props". This screen
+ * holds four independent `useState`s that are seeded from the view and are
+ * therefore free to survive it — `BuildDrawer`, `DeployDrawer`, `Transcript`
+ * and the diagnosis evidence — and the test above exists because one of them
+ * did exactly that. Every one of them is between the reader and one of the
+ * four presentations this criterion names.
+ *
+ * **The ticket's own bar is still a real terminal Deploy watched on the real
+ * screen**, which no test replaces. This is the regression guard underneath it.
+ */
+describe('the mounted Deploy screen replaces what a newer view says', () => {
+  test('a running build going red moves phase, diagnosis, checklist and log together', () => {
+    // One transition, chosen because it is the only one that moves all four at
+    // once: `building` is `LIVE_STATUS` with no log text and a full resource
+    // checklist, `buildFailed` is red with a diagnosis, a failed step and eight
+    // lines of runner output.
+    const building: DeployView = DEPLOY_SCENARIOS.building;
+    const failed: DeployView = DEPLOY_SCENARIOS.buildFailed;
+
+    const container = fakeDocument.createElement('div');
+    let root!: Root;
+    act(() => {
+      root = createRoot(container as unknown as Element);
+      root.render(<DeployDetail view={building} />);
+    });
+    const screen = () => container.textContent;
+
+    // Phase, and the headline under it.
+    expect(screen()).toContain(building.phaseWord);
+    expect(screen()).toContain(building.headline);
+    // Diagnosis: there is none while it is building, and an empty panel would
+    // be worse than none.
+    expect(screen()).not.toContain('BUILD_FAILED');
+    // Checklist: the deploy-side one is present and every resource is waiting,
+    // and the build-side one has `run build` still going.
+    expect(screen()).toContain(`Resources on ${building.target}`);
+    expect(screen()).toContain('14s');
+    // Log presentation: §4's `LIVE_STATUS` sentence stands in for text that
+    // this runner will not release until the run ends.
+    expect(screen()).toContain('reports step status live');
+    expect(screen()).not.toContain('Failed to compile');
+
+    act(() => {
+      root.render(<DeployDetail view={failed} />);
+    });
+
+    expect(screen()).toContain(failed.phaseWord);
+    expect(screen()).toContain(failed.headline);
+    expect(screen()).not.toContain(building.headline);
+    expect(screen()).toContain('BUILD_FAILED');
+    expect(screen()).toContain(failed.diagnosis?.detail ?? '');
+    // The resource checklist goes away with the release it described, and the
+    // build checklist reports the step that died.
+    expect(screen()).not.toContain(`Resources on ${failed.target}`);
+    expect(screen()).toContain('2.9s');
+    expect(screen()).not.toContain('14s');
+    // The `LIVE_STATUS` sentence is replaced by the text it was standing in
+    // for — which is only reachable because `Transcript` springs open on red,
+    // the claim the describe above pins.
+    expect(screen()).not.toContain('reports step status live');
+    expect(screen()).toContain('Failed to compile');
 
     act(() => {
       root.unmount();

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -15,7 +15,7 @@ import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 import type { DeployView, WorkspaceView } from '../../src/web/model.ts';
 import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
-import { Workspace } from '../../src/web/views/apps/workspace.tsx';
+import { ReachEditor, Workspace } from '../../src/web/views/apps/workspace.tsx';
 import { Gate } from '../../src/web/views/auth/gate.tsx';
 import { CredentialSettingsView } from '../../src/web/views/auth/settings.tsx';
 import { RepositoryList } from '../../src/web/views/repos/list.tsx';
@@ -737,5 +737,71 @@ describe('the Targets surface', () => {
 
   test('says nothing about connecting when there is nothing left to connect', () => {
     expect(targets()).not.toContain('Waiting to be connected');
+  });
+
+  test('a connected cluster can be corrected without submitting the whole manifest', () => {
+    // 52's first criterion. The connect form was reachable only from an
+    // unconfigured seed, so the gateway, the authenticated edge, the config
+    // store and the address a record points at were editable nowhere in the
+    // product once a Target existed — the procedure was to hand-write the whole
+    // installation document for a change of three fields.
+    expect(targets()).toContain('Edit connection');
+  });
+
+  test('a Target whose row and manifest entry disagree says so, in paths', () => {
+    const markup = words(targets());
+    expect(markup).toContain(
+      'connection.chartValues.platform.gateway.name, connection.chartValues.platform.gateway.namespace',
+    );
+    // The row wins, and the sentence has to say which way round that is: a
+    // restart leaves the correction alone and saving Settings does not.
+    expect(markup).toContain('a restart leaves it alone');
+    // Paths, never values — the same promise `diffManifestPaths` makes, kept
+    // all the way onto the screen.
+    expect(markup).not.toContain('spindrift-apps');
+  });
+});
+
+describe('changing how a Component is reached (§9)', () => {
+  const view = WORKSPACE_SCENARIOS.service;
+
+  test('reach is not editable where no act is wired', () => {
+    // The fixture screens render this view with no acts. A form whose Save
+    // cannot be called is worse than no form.
+    expect(workspace(view)).not.toContain('Save reach');
+  });
+
+  test('the affordance is on the Component that has one', () => {
+    const markup = renderToStaticMarkup(
+      <Workspace
+        view={view}
+        onSetReach={async () => ({ ok: true, pendingRelease: [] })}
+      />,
+    );
+    expect(markup).toContain('Reach');
+  });
+
+  test('the edit says it takes effect on the next Deploy, not on the one serving', () => {
+    const markup = words(
+      renderToStaticMarkup(
+        <ReachEditor
+          component={view.components[0]!}
+          onSetReach={async () => ({ ok: true, pendingRelease: [] })}
+          onDone={() => undefined}
+        />,
+      ),
+    );
+
+    // §9 keeps exposure out of the mutable-in-place category, and the App chart
+    // renders the route and the filter from values written at deploy time — so
+    // the one thing this form must never read as is a toggle that took effect.
+    expect(markup).toContain(
+      'takes effect on the next Deploy rather than on the one that is serving',
+    );
+    // Both halves of §9's grid, in the words the creation flow uses — the same
+    // constants, so a developer meets the decision once.
+    for (const cell of ['none', 'private', 'public', 'proxy']) {
+      expect(markup).toContain(cell);
+    }
   });
 });


### PR DESCRIPTION
Spindrift could **create** Components and Targets and deploy them, and could not **change** them. Two tickets, one theme — closes **54** and **52**.

The operator hit both today: *"There's no way to 'flip sdd to private' in the UI"* and *"those values aren't even available in the web UI... we need to work on the target lifecycle."*

## 54 — a Component's reach was frozen at creation

`reach` and `auth` appeared in exactly one input schema, `createComponentInput`. After creation the only ways to change them were deleting and re-creating the Component — losing its Deploy history and config pins — or editing Postgres by hand.

`setComponentReach` writes the row and asks the platform for nothing. It returns `pendingRelease` — the Targets whose current release still pins the previous answer — so the form says so instead of reading as done.

**Deliberately unlike `setConfig`**, which ends by writing an intent: §10 makes a config change produce a Deploy and §9 does not, and a reach change that took effect on Save would drop a live route with nothing having been read.

The grid rule is **shared, not restated**: `authHasARoute` moved beside `AUTH_NEEDS_A_ROUTE` in `domain/desired-state.ts`, and both schemas refine on it. The screen reuses the creation flow's own `REACHES`/`AUTHS`/`REACH_NOTE`/`Choice`, so the grid is expressed once.

`deploys.reach`/`deploys.auth` carried a comment about "a Component edited mid-attempt must not retroactively change what a running attempt is placing" — written for an edit path that did not exist. It does now, and a test puts an edit in the window between `createDeploy` and the loop claiming it, asserting **through the App chart's own values** that the attempt places `private`+`proxy` and the next release places `public`+`none`, hostnames included.

## 52 — a Target edit was reverted by the next boot

`connectTarget` updates the row, but `loadStoredManifest` ends with `writeStoredManifest(db, declared)` on **every boot**, and `reconcileManifestTargets` re-asserted the manifest's copy over it. An operator's correction was silently undone by the next rollout, and the screen that accepted it showed the old values again with no explanation.

**Decision: the row wins, and the divergence is reported** — ticket 51's answer, one noun down.

`loadStoredManifest`'s own contract already says *"a rollout must not revert what an operator just configured."* That trailing write was the one call site breaking the rule it sits under.

Promotion the other way — edit writes into the stored manifest — is ruled out by a hazard the repo already names. `readStoredManifest` warns that writing resolved values back into the authored document *"would bake this pod's environment into the durable document and make the next pod's environment stop mattering"*, and `connectTarget` holds a **resolved** `TargetConnection`. It would also widen the manifest with every UI-created Target, making 51's `manifestDivergence` fire on Targets git never declared.

`ManifestWrite = 'declared' | 'booted'` draws the line: a manifest *becoming* this installation's (the seed path and `configureInstallation`, which the module already treats as one act) asserts its connections; a boot writing back what was already there does not. A boot still creates a row the document names and the table lacks, and still repairs `rank` from manifest order — facts only the document has, and neither editable on the row.

## Verification

Each behaviour proven by **reverting it and watching the test fail**. The 52 revert reproduces the defect verbatim:

```
- "name": "cluster-gateway",    "namespace": "gateway"             (operator's edit)
+ "name": "gateway-that-moved", "namespace": "gateway-that-moved"  (manifest)
(fail) an operator's Target correction outlives the next boot
(fail) a boot leaves an operator's Target connection alone

Expected: false / Received: true
(fail) a Component with no route has nothing to authenticate in front of

Expected: "private" / Received: "public"
(fail) the attempt renders its own pin, and the next release renders the edit
```

`1410 pass / 0 fail` across 102 files. typecheck and biome clean.

## Known gaps, stated

- The Target edit form doesn't pre-select the *currently configured* gateway — it defaults to the probe's first. Visible in the summary line before Connect, so the silent-move risk exists only on a multi-gateway cluster.
- Cloud Targets get no edit surface: `platform` values are a cluster's, and a project has no probe to read itself back through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)