### PR TITLE
fix(bluenose): let a public Component's invoker binding be written

### DIFF
--- a/terraform/gcp/projects/bluenose/policy.tf
+++ b/terraform/gcp/projects/bluenose/policy.tf
@@ -82,3 +82,41 @@ resource "google_org_policy_policy" "allow_public_cloud_run_invoker" {
     }
   }
 }
+
+# The second half of the same grant, and it fails separately.
+#
+# `iam.allowedPolicyMemberDomains` (organization/baseline-policies.tf) permits
+# only principals belonging to this organization's Cloud Identity customer.
+# `allUsers` belongs to no customer, so the same binding is refused a second
+# time with a different sentence:
+#
+#   the invoker policy for {reach: public, auth: none} could not be written:
+#   One or more users named in the policy do not belong to a permitted
+#   customer, perhaps due to an organization policy.
+#
+# Every enforced constraint is an independent AND'd check, so relaxing the
+# managed constraint above does nothing for this one — both have to give
+# before a public Component can answer the internet.
+#
+# `allow_all` is broader than the grant needs: it permits any domain in this
+# project, not merely the public principal. The constraint's list form takes
+# customer IDs, and `allUsers` is not one, so there is no value that names it
+# — the same shape of dead end as the managed constraint above. This follows
+# the project-level override already used for the same constraint in
+# `terraform/gcp/projects/lolcorp/policy.tf` and `homelab-ng/policy.tf`; the
+# org default stays strict everywhere else.
+#
+# Removing this: the same two exits as above — Cloud Run's
+# `invoker_iam_disabled` on public Services would retire the `allUsers`
+# binding entirely, and with it both of these overrides.
+resource "google_org_policy_policy" "allow_public_cloud_run_domains" {
+  name   = "projects/${local.project}/policies/iam.allowedPolicyMemberDomains"
+  parent = "projects/${local.project}"
+
+  spec {
+    inherit_from_parent = false
+    rules {
+      allow_all = "TRUE"
+    }
+  }
+}


### PR DESCRIPTION
## What

A `{reach: public, auth: none}` Cloud Run Component binds `roles/run.invoker` to `allUsers` (`apps/spindrift/src/adapters/deploy/cloudrun/service.ts:208-215`). Two independent organization policies refuse that grant, and both have to give before a public Component can answer the internet.

```
the invoker policy for {reach: public, auth: none} could not be written:
Operation denied by org policy ... "constraints/iam.managed.allowedPolicyMembers"

the invoker policy for {reach: public, auth: none} could not be written:
One or more users named in the policy do not belong to a permitted customer,
perhaps due to an organization policy.
```

The first admits only the organization's own principal set. The second admits only principals in the organization's Cloud Identity customer. Every enforced constraint is a separate AND'd check, so relaxing one does nothing for the other — the second error only became visible after the first was addressed.

## Why the override is blunt

Neither constraint offers a narrow carve-out for this grant:

- `iam.managed.allowedPolicyMembers` — `allowedMemberSubjects` requires every entry to contain a `:` (`user:`, `serviceAccount:`), so the bare principal `allUsers` cannot be listed at any parent, and `allowedPrincipalSets` accepts only organization principal sets.
- `iam.allowedPolicyMemberDomains` — the list form takes customer IDs, and `allUsers` is not one.

So the only lever either exposes is its own enforcement, scoped. Both are overridden at the **project** level on the Spindrift vessel; the organization defaults are untouched everywhere else. This follows the project-level override already used for the domains constraint in `terraform/gcp/projects/lolcorp/policy.tf` and `terraform/gcp/projects/homelab-ng/policy.tf`.

## What it costs

Everything in this project loses both checks, not merely Cloud Run's invoker binding. The project is single-purpose — Spindrift's Cloud Run vessel — so there is little else for a stray grant to reach, and Binary Authorization plus the controller's own role grants remain. Both comments in the file say so in those terms rather than implying the exception is free.

## Removing it

Cloud Run's `invoker_iam_disabled` on public Services would retire the `allUsers` binding entirely, and with it both overrides. `run.managed.requireInvokerIam` is unset here, so that route is already permitted.

`tofu validate`: `Success! The configuration is valid.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017va47DJzPQ85FDuPbecBBL