### PR TITLE
fix(spindrift): let an existing Target keep its asserted reach, and ask at deploy

### DIFF
--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -43,7 +43,13 @@ import {
   targets,
 } from '../../db/schema.ts';
 import { DEFAULT_MINIMUM_BUILD_LEVEL } from '../../domain/build-route.ts';
-import { artifactTypeFor, placementTargetOf } from '../../domain/placement.ts';
+import {
+  artifactTypeFor,
+  DEFAULT_PLATFORM,
+  placementTargetOf,
+  reachExclusions,
+  sentence,
+} from '../../domain/placement.ts';
 import { demandSentence, migrationFor } from '../config/migration.ts';
 import { type PinnedConfig, readPinnedConfig } from '../config/pinned.ts';
 import {
@@ -359,18 +365,44 @@ export async function checkDeployable(
   // carries the shape it was built for, so a `files` artifact reaching a Target
   // that runs images is not a deploy that fails later — it is one that never
   // starts, which is the whole reason resolution runs before the build.
-  const shape = artifactTypeFor(
-    component.kind,
-    placementTargetOf(target, {
-      artifactTypes:
-        context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
-      manifest: context.manifest,
-    }),
-  );
+  const placement = placementTargetOf(target, {
+    artifactTypes:
+      context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+    manifest: context.manifest,
+  });
+  const shape = artifactTypeFor(component.kind, placement);
   if (build.targetShape !== shape) {
     return refuse(
       'NOT_DEPLOYABLE',
       `Build ${build.id} produced ${build.targetShape}, and ${target.name} takes ${shape} — this placement needs a rebuild`,
+    );
+  }
+
+  // §3's asserted half, asked where it binds. Placement filtered on it when the
+  // developer was *offered* this Target, and nothing re-asked when the Deploy
+  // was created — so a Component could be released at a reach its Target
+  // declares it does not serve, which makes that declaration advisory. It is a
+  // boundary: a Target that says it has no public address is stating something
+  // about the network it is on, not a preference.
+  //
+  // Reach and auth only. The rest of `exclusionsFor` belongs to the screen that
+  // offers a placement, not to the act of releasing one — refusing an UNHEALTHY
+  // Target here would block the rollback `./rollback.ts` exists to keep possible
+  // while the Target is unhealthy.
+  const unserved = reachExclusions(placement.capabilities, component);
+  if (unserved.length > 0) {
+    const why = unserved
+      .map((reason) =>
+        sentence(reason, {
+          kind: component.kind,
+          reach: component.reach,
+          platform: DEFAULT_PLATFORM,
+        }),
+      )
+      .join('; ');
+    return refuse(
+      'NOT_DEPLOYABLE',
+      `${target.name} does not serve this Component's ${component.reach} reach — ${why}`,
     );
   }
 

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -377,6 +377,11 @@ export const connectTarget: Command<
         inspectedAt: now,
         status: 'connected',
         updatedAt: now,
+        // The same assertion the INSERT branch takes. Without it a reconnect
+        // dropped what the operator had just stated on the connect screen —
+        // which derives both from the gateway address and the tunnel — so §3's
+        // asserted half could only ever be set by a Target's very first write.
+        ...assertedBy(input),
       })
       .where(eq(targets.id, existing.id))
       .returning();

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -390,20 +390,33 @@ async function reconcileManifestTargets(
       })
       .onConflictDoUpdate({
         target: targets.name,
-        set: hasConnectionChange
-          ? {
-              rank,
-              ...(existing?.status === 'disconnected'
-                ? {}
-                : { status: 'connected' as const }),
-              connection: declaredConnection,
-              health: 'unhealthy' as const,
-              prerequisites: awaitingInspection,
-              discovery: null,
-              inspectedAt: null,
-              updatedAt: sql`now()`,
-            }
-          : { rank },
+        set: {
+          rank,
+          // §3's asserted half follows the connection, not the rank: a reach is
+          // something an operator can have set on the row — the connect screen
+          // derives one from the gateway and the tunnel and posts it — so a
+          // `booted` write must not re-assert the document's copy over it, for
+          // the reason {@link ManifestWrite} records. A `declared` write is an
+          // operator submitting this document, so there it is desired state.
+          //
+          // Outside the `hasConnectionChange` branch deliberately: a
+          // declaration can correct a reach without touching the connection,
+          // and folded in there that edit would land nothing.
+          ...(write === 'declared' ? assertedBySeed(target) : {}),
+          ...(hasConnectionChange
+            ? {
+                ...(existing?.status === 'disconnected'
+                  ? {}
+                  : { status: 'connected' as const }),
+                connection: declaredConnection,
+                health: 'unhealthy' as const,
+                prerequisites: awaitingInspection,
+                discovery: null,
+                inspectedAt: null,
+                updatedAt: sql`now()`,
+              }
+            : {}),
+        },
       });
   }
 }
