### PR TITLE
fix(binauthz): register the signing key under the id the signer stamps

### DIFF
--- a/terraform/gcp/projects/trusted-builds/binary-authorization.tf
+++ b/terraform/gcp/projects/trusted-builds/binary-authorization.tf
@@ -7,6 +7,26 @@ resource "google_binary_authorization_attestor" "provenance" {
     public_keys {
       comment = "Next-gen KMS key"
 
+      # The name the *signer* stamps, because that is the only name admission
+      # matches on.
+      #
+      # `attestations sign-and-create --keyversion-*` writes the KMS key
+      # version's resource URI into the attestation as its public key id, and
+      # Binary Authorization then looks that string up on the attestor. Leave
+      # this unset and the API invents an id instead — here it kept the
+      # fingerprint of the PGP key this PKIX key replaced, `0A1EC650…`, which no
+      # signer has ever produced. The build stays green because
+      # `sign-and-create` succeeds either way; the mismatch surfaces one project
+      # and one deploy later as `denied by attestor` on an artifact that really
+      # was attested.
+      #
+      # Composed, never pasted. The URI ends in `/cryptoKeyVersions/N`, so a
+      # rotation moves it — and a hardcoded copy would go wrong in exactly the
+      # way described above, silently. `.name` is the version the attestor is
+      # registering the public half of, so the id and the PEM below cannot come
+      # from different versions.
+      id = "//cloudkms.googleapis.com/v1/${data.google_kms_crypto_key_latest_version.signer.name}"
+
       pkix_public_key {
         public_key_pem      = data.google_kms_crypto_key_latest_version.signer.public_key[0].pem
         signature_algorithm = data.google_kms_crypto_key_latest_version.signer.public_key[0].algorithm


### PR DESCRIPTION
## The bug

`bluenose-cloudrun` refuses artifacts with `denied by attestor
projects/trusted-builds/attestors/provenance` on images that *are* attested.

The two sides disagree about what the key is called. The signer — both build
routes, via `gcloud beta container binauthz attestations sign-and-create
--keyversion-*` — stamps the KMS key version's **resource URI** into the
attestation as its public key id. Binary Authorization matches on that string
and finds nothing on the attestor, which said so at build time and only there:

```
WARNING: No public key with ID
[//cloudkms.googleapis.com/v1/projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer/cryptoKeyVersions/1]
found on attestor [projects/trusted-builds/attestors/provenance]
```

(`keyRings/keys` is not a typo — the key ring is named `keys`,
`terraform/gcp/projects/trusted-builds/kms.tf:1`.)

`binary-authorization.tf` declared the key with a PEM and an algorithm and no
`id`, so the API kept one of its own:

```
$ gcloud container binauthz attestors describe provenance --project=trusted-builds
  publicKeys:
  - comment: Next-gen KMS key
    id: 0A1EC6508B2EE0E064F4CDBAEFA8200E0C4946C8
    pkixPublicKey:
      signatureAlgorithm: RSA_SIGN_PKCS1_4096_SHA512
```

That hex is the fingerprint of the PGP key this PKIX key replaced — it is still
sitting in the commented-out block a few lines below in the same file
(`binary-authorization.tf:31`, `FiEECh7GUIsu4OBk9M2676ggDgxJRsg`). It is not a
name any signer has ever produced.

## The fix

Set `id` on the `public_keys` block to the key version's resource URI.

Composed, never pasted: the URI ends in `/cryptoKeyVersions/N`, so a rotation
moves it and a literal would go silently wrong in exactly the way above. It is
derived from the same data source the PEM comes from, so the id and the public
half cannot describe different versions.

## Replace, not keep alongside

An attestor can hold several keys, so removing one is worth a moment. This one
is safe to replace:

* No attestation has ever been written under `0A1EC650…`. The signer has always
  stamped the KMS URI — that is what the warning above is reporting.
* Same PEM, same algorithm, same key version. Only the label changes; nothing
  that verified before stops verifying.
* Keeping it would mean a second `public_keys` block carrying the same PEM under
  a hardcoded fingerprint of a retired PGP key — a registered name nothing can
  produce, and precisely the ambiguity that made this hard to see.

## Verification

`tofu init -backend=false && tofu validate` → `Success! The configuration is
valid.`

`tofu plan` (read-only, `-lock=false`; **not** applied — this goes through
Atlantis):

```
  # google_binary_authorization_attestor.provenance will be updated in-place
  ~ resource "google_binary_authorization_attestor" "provenance" {
      ~ attestation_authority_note {
          ~ public_keys {
              ~ id = "0A1EC6508B2EE0E064F4CDBAEFA8200E0C4946C8" -> "//cloudkms.googleapis.com/v1/projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer/cryptoKeyVersions/1"
            }
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The derived value is character-for-character the URI the warning named.

The after-state cannot be shown without the apply. Once Atlantis applies,
`gcloud container binauthz attestors describe provenance
--project=trusted-builds` should report that URI as the key's `id`, the next
build's attest step should complete without the `No public key with ID` warning,
and admission on `bluenose-cloudrun` should stop refusing attested artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL