### PR TITLE
fix(spindrift): a contract check that could not read the pods is not green

### DIFF
--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -627,9 +627,9 @@ export class KubernetesDeployAdapter implements DeployAdapter {
    * cleanly, reports green, and runs without the config it was handed.
    *
    * Pods carrying no annotation are not chart output and are ignored, which
-   * also keeps a foreign pod sharing the namespace out of the verdict. No pods,
-   * or a cluster that does not serve them, is met: zero rendered objects is
-   * zero skew.
+   * also keeps a foreign pod sharing the namespace out of the verdict. An
+   * empty read is met — zero rendered objects is zero skew — but a read that
+   * did not happen is **not**: see below.
    *
    * ponytail: this observes the **last** render, not the next — a Target with
    * nothing deployed reads green and a skew is caught one deploy late. That is
@@ -641,24 +641,67 @@ export class KubernetesDeployAdapter implements DeployAdapter {
     api: KubernetesApi,
     connection: KubernetesAdapterConnection,
   ): Promise<[boolean, string?]> {
-    const pods = await api
-      .list({
+    // "Nothing is rendered here yet" and "I was not allowed to look" are
+    // different facts and only the first one is zero skew. Collapsing them —
+    // an empty array standing in for a refusal, `every` over it vacuously
+    // true — is a check reporting met without ever having observed the thing
+    // it names, which is the exact shape this check replaced. So an unreadable
+    // pod list is a prerequisite failure naming why, and the operator whose
+    // Role was never bound is told to bind it rather than told everything is
+    // fine.
+    const unreadable = (why: string): [boolean, string] => [
+      false,
+      `Spindrift could not read the pods in ${connection.namespace} (${why}), so the value contract this Target renders under is unknown`,
+    ];
+
+    let pods: KubernetesObject[] | null;
+    try {
+      pods = await api.list({
         apiVersion: 'v1',
         plural: 'pods',
         namespace: connection.namespace,
-      })
-      .catch(() => null);
+      });
+    } catch (cause) {
+      return unreadable(
+        cause instanceof KubernetesRequestError
+          ? `the API server answered ${cause.status}`
+          : String(cause),
+      );
+    }
+    if (pods === null) return unreadable('the API server does not serve them');
 
-    const found = [
-      ...new Set(
-        (pods ?? [])
-          .map(
-            (pod) =>
-              pod.metadata.annotations?.['spindrift.dev/values-contract'],
-          )
-          .filter((contract) => contract !== undefined),
-      ),
-    ];
+    // Only what is desired *now* counts. A terminated pod is the residue of a
+    // render that is over, so a Completed run of a job would otherwise hold a
+    // Target red until the CronJob next fired; and of what is left only the
+    // newest pod of each Component counts, so a rolling update reads the
+    // render that is replacing the old one rather than reading both at once
+    // and calling the overlap skew.
+    //
+    // Filtered here rather than by `fieldSelector` because the grouping has to
+    // happen in this process anyway and a vessel namespace holds tens of pods,
+    // not thousands.
+    const newest = new Map<string, { contract: string; at: string }>();
+    for (const pod of pods) {
+      const contract =
+        pod.metadata.annotations?.['spindrift.dev/values-contract'];
+      if (contract === undefined) continue;
+      const phase = (pod.status as { phase?: string } | undefined)?.phase;
+      if (phase === 'Succeeded' || phase === 'Failed') continue;
+      // `spindrift-app.selectorLabels` — one App's one Component, and the one
+      // grouping the chart itself guarantees is on every pod it renders.
+      const labels = pod.metadata.labels ?? {};
+      const component = `${labels['app.kubernetes.io/part-of']}/${labels['app.kubernetes.io/name']}`;
+      const at = String(pod.metadata.creationTimestamp ?? '');
+      const seen = newest.get(component);
+      if (seen === undefined || at > seen.at) {
+        newest.set(component, { contract, at });
+      }
+    }
+
+    const found = [...new Set([...newest.values()].map((pod) => pod.contract))];
+    // Met with nothing to say, rather than a sentence about a contract nobody
+    // named: this Target has rendered nothing under the App chart.
+    if (found.length === 0) return [true];
 
     return [
       found.every((contract) => contract === VALUES_CONTRACT),

--- a/apps/spindrift/src/db/migrations/0024_drop_chart_contract.sql
+++ b/apps/spindrift/src/db/migrations/0024_drop_chart_contract.sql
@@ -1,0 +1,54 @@
+-- The stored manifest loses `chartContract`, because the schema just did.
+--
+-- Removing the key from `manifest.schema.ts` and from the mounted ConfigMap
+-- leaves a third copy untouched, and it is the copy that governs:
+-- `loadStoredManifest` resolves `stored ?? declaration`, and
+-- `readStoredManifest` parses that row through the same `.strict()` schema
+-- (`src/config/manifest-store.ts`). A strict schema rejects a key it no longer
+-- declares, and `validateManifest` throws rather than degrading, so an
+-- installation whose row still carried the key would not boot at all —
+-- `targets.0.connection: Unrecognized key: "chartContract"`.
+--
+-- So the field cannot be deleted from the schema without also deleting it from
+-- the documents already written under the old one. That is this file.
+--
+-- Ordering is already safe and needs no hook: every Deployment runs an init
+-- container that blocks until the migration journal holds every migration in
+-- the image (see the schema wait in
+-- `packages/charts/spindrift/templates/deployment.yaml`), so no process parses
+-- the document until this has run.
+--
+-- `targets.connection` is deliberately NOT touched. That column is a
+-- `.$type<>()` cast with no runtime validation, so a stale key there is inert;
+-- rewriting it would be churn for a read nothing performs.
+--
+-- The array is rebuilt rather than edited in place because jsonb has no
+-- map-over-array. `WITH ORDINALITY` and the matching `ORDER BY` are
+-- load-bearing: `reconcileManifestTargets` reads a Target's `rank` from its
+-- position in this array, so an aggregate that reordered it would silently
+-- re-rank every Target.
+UPDATE "installation"
+SET "manifest" = jsonb_set(
+	"manifest",
+	'{targets}',
+	(
+		SELECT coalesce(
+			jsonb_agg(
+				CASE
+					WHEN jsonb_typeof("target" -> 'connection') = 'object'
+						THEN jsonb_set(
+							"target",
+							'{connection}',
+							("target" -> 'connection') - 'chartContract'
+						)
+					ELSE "target"
+				END
+				ORDER BY "position"
+			),
+			'[]'::jsonb
+		)
+		FROM jsonb_array_elements("manifest" -> 'targets')
+			WITH ORDINALITY AS "entry"("target", "position")
+	)
+)
+WHERE jsonb_typeof("manifest" -> 'targets') = 'array';

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1785374380767,
       "tag": "0023_valkey_engine",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1785374380768,
+      "tag": "0024_drop_chart_contract",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -30,6 +30,7 @@ import { blameFor } from '../../src/adapters/deploy/contract.ts';
 import { KubernetesApi } from '../../src/adapters/deploy/kubernetes/api.ts';
 import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
 import { VALUES_CONTRACT } from '../../src/adapters/deploy/kubernetes/values.ts';
+import type { PrerequisiteResult } from '../../src/domain/capabilities.ts';
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import type {
   KubernetesAdapterConnection,
@@ -80,16 +81,35 @@ function connection(
   };
 }
 
-/** A pod as the App chart renders it: stamped with the contract it came from. */
-function podRenderedUnder(contract: string): FakeObject {
+/**
+ * A pod as the App chart renders it: stamped with the contract it came from,
+ * and carrying the Component labels the chart puts on every pod it renders.
+ */
+function podRenderedUnder(
+  contract: string,
+  overrides: { name?: string; createdAt?: string; phase?: string } = {},
+): FakeObject {
   return {
     apiVersion: 'v1',
     kind: 'Pod',
     metadata: {
-      name: 'blog-web-abc',
+      name: overrides.name ?? 'blog-web-abc',
+      labels: POD_LABELS,
+      creationTimestamp: overrides.createdAt ?? '2026-01-01T00:00:00Z',
       annotations: { 'spindrift.dev/values-contract': contract },
     },
+    ...(overrides.phase === undefined
+      ? {}
+      : { status: { phase: overrides.phase } }),
   };
+}
+
+/** What the standing checklist concluded about the value contract. */
+async function contractCheck(
+  adapter: KubernetesDeployAdapter,
+): Promise<PrerequisiteResult | undefined> {
+  const { prerequisites } = await adapter.inspect(target());
+  return prerequisites.find((item) => item.name === 'CHART_CONTRACT');
 }
 
 function target(
@@ -710,11 +730,58 @@ describe('the checklist', () => {
         pods: [{ apiVersion: 'v1', kind: 'Pod', metadata: { name: 'other' } }],
       },
     });
-    expect(
-      (await foreign.adapter.inspect(target())).prerequisites.find(
-        (item) => item.name === 'CHART_CONTRACT',
-      )?.met,
-    ).toBe(true);
+    const nothing = await contractCheck(foreign.adapter);
+    expect(nothing?.met).toBe(true);
+    // And it says nothing, rather than naming a contract nobody rendered.
+    expect(nothing?.detail).toBeUndefined();
+  });
+
+  test('a pod list this identity may not read is not a green contract check', async () => {
+    // The failure mode this whole check exists to remove: a prerequisite that
+    // reports met without having observed the thing it names. A cluster that
+    // refuses the read answers `403`, and an empty result standing in for that
+    // refusal makes "every rendered object agrees" vacuously true — so a
+    // Target whose Role was never bound would read green forever.
+    const { adapter } = adapterFor({ forbidden: ['pods'] });
+
+    const contract = await contractCheck(adapter);
+    expect(contract?.met).toBe(false);
+    expect(contract?.detail).toContain('403');
+  });
+
+  test('a rolling update is not skew, and a finished pod does not outlive its render', async () => {
+    // Both are the same mistake: reading a pod that is not desired state.
+    //
+    // During a rolling update after a contract bump the old ReplicaSet's pod
+    // and the new one coexist, and only the newer of the two says what the
+    // release now renders.
+    const rolling = adapterFor({
+      lists: {
+        pods: [
+          podRenderedUnder('2', {
+            name: 'blog-web-old',
+            createdAt: '2026-01-01T00:00:00Z',
+          }),
+          podRenderedUnder(VALUES_CONTRACT, {
+            name: 'blog-web-new',
+            createdAt: '2026-01-02T00:00:00Z',
+          }),
+        ],
+      },
+    });
+    expect((await contractCheck(rolling.adapter))?.met).toBe(true);
+
+    // And a job's Completed pod is the residue of a render that is over: a
+    // CronJob upgraded to the current contract but not yet fired again would
+    // otherwise be held red by its own history.
+    const finished = adapterFor({
+      lists: {
+        pods: [
+          podRenderedUnder('2', { name: 'blog-cron-1', phase: 'Succeeded' }),
+        ],
+      },
+    });
+    expect((await contractCheck(finished.adapter))?.met).toBe(true);
   });
 });
 