@@ -414,6 +427,8 @@ async function reconcileManifestTargets(
  * Omitted rather than nulled when absent, so a declaration that says nothing
  * about reach leaves whatever an operator asserted through the UI standing —
  * the same "a declaration seeds, it does not govern" rule the connection follows.
+ * That rule is why this is spread on update only for a `declared` write: see the
+ * set clause above and {@link ManifestWrite}.
  */
 function assertedBySeed(target: TargetSeed): {
   reaches?: ('none' | 'private' | 'public')[];

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -267,10 +267,18 @@ export function artifactTypeFor(
   return 'image';
 }
 
-/** The sentence behind each exclusion, in the developer's terms. */
-function sentence(
+/**
+ * The sentence behind each exclusion, in the developer's terms.
+ *
+ * Exported, and narrowed to the three fields it actually reads, because the
+ * deploy path refuses with {@link reachExclusions} and has to refuse in the
+ * same words the placement screen offered — a developer told "this Target has
+ * no way to serve a public address" when they picked it, and told something
+ * else when they deployed, is being told about two different systems.
+ */
+export function sentence(
   reason: Exclusion,
-  requirements: DerivedRequirements,
+  requirements: Pick<DerivedRequirements, 'kind' | 'reach' | 'platform'>,
 ): string {
   switch (reason) {
     case 'UNHEALTHY':
@@ -359,6 +367,49 @@ function fits(asked: string | undefined, ceiling: string | undefined): boolean {
   return wanted <= limit;
 }
 
+/**
+ * Whether a Target serves the reach a Component asks for, and can authenticate
+ * it — §3's asserted half, and the only part of {@link exclusionsFor} the
+ * deploy path re-asks.
+ *
+ * Reach and auth join separately, because they are separate facts: a Target can
+ * serve a reach it cannot authenticate, and the sentence a developer needs is
+ * different in each case. Filtering both ways is what makes picking the static
+ * Target *mean* public (§13, §28) — it asserts `public` and nothing else, so
+ * every other reach is excluded by the ordinary join.
+ *
+ * §9's hard rule is the second half, where it binds: a Component asking to be
+ * authenticated must land on a Target whose edge can honestly authenticate
+ * *that reach*. The case that shape exists for is a Target that has the
+ * mechanism and an audience too narrow to stand in front of an address anyone
+ * can reach — it answers for `private` and not for `public`.
+ *
+ * **One implementation for two callers, deliberately.** The screen that offers a
+ * placement and the command that creates the Deploy have to answer this
+ * identically or the boundary is advisory: a Target that declares it cannot
+ * serve the public was excluded on the placement screen and deployed to anyway,
+ * because nothing on the deploy path asked. Only these two exclusions are lifted
+ * — a deploy that re-ran the whole of `exclusionsFor` would newly refuse an
+ * UNHEALTHY Target, which is exactly the rollback `deploys/rollback.ts` exists
+ * to keep possible during an incident.
+ */
+export function reachExclusions(
+  can: Pick<TargetCapabilities, 'reaches' | 'authReaches'>,
+  requirements: Pick<DerivedRequirements, 'reach' | 'auth'>,
+): readonly Exclusion[] {
+  const reasons: Exclusion[] = [];
+  if (!can.reaches.includes(requirements.reach)) {
+    reasons.push('REACH_UNSUPPORTED');
+  }
+  if (
+    requirements.auth === 'proxy' &&
+    !can.authReaches.includes(requirements.reach)
+  ) {
+    reasons.push('AUTH_UNSUPPORTED');
+  }
+  return reasons;
+}
+
 /** Every reason one Target fails one App's derived requirements. */
 export function exclusionsFor(
   target: PlacementTarget,
@@ -371,26 +422,7 @@ export function exclusionsFor(
   if (!target.healthy) reasons.push('UNHEALTHY');
   if (!can.kinds.includes(requirements.kind)) reasons.push('KIND_UNSUPPORTED');
 
-  // Reach and auth join separately, because they are separate facts: a Target
-  // can serve a reach it cannot authenticate, and the sentence a developer needs
-  // is different in each case. Filtering both ways is what makes picking the
-  // static Target *mean* public (§13, §28) — it asserts `public` and nothing
-  // else, so every other reach is excluded by the ordinary join.
-  if (!can.reaches.includes(requirements.reach)) {
-    reasons.push('REACH_UNSUPPORTED');
-  }
-
-  // §9's hard rule, where it binds: a Component asking to be authenticated must
-  // land on a Target whose edge can honestly authenticate *that reach*. The case
-  // this shape exists for is a Target that has the mechanism and an audience too
-  // narrow to stand in front of an address anyone can reach — it answers for
-  // `private` and not for `public`.
-  if (
-    requirements.auth === 'proxy' &&
-    !can.authReaches.includes(requirements.reach)
-  ) {
-    reasons.push('AUTH_UNSUPPORTED');
-  }
+  reasons.push(...reachExclusions(can, requirements));
 
   // A route needs something to attach to. Without this the Deploy goes green
   // with `parentRefs` naming a Gateway that is the empty string, which is a

--- a/apps/spindrift/test/commands/component-reach.test.ts
+++ b/apps/spindrift/test/commands/component-reach.test.ts
@@ -239,6 +239,14 @@ describe('a Component edited mid-attempt does not change what is being placed', 
     const { component, target, build } = await fixture('private', 'proxy');
     const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
     const adapters = registryOf(adapter);
+    // The tunnel an operator states, because §3 says nothing reports one. This
+    // test moves the Component to `public` and presses Deploy, and the deploy
+    // path now filters on the asserted reach — so a Target that claims no
+    // public address would refuse the second release rather than render it.
+    await database()
+      .db.update(targets)
+      .set({ reaches: ['none', 'private', 'public'] })
+      .where(eq(targets.id, target.id));
 
     // The intent, pinned at `private` + `proxy` — and then the edit, before
     // the loop has claimed it. This is the window `deploys.reach` exists for.

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -107,7 +107,21 @@ function context(adapters: AdapterRegistry): CommandContext {
 
 /** An App, a Component, and a connected Target that accepts images. */
 async function fixture(
-  options: { kind?: 'service' | 'website'; adapter?: TargetAdapter } = {},
+  options: {
+    kind?: 'service' | 'website';
+    adapter?: TargetAdapter;
+    /**
+     * The Component's §9 pair, which the deploy path now filters on.
+     *
+     * Defaulted by the column rather than here — `private` behind the Target's
+     * authenticated edge — because that is what the cluster fixture serves. A
+     * test on a `static` Target has to state `public`: static hosting asserts
+     * `public` and nothing else, so a private Component there is a placement
+     * that was never offered and is now refused where it is released too.
+     */
+    reach?: 'none' | 'private' | 'public';
+    auth?: 'none' | 'proxy';
+  } = {},
 ) {
   const db = database().db;
   const [app] = await db
@@ -121,6 +135,8 @@ async function fixture(
       name: 'web',
       kind: options.kind ?? 'service',
       expose: true,
+      ...(options.reach === undefined ? {} : { reach: options.reach }),
+      ...(options.auth === undefined ? {} : { auth: options.auth }),
     })
     .returning();
   const [target] = await db
@@ -258,6 +274,98 @@ describe('createDeploy writes an intent, and only an intent', () => {
     expect(result.failure.message).toContain('rebuild');
   });
 
+  test('a Component is refused at a reach its Target does not assert', async () => {
+    // §3's filter, asked where the release actually happens. Placement excluded
+    // this Target when the developer was offered it; nothing re-asked when the
+    // Deploy was created, so "the Target says it cannot and it happened anyway"
+    // was the whole of the defect — a declared boundary that was advisory.
+    const { component, target } = await fixture();
+    // `auth: 'none'` so this is a claim about reach alone — the authenticated
+    // edge is the test below, and a Component carrying both would be refused
+    // twice and prove neither.
+    await database()
+      .db.update(components)
+      .set({ reach: 'public', auth: 'none' })
+      .where(eq(components.id, component.id));
+    const build = await succeededBuild(component.id, 60);
+    const intent = {
+      componentId: component.id,
+      targetId: target.id,
+      buildId: build.id,
+    };
+
+    const refused = await createDeploy(
+      intent,
+      context(registryOf(capableAdapter())),
+    );
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(refused.failure.message).toContain(target.name);
+    expect(refused.failure.message).toContain(
+      'no way to serve a public address',
+    );
+    expect(await desiredRow(component.id, target.id)).toBeUndefined();
+
+    // Rollback shares this gate, and has to: a Component released at a reach
+    // its Target does not serve is the same defect whichever intent wrote it,
+    // and a guard that lived in `createDeploy` alone would leave rollback and
+    // `setConfig` open.
+    const rolled = await rollbackDeploy(
+      intent,
+      context(registryOf(capableAdapter())),
+    );
+    expect(rolled.ok).toBe(false);
+    if (rolled.ok) return;
+    expect(rolled.failure.message).toContain(
+      'no way to serve a public address',
+    );
+
+    // And it reads the asserted column rather than refusing `public`
+    // categorically: the operator states the tunnel, because §3 says nothing
+    // reports one, and the same call goes through.
+    await database()
+      .db.update(targets)
+      .set({ reaches: ['none', 'private', 'public'] })
+      .where(eq(targets.id, target.id));
+
+    const allowed = await createDeploy(
+      intent,
+      context(registryOf(capableAdapter())),
+    );
+    expect(allowed.ok).toBe(true);
+    if (!allowed.ok) return;
+    expect((await desiredRow(component.id, target.id))?.desiredDeployId).toBe(
+      allowed.value.deployId,
+    );
+  });
+
+  test('a Target with no authenticated edge for a reach refuses a proxied Component', async () => {
+    // §9's half, which no live Component exercises today: the fixture Target
+    // asserts an edge for `private` and serves `public` once the tunnel is
+    // stated, so it can carry a public address and still not authenticate one.
+    const { component, target } = await fixture();
+    await database()
+      .db.update(components)
+      .set({ reach: 'public', auth: 'proxy' })
+      .where(eq(components.id, component.id));
+    await database()
+      .db.update(targets)
+      .set({ reaches: ['none', 'private', 'public'], authReaches: ['private'] })
+      .where(eq(targets.id, target.id));
+    const build = await succeededBuild(component.id, 61);
+
+    const result = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('admits a single user');
+  });
+
   test('a disconnected Target takes nothing new', async () => {
     const { component, target } = await fixture();
     await database()
@@ -280,6 +388,10 @@ describe('createDeploy writes an intent, and only an intent', () => {
     const { component, target } = await fixture({
       kind: 'website',
       adapter: 'static',
+      // What a site on static hosting is: a public address with no runtime to
+      // authenticate anything, which is the only placement that Target offers.
+      reach: 'public',
+      auth: 'none',
     });
     const deployAdapter = new FakeDeployAdapter({
       adapter: 'static',
@@ -416,6 +528,10 @@ describe('createDeploy writes an intent, and only an intent', () => {
     const { component, target } = await fixture({
       kind: 'website',
       adapter: 'static',
+      // What a site on static hosting is: a public address with no runtime to
+      // authenticate anything, which is the only placement that Target offers.
+      reach: 'public',
+      auth: 'none',
     });
     const deployAdapter = new FakeDeployAdapter({
       adapter: 'static',

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -254,6 +254,32 @@ describe('the act is credential-shaped though the noun is flat', () => {
     expect(rows).toHaveLength(3);
   });
 
+  test('a reconnect updates what the operator asserted about reach', async () => {
+    const { registry } = fakes();
+    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+    expect((await targetRow('cluster'))?.reaches).toBeNull();
+
+    // The connect screen derives both of these — `reaches` from the gateway's
+    // private address and the tunnel hostname, `authReaches` from the
+    // ExternalAuth backend — and posts them with every submission. The update
+    // branch used to set connection, health, prerequisites, discovery,
+    // inspectedAt, status and updatedAt and nothing else, so an operator
+    // correcting a Target that already existed had their assertion silently
+    // discarded and no way to see why.
+    await connectTarget(
+      clusterInput({
+        name: 'cluster',
+        reaches: ['none', 'private', 'public'],
+        authReaches: ['private'],
+      }),
+      context(registry),
+    );
+
+    const row = await targetRow('cluster');
+    expect(row?.reaches).toEqual(['none', 'private', 'public']);
+    expect(row?.authReaches).toEqual(['private']);
+  });
+
   test('connect fills a manifest-seeded Target without changing its rank', async () => {
     const { registry } = fakes();
     const [seed] = await database()

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -539,6 +539,57 @@ describe('the stored installation manifest', () => {
     expect(cluster?.rank).toBe(99);
   });
 
+  test('a declared write updates an existing Target’s asserted reaches, and a boot does not', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
+    });
+    const seeded = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    // Nobody has said, so the row asserts nothing and the adapter's floor is
+    // the whole answer — §3's asserted half is stated, never reported.
+    expect(seeded?.reaches).toBeNull();
+
+    // The declaration now states one. Before this, `reaches` was written on
+    // INSERT only: a Target that already existed could never be given an
+    // asserted reach through any supported path, so a document that had always
+    // declared `public` never reached the row rendering the deploy.
+    const [cluster, ...rest] = connectedManifest.targets;
+    const asserting = {
+      ...connectedManifest,
+      targets: [
+        {
+          ...cluster!,
+          reaches: ['none', 'private', 'public'],
+          authReaches: ['private'],
+        },
+        ...rest,
+      ],
+    } as AuthoredManifest;
+    await writeStoredManifest(database().db, asserting);
+
+    const declared = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(declared?.reaches).toEqual(['none', 'private', 'public']);
+    expect(declared?.authReaches).toEqual(['private']);
+
+    // And the other half of 52's rule, one noun down: a reach is something an
+    // operator can have set on the row through the connect screen, so a boot —
+    // which declares nothing, it only writes back the document the installation
+    // already had — must leave it exactly where the operator put it.
+    await database()
+      .db.update(targets)
+      .set({ reaches: ['none'] })
+      .where(eq(targets.name, 'cluster'));
+    await writeStoredManifest(database().db, asserting, 'booted');
+
+    const booted = await database().db.query.targets.findFirst({
+      where: (targets, { eq }) => eq(targets.name, 'cluster'),
+    });
+    expect(booted?.reaches).toEqual(['none']);
+  });
+
   test('repairs a stored Target rank from manifest order', async () => {
     await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,


### PR DESCRIPTION
Two defects that compound: a Target's asserted `reaches`/`authReaches` could not
be updated, and nothing on the path that creates a Deploy read them. Together
they made a declared boundary both unwritable and unread.

## The columns were INSERT-only

`reaches` and `authReaches` were absent from the `onConflictDoUpdate` set clause
in `apps/spindrift/src/config/manifest-store.ts:391` (which sets `rank`, or
`rank` plus the connection fields) and from `connectTarget`'s update branch at
`apps/spindrift/src/commands/targets/connect.ts:366` (connection, health,
prerequisites, discovery, inspectedAt, status, updatedAt — and nothing else).
No supported command path could give an **existing** Target an asserted reach.

The connect screen really does derive them — `reaches` from the gateway's
private address and the tunnel hostname, `authReaches` from the ExternalAuth
backend (`src/domain/target-onboarding.ts:291`) — so a reconnect silently
discarded what the operator had just stated, and the screen that accepted it
then showed the old values with no reason why.

The seed path now writes them on update too, but **only for a `declared`
write**. `ManifestWrite` (`manifest-store.ts:111`) records a live incident
behind that distinction: a `booted` write must not re-assert the document's copy
of something an operator can have edited on the row, and a reach is exactly
that. It sits beside `rank` rather than inside the `hasConnectionChange` branch,
because a declaration can correct a reach without touching the connection and
folded in there that edit would land nothing.

## Nothing on the deploy path asked

`exclusionsFor` and `resolvePlacement` are called from
`commands/apps/resolve-placement.ts`, `commands/creation-drafts/lifecycle.ts`
and `commands/targets/list.ts` — the screens that *offer* a placement. Nothing
re-asked when the Deploy was created, so a Component could be released at a
reach its Target declares it does not serve. "The Target says it cannot and it
happened anyway" is the more alarming half: a Target that declares no public
address is stating a fact about the network it is on, and it was advisory.

The two reach/auth blocks lift out of `exclusionsFor` into an exported
`reachExclusions`, and `checkDeployable` calls it — one implementation, so the
screen that offers a placement and the command that releases one cannot drift.
`checkDeployable` rather than `createDeploy` because `rollbackDeploy` and
`setConfig` call it directly, and a rollback or a config change that re-releases
a Component at an unserved reach is the same defect.

**Reach and auth only, deliberately.** Running the whole of `exclusionsFor` on
the deploy path would newly refuse on UNHEALTHY — which would block the rollback
`src/commands/deploys/rollback.ts:16` exists to keep possible during an
incident — plus NO_GATEWAY, ARCH_UNSUPPORTED, REGISTRY_UNREACHABLE and
QUOTA_EXHAUSTED, none of which anyone asked for. The refusal reuses the existing
`NOT_DEPLOYABLE` code and the existing sentences from `sentence()`, so a
developer reads the same words the placement screen showed them.

## Order of operations after merge — please read

The guard refuses nothing that is live **once the row carries what the document
already declares**, and the live installation's rows do not carry it yet:

```
name              | reaches        | auth_reaches
bluenose-cloudrun |                |
bluenose-static   |                |
folly             | {none,private} | {private}
offsite           |                |
```

`offsite` reading NULL falls back to the kubernetes floor `['none','private']`,
and two live Components on it are at `reach: public`. Until the row is repaired
they cannot be deployed, rolled back, or have their config changed.

The repair is **not** automatic — a pod restart is a `booted` write and, by the
design above, deliberately changes nothing. It is: **open Settings and press
Save.** `configureInstallation` posts the stored document back whole and
defaults to `declared`. That is safe because the stored document already carries
the right values — verified read-only against the live database:

```
offsite           | reaches [none, private, public] | authReaches [private]
folly             | reaches [none, private]         | authReaches [private]
bluenose-cloudrun | null                            | null
bluenose-static   | null                            | null
```

After Save, `select name, reaches, auth_reaches from targets` should show
offsite as `{none,private,public}`/`{private}`. **Do that before the next deploy
attempt on offsite.**

The bluenose NULLs are correct and are not touched: `reaches` exists only on the
`kubernetes` variant of the seed schema, and the adapter floors already answer
correctly — cloudrun `['none','public']`, static `['public']`. The live
cloudrun website at `public` is served by its floor and is unaffected.

## Tests

Four new tests, all against real Postgres:

- **`test/config/manifest-store.test.ts`** — a `declared` write updates an
  existing Target's asserted reaches; a `booted` write leaves an operator's row
  value alone. The second half pins the precedence, so a later "just make it
  unconditional like `rank`" turns red instead of quietly reintroducing the
  incident `ManifestWrite` documents.
- **`test/commands/targets.test.ts`** — a reconnect updates what the operator
  asserted, instead of dropping it.
- **`test/commands/deploys.test.ts`** — a Component at `public` on a Target that
  asserts nothing is refused with `NOT_DEPLOYABLE` naming the Target, and
  `rollbackDeploy` refuses identically; then asserting the reach on the row lets
  the identical call through and write its `deploys` row, which is what proves
  the guard reads the column rather than refusing `public` categorically.
- **`test/commands/deploys.test.ts`** — the auth arm: a Target that serves
  `public` and authenticates only `private` refuses a proxied public Component.
  No live Component uses proxy auth, so this arm is untestable against
  production by construction.

`test/commands/component-reach.test.ts` needed its Target to assert the tunnel:
it moves a Component to `public` mid-test and presses Deploy, which the guard
now filters. Fixed by stating the reach on that test's Target, not by loosening
the guard.

Full suite: **1411 pass / 0 fail across 103 files** (baseline on `main` is 1407;
+4 new). `bun run typecheck` and `bun run lint` both exit 0.

Each half was proved by reverting it and watching the new test fail:

```
# manifest-store + connect assertions removed
(fail) a declared write updates an existing Target's asserted reaches, and a boot does not
(fail) a reconnect updates what the operator asserted about reach
  Expected ["none","private","public"] / Received null

# the reach guard removed from checkDeployable
(fail) a Component is refused at a reach its Target does not assert
(fail) a Target with no authenticated edge for a reach refuses a proxied Component
  expect(refused.ok).toBe(false) — Received: true
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5psRW53mdUPRZjf3MyGsv
