### PR TITLE
feat(spindrift): let the manifest declare a vessel

### DIFF
--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -10,13 +10,7 @@ import type { Database } from '../db/client.ts';
 import { installation, targets, vessels } from '../db/schema.ts';
 import { unreachablePrerequisites } from '../domain/capabilities.ts';
 import type { TargetConnection } from '../domain/target.ts';
-import {
-  claimsDisagree,
-  unionOfClaims,
-  type VesselKind,
-  type VesselLocation,
-  vesselKindFor,
-} from '../domain/vessel.ts';
+import type { VesselKind, VesselLocation } from '../domain/vessel.ts';
 import type {
   AuthoredManifest,
   InstallationManifest,
@@ -343,7 +337,10 @@ async function reconcileManifestTargets(
 
   for (const [rank, target] of manifest.targets.entries()) {
     const { name, adapter } = target;
-    const vessel = reconciledVessels.get(vesselNameOfSeed(target))!;
+    // Non-null because the document-level refinement in `manifest.schema.ts`
+    // refuses a Target whose `vessel` names nothing declared, so a validated
+    // manifest cannot reach here with a reference that does not resolve.
+    const vessel = reconciledVessels.get(target.vessel)!;
     const declaredConnection = connectionFromSeed(target);
     const existing = await db.query.targets.findFirst({
       where: (targets, { eq }) => eq(targets.name, name),
@@ -443,66 +440,34 @@ function assertedBySeed(target: TargetSeed): {
   };
 }
 
+/**
+ * The surface half of a seed, which is now the whole of what a seed's
+ * connection carries.
+ *
+ * A straight widening: the schema no longer accepts a boundary fact on a
+ * Target's connection, so there is nothing left to strip. It stays a function
+ * because the adapter tag lives on the seed and inside `TargetConnection`, and
+ * the discriminated union is what carries it across.
+ */
 function connectionFromSeed(target: TargetSeed): TargetConnection | null {
   if (target.connection === undefined) return null;
-  // The boundary's half is stripped out here and lands on the vessel instead.
-  // The seed format still states it per surface — see `vesselNameOfSeed` for
-  // why that is deliberate, and #61 for its removal.
-  switch (target.adapter) {
-    case 'kubernetes': {
-      const {
-        apiServer: _apiServer,
-        servedHosts: _servedHosts,
-        reachableRegistries: _reachableRegistries,
-        ...surface
-      } = target.connection;
-      return { adapter: 'kubernetes', ...surface };
-    }
-    case 'cloudrun': {
-      const {
-        project: _project,
-        servedHosts: _servedHosts,
-        reachableRegistries: _reachableRegistries,
-        ...surface
-      } = target.connection;
-      return { adapter: 'cloudrun', ...surface };
-    }
-    case 'static': {
-      const {
-        project: _project,
-        servedHosts: _servedHosts,
-        ...surface
-      } = target.connection;
-      return { adapter: 'static', ...surface };
-    }
-  }
+  return { adapter: target.adapter, ...target.connection } as TargetConnection;
 }
 
 /**
- * Which vessel a seed is a surface of.
+ * The vessel row each declared vessel is, keyed by name.
  *
- * **The one place left that recovers a boundary from a name**, and it is here
- * rather than in the domain because the *manifest format* still states a
- * boundary per surface: two cloud seeds say they share a project by being
- * called `<name>-cloudrun` and `<name>-static`, which `manifest.schema.ts`
- * enforces. Everything downstream reads `vesselId`.
+ * **No derivation.** The document says which boundaries exist and where they
+ * are; nothing here recovers one from a Target's name, and nothing reconciles
+ * two surfaces' competing claims about one boundary, because the schema no
+ * longer lets a surface make one. Documents that were written that way are
+ * brought forward once, in `manifest-upgrade.ts`, before they ever reach here.
  *
- * Giving the manifest a `vessels` array — and deleting this — is #61. It was
- * kept out of the change that introduced the Vessel row because a manifest
- * schema change has a failure mode where the stored document fails validation
- * and the installation is silently re-seeded from its declaration, which is
- * worth landing on its own.
+ * `null` rather than omitted for an unstated fact, because these are column
+ * values: the row's `location`, `served_hosts` and `reachable_registries` are
+ * nullable exactly so a seeded-but-unconnected boundary is representable.
  */
-function vesselNameOfSeed(target: TargetSeed): string {
-  if (target.adapter === 'kubernetes') return target.name;
-  const suffix = `-${target.adapter}`;
-  return target.name.endsWith(suffix)
-    ? target.name.slice(0, -suffix.length)
-    : target.name;
-}
-
-/** The vessels a manifest's seeds describe between them. */
-function vesselsFromSeeds(manifest: AuthoredManifest): Map<
+function vesselRowsOf(manifest: AuthoredManifest): Map<
   string,
   {
     kind: VesselKind;
@@ -511,89 +476,27 @@ function vesselsFromSeeds(manifest: AuthoredManifest): Map<
     reachableRegistries: string[] | null;
   }
 > {
-  const byName = new Map<
-    string,
-    {
-      kind: VesselKind;
-      location: VesselLocation | null;
-      servedHosts: string[] | null;
-      reachableRegistries: string[] | null;
-      served: (readonly string[] | undefined)[];
-      registries: (readonly string[] | undefined)[];
-    }
-  >();
-
-  for (const target of manifest.targets) {
-    const name = vesselNameOfSeed(target);
-    const kind = vesselKindFor(target.adapter);
-    const entry = byName.get(name) ?? {
-      kind,
-      location: null,
-      servedHosts: null,
-      reachableRegistries: null,
-      served: [],
-      registries: [],
-    };
-
-    if (target.connection !== undefined) {
-      // Either surface of a project states the same project id; the first to
-      // arrive settles it, and the schema's pairing rule is what makes them
-      // agree.
-      if (target.adapter === 'kubernetes') {
-        entry.location ??= {
-          kind: 'cluster',
-          apiServer: target.connection.apiServer,
-        };
-        entry.registries.push(target.connection.reachableRegistries);
-      } else {
-        entry.location ??= {
-          kind: 'gcp-project',
-          project: target.connection.project,
-        };
-        if (target.adapter === 'cloudrun') {
-          entry.registries.push(target.connection.reachableRegistries);
-        }
-      }
-      entry.served.push(target.connection.servedHosts);
-    }
-    byName.set(name, entry);
-  }
-
-  const vesselsByName = new Map<
-    string,
-    {
-      kind: VesselKind;
-      location: VesselLocation | null;
-      servedHosts: string[] | null;
-      reachableRegistries: string[] | null;
-    }
-  >();
-  for (const [name, entry] of byName) {
-    // The union, not a winner: two surfaces of one boundary *can* state
-    // different reach today, and silently taking one would be the bug the
-    // Vessel row exists to prevent.
-    const servedHosts = entry.served.some((claim) => claim !== undefined)
-      ? unionOfClaims(entry.served)
-      : null;
-    const reachableRegistries = entry.registries.some(
-      (claim) => claim !== undefined,
-    )
-      ? unionOfClaims(entry.registries)
-      : null;
-    if (claimsDisagree(entry.served) || claimsDisagree(entry.registries)) {
-      console.warn(
-        `installation manifest: the surfaces of vessel ${name} state different reach; ` +
-          'the union is stored, and stating it once per vessel is #61',
-      );
-    }
-    vesselsByName.set(name, {
-      kind: entry.kind,
-      location: entry.location,
-      servedHosts,
-      reachableRegistries,
-    });
-  }
-  return vesselsByName;
+  return new Map(
+    manifest.vessels.map((vessel) => [
+      vessel.name,
+      {
+        kind: vessel.kind,
+        // The kind is folded back into the location because
+        // {@link VesselLocation} is discriminated on its own. The document
+        // states it once, on the vessel, so the two cannot disagree.
+        location:
+          vessel.location === undefined
+            ? null
+            : ({ kind: vessel.kind, ...vessel.location } as VesselLocation),
+        servedHosts:
+          vessel.servedHosts === undefined ? null : [...vessel.servedHosts],
+        reachableRegistries:
+          vessel.reachableRegistries === undefined
+            ? null
+            : [...vessel.reachableRegistries],
+      },
+    ]),
+  );
 }
 
 /** One reconciled vessel: its id, and whether this pass moved it. */
@@ -620,7 +523,7 @@ async function reconcileManifestVessels(
   write: ManifestWrite,
 ): Promise<Map<string, ReconciledVessel>> {
   const reconciled = new Map<string, ReconciledVessel>();
-  for (const [name, vessel] of vesselsFromSeeds(manifest)) {
+  for (const [name, vessel] of vesselRowsOf(manifest)) {
     const existing = await db.query.vessels.findFirst({
       where: (vessels, { eq }) => eq(vessels.name, name),
     });

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -1,0 +1,188 @@
+/**
+ * Bringing a manifest document written under an older schema up to this one.
+ *
+ * **This is what stands between a schema change and a silently re-seeded
+ * installation.** The stored row governs — `loadStoredManifest` resolves
+ * `stored ?? declaration ?? placeholder` — and a row this build cannot parse is
+ * a row this build treats as having no seed at all, so it re-seeds from the
+ * mounted declaration and discards everything an operator configured through
+ * the UI. That fallback is right for a genuinely corrupt document and wrong for
+ * a merely old one, and validation alone cannot tell them apart. This module
+ * is what makes the difference: run before validation, an old document becomes
+ * a current one and never reaches the fallback, and a document that still fails
+ * afterwards is a real fault.
+ *
+ * It runs inside {@link validateManifest}, which is the one gate every document
+ * passes through — the stored row, the mounted declaration, and the document
+ * `configureInstallation` accepts. The mounted declaration matters as much as
+ * the row here: a declaration and the image that understands it land in
+ * separate merges, so for the window between them an installation is reading a
+ * document written for the other schema, whichever direction the skew runs in.
+ *
+ * Every upgrade here is a **pure function of the document**, never of the
+ * database or the environment. That is what lets `loadStoredManifest` persist
+ * the result by writing back the document it just read, inside the transaction
+ * it already opens, rather than needing a migration step of its own.
+ *
+ * `test/config/manifest-upgrade.test.ts` holds a fixture per historical shape
+ * and boots each one; adding a shape to that corpus is how a future schema
+ * change proves it did not make the re-seed reachable.
+ */
+import {
+  unionOfClaims,
+  type VesselKind,
+  vesselKindFor,
+} from '../domain/vessel.ts';
+
+/** A JSON object, as a document is before anything has validated it. */
+type Document = Record<string, unknown>;
+
+function asDocument(value: unknown): Document | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Document)
+    : null;
+}
+
+/**
+ * A manifest document as the running schema expects it.
+ *
+ * Returns its argument untouched when there is nothing to do, which is the
+ * common case: every document written since this shipped is already current,
+ * and an unrecognizable one is left exactly as it arrived so validation reports
+ * what is wrong with it rather than reporting what this function made of it.
+ */
+export function upgradeManifestDocument(document: unknown): unknown {
+  return addDeclaredVessels(document);
+}
+
+/**
+ * Give a document that predates `vessels` the array it is missing.
+ *
+ * A vessel used to be spelled as the shared prefix of `<name>-cloudrun` and
+ * `<name>-static`, with its own facts — where it is, what it can reach —
+ * restated on each surface's connection. **This function holds the last suffix
+ * parse in the codebase**, deliberately: recovering a boundary from a name is
+ * exactly what the `vessels` key exists to stop, and the only honest place for
+ * that logic is a one-shot upgrade of the documents that were written that way.
+ *
+ * The derivation is the one the seeding path performed on every boot before
+ * this key existed, so an installation upgraded here gets the same vessel rows
+ * it already has: the same names, and the same union of what two surfaces of
+ * one boundary each claimed about it.
+ */
+function addDeclaredVessels(document: unknown): unknown {
+  const manifest = asDocument(document);
+  if (manifest === null || 'vessels' in manifest) return document;
+
+  const seeds = Array.isArray(manifest.targets) ? manifest.targets : null;
+  if (seeds === null) return document;
+
+  const vessels = new Map<
+    string,
+    {
+      name: string;
+      kind: VesselKind;
+      location?: Document;
+      served: (readonly string[] | undefined)[];
+      registries: (readonly string[] | undefined)[];
+    }
+  >();
+  const targets: Document[] = [];
+
+  for (const seed of seeds) {
+    const target = asDocument(seed);
+    const adapter = target?.adapter;
+    const name = target?.name;
+    if (
+      target === null ||
+      typeof name !== 'string' ||
+      (adapter !== 'kubernetes' &&
+        adapter !== 'cloudrun' &&
+        adapter !== 'static')
+    ) {
+      // Not a document this function recognizes. Hand it back whole so
+      // validation names what is actually wrong with it.
+      return document;
+    }
+
+    const vesselName =
+      adapter === 'kubernetes' ? name : stripSuffix(name, `-${adapter}`);
+    const kind = vesselKindFor(adapter);
+    const vessel = vessels.get(vesselName) ?? {
+      name: vesselName,
+      kind,
+      served: [],
+      registries: [],
+    };
+
+    const connection = asDocument(target.connection);
+    if (connection !== null) {
+      // The first surface to state where the boundary is settles it; under the
+      // old schema the pairing rule was what made two surfaces of one project
+      // agree about that.
+      const {
+        apiServer,
+        project,
+        servedHosts,
+        reachableRegistries,
+        ...surface
+      } = connection;
+      vessel.location ??=
+        kind === 'cluster'
+          ? apiServer === undefined
+            ? undefined
+            : { apiServer }
+          : project === undefined
+            ? undefined
+            : { project };
+      vessel.served.push(asStrings(servedHosts));
+      // `static` never carried this key, so it contributes nothing rather than
+      // an empty claim — `undefined` is unstated and `[]` is stated-and-empty.
+      if (adapter !== 'static') {
+        vessel.registries.push(asStrings(reachableRegistries));
+      }
+      targets.push({ ...target, vessel: vesselName, connection: surface });
+    } else {
+      targets.push({ ...target, vessel: vesselName });
+    }
+    vessels.set(vesselName, vessel);
+  }
+
+  return {
+    ...manifest,
+    vessels: [...vessels.values()].map(
+      ({ served, registries, location, ...vessel }): Document => ({
+        ...vessel,
+        // Omitted rather than present-and-undefined when no surface said where
+        // the boundary is: the column is nullable for the same reason, and a
+        // key that is there holding nothing is a third state nobody reads.
+        ...(location === undefined ? {} : { location }),
+        // The union rather than a winner, matching the backfill: two surfaces
+        // of one boundary *could* state different reach under the old schema,
+        // and silently taking one would be the bug the vessel exists to
+        // prevent. Omitted entirely when no surface stated it, because absent
+        // and `[]` mean different things.
+        ...(served.some((claim) => claim !== undefined)
+          ? { servedHosts: unionOfClaims(served) }
+          : {}),
+        ...(registries.some((claim) => claim !== undefined)
+          ? { reachableRegistries: unionOfClaims(registries) }
+          : {}),
+      }),
+    ),
+    // Rebuilt in place, in order: `reconcileManifestTargets` reads a Target's
+    // rank from its position in this array.
+    targets,
+  };
+}
+
+function stripSuffix(value: string, suffix: string): string {
+  return value.endsWith(suffix) ? value.slice(0, -suffix.length) : value;
+}
+
+/** A claim about a boundary, or `undefined` for anything that is not one. */
+function asStrings(value: unknown): readonly string[] | undefined {
+  return Array.isArray(value) && value.every((it) => typeof it === 'string')
+    ? value
+    : undefined;
+}

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -21,11 +21,23 @@
  */
 import { z } from 'zod';
 import type { FederationConfig } from '../adapters/deploy/cloud/federation.ts';
+// `src/domain/vessel.ts` imports `TargetAdapter` back from here, and that is a
+// type-only edge, so the cycle is erased at runtime. Restating the table here
+// to avoid it would be the duplication that table exists to end.
+import { surfacesOf } from '../domain/vessel.ts';
 
 /** A non-empty string with no surrounding whitespace. */
 const nonEmptyString = z.string().trim().min(1);
 
-/** A Target identifier accepted by both the manifest and the connect act. */
+/**
+ * A Target or Vessel identifier accepted by both the manifest and the connect
+ * act.
+ *
+ * One spelling for both nouns because a Target name and a Vessel name land in
+ * the same places — a DNS-shaped label in a URL path and a column with a unique
+ * index — and two regexes that had to agree would be two regexes that could
+ * disagree.
+ */
 export const targetNameSchema = nonEmptyString
   .max(63)
   .regex(
@@ -180,18 +192,88 @@ const kubernetesDeliverySchema = z.discriminatedUnion('flavour', [
 const reachSchema = z.enum(['none', 'private', 'public']);
 
 /**
+ * The facts every kind of vessel states about itself, whatever it is.
+ *
+ * Both are properties of the **boundary** — of the network a cluster or a
+ * project sits on — so they are true for every surface on it and impossible for
+ * two of those surfaces to disagree about. That is the whole reason they are
+ * here rather than on a Target: `src/domain/vessel.ts` records what it cost
+ * when they were stated per surface.
+ *
+ * Optional rather than defaulted, matching the row: absent means unstated, and
+ * `[]` means stated-and-empty. A Target with no declared `reachableRegistries`
+ * gets the first of `supplyChain.registry`, which is not the same answer as one
+ * that reaches none.
+ */
+const vesselFacts = {
+  name: targetNameSchema,
+  servedHosts: z.array(nonEmptyString).optional(),
+  reachableRegistries: z.array(nonEmptyString).optional(),
+};
+
+/**
+ * A Vessel declared by installation desired state — §13's tenancy boundary,
+ * named rather than spelled as a shared prefix of two Target names.
+ *
+ * Discriminated on `kind` for the reason `VesselLocation` is: a `cluster` with
+ * a project id is not a state the domain has a name for, and the location's
+ * shape follows from the kind rather than being a bag of optional keys beside
+ * it. The `kind` inside {@link VesselLocation} is therefore not restated here —
+ * it is this key, and a document that carried both could carry two answers.
+ *
+ * `location` is optional for exactly the reason the column is nullable: a
+ * declaration may seed a boundary's identity and rank without stating how to
+ * reach it, leaving the connect act to supply that. A Target is addressable
+ * when its own connection **and** its vessel's location are both present.
+ */
+export const vesselSeedSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      ...vesselFacts,
+      kind: z.literal('cluster'),
+      location: z
+        .object({
+          /** §13's prerequisite is OIDC against this endpoint. */
+          apiServer: z.url(),
+        })
+        .strict()
+        .optional(),
+    })
+    .strict(),
+  z
+    .object({
+      ...vesselFacts,
+      kind: z.literal('gcp-project'),
+      location: z
+        .object({
+          /** The project every surface on this vessel deploys into (§14). */
+          project: nonEmptyString,
+        })
+        .strict()
+        .optional(),
+    })
+    .strict(),
+]);
+
+/**
  * A Target declared by installation desired state.
  *
  * Connection facts are optional so an operator may still seed an identity and
  * connect it through the product. When supplied, they are ordinary,
  * credential-free platform configuration and make the connection reproducible
  * from Git.
+ *
+ * **Only facts true of this runtime surface and not of its neighbours.** Where
+ * the boundary is, and what it can reach, are declared once on the vessel this
+ * names.
  */
 export const targetSeedSchema = z.discriminatedUnion('adapter', [
   z
     .object({
       /** Stable identifier, unique within the installation. */
       name: targetNameSchema,
+      /** The vessel this Target is a surface on, by name (§13). */
+      vessel: targetNameSchema,
       adapter: z.literal('kubernetes'),
       /**
        * §3's asserted half, declared so a torn-down installation comes back
@@ -202,11 +284,8 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
       authReaches: z.array(reachSchema).optional(),
       connection: z
         .object({
-          apiServer: z.url(),
           namespace: nonEmptyString,
           delivery: kubernetesDeliverySchema,
-          servedHosts: z.array(nonEmptyString).optional(),
-          reachableRegistries: z.array(nonEmptyString).optional(),
           logHistorySeconds: z.number().int().nonnegative().optional(),
           /**
            * §7's operator class, verbatim. Untyped for the reason
@@ -223,17 +302,15 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
   z
     .object({
       name: targetNameSchema,
+      vessel: targetNameSchema,
       adapter: z.literal('cloudrun'),
       connection: z
         .object({
-          project: nonEmptyString,
           region: nonEmptyString,
           endpoint: z.url(),
           policyEndpoint: z.url().optional(),
           /** The identity a revision runs as. See `CloudRunConnection`. */
           serviceAccount: nonEmptyString.optional(),
-          servedHosts: z.array(nonEmptyString).optional(),
-          reachableRegistries: z.array(nonEmptyString).optional(),
           logHistorySeconds: z.number().int().nonnegative().optional(),
         })
         .strict()
@@ -243,12 +320,11 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
   z
     .object({
       name: targetNameSchema,
+      vessel: targetNameSchema,
       adapter: z.literal('static'),
       connection: z
         .object({
-          project: nonEmptyString,
           endpoint: z.url(),
-          servedHosts: z.array(nonEmptyString).optional(),
         })
         .strict()
         .optional(),
@@ -573,6 +649,30 @@ export const installationManifestSchema = z
       .strict(),
 
     /**
+     * The tenancy boundaries this installation deploys into (§13, §14).
+     *
+     * Declared rather than derived. Before this key existed, a vessel was
+     * spelled as the shared prefix of `<name>-cloudrun` and `<name>-static`,
+     * enforced here by a rule that made a naming convention load-bearing and
+     * left the boundary's own facts — where it is, what it can reach — stated
+     * twice, once per surface, where the two could disagree. Naming it is what
+     * makes the next backend additive: every one worth adding is a boundary
+     * hosting several runtimes, so the convention would only get more
+     * load-bearing, never less.
+     *
+     * Target names keep their suffixes. They are decorative now, which is the
+     * point: nothing parses them.
+     */
+    vessels: z
+      .array(vesselSeedSchema)
+      .min(1)
+      .refine(
+        (vessels) =>
+          new Set(vessels.map((v) => v.name)).size === vessels.length,
+        'vessel names must be unique',
+      ),
+
+    /**
      * Targets in rank order. A Target with connection facts is reconciled as
      * connected; one without them exists for an operator to connect in-product.
      * Rank is one global ordered list (§13), so array order is placement order.
@@ -584,41 +684,54 @@ export const installationManifestSchema = z
         (targets) =>
           new Set(targets.map((t) => t.name)).size === targets.length,
         'target names must be unique',
-      )
-      .superRefine((targets, context) => {
-        const seeds = new Map(targets.map((target) => [target.name, target]));
-        targets.forEach((target, index) => {
-          if (target.adapter === 'kubernetes') return;
-
-          const suffix = `-${target.adapter}`;
-          const base = target.name.endsWith(suffix)
-            ? target.name.slice(0, -suffix.length)
-            : '';
-          const counterpart =
-            target.adapter === 'cloudrun' ? 'static' : 'cloudrun';
-          const counterpartName = `${base}-${counterpart}`;
-          if (
-            base.length === 0 ||
-            seeds.get(counterpartName)?.adapter !== counterpart
-          ) {
-            context.addIssue({
-              code: 'custom',
-              path: [index, 'name'],
-              message:
-                'cloud Targets must be a matched <name>-cloudrun and ' +
-                '<name>-static pair',
-            });
-          }
-        });
-      }),
+      ),
   })
-  .strict();
+  .strict()
+  /**
+   * Every Target names a declared vessel, and one whose kind carries its
+   * surface.
+   *
+   * At the document level rather than on `targets`, because it is the one rule
+   * in this schema that reads two keys at once. It replaces the
+   * `<name>-cloudrun` / `<name>-static` pairing rule, and it is a stronger
+   * check than that one was: the pairing rule could only say that two names
+   * looked related, while this one refuses a reference that does not resolve —
+   * which is what `reconcileManifestTargets` needs, since it looks a vessel up
+   * by name and has nothing honest to do with a Target whose boundary is not
+   * in the document.
+   *
+   * The kind check is what keeps `SURFACES_BY_VESSEL_KIND` the single statement
+   * of which runtimes a boundary carries: a `cloudrun` Target on a `cluster` is
+   * refused here rather than reaching an adapter that has no way to place it.
+   */
+  .superRefine((manifest, context) => {
+    const kinds = new Map(manifest.vessels.map((v) => [v.name, v.kind]));
+    manifest.targets.forEach((target, index) => {
+      const kind = kinds.get(target.vessel);
+      if (kind === undefined) {
+        context.addIssue({
+          code: 'custom',
+          path: ['targets', index, 'vessel'],
+          message: `no vessel named ${target.vessel} is declared`,
+        });
+        return;
+      }
+      if (!(surfacesOf(kind) as readonly string[]).includes(target.adapter)) {
+        context.addIssue({
+          code: 'custom',
+          path: ['targets', index, 'vessel'],
+          message: `a ${kind} vessel does not carry a ${target.adapter} surface`,
+        });
+      }
+    });
+  });
 
 export type TargetAdapter = z.infer<typeof targetAdapterSchema>;
 export type StoreAdapter = z.infer<typeof storeAdapterSchema>;
 export type BuildRouteAdapter = z.infer<typeof buildRouteAdapterSchema>;
 export type BuildRouteConfig = z.infer<typeof buildRouteSchema>;
 export type TargetSeed = z.infer<typeof targetSeedSchema>;
+export type VesselSeed = z.infer<typeof vesselSeedSchema>;
 export type GatewayAuthConfig = z.infer<typeof gatewayAuthSchema>;
 
 /**

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -16,6 +16,7 @@ import {
   type InstallationManifest,
   installationManifestSchema,
 } from './manifest.schema.ts';
+import { upgradeManifestDocument } from './manifest-upgrade.ts';
 
 /** Path to a YAML or JSON manifest document. */
 export const MANIFEST_PATH_VAR = 'SPINDRIFT_MANIFEST_PATH';
@@ -57,12 +58,29 @@ export function parseManifest(
   return validateManifest(parsed, source);
 }
 
-/** Validate a parsed or stored manifest and report every bad field together. */
+/**
+ * Validate a parsed or stored manifest and report every bad field together.
+ *
+ * **Upgrade first, then validate — and that order is the whole of it.** The
+ * stored row governs, and `loadStoredManifest` treats a row it cannot parse as
+ * a row with no seed in it, re-seeding from the mounted declaration and
+ * discarding whatever an operator configured through the UI. Validating a
+ * document written under the previous schema before bringing it forward is
+ * therefore not a stricter read: it is that discard, fired on a document that
+ * was merely old rather than wrong.
+ *
+ * Here rather than at either call site because both need it and neither should
+ * have to remember: the row and the mounted declaration are written by
+ * different acts at different times, and a rollout routinely has one of them
+ * older than the running build. See `manifest-upgrade.ts`.
+ */
 export function validateManifest(
   manifest: unknown,
   source: string,
 ): AuthoredManifest {
-  const result = installationManifestSchema.safeParse(manifest);
+  const result = installationManifestSchema.safeParse(
+    upgradeManifestDocument(manifest),
+  );
   if (!result.success) {
     const issues = result.error.issues
       .map((issue) => {
@@ -142,12 +160,24 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
       'http://onepassword-connect.external-secrets.svc.cluster.local:8080',
     container: 'spindrift-vault',
   },
+  vessels: [
+    {
+      name: 'primary',
+      kind: 'cluster',
+      location: { apiServer: 'https://kubernetes.default.svc' },
+    },
+    {
+      name: 'spindrift',
+      kind: 'gcp-project',
+      location: { project: 'spindrift-vessel' },
+    },
+  ],
   targets: [
     {
       name: 'primary',
+      vessel: 'primary',
       adapter: 'kubernetes',
       connection: {
-        apiServer: 'https://kubernetes.default.svc',
         namespace: 'spindrift-apps',
         delivery: {
           flavour: 'flux-helmrelease',
@@ -158,18 +188,18 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
     },
     {
       name: 'spindrift-cloudrun',
+      vessel: 'spindrift',
       adapter: 'cloudrun',
       connection: {
-        project: 'spindrift-vessel',
         region: 'spindrift-region',
         endpoint: 'https://run.googleapis.com',
       },
     },
     {
       name: 'spindrift-static',
+      vessel: 'spindrift',
       adapter: 'static',
       connection: {
-        project: 'spindrift-vessel',
         endpoint: 'https://firebasehosting.googleapis.com',
       },
     },

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -352,14 +352,34 @@ export function targetSeedOf(
 ): Record<string, unknown> {
   return {
     name: plan.name,
+    // A connected cluster's one surface takes the vessel's name unchanged —
+    // the same rule `vesselFor` applies on the connect path, so the document
+    // and the act name the same boundary.
+    vessel: plan.name,
     adapter: 'kubernetes',
     ...(plan.reaches.length > 0 ? { reaches: plan.reaches } : {}),
     ...(plan.authReaches.length > 0 ? { authReaches: plan.authReaches } : {}),
     connection: {
-      apiServer: plan.apiServer,
       namespace: plan.namespace,
       delivery: plan.delivery,
       chartValues: plan.chartValues,
     },
+  };
+}
+
+/**
+ * The boundary half of the same act, under `vessels:`.
+ *
+ * Separate from {@link targetSeedOf} because the two land in different arrays
+ * of one document, and one act now writes to both: where the cluster is is a
+ * fact about the boundary, not about the surface deployed onto it.
+ */
+export function vesselSeedOf(
+  plan: ClusterConnectPlan,
+): Record<string, unknown> {
+  return {
+    name: plan.name,
+    kind: 'cluster',
+    location: { apiServer: plan.apiServer },
   };
 }

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -50,6 +50,7 @@ import {
   type ClusterConnectChoices,
   clusterConnectPlan,
   targetSeedOf,
+  vesselSeedOf,
 } from '../../../domain/target-onboarding.ts';
 import type { VesselKind } from '../../../domain/vessel.ts';
 import { command, type InputOf, type OutputOf } from '../../client.ts';
@@ -613,14 +614,20 @@ function Declaration({
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
         <p className="text-[11px] text-subtle">
-          The same connection, under <span className="font-mono">targets:</span>{' '}
-          in the installation manifest. A declaration seeds an installation that
-          has none; it does not overwrite one that is already configured.
+          The same connection, under <span className="font-mono">vessels:</span>{' '}
+          and <span className="font-mono">targets:</span> in the installation
+          manifest. A declaration seeds an installation that has none; it does
+          not overwrite one that is already configured.
         </p>
-        {/* JSON, which is valid YAML. An emitter would be a thing to maintain
-            for output nobody parses back. */}
+        {/* Both arrays, because one connect act names a boundary and a surface
+            on it. JSON, which is valid YAML — an emitter would be a thing to
+            maintain for output nobody parses back. */}
         <pre className="overflow-x-auto rounded-md border border-border bg-background px-3 py-2 font-mono text-[11px]">
-          {JSON.stringify([targetSeedOf(plan)], null, 2)}
+          {JSON.stringify(
+            { vessels: [vesselSeedOf(plan)], targets: [targetSeedOf(plan)] },
+            null,
+            2,
+          )}
         </pre>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/spindrift/test/commands/installation-configure.test.ts
+++ b/apps/spindrift/test/commands/installation-configure.test.ts
@@ -137,8 +137,8 @@ describe('configuring an installation', () => {
     const swapped = {
       ...manifest,
       targets: [
-        { name: 'cluster', adapter: 'kubernetes' },
-        { name: 'cloud-cloudrun', adapter: 'kubernetes' },
+        { name: 'cluster', vessel: 'cluster', adapter: 'kubernetes' },
+        { name: 'cloud-cloudrun', vessel: 'cluster', adapter: 'kubernetes' },
       ],
     } as InstallationManifest;
 

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -368,12 +368,19 @@ describe('an operator’s Target correction outlives the next boot', () => {
     const platform = input.chartValues?.platform as Record<string, unknown>;
     return {
       ...toAuthoredManifest(manifest),
+      vessels: [
+        {
+          name: 'cluster',
+          kind: 'cluster' as const,
+          location: { apiServer: input.apiServer },
+        },
+      ],
       targets: [
         {
           name: 'cluster',
+          vessel: 'cluster',
           adapter: 'kubernetes' as const,
           connection: {
-            apiServer: input.apiServer,
             namespace: input.namespace,
             delivery: input.delivery,
             chartValues: { platform: { ...platform, gateway } },
@@ -598,12 +605,19 @@ describe('reconnect re-adopts via observe', () => {
     });
     const declared = {
       ...manifest,
+      vessels: [
+        {
+          name: input.name,
+          kind: 'cluster',
+          location: { apiServer: input.apiServer },
+        },
+      ],
       targets: [
         {
           name: input.name,
+          vessel: input.name,
           adapter: 'kubernetes',
           connection: {
-            apiServer: input.apiServer,
             namespace: input.namespace,
             delivery: input.delivery,
           },

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -29,12 +29,24 @@ const fixtureText = await Bun.file(FIXTURE).text();
 const fixtureManifest = Bun.YAML.parse(fixtureText) as AuthoredManifest;
 const connectedManifest = {
   ...fixtureManifest,
+  vessels: [
+    {
+      name: 'cluster',
+      kind: 'cluster',
+      location: { apiServer: 'https://cluster.example.test' },
+    },
+    {
+      name: 'cloud',
+      kind: 'gcp-project',
+      location: { project: 'example-vessel' },
+    },
+  ],
   targets: [
     {
       name: 'cluster',
+      vessel: 'cluster',
       adapter: 'kubernetes',
       connection: {
-        apiServer: 'https://cluster.example.test',
         namespace: 'apps',
         delivery: {
           flavour: 'flux-helmrelease',
@@ -45,18 +57,18 @@ const connectedManifest = {
     },
     {
       name: 'cloud-cloudrun',
+      vessel: 'cloud',
       adapter: 'cloudrun',
       connection: {
-        project: 'example-vessel',
         region: 'example-region',
         endpoint: 'https://run.example.test',
       },
     },
     {
       name: 'cloud-static',
+      vessel: 'cloud',
       adapter: 'static',
       connection: {
-        project: 'example-vessel',
         endpoint: 'https://hosting.example.test',
       },
     },
@@ -206,16 +218,13 @@ describe('the stored installation manifest', () => {
       .where(eq(targets.name, 'cluster'));
     const changed = {
       ...connectedManifest,
-      targets: connectedManifest.targets.map((target) =>
-        target.adapter === 'kubernetes'
+      vessels: connectedManifest.vessels.map((vessel) =>
+        vessel.kind === 'cluster'
           ? {
-              ...target,
-              connection: {
-                ...target.connection,
-                apiServer: 'https://replacement.example.test',
-              },
+              ...vessel,
+              location: { apiServer: 'https://replacement.example.test' },
             }
-          : target,
+          : vessel,
       ),
     } satisfies AuthoredManifest;
 
@@ -516,8 +525,8 @@ describe('the stored installation manifest', () => {
       ...fixtureManifest,
       installation: 'incompatible',
       targets: [
-        { name: 'cluster', adapter: 'kubernetes' },
-        { name: 'cloud-cloudrun', adapter: 'kubernetes' },
+        { name: 'cluster', vessel: 'cluster', adapter: 'kubernetes' },
+        { name: 'cloud-cloudrun', vessel: 'cluster', adapter: 'kubernetes' },
       ],
     } satisfies AuthoredManifest;
 
@@ -716,21 +725,18 @@ describe('naming where a declaration disagrees with the stored row', () => {
   test('the report carries the path that differs, never the values', () => {
     const stored = {
       ...connectedManifest,
-      targets: connectedManifest.targets.map((target) =>
-        target.adapter === 'kubernetes'
+      vessels: connectedManifest.vessels.map((vessel) =>
+        vessel.kind === 'cluster'
           ? {
-              ...target,
-              connection: {
-                ...target.connection,
-                apiServer: 'https://replacement.example.test',
-              },
+              ...vessel,
+              location: { apiServer: 'https://replacement.example.test' },
             }
-          : target,
+          : vessel,
       ),
     } satisfies AuthoredManifest;
 
     const paths = diffManifestPaths(connectedManifest, stored);
-    expect(paths).toEqual(['targets.0.connection.apiServer']);
+    expect(paths).toEqual(['vessels.0.location.apiServer']);
     // Neither the declared value nor the stored value appears anywhere in
     // what was returned — a path names *where* the two documents disagree,
     // never *what* they disagree about. That is what keeps a value the
@@ -748,16 +754,15 @@ describe('naming where a declaration disagrees with the stored row', () => {
     });
     const declared = {
       ...connectedManifest,
-      targets: connectedManifest.targets.map((target) =>
-        target.adapter === 'kubernetes'
+      vessels: connectedManifest.vessels.map((vessel) =>
+        vessel.kind === 'cluster'
           ? {
-              ...target,
-              connection: {
-                ...target.connection,
+              ...vessel,
+              location: {
                 apiServer: 'https://declared-elsewhere.example.test',
               },
             }
-          : target,
+          : vessel,
       ),
     } satisfies AuthoredManifest;
 
@@ -782,7 +787,7 @@ describe('naming where a declaration disagrees with the stored row', () => {
     const messages = calls.map((call) => String(call[0]));
     expect(
       messages.some((message) =>
-        message.includes('targets.0.connection.apiServer'),
+        message.includes('vessels.0.location.apiServer'),
       ),
     ).toBe(true);
     expect(

--- a/apps/spindrift/test/config/manifest-upgrade.test.ts
+++ b/apps/spindrift/test/config/manifest-upgrade.test.ts
@@ -1,0 +1,194 @@
+/**
+ * A stored manifest written under an older schema is upgraded, never discarded.
+ *
+ * **This is the test that makes the next manifest schema change safe, not just
+ * this one.** The stored row governs — `loadStoredManifest` resolves
+ * `stored ?? declaration ?? placeholder` — and a row this build cannot parse is
+ * a row this build treats as unseeded, so it re-seeds from the mounted
+ * declaration and silently discards everything an operator configured through
+ * the UI. Nothing used to fail when a schema change made that reachable. The
+ * failure mode is quiet, it lands on a real installation, and the only signal
+ * is a `console.warn` in a pod log nobody is reading during a rollout.
+ *
+ * So the corpus in `test/fixtures/stored-manifests/` holds one frozen snapshot
+ * per shape a stored document has ever had, and every one of them has to boot.
+ * Two rules keep it honest:
+ *
+ * 1. **A file in that directory is never edited.** It is a document that really
+ *    was written to a real installation; editing it forward proves only that a
+ *    document written today parses today.
+ * 2. **The newest file must need no upgrade at all.** That is the forcing
+ *    function: a schema change that stops accepting it fails here, and the
+ *    only way to go green is to add the next snapshot and teach
+ *    `manifest-upgrade.ts` the step between them.
+ */
+import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type {
+  AuthoredManifest,
+  InstallationManifest,
+} from '../../src/config/manifest.schema.ts';
+import {
+  MANIFEST_INLINE_VAR,
+  validateManifest,
+} from '../../src/config/manifest.ts';
+import { loadStoredManifest } from '../../src/config/manifest-store.ts';
+import { upgradeManifestDocument } from '../../src/config/manifest-upgrade.ts';
+import { installation } from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const CORPUS = join(import.meta.dir, '../fixtures/stored-manifests');
+const SNAPSHOTS = readdirSync(CORPUS)
+  .filter((name) => name.endsWith('.yaml'))
+  .sort();
+
+/** The declaration a re-seed would fall back to — a different installation. */
+const DECLARATION = await Bun.file(
+  join(import.meta.dir, '../fixtures/installation.example.yaml'),
+).text();
+
+/**
+ * One snapshot, parsed fresh.
+ *
+ * Per call rather than once: these are handed to a write path, and a shared
+ * parse would let one test's mutation reach the next.
+ */
+function snapshot(name: string): Record<string, unknown> {
+  return Bun.YAML.parse(readFileSync(join(CORPUS, name), 'utf8')) as Record<
+    string,
+    unknown
+  >;
+}
+
+const database = withIsolatedDatabase();
+
+describe('every stored manifest this project has ever written', () => {
+  test.each(SNAPSHOTS)('%s boots without re-seeding', async (name) => {
+    const document = snapshot(name);
+    await database()
+      .db.insert(installation)
+      .values({ manifest: document as unknown as AuthoredManifest });
+
+    // `bun:test`'s `spyOn` does not intercept `console.warn`, so this captures
+    // it the plain way — the same shape `manifest-store.test.ts` uses.
+    const original = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: unknown[]) => {
+      warnings.push(String(args[0]));
+    };
+    let loaded: InstallationManifest;
+    try {
+      loaded = await loadStoredManifest(database().db, {
+        // A declaration is mounted on purpose. Without one the re-seed path
+        // throws instead of firing, and this test would pass on a build that
+        // discards the row — which is the exact failure it exists to catch.
+        [MANIFEST_INLINE_VAR]: DECLARATION,
+      });
+    } finally {
+      console.warn = original;
+    }
+
+    // The document that was stored is the document that was loaded. If a schema
+    // change made this row unreadable, `installation` would read `example` —
+    // the declaration's — and everything the operator configured would be gone.
+    expect(loaded.installation).toBe(document.installation as string);
+    expect(warnings.filter((message) => message.includes('re-seeded'))).toEqual(
+      [],
+    );
+
+    // Rewritten in place, and fully: what is on the row afterwards is a current
+    // document, so the upgrade runs once rather than on every boot forever.
+    const [row] = await database()
+      .db.select({ manifest: installation.manifest })
+      .from(installation);
+    expect(() => validateManifest(row?.manifest, name)).not.toThrow();
+    expect(upgradeManifestDocument(row?.manifest)).toEqual(
+      row?.manifest as unknown,
+    );
+  });
+
+  test('the newest snapshot is the shape this build writes, needing no upgrade', () => {
+    const newest = SNAPSHOTS.at(-1);
+    if (newest === undefined) throw new Error('the corpus is empty');
+    const document = snapshot(newest);
+
+    // Read the failure, not just the assertion: if this fails, the manifest
+    // schema stopped accepting the document shape currently in production.
+    // Copy `${newest}` to the next number, edit the copy to the new shape, and
+    // add the step to `manifest-upgrade.ts`. Editing `${newest}` in place makes
+    // this green and leaves every real installation on the old shape one boot
+    // away from being silently re-seeded.
+    expect(upgradeManifestDocument(document)).toEqual(document);
+    expect(() => validateManifest(document, newest)).not.toThrow();
+  });
+
+  test('the oldest snapshot is genuinely refused without the upgrade', () => {
+    // The premise. Without it the corpus proves nothing — a document nothing
+    // would have rejected is not evidence that an upgrade is load-bearing.
+    const oldest = SNAPSHOTS.at(0);
+    if (oldest === undefined) throw new Error('the corpus is empty');
+    expect(upgradeManifestDocument(snapshot(oldest))).not.toEqual(
+      snapshot(oldest),
+    );
+  });
+});
+
+describe('the vessels a pre-declaration document is upgraded into', () => {
+  const document = snapshot('01-suffix-paired-vessels.yaml');
+
+  test('are the ones the seeding path used to derive on every boot', () => {
+    // The same names, the same locations, and the same union of what two
+    // surfaces of one boundary each claimed — so an installation upgraded here
+    // keeps the vessel rows it already has rather than growing a second set.
+    const upgraded = upgradeManifestDocument(document) as {
+      vessels: unknown[];
+    };
+    expect(upgraded.vessels).toEqual([
+      {
+        name: 'cluster',
+        kind: 'cluster',
+        location: { apiServer: 'https://cluster.example.test' },
+        servedHosts: ['apps.example.test'],
+        reachableRegistries: ['registry.example.test'],
+      },
+      {
+        name: 'cloud',
+        kind: 'gcp-project',
+        location: { project: 'example-vessel' },
+        // The union, not a winner: the two surfaces stated different hosts and
+        // taking one would be the bug the vessel exists to prevent.
+        servedHosts: ['hosting.example.test', 'run.example.test'],
+        reachableRegistries: ['mirror.example.test'],
+      },
+    ]);
+  });
+
+  test('leave the Targets in order, carrying only their own surface', () => {
+    // Rank is read from this array's order, so a rewrite that reordered it
+    // would silently re-rank the installation.
+    const upgraded = upgradeManifestDocument(document) as {
+      targets: { name: string; vessel: string; connection?: object }[];
+    };
+    expect(
+      upgraded.targets.map((target) => [target.name, target.vessel]),
+    ).toEqual([
+      ['cluster', 'cluster'],
+      ['cloud-cloudrun', 'cloud'],
+      ['cloud-static', 'cloud'],
+    ]);
+    for (const target of upgraded.targets) {
+      expect(Object.keys(target.connection ?? {})).not.toContain('apiServer');
+      expect(Object.keys(target.connection ?? {})).not.toContain('project');
+      expect(Object.keys(target.connection ?? {})).not.toContain('servedHosts');
+      expect(Object.keys(target.connection ?? {})).not.toContain(
+        'reachableRegistries',
+      );
+    }
+  });
+
+  test('is a no-op on a document that already declares them', () => {
+    const current = snapshot('02-declared-vessels.yaml');
+    expect(upgradeManifestDocument(current)).toEqual(current);
+  });
+});

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -133,9 +133,41 @@ describe('boot fails loudly', () => {
     expect(() => parseManifest(document, 'test')).toThrow(/unique/);
   });
 
-  test('when cloud Targets are not a connectable pair', () => {
-    const document = fixtureText.replace('name: cloud-static', 'name: hosting');
-    expect(() => parseManifest(document, 'test')).toThrow(/matched/);
+  test('when a Target names a vessel the document does not declare', () => {
+    // What replaced the `<name>-cloudrun` / `<name>-static` pairing rule, and a
+    // stronger check than it was: that rule could only say two names looked
+    // related, and this one refuses a reference that resolves to nothing —
+    // which is what `reconcileManifestTargets` needs, since it looks a vessel
+    // up by name and has nothing honest to do without one.
+    const document = fixtureText.replace(
+      '    vessel: cloud\n    adapter: static',
+      '    vessel: hosting\n    adapter: static',
+    );
+    expect(() => parseManifest(document, 'test')).toThrow(
+      /targets\.2\.vessel: no vessel named hosting is declared/,
+    );
+  });
+
+  test('when a Target names a vessel whose kind cannot carry its surface', () => {
+    // `SURFACES_BY_VESSEL_KIND` is the one statement of which runtimes a
+    // boundary carries, and this is where the document is held to it — a
+    // `cloudrun` surface on a cluster is refused here rather than reaching an
+    // adapter that has no way to place it.
+    const document = fixtureText.replace(
+      '    vessel: cloud\n    adapter: cloudrun',
+      '    vessel: cluster\n    adapter: cloudrun',
+    );
+    expect(() => parseManifest(document, 'test')).toThrow(
+      /a cluster vessel does not carry a cloudrun surface/,
+    );
+  });
+
+  test('on duplicate vessel names', () => {
+    const document = fixtureText.replace(
+      '  - name: cloud\n',
+      '  - name: cluster\n',
+    );
+    expect(() => parseManifest(document, 'test')).toThrow(/unique/);
   });
 
   test('with no targets at all', () => {

--- a/apps/spindrift/test/domain/target-connect-plan.test.ts
+++ b/apps/spindrift/test/domain/target-connect-plan.test.ts
@@ -21,11 +21,15 @@
  * looking plausible.
  */
 import { describe, expect, test } from 'bun:test';
-import { targetSeedSchema } from '../../src/config/manifest.schema.ts';
+import {
+  targetSeedSchema,
+  vesselSeedSchema,
+} from '../../src/config/manifest.schema.ts';
 import {
   type ClusterConnectChoices,
   clusterConnectPlan,
   targetSeedOf,
+  vesselSeedOf,
 } from '../../src/domain/target-onboarding.ts';
 
 const BASE: ClusterConnectChoices = {
@@ -144,9 +148,25 @@ describe('a cluster connect plan', () => {
       throw new Error(`declared a ${parsed.data.adapter} Target`);
     }
     expect(parsed.data.name).toBe('metal');
+    expect(parsed.data.vessel).toBe('metal');
     expect(parsed.data.reaches).toEqual(plan.reaches);
-    expect(parsed.data.connection?.apiServer).toBe(BASE.apiServer);
     expect(parsed.data.connection?.chartValues).toEqual(plan.chartValues);
+  });
+
+  test('declares the boundary the same act connects', () => {
+    // Where the cluster is left the Target's connection when the vessel became
+    // a declared noun, so the screen's rendered document has to name it in the
+    // array it now lives in — otherwise an operator pastes a fragment that
+    // parses and points nowhere.
+    const plan = clusterConnectPlan(BLENDED);
+    const parsed = vesselSeedSchema.safeParse(vesselSeedOf(plan));
+
+    if (!parsed.success) throw parsed.error;
+    if (parsed.data.kind !== 'cluster') {
+      throw new Error(`declared a ${parsed.data.kind} vessel`);
+    }
+    expect(parsed.data.name).toBe('metal');
+    expect(parsed.data.location?.apiServer).toBe(BASE.apiServer);
   });
 });
 

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -76,11 +76,25 @@ secretStore:
   endpoint: https://secrets.example.test
   container: example-secrets
 
+# The tenancy boundaries. Named, so nothing has to recover one from the shared
+# prefix of two Target names — the cloud vessel below carries two surfaces and
+# says so once. No `location` on either: this fixture seeds identity and rank
+# and leaves how to reach them to the connect act, which is the half-ready state
+# §13 intends to be visible.
+vessels:
+  - name: cluster
+    kind: cluster
+  - name: cloud
+    kind: gcp-project
+
 # Rank order: placement considers these top to bottom.
 targets:
   - name: cluster
+    vessel: cluster
     adapter: kubernetes
   - name: cloud-cloudrun
+    vessel: cloud
     adapter: cloudrun
   - name: cloud-static
+    vessel: cloud
     adapter: static

--- a/apps/spindrift/test/fixtures/stored-manifests/01-suffix-paired-vessels.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/01-suffix-paired-vessels.yaml
@@ -1,0 +1,107 @@
+# A stored manifest as it was written before `vessels` was a key.
+#
+# **Frozen. Never edit this file to match a schema change** — that is the one
+# thing that would make the corpus it belongs to stop meaning anything. It is a
+# snapshot of a document that really was written to a real installation's
+# `installation.manifest` column, and the property under test is that such a
+# document still boots. Editing it forward proves only that a document written
+# today parses today.
+#
+# The shape: a vessel was the shared prefix of `<name>-cloudrun` and
+# `<name>-static`, and the boundary's own facts — where it is, what it can
+# reach — were restated on every surface's connection.
+#
+# `installation` is deliberately not the value any declaration in this suite
+# carries, so a boot that silently re-seeded from a declaration instead of
+# loading this document is visible rather than plausible.
+installation: stored-before-vessels
+
+controlPlane:
+  hostname: spindrift.example.test
+
+auth:
+  gateway: null
+
+dns:
+  zones:
+    private: apps.example.test
+    public: example.test
+
+sources:
+  buckets:
+    - example-source-bucket
+  defaultBucket: example-source-bucket
+
+cloud:
+  artifactsProject: example-artifacts
+  homeVesselProject: example-home
+
+charts:
+  app: example/spindrift-app
+
+supplyChain:
+  registry: registry.example.test/artifacts
+  verifier: verifier.example.test
+  signer: gcpkms://projects/example-artifacts/locations/example-region/keyRings/keys/cryptoKeys/signer
+
+github:
+  clientId: Iv1.example
+  oauthBaseUrl: https://git.example.test
+  apiBaseUrl: https://api.git.example.test
+  buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
+
+build:
+  routes:
+    - name: hosted
+      adapter: github-actions
+  zeroConfigFrontend: registry.example.test/zero-config:pinned
+
+secretStore:
+  adapter: gcp-secret-manager
+  endpoint: https://secrets.example.test
+  container: example-secrets
+
+targets:
+  - name: cluster
+    adapter: kubernetes
+    reaches: [none, private]
+    authReaches: [private]
+    connection:
+      apiServer: https://cluster.example.test
+      namespace: apps
+      delivery:
+        flavour: flux-helmrelease
+        namespace: apps
+        sourceRef:
+          name: infra
+          namespace: flux-system
+      reachableRegistries:
+        - registry.example.test
+      servedHosts:
+        - apps.example.test
+      chartValues:
+        platform:
+          gateway:
+            name: cluster-gateway
+            namespace: gateway
+  # The two surfaces of one project, and the two places its facts were stated.
+  # `servedHosts` deliberately disagrees between them: two surfaces of one
+  # boundary genuinely could, and the union is what the seeding path stored.
+  - name: cloud-cloudrun
+    adapter: cloudrun
+    connection:
+      project: example-vessel
+      region: example-region
+      endpoint: https://run.example.test
+      serviceAccount: runtime@example-vessel.iam.gserviceaccount.com
+      reachableRegistries:
+        - mirror.example.test
+      servedHosts:
+        - run.example.test
+  - name: cloud-static
+    adapter: static
+    connection:
+      project: example-vessel
+      endpoint: https://hosting.example.test
+      servedHosts:
+        - hosting.example.test

--- a/apps/spindrift/test/fixtures/stored-manifests/02-declared-vessels.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/02-declared-vessels.yaml
@@ -1,0 +1,109 @@
+# A stored manifest as this build writes one: the vessel is a declared noun.
+#
+# **The newest file in this corpus, and the test asserts this build needs no
+# upgrade to read it.** That is the forcing function: change the manifest schema
+# in any way that stops accepting this document, and the assertion fails. The
+# fix is never to edit this file — it is to copy it to the next number, edit
+# *that* to the new shape, and teach `manifest-upgrade.ts` how to get from here
+# to there. Doing it the other way round is exactly how a schema change reaches
+# production able to discard a configured installation.
+#
+# `installation` differs from every declaration this suite mounts, for the
+# reason `01` gives.
+installation: stored-with-vessels
+
+controlPlane:
+  hostname: spindrift.example.test
+
+auth:
+  gateway: null
+
+dns:
+  zones:
+    private: apps.example.test
+    public: example.test
+
+sources:
+  buckets:
+    - example-source-bucket
+  defaultBucket: example-source-bucket
+
+cloud:
+  artifactsProject: example-artifacts
+  homeVesselProject: example-home
+
+charts:
+  app: example/spindrift-app
+
+supplyChain:
+  registry: registry.example.test/artifacts
+  verifier: verifier.example.test
+  signer: gcpkms://projects/example-artifacts/locations/example-region/keyRings/keys/cryptoKeys/signer
+
+github:
+  clientId: Iv1.example
+  oauthBaseUrl: https://git.example.test
+  apiBaseUrl: https://api.git.example.test
+  buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
+
+build:
+  routes:
+    - name: hosted
+      adapter: github-actions
+  zeroConfigFrontend: registry.example.test/zero-config:pinned
+
+secretStore:
+  adapter: gcp-secret-manager
+  endpoint: https://secrets.example.test
+  container: example-secrets
+
+vessels:
+  - name: cluster
+    kind: cluster
+    location:
+      apiServer: https://cluster.example.test
+    reachableRegistries:
+      - registry.example.test
+    servedHosts:
+      - apps.example.test
+  - name: cloud
+    kind: gcp-project
+    location:
+      project: example-vessel
+    reachableRegistries:
+      - mirror.example.test
+    servedHosts:
+      - hosting.example.test
+      - run.example.test
+
+targets:
+  - name: cluster
+    vessel: cluster
+    adapter: kubernetes
+    reaches: [none, private]
+    authReaches: [private]
+    connection:
+      namespace: apps
+      delivery:
+        flavour: flux-helmrelease
+        namespace: apps
+        sourceRef:
+          name: infra
+          namespace: flux-system
+      chartValues:
+        platform:
+          gateway:
+            name: cluster-gateway
+            namespace: gateway
+  - name: cloud-cloudrun
+    vessel: cloud
+    adapter: cloudrun
+    connection:
+      region: example-region
+      endpoint: https://run.example.test
+      serviceAccount: runtime@example-vessel.iam.gserviceaccount.com
+  - name: cloud-static
+    vessel: cloud
+    adapter: static
+    connection:
+      endpoint: https://hosting.example.test

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -216,7 +216,7 @@ describe('configuring this installation from the browser', () => {
     await seed();
     const declared = [
       ...fixture.targets,
-      { name: 'spare', adapter: 'kubernetes' },
+      { name: 'spare', vessel: 'cluster', adapter: 'kubernetes' },
     ];
     const edited = withValueAt(fixture, ['targets'], declared);
 
@@ -267,8 +267,8 @@ describe('configuring this installation from the browser', () => {
       fixture,
       ['targets'],
       [
-        { name: 'cluster', adapter: 'kubernetes' },
-        { name: 'cloud-cloudrun', adapter: 'kubernetes' },
+        { name: 'cluster', vessel: 'cluster', adapter: 'kubernetes' },
+        { name: 'cloud-cloudrun', vessel: 'cluster', adapter: 'kubernetes' },
       ],
     );
 

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -152,8 +152,62 @@ spec:
         buckets:
           - bluenose-spindrift-source
         defaultBucket: bluenose-spindrift-source
+      # The tenancy boundaries this installation deploys into. Where a boundary
+      # is, and what it can reach, are facts about the boundary and are stated
+      # here once — a Target below states only what is true of its own runtime
+      # surface and names the vessel it sits on.
+      vessels:
+        - name: offsite
+          kind: cluster
+          location:
+            apiServer: https://kubernetes.default.svc
+          # GHCR and not the artifact registry: these packages are public, so
+          # the kubelet pulls them with no credential at all. Reaching the
+          # artifact registry would mean an imagePullSecret in every App
+          # namespace, which is a stored credential §13 does not have.
+          #
+          # The host rather than the `ghcr.io/jonpulsifer` namespace, because
+          # the kubelet's anonymous pull is a property of the registry and not
+          # of one owner's packages. `artifactAddress` accepts either.
+          reachableRegistries:
+            - ghcr.io
+        # The on-site cluster, reached across the peer OIDC trust rather than
+        # in-cluster: `nix/services/k8s` admits this installation's service
+        # account as `federated:system:serviceaccount:spindrift:spindrift`, and
+        # `clusters/folly/apps/spindrift-target` binds it the discovery,
+        # delivery, and chart-source roles. Nothing here is a credential — the
+        # projected token is minted per request for the `api` audience.
+        - name: folly
+          kind: cluster
+          location:
+            apiServer: https://folly.lolwtf.ca:6443
+          # Public packages, so the kubelet pulls them with no credential — the
+          # same reason offsite names GHCR rather than the artifact registry.
+          reachableRegistries:
+            - ghcr.io/jonpulsifer
+        # One project, two runtime surfaces. That it is one boundary is what
+        # this entry says; before it existed the two Targets said it by sharing
+        # a name prefix and restating the project id.
+        - name: bluenose
+          kind: gcp-project
+          location:
+            project: bluenose
+          # The artifact registry and nothing else. Cloud Run pulls through a
+          # cache mirror that cannot parse the OCI index pushed to GHCR, so
+          # naming the registry it *can* read is what keeps a Deploy here from
+          # pinning a reference it will fail on. `serverless-robot-prod` holds
+          # `artifactregistry.reader` on it — see
+          # terraform/gcp/projects/trusted-builds/artifact-registry.tf.
+          #
+          # The host, which names this installation's one artifact registry
+          # namespace unambiguously. `artifactAddress` takes the fuller
+          # `…/trusted-builds/i` spelling too, and would need it if a second
+          # namespace on this host were ever added to `supplyChain.registry`.
+          reachableRegistries:
+            - northamerica-northeast1-docker.pkg.dev
       targets:
         - name: offsite
+          vessel: offsite
           # Every reach: this cluster has a load-balancer address on the lab net
           # and a Cloudflare tunnel in front of it.
           reaches: [none, private, public]
@@ -171,18 +225,7 @@ spec:
               sourceRef:
                 name: infra
                 namespace: flux-system
-            apiServer: https://kubernetes.default.svc
             namespace: spindrift-apps
-            # GHCR and not the artifact registry: these packages are public, so
-            # the kubelet pulls them with no credential at all. Reaching the
-            # artifact registry would mean an imagePullSecret in every App
-            # namespace, which is a stored credential §13 does not have.
-            #
-            # The host rather than the `ghcr.io/jonpulsifer` namespace, because
-            # the kubelet's anonymous pull is a property of the registry and not
-            # of one owner's packages. `artifactAddress` accepts either.
-            reachableRegistries:
-              - ghcr.io
             # §7's operator class: what the App chart needs about *this*
             # cluster. Spindrift never renders into it.
             chartValues:
@@ -217,13 +260,8 @@ spec:
                   # itself, which the chart always admits as a sibling.
                   allowedNamespaces:
                     - oauth2-proxy
-        # The on-site cluster, reached across the peer OIDC trust rather than
-        # in-cluster: `nix/services/k8s` admits this installation's service
-        # account as `federated:system:serviceaccount:spindrift:spindrift`, and
-        # `clusters/folly/apps/spindrift-target` binds it the discovery,
-        # delivery, and chart-source roles. Nothing here is a credential — the
-        # projected token is minted per request for the `api` audience.
         - name: folly
+          vessel: folly
           # No tunnel of its own is named to Spindrift, so this Target serves
           # what its gateway's RFC1918 address reaches and nothing beyond it.
           # Adding one is this list plus `dns.tunnelHostname`, either here or on
@@ -238,13 +276,7 @@ spec:
               sourceRef:
                 name: infra
                 namespace: flux-system
-            apiServer: https://folly.lolwtf.ca:6443
             namespace: spindrift-apps
-            # Public packages, so the kubelet pulls them with no credential —
-            # the same reason offsite names GHCR rather than the artifact
-            # registry.
-            reachableRegistries:
-              - ghcr.io/jonpulsifer
             chartValues:
               platform:
                 # This cluster's own Apps gateway
@@ -281,10 +313,10 @@ spec:
                   allowedNamespaces:
                     - oauth2-proxy
         - name: bluenose-cloudrun
+          vessel: bluenose
           adapter: cloudrun
           connection:
             region: northamerica-northeast1
-            project: bluenose
             endpoint: https://run.googleapis.com
             # Where this project's admission policy is read from. Naming it is
             # also what makes the Service declare `binaryAuthorization.
@@ -299,23 +331,10 @@ spec:
             # the controller's `actAs` on it are declared in
             # terraform/gcp/projects/bluenose/iam.tf for exactly this.
             serviceAccount: spindrift-runtime@bluenose.iam.gserviceaccount.com
-            # The artifact registry and nothing else. Cloud Run pulls through a
-            # cache mirror that cannot parse the OCI index pushed to GHCR, so
-            # naming the registry it *can* read is what keeps a Deploy here from
-            # pinning a reference it will fail on. `serverless-robot-prod` holds
-            # `artifactregistry.reader` on it — see
-            # terraform/gcp/projects/trusted-builds/artifact-registry.tf.
-            #
-            # The host, which names this installation's one artifact registry
-            # namespace unambiguously. `artifactAddress` takes the fuller
-            # `…/trusted-builds/i` spelling too, and would need it if a second
-            # namespace on this host were ever added to `supplyChain.registry`.
-            reachableRegistries:
-              - northamerica-northeast1-docker.pkg.dev
         - name: bluenose-static
+          vessel: bluenose
           adapter: static
           connection:
-            project: bluenose
             endpoint: https://firebasehosting.googleapis.com
       secretStore:
         adapter: onepassword


### PR DESCRIPTION
A vessel was spelled as the shared prefix of `<name>-cloudrun` and
`<name>-static`, enforced by a `superRefine` in `manifest.schema.ts` and sliced
back off in `manifest-store.ts`. That made a naming convention load-bearing and
left the boundary's own facts — where it is, what it can reach — stated twice,
once per surface, where the two could disagree.

## What changed

The manifest has a `vessels` array, and a Target names the vessel it is a
surface of:

```yaml
vessels:
  - name: bluenose
    kind: gcp-project
    location: { project: bluenose }
    reachableRegistries: [...]

targets:
  - name: bluenose-cloudrun
    vessel: bluenose
    adapter: cloudrun
    connection: { region: ..., endpoint: ... }
```

Target names keep their suffixes; nothing parses them. The pairing rule is
replaced by a document-level refinement that refuses a Target whose `vessel`
resolves to nothing, or resolves to a boundary whose kind does not carry that
surface. That is a stronger check than the one it replaces — the pairing rule
could only say two names looked related — and it is the check
`reconcileManifestTargets` actually needs, since it looks a vessel up by name
and has nothing honest to do with a reference that does not resolve.

## The dangerous half is the upgrade, not the schema

The stored row governs: `loadStoredManifest` resolves
`stored ?? declaration ?? placeholder`, and **a row this build cannot parse is
a row it treats as unseeded** — so it re-seeds from the mounted declaration and
silently discards everything an operator configured through the UI. Any manifest
schema change can reach that path.

So `src/config/manifest-upgrade.ts` runs inside `validateManifest`, before the
schema sees the document. An old document becomes a current one and never
reaches the fallback; one that still fails afterwards is a real fault. It is a
pure function of the document, so `loadStoredManifest` persists the result by
writing back the document it just read, inside the transaction it already opens
to reconcile Targets and vessels — no migration step of its own. It holds the
last suffix parse in the codebase, which is the only honest place left for it.

`validateManifest` is the gate both the row and the mounted declaration pass
through, which matters here: a declaration and the image that understands it
land in separate merges, so for the window between them one of the two is
always written for the other schema.

## Something now fails if a future schema change can re-seed

Nothing used to. `test/fixtures/stored-manifests/` holds a frozen snapshot per
shape a stored document has ever had. Every snapshot has to boot with a
*different* declaration mounted and come back as itself, and the newest snapshot
must need no upgrade at all.

That last assertion is the forcing function: a schema change that stops
accepting today's shape fails there, and the only way to green is to add the
next snapshot and teach `manifest-upgrade.ts` the step between them. The files
say, in their own headers, that editing them forward is the one thing that would
make the corpus meaningless.

Proven by reverting the upgrade call in `validateManifest` and re-running:

```
expect(loaded.installation).toBe(document.installation as string);
                            ^
error: expect(received).toBe(expected)

Expected: "stored-before-vessels"
Received: "example"

(fail) every stored manifest this project has ever written >
       01-suffix-paired-vessels.yaml boots without re-seeding
```

The stored row was discarded and the mounted declaration took over — exactly the
failure mode, reproduced on demand.

## The offsite declaration

Moved onto the new shape. Its pre-change document, run through the upgrade, is
identical to the new one:

```
the stored row loads clean under the new schema: true
upgraded == the new declaration: true
raw upgrade output differs from the raw row: true
```

Same vessel names (`offsite`, `folly`, `bluenose`), same locations — so the
installation reuses the vessel rows it already has rather than growing a second
set, and manifest divergence stays empty across the rollout.

## Checks

`bun test` 1476 pass / 0 fail across 109 files; `bun run typecheck` and
`bun run lint` clean; `mise run k8s:render-apps` renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL
