### PR TITLE
fix(coredns): bypass denial cache for public zones

### DIFF
--- a/docs/pages/Runbooks___Deploy a NixOS Host.md
+++ b/docs/pages/Runbooks___Deploy a NixOS Host.md
@@ -10,6 +10,7 @@ tags:: runbook, nixos
 	- ```bash
 	  nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel --no-link
 	  ```
+	- Operator-run ARM host builds always use [[Fleet/forge]]; use the exact pre-PR build command in [[Runbooks/Validate Infra Changes]].
 	- Run a harmless remote command through the host app:
 	- ```bash
 	  nix run .#<hostname> -- date

--- a/docs/pages/Runbooks___Validate Infra Changes.md
+++ b/docs/pages/Runbooks___Validate Infra Changes.md
@@ -12,9 +12,13 @@ tags:: runbook, validation
 	- ```bash
 	  nix flake check
 	  ```
-	- Host build:
+	- Native x86 host build:
 	- ```bash
-	  nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel --no-link
+	  HOST=<hostname> mise run nix:build
+	  ```
+	- Operator-run ARM host builds always use [[Fleet/forge]]. Select forge as the Nix store so evaluation inputs, substitutions, and builds stay on the builder:
+	- ```bash
+	  NIX_REMOTE=ssh-ng://forge.lolwtf.ca HOST=<hostname> mise run nix:build
 	  ```
 	- See [[Runbooks/Deploy a NixOS Host]].
 - # Kubernetes

--- a/nix/services/coredns-sinkhole.nix
+++ b/nix/services/coredns-sinkhole.nix
@@ -42,7 +42,7 @@ in
           fallthrough
         }
         cache {
-          disable denial ${fleet.dnsZone}
+          disable denial ${fleet.dnsZone} lolwtf.dev pulsifer.ca
         }
         forward . ${lib.concatStringsSep " " (map (upstream: "tls://${upstream}") upstreams)} {
           policy random


### PR DESCRIPTION
## Summary

Bypass CoreDNS denial caching for `lolwtf.dev` and `pulsifer.ca`, while preserving the existing `lolwtf.ca` bypass. Document forge as the operator-run ARM build store.

## Changes

- add `lolwtf.dev` and `pulsifer.ca` to the sinkhole denial-cache bypass
- document username-free forge remote-store validation for ARM hosts

## Test plan

- [x] `mise run nix:fmt`
- [x] `mise run nix:check`
- [x] `NIX_REMOTE=ssh-ng://forge.lolwtf.ca HOST=spore mise run nix:build`
- [x] `NIX_REMOTE=ssh-ng://forge.lolwtf.ca HOST=capsule mise run nix:build`
- [x] `mise run docs:build`
- [x] `mise run docs:check`
- [x] switched spore and capsule using forge and verified CoreDNS health
- [x] redeployed forge from itself and verified host health

Cloudpi4 was intentionally excluded from this rollout.
