### PR TITLE
fix(oauth2-proxy): ask GitHub for the scope the user check needs

### DIFF
--- a/clusters/base/apps/oauth2-proxy/helm-release.yaml
+++ b/clusters/base/apps/oauth2-proxy/helm-release.yaml
@@ -34,7 +34,17 @@ spec:
     extraArgs:
       provider: github
       github-user: jonpulsifer
-      scope: user:email
+      # `read:org` is not optional beside `github-user`. Restricting to a user
+      # makes the provider enumerate the caller's organizations before it
+      # decides, and GitHub refuses that read under `user:email` alone:
+      #
+      #   403 You need at least read:org scope or user scope to list your
+      #   organizations.
+      #
+      # The proxy turns that refusal into a 500 on `/oauth2/callback`, so the
+      # sign-in fails *after* the operator has already approved on github.com —
+      # far enough from the cause that the log line is the only thing naming it.
+      scope: user:email read:org
       reverse-proxy: "true"
       trusted-proxy-ip: ${K8S_NODE_CIDR}
       redirect-url: https://oauth2.${SECRET_DOMAIN}/oauth2/callback


### PR DESCRIPTION
## What

`clusters/base/apps/oauth2-proxy/helm-release.yaml` requests `scope: user:email` while also setting `github-user`. Those two disagree: restricting sign-in to a named user makes the provider enumerate the caller's organizations, and GitHub refuses that read under `user:email` alone.

```
403 You need at least read:org scope or user scope to list your organizations.
```

## Why it is hard to see

The proxy turns the 403 into a **500 on `/oauth2/callback`** — so sign-in fails *after* the operator has already approved on github.com. Nothing on the way there says why. Observed live:

```
[2026/08/04 01:05:02] [oauthproxy.go:935] Error creating session during OAuth2
  callback: unexpected status "403": {"message":"You need at least read:org
  scope or user scope to list your organizations.", ...}

GET /oauth2/callback?code=... HTTP/1.1 ... 500 2772 1.226
```

Retrying produces `bad_verification_code` on top, because the authorization code is already spent — a symptom that hides the real error.

## Consequence

Widening the scope means the OAuth app asks for organization read access, so **the operator has to re-approve once** on next sign-in. That is the whole behavioural change.

This lands in `clusters/base/`, so it applies to both clusters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL