### PR TITLE
fix(spindrift): back discovery's claims with assertions that fail without them

### DIFF
--- a/apps/spindrift/src/commands/installation/discover.ts
+++ b/apps/spindrift/src/commands/installation/discover.ts
@@ -94,9 +94,12 @@ export interface DiscoverInstallationFactsResult {
  * a wrong suggestion — which is why it is only ever `suggested`, never asserted
  * as the answer. A URL that does not match at all yields nothing rather than a
  * fragment of one.
+ *
+ * The bounds are GCP's own for a project id: 6 to 30 characters, opening with a
+ * letter — so one leading `[a-z]` and 5 to 29 after it.
  */
 const SERVICE_ACCOUNT_PROJECT =
-  /@([a-z][a-z0-9-]{4,28})\.iam\.gserviceaccount\.com/;
+  /@([a-z][a-z0-9-]{5,29})\.iam\.gserviceaccount\.com/;
 
 export const discoverInstallationFacts: Command<
   DiscoverInstallationFactsInput,
@@ -225,6 +228,13 @@ function mapped(
  * on one bucket and one key is not usually granted `projects.list`. So a
  * suggestion turns a refusal into an answer, and joins a listing it is already
  * part of without being repeated.
+ *
+ * This is the one place the two arms are crossed — a refused listing comes out
+ * `found` — so the candidate carries where it came from in the text an operator
+ * reads. Without that, a `403` on `projects.list` is indistinguishable on the
+ * screen from a project the cloud confirmed, which is the laundering this whole
+ * path exists to prevent. It leads the list rather than merging into it, so the
+ * labelled one is the one shown and the one marked as the suggestion.
  */
 function withSuggestion(
   fact: DiscoveredFact,
@@ -235,19 +245,31 @@ function withSuggestion(
   return {
     path: fact.path,
     kind: 'found',
-    candidates: listed.some((candidate) => candidate.value === suggested.value)
-      ? listed
-      : [suggested, ...listed],
+    candidates: [
+      suggested,
+      ...listed.filter((candidate) => candidate.value !== suggested.value),
+    ],
     suggested,
   };
 }
 
-/** The home vessel this installation's own identity lives in, if it says. */
+/**
+ * The home vessel this installation's own identity lives in, if it says.
+ *
+ * Labelled with its provenance, not with the bare id: what is written is the
+ * project, but what is read is where the answer came from — this deployment's
+ * own credential rather than anything the cloud was asked.
+ */
 function homeVesselOf(
   federation: FederationConfig,
 ): DiscoveredCandidate | null {
   const url = federation.impersonationUrl;
   if (url === null) return null;
   const project = SERVICE_ACCOUNT_PROJECT.exec(url)?.[1];
-  return project === undefined ? null : plain(project);
+  return project === undefined
+    ? null
+    : {
+        label: `${project} — this deployment’s own credential`,
+        value: project,
+      };
 }

--- a/apps/spindrift/src/web/views/auth/discovery.tsx
+++ b/apps/spindrift/src/web/views/auth/discovery.tsx
@@ -1,5 +1,5 @@
 /**
- * Confirming cloud facts instead of typing them (§13, §20, ticket 32 slice 2).
+ * Confirming cloud facts instead of typing them (§13, §20).
  *
  * The settings form below this panel can already edit every manifest key. What
  * it cannot do is tell an operator what the right value *is* — so a project id
@@ -12,8 +12,8 @@
  * requirement `installation.tsx` states for the form itself. Every answer
  * carries its own `path`, the panel titles it with {@link humanize} of the last
  * segment, and applying a candidate is {@link withValueAt} at that path — so
- * the panel keeps working as ticket 33 removes keys from the schema, and a
- * value it cannot place is not a value it can silently misplace.
+ * the panel keeps working as keys leave the schema, and a value it cannot place
+ * is not a value it can silently misplace.
  *
  * **A refusal reads as a fact, not as a field error.** That is the third of the
  * three refusals `installation.tsx` keeps apart: `unavailable` means the cloud
@@ -34,6 +34,51 @@ import { humanize } from '../../forms/schema.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
 import { Field } from '../../ui/field.tsx';
+
+/** One ask, in the two arms every answer on this path comes back in. */
+export type DiscoveryAnswer =
+  | { readonly facts: readonly DiscoveredFact[] }
+  | { readonly refusal: string };
+
+/**
+ * The request the panel makes, and the fold of everything it can come back as.
+ *
+ * Named and exported rather than living inside the click handler, for the
+ * reason {@link applyDiscovered} is: the two things worth asserting here are
+ * **which narrowing arguments are sent** and **that no way of failing turns
+ * into an empty answer**, and neither needs a browser to observe. The panel
+ * around it is then a shell that puts the result in state.
+ *
+ * Three ways of coming back, one shape: a result, a refusal the server gave,
+ * and a `fetch` or a non-JSON body that never reached the command layer at all.
+ * The last one throws out of `command`, and swallowing it into `facts: []`
+ * would put a blank on a confirmation screen that reads as a confirmed answer.
+ */
+export async function askInstallationCloud(narrowing: {
+  readonly project: string;
+  readonly kmsLocation: string;
+}): Promise<DiscoveryAnswer> {
+  const project = narrowing.project.trim();
+  const kmsLocation = narrowing.kmsLocation.trim();
+  try {
+    const result = await command('discoverInstallationFacts', {
+      // Absent rather than empty: the command's input is `.strict()` and an
+      // empty project is not a project, it is the first pass.
+      ...(project === '' ? {} : { project }),
+      ...(kmsLocation === '' ? {} : { kmsLocation }),
+    });
+    return result.ok
+      ? { facts: result.value.facts }
+      : { refusal: result.failure.message };
+  } catch (cause) {
+    return {
+      refusal:
+        cause instanceof Error
+          ? cause.message
+          : 'This installation could not be asked about its cloud.',
+    };
+  }
+}
 
 /**
  * Ask the cloud, then apply what an operator confirms.
@@ -61,32 +106,10 @@ export function DiscoveryPanel({
 
   const discover = async () => {
     setBusy(true);
-    setRefusal(null);
-    try {
-      const result = await command('discoverInstallationFacts', {
-        // Absent rather than empty: the command's input is `.strict()` and an
-        // empty project is not a project, it is the first pass.
-        ...(project.trim() === '' ? {} : { project: project.trim() }),
-        ...(kmsLocation.trim() === ''
-          ? {}
-          : { kmsLocation: kmsLocation.trim() }),
-      });
-      if (result.ok) {
-        setFacts(result.value.facts);
-      } else {
-        setFacts(null);
-        setRefusal(result.failure.message);
-      }
-    } catch (cause) {
-      setFacts(null);
-      setRefusal(
-        cause instanceof Error
-          ? cause.message
-          : 'This installation could not be asked about its cloud.',
-      );
-    } finally {
-      setBusy(false);
-    }
+    const answer = await askInstallationCloud({ project, kmsLocation });
+    setFacts('facts' in answer ? answer.facts : null);
+    setRefusal('refusal' in answer ? answer.refusal : null);
+    setBusy(false);
   };
 
   return (
@@ -131,24 +154,7 @@ export function DiscoveryPanel({
             {busy ? 'Asking…' : 'Ask this installation’s cloud'}
           </Button>
         </div>
-        {refusal === null ? null : (
-          <div
-            role="alert"
-            className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground"
-          >
-            <CircleAlert
-              aria-hidden="true"
-              className="mt-0.5 size-4 text-subtle"
-            />
-            <div>
-              <p className="font-medium">Nothing could be discovered.</p>
-              <p className="mt-0.5">{refusal}</p>
-              <p className="mt-1 text-muted-foreground">
-                This is a fact about the installation, not a field to correct.
-              </p>
-            </div>
-          </div>
-        )}
+        {refusal === null ? null : <DiscoveryRefusal reason={refusal} />}
         {facts === null ? null : (
           <DiscoveredFactList
             facts={facts}
@@ -160,6 +166,33 @@ export function DiscoveryPanel({
         )}
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * The whole ask having failed, in the neutral voice.
+ *
+ * Not a field error, and the markup says which: `role="alert"` beside a
+ * sentence about the installation rather than an error class on an input. An
+ * operator cannot fix an absent federation or a `403` by re-typing a value in
+ * the form below, and telling them to would be the third of the three refusals
+ * `installation.tsx` keeps apart, collapsed into the first.
+ */
+export function DiscoveryRefusal({ reason }: { readonly reason: string }) {
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground"
+    >
+      <CircleAlert aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+      <div>
+        <p className="font-medium">Nothing could be discovered.</p>
+        <p className="mt-0.5">{reason}</p>
+        <p className="mt-1 text-muted-foreground">
+          This is a fact about the installation, not a field to correct.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/spindrift/test/commands/installation-discover.test.ts
+++ b/apps/spindrift/test/commands/installation-discover.test.ts
@@ -149,6 +149,41 @@ describe('a refusal is never an empty answer', () => {
     if (fact.kind !== 'unavailable') return;
     expect(fact.reason).toContain('Cloud Storage');
     expect(fact.reason).toContain(PROJECT);
+    // Which refusal, not just that there was one. A disabled API arrives as a
+    // `403` like a missing grant does, and telling an operator they lack a
+    // permission they already hold sends them to write IAM policy for a switch
+    // in a console. The sentence has to be the console's.
+    expect(fact.reason).toContain('not enabled');
+    expect(fact.reason).not.toContain('may not list');
+  });
+
+  test('a disabled API is still read when only the message says so', async () => {
+    // The other shape the same fact arrives in: these APIs put the reason in
+    // `error.details[].reason` on some calls and only in the message on
+    // others, which is why the fold matches the body as well as the parsed
+    // reason. One of the two halves being unbacked is one half of operators
+    // being told to fix a permission that is correct.
+    const { context } = installation({
+      projects: [PROJECT],
+      refuse: {
+        storage: {
+          status: 403,
+          message:
+            'Cloud Storage API has not been used in project 1 before or it is disabled. SERVICE_DISABLED',
+        },
+      },
+    });
+
+    const fact = factAt(
+      await discover(context, { project: PROJECT }),
+      'sources',
+      'buckets',
+    );
+
+    expect(fact.kind).toBe('unavailable');
+    if (fact.kind !== 'unavailable') return;
+    expect(fact.reason).toContain('not enabled');
+    expect(fact.reason).not.toContain('may not list');
   });
 
   test('a project with no buckets is found, with none', async () => {
@@ -326,6 +361,51 @@ describe('truncation is not silence', () => {
     ]);
     expect(fake.requests).toHaveLength(3);
   });
+
+  test('a listing that will not end is refused, never cut short', async () => {
+    // The cap earns its place only if hitting it says so. A `break` here would
+    // answer twenty projects out of thirty as a complete list — the same defect
+    // as an empty answer, wearing a plausible number.
+    const { context, fake } = installation({
+      projects: Array.from({ length: 30 }, (_, index) => `example-${index}`),
+      pageSize: 1,
+    });
+
+    const fact = factAt(await discover(context), 'cloud', 'artifactsProject');
+
+    expect(fact.kind).toBe('unavailable');
+    if (fact.kind !== 'unavailable') return;
+    expect(fact.reason).toContain('did not finish listing');
+    // And it stopped asking, rather than walking all thirty pages anyway.
+    expect(fake.requests.length).toBeLessThan(30);
+  });
+
+  test('more key rings than one pass will open is refused, not sampled', async () => {
+    // Same rule one API over: `signingKeys` opens each ring with its own call,
+    // so the cap is on rings rather than pages — and a signer list built from
+    // the first twenty rings of thirty is a manifest that validates and then
+    // fails at the first cosign call.
+    const { context } = installation({
+      projects: [PROJECT],
+      buckets: { [PROJECT]: [] },
+      keys: Array.from({ length: 30 }, (_, index) => ({
+        project: PROJECT,
+        location: 'a-region',
+        ring: `ring-${index}`,
+        name: 'signer',
+      })),
+    });
+
+    const fact = factAt(
+      await discover(context, { project: PROJECT, kmsLocation: 'a-region' }),
+      'supplyChain',
+      'signer',
+    );
+
+    expect(fact.kind).toBe('unavailable');
+    if (fact.kind !== 'unavailable') return;
+    expect(fact.reason).toContain('key rings');
+  });
 });
 
 describe('the credential answers what it can without a call', () => {
@@ -342,7 +422,31 @@ describe('the credential answers what it can without a call', () => {
 
     expect(fact.kind).toBe('found');
     if (fact.kind !== 'found') return;
-    expect(fact.suggested).toEqual({ label: PROJECT, value: PROJECT });
+    // The project is what gets written; where it came from is what gets read.
+    expect(fact.suggested?.value).toBe(PROJECT);
+    expect(fact.suggested?.label).toContain('credential');
+  });
+
+  test('a project id at GCP’s longest is still read out of the identity', async () => {
+    // The bound, exactly: GCP project ids run 6 to 30 characters, and a regex
+    // one short at the top silently stops suggesting anything for the longest
+    // legal name — a wrong answer that looks like "this credential says
+    // nothing".
+    const longest = 'example-home-with-a-longer-nam';
+    expect(longest).toHaveLength(30);
+    const fake = new FakeGcpDiscovery({ token: TOKEN, refuse: {} });
+    const context = contextFor(
+      fake,
+      manifestWith({
+        impersonationUrl: `https://iamcredentials.example.test/v1/projects/-/serviceAccounts/controller@${longest}.iam.gserviceaccount.com:generateAccessToken`,
+      }),
+    );
+
+    const fact = factAt(await discover(context), 'cloud', 'homeVesselProject');
+
+    expect(fact.kind).toBe('found');
+    if (fact.kind !== 'found') return;
+    expect(fact.suggested?.value).toBe(longest);
   });
 
   test('an identity that is not a service account suggests nothing', async () => {
@@ -376,8 +480,17 @@ describe('the credential answers what it can without a call', () => {
     );
 
     const facts = await discover(context);
+    const home = factAt(facts, 'cloud', 'homeVesselProject');
 
-    expect(factAt(facts, 'cloud', 'homeVesselProject').kind).toBe('found');
+    expect(home.kind).toBe('found');
+    if (home.kind !== 'found') return;
+    // This is the one place the two arms are crossed — a refused listing comes
+    // back `found` — so the candidate has to say where it came from. Without
+    // that, a `403` on `projects.list` reads on the screen exactly like a
+    // project the cloud confirmed, which is the laundering the arms exist for.
+    expect(home.candidates).toHaveLength(1);
+    expect(home.candidates[0]?.label).toContain('credential');
+    expect(home.candidates[0]?.value).toBe(PROJECT);
     // And the key it cannot suggest anything for stays honest about the same
     // refusal, rather than borrowing the answer.
     expect(factAt(facts, 'cloud', 'artifactsProject').kind).toBe('unavailable');
@@ -397,6 +510,25 @@ describe('an installation with no cloud identity', () => {
     expect(result.failure.message).toContain('this installation');
     // Proven rather than described: nothing was asked, so nothing failed.
     expect(fake.requests).toEqual([]);
+  });
+
+  test('a registry that builds no discovery client is refused as a fact too', async () => {
+    // `discovery` is optional on `AdapterRegistry` for the reason the four
+    // lookups above it are — a hand-built registry omits what it has no opinion
+    // about — so the absent case is reachable and is a different sentence from
+    // the absent-federation one above. A process that cannot reach a cloud API
+    // is a fact about the process, not about the manifest.
+    const { context } = installation({ projects: [PROJECT] });
+
+    const result = await discoverInstallationFacts(
+      {},
+      { ...context, adapters: { ...context.adapters, discovery: () => null } },
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('this process');
   });
 });
 

--- a/apps/spindrift/test/web/installation-discovery.test.tsx
+++ b/apps/spindrift/test/web/installation-discovery.test.tsx
@@ -1,16 +1,25 @@
 /**
- * The confirmation panel ticket 32 slice 2 exists to build.
+ * Cloud facts shown for confirmation rather than typed.
  *
- * Two claims, and neither is about a request:
+ * Four claims:
  *
- * 1. **The two arms read as two different things.** A field the cloud could not
+ * 1. **The panel is on the settings surface.** The whole criterion is that an
+ *    operator confirms rather than types, and a panel nothing mounts confirms
+ *    nothing. Asserted against the real `InstallationSettingsView`, so removing
+ *    the element fails here rather than passing quietly.
+ * 2. **The two arms read as two different things.** A field the cloud could not
  *    answer shows the sentence saying why; a field it answered with nothing
  *    shows that it is empty. A panel that rendered a refusal as a blank would be
  *    the original defect wearing a UI.
- * 2. **Nothing here names a manifest key.** The headings are the schema's own
+ * 3. **Nothing here names a manifest key.** The headings are the schema's own
  *    keys humanized, and applying a candidate writes at the path the command
- *    gave — so ticket 33 removing a key removes it from this panel too, rather
- *    than leaving a control for a field that no longer exists.
+ *    gave — so a key leaving the schema leaves this panel too, rather than
+ *    leaving a control for a field that no longer exists.
+ * 4. **The request carries the narrowing the operator typed, and every way of
+ *    failing comes back as a sentence.** This repo has no DOM, so the assertion
+ *    is against `askInstallationCloud` and `DiscoveryRefusal` directly — the two
+ *    pieces the panel is a shell around — with `fetch` stubbed beneath the real
+ *    typed client.
  */
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -18,10 +27,15 @@ import type {
   DiscoveredCandidate,
   DiscoveredFact,
 } from '../../src/commands/installation/discover.ts';
+import { manifestFields } from '../../src/web/forms/manifest.ts';
 import {
   applyDiscovered,
+  askInstallationCloud,
   DiscoveredFactList,
+  DiscoveryRefusal,
 } from '../../src/web/views/auth/discovery.tsx';
+import { InstallationSettingsView } from '../../src/web/views/auth/installation.tsx';
+import { fixtureManifest } from '../harness/installation.ts';
 
 const FACTS: readonly DiscoveredFact[] = [
   {
@@ -108,5 +122,153 @@ describe('confirming a value edits the document at the path it came with', () =>
     expect(applyDiscovered(document, fact, bucket)).toMatchObject({
       sources: { buckets: ['a-bucket'] },
     });
+  });
+});
+
+const manifest = await fixtureManifest();
+
+describe('the panel is part of the settings surface', () => {
+  const markup = renderToStaticMarkup(
+    <InstallationSettingsView
+      fields={manifestFields()}
+      document={manifest as unknown}
+      errors={new Map()}
+      outcome={null}
+      saving={false}
+      onChange={() => undefined}
+      onSave={() => undefined}
+      onReload={() => undefined}
+    />,
+  );
+
+  test('the screen an operator edits the manifest on offers the ask', () => {
+    // The second half of the criterion, and the half a component test cannot
+    // reach: facts are shown *for confirmation*, which is only true if the
+    // panel is on the screen that edits the manifest. Both inputs are named
+    // here because `manifestFields()` produces no `discovery.` key — nothing
+    // but the panel can satisfy this.
+    expect(markup).toContain('name="discovery.project"');
+    expect(markup).toContain('name="discovery.kmsLocation"');
+  });
+
+  test('it sits above the form, where the value is confirmed before it is typed', () => {
+    // Order, not just presence: a confirmation offered underneath the field it
+    // would have saved a typo in is a confirmation nobody reaches first.
+    expect(markup.indexOf('name="discovery.project"')).toBeLessThan(
+      markup.indexOf('name="cloud.homeVesselProject"'),
+    );
+  });
+});
+
+/** What the stubbed transport recorded of one request. */
+interface Sent {
+  readonly path: string;
+  readonly body: unknown;
+}
+
+const realFetch = globalThis.fetch;
+
+/**
+ * One ask, with a stubbed `fetch` under the real typed client.
+ *
+ * Under the client rather than in place of it: the claim is about the request
+ * that leaves the browser, and a stub of `command` itself would assert only
+ * that the panel calls a function this test also wrote.
+ */
+async function ask(
+  narrowing: { project: string; kmsLocation: string },
+  respond: () => Response,
+): Promise<{
+  readonly sent: readonly Sent[];
+  readonly answer: Awaited<ReturnType<typeof askInstallationCloud>>;
+}> {
+  const sent: Sent[] = [];
+  globalThis.fetch = (async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ) => {
+    sent.push({
+      path: String(input),
+      body: JSON.parse(String(init?.body ?? 'null')) as unknown,
+    });
+    return respond();
+  }) as typeof fetch;
+  try {
+    return { sent, answer: await askInstallationCloud(narrowing) };
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}
+
+const NO_FACTS = () => Response.json({ ok: true, value: { facts: [] } });
+
+describe('what the panel asks the cloud', () => {
+  test('an empty input is absent from the request, not sent empty', async () => {
+    const { sent, answer } = await ask(
+      { project: '  example-home  ', kmsLocation: '   ' },
+      NO_FACTS,
+    );
+
+    // Exactly this object: the command's input is `.strict()`, so an empty
+    // `kmsLocation` is a rejected request rather than a first pass, and an
+    // untrimmed project is a project id nothing in the cloud is named.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]?.body).toEqual({ project: 'example-home' });
+    expect(answer).toEqual({ facts: [] });
+  });
+
+  test('both narrowings are sent when both are given', async () => {
+    const { sent } = await ask(
+      { project: 'example-home', kmsLocation: ' a-region ' },
+      NO_FACTS,
+    );
+
+    expect(sent[0]?.body).toEqual({
+      project: 'example-home',
+      kmsLocation: 'a-region',
+    });
+  });
+
+  test('a refused command comes back as its sentence', async () => {
+    const { answer } = await ask({ project: '', kmsLocation: '' }, () =>
+      Response.json({
+        ok: false,
+        failure: {
+          code: 'NOT_DEPLOYABLE',
+          message: 'this installation mounts no cloud federation credential',
+        },
+      }),
+    );
+
+    expect(answer).toEqual({
+      refusal: 'this installation mounts no cloud federation credential',
+    });
+  });
+
+  test('a transport that never reached the command layer is a sentence too', async () => {
+    // The one case `command` throws on: a proxy answering HTML is not the
+    // server answering. Swallowed into `facts: []` it would render as a cloud
+    // that confirmed nothing exists.
+    const { answer } = await ask(
+      { project: '', kmsLocation: '' },
+      () => new Response('<html>a proxy</html>', { status: 502 }),
+    );
+
+    expect(answer).not.toHaveProperty('facts');
+    expect(answer).toHaveProperty('refusal');
+  });
+});
+
+describe('a refusal is shown as a fact about the installation', () => {
+  const markup = renderToStaticMarkup(
+    <DiscoveryRefusal reason="this installation mounts no cloud federation credential" />,
+  );
+
+  test('it is announced, carries its sentence, and is not a field error', () => {
+    expect(markup).toContain('role="alert"');
+    expect(markup).toContain(
+      'this installation mounts no cloud federation credential',
+    );
+    expect(markup).toContain('not a field to correct');
   });
 });


### PR DESCRIPTION
Follow-up to the cloud-discovery work: several of the things that path documents were observed by nothing. Each item below was proven by making the mutation and watching the named test go red.

**The panel could be unmounted and nothing noticed.** "Cloud facts shown for confirmation rather than typed" is only true where the panel is on the screen that edits the manifest, and deleting `<DiscoveryPanel>` from `InstallationSettingsView` left every web test green. Now asserted against the real view, including that it sits above the form.

**The request path was untested.** Dropping the `project`/`kmsLocation` narrowing from the command call, or deleting the refusal alert entirely, both passed. The ask and the alert are lifted out of the click handler into `askInstallationCloud` and `DiscoveryRefusal`, which is the depth this repo has (no DOM in the suite): the assertions run against the real typed client with `fetch` stubbed under it, covering which arguments leave the browser, an empty input being absent rather than sent empty, a refused command, and a transport that never reached the command layer.

**`SERVICE_DISABLED` was asserted by nothing.** Replacing the condition with `false` kept the disabled-API test green, because the fallthrough `403` sentence happens to quote the API's own message. The sentence is now pinned to "not enabled" and away from "may not list", in both shapes the fact arrives in — a parsed `error.details[].reason` and a bare message substring.

**"Truncation is not silence" was half-proven.** Replacing the page-cap refusal with a `break` — silent truncation, the exact defect the comment names — kept the suite green, as did deleting the key-ring cap. Both now have a test.

**`withSuggestion` folds a refusal into a positive-looking answer.** A `403` on `projects.list` still yields `found` for `cloud.homeVesselProject` on the impersonation-URL heuristic, which is deliberate and is the likely live posture. It is now visible: that candidate is labelled with its provenance rather than the bare id, and it leads the list so the labelled one is what is shown and marked. The value written is unchanged.

**Off-by-one in the service-account pattern.** `[a-z][a-z0-9-]{4,28}` matched 5-29 characters; GCP project ids are 6-30. Widened, with a test at the 30-character bound.

**The absent-adapter refusal.** `discovery` is optional on `AdapterRegistry`, so the guard is reachable through any registry that omits it — covered now rather than deleted.

Also removed the tracker references from the header comments of `discovery.tsx` and its test; shipped text is self-contained.

Suite: 1449 pass / 0 fail. `typecheck` and `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5psRW53mdUPRZjf3MyGsv
