### PR TITLE
fix(spindrift): attest what a runtime runs, not what is attached to it

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -444,6 +444,21 @@ jobs:
           # what makes the question the runtime asks one that has an answer.
           # `imagetools` reads the index with the credentials the login steps
           # already wrote, so this needs nothing of its own.
+          #
+          # **A child here means a manifest a runtime can run.** The same
+          # `provenance` and `sbom` that make this an index also hang their own
+          # manifests off it, and those are not images: `platform` is
+          # `unknown/unknown` and the entry is annotated
+          # `vnd.docker.reference.type: attestation-manifest`. Nothing ever
+          # resolves to one and no admission decision is ever made about one, so
+          # attesting them buys nothing and costs a KMS signing operation and an
+          # occurrence per destination per build — and buries the occurrence
+          # that matters in a list an operator has to read while diagnosing a
+          # refusal.
+          #
+          # Selected by what the entry *is*, never by how many there are. "Drop
+          # the last two" is correct today and wrong the first time a second
+          # platform or a third attachment appears, with nothing to report it.
           while IFS= read -r destination; do
             [ -n "$destination" ] || continue
             attest "$destination" "$DIGEST"
@@ -452,7 +467,13 @@ jobs:
             # an assignment is. A registry having a bad moment must not read as
             # an index with no children.
             manifests="$(docker buildx imagetools inspect --raw \
-              "${destination}@${DIGEST}" | jq -r '.manifests[]?.digest')"
+              "${destination}@${DIGEST}" | jq -r '
+                .manifests[]?
+                | select(.annotations["vnd.docker.reference.type"]
+                         != "attestation-manifest")
+                | select((.platform.os // "") != "unknown"
+                         and (.platform.architecture // "") != "unknown")
+                | .digest')"
             for child in $manifests; do
               attest "$destination" "$child"
             done

--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -752,9 +752,22 @@ attest() {
 # it. The children are attested as well so the question the runtime asks has an
 # answer whichever digest it resolved to.
 #
-# Unfiltered on purpose: the attestation-manifest child is attested too. "Every
-# manifest under the index" is a rule with no exception to get wrong, and a
-# spare occurrence costs nothing.
+# A child means a manifest a runtime can run, which is not every entry the
+# index names. The same \`--attest\` that makes this an index hangs its own
+# manifests off it, and those are not images: \`platform\` is
+# \`unknown/unknown\` and the entry is annotated \`vnd.docker.reference.type:
+# attestation-manifest\`. Nothing resolves to one and no admission decision is
+# ever made about one, so attesting them buys nothing and costs a KMS signing
+# operation and an occurrence per destination per build — and buries the
+# occurrence that matters in a list an operator has to read while diagnosing a
+# refusal.
+#
+# Selected by what the entry *is*, never by how many there are. "Drop the last
+# two" is correct today and wrong the first time a second platform or a third
+# attachment appears, with nothing to report it. An entry that names no
+# platform at all is kept: unrecognised is not the same as unrunnable, and the
+# failure that matters is the one where a runtime resolves to a digest nothing
+# attested.
 #
 # Every media type accepted and not only the index ones, for the same reason: a
 # push with no index has to answer this call rather than 404 it, and
@@ -766,6 +779,12 @@ children() {
     "https://\${1%%/*}/v2/\${1#*/}/manifests/\${2}" \\
   | "\${CLOUDSDK_PYTHON:-python3}" -c 'import json, sys
 for manifest in json.load(sys.stdin).get("manifests", []):
+    annotations = manifest.get("annotations") or {}
+    if annotations.get("vnd.docker.reference.type") == "attestation-manifest":
+        continue
+    platform = manifest.get("platform") or {}
+    if platform.get("os") == "unknown" or platform.get("architecture") == "unknown":
+        continue
     print(manifest["digest"])'
 }
 

--- a/apps/spindrift/test/adapters/build-attest-selection.test.ts
+++ b/apps/spindrift/test/adapters/build-attest-selection.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The hosted route's attest step, run as the file actually ships it.
+ *
+ * The same argument `build-report-statement.test.ts` makes: every other test in
+ * this tree stands a fake in front of the runner, and a workflow that signs the
+ * wrong set of digests passes all of them. Running the step's own `run:` script
+ * is what catches it.
+ *
+ * The cloud route's half of this lives in `build-routes.test.ts`, next to the
+ * fake that composes its steps.
+ */
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  ATTACHMENT_DIGEST,
+  attested,
+  GCLOUD_STUB,
+  INDEX_DIGEST,
+  indexStub,
+  RUNTIME_DIGEST,
+} from '../harness/attest-step.ts';
+
+const WORKFLOW = join(
+  import.meta.dir,
+  '../../../../.github/workflows/spindrift-build.yml',
+);
+const ATTEST_STEP = 'Attest the artifact';
+
+const SIGNER =
+  'gcpkms://projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer';
+const ATTESTOR = 'projects/trusted-builds/attestors/provenance';
+const DESTINATION =
+  'northamerica-northeast1-docker.pkg.dev/trusted-builds/i/demo/web';
+
+/** The `run:` script of the named step, straight out of the shipped file. */
+async function attestScript(): Promise<string> {
+  const document = Bun.YAML.parse(await Bun.file(WORKFLOW).text()) as {
+    jobs: { build: { steps: { name?: string; run?: string }[] } };
+  };
+  const step = document.jobs.build.steps.find((s) => s.name === ATTEST_STEP);
+  if (step?.run === undefined) {
+    throw new Error(`${WORKFLOW} has no “${ATTEST_STEP}” step with a script`);
+  }
+  return step.run;
+}
+
+describe('the hosted route attests what a runtime can run', () => {
+  test('the index and the platform manifest, and not the attachment', async () => {
+    const digests = await attested(
+      await attestScript(),
+      { gcloud: GCLOUD_STUB, docker: indexStub() },
+      {
+        ATTESTOR,
+        SIGNER,
+        DESTINATIONS: DESTINATION,
+        DIGEST: INDEX_DIGEST,
+        CLOUDSDK_CORE_DISABLE_PROMPTS: '1',
+      },
+    );
+
+    // The index, because that is the reference a Deploy pins; and the manifest
+    // a runtime resolves it to, because that is the digest admission is asked
+    // about. Two signing operations for a single-platform build, not three.
+    expect(digests).toEqual([
+      `${DESTINATION}@${INDEX_DIGEST}`,
+      `${DESTINATION}@${RUNTIME_DIGEST}`,
+    ]);
+    expect(digests).not.toContain(`${DESTINATION}@${ATTACHMENT_DIGEST}`);
+  });
+});

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -45,6 +45,14 @@ import {
   RUN_NAME_PREFIX,
 } from '../../src/integrations/github/config-pr.ts';
 import {
+  ATTACHMENT_DIGEST,
+  attested,
+  GCLOUD_STUB,
+  INDEX_DIGEST,
+  indexStub,
+  RUNTIME_DIGEST,
+} from '../harness/attest-step.ts';
+import {
   FakeCloudBuild,
   type FakeCloudBuildOptions,
 } from '../harness/fakes/cloud-build-api.ts';
@@ -600,6 +608,41 @@ describe('the cloud build route', () => {
     const children = program.slice(program.indexOf('# The children,'));
     expect(children).toContain(`${CLOUD_REGISTRY}/example-builds/i/app`);
     expect(children).not.toContain('registry.example.test');
+  });
+
+  test('the attachments hanging off that index are not', async () => {
+    // A child is a manifest a runtime can run. `--attest` hangs BuildKit's own
+    // `provenance` and `sbom` manifests off the same index — `unknown/unknown`,
+    // annotated `attestation-manifest` — and nothing ever resolves to one, so
+    // each one signed is a KMS operation and an occurrence per destination per
+    // build spent on a digest no admission decision is made about.
+    //
+    // Run rather than read: an assertion on the text of the selection would
+    // pass for any expression that merely mentions `attestation-manifest`.
+    const { api, route } = cloudRoute(
+      {},
+      {},
+      { signer: SIGNER, attestor: ATTESTOR },
+    );
+    await run(route.build(archiveSource(), cloudSpec));
+
+    const references = await attested(api.steps[0]?.[1]?.args?.[1] ?? '', {
+      gcloud: GCLOUD_STUB,
+      curl: indexStub(),
+      // The `/workspace` volume the builder wrote the digest to. This box has
+      // no such path and reading it is the step's first line.
+      cat: `echo '${INDEX_DIGEST}'`,
+    });
+
+    // Every destination at the index, then the platform manifest under the one
+    // this step can read a manifest back out of. The attachment appears
+    // nowhere.
+    expect(references).toEqual([
+      `${CLOUD_REGISTRY}/example-builds/i/app@${INDEX_DIGEST}`,
+      `registry.example.test/app@${INDEX_DIGEST}`,
+      `${CLOUD_REGISTRY}/example-builds/i/app@${RUNTIME_DIGEST}`,
+    ]);
+    expect(references.join('\n')).not.toContain(ATTACHMENT_DIGEST);
   });
 
   test('an installation that named no attestor submits no attestation', async () => {

--- a/apps/spindrift/test/extraction/no-literals.test.ts
+++ b/apps/spindrift/test/extraction/no-literals.test.ts
@@ -110,6 +110,11 @@ const PROJECT_ID_ALLOWLIST = new Set<string>([
   // The vendor subcommand that writes an attestation. Same kind of thing as
   // the two below it: a tool's own vocabulary, identical in every installation.
   'sign-and-create',
+  // The value BuildKit annotates its `provenance` and `sbom` manifests with,
+  // read by the attestation step to tell an entry a runtime can run from one it
+  // cannot. A registry's own vocabulary — the same string under every index
+  // BuildKit has ever pushed, in every installation.
+  'attestation-manifest',
   'slsa-verifier',
   'verify-image',
   'verify-signature',

--- a/apps/spindrift/test/harness/attest-step.ts
+++ b/apps/spindrift/test/harness/attest-step.ts
@@ -1,0 +1,131 @@
+/**
+ * Running a route's attest step for real, to see what it would have signed.
+ *
+ * Both build routes attest the index and then the children the registry names
+ * under it, because an index is not what a runtime runs — Cloud Run resolves it
+ * to its own platform's manifest *before* admission, and a digest nothing
+ * attested reads as `denied by attestor` on an artifact that was attested one
+ * indirection up.
+ *
+ * What a child is, though, is the thing worth testing: BuildKit's `provenance`
+ * and `sbom` hang manifests off that same index, nothing ever resolves to one,
+ * and each one signed is a KMS operation and an occurrence per destination per
+ * build spent on a digest no admission decision is made about.
+ *
+ * Asserting on the *text* of a selection would pass for any expression that
+ * merely mentions `attestation-manifest`. So the step is run instead: what
+ * leaves the box is stubbed, and the digests the step named are the digests it
+ * would have signed.
+ */
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * A registry's answer for a real single-platform build, captured 2026-08-04
+ * from `ghcr.io/jonpulsifer/spindrift@sha256:426ae4ac…`.
+ *
+ * One platform was asked for and two manifests came back. That is the whole
+ * problem in one document: `provenance` and `sbom` make the push an index even
+ * at one platform, and the second entry is the attestation manifest they hang
+ * off it — `unknown/unknown`, annotated `attestation-manifest`, and not
+ * something any runtime can run.
+ */
+export const SINGLE_PLATFORM_INDEX = {
+  schemaVersion: 2,
+  mediaType: 'application/vnd.oci.image.index.v1+json',
+  manifests: [
+    {
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      digest:
+        'sha256:25790e965850eb3e5cae462b96cbd8eeea9c204a3852bcc6d47ba526845066ee',
+      size: 3921,
+      platform: { architecture: 'amd64', os: 'linux' },
+    },
+    {
+      mediaType: 'application/vnd.oci.image.manifest.v1+json',
+      digest:
+        'sha256:9cfb02d0b233985e598e92a066549cb5738083e1bef29bd15c9e6961f93ec731',
+      size: 839,
+      annotations: {
+        'vnd.docker.reference.digest':
+          'sha256:25790e965850eb3e5cae462b96cbd8eeea9c204a3852bcc6d47ba526845066ee',
+        'vnd.docker.reference.type': 'attestation-manifest',
+      },
+      platform: { architecture: 'unknown', os: 'unknown' },
+    },
+  ],
+};
+
+/** The index the builder reported — what a Deploy pins. */
+export const INDEX_DIGEST =
+  'sha256:426ae4acd70b00275a15f9ea9191666ac15d472fb369f57f9f4b89de7c3305ac';
+/** The manifest a runtime resolves that index to — what admission asks about. */
+export const RUNTIME_DIGEST = SINGLE_PLATFORM_INDEX.manifests[0]?.digest ?? '';
+/** BuildKit's own attachment — what no runtime ever asks about. */
+export const ATTACHMENT_DIGEST =
+  SINGLE_PLATFORM_INDEX.manifests[1]?.digest ?? '';
+
+/** Enough `gcloud` for a step that lists a key version and then signs. */
+export const GCLOUD_STUB = `case "$*" in
+  *print-access-token*) echo stub-token ;;
+esac
+exit 0`;
+
+/**
+ * A command that answers with the index and ignores how it was asked.
+ *
+ * `printf` rather than a `cat` heredoc, because a stub directory is on `PATH`
+ * ahead of everything and a step that stubs `cat` would otherwise be stubbing
+ * this too.
+ */
+export function indexStub(): string {
+  return `printf '%s\\n' '${JSON.stringify(SINGLE_PLATFORM_INDEX)}'`;
+}
+
+/**
+ * Run `script` with `stubs` shadowing the commands that would leave the box,
+ * and return the `destination@digest` references its own `attesting …` lines
+ * named, in order.
+ *
+ * `bash`, not `sh`: both steps open with `set -euo pipefail`, which a POSIX
+ * shell refuses outright — running them under the wrong shell tests a script
+ * neither route executes.
+ */
+export async function attested(
+  script: string,
+  stubs: Record<string, string>,
+  env: Record<string, string> = {},
+): Promise<string[]> {
+  const directory = await mkdtemp(join(tmpdir(), 'spindrift-attest-'));
+  try {
+    const bin = join(directory, 'bin');
+    for (const [name, body] of Object.entries(stubs)) {
+      const path = join(bin, name);
+      await Bun.write(path, `#!/usr/bin/env bash\n${body}\n`);
+      await chmod(path, 0o755);
+    }
+    const path = join(directory, 'step.sh');
+    await writeFile(path, script);
+
+    const child = Bun.spawn(['bash', path], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: { PATH: `${bin}:${Bun.env.PATH ?? ''}`, ...env },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+      child.exited,
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(`the attest step failed:\n${stdout}\n${stderr}`);
+    }
+
+    return [...stdout.matchAll(/^attesting (\S+)$/gm)].map(
+      (match) => match[1] ?? '',
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
## The loop stays

Both build routes attest the index and then every child the registry names
under it, and that is not the bug. An index is not what a runtime runs: Cloud
Run resolves it to its own platform's manifest *before* admission, and Binary
Authorization is then asked about a digest nothing attested — `denied by
attestor` on an artifact that really was attested, one indirection up.
Attesting the children is what makes the runtime's question answerable, and the
comment explaining that survives verbatim.

## What was wrong is the definition of "child"

The same `provenance` and `sbom` that make this an image index even at one
platform hang their **own** manifests off it. Those are not images:

```json
{
  "digest": "sha256:9cfb02d0…",
  "annotations": {
    "vnd.docker.reference.type": "attestation-manifest",
    "vnd.docker.reference.digest": "sha256:25790e96…"
  },
  "platform": {"architecture": "unknown", "os": "unknown"}
}
```

Nothing ever resolves to one and no admission decision is ever made about one.
Each was a KMS signing operation and an occurrence per destination per build,
spent on a digest no verifier asks about — and it buries the occurrence that
matters in a list an operator has to read past while diagnosing a refusal.

Selected by what the entry **is** — unknown platform, or the
attestation-manifest annotation — never by how many there are. "Drop the last
two" is correct today and wrong the first time a second platform or a third
attachment appears, in a way nothing reports.

An entry that names no platform at all is kept. Unrecognised is not the same as
unrunnable, and the failure worth avoiding is the one where a runtime resolves
to a digest nothing attested.

## Both routes

The hosted route's `jq` and the cloud route's Python
(`apps/spindrift/src/adapters/build/cloud-build.ts:762`) were the same rule
written twice — the cloud one with a comment saying it was unfiltered on
purpose. Fixing one leaves the other signing attachments, so both move together
and the stale rationale goes with them.

## Before and after

Against a real single-platform index —
`ghcr.io/jonpulsifer/spindrift@sha256:426ae4ac…`, fetched from the registry and
kept as the test fixture:

```
$ jq -r '.manifests[]?.digest' index.json          # before
sha256:25790e965850eb3e5cae462b96cbd8eeea9c204a3852bcc6d47ba526845066ee
sha256:9cfb02d0b233985e598e92a066549cb5738083e1bef29bd15c9e6961f93ec731

$ jq -r '<the new filter>' index.json              # after
sha256:25790e965850eb3e5cae462b96cbd8eeea9c204a3852bcc6d47ba526845066ee
```

Three signing operations per destination become two.

## The check

Asserting on the *text* of the selection would pass for any expression that
merely mentions `attestation-manifest`, so both steps are run for real:
`gcloud` and the registry read stubbed, the index above as the fixture, and the
step's own `attesting …` lines are what it would have signed.

* `test/adapters/build-attest-selection.test.ts` pulls the `Attest the
  artifact` step's `run:` script straight out of the shipped workflow and runs
  it — same technique as `build-report-statement.test.ts`.
* `test/adapters/build-routes.test.ts` runs the program the cloud route
  actually submits, and pins the whole reference list: both destinations at the
  index, then the platform manifest under the only one this step holds a
  credential to read a manifest back out of.

Reverting either selection fails its test with the attachment digest in the
diff.

```
$ bun test test/adapters
 269 pass  0 fail

$ mise run ts:check
 Tasks: 4 successful, 4 total
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL