### PR TITLE
fix(spindrift-app): publish the record the route asks for

### DIFF
--- a/packages/charts/spindrift-app/templates/dnsendpoint.yaml
+++ b/packages/charts/spindrift-app/templates/dnsendpoint.yaml
@@ -1,0 +1,68 @@
+{{/*
+The record each of this Component's hostnames answers to, **stated** rather than
+inferred from the objects around it.
+
+Why a DNSEndpoint and not annotations on the route. external-dns's
+`gateway-httproute` source reads `external-dns.alpha.kubernetes.io/target` off
+the **Gateway**, never off an HTTPRoute (`source/gateway.go`,
+`newGatewayListenerObject`), and falls back to the parent Gateway's
+`status.addresses` when the Gateway carries none. It reads
+`cloudflare-proxied` off the *route*. So a route annotated for `public` got the
+proxy flag it asked for and the gateway's own RFC1918 address as the target —
+Cloudflare rejects that pairing, and the whole-zone sync soft-errors.
+
+That is not a bug to route around: a route can never state its own target, and
+every Component on a shared gateway would otherwise publish the same address.
+`reach` is per-Component, so the record has to be a per-Component object. The
+`crd` source reads exactly what is written here, which is why this is the one
+place the reach decision is expressible without a controller re-deriving it.
+
+Rendered on the route's own condition — same `serving` and `reach` test — so a
+name is published exactly when something is listening on it, and `reach: none`
+publishes nothing at all.
+*/}}
+{{- if and (include "spindrift-app.serving" .) (ne .Values.app.reach "none") }}
+{{- $private := eq .Values.app.reach "private" }}
+{{/*
+The three facts `reach` decides, resolved once. `private` is an A record at the
+gateway's own load-balancer address, unproxied: RFC1918, so the record type *is*
+the boundary and no policy has to be attached to it. `public` is a proxied CNAME
+at the Target's tunnel, whose ingress stays the single static wildcard rule
+Terraform owns — Spindrift never writes tunnel config (§9).
+*/}}
+{{- $recordType := ternary "A" "CNAME" $private }}
+{{- $target := ternary .Values.platform.dns.privateAddress .Values.platform.dns.tunnelHostname $private }}
+{{- $proxied := ternary "false" "true" $private }}
+{{- if not $target }}
+{{- fail (printf "platform.dns.%s is required for reach: %s" (ternary "privateAddress" "tunnelHostname" $private) .Values.app.reach) }}
+{{- end }}
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: {{ include "spindrift-app.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spindrift-app.labels" . | nindent 4 }}
+  annotations:
+    {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
+spec:
+  endpoints:
+    {{/*
+    One endpoint per hostname: the canonical name and the vanity name are the
+    same Component at the same reach, and both ride the one route.
+    */}}
+    {{- range .Values.app.hostnames }}
+    - dnsName: {{ . | quote }}
+      recordType: {{ $recordType }}
+      targets:
+        - {{ $target | quote }}
+      {{/*
+      The proxy flag travels as provider config rather than an annotation
+      because the `crd` source passes `providerSpecific` through untouched,
+      where an annotation on this object would be ignored.
+      */}}
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: {{ $proxied | quote }}
+    {{- end }}
+{{- end }}

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -7,19 +7,27 @@ gateway with it. The wildcard TLS listener the vessel carries is what lets a
 flat App name be served without this chart owning a certificate.
 
 Two independent facts render here. `app.reach` decides whether a route exists at
-all and which record external-dns publishes for it; `app.auth` decides whether
-an ExternalAuth filter sits on that route. A Component with `reach: none` has no
-route — it is a workload boundary, and a route onto the shared gateway would be
-exactly the alternate origin it asked not to have.
+all; `app.auth` decides whether an ExternalAuth filter sits on that route. A
+Component with `reach: none` has no route — it is a workload boundary, and a
+route onto the shared gateway would be exactly the alternate origin it asked not
+to have.
 
-The DNS annotations are the mechanism rather than a leak, which is why the
-blanket `external-dns.alpha.kubernetes.io/exclude` this template used to carry
-is gone. `private` publishes the gateway's own load-balancer address: RFC1918,
-so the record type *is* the boundary and no policy has to be attached to it.
-`public` publishes a proxied CNAME at the Target's tunnel, whose ingress stays
-the single static wildcard rule Terraform owns — Spindrift never writes tunnel
-config (§9). The bypass concern the old comment named lives in the NetworkPolicy,
-which covers every Component whatever its reach.
+**Which record gets published is not decided here**, and this route is held out
+of DNS entirely. `templates/dnsendpoint.yaml` carries that decision and explains
+why it cannot live on a route. What matters here is that only one of them
+publishes: external-dns's `gateway-httproute` source would otherwise emit its
+own endpoint for these same hostnames, targeting the parent Gateway's status
+address — the same name claimed twice, at two record types, by two sources.
+
+The hold-out is `…/controller`, which the source honours per object: it skips
+any route whose value is not `dns-controller` (`source/annotations`,
+`IsControllerMismatch`). It is a real annotation, unlike the `…/exclude` this
+template once carried, and it is scoped to the routes this chart renders — no
+cluster-wide source filter, so nothing else in the zone changes shape. The value
+only has to differ from `dns-controller`; it names the lab domain and the object
+that publishes instead, so a `kubectl get -o yaml` says where the record went.
+The bypass concern the old comment named lives in the NetworkPolicy, which
+covers every Component whatever its reach.
 */}}
 {{- if and (include "spindrift-app.serving" .) (ne .Values.app.reach "none") }}
 {{- if not .Values.platform.gateway.name }}
