### PR TITLE
fix(spindrift): return the browser to the App it signed in from

### DIFF
--- a/.github/scripts/render-cluster-apps.sh
+++ b/.github/scripts/render-cluster-apps.sh
@@ -147,13 +147,74 @@ cookie_scope_contract() {
   ' "$rendered")
 }
 
+# Where the browser is sent after it signs in.
+#
+# Nothing on the ExternalAuth check path hands oauth2-proxy an origin: the
+# filter has no field that injects a header, and the `Host` Envoy forwards is
+# equal to the one the proxy already has, which is the comparison
+# `getXForwardedHeadersRedirect` refuses on. The proxy then answers with a bare
+# path, and the callback — on a different host — resolves it against itself. So
+# the origin is composed by the shim beside the proxy, and this is the assertion
+# that it still is.
+#
+# The failure it catches is silent: the check keeps passing, every App keeps
+# serving, and only a browser completing a sign-in lands on the wrong host.
+# `proxy_set_header` is named rather than any header directive because
+# replacing, not appending, is what stops a client's own copy at this hop.
+authz_checks=0
+authz_redirect_contract() {
+  local rendered="$1" overlay="$2"
+  local conf="$WORK/authz-${overlay//\//_}.conf" target
+
+  yq eval-all '
+    select(.kind == "HelmRelease")
+    | .spec.values.extraObjects[]?
+    | select(.kind == "ConfigMap")
+    | .data."nginx.conf"
+  ' "$rendered" >"$conf" 2>/dev/null || true
+
+  grep -q '[^[:space:]]' "$conf" || return 0
+  authz_checks=$((authz_checks + 1))
+
+  target="$(sed -n \
+    's/^[[:space:]]*proxy_set_header[[:space:]]\{1,\}X-Auth-Request-Redirect[[:space:]]\{1,\}\(.*\);[[:space:]]*$/\1/p' \
+    "$conf")"
+
+  # Absolute, and built from the host the request arrived on. Anything else —
+  # a dropped scheme, a bare `$request_uri`, a deleted directive — is the
+  # host-relative target this whole arrangement exists to replace.
+  #
+  # shellcheck disable=SC2016  # `$http_host` is nginx's variable, not the shell's
+  case "$target" in
+    'https://$http_host'*)
+      printf '  authz redirect %s: "%s"\n' "$overlay" "$target"
+      ;;
+    *)
+      printf '  FAILED %s: the ext_authz shim sets X-Auth-Request-Redirect to "%s",\n' \
+        "$overlay" "$target"
+      printf '    not an absolute origin composed from the request host\n'
+      failures=$((failures + 1))
+      ;;
+  esac
+}
+
 for overlay in "${OVERLAYS[@]}"; do
   rendered="$WORK/${overlay//\//_}.yaml"
   kubectl kustomize "$overlay" >"$rendered"
   printf 'rendered %s\n' "$overlay"
   template_releases "$rendered" "$overlay"
   cookie_scope_contract "$rendered" "$overlay"
+  authz_redirect_contract "$rendered" "$overlay"
 done
+
+# Same silence problem as the cookie contract below: an `extraObjects` rename
+# or a deleted ConfigMap would leave nothing to check and read green.
+if [ "$authz_checks" -eq 0 ]; then
+  printf '\nNo rendered HelmRelease carries an extraObjects ConfigMap with an\n'
+  printf 'nginx.conf, so the ext_authz redirect contract checked nothing. Either\n'
+  printf 'the shim moved or an overlay is missing from OVERLAYS in %s.\n' "${BASH_SOURCE[0]}"
+  failures=$((failures + 1))
+fi
 
 # The contract above has to have looked at something. `redirect-url` is what
 # selects a release into it, so a rename or a deleted key would otherwise turn

--- a/clusters/base/apps/oauth2-proxy/helm-release.yaml
+++ b/clusters/base/apps/oauth2-proxy/helm-release.yaml
@@ -58,11 +58,144 @@ spec:
       ping-path: ""
       ready-path: ""
 
+    # The ext_authz shim, and the whole reason it exists.
+    #
+    # oauth2-proxy needs an absolute origin to send the browser back to after
+    # sign-in. Behind the ExternalAuth filter it is shown the App's `Host` but
+    # no origin it will use: `pkg/app/redirect/getters.go` reaches
+    # `getXForwardedHeadersRedirect` only when `req.Host != GetRequestHost(req)`,
+    # and with nothing setting `X-Forwarded-Host` those are the same string by
+    # construction. It falls through to `getURIRedirect` and answers with a bare
+    # path, which the callback host then resolves against *itself*.
+    #
+    # Gateway API's ExternalAuth filter has no field that injects a header into
+    # its check request — `allowedHeaders` permits, it does not create — so the
+    # origin is composed one hop later instead. nginx listens on 4181, builds
+    # `X-Auth-Request-Redirect` out of the `Host` Envoy's ext_authz client
+    # already forwards, and proxies to oauth2-proxy on 4180.
+    # `getXAuthRequestRedirect` is consulted ahead of the `X-Forwarded-*` pair
+    # and carries no trusted-proxy gate, so it answers on every request rather
+    # than on the subset that arrives from a trusted address.
+    #
+    # `proxy_set_header` replaces, so a browser cannot smuggle its own
+    # `X-Auth-Request-Redirect` through this hop. The filter not listing that
+    # header in `allowedHeaders` is the other half of the same guard;
+    # `packages/charts/spindrift-app/tests/render.test.ts` pins both.
+    #
+    # `?rd=` is covered by neither. `getRdQuerystringRedirect` runs first, reads
+    # the query string of the request as it arrives, and is gated only by
+    # `whitelist-domain` — so a caller can still pick any host in this zone as
+    # its own post-sign-in destination.
+    #
+    # Only the check path goes through the shim. oauth2-proxy's own endpoints
+    # stay on port 80: `getXAuthRequestRedirect` does not strip the proxy
+    # prefix, so an origin injected in front of `/oauth2/start` points the proxy
+    # at itself.
+    extraContainers:
+      - name: authz-shim
+        image: docker.io/nginxinc/nginx-unprivileged:1.29-alpine@sha256:0c79d56aee561a1d81c63f00eee5fb5fe29279560cdc55e91425133104c7fbe6
+        command: [nginx, -c, /etc/nginx/shim/nginx.conf, -g, "daemon off;"]
+        ports:
+          - name: authz
+            containerPort: 4181
+            protocol: TCP
+        volumeMounts:
+          - name: authz-shim
+            mountPath: /etc/nginx/shim
+            readOnly: true
+          - name: authz-tmp
+            mountPath: /tmp
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 101
+          runAsGroup: 101
+          seccompProfile:
+            type: RuntimeDefault
+        resources:
+          requests:
+            cpu: 10m
+            memory: 16Mi
+          limits:
+            memory: 32Mi
+
+    extraVolumes:
+      - name: authz-shim
+        configMap:
+          name: oauth2-proxy-authz
+      # nginx writes a pid file and creates its temp paths at startup, and the
+      # root filesystem is read-only, so both are pointed here.
+      - name: authz-tmp
+        emptyDir: {}
+
+    extraObjects:
+      - apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: oauth2-proxy-authz
+        data:
+          # nginx's `$var` passes through Flux's postBuild substitution
+          # untouched — only `${var}` is a substitution token. The nginx config
+          # in `clusters/folly/apps/dump` renders `$uri` through the same
+          # mechanism and arrives intact.
+          nginx.conf: |
+            worker_processes 1;
+            pid /tmp/nginx.pid;
+            error_log stderr warn;
+            events {}
+            http {
+              # oauth2-proxy logs every check with the App's host on it; a
+              # second copy of the same line here says nothing new.
+              access_log off;
+              client_body_temp_path /tmp/client_body;
+              proxy_temp_path /tmp/proxy;
+              fastcgi_temp_path /tmp/fastcgi;
+              uwsgi_temp_path /tmp/uwsgi;
+              scgi_temp_path /tmp/scgi;
+              server {
+                listen 4181;
+                location / {
+                  proxy_pass http://127.0.0.1:4180;
+                  # Preserved so the proxy's own log still names the App the
+                  # check was for; the default sends 127.0.0.1:4180 instead.
+                  proxy_set_header Host $http_host;
+                  # The scheme is literal rather than $http_x_forwarded_proto.
+                  # Envoy sets that from the listener that accepted the request
+                  # and the tunnel reaches this gateway over plain HTTP, so a
+                  # browser on https would be handed back an http origin — one
+                  # the Secure session cookie is never sent to.
+                  proxy_set_header X-Auth-Request-Redirect https://$http_host$request_uri;
+                }
+              }
+            }
+      # The filter's backendRef. `service.portNumber` is a single port, so the
+      # shim's is its own Service over the same pods.
+      - apiVersion: v1
+        kind: Service
+        metadata:
+          name: oauth2-proxy-authz
+        spec:
+          type: ClusterIP
+          selector:
+            app.kubernetes.io/name: oauth2-proxy
+            app.kubernetes.io/instance: oauth2-proxy
+          ports:
+            - name: authz
+              port: 4181
+              targetPort: authz
+              protocol: TCP
+              appProtocol: http
+
     replicaCount: 2
     enableServiceLinks: false
 
     podAnnotations:
       secret.reloader.stakater.com/reload: oauth2-proxy
+      configmap.reloader.stakater.com/reload: oauth2-proxy-authz
 
     serviceAccount:
       enabled: true

--- a/clusters/base/apps/oauth2-proxy/spindrift-reference-grant.yaml
+++ b/clusters/base/apps/oauth2-proxy/spindrift-reference-grant.yaml
@@ -10,6 +10,14 @@ spec:
       kind: HTTPRoute
       namespace: spindrift-apps
   to:
+    # `-authz` is the shim the ExternalAuth filter points at (see the
+    # HelmRelease beside this). `oauth2-proxy` stays granted because a Target's
+    # `platform.externalAuth` lives in Spindrift's own durable row, not in the
+    # declaration — an installation still naming the port-80 Service keeps
+    # resolving until an operator repoints it.
     - group: ""
       kind: Service
       name: oauth2-proxy
+    - group: ""
+      kind: Service
+      name: oauth2-proxy-authz

--- a/clusters/folly/apps/oauth2-proxy/httproute.yaml
+++ b/clusters/folly/apps/oauth2-proxy/httproute.yaml
@@ -12,10 +12,15 @@ spec:
   hostnames:
     - "oauth2.${SECRET_DOMAIN}"
   rules:
+    # The whole hostname, for the reason the offsite route carries in full
+    # (`clusters/offsite/apps/oauth2-proxy/httproute.yaml`): a browser can
+    # arrive here on a path that belongs to an App, and a route matching only
+    # `/oauth2` leaves Envoy answering 404 to something the proxy could answer
+    # honestly. Nothing widens — the proxy's only upstream is `static://200`.
     - matches:
         - path:
             type: PathPrefix
-            value: /oauth2
+            value: /
       backendRefs:
         - name: oauth2-proxy
           port: 80

--- a/clusters/offsite/apps/oauth2-proxy/httproute.yaml
+++ b/clusters/offsite/apps/oauth2-proxy/httproute.yaml
@@ -25,26 +25,24 @@ spec:
   hostnames:
     - "oauth2.${SPINDRIFT_DOMAIN}"
   rules:
-    # The whole hostname, not just `/oauth2`. A sign-in that starts at an App
-    # ends here on a path that belongs to the App: the `state` oauth2-proxy
-    # mints behind the ExternalAuth filter is host-relative — it cannot be
-    # anything else, see the measurement on the App chart's route — so the
-    # callback resolves it against its own host and sends the browser to
-    # `oauth2.${SPINDRIFT_DOMAIN}/whatever/the/App/served`. Matched only against
-    # `/oauth2`, that request fell off the route table and Envoy answered 404
-    # before oauth2-proxy ever saw it, which is why nothing in the proxy's log
-    # named it.
+    # The whole hostname, not just `/oauth2`. A browser can reach this host on a
+    # path that belongs to an App: the `state` a sign-in carries is whatever
+    # oauth2-proxy resolved as its return target, and a host-relative one — the
+    # answer whenever nothing hands the proxy an origin — is resolved by the
+    # callback against *this* host. `?rd=` is the other way in, and it needs no
+    # header at all. Matching only `/oauth2` leaves such a request off the route
+    # table entirely, so Envoy answers 404 and the proxy's log never names it.
     #
-    # Matching `/` sends it to the proxy instead, where it becomes a blank 200
-    # off the `static://200` upstream — or a sign-in, for a browser that has no
-    # session yet. That is not the browser landing back on the App and it does
-    # not pretend to be; the App's identity is gone by then. It is the honest
-    # answer available at this host: the operator is signed in, and the page
-    # says so by not being an error.
+    # Matching `/` sends it to the proxy instead, where it is a blank 200 off
+    # the `static://200` upstream — or a sign-in, for a browser with no session
+    # yet. That is not the browser landing back on the App and does not pretend
+    # to be; the App's identity is gone by then. It is the honest answer
+    # available at this host: the operator is signed in, and the page says so by
+    # not being an error.
     #
     # Nothing is widened by this. The proxy's only upstream is `static://200`,
     # so there is no origin behind it to reach, and its own `/oauth2/*`
-    # endpoints were already served here.
+    # endpoints are served here either way.
     - matches:
         - path:
             type: PathPrefix

--- a/clusters/offsite/apps/oauth2-proxy/httproute.yaml
+++ b/clusters/offsite/apps/oauth2-proxy/httproute.yaml
@@ -25,10 +25,30 @@ spec:
   hostnames:
     - "oauth2.${SPINDRIFT_DOMAIN}"
   rules:
+    # The whole hostname, not just `/oauth2`. A sign-in that starts at an App
+    # ends here on a path that belongs to the App: the `state` oauth2-proxy
+    # mints behind the ExternalAuth filter is host-relative — it cannot be
+    # anything else, see the measurement on the App chart's route — so the
+    # callback resolves it against its own host and sends the browser to
+    # `oauth2.${SPINDRIFT_DOMAIN}/whatever/the/App/served`. Matched only against
+    # `/oauth2`, that request fell off the route table and Envoy answered 404
+    # before oauth2-proxy ever saw it, which is why nothing in the proxy's log
+    # named it.
+    #
+    # Matching `/` sends it to the proxy instead, where it becomes a blank 200
+    # off the `static://200` upstream — or a sign-in, for a browser that has no
+    # session yet. That is not the browser landing back on the App and it does
+    # not pretend to be; the App's identity is gone by then. It is the honest
+    # answer available at this host: the operator is signed in, and the page
+    # says so by not being an error.
+    #
+    # Nothing is widened by this. The proxy's only upstream is `static://200`,
+    # so there is no origin behind it to reach, and its own `/oauth2/*`
+    # endpoints were already served here.
     - matches:
         - path:
             type: PathPrefix
-            value: /oauth2
+            value: /
       backendRefs:
         - name: oauth2-proxy
           port: 80

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -251,10 +251,15 @@ spec:
                 gateway:
                   name: spindrift-apps
                   namespace: spindrift-apps
+                # The shim beside oauth2-proxy, not oauth2-proxy's own port 80.
+                # It composes the absolute origin the browser is returned to
+                # after sign-in, which nothing on the check path otherwise
+                # carries; `clusters/base/apps/oauth2-proxy/helm-release.yaml`
+                # holds the mechanism.
                 externalAuth:
-                  name: oauth2-proxy
+                  name: oauth2-proxy-authz
                   namespace: oauth2-proxy
-                  port: 80
+                  port: 4181
                 # The chart requires this whenever a Component has config: the
                 # ExternalSecret names the store, and an unset name renders an
                 # object that never syncs behind a workload that waits forever.
@@ -303,14 +308,24 @@ spec:
                   namespace: spindrift-apps
                 # Answers on `oauth2.${SECRET_DOMAIN}` here rather than in the
                 # App zone, so the sign-in redirect leaves this gateway for
-                # `cluster-gateway`. That is one hop rather than a 404: the
+                # `cluster-gateway`. That much is one hop rather than a 404: the
                 # ExternalAuth filter is a backend reference, granted by the
                 # ReferenceGrant in `clusters/base/apps/oauth2-proxy`, and is
                 # not affected by which gateway serves the sign-in name.
+                #
+                # The sign-in itself does not complete on this Target. This
+                # cluster's proxy scopes its cookies to `.${SECRET_DOMAIN}`,
+                # which is where its callback is, and an App here is minted
+                # under `dns.zones` — `.${SPINDRIFT_DOMAIN}`. A browser at the
+                # App drops a cookie for a domain that does not cover the host
+                # it was served from, and `whitelist-domain` refuses the return
+                # trip for the same reason. Closing it needs one host to serve
+                # both halves: a second GitHub OAuth App with a callback in the
+                # App zone, or the App zone and the callback zone made one.
                 externalAuth:
-                  name: oauth2-proxy
+                  name: oauth2-proxy-authz
                   namespace: oauth2-proxy
-                  port: 80
+                  port: 4181
                 secretStore:
                   kind: ClusterSecretStore
                   name: onepassword-connect

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -22,9 +22,12 @@ address — the same name claimed twice, at two record types, by two sources.
 **`allowedHeaders` permits, it does not create.** The two it names are what
 oauth2-proxy is shown of the original request, on top of the `Host`, method and
 path Envoy's ext_authz client includes on its own. `cookie` carries the session
-the check is about. `x-forwarded-proto` is the one header of its family this
-gateway composes — Cilium's Envoy sets it and overwrites whatever the client
-sent, beside the `x-forwarded-for` it appends to.
+the check is about. Cilium's Envoy composes two headers of the `x-forwarded-*`
+family: it sets `x-forwarded-proto`, overwriting whatever the client sent, and
+appends to `x-forwarded-for`. The check needs the first and has no use for the
+second. `authorization` is unlisted for a different reason — no provider this
+deployment configures reads it, with neither an htpasswd file nor bearer-token
+skipping in play.
 
 Nothing sets `x-forwarded-host` or `x-forwarded-uri`, and oauth2-proxy reads
 neither to any effect: it treats a request as forwarded only when

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -24,19 +24,25 @@ oauth2-proxy is shown of the original request, on top of the `Host`, method and
 path Envoy's ext_authz client includes on its own. `cookie` carries the session
 the check is about. Cilium's Envoy composes two headers of the `x-forwarded-*`
 family: it sets `x-forwarded-proto`, overwriting whatever the client sent, and
-appends to `x-forwarded-for`. The check needs the first and has no use for the
-second. `authorization` is unlisted for a different reason — no provider this
-deployment configures reads it, with neither an htpasswd file nor bearer-token
-skipping in play.
+appends to `x-forwarded-for`. `x-forwarded-proto` is listed because Envoy is the
+hop that writes it, not because the check depends on it — every `x-forwarded-*`
+read in oauth2-proxy goes through `CanTrustForwardedHeaders`, and the check now
+arrives from `127.0.0.1`, which is outside `trusted-proxy-ip` on every replica.
+`authorization` is unlisted for a different reason — no provider this deployment
+configures reads it, with neither an htpasswd file nor bearer-token skipping in
+play.
 
-Nothing sets `x-forwarded-host` or `x-forwarded-uri`, and oauth2-proxy reads
-neither to any effect: it treats a request as forwarded only when
-`req.Host != GetRequestHost(req)`, so a header holding this Component's own
-hostname equals the `Host` beside it and yields a host-relative target every
-time. Measured, not reasoned. They are absent because they are inert — not
-because listing them would open anything. `?rd=` lets a caller name its own
-post-sign-in destination anywhere in the zone with no `allowedHeaders` entry at
-all, and that stays open.
+`x-forwarded-host` and `x-forwarded-uri` are absent because permitting them
+opened something, not because they did nothing. No hop sets either, so only a
+client could, and the two are read differently: `x-forwarded-host` is inert on
+its own — `IsForwardedRequest` needs `req.Host != GetRequestHost(req)`, and a
+header holding this Component's own hostname equals the `Host` beside it — but
+`x-forwarded-uri` is read straight through `GetRequestURI` with no such
+comparison, so a client did choose the path the sign-in returned to, on
+whichever replica's source address fell inside `trusted-proxy-ip`. Measured
+both ways, not reasoned. The shim closes the gate rather than the header:
+`CanTrustForwardedHeaders` is now false for every replica. `?rd=` needs no
+`allowedHeaders` entry at all and stays open.
 
 `x-auth-request-redirect` is the header oauth2-proxy honours without any trust
 gate, and its absence here is load-bearing rather than incidental: a browser

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -19,24 +19,29 @@ publishes: external-dns's `gateway-httproute` source would otherwise emit its
 own endpoint for these same hostnames, targeting the parent Gateway's status
 address — the same name claimed twice, at two record types, by two sources.
 
-**`allowedHeaders` permits, it does not create.** The three it names are what
+**`allowedHeaders` permits, it does not create.** The two it names are what
 oauth2-proxy is shown of the original request, on top of the `Host`, method and
-path Envoy's ext_authz client includes on its own. Only `x-forwarded-proto` is
-real: Cilium's gateway sets it and overwrites whatever the client sent. Nothing
-sets `x-forwarded-host` or `x-forwarded-uri`, so listing them permitted a header
-no hop was producing — and left the **client** free to produce it, choosing its
-own post-sign-in destination inside the zone. They are not listed for that
-reason.
+path Envoy's ext_authz client includes on its own. `cookie` carries the session
+the check is about. `x-forwarded-proto` is the one header of its family this
+gateway composes — Cilium's Envoy sets it and overwrites whatever the client
+sent, beside the `x-forwarded-for` it appends to.
 
