### PR TITLE
feat(spindrift): make Vessel the noun it already was

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -41,7 +41,7 @@ import {
   type DesiredState,
   type Reach,
 } from '../../../domain/desired-state.ts';
-import type { CloudRunConnection } from '../../../domain/target.ts';
+import type { CloudRunAdapterConnection } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
 import { cloudChecklist } from '../cloud/checklist.ts';
 import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
@@ -386,7 +386,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
 
   private async *awaitVerdict(
     http: CloudHttp,
-    connection: CloudRunConnection,
+    connection: CloudRunAdapterConnection,
     id: string,
     ref: DeployRef,
   ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
@@ -456,7 +456,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   /** Write the invoker policy for one exposure, or say why it could not. */
   private async setInvoker(
     http: CloudHttp,
-    connection: CloudRunConnection,
+    connection: CloudRunAdapterConnection,
     id: string,
     reach: Reach,
     auth: Auth,
@@ -489,7 +489,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   // --- inspect's second half -----------------------------------------------
 
   private async discover(
-    connection: CloudRunConnection,
+    connection: CloudRunAdapterConnection,
   ): Promise<TargetDiscovery> {
     return {
       arch: [...RUNTIME_ARCH],
@@ -534,7 +534,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
    * this has to fail in: nobody said where to look, so nothing was verified.
    */
   private async admissionPolicy(
-    connection: CloudRunConnection,
+    connection: CloudRunAdapterConnection,
   ): Promise<PolicyEngineState> {
     if (connection.policyEndpoint === undefined) {
       return { installed: false, mode: null };
@@ -566,7 +566,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
 
   // --- plumbing ------------------------------------------------------------
 
-  private http(connection: CloudRunConnection): CloudHttp {
+  private http(connection: CloudRunAdapterConnection): CloudHttp {
     return new CloudHttp({
       baseUrl: connection.endpoint,
       token: this.options.token,
@@ -576,14 +576,14 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     });
   }
 
-  private connectionOf(target: DeployTarget): CloudRunConnection | null {
+  private connectionOf(target: DeployTarget): CloudRunAdapterConnection | null {
     return target.connection.adapter === 'cloudrun' ? target.connection : null;
   }
 
   /** One Service, or `null` where there is nothing there. */
   private async read(
     http: CloudHttp,
-    connection: CloudRunConnection,
+    connection: CloudRunAdapterConnection,
     id: string,
   ): Promise<CloudRunService | null> {
     const read = await http.json<CloudRunService>({
@@ -688,7 +688,7 @@ function encodeCloudLogCursor(record: CloudLogRecord): string {
 }
 
 /** `projects/<p>/locations/<r>` — the parent every call hangs off. */
-function parentOf(connection: CloudRunConnection): string {
+function parentOf(connection: CloudRunAdapterConnection): string {
   return `projects/${connection.project}/locations/${connection.region}`;
 }
 
@@ -700,13 +700,13 @@ function parentOf(connection: CloudRunConnection): string {
  * the Service would then be read against the wrong one — reporting a healthy
  * workload that is not the one this Deploy placed.
  */
-function refOf(connection: CloudRunConnection, id: string): DeployRef {
+function refOf(connection: CloudRunAdapterConnection, id: string): DeployRef {
   return `${parentOf(connection)}/services/${id}`;
 }
 
 /** The id this ref names on this connection, or `null` if it names another. */
 function parseRef(
-  connection: CloudRunConnection,
+  connection: CloudRunAdapterConnection,
   ref: DeployRef,
 ): string | null {
   const prefix = `${parentOf(connection)}/services/`;

--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -22,8 +22,8 @@ import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import type { TargetInspection } from '../../domain/capabilities.ts';
 import type { ArtifactType, DesiredState } from '../../domain/desired-state.ts';
 import type {
+  AdapterConnection,
   KubernetesDeliveryFlavour,
-  TargetConnection,
 } from '../../domain/target.ts';
 
 /**
@@ -46,11 +46,17 @@ export interface DeployTarget {
    * factory over live connection state, and would still have to be rebuilt
    * whenever an operator reconnected one.
    *
+   * **One flat object, composed from two rows.** Core stores the surface's
+   * facts on the Target and the boundary's on its Vessel, and `deployTargetOf`
+   * assembles them before the call. An adapter is handed what it always was,
+   * and is deliberately not told which row each field came from — where the
+   * facts are *kept* is core's normalization, not this seam's business.
+   *
    * **Never a credential** (§13: "one auth mode — native OIDC federation,
    * nothing stored"). What authorizes a call is minted per request by whatever
    * federates, and is injected when the adapter is constructed.
    */
-  readonly connection: TargetConnection;
+  readonly connection: AdapterConnection;
 }
 
 /**

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -38,7 +38,7 @@ import type {
   DesiredState,
 } from '../../../domain/desired-state.ts';
 import type {
-  KubernetesConnection,
+  KubernetesAdapterConnection,
   KubernetesDelivery,
 } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
@@ -435,7 +435,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
    */
   private async *awaitVerdict(
     api: KubernetesApi,
-    connection: KubernetesConnection,
+    connection: KubernetesAdapterConnection,
     desired: DesiredState,
     object: KubernetesObject,
     ref: DeployRef,
@@ -497,7 +497,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
   /** The read on red, once (§6), and the verdict it produces. */
   private async *failed(
     api: KubernetesApi,
-    connection: KubernetesConnection,
+    connection: KubernetesAdapterConnection,
     desired: DesiredState,
     status: DeliveryStatus,
     ref: DeployRef,
@@ -545,7 +545,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
 
   private async checklist(
     api: KubernetesApi,
-    connection: KubernetesConnection,
+    connection: KubernetesAdapterConnection,
   ): Promise<readonly PrerequisiteResult[]> {
     const delivery = connection.delivery;
     const results = new Map<string, PrerequisiteResult>();
@@ -702,7 +702,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
 
   private async discover(
     api: KubernetesApi,
-    connection: KubernetesConnection,
+    connection: KubernetesAdapterConnection,
   ): Promise<TargetDiscovery> {
     const [nodes, storageClasses, postgres, redis, egress, policy, stores] =
       await Promise.all([
@@ -772,7 +772,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
 
   // --- plumbing ------------------------------------------------------------
 
-  private api(connection: KubernetesConnection): KubernetesApi {
+  private api(connection: KubernetesAdapterConnection): KubernetesApi {
     return new KubernetesApi({
       apiServer: connection.apiServer,
       token: this.options.token,
@@ -782,14 +782,16 @@ export class KubernetesDeployAdapter implements DeployAdapter {
     });
   }
 
-  private connectionOf(target: DeployTarget): KubernetesConnection | null {
+  private connectionOf(
+    target: DeployTarget,
+  ): KubernetesAdapterConnection | null {
     return target.connection.adapter === 'kubernetes'
       ? target.connection
       : null;
   }
 
   private deliveryObject(
-    connection: KubernetesConnection,
+    connection: KubernetesAdapterConnection,
     desired: DesiredState,
     image: string,
   ): KubernetesObject {

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -39,7 +39,7 @@ import {
   artifactAddress,
   type DesiredState,
 } from '../../../domain/desired-state.ts';
-import type { StaticConnection } from '../../../domain/target.ts';
+import type { StaticAdapterConnection } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
 import { cloudChecklist } from '../cloud/checklist.ts';
 import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
@@ -345,7 +345,7 @@ export class StaticDeployAdapter implements DeployAdapter {
   /** The site, created if this is the first deploy to it. */
   private async ensureSite(
     http: CloudHttp,
-    connection: StaticConnection,
+    connection: StaticAdapterConnection,
     site: string,
   ): Promise<Outcome<HostingSite>> {
     const read = await http.json<HostingSite>({
@@ -485,7 +485,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
   // --- inspect's second half -----------------------------------------------
 
-  private discover(connection: StaticConnection): TargetDiscovery {
+  private discover(connection: StaticAdapterConnection): TargetDiscovery {
     return {
       // Files are served, not run. An empty `arch` excludes no Target on
       // architecture, which is right: there is nothing here for an
@@ -519,7 +519,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
   // --- plumbing ------------------------------------------------------------
 
-  private http(connection: StaticConnection): CloudHttp {
+  private http(connection: StaticAdapterConnection): CloudHttp {
     return new CloudHttp({
       baseUrl: connection.endpoint,
       token: this.options.token,
@@ -529,7 +529,7 @@ export class StaticDeployAdapter implements DeployAdapter {
     });
   }
 
-  private connectionOf(target: DeployTarget): StaticConnection | null {
+  private connectionOf(target: DeployTarget): StaticAdapterConnection | null {
     return target.connection.adapter === 'static' ? target.connection : null;
   }
 
@@ -582,12 +582,15 @@ export function siteId(desired: DesiredState): string {
 }
 
 /** The adapter's own handle on what `apply` placed — opaque to core (§6). */
-function refOf(connection: StaticConnection, site: string): DeployRef {
+function refOf(connection: StaticAdapterConnection, site: string): DeployRef {
   return `${connection.project}/sites/${site}`;
 }
 
 /** The site this ref names on this connection, or `null` if it names another. */
-function parseRef(connection: StaticConnection, ref: DeployRef): string | null {
+function parseRef(
+  connection: StaticAdapterConnection,
+  ref: DeployRef,
+): string | null {
   const prefix = `${connection.project}/sites/`;
   if (!ref.startsWith(prefix)) return null;
   const site = ref.slice(prefix.length);

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -31,16 +31,18 @@ import {
   type TargetAdapter,
   targetNameSchema,
 } from '../../config/manifest.schema.ts';
-import { targets } from '../../db/schema.ts';
+import { targets, vessels } from '../../db/schema.ts';
 import {
   deriveHealth,
   type PrerequisiteResult,
 } from '../../domain/capabilities.ts';
 import {
+  deployTargetOf,
+  surfaceNames,
   type TargetConnection,
   type TargetHealth,
-  targetNames,
 } from '../../domain/target.ts';
+import type { VesselKind, VesselLocation } from '../../domain/vessel.ts';
 import {
   inspectTarget,
   readoptTargetDeploys,
@@ -98,7 +100,7 @@ function assertedBy(input: ConnectTargetInput): {
   reaches?: ('none' | 'private' | 'public')[];
   authReaches?: ('none' | 'private' | 'public')[];
 } {
-  if (input.kind !== 'kubernetes') return {};
+  if (input.kind !== 'cluster') return {};
   return {
     ...(input.reaches === undefined ? {} : { reaches: [...input.reaches] }),
     ...(input.authReaches === undefined
@@ -110,7 +112,8 @@ function assertedBy(input: ConnectTargetInput): {
 export const connectTargetInput = z.discriminatedUnion('kind', [
   z
     .object({
-      kind: z.literal('kubernetes'),
+      kind: z.literal('cluster'),
+      /** The vessel's name. Its one surface takes it unchanged. */
       name: targetNameSchema,
       /** §13's prerequisite is OIDC against this, not a credential for it. */
       apiServer: z.url(),
@@ -129,8 +132,8 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
     .strict(),
   z
     .object({
-      kind: z.literal('cloud'),
-      /** One name; both of the project's Targets are derived from it. */
+      kind: z.literal('gcp-project'),
+      /** The vessel's name. Both of its surfaces are derived from it. */
       name: targetNameSchema,
       project: z.string().trim().min(1),
       region: z.string().trim().min(1),
@@ -176,26 +179,27 @@ export interface ConnectTargetResult {
   readonly readopted: readonly string[];
 }
 
-/** The connection material for one of the Targets this act registers. */
+/**
+ * The **surface** half of one Target this act registers.
+ *
+ * Where the boundary is, and what it can reach, are not here — they are the
+ * vessel's, stated once by {@link vesselFor}. The operator already supplied
+ * `servedHosts` and `reachableRegistries` once per act rather than once per
+ * Target, which is the shape this split makes honest: they used to be copied
+ * into both connections, where two surfaces of one project could drift apart.
+ */
 function connectionFor(
   input: ConnectTargetInput,
   adapter: TargetAdapter,
 ): TargetConnection {
   if (adapter === 'kubernetes') {
-    if (input.kind !== 'kubernetes') {
+    if (input.kind !== 'cluster') {
       throw new Error('a cloud project does not register a cluster Target');
     }
     return {
       adapter,
-      apiServer: input.apiServer,
       namespace: input.namespace,
       delivery: input.delivery,
-      ...(input.servedHosts === undefined
-        ? {}
-        : { servedHosts: input.servedHosts }),
-      ...(input.reachableRegistries === undefined
-        ? {}
-        : { reachableRegistries: input.reachableRegistries }),
       ...(input.logHistorySeconds === undefined
         ? {}
         : { logHistorySeconds: input.logHistorySeconds }),
@@ -207,36 +211,46 @@ function connectionFor(
         : { chartContract: input.chartContract }),
     };
   }
-  if (input.kind !== 'cloud') {
+  if (input.kind !== 'gcp-project') {
     throw new Error('a cluster does not register a cloud Target');
   }
   if (adapter === 'cloudrun') {
     return {
       adapter,
-      project: input.project,
       region: input.region,
       endpoint: input.runEndpoint,
       ...(input.policyEndpoint === undefined
         ? {}
         : { policyEndpoint: input.policyEndpoint }),
-      ...(input.servedHosts === undefined
-        ? {}
-        : { servedHosts: input.servedHosts }),
-      ...(input.reachableRegistries === undefined
-        ? {}
-        : { reachableRegistries: input.reachableRegistries }),
+      // Only this surface has a runtime to have produced output; static
+      // hosting gets §17's honest empty state rather than a duration.
       ...(input.logHistorySeconds === undefined
         ? {}
         : { logHistorySeconds: input.logHistorySeconds }),
     };
   }
+  return { adapter, endpoint: input.hostingEndpoint };
+}
+
+/** The boundary this act connects, as a row to create or update. */
+function vesselFor(input: ConnectTargetInput): {
+  kind: VesselKind;
+  location: VesselLocation;
+  servedHosts: string[] | null;
+  reachableRegistries: string[] | null;
+} {
   return {
-    adapter,
-    project: input.project,
-    endpoint: input.hostingEndpoint,
-    ...(input.servedHosts === undefined
-      ? {}
-      : { servedHosts: input.servedHosts }),
+    kind: input.kind,
+    location:
+      input.kind === 'cluster'
+        ? { kind: 'cluster', apiServer: input.apiServer }
+        : { kind: 'gcp-project', project: input.project },
+    servedHosts:
+      input.servedHosts === undefined ? null : [...input.servedHosts],
+    reachableRegistries:
+      input.reachableRegistries === undefined
+        ? null
+        : [...input.reachableRegistries],
   };
 }
 
@@ -248,7 +262,7 @@ export const connectTarget: Command<
   // This is that time — the operator who typed these is still here to be told
   // which key was not theirs, which is not true of the deploy that would
   // otherwise discover it.
-  if (input.kind === 'kubernetes') {
+  if (input.kind === 'cluster') {
     const issues = operatorValuesIssues(input.chartValues);
     if (issues.length > 0) {
       return failed(
@@ -266,19 +280,52 @@ export const connectTarget: Command<
   const registered: ConnectedTarget[] = [];
   const readopted: string[] = [];
 
-  for (const { name, adapter } of targetNames(input.kind, input.name)) {
+  // The boundary first, because every surface below is a row that references
+  // it. Idempotent by name for the same reason connect is: reconnecting a
+  // project must reuse its vessel rather than mint a second one that its two
+  // surfaces would then be split across.
+  const desiredVessel = vesselFor(input);
+  const existingVessel = (
+    await context.db.select().from(vessels).where(eq(vessels.name, input.name))
+  )[0];
+  const vessel =
+    existingVessel === undefined
+      ? (
+          await context.db
+            .insert(vessels)
+            .values({
+              name: input.name,
+              ...desiredVessel,
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning()
+        )[0]!
+      : (
+          await context.db
+            .update(vessels)
+            .set({ ...desiredVessel, updatedAt: now })
+            .where(eq(vessels.id, existingVessel.id))
+            .returning()
+        )[0]!;
+
+  for (const { name, adapter } of surfaceNames(input.kind, input.name)) {
     const existing = (
       await context.db.select().from(targets).where(eq(targets.name, name))
     )[0];
 
     const connection = connectionFor(input, adapter);
+    // The flat view the adapter takes, composed from the surface just built and
+    // the boundary above it — the same composition the loops perform.
+    const ref = deployTargetOf(
+      { name, adapter, connection },
+      // Built from what was just written rather than re-read: `vesselFor`
+      // always states a location, which the nullable column cannot know.
+      { ...desiredVessel, location: desiredVessel.location },
+    );
     // One pass of the same loop §13 runs on a schedule — not a second notion of
     // what "healthy" means that happens to run at connect time.
-    const { prerequisites, discovery } = await inspectTarget(context, {
-      name,
-      adapter,
-      connection,
-    });
+    const { prerequisites, discovery } = await inspectTarget(context, ref);
     const health = deriveHealth(prerequisites, adapter);
 
     if (existing === undefined) {
@@ -293,6 +340,7 @@ export const connectTarget: Command<
         .values({
           name,
           adapter,
+          vesselId: vessel.id,
           connection,
           health,
           prerequisites,
@@ -318,6 +366,10 @@ export const connectTarget: Command<
     const [row] = await context.db
       .update(targets)
       .set({
+        // A reconnect may move a surface onto a different vessel — connecting
+        // the same name against another project is a correction, not a second
+        // Target.
+        vesselId: vessel.id,
         connection,
         health,
         prerequisites,
@@ -331,12 +383,7 @@ export const connectTarget: Command<
 
     if (existing.status === 'disconnected') {
       readopted.push(
-        ...(await readoptTargetDeploys(
-          context,
-          existing.id,
-          { name, adapter, connection },
-          now,
-        )),
+        ...(await readoptTargetDeploys(context, existing.id, ref, now)),
       );
     }
 

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -84,6 +84,9 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
   context,
 ) => {
   const allTargets = await context.db.query.targets.findMany({
+    // The boundary comes with every surface: it is half of what an adapter is
+    // handed, and it is what groups these rows into connect acts.
+    with: { vessel: true },
     orderBy: (targets, { asc }) => [asc(targets.rank)],
   });
 
@@ -140,10 +143,12 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
       // address problem with the Targets the other way round.
       edit:
         target.adapter === 'kubernetes' &&
-        target.connection?.adapter === 'kubernetes'
+        target.connection?.adapter === 'kubernetes' &&
+        target.vessel.location?.kind === 'cluster'
           ? {
-              apiServer: target.connection.apiServer,
-              proposal: connectionProposal([target], 'kubernetes'),
+              // The cluster's address is the vessel's, not the surface's.
+              apiServer: target.vessel.location.apiServer,
+              proposal: connectionProposal([target], 'cluster'),
             }
           : null,
     });

--- a/apps/spindrift/src/commands/targets/probe.ts
+++ b/apps/spindrift/src/commands/targets/probe.ts
@@ -72,10 +72,12 @@ export const probeCluster: Command<
     );
   }
 
-  const rows = await context.db.query.targets.findMany();
+  const rows = await context.db.query.targets.findMany({
+    with: { vessel: true },
+  });
   return ok({
     probe: await adapter.probe(input.apiServer),
-    proposal: connectionProposal(rows, 'kubernetes'),
+    proposal: connectionProposal(rows, 'cluster'),
     rendersContract: VALUES_CONTRACT,
   });
 };

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -7,9 +7,16 @@
  */
 import { sql } from 'drizzle-orm';
 import type { Database } from '../db/client.ts';
-import { installation, targets } from '../db/schema.ts';
+import { installation, targets, vessels } from '../db/schema.ts';
 import { unreachablePrerequisites } from '../domain/capabilities.ts';
 import type { TargetConnection } from '../domain/target.ts';
+import {
+  claimsDisagree,
+  unionOfClaims,
+  type VesselKind,
+  type VesselLocation,
+  vesselKindFor,
+} from '../domain/vessel.ts';
 import type {
   AuthoredManifest,
   InstallationManifest,
@@ -332,8 +339,11 @@ async function reconcileManifestTargets(
   manifest: AuthoredManifest,
   write: ManifestWrite,
 ): Promise<void> {
+  const reconciledVessels = await reconcileManifestVessels(db, manifest, write);
+
   for (const [rank, target] of manifest.targets.entries()) {
     const { name, adapter } = target;
+    const vessel = reconciledVessels.get(vesselNameOfSeed(target))!;
     const declaredConnection = connectionFromSeed(target);
     const existing = await db.query.targets.findFirst({
       where: (targets, { eq }) => eq(targets.name, name),
@@ -348,16 +358,20 @@ async function reconcileManifestTargets(
       'Declared Target connection is awaiting inspection',
       adapter,
     );
+    // Either half moving invalidates the assessment: the surface's own facts,
+    // or the boundary they are facts about.
     const hasConnectionChange =
-      write === 'declared' &&
-      declaredConnection !== null &&
-      !Bun.deepEquals(existing?.connection, declaredConnection, true);
+      vessel.moved ||
+      (write === 'declared' &&
+        declaredConnection !== null &&
+        !Bun.deepEquals(existing?.connection, declaredConnection, true));
 
     await db
       .insert(targets)
       .values({
         name,
         adapter,
+        vesselId: vessel.id,
         rank,
         status:
           declaredConnection === null
@@ -416,14 +430,205 @@ function assertedBySeed(target: TargetSeed): {
 
 function connectionFromSeed(target: TargetSeed): TargetConnection | null {
   if (target.connection === undefined) return null;
+  // The boundary's half is stripped out here and lands on the vessel instead.
+  // The seed format still states it per surface — see `vesselNameOfSeed` for
+  // why that is deliberate, and #61 for its removal.
   switch (target.adapter) {
-    case 'kubernetes':
-      return { adapter: 'kubernetes', ...target.connection };
-    case 'cloudrun':
-      return { adapter: 'cloudrun', ...target.connection };
-    case 'static':
-      return { adapter: 'static', ...target.connection };
+    case 'kubernetes': {
+      const {
+        apiServer: _apiServer,
+        servedHosts: _servedHosts,
+        reachableRegistries: _reachableRegistries,
+        ...surface
+      } = target.connection;
+      return { adapter: 'kubernetes', ...surface };
+    }
+    case 'cloudrun': {
+      const {
+        project: _project,
+        servedHosts: _servedHosts,
+        reachableRegistries: _reachableRegistries,
+        ...surface
+      } = target.connection;
+      return { adapter: 'cloudrun', ...surface };
+    }
+    case 'static': {
+      const {
+        project: _project,
+        servedHosts: _servedHosts,
+        ...surface
+      } = target.connection;
+      return { adapter: 'static', ...surface };
+    }
   }
+}
+
+/**
+ * Which vessel a seed is a surface of.
+ *
+ * **The one place left that recovers a boundary from a name**, and it is here
+ * rather than in the domain because the *manifest format* still states a
+ * boundary per surface: two cloud seeds say they share a project by being
+ * called `<name>-cloudrun` and `<name>-static`, which `manifest.schema.ts`
+ * enforces. Everything downstream reads `vesselId`.
+ *
+ * Giving the manifest a `vessels` array — and deleting this — is #61. It was
+ * kept out of the change that introduced the Vessel row because a manifest
+ * schema change has a failure mode where the stored document fails validation
+ * and the installation is silently re-seeded from its declaration, which is
+ * worth landing on its own.
+ */
+function vesselNameOfSeed(target: TargetSeed): string {
+  if (target.adapter === 'kubernetes') return target.name;
+  const suffix = `-${target.adapter}`;
+  return target.name.endsWith(suffix)
+    ? target.name.slice(0, -suffix.length)
+    : target.name;
+}
+
+/** The vessels a manifest's seeds describe between them. */
+function vesselsFromSeeds(manifest: AuthoredManifest): Map<
+  string,
+  {
+    kind: VesselKind;
+    location: VesselLocation | null;
+    servedHosts: string[] | null;
+    reachableRegistries: string[] | null;
+  }
+> {
+  const byName = new Map<
+    string,
+    {
+      kind: VesselKind;
+      location: VesselLocation | null;
+      servedHosts: string[] | null;
+      reachableRegistries: string[] | null;
+      served: (readonly string[] | undefined)[];
+      registries: (readonly string[] | undefined)[];
+    }
+  >();
+
+  for (const target of manifest.targets) {
+    const name = vesselNameOfSeed(target);
+    const kind = vesselKindFor(target.adapter);
+    const entry = byName.get(name) ?? {
+      kind,
+      location: null,
+      servedHosts: null,
+      reachableRegistries: null,
+      served: [],
+      registries: [],
+    };
+
+    if (target.connection !== undefined) {
+      // Either surface of a project states the same project id; the first to
+      // arrive settles it, and the schema's pairing rule is what makes them
+      // agree.
+      if (target.adapter === 'kubernetes') {
+        entry.location ??= {
+          kind: 'cluster',
+          apiServer: target.connection.apiServer,
+        };
+        entry.registries.push(target.connection.reachableRegistries);
+      } else {
+        entry.location ??= {
+          kind: 'gcp-project',
+          project: target.connection.project,
+        };
+        if (target.adapter === 'cloudrun') {
+          entry.registries.push(target.connection.reachableRegistries);
+        }
+      }
+      entry.served.push(target.connection.servedHosts);
+    }
+    byName.set(name, entry);
+  }
+
+  const vesselsByName = new Map<
+    string,
+    {
+      kind: VesselKind;
+      location: VesselLocation | null;
+      servedHosts: string[] | null;
+      reachableRegistries: string[] | null;
+    }
+  >();
+  for (const [name, entry] of byName) {
+    // The union, not a winner: two surfaces of one boundary *can* state
+    // different reach today, and silently taking one would be the bug the
+    // Vessel row exists to prevent.
+    const servedHosts = entry.served.some((claim) => claim !== undefined)
+      ? unionOfClaims(entry.served)
+      : null;
+    const reachableRegistries = entry.registries.some(
+      (claim) => claim !== undefined,
+    )
+      ? unionOfClaims(entry.registries)
+      : null;
+    if (claimsDisagree(entry.served) || claimsDisagree(entry.registries)) {
+      console.warn(
+        `installation manifest: the surfaces of vessel ${name} state different reach; ` +
+          'the union is stored, and stating it once per vessel is #61',
+      );
+    }
+    vesselsByName.set(name, {
+      kind: entry.kind,
+      location: entry.location,
+      servedHosts,
+      reachableRegistries,
+    });
+  }
+  return vesselsByName;
+}
+
+/** One reconciled vessel: its id, and whether this pass moved it. */
+interface ReconciledVessel {
+  readonly id: string;
+  /**
+   * Whether the boundary changed in a way its surfaces have to be reassessed
+   * for.
+   *
+   * A Target's checklist is a set of claims about a place — that the namespace
+   * exists, that the federated identity may act there. Move the place and every
+   * one of those claims is about somewhere else, so the surfaces are reassessed
+   * exactly as they are when their own connection changes. Without this a
+   * re-pointed `apiServer` would leave every Target on it reading `healthy`
+   * against a cluster nobody has looked at.
+   */
+  readonly moved: boolean;
+}
+
+/** Create or update the vessels a manifest describes, and return their ids. */
+async function reconcileManifestVessels(
+  db: Pick<Database, 'insert' | 'query'>,
+  manifest: AuthoredManifest,
+  write: ManifestWrite,
+): Promise<Map<string, ReconciledVessel>> {
+  const reconciled = new Map<string, ReconciledVessel>();
+  for (const [name, vessel] of vesselsFromSeeds(manifest)) {
+    const existing = await db.query.vessels.findFirst({
+      where: (vessels, { eq }) => eq(vessels.name, name),
+    });
+    const moved =
+      write === 'declared' &&
+      vessel.location !== null &&
+      !Bun.deepEquals(existing?.location, vessel.location, true);
+    const [row] = await db
+      .insert(vessels)
+      .values({ name, ...vessel })
+      .onConflictDoUpdate({
+        target: vessels.name,
+        set: {
+          kind: vessel.kind,
+          location: vessel.location,
+          servedHosts: vessel.servedHosts,
+          reachableRegistries: vessel.reachableRegistries,
+        },
+      })
+      .returning({ id: vessels.id });
+    reconciled.set(name, { id: row!.id, moved });
+  }
+  return reconciled;
 }
 
 /**

--- a/apps/spindrift/src/db/migrations/0022_vessels.sql
+++ b/apps/spindrift/src/db/migrations/0022_vessels.sql
@@ -1,0 +1,107 @@
+-- The Vessel becomes a row.
+--
+-- §13 declined a noun above `Target`: "the shared thing between them is an
+-- argument to a command, not an entity." That reasoning holds for the *split* —
+-- a cloud project genuinely is two Targets, because placement determines
+-- artifact shape — and not for the absence of the noun. What followed was a
+-- boundary spelled as a name prefix, sliced back off in four separate places,
+-- and boundary facts stored once per surface where two surfaces of one project
+-- could disagree about them.
+--
+-- Additive, then narrowing, in one file: create, backfill, constrain, strip.
+-- The harness replays this verbatim (`test/harness/db.ts`), so the backfill runs
+-- in every database test rather than being a script nobody executes twice.
+
+CREATE TYPE "public"."vessel_kind" AS ENUM('cluster', 'gcp-project');--> statement-breakpoint
+
+CREATE TABLE "vessels" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"kind" "vessel_kind" NOT NULL,
+	-- Nullable for the same reason `targets.connection` is: a manifest seeds a
+	-- vessel's identity without necessarily stating how to reach it, and that
+	-- half-ready state is one §13 intends to be visible.
+	"location" jsonb,
+	"served_hosts" text[],
+	"reachable_registries" text[],
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "vessels_name_unique" UNIQUE("name")
+);--> statement-breakpoint
+
+ALTER TABLE "targets" ADD COLUMN "vessel_id" uuid;--> statement-breakpoint
+
+-- One vessel per cluster. Its Target keeps its own name, because there is no
+-- sibling surface to disambiguate it from.
+INSERT INTO "vessels" ("name", "kind", "location", "served_hosts", "reachable_registries")
+SELECT
+	t."name",
+	'cluster'::"vessel_kind",
+	CASE
+		WHEN t."connection" ? 'apiServer'
+		THEN jsonb_build_object('kind', 'cluster', 'apiServer', t."connection"->>'apiServer')
+	END,
+	ARRAY(SELECT jsonb_array_elements_text(t."connection"->'servedHosts')),
+	ARRAY(SELECT jsonb_array_elements_text(t."connection"->'reachableRegistries'))
+FROM "targets" t
+WHERE t."adapter" = 'kubernetes';--> statement-breakpoint
+
+-- One vessel per cloud project. **The last time a boundary is recovered from a
+-- name**: the two surfaces say they share a project by being called
+-- `<name>-cloudrun` and `<name>-static`, which is the convention this change
+-- retires everywhere except the manifest seeding path (see #61).
+--
+-- `servedHosts` is unioned rather than picked from a winner. Two surfaces of one
+-- project *can* state different reach today, and silently taking one would be
+-- the bug the Vessel row exists to prevent.
+INSERT INTO "vessels" ("name", "kind", "location", "served_hosts", "reachable_registries")
+SELECT
+	regexp_replace(t."name", '-(cloudrun|static)$', ''),
+	'gcp-project'::"vessel_kind",
+	CASE
+		WHEN bool_or(t."connection" ? 'project')
+		THEN jsonb_build_object(
+			'kind', 'gcp-project',
+			'project', min(t."connection"->>'project')
+		)
+	END,
+	ARRAY(
+		SELECT DISTINCT jsonb_array_elements_text(
+			jsonb_path_query_array(jsonb_agg(t."connection"), '$[*].servedHosts[*]')
+		) ORDER BY 1
+	),
+	ARRAY(
+		SELECT DISTINCT jsonb_array_elements_text(
+			jsonb_path_query_array(jsonb_agg(t."connection"), '$[*].reachableRegistries[*]')
+		) ORDER BY 1
+	)
+FROM "targets" t
+WHERE t."adapter" IN ('cloudrun', 'static')
+GROUP BY regexp_replace(t."name", '-(cloudrun|static)$', '');--> statement-breakpoint
+
+UPDATE "targets" t SET "vessel_id" = v."id"
+FROM "vessels" v
+WHERE v."name" = CASE
+	WHEN t."adapter" = 'kubernetes' THEN t."name"
+	ELSE regexp_replace(t."name", '-(cloudrun|static)$', '')
+END;--> statement-breakpoint
+
+-- An empty array is not the same claim as an absent one: absent means nobody
+-- stated it, and `[]` would read as "reaches nothing" (see `exclusionsFor`).
+UPDATE "vessels" SET
+	"served_hosts" = CASE WHEN cardinality("served_hosts") = 0 THEN NULL ELSE "served_hosts" END,
+	"reachable_registries" = CASE WHEN cardinality("reachable_registries") = 0 THEN NULL ELSE "reachable_registries" END;--> statement-breakpoint
+
+ALTER TABLE "targets" ALTER COLUMN "vessel_id" SET NOT NULL;--> statement-breakpoint
+
+-- `restrict`, matching `apps.repository_id`: removing a vessel must never be a
+-- way to delete the Targets that reference it.
+ALTER TABLE "targets" ADD CONSTRAINT "targets_vessel_id_vessels_id_fk"
+	FOREIGN KEY ("vessel_id") REFERENCES "public"."vessels"("id")
+	ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+
+-- The surface keeps only what is true of it and not of its neighbours. What is
+-- true of the boundary now lives in exactly one place.
+UPDATE "targets"
+SET "connection" = "connection" - 'apiServer' - 'project' - 'servedHosts' - 'reachableRegistries'
+WHERE "connection" IS NOT NULL;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1785374380765,
       "tag": "0021_drift_detail",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1785374380766,
+      "tag": "0022_vessels",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -51,6 +51,7 @@ import type {
 import type { Draft } from '../domain/creation-draft.ts';
 import type { ConfigEntry } from '../domain/desired-state.ts';
 import type { TargetConnection } from '../domain/target.ts';
+import { VESSEL_KINDS, type VesselLocation } from '../domain/vessel.ts';
 import type { CoreSignature } from '../supply-chain/sign.ts';
 import type { BackendProvenanceAssessment } from '../supply-chain/verify.ts';
 
@@ -194,6 +195,17 @@ export const targetAdapter = pgEnum('target_adapter', [
   'cloudrun',
   'static',
 ]);
+
+/**
+ * The tenancy boundary a Target is a surface on — `VesselKind` in
+ * `src/domain/vessel.ts`.
+ *
+ * A different axis from {@link targetAdapter}, which names the runtime: a
+ * `gcp-project` carries two adapters, and `kubernetes` is one adapter on a
+ * `cluster`. Kept as an independent enum here for the reason the adapter one
+ * is.
+ */
+export const vesselKind = pgEnum('vessel_kind', VESSEL_KINDS);
 
 /**
  * §13: "Disconnect always works: live Deploys go `orphaned`... reconnect
@@ -835,19 +847,79 @@ export const datastores = pgTable('datastores', {
  * time it reads them. Storing a derived value is storing something that can
  * be stale in a way nothing will notice.
  */
+/**
+ * The tenancy boundary Targets are surfaces on (§13, §14).
+ *
+ * One row per place things deploy into — a cluster, a cloud project, later
+ * whatever other tenancy container a provider offers. What lives here is every
+ * fact that is
+ * true of the boundary rather than of one runtime on it, which is what makes it
+ * impossible for two surfaces to disagree about one of them. See
+ * `src/domain/vessel.ts` for why this noun exists after §13 declined it.
+ */
+export const vessels = pgTable(
+  'vessels',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    name: text('name').notNull(),
+    kind: vesselKind('kind').notNull(),
+    /**
+     * Where the boundary is, in its own kind's terms. Never a credential.
+     *
+     * Null for the same reason `targets.connection` is null: the manifest seeds
+     * a vessel's identity and rank without necessarily stating how to reach it,
+     * and that half-ready state is one §13 intends to be visible rather than
+     * one to fabricate a value for. A Target is addressable exactly when its
+     * own connection **and** its vessel's location are both present.
+     */
+    location: jsonbDocument('location').$type<VesselLocation>(),
+    /** §33's reachability input, stated once for every surface on this vessel. */
+    servedHosts: text('served_hosts').array(),
+    /** §3, and boundary-shaped for the same reason. */
+    reachableRegistries: text('reachable_registries').array(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // Connect is idempotent by name at the vessel level too: reconnecting a
+    // project must reuse its vessel rather than minting a second one that its
+    // surfaces would then be split across.
+    unique('vessels_name_unique').on(table.name),
+  ],
+);
+
 export const targets = pgTable(
   'targets',
   {
     id: uuid('id').primaryKey().defaultRandom(),
     name: text('name').notNull(),
     adapter: targetAdapter('adapter').notNull(),
+    /**
+     * The boundary this Target is a surface on.
+     *
+     * `restrict` rather than `cascade`, matching `apps.repositoryId`: removing
+     * a vessel must never be a way to delete the Targets that reference it,
+     * and a vessel with live surfaces is not a vessel anyone meant to drop.
+     */
+    vesselId: uuid('vessel_id')
+      .notNull()
+      .references(() => vessels.id, { onDelete: 'restrict' }),
     status: targetStatus('status').notNull().default('connected'),
     /** §13: "set a global ordered rank across Targets." */
     rank: integer('rank').notNull(),
     /**
-     * How the adapter reaches this Target — `TargetConnection` in
-     * `src/domain/target.ts`. Never a credential: §13 settles one auth mode,
-     * "native OIDC federation, nothing stored."
+     * The **surface** half of how this Target is reached —
+     * `TargetConnection` in `src/domain/target.ts`. Never a credential: §13
+     * settles one auth mode, "native OIDC federation, nothing stored."
+     *
+     * Only facts true of this runtime and not of its neighbours on the same
+     * vessel: a region, an API root, a namespace, a delivery flavour. Where the
+     * boundary *is*, and what it can reach, belong to {@link vessels} — the
+     * adapter still receives one flat view, composed by `deployTargetOf`.
      *
      * Null means the manifest has established the Target's identity and rank,
      * but neither desired state nor an operator has supplied connection facts.
@@ -1340,9 +1412,17 @@ export const datastoresRelations = relations(datastores, ({ one }) => ({
   }),
 }));
 
-export const targetsRelations = relations(targets, ({ many }) => ({
+export const targetsRelations = relations(targets, ({ one, many }) => ({
+  vessel: one(vessels, {
+    fields: [targets.vesselId],
+    references: [vessels.id],
+  }),
   deploys: many(deploys),
   datastores: many(datastores),
+}));
+
+export const vesselsRelations = relations(vessels, ({ many }) => ({
+  targets: many(targets),
 }));
 
 export const configItemsRelations = relations(configItems, ({ one }) => ({
@@ -1415,6 +1495,8 @@ export type NewComponentTargetDesired =
 export type Datastore = typeof datastores.$inferSelect;
 export type NewDatastore = typeof datastores.$inferInsert;
 export type Target = typeof targets.$inferSelect;
+export type Vessel = typeof vessels.$inferSelect;
+export type NewVessel = typeof vessels.$inferInsert;
 export type NewTarget = typeof targets.$inferInsert;
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -29,7 +29,8 @@ import type {
   PendingTargetConnection,
   TargetConnectionProposal,
 } from '../web/model.ts';
-import { CLOUD_ADAPTERS, type TargetConnection } from './target.ts';
+import { surfaceNames, type TargetConnection } from './target.ts';
+import type { VesselKind } from './vessel.ts';
 
 /** The columns this reasoning reads, without importing the table. */
 export interface OnboardingTargetRow {
@@ -37,12 +38,12 @@ export interface OnboardingTargetRow {
   readonly adapter: TargetAdapter;
   readonly connection: TargetConnection | null;
   readonly health: 'healthy' | 'unhealthy';
-}
-
-/** The project name behind one of a cloud project's two derived Target names. */
-function cloudProjectOf(name: string, adapter: TargetAdapter): string | null {
-  const suffix = `-${adapter}`;
-  return name.endsWith(suffix) ? name.slice(0, -suffix.length) : null;
+  /** The boundary this surface sits on — what groups the rows into acts. */
+  readonly vessel: {
+    readonly id: string;
+    readonly name: string;
+    readonly kind: VesselKind;
+  };
 }
 
 /**
@@ -132,9 +133,9 @@ function cloudProposal(
 /** What a screen would propose for a fresh connect of this shape. */
 export function connectionProposal(
   rows: readonly OnboardingTargetRow[],
-  kind: 'kubernetes' | 'cloud',
+  kind: VesselKind,
 ): TargetConnectionProposal {
-  return kind === 'kubernetes' ? kubernetesProposal(rows) : cloudProposal(rows);
+  return kind === 'cluster' ? kubernetesProposal(rows) : cloudProposal(rows);
 }
 
 /**
@@ -150,41 +151,30 @@ export function pendingConnections(
   rows: readonly OnboardingTargetRow[],
 ): readonly PendingTargetConnection[] {
   const unconfigured = rows.filter((row) => row.connection === null);
-  const pending: PendingTargetConnection[] = [];
-  const cloudProjects = new Set<string>();
+  const byVessel = new Map<string, OnboardingTargetRow[]>();
 
   for (const row of unconfigured) {
-    if (row.adapter === 'kubernetes') {
-      pending.push({
-        kind: 'kubernetes',
-        name: row.name,
-        targets: [row.name],
-        proposal: connectionProposal(rows, 'kubernetes'),
-      });
-      continue;
-    }
-    // A cloud Target whose name does not carry its adapter's suffix cannot be
-    // reached by `connectTarget`, which derives both names from one project
-    // name. Listing it as connectable would offer a button that registers two
-    // Targets neither of which is this row.
-    const project = cloudProjectOf(row.name, row.adapter);
-    if (project === null) continue;
-    cloudProjects.add(project);
+    const group = byVessel.get(row.vessel.id);
+    if (group === undefined) byVessel.set(row.vessel.id, [row]);
+    else group.push(row);
   }
 
-  for (const project of cloudProjects) {
-    pending.push({
-      kind: 'cloud',
-      name: project,
-      // Both names the act will write, whether or not both are unconfigured
-      // today: connecting re-registers the pair, and saying so is what stops
-      // the confirmation from under-reporting what it is about to touch.
-      targets: CLOUD_ADAPTERS.map((adapter) => `${project}-${adapter}`),
-      proposal: connectionProposal(rows, 'cloud'),
-    });
-  }
-
-  return pending;
+  return [...byVessel.values()].map((group) => {
+    const vessel = group[0]!.vessel;
+    return {
+      kind: vessel.kind,
+      name: vessel.name,
+      // Every surface the act will write, whether or not all of them are
+      // unconfigured today: connecting re-registers the whole vessel, and
+      // saying so is what stops the confirmation from under-reporting what it
+      // is about to touch. Read off the vessel's kind rather than recovered
+      // from a name.
+      targets: surfaceNames(vessel.kind, vessel.name).map(
+        (surface) => surface.name,
+      ),
+      proposal: connectionProposal(rows, vessel.kind),
+    };
+  });
 }
 
 // --- Connecting a cluster, one component at a time --------------------------
@@ -233,7 +223,7 @@ export interface ClusterConnectChoices {
 
 /** What `connectTarget` takes for a cluster, assembled from the choices. */
 export interface ClusterConnectPlan {
-  readonly kind: 'kubernetes';
+  readonly kind: 'cluster';
   readonly name: string;
   readonly apiServer: string;
   readonly namespace: string;
@@ -305,7 +295,7 @@ export function clusterConnectPlan(
   ];
 
   return {
-    kind: 'kubernetes',
+    kind: 'cluster',
     name: choices.name,
     apiServer: choices.apiServer,
     namespace: choices.namespace,

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -22,6 +22,7 @@
  *   `observe`, and the confirmation names what it strands."
  */
 import type { TargetAdapter } from '../config/manifest.schema.ts';
+import { surfacesOf, type VesselKind, type VesselLocation } from './vessel.ts';
 
 /**
  * How to reach one Target, in whatever terms its adapter needs.
@@ -67,8 +68,6 @@ export function hasTargetConnection<
  */
 export interface CloudRunConnection {
   adapter: 'cloudrun';
-  /** The vessel project this Target deploys into (§14). */
-  project: string;
   region: string;
   /** The runtime's API root, without a trailing slash. */
   endpoint: string;
@@ -98,9 +97,6 @@ export interface CloudRunConnection {
    * account and the `actAs` grant for exactly this.
    */
   serviceAccount?: string;
-  /** §33's static reachability input, stated by the operator (§3). */
-  servedHosts?: readonly string[];
-  reachableRegistries?: readonly string[];
   /** §18: how far back a tail can honestly reach, in seconds. */
   logHistorySeconds?: number;
 }
@@ -115,12 +111,8 @@ export interface CloudRunConnection {
  */
 export interface StaticConnection {
   adapter: 'static';
-  /** The vessel project this Target's sites live in (§14). */
-  project: string;
   /** The hosting product's API root, without a trailing slash. */
   endpoint: string;
-  /** §33's static reachability input, stated by the operator (§3). */
-  servedHosts?: readonly string[];
 }
 
 /**
@@ -139,19 +131,9 @@ export interface StaticConnection {
  */
 export interface KubernetesConnection {
   adapter: 'kubernetes';
-  /** The API server endpoint (§13's prerequisite is OIDC against it). */
-  apiServer: string;
   /** The namespace an App's workloads land in. Never created by Spindrift (§7). */
   namespace: string;
   delivery: KubernetesDelivery;
-  /**
-   * §33: hosts this Target serves itself, the input to the static reachability
-   * check `offlineDeploy` is derived from. An operator's statement, because no
-   * cluster API reports what it can reach.
-   */
-  servedHosts?: readonly string[];
-  /** Registries reachable from this Target, likewise stated (§3). */
-  reachableRegistries?: readonly string[];
   /**
    * §18: "how far back a tail can honestly reach", in seconds. Stated rather
    * than discovered, because the log store is beside the cluster and not in it.
@@ -221,19 +203,109 @@ export type KubernetesDelivery =
 export interface DeployTargetRef {
   readonly name: string;
   readonly adapter: TargetAdapter;
-  readonly connection: TargetConnection;
+  readonly connection: AdapterConnection;
 }
 
-/** The narrow view of a Target row the adapter contract takes. */
-export function deployTargetOf(target: {
-  name: string;
-  adapter: TargetAdapter;
-  connection: TargetConnection;
-}): DeployTargetRef {
+/**
+ * The flat connection an adapter receives — surface facts plus its vessel's.
+ *
+ * **This is why splitting the row did not move the adapter seam.** An adapter
+ * has always been handed one object carrying everything it needs to reach a
+ * Target, and it still is; core assembles it from two rows instead of one.
+ * Neither `DeployAdapter` nor any conformance test knows the difference, which
+ * is what made normalizing the storage affordable.
+ */
+export type AdapterConnection =
+  | (KubernetesConnection & VesselFacts & { apiServer: string })
+  | (CloudRunConnection & VesselFacts & { project: string })
+  | (StaticConnection & VesselFacts & { project: string });
+
+/** The boundary's half of the flat view, identical for every surface on it. */
+interface VesselFacts {
+  servedHosts?: readonly string[];
+  reachableRegistries?: readonly string[];
+}
+
+/**
+ * One adapter's arm of the flat view.
+ *
+ * Each adapter narrows `DeployTarget.connection` to its own arm before reading
+ * it, exactly as it did when the connection was one row — the discriminant is
+ * still `adapter`, and the shape it selects now simply includes the vessel's
+ * contribution.
+ */
+export type KubernetesAdapterConnection = Extract<
+  AdapterConnection,
+  { adapter: 'kubernetes' }
+>;
+export type CloudRunAdapterConnection = Extract<
+  AdapterConnection,
+  { adapter: 'cloudrun' }
+>;
+export type StaticAdapterConnection = Extract<
+  AdapterConnection,
+  { adapter: 'static' }
+>;
+
+/** The Vessel columns {@link deployTargetOf} reads, without importing the row. */
+export interface VesselRef {
+  readonly location: VesselLocation;
+  readonly servedHosts: readonly string[] | null;
+  readonly reachableRegistries: readonly string[] | null;
+}
+
+/**
+ * Whether a vessel has been told where it is.
+ *
+ * The mirror of {@link hasTargetConnection}, and used beside it: a Target is
+ * addressable exactly when the surface carries its own facts *and* the boundary
+ * carries its location. Both are set by the same act, so in practice they agree
+ * — but the types do not know that, and a guard is cheaper than an invariant
+ * nobody checks.
+ */
+export function hasVesselLocation<
+  T extends { location: VesselLocation | null },
+>(vessel: T): vessel is T & VesselRef {
+  return vessel.location !== null;
+}
+
+/**
+ * The narrow view of a Target row the adapter contract takes.
+ *
+ * Composes the surface's connection with its vessel's location and reach. The
+ * vessel is a parameter rather than something this reads, because a domain
+ * function that queried would be a domain function the database could break —
+ * every caller already joins the row it needs.
+ */
+export function deployTargetOf(
+  target: {
+    name: string;
+    adapter: TargetAdapter;
+    connection: TargetConnection;
+  },
+  vessel: VesselRef,
+): DeployTargetRef {
+  const reach = {
+    ...(vessel.servedHosts === null ? {} : { servedHosts: vessel.servedHosts }),
+    ...(vessel.reachableRegistries === null
+      ? {}
+      : { reachableRegistries: vessel.reachableRegistries }),
+  };
+  const where =
+    vessel.location.kind === 'cluster'
+      ? { apiServer: vessel.location.apiServer }
+      : { project: vessel.location.project };
+
   return {
     name: target.name,
     adapter: target.adapter,
-    connection: target.connection,
+    // The union is discriminated on `adapter`, and the surface half already
+    // carries it, so the spread lands in exactly one arm.
+    connection: {
+      ...target.connection,
+      ...reach,
+      ...where,
+    } as AdapterConnection,
   };
 }
 
@@ -288,25 +360,29 @@ export function deployState(deploy: DeployStateInput): DeployState {
 export const STRANDABLE_PHASES = ['APPLYING', 'WAITING', 'LIVE'] as const;
 
 /**
- * The connect act's two shapes (§13).
+ * The surfaces one connect act registers, and what to call each (§13).
  *
- * "The connect act is credential-shaped though the noun is flat: one 'connect a
- * cloud project' registers both project-specific Targets, so a `Provider` noun
- * earns nothing." A cluster is one Target; a cloud project is two, and which two
- * is a fact about the cloud rather than a choice the operator makes.
+ * §13's split stands: a cluster is one Target and a cloud project is two, and
+ * which two is a fact about the boundary rather than a choice the operator
+ * makes. What changed is that the boundary is now a row, so this returns the
+ * surfaces of a {@link VesselKind} rather than branching on the word "cloud" —
+ * see `SURFACES_BY_VESSEL_KIND` in `vessel.ts`, which is the whole of that fact.
+ *
+ * **The suffix is now decorative.** It is a readable name for a surface, and
+ * nothing parses it back out: which vessel a Target belongs to is its
+ * `vesselId`. A Target named anything at all groups correctly, which is the
+ * behaviour `cloudProjectOf` used to deny.
+ *
+ * A single-surface vessel takes the vessel's own name unchanged: the suffix
+ * exists to tell siblings apart, and a vessel with one surface has none.
  */
-export const CLOUD_ADAPTERS = ['cloudrun', 'static'] as const;
-
-/** Names for the Targets one connect act registers, from the operator's name. */
-export function targetNames(
-  kind: 'kubernetes' | 'cloud',
-  name: string,
+export function surfaceNames(
+  kind: VesselKind,
+  vessel: string,
 ): { name: string; adapter: TargetAdapter }[] {
-  if (kind === 'kubernetes') return [{ name, adapter: 'kubernetes' }];
-  // Suffixed rather than asked for, because the operator connected one project
-  // and §13 makes the split a consequence of the model, not a decision.
-  return CLOUD_ADAPTERS.map((adapter) => ({
-    name: `${name}-${adapter}`,
+  const surfaces = surfacesOf(kind);
+  return surfaces.map((adapter) => ({
+    name: surfaces.length === 1 ? vessel : `${vessel}-${adapter}`,
     adapter,
   }));
 }

--- a/apps/spindrift/src/domain/vessel.ts
+++ b/apps/spindrift/src/domain/vessel.ts
@@ -1,0 +1,150 @@
+/**
+ * The Vessel — the tenancy boundary a Target is a surface on (§13, §14).
+ *
+ * §13 declined a second noun above `Target`: "the connect act is
+ * credential-shaped though the noun is flat, so one 'connect a cloud project'
+ * registers both of that project's Targets and the shared thing between them is
+ * an argument to a command, not an entity."
+ *
+ * That reasoning holds for the *split* and not for the absence of the noun. A
+ * cloud project genuinely is two Targets, because placement determines artifact
+ * shape and a single "Cloud" Target would leave a website ambiguous between the
+ * Cloud Run rendering and the static one. What follows from that is
+ * **Target = Vessel × runtime surface**, not that the vessel does not exist —
+ * and the vessel did exist, spelled as a name prefix that four separate places
+ * sliced back off:
+ *
+ * - the fan-out that minted `<project>-cloudrun` and `<project>-static`,
+ * - `cloudProjectOf` in `target-onboarding.ts`, recovering it for the UI,
+ * - a `superRefine` in the manifest schema validating the convention,
+ * - and `project` / `servedHosts` duplicated across both connections, where two
+ *   surfaces of one boundary could state different values for one fact.
+ *
+ * The forcing argument is what comes next. Every backend worth adding is a
+ * boundary hosting several runtimes: an edge platform's account serves static
+ * sites *and* runs functions, and both are one tenancy boundary with one
+ * credential. So the suffix convention gets load-bearing rather than cheaper.
+ *
+ * **The adapter seam does not move.** `deployTargetOf` composes the flat
+ * `TargetConnection` an adapter already receives out of two rows instead of one,
+ * so `DeployAdapter`, `DeployTarget`, and every conformance test are untouched.
+ * This is a core-side normalization, not a change to §6's contract.
+ */
+import type { TargetAdapter } from '../config/manifest.schema.ts';
+
+/**
+ * What kind of boundary this is.
+ *
+ * Named for the tenancy container itself rather than for the adapter that
+ * drives a surface on it, because those are different axes: a `gcp-project`
+ * carries two adapters, and `kubernetes` is one adapter on a `cluster`. Every
+ * future value is vendor-shaped in the same way, naming one provider's tenancy
+ * container, which is what makes them additive.
+ */
+export const VESSEL_KINDS = ['cluster', 'gcp-project'] as const;
+
+export type VesselKind = (typeof VESSEL_KINDS)[number];
+
+/**
+ * The surfaces each kind of vessel carries (§13's split, as a table).
+ *
+ * This replaces `targetNames()` and `CLOUD_ADAPTERS`. One connect act registers
+ * one row per entry here, which is the same behaviour as before — stated as a
+ * fact about the vessel kind rather than as a branch on the word "cloud".
+ *
+ * Adding a backend is adding a row — one vessel kind mapped to the surfaces it
+ * serves — and needs nothing else in this file.
+ */
+export const SURFACES_BY_VESSEL_KIND = {
+  cluster: ['kubernetes'],
+  'gcp-project': ['cloudrun', 'static'],
+} as const satisfies Record<VesselKind, readonly TargetAdapter[]>;
+
+/** The surfaces one connect act registers on a vessel of this kind. */
+export function surfacesOf(kind: VesselKind): readonly TargetAdapter[] {
+  return SURFACES_BY_VESSEL_KIND[kind];
+}
+
+/** Which kind of vessel carries this surface. */
+export function vesselKindFor(adapter: TargetAdapter): VesselKind {
+  for (const kind of VESSEL_KINDS) {
+    if (
+      (SURFACES_BY_VESSEL_KIND[kind] as readonly string[]).includes(adapter)
+    ) {
+      return kind;
+    }
+  }
+  // Unreachable while the table above covers every adapter, which
+  // `satisfies Record<VesselKind, ...>` and the test in
+  // `test/domain/vessel.test.ts` between them keep true.
+  throw new Error(`no vessel kind carries the ${adapter} surface`);
+}
+
+/**
+ * Where the boundary is, in its own kind's terms.
+ *
+ * A discriminated union rather than nullable columns, for the reason
+ * `TargetConnection` gives: a `cluster` with a project id is not a state the
+ * domain has a name for.
+ *
+ * **No credential, in either arm** (§13). What authorizes a call is minted per
+ * request by whatever federates.
+ */
+export type VesselLocation = ClusterLocation | GcpProjectLocation;
+
+export interface ClusterLocation {
+  kind: 'cluster';
+  /** The API server endpoint. §13's prerequisite is OIDC against it. */
+  apiServer: string;
+}
+
+export interface GcpProjectLocation {
+  kind: 'gcp-project';
+  /** The project every surface on this vessel deploys into (§14). */
+  project: string;
+}
+
+/**
+ * The Vessel row, as the domain reads it.
+ *
+ * Everything here is a fact about the boundary — true for every surface on it,
+ * and therefore impossible for two of them to disagree about. A fact that is
+ * true of one surface and not another belongs on the Target.
+ */
+export interface Vessel {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: VesselKind;
+  readonly location: VesselLocation;
+  /**
+   * §33's static reachability input. A property of the network the boundary
+   * sits on, which is why it is stated once here rather than per surface.
+   */
+  readonly servedHosts: readonly string[];
+  /** §3, and boundary-shaped for the same reason. */
+  readonly reachableRegistries: readonly string[];
+}
+
+/**
+ * Reconcile what two surfaces of one boundary each claimed about it.
+ *
+ * Used by the backfill and by manifest seeding, which are the two paths where a
+ * per-surface statement of a boundary fact still arrives. The union rather than
+ * a winner: today the two *can* disagree, and silently taking one would be the
+ * bug this noun exists to prevent. Callers log when the inputs differ.
+ */
+export function unionOfClaims(
+  claims: readonly (readonly string[] | undefined)[],
+): string[] {
+  return [...new Set(claims.flatMap((claim) => claim ?? []))].sort();
+}
+
+/** Whether two surfaces stated different things about one boundary fact. */
+export function claimsDisagree(
+  claims: readonly (readonly string[] | undefined)[],
+): boolean {
+  const stated = claims.filter((claim) => claim !== undefined);
+  if (stated.length < 2) return false;
+  const first = JSON.stringify([...(stated[0] ?? [])].sort());
+  return stated.some((claim) => JSON.stringify([...claim].sort()) !== first);
+}

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -54,6 +54,7 @@ import {
   type Deploy,
   deploys,
   targets,
+  vessels,
 } from '../db/schema.ts';
 import { recordDeployEvent } from '../domain/attempt-log.ts';
 import type { DesiredState } from '../domain/desired-state.ts';
@@ -67,7 +68,9 @@ import { DEFAULT_PLATFORM } from '../domain/placement.ts';
 import {
   deployTargetOf,
   hasTargetConnection,
+  hasVesselLocation,
   type TargetWithConnection,
+  type VesselRef,
 } from '../domain/target.ts';
 
 /** What the loop needs. No principal: nobody asked for it to run. */
@@ -225,6 +228,8 @@ interface AttemptSubject {
   readonly component: typeof components.$inferSelect;
   readonly build: typeof builds.$inferSelect;
   readonly target: TargetWithConnection<typeof targets.$inferSelect>;
+  /** The boundary the Target is a surface on — half of what the adapter gets. */
+  readonly vessel: typeof vessels.$inferSelect & VesselRef;
   readonly adapter: DeployAdapter;
 }
 
@@ -328,7 +333,7 @@ export async function runAttempt(
     context.manifest,
     await soleServingComponent(context, subject),
   );
-  const targetRef = deployTargetOf(subject.target);
+  const targetRef = deployTargetOf(subject.target, subject.vessel);
 
   let verdict: DeployVerdict;
   try {
@@ -516,7 +521,7 @@ export async function observeConverged(
     let state: ObservedState | null = null;
     try {
       state = await subject.adapter.observe(
-        deployTargetOf(subject.target),
+        deployTargetOf(subject.target, subject.vessel),
         deploy.ref,
       );
     } catch {
@@ -582,17 +587,26 @@ async function subjectOf(
       app: apps,
       build: builds,
       target: targets,
+      vessel: vessels,
     })
     .from(deploys)
     .innerJoin(components, eq(deploys.componentId, components.id))
     .innerJoin(apps, eq(components.appId, apps.id))
     .innerJoin(builds, eq(deploys.buildId, builds.id))
     .innerJoin(targets, eq(deploys.targetId, targets.id))
+    // Inner, not left: `vesselId` is NOT NULL, so a Target with no vessel is
+    // not a state that exists — and joining it here is what lets one read
+    // assemble everything the adapter is handed.
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
     .where(eq(deploys.id, deploy.id));
 
   if (row === undefined) return null;
   const target = row.target;
-  if (!hasTargetConnection(target)) return null;
+  const vessel = row.vessel;
+  // Addressable means both halves: the surface's own facts and the boundary's
+  // location. They are written by one act, so disagreeing is not a state that
+  // occurs — but nothing enforces that, so it is checked rather than assumed.
+  if (!hasTargetConnection(target) || !hasVesselLocation(vessel)) return null;
 
   const adapter = context.adapters.deploy(target.adapter);
   if (adapter === null) return null;
@@ -601,6 +615,7 @@ async function subjectOf(
     deploy,
     ...row,
     target,
+    vessel,
     adapter,
   };
 }

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -24,7 +24,13 @@ import { and, eq, isNotNull } from 'drizzle-orm';
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
-import { deploys, type Target, targets } from '../db/schema.ts';
+import {
+  deploys,
+  type Target,
+  targets,
+  type Vessel,
+  vessels,
+} from '../db/schema.ts';
 import {
   deriveHealth,
   type PrerequisiteResult,
@@ -35,6 +41,7 @@ import {
   type DeployTargetRef,
   deployTargetOf,
   hasTargetConnection,
+  hasVesselLocation,
   type TargetHealth,
 } from '../domain/target.ts';
 
@@ -116,16 +123,23 @@ export async function restoreDeclaredTargetConnections(
   if (declared.size === 0) return [];
 
   const disconnected = await context.db
-    .select()
+    .select({ target: targets, vessel: vessels })
     .from(targets)
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
     .where(eq(targets.status, 'disconnected'));
   const readopted: string[] = [];
 
-  for (const target of disconnected) {
-    if (!declared.has(target.name) || !hasTargetConnection(target)) continue;
+  for (const { target, vessel } of disconnected) {
+    if (
+      !declared.has(target.name) ||
+      !hasTargetConnection(target) ||
+      !hasVesselLocation(vessel)
+    ) {
+      continue;
+    }
 
     const now = context.clock.now();
-    const ref = deployTargetOf(target);
+    const ref = deployTargetOf(target, vessel);
     const { prerequisites, discovery } = await inspectTarget(context, ref);
     const health = deriveHealth(prerequisites, target.adapter);
     await context.db
@@ -212,14 +226,19 @@ export interface TargetRefresh {
 export async function refreshTarget(
   context: TargetLoopContext,
   target: Pick<Target, 'id' | 'name' | 'adapter' | 'health' | 'connection'>,
+  /** The boundary half of what the adapter is handed. */
+  vessel: Pick<Vessel, 'location' | 'servedHosts' | 'reachableRegistries'>,
 ): Promise<TargetRefresh> {
   if (!hasTargetConnection(target)) {
     throw new Error(`Target ${target.name} has no connection to refresh`);
   }
+  if (!hasVesselLocation(vessel)) {
+    throw new Error(`Target ${target.name} sits on a vessel with no location`);
+  }
   const now = context.clock.now();
   const { prerequisites, discovery } = await inspectTarget(
     context,
-    deployTargetOf(target),
+    deployTargetOf(target, vessel),
   );
   const health = deriveHealth(prerequisites, target.adapter);
 
@@ -254,19 +273,20 @@ export async function refreshAllTargets(
   context: TargetLoopContext,
 ): Promise<readonly TargetRefresh[]> {
   const connected = await context.db
-    .select()
+    .select({ target: targets, vessel: vessels })
     .from(targets)
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
     .where(eq(targets.status, 'connected'));
 
   const refreshed: TargetRefresh[] = [];
-  for (const target of connected) {
+  for (const { target, vessel } of connected) {
     // A manifest seed is disconnected, so this is defensive against a
     // malformed row rather than part of the ordinary bootstrap path.
-    if (!hasTargetConnection(target)) continue;
+    if (!hasTargetConnection(target) || !hasVesselLocation(vessel)) continue;
     // Sequential rather than concurrent: the far sides are other people's
     // control planes, and a fleet of Targets refreshing in lockstep is a
     // thundering herd against every one of them at once.
-    refreshed.push(await refreshTarget(context, target));
+    refreshed.push(await refreshTarget(context, target, vessel));
   }
   return refreshed;
 }

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -27,6 +27,7 @@ import type {
   Reach,
 } from '../domain/desired-state.ts';
 import type { Exclusion } from '../domain/placement.ts';
+import type { VesselKind } from '../domain/vessel.ts';
 
 /**
  * §6's phases, verbatim: `PENDING → APPLYING → WAITING → LIVE | FAILED`.
@@ -661,16 +662,19 @@ export interface TargetListItem {
 /**
  * A connect act this installation is waiting on (§13).
  *
- * One entry per *act*, not per Target: connecting a cloud project registers
- * both of its Targets, so `bluenose-cloudrun` and `bluenose-static` are one
- * pending connection named `bluenose`. §13 is explicit that the split is "a
- * consequence of the model, not a decision", and an onboarding screen that
- * listed two cards would be making the operator learn the second noun that
- * decision exists to avoid.
+ * **One entry per vessel**, which is the same thing as one per act: connecting
+ * a project registers every surface on it, so `bluenose-cloudrun` and
+ * `bluenose-static` are one pending connection named `bluenose`. §13 is
+ * explicit that the split is "a consequence of the model, not a decision", and
+ * a screen listing two cards would make the operator learn it.
+ *
+ * The grouping is now a read rather than a reconstruction. These rows share a
+ * `vesselId`; nothing recovers the act's name by slicing a suffix off a
+ * Target's, which is what used to make an off-convention name unconnectable.
  */
 export interface PendingTargetConnection {
-  /** What `connectTarget` takes as its `kind`. */
-  readonly kind: 'kubernetes' | 'cloud';
+  /** What `connectTarget` takes as its `kind` — the vessel's kind. */
+  readonly kind: VesselKind;
   /** What `connectTarget` takes as its `name`. */
   readonly name: string;
   /** Every Target name this one act would configure. */

--- a/apps/spindrift/src/web/streams.ts
+++ b/apps/spindrift/src/web/streams.ts
@@ -20,11 +20,16 @@ import type {
 import type { RequestAuthentication } from '../auth/types.ts';
 import type { CommandContext, Principal } from '../commands/types.ts';
 import { onAttemptEvent } from '../db/notify.ts';
-import { components, deploys, targets } from '../db/schema.ts';
+import { components, deploys, targets, vessels } from '../db/schema.ts';
 import {
   type AttemptLogCursor,
   readAttemptStream,
 } from '../domain/attempt-log.ts';
+import {
+  deployTargetOf,
+  hasTargetConnection,
+  hasVesselLocation,
+} from '../domain/target.ts';
 import {
   ATTEMPT_STREAM_PATH,
   type AttemptStreamMessage,
@@ -197,13 +202,17 @@ async function upgradeRuntime(
     .where(eq(components.id, componentId))
     .limit(1);
   const [target] = await authenticated.context.db
-    .select()
+    .select({ target: targets, vessel: vessels })
     .from(targets)
+    // The boundary carries where this Target is, which the tail needs as much
+    // as the surface's own facts.
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
     .where(eq(targets.id, targetId))
     .limit(1);
   if (!component || !target) {
     return refusal(404, 'NOT_FOUND', 'the Component or Target does not exist');
   }
+  const { target: surface, vessel } = target;
   if (component.kind === 'job') {
     return refusal(
       409,
@@ -217,18 +226,18 @@ async function upgradeRuntime(
     .where(
       and(
         eq(deploys.componentId, component.id),
-        eq(deploys.targetId, target.id),
+        eq(deploys.targetId, surface.id),
       ),
     )
     .limit(1);
-  if (!placed || target.connection === null) {
+  if (!placed || !hasTargetConnection(surface) || !hasVesselLocation(vessel)) {
     return refusal(
       409,
       'NO_RUNTIME',
       'this Component has no runtime on that Target',
     );
   }
-  const adapter = authenticated.context.adapters.deploy(target.adapter);
+  const adapter = authenticated.context.adapters.deploy(surface.adapter);
   if (adapter === null) {
     return refusal(
       409,
@@ -248,11 +257,7 @@ async function upgradeRuntime(
     data: {
       kind: 'runtime',
       adapter,
-      target: {
-        name: target.name,
-        adapter: target.adapter,
-        connection: target.connection,
-      },
+      target: deployTargetOf(surface, vessel),
       subject: { app: app.name, component: component.name },
       cursor: after,
       closed: false,

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -51,6 +51,7 @@ import {
   clusterConnectPlan,
   targetSeedOf,
 } from '../../../domain/target-onboarding.ts';
+import type { VesselKind } from '../../../domain/vessel.ts';
 import { command, type InputOf, type OutputOf } from '../../client.ts';
 import type { TargetConnectionProposal } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
@@ -74,7 +75,7 @@ type Scan =
   | { readonly state: 'failed'; readonly message: string };
 
 export function ConnectTargetForm(props: {
-  kind: 'kubernetes' | 'cloud';
+  kind: VesselKind;
   name: string;
   /** True on the "add a Target" path, where no manifest seed named it. */
   nameEditable?: boolean;
@@ -98,7 +99,7 @@ export function ConnectTargetForm(props: {
   return (
     <div className="flex flex-col gap-4">
       <Heading {...props} />
-      {props.kind === 'kubernetes' ? (
+      {props.kind === 'cluster' ? (
         <ConnectCluster {...props} />
       ) : (
         <ConnectCloud {...props} />
@@ -113,7 +114,7 @@ function Heading({
   targets,
   proposal,
 }: {
-  kind: 'kubernetes' | 'cloud';
+  kind: VesselKind;
   name: string;
   targets: readonly string[];
   proposal: TargetConnectionProposal;
@@ -121,14 +122,14 @@ function Heading({
   return (
     <>
       <div className="flex flex-wrap items-center gap-2">
-        {kind === 'kubernetes' ? (
+        {kind === 'cluster' ? (
           <Server aria-hidden="true" className="size-4 text-muted-foreground" />
         ) : (
           <Layers aria-hidden="true" className="size-4 text-muted-foreground" />
         )}
         <span className="font-mono text-sm font-semibold">{name}</span>
         <Badge tone="idle">
-          {kind === 'kubernetes' ? 'cluster' : 'cloud project'}
+          {kind === 'cluster' ? 'cluster' : 'cloud project'}
         </Badge>
         {proposal.carriedFrom !== null ? (
           <span className="ml-auto text-xs text-muted-foreground">
@@ -711,7 +712,7 @@ function ConnectCloud({
           disabled={!ready || connecting}
           onClick={() =>
             onConnect({
-              kind: 'cloud',
+              kind: 'gcp-project',
               name,
               project: project.trim(),
               region: region.trim(),

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -103,7 +103,7 @@ export function TargetList({
    * there is. With no pending entry there is nothing seeded either, and an empty
    * proposal is the honest input: nothing has been learnt to carry.
    */
-  const clusterProposal = pending.find((entry) => entry.kind === 'kubernetes')
+  const clusterProposal = pending.find((entry) => entry.kind === 'cluster')
     ?.proposal ?? { carriedFrom: null };
 
   return (
@@ -140,7 +140,7 @@ export function TargetList({
         <Card>
           <CardContent>
             <ConnectTargetForm
-              kind="kubernetes"
+              kind="cluster"
               name=""
               nameEditable
               targets={[]}
@@ -221,7 +221,7 @@ function PendingConnections({
                 {entry.name}
               </span>
               <Badge tone="idle">
-                {entry.kind === 'kubernetes' ? 'cluster' : 'cloud project'}
+                {entry.kind === 'cluster' ? 'cluster' : 'cloud project'}
               </Badge>
               <span className="text-xs text-muted-foreground">
                 declared in the manifest, never connected
@@ -388,7 +388,7 @@ function TargetCard({
         {editing && target.edit ? (
           <div className="rounded-md border border-border-soft bg-secondary/40 px-4 py-4">
             <ConnectTargetForm
-              kind="kubernetes"
+              kind="cluster"
               name={target.name}
               apiServer={target.edit.apiServer}
               targets={[target.name]}

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -39,7 +39,7 @@ import {
   deriveVerifiedDeploy,
 } from '../../src/domain/capabilities.ts';
 import type { DesiredState, Reach } from '../../src/domain/desired-state.ts';
-import type { CloudRunConnection } from '../../src/domain/target.ts';
+import type { CloudRunAdapterConnection } from '../../src/domain/target.ts';
 import {
   FakeCloudRun,
   type FakeCloudRunOptions,
@@ -48,7 +48,7 @@ import {
 } from '../harness/fakes/cloudrun-api.ts';
 import { CLOUD_ENDPOINTS } from '../harness/installation.ts';
 
-const CONNECTION: CloudRunConnection = {
+const CONNECTION: CloudRunAdapterConnection = {
   adapter: 'cloudrun',
   project: 'example-vessel',
   region: 'somewhere',
@@ -56,7 +56,9 @@ const CONNECTION: CloudRunConnection = {
   policyEndpoint: CLOUD_ENDPOINTS.policy,
 };
 
-function target(overrides: Partial<CloudRunConnection> = {}): DeployTarget {
+function target(
+  overrides: Partial<CloudRunAdapterConnection> = {},
+): DeployTarget {
   return {
     name: 'cloud',
     adapter: 'cloudrun',

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -20,7 +20,7 @@ import {
 import { prerequisitesFor } from '../../src/domain/capabilities.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
-import { connectionFor } from '../harness/installation.ts';
+import { deployTargetFor } from '../harness/installation.ts';
 
 /**
  * §6's table, transcribed. A reviewer can check this against the spec without
@@ -105,11 +105,7 @@ describe("§6's failure vocabulary", () => {
   });
 });
 
-const target = {
-  name: 'somewhere',
-  adapter: 'kubernetes',
-  connection: connectionFor('kubernetes'),
-} as const;
+const target = deployTargetFor('kubernetes', 'somewhere');
 
 const desired: DesiredState = {
   deploy: 'deploy-1',

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -32,7 +32,7 @@ import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/in
 import { VALUES_CONTRACT } from '../../src/adapters/deploy/kubernetes/values.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import type {
-  KubernetesConnection,
+  KubernetesAdapterConnection,
   KubernetesDelivery,
 } from '../../src/domain/target.ts';
 import {
@@ -69,8 +69,8 @@ const SERVED = {
 };
 
 function connection(
-  overrides: Partial<KubernetesConnection> = {},
-): KubernetesConnection {
+  overrides: Partial<KubernetesAdapterConnection> = {},
+): KubernetesAdapterConnection {
   return {
     adapter: 'kubernetes',
     apiServer: 'https://cluster.example.test',
@@ -82,7 +82,7 @@ function connection(
 }
 
 function target(
-  connectionOverrides: Partial<KubernetesConnection> = {},
+  connectionOverrides: Partial<KubernetesAdapterConnection> = {},
 ): DeployTarget {
   return {
     name: 'cluster',

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -34,7 +34,7 @@ import {
 } from '../../src/adapters/deploy/static/index.ts';
 import { deriveHealth } from '../../src/domain/capabilities.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
-import type { StaticConnection } from '../../src/domain/target.ts';
+import type { StaticAdapterConnection } from '../../src/domain/target.ts';
 import {
   FakeHosting,
   type FakeHostingOptions,
@@ -44,7 +44,7 @@ import { bytes, header, tar, tarball } from '../harness/tar.ts';
 
 const DEPOT = 'https://artifacts.example.test';
 
-const CONNECTION: StaticConnection = {
+const CONNECTION: StaticAdapterConnection = {
   adapter: 'static',
   project: 'example-vessel',
   endpoint: CLOUD_ENDPOINTS.hosting,

--- a/apps/spindrift/test/commands/delete-app.test.ts
+++ b/apps/spindrift/test/commands/delete-app.test.ts
@@ -40,7 +40,7 @@ import {
 } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest } from '../harness/installation.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -97,7 +97,7 @@ function context(registry: AdapterRegistry): CommandContext {
 async function seedTarget(name: string) {
   const [target] = await database()
     .db.insert(targets)
-    .values({ name, adapter: 'kubernetes', rank: 0, health: 'healthy' })
+    .values(targetValues({ name, adapter: 'kubernetes', health: 'healthy' }))
     .returning();
   return target!;
 }

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -45,7 +45,7 @@ import {
 } from '../../src/db/schema.ts';
 import { deployState } from '../../src/domain/target.ts';
 import { restoreDeclaredTargetConnections } from '../../src/reconciler/target-loop.ts';
-import { withIsolatedDatabase } from '../harness/db.ts';
+import { defaultVesselId, withIsolatedDatabase } from '../harness/db.ts';
 import {
   FakeDeployAdapter,
   type FakeDeployAdapterOptions,
@@ -225,13 +225,11 @@ describe('the act is credential-shaped though the noun is flat', () => {
     // act asked for both, and neither Target carries the other's.
     expect((await targetRow('vessel-cloudrun'))?.connection).toEqual({
       adapter: 'cloudrun',
-      project: 'example-vessel',
       region: 'here',
       endpoint: CLOUD_ENDPOINTS.run,
     });
     expect((await targetRow('vessel-static'))?.connection).toEqual({
       adapter: 'static',
-      project: 'example-vessel',
       endpoint: CLOUD_ENDPOINTS.hosting,
     });
   });
@@ -263,6 +261,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
       .values({
         name: 'cluster',
         adapter: 'kubernetes',
+        vesselId: defaultVesselId('cluster'),
         rank: 4,
         status: 'disconnected',
         connection: null,
@@ -292,6 +291,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
         {
           name: 'vessel-cloudrun',
           adapter: 'cloudrun',
+          vesselId: defaultVesselId('gcp-project'),
           rank: 2,
           status: 'disconnected',
           connection: null,
@@ -300,6 +300,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
         {
           name: 'vessel-static',
           adapter: 'static',
+          vesselId: defaultVesselId('gcp-project'),
           rank: 3,
           status: 'disconnected',
           connection: null,

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -22,7 +22,7 @@ import {
   deploys,
   targets,
 } from '../../src/db/schema.ts';
-import { withIsolatedDatabase } from '../harness/db.ts';
+import { defaultVesselId, withIsolatedDatabase } from '../harness/db.ts';
 import {
   SupplyChainHarness,
   testSignature,
@@ -764,11 +764,11 @@ describe('getDeployDetail command', () => {
       .values({
         name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
         adapter: 'kubernetes',
+        vesselId: defaultVesselId('cluster'),
         health: 'healthy',
         rank: 1,
         connection: {
           adapter: 'kubernetes',
-          apiServer: 'https://10.0.0.1:6443',
           namespace: 'default',
           delivery: {
             flavour: 'flux-helmrelease',
@@ -856,11 +856,11 @@ describe('getDeployDetail command', () => {
       .values({
         name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
         adapter: 'kubernetes',
+        vesselId: defaultVesselId('cluster'),
         health: 'healthy',
         rank: 1,
         connection: {
           adapter: 'kubernetes',
-          apiServer: 'https://10.0.0.1:6443',
           namespace: 'default',
           delivery: {
             flavour: 'flux-helmrelease',

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -140,7 +140,6 @@ describe('the stored installation manifest', () => {
         status: 'connected',
         connection: {
           adapter: 'kubernetes',
-          apiServer: 'https://cluster.example.test',
           namespace: 'apps',
           delivery: {
             flavour: 'flux-helmrelease',
@@ -155,7 +154,6 @@ describe('the stored installation manifest', () => {
         status: 'connected',
         connection: {
           adapter: 'cloudrun',
-          project: 'example-vessel',
           region: 'example-region',
           endpoint: 'https://run.example.test',
         },
@@ -165,8 +163,35 @@ describe('the stored installation manifest', () => {
         status: 'connected',
         connection: {
           adapter: 'static',
-          project: 'example-vessel',
           endpoint: 'https://hosting.example.test',
+        },
+      },
+    ]);
+
+    // The boundary facts the seeds stated per surface are stored once. Both
+    // cloud surfaces are one vessel, named for what the suffix used to encode.
+    const vesselRows = await database().db.query.vessels.findMany({
+      orderBy: (vessels, { asc }) => [asc(vessels.name)],
+    });
+    expect(
+      vesselRows
+        // The harness seeds one vessel per kind for fixtures that insert a
+        // Target directly; what this test is about is the ones the manifest
+        // described.
+        .filter((vessel) => !vessel.name.startsWith('fixture-'))
+        .map(({ name, kind, location }) => ({ name, kind, location })),
+    ).toEqual([
+      {
+        name: 'cloud',
+        kind: 'gcp-project',
+        location: { kind: 'gcp-project', project: 'example-vessel' },
+      },
+      {
+        name: 'cluster',
+        kind: 'cluster',
+        location: {
+          kind: 'cluster',
+          apiServer: 'https://cluster.example.test',
         },
       },
     ]);
@@ -208,7 +233,14 @@ describe('the stored installation manifest', () => {
     const cluster = await database().db.query.targets.findFirst({
       where: (targets, { eq }) => eq(targets.name, 'cluster'),
     });
-    expect(cluster?.connection).toMatchObject({
+    // The address moved to the boundary, so that is where the edit lands —
+    // and the surface it carries is still reassessed, because what changed is
+    // still where this Target is.
+    const clusterVessel = await database().db.query.vessels.findFirst({
+      where: (vessels, { eq }) => eq(vessels.name, 'cluster'),
+    });
+    expect(clusterVessel?.location).toEqual({
+      kind: 'cluster',
       apiServer: 'https://replacement.example.test',
     });
     expect(cluster?.health).toBe('unhealthy');
@@ -226,7 +258,8 @@ describe('the stored installation manifest', () => {
     // Target through the product and the document still declares the old one.
     const corrected = {
       adapter: 'kubernetes' as const,
-      apiServer: 'https://cluster.example.test',
+      // No `apiServer`: where the cluster is belongs to its vessel now, and
+      // this is the surface's half.
       namespace: 'apps',
       delivery: {
         flavour: 'flux-helmrelease' as const,
@@ -348,7 +381,6 @@ describe('the stored installation manifest', () => {
         status: 'connected',
         connection: {
           adapter: 'kubernetes',
-          apiServer: 'https://cluster.example.test',
           namespace: 'apps',
           delivery: {
             flavour: 'flux-helmrelease',
@@ -374,7 +406,6 @@ describe('the stored installation manifest', () => {
     expect(after?.status).toBe('connected');
     expect(after?.connection).toEqual({
       adapter: 'kubernetes',
-      apiServer: 'https://cluster.example.test',
       namespace: 'apps',
       delivery: {
         flavour: 'flux-helmrelease',

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -34,7 +34,7 @@ import type {
   ArtifactType,
   DesiredState,
 } from '../../src/domain/desired-state.ts';
-import { connectionFor } from '../harness/installation.ts';
+import { deployTargetFor } from '../harness/installation.ts';
 
 /** Names the suite has been run over, collected as the suites declare them. */
 const enrolled = {
@@ -116,11 +116,7 @@ export function deployAdapterSuite(
 
   describe(`deploy contract: ${label}`, () => {
     const adapter = make().adapter;
-    const target: DeployTarget = {
-      name: 'target',
-      adapter,
-      connection: connectionFor(adapter),
-    };
+    const target: DeployTarget = deployTargetFor(adapter, 'target');
 
     test('declares at least one artifact type it accepts', () => {
       expect(make().artifactTypes.length).toBeGreaterThan(0);

--- a/apps/spindrift/test/domain/target-onboarding.test.ts
+++ b/apps/spindrift/test/domain/target-onboarding.test.ts
@@ -14,13 +14,24 @@ import {
   pendingConnections,
 } from '../../src/domain/target-onboarding.ts';
 
+const OFFSITE_VESSEL = {
+  id: 'vessel-offsite',
+  name: 'offsite',
+  kind: 'cluster',
+} as const;
+const BLUENOSE_VESSEL = {
+  id: 'vessel-bluenose',
+  name: 'bluenose',
+  kind: 'gcp-project',
+} as const;
+
 const CLUSTER: OnboardingTargetRow = {
   name: 'offsite',
   adapter: 'kubernetes',
   health: 'healthy',
+  vessel: OFFSITE_VESSEL,
   connection: {
     adapter: 'kubernetes',
-    apiServer: 'https://kubernetes.default.svc',
     namespace: 'spindrift-apps',
     delivery: {
       flavour: 'flux-helmrelease',
@@ -35,9 +46,9 @@ const CLOUD_RUN: OnboardingTargetRow = {
   name: 'bluenose-cloudrun',
   adapter: 'cloudrun',
   health: 'healthy',
+  vessel: BLUENOSE_VESSEL,
   connection: {
     adapter: 'cloudrun',
-    project: 'bluenose',
     region: 'northamerica-northeast1',
     endpoint: 'https://run.googleapis.example',
     policyEndpoint: 'https://binaryauthorization.googleapis.example',
@@ -48,9 +59,9 @@ const CLOUD_STATIC: OnboardingTargetRow = {
   name: 'bluenose-static',
   adapter: 'static',
   health: 'healthy',
+  vessel: BLUENOSE_VESSEL,
   connection: {
     adapter: 'static',
-    project: 'bluenose',
     endpoint: 'https://firebasehosting.googleapis.example',
   },
 };
@@ -58,8 +69,11 @@ const CLOUD_STATIC: OnboardingTargetRow = {
 function unconfigured(
   name: string,
   adapter: OnboardingTargetRow['adapter'],
+  vessel: OnboardingTargetRow['vessel'] = adapter === 'kubernetes'
+    ? OFFSITE_VESSEL
+    : BLUENOSE_VESSEL,
 ): OnboardingTargetRow {
-  return { name, adapter, health: 'unhealthy', connection: null };
+  return { name, adapter, health: 'unhealthy', connection: null, vessel };
 }
 
 describe('what is still waiting to be connected', () => {
@@ -83,7 +97,7 @@ describe('what is still waiting to be connected', () => {
 
     expect(pending).toHaveLength(1);
     expect(pending[0]).toMatchObject({
-      kind: 'cloud',
+      kind: 'gcp-project',
       name: 'bluenose',
       targets: ['bluenose-cloudrun', 'bluenose-static'],
     });
@@ -103,21 +117,35 @@ describe('what is still waiting to be connected', () => {
     ]);
   });
 
-  test('a cloud Target whose name carries no adapter suffix is not offered', () => {
-    // `connectTarget` derives both names from one project name, so there is no
-    // input that would produce this row. A button for it would register two
-    // Targets, neither of them this one.
-    expect(pendingConnections([unconfigured('bluenose', 'cloudrun')])).toEqual(
-      [],
-    );
+  test('a Target whose name carries no adapter suffix is still offered', () => {
+    // This used to be dropped: the act's name was recovered by slicing the
+    // adapter suffix off the row's, so a row that carried none was
+    // unconnectable — a Target the screen listed nowhere and no button could
+    // reach. The boundary is a row now, so the name is read rather than
+    // reconstructed and the convention binds nothing.
+    expect(
+      pendingConnections([unconfigured('anything-at-all', 'cloudrun')]),
+    ).toEqual([
+      {
+        kind: 'gcp-project',
+        name: BLUENOSE_VESSEL.name,
+        targets: [
+          `${BLUENOSE_VESSEL.name}-cloudrun`,
+          `${BLUENOSE_VESSEL.name}-static`,
+        ],
+        proposal: { carriedFrom: null },
+      },
+    ]);
   });
 
-  test('a cluster is one act named exactly as the manifest seeded it', () => {
+  test('a cluster is one act named for the vessel it sits on', () => {
     expect(pendingConnections([unconfigured('folly', 'kubernetes')])).toEqual([
       {
-        kind: 'kubernetes',
-        name: 'folly',
-        targets: ['folly'],
+        kind: 'cluster',
+        name: OFFSITE_VESSEL.name,
+        // One surface, so it takes the vessel's name unchanged: the suffix
+        // exists to tell siblings apart and there are none.
+        targets: [OFFSITE_VESSEL.name],
         proposal: { carriedFrom: null },
       },
     ]);
@@ -126,12 +154,14 @@ describe('what is still waiting to be connected', () => {
 
 describe('what a connect may be prefilled with', () => {
   test('nothing, when this installation has nothing to learn from', () => {
-    expect(connectionProposal([], 'kubernetes')).toEqual({ carriedFrom: null });
-    expect(connectionProposal([], 'cloud')).toEqual({ carriedFrom: null });
+    expect(connectionProposal([], 'cluster')).toEqual({ carriedFrom: null });
+    expect(connectionProposal([], 'gcp-project')).toEqual({
+      carriedFrom: null,
+    });
   });
 
   test('a cluster carries its delivery and namespace, never its API server', () => {
-    const proposal = connectionProposal([CLUSTER], 'kubernetes');
+    const proposal = connectionProposal([CLUSTER], 'cluster');
 
     expect(proposal).toEqual({
       carriedFrom: 'offsite',
@@ -145,7 +175,10 @@ describe('what a connect may be prefilled with', () => {
   });
 
   test('a cloud project carries its endpoints and region, never its project id', () => {
-    const proposal = connectionProposal([CLOUD_RUN, CLOUD_STATIC], 'cloud');
+    const proposal = connectionProposal(
+      [CLOUD_RUN, CLOUD_STATIC],
+      'gcp-project',
+    );
 
     expect(proposal).toEqual({
       carriedFrom: 'bluenose-cloudrun',
@@ -166,14 +199,14 @@ describe('what a connect may be prefilled with', () => {
 
     // Copying a Target that does not work forward is the fastest way to turn
     // one broken Target into two.
-    expect(connectionProposal([broken, CLUSTER], 'kubernetes')).toMatchObject({
+    expect(connectionProposal([broken, CLUSTER], 'cluster')).toMatchObject({
       carriedFrom: 'offsite',
     });
   });
 
   test('it falls back to an unhealthy Target rather than proposing nothing', () => {
     const broken: OnboardingTargetRow = { ...CLUSTER, health: 'unhealthy' };
-    expect(connectionProposal([broken], 'kubernetes')).toMatchObject({
+    expect(connectionProposal([broken], 'cluster')).toMatchObject({
       carriedFrom: 'offsite',
     });
   });

--- a/apps/spindrift/test/extraction/no-dns-credential.test.ts
+++ b/apps/spindrift/test/extraction/no-dns-credential.test.ts
@@ -23,9 +23,13 @@
  *
  * That the claim is not satisfied *vacuously* — by there being no DNS at all —
  * is asserted where the records now live, in
- * `packages/charts/spindrift-app/tests/render.test.ts`. There is no allowlist
- * here: nothing in `src/` has any reason to name a zone provider, including to
- * explain that it does not.
+ * `packages/charts/spindrift-app/tests/render.test.ts`.
+ *
+ * One exemption, and it is about naming rather than holding — see
+ * {@link NAMES_A_BRAND}. Everything else under `src/` is scanned, prose
+ * included: a comment explaining that this software holds no zone credential
+ * is still a comment naming a zone provider, and that rule is easier to keep
+ * than to argue with.
  */
 import { describe, expect, test } from 'bun:test';
 import { readdir } from 'node:fs/promises';
@@ -66,6 +70,21 @@ const FORBIDDEN: readonly { pattern: RegExp; why: string }[] = [
 
 const BINARY = /\.(png|jpe?g|gif|ico|webp|avif|woff2?|ttf|otf|pdf|zip|gz)$/i;
 
+/**
+ * Where a provider's **name** is the subject rather than a credential.
+ *
+ * The logo module maps a platform's name to its mark so the UI can render it,
+ * which is the one legitimate reason this software says a provider's name out
+ * loud: a brand on a button is not a zone token, and the module holds no
+ * client, no endpoint, and nothing to authenticate with. A directory rather
+ * than a file, because the marks are assets beside their index.
+ *
+ * Narrow on purpose. Every other path under `src/` is still scanned, and the
+ * test below proves the exemption does not extend to a file that merely has
+ * "logos" in its name.
+ */
+const NAMES_A_BRAND = 'src/web/client/logos/';
+
 interface SourceFile {
   path: string;
   source: string;
@@ -90,6 +109,7 @@ async function readSource(dir: string): Promise<SourceFile[]> {
 function findCredentials(files: readonly SourceFile[]): string[] {
   const offenders: string[] = [];
   for (const file of files) {
+    if (file.path.startsWith(NAMES_A_BRAND)) continue;
     for (const { pattern, why } of FORBIDDEN) {
       if (pattern.test(file.source)) {
         offenders.push(`${file.path}: ${pattern} — ${why}`);
@@ -128,6 +148,16 @@ describe('the scanner catches a deliberately dirty file', () => {
     const dirty: SourceFile[] = [
       {
         path: 'src/adapters/dns/zone.ts',
+        source: "import Cloudflare from 'cloudflare';\n",
+      },
+    ];
+    expect(findCredentials(dirty)).not.toEqual([]);
+  });
+
+  test('the brand exemption is that directory, not any file naming a logo', () => {
+    const dirty: SourceFile[] = [
+      {
+        path: 'src/web/views/targets/logos.ts',
         source: "import Cloudflare from 'cloudflare';\n",
       },
     ];

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -25,6 +25,7 @@ import {
 import { BUILD_ROUTE_REFUSALS } from '../../src/domain/build-route.ts';
 import { PRESET_DEPENDENCIES } from '../../src/domain/detection/declared.ts';
 import { KUBERNETES_DELIVERY_FLAVOURS } from '../../src/domain/target.ts';
+import { VESSEL_KINDS } from '../../src/domain/vessel.ts';
 
 const APP = join(import.meta.dir, '../..');
 
@@ -70,6 +71,10 @@ const PROJECT_ID_ALLOWLIST = new Set<string>([
   // Delivery flavours wear the same shape and are the same kind of thing: the
   // name of a mechanism this software knows, identical in every installation.
   ...KUBERNETES_DELIVERY_FLAVOURS,
+  // The tenancy boundaries a Target can sit on. `gcp-project` names a kind of
+  // place, not a place: every installation with a cloud vessel has one, and the
+  // project it points at is in the row rather than in this source.
+  ...VESSEL_KINDS,
   // Why a build route is not usable for a Target — vocabulary again, read from
   // the domain rather than restated, so adding one does not break a test here.
   ...BUILD_ROUTE_REFUSALS,

--- a/apps/spindrift/test/harness/db.ts
+++ b/apps/spindrift/test/harness/db.ts
@@ -42,6 +42,8 @@ import {
   type Database,
   databaseUrl,
 } from '../../src/db/client.ts';
+import { vessels } from '../../src/db/schema.ts';
+import { VESSEL_KINDS, type VesselKind } from '../../src/domain/vessel.ts';
 
 const MIGRATIONS = join(import.meta.dir, '../../src/db/migrations');
 
@@ -116,6 +118,29 @@ export interface IsolatedDatabase {
 }
 
 /**
+ * The vessel a fixture Target sits on, one per kind, per isolated database.
+ *
+ * `targets.vessel_id` is NOT NULL, so every Target row a test inserts needs a
+ * boundary to reference. Seeding one here rather than asking each of the forty
+ * insert sites to build a pair keeps those tests about what they were about —
+ * and the pair is what production always has, so a fixture without one would be
+ * a row the schema does not permit.
+ *
+ * Read synchronously by `targetValues()`, which is a value builder and cannot
+ * await. Set by {@link createIsolatedDatabase} before any test body runs.
+ */
+let defaultVessels: Readonly<Record<VesselKind, string>> | null = null;
+
+export function defaultVesselId(kind: VesselKind): string {
+  if (defaultVessels === null) {
+    throw new Error(
+      'no isolated database is open — defaultVesselId() was read outside a test',
+    );
+  }
+  return defaultVessels[kind];
+}
+
+/**
  * Create, migrate, and hand back one private schema.
  *
  * Callers that want it around every test should use {@link withIsolatedDatabase};
@@ -142,10 +167,31 @@ export async function createIsolatedDatabase(): Promise<IsolatedDatabase> {
     await client.unsafe(statement);
   }
 
+  const db = createDb(client);
+  const seeded = await db
+    .insert(vessels)
+    .values(
+      VESSEL_KINDS.map((kind) => ({
+        name: `fixture-${kind}`,
+        kind,
+        location:
+          kind === 'cluster'
+            ? ({
+                kind: 'cluster',
+                apiServer: 'https://cluster.example.test',
+              } as const)
+            : ({ kind: 'gcp-project', project: 'example-vessel' } as const),
+      })),
+    )
+    .returning({ id: vessels.id, kind: vessels.kind });
+  defaultVessels = Object.fromEntries(
+    seeded.map((row) => [row.kind, row.id]),
+  ) as Record<VesselKind, string>;
+
   return {
     schema,
     client,
-    db: createDb(client),
+    db,
     connect,
     async close() {
       for (const open of opened) await open.close();

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -27,8 +27,20 @@ import {
   parseManifest,
   resolveManifest,
 } from '../../src/config/manifest.ts';
-import type { NewTarget } from '../../src/db/schema.ts';
-import type { TargetConnection } from '../../src/domain/target.ts';
+import type { Database } from '../../src/db/client.ts';
+import {
+  type NewTarget,
+  type NewVessel,
+  type Vessel,
+  vessels,
+} from '../../src/db/schema.ts';
+import {
+  type DeployTargetRef,
+  deployTargetOf,
+  type TargetConnection,
+} from '../../src/domain/target.ts';
+import { vesselKindFor } from '../../src/domain/vessel.ts';
+import { defaultVesselId } from './db.ts';
 
 const FIXTURE = join(import.meta.dir, '../fixtures/installation.example.yaml');
 
@@ -86,7 +98,7 @@ export function clusterInput(
   overrides: Partial<KubernetesConnectInput> = {},
 ): KubernetesConnectInput {
   return {
-    kind: 'kubernetes',
+    kind: 'cluster',
     name: 'cluster',
     apiServer: 'https://cluster.example.test',
     namespace: 'apps',
@@ -124,7 +136,7 @@ export function clusterInput(
 /** The kubernetes arm of `connectTargetInput`. */
 export type KubernetesConnectInput = Extract<
   ConnectTargetInput,
-  { kind: 'kubernetes' }
+  { kind: 'cluster' }
 >;
 
 /**
@@ -146,7 +158,7 @@ export function cloudInput(
   overrides: Partial<CloudConnectInput> = {},
 ): CloudConnectInput {
   return {
-    kind: 'cloud',
+    kind: 'gcp-project',
     name: 'cloud',
     project: 'example-vessel',
     region: 'somewhere',
@@ -157,16 +169,24 @@ export function cloudInput(
 }
 
 /** The cloud arm of `connectTargetInput`. */
-export type CloudConnectInput = Extract<ConnectTargetInput, { kind: 'cloud' }>;
+export type CloudConnectInput = Extract<
+  ConnectTargetInput,
+  { kind: 'gcp-project' }
+>;
 
-/** A connection of the shape one adapter type needs. */
+/**
+ * The **surface** half of a connection, as its adapter needs it.
+ *
+ * Where the boundary is, and what it can reach, are {@link vesselFor}'s — the
+ * same split the row has. A test that needs the flat view an adapter receives
+ * composes them with `deployTargetOf`, exactly as core does.
+ */
 export function connectionFor(adapter: TargetAdapter): TargetConnection {
   switch (adapter) {
     case 'kubernetes': {
       const input = clusterInput();
       return {
         adapter,
-        apiServer: input.apiServer,
         namespace: input.namespace,
         delivery: input.delivery,
         // Mirrors what the connect act stores, field for field: a helper that
@@ -184,7 +204,6 @@ export function connectionFor(adapter: TargetAdapter): TargetConnection {
       const input = cloudInput();
       return {
         adapter,
-        project: input.project,
         region: input.region,
         endpoint: input.runEndpoint,
         policyEndpoint: CLOUD_ENDPOINTS.policy,
@@ -192,13 +211,62 @@ export function connectionFor(adapter: TargetAdapter): TargetConnection {
     }
     case 'static': {
       const input = cloudInput();
-      return {
-        adapter,
-        project: input.project,
-        endpoint: input.hostingEndpoint,
-      };
+      return { adapter, endpoint: input.hostingEndpoint };
     }
   }
+}
+
+/** The boundary one adapter's surfaces sit on. */
+export function vesselFor(adapter: TargetAdapter): NewVessel {
+  const kind = vesselKindFor(adapter);
+  return {
+    name: `vessel-${crypto.randomUUID()}`,
+    kind,
+    location:
+      kind === 'cluster'
+        ? { kind: 'cluster', apiServer: clusterInput().apiServer }
+        : { kind: 'gcp-project', project: cloudInput().project },
+  };
+}
+
+/**
+ * A vessel row a Target can reference, inserted and returned.
+ *
+ * Every Target needs one — `vesselId` is NOT NULL — so this is what most
+ * fixtures reach for rather than building the pair by hand.
+ */
+export async function insertVessel(
+  db: Database,
+  adapter: TargetAdapter = 'kubernetes',
+  overrides: Partial<NewVessel> = {},
+): Promise<Vessel> {
+  const [row] = await db
+    .insert(vessels)
+    .values({ ...vesselFor(adapter), ...overrides })
+    .returning();
+  return row!;
+}
+
+/**
+ * The flat view an adapter receives, composed exactly as core composes it.
+ *
+ * A test that calls an adapter verb wants this rather than {@link connectionFor}
+ * on its own: the surface half alone is not addressable, and building the pair
+ * by hand in each test is how the two drift apart.
+ */
+export function deployTargetFor(
+  adapter: TargetAdapter,
+  name = `target-${adapter}`,
+): DeployTargetRef {
+  const vessel = vesselFor(adapter);
+  return deployTargetOf(
+    { name, adapter, connection: connectionFor(adapter) },
+    {
+      location: vessel.location!,
+      servedHosts: vessel.servedHosts ?? null,
+      reachableRegistries: vessel.reachableRegistries ?? null,
+    },
+  );
 }
 
 /** A complete, healthy Target row, with anything a test cares about overridden. */
@@ -208,6 +276,9 @@ export function targetValues(overrides: Partial<NewTarget> = {}): NewTarget {
     name: `target-${crypto.randomUUID()}`,
     adapter,
     rank: 0,
+    // The isolated database seeds one vessel per kind; a Target that wants its
+    // own passes it. See `defaultVesselId`.
+    vesselId: defaultVesselId(vesselKindFor(adapter)),
     connection: connectionFor(adapter),
     health: 'healthy',
     // The cluster fixture wires an ExternalAuth backend, so it asserts the edge

--- a/apps/spindrift/test/reconciler/target-loop.test.ts
+++ b/apps/spindrift/test/reconciler/target-loop.test.ts
@@ -20,7 +20,7 @@ import type {
   CommandContext,
 } from '../../src/commands/types.ts';
 import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
-import { apps, components, targets } from '../../src/db/schema.ts';
+import { apps, components, targets, vessels } from '../../src/db/schema.ts';
 import { prerequisitesFor } from '../../src/domain/capabilities.ts';
 import {
   refreshAllTargets,
@@ -91,6 +91,15 @@ async function targetRow(name: string) {
     .db.select()
     .from(targets)
     .where(eq(targets.name, name));
+  return rows[0]!;
+}
+
+/** The boundary a Target sits on — half of what `refreshTarget` inspects. */
+async function vesselOf(id: string) {
+  const rows = await database()
+    .db.select()
+    .from(vessels)
+    .where(eq(vessels.id, id));
   return rows[0]!;
 }
 
@@ -172,10 +181,18 @@ describe('one pass over every connected Target', () => {
       .returning();
 
     const down: AdapterRegistry = { ...registry, deploy: () => unreachable };
-    await refreshTarget(context(down, clock), row!);
+    await refreshTarget(
+      context(down, clock),
+      row!,
+      await vesselOf(row!.vesselId),
+    );
     expect((await targetRow('cluster')).health).toBe('unhealthy');
 
-    await refreshTarget(context(registry, clock), await targetRow('cluster'));
+    await refreshTarget(
+      context(registry, clock),
+      await targetRow('cluster'),
+      await vesselOf(row!.vesselId),
+    );
     expect((await targetRow('cluster')).health).toBe('healthy');
   });
 });

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -718,7 +718,7 @@ describe('the Targets surface', () => {
   test('offers to finish a Target the manifest seeded and nobody connected', () => {
     const markup = targets([
       {
-        kind: 'cloud',
+        kind: 'gcp-project',
         name: 'a-project',
         targets: ['a-project-cloudrun', 'a-project-static'],
         proposal: {


### PR DESCRIPTION
§13 declined a noun above `Target` — "the shared thing between them is an argument to a command, not an entity." That reasoning holds for the **split** and not for the absence of the noun. A cloud project genuinely is two Targets, because placement determines artifact shape and a single "Cloud" Target would leave a website ambiguous between the two renderings. What follows is **Target = Vessel × runtime surface**, not that the vessel does not exist.

It existed. It was spelled as a name prefix, and four places sliced it back off:

| Site | What it did |
| --- | --- |
| `domain/target.ts` | `targetNames()` minted `<project>-cloudrun` / `<project>-static` |
| `domain/target-onboarding.ts` | `cloudProjectOf()` — `name.slice(0, -suffix.length)` to get it back |
| `config/manifest.schema.ts` | a `superRefine` validating the suffix pairing |
| `domain/target.ts` | `project` / `servedHosts` duplicated across both connections |

The convention was load-bearing, not decorative: a cloud Target whose name lacked its adapter suffix **could not be reached by `connectTarget` at all**, which `target-onboarding.ts` said out loud and worked around.

## What changes

The boundary becomes a row. What is true of the place lives on `vessels` — where it is, the hosts it serves, the registries it can pull from. What is true of one runtime stays on the Target: a region, an API root, a namespace, a delivery flavour.

**The adapter seam does not move**, which is what made this affordable. `deployTargetOf(target, vessel)` composes the flat connection an adapter has always received out of two rows instead of one, so `DeployAdapter`, `DeployTarget`, and every conformance test are untouched — no adapter logic changed. Where the facts are *kept* is core's normalization, not that seam's business.

`vessel_kind` names the tenancy container rather than reusing the connect act's `kubernetes | cloud`. Two values, no external consumers, cheapest this rename will ever be. `SURFACES_BY_VESSEL_KIND` replaces `targetNames` and `CLOUD_ADAPTERS`, and is where a boundary serving several runtimes lands with no other change.

Target names are unchanged — `bluenose-cloudrun` stays. The suffix stops being *parsed*, so no live row is renamed, the migration stays small, and a Target named anything at all now groups onto its vessel correctly.

## One thing the tests caught that the plan missed

Moving a vessel's location left its surfaces reading `healthy` against a cluster nobody had re-inspected. A Target's checklist is a set of claims about a place, so moving the place invalidates every one of them. A vessel that moves now reassesses its surfaces exactly as a changed connection does.

## The manifest is deliberately untouched

A schema change there has a failure mode where the stored document fails validation and the installation is **silently re-seeded from its declaration**, discarding whatever was configured through the UI. Worth landing on its own rather than beside a table split.

So `manifest-store.ts` derives a vessel from a seed pair on the way in, and that is the one remaining place a boundary is recovered from a name — four sites down to one, and the survivor confined to a boundary adapter rather than load-bearing in the domain, the connect command, and the UI. Where two surfaces of one vessel state different reach, the union is stored and the disagreement logged; silently taking one would be the bug this noun exists to prevent.

## Migration

`0022_vessels.sql`, hand-written with its backfill, following this repo's convention (drizzle snapshots stop at `0013`; everything since is hand-written). Additive then narrowing: create, backfill, constrain, strip. The harness replays committed SQL verbatim, so the backfill runs in every database test rather than being a script nobody executes twice.

## The second commit unbreaks `main`

`main` is currently red, and it is my doing. #1650 removed the DNS scanner's allowlist, arguing nothing in `src/` has reason to name a zone provider — and #1651 landed beside it with a logo module mapping a platform's name to its mark. Both were right; they merged into a contradiction.

One exemption, scoped to that directory, with a test proving it does not extend to a file that merely has "logos" in its name. A brand on a button is not a zone token: the module holds no client, no endpoint, and nothing to authenticate with.

## Verification

- `bun test` — **1406 pass**, against a real Postgres.
- `tsc --noEmit` — clean across `src/` and `test/`.
- `bun run lint` — exits 0.
- The extraction greps earned their keep twice: they caught provider and installation names I had written into `src/` comments (reworded), and then the collision above. `VESSEL_KINDS` joins the project-id allowlist beside the other vocabularies, read from the domain as those are.

Two onboarding tests asserted the behaviour this removes — including one named *"a cloud Target whose name carries no adapter suffix is not offered"*. Rewritten to assert it **is** offered.

### Unrelated flake, for the record

`test/db/migrate.test.ts` can fail under full-suite load: its `afterEach` allows 15s, and `DROP DATABASE ... WITH (FORCE)` forces a checkpoint that took 15–30s on my local Postgres. Verified pre-existing — the same instrumentation on `main` shows the same times and the same failure. Untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
