### PR TITLE
fix(spindrift): stop trusting X-Forwarded-* from an address that moves

### DIFF
--- a/clusters/base/apps/oauth2-proxy/helm-release.yaml
+++ b/clusters/base/apps/oauth2-proxy/helm-release.yaml
@@ -45,8 +45,35 @@ spec:
       # sign-in fails *after* the operator has already approved on github.com —
       # far enough from the cause that the log line is the only thing naming it.
       scope: user:email read:org
-      reverse-proxy: "true"
-      trusted-proxy-ip: ${K8S_NODE_CIDR}
+      # `reverse-proxy` and `trusted-proxy-ip` are both deliberately absent.
+      #
+      # No CIDR names the gateway, because the gateway does not have one
+      # address. What oauth2-proxy sees is whatever Cilium's datapath left on
+      # the connection, and that varies with where the answering replica sits:
+      # one host, probing both replicas in the same breath, is seen as its node
+      # address by the replica on the other node and as that node's
+      # `cilium_host` router address by the replica beside it. Through the
+      # gateway the hop is seen as an address in the pod CIDR belonging to no
+      # pod at all. Only the first of those is inside `${K8S_NODE_CIDR}`, so
+      # naming it made two byte-identical replicas answer one request two ways
+      # — one composed an origin out of a client-supplied `X-Forwarded-Host`
+      # and logged it as the request's host, the other ignored it.
+      #
+      # Widening to the pod CIDR would make them agree by putting every pod in
+      # the cluster inside the trust boundary: any pod can reach this Service
+      # directly, so `X-Forwarded-Host` would become a header anything in the
+      # cluster can set. Consistency is not worth that.
+      #
+      # Trusting nothing costs nothing here, because nothing on the way in
+      # composes `X-Forwarded-Host` or `X-Forwarded-Uri`. `redirect-url` below
+      # is absolute, so `getOAuthRedirectURI` returns it without consulting
+      # either, and the shim's `X-Auth-Request-Redirect` is read ahead of them
+      # and ungated — see the block below.
+      #
+      # They have to go together. `reverse-proxy: "true"` left on its own is not
+      # the cautious half of this: `oauthproxy.go`'s `buildTrustedProxyNetSet`
+      # substitutes `0.0.0.0/0, ::/0` when `--trusted-proxy-ip` is empty, so the
+      # flag alone trusts every caller rather than none.
       redirect-url: https://oauth2.${SECRET_DOMAIN}/oauth2/callback
       whitelist-domain: .${SECRET_DOMAIN}
       cookie-domain: .${SECRET_DOMAIN}

--- a/clusters/base/apps/oauth2-proxy/helm-release.yaml
+++ b/clusters/base/apps/oauth2-proxy/helm-release.yaml
@@ -66,11 +66,12 @@ spec:
       #
       # Trusting nothing loses no behaviour, because nothing on the way in
       # composes `X-Forwarded-Host` or `X-Forwarded-Uri`. Envoy's ext_authz
-      # client forwards only what a route's `allowedHeaders` names, and
-      # `packages/charts/spindrift-app/templates/httproute.yaml` names neither —
-      # on the check's way to port 80 and on its way through the shim below
-      # alike. `redirect-url` further down is absolute, so `getOAuthRedirectURI`
-      # returns it without consulting either.
+      # client carries no header a route's `allowedHeaders` has not named,
+      # beyond the `Host`, method and path it includes on its own, and
+      # `packages/charts/spindrift-app/templates/httproute.yaml` names neither
+      # of those two — on the check's way to port 80 and on its way through the
+      # shim below alike. `redirect-url` further down is absolute, so
+      # `getOAuthRedirectURI` returns it without consulting either.
       #
       # It does change one thing, and the change is in the log rather than the
       # decision. `pkg/validation` installs

--- a/clusters/base/apps/oauth2-proxy/helm-release.yaml
+++ b/clusters/base/apps/oauth2-proxy/helm-release.yaml
@@ -64,11 +64,22 @@ spec:
       # directly, so `X-Forwarded-Host` would become a header anything in the
       # cluster can set. Consistency is not worth that.
       #
-      # Trusting nothing costs nothing here, because nothing on the way in
-      # composes `X-Forwarded-Host` or `X-Forwarded-Uri`. `redirect-url` below
-      # is absolute, so `getOAuthRedirectURI` returns it without consulting
-      # either, and the shim's `X-Auth-Request-Redirect` is read ahead of them
-      # and ungated — see the block below.
+      # Trusting nothing loses no behaviour, because nothing on the way in
+      # composes `X-Forwarded-Host` or `X-Forwarded-Uri`. Envoy's ext_authz
+      # client forwards only what a route's `allowedHeaders` names, and
+      # `packages/charts/spindrift-app/templates/httproute.yaml` names neither —
+      # on the check's way to port 80 and on its way through the shim below
+      # alike. `redirect-url` further down is absolute, so `getOAuthRedirectURI`
+      # returns it without consulting either.
+      #
+      # It does change one thing, and the change is in the log rather than the
+      # decision. `pkg/validation` installs
+      # `logger.SetGetClientFunc(ip.GetClientString(…))` only under
+      # `reverse-proxy`, so with the flag gone the client column falls back to
+      # the logger's own default of `r.RemoteAddr`: `10.101.1.197:41234` with
+      # the ephemeral port on it rather than `10.101.1.197`, and `X-Real-IP` no
+      # longer consulted there. It names the same hop either way, and that hop
+      # was never the browser.
       #
       # They have to go together. `reverse-proxy: "true"` left on its own is not
       # the cautious half of this: `oauthproxy.go`'s `buildTrustedProxyNetSet`

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -19,30 +19,40 @@ publishes: external-dns's `gateway-httproute` source would otherwise emit its
 own endpoint for these same hostnames, targeting the parent Gateway's status
 address — the same name claimed twice, at two record types, by two sources.
 
-**`allowedHeaders` permits, it does not create.** The two it names are what
-oauth2-proxy is shown of the original request, on top of the `Host`, method and
-path Envoy's ext_authz client includes on its own. `cookie` carries the session
-the check is about. Cilium's Envoy composes two headers of the `x-forwarded-*`
-family: it sets `x-forwarded-proto`, overwriting whatever the client sent, and
-appends to `x-forwarded-for`. `x-forwarded-proto` is listed because Envoy is the
-hop that writes it, not because the check depends on it — every `x-forwarded-*`
-read in oauth2-proxy goes through `CanTrustForwardedHeaders`, which is false
-whatever the check's source address, because `reverse-proxy` is unset.
-`authorization` is unlisted for a different reason — no provider this deployment
-configures reads it, with neither an htpasswd file nor bearer-token skipping in
-play.
+**`allowedHeaders` permits, it does not create.** `cookie` is the only header it
+names, on top of the `Host`, method and path Envoy's ext_authz client includes
+on its own: the session is the whole of what the check reads. `authorization` is
+unlisted because no provider this deployment configures reads it, with neither
+an htpasswd file nor bearer-token skipping in play.
 
-`x-forwarded-host` and `x-forwarded-uri` are absent because permitting them
-opened something, not because they did nothing. No hop sets either, so only a
-client could, and the two are read differently: `x-forwarded-host` is inert on
-its own — `IsForwardedRequest` needs `req.Host != GetRequestHost(req)`, and a
-header holding this Component's own hostname equals the `Host` beside it — but
-`x-forwarded-uri` is read straight through `GetRequestURI` with no such
-comparison, so a client picks the path the sign-in returns to on any replica
-that trusts it. Measured both ways, not reasoned. Two things close that gate
-independently of this list, and both are gates rather than header filters: the
-check reaches oauth2-proxy from the shim at `127.0.0.1`, and oauth2-proxy trusts
-no address at all — `CanTrustForwardedHeaders` is false for every replica.
+**No `x-forwarded-*` header is listed, and this list is the only thing that
+keeps the family out of the check.** It holds whichever backend
+`platform.externalAuth` names, because it is this filter that decides what
+crosses, not the backend — the same list guards a check that lands on
+oauth2-proxy's own port and one that goes through the ext_authz shim beside it.
+Cilium's Envoy does compose two of them on the request itself, setting
+`x-forwarded-proto` over whatever the client sent and appending to
+`x-forwarded-for`; forwarding either buys the check nothing. oauth2-proxy has
+its own gate — every `x-forwarded-*` read goes through
+`CanTrustForwardedHeaders`, which returns false on `!s.ReverseProxy` before it
+looks at an address, because
+`clusters/base/apps/oauth2-proxy/helm-release.yaml` sets no `reverse-proxy` —
+but that is one gate, in a file this chart does not own, one flag from opening.
+The omission here is the half that does not move.
+
+All three were measured against a replica that did trust its caller, and the
+result is why none of them is listed. `x-forwarded-host` is the dangerous one
+rather than the inert one: `IsForwardedRequest` fires on
+`req.Host != GetRequestHost(req)`, so a value naming *another* host in the zone
+— not this Component's own, which is the one value an attacker has no use for —
+makes `getXForwardedHeadersRedirect` compose where the sign-in returns to, and
+`whitelist-domain` accepts any sibling in the zone. `x-forwarded-uri` picks the
+path on that origin, read straight through `GetRequestURI` with no such
+comparison. `x-forwarded-proto` is what makes the pair a *valid* absolute URL:
+`GetRequestProto` otherwise answers `req.URL.Scheme`, empty on a server request,
+and the resulting `://host/path` fails `validateRedirect` and falls back to the
+bare path. Forged host and proto together returned an absolute
+`https://<sibling>/…` as the sign-in state; host alone stayed a bare path.
 `?rd=` needs no `allowedHeaders` entry at all and stays open.
 
 `x-auth-request-redirect` is the header oauth2-proxy honours without any trust
