### PR TITLE
feat(spindrift): discover cloud facts instead of typing them

### DIFF
--- a/apps/spindrift/src/adapters/cloud-discovery.ts
+++ b/apps/spindrift/src/adapters/cloud-discovery.ts
@@ -1,0 +1,364 @@
+/**
+ * Asking the cloud what this installation already is (§13, §20).
+ *
+ * §20 puts every value naming an installation in the manifest, and until now
+ * every one of them was typed there by hand — including the ones the pod's own
+ * federated identity could simply be asked for. A mistyped project or bucket is
+ * invisible until a build stages a source archive and fails on a signed URL, so
+ * the value of asking is not convenience: it is that a confirmed answer cannot
+ * be a typo.
+ *
+ * **The two arms are the whole point.** A read either produced an answer or it
+ * did not, and those are different types rather than the same list at different
+ * lengths. `{ kind: 'found', candidates: [] }` says *this project has no
+ * buckets* — a fact an operator can act on. A `403`, a disabled API, a DNS
+ * failure or an absent federation say *nothing was established*, and collapsing
+ * them into an empty array would put an empty value on a confirmation screen
+ * that reads exactly like an answer. This is `cloudChecklist`'s rule in
+ * `deploy/cloud/checklist.ts` — "an item that could not be assessed is reported
+ * unmet, with a detail saying so rather than asserting a fault it did not
+ * observe" — with `unavailable` in place of `unmet`.
+ *
+ * **No credential here, and no second one anywhere.** The token is a provider
+ * called per request, exactly as the two cloud deploy adapters and the cloud
+ * build route take it, and `registry.ts` hands all four the same one — so the
+ * hourly STS-and-impersonation exchange in `deploy/cloud/federation.ts` is made
+ * once for the process rather than once per discovery call.
+ *
+ * **A concrete class, not an interface.** § Seam 2's pattern is "a fake of the
+ * far-side HTTP API behind the real client, with the test asserting the requests
+ * that were made", which {@link CloudHttp}'s injected transport already gives.
+ * An interface over one implementation would only move the seam somewhere it is
+ * not needed. For the same reason the three API hosts are constants rather than
+ * options: a test stands its fake behind `fetch` and answers these hostnames,
+ * and an installation behind a service perimeter would need an override here —
+ * which is a change to make when one exists, not before.
+ */
+import {
+  CloudHttp,
+  type CloudResponse,
+  type Fetcher,
+  type TokenProvider,
+} from './deploy/cloud/http.ts';
+
+/** Where the three APIs discovery reads live. Named by the software, always. */
+const RESOURCE_MANAGER = 'https://cloudresourcemanager.googleapis.com';
+const STORAGE = 'https://storage.googleapis.com';
+const KEY_MANAGEMENT = 'https://cloudkms.googleapis.com';
+
+/**
+ * The reason code a cloud API uses for "this service is not turned on here".
+ *
+ * Matched as a substring as well as a parsed reason, for the reason
+ * `checklist.ts` gives: the same fact arrives as a `reason` detail on some calls
+ * and only inside the message on others, and an operator whose project has the
+ * API switched off must not be told they lack a permission that is correct.
+ */
+const SERVICE_DISABLED = 'SERVICE_DISABLED';
+
+/**
+ * The purpose a key must have to sign anything.
+ *
+ * Filtered rather than offered, because a symmetric encryption key produces a
+ * `supplyChain.signer` that validates, saves, reconciles, and then fails at the
+ * first cosign call — the invisible-until-a-build-fails shape discovery exists
+ * to remove.
+ */
+const SIGNING_PURPOSE = 'ASYMMETRIC_SIGN';
+
+/**
+ * How many pages a listing will walk, and how many key rings it will open.
+ *
+ * ponytail: fixed caps rather than a budget, because the far side is a paging
+ * API answering a confirmation screen. Hitting either is reported as
+ * `unavailable` rather than silently truncated — a short list that looks
+ * complete is the same defect as an empty one that looks like an answer. Raise
+ * them if a real installation ever reaches one.
+ */
+const MAX_PAGES = 20;
+const MAX_KEY_RINGS = 20;
+
+/**
+ * What one read produced.
+ *
+ * `suggested` is the one candidate most likely right, and the rule for it here
+ * is the only one this layer can honestly apply: where exactly one thing exists,
+ * that is the answer. Anything richer — a heuristic drawn from the credential,
+ * say — belongs to the caller that holds the fact it is drawn from.
+ */
+export type Discovered<Value> =
+  | {
+      readonly kind: 'found';
+      readonly candidates: readonly Value[];
+      readonly suggested: Value | null;
+    }
+  | { readonly kind: 'unavailable'; readonly reason: string };
+
+/** What was being asked about, in the sentence an operator reads. */
+interface Subject {
+  /** What the service is called where an operator would go to enable it. */
+  readonly service: string;
+  /** What was being listed, named for the refusal sentence. */
+  readonly scope: string;
+}
+
+/** A listing that either completed or has a sentence saying why it did not. */
+type Listing<Item> =
+  | { readonly ok: true; readonly items: readonly Item[] }
+  | { readonly ok: false; readonly reason: string };
+
+/**
+ * A page of any of these APIs.
+ *
+ * Read structurally rather than typed per call: the three APIs name their array
+ * differently — `projects`, `items`, `locations`, `keyRings`, `cryptoKeys` — and
+ * every one of them carries `nextPageToken`, which is the only key the paging
+ * loop itself has to understand.
+ */
+type Page = Record<string, unknown>;
+
+export interface GcpDiscoveryOptions {
+  /** Mints a bearer token per request. Never a stored credential (§13). */
+  readonly token: TokenProvider;
+  /** Injected so a test can stand a fake far side behind the real client. */
+  readonly fetch?: Fetcher;
+}
+
+/** The reads discovery makes, each answering both arms and never throwing. */
+export class GcpDiscovery {
+  private readonly resourceManager: CloudHttp;
+  private readonly storage: CloudHttp;
+  private readonly keyManagement: CloudHttp;
+
+  constructor(options: GcpDiscoveryOptions) {
+    const client = (baseUrl: string) =>
+      new CloudHttp({
+        baseUrl,
+        token: options.token,
+        ...(options.fetch ? { fetch: options.fetch } : {}),
+      });
+    this.resourceManager = client(RESOURCE_MANAGER);
+    this.storage = client(STORAGE);
+    this.keyManagement = client(KEY_MANAGEMENT);
+  }
+
+  /** Every project this identity can see, active ones only. */
+  async projects(): Promise<Discovered<string>> {
+    const listed = await this.collect<{
+      projectId?: string;
+      lifecycleState?: string;
+    }>(
+      this.resourceManager,
+      {
+        service: 'Resource Manager',
+        scope: 'the projects this identity holds',
+      },
+      '/v1/projects',
+      (page) =>
+        (page.projects as
+          | { projectId?: string; lifecycleState?: string }[]
+          | undefined) ?? [],
+    );
+    if (!listed.ok) return unavailable(listed.reason);
+    // A project pending deletion is still listed and cannot be deployed to;
+    // offering one would put a name on a confirmation screen that stops
+    // resolving part way through the month.
+    return found(
+      listed.items
+        .filter((project) => (project.lifecycleState ?? 'ACTIVE') === 'ACTIVE')
+        .flatMap((project) =>
+          project.projectId === undefined ? [] : [project.projectId],
+        ),
+    );
+  }
+
+  /** Every storage bucket in one project. */
+  async buckets(project: string): Promise<Discovered<string>> {
+    const listed = await this.collect<{ name?: string }>(
+      this.storage,
+      { service: 'Cloud Storage', scope: `the buckets in ${project}` },
+      '/storage/v1/b',
+      (page) => (page.items as { name?: string }[] | undefined) ?? [],
+      { project },
+    );
+    if (!listed.ok) return unavailable(listed.reason);
+    return found(
+      listed.items.flatMap((bucket) =>
+        bucket.name === undefined ? [] : [bucket.name],
+      ),
+    );
+  }
+
+  /**
+   * The key locations one project offers.
+   *
+   * Not a manifest value itself — it is what makes {@link signingKeys}
+   * answerable. Key rings are listed per concrete location, so a caller with no
+   * location either names one or reads this list to pick from; fanning out over
+   * every location would be forty calls behind one confirm button.
+   */
+  async keyLocations(project: string): Promise<Discovered<string>> {
+    const listed = await this.collect<{ locationId?: string }>(
+      this.keyManagement,
+      { service: 'Cloud KMS', scope: `the key locations of ${project}` },
+      `/v1/projects/${encodeURIComponent(project)}/locations`,
+      (page) => (page.locations as { locationId?: string }[] | undefined) ?? [],
+    );
+    if (!listed.ok) return unavailable(listed.reason);
+    return found(
+      listed.items.flatMap((location) =>
+        location.locationId === undefined ? [] : [location.locationId],
+      ),
+    );
+  }
+
+  /**
+   * Every key in one project and location that can sign, as a signer reference.
+   *
+   * The reference is `gcpkms://` prefixed to the key's own resource name,
+   * verbatim, because that is the exact form the placeholder manifest and every
+   * real one already carry — assembling the six segments by hand is where a typo
+   * becomes a signing failure nothing catches until a build.
+   *
+   * ponytail: one call per key ring, sequentially. Key rings in a single
+   * project and location are one permission and there are rarely more than a
+   * handful; a ring that refuses stops the read rather than being skipped,
+   * because a partial key list offered as complete is the defect this file is
+   * about.
+   */
+  async signingKeys(
+    project: string,
+    location: string,
+  ): Promise<Discovered<string>> {
+    const where = `${encodeURIComponent(project)}/locations/${encodeURIComponent(location)}`;
+    const subject = {
+      service: 'Cloud KMS',
+      scope: `the signing keys in ${project} at ${location}`,
+    };
+    const rings = await this.collect<{ name?: string }>(
+      this.keyManagement,
+      subject,
+      `/v1/projects/${where}/keyRings`,
+      (page) => (page.keyRings as { name?: string }[] | undefined) ?? [],
+    );
+    if (!rings.ok) return unavailable(rings.reason);
+
+    const names = rings.items.flatMap((ring) =>
+      ring.name === undefined ? [] : [ring.name],
+    );
+    if (names.length > MAX_KEY_RINGS) {
+      return unavailable(
+        `${subject.scope} span ${names.length} key rings, more than discovery will open in one pass`,
+      );
+    }
+
+    const keys: string[] = [];
+    for (const ring of names) {
+      const listed = await this.collect<{ name?: string; purpose?: string }>(
+        this.keyManagement,
+        subject,
+        `/v1/${ring}/cryptoKeys`,
+        (page) =>
+          (page.cryptoKeys as
+            | { name?: string; purpose?: string }[]
+            | undefined) ?? [],
+      );
+      if (!listed.ok) return unavailable(listed.reason);
+      for (const key of listed.items) {
+        if (key.purpose !== SIGNING_PURPOSE || key.name === undefined) continue;
+        keys.push(`gcpkms://${key.name}`);
+      }
+    }
+    return found(keys);
+  }
+
+  /**
+   * Walk one paginated listing to the end.
+   *
+   * Paginated because these APIs are: a single-page read of a project's buckets
+   * answers a short list that looks complete, which on a confirmation screen is
+   * indistinguishable from the truth. The loop is the one
+   * `store/gcp-secret-manager.ts` already runs, with a cap on it — a hostile or
+   * broken far side that keeps handing out continuation tokens gets a stated
+   * refusal rather than an unbounded loop.
+   */
+  private async collect<Item>(
+    http: CloudHttp,
+    subject: Subject,
+    path: string,
+    items: (page: Page) => readonly Item[],
+    query: Readonly<Record<string, string>> = {},
+  ): Promise<Listing<Item>> {
+    const collected: Item[] = [];
+    let pageToken: string | undefined;
+    let pages = 0;
+
+    do {
+      const response = await http.json<Page>({
+        method: 'GET',
+        path,
+        query: { ...query, ...(pageToken === undefined ? {} : { pageToken }) },
+      });
+      if (!response.ok)
+        return { ok: false, reason: reasonFor(response, subject) };
+      const page: Page = response.value ?? {};
+      collected.push(...items(page));
+      const next = page.nextPageToken;
+      pageToken = typeof next === 'string' && next !== '' ? next : undefined;
+      pages += 1;
+      if (pages >= MAX_PAGES && pageToken !== undefined) {
+        return {
+          ok: false,
+          reason: `${subject.scope} did not finish listing within ${MAX_PAGES} pages`,
+        };
+      }
+    } while (pageToken !== undefined);
+
+    return { ok: true, items: collected };
+  }
+}
+
+/**
+ * Fold a refused read into the sentence an operator reads.
+ *
+ * The table is `cloudChecklist`'s, for the same reason: the shape of the refusal
+ * is the one thing a cloud API is reliably precise about, and each shape sends
+ * an operator somewhere different. A disabled service is a switch in a console;
+ * a `403` is an IAM grant; a `404` is a project that is not there. Telling them
+ * apart is the whole difference between a fact and a shrug.
+ */
+function reasonFor(
+  failure: Extract<CloudResponse<unknown>, { ok: false }>,
+  subject: Subject,
+): string {
+  if (failure.kind === 'transport') {
+    return `${subject.service} could not be reached: ${failure.message}`;
+  }
+  if (
+    failure.reason === SERVICE_DISABLED ||
+    failure.body.includes(SERVICE_DISABLED)
+  ) {
+    return `the ${subject.service} API is not enabled, so ${subject.scope} could not be listed`;
+  }
+  if (failure.status === 401 || failure.status === 403) {
+    return `the federated identity may not list ${subject.scope}: ${failure.message}`;
+  }
+  if (failure.status === 404) {
+    return `${subject.scope} could not be found`;
+  }
+  return `${subject.service} answered ${failure.status}: ${failure.message}`;
+}
+
+/** An answer, with the only suggestion this layer can honestly make. */
+function found(candidates: readonly string[]): Discovered<string> {
+  return {
+    kind: 'found',
+    candidates,
+    suggested: candidates.length === 1 ? (candidates[0] ?? null) : null,
+  };
+}
+
+/** No answer, and the reason there is none. Never an empty list. */
+function unavailable(reason: string): Discovered<string> {
+  return { kind: 'unavailable', reason };
+}

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -53,6 +53,7 @@ import { CloudBuildRoute } from './build/cloud-build.ts';
 import type { BuildAdapter } from './build/contract.ts';
 import { GitHubActionsBuildRoute } from './build/github-actions.ts';
 import { InClusterBuildRoute } from './build/in-cluster.ts';