--- a/apps/spindrift/test/adapters/values.test.ts
+++ b/apps/spindrift/test/adapters/values.test.ts
@@ -17,6 +17,12 @@
  * deliberately sealed off from this package — it "knows about Helm and YAML
  * and nothing else" (`packages/charts/spindrift-app/tests/render.ts`), while
  * `values.ts` reaches into the domain layer.
+ *
+ * Reading across a package boundary means the runner has to be told: Turbo
+ * hashes a task from its own package's files, so `Chart.yaml` is named in
+ * `spindrift#test`'s `inputs` in the root `turbo.json`. Without that, the one
+ * change this guard exists to catch does not invalidate the task and CI serves
+ * a cached pass over a real skew — the same failure as the check it replaced.
  */
 
 import { describe, expect, test } from 'bun:test';

--- a/apps/spindrift/test/db/manifest-legacy-keys.test.ts
+++ b/apps/spindrift/test/db/manifest-legacy-keys.test.ts
@@ -1,0 +1,99 @@
+/**
+ * The stored manifest and the strict schema have to stay in agreement.
+ *
+ * `manifest.schema.ts` is `.strict()` and `readStoredManifest` parses the
+ * **database row** through it, so removing a key from the schema without
+ * removing it from documents already written under the old one is a boot
+ * failure, not a degraded read: `validateManifest` throws, and every process
+ * calls it before it can serve. Dropping `chartContract` was exactly that
+ * shape — the ConfigMap and the schema lost the key while the row that
+ * actually governs (`stored ?? declaration`) kept it.
+ *
+ * These tests run the **committed migration file** rather than a copy of its
+ * statement, so they fail if the file is edited or deleted, and they assert the
+ * property that matters rather than the mechanism: a document written under the
+ * old schema is accepted by the new one after migrating.
+ */
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
+import {
+  DEFAULT_PLACEHOLDER_MANIFEST,
+  validateManifest,
+} from '../../src/config/manifest.ts';
+import { installation } from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const MIGRATION = join(
+  import.meta.dir,
+  '../../src/db/migrations/0024_drop_chart_contract.sql',
+);
+
+/**
+ * A manifest as it was authored before `chartContract` was removed. Built from
+ * the placeholder so it stays a real document — every other key has to survive
+ * the rewrite, and a hand-rolled stub would not notice if they did not.
+ */
+function legacyDocument(): Record<string, unknown> {
+  const document = structuredClone(
+    DEFAULT_PLACEHOLDER_MANIFEST,
+  ) as unknown as Record<string, unknown>;
+  const targets = document.targets as Record<string, unknown>[];
+  for (const target of targets) {
+    const connection = target.connection as Record<string, unknown> | undefined;
+    if (connection) connection.chartContract = '3';
+  }
+  return document;
+}
+
+const database = withIsolatedDatabase();
+
+describe('a manifest written under the previous schema', () => {
+  test('is refused by the strict schema while it still carries chartContract', () => {
+    // The premise. Without this the next test proves nothing — a migration that
+    // strips a key nobody would have rejected is not load-bearing.
+    expect(() => validateManifest(legacyDocument(), 'legacy document')).toThrow(
+      /chartContract/,
+    );
+  });
+
+  test('is accepted once the committed migration has stripped the key', async () => {
+    const { db, client } = database();
+    const document = legacyDocument();
+    await db.insert(installation).values({
+      manifest: document as unknown as AuthoredManifest,
+    });
+
+    await client.unsafe(await Bun.file(MIGRATION).text());
+
+    const [row] = await db
+      .select({ manifest: installation.manifest })
+      .from(installation);
+    expect(() =>
+      validateManifest(row?.manifest, 'migrated document'),
+    ).not.toThrow();
+  });
+
+  test('keeps every Target, in order, because rank is read from that order', async () => {
+    // `reconcileManifestTargets` derives a Target's rank from its position in
+    // this array, so an aggregate that dropped or reordered an element would
+    // silently re-rank the installation.
+    const { db, client } = database();
+    const document = legacyDocument();
+    const before = (document.targets as { name: string }[]).map((t) => t.name);
+    await db.insert(installation).values({
+      manifest: document as unknown as AuthoredManifest,
+    });
+
+    await client.unsafe(await Bun.file(MIGRATION).text());
+
+    const [row] = await db
+      .select({ manifest: installation.manifest })
+      .from(installation);
+    expect(row).toBeDefined();
+    const migrated = row?.manifest as unknown as {
+      targets: { name: string }[];
+    };
+    expect(migrated.targets.map((t) => t.name)).toEqual(before);
+  });
+});

