### PR TITLE
ci(containers): let each image declare its own build needs

### DIFF
--- a/.github/containers.json
+++ b/.github/containers.json
@@ -42,7 +42,6 @@
     "kernel-builder",
     "openclaw",
     "workstation",
-    "hermes",
-    "slingshot"
+    "hermes"
   ]
 }

--- a/.github/scripts/detect-containers.sh
+++ b/.github/scripts/detect-containers.sh
@@ -13,8 +13,18 @@
 # build.json format (array of build objects):
 #   [{ "image": "name", "context": ".", "file": "path/Dockerfile",
 #      "build-args": "KEY=val", "platforms": "linux/amd64,linux/arm64",
+#      "no-cache-filters": "stage", "gcp-credentials": true,
 #      "watch": ["extra/path"] }]
 # All fields except "image" are optional.
+#
+# An image's own build needs live here rather than in the workflow. A matrix
+# job that branches on `matrix.image == 'x'` is a generic job that has to be
+# edited every time an app grows a requirement — and the branch lands two files
+# away from the Dockerfile that needs it.
+#
+# `gcp-credentials` asks for the workload-identity federation the workflow then
+# mounts as the `gcp_credentials` build secret, which is the id the requesting
+# Dockerfile's `--mount=type=secret` names.
 #
 # Input:  CHANGED_FILES env var — newline-separated list of changed file paths
 # Output: has_changes and matrix written to GITHUB_OUTPUT
@@ -85,6 +95,10 @@ for dockerfile in "${dockerfiles[@]}"; do
     file=$(jq -r '.file        // ""' <<<"$entry")
     build_args=$(jq -r '."build-args" // ""' <<<"$entry")
     platforms=$(jq -r '.platforms   // ""' <<<"$entry")
+    no_cache_filters=$(jq -r '."no-cache-filters" // ""' <<<"$entry")
+    # Emitted as a string rather than a boolean so every matrix field is one
+    # kind of thing and the workflow tests them all the same way — `!= ''`.
+    gcp_credentials=$(jq -r 'if ."gcp-credentials" then "true" else "" end' <<<"$entry")
     deploy_manifests=$(jq -c --arg img "$image" '.deploy[$img] // []' "$manifest")
 
     should_build="$rebuild_all"
@@ -101,8 +115,10 @@ for dockerfile in "${dockerfiles[@]}"; do
     if [[ "$should_build" == "true" ]]; then
       includes=$(jq -cn --argjson a "$includes" \
         --arg img "$image" --arg ctx "$context" --arg f "$file" --arg ba "$build_args" \
-        --arg p "$platforms" --argjson m "$deploy_manifests" \
-        '$a + [{"image":$img,"context":$ctx,"file":$f,"build-args":$ba,"platforms":$p,"manifests":$m}]')
+        --arg p "$platforms" --arg ncf "$no_cache_filters" --arg gcp "$gcp_credentials" \
+        --argjson m "$deploy_manifests" \
+        '$a + [{"image":$img,"context":$ctx,"file":$f,"build-args":$ba,"platforms":$p,
+                "no-cache-filters":$ncf,"gcp-credentials":$gcp,"manifests":$m}]')
     fi
   done
 done

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -48,8 +48,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - name: Authenticate Slingshot build to Google Cloud
-        if: matrix.image == 'slingshot'
+      # Which images need what is declared in each app's build.json, not here.
+      # This job knows how to run a build; it does not know any app's name.
+      - name: Authenticate build to Google Cloud
+        if: matrix.gcp-credentials != ''
         id: gcp_auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
@@ -100,11 +102,8 @@ jobs:
             type=gha,scope=${{ matrix.image }}-main
             type=gha,scope=${{ matrix.image }}-push
           cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ github.ref_name }}
-          # The Spindrift runner is cheap and is the layer that packages its
-          # two entrypoints. Always rebuild it; dependency/build stages remain
-          # cached.
-          no-cache-filters: ${{ matrix.image == 'spindrift' && 'runner' || '' }}
-          secret-files: ${{ matrix.image == 'slingshot' && format('gcp_credentials={0}', steps.gcp_auth.outputs.credentials_file_path) || '' }}
+          no-cache-filters: ${{ matrix.no-cache-filters }}
+          secret-files: ${{ matrix.gcp-credentials != '' && format('gcp_credentials={0}', steps.gcp_auth.outputs.credentials_file_path) || '' }}
           sbom: true
           provenance: true
       - name: Scan ${{ matrix.image }} image with Trivy

--- a/apps/slingshot/build.json
+++ b/apps/slingshot/build.json
@@ -1,9 +1,11 @@
 [
   {
+    "_comment": "gcp-credentials: the Dockerfile mounts a gcp_credentials build secret (--mount=type=secret,id=gcp_credentials,required=true), so the build job federates for one before it starts.",
     "image": "slingshot",
     "context": ".",
     "file": "apps/slingshot/Dockerfile",
     "platforms": "linux/amd64",
+    "gcp-credentials": true,
     "watch": [
       "apps/slingshot",
       "packages/typescript-config",

--- a/apps/spindrift/build.json
+++ b/apps/spindrift/build.json
@@ -1,9 +1,11 @@
 [
   {
+    "_comment": "no-cache-filters: the runner stage is cheap and is the layer that packages the two entrypoints, so it is always rebuilt. The dependency and build stages stay cached.",
     "image": "spindrift",
     "context": ".",
     "file": "apps/spindrift/Dockerfile",
     "platforms": "linux/amd64",
+    "no-cache-filters": "runner",
     "watch": [
       "apps/spindrift",
       "packages/typescript-config",


### PR DESCRIPTION
## Summary

The containers build matrix branched on `matrix.image == '<name>'` three times.
Those are per-image facts, so they move to each image's `build.json` — where
`platforms` and `build-args` already live — and the workflow stops knowing any
app's name.

## Changes

- `detect-containers.sh` emits two new matrix fields read from `build.json`:
  `no-cache-filters` (passthrough) and `gcp-credentials`. The latter is emitted
  as `"true"` / `""` rather than a boolean so every matrix field is one kind of
  thing and the workflow tests them all with `!= ''`.
- `apps/spindrift/build.json` declares `"no-cache-filters": "runner"`;
  `apps/slingshot/build.json` declares `"gcp-credentials": true`. Each carries
  its rationale in a `_comment`, the pattern `containers.json` already uses.
- `slingshot` was listed in both `build` and `ignore` in `containers.json`.
  `is_build` is checked first so it published anyway; the `ignore` entry was a
  false statement of intent and is gone.

Behaviour is unchanged. `matrix.build-args` already dereferences a hyphenated
property in this workflow, so the two new hyphenated fields need nothing special.

## Test Plan

- [x] Ran `detect-containers.sh` locally: `slingshot` → `gcp-credentials: "true"`,
      `spindrift` → `no-cache-filters: "runner"`, the other nine images empty for
      both — matching the conditionals this replaces exactly.
- [x] `shellcheck` and `shfmt -i 2 -ci -bn` clean on the changed script; workflow
      YAML and all three JSON files parse.
- [ ] This PR edits `containers.yml`, `detect-containers.sh` and
      `containers.json`, so `rebuild_all` fires and every image builds once. That
      run is the real check: slingshot's federated build secret and spindrift's
      uncached `runner` stage both have to still work.
