### PR TITLE
chore(renovate): stop tracking artifacts this repo publishes under clusters/

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -470,5 +470,38 @@
       matchFileNames: ['clusters/*/networking/git-repository-gateway-api.yaml'],
       enabled: false,
     },
+    {
+      // Under `clusters/`, everything this owner publishes is delivered by CD,
+      // and Renovate tracking it is Renovate chasing this repository's own
+      // output. The registry is downstream of the tree in both directions:
+      //
+      //   images — `.github/containers.json` maps each image to the manifests
+      //     that pin it, and `containers.yml` rewrites the digest on the merge
+      //     that built it. A Renovate digest PR duplicates that work and races
+      //     it: `:latest` can move between the lookup and the merge, which is
+      //     how an older revision gets deployed after newer code lands.
+      //
+      //   charts — `spindrift-charts.yml` pushes each chart under the version
+      //     its own Chart.yaml carries, and a conformance test asserts each
+      //     consumer's `ref.tag` equals that version. GHCR therefore never
+      //     holds a tag the tree has not already named, so there is nothing to
+      //     bump toward; a tag moved on its own is a red test, not an upgrade.
+      //
+      // Scoped to `clusters/` on purpose, not to the owner. `apps/spindrift/`'s
+      // Dockerfile pins `ghcr.io/jonpulsifer/spindrift-verifier` by digest to
+      // build the verifier binary in, that image has no `deploy` entry, and
+      // Renovate is the only thing that updates it — an owner-wide block would
+      // strand a supply-chain pin. The rule above keeps that one reviewed.
+      //
+      // Third-party charts and images consumed the same way are untouched and
+      // still bump.
+      description: 'Under clusters/, first-party artifacts are delivered by CD, not Renovate',
+      matchFileNames: ['clusters/**'],
+      matchPackageNames: [
+        '/^ghcr\\.io\\/jonpulsifer\\//',
+        '/^docker\\.io\\/jonpulsifer\\//',
+      ],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
Renovate currently tracks every first-party image and both Spindrift charts.
Its dependency dashboard lists them:

```text
clusters/base/platform/spindrift-target/oci-repository.yaml (1)
  ghcr.io/jonpulsifer/charts/spindrift-app  0.2.0
clusters/offsite/apps/spindrift/oci-repository.yaml (1)
  ghcr.io/jonpulsifer/charts/spindrift      0.1.2
  ghcr.io/jonpulsifer/spindrift    latest@sha256:4ef56efc…
  ghcr.io/jonpulsifer/hub          latest@sha256:6345e0d0…
  ghcr.io/jonpulsifer/atlantis     latest@sha256:3186a68c…
  ghcr.io/jonpulsifer/actions-runner latest@sha256:3d108a13…
```

None of it should be Renovate's. The registry is downstream of this tree in
both directions, so Renovate is chasing its own output.

**Images.** `.github/containers.json` maps each image to the manifests that
pin it, and `containers.yml` rewrites the digest on the merge that built it —
every one of the pins above was last written by `github-actions[bot]`, not by
Renovate. A Renovate digest PR duplicates that work and races it: `:latest`
can move between the lookup and the merge, which deploys an older revision
after newer code lands. That hazard is already spelled out in the rule
directly above this one, which only ever mitigated it by requiring review.

**Charts.** `spindrift-charts.yml` pushes each chart under the version its own
`Chart.yaml` carries, and a conformance test asserts each consumer's `ref.tag`
equals that version. GHCR therefore never holds a tag the tree has not already
named — there is nothing to bump toward. If a tag ever did appear on its own,
bumping it would turn that test red rather than upgrade anything. The correct
flow is what already happened here: the installer chart went `0.1.1 → 0.1.2`
with `Chart.yaml` and the OCIRepository moving in the same commit.

## Scoped to `clusters/`, not to the owner

This is the part worth reviewing. `apps/spindrift/Dockerfile` pins

```dockerfile
FROM ghcr.io/jonpulsifer/spindrift-verifier:latest@sha256:55bf1543… AS supply-chain-tools
```

to build the verifier binary into the Spindrift image. `spindrift-verifier` is
in `containers.json`'s `build` allowlist but has **no `deploy` entry**, so CD
never touches that digest — Renovate is the only thing that updates it. An
owner-wide block would silently strand a supply-chain pin. Matching on
`clusters/**` leaves it alone, and the existing review-required rule for
first-party digests now governs exactly that one pin, which is where it
belongs.

Third-party charts and images consumed through the same managers are
untouched and still bump — Renovate has moved an `OCIRepository` tag here
before (`9eeece6c`, `quay.io/cilium/charts/cilium 1.19.5 → 1.19.6`), and that
keeps working.

## Verification

`renovate-config-validator` passes:

```text
INFO: Validating .github/renovate.json5 as global config
INFO: Config validated successfully against 1 file(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5L7Drqigda9beYvnQ5mHw