@@ -102,7 +112,6 @@ spec:
             http:
               allowedHeaders:
                 - cookie
-                - x-forwarded-proto
               allowedResponseHeaders:
                 - set-cookie
                 - x-auth-request-email

--- a/packages/charts/spindrift-app/templates/httproute.yaml
+++ b/packages/charts/spindrift-app/templates/httproute.yaml
@@ -26,8 +26,8 @@ the check is about. Cilium's Envoy composes two headers of the `x-forwarded-*`
 family: it sets `x-forwarded-proto`, overwriting whatever the client sent, and
 appends to `x-forwarded-for`. `x-forwarded-proto` is listed because Envoy is the
 hop that writes it, not because the check depends on it — every `x-forwarded-*`
-read in oauth2-proxy goes through `CanTrustForwardedHeaders`, and the check now
-arrives from `127.0.0.1`, which is outside `trusted-proxy-ip` on every replica.
+read in oauth2-proxy goes through `CanTrustForwardedHeaders`, which is false
+whatever the check's source address, because `reverse-proxy` is unset.
 `authorization` is unlisted for a different reason — no provider this deployment
 configures reads it, with neither an htpasswd file nor bearer-token skipping in
 play.
@@ -38,11 +38,12 @@ client could, and the two are read differently: `x-forwarded-host` is inert on
 its own — `IsForwardedRequest` needs `req.Host != GetRequestHost(req)`, and a
 header holding this Component's own hostname equals the `Host` beside it — but
 `x-forwarded-uri` is read straight through `GetRequestURI` with no such
-comparison, so a client did choose the path the sign-in returned to, on
-whichever replica's source address fell inside `trusted-proxy-ip`. Measured
-both ways, not reasoned. The shim closes the gate rather than the header:
-`CanTrustForwardedHeaders` is now false for every replica. `?rd=` needs no
-`allowedHeaders` entry at all and stays open.
+comparison, so a client picks the path the sign-in returns to on any replica
+that trusts it. Measured both ways, not reasoned. Two things close that gate
+independently of this list, and both are gates rather than header filters: the
+check reaches oauth2-proxy from the shim at `127.0.0.1`, and oauth2-proxy trusts
+no address at all — `CanTrustForwardedHeaders` is false for every replica.
+`?rd=` needs no `allowedHeaders` entry at all and stays open.
 
 `x-auth-request-redirect` is the header oauth2-proxy honours without any trust
 gate, and its absence here is load-bearing rather than incidental: a browser

