### PR TITLE
fix(cloudflare): declare pulsifer.ca DNSSEC status so the plan converges

### DIFF
--- a/terraform/network/cloudflare/pulsifer.ca.tf
+++ b/terraform/network/cloudflare/pulsifer.ca.tf
@@ -24,8 +24,13 @@ resource "cloudflare_zone" "pulsifer_ca" {
   name = "pulsifer.ca"
 }
 
+# status is optional and NOT computed, so leaving it unset plans
+# "disabled" -> null on every run and never converges. Declare the desired
+# state; the parent .ca delegation needs the DS record from this resource's
+# `ds` output before any resolver actually validates the zone.
 resource "cloudflare_zone_dnssec" "pulsifer_ca_dnssec" {
   zone_id = cloudflare_zone.pulsifer_ca.id
+  status  = "active"
 }
 
 resource "cloudflare_zone_setting" "pulsifer_ca" {


### PR DESCRIPTION
## Summary

`terraform/network/cloudflare` has shown the same unapplied change on every plan for a long time:

```
! resource "cloudflare_zone_dnssec" "pulsifer_ca_dnssec" {
+       ds               = (known after apply)
+       key_tag          = (known after apply)
+       public_key       = (known after apply)
-       status           = "disabled" -> null
    }
```

`cloudflare_zone_dnssec.status` is `optional` and **not** `computed` in provider v5 (confirmed against the 5.22.0 schema; allowed values `"active"` / `"disabled"`). A config carrying only `zone_id` therefore reads as null while state holds `"disabled"`, so the plan proposes `"disabled" -> null` forever and drags every computed attribute into known-after-apply. Applying never settled it, because the API reported the same value straight back.

`fdfb0cd4 "feat: enable DNSSEC for pulsifer.ca"` added the resource intending DNSSEC on, but the zone is unsigned today. Declaring `status = "active"` converges the plan and realizes that original intent.

## Changes

- set `status = "active"` on `cloudflare_zone_dnssec.pulsifer_ca_dnssec`, with a comment on why the argument cannot be omitted

## Blast radius

Signing the zone changes no resolution on its own — validators only care once the DS record is published at the parent. Verified `pulsifer.ca` is currently unsigned, so there is no stale DS to conflict with:

- `dig DNSKEY pulsifer.ca @hassan.ns.cloudflare.com` — empty
- `dig DS pulsifer.ca @1.1.1.1` — empty

## Follow-up

To actually get DNSSEC validation, publish the DS record from this resource's `ds` output at the `.ca` registrar. Until then the zone is signed but unvalidated, which is inert.

## Test Plan

- [x] `tofu fmt -check -recursive terraform/network/cloudflare`
- [x] `tofu validate` in `terraform/network/cloudflare`
- [x] confirmed the provider schema marks `status` optional-not-computed, which is the root cause
- [ ] Atlantis plan shows the resource converging rather than the perpetual known-after-apply diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)