### PR TITLE
feat(spindrift): run a job on Cloud Run

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -188,14 +188,14 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     }
 
     const job = desired.kind === 'job';
-    // A schedule fires nothing here yet, and dropping it silently is the one
-    // outcome worse than refusing it: a Component would report `LIVE` on a
-    // cadence nothing keeps. Cloud Run's Job resource carries no schedule at
-    // all — firing one is Cloud Scheduler's job, and standing that up needs an
-    // API this vessel has not enabled and an invoker binding nothing creates
-    // (**72**). `REJECTED` because §6 puts it with the refusals a developer
-    // answers by changing the request: drop the schedule, or place it on a
-    // Target that keeps one.
+    // Place refuses this first: `FIRES_SCHEDULES_BY_ADAPTER` makes a scheduled
+    // job a `NO_SCHEDULER` non-candidate here, in the same words. This is the
+    // backstop for the path that asks for a Deploy without asking Place —
+    // dropping the schedule silently is the one outcome worse than refusing it,
+    // because a Component would report `LIVE` on a cadence nothing keeps.
+    // `REJECTED` because §6 puts it with the refusals a developer answers by
+    // changing the request: drop the schedule, or place it on a Target that
+    // keeps one (**72**).
     if (job && desired.schedule !== undefined) {
       yield this.status('FAILED', { reason: 'REJECTED' });
       return {

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -2,18 +2,26 @@
  * The Cloud Run deploy adapter (§6).
  *
  * Accepts an `image`, talks to the runtime's own API directly, and reads status
- * from the revision's conditions. There is no operator in between and nothing
+ * off the resource's own conditions. There is no operator in between and nothing
  * to install: §6's "the GitOps operator *is* the pluggable machinery" has no
  * analogue here, which is why this adapter is smaller than the Kubernetes one
  * and why the Target's connection carries an endpoint rather than a flavour.
+ *
+ * **Two collections, one adapter.** A `service` or a `website` is a Service and
+ * a `job` is a Job: two resources with separate APIs, separate documents and
+ * separate ideas of what readiness means. The kind picks one at `apply`, and the
+ * ref carries it from then on — `observe` and `destroy` are handed a ref and no
+ * Component, so nothing else could tell them which API to ask. `service.ts` and
+ * `job.ts` render the two documents; this file is the only thing that knows both
+ * exist.
  *
  * **Never the build-from-source path** (§4). The runtime will happily take a
  * source archive and build it, and taking that offer would give this
  * installation a second build engine — with its own frontends, its own
  * defaults, and its own idea of what a website is — reachable only from one of
  * three backends. §4's "build is always separate from deploy" is what forbids
- * it, `service.ts` is where the document that carries no build is rendered, and
- * `test/adapters/cloudrun.test.ts` is what notices if one appears.
+ * it, `service.ts` and `job.ts` are where the documents that carry no build are
+ * rendered, and `test/adapters/cloudrun.test.ts` is what notices if one appears.
  *
  * **Nothing here watches.** `apply` polls the Service it just wrote for a
  * bounded window and `observe` is one read, exactly as the Kubernetes adapter
@@ -59,15 +67,16 @@ import type {
   RuntimeLogSubject,
   RuntimeLogTailOptions,
 } from '../contract.ts';
+import { cloudRunJob } from './job.ts';
 import {
   allowsUnauthenticated,
   cloudRunService,
   invokerPolicy,
-  serviceId,
+  workloadId,
 } from './service.ts';
 import {
-  type CloudRunService,
   type CloudRunStatus,
+  type CloudRunWorkload,
   cloudRunStatus,
   servingDigest,
 } from './status.ts';
@@ -92,6 +101,17 @@ const DEFAULT_POLL_MS = 2_000;
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
 const DEFAULT_LOGS_ENDPOINT = 'https://logging.googleapis.com';
 const SERVICE_ID_LIMIT = 63;
+
+/**
+ * The two API collections this adapter places into.
+ *
+ * A Component's kind chooses one at apply, and a ref carries it thereafter —
+ * see {@link refOf}. There is no third: the runtime's other resources are
+ * things this adapter reads, never things it creates.
+ */
+const SERVICES = 'services';
+const JOBS = 'jobs';
+type Collection = typeof SERVICES | typeof JOBS;
 
 /** How the operator would name the service in the sentence about enabling it. */
 const SERVICE_NAME = 'Cloud Run';
@@ -167,8 +187,28 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       );
     }
 
-    const id = serviceId(desired);
-    const ref = refOf(connection, id);
+    const job = desired.kind === 'job';
+    // A schedule fires nothing here yet, and dropping it silently is the one
+    // outcome worse than refusing it: a Component would report `LIVE` on a
+    // cadence nothing keeps. Cloud Run's Job resource carries no schedule at
+    // all — firing one is Cloud Scheduler's job, and standing that up needs an
+    // API this vessel has not enabled and an invoker binding nothing creates
+    // (**72**). `REJECTED` because §6 puts it with the refusals a developer
+    // answers by changing the request: drop the schedule, or place it on a
+    // Target that keeps one.
+    if (job && desired.schedule !== undefined) {
+      yield this.status('FAILED', { reason: 'REJECTED' });
+      return {
+        phase: 'FAILED',
+        reason: 'REJECTED',
+        detail:
+          'this Target runs a job but has nothing to fire it on a schedule',
+      };
+    }
+
+    const id = workloadId(desired);
+    const collection = job ? JOBS : SERVICES;
+    const ref = refOf(connection, collection, id);
     const http = this.http(connection);
 
     yield this.status('APPLYING', { resource: id });
@@ -181,7 +221,10 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     // call finds no Service and does nothing, which is why the policy is
     // written again after the rollout below: the closed state is **asserted**
     // on every deploy rather than inherited from the platform's default.
-    if (!allowsUnauthenticated(desired.reach, desired.auth)) {
+    //
+    // A job has no exposure to assert in either direction: nothing routes to it
+    // and nothing invokes it, so there is no policy that would mean anything.
+    if (!job && !allowsUnauthenticated(desired.reach, desired.auth)) {
       const tightened = await this.setInvoker(
         http,
         connection,
@@ -195,18 +238,23 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       }
     }
 
-    const document = cloudRunService(desired, {
+    const render = {
       project: connection.project,
       image,
       serviceAccount: connection.serviceAccount ?? null,
       // §16's "one signature, two verifiers": `policyEndpoint` is where this
       // project's admission policy is read from, so a Target that names one is
-      // a Target whose project has a policy the Service must submit to.
+      // a Target whose project has a policy the workload must submit to. The
+      // vessel's `run.allowedBinaryAuthorizationPolicies` constraint applies to
+      // Jobs as well as Services, so both declare it.
       useProjectAdmissionPolicy: connection.policyEndpoint !== undefined,
-    });
+    };
+    const document = job
+      ? cloudRunJob(desired, render)
+      : cloudRunService(desired, render);
     const applied = await http.json<unknown>({
       method: 'PATCH',
-      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}`,
+      path: `/v2/${parentOf(connection)}/${collection}/${encodeURIComponent(id)}`,
       // Create-or-update in one call, which is what makes `apply` idempotent
       // without core having to remember whether it placed this before.
       query: { allowMissing: 'true' },
@@ -217,10 +265,16 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       yield this.status('FAILED', { resource: id, reason: verdict.reason });
       return verdict;
     }
-    yield this.log(`applied service ${id}`, id);
+    yield this.log(`applied ${job ? 'job' : 'service'} ${id}`, id);
 
-    const verdict = yield* this.awaitVerdict(http, connection, id, ref);
-    if (verdict.phase !== 'LIVE') return verdict;
+    const verdict = yield* this.awaitVerdict(
+      http,
+      connection,
+      collection,
+      id,
+      ref,
+    );
+    if (verdict.phase !== 'LIVE' || job) return verdict;
 
     // Now that the Service exists, the policy this exposure means is written
     // whichever direction it moved. Opening can only happen here — granting
@@ -248,10 +302,15 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   ): Promise<ObservedState | null> {
     const connection = this.connectionOf(target);
     if (connection === null) return null;
-    const id = parseRef(connection, ref);
-    if (id === null) return null;
+    const placed = parseRef(connection, ref);
+    if (placed === null) return null;
 
-    const read = await this.read(this.http(connection), connection, id);
+    const read = await this.read(
+      this.http(connection),
+      connection,
+      placed.collection,
+      placed.id,
+    );
     if (read === null) return null;
 
     const status = cloudRunStatus(read);
@@ -267,12 +326,14 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   async destroy(target: DeployTarget, ref: DeployRef): Promise<void> {
     const connection = this.connectionOf(target);
     if (connection === null) return;
-    const id = parseRef(connection, ref);
-    if (id === null) return;
+    const placed = parseRef(connection, ref);
+    if (placed === null) return;
 
+    const { collection, id } = placed;
+    const noun = collection === JOBS ? 'job' : 'service';
     const deleted = await this.http(connection).json<unknown>({
       method: 'DELETE',
-      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}`,
+      path: `/v2/${parentOf(connection)}/${collection}/${encodeURIComponent(id)}`,
     });
     // §6's idempotence: destroying what is already gone succeeds. Every other
     // refusal is raised, because a delete that silently did nothing is how an
@@ -281,8 +342,8 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     if (deleted.kind === 'status' && deleted.status === 404) return;
     throw new Error(
       deleted.kind === 'status'
-        ? `deleting service ${id} failed with ${deleted.status}: ${deleted.message}`
-        : `deleting service ${id} failed: ${deleted.message}`,
+        ? `deleting ${noun} ${id} failed with ${deleted.status}: ${deleted.message}`
+        : `deleting ${noun} ${id} failed: ${deleted.message}`,
     );
   }
 
@@ -387,6 +448,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   private async *awaitVerdict(
     http: CloudHttp,
     connection: CloudRunAdapterConnection,
+    collection: Collection,
     id: string,
     ref: DeployRef,
   ): AsyncGenerator<DeployEvent, DeployVerdict, void> {
@@ -398,7 +460,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     let reported: DeployPhase = 'APPLYING';
 
     for (;;) {
-      const service = await this.read(http, connection, id);
+      const service = await this.read(http, connection, collection, id);
       const status: CloudRunStatus =
         service === null ? { phase: 'APPLYING' } : cloudRunStatus(service);
 
@@ -415,7 +477,9 @@ export class CloudRunDeployAdapter implements DeployAdapter {
         // §9: the platform names its own, so the canonical address comes back
         // across this seam rather than being handed in. A Service reported
         // ready with no `uri` is the one case core cannot fill in, and an
-        // absent url is more honest than a name core assembled.
+        // absent url is more honest than a name core assembled. A Job document
+        // has no `uri` member at all, which is the same absence meaning
+        // something stronger: there is no address, because nothing routes here.
         const uri = service?.uri;
         return {
           phase: 'LIVE',
@@ -580,15 +644,16 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     return target.connection.adapter === 'cloudrun' ? target.connection : null;
   }
 
-  /** One Service, or `null` where there is nothing there. */
+  /** One Service or Job, or `null` where there is nothing there. */
   private async read(
     http: CloudHttp,
     connection: CloudRunAdapterConnection,
+    collection: Collection,
     id: string,
-  ): Promise<CloudRunService | null> {
-    const read = await http.json<CloudRunService>({
+  ): Promise<CloudRunWorkload | null> {
+    const read = await http.json<CloudRunWorkload>({
       method: 'GET',
-      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}`,
+      path: `/v2/${parentOf(connection)}/${collection}/${encodeURIComponent(id)}`,
     });
     return read.ok ? (read.value ?? null) : null;
   }
@@ -697,20 +762,34 @@ function parentOf(connection: CloudRunAdapterConnection): string {
  *
  * It carries the project and the region as well as the id because an operator
  * may reconnect a Target against a different project, and a ref that named only
- * the Service would then be read against the wrong one — reporting a healthy
+ * the resource would then be read against the wrong one — reporting a healthy
  * workload that is not the one this Deploy placed.
+ *
+ * It carries the **collection** for a reason that outlives this change:
+ * `observe` and `destroy` are handed a ref and nothing else — no Component, no
+ * kind — so the handle is the only thing that can say which API to ask. Which
+ * is also why the ref shape written before jobs existed still parses: every ref
+ * already stored says `services`, and reading the collection out of the ref
+ * rather than deriving it from a kind is what keeps those readable instead of
+ * orphaning every running Service.
  */
-function refOf(connection: CloudRunAdapterConnection, id: string): DeployRef {
-  return `${parentOf(connection)}/services/${id}`;
+function refOf(
+  connection: CloudRunAdapterConnection,
+  collection: Collection,
+  id: string,
+): DeployRef {
+  return `${parentOf(connection)}/${collection}/${id}`;
 }
 
-/** The id this ref names on this connection, or `null` if it names another. */
+/** What this ref names on this connection, or `null` if it names another. */
 function parseRef(
   connection: CloudRunAdapterConnection,
   ref: DeployRef,
-): string | null {
-  const prefix = `${parentOf(connection)}/services/`;
+): { collection: Collection; id: string } | null {
+  const prefix = `${parentOf(connection)}/`;
   if (!ref.startsWith(prefix)) return null;
-  const id = ref.slice(prefix.length);
-  return id.length === 0 || id.includes('/') ? null : id;
+  const [collection, ...rest] = ref.slice(prefix.length).split('/');
+  if (collection !== SERVICES && collection !== JOBS) return null;
+  const id = rest.join('/');
+  return id.length === 0 || id.includes('/') ? null : { collection, id };
 }

--- a/apps/spindrift/src/adapters/deploy/cloudrun/job.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/job.ts
@@ -1,0 +1,94 @@
+/**
+ * `DesiredState` rendered as one Cloud Run Job (§6).
+ *
+ * Written the same way as its neighbour and for the same reason: **core
+ * describes, the adapter renders**, and a pure function returning a plain
+ * object is a document a test can assert whole without a fake API standing by.
+ *
+ * **What a job on this backend is.** A Job resource that exists and is triggered
+ * by nothing. That is the exact analogue of the Kubernetes side, where
+ * `packages/charts/spindrift-app/templates/cronjob.yaml` renders a CronJob with
+ * `suspend: true` and a date that never occurs for an unscheduled job — the
+ * object has to exist for anything to have something to trigger. Cloud Run
+ * reaches the same state by having no scheduler in front of it, because a Job
+ * carries no schedule of its own: firing one is a separate service (**72**) and
+ * running one on demand is a `DeployAdapter` verb that does not exist (**73**).
+ *
+ * **The template nests twice.** `Job.template` is an `ExecutionTemplate` and
+ * `ExecutionTemplate.template` is a `TaskTemplate`; the containers live in the
+ * inner one. A Service nests once, so pointing the Service's shape at a Job
+ * yields `Unknown name "template.containers"` — an error that reads like a
+ * field-name problem and is a nesting problem. `test/harness/fakes/cloudrun-api.ts`
+ * holds the closed Job schema that makes that mistake fail here rather than in
+ * a vessel.
+ *
+ * **Nothing Service-only is rendered.** `ingress`, `containerPort` and the
+ * invoker policy are all answers to "who may reach this", and a Job is reached
+ * by nobody: the resource has no `ingress` member and nothing routes to it. So
+ * a job's `reach` is `none`, which
+ * `ASSERTED_REACHES_BY_ADAPTER.cloudrun` already serves, and the chart says the
+ * same thing one layer over — `spindrift-app.serving` is "a job is the only
+ * workload branch and never serves".
+ */
+import type { DesiredState } from '../../../domain/desired-state.ts';
+import {
+  type CloudRunRenderContext,
+  workloadContainer,
+  workloadLabels,
+} from './service.ts';
+
+/**
+ * How many times the runtime retries a task that exits non-zero.
+ *
+ * Zero, matching the chart's `backoffLimit: 0` on the same Component's CronJob.
+ * The runtime's own default is 3, so leaving this out would mean the same App
+ * retries three times on one backend and not at all on the other — a difference
+ * a developer would meet as their job having run four times.
+ */
+const MAX_RETRIES = 0;
+
+/**
+ * One Job document, ready to be applied.
+ *
+ * The `labels` are the Service's three, for the reason given where they are
+ * built. The Deploy id goes on the **execution template** rather than on the
+ * Job, mirroring where it goes on a Service: it changes every deploy, so it
+ * belongs on the thing that is created anew each time an execution runs, which
+ * is what lets a task be traced back to the Deploy that placed it.
+ *
+ * `binaryAuthorization` is carried on exactly the same condition as a Service's.
+ * The vessel's `run.allowedBinaryAuthorizationPolicies` constraint
+ * (`terraform/gcp/projects/bluenose/policy.tf`) allows `is:default` and nothing
+ * else, "so a deployer cannot opt a service out of verification" — and Cloud
+ * Run applies that constraint to Jobs as well as to Services. A Job that named
+ * no policy would be a Job with none, which is what the constraint exists to
+ * refuse. Declaring it is how this Deploy submits to the check (§16's second
+ * verifier), not how it escapes one.
+ *
+ * `parallelism` and `taskCount` are absent rather than set to 1: those are the
+ * runtime's own defaults, and a value invented here would be core deciding a
+ * workload's shape — the scheduler §3 says placement is not.
+ */
+export function cloudRunJob(
+  desired: DesiredState,
+  context: CloudRunRenderContext,
+): Record<string, unknown> {
+  const labels = workloadLabels(desired);
+
+  return {
+    labels,
+    ...(context.useProjectAdmissionPolicy
+      ? { binaryAuthorization: { useDefault: true } }
+      : {}),
+    template: {
+      labels: { ...labels, 'spindrift-deploy': desired.deploy },
+      template: {
+        ...(context.serviceAccount === null
+          ? {}
+          : { serviceAccount: context.serviceAccount }),
+        containers: [workloadContainer(desired, context)],
+        maxRetries: MAX_RETRIES,
+      },
+    },
+  };
+}

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -261,9 +261,8 @@ const WORKLOAD_ID_LIMIT = 63;
  * One resource per (App, Component), so a re-deploy is a new revision of the
  * same Service, or the same Job with a new template.
  *
- * Shared between the two documents because the id is the *Component's*, not the
- * resource's: a Component that changed kind would otherwise leave the workload
- * it used to be running under a name nothing looks at.
+ * The kind is not part of the name: the collection is part of the ref, so
+ * `jobs/{id}` and `services/{id}` name two resources rather than collide.
  */
 export function workloadId(desired: DesiredState): string {
   return workloadName(desired, WORKLOAD_ID_LIMIT);

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -116,12 +116,7 @@ export function cloudRunService(
   desired: DesiredState,
   context: CloudRunRenderContext,
 ): Record<string, unknown> {
-  const limits = resourceLimits(desired);
-  const labels = {
-    'spindrift-managed': 'true',
-    'spindrift-app': desired.app,
-    'spindrift-component': desired.component,
-  };
+  const labels = workloadLabels(desired);
 
   return {
     labels,
@@ -136,13 +131,50 @@ export function cloudRunService(
         : { serviceAccount: context.serviceAccount }),
       containers: [
         {
-          image: context.image,
+          ...workloadContainer(desired, context),
+          // A Service is contacted; a Job is not. This is the one member of the
+          // container that belongs to only one of the two documents, which is
+          // why it is added here rather than being made optional above.
           ports: [{ containerPort: CONTAINER_PORT }],
-          env: environment(desired.config, context.project),
-          ...(limits === null ? {} : { resources: { limits } }),
         },
       ],
     },
+  };
+}
+
+/**
+ * The three names on every workload this adapter places.
+ *
+ * The same three the Kubernetes adapter puts on its delivery object, and shared
+ * between the two documents this file's neighbour and this one render — a
+ * second copy would be two answers to "which App is this" that could drift.
+ */
+export function workloadLabels(desired: DesiredState): Record<string, string> {
+  return {
+    'spindrift-managed': 'true',
+    'spindrift-app': desired.app,
+    'spindrift-component': desired.component,
+  };
+}
+
+/**
+ * The container both documents carry, with nothing either one adds.
+ *
+ * §4's "build is always separate from deploy" lives here as much as in the
+ * documents: an image, a pinned reference per config key, and a size — nothing
+ * that could cause the runtime to build. Shared rather than written twice
+ * because a Job's container and a Service's container are the same container,
+ * and the one difference between them (`ports`) is the caller's to add.
+ */
+export function workloadContainer(
+  desired: DesiredState,
+  context: CloudRunRenderContext,
+): Record<string, unknown> {
+  const limits = resourceLimits(desired);
+  return {
+    image: context.image,
+    env: environment(desired.config, context.project),
+    ...(limits === null ? {} : { resources: { limits } }),
   };
 }
 
@@ -219,12 +251,20 @@ export function invokerPolicy(
 }
 
 /**
- * The longest name the runtime accepts for a Service — the same ceiling a
- * Kubernetes object name has, which is why both go through one helper.
+ * The longest name the runtime accepts for a Service or a Job — the same
+ * ceiling a Kubernetes object name has, which is why both go through one
+ * helper.
  */
-const SERVICE_ID_LIMIT = 63;
+const WORKLOAD_ID_LIMIT = 63;
 
-/** One Service per (App, Component), so a re-deploy is a new revision. */
-export function serviceId(desired: DesiredState): string {
-  return workloadName(desired, SERVICE_ID_LIMIT);
+/**
+ * One resource per (App, Component), so a re-deploy is a new revision of the
+ * same Service, or the same Job with a new template.
+ *
+ * Shared between the two documents because the id is the *Component's*, not the
+ * resource's: a Component that changed kind would otherwise leave the workload
+ * it used to be running under a name nothing looks at.
+ */
+export function workloadId(desired: DesiredState): string {
+  return workloadName(desired, WORKLOAD_ID_LIMIT);
 }

--- a/apps/spindrift/src/adapters/deploy/cloudrun/status.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/status.ts
@@ -1,5 +1,5 @@
 /**
- * What a Cloud Run Service says, in §6's vocabulary rather than its own.
+ * What a Cloud Run Service or Job says, in §6's vocabulary rather than its own.
  *
  * §6 gives the user **one shared vocabulary** along one timeline, so the
  * runtime's condition states and reason enums never reach core. This is the
@@ -8,20 +8,54 @@
  * where the platform is precise about *why*, and a test should be able to hand
  * them over one at a time.
  *
- * **Status comes from the revision, not from the apply.** A Service accepted by
- * the API has not started anything: `terminalCondition` is what turns pending
- * into a verdict, which is why §6's phases come from the platform and never from
- * core's idea of readiness.
+ * **Status comes from the resource, not from the apply.** A Service accepted by
+ * the API has not started anything and neither has an accepted Job:
+ * `terminalCondition` is what turns pending into a verdict, which is why §6's
+ * phases come from the platform and never from core's idea of readiness. Both
+ * resources report it in the same shape, so one reading serves both — the
+ * documents differ in what they *are*, not in how they say whether they are
+ * ready.
  */
 import type { DeployPhase, FailureReason } from '../contract.ts';
 
-/** The Service fields this adapter reads. Everything else is left alone. */
-export interface CloudRunService {
-  readonly uri?: string;
+/**
+ * What every workload this adapter places says about itself.
+ *
+ * A Service and a Job report readiness identically — one `terminalCondition`
+ * and a list of `conditions`, in the same vocabulary — which is why
+ * {@link cloudRunStatus} takes both and there is no second translation table.
+ * A Job's readiness is its own conditions, not a Service's revisions and
+ * traffic, and this is the part of the Service reading that never depended on
+ * either.
+ */
+export interface CloudRunConditions {
   readonly terminalCondition?: CloudRunCondition;
   readonly conditions?: readonly CloudRunCondition[];
-  readonly template?: {
-    readonly containers?: readonly { readonly image?: string }[];
+}
+
+/** The template both documents end in, whatever they wrap it in. */
+export interface CloudRunTaskTemplate {
+  readonly containers?: readonly { readonly image?: string }[];
+}
+
+/**
+ * The fields this adapter reads back off a Service or a Job.
+ *
+ * One interface rather than two because the difference between the documents is
+ * one level of nesting and one absent field, and both are read by code that has
+ * a ref rather than a kind: `observe` and `destroy` are handed an opaque handle
+ * (§6) and no Component.
+ *
+ * `uri` is a Service's — a Job has no address, and reading it off a Job document
+ * yields `undefined`, which is exactly the answer core wants for something
+ * nothing routes to. `template.template` is a Job's — a Service's
+ * `TaskTemplate` has no such member, which is what makes {@link servingDigest}
+ * able to tell the shapes apart without being told.
+ */
+export interface CloudRunWorkload extends CloudRunConditions {
+  readonly uri?: string;
+  readonly template?: CloudRunTaskTemplate & {
+    readonly template?: CloudRunTaskTemplate;
   };
 }
 
@@ -80,8 +114,8 @@ const REASONS: Readonly<Record<string, FailureReason>> = {
 const SUCCEEDED = 'CONDITION_SUCCEEDED';
 const FAILED = 'CONDITION_FAILED';
 
-/** Translate one Service document into §6's phase and reason. */
-export function cloudRunStatus(service: CloudRunService): CloudRunStatus {
+/** Translate one Service or Job document into §6's phase and reason. */
+export function cloudRunStatus(service: CloudRunConditions): CloudRunStatus {
   const terminal = service.terminalCondition;
   if (terminal === undefined) {
     // Applied, and the runtime has not yet said anything about it.
@@ -128,7 +162,7 @@ export function cloudRunStatus(service: CloudRunService): CloudRunStatus {
 
 /** The first non-terminal condition that is itself failing, for its message. */
 function failingCondition(
-  service: CloudRunService,
+  service: CloudRunConditions,
 ): CloudRunCondition | undefined {
   return (service.conditions ?? []).find(
     (condition) => condition.state === FAILED,
@@ -136,15 +170,24 @@ function failingCondition(
 }
 
 /**
- * The digest actually serving, as the Service still carries it.
+ * The digest actually placed, as the workload still carries it.
  *
- * Read off the template's image rather than off the latest ready revision,
- * because the template is what core wrote and what drift is measured against.
- * An image with no digest yields an empty string, which compares unequal to
- * every desired digest — drift is surfaced rather than assumed away (§6).
+ * Read off the template's image rather than off the latest ready revision or
+ * the latest execution, because the template is what core wrote and what drift
+ * is measured against. An image with no digest yields an empty string, which
+ * compares unequal to every desired digest — drift is surfaced rather than
+ * assumed away (§6).
+ *
+ * **The inner template first, because only a Job has one.** A Service's
+ * `template` is the task template; a Job's `template` is an `ExecutionTemplate`
+ * whose own `template` is. A `TaskTemplate` has no `template` member at all, so
+ * the inner read is present exactly when the document is a Job — which is why
+ * this needs no kind handed to it, and why `observe` can answer a ref whose
+ * collection it has only just parsed.
  */
-export function servingDigest(service: CloudRunService): string {
-  const image = service.template?.containers?.[0]?.image ?? '';
+export function servingDigest(workload: CloudRunWorkload): string {
+  const template = workload.template?.template ?? workload.template;
+  const image = template?.containers?.[0]?.image ?? '';
   const at = image.lastIndexOf('@');
   return at === -1 ? '' : image.slice(at + 1);
 }

--- a/apps/spindrift/src/commands/apps/resolve-placement.ts
+++ b/apps/spindrift/src/commands/apps/resolve-placement.ts
@@ -98,6 +98,7 @@ export const resolveComponentPlacement: Command<
     component.kind,
     component.reach,
     component.auth,
+    component.schedule,
     [
       ...attached.map(
         (datastore): RequiredDatastore => ({
@@ -163,18 +164,24 @@ export const resolveComponentPlacement: Command<
  * Target for a requirement nothing has actually established. The three
  * requirements that *are* known at this point — kind, exposure, and attached
  * Datastores — are the three §3 and §11 name as decisive.
+ *
+ * A job's `schedule` joins them: it is authored, not detected, and a Target
+ * with nothing to fire it on that cadence is a non-candidate rather than a
+ * Deploy that is refused after a build.
  */
 function derive(
   context: CommandContext,
   kind: DerivedRequirements['kind'],
   reach: Reach,
   auth: Auth,
+  schedule: string | null,
   attached: readonly RequiredDatastore[],
 ): DerivedRequirements {
   return {
     kind,
     reach,
     auth,
+    ...(schedule === null ? {} : { schedule }),
     platform: DEFAULT_PLATFORM,
     registries: context.manifest.supplyChain.registry,
     resources: {},

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -236,6 +236,7 @@ export function deployPathReferences(
 export interface TargetCapabilities {
   // From the adapter type.
   kinds: readonly ComponentKind[];
+  firesSchedules: boolean;
   artifactTypes: readonly ArtifactType[];
 
   // Discovered.
@@ -278,16 +279,37 @@ export interface TargetCapabilities {
  *
  * Two things a job here does not have, and each is a filed ticket rather than
  * a silence: **a schedule**, which needs Cloud Scheduler standing in front of
- * the Job and an API this vessel has not enabled (**72**) — the adapter refuses
- * a schedule at apply rather than dropping it — and **an on-demand run**, which
- * needs a verb `DeployAdapter` does not have and every adapter would have to
- * answer (**73**).
+ * the Job and an API this vessel has not enabled (**72**) and is therefore a
+ * non-candidate at Place — see {@link FIRES_SCHEDULES_BY_ADAPTER} — and **an
+ * on-demand run**, which needs a verb `DeployAdapter` does not have and every
+ * adapter would have to answer (**73**).
  */
 export const KINDS_BY_ADAPTER = {
   kubernetes: ['service', 'website', 'job'],
   cloudrun: ['service', 'website', 'job'],
   static: ['website'],
 } as const satisfies Record<TargetAdapter, readonly ComponentKind[]>;
+
+/**
+ * Which adapters fire a job at the times its `schedule` names.
+ *
+ * From the adapter type for the same reason {@link KINDS_BY_ADAPTER} is: what
+ * the code driving the Target renders. The App chart renders a CronJob, and the
+ * cluster's own controller fires it. Cloud Run's Job resource carries no cron
+ * expression at all — firing one is Cloud Scheduler standing in front of it,
+ * which needs an API this vessel has not enabled and an invoker binding nothing
+ * creates (**72**).
+ *
+ * It is a row of its own rather than a second kind because the *kind* is
+ * rendered here and the *schedule* is not: §3's grammar refuses a scheduled job
+ * at Place with a sentence saying which of the two is missing, so a developer
+ * hears it before a build rather than after one.
+ */
+export const FIRES_SCHEDULES_BY_ADAPTER = {
+  kubernetes: true,
+  cloudrun: false,
+  static: false,
+} as const satisfies Record<TargetAdapter, boolean>;
 
 /**
  * What each adapter serves before an operator asserts anything.
@@ -400,6 +422,7 @@ export function resolveCapabilities(
 ): TargetCapabilities {
   return {
     kinds: KINDS_BY_ADAPTER[context.adapter],
+    firesSchedules: FIRES_SCHEDULES_BY_ADAPTER[context.adapter],
     artifactTypes: context.artifactTypes,
 
     arch: discovery.arch,

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -269,17 +269,23 @@ export interface TargetCapabilities {
  * *mean* public" (§13) a consequence of the model rather than a rule bolted on
  * top of it.
  *
- * **`cloudrun` runs no job yet**, and that is this table's honest reading
- * rather than a disagreement with §3. A job on this backend is a second
- * resource with its own API and a schedule that lives in a separate scheduling
- * service — Task 33's work, not the Service path Task 28 built. Until it
- * exists, a job's placement here is a non-candidate with the sentence "this
- * Target does not run jobs" (§3's grammar), which is refused at Place rather
- * than accepted and failed at apply.
+ * **A job on `cloudrun` is a Job resource that exists and is triggered by
+ * nothing**, which is the same thing a job is on `kubernetes`: the App chart
+ * renders an unscheduled job as a *suspended* CronJob, because the object has
+ * to exist for anything to have something to trigger. Cloud Run reaches that
+ * state by having no scheduler in front of the Job rather than by suspending
+ * it, since a Job carries no schedule of its own.
+ *
+ * Two things a job here does not have, and each is a filed ticket rather than
+ * a silence: **a schedule**, which needs Cloud Scheduler standing in front of
+ * the Job and an API this vessel has not enabled (**72**) — the adapter refuses
+ * a schedule at apply rather than dropping it — and **an on-demand run**, which
+ * needs a verb `DeployAdapter` does not have and every adapter would have to
+ * answer (**73**).
  */
 export const KINDS_BY_ADAPTER = {
   kubernetes: ['service', 'website', 'job'],
-  cloudrun: ['service', 'website'],
+  cloudrun: ['service', 'website', 'job'],
   static: ['website'],
 } as const satisfies Record<TargetAdapter, readonly ComponentKind[]>;
 

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -392,11 +392,22 @@ function fits(asked: string | undefined, ceiling: string | undefined): boolean {
  * — a deploy that re-ran the whole of `exclusionsFor` would newly refuse an
  * UNHEALTHY Target, which is exactly the rollback `deploys/rollback.ts` exists
  * to keep possible during an incident.
+ *
+ * **A job joins on neither**, because nothing routes to one and nothing stands
+ * in front of one. Both renderers say so: the App chart's `serving` helper is
+ * "a job is the only workload branch and never serves", so a job gets no
+ * Service, no HTTPRoute and no DNSEndpoint whatever its reach, and a Cloud Run
+ * Job document has no `ingress` member and no invoker policy. Judging a job by
+ * the reach column it carries would decide candidacy on a field its rendering
+ * ignores — refusing a Target that will run it perfectly well, or worse,
+ * *offering* one on the strength of a public address nothing will publish.
  */
 export function reachExclusions(
   can: Pick<TargetCapabilities, 'reaches' | 'authReaches'>,
-  requirements: Pick<DerivedRequirements, 'reach' | 'auth'>,
+  requirements: Pick<DerivedRequirements, 'kind' | 'reach' | 'auth'>,
 ): readonly Exclusion[] {
+  if (requirements.kind === 'job') return [];
+
   const reasons: Exclusion[] = [];
   if (!can.reaches.includes(requirements.reach)) {
     reasons.push('REACH_UNSUPPORTED');
@@ -426,8 +437,13 @@ export function exclusionsFor(
 
   // A route needs something to attach to. Without this the Deploy goes green
   // with `parentRefs` naming a Gateway that is the empty string, which is a
-  // route attached to nothing and a URL that answers nothing.
-  if (requirements.reach !== 'none' && !target.routesAttachTo) {
+  // route attached to nothing and a URL that answers nothing. A job renders no
+  // route to attach, for the reason {@link reachExclusions} gives.
+  if (
+    requirements.kind !== 'job' &&
+    requirements.reach !== 'none' &&
+    !target.routesAttachTo
+  ) {
     reasons.push('NO_GATEWAY');
   }
 

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -66,6 +66,7 @@ export const EXCLUSIONS = [
   'REACH_UNSUPPORTED',
   'AUTH_UNSUPPORTED',
   'NO_GATEWAY',
+  'NO_SCHEDULER',
   'ARCH_UNSUPPORTED',
   'RESOURCES_EXCEED_CEILING',
   'NO_GPU',
@@ -117,6 +118,12 @@ export interface DerivedRequirements {
   readonly kind: ComponentKind;
   readonly reach: Reach;
   readonly auth: Auth;
+  /**
+   * §2: "`schedule` is a field on a job, not a kind." Absent means unscheduled,
+   * which every backend that runs a job can honour; present names a cadence
+   * something has to keep, and not every backend has anything that keeps one.
+   */
+  readonly schedule?: string;
   readonly platform: Platform;
   readonly resources: Resources;
   readonly gpu: boolean;
@@ -301,6 +308,8 @@ export function sentence(
         : 'this Target has no authenticated edge to put in front of this Component';
     case 'NO_GATEWAY':
       return 'this Target names no gateway for a route to attach to';
+    case 'NO_SCHEDULER':
+      return 'this Target runs a job but has nothing to fire it on a schedule';
     case 'ARCH_UNSUPPORTED':
       return `this Target does not run ${requirements.platform.arch}`;
     case 'RESOURCES_EXCEED_CEILING':
@@ -392,22 +401,11 @@ function fits(asked: string | undefined, ceiling: string | undefined): boolean {
  * — a deploy that re-ran the whole of `exclusionsFor` would newly refuse an
  * UNHEALTHY Target, which is exactly the rollback `deploys/rollback.ts` exists
  * to keep possible during an incident.
- *
- * **A job joins on neither**, because nothing routes to one and nothing stands
- * in front of one. Both renderers say so: the App chart's `serving` helper is
- * "a job is the only workload branch and never serves", so a job gets no
- * Service, no HTTPRoute and no DNSEndpoint whatever its reach, and a Cloud Run
- * Job document has no `ingress` member and no invoker policy. Judging a job by
- * the reach column it carries would decide candidacy on a field its rendering
- * ignores — refusing a Target that will run it perfectly well, or worse,
- * *offering* one on the strength of a public address nothing will publish.
  */
 export function reachExclusions(
   can: Pick<TargetCapabilities, 'reaches' | 'authReaches'>,
-  requirements: Pick<DerivedRequirements, 'kind' | 'reach' | 'auth'>,
+  requirements: Pick<DerivedRequirements, 'reach' | 'auth'>,
 ): readonly Exclusion[] {
-  if (requirements.kind === 'job') return [];
-
   const reasons: Exclusion[] = [];
   if (!can.reaches.includes(requirements.reach)) {
     reasons.push('REACH_UNSUPPORTED');
@@ -435,15 +433,20 @@ export function exclusionsFor(
 
   reasons.push(...reachExclusions(can, requirements));
 
+  // The kind is rendered here and the schedule is not, so this is its own
+  // reason rather than KIND_UNSUPPORTED: Cloud Run runs the Job and has nothing
+  // to fire it, and saying "this Target does not run jobs" would be false in
+  // the sentence a developer reads. Refused at Place because §3 refuses a
+  // non-candidate there — the alternative is a build and a Deploy that end in
+  // the adapter's REJECTED.
+  if (requirements.schedule !== undefined && !can.firesSchedules) {
+    reasons.push('NO_SCHEDULER');
+  }
+
   // A route needs something to attach to. Without this the Deploy goes green
   // with `parentRefs` naming a Gateway that is the empty string, which is a
-  // route attached to nothing and a URL that answers nothing. A job renders no
-  // route to attach, for the reason {@link reachExclusions} gives.
-  if (
-    requirements.kind !== 'job' &&
-    requirements.reach !== 'none' &&
-    !target.routesAttachTo
-  ) {
+  // route attached to nothing and a URL that answers nothing.
+  if (requirements.reach !== 'none' && !target.routesAttachTo) {
     reasons.push('NO_GATEWAY');
   }
 

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -439,7 +439,16 @@ export function exclusionsFor(
   // the sentence a developer reads. Refused at Place because §3 refuses a
   // non-candidate there — the alternative is a build and a Deploy that end in
   // the adapter's REJECTED.
-  if (requirements.schedule !== undefined && !can.firesSchedules) {
+  //
+  // Gated on the kind for the same reason it exists at all. Its sentence opens
+  // by granting that this Target "runs a job", so on a Target that renders none
+  // — `static` — it would sit beside KIND_UNSUPPORTED contradicting it on one
+  // row. A reason speaks only where its own sentence is true.
+  if (
+    requirements.schedule !== undefined &&
+    can.kinds.includes(requirements.kind) &&
+    !can.firesSchedules
+  ) {
     reasons.push('NO_SCHEDULER');
   }
 

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -22,6 +22,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { CloudRunDeployAdapter } from '../../src/adapters/deploy/cloudrun/index.ts';
+import { cloudRunJob } from '../../src/adapters/deploy/cloudrun/job.ts';
 import {
   cloudRunService,
   INGRESS,
@@ -643,6 +644,218 @@ describe('the reach a Target rejects is a state, not a crash', () => {
       });
       expect(document.ingress).toBe(ingressFor(reach));
     }
+  });
+});
+
+describe('§3: a job is a Job that exists and is triggered by nothing', () => {
+  /** A job, with the only reach nothing routing to it can honestly claim. */
+  const job = (overrides: Partial<DesiredState> = {}) =>
+    desired({
+      component: 'nightly',
+      kind: 'job',
+      reach: 'none',
+      auth: 'none',
+      ...overrides,
+    });
+
+  const RENDER = {
+    project: 'example-vessel',
+    image: 'registry.example.test/shop@sha256:abc',
+    serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
+    useProjectAdmissionPolicy: true,
+  };
+
+  test('the whole document is the doubled template and nothing else', () => {
+    // Asserted whole rather than field by field, the way the Service document
+    // is: what makes this document right is as much what is absent from it as
+    // what is in it, and only an exact comparison sees an absence.
+    expect(
+      cloudRunJob(
+        job({
+          config: [
+            {
+              name: 'TOKEN',
+              secret: { key: 'shop-nightly-token', version: '3' },
+            },
+          ],
+          requirements: {
+            platform: { os: 'linux', arch: 'amd64' },
+            resources: { cpu: '1', memory: '512Mi' },
+          },
+        }),
+        RENDER,
+      ),
+    ).toEqual({
+      labels: {
+        'spindrift-managed': 'true',
+        'spindrift-app': 'shop',
+        'spindrift-component': 'nightly',
+      },
+      binaryAuthorization: { useDefault: true },
+      template: {
+        labels: {
+          'spindrift-managed': 'true',
+          'spindrift-app': 'shop',
+          'spindrift-component': 'nightly',
+          'spindrift-deploy': 'deploy-1',
+        },
+        // `Job.template` is an ExecutionTemplate; its own `template` is the
+        // TaskTemplate. A Service nests once, and rendering that shape here
+        // produces an error that reads like a field-name problem.
+        template: {
+          serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
+          containers: [
+            {
+              image: 'registry.example.test/shop@sha256:abc',
+              env: [
+                {
+                  name: 'TOKEN',
+                  valueSource: {
+                    secretKeyRef: {
+                      secret:
+                        'projects/example-vessel/secrets/shop-nightly-token',
+                      version: '3',
+                    },
+                  },
+                },
+              ],
+              resources: { limits: { cpu: '1', memory: '512Mi' } },
+            },
+          ],
+          // The chart's `backoffLimit: 0` on the same Component's CronJob. The
+          // runtime's own default is 3, so leaving it out would mean one App
+          // retrying on one backend and not on the other.
+          maxRetries: 0,
+        },
+      },
+    });
+  });
+
+  test('nothing that answers "who may reach this" is rendered or written', async () => {
+    // `ingress`, a container port and the invoker policy are all Service
+    // concepts: the Job resource has no `ingress` member, nothing routes to a
+    // Job, and nothing invokes one. The fake's closed Job schema refuses the
+    // first two; the request log is what proves the third never happened.
+    const document = cloudRunJob(job(), RENDER);
+    expect(document).not.toHaveProperty('ingress');
+    expect(JSON.stringify(document)).not.toContain('containerPort');
+
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), job()));
+    expect(verdict.phase).toBe('LIVE');
+    expect(
+      api.requests.filter((request) => request.path.endsWith(':setIamPolicy')),
+    ).toEqual([]);
+  });
+
+  test('the runtime accepts it, and reports no address for it', async () => {
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), job()));
+
+    expect(api.job('shop-nightly')).toBeDefined();
+    expect(api.service('shop-nightly')).toBeUndefined();
+    expect(verdict.phase).toBe('LIVE');
+    // §9: core mints nothing. A Job has no `uri` member at all, so the absence
+    // here is the platform saying there is no address rather than core
+    // declining to invent one.
+    if (verdict.phase === 'LIVE') expect(verdict.url).toBeUndefined();
+  });
+
+  test('the Service nesting would be refused by the API, not silently taken', async () => {
+    // The negative half of the first test. Google's protobuf-JSON parsers
+    // reject an unknown member, so a renderer that nested once would fail at
+    // apply with a message about a *name* rather than about a shape — which is
+    // why the fake carries a closed Job schema rather than a `Map.set`.
+    const { api } = adapterFor();
+    const response = await api.fetch(
+      new Request(
+        `${api.endpoint}/v2/projects/example-vessel/locations/somewhere/jobs/shop-nightly?allowMissing=true`,
+        {
+          method: 'PATCH',
+          headers: { authorization: `Bearer ${api.token()}` },
+          body: JSON.stringify({ template: { containers: [{ image: 'x' }] } }),
+        },
+      ),
+    );
+    expect(response.status).toBe(400);
+    const refusal = (await response.json()) as { error: { message: string } };
+    expect(refusal.error.message).toContain(
+      'Unknown name "template.containers"',
+    );
+  });
+
+  test('a schedule is refused rather than dropped', async () => {
+    // A Cloud Run Job carries no schedule, and nothing in this vessel fires one
+    // (**72**). Rendering the Job and saying nothing would leave a Component
+    // reporting LIVE on a cadence nothing keeps — the same failure shape as a
+    // declared change that reaches storage and never reaches what acts on it.
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(
+      adapter.apply(target(), job({ schedule: '0 3 * * *' })),
+    );
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('REJECTED');
+      expect(blameFor(verdict.reason)).toBe('developer');
+      expect(verdict.detail).toContain('schedule');
+    }
+    // Nothing was placed: a refusal that had already written the Job would be
+    // the silent drop wearing an error message.
+    expect(
+      api.requests.filter((request) => request.method === 'PATCH'),
+    ).toEqual([]);
+  });
+});
+
+describe('the ref an adapter hands back names its own collection', () => {
+  const job = () =>
+    desired({ component: 'nightly', kind: 'job', reach: 'none', auth: 'none' });
+
+  /** The shape of every ref written before jobs existed. */
+  const LEGACY_SERVICE_REF =
+    'projects/example-vessel/locations/somewhere/services/shop-web';
+
+  test('a job round-trips through observe and destroy', async () => {
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), job()));
+    expect(verdict.ref).toBe(
+      'projects/example-vessel/locations/somewhere/jobs/shop-nightly',
+    );
+
+    const observed = await adapter.observe(target(), verdict.ref as string);
+    expect(observed?.phase).toBe('LIVE');
+    expect(observed?.artifactDigest).toBe('sha256:abc');
+
+    await adapter.destroy(target(), verdict.ref as string);
+    expect(api.job('shop-nightly')).toBeUndefined();
+  });
+
+  test('a Service ref written before jobs existed still round-trips', async () => {
+    // Every ref in the database today says `services`. `observe` and `destroy`
+    // are handed one with no kind beside it, so a parser that had learned only
+    // `/jobs/` would orphan every running Service — nothing would read it and
+    // nothing would delete it.
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desired()));
+    expect(verdict.ref).toBe(LEGACY_SERVICE_REF);
+
+    const observed = await adapter.observe(target(), LEGACY_SERVICE_REF);
+    expect(observed?.phase).toBe('LIVE');
+    expect(observed?.artifactDigest).toBe('sha256:abc');
+
+    await adapter.destroy(target(), LEGACY_SERVICE_REF);
+    expect(api.service('shop-web')).toBeUndefined();
+  });
+
+  test('a collection this adapter does not place into is not a ref', async () => {
+    const { adapter } = adapterFor();
+    await drain(adapter.apply(target(), desired()));
+    expect(
+      await adapter.observe(
+        target(),
+        'projects/example-vessel/locations/somewhere/executions/shop-web',
+      ),
+    ).toBeNull();
   });
 });
 

--- a/apps/spindrift/test/commands/placement.test.ts
+++ b/apps/spindrift/test/commands/placement.test.ts
@@ -179,11 +179,23 @@ describe('resolution is derived, and it is a query', () => {
 
   test('nowhere fits is returned, with a reason for every Target', async () => {
     const registry = fakes();
-    await connectEverything(registry);
-    const { component } = await seedComponent('job', 'public', 'none');
+    const connected = await connectEverything(registry);
+    const { app, component } = await seedComponent('service', 'public', 'none');
 
-    // A public job: the cluster runs jobs and has no public reach, and neither
-    // cloud backend runs a job at all. Every row has a reason.
+    // A public service with a cluster-local Datastore attached: the cluster
+    // hosts the Datastore and has no public reach, and the two cloud Targets
+    // serve the public and cannot reach a Datastore that stays where it is
+    // (§11). Two facts pulling opposite ways, so every row has a reason.
+    await database()
+      .db.insert(datastores)
+      .values({
+        name: 'primary',
+        engine: 'postgres',
+        provenance: 'managed',
+        appId: app.id,
+        targetId: connected.get('cluster')!.id,
+      });
+
     const placement = await place(registry, component.id);
     expect(placement.suggestedTargetId).toBeNull();
     expect(placement.options.every((option) => !option.candidate)).toBe(true);

--- a/apps/spindrift/test/commands/placement.test.ts
+++ b/apps/spindrift/test/commands/placement.test.ts
@@ -95,6 +95,7 @@ async function seedComponent(
   kind: ComponentKind = 'service',
   reach: Component['reach'] = 'private',
   auth: Component['auth'] = 'proxy',
+  schedule: string | null = null,
 ) {
   const db = database().db;
   const [app] = await db
@@ -103,7 +104,7 @@ async function seedComponent(
     .returning();
   const [component] = await db
     .insert(components)
-    .values({ appId: app!.id, name: 'web', kind, reach, auth })
+    .values({ appId: app!.id, name: 'web', kind, reach, auth, schedule })
     .returning();
   return { app: app!, component: component! };
 }
@@ -175,6 +176,32 @@ describe('resolution is derived, and it is a query', () => {
     const run = placement.options.find((o) => o.name === 'vessel-cloudrun')!;
     expect(run.candidate).toBe(true);
     expect(run.artifactType).toBe('image');
+  });
+
+  test("a job's schedule is derived, and refuses the backend that fires none", async () => {
+    const registry = fakes();
+    await connectEverything(registry);
+    const { component } = await seedComponent(
+      'job',
+      'none',
+      'none',
+      '0 3 * * *',
+    );
+
+    // The Cloud Run adapter renders the Job and nothing fires it, so the
+    // schedule is what excludes it — and it is excluded here rather than after
+    // a build, which is what §3 puts resolution before the build for.
+    const placement = await place(registry, component.id);
+    const run = placement.options.find((o) => o.name === 'vessel-cloudrun')!;
+    expect(run.candidate).toBe(false);
+    expect(run.reasons).toEqual(['NO_SCHEDULER']);
+    expect(run.detail).toEqual([
+      'this Target runs a job but has nothing to fire it on a schedule',
+    ]);
+    // The cluster's own controller fires the CronJob the chart renders.
+    expect(placement.suggestedTargetId).toBe(
+      placement.options.find((o) => o.name === 'cluster')!.targetId,
+    );
   });
 
   test('nowhere fits is returned, with a reason for every Target', async () => {

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -504,6 +504,17 @@ describe('§3: a kind an adapter does not render is refused at Place', () => {
     expect(exclusionsFor(target({ adapter: 'kubernetes' }), scheduled)).toEqual(
       [],
     );
+    // A backend that renders no job at all says so once. NO_SCHEDULER's
+    // sentence opens by granting that this Target runs a job, so beside
+    // KIND_UNSUPPORTED it would contradict it on a single row — and
+    // `bluenose-static` is a connected Target, so that is a row a developer
+    // reads rather than a shape only a test constructs.
+    // REACH_UNSUPPORTED rides along because `static` serves only `public`;
+    // what matters is that NO_SCHEDULER is not the third.
+    expect(exclusionsFor(target({ adapter: 'static' }), scheduled)).toEqual([
+      'KIND_UNSUPPORTED',
+      'REACH_UNSUPPORTED',
+    ]);
   });
 
   test('a service and a website are both rendered there', () => {

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -470,14 +470,44 @@ describe('§10: the reach rule does not bind a website', () => {
 });
 
 describe('§3: a kind an adapter does not render is refused at Place', () => {
-  test('a job is a non-candidate on the cloud runtime, with the reason', () => {
-    // `KINDS_BY_ADAPTER` is "a property of the code": the Cloud Run adapter
-    // renders Services, and a job there is Task 33's work. Until it exists the
-    // honest answer is a non-candidate with a stated reason, which fails at
-    // Place rather than at apply.
+  test('a job is a candidate on the cloud runtime', () => {
+    // `KINDS_BY_ADAPTER` is "a property of the code", and the Cloud Run adapter
+    // now renders a Job as well as a Service. A job reaches `none` because
+    // nothing routes to one — which is what the adapter renders, and what the
+    // App chart's `serving` helper says one layer over.
     const cloud = target({ adapter: 'cloudrun' });
-    const reasons = exclusionsFor(cloud, requirements({ kind: 'job' }));
-    expect(reasons).toContain('KIND_UNSUPPORTED');
+    expect(
+      exclusionsFor(
+        cloud,
+        requirements({ kind: 'job', reach: 'none', auth: 'none' }),
+      ),
+    ).toEqual([]);
+  });
+
+  test('a job is judged on neither the reach nor the auth it carries', () => {
+    // Nothing routes to a job on either backend that runs one, so the reach
+    // column has no effect on what is rendered — the App chart's `serving`
+    // helper and the Cloud Run Job document both say so. Judging candidacy on
+    // it would refuse a Target that runs the job perfectly well, and the
+    // Component's reach defaults to `private`.
+    const cloud = target({ adapter: 'cloudrun' });
+    const cluster = target({ adapter: 'kubernetes' });
+    for (const reach of ['none', 'private', 'public'] as const) {
+      expect(
+        exclusionsFor(cloud, requirements({ kind: 'job', reach })),
+      ).toEqual([]);
+      expect(
+        exclusionsFor(cluster, requirements({ kind: 'job', reach })),
+      ).toEqual([]);
+    }
+    // And not because a job stopped needing a gateway that is there: it never
+    // renders a route to attach to one.
+    expect(
+      exclusionsFor(
+        target({ adapter: 'kubernetes', routesAttachTo: false }),
+        requirements({ kind: 'job', reach: 'public' }),
+      ),
+    ).toEqual([]);
   });
 
   test('a service and a website are both rendered there', () => {

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -484,30 +484,26 @@ describe('§3: a kind an adapter does not render is refused at Place', () => {
     ).toEqual([]);
   });
 
-  test('a job is judged on neither the reach nor the auth it carries', () => {
-    // Nothing routes to a job on either backend that runs one, so the reach
-    // column has no effect on what is rendered — the App chart's `serving`
-    // helper and the Cloud Run Job document both say so. Judging candidacy on
-    // it would refuse a Target that runs the job perfectly well, and the
-    // Component's reach defaults to `private`.
+  test('a schedule nothing fires is refused at Place, and only a schedule', () => {
+    // The kind is rendered on this backend and the schedule is not, so the
+    // refusal is its own reason and lands at Place — a scheduled job accepted
+    // here would be refused by the adapter after a build and a Deploy, which is
+    // the direction §3 exists to prevent.
     const cloud = target({ adapter: 'cloudrun' });
-    const cluster = target({ adapter: 'kubernetes' });
-    for (const reach of ['none', 'private', 'public'] as const) {
-      expect(
-        exclusionsFor(cloud, requirements({ kind: 'job', reach })),
-      ).toEqual([]);
-      expect(
-        exclusionsFor(cluster, requirements({ kind: 'job', reach })),
-      ).toEqual([]);
-    }
-    // And not because a job stopped needing a gateway that is there: it never
-    // renders a route to attach to one.
-    expect(
-      exclusionsFor(
-        target({ adapter: 'kubernetes', routesAttachTo: false }),
-        requirements({ kind: 'job', reach: 'public' }),
-      ),
-    ).toEqual([]);
+    const unscheduled = requirements({
+      kind: 'job',
+      reach: 'none',
+      auth: 'none',
+    });
+    const scheduled = { ...unscheduled, schedule: '0 3 * * *' };
+
+    expect(exclusionsFor(cloud, scheduled)).toEqual(['NO_SCHEDULER']);
+    expect(exclusionsFor(cloud, unscheduled)).toEqual([]);
+    // The cluster's own controller fires the CronJob the chart renders, so the
+    // same Component is a candidate there.
+    expect(exclusionsFor(target({ adapter: 'kubernetes' }), scheduled)).toEqual(
+      [],
+    );
   });
 
   test('a service and a website are both rendered there', () => {

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -18,9 +18,11 @@
  *   polled pass, which is the whole of `apply`'s second half.
  * - **A document carrying a field the v2 schema does not define is refused.**
  *   Google's protobuf-JSON parsers reject unknown members with `400
- *   INVALID_ARGUMENT`, and the rendered Service is the single document
- *   standing between this product and a Cloud Run deploy — a `Map.set` is not
- *   a check.
+ *   INVALID_ARGUMENT`, and the rendered document is the single thing standing
+ *   between this product and a Cloud Run deploy — a `Map.set` is not a check.
+ *   There is a schema per collection, and they differ in the ways that bite: a
+ *   `Job` has no `ingress`, and it wraps its container one level deeper than a
+ *   `Service` does.
  * - **A refusal carries a body with a machine-readable reason**, because the
  *   checklist tells "the service is off" from "you may not" from "there is no
  *   such project" by exactly that, and a bare status code would leave nothing to
@@ -151,6 +153,62 @@ const SERVICE_SCHEMA: ServiceSchema = {
 };
 
 /**
+ * `TaskTemplate` — the inner half of a Job's doubled template.
+ *
+ * The container is the same message a revision holds, which is the point: the
+ * two documents differ in how deeply they wrap it and in nothing else. Note
+ * what is *not* here that `REVISION_TEMPLATE` has — `scaling`, `revision`,
+ * `sessionAffinity`, `healthCheckDisabled` — and note that `Job` has no
+ * `ingress` at all. Those absences are the whole value of a closed schema: a
+ * renderer that reached for a Service concept is refused here rather than in a
+ * vessel.
+ */
+const TASK_TEMPLATE: ServiceSchema = {
+  containers: [CONTAINER],
+  volumes: true,
+  maxRetries: true,
+  timeout: true,
+  serviceAccount: true,
+  executionEnvironment: true,
+  encryptionKey: true,
+  vpcAccess: true,
+  nodeSelector: true,
+  gpuZonalRedundancyDisabled: true,
+};
+
+/** `ExecutionTemplate` — the outer half, which holds no container itself. */
+const EXECUTION_TEMPLATE: ServiceSchema = {
+  labels: true,
+  annotations: true,
+  parallelism: true,
+  taskCount: true,
+  template: TASK_TEMPLATE,
+  client: true,
+  clientVersion: true,
+};
+
+const JOB_SCHEMA: ServiceSchema = {
+  name: true,
+  uid: true,
+  generation: true,
+  labels: true,
+  annotations: true,
+  client: true,
+  clientVersion: true,
+  launchStage: true,
+  binaryAuthorization: true,
+  template: EXECUTION_TEMPLATE,
+  startExecutionToken: true,
+  runExecutionToken: true,
+};
+
+/** The two collections a v2 path can name, and what each one accepts. */
+const SCHEMAS: Record<string, ServiceSchema> = {
+  services: SERVICE_SCHEMA,
+  jobs: JOB_SCHEMA,
+};
+
+/**
  * The first member the document names that the schema does not, if any.
  *
  * Reported by path rather than by name alone, because "Unknown name `foo`" in
@@ -241,9 +299,15 @@ export class FakeCloudRun {
   /** Every Operation a write answered with, in order — what a poll would use. */
   readonly operations: { name: string; done: boolean }[] = [];
 
-  /** Services this project holds, by id. */
-  private readonly services = new Map<string, Record<string, unknown>>();
-  /** Invoker policies, by service id — the assertion surface for exposure. */
+  /**
+   * What this project holds, by `<collection>/<id>`.
+   *
+   * Keyed by both because a Service and a Job may share a name: they are
+   * separate collections in the same project, and a fake that collapsed them
+   * would hide exactly the case `parseRef` exists to get right.
+   */
+  private readonly resources = new Map<string, Record<string, unknown>>();
+  /** Invoker policies, by `<collection>/<id>` — the surface for exposure. */
   private readonly policies = new Map<string, unknown>();
   private readonly reads = new Map<string, number>();
   /** Reads a just-created Service still owes before it can be seen. */
@@ -268,12 +332,17 @@ export class FakeCloudRun {
 
   /** What the project holds now — the assertion surface for a write. */
   service(id: string): Record<string, unknown> | undefined {
-    return this.services.get(id);
+    return this.resources.get(`services/${id}`);
+  }
+
+  /** The same, for the other collection. */
+  job(id: string): Record<string, unknown> | undefined {
+    return this.resources.get(`jobs/${id}`);
   }
 
   /** The invoker policy written for one Service, if any was. */
   policy(id: string): unknown {
-    return this.policies.get(id);
+    return this.policies.get(`services/${id}`);
   }
 
   /** Requests the adapter made, in order — what § Seam 2 asserts on. */
@@ -304,14 +373,27 @@ export class FakeCloudRun {
       return this.admissionResponse();
     }
 
-    const parent = `/v2/projects/${this.project}/locations/${this.region}/services`;
+    const parent = `/v2/projects/${this.project}/locations/${this.region}/`;
     if (!url.pathname.startsWith(parent)) {
       return json(404, {
         error: { message: 'no such path', status: 'NOT_FOUND' },
       });
     }
 
-    const rest = url.pathname.slice(parent.length).replace(/^\//, '');
+    // The collection is part of the path rather than a mode this fake is put
+    // into, because that is what it is on the real API — and because a ref that
+    // named the wrong one has to reach a 404 here rather than silently reading
+    // the other collection's resource of the same name.
+    const [collection, ...segments] = url.pathname
+      .slice(parent.length)
+      .split('/');
+    if (collection === undefined || SCHEMAS[collection] === undefined) {
+      return json(404, {
+        error: { message: 'no such collection', status: 'NOT_FOUND' },
+      });
+    }
+
+    const rest = segments.join('/');
     if (rest === '') {
       if (this.options.refuseList !== undefined) {
         return json(
@@ -319,33 +401,40 @@ export class FakeCloudRun {
           this.options.refuseList.body,
         );
       }
-      return json(200, { services: [...this.services.values()] });
+      return json(200, { [collection]: [...this.held(collection)] });
     }
 
-    const [id, verb] = rest.split(':', 2);
-    if (id === undefined || id === '') return json(404, notFound());
+    const [name, verb] = rest.split(':', 2);
+    if (name === undefined || name === '') return json(404, notFound());
+    const key = `${collection}/${name}`;
 
     if (verb === 'setIamPolicy') {
       if (this.options.refuseIam !== undefined) {
         return json(this.options.refuseIam.status, this.options.refuseIam.body);
       }
-      if (!this.services.has(id)) return json(404, notFound());
-      this.policies.set(id, body);
+      if (!this.resources.has(key)) return json(404, notFound());
+      this.policies.set(key, body);
       return json(200, (body as { policy?: unknown })?.policy ?? {});
     }
 
     switch (request.method) {
       case 'GET':
-        return this.readResponse(id);
+        return this.readResponse(key);
       case 'PATCH':
-        return this.applyResponse(url, id, body as Record<string, unknown>);
+        return this.applyResponse(
+          url,
+          collection,
+          key,
+          name,
+          body as Record<string, unknown>,
+        );
       case 'DELETE':
-        if (!this.services.has(id)) return json(404, notFound());
-        this.services.delete(id);
-        this.policies.delete(id);
-        this.reads.delete(id);
-        this.creating.delete(id);
-        return json(200, this.operation(id, true));
+        if (!this.resources.has(key)) return json(404, notFound());
+        this.resources.delete(key);
+        this.policies.delete(key);
+        this.reads.delete(key);
+        this.creating.delete(key);
+        return json(200, this.operation(name, true));
       default:
         return json(405, {
           error: { message: `${request.method} is not supported` },
@@ -353,36 +442,45 @@ export class FakeCloudRun {
     }
   };
 
+  /** Everything stored in one collection. */
+  private held(collection: string): Record<string, unknown>[] {
+    return [...this.resources]
+      .filter(([key]) => key.startsWith(`${collection}/`))
+      .map(([, held]) => held);
+  }
+
   private admissionResponse(): Response {
     const policy = this.options.admissionPolicy;
     if (policy === undefined || policy === null) return json(404, notFound());
     return json(200, policy);
   }
 
-  private readResponse(id: string): Response {
-    // The Service is created *behind* the Operation the write returned, so for
+  private readResponse(key: string): Response {
+    // The resource is created *behind* the Operation the write returned, so for
     // a while after a create it is genuinely not there yet. `read()` must map
     // that to "still applying" rather than to a failure.
-    const owed = this.creating.get(id) ?? 0;
+    const owed = this.creating.get(key) ?? 0;
     if (owed > 0) {
-      this.creating.set(id, owed - 1);
+      this.creating.set(key, owed - 1);
       return json(404, notFound());
     }
-    const service = this.services.get(id);
-    if (service === undefined) return json(404, notFound());
+    const held = this.resources.get(key);
+    if (held === undefined) return json(404, notFound());
 
-    // The runtime writes the terminal condition *after* the Service exists,
+    // The runtime writes the terminal condition *after* the resource exists,
     // which is what makes `apply` poll rather than assume.
     const script = this.options.service ?? READY;
-    const reads = (this.reads.get(id) ?? 0) + 1;
-    this.reads.set(id, reads);
+    const reads = (this.reads.get(key) ?? 0) + 1;
+    this.reads.set(key, reads);
     const status = script(reads);
-    return json(200, status === null ? service : { ...service, ...status });
+    return json(200, status === null ? held : { ...held, ...status });
   }
 
   private applyResponse(
     url: URL,
-    id: string,
+    collection: string,
+    key: string,
+    name: string,
     document: Record<string, unknown>,
   ): Response {
     if (this.options.refuse !== undefined) {
@@ -392,37 +490,50 @@ export class FakeCloudRun {
     // fake that created regardless would let the adapter drop the parameter
     // and still pass, so the refusal is modelled rather than assumed.
     if (
-      !this.services.has(id) &&
+      !this.resources.has(key) &&
       url.searchParams.get('allowMissing') !== 'true'
     ) {
       return json(404, notFound());
     }
-    const rejected = this.schemaProblem(document);
+    const rejected = this.schemaProblem(collection, document);
     if (rejected !== null) return rejected;
 
-    const creating = !this.services.has(id);
+    const creating = !this.resources.has(key);
     const stored = {
       ...document,
-      name: id,
-      uri: `https://${id}.run.example.test`,
+      name,
+      // Only a Service is addressable. A fake that minted a `uri` for a Job
+      // would hand the adapter a URL for something nothing routes to, and the
+      // one assertion that a job reports no address would pass for the wrong
+      // reason.
+      ...(collection === 'services'
+        ? { uri: `https://${name}.run.example.test` }
+        : {}),
     };
-    this.services.set(id, stored);
-    this.reads.set(id, 0);
+    this.resources.set(key, stored);
+    this.reads.set(key, 0);
     if (creating) {
-      this.creating.set(id, this.options.createLatencyReads ?? 1);
+      this.creating.set(key, this.options.createLatencyReads ?? 1);
     }
-    return json(200, this.operation(id, false));
+    return json(200, this.operation(name, false));
   }
 
   /** Why the API would refuse this document, or `null` if it would not. */
-  private schemaProblem(document: Record<string, unknown>): Response | null {
-    const unknown = unknownMember(document, SERVICE_SCHEMA);
+  private schemaProblem(
+    collection: string,
+    document: Record<string, unknown>,
+  ): Response | null {
+    const job = collection === 'jobs';
+    const unknown = unknownMember(
+      document,
+      SCHEMAS[collection] as ServiceSchema,
+    );
     if (unknown !== null) {
       return json(400, {
         error: {
           code: 400,
           status: 'INVALID_ARGUMENT',
-          message: `Invalid JSON payload received. Unknown name "${unknown}" at 'service'.`,
+          message: `Invalid JSON payload received. Unknown name "${unknown}" at '${job ? 'job' : 'service'}'.`,
         },
       });
     }
@@ -431,8 +542,11 @@ export class FakeCloudRun {
       | undefined
       | null;
     const label =
-      labelProblem(document.labels, 'service') ??
-      labelProblem(template?.labels, 'revision template');
+      labelProblem(document.labels, job ? 'job' : 'service') ??
+      labelProblem(
+        template?.labels,
+        job ? 'execution template' : 'revision template',
+      );
     if (label !== null) {
       return json(400, {
         error: { code: 400, status: 'INVALID_ARGUMENT', message: label },


### PR DESCRIPTION
Cloud Run grows a third Component kind. `KINDS_BY_ADAPTER.cloudrun` claimed
`service` and `website`, and the comment above it said in as many words that
this backend runs no job — so a `kind: job` Component was a `KIND_UNSUPPORTED`
non-candidate on every Cloud Run Target while the Kubernetes side had rendered
a suspended CronJob for the same Component all along.

**Scope: the Job exists, and nothing triggers it.** That is the exact analogue
of `packages/charts/spindrift-app/templates/cronjob.yaml`, which renders a
*suspended* CronJob when a job carries no schedule. A schedule and an on-demand
run are deliberately out — both are named below and both are refused honestly
rather than half-built.

## What is here

- `src/adapters/deploy/cloudrun/job.ts` — a pure render function beside
  `service.ts`, returning the whole document so a test can assert it exactly
  without a fake API standing by.
- `src/adapters/deploy/cloudrun/index.ts` — `apply`, `observe` and `destroy`
  branch on the kind, and `refOf`/`parseRef` round-trip both collections.
- `src/domain/capabilities.ts` — the row gains `job`, and a new
  `FIRES_SCHEDULES_BY_ADAPTER` beside it carries the half that is still absent.
- `src/domain/placement.ts` — `NO_SCHEDULER`, so a scheduled job on this
  backend is refused at Place with a sentence, not after a build and a Deploy.

## Three things worth review attention

**The Job document nests `template` twice.** `Job.template` is an
`ExecutionTemplate` whose own `template` is the `TaskTemplate` holding the
container; a Service nests it once. The shape was checked against the Cloud Run
Admin API v2 reference rather than from memory, and reverting it to the single
nesting fails four tests — including the adapter returning `FAILED` off the
API's own `Unknown name "template.containers" at 'job'`.

**A job renders nothing that answers "who may reach this".** No `ingress`, no
`containerPort`, no `:setIamPolicy` call. A test asserts all three absences,
and the fake's closed schema has no `ingress` field at all, so a regression is
a 400 rather than a silently-accepted document.

**Existing refs keep working.** Every ref already stored names
`.../services/{id}`. `parseRef` accepting only `jobs` fails three tests, two of
them pre-existing Service tests — which is the point: `observe` and `destroy`
both route through it, and a ref that stops parsing orphans a running Service.

## What is not here

A `schedule` is refused at Place rather than honoured: Cloud Scheduler is not
enabled on the vessel (`terraform/gcp/projects/bluenose/services.tf`), and
firing a Job needs that plus a scheduler identity. An on-demand run is a
`DeployAdapter` contract change — `src/adapters/deploy/contract.ts` has
apply/observe/destroy/tail/inspect and no `run` — so every adapter would have
to answer it. Both are tracked separately.

No terraform. `terraform/gcp/projects/bluenose/iam.tf` already grants
`roles/run.admin`, which covers `run.jobs.*`.

## Verification

1517 pass / 0 fail across 113 files, typecheck clean, lint at its pre-existing
baseline. Four separate reverts were run and each fails the tests that cover
it. No live proof: this installation has no `kind: job` Component, confirmed
against the database rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5L7Drqigda9beYvnQ5mHw