--- a/apps/spindrift/test/harness/fakes/kubernetes-api.ts
+++ b/apps/spindrift/test/harness/fakes/kubernetes-api.ts
@@ -57,6 +57,16 @@ export interface FakeKubernetesOptions {
   objects?: Record<string, FakeObject>;
   /** Collections a list call returns, keyed by plural. */
   lists?: Record<string, FakeObject[]>;
+  /**
+   * Plurals this identity may not list, answered `403`.
+   *
+   * A cluster that serves a kind and refuses to show it is the ordinary state
+   * of a Role that was never bound, and it is a *third* answer alongside the
+   * two above: not an empty list and not an unserved kind. A caller that reads
+   * a refusal as either of those is reporting a fact it never observed, so the
+   * fake has to be able to produce one.
+   */
+  forbidden?: readonly string[];
   /** What an applied delivery object's status becomes over successive reads. */
   status?: StatusScript;
   /** When set, every apply is refused with this status and body. */
@@ -324,6 +334,16 @@ export class FakeKubernetes {
    * inverse — an unseeded kind is absent, not unheard of.
    */
   private listResponse(parsed: ParsedPath, query: URLSearchParams): Response {
+    if (this.options.forbidden?.includes(parsed.plural)) {
+      return json(403, {
+        kind: 'Status',
+        apiVersion: 'v1',
+        status: 'Failure',
+        reason: 'Forbidden',
+        code: 403,
+        message: `${parsed.plural} is forbidden: User "spindrift" cannot list resource "${parsed.plural}" in the namespace "${parsed.namespace ?? ''}"`,
+      });
+    }
     const kinds = this.kindsOf(parsed.apiVersion);
     const serves =
       (kinds ?? []).some((kind) => pluralOf(kind) === parsed.plural) ||

--- a/turbo.json
+++ b/turbo.json
@@ -41,6 +41,15 @@
       "env": ["DATABASE_URL"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
+    "spindrift#test": {
+      "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/charts/spindrift-app/Chart.yaml"
+      ],
+      "env": ["DATABASE_URL"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+    },
     "typecheck": {
       "dependsOn": ["^typecheck"],
       "outputs": []


### PR DESCRIPTION
Follow-up to the value-contract check: it read the contract off the cluster
instead of off a stored claim, but it could still report green without having
observed anything.

## The check failed open

`chartContract` did `.catch(() => null)` on the pod list and then `every` over
an empty array, which is vacuously true. A cluster that answers `403` on
`GET .../pods` — the ordinary state of a Role that was never bound — therefore
reported the prerequisite **met**. That is the same shape the check was written
to remove: a passing check that never observed the thing it names.

"Nothing is rendered here yet" and "I was not allowed to look" are now different
answers. An empty list stays met, because zero rendered objects is zero skew; a
throw or an unserved kind is a failure naming the status the API server gave, so
the operator is told to bind the Role rather than told everything is fine.

`FakeKubernetes` grew a `forbidden` option, because a refusal was previously not
a state any test could produce — it is a third answer alongside "empty list" and
"kind not served".

## The pod query read state that is not desired state

It listed every pod in the namespace with no phase and no grouping, so a
Completed run of a job held a Target red until the CronJob next fired, and the
overlap during a rolling update after a contract bump read as skew.

It now skips terminated pods and keeps only the newest pod of each Component
(`spindrift-app.selectorLabels`, the grouping the chart guarantees on everything
it renders). Filtered in-process rather than by `fieldSelector` because the
grouping has to happen here anyway and a vessel namespace holds tens of pods.

## The cross-check could not fire in CI

`test/adapters/values.test.ts` reads `packages/charts/spindrift-app/Chart.yaml`,
but Turbo hashes `test` from the files of the package that owns it. Editing
`Chart.yaml` left `spindrift#test`'s hash untouched, so CI could serve a cached
pass over a real skew — the same failure the guard exists to catch.

`Chart.yaml` is now named in that task's `inputs`, verified against
`turbo run test --filter=spindrift --dry=json`:

| | `spindrift#test` hash |
| --- | --- |
| before, Chart.yaml unchanged | `499a3098ff71f9c7` |
| before, Chart.yaml bumped to `99` | `499a3098ff71f9c7` |
| after, Chart.yaml unchanged | `161fccb7dc2eb97c` |
| after, Chart.yaml bumped to `99` | `a11fa82caf1c6caa` |

## Also carried

The migration dropping the retired `chartContract` key from the stored
`installation.manifest`, which did not make the earlier merge.

## Checks

- `bun test` in `apps/spindrift`: 1442 pass, 0 fail
- `bun test` in `packages/charts`: 65 pass, 0 fail
- `bun run typecheck`, `bun run lint`: clean (the three lint warnings are
  pre-existing and in untouched files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F5psRW53mdUPRZjf3MyGsv