+import { GcpDiscovery } from './cloud-discovery.ts';
 import { workloadIdentityToken } from './deploy/cloud/federation.ts';
 import { CloudRunDeployAdapter } from './deploy/cloudrun/index.ts';
 import type { DeployAdapter } from './deploy/contract.ts';
@@ -214,6 +215,12 @@ export function createAdapterRegistry(
   // `cloudTokenFor` mints — see `cloud/federation.ts`. The cloud build route
   // submits with it too, so it is resolved before the routes are built.
   const cloud = cloudTokenFor(options);
+
+  // A fourth consumer of that one provider rather than a fourth credential.
+  const discovery = new GcpDiscovery({
+    token: cloud,
+    ...(options.fetch ? { fetch: options.fetch } : {}),
+  });
 
   // §16's ordered list: the manifest's order *is* the admin rank, so the map is
   // built from it in order and `buildRouteProfiles` reads it back the same way.
@@ -383,6 +390,25 @@ export function createAdapterRegistry(
 
     repositoryAuthorization(): RepositoryAuthorization | null {
       return repositoryAuthorization;
+    },
+
+    /**
+     * The reads that answer what an operator would otherwise type (§20).
+     *
+     * Built on the same `cloud` provider resolved above, not on a second one:
+     * that is what makes discovery share `federation.ts`'s cache — one token
+     * exchange an hour for the whole process — instead of re-running the STS
+     * and impersonation round trip on every question asked.
+     *
+     * Never `null` here, even where this installation configured no federation.
+     * `cloudTokenFor` answers that case with a provider that refuses, and
+     * `CloudHttp` turns a refusing provider into a transport failure carrying
+     * its own sentence — so the screen reads "could not be reached, because…"
+     * rather than a client that is silently absent. `null` remains in the
+     * signature for the registries that do not build one at all.
+     */
+    discovery(): GcpDiscovery {
+      return discovery;
     },
 
     supplyChain() {

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -42,6 +42,7 @@ export { getDeployDetail } from './deploys/get-detail.ts';
 export { listDeploys } from './deploys/list.ts';
 export { rollbackDeploy } from './deploys/rollback.ts';
 export { configureInstallation } from './installation/configure.ts';
+export { discoverInstallationFacts } from './installation/discover.ts';
 export { getInstallationManifest } from './installation/get.ts';
 export {
   beginRepositoryAuthorization,

--- a/apps/spindrift/src/commands/installation/discover.ts
+++ b/apps/spindrift/src/commands/installation/discover.ts
@@ -1,0 +1,253 @@
+/**
+ * `discoverInstallationFacts` — ask the cloud for what an operator types (§20).
+ *
+ * §20 makes the manifest the one place a value naming this installation lives,
+ * and a good half of those values are facts the pod's own federated identity
+ * can simply be asked for. This command asks, and answers as **proposals
+ * against manifest paths** rather than as a shaped result object.
+ *
+ * **Paths, not field names, and that is load-bearing.** The settings surface
+ * names no manifest key on purpose — `web/views/auth/installation.tsx` says why:
+ * the schema is losing keys to the chart and gaining others, and a hand-listed
+ * form absorbs neither. A discovery result that carried named fields would put
+ * the list back, one layer down. So each answer carries `path` — the segments
+ * `forms/document.ts` already edits a document by — and the screen applies a
+ * chosen value with `withValueAt` without knowing what it just set.
+ *
+ * **Every answer has two arms, and a refusal is never an empty list.** That is
+ * `adapters/cloud-discovery.ts`'s rule, carried through unchanged: a project
+ * with no buckets is `found` with no candidates, and a project whose Storage API
+ * is switched off is `unavailable` with a sentence saying so. Flattening those
+ * would put a blank on a confirmation screen that reads exactly like a
+ * confirmed answer, which is the failure this whole path exists to remove.
+ *
+ * **Staged, because the calls are not all free.** With no project named, only
+ * the project list is fetched and everything below it says so — a stated fact,
+ * not an empty answer. With a project, its buckets and its key locations are
+ * fetched in parallel, each folded on its own so one refused API cannot turn two
+ * good answers into three refusals. The signer needs a location as well, because
+ * Cloud KMS lists key rings per concrete location and fanning out over every
+ * location a project offers is forty calls behind one button.
+ *
+ * Server-only imports are deliberately absent, for the reason
+ * `installation/get.ts` names: the browser bundle reaches this layer's types,
+ * and a command that pulls in a database module breaks the client build.
+ */
+import { z } from 'zod';
+import type {
+  Discovered,
+  GcpDiscovery,
+} from '../../adapters/cloud-discovery.ts';
+import type { FederationConfig } from '../../adapters/deploy/cloud/federation.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const discoverInstallationFactsInput = z
+  .object({
+    /**
+     * Which project to look inside. Absent on the first pass, when the answer
+     * to "which project" is itself one of the things being discovered.
+     */
+    project: z.string().trim().min(1).optional(),
+    /** Which key location to list signing keys from. See the note above. */
+    kmsLocation: z.string().trim().min(1).optional(),
+  })
+  .strict();
+
+export type DiscoverInstallationFactsInput = z.infer<
+  typeof discoverInstallationFactsInput
+>;
+
+/** One value an operator may confirm: what they read, and what gets written. */
+export interface DiscoveredCandidate {
+  /** What the operator reads. */
+  readonly label: string;
+  /**
+   * What is written at the fact's path when this candidate is chosen, verbatim.
+   *
+   * Carried rather than derived because the two are not always the same shape:
+   * `sources.buckets` is a list and takes `[name]`, while `sources.defaultBucket`
+   * takes the same name bare. A screen deriving that would be a screen with an
+   * opinion about the schema, which is exactly what it must not have.
+   */
+  readonly value: unknown;
+}
+
+/** One manifest path, and what discovery could say about it. */
+export type DiscoveredFact = {
+  /** Where the chosen value belongs, as `forms/document.ts` addresses it. */
+  readonly path: readonly string[];
+} & Discovered<DiscoveredCandidate>;
+
+export interface DiscoverInstallationFactsResult {
+  /** In display order. Empty is not a state this command can produce. */
+  readonly facts: readonly DiscoveredFact[];
+}
+
+/**
+ * The project in an impersonated service account's own address.
+ *
+ * ponytail: a heuristic, and marked as one. It reads
+ * `…@<project>.iam.gserviceaccount.com` out of the impersonation URL the
+ * deployment's credential already carries, which costs no API call and is right
+ * for every installation whose controller identity lives in its own home
+ * vessel. An installation that impersonates an identity from somewhere else gets
+ * a wrong suggestion — which is why it is only ever `suggested`, never asserted
+ * as the answer. A URL that does not match at all yields nothing rather than a
+ * fragment of one.
+ */
+const SERVICE_ACCOUNT_PROJECT =
+  /@([a-z][a-z0-9-]{4,28})\.iam\.gserviceaccount\.com/;
+
+export const discoverInstallationFacts: Command<
+  DiscoverInstallationFactsInput,
+  DiscoverInstallationFactsResult
+> = async (input, context) => {
+  // Refused before anything is asked, and asserted by the test that no request
+  // was made: an installation with no federation has no cloud identity at all,
+  // which is a fact about the installation rather than a failed probe. Mirrors
+  // `storage/test-bucket.ts`, and `NOT_DEPLOYABLE` is the code for exactly this
+  // — the caller is told about the world, not asked to fix a field.
+  if (context.manifest.cloud.federation === null) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this installation mounts no cloud federation credential, so nothing about its cloud can be discovered',
+    );
+  }
+  const discovery = context.adapters.discovery?.() ?? null;
+  if (discovery === null) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this process cannot reach a cloud API, so nothing about this installation can be discovered',
+    );
+  }
+
+  const { project, kmsLocation } = input;
+  // Three independent reads, each folded into its own answer. Never one
+  // `try` and never one rejection path: `GcpDiscovery` returns its failures,
+  // so a single catch here would silently turn two good answers into refusals.
+  const [projects, buckets, signers] = await Promise.all([
+    discovery.projects(),
+    project === undefined
+      ? needsProject('buckets')
+      : discovery.buckets(project),
+    project === undefined
+      ? needsProject('signing keys')
+      : signingKeysIn(discovery, project, kmsLocation),
+  ]);
+
+  const suggestedVessel = homeVesselOf(context.manifest.cloud.federation);
+
+  return ok({
+    facts: [
+      withSuggestion(
+        mapped(['cloud', 'homeVesselProject'], projects, plain),
+        suggestedVessel,
+      ),
+      mapped(['cloud', 'artifactsProject'], projects, plain),
+      // The same one read, answered against both keys: a bucket chosen for one
+      // and not the other leaves a manifest whose default is not among its
+      // buckets, which validates and then stages nowhere.
+      mapped(['sources', 'buckets'], buckets, (name) => ({
+        label: name,
+        value: [name],
+      })),
+      mapped(['sources', 'defaultBucket'], buckets, plain),
+      mapped(['supplyChain', 'signer'], signers, plain),
+    ],
+  });
+};
+
+/** A candidate whose written value is the string the operator read. */
+function plain(value: string): DiscoveredCandidate {
+  return { label: value, value };
+}
+
+/**
+ * A fact that was not asked about because the question needs a project first.
+ *
+ * Stated rather than probed, which is the posture `listSourceBuckets.canVerify`
+ * already takes: an answer nobody asked for is not the same as an answer that
+ * came back empty, and saying which is which is the whole job here.
+ */
+function needsProject(what: string): Promise<Discovered<string>> {
+  return Promise.resolve({
+    kind: 'unavailable',
+    reason: `name a project and run discovery again to list its ${what}`,
+  });
+}
+
+/**
+ * Signing keys, or the sentence naming what is missing before they can be read.
+ *
+ * The extra call in the second arm earns its place twice: it tells the operator
+ * which locations they may name, and its own refusal is the honest reason the
+ * signer could not be read — a Cloud KMS that answers nothing here would
+ * otherwise be reported as "name a location", sending them to supply an input
+ * that was never the problem.
+ */
+async function signingKeysIn(
+  discovery: GcpDiscovery,
+  project: string,
+  location: string | undefined,
+): Promise<Discovered<string>> {
+  if (location !== undefined) return discovery.signingKeys(project, location);
+  const locations = await discovery.keyLocations(project);
+  if (locations.kind === 'unavailable') return locations;
+  return {
+    kind: 'unavailable',
+    reason:
+      locations.candidates.length === 0
+        ? 'this project offers no key locations, so it holds no signing key'
+        : `name a key location and run discovery again — this project offers ${locations.candidates.join(', ')}`,
+  };
+}
+
+/** One read, against one manifest path, in whichever arm it came back in. */
+function mapped(
+  path: readonly string[],
+  discovered: Discovered<string>,
+  to: (value: string) => DiscoveredCandidate,
+): DiscoveredFact {
+  if (discovered.kind === 'unavailable') return { path, ...discovered };
+  return {
+    path,
+    kind: 'found',
+    candidates: discovered.candidates.map(to),
+    suggested: discovered.suggested === null ? null : to(discovered.suggested),
+  };
+}
+
+/**
+ * Fold the credential's own answer in ahead of whatever the listing said.
+ *
+ * A suggestion this installation carries is worth more than a list it may not
+ * have permission to read, and it is the likely live case: an identity granted
+ * on one bucket and one key is not usually granted `projects.list`. So a
+ * suggestion turns a refusal into an answer, and joins a listing it is already
+ * part of without being repeated.
+ */
+function withSuggestion(
+  fact: DiscoveredFact,
+  suggested: DiscoveredCandidate | null,
+): DiscoveredFact {
+  if (suggested === null) return fact;
+  const listed = fact.kind === 'found' ? fact.candidates : [];
+  return {
+    path: fact.path,
+    kind: 'found',
+    candidates: listed.some((candidate) => candidate.value === suggested.value)
+      ? listed
+      : [suggested, ...listed],
+    suggested,
+  };
+}
+
+/** The home vessel this installation's own identity lives in, if it says. */
+function homeVesselOf(
+  federation: FederationConfig,
+): DiscoveredCandidate | null {
+  const url = federation.impersonationUrl;
+  if (url === null) return null;
+  const project = SERVICE_ACCOUNT_PROJECT.exec(url)?.[1];
+  return project === undefined ? null : plain(project);
+}

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -71,6 +71,10 @@ import {
   configureInstallationInput,
 } from './installation/configure.ts';
 import {
+  discoverInstallationFacts,
+  discoverInstallationFactsInput,
+} from './installation/discover.ts';
+import {
   getInstallationManifest,
   getInstallationManifestInput,
 } from './installation/get.ts';
@@ -207,6 +211,10 @@ export const commandRegistry = {
   getInstallationManifest: {
     input: getInstallationManifestInput,
     handler: getInstallationManifest,
+  },
+  discoverInstallationFacts: {
+    input: discoverInstallationFactsInput,
+    handler: discoverInstallationFacts,
   },
   replaceConfig: { input: replaceConfigInput, handler: replaceConfig },
   uploadArchive: { input: uploadArchiveInput, handler: uploadArchive },

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -20,6 +20,7 @@
  * of them can be replaced.
  */
 import type { BuildAdapter } from '../adapters/build/contract.ts';
+import type { GcpDiscovery } from '../adapters/cloud-discovery.ts';
 import type { DeployAdapter } from '../adapters/deploy/contract.ts';
 import type { SecretStore } from '../adapters/store/contract.ts';
 import type {
@@ -138,6 +139,21 @@ export interface AdapterRegistry {
    * ceremony.
    */
   repositoryAuthorization?(): RepositoryAuthorization | null;
+  /**
+   * Reading the cloud this installation already runs in (§13, §20).
+   *
+   * Answers what an operator would otherwise type into the manifest by hand —
+   * projects, buckets, signing keys — over the same federated provider the
+   * cloud deploy adapters and the cloud build route are given, so the token
+   * exchange is made once per process rather than once per question.
+   *
+   * Optional for the reason the four lookups above it are: a registry that
+   * cannot reach a cloud API is an ordinary installation, and every hand-built
+   * test registry that has no opinion about discovery stays honest by omitting
+   * it. A command that finds it absent says so rather than reaching for a
+   * global.
+   */
+  discovery?(): GcpDiscovery | null;
   /**
    * Core's verifier and signer (§16).
    *

--- a/apps/spindrift/src/web/views/auth/discovery.tsx
+++ b/apps/spindrift/src/web/views/auth/discovery.tsx
@@ -1,0 +1,244 @@
+/**
+ * Confirming cloud facts instead of typing them (§13, §20, ticket 32 slice 2).
+ *
+ * The settings form below this panel can already edit every manifest key. What
+ * it cannot do is tell an operator what the right value *is* — so a project id
+ * or a signer URI is typed from memory, and a typo is invisible until a build
+ * dies on a signed URL. `discoverInstallationFacts` asks the cloud with the
+ * credential the pod already holds; this is the hand that reaches it and the
+ * screen that shows what came back.
+ *
+ * **Nothing here names a manifest key**, which is the same correctness
+ * requirement `installation.tsx` states for the form itself. Every answer
+ * carries its own `path`, the panel titles it with {@link humanize} of the last
+ * segment, and applying a candidate is {@link withValueAt} at that path — so
+ * the panel keeps working as ticket 33 removes keys from the schema, and a
+ * value it cannot place is not a value it can silently misplace.
+ *
+ * **A refusal reads as a fact, not as a field error.** That is the third of the
+ * three refusals `installation.tsx` keeps apart: `unavailable` means the cloud
+ * did not answer, which is nothing an operator can fix by re-typing a value in
+ * this form. It renders in the neutral voice, beside the field it could not
+ * answer, with the sentence the command produced — never as a blank, because a
+ * blank on a confirmation screen reads as a confirmed answer.
+ */
+import { CircleAlert, Search } from 'lucide-react';
+import { useState } from 'react';
+import type {
+  DiscoveredCandidate,
+  DiscoveredFact,
+} from '../../../commands/installation/discover.ts';
+import { command } from '../../client.ts';
+import { withValueAt } from '../../forms/document.ts';
+import { humanize } from '../../forms/schema.ts';
+import { Button } from '../../ui/button.tsx';
+import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
+import { Field } from '../../ui/field.tsx';
+
+/**
+ * Ask the cloud, then apply what an operator confirms.
+ *
+ * Self-contained rather than lifted into `InstallationSettingsView`'s props:
+ * everything it holds — the two narrowing inputs, the last answer, whether a
+ * request is in flight — is its own, and the only thing it has to say to the
+ * screen around it is the edited document, which is the same `onChange` every
+ * control on the page already speaks.
+ */
+export function DiscoveryPanel({
+  document,
+  disabled = false,
+  onChange,
+}: {
+  readonly document: unknown;
+  readonly disabled?: boolean;
+  onChange(document: unknown): void;
+}) {
+  const [project, setProject] = useState('');
+  const [kmsLocation, setKmsLocation] = useState('');
+  const [facts, setFacts] = useState<readonly DiscoveredFact[] | null>(null);
+  const [refusal, setRefusal] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const discover = async () => {
+    setBusy(true);
+    setRefusal(null);
+    try {
+      const result = await command('discoverInstallationFacts', {
+        // Absent rather than empty: the command's input is `.strict()` and an
+        // empty project is not a project, it is the first pass.
+        ...(project.trim() === '' ? {} : { project: project.trim() }),
+        ...(kmsLocation.trim() === ''
+          ? {}
+          : { kmsLocation: kmsLocation.trim() }),
+      });
+      if (result.ok) {
+        setFacts(result.value.facts);
+      } else {
+        setFacts(null);
+        setRefusal(result.failure.message);
+      }
+    } catch (cause) {
+      setFacts(null);
+      setRefusal(
+        cause instanceof Error
+          ? cause.message
+          : 'This installation could not be asked about its cloud.',
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <Search aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+        <div>
+          <CardTitle>What this installation's cloud says</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Read with the credential this deployment already mounts. Nothing is
+            written until a value is applied below and the manifest is saved.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        <div className="flex flex-col gap-4 sm:flex-row">
+          <Field
+            name="discovery.project"
+            label="Project"
+            hint="Leave empty to list the projects this identity can see."
+            value={project}
+            disabled={disabled || busy}
+            onChange={(event) => setProject(event.target.value)}
+          />
+          <Field
+            name="discovery.kmsLocation"
+            label="Key location"
+            hint="Signing keys are listed one location at a time."
+            value={kmsLocation}
+            disabled={disabled || busy}
+            onChange={(event) => setKmsLocation(event.target.value)}
+          />
+        </div>
+        <div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={disabled || busy}
+            onClick={() => void discover()}
+          >
+            <Search aria-hidden="true" />
+            {busy ? 'Asking…' : 'Ask this installation’s cloud'}
+          </Button>
+        </div>
+        {refusal === null ? null : (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground"
+          >
+            <CircleAlert
+              aria-hidden="true"
+              className="mt-0.5 size-4 text-subtle"
+            />
+            <div>
+              <p className="font-medium">Nothing could be discovered.</p>
+              <p className="mt-0.5">{refusal}</p>
+              <p className="mt-1 text-muted-foreground">
+                This is a fact about the installation, not a field to correct.
+              </p>
+            </div>
+          </div>
+        )}
+        {facts === null ? null : (
+          <DiscoveredFactList
+            facts={facts}
+            disabled={disabled || busy}
+            onApply={(fact, candidate) =>
+              onChange(applyDiscovered(document, fact, candidate))
+            }
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * The document with one confirmed value in it.
+ *
+ * Named rather than inlined so it can be asserted without a browser: the whole
+ * of what confirming does is put a value the command produced at a path the
+ * command produced, and neither of those is this screen's to decide. A version
+ * of this that reached for a key name would compile and would be the bug the
+ * panel exists to avoid.
+ */
+export function applyDiscovered(
+  document: unknown,
+  fact: DiscoveredFact,
+  candidate: DiscoveredCandidate,
+): unknown {
+  return withValueAt(document, fact.path, candidate.value);
+}
+
+/**
+ * What came back, one row per manifest path.
+ *
+ * Pure, and exported, because this is the half with a claim in it: the two arms
+ * have to read as two different things, and that is a statement about markup
+ * rather than about a request.
+ */
+export function DiscoveredFactList({
+  facts,
+  disabled = false,
+  onApply,
+}: {
+  readonly facts: readonly DiscoveredFact[];
+  readonly disabled?: boolean;
+  onApply(fact: DiscoveredFact, candidate: DiscoveredCandidate): void;
+}) {
+  return (
+    <dl className="flex flex-col gap-3">
+      {facts.map((fact) => (
+        <div
+          key={fact.path.join('.')}
+          className="flex flex-col gap-1 border-t border-border pt-3 first:border-t-0 first:pt-0"
+        >
+          <dt className="text-[11.5px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+            {/* The last segment, humanized. Never a key written here — the
+                path came from the command, and the schema owns which keys
+                exist. */}
+            {humanize(fact.path[fact.path.length - 1] ?? '')}
+          </dt>
+          <dd className="text-sm">
+            {fact.kind === 'unavailable' ? (
+              <span className="text-muted-foreground">{fact.reason}</span>
+            ) : fact.candidates.length === 0 ? (
+              <span className="text-muted-foreground">
+                Nothing of this kind exists here.
+              </span>
+            ) : (
+              <div className="flex flex-wrap gap-2">
+                {fact.candidates.map((candidate) => (
+                  <Button
+                    key={candidate.label}
+                    type="button"
+                    size="sm"
+                    variant={
+                      candidate.label === fact.suggested?.label
+                        ? 'default'
+                        : 'outline'
+                    }
+                    disabled={disabled}
+                    onClick={() => onApply(fact, candidate)}
+                  >
+                    {candidate.label}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -48,6 +48,7 @@ import { SchemaFields } from '../../forms/render.tsx';
 import type { FormField } from '../../forms/schema.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
+import { DiscoveryPanel } from './discovery.tsx';
 
 /** What the last save attempt produced. */
 export type SaveOutcome =
@@ -252,6 +253,17 @@ export function InstallationSettingsView({
       }}
     >
       <ManifestDivergenceNotice paths={divergence} />
+
+      {/* Above the form, because it is the step that comes before editing: a
+          value confirmed from the cloud is a value nobody has to type, and one
+          typed here is a value nothing checked. It edits the same document
+          through the same `onChange`, so a discovered value is an unsaved edit
+          like any other until the whole manifest is saved. */}
+      <DiscoveryPanel
+        document={document}
+        disabled={saving}
+        onChange={onChange}
+      />
 
       <Card>
         <CardHeader>

--- a/apps/spindrift/test/adapters/registry.test.ts
+++ b/apps/spindrift/test/adapters/registry.test.ts
@@ -13,6 +13,7 @@ import {
   installationServiceAccountToken,
 } from '../../src/adapters/registry.ts';
 import { parseManifest, resolveManifest } from '../../src/config/manifest.ts';
+import { FakeGcpDiscovery } from '../harness/fakes/gcp-discovery-api.ts';
 
 test('the installation token provider follows the projected path', async () => {
   const path = join('/tmp', `spindrift-identity-token-${crypto.randomUUID()}`);
@@ -63,4 +64,45 @@ test('source adapter returns explicitly passed source stager when provided', asy
   });
 
   expect(registry.source?.()).toBe(customStager);
+});
+
+/**
+ * Discovery is a fourth consumer of the one federated provider, not a fourth
+ * credential.
+ *
+ * The property worth asserting is not that the lookup answers something — it is
+ * *which* token the request carries. `src/storage/cloud.ts` shows the other
+ * shape: a second `workloadIdentityToken` constructed per call, which re-runs
+ * the STS and impersonation exchange every time and defeats the cache in
+ * `deploy/cloud/federation.ts`. A discovery client wired that way would pass
+ * every fold assertion in `test/commands/installation-discover.test.ts` and
+ * still be the wrong wiring.
+ */
+test('discovery reaches the cloud with the registry-wide token', async () => {
+  const yaml = await Bun.file(
+    join(import.meta.dir, '../fixtures/installation.example.yaml'),
+  ).text();
+  const manifest = await resolveManifest(parseManifest(yaml, 'test'), {});
+  const fake = new FakeGcpDiscovery({
+    token: 'the-registry-token',
+    projects: ['example-home'],
+  });
+
+  const registry = createAdapterRegistry({
+    manifest,
+    env: {},
+    cloudToken: () => 'the-registry-token',
+    fetch: fake.fetch,
+  });
+
+  const discovery = registry.discovery?.() ?? null;
+  expect(discovery).not.toBeNull();
+  expect(await discovery?.projects()).toEqual({
+    kind: 'found',
+    candidates: ['example-home'],
+    suggested: 'example-home',
+  });
+  expect(fake.requests.map((request) => request.authorization)).toEqual([
+    'Bearer the-registry-token',
+  ]);
 });

--- a/apps/spindrift/test/commands/installation-discover.test.ts
+++ b/apps/spindrift/test/commands/installation-discover.test.ts
@@ -1,0 +1,454 @@
+/**
+ * Discovering what an operator would otherwise type (§13, §20).
+ *
+ * The claim under test is one sentence: **a refusal is not an empty list.** A
+ * confirmation screen showing "buckets: none" is an answer an operator will act
+ * on, and producing it from a `403`, a switched-off API or an unreachable
+ * network is worse than producing nothing — it launders a failed probe into a
+ * fact. So the assertions below are about the *arm* an answer came back in, not
+ * about the wording of a message, and the first three fail if that distinction
+ * is ever collapsed.
+ *
+ * Driven through a real {@link createAdapterRegistry} against a fake far side,
+ * per § Seam 2. The registry is not incidental: the whole point of discovery
+ * living there is that it shares the one federated provider the cloud deploy
+ * adapters use, so a test that handed the command a hand-built client would
+ * prove the fold and none of the wiring.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createAdapterRegistry } from '../../src/adapters/registry.ts';
+import {
+  type DiscoveredFact,
+  discoverInstallationFacts,
+} from '../../src/commands/installation/discover.ts';
+import type { CommandContext } from '../../src/commands/types.ts';
+import { installationManifestSchema } from '../../src/config/manifest.schema.ts';
+import type { InstallationManifest } from '../../src/config/manifest.ts';
+import type { Database } from '../../src/db/client.ts';
+import { describeObject, type FormField } from '../../src/web/forms/schema.ts';
+import {
+  FakeGcpDiscovery,
+  type FakeGcpDiscoveryOptions,
+} from '../harness/fakes/gcp-discovery-api.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const TOKEN = 'a-federated-token';
+const PROJECT = 'example-home';
+
+/**
+ * A database that fails if it is touched.
+ *
+ * Discovery reads the cloud and writes nothing — confirming a value is
+ * `configureInstallation`'s act, not this one's — and a fixture row here would
+ * only be a way for that to stop being true unnoticed.
+ */
+const db = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error('discovery reached the database');
+    },
+  },
+) as Database;
+
+const fixture = await fixtureManifest();
+
+/** The fixture installation, with whatever federation a test needs. */
+function manifestWith(
+  federation: Partial<
+    NonNullable<InstallationManifest['cloud']['federation']>
+  > | null,
+): InstallationManifest {
+  return {
+    ...fixture,
+    cloud: {
+      ...fixture.cloud,
+      federation:
+        federation === null
+          ? null
+          : { ...fixture.cloud.federation!, ...federation },
+    },
+  };
+}
+
+function contextFor(
+  fake: FakeGcpDiscovery,
+  manifest: InstallationManifest = manifestWith({}),
+): CommandContext {
+  return {
+    principal: { id: 'user-1', displayName: 'Operator' },
+    clock: { now: () => new Date('2026-08-03T00:00:00.000Z') },
+    db,
+    manifest,
+    adapters: createAdapterRegistry({
+      manifest,
+      env: {},
+      // The credential the registry hands every cloud client. Injected here so
+      // the fake can assert which one arrived, exactly as the token exchange
+      // would have minted it.
+      cloudToken: () => TOKEN,
+      fetch: fake.fetch,
+    }),
+  };
+}
+
+/** Everything wired for one run: a fake far side and a context over it. */
+function installation(options: FakeGcpDiscoveryOptions = {}) {
+  const fake = new FakeGcpDiscovery({ token: TOKEN, ...options });
+  return { fake, context: contextFor(fake) };
+}
+
+/** One fact by the manifest path it proposes a value for. */
+function factAt(
+  facts: readonly DiscoveredFact[],
+  ...path: string[]
+): DiscoveredFact {
+  const found = facts.find((fact) => fact.path.join('.') === path.join('.'));
+  if (found === undefined) {
+    throw new Error(`discovery answered nothing for ${path.join('.')}`);
+  }
+  return found;
+}
+
+async function discover(
+  context: CommandContext,
+  input: { project?: string; kmsLocation?: string } = {},
+): Promise<readonly DiscoveredFact[]> {
+  const result = await discoverInstallationFacts(input, context);
+  if (!result.ok) {
+    throw new Error(`discovery refused: ${result.failure.message}`);
+  }
+  return result.value.facts;
+}
+
+describe('a refusal is never an empty answer', () => {
+  test('a disabled Storage API is unavailable, not a project with no buckets', async () => {
+    const { context } = installation({
+      projects: [PROJECT],
+      refuse: {
+        storage: {
+          status: 403,
+          reason: 'SERVICE_DISABLED',
+          message: 'Cloud Storage API has not been used in this project',
+        },
+      },
+    });
+
+    const fact = factAt(
+      await discover(context, { project: PROJECT }),
+      'sources',
+      'buckets',
+    );
+
+    expect(fact.kind).toBe('unavailable');
+    // On the arm, not on the sentence. A regression that answered
+    // `{ candidates: [] }` here would still carry a plausible message; what it
+    // could not do is stop having candidates at all.
+    expect(fact).not.toHaveProperty('candidates');
+    expect(fact).not.toHaveProperty('suggested');
+    if (fact.kind !== 'unavailable') return;
+    expect(fact.reason).toContain('Cloud Storage');
+    expect(fact.reason).toContain(PROJECT);
+  });
+
+  test('a project with no buckets is found, with none', async () => {
+    const { context } = installation({
+      projects: [PROJECT],
+      buckets: { [PROJECT]: [] },
+    });
+
+    const fact = factAt(
+      await discover(context, { project: PROJECT }),
+      'sources',
+      'buckets',
+    );
+
+    expect(fact.kind).toBe('found');
+    if (fact.kind !== 'found') return;
+    expect(fact.candidates).toEqual([]);
+    expect(fact.suggested).toBeNull();
+  });
+
+  test('one refused API does not refuse the others', async () => {
+    const { context } = installation({
+      projects: [PROJECT, 'example-artifacts'],
+      buckets: { [PROJECT]: ['example-source-bucket'] },
+      refuse: { keyManagement: { status: 403 } },
+    });
+
+    const facts = await discover(context, { project: PROJECT });
+
+    expect(factAt(facts, 'cloud', 'artifactsProject').kind).toBe('found');
+    expect(factAt(facts, 'sources', 'buckets').kind).toBe('found');
+    expect(factAt(facts, 'supplyChain', 'signer').kind).toBe('unavailable');
+  });
+});
+
+describe('what the reads answer', () => {
+  test('a bucket lands as a list and as the default, from one read', async () => {
+    const { context, fake } = installation({
+      projects: [PROJECT],
+      buckets: { [PROJECT]: ['example-source-bucket'] },
+    });
+
+    const facts = await discover(context, { project: PROJECT });
+    const buckets = factAt(facts, 'sources', 'buckets');
+    const fallback = factAt(facts, 'sources', 'defaultBucket');
+
+    expect(buckets.kind).toBe('found');
+    expect(fallback.kind).toBe('found');
+    if (buckets.kind !== 'found' || fallback.kind !== 'found') return;
+    // The same name, in the two shapes the two keys take. A screen deriving
+    // that would be a screen with an opinion about the schema.
+    expect(buckets.suggested).toEqual({
+      label: 'example-source-bucket',
+      value: ['example-source-bucket'],
+    });
+    expect(fallback.suggested).toEqual({
+      label: 'example-source-bucket',
+      value: 'example-source-bucket',
+    });
+    // One read, not two: both keys are answered from a single bucket listing.
+    expect(
+      fake.requests.filter((request) => request.path === '/storage/v1/b'),
+    ).toHaveLength(1);
+  });
+
+  test('only a key that can sign is offered, as a gcpkms reference', async () => {
+    const { context } = installation({
+      projects: [PROJECT],
+      buckets: { [PROJECT]: [] },
+      keys: [
+        {
+          project: PROJECT,
+          location: 'a-region',
+          ring: 'keys',
+          name: 'signer',
+        },
+        {
+          project: PROJECT,
+          location: 'a-region',
+          ring: 'keys',
+          name: 'envelope',
+          purpose: 'ENCRYPT_DECRYPT',
+        },
+      ],
+    });
+
+    const fact = factAt(
+      await discover(context, { project: PROJECT, kmsLocation: 'a-region' }),
+      'supplyChain',
+      'signer',
+    );
+
+    expect(fact.kind).toBe('found');
+    if (fact.kind !== 'found') return;
+    // The URI is the prefix plus the key's own resource name, verbatim —
+    // assembling the six segments by hand is where a typo becomes a signing
+    // failure nothing catches until a build.
+    expect(fact.candidates.map((candidate) => candidate.value)).toEqual([
+      `gcpkms://projects/${PROJECT}/locations/a-region/keyRings/keys/cryptoKeys/signer`,
+    ]);
+  });
+
+  test('a signer with no location named says which locations there are', async () => {
+    const { context } = installation({
+      projects: [PROJECT],
+      buckets: { [PROJECT]: [] },
+      keyLocations: { [PROJECT]: ['a-region', 'another-region'] },
+    });
+
+    const fact = factAt(
+      await discover(context, { project: PROJECT }),
+      'supplyChain',
+      'signer',
+    );
+
+    expect(fact.kind).toBe('unavailable');
+    if (fact.kind !== 'unavailable') return;
+    expect(fact.reason).toContain('a-region');
+    expect(fact.reason).toContain('another-region');
+  });
+
+  test('with no project named, nothing below one is guessed at', async () => {
+    const { context, fake } = installation({ projects: [PROJECT] });
+
+    const facts = await discover(context);
+
+    expect(factAt(facts, 'cloud', 'artifactsProject').kind).toBe('found');
+    for (const path of [
+      ['sources', 'buckets'],
+      ['supplyChain', 'signer'],
+    ]) {
+      const fact = factAt(facts, ...path);
+      expect(fact.kind).toBe('unavailable');
+      if (fact.kind !== 'unavailable') continue;
+      expect(fact.reason).toContain('name a project');
+    }
+    // Stated rather than probed: no project means no call that needed one.
+    expect(fake.requests.map((request) => request.host)).toEqual([
+      'cloudresourcemanager.googleapis.com',
+    ]);
+  });
+
+  test('a project pending deletion is listed by the API and never offered', async () => {
+    const { context } = installation({
+      projects: [PROJECT],
+      deletedProjects: ['example-retired'],
+    });
+
+    const fact = factAt(await discover(context), 'cloud', 'artifactsProject');
+
+    expect(fact.kind).toBe('found');
+    if (fact.kind !== 'found') return;
+    expect(fact.candidates.map((candidate) => candidate.value)).toEqual([
+      PROJECT,
+    ]);
+  });
+});
+
+describe('truncation is not silence', () => {
+  test('a paginated project list is walked to the end', async () => {
+    const { context, fake } = installation({
+      projects: [PROJECT, 'example-artifacts', 'example-vessel'],
+      pageSize: 1,
+    });
+
+    const fact = factAt(await discover(context), 'cloud', 'artifactsProject');
+
+    expect(fact.kind).toBe('found');
+    if (fact.kind !== 'found') return;
+    // A single-page read answers one plausible project and reads as complete.
+    expect(fact.candidates.map((candidate) => candidate.value)).toEqual([
+      PROJECT,
+      'example-artifacts',
+      'example-vessel',
+    ]);
+    expect(fake.requests).toHaveLength(3);
+  });
+});
+
+describe('the credential answers what it can without a call', () => {
+  test('the impersonated identity suggests the home vessel', async () => {
+    const fake = new FakeGcpDiscovery({ token: TOKEN, refuse: {} });
+    const context = contextFor(
+      fake,
+      manifestWith({
+        impersonationUrl: `https://iamcredentials.example.test/v1/projects/-/serviceAccounts/controller@${PROJECT}.iam.gserviceaccount.com:generateAccessToken`,
+      }),
+    );
+
+    const fact = factAt(await discover(context), 'cloud', 'homeVesselProject');
+
+    expect(fact.kind).toBe('found');
+    if (fact.kind !== 'found') return;
+    expect(fact.suggested).toEqual({ label: PROJECT, value: PROJECT });
+  });
+
+  test('an identity that is not a service account suggests nothing', async () => {
+    // The fixture's own credential impersonates a host that is not a service
+    // account address. A partial match must yield nothing rather than a
+    // fragment of a project name presented as an answer.
+    const { context } = installation({ projects: [] });
+
+    const fact = factAt(await discover(context), 'cloud', 'homeVesselProject');
+
+    expect(fact.kind).toBe('found');
+    if (fact.kind !== 'found') return;
+    expect(fact.suggested).toBeNull();
+    expect(fact.candidates).toEqual([]);
+  });
+
+  test('a suggestion survives a project list this identity may not read', async () => {
+    // The likely live posture: an identity granted on one bucket and one key is
+    // not usually granted `projects.list`. The credential still knows its own
+    // project, and losing that to a refusal elsewhere would be discovery
+    // refusing a question it had already answered.
+    const fake = new FakeGcpDiscovery({
+      token: TOKEN,
+      refuse: { resourceManager: { status: 403 } },
+    });
+    const context = contextFor(
+      fake,
+      manifestWith({
+        impersonationUrl: `https://iamcredentials.example.test/v1/projects/-/serviceAccounts/controller@${PROJECT}.iam.gserviceaccount.com:generateAccessToken`,
+      }),
+    );
+
+    const facts = await discover(context);
+
+    expect(factAt(facts, 'cloud', 'homeVesselProject').kind).toBe('found');
+    // And the key it cannot suggest anything for stays honest about the same
+    // refusal, rather than borrowing the answer.
+    expect(factAt(facts, 'cloud', 'artifactsProject').kind).toBe('unavailable');
+  });
+});
+
+describe('an installation with no cloud identity', () => {
+  test('is refused as a fact, before a single request', async () => {
+    const fake = new FakeGcpDiscovery({ token: TOKEN });
+    const context = contextFor(fake, manifestWith(null));
+
+    const result = await discoverInstallationFacts({}, context);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('this installation');
+    // Proven rather than described: nothing was asked, so nothing failed.
+    expect(fake.requests).toEqual([]);
+  });
+});
+
+describe('every path discovery proposes is a path the manifest has', () => {
+  /** Walk the schema the settings form is generated from, key by key. */
+  function resolves(path: readonly string[]): boolean {
+    let fields: readonly FormField[] = describeObject(
+      installationManifestSchema,
+    );
+    for (const [index, key] of path.entries()) {
+      const field = fields.find((candidate) => candidate.key === key);
+      if (field === undefined) return false;
+      if (index === path.length - 1) return true;
+      if (field.node.kind !== 'object') return false;
+      fields = field.node.fields;
+    }
+    return false;
+  }
+
+  test('the walk rejects a key the schema no longer has', () => {
+    // The exact staleness this test exists to catch: `dns.apexZone` was the
+    // key when discovery was first specified, and `dns.zones.private` is the
+    // key now. A detector nobody has seen fail is not a detector.
+    expect(resolves(['dns', 'apexZone'])).toBe(false);
+    expect(resolves(['dns', 'zones', 'private'])).toBe(true);
+  });
+
+  test('each answered path resolves to a real field', async () => {
+    const { context } = installation({
+      projects: [PROJECT],
+      buckets: { [PROJECT]: ['example-source-bucket'] },
+      keys: [
+        {
+          project: PROJECT,
+          location: 'a-region',
+          ring: 'keys',
+          name: 'signer',
+        },
+      ],
+    });
+
+    const facts = await discover(context, {
+      project: PROJECT,
+      kmsLocation: 'a-region',
+    });
+
+    expect(facts.length).toBeGreaterThan(0);
+    for (const fact of facts) {
+      expect([fact.path.join('.'), resolves(fact.path)]).toEqual([
+        fact.path.join('.'),
+        true,
+      ]);
+    }
+  });
+});

--- a/apps/spindrift/test/harness/fakes/gcp-discovery-api.ts
+++ b/apps/spindrift/test/harness/fakes/gcp-discovery-api.ts
@@ -1,0 +1,266 @@
+/**
+ * A fake of the three APIs discovery reads (§ Seam 2).
+ *
+ * The far-side HTTP API behind the real client, so `GcpDiscovery`'s real
+ * resource names, its real query parameters, its real page loop and its real
+ * key-purpose filter are all exercised. One `Fetcher` rather than three,
+ * routing on the host, because that is what the client is actually handed: it
+ * addresses three hostnames through one injected transport, and a test that
+ * substituted a per-API stub would never prove the client sends the right
+ * request to the right host.
+ *
+ * Five behaviours are modelled because the client has to survive them, not
+ * because they decorate:
+ *
+ * - **A wrong bearer is a `401`**, so a test can prove which credential arrived.
+ * - **A disabled service is a `403` carrying `SERVICE_DISABLED` in
+ *   `error.details`**, which is the shape the fold keys on and the one that must
+ *   not be reported as a missing permission.
+ * - **An unknown project is a `404`**, distinct from a refusal.
+ * - **Listing is paginated at a deliberately tiny page**, because a client that
+ *   reads one page answers a short list that looks complete.
+ * - **A key of the wrong purpose exists**, so the filter is run rather than
+ *   assumed. A symmetric key offered as a signer is a manifest that validates
+ *   and then fails at the first cosign call.
+ */
+import type { Fetcher } from '../../../src/adapters/deploy/cloud/http.ts';
+
+/** One key the fake holds, and where it lives. */
+export interface FakeCryptoKey {
+  readonly project: string;
+  readonly location: string;
+  readonly ring: string;
+  readonly name: string;
+  /** Defaults to a signing key; a test sets another to exercise the filter. */
+  readonly purpose?: string;
+}
+
+/** How one of the three APIs refuses everything asked of it. */
+export interface FakeRefusal {
+  readonly status: number;
+  /** Placed in `error.details[].reason`, as the real APIs place it. */
+  readonly reason?: string;
+  readonly message?: string;
+}
+
+export interface FakeGcpDiscoveryOptions {
+  readonly token?: string;
+  /** Project ids Resource Manager lists as active, in order. */
+  readonly projects?: readonly string[];
+  /** Listed too, and pending deletion — an answer that is not a candidate. */
+  readonly deletedProjects?: readonly string[];
+  readonly buckets?: Readonly<Record<string, readonly string[]>>;
+  readonly keyLocations?: Readonly<Record<string, readonly string[]>>;
+  readonly keys?: readonly FakeCryptoKey[];
+  /** Items per page. Small on purpose, to run the client's page loop. */
+  readonly pageSize?: number;
+  readonly refuse?: {
+    readonly resourceManager?: FakeRefusal;
+    readonly storage?: FakeRefusal;
+    readonly keyManagement?: FakeRefusal;
+  };
+}
+
+export interface RecordedRequest {
+  readonly method: string;
+  readonly host: string;
+  readonly path: string;
+  readonly query: Record<string, string>;
+  readonly authorization: string | null;
+}
+
+const RESOURCE_MANAGER_HOST = 'cloudresourcemanager.googleapis.com';
+const STORAGE_HOST = 'storage.googleapis.com';
+const KEY_MANAGEMENT_HOST = 'cloudkms.googleapis.com';
+
+export class FakeGcpDiscovery {
+  readonly requests: RecordedRequest[] = [];
+
+  private readonly token: string;
+  private readonly options: FakeGcpDiscoveryOptions;
+  private readonly pageSize: number;
+
+  constructor(options: FakeGcpDiscoveryOptions = {}) {
+    this.options = options;
+    this.token = options.token ?? 'federated-token';
+    this.pageSize = options.pageSize ?? 100;
+  }
+
+  readonly fetch: Fetcher = async (request) => {
+    const url = new URL(request.url);
+    this.requests.push({
+      method: request.method,
+      host: url.host,
+      path: url.pathname,
+      query: Object.fromEntries(url.searchParams),
+      authorization: request.headers.get('Authorization'),
+    });
+
+    if (request.headers.get('Authorization') !== `Bearer ${this.token}`) {
+      return error(401, { message: 'the caller is not authenticated' });
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean);
+    switch (url.host) {
+      case RESOURCE_MANAGER_HOST:
+        return this.resourceManager(segments, url.searchParams);
+      case STORAGE_HOST:
+        return this.storage(segments, url.searchParams);
+      case KEY_MANAGEMENT_HOST:
+        return this.keyManagement(segments, url.searchParams);
+      default:
+        return error(404, { message: `nothing is served at ${url.host}` });
+    }
+  };
+
+  private resourceManager(
+    segments: readonly string[],
+    query: URLSearchParams,
+  ): Response {
+    const refused = refusalOf(this.options.refuse?.resourceManager);
+    if (refused !== null) return refused;
+    if (segments[0] !== 'v1' || segments[1] !== 'projects') {
+      return error(404, { message: 'no such route' });
+    }
+    const all = [
+      ...(this.options.projects ?? []).map((projectId) => ({
+        projectId,
+        lifecycleState: 'ACTIVE',
+      })),
+      ...(this.options.deletedProjects ?? []).map((projectId) => ({
+        projectId,
+        lifecycleState: 'DELETE_REQUESTED',
+      })),
+    ];
+    return this.page('projects', all, query);
+  }
+
+  private storage(
+    segments: readonly string[],
+    query: URLSearchParams,
+  ): Response {
+    const refused = refusalOf(this.options.refuse?.storage);
+    if (refused !== null) return refused;
+    if (segments[0] !== 'storage' || segments[2] !== 'b') {
+      return error(404, { message: 'no such route' });
+    }
+    const project = query.get('project');
+    if (project === null) {
+      return error(400, { message: 'the project parameter is required' });
+    }
+    const buckets = this.options.buckets?.[project];
+    if (buckets === undefined) {
+      return error(404, { message: `there is no project named ${project}` });
+    }
+    return this.page(
+      'items',
+      buckets.map((name) => ({ name })),
+      query,
+    );
+  }
+
+  private keyManagement(
+    segments: readonly string[],
+    query: URLSearchParams,
+  ): Response {
+    const refused = refusalOf(this.options.refuse?.keyManagement);
+    if (refused !== null) return refused;
+    // /v1/projects/{p}/locations[/{l}/keyRings[/{r}/cryptoKeys]]
+    const [version, projects, project, locations, location, rings, ring, keys] =
+      segments;
+    if (version !== 'v1' || projects !== 'projects' || project === undefined) {
+      return error(404, { message: 'no such route' });
+    }
+
+    if (segments.length === 4 && locations === 'locations') {
+      const offered = this.options.keyLocations?.[project];
+      if (offered === undefined) {
+        return error(404, { message: `there is no project named ${project}` });
+      }
+      return this.page(
+        'locations',
+        offered.map((locationId) => ({
+          locationId,
+          name: `projects/${project}/locations/${locationId}`,
+        })),
+        query,
+      );
+    }
+
+    const held = this.options.keys ?? [];
+    if (segments.length === 6 && rings === 'keyRings') {
+      const named = new Set(
+        held
+          .filter((key) => key.project === project && key.location === location)
+          .map((key) => key.ring),
+      );
+      return this.page(
+        'keyRings',
+        [...named].map((name) => ({
+          name: `projects/${project}/locations/${location}/keyRings/${name}`,
+        })),
+        query,
+      );
+    }
+
+    if (segments.length === 8 && keys === 'cryptoKeys') {
+      const inRing = held.filter(
+        (key) =>
+          key.project === project &&
+          key.location === location &&
+          key.ring === ring,
+      );
+      return this.page(
+        'cryptoKeys',
+        inRing.map((key) => ({
+          name: `projects/${project}/locations/${location}/keyRings/${ring}/cryptoKeys/${key.name}`,
+          purpose: key.purpose ?? 'ASYMMETRIC_SIGN',
+        })),
+        query,
+      );
+    }
+
+    return error(404, { message: 'no such route' });
+  }
+
+  /** One page of a listing, with the continuation the client has to follow. */
+  private page(
+    key: string,
+    all: readonly unknown[],
+    query: URLSearchParams,
+  ): Response {
+    const offset = Number(query.get('pageToken') ?? '0');
+    const next = offset + this.pageSize;
+    return Response.json({
+      [key]: all.slice(offset, next),
+      ...(next < all.length ? { nextPageToken: String(next) } : {}),
+    });
+  }
+}
+
+/** A configured blanket refusal, in the shape the real APIs answer with. */
+function refusalOf(refusal: FakeRefusal | undefined): Response | null {
+  if (refusal === undefined) return null;
+  return error(refusal.status, {
+    message: refusal.message ?? 'the caller may not act here',
+    ...(refusal.reason === undefined ? {} : { reason: refusal.reason }),
+  });
+}
+
+function error(
+  status: number,
+  detail: { message: string; reason?: string },
+): Response {
+  return Response.json(
+    {
+      error: {
+        code: status,
+        message: detail.message,
+        ...(detail.reason === undefined
+          ? {}
+          : { details: [{ reason: detail.reason }] }),
+      },
+    },
+    { status },
+  );
+}

--- a/apps/spindrift/test/web/installation-discovery.test.tsx
+++ b/apps/spindrift/test/web/installation-discovery.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * The confirmation panel ticket 32 slice 2 exists to build.
+ *
+ * Two claims, and neither is about a request:
+ *
+ * 1. **The two arms read as two different things.** A field the cloud could not
+ *    answer shows the sentence saying why; a field it answered with nothing
+ *    shows that it is empty. A panel that rendered a refusal as a blank would be
+ *    the original defect wearing a UI.
+ * 2. **Nothing here names a manifest key.** The headings are the schema's own
+ *    keys humanized, and applying a candidate writes at the path the command
+ *    gave — so ticket 33 removing a key removes it from this panel too, rather
+ *    than leaving a control for a field that no longer exists.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type {
+  DiscoveredCandidate,
+  DiscoveredFact,
+} from '../../src/commands/installation/discover.ts';
+import {
+  applyDiscovered,
+  DiscoveredFactList,
+} from '../../src/web/views/auth/discovery.tsx';
+
+const FACTS: readonly DiscoveredFact[] = [
+  {
+    path: ['cloud', 'homeVesselProject'],
+    kind: 'found',
+    candidates: [{ label: 'example-home', value: 'example-home' }],
+    suggested: { label: 'example-home', value: 'example-home' },
+  },
+  {
+    path: ['sources', 'buckets'],
+    kind: 'unavailable',
+    reason:
+      'the Cloud Storage API is not enabled, so the buckets in example-home could not be listed',
+  },
+  {
+    path: ['supplyChain', 'signer'],
+    kind: 'found',
+    candidates: [],
+    suggested: null,
+  },
+];
+
+function panel(): string {
+  return renderToStaticMarkup(
+    <DiscoveredFactList facts={FACTS} onApply={() => undefined} />,
+  );
+}
+
+describe('what the panel shows', () => {
+  const markup = panel();
+
+  test('a discovered value is offered as a thing to confirm', () => {
+    expect(markup).toContain('example-home');
+  });
+
+  test('a refusal is shown as the sentence it came with', () => {
+    expect(markup).toContain('the Cloud Storage API is not enabled');
+  });
+
+  test('an honest empty says so rather than showing nothing', () => {
+    // The whole claim, on the screen: this reads differently from the row above
+    // it, and neither reads like a blank field waiting to be typed in.
+    expect(markup).toContain('Nothing of this kind exists here');
+  });
+
+  test('headings are the schema keys humanized, not written here', () => {
+    expect(markup).toContain('Home vessel project');
+    expect(markup).toContain('Signer');
+  });
+});
+
+describe('confirming a value edits the document at the path it came with', () => {
+  const document = {
+    cloud: { homeVesselProject: 'typed-by-hand' },
+    sources: { buckets: [], defaultBucket: 'typed-by-hand' },
+  };
+
+  test('the value lands at the path, and nothing else moves', () => {
+    const fact = FACTS[0]!;
+    // `candidates` is only reachable on the arm that has one — which is the
+    // property the command's two arms exist for, asserted here by the compiler
+    // rather than by an expectation.
+    if (fact.kind !== 'found') throw new Error('the fixture lost its arm');
+    expect(applyDiscovered(document, fact, fact.candidates[0]!)).toEqual({
+      cloud: { homeVesselProject: 'example-home' },
+      sources: { buckets: [], defaultBucket: 'typed-by-hand' },
+    });
+  });
+
+  test('a list-valued key takes the shape its candidate carried', () => {
+    // The reason a candidate carries a value at all: `sources.buckets` is a
+    // list and `sources.defaultBucket` is not, and a panel deriving that would
+    // be a panel with an opinion about the schema.
+    const bucket: DiscoveredCandidate = {
+      label: 'a-bucket',
+      value: ['a-bucket'],
+    };
+    const fact: DiscoveredFact = {
+      path: ['sources', 'buckets'],
+      kind: 'found',
+      candidates: [bucket],
+      suggested: bucket,
+    };
+    expect(applyDiscovered(document, fact, bucket)).toMatchObject({
+      sources: { buckets: ['a-bucket'] },
+    });
+  });
+});


### PR DESCRIPTION
## The defect

Half the installation manifest is facts the pod's own federated identity can be
asked for — its projects, its source buckets, its signing key — and every one of
them is authored by hand. A mistyped project id validates, saves, reconciles,
and then fails at the first build with a message about a signed URL; a signer
URI assembled a segment at a time fails at the first cosign call. Neither is
visible in the form that produced it.

## The change

`discoverInstallationFacts` asks the cloud, over **the same federated provider**
`createAdapterRegistry` already resolves for the two cloud deploy adapters and
the cloud build route (`src/adapters/registry.ts:216`), so the STS and
impersonation exchange stays cached per process rather than being re-run per
question. `src/storage/cloud.ts` is deliberately untouched — it constructs a
provider per call and throws instead of answering — because rewriting it is a
behaviour change to the Storage screen that does not belong in this diff.

**Two arms, and they are the point.** `{ kind: 'found', candidates: [] }` says
*this project has no buckets*. A `403`, a disabled API, or a dead socket is
`{ kind: 'unavailable', reason }`. They are distinct types, so a refusal cannot
be produced as an empty list that reads like a confirmed answer. The fold is
`src/adapters/deploy/cloud/checklist.ts`'s status table with `unavailable` in
place of `unmet`.

**Answers carry manifest paths, not field names.** The settings surface names no
manifest key on purpose (`src/web/views/auth/installation.tsx:12-18`), and a
result with named fields would put that list back one layer down. Each row is
titled with `humanize()` of its last path segment and applied with
`withValueAt`, so a key leaving the schema leaves the panel with it.

Also here:

- **Staged.** With no project named only the project list is fetched and the rest
  say so. Buckets and keys are folded independently, so one refused API cannot
  turn two good answers into three refusals.
- Keys are filtered on `ASYMMETRIC_SIGN` and rendered as `gcpkms://` plus the
  resource name verbatim.
- Listings follow `nextPageToken`, capped, because a single-page read answers a
  short list that looks complete.
- The home vessel is suggested from the impersonated service account's own
  address at no API cost, marked a heuristic, and yields nothing rather than a
  fragment when the URL does not match.
- No federation is refused as `NOT_DEPLOYABLE` **before any request**, asserted
  by the fake having recorded none.

DNS is not discovered: the zones the original sketch named are not keys this
schema has (`dns.zones.{private,public}` is), and
`test/extraction/no-dns-credential.test.ts:53-70` bans a zone-provider client
under `src/` on §9 grounds regardless.

## Evidence

Full suite, `apps/spindrift`:

```text
$ bun test
 1429 pass
 2 fail
 4212 expect() calls
Ran 1431 tests across 105 files. [153.19s]
```

1407 before, 24 added. The two failures are `test/db/migrate.test.ts`'s known
`afterEach` timeout under a loaded local Postgres — it reproduces alone and on
an untouched tree.

`bun run typecheck`, `bun run lint` and `bun run build` are clean; the client
bundle assertions in `test/web/client-bundle.test.ts` still pass, so the new
command pulls no server-only module into the browser graph.

**Proved by reverting.** Each of these was applied to the merged tree, the
suite run, and the change put back:

```text
# a failed bucket read answered as an empty list
-    if (!listed.ok) return unavailable(listed.reason);
+    if (!listed.ok) return found([]);

  expect(fact.kind).toBe('unavailable');
  error: expect(received).toBe(expected)
  Expected: "unavailable"
  Received: "found"
  (fail) a refusal is never an empty answer > a disabled Storage API is
         unavailable, not a project with no buckets
```

```text
# the continuation token dropped after one page
+      pageToken = undefined;

  error: expect(received).toEqual(expected)
  @@ -2,4 +2,3 @@
      "example-home",
  -   "example-artifacts",
  -   "example-vessel",
    ]
  (fail) truncation is not silence > a paginated project list is walked to the end
```

```text
# the federation refusal moved below the fan-out
  expect(fake.requests).toEqual([]);
  error: expect(received).toEqual(expected)
  - []
  + [ { "authorization": "Bearer a-federated-token",
  +     "host": "cloudresourcemanager.googleapis.com",
  +     "method": "GET", "path": "/v1/projects", "query": {} } ]
  (fail) an installation with no cloud identity > is refused as a fact, before a
         single request
```

```text
# the key-purpose filter removed
-        if (key.purpose !== SIGNING_PURPOSE || key.name === undefined) continue;
+        if (key.name === undefined) continue;

  error: expect(received).toEqual(expected)
  +   "gcpkms://projects/example-home/locations/a-region/keyRings/keys/cryptoKeys/envelope",
  (fail) what the reads answer > only a key that can sign is offered, as a
         gcpkms reference
```

## What is proven by fake, and what is not

Everything above is proven against `test/harness/fakes/gcp-discovery-api.ts` —
request shapes, status-code folding, arm selection, pagination, path validity,
the zero-request refusal. That is this repo's established seam and is expected.

**A live run would still be needed to establish four things**, and one of them
is likely to be a "no":

1. That the deployed identity holds `resourcemanager.projects.get`,
   `storage.buckets.list`, `cloudkms.keyRings.list` and
   `cloudkms.cryptoKeys.list`. Today's Terraform grants it the bucket and the
   signer key, not list permissions on projects or key rings — so the most
   likely live outcome is a **correct `unavailable` on most fields** until IAM
   is widened. The home-vessel suggestion is the one answer that survives that,
   which is why it is folded in ahead of the listing.
2. That `cloudresourcemanager.googleapis.com` and `cloudkms.googleapis.com` are
   enabled in the projects involved.
3. Whether Cloud KMS accepts `-` as a location wildcard. Assumed **no**, which
   is why the design lists locations rather than betting on it.
4. The exact JSON field names each API answers with. The fake asserts them by
   construction; only a real call confirms them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5psRW53mdUPRZjf3MyGsv