-Adding them back does not buy the return trip either, and that is the part worth
-knowing before trying. oauth2-proxy treats a request as forwarded only when
-`req.Host != GetRequestHost(req)` — the `Host` Envoy already forwards against the
-`x-forwarded-host` it does not — so a header set to this Component's own hostname
-is equal to the one beside it and changes nothing. Measured, not reasoned:
-`x-forwarded-host` equal to the real host yields a host-relative target every
-time. The header that would work is `x-auth-request-redirect`, built from
-`:authority` and injected by the filter itself, and `ExternalAuth` has no field
-that injects anything.
+Nothing sets `x-forwarded-host` or `x-forwarded-uri`, and oauth2-proxy reads
+neither to any effect: it treats a request as forwarded only when
+`req.Host != GetRequestHost(req)`, so a header holding this Component's own
+hostname equals the `Host` beside it and yields a host-relative target every
+time. Measured, not reasoned. They are absent because they are inert — not
+because listing them would open anything. `?rd=` lets a caller name its own
+post-sign-in destination anywhere in the zone with no `allowedHeaders` entry at
+all, and that stays open.
+
+`x-auth-request-redirect` is the header oauth2-proxy honours without any trust
+gate, and its absence here is load-bearing rather than incidental: a browser
+that sets one would otherwise choose where the sign-in returns to. The value the
+flow uses is composed inside the auth pod instead, by the shim
+`platform.externalAuth` points at
+(`clusters/base/apps/oauth2-proxy/helm-release.yaml`), whose `proxy_set_header`
+replaces any inbound copy. Both halves are pinned in `tests/render.test.ts`.
 
 The hold-out is `…/controller`, which the source honours per object: it skips
 any route whose value is not `dns-controller` (`source/annotations`,
@@ -86,7 +91,6 @@ spec:
               port: {{ .Values.platform.externalAuth.port }}
             http:
               allowedHeaders:
-                - authorization
                 - cookie
                 - x-forwarded-proto
               allowedResponseHeaders:

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -19,6 +19,25 @@ publishes: external-dns's `gateway-httproute` source would otherwise emit its
 own endpoint for these same hostnames, targeting the parent Gateway's status
 address — the same name claimed twice, at two record types, by two sources.
 
+**`allowedHeaders` permits, it does not create.** The three it names are what
+oauth2-proxy is shown of the original request, on top of the `Host`, method and
+path Envoy's ext_authz client includes on its own. Only `x-forwarded-proto` is
+real: Cilium's gateway sets it and overwrites whatever the client sent. Nothing
+sets `x-forwarded-host` or `x-forwarded-uri`, so listing them permitted a header
+no hop was producing — and left the **client** free to produce it, choosing its
+own post-sign-in destination inside the zone. They are not listed for that
+reason.
+
+Adding them back does not buy the return trip either, and that is the part worth
+knowing before trying. oauth2-proxy treats a request as forwarded only when
+`req.Host != GetRequestHost(req)` — the `Host` Envoy already forwards against the
+`x-forwarded-host` it does not — so a header set to this Component's own hostname
+is equal to the one beside it and changes nothing. Measured, not reasoned:
+`x-forwarded-host` equal to the real host yields a host-relative target every
+time. The header that would work is `x-auth-request-redirect`, built from
+`:authority` and injected by the filter itself, and `ExternalAuth` has no field
+that injects anything.
+
 The hold-out is `…/controller`, which the source honours per object: it skips
 any route whose value is not `dns-controller` (`source/annotations`,
 `IsControllerMismatch`). It is a real annotation, unlike the `…/exclude` this
@@ -69,9 +88,7 @@ spec:
               allowedHeaders:
                 - authorization
                 - cookie
-                - x-forwarded-host
                 - x-forwarded-proto
-                - x-forwarded-uri
               allowedResponseHeaders:
                 - set-cookie
                 - x-auth-request-email

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -364,13 +364,15 @@ describe('the route', () => {
             port: 80,
           },
           http: {
-            allowedHeaders: [
-              'authorization',
-              'cookie',
-              'x-forwarded-host',
-              'x-forwarded-proto',
-              'x-forwarded-uri',
-            ],
+            // Exactly three, and the exactness is the point. `allowedHeaders`
+            // permits a header through to oauth2-proxy; it does not create one.
+            // Cilium's gateway sets `x-forwarded-proto` and nothing else of
+            // this family, so `x-forwarded-host` and `x-forwarded-uri` admitted
+            // a value only a *client* could supply — letting the caller pick
+            // where its own sign-in returns to, anywhere in the zone. Re-adding
+            // either fails here, which is the guard: the template comment
+            // carries the measurement, this carries the assertion.
+            allowedHeaders: ['authorization', 'cookie', 'x-forwarded-proto'],
             allowedResponseHeaders: [
               'set-cookie',
               'x-auth-request-email',

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -364,15 +364,15 @@ describe('the route', () => {
             port: 80,
           },
           http: {
-            // Exactly three, and the exactness is the point. `allowedHeaders`
+            // Exactly two, and the exactness is the point. `allowedHeaders`
             // permits a header through to oauth2-proxy; it does not create one.
-            // Cilium's gateway sets `x-forwarded-proto` and nothing else of
-            // this family, so `x-forwarded-host` and `x-forwarded-uri` admitted
-            // a value only a *client* could supply — letting the caller pick
-            // where its own sign-in returns to, anywhere in the zone. Re-adding
-            // either fails here, which is the guard: the template comment
-            // carries the measurement, this carries the assertion.
-            allowedHeaders: ['authorization', 'cookie', 'x-forwarded-proto'],
+            // `x-forwarded-proto` is the one header of its family Cilium's
+            // Envoy composes; `x-forwarded-host` and `x-forwarded-uri` reach
+            // the proxy only if a client supplies them and change nothing when
+            // it does, and `authorization` is read by no provider this
+            // deployment configures. The template comment carries the
+            // measurement, this carries the assertion.
+            allowedHeaders: ['cookie', 'x-forwarded-proto'],
             allowedResponseHeaders: [
               'set-cookie',
               'x-auth-request-email',
@@ -382,6 +382,25 @@ describe('the route', () => {
         },
       },
     ]);
+  });
+
+  test('the filter never forwards the header that names the return target', async () => {
+    // `getXAuthRequestRedirect` (oauth2-proxy `pkg/app/redirect/getters.go`)
+    // reads `X-Auth-Request-Redirect` with no trusted-proxy gate at all, so
+    // whoever puts that header on the check request decides where a sign-in
+    // returns to. The value the flow uses is composed inside the auth pod, by
+    // the shim `platform.externalAuth` points at; the only thing keeping a
+    // *browser* from composing one instead is that Envoy is never told to
+    // forward it. That absence is the guard, so it is asserted rather than
+    // left to the list above happening not to mention it.
+    const route = one(
+      await render({ app: { reach: 'private', auth: 'proxy' } }),
+      'HTTPRoute',
+    );
+    const { allowedHeaders } = route.spec.rules[0].filters[0].externalAuth.http;
+    expect(
+      (allowedHeaders as string[]).map((header) => header.toLowerCase()),
+    ).not.toContain('x-auth-request-redirect');
   });
 
   test('auth: none renders no filter, at either reach', async () => {

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -366,12 +366,13 @@ describe('the route', () => {
           http: {
             // Exactly two, and the exactness is the point. `allowedHeaders`
             // permits a header through to oauth2-proxy; it does not create one.
-            // `x-forwarded-proto` is the one header of its family Cilium's
-            // Envoy composes; `x-forwarded-host` and `x-forwarded-uri` reach
-            // the proxy only if a client supplies them and change nothing when
-            // it does, and `authorization` is read by no provider this
-            // deployment configures. The template comment carries the
-            // measurement, this carries the assertion.
+            // Cilium's Envoy composes `x-forwarded-proto` and appends to
+            // `x-forwarded-for`, and the check needs only the first;
+            // `x-forwarded-host` and `x-forwarded-uri` reach the proxy only if
+            // a client supplies them and change nothing when it does; and
+            // `authorization` is read by no provider this deployment
+            // configures. The template comment carries the measurement, this
+            // carries the assertion.
             allowedHeaders: ['cookie', 'x-forwarded-proto'],
             allowedResponseHeaders: [
               'set-cookie',

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -366,10 +366,13 @@ describe('the route', () => {
           http: {
             // Exactly two, and the exactness is the point. `allowedHeaders`
             // permits a header through to oauth2-proxy; it does not create one.
-            // Cilium's Envoy composes `x-forwarded-proto` and appends to
-            // `x-forwarded-for`, and the check needs only the first;
-            // `x-forwarded-host` and `x-forwarded-uri` reach the proxy only if
-            // a client supplies them and change nothing when it does; and
+            // `x-forwarded-proto` is here because Envoy is the hop that writes
+            // it, not because the check reads it — every `x-forwarded-*` read
+            // is gated on `CanTrustForwardedHeaders`, false from the shim's
+            // `127.0.0.1`. `x-forwarded-host` and `x-forwarded-uri` are absent
+            // because only a client could set them, and `x-forwarded-uri` is
+            // read straight through `GetRequestURI` with no `IsForwardedRequest`
+            // comparison — it chose the path the sign-in returned to.
             // `authorization` is read by no provider this deployment
             // configures. The template comment carries the measurement, this
             // carries the assertion.


### PR DESCRIPTION
A browser that signed in through an `auth: proxy` App landed on a 404 at the
auth host instead of back on the App, and the auth host's root served nothing
at all. Both halves are fixed here.

## What was actually wrong

The `state` a sign-in carries was a bare path, so the callback — which runs on
a different host — resolved it against *its own* host. The obvious causes were
both wrong, and measuring beat guessing:

- **Envoy sets neither `x-forwarded-host` nor `x-forwarded-uri`.** A probe
  supplying each one by hand had its value survive untouched. `allowedHeaders`
  was permitting headers no hop was producing.
- **Injecting the App's own hostname would not have helped either.**
  oauth2-proxy treats a request as forwarded only when
  `req.Host != GetRequestHost(req)`; with no `X-Forwarded-Host` those are the
  same string by construction, so the comparison is false and the redirect
  degrades to a path. Confirmed with an `X-Forwarded-Host` *equal* to the real
  host across ten runs — a host-relative target every time.

The proxy already knows the App's hostname: Envoy's ext_authz client includes
`Host` on its own, and the proxy logs it. It just will not use it.

## The fix

A stock nginx sidecar in the oauth2-proxy pod composes the absolute origin from
the `Host` the check already carries and hands it to oauth2-proxy as
`X-Auth-Request-Redirect`, which is read with no trust gate. Config only — no
new image, no build pipeline, no PDB, no NetworkPolicy, and no failure domain
independent of the proxy it fronts.

Both `Service` names stay in the ReferenceGrant so nothing breaks at merge; the
stored Target row is repointed afterwards.

Separately, the auth host's route now matches `/` rather than `/oauth2`, so its
root reaches the proxy instead of falling off the route table. That is
deliberate and is not a fix for the return target — a mis-sent browser gets an
honest answer rather than Envoy's bare 404.

## Two absences doing real work

`x-auth-request-redirect` is honoured by oauth2-proxy without any trust gate,
so its **absence** from `allowedHeaders` is the only thing stopping a browser
choosing where its own sign-in returns to. That absence is now pinned by a named
test, and the sidecar sets rather than appends the header so a forged one dies
at the hop regardless.

`x-forwarded-host` and `x-forwarded-uri` are gone from `allowedHeaders`. The
first was inert. The second was not — it is read straight through
`GetRequestURI` with no `IsForwardedRequest` comparison, so a client could
choose the path the sign-in returned to, on whichever replica's source address
fell inside `trusted-proxy-ip`. The comments say which is which, because an
earlier revision of this branch got it wrong in both directions.

## What is not closed

The round trip itself is a browser observation against unmerged code and is not
claimed. The CSRF-cookie criterion holds for the offsite Target only — the
other cluster advertises the same auth cell with a cookie domain its App zone
cannot store — and is left unchecked rather than checked on partial evidence.

An unrelated live defect surfaced on the way: oauth2-proxy's `trusted-proxy-ip`
covers the node CIDR but not the pod CIDR, so identical requests were answered
differently depending on which replica served. The sidecar routes around it
rather than fixing it, and widening the CIDR would widen spoofability, so it is
tracked on its own.

## Verification

Chart 42 pass / 0 fail; `apps/spindrift` 1507 pass / 0 fail; typecheck and lint
clean; `k8s:render-apps` green with both cookie-scope guards and both new
authorization guards; `docs:check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5L7Drqigda9beYvnQ5mHw