--- a/packages/charts/spindrift-app/tests/render.test.ts
+++ b/packages/charts/spindrift-app/tests/render.test.ts
@@ -364,19 +364,24 @@ describe('the route', () => {
             port: 80,
           },
           http: {
-            // Exactly two, and the exactness is the point. `allowedHeaders`
+            // Exactly one, and the exactness is the point. `allowedHeaders`
             // permits a header through to oauth2-proxy; it does not create one.
-            // `x-forwarded-proto` is here because Envoy is the hop that writes
-            // it, not because the check reads it — every `x-forwarded-*` read
-            // is gated on `CanTrustForwardedHeaders`, false from the shim's
-            // `127.0.0.1`. `x-forwarded-host` and `x-forwarded-uri` are absent
-            // because only a client could set them, and `x-forwarded-uri` is
-            // read straight through `GetRequestURI` with no `IsForwardedRequest`
-            // comparison — it chose the path the sign-in returned to.
+            // `cookie` carries the session, which is all the check reads.
+            //
+            // No `x-forwarded-*` is listed, and this list is the only thing
+            // that keeps the family out of the check — it applies whichever
+            // backend `platform.externalAuth` names. oauth2-proxy's own gate
+            // (`CanTrustForwardedHeaders`, false while `reverse-proxy` is
+            // unset) lives in `clusters/base/apps/oauth2-proxy/helm-release.yaml`
+            // and is one flag from opening. Past it, `x-forwarded-host` naming
+            // a sibling host flips `IsForwardedRequest`, `x-forwarded-uri`
+            // picks the path on it through `GetRequestURI` with no such
+            // comparison, and `x-forwarded-proto` is what makes the pair a
+            // valid absolute URL rather than a rejected `://host/path`.
             // `authorization` is read by no provider this deployment
             // configures. The template comment carries the measurement, this
             // carries the assertion.
-            allowedHeaders: ['cookie', 'x-forwarded-proto'],
+            allowedHeaders: ['cookie'],
             allowedResponseHeaders: [
               'set-cookie',
               'x-auth-request-email',


### PR DESCRIPTION
## Two identical replicas, one request, two answers

`clusters/base/apps/oauth2-proxy/helm-release.yaml` set `trusted-proxy-ip` to
the node CIDR, on the assumption that the gateway reaches oauth2-proxy from a
node address. It does not reach it from *an* address at all. From one host,
probing both replicas in the same breath, offsite today:

```
$ ssh oldschool  # 10.89.0.11, inside K8S_NODE_CIDR 10.89.0.0/28
$ for ip in 10.101.0.31 10.101.1.62; do
    curl -s -o /dev/null -w '%{redirect_url}\n' \
      -H 'Host: oauth2.lolwtf.dev' \
      -H 'X-Forwarded-Proto: https' -H 'X-Forwarded-Host: sdd-web.lolwtf.dev' \
      "http://$ip:4180/node-probe"; done

10.101.0.31  …&state=tSGgvzC1…%3Ahttps%3A%2F%2Fsdd-web.lolwtf.dev%2Fnode-probe
10.101.1.62  …&state=uXkHPo-c…%3A%2Fnode-probe
```

The replica on the other node composed an origin out of a header the client
made up. The replica on the same node ignored it. The proxies' own logs name
why, and show the forged host reaching the access log as the request's host on
the trusting side:

```
6nvch (retrofit)   10.89.0.11    … sdd-web.lolwtf.dev GET - "/node-probe" 302
kk7hw (oldschool)  10.101.1.197  … oauth2.lolwtf.dev  GET - "/node-probe" 302
```

`10.101.1.197` is oldschool's own `cilium_host` router address — Cilium
masquerades the same-node hop to it, and that address is in the pod CIDR, not
the node CIDR. Through the gateway the hop is seen as `10.101.1.36`, a pod-CIDR
address belonging to no pod. One logical hop, three source addresses, one of
them inside the CIDR the config named. Which behaviour a request got depended on
which replica the Service picked.

## Trusting nothing rather than trusting the pod network

Widening to cover the pod CIDR would make the replicas agree. It would also make
every pod in the cluster a trusted source of `X-Forwarded-*`, since any pod can
reach this Service directly — the trust boundary handed to the whole cluster in
exchange for consistency.

Nothing on the way in composes `X-Forwarded-Host` or `X-Forwarded-Uri`. Envoy's
ext_authz client forwards only what a route's `allowedHeaders` names, and
`packages/charts/spindrift-app/templates/httproute.yaml` names neither — that
holds whichever backend `platform.externalAuth` points at, since the filter and
not the backend decides what crosses. `redirect-url` is absolute, so
`getOAuthRedirectURI` (`oauthproxy.go:1113`) returns it without consulting
either. Trusting nothing loses no behaviour that exists here, and the reasoning
is now recorded beside the absence rather than left to be rediscovered.

It does change one thing, in the log rather than the decision.
`pkg/validation/options.go` installs
`logger.SetGetClientFunc(ip.GetClientString(…))` only under `reverse-proxy`, so
the client column falls back to the logger's own default of `r.RemoteAddr`
(`pkg/logger/logger.go:124`) — `10.101.1.197:41234` with the ephemeral port
rather than `10.101.1.197`, and `X-Real-IP` no longer consulted there. Same hop
named either way, and that hop was never the browser.

## Why both flags leave together

`reverse-proxy: "true"` on its own is not the cautious half of this. v7.15.3's
`buildTrustedProxyNetSet` substitutes the default when the CIDR list is empty:

```go
if opts.ReverseProxy && len(trustedProxyIPs) == 0 {
	logger.Print("WARNING: --reverse-proxy is enabled but no --trusted-proxy-ip CIDRs were configured. All connecting IPs are trusted …")
	trustedProxyIPs = defaultTrustedProxyIPs   // {"0.0.0.0/0", "::/0"}
}
```

Keeping the flag alone would trust every caller instead of none — strictly worse
than what is there today. Dropping it is what makes
`RequestScope.CanTrustForwardedHeaders` return `false` on its first condition,
for every replica, from every address.

## One header out of `allowedHeaders`

`x-forwarded-proto` was listed because Envoy is the hop that writes it. With
`reverse-proxy` gone, `GetRequestProto` answers `req.URL.Scheme` for every
request from every address, and all four call sites in the tree go through that
one function — so no path in oauth2-proxy reads the header.

It is not inert in principle, which is why it goes rather than gets a comment
saying it is harmless. It is exactly what turns a forged `x-forwarded-host` into
a *valid* absolute origin: without a proto, `getXForwardedHeadersRedirect`
composes `://host/path`, `validateRedirect` rejects it, and the flow falls back
to the bare path. Measured that way — forged host and proto together produced
`https%3A%2F%2Fsdd-web.lolwtf.dev%2F…` as the sign-in state, host alone stayed a
bare path. `allowedHeaders` governs the check request only, so removing it
changes nothing about what an App is shown.

## What this does not touch

`K8S_NODE_CIDR` stays. This was not its only consumer: both clusters'
`networking/tailscale-connectors/connector.yaml` advertise it,
`clusters/offsite/apps/dave.yaml:45` lists it among its own trusted proxies,
`nix/services/k8s/networks.nix:27` reads it, both UniFi roots derive networks and
firewall rules from it, and `.github/policy/cluster-topology.rego` constrains it.
Nothing about it is dead.

## The reasoning around the route filter, corrected

The comment block in `packages/charts/spindrift-app/templates/httproute.yaml`
justified its `allowedHeaders` omissions by where `trusted-proxy-ip` fell, so it
had to be restated or it would name a setting that no longer exists. Two things
it said are wrong on their own terms, and a why-comment that has stopped being
true is a defect like a code one:

- It claimed **two independent gates** close the `x-forwarded-*` path — the
  omission from `allowedHeaders`, and the check arriving from the ext_authz shim
  at `127.0.0.1`. The second is not a gate. `pkg/apis/middleware/scope.go` has no
  loopback case, only `isUnixSocketRemoteAddr`, so loopback was excluded only
  *relative to* the CIDR this branch deletes — and under the misconfiguration the
  helm-release comment warns about (`reverse-proxy` alone, `0.0.0.0/0`
  substituted) `127.0.0.1` would be inside the trusted set. There is one gate in
  oauth2-proxy, `reverse-proxy` unset, and it lives in a file the chart does not
  own. What holds regardless of source address, and on the shim path and the
  port-80 path alike, is that this filter forwards no `x-forwarded-*` at all.
- It called `x-forwarded-host` **inert on its own**. It is the dangerous half:
  `IsForwardedRequest` fires on `req.Host != GetRequestHost(req)`, so a value
  naming *another* host in the zone — not this Component's own, which is the one
  value an attacker has no use for — reaches `getXForwardedHeadersRedirect`, and
  `whitelist-domain` accepts any sibling.

`tests/render.test.ts` carried the same superseded reasoning in its assertion
comment and is corrected with it.

## Risk, and what the operator owes after merge

This sits in front of sign-in for the whole fleet, so the load-bearing claim was
checked before the edit: the check path never depended on this trust, because no
`x-forwarded-*` header reaches it — the filter's `allowedHeaders` names none of
them. That holds on both routes the fleet runs today, whose `backendRef` is
`Service oauth2-proxy.oauth2-proxy:80`, and it would hold equally through the
shim. Both clusters share this base; folly's proxy is configured identically and
is affected identically.

Nothing changes until Flux reconciles. The probe above is the one to re-run
afterwards — same command, both pod IPs, and the two lines should now agree on
the bare `%2Fnode-probe` form. Worth also confirming no `WARNING: --reverse-proxy
is enabled but no --trusted-proxy-ip` line appears in either replica's log, which
would mean only half the pair was dropped. `mise run k8s:render-apps` is clean
and the `spindrift-app` render tests pass (42/42); no other suite is touched.
