### PR TITLE
fix(oauth2-proxy): scope offsite's cookies to the zone that serves the callback

### DIFF
--- a/.github/scripts/render-cluster-apps.sh
+++ b/.github/scripts/render-cluster-apps.sh
@@ -14,11 +14,17 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
+# Each entry is a path some Flux Kustomization names, so an overlay that is its
+# own `spec.path` belongs here in its own right — being under `clusters/*/apps`
+# does not mean the aggregate overlay includes it. oauth2-proxy is exactly that
+# case, and it was rendered by nothing until it was listed.
 OVERLAYS=(
   clusters/folly/apps
   clusters/offsite/apps
   clusters/folly/apps/arc
   clusters/offsite/apps/arc
+  clusters/folly/apps/oauth2-proxy
+  clusters/offsite/apps/oauth2-proxy
   clusters/folly/monitoring
 )
 
@@ -93,12 +99,71 @@ template_releases() {
   done <"$list"
 }
 
+# A sign-in that starts at one host and calls back at another needs both hosts
+# inside the cookie's scope, or the browser carries neither cookie across:
+# the CSRF cookie is written where the flow starts and read at the callback,
+# and the session cookie is written at the callback and read back at the App.
+#
+# So oauth2-proxy's `cookie-domain` must cover the host in its own
+# `redirect-url`. That single rule catches both ways this has actually broken:
+# an absent or null `cookie-domain`, which leaves every cookie host-only and
+# unreadable one hop later; and a `cookie-domain` naming the *other* cluster's
+# apex, which a strategic merge produces silently the moment an overlay omits
+# the key (see `clusters/offsite/apps/oauth2-proxy/helm-release-patch.yaml`).
+#
+# Flux has not substituted its `${VAR}` postbuild values at this point, and that
+# is what makes the second case visible: comparing the literal tokens is exactly
+# how `.${SECRET_DOMAIN}` under `oauth2.${SPINDRIFT_DOMAIN}` fails to match.
+cookie_checks=0
+cookie_scope_contract() {
+  local rendered="$1" overlay="$2"
+  local ns name url domain host rest
+
+  while IFS=$'\t' read -r ns name url domain; do
+    [ -n "${ns:-}" ] || continue
+    cookie_checks=$((cookie_checks + 1))
+
+    host="${url#*://}"
+    host="${host%%/*}"
+    rest="${host%"$domain"}"
+
+    # `rest` empty means cookie-domain equals the callback host exactly: a
+    # host-only cookie the App can never read, which is the loop, not a fix.
+    if [ -z "$domain" ] || [ "$rest" = "$host" ] || [ -z "$rest" ]; then
+      printf '  FAILED %s/%s (%s): cookie-domain "%s" does not cover the redirect-url host "%s"\n' \
+        "$ns" "$name" "$overlay" "$domain" "$host"
+      failures=$((failures + 1))
+    else
+      printf '  cookie scope %s/%s: "%s" covers "%s"\n' "$ns" "$name" "$domain" "$host"
+    fi
+  done < <(yq eval-all '
+    select(.kind == "HelmRelease")
+    | select(.spec.values.extraArgs."redirect-url" // "" | length > 0)
+    | [[ (.metadata.namespace // "default"),
+         .metadata.name,
+         .spec.values.extraArgs."redirect-url",
+         (.spec.values.extraArgs."cookie-domain" // "") ]]
+    | @tsv
+  ' "$rendered")
+}
+
 for overlay in "${OVERLAYS[@]}"; do
   rendered="$WORK/${overlay//\//_}.yaml"
   kubectl kustomize "$overlay" >"$rendered"
   printf 'rendered %s\n' "$overlay"
   template_releases "$rendered" "$overlay"
+  cookie_scope_contract "$rendered" "$overlay"
 done
+
+# The contract above has to have looked at something. `redirect-url` is what
+# selects a release into it, so a rename or a deleted key would otherwise turn
+# the whole check into silence that reads green.
+if [ "$cookie_checks" -eq 0 ]; then
+  printf '\nNo rendered HelmRelease declares extraArgs.redirect-url, so the cookie\n'
+  printf 'scope contract checked nothing. Either the key moved or an overlay is\n'
+  printf 'missing from OVERLAYS in %s.\n' "${BASH_SOURCE[0]}"
+  failures=$((failures + 1))
+fi
 
 # A HelmRelease that names an in-repo chart but lives outside the overlays above
 # is exactly the gap this script closes, so it is an error rather than silence:

--- a/clusters/offsite/apps/oauth2-proxy/helm-release-patch.yaml
+++ b/clusters/offsite/apps/oauth2-proxy/helm-release-patch.yaml
@@ -7,15 +7,43 @@ spec:
   values:
     extraArgs:
       redirect-url: https://oauth2.${SPINDRIFT_DOMAIN}/oauth2/callback
-      # The session cookie is host-only, for whatever x-forwarded-host the
-      # filter passed. A zone-wide cookie would be sent to an `auth: none` App
-      # on this same zone — handing the token that unlocks every authenticated
-      # App to the one workload deliberately exposed.
+      # Both cookies are scoped to this zone, because the sign-in spans two
+      # hosts and a host-only cookie cannot cross between them.
       #
-      # Explicitly null rather than absent. `extraArgs` is a map, so a strategic
-      # merge that simply omits the key merges the base's value straight through:
-      # this overlay read as "no cookie-domain" and shipped `.${SECRET_DOMAIN}`,
-      # the *other* cluster's apex, on every session cookie offsite issued.
-      cookie-domain: null
-      # whitelist-domain still permits the return trip after sign-in.
+      # The ExternalAuth filter on an App's route
+      # (`packages/charts/spindrift-app/templates/httproute.yaml`) sets no
+      # `http.path`, so oauth2-proxy runs its whole flow at the App's own host:
+      # it mints the provider redirect there and writes the CSRF cookie there.
+      # `redirect-url` above pins the callback to one host, which is all the
+      # GitHub OAuth App registers. So the two halves land on different hosts —
+      # the CSRF cookie is written at the App, the callback is served at
+      # `oauth2.${SPINDRIFT_DOMAIN}`, and a host-only cookie is unreadable
+      # there. The proxy finds no CSRF token and answers the operator with
+      #
+      #   Login Failed: Unable to find a valid CSRF token. Please try again.
+      #
+      # after they have already approved on github.com. The session cookie has
+      # the mirror-image problem: minted at the callback host, it is not sent
+      # back to the App, so the filter denies again and the browser loops.
+      #
+      # What this costs. A zone-scoped cookie is sent to every App on this zone,
+      # including the `auth: none` ones — the workloads deliberately exposed
+      # without a gate now receive the session token that unlocks every
+      # authenticated App beside them. That is not hypothetical; `auth: none`
+      # Apps share this zone today. It is an accepted risk, not a refuted one.
+      #
+      # Making it host-only again needs the two halves on one host: either
+      # unauthenticated Apps move off this zone, so the cookie can be scoped to
+      # a parent only authenticated Apps sit under, or a callback is registered
+      # per App hostname — and a GitHub OAuth App registers exactly one.
+      #
+      # Explicitly written rather than absent. `extraArgs` is a map, so a
+      # strategic merge that simply omits the key merges the base's value
+      # straight through: this overlay once read as "no cookie-domain" and
+      # shipped `.${SECRET_DOMAIN}`, the *other* cluster's apex, on every
+      # session cookie offsite issued. Deleting this line does not restore a
+      # host-only cookie — it scopes offsite's cookies to folly's domain.
+      # `.github/scripts/render-cluster-apps.sh` fails on both mistakes.
+      cookie-domain: .${SPINDRIFT_DOMAIN}
+      # whitelist-domain permits the return trip after sign-in.
       whitelist-domain: .${SPINDRIFT_DOMAIN}


### PR DESCRIPTION
Signing in to an `auth: proxy` App on offsite fails. After approving on
github.com the operator lands on:

```
Login Failed: Unable to find a valid CSRF token. Please try again.   (403)
```

## Why

The ExternalAuth filter on an App's route sets no `http.path`
(`packages/charts/spindrift-app/templates/httproute.yaml:55-78`), so
oauth2-proxy runs its **whole** sign-in flow at the App's own host — it mints
the provider redirect there and writes the CSRF cookie there. But
`redirect-url` pins the callback to `oauth2.${SPINDRIFT_DOMAIN}`, which is the
only callback the GitHub OAuth App registers.

So the two halves of the flow sit on different hosts, and with
`cookie-domain: null` the cookie is host-only to the first of them:

```
$ curl -D- https://sdd-private-web.lolwtf.dev
HTTP/1.1 302 Found
location: https://github.com/login/oauth/authorize?…&redirect_uri=https%3A%2F%2Foauth2.lolwtf.dev%2Foauth2%2Fcallback&…
set-cookie: __Secure-oauth2_proxy_csrf=…; Path=/; Max-Age=900; HttpOnly; Secure; SameSite=Lax
```

No `Domain` attribute. GitHub returns the browser to
`oauth2.lolwtf.dev/oauth2/callback`, which cannot read it, and the proxy 403s.

The session cookie has the mirror-image problem: minted at the callback host,
it is never sent back to the App, so the filter denies again and the browser
loops. One cookie scope fixes both halves.

## The change

`cookie-domain: .${SPINDRIFT_DOMAIN}` on offsite's overlay. Written explicitly
rather than deleted — `extraArgs` is a map, so omitting the key merges the
base's `.${SECRET_DOMAIN}` straight through and scopes offsite's cookies to
folly's apex.

**What it costs.** Every App on this zone now receives the session cookie,
including the `auth: none` ones — the workloads deliberately exposed without a
gate. The previous comment protected against exactly that, so it is rewritten
rather than deleted: it now states what is true, what it costs, and what would
have to change to make the cookie host-only again (unauthenticated Apps off
this zone, or a registered callback per App hostname — and a GitHub OAuth App
registers exactly one).

## The check

`render-cluster-apps.sh` gains the invariant the fix rests on: a release's
`cookie-domain` must cover the host in its own `redirect-url`. Comparing the
literal, pre-substitution `${VAR}` tokens is what makes the wrong-cluster case
visible.

Both failure modes were reproduced by reverting:

```
# cookie-domain: null
FAILED oauth2-proxy/oauth2-proxy (clusters/offsite/apps/oauth2-proxy): cookie-domain "" does not cover the redirect-url host "oauth2.${SPINDRIFT_DOMAIN}"

# key deleted — the strategic-merge trap
FAILED oauth2-proxy/oauth2-proxy (clusters/offsite/apps/oauth2-proxy): cookie-domain ".${SECRET_DOMAIN}" does not cover the redirect-url host "oauth2.${SPINDRIFT_DOMAIN}"
```

and green with the fix in place:

```
cookie scope oauth2-proxy/oauth2-proxy: ".${SECRET_DOMAIN}" covers "oauth2.${SECRET_DOMAIN}"
cookie scope oauth2-proxy/oauth2-proxy: ".${SPINDRIFT_DOMAIN}" covers "oauth2.${SPINDRIFT_DOMAIN}"
```

The oauth2-proxy overlays are their own Flux `spec.path` and were rendered by
nothing before this, so both clusters' are added to `OVERLAYS`. folly's config
already satisfies the contract and is unchanged.

## Verifying after merge

The unauthenticated half is curl-able: both entry points should now carry
`Domain=lolwtf.dev` on `__Secure-oauth2_proxy_csrf`.

```
curl -D- https://sdd-private-web.lolwtf.dev
curl -D- https://oauth2.lolwtf.dev/oauth2/start
```

The authenticated half needs a browser and cannot be shown here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL
