### PR TITLE
feat(spindrift): publish the installer chart as a pinned OCI artifact

### DIFF
--- a/.github/workflows/spindrift-charts.yml
+++ b/.github/workflows/spindrift-charts.yml
@@ -1,0 +1,79 @@
+name: spindrift-charts
+
+# Publishes the Spindrift installer chart as an independently pinned,
+# extractable OCI artifact instead of a path this repository's own GitRepository
+# source has to be checked out to reach. See
+# clusters/offsite/apps/spindrift/oci-repository.yaml for the consumer and
+# packages/charts/spindrift/Chart.yaml for the version this pushes.
+#
+# packages/charts/spindrift-app is linted and packaged here too, so a broken
+# chart is caught before merge, but it is not pushed: the kubernetes deploy
+# adapter that renders every App's HelmRelease still hardcodes a GitRepository
+# source (apps/spindrift/src/adapters/deploy/kubernetes/flux-helmrelease.ts),
+# so a pushed artifact nothing consumes would just be dead weight in the
+# registry — see the header comment on
+# clusters/offsite/apps/spindrift/helm-release.yaml for the rest of that gap.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/charts/spindrift/**'
+      - 'packages/charts/spindrift-app/**'
+      - '.github/workflows/spindrift-charts.yml'
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'packages/charts/spindrift/**'
+      - 'packages/charts/spindrift-app/**'
+      - '.github/workflows/spindrift-charts.yml'
+
+# Cancel superseded runs on the same ref instead of letting them pile up.
+concurrency:
+  group: spindrift-charts-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Install helm
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install_args: helm
+      - name: Lint charts
+        run: |
+          set -euo pipefail
+          helm lint packages/charts/spindrift
+          helm lint packages/charts/spindrift-app
+      - name: Package charts
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          helm package packages/charts/spindrift -d dist
+          helm package packages/charts/spindrift-app -d dist
+      - name: Login to GitHub Container Registry
+        # Only needed for the push (on main); PRs lint and package to validate
+        # without pushing, matching the pattern containers.yml uses for images —
+        # a fork's PR has no access to this credential either way.
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+      - name: Push installer chart
+        # Only the installer chart: see the workflow header for why
+        # spindrift-app is packaged above but stops there. Named explicitly
+        # rather than a `dist/spindrift-*.tgz` glob, which `spindrift-app-*.tgz`
+        # also satisfies.
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          version="$(grep '^version:' packages/charts/spindrift/Chart.yaml | awk '{print $2}')"
+          helm push "dist/spindrift-${version}.tgz" oci://ghcr.io/jonpulsifer/charts

--- a/apps/spindrift/test/conformance/second-target-admission.test.ts
+++ b/apps/spindrift/test/conformance/second-target-admission.test.ts
@@ -15,6 +15,7 @@
  * - Only after every ticket's acceptance criteria pass is the effort recorded as Spindrift v1.
  */
 import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
 import { eq } from 'drizzle-orm';
 import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
 import {
@@ -65,6 +66,43 @@ const clock: Clock = { now: () => FROZEN };
 
 function digest(seed: number): string {
   return `sha256:${seed.toString(16).padStart(64, '0')}`;
+}
+
+/** The repository root, for reading the cluster manifests this test proves. */
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+
+/**
+ * Whether a rendered `HelmRelease`'s chart source is an independently pinned,
+ * extractable artifact rather than a path resolved inside this installation's
+ * own repository checkout.
+ *
+ * The old shape — `chart.spec.sourceRef.kind: GitRepository` plus a
+ * `chart.spec.chart` path — names somewhere inside a clone of this
+ * repository, which is not an artifact on its own: nothing about the string
+ * `packages/charts/spindrift` can be pulled by itself. A `chartRef` naming an
+ * `OCIRepository` names an object Flux already pulled from a registry by tag,
+ * independent of this repository's working tree, which is what "extractable"
+ * means for a chart. This is the whole difference the old assertion missed —
+ * it checked only that *some* string was present, which a repository-local
+ * path satisfies exactly as an OCI reference would.
+ */
+function isExtractableChartSource(release: {
+  spec?: {
+    chart?: { spec?: { chart?: string; sourceRef?: { kind?: string } } };
+    chartRef?: { kind?: string };
+  };
+}): boolean {
+  return release.spec?.chartRef?.kind === 'OCIRepository';
+}
+
+/**
+ * Whether an App chart reference names an artifact independent of this
+ * repository, rather than a path only this repository's own checkout
+ * resolves — the same distinction {@link isExtractableChartSource} draws for
+ * the installer, applied to the string `manifest.charts.app` carries.
+ */
+function isExtractableAppChartRef(ref: string): boolean {
+  return ref.startsWith('oci://');
 }
 
 function harnessRegistry(
@@ -255,13 +293,68 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
     );
   });
 
-  test('Installer and App chart distribution use independently pinned, extractable artifacts', async () => {
-    // The App chart is a pinned reference an installation declares. The
-    // installer chart is not one of these: it named the release this process is
-    // already running from, nothing read it, and it has been removed.
-    expect(manifest.charts.app).toBeDefined();
-    expect(typeof manifest.charts.app).toBe('string');
-    expect(manifest.charts).not.toHaveProperty('installer');
+  test('Installer chart distribution is an independently pinned, extractable OCI artifact', async () => {
+    // Read the real cluster manifests rather than a fixture: the point of
+    // this criterion is what this installation actually deploys from, and a
+    // fixture that says the right thing while the repo says the old thing is
+    // exactly the false positive this test replaces.
+    const helmRelease = Bun.YAML.parse(
+      await Bun.file(
+        join(REPO_ROOT, 'clusters/offsite/apps/spindrift/helm-release.yaml'),
+      ).text(),
+    ) as Parameters<typeof isExtractableChartSource>[0];
+    expect(isExtractableChartSource(helmRelease)).toBe(true);
+
+    const ociRepository = Bun.YAML.parse(
+      await Bun.file(
+        join(REPO_ROOT, 'clusters/offsite/apps/spindrift/oci-repository.yaml'),
+      ).text(),
+    ) as { spec?: { url?: string; ref?: { tag?: string; digest?: string } } };
+    expect(ociRepository.spec?.url).toMatch(/^oci:\/\//);
+    expect(
+      ociRepository.spec?.ref?.tag ?? ociRepository.spec?.ref?.digest,
+    ).toBeTruthy();
+  });
+
+  test('the installer check catches a repository-local chart path', () => {
+    // The exact shape clusters/offsite/apps/spindrift/helm-release.yaml
+    // carried before this ticket: `packages/charts/spindrift` resolved
+    // through GitRepository/infra. A detector nobody has seen fail is not a
+    // detector — this is the proof the assertion above is not vacuous.
+    const beforeThisFix = {
+      spec: {
+        chart: {
+          spec: {
+            chart: 'packages/charts/spindrift',
+            sourceRef: {
+              kind: 'GitRepository',
+              name: 'infra',
+              namespace: 'flux-system',
+            },
+          },
+        },
+      },
+    };
+    expect(isExtractableChartSource(beforeThisFix)).toBe(false);
+  });
+
+  // The App chart is not the same yet. Every per-Component HelmRelease the
+  // kubernetes adapter renders still sources `manifest.charts.app` from
+  // GitRepository/infra by path: `helmRelease()`
+  // (src/adapters/deploy/kubernetes/flux-helmrelease.ts) hardcodes
+  // `sourceRef.kind: GitRepository`, and the delivery schema's `sourceRef`
+  // (`kubernetesDeliverySchema` in src/config/manifest.schema.ts) is `.strict()`
+  // with no `kind` field to say otherwise. Pointing `charts.app` at an OCI
+  // reference without that adapter support would not distribute anything —
+  // Flux would try to resolve the reference as a path inside the named
+  // GitRepository and fail every deploy. That is real adapter work — a second
+  // Flux source per Kubernetes Target, a schema change, and a live
+  // `configureInstallation` on top, since the stored manifest wins over any
+  // declaration — so it stays a `test.todo` rather than a passing assertion
+  // that is not backed by anything, which is the mistake this whole test
+  // exists to stop repeating.
+  test.todo('App chart distribution is an independently pinned, extractable OCI artifact', () => {
+    expect(isExtractableAppChartRef(manifest.charts.app)).toBe(true);
   });
 
   test('Status, diagnosis, and logs identify the second Target while preserving App-first product view', async () => {

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -3,24 +3,39 @@
 # this namespace exactly as it owns Atlantis's and hub's, which is what resolves
 # a deploy layer that would otherwise have to deploy itself.
 #
-# The chart is sourced from GitRepository/infra rather than OCI. That costs the
-# per-Target chart pinning and leaves the extraction path unexercised; reversing
-# it is one workflow plus a source swap, and must happen before extraction.
+# The installer chart is an independently pinned, extractable OCI artifact, not
+# this installation's repository-local chart path. `oci-repository.yaml` names
+# the artifact; `.github/workflows/spindrift-charts.yml` is what puts it there,
+# packaging and pushing `packages/charts/spindrift` on every merge that touches
+# it. That closes the installer half of the per-Target chart pinning the
+# extraction path wants.
+#
+# The App chart (`manifest.charts.app` below) is not the same yet, and cannot
+# be flipped the same way. Every per-Component `HelmRelease` the kubernetes
+# adapter renders for a deployed App still sources it from `GitRepository/infra`
+# by path: the adapter hardcodes `sourceRef.kind: GitRepository`
+# (apps/spindrift/src/adapters/deploy/kubernetes/flux-helmrelease.ts) and the
+# manifest's delivery `sourceRef` schema carries no `kind` to say otherwise
+# (apps/spindrift/src/config/manifest.schema.ts, `kubernetesDeliverySchema`).
+# Reversing that is a second Flux source per Kubernetes Target, a schema and
+# adapter change, and — because the stored manifest always wins over this
+# declaration — a live `configureInstallation` on top, not a file edit here.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: spindrift
   namespace: spindrift
+  labels:
+    # clusters/offsite/apps/kustomization.yaml patches `chart.spec.interval`
+    # onto every HelmRelease that is *not* labeled this way — that field only
+    # exists on a GitRepository/HelmRepository-sourced chart, and a chartRef
+    # release like this one has no `chart.spec` for the patch to land on.
+    source.toolkit.fluxcd.io/kind: OCIRepository
 spec:
   interval: 5m
-  chart:
-    spec:
-      chart: packages/charts/spindrift
-      reconcileStrategy: Revision
-      sourceRef:
-        kind: GitRepository
-        name: infra
-        namespace: flux-system
+  chartRef:
+    kind: OCIRepository
+    name: spindrift
   values:
     # Renovate pins the digest on this line and Flux rolls it out. The image's
     # manifest schema and the chart must agree on which keys a declaration may

--- a/clusters/offsite/apps/spindrift/kustomization.yaml
+++ b/clusters/offsite/apps/spindrift/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
   - gateway.yaml
   - ca-bundle.yaml
   - secret.sops.yaml
+  - oci-repository.yaml
   - helm-release.yaml
   - target-rbac.yaml

--- a/clusters/offsite/apps/spindrift/oci-repository.yaml
+++ b/clusters/offsite/apps/spindrift/oci-repository.yaml
@@ -1,0 +1,21 @@
+---
+# The installer chart, as an independently pinned, extractable artifact rather
+# than this installation's own repository-local path.
+# .github/workflows/spindrift-charts.yml packages and pushes
+# packages/charts/spindrift here on every merge that touches it, tagged with
+# the version Chart.yaml carries — the same convention `Chart.yaml` version
+# bumps use everywhere else a chart is consumed by tag (see
+# clusters/base/apps/reloader/oci-repository.yaml).
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: spindrift
+  namespace: spindrift
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.1
+  url: oci://ghcr.io/jonpulsifer/charts/spindrift


### PR DESCRIPTION
## Summary

- The installer chart is now an independently pinned, extractable OCI artifact. `clusters/offsite/apps/spindrift/helm-release.yaml` sources it through `chartRef: {kind: OCIRepository, name: spindrift}` instead of `GitRepository/infra` by repository-local path — the same pattern already used for `reloader`, `arc-system`, and `cilium` in this repo. `clusters/offsite/apps/spindrift/oci-repository.yaml` names the artifact: `oci://ghcr.io/jonpulsifer/charts/spindrift`, tag `0.1.1` (the version `packages/charts/spindrift/Chart.yaml` already carries).
- New `.github/workflows/spindrift-charts.yml` packages and pushes that chart on every merge to `main` that touches `packages/charts/spindrift/**`, following the auth/permissions pattern `containers.yml` already uses for images (`packages: write`, `GITHUB_TOKEN` login, no push on PRs).
- `packages/charts/spindrift-app` is linted and packaged in the same workflow — so a broken chart is caught in CI — but **not pushed**. The kubernetes deploy adapter that renders every App's `HelmRelease` still hardcodes a `GitRepository` source (`apps/spindrift/src/adapters/deploy/kubernetes/flux-helmrelease.ts:80-84`), and the delivery `sourceRef` schema is `.strict()` with no `kind` field to point it at OCI instead (`apps/spindrift/src/config/manifest.schema.ts`). Distributing that chart over OCI needs an adapter change, not just a workflow and a `clusters/` swap. Both the `helm-release.yaml` header comment and the conformance test below spell this out.
- Replaced the conformance assertion at `apps/spindrift/test/conformance/second-target-admission.test.ts` that only checked `manifest.charts.app` was a defined string — a repository-local path satisfies that exactly as an OCI reference would — with one that reads the real cluster manifests and checks for `chartRef`/`OCIRepository`, plus a permanent regression test (`the installer check catches a repository-local chart path`) proving the new check actually rejects the old shape. The still-open App-chart half is left as `test.todo` with the reason recorded in a code comment, rather than a passing assertion nothing backs.

## Why not the App chart too

Tracing the actual render path (`registry.ts` → `KubernetesDeployAdapter` → `helmRelease()`) shows every per-Component `HelmRelease` the adapter writes for a deployed App is built with `sourceRef.kind` hardcoded to `GitRepository`, and the prerequisite check that verifies the chart source exists (`chartSource()`) only ever looks for a `GitRepository` resource. Flipping `manifest.charts.app` to an OCI reference without changing that would not distribute anything — Flux would try to resolve the reference as a path inside `GitRepository/infra` and fail every deploy. That's real adapter work (a second Flux source per Kubernetes Target, a schema change, and — since the stored manifest always wins over a declaration — a live reconfigure on top), not something this PR's scope covers safely.

## Merge ordering

None required beyond normal eventual consistency. The chart version (`0.1.1`) is chosen in this PR rather than produced by it, so `clusters/offsite/apps/spindrift/oci-repository.yaml` can reference it up front. On merge, the publish workflow and Flux's `OCIRepository` reconciliation both key off the same push to `main`; if Flux polls before the workflow finishes publishing, that reconcile attempt fails and self-heals at the next interval (`15m`) with no operator action needed — the running installer pods are unaffected either way, since a not-ready `HelmRelease` source doesn't tear down what's already deployed.

**One manual step is likely needed once, outside git:** this creates a new GHCR package (`ghcr.io/jonpulsifer/charts/spindrift`). GitHub Container Registry packages published via `GITHUB_TOKEN` from a workflow commonly default to **private** even from a public repository, unlike this repo's existing image packages (which pull anonymously today and were presumably made public by hand at some point). If the first `OCIRepository` reconcile fails on a pull-auth error rather than "not found", the fix is flipping that package's visibility to public in GitHub's package settings — no code change.

## Test plan

- [x] `bun run typecheck` and `bun run lint` — both exit 0 in `apps/spindrift`.
- [x] `bun test` in `apps/spindrift` (Postgres on `127.0.0.1:5432`) — **1467 pass, 1 todo, 0 fail** across 108 files.
- [x] `bash .github/scripts/render-cluster-apps.sh` (also `mise run k8s:render-apps`) — exits 0; `spindrift/spindrift` now reports `skipped … chartRef (OCIRepository), chart not in this repo`, the same as the other OCI-sourced releases.
- [x] `helm lint packages/charts/spindrift` and `helm lint packages/charts/spindrift-app` — both pass.
- [x] Proved the new conformance assertion actually distinguishes the two shapes: temporarily restored the pre-fix `helm-release.yaml` content and reran the installer test alone — it fails with `Expected: true / Received: false` at the `isExtractableChartSource` check, exactly as expected before restoring the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL