### PR TITLE
fix(bluenose): let allUsers hold roles/run.invoker in the Spindrift vessel

### DIFF
--- a/terraform/gcp/projects/bluenose/policy.tf
+++ b/terraform/gcp/projects/bluenose/policy.tf
@@ -35,3 +35,50 @@ resource "google_org_policy_policy" "require_cloud_run_binary_authorization" {
 
   depends_on = [google_binary_authorization_policy.spindrift]
 }
+
+# The org's iam.managed.allowedPolicyMembers (organization/baseline-policies.tf)
+# only ever grants roles to the org's own principal set. Spindrift's `{reach:
+# public, auth: none}` Cloud Run Components bind `roles/run.invoker` to
+# `allUsers` (apps/spindrift/src/adapters/deploy/cloudrun/service.ts) so that
+# is exactly the grant the org policy blocks, and there is no narrower fix
+# available inside the constraint itself: `allowedMemberSubjects` requires
+# every entry to contain a `:` (`user:...`, `serviceAccount:...`), so the
+# bare special principal `allUsers` cannot be listed there at any parent —
+# org, folder, or project — and `allowedPrincipalSets` only accepts
+# organization principal sets. Google's own domain-restricted-sharing docs
+# say allowing `allUsers`/`allAuthenticatedUsers` is only possible through a
+# hand-authored custom constraint, and a custom constraint cannot carve an
+# exception out of a *different*, already-enforced constraint — every
+# enforced constraint on a resource is a separate AND'd check, none of them
+# "wins" over another. The only lever this constraint exposes is turning its
+# own enforcement off for a scope, so that is what this does, at the
+# narrowest scope that covers Spindrift's runtime project and nothing wider.
+#
+# What this actually costs: everything under this project — not just Cloud
+# Run's invoker binding — loses domain-restricted sharing. A binding minted
+# anywhere in bluenose (a bucket ACL, a service account grant) could in
+# principle name a principal outside the org and the org policy would no
+# longer be the backstop that catches it; Binary Authorization and the
+# controller's own role grants (iam.tf) are what keep that theoretical from
+# being reachable in practice. bluenose is single-purpose (Spindrift's Cloud
+# Run vessel, see README.md) so there is nothing else in this project for a
+# stray grant to reach.
+#
+# Removing this: either GCP extends the managed constraint to accept
+# `allUsers` (or the org adopts the legacy iam.allowedPolicyMemberDomains
+# constraint's allUsers exception instead), or Spindrift stops needing an
+# `allUsers` IAM binding at all by setting Cloud Run's own
+# `invoker_iam_disabled` field on public Services — which the
+# run.managed.requireInvokerIam managed constraint (unset here, org default
+# ALLOW) already permits — instead of granting `roles/run.invoker`.
+resource "google_org_policy_policy" "allow_public_cloud_run_invoker" {
+  name   = "projects/${local.project}/policies/iam.managed.allowedPolicyMembers"
+  parent = "projects/${local.project}"
+
+  spec {
+    inherit_from_parent = false
+    rules {
+      enforce = "FALSE"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Spindrift's `{reach: public, auth: none}` Cloud Run Components bind `roles/run.invoker` to `allUsers` (`apps/spindrift/src/adapters/deploy/cloudrun/service.ts:208-215`, see the comment at 85-95 for why only that cell relaxes the check). The org's `iam.managed.allowedPolicyMembers` policy (`terraform/gcp/organization/baseline-policies.tf:42`) only ever grants roles to the org's own principal set, so a public deploy fails:

```
the invoker policy for {reach: public, auth: none} could not be written:
Operation denied by org policy on resource '.../northamerica-northeast1/plainboi-web':
["constraints/iam.managed.allowedPolicyMembers": ...]
```

## Why a project-level override, not a wider one

The constraint's own parameter schema rules out anything narrower than "disable enforcement for a scope": `allowedMemberSubjects` requires every entry to contain a `:` (`user:...`, `serviceAccount:...`), so the bare special principal `allUsers` cannot be listed there at any parent — org, folder, or project. `allowedPrincipalSets` only accepts organization principal sets. Google's own domain-restricted-sharing docs confirm allowing `allUsers`/`allAuthenticatedUsers` is only possible through a hand-authored custom constraint targeting `iam.googleapis.com/AllowPolicy` — and a custom constraint can't carve an exception out of a *different*, already-enforced constraint, since every enforced constraint on a resource is a separate AND'd check.

So the only lever `iam.managed.allowedPolicyMembers` exposes is turning its own enforcement off for a scope. This adds that override at `parent = "projects/bluenose"` only — the vessel project Spindrift's Cloud Run runtime lives in and nothing else — leaving the org-level policy exactly as it is everywhere else.

**What this costs, stated plainly:** everything under `bluenose`, not just Cloud Run's invoker binding, loses domain-restricted sharing — a binding minted anywhere in the project could in principle name a principal outside the org. `bluenose` is single-purpose (Spindrift's Cloud Run vessel), so there's nothing else in the project for a stray grant to reach, and Binary Authorization plus the controller's own scoped role grants (`iam.tf`) are what keep that theoretical from being reachable in practice.

**Removing this later:** either GCP extends the managed constraint to accept `allUsers`, or Spindrift stops needing an `allUsers` IAM binding at all by setting Cloud Run's own `invoker_iam_disabled` field on public Services instead of granting `roles/run.invoker` — the `run.managed.requireInvokerIam` managed constraint (unset here, org default `ALLOW`) already permits that today.

## Validate

```
$ tofu init -backend=false && tofu validate
Success! The configuration is valid.

$ tofu plan   # read-only, against real state
Plan: 1 to add, 0 to change, 0 to destroy.
  # google_org_policy_policy.allow_public_cloud_run_invoker will be created
```

Nothing else in the plan is touched. No `tofu apply` was run — Atlantis owns the apply on this PR.

## Test plan

- [ ] Atlantis autoplans on this PR and shows the same single-resource add
- [ ] `atlantis apply` after review
- [ ] Re-trigger the `plainboi-web` deploy and confirm the invoker policy write succeeds