### PR TITLE
fix(cloudflare): stop the App zone answering for names nothing serves

### DIFF
--- a/terraform/network/cloudflare/modules/tunnel/tunnel.tf
+++ b/terraform/network/cloudflare/modules/tunnel/tunnel.tf
@@ -15,8 +15,15 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "this" {
   config     = var.config
 }
 
+# Routing a hostname and publishing a record for it are two decisions, and a
+# wildcard is where they come apart. A wildcard ingress rule is a routing
+# catch-all — it is how the tunnel accepts a name some other controller
+# published. A wildcard proxied CNAME is a claim over every name in the zone,
+# which answers for names nothing serves: the caller authenticates and then
+# meets a 404 at the gateway, and a deleted App keeps resolving. Apps publish
+# their own records now, so the record half of the wildcard has no work left.
 resource "cloudflare_dns_record" "cf" {
-  for_each = { for ingress in var.config.ingress : ingress.hostname => ingress if ingress.hostname != null }
+  for_each = { for ingress in var.config.ingress : ingress.hostname => ingress if ingress.hostname != null && !startswith(ingress.hostname, "*.") }
   zone_id  = var.zone_id
   comment  = "terraform managed"
   name     = each.value.hostname

--- a/terraform/network/cloudflare/spindrift.tf
+++ b/terraform/network/cloudflare/spindrift.tf
@@ -42,52 +42,10 @@ resource "onepassword_item" "spindrift_cloudflared" {
   ]
 }
 
-# This is the Target's default Private audience. Public exposure requires a
-# more-specific bypass application for the Component hostname; until that
-# exists, the wildcard policy fails closed rather than weakening access.
-resource "cloudflare_zero_trust_access_application" "spindrift_private" {
-  account_id       = local.fml_account_id
-  name             = "Spindrift Private Apps"
-  domain           = "*.${cloudflare_zone.lolwtf_dev.name}"
-  type             = "self_hosted"
-  session_duration = "24h"
-
-  policies = [
-    {
-      name       = "operator"
-      decision   = "allow"
-      precedence = 1
-      include = [
-        {
-          email = {
-            email = "jonathan@pulsifer.ca"
-          }
-        }
-      ]
-    }
-  ]
-}
-
-# OAuth completes on the same parent domain as Spindrift's application
-# cookies. The callback must remain reachable before a user has an Access
-# session, so this exact hostname bypasses the enclosing wildcard policy.
-resource "cloudflare_zero_trust_access_application" "spindrift_oauth_callback" {
-  account_id       = local.fml_account_id
-  name             = "Spindrift OAuth Callback"
-  domain           = "oauth2.${cloudflare_zone.lolwtf_dev.name}"
-  type             = "self_hosted"
-  session_duration = "24h"
-
-  policies = [
-    {
-      name       = "OAuth callback"
-      decision   = "bypass"
-      precedence = 1
-      include = [
-        {
-          everyone = {}
-        }
-      ]
-    }
-  ]
-}
+# Access carries no application over this zone. A Component states its own
+# audience: `reach: private` publishes an RFC1918 address, so the record type
+# is the boundary and no policy has to hold it, and `auth: proxy` is enforced
+# in-cluster by the ExternalAuth filter on the route. An Access application
+# over the whole zone would add a second prompt in front of the first for a
+# Component that already authenticates, and hold nothing closed for one that
+# deliberately does not.


### PR DESCRIPTION
One proxied CNAME at `*.lolwtf.dev` answers for every name in the zone. A name with no workload behind it authenticates through Access and then meets a 404 at the gateway, because the tunnel forwarded a hostname no route matched — and a deleted app keeps resolving the same way.

Apps publish their own records now, so the wildcard's **record** half has no work left. Its **routing** half still does: a public app publishes a proxied CNAME at the tunnel, and the wildcard ingress rule is what makes the tunnel accept it. The module treated those as one decision. Excluding wildcard hostnames from the DNS-record `for_each` splits them — the ingress rule stays, the record goes.

### Blast radius

`*.lolwtf.dev` is the only wildcard any caller of this module declares:

| caller | ingress hostname | records before | after |
| --- | --- | --- | --- |
| `tunnel_folly` | none (`http_status:418`) | 0 | 0 |
| `tunnel_offsite` | `tf.lolwtf.ca` | 1 | 1 |
| `tunnel_spindrift` | `*.lolwtf.dev` | 1 | **0** |

Expect **three destroys, zero creates**, and nothing touching `module.tunnel_offsite`.

### Why both Access applications go too

- `spindrift_private` was fail-closed cover for a wildcard that will not exist. A component states its own audience now: `reach: private` publishes an RFC1918 address, so the record type is the boundary and no policy has to hold it; `auth: proxy` is enforced in-cluster by the ExternalAuth filter on the route. Keeping it would mean two prompts for one login.
- `spindrift_oauth_callback` was the bypass carved out of that policy. With no enclosing policy there is nothing to bypass.

### Verified before removal

Every name that must keep resolving does so from a record this change does not touch:

```text
statty-web.lolwtf.dev  -> 172.64.80.1   # public: its own DNSEndpoint, crd source, proxied
sdd-web.lolwtf.dev     -> 10.89.0.69    # private: gateway-httproute source
oauth2.lolwtf.dev      -> 10.89.0.69    # callback: gateway-httproute source

$ dig TXT k8s.cname-statty-web.lolwtf.dev
"heritage=external-dns,external-dns/owner=offsite,\
 external-dns/resource=crd/spindrift-apps/statty-web"
```

That TXT registry entry names the DNSEndpoint, so the public name is the app's own record and not the wildcard. The names that stop resolving are the ones with nothing behind them:

```text
plainboi.lolwtf.dev          -> 302 to Access login, then 404   # deleted app
nothing-here-xyz.lolwtf.dev  -> 302 to Access login, then 404   # never existed
```

`tofu fmt -check` and `tofu validate` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5psRW53mdUPRZjf3MyGsv