### PR TITLE
fix(spindrift): attest the manifests under the index, not only the index

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -413,18 +413,11 @@ jobs:
           version="${version:-1}"
           echo "attesting with key version ${version}"
 
-          # Once per destination, and for a sharper reason than the signature:
-          # an attestation is an occurrence bound to an **`--artifact-url`**, so
-          # one made against `ghcr.io/…` says nothing about the same digest at
-          # `…-docker.pkg.dev/…`. Binary Authorization would refuse the exact
-          # image it had already attested, because the URL it was asked about is
-          # not the URL it was told about.
-          while IFS= read -r destination; do
-            [ -n "$destination" ] || continue
-            echo "attesting ${destination}@${DIGEST}"
+          attest() {
+            echo "attesting ${1}@${2}"
             gcloud beta container binauthz attestations sign-and-create \
               --project="$attestor_project" \
-              --artifact-url="${destination}@${DIGEST}" \
+              --artifact-url="${1}@${2}" \
               --attestor="$attestor_name" \
               --attestor-project="$attestor_project" \
               --keyversion-project="$key_project" \
@@ -432,6 +425,37 @@ jobs:
               --keyversion-keyring="$(field keyRings)" \
               --keyversion-key="$(field cryptoKeys)" \
               --keyversion="$version"
+          }
+
+          # Once per destination, and for a sharper reason than the signature:
+          # an attestation is an occurrence bound to an **`--artifact-url`**, so
+          # one made against `ghcr.io/…` says nothing about the same digest at
+          # `…-docker.pkg.dev/…`. Binary Authorization would refuse the exact
+          # image it had already attested, because the URL it was asked about is
+          # not the URL it was told about.
+          #
+          # And once per manifest *under* each destination's index. `provenance`
+          # and `sbom` above make this push an OCI **image index** even at one
+          # platform, so `$DIGEST` names an index — and an index is not what a
+          # runtime runs. Cloud Run resolves it to the child manifest for its own
+          # platform *before* admission, and Binary Authorization is then asked
+          # about a digest nothing attested: `denied by attestor` on an artifact
+          # that was attested, one indirection up. Attesting the children too is
+          # what makes the question the runtime asks one that has an answer.
+          # `imagetools` reads the index with the credentials the login steps
+          # already wrote, so this needs nothing of its own.
+          while IFS= read -r destination; do
+            [ -n "$destination" ] || continue
+            attest "$destination" "$DIGEST"
+            # Assigned before it is looped over, because a failing command
+            # substitution in a `for` list is not what `-e` acts on and one in
+            # an assignment is. A registry having a bad moment must not read as
+            # an index with no children.
+            manifests="$(docker buildx imagetools inspect --raw \
+              "${destination}@${DIGEST}" | jq -r '.manifests[]?.digest')"
+            for child in $manifests; do
+              attest "$destination" "$child"
+            done
           done <<< "$DESTINATIONS"
 
       # The one line Spindrift reads. Base64 because this stdout goes through

--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -552,8 +552,25 @@ function googleRegistryHosts(destinations: readonly string[]): string[] {
   const hosts = destinations.map(
     (destination) => destination.split('/')[0] ?? '',
   );
-  return [...new Set(hosts)].filter(
-    (host) => host.endsWith('docker.pkg.dev') || host === 'gcr.io',
+  return [...new Set(hosts)].filter(isGoogleRegistryHost);
+}
+
+function isGoogleRegistryHost(host: string): boolean {
+  return host.endsWith('docker.pkg.dev') || host === 'gcr.io';
+}
+
+/**
+ * The destinations the attestation step can read a manifest back out of.
+ *
+ * Same boundary as {@link googleRegistryHosts} and for the same reason — one
+ * metadata token, one vendor's registries — but by destination rather than by
+ * host, because what the step reads is a repository's manifest and not a host.
+ */
+function googleRegistryDestinations(
+  destinations: readonly string[],
+): readonly string[] {
+  return destinations.filter((destination) =>
+    isGoogleRegistryHost(destination.split('/')[0] ?? ''),
   );
 }
 
@@ -709,16 +726,11 @@ version=$(gcloud kms keys versions list \\
 version="\${version:-1}"
 echo "attesting with key version \${version}"
 
-# Once per destination, and for a sharper reason than a signature: an
-# attestation is an occurrence bound to an --artifact-url, so one made against
-# one registry says nothing about the same digest in another. Binary
-# Authorization would refuse the exact image it had already attested, because
-# the URL it was asked about is not the URL it was told about.
-for destination in ${destinations.map(quote).join(' ')}; do
-  echo "attesting \${destination}@\${digest}"
+attest() {
+  echo "attesting \${1}@\${2}"
   gcloud beta container binauthz attestations sign-and-create \\
     --project=${attestorProject} \\
-    --artifact-url="\${destination}@\${digest}" \\
+    --artifact-url="\${1}@\${2}" \\
     --attestor=${quote(attestor[2] ?? '')} \\
     --attestor-project=${attestorProject} \\
     --keyversion-project=${quote(key.project)} \\
@@ -726,8 +738,65 @@ for destination in ${destinations.map(quote).join(' ')}; do
     --keyversion-keyring=${quote(key.keyRing)} \\
     --keyversion-key=${quote(key.key)} \\
     --keyversion="\${version}"
+}
+
+# Every manifest the index names, read off the registry.
+#
+# BuildKit exports an OCI **image index** whenever \`--attest\` is on — which it
+# always is (\`buildkit.ts\`) — even for a single platform. So the digest the
+# builder reported names an index, and an index is not what a runtime runs:
+# Cloud Run resolves it to the child manifest for its own platform *before*
+# admission, and Binary Authorization is then asked about a digest nothing
+# attested. That reads as \`denied by attestor\` on an artifact that was
+# attested, one indirection up, and no amount of re-attesting the index fixes
+# it. The children are attested as well so the question the runtime asks has an
+# answer whichever digest it resolved to.
+#
+# Unfiltered on purpose: the attestation-manifest child is attested too. "Every
+# manifest under the index" is a rule with no exception to get wrong, and a
+# spare occurrence costs nothing.
+#
+# Every media type accepted and not only the index ones, for the same reason: a
+# push with no index has to answer this call rather than 404 it, and
+# \`manifests\` is simply absent from what comes back.
+children() {
+  curl --fail --silent --show-error \\
+    --header "Authorization: Bearer $(gcloud auth print-access-token)" \\
+    --header 'Accept: application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \\
+    "https://\${1%%/*}/v2/\${1#*/}/manifests/\${2}" \\
+  | "\${CLOUDSDK_PYTHON:-python3}" -c 'import json, sys
+for manifest in json.load(sys.stdin).get("manifests", []):
+    print(manifest["digest"])'
+}
+
+# Once per destination, and for a sharper reason than a signature: an
+# attestation is an occurrence bound to an --artifact-url, so one made against
+# one registry says nothing about the same digest in another. Binary
+# Authorization would refuse the exact image it had already attested, because
+# the URL it was asked about is not the URL it was told about.
+for destination in ${destinations.map(quote).join(' ')}; do
+  attest "$destination" "$digest"
 done
-`,
+${
+  googleRegistryDestinations(destinations).length === 0
+    ? ''
+    : `
+# The children, for the vendor's own registries and not for every destination:
+# this step holds one metadata token and that is what it authenticates to. A
+# destination elsewhere is attested at the index alone, which is all its
+# verifier reads — Binary Authorization is not what admits it.
+for destination in ${googleRegistryDestinations(destinations).map(quote).join(' ')}; do
+  # Assigned before it is looped over, because a failing command substitution
+  # in a \`for\` list is not what \`-e\` acts on and one in an assignment is. A
+  # registry having a bad moment must not read as an index with no children,
+  # which is a green build whose Deploy is refused later by a policy.
+  manifests=$(children "$destination" "$digest")
+  for child in $manifests; do
+    attest "$destination" "$child"
+  done
+done
+`
+}`,
     ],
   };
 }

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -578,6 +578,30 @@ describe('the cloud build route', () => {
     expect(program).toContain('/workspace/spindrift-digest');
   });
 
+  test('the manifests under the index are attested too', async () => {
+    // BuildKit's `--attest` makes every push an image index, so the reported
+    // digest names an index rather than the image a runtime runs. Cloud Run
+    // resolves the index to its own platform's child *before* admission, and
+    // Binary Authorization then asks about a digest nothing attested — which
+    // reads as `denied by attestor` on an artifact that was attested.
+    const { api, route } = cloudRoute(
+      {},
+      {},
+      { signer: SIGNER, attestor: ATTESTOR },
+    );
+    await run(route.build(archiveSource(), cloudSpec));
+
+    const program = api.steps[0]?.[1]?.args?.[1] ?? '';
+    expect(program).toContain('manifests');
+    expect(program).toContain('attest "$destination" "$child"');
+    // The vendor's registries and no others: this step holds one metadata
+    // token, and a destination it cannot read a manifest back out of is
+    // attested at the index alone.
+    const children = program.slice(program.indexOf('# The children,'));
+    expect(children).toContain(`${CLOUD_REGISTRY}/example-builds/i/app`);
+    expect(children).not.toContain('registry.example.test');
+  });
+
   test('an installation that named no attestor submits no attestation', async () => {
     const { api, route } = cloudRoute();
     await run(route.build(archiveSource(), cloudSpec));


### PR DESCRIPTION
## Summary

A Cloud Run deploy was refused with `denied by attestor projects/trusted-builds/attestors/provenance: No attestations found`, on an artifact that had in fact been attested. The attestor and its KMS key are fine — the digest asked about was not the digest attested.

BuildKit exports an OCI **image index** whenever `--attest` is on, which it always is (`buildkit.ts` passes `--attest=type=provenance,mode=max` and `--attest=type=sbom`), even for a single platform. So the digest a build reports — and the one core signs and the routes attest — names an index. Cloud Run resolves that index to the child manifest for its own platform *before* admission, and Binary Authorization is then asked about a digest nothing attested.

```
index   sha256:55be749f…   attested on both destinations, cosign .sig, tagged latest
 ├─ sha256:68a70ac0…  linux/amd64          ← what the revision spec carries
 └─ sha256:1cf6a31e…  attestation-manifest
```

Every `plainboi-web` revision pins a resolved child rather than the index it was deployed from, which is the same story from the other side.

Both attesting routes now attest every manifest the index names as well, so the question the runtime asks has an answer whichever digest it resolved to.

## Changes

- `adapters/build/cloud-build.ts` — the attest step reads the index off the registry with the metadata token it already mints and attests each child. Scoped to the vendor's own registries, because that token authenticates to those; a destination elsewhere is attested at the index alone, which is all its verifier reads.
- `.github/workflows/spindrift-build.yml` — the same, read with `imagetools inspect --raw` and the credentials the login steps already wrote.
- `test/adapters/build-routes.test.ts` — asserts the children are attested and that the expansion stays inside that registry boundary.

Both loops assign the manifest list before iterating it: a failing command substitution in a `for` list is not what `set -e` acts on, and one in an assignment is. A registry having a bad moment must not read as an index with no children.

## Test Plan

- [ ] `bun test test/adapters/build-routes.test.ts` in `apps/spindrift` — 53 pass
- [ ] `mise run ts:check` — clean
- [ ] After the controller image rolls out, rebuild an App with a Cloud Run Target and confirm `gcloud container binauthz attestations list --attestor=provenance --attestor-project=trusted-builds` carries both the index digest and its `linux/amd64` child
- [ ] Confirm the Cloud Run deploy of that build is admitted

## Not in this change

Artifacts built before this ships stay denied — they need a rebuild to pick up the child attestations. Separately, the in-cluster build route has no attest step at all, so an App on that route is refused by a Cloud Run Target for an unrelated reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