@@ -34,19 +42,7 @@ metadata:
     {{- include "spindrift-app.labels" . | nindent 4 }}
   annotations:
     {{- include "spindrift-app.contractAnnotations" . | nindent 4 }}
-    {{- if eq .Values.app.reach "private" }}
-    {{- if not .Values.platform.dns.privateAddress }}
-    {{- fail "platform.dns.privateAddress is required for reach: private" }}
-    {{- end }}
-    external-dns.alpha.kubernetes.io/target: {{ .Values.platform.dns.privateAddress | quote }}
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
-    {{- else }}
-    {{- if not .Values.platform.dns.tunnelHostname }}
-    {{- fail "platform.dns.tunnelHostname is required for reach: public" }}
-    {{- end }}
-    external-dns.alpha.kubernetes.io/target: {{ .Values.platform.dns.tunnelHostname | quote }}
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
-    {{- end }}
+    external-dns.alpha.kubernetes.io/controller: lolwtf.ca/spindrift-dnsendpoint
 spec:
   parentRefs:
     - name: {{ .Values.platform.gateway.name }}

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -19,6 +19,7 @@ describe('kind branches', () => {
     const objects = await render();
     expect(kinds(objects).sort()).toEqual([
       'CiliumNetworkPolicy',
+      'DNSEndpoint',
       'Deployment',
       'HTTPRoute',
       'NetworkPolicy',
@@ -50,6 +51,7 @@ describe('website is not a branch', () => {
     });
     expect(kinds(website).sort()).toEqual([
       'CiliumNetworkPolicy',
+      'DNSEndpoint',
       'Deployment',
       'HTTPRoute',
       'NetworkPolicy',
@@ -404,27 +406,20 @@ describe('the route', () => {
     expect(route.spec.rules[0].filters?.[0]?.type).toBe('ExternalAuth');
   });
 
-  test('reach decides the record external-dns publishes', async () => {
-    // The record type is the boundary. An RFC1918 address is not reachable from
-    // the internet whatever policy is or is not attached to it, which is what
-    // lets the proxied wildcard be retired without weakening anything.
-    const asPrivate = one(
-      await render({ app: { reach: 'private', auth: 'proxy' } }),
-      'HTTPRoute',
-    );
-    expect(asPrivate.metadata.annotations).toMatchObject({
-      'external-dns.alpha.kubernetes.io/target': '10.89.0.67',
-      'external-dns.alpha.kubernetes.io/cloudflare-proxied': 'false',
-    });
-
-    const asPublic = one(
-      await render({ app: { reach: 'public', auth: 'none' } }),
-      'HTTPRoute',
-    );
-    expect(asPublic.metadata.annotations).toMatchObject({
-      'external-dns.alpha.kubernetes.io/target': 'tunnel.example.test',
-      'external-dns.alpha.kubernetes.io/cloudflare-proxied': 'true',
-    });
+  test('the route is held out of DNS, so only one source publishes', async () => {
+    // Without this the `gateway-httproute` source emits its own endpoint for
+    // these hostnames, targeting the parent Gateway's status address: the same
+    // name claimed twice, at two record types, by two sources. The value only
+    // has to differ from `dns-controller` for the source to skip the object.
+    for (const reach of ['private', 'public'] as const) {
+      const route = one(await render({ app: { reach } }), 'HTTPRoute');
+      const controller =
+        route.metadata.annotations?.[
+          'external-dns.alpha.kubernetes.io/controller'
+        ];
+      expect(controller).toBeDefined();
+      expect(controller).not.toBe('dns-controller');
+    }
   });
 
   test('a route with no gateway to attach to fails to render', async () => {
@@ -434,6 +429,125 @@ describe('the route', () => {
     expect(
       render({ platform: { gateway: { name: '', namespace: '' } } }),
     ).rejects.toThrow(/gateway/);
+  });
+});
+
+describe('the published record', () => {
+  test('reach decides the record, and the chart states it', async () => {
+    // The record type is the boundary. An RFC1918 address is not reachable from
+    // the internet whatever policy is or is not attached to it, which is what
+    // lets the proxied wildcard be retired without weakening anything.
+    const asPrivate = one(
+      await render({ app: { reach: 'private', auth: 'proxy' } }),
+      'DNSEndpoint',
+    );
+    expect(asPrivate.spec.endpoints).toEqual([
+      {
+        dnsName: 'blog-web.apps.example.test',
+        recordType: 'A',
+        targets: ['10.89.0.67'],
+        providerSpecific: [
+          {
+            name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
+            value: 'false',
+          },
+        ],
+      },
+    ]);
+
+    const asPublic = one(
+      await render({ app: { reach: 'public', auth: 'none' } }),
+      'DNSEndpoint',
+    );
+    expect(asPublic.spec.endpoints).toEqual([
+      {
+        dnsName: 'blog-web.apps.example.test',
+        recordType: 'CNAME',
+        targets: ['tunnel.example.test'],
+        providerSpecific: [
+          {
+            name: 'external-dns.alpha.kubernetes.io/cloudflare-proxied',
+            value: 'true',
+          },
+        ],
+      },
+    ]);
+  });
+
+  test("the target is the Target's value, not the gateway it routes onto", async () => {
+    // The defect this chart shipped with was invisible for exactly one reason:
+    // `platform.dns.privateAddress` happened to equal the parent Gateway's own
+    // status address, so a record derived from the gateway and a record derived
+    // from the chart agreed. They are independent inputs and this pins them
+    // apart — a private address that is nothing else in the render.
+    const endpoint = one(
+      await render({
+        platform: {
+          gateway: { name: 'cluster-gateway', namespace: 'gateway' },
+          dns: { privateAddress: '10.99.99.99' },
+        },
+      }),
+      'DNSEndpoint',
+    );
+    expect(endpoint.spec.endpoints[0].targets).toEqual(['10.99.99.99']);
+  });
+
+  test('every hostname on the route is published', async () => {
+    // The canonical name and the vanity name are the same Component at the same
+    // reach, so a record that covered only the first would leave the second
+    // resolving to whatever wildcard still answers for the zone.
+    const endpoint = one(
+      await render({
+        app: {
+          reach: 'public',
+          hostnames: ['blog-web.apps.example.test', 'blog.vanity.example.test'],
+        },
+      }),
+      'DNSEndpoint',
+    );
+    expect(
+      endpoint.spec.endpoints.map((e: { dnsName: string }) => e.dnsName),
+    ).toEqual(['blog-web.apps.example.test', 'blog.vanity.example.test']);
+    for (const e of endpoint.spec.endpoints) {
+      expect(e.recordType).toBe('CNAME');
+      expect(e.targets).toEqual(['tunnel.example.test']);
+    }
+  });
+
+  test("it renders on the route's condition, and never without one", async () => {
+    // A record for a name nothing routes is the failure the wildcard already
+    // was: it resolves, it authenticates, and it 404s.
+    for (const reach of ['private', 'public'] as const) {
+      expect(kinds(await render({ app: { reach } }))).toContain('DNSEndpoint');
+    }
+    for (const values of [
+      { app: { reach: 'none', auth: 'none' } },
+      { app: { kind: 'job' } },
+      { app: { expose: false } },
+    ]) {
+      const objects = await render(values);
+      expect(kinds(objects)).not.toContain('DNSEndpoint');
+      expect(kinds(objects)).not.toContain('HTTPRoute');
+    }
+  });
+
+  test('a reach with nowhere to point fails to render', async () => {
+    // Rendering a record with an empty target publishes a name that resolves to
+    // nothing, which is worse than a Deploy that refuses: it is indistinguishable
+    // from a working App until someone fetches it.
+    await expect(
+      render({
+        app: { reach: 'private' },
+        platform: { dns: { privateAddress: '' } },
+      }),
+    ).rejects.toThrow(/platform\.dns\.privateAddress/);
+
+    await expect(
+      render({
+        app: { reach: 'public' },
+        platform: { dns: { tunnelHostname: '' } },
+      }),
+    ).rejects.toThrow(/platform\.dns\.tunnelHostname/);
   });
 });
 


### PR DESCRIPTION
An App's `reach` decided its route's DNS annotations, and the annotation that
decides the record was never read.

## The defect

external-dns's `gateway-httproute` source takes a route's target from the
**parent Gateway**, not from the route — `TargetsFromTargetAnnotation(gw.Annotations)`
in `source/gateway.go`, falling back to the Gateway's `status.addresses` when the
Gateway carries none. It *does* read `cloudflare-proxied` off the route. Half the
annotation pair was honoured and the deciding half was not.

So a `reach: public` Component asked for a proxied CNAME at the Target's tunnel
and got the proxy flag applied to the gateway's own RFC1918 address. Cloudflare
rejects that pairing, and the whole-zone sync soft-errors until the Component
stops being public.

`reach: private` was correct only by coincidence: `platform.dns.privateAddress`
happens to equal the Gateway's status address, so the value nobody read and the
value everybody used agreed. A second gateway, or a Target whose private address
is not its gateway's, breaks private exactly the way public already broke.

## The fix

A route structurally cannot state its own target, and every Component on a
shared gateway would publish the same address if it could. `reach` is
per-Component, so the record has to be a per-Component object.

The chart renders a `DNSEndpoint`, which the `crd` source reads verbatim —
including `providerSpecific` for the proxy flag. That source is already enabled
on this cluster and already publishes records in these zones.

The route holds itself out of DNS with `…/controller`, which the gateway source
honours per object: it skips any route whose value is not `dns-controller`.
Deliberately **not** a `--gateway-label-filter` — a source-wide selector takes
every Gateway in the cluster with it if it is wrong, where this is scoped to the
routes this chart renders and leaves every other name in the zone publishing
exactly as it does today. The `oauth2-proxy` route is untouched.

No new value, so the value contract does not move.

## Verification

Each guard was proven by breaking it, not by passing — five mutations, each
failing a distinct test:

| Mutation | Test that failed |
| --- | --- |
| drop the `…/controller` hold-out | the route is held out of DNS |
| target from a literal, not `platform.dns.*` | the target is the Target's value |
| `reach` pinned to one branch | reach decides the record |
| drop the empty-target guard | a reach with nowhere to point fails |
| publish only the first hostname | every hostname is published |

42 pass / 0 fail. `mise run ts:check` and `mise run k8s:render-apps` clean.

The `crd` source was confirmed working on this cluster before being built on:
`nest.pulsifer.ca` and `dave.lolwtf.ca` both resolve and carry
`external-dns/resource=crd/default/…` TXT ownership. RBAC is cluster-wide and
`providerSpecific` is in the installed CRD schema.

## What merging does

All three App HelmReleases are `reconcileStrategy: Revision` against
`GitRepository/infra`, so this re-renders every one of them on merge without a
redeploy. All three are currently `private` and publish `A 10.89.0.69`; each
swaps to a DNSEndpoint carrying the identical record inside one Helm upgrade.

**Expected DNS change: none.** Only the TXT `resource=` label moves from
`httproute/spindrift-apps/<name>` to `crd/spindrift-apps/<name>`. That flip is
the thing to watch — anything else changing means this is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ENgiNXY3prHnYVq2hCqQeg