### PR TITLE
fix(spindrift): finish the checklist when the build does, and key the Deploy screen

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -127,11 +127,16 @@ export const getAppWorkspace: Command<
   // deployed, went red". A checkpoint is a status event by definition — §6's
   // `{phase, resource?, reason?}` — so the filter is the whole selection, and
   // the text stays where it belongs, on the attempt screen each entry links to.
+  // Ten, and this is the only bound: the workspace renders what it is given, so
+  // a second limit in the view could only disagree with this one. Three showed
+  // one attempt's worth of checkpoints, and the shape the timeline exists to
+  // make legible — built, deployed, went red — is three attempts, not three
+  // events.
   const events = await context.db.query.attemptEvents.findMany({
     where: (ev, { eq, and }) =>
       and(eq(ev.appId, app.id), eq(ev.eventType, 'status')),
     orderBy: (ev, { desc }) => [desc(ev.id)],
-    limit: 3,
+    limit: 10,
   });
 
   const now = context.clock.now();

--- a/apps/spindrift/src/commands/builds/view.ts
+++ b/apps/spindrift/src/commands/builds/view.ts
@@ -115,7 +115,7 @@ export async function buildViewOf(
       tone: event.reason ? ('error' as const) : undefined,
     }));
 
-  const steps = checkpointsOf(events);
+  const steps = checkpointsOf(events, status);
 
   return {
     view: {
@@ -131,6 +131,14 @@ export async function buildViewOf(
       log: log.length > 0 ? log.slice(-LOG_TAIL) : null,
       logTotal: log.length,
       runner: build.runner ?? 'hosted runner',
+      // §20: the route table is a manifest value, so the route name a Build
+      // recorded is resolved against it here rather than by the screen — the
+      // browser has no manifest, and inventing a name→platform table in the
+      // client would be a second copy of an installation's configuration.
+      runnerAdapter:
+        context.manifest.build.routes.find(
+          (route) => route.name === build.runner,
+        )?.adapter ?? null,
       runUrl: build.runUrl ?? null,
     },
     events,
@@ -168,18 +176,45 @@ function stepStatusOf(phase: string | null, failed: boolean): StepStatus {
  * status event for a name wins; the pair of timestamps around it gives the step
  * a duration, which is the whole reason a reader scans this list.
  *
- * A name carried only by log lines — `dispatch`, `provenance` — never gets a
- * status event, so it keeps its sentence as its detail instead of a duration.
- * That is the one thing it has to say, and dropping it would leave a bare word.
+ * A name carried only by log lines — `dispatch`, `provenance`, and the runner's
+ * own job entry — never gets a status event, so it keeps its sentence as its
+ * detail instead of a duration. That is the one thing it has to say, and
+ * dropping it would leave a bare word.
+ *
+ * **A finished run leaves nothing in progress**, which is why the Build's own
+ * status is an argument here. Two different names would otherwise sit at
+ * `running` on a build that ended minutes ago, and each needs its own answer
+ * because the two know different amounts:
+ *
+ * - A **log-only** name never claimed to be a step and has no verdict of its
+ *   own. Once the run is over it is not in progress, so it resolves to `done` —
+ *   or to `failed` where one of its own lines carried a reason, which is the
+ *   same rule {@link stepStatusOf} applies to a status event. Taking the run's
+ *   verdict instead would paint `dispatch` red on a build that failed three
+ *   steps later, which is a claim about dispatch that nothing recorded.
+ * - A name whose **last status event said `RUNNING`** is a real step the runner
+ *   started and never closed out — a killed job, a lost final event. That one
+ *   *was* in progress when the run ended, so the run's verdict is honestly its
+ *   own: it is where the build stopped.
  */
-function checkpointsOf(events: readonly AttemptEvent[]): ChecklistItem[] {
+function checkpointsOf(
+  events: readonly AttemptEvent[],
+  runStatus: StepStatus,
+): ChecklistItem[] {
   interface Checkpoint {
     status: StepStatus;
+    /** No status event has ever named this checkpoint. */
+    logOnly: boolean;
+    /** A line under this name carried a failure reason. */
+    errored: boolean;
     from: Date;
     to: Date | null;
     line: string | null;
   }
   const seen = new Map<string, Checkpoint>();
+  // `waiting` and `running` are the two non-terminal answers `buildStepStatus`
+  // gives; anything else means the runner is done talking about this build.
+  const finished = runStatus !== 'running' && runStatus !== 'waiting';
 
   for (const event of events) {
     const name = event.resource;
@@ -192,6 +227,8 @@ function checkpointsOf(events: readonly AttemptEvent[]): ChecklistItem[] {
         status: isLog
           ? 'running'
           : stepStatusOf(event.phase, event.reason !== null),
+        logOnly: isLog,
+        errored: isLog && event.reason !== null,
         from: event.createdAt,
         to: null,
         line: isLog ? event.line : null,
@@ -201,17 +238,33 @@ function checkpointsOf(events: readonly AttemptEvent[]): ChecklistItem[] {
 
     if (isLog) {
       if (event.line) prior.line = event.line;
+      if (event.reason !== null) prior.errored = true;
       continue;
     }
+    prior.logOnly = false;
     prior.status = stepStatusOf(event.phase, event.reason !== null);
     prior.to = prior.status === 'running' ? null : event.createdAt;
   }
 
   return Array.from(seen, ([name, checkpoint]) => ({
     name,
-    status: checkpoint.status,
+    status: resolvedStatus(checkpoint, runStatus, finished),
     ...detailOf(checkpoint),
   }));
+}
+
+/** One checkpoint's status, with a finished run's claim on it applied. */
+function resolvedStatus(
+  checkpoint: { status: StepStatus; logOnly: boolean; errored: boolean },
+  runStatus: StepStatus,
+  finished: boolean,
+): StepStatus {
+  if (!finished || checkpoint.status !== 'running') return checkpoint.status;
+  return checkpoint.logOnly
+    ? checkpoint.errored
+      ? 'failed'
+      : 'done'
+    : runStatus;
 }
 
 function detailOf(checkpoint: {

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -126,7 +126,33 @@ export function App() {
   );
 }
 
-function Screen({
+/**
+ * The route table.
+ *
+ * **A screen that names one object is keyed on that object's id.** Every screen
+ * below that takes an id holds evidence about *that* object in `useState` —
+ * a Deploy's checklist, log, diagnosis and phase; a Build's attempt; a
+ * workspace's timeline — and React reuses a component instance whose type and
+ * position are unchanged. Switching between two Deploys of the same App is
+ * exactly that case: without a key the instance survives, so the previous
+ * Deploy's evidence stays on screen under the new Deploy's id until the fetch
+ * for it returns, and every `useState` seeded from the old view (the build
+ * drawer's open-ness, the transcript's) carries over with it. A different App
+ * does not look broken only because the id in the path happens to change more
+ * of the tree — the bug is the same one, and the key is what refuses it.
+ *
+ * The key does the second half too: a remount unmounts the old instance, which
+ * runs its effect cleanup, which drops that fetch's `live` flag and closes its
+ * stream. An in-flight response for the object navigated away from then has no
+ * state cell left to write into — a structural guarantee rather than a race the
+ * `live` flag has to win.
+ *
+ * Exported for `test/web/deploy-detail-mounted.test.tsx`, which mounts this
+ * table and changes the path: the claim above is about *this* function's keys,
+ * and a test that rendered `DeployScreen` itself would be asserting its own key
+ * prop.
+ */
+export function Screen({
   path,
   onNavigate,
 }: {
@@ -145,12 +171,22 @@ function Screen({
     );
   if (path.startsWith('/apps/new')) {
     const draftId = path.replace(/^\/apps\/new\/?/, '') || null;
-    return <NewAppScreen draftId={draftId} onNavigate={onNavigate} />;
+    return (
+      <NewAppScreen
+        key={draftId ?? 'new'}
+        draftId={draftId}
+        onNavigate={onNavigate}
+      />
+    );
   }
   if (path.startsWith('/deploys')) {
     const deployId = path.replace(/^\/deploys\/?/, '');
     return deployId ? (
-      <DeployScreen deployId={deployId} onNavigate={onNavigate} />
+      <DeployScreen
+        key={deployId}
+        deployId={deployId}
+        onNavigate={onNavigate}
+      />
     ) : (
       <DeploysScreen onNavigate={onNavigate} />
     );
@@ -161,7 +197,7 @@ function Screen({
   if (path.startsWith('/builds')) {
     const buildId = path.replace(/^\/builds\/?/, '');
     return buildId ? (
-      <BuildScreen buildId={buildId} onNavigate={onNavigate} />
+      <BuildScreen key={buildId} buildId={buildId} onNavigate={onNavigate} />
     ) : (
       <BuildsScreen onNavigate={onNavigate} />
     );
@@ -171,9 +207,18 @@ function Screen({
   if (path === '/apps') return <AppsScreen onNavigate={onNavigate} />;
   if (path.startsWith('/apps/')) {
     const appName = path.replace(/^\/apps\//, '');
-    return <WorkspaceScreen appName={appName} onNavigate={onNavigate} />;
+    return (
+      <WorkspaceScreen
+        key={appName}
+        appName={appName}
+        onNavigate={onNavigate}
+      />
+    );
   }
-  return <WorkspaceScreen appName={path.slice(1)} onNavigate={onNavigate} />;
+  const appName = path.slice(1);
+  return (
+    <WorkspaceScreen key={appName} appName={appName} onNavigate={onNavigate} />
+  );
 }
 
 function SettingsScreen({

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -125,6 +125,23 @@ export interface BuildView {
   /** The runner that produced it, for the header. */
   readonly runner: string;
   /**
+   * The *platform* behind {@link runner}, as `manifest.build.routes` declares
+   * it — `github-actions`, `cloud-build`, `in-cluster`.
+   *
+   * Carried beside the runner rather than instead of it, because the two answer
+   * different questions and only one of them is stable. `runner` is the route's
+   * name, which an installation chooses: "hosted" says which of *this*
+   * installation's routes ran and nothing at all about what it is. The platform
+   * is what tells an operator which failure modes are on the table — hosted CI
+   * and the cloud builder fail in entirely different ways — and it is the key
+   * the screen draws a mark from, the way a Target's adapter is.
+   *
+   * `null` for a Build whose recorded runner matches no configured route: a
+   * route can be retired while its Builds stay readable, and naming no platform
+   * is the honest answer there rather than guessing at one.
+   */
+  readonly runnerAdapter: string | null;
+  /**
    * Where this build can be watched on the runner's own surface, or `null`
    * where the runner has none.
    *

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -42,7 +42,9 @@ import {
   Rocket,
   Undo2,
 } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
+import type { LogoName } from '../../client/logos/index.ts';
 import { Checklist } from '../../components/checklist.tsx';
 import { DiagnosisPanel, DriftPanel } from '../../components/diagnosis.tsx';
 import { LogPane, Notice } from '../../components/log-pane.tsx';
@@ -55,7 +57,30 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '../../ui/collapsible.tsx';
+import { Logo } from '../../ui/logo.tsx';
 import { cn } from '../../ui/utils.ts';
+
+/**
+ * The mark and the name for a build route's platform.
+ *
+ * The same shape `targets/list.tsx` uses for a Target's adapter, and here for
+ * the same reason: an installation names its own routes ("hosted", "cloud"),
+ * so the route's *name* identifies nothing to somebody who did not configure
+ * it. The adapter does, and it is a closed vocabulary
+ * (`manifest.schema.ts`'s `buildRouteAdapterSchema`).
+ *
+ * `in-cluster` gets the Kubernetes mark because that is literally where it
+ * runs — §4's build Job — not because the App is going to Kubernetes.
+ *
+ * Keyed by a `string` rather than the enum, so a route this build grew and
+ * this table has not is a missing key rather than a crash: the runner's name
+ * is still rendered, only unaccompanied.
+ */
+const BUILD_ADAPTER: Record<string, { logo: LogoName; label: string }> = {
+  'github-actions': { logo: 'github', label: 'GitHub Actions' },
+  'cloud-build': { logo: 'google-cloud', label: 'Cloud Build' },
+  'in-cluster': { logo: 'kubernetes', label: 'in-cluster' },
+};
 
 /**
  * What the operator can do from here, and which one is running.
@@ -179,16 +204,45 @@ function Chrome({
       <dl className="ml-auto flex flex-wrap gap-x-6 gap-y-1">
         <Meta label="Source" value={sourceRef(view.source)} />
         <Meta label="Target" value={view.target} />
-        <Meta
-          label="Build"
-          value={
-            view.build === null
-              ? 'none · extracted'
-              : `${view.build.runner} · ${view.build.fidelity}`
-          }
-        />
+        <Meta label="Build" value={<Builder view={view} />} />
       </dl>
     </div>
+  );
+}
+
+/**
+ * Which builder ran this build — the platform, not just the route's name.
+ *
+ * "Building on hosted" names one installation's route and leaves an operator
+ * unable to tell GitHub Actions from Cloud Build, which is the fact that
+ * decides where to go look: the two fail in different places, over different
+ * credentials, with different things to read. So the route name stays (it is
+ * what an operator configured and what the manifest calls it) and the platform
+ * is stated beside it, with its mark, exactly as a Target or a repository
+ * identifies its platform.
+ *
+ * The mark is decorative — `Logo` hides it from assistive technology — so the
+ * platform is named in words as well. A logo that is the only carrier of a fact
+ * is a fact a screen reader never reads out.
+ */
+function Builder({ view }: { view: DeployView }) {
+  const build = view.build;
+  // §4's supplied artifact: no builder ran, so there is no platform to name.
+  if (build === null) return <>none · extracted</>;
+
+  const platform =
+    build.runnerAdapter === null
+      ? undefined
+      : BUILD_ADAPTER[build.runnerAdapter];
+
+  return (
+    <span className="flex items-center gap-1.5">
+      {platform ? <Logo name={platform.logo} className="size-3.5" /> : null}
+      <span>
+        {build.runner}
+        {platform ? ` · ${platform.label}` : ''} · {build.fidelity}
+      </span>
+    </span>
   );
 }
 
@@ -210,7 +264,7 @@ function shorten(ref: string): string {
   return bare.length > 12 ? bare.slice(0, 12) : bare;
 }
 
-function Meta({ label, value }: { label: string; value: string }) {
+function Meta({ label, value }: { label: string; value: ReactNode }) {
   return (
     <div className="flex flex-col gap-0.5">
       <dt>

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -149,7 +149,13 @@ export function Workspace({
       </div>
 
       <div className="grid gap-4 md:grid-cols-2">
-        <Activity entries={view.activity.slice(0, 3)} onNavigate={onNavigate} />
+        {/*
+          Every entry the view carries, un-sliced. `getAppWorkspace` bounds the
+          query that produces them, and a second bound here would be a number
+          that can silently disagree with it — a limit raised on the server and
+          not here reads as applied and is not.
+        */}
+        <Activity entries={view.activity} onNavigate={onNavigate} />
         <Runtime view={view} onNavigate={onNavigate} />
       </div>
     </div>

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -577,7 +577,47 @@ describe('getAppWorkspace command', () => {
 });
 
 describe('the workspace as a way into the system', () => {
-  test('caps at three checkpoints and gives each one an attempt to open', async () => {
+  test('carries ten checkpoints, which is what a whole sequence needs', async () => {
+    // Three was one attempt's worth of checkpoints, so the shape the timeline
+    // exists to show — built, deployed, went red — never fitted on it. The
+    // number is bounded here and nowhere else: the workspace view renders what
+    // it is handed, so this query is the only thing that can be wrong about it.
+    const ctx = context();
+    const { appName, appId, componentId } = await scaffold(ctx, {
+      prefix: 'decade',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'd101010',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'SUCCEEDED',
+        runner: 'hosted runner',
+      })
+      .returning();
+
+    // Twelve, so the answer is a bound rather than "everything there is".
+    await ctx.db.insert(attemptEvents).values(
+      Array.from({ length: 12 }, () => ({
+        appId,
+        componentId,
+        attemptKind: 'build' as const,
+        buildId: build!.id,
+        eventType: 'status' as const,
+        phase: 'RUNNING',
+      })),
+    );
+
+    const result = await getAppWorkspace({ name: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.workspace.activity.length).toBe(10);
+  });
+
+  test('carries status checkpoints only, each with an attempt to open', async () => {
     // `attempt_events` constrains every row to exactly one attempt, so every
     // entry has somewhere to go. An entry that led nowhere would be the one
     // thing on the screen a reader could not act on.
@@ -656,15 +696,21 @@ describe('the workspace as a way into the system', () => {
     if (!result.ok) return;
 
     const { workspace } = result.value;
-    // Three checkpoints, not the log or the fourth status. Every log line an
-    // adapter emits lands in the same table, and reading it raw made the
-    // timeline the last twenty lines of whatever ran most recently — the
-    // transcript belongs on the attempt screen each entry links to, not here.
-    expect(workspace.activity.length).toBe(3);
+    // Every status checkpoint and none of the log. Every log line an adapter
+    // emits lands in the same table, and reading it raw made the timeline the
+    // last twenty lines of whatever ran most recently — the transcript belongs
+    // on the attempt screen each entry links to, not here.
+    //
+    // Four of the five rows written, because the bound is ten: a timeline is
+    // there to show a build-deploy-fail sequence, and three entries could not
+    // hold one. The log line is the row that is missing, which is the whole
+    // claim.
+    expect(workspace.activity.length).toBe(4);
     expect(workspace.activity.map((entry) => entry.title)).toEqual([
       `Deploy ${deploy!.id} live`,
       `Deploy ${deploy!.id} applying`,
       `Build ${build!.id} succeeded`,
+      `Build ${build!.id} running`,
     ]);
     for (const entry of workspace.activity) {
       expect(entry.deployId ?? entry.buildId).not.toBeNull();
@@ -1173,6 +1219,260 @@ describe('getDeployDetail command', () => {
     expect(result.value.deploy.build?.steps).toEqual([
       { name: 'build / run build', status: 'failed', detail: '3.0s' },
     ]);
+  });
+
+  test('a finished build leaves no checkpoint in progress', async () => {
+    // Observed on a real build that had already succeeded: every step `done`,
+    // and one more entry at `running` forever. The name was `build / build` —
+    // the runner's *job*, two path segments where a step has three — and it
+    // only ever carried log lines. A name folded from log lines alone is born
+    // `running` and the log branch never revisits its status, so there was no
+    // path off it. That is true of every log-only name, not of the job: the
+    // same defect had `dispatch` and `provenance` showing the same permanent
+    // orange dot, which is why the fix is the fold's and not a special case.
+    const ctx = context();
+    const { componentId, appId, target } = await scaffold(ctx, {
+      prefix: 'orphan',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'a420042',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'a'.repeat(64)}`,
+        status: 'SUCCEEDED',
+        runner: 'hosted',
+      })
+      .returning();
+
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'LIVE',
+      })
+      .returning();
+
+    const attempt = {
+      appId,
+      componentId,
+      attemptKind: 'build' as const,
+      buildId: build!.id,
+    };
+
+    await ctx.db.insert(attemptEvents).values([
+      // The one real step, reported the way a route reports one.
+      {
+        ...attempt,
+        resource: 'build / build / Complete job',
+        eventType: 'status',
+        phase: 'RUNNING',
+        createdAt: FROZEN,
+      },
+      {
+        ...attempt,
+        resource: 'build / build / Complete job',
+        eventType: 'status',
+        phase: 'SUCCEEDED',
+        createdAt: new Date(FROZEN.getTime() + 2000),
+      },
+      // Three names that never get a status event at all. `build / build` is
+      // the runner's job — two path segments where the step above has three.
+      {
+        ...attempt,
+        resource: 'dispatch',
+        eventType: 'log',
+        line: 'workflow accepted',
+        createdAt: FROZEN,
+      },
+      {
+        ...attempt,
+        resource: 'build / build',
+        eventType: 'log',
+        line: 'Cleaning up orphan processes',
+        createdAt: new Date(FROZEN.getTime() + 3000),
+      },
+      {
+        ...attempt,
+        resource: 'provenance',
+        eventType: 'log',
+        line: 'attestation written',
+        createdAt: new Date(FROZEN.getTime() + 4000),
+      },
+    ]);
+
+    const result = await getDeployDetail({ id: deploy!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const steps = result.value.deploy.build?.steps ?? [];
+    expect(steps.length).toBe(4);
+    // The criterion, stated as bluntly as it reads: the run is over, so nothing
+    // in the list claims to still be going.
+    expect(steps.filter((step) => step.status === 'running')).toEqual([]);
+    // And a log-only name keeps its sentence, because that sentence is the one
+    // thing it has to say — resolving it must not cost the detail.
+    expect(steps).toContainEqual({
+      name: 'build / build',
+      status: 'done',
+      detail: 'Cleaning up orphan processes',
+    });
+    expect(steps).toContainEqual({
+      name: 'dispatch',
+      status: 'done',
+      detail: 'workflow accepted',
+    });
+  });
+
+  test('a step the runner never closed out takes the run’s verdict, and a log-only name does not', async () => {
+    // The other half of "nothing is in progress once the run is over", and the
+    // reason the two are not one rule. A step that was reported `RUNNING` and
+    // never closed — a killed job, a lost final event — *was* in flight when the
+    // build died, so the build's verdict is honestly its own. A log-only name
+    // was never a step and has no verdict to inherit: painting `dispatch` red
+    // because the build failed four steps later would assert something about
+    // dispatch that nothing recorded.
+    const ctx = context();
+    const { componentId, appId, target } = await scaffold(ctx, {
+      prefix: 'killed',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'b430043',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'FAILED',
+        runner: 'hosted',
+      })
+      .returning();
+
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'FAILED',
+      })
+      .returning();
+
+    await ctx.db.insert(attemptEvents).values([
+      {
+        appId,
+        componentId,
+        attemptKind: 'build' as const,
+        buildId: build!.id,
+        resource: 'build / run build',
+        eventType: 'status' as const,
+        phase: 'RUNNING',
+        createdAt: FROZEN,
+      },
+      {
+        appId,
+        componentId,
+        attemptKind: 'build' as const,
+        buildId: build!.id,
+        resource: 'dispatch',
+        eventType: 'log' as const,
+        line: 'workflow accepted',
+        createdAt: FROZEN,
+      },
+    ]);
+
+    const result = await getDeployDetail({ id: deploy!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.deploy.build?.steps).toEqual([
+      { name: 'build / run build', status: 'failed' },
+      { name: 'dispatch', status: 'done', detail: 'workflow accepted' },
+    ]);
+  });
+
+  test('names the platform behind the route a build ran on', async () => {
+    // "Building on hosted" names a route, and a route name is an installation's
+    // own word for it. Which *platform* ran the build is what says where to go
+    // look when it goes wrong, and it is only knowable from the manifest's route
+    // table — which the browser does not have, so it is resolved here.
+    const ctx = context();
+    const { componentId, target } = await scaffold(ctx, { prefix: 'platform' });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'c440044',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'SUCCEEDED',
+        artifactDigest: `sha256:${'c'.repeat(64)}`,
+        // The fixture installation's `cloud-build` route, so this asserts a
+        // lookup rather than a constant that happens to say `github-actions`.
+        runner: 'managed',
+      })
+      .returning();
+
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'LIVE',
+      })
+      .returning();
+
+    const result = await getDeployDetail({ id: deploy!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.deploy.build?.runner).toBe('managed');
+    expect(result.value.deploy.build?.runnerAdapter).toBe('cloud-build');
+  });
+
+  test('names no platform for a route this installation no longer has', async () => {
+    // A route can be retired while its Builds stay readable. Naming no platform
+    // is the honest answer there; guessing at one would put a mark on a build
+    // that says it ran somewhere nothing says it ran.
+    const ctx = context();
+    const { componentId, target } = await scaffold(ctx, { prefix: 'retired' });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'e460046',
+        targetShape: 'image',
+        artifactType: 'image',
+        status: 'SUCCEEDED',
+        artifactDigest: `sha256:${'e'.repeat(64)}`,
+        runner: 'a-route-that-was-retired',
+      })
+      .returning();
+
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'LIVE',
+      })
+      .returning();
+
+    const result = await getDeployDetail({ id: deploy!.id }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.value.deploy.build?.runnerAdapter).toBeNull();
   });
 });
 

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -117,6 +117,10 @@ const BUILT = {
   // exercise it.
   logTotal: 812,
   runner: 'hosted runner',
+  // The route's name and the platform behind it are two different facts —
+  // "hosted runner" is what this installation calls the route, and the adapter
+  // is what tells a reader it is GitHub Actions rather than Cloud Build.
+  runnerAdapter: 'github-actions',
   runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
 } as const;
 
@@ -163,6 +167,7 @@ export const DEPLOY_SCENARIOS = {
       log: null,
       logTotal: 0,
       runner: 'hosted runner',
+      runnerAdapter: 'github-actions',
       runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
     },
   },
@@ -214,6 +219,7 @@ export const DEPLOY_SCENARIOS = {
       // nothing was left behind.
       logTotal: 8,
       runner: 'hosted runner',
+      runnerAdapter: 'github-actions',
       runUrl: 'https://example.invalid/acme/widgets/actions/runs/1234567890',
     },
   },
@@ -480,6 +486,19 @@ export const WORKSPACE_SCENARIOS = {
         status: 'failed',
         deployId: 40,
         buildId: null,
+      },
+      // The fourth entry is the point of the fixture, not padding: a
+      // build-deploy-fail sequence is four checkpoints long, and a timeline
+      // holding three could never show one. It is what the workspace's
+      // rendering claim is asserted against.
+      {
+        kind: 'build',
+        title: 'Build 39 failed',
+        detail: 'main · 4a91b02 · exit 1 in run build',
+        when: '1d ago',
+        status: 'failed',
+        deployId: null,
+        buildId: 39,
       },
     ],
     runtime: {

--- a/apps/spindrift/test/web/deploy-detail-mounted.test.tsx
+++ b/apps/spindrift/test/web/deploy-detail-mounted.test.tsx
@@ -1,5 +1,5 @@
 /**
- * The assertions `views.test.tsx` cannot make (ticket 08, criterion 3).
+ * The assertions `views.test.tsx` cannot make.
  *
  * That file's own header explains why it renders through
  * `renderToStaticMarkup`: every rule it checks is a statement about what a
@@ -25,10 +25,18 @@
  * simulates a click), and a `getBoundingClientRect` that satisfies
  * `CollapsibleContent`'s layout-effect without a real layout. It is not a DOM
  * implementation; it is the subset this one component tree touches.
+ *
+ * The second half of the file mounts the **route table** rather than one view,
+ * for the same structural reason: navigating between two Deploys of one App
+ * changes a prop and nothing else, so what happens to the mounted instance *is*
+ * the behaviour under test. `fetch` and `WebSocket` are stubbed on the same
+ * globals the shim already owns — the client reaches the network through
+ * exactly those two and nothing else.
  */
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
+import { Screen } from '../../src/web/app.tsx';
 import type { DeployView } from '../../src/web/model.ts';
 import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
 import { DEPLOY_SCENARIOS } from '../fixtures/scenarios.ts';
@@ -237,6 +245,40 @@ const previousActEnv = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: unknown })
 const previousHTMLIFrameElement = (
   globalThis as { HTMLIFrameElement?: unknown }
 ).HTMLIFrameElement;
+const previousWebSocket = (globalThis as { WebSocket?: unknown }).WebSocket;
+const previousFetch = globalThis.fetch;
+
+/**
+ * What the mounted route table is allowed to answer with.
+ *
+ * The screens reach the network through exactly two globals — `client.ts` is a
+ * `fetch` and `stream-client.ts` is a `WebSocket`, both stated in their own
+ * headers — so replacing those two is the whole seam, with no module mocking
+ * and no injected transport that only a test would ever pass.
+ *
+ * Deliberately a *deferred* answer rather than a resolved value: the second
+ * claim below is entirely about when a response lands relative to a
+ * navigation, and a stub that resolved eagerly could not express it.
+ */
+const pending = new Map<number, (deploy: DeployView) => void>();
+
+function answerFor(id: number): Promise<unknown> {
+  return new Promise((resolve) => {
+    pending.set(id, (deploy) =>
+      resolve({ json: async () => ({ ok: true, value: { deploy } }) }),
+    );
+  });
+}
+
+/** Resolve one Deploy's in-flight read and let React commit the result. */
+async function answer(id: number, deploy: DeployView): Promise<void> {
+  const respond = pending.get(id);
+  if (!respond) throw new Error(`nothing is asking for deploy ${id}`);
+  pending.delete(id);
+  await act(async () => {
+    respond(deploy);
+  });
+}
 
 Object.assign(globalThis, {
   document: fakeDocument,
@@ -256,6 +298,22 @@ Object.assign(globalThis, {
   // `element instanceof window.HTMLIFrameElement`; nothing here ever is
   // one, but the right-hand side still has to be a real constructor.
   HTMLIFrameElement: class {},
+  // `subscribeAttempt` opens one of these as soon as the first read returns.
+  // Nothing here pushes events — the claims below are about the read — so it
+  // only has to be constructible and closeable.
+  WebSocket: class {
+    onmessage: unknown = null;
+    onclose: unknown = null;
+    onerror: unknown = null;
+    close(): void {}
+  },
+  // Every command goes through this, and the id it is asking about is in the
+  // body rather than the path: `pathFor` names the command, not the object.
+  fetch: async (_url: string, init?: { body?: string }) => {
+    const { id } = JSON.parse(init?.body ?? '{}') as { id?: number };
+    if (id === undefined) throw new Error('a command asked for no id');
+    return await answerFor(id);
+  },
 });
 fakeDocument.defaultView = globalThis;
 
@@ -268,6 +326,8 @@ afterAll(() => {
     cancelAnimationFrame: previousCancelRaf,
     IS_REACT_ACT_ENVIRONMENT: previousActEnv,
     HTMLIFrameElement: previousHTMLIFrameElement,
+    WebSocket: previousWebSocket,
+    fetch: previousFetch,
   });
 });
 
@@ -395,5 +455,109 @@ describe('the mounted Deploy screen replaces what a newer view says', () => {
     act(() => {
       root.unmount();
     });
+  });
+});
+
+/**
+ * Switching between two Deploys of the same App.
+ *
+ * The bug this pins only exists between two objects of the *same shape*.
+ * Navigating App → App changes enough of the tree that the screen is rebuilt;
+ * Deploy → Deploy changes one prop, so React keeps the mounted `DeployScreen`
+ * and everything it is holding — the checklist, the log, the diagnosis and the
+ * phase of the Deploy you just left — until a read for the new one returns.
+ *
+ * These render the route table rather than `DeployScreen`, because the fix is a
+ * key on the element the table creates. A test that rendered `DeployScreen`
+ * directly would have to supply that key itself, and would then be asserting
+ * its own prop.
+ */
+describe('switching between two Deploys of one App', () => {
+  const previous: DeployView = {
+    ...DEPLOY_SCENARIOS.buildFailed,
+    id: 42,
+    buildId: 41,
+  };
+  const current: DeployView = {
+    ...DEPLOY_SCENARIOS.live,
+    id: 43,
+    buildId: 43,
+    headline: 'Deployed 4 seconds ago',
+  };
+
+  beforeEach(() => {
+    pending.clear();
+  });
+
+  const mount = () => {
+    const container = fakeDocument.createElement('div');
+    let root!: Root;
+    act(() => {
+      root = createRoot(container as unknown as Element);
+    });
+    return {
+      text: () => container.textContent,
+      show: (path: string) =>
+        act(() => {
+          root.render(<Screen path={path} onNavigate={() => undefined} />);
+        }),
+      unmount: () => act(() => root.unmount()),
+    };
+  };
+
+  test('the second Deploy carries none of the first one’s evidence', async () => {
+    const screen = mount();
+    screen.show('/deploys/42');
+    await answer(42, previous);
+
+    // Deploy 42, in full: its phase, its diagnosis, its failed step, its log.
+    expect(screen.text()).toContain(previous.headline);
+    expect(screen.text()).toContain('BUILD_FAILED');
+    expect(screen.text()).toContain('run build');
+    expect(screen.text()).toContain('Failed to compile');
+
+    screen.show('/deploys/43');
+
+    // Before deploy 43 has answered. Every one of 42's four presentations is
+    // already gone — the screen says it is loading rather than showing another
+    // release's evidence under this one's id.
+    expect(screen.text()).not.toContain(previous.headline);
+    expect(screen.text()).not.toContain('BUILD_FAILED');
+    expect(screen.text()).not.toContain('Failed to compile');
+
+    await answer(43, current);
+
+    expect(screen.text()).toContain(current.headline);
+    expect(screen.text()).not.toContain(previous.headline);
+    expect(screen.text()).not.toContain('BUILD_FAILED');
+    expect(screen.text()).not.toContain('Failed to compile');
+
+    screen.unmount();
+  });
+
+  test('a read for the Deploy you left cannot write into the one on screen', async () => {
+    // Invisible on a fast connection and certain on a slow one: the screen
+    // polls, so a read issued for deploy 42 can still be in flight when 43 is
+    // asked for and resolve *after* 43 has rendered. Nothing about the order
+    // the network answers in is under this screen's control, so the guarantee
+    // has to be structural — 42's read has no state cell left to write into.
+    const screen = mount();
+    screen.show('/deploys/42');
+
+    // 42 is asked for and never answered.
+    expect(pending.has(42)).toBe(true);
+
+    screen.show('/deploys/43');
+    await answer(43, current);
+    expect(screen.text()).toContain(current.headline);
+
+    // And now the response for the Deploy that was navigated away from lands.
+    await answer(42, previous);
+
+    expect(screen.text()).toContain(current.headline);
+    expect(screen.text()).not.toContain(previous.headline);
+    expect(screen.text()).not.toContain('BUILD_FAILED');
+
+    screen.unmount();
   });
 });

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -13,6 +13,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { logos } from '../../src/web/client/logos/index.ts';
 import type { DeployView, WorkspaceView } from '../../src/web/model.ts';
 import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
 import { ReachEditor, Workspace } from '../../src/web/views/apps/workspace.tsx';
@@ -223,6 +224,38 @@ describe('the GitHub repository connector', () => {
     ]) {
       expect(markup).not.toContain(field);
     }
+  });
+});
+
+describe('the deploy screen names the builder', () => {
+  test('states the platform in words and draws its mark', () => {
+    // "Building on hosted" names a route, which is a word an installation chose
+    // for itself. An operator reading it cannot tell GitHub Actions from Cloud
+    // Build, and the two fail in different places over different credentials —
+    // so the platform is named beside the route, the way a Target and a
+    // repository already identify theirs.
+    const view = DEPLOY_SCENARIOS.live;
+    expect(view.build?.runnerAdapter).toBe('github-actions');
+
+    const markup = deploy(view);
+    // In words, because `Logo` is `aria-hidden` by construction: a mark that is
+    // the only carrier of a fact is a fact a screen reader never reads out.
+    expect(words(markup)).toContain('GitHub Actions');
+    expect(markup).toContain(view.build!.runner);
+    // And the mark itself, from the same barrel every other platform mark comes
+    // from rather than a second one invented for this panel.
+    expect(markup).toContain(logos.github);
+  });
+
+  test('a release that was never built names no builder at all', () => {
+    // §4's supplied artifact: nothing ran, so there is no platform, and a mark
+    // here would be a claim about a builder that was never involved.
+    const view = DEPLOY_SCENARIOS.extracted;
+    expect(view.build).toBeNull();
+
+    const markup = deploy(view);
+    expect(words(markup)).toContain('none · extracted');
+    expect(markup).not.toContain(logos.github);
   });
 });
 
@@ -531,12 +564,13 @@ describe('the compact App history', () => {
     <Workspace view={view} onNavigate={() => undefined} />,
   );
 
-  test('shows only the three newest checkpoints', () => {
-    for (const entry of view.activity.slice(0, 3)) {
+  test('shows every checkpoint it was handed, not the first three', () => {
+    // The bound belongs to `getAppWorkspace`, which asks for ten. A second one
+    // here could only disagree with it, and the way it disagreed was silent:
+    // the query was raised and the screen went on showing three.
+    expect(view.activity.length).toBeGreaterThan(3);
+    for (const entry of view.activity) {
       expect(markup).toContain(entry.title);
-    }
-    for (const entry of view.activity.slice(3)) {
-      expect(markup).not.toContain(entry.title);
     }
     expect(markup).toContain('Recent checkpoints');
   });
@@ -557,14 +591,14 @@ describe('the App workspace', () => {
       <Workspace view={view} onNavigate={() => undefined} />,
     );
 
-    for (const entry of view.activity.slice(0, 3)) {
+    for (const entry of view.activity) {
       expect(entry.deployId ?? entry.buildId).not.toBeNull();
       expect(markup).toContain(entry.title);
     }
     // Rendered as buttons rather than static rows — one per visible checkpoint,
     // plus the global ledger links and release link in the hero.
     const buttons = markup.split('<button').length - 1;
-    expect(buttons).toBeGreaterThanOrEqual(Math.min(view.activity.length, 3));
+    expect(buttons).toBeGreaterThanOrEqual(view.activity.length);
   });
 
   test('a website states that it has no runtime', () => {


### PR DESCRIPTION
Four defects an operator hit watching a real build on the Deploy screen. All four are the Deploy/build panel and the App workspace.

## A finished build left a checkpoint running forever

`checkpointsOf` (`apps/spindrift/src/commands/builds/view.ts:175`) folds attempt events by name, and the first event for a name settles its status with `isLog ? 'running' : stepStatusOf(...)`. A name whose events are *only* log lines is therefore born `running`, and the log branch updates its `line` and never its status — there is no path off `running`, not when the job ends and not when the build concludes.

A build that had already succeeded (`status: done`, `duration: 159s`, App at `WAITING — Built`) showed all eighteen real steps `done` plus a nineteenth entry:

```text
done     build / build / Complete job
running  build / build          Cleaning up orphan processes
```

`build / build` is the runner's **job**, not a step — two path segments where every real step has three. And it was never specific to the job: `dispatch` and `provenance` are log-only too, and had the same permanent orange dot. The fix is the fold's, not a case for one name.

The Build's own status is now an argument, and **a finished run leaves nothing in progress**. The two shapes get different answers because they know different amounts:

- A **log-only** name never claimed to be a step and has no verdict to inherit. It resolves to `done` — or `failed` where one of its own lines carried a reason, which is the rule `stepStatusOf` already applies to a status event — and keeps its sentence as its detail.
- A name whose **last status event said `RUNNING`** is a real step the runner started and never closed out (a killed job, a lost final event). That one *was* in flight when the run ended, so it takes the run's verdict: it is where the build stopped.

Taking the run's verdict for both would paint `dispatch` red on a build that failed three steps later, which is a claim about dispatch that nothing recorded.

## The panel named a route, not a platform

"Building on hosted" says which of an installation's routes ran and nothing about what it is; hosted CI and the cloud builder fail in entirely different places, over different credentials, with different things to read. `BuildView` now carries `runnerAdapter`, resolved in the command layer against `manifest.build.routes` — the browser has no manifest, and a name→platform table in the client would be a second copy of an installation's configuration.

The Build row on the attempt screen states the platform beside the route with its mark, through the same `Logo` and the same adapter-to-mark table shape `src/web/views/targets/list.tsx` already uses:

```
Build   [] hosted · GitHub Actions · LIVE_TEXT
```

Named in words as well as drawn, because `Logo` is `aria-hidden` by construction — a mark that is the only carrier of a fact is a fact a screen reader never reads out. A route an installation has since retired resolves to no platform rather than a guess.

## Switching between two Deploys of one App showed the previous one

The route table created `<DeployScreen>` unkeyed, so navigating Deploy → Deploy changed one prop and React kept the mounted instance. The checklist, log, diagnosis and phase of the Deploy just left stayed on screen under the new Deploy's id until its read returned, along with every `useState` seeded from the old view (the build drawer's open-ness, the transcript's). It only shows up between two objects of the same shape — App → App changes enough of the tree to look fine, which is why it read as a Deploy-only bug rather than a missing key.

Every screen in the table that names one object is now keyed on that object's id. The key does the second half too: a remount unmounts the old instance and runs its effect cleanup, so an in-flight read for the Deploy navigated away from has no state cell left to write into — structural, rather than a race the existing `live` flag has to win. Both mechanisms named in the report were checked; the second was already guarded by that flag and is now guaranteed instead, with a test that fails when either is removed.

## Recent activity showed three checkpoints

Bounded in two places that could disagree — `limit: 3` in `getAppWorkspace` and a `slice(0, 3)` in the workspace view. The query is now the only bound and asks for ten; the view renders what it is handed, so a limit raised on one side cannot read as applied while the other still clips it. Three was one attempt's worth of checkpoints, so the build-deploy-fail sequence the timeline exists to show never fitted on it.

## Tests

`test/web/deploy-detail-transcript.test.tsx` is renamed to `deploy-detail-mounted.test.tsx` — its subject is the class of claim that needs a live `react-dom/client` root, not the transcript — and gains the two Deploy-switch tests. They mount the route table rather than `DeployScreen` (the fix is a key on the element the table creates; a test rendering the screen directly would be asserting its own prop) and stub the two globals the client reaches the network through, `fetch` and `WebSocket`, on the shim that file already owns. No module mocking, no new dependency.

Each fix was reverted and watched to fail:

| Reverted | Fails |
| --- | --- |
| checkpoint resolution | `a finished build leaves no checkpoint in progress` — reproduces `build / build … running` with `Cleaning up orphan processes`, plus `dispatch` and `provenance` |
| platform lookup | `states the platform in words and draws its mark` |
| `key` on `DeployScreen` | `the second Deploy carries none of the first one's evidence` |
| `key` **and** the `live` flag | both switch tests, so neither is vacuous |
| `limit: 10` | `carries ten checkpoints, which is what a whole sequence needs` |
| `slice(0, 3)` restored | two workspace rendering tests |

`bun test` 1503 pass / 0 fail / 1 todo (1494 before), `bun run typecheck` clean, `bun run lint` at its baseline of 2 warnings and 6 infos, all pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL
