### PR TITLE
feat(spindrift): onboard an installation nobody has configured

### DIFF
--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -44,7 +44,7 @@ import {
   type AuthoredManifest,
   toAuthoredManifest,
 } from '../../config/manifest.schema.ts';
-import { isPlaceholderInstallation } from '../../config/manifest.ts';
+import { isUnconfiguredInstallation } from '../../config/manifest.ts';
 import { type Command, ok } from '../types.ts';
 
 export const getInstallationManifestInput = z.object({}).strict();
@@ -63,8 +63,8 @@ export interface GetInstallationManifestResult {
    */
   readonly manifestDivergence: readonly string[];
   /**
-   * Whether anybody has configured this installation, or it is still the
-   * placeholder `loadStoredManifest` seeds an unseeded row with.
+   * Whether anybody has answered this installation's genuine choices, or they
+   * are still the stand-ins `loadStoredManifest` seeds an unseeded row with.
    *
    * Answered here rather than by a command of its own because the caller that
    * needs it — the browser deciding between onboarding and the product — needs
@@ -73,10 +73,17 @@ export interface GetInstallationManifestResult {
    * between them.
    *
    * Current by construction, for the reason above: `context.manifest` is
-   * resolved per dispatch, and {@link isPlaceholderInstallation} is a pure
-   * function of it. So the dispatch that follows a `configureInstallation`
-   * answers `true`, and onboarding ends because the installation is configured
-   * rather than because a screen decided it was finished.
+   * resolved per dispatch, and {@link isUnconfiguredInstallation} is a pure
+   * function of it, so the dispatch that follows a `configureInstallation`
+   * already reads the row that write left.
+   *
+   * **The browser does not wait for that dispatch, and this is where the two
+   * part.** `app.tsx` moves to the product when the wizard reports a saved
+   * document rather than re-reading this command, which costs a round trip on
+   * every completed onboarding to re-learn what the write just proved. The
+   * price of not paying it is the corner the predicate names: an operator who
+   * confirms all four stand-ins unchanged gets the product now and the wizard
+   * on the next load, because the write was real and configured nothing.
    */
   readonly configured: boolean;
 }
@@ -90,9 +97,8 @@ export const getInstallationManifest: Command<
     manifest,
     manifestDivergence: context.manifestDivergence ?? [],
     // The authored document, not the resolved one: the deployment's federation
-    // is joined onto `context.manifest` per read, and comparing that against a
-    // constant that cannot carry it would answer `configured` for every
-    // installation, including the one that has configured nothing.
-    configured: !isPlaceholderInstallation(manifest),
+    // is joined onto `context.manifest` per read, and the predicate reads keys
+    // an authored document is the only place to state.
+    configured: !isUnconfiguredInstallation(manifest),
   });
 };

--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -44,6 +44,7 @@ import {
   type AuthoredManifest,
   toAuthoredManifest,
 } from '../../config/manifest.schema.ts';
+import { isPlaceholderInstallation } from '../../config/manifest.ts';
 import { type Command, ok } from '../types.ts';
 
 export const getInstallationManifestInput = z.object({}).strict();
@@ -61,13 +62,37 @@ export interface GetInstallationManifestResult {
    * along with one.
    */
   readonly manifestDivergence: readonly string[];
+  /**
+   * Whether anybody has configured this installation, or it is still the
+   * placeholder `loadStoredManifest` seeds an unseeded row with.
+   *
+   * Answered here rather than by a command of its own because the caller that
+   * needs it — the browser deciding between onboarding and the product — needs
+   * the document in the same breath, and a second command would be a second
+   * round trip to learn two halves of one answer that can be inconsistent
+   * between them.
+   *
+   * Current by construction, for the reason above: `context.manifest` is
+   * resolved per dispatch, and {@link isPlaceholderInstallation} is a pure
+   * function of it. So the dispatch that follows a `configureInstallation`
+   * answers `true`, and onboarding ends because the installation is configured
+   * rather than because a screen decided it was finished.
+   */
+  readonly configured: boolean;
 }
 
 export const getInstallationManifest: Command<
   GetInstallationManifestInput,
   GetInstallationManifestResult
-> = async (_input, context) =>
-  ok({
-    manifest: toAuthoredManifest(context.manifest),
+> = async (_input, context) => {
+  const manifest = toAuthoredManifest(context.manifest);
+  return ok({
+    manifest,
     manifestDivergence: context.manifestDivergence ?? [],
+    // The authored document, not the resolved one: the deployment's federation
+    // is joined onto `context.manifest` per read, and comparing that against a
+    // constant that cannot carry it would answer `configured` for every
+    // installation, including the one that has configured nothing.
+    configured: !isPlaceholderInstallation(manifest),
   });
+};

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -230,10 +230,21 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * a session exists. A predicate whose one `true` sits behind a door that cannot
  * open is a wizard nobody can be shown.
  *
- * Reading only the genuine choices makes the reachable state the ordinary one: a
- * declaration that seeds the deployment facts — a real hostname above all — and
- * leaves the operator's own answers at their stand-ins. That installation can
- * enrol somebody, and what they are shown first is the four questions.
+ * **What that actually makes reachable, and it is not yet the ordinary case.** A
+ * declaration carrying a real `controlPlane.hostname` with these four left at
+ * their stand-ins answers `true` and *can* enrol somebody, so the reachable set
+ * is no longer empty. It is not a document anybody writes by accident: nothing
+ * in `installationManifestSchema` is optional, so an operator cannot **leave**
+ * the genuine choices — every key must be authored — and the values one would
+ * have to type to stay unconfigured are `installation: default`, this
+ * repository's own production GitHub App id, somebody else's GHCR namespace and
+ * `onepassword`. What makes the wizard ordinarily reachable is the chart seeding
+ * the deployment facts it already holds, `controlPlane.hostname` above all, so
+ * that the *placeholder* — what an installation with no declaration at all is
+ * seeded with — is itself an installation a browser will run a ceremony
+ * against. That is a change to the chart, not to this predicate, and until it
+ * lands the honest statement is: a seeded declaration reaches the wizard, a bare
+ * `manifest: {}` install still cannot sign in to be shown it.
  *
  * **All four, not any**, and a false positive here replaces the whole product
  * with a wizard, so the direction matters. Two of the four are legitimately the

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -217,24 +217,55 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * copy of a fact the row already carries whole, and it would go stale the first
  * time somebody edited the row by hand or restored a database.
  *
- * So the answer is the document compared against the constant above. Two
- * properties follow that a flag would not have: it is current the moment the
- * row changes, which is what lets a wizard's save stop the wizard being shown;
- * and it is the same answer in the reconciler, in the web process, and in a
- * test, because it is a pure function of the document.
+ * **The four values below and not the whole document**, which is the difference
+ * between a predicate with a reachable `true` and one without. The manifest is
+ * three kinds of value: deployment facts the chart already knows, cloud facts
+ * discovery can ask for, and the genuine choices — what this installation is
+ * called, whose GitHub App it speaks as, where its artifacts are published, and
+ * which store it delivers config through. Comparing the *whole* document made
+ * `true` reachable for exactly one document, the placeholder verbatim, and that
+ * document names `spindrift.example.com` as its control plane. `serve.ts` binds
+ * the passkey relying party to that hostname at boot, so a browser refuses every
+ * ceremony against it and nobody can sign in — and onboarding renders only after
+ * a session exists. A predicate whose one `true` sits behind a door that cannot
+ * open is a wizard nobody can be shown.
  *
- * **A mounted declaration therefore configures an installation**, which is
- * right: an operator who wrote a manifest has configured this installation by
- * definition, and offering them onboarding would be offering to redo work they
- * already did.
+ * Reading only the genuine choices makes the reachable state the ordinary one: a
+ * declaration that seeds the deployment facts — a real hostname above all — and
+ * leaves the operator's own answers at their stand-ins. That installation can
+ * enrol somebody, and what they are shown first is the four questions.
  *
- * The named cost: an operator who saves this exact document unchanged is still
- * unconfigured, and will be shown onboarding again. That is honest — they
- * confirmed nothing — but it does mean "configured" is not a record of a
- * *ceremony*, only of a document.
+ * **All four, not any**, and a false positive here replaces the whole product
+ * with a wizard, so the direction matters. Two of the four are legitimately the
+ * stand-in on a configured installation — this repo's own deployment speaks as
+ * the same GitHub App the placeholder names, and `onepassword` is one of two
+ * adapters — so "any is a stand-in" would answer unconfigured for a live
+ * installation. `test/config/installation-configured.test.ts` pins the live
+ * document against this.
+ *
+ * **A mounted declaration that answers all four therefore configures an
+ * installation**, which is right: an operator who chose them has configured this
+ * installation by definition, and offering them onboarding would be offering to
+ * redo work they already did.
+ *
+ * The named cost: an operator who confirms all four unchanged is still
+ * unconfigured, and will be shown onboarding again on the next load. That is
+ * honest — they chose nothing — but it does mean "configured" is a record of a
+ * document, not of a ceremony.
  */
-export function isPlaceholderInstallation(manifest: AuthoredManifest): boolean {
-  return Bun.deepEquals(manifest, DEFAULT_PLACEHOLDER_MANIFEST, true);
+export function isUnconfiguredInstallation(
+  manifest: AuthoredManifest,
+): boolean {
+  const stand = DEFAULT_PLACEHOLDER_MANIFEST;
+  return (
+    manifest.installation === stand.installation &&
+    manifest.github.clientId === stand.github.clientId &&
+    manifest.secretStore.adapter === stand.secretStore.adapter &&
+    // The one that is a list. A bare string is the same document as a
+    // one-element list by the time it is parsed (`manifest.schema.ts`), so both
+    // sides are arrays here and neither spelling changes the answer.
+    Bun.deepEquals(manifest.supplyChain.registry, stand.supplyChain.registry)
+  );
 }
 
 /**

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -207,6 +207,37 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
 };
 
 /**
+ * Whether nobody has configured this installation yet.
+ *
+ * **Derived, not flagged**, and that is the whole of the design. `loadStoredManifest`
+ * resolves `stored ?? declaration ?? placeholder` and then writes whichever arm
+ * it took back to the row — so by the time anything can ask the question, the
+ * placeholder arm is no longer distinguishable by *when* it was taken, only by
+ * *what it wrote*. A boolean column recording which arm ran would be a second
+ * copy of a fact the row already carries whole, and it would go stale the first
+ * time somebody edited the row by hand or restored a database.
+ *
+ * So the answer is the document compared against the constant above. Two
+ * properties follow that a flag would not have: it is current the moment the
+ * row changes, which is what lets a wizard's save stop the wizard being shown;
+ * and it is the same answer in the reconciler, in the web process, and in a
+ * test, because it is a pure function of the document.
+ *
+ * **A mounted declaration therefore configures an installation**, which is
+ * right: an operator who wrote a manifest has configured this installation by
+ * definition, and offering them onboarding would be offering to redo work they
+ * already did.
+ *
+ * The named cost: an operator who saves this exact document unchanged is still
+ * unconfigured, and will be shown onboarding again. That is honest — they
+ * confirmed nothing — but it does mean "configured" is not a record of a
+ * *ceremony*, only of a document.
+ */
+export function isPlaceholderInstallation(manifest: AuthoredManifest): boolean {
+  return Bun.deepEquals(manifest, DEFAULT_PLACEHOLDER_MANIFEST, true);
+}
+
+/**
  * Read the manifest the environment points at.
  *
  * `SPINDRIFT_MANIFEST_PATH` wins over `SPINDRIFT_MANIFEST`. If neither is set,

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -36,6 +36,7 @@ import { NewApp } from './views/apps/new/index.tsx';
 import { type SetReach, Workspace } from './views/apps/workspace.tsx';
 import { Gate } from './views/auth/gate.tsx';
 import { InstallationSettings } from './views/auth/installation.tsx';
+import { Onboarding } from './views/auth/onboarding.tsx';
 import { IdentitySettings } from './views/auth/settings.tsx';
 import { BuildLedger } from './views/operations/builds.tsx';
 import { DeployLedger } from './views/operations/deploys.tsx';
@@ -64,9 +65,27 @@ type Gatekeeping =
     }
   | { readonly state: 'signed-in'; readonly principal: Principal };
 
+/**
+ * Whether this installation has been configured, and the document to onboard
+ * from if it has not.
+ *
+ * The same shape as {@link Gatekeeping} and for the same reason: which screen
+ * renders is a fact about the installation rather than a choice anybody makes,
+ * and `asking` is a third state because rendering the product for one frame and
+ * then replacing it with onboarding is the flash of a broken app this exists to
+ * remove.
+ */
+export type Configuration =
+  | { readonly state: 'asking' }
+  | { readonly state: 'unconfigured'; readonly manifest: unknown }
+  | { readonly state: 'configured' };
+
 export function App() {
   const route = useRoute();
   const [gate, setGate] = useState<Gatekeeping>({ state: 'asking' });
+  const [installation, setInstallation] = useState<Configuration>({
+    state: 'asking',
+  });
 
   useEffect(() => {
     let live = true;
@@ -93,6 +112,48 @@ export function App() {
     };
   }, []);
 
+  /**
+   * Ask, once there is somebody to ask on behalf of, whether this installation
+   * has been configured.
+   *
+   * **After the session rather than beside it**, which costs a second round
+   * trip before the first paint of the product. The alternative is firing an
+   * unauthenticated command on every anonymous load to learn a fact only a
+   * signed-in operator can act on, and a 401 on the sign-in screen every time
+   * is the worse trade.
+   *
+   * **A read that fails means the product**, not onboarding. Onboarding is the
+   * more disruptive answer — it replaces the whole application — so a transport
+   * failure resolves to the state that takes nothing away, and Settings still
+   * reaches everything this screen would have asked.
+   */
+  useEffect(() => {
+    if (gate.state !== 'signed-in') {
+      // A sign-out has to un-answer this: the next operator to sign in is a
+      // different session on a possibly different installation state, and
+      // carrying the previous answer over would show them the product while
+      // this effect was still asking.
+      setInstallation({ state: 'asking' });
+      return;
+    }
+    let live = true;
+    command('getInstallationManifest', {})
+      .then((result) => {
+        if (!live) return;
+        setInstallation(
+          result.ok && !result.value.configured
+            ? { state: 'unconfigured', manifest: result.value.manifest }
+            : { state: 'configured' },
+        );
+      })
+      .catch(() => {
+        if (live) setInstallation({ state: 'configured' });
+      });
+    return () => {
+      live = false;
+    };
+  }, [gate.state]);
+
   if (gate.state === 'asking') return null;
 
   if (gate.state === 'anonymous') {
@@ -106,11 +167,12 @@ export function App() {
   }
 
   return (
-    <AppShell
+    <SignedIn
+      principal={gate.principal}
+      installation={installation}
       path={route.path}
       onNavigate={route.navigate}
-      principal={gate.principal}
-      themeControl={<ThemeToggle />}
+      onConfigured={() => setInstallation({ state: 'configured' })}
       onSignOut={() => {
         void signOut().then(() =>
           setGate({
@@ -120,8 +182,65 @@ export function App() {
           }),
         );
       }}
+    />
+  );
+}
+
+/**
+ * What somebody who has signed in is shown.
+ *
+ * Two things, and which one is not a preference: an installation that has been
+ * configured gets the product, and one that has not gets onboarding *instead
+ * of* it. Not beside it and not after it — an unconfigured installation has no
+ * Apps, no Builds and no Targets, so the product it would otherwise render is a
+ * navigation to six empty screens with one form buried at the end of it, and
+ * every act reachable from there refuses on whichever placeholder it read first.
+ *
+ * Exported for `test/web/onboarding.test.tsx`, for the same reason {@link Screen}
+ * is exported for the mounted route-table test: the claim is about *this*
+ * function's branches, and a test that rendered `Onboarding` directly would be
+ * asserting that a component it constructed itself renders. The discovery panel
+ * on the settings screen shipped in exactly that state — every test around it
+ * passed, and deleting the one line that mounted it changed nothing.
+ */
+export function SignedIn({
+  principal,
+  installation,
+  path,
+  onNavigate,
+  onConfigured,
+  onSignOut,
+}: {
+  readonly principal: Principal;
+  readonly installation: Configuration;
+  readonly path: string;
+  onNavigate(path: string): void;
+  onConfigured(): void;
+  onSignOut(): void;
+}) {
+  if (installation.state === 'asking') return null;
+
+  if (installation.state === 'unconfigured') {
+    return (
+      <Onboarding
+        initial={installation.manifest}
+        onDone={(next) => {
+          onConfigured();
+          if (next !== null) onNavigate(next);
+        }}
+      />
+    );
+  }
+
+  return (
+    <AppShell
+      path={path}
+      onNavigate={onNavigate}
+      principal={principal}
+      themeControl={<ThemeToggle />}
+      onSignOut={onSignOut}
     >
-      <Screen path={route.path} onNavigate={route.navigate} />
+      <Screen path={path} onNavigate={onNavigate} />
     </AppShell>
   );
 }

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -80,6 +80,15 @@ export type Configuration =
   | { readonly state: 'unconfigured'; readonly manifest: unknown }
   | { readonly state: 'configured' };
 
+/**
+ * How long the whole product waits on the read below before rendering anyway.
+ *
+ * Generous, because the answer decides which application an operator is looking
+ * at and guessing early on a merely-slow installation would replace the product
+ * with a wizard for no reason. It is a ceiling on a hang, not a latency budget.
+ */
+const ASK_TIMEOUT_MS = 10_000;
+
 export function App() {
   const route = useRoute();
   const [gate, setGate] = useState<Gatekeeping>({ state: 'asking' });
@@ -126,6 +135,15 @@ export function App() {
    * more disruptive answer — it replaces the whole application — so a transport
    * failure resolves to the state that takes nothing away, and Settings still
    * reaches everything this screen would have asked.
+   *
+   * **And a read that never answers means the same thing**, which needs the
+   * deadline below because a rejection is not the failure mode this one has. A
+   * request a proxy is holding open, or one issued into a pod mid-rollout, does
+   * not reject — it hangs, and `SignedIn` renders nothing while the answer is
+   * outstanding. Without a deadline that is a blank document with no chrome and
+   * no way to sign out, for as long as the socket stays up. The whole product is
+   * behind this one read, so the read is not allowed to be the thing that never
+   * finishes.
    */
   useEffect(() => {
     if (gate.state !== 'signed-in') {
@@ -137,20 +155,28 @@ export function App() {
       return;
     }
     let live = true;
-    command('getInstallationManifest', {})
+    let deadline: ReturnType<typeof setTimeout> | undefined;
+    Promise.race([
+      command('getInstallationManifest', {}),
+      new Promise<null>((resolve) => {
+        deadline = setTimeout(() => resolve(null), ASK_TIMEOUT_MS);
+      }),
+    ])
       .then((result) => {
         if (!live) return;
         setInstallation(
-          result.ok && !result.value.configured
+          result !== null && result.ok && !result.value.configured
             ? { state: 'unconfigured', manifest: result.value.manifest }
             : { state: 'configured' },
         );
       })
       .catch(() => {
         if (live) setInstallation({ state: 'configured' });
-      });
+      })
+      .finally(() => clearTimeout(deadline));
     return () => {
       live = false;
+      clearTimeout(deadline);
     };
   }, [gate.state]);
 

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -165,7 +165,7 @@ export function App() {
       .then((result) => {
         if (!live) return;
         setInstallation(
-          result !== null && result.ok && !result.value.configured
+          result?.ok && !result.value.configured
             ? { state: 'unconfigured', manifest: result.value.manifest }
             : { state: 'configured' },
         );

--- a/apps/spindrift/src/web/forms/manifest.ts
+++ b/apps/spindrift/src/web/forms/manifest.ts
@@ -11,6 +11,7 @@
  * Nothing here lists a key. Both functions are the schema applied to something.
  */
 import { installationManifestSchema } from '../../config/manifest.schema.ts';
+import type { Path } from './document.ts';
 import type { FieldErrors } from './render.tsx';
 import { describeObject, type FormField } from './schema.ts';
 
@@ -25,6 +26,28 @@ const FIELDS: readonly FormField[] = describeObject(installationManifestSchema);
 
 export function manifestFields(): readonly FormField[] {
   return FIELDS;
+}
+
+/**
+ * The schema's description of one key, by path — `null` for a path this build's
+ * schema does not have.
+ *
+ * Here rather than beside either caller because both of them are asking the same
+ * question about the same schema and neither owns it: the wizard asks it to
+ * render a named key and to refuse visibly when that key has gone, and
+ * discovery's test asks it to prove that every path the cloud proposes is a path
+ * the document can hold. Two walks would be two answers about one schema, and
+ * the one that drifted would be the one nobody was reading.
+ */
+export function manifestFieldAt(at: Path): FormField | null {
+  let fields: readonly FormField[] = FIELDS;
+  let found: FormField | null = null;
+  for (const step of at) {
+    found = fields.find((field) => field.key === step) ?? null;
+    if (found === null) return null;
+    fields = found.node.kind === 'object' ? found.node.fields : [];
+  }
+  return found;
 }
 
 /**

--- a/apps/spindrift/src/web/forms/manifest.ts
+++ b/apps/spindrift/src/web/forms/manifest.ts
@@ -57,6 +57,11 @@ export function manifestFieldAt(at: Path): FormField | null {
  * rendered against the control that produced it rather than in a list at the
  * bottom of the screen — `dns.zones.private` names one input, and `targets.1.name`
  * names one row of one array.
+ *
+ * An issue against the document itself has an empty path — strict mode's
+ * unrecognized-key refusal is one — and is spelled `(root)` rather than `''`,
+ * the same word `validateManifest` uses for it. Both callers put these keys in a
+ * sentence, and "because  is not valid" is a sentence with a hole in it.
  */
 export function manifestIssues(document: unknown): FieldErrors {
   const result = installationManifestSchema.safeParse(document);
@@ -64,7 +69,7 @@ export function manifestIssues(document: unknown): FieldErrors {
 
   const errors = new Map<string, string[]>();
   for (const issue of result.error.issues) {
-    const path = issue.path.map(String).join('.');
+    const path = issue.path.map(String).join('.') || '(root)';
     const existing = errors.get(path);
     if (existing === undefined) {
       errors.set(path, [issue.message]);

--- a/apps/spindrift/src/web/forms/schema.ts
+++ b/apps/spindrift/src/web/forms/schema.ts
@@ -80,6 +80,8 @@ interface Definition {
   readonly shape?: Record<string, unknown>;
   readonly element?: unknown;
   readonly innerType?: unknown;
+  /** A pipe's accepting end — what a document may say. See {@link describeSchema}. */
+  readonly in?: unknown;
   readonly options?: readonly unknown[];
   readonly discriminator?: string;
   readonly entries?: Record<string, string | number>;
@@ -185,6 +187,14 @@ export function describeSchema(schema: unknown): FormNode {
       return { kind: 'array', element: describeSchema(def.element) };
     case 'union':
       return unionNode(def);
+    case 'pipe':
+      // Zod 4 makes `.transform()` a pipe: an accepting schema, then a
+      // function. The function is not a shape and never will be, so the half
+      // worth describing is the accepting one — what a document is allowed to
+      // *say*, which is exactly what a form edits and what re-validation runs
+      // against. Describing the far end would mean describing a transform,
+      // which is the `unsupported` this case exists to stop being the answer.
+      return describeSchema(def.in);
     default:
       return { kind: 'unsupported', type: def.type };
   }
@@ -232,7 +242,51 @@ function unionNode(def: Definition): FormNode {
       node,
     };
   });
-  return { kind: 'union', discriminator, variants };
+  return (
+    oneOrMany(discriminator, variants) ?? {
+      kind: 'union',
+      discriminator,
+      variants,
+    }
+  );
+}
+
+/**
+ * `T | T[]` described as `T[]`, which is the only thing it ever meant.
+ *
+ * An untagged union in this schema is not a choice an operator makes — it is a
+ * document being allowed to spell one value two ways. `supplyChain.registry` is
+ * the case and its own comment is the rule: "A bare string is the same document
+ * as a one-element list and stays legal, so an installation with one registry
+ * says one thing and no stored manifest needs rewriting to keep parsing." The
+ * narrow arm exists for documents already written; the wide arm is what the
+ * value *is*, and it is what the transform on the far side of the pipe produces
+ * either way.
+ *
+ * So a form offers the list. The alternative is a variant selector asking an
+ * operator whether they would like to type one registry or several — a question
+ * about a spelling, in front of somebody configuring an installation for the
+ * first time.
+ *
+ * `null` for anything else, deliberately: this recognises exactly the shape it
+ * describes, by comparing the array arm's element against the other arm rather
+ * than by trusting the order they were declared in. A genuine untagged union of
+ * two unrelated shapes stays a union and keeps whatever the union control makes
+ * of it — being unable to render one honestly is a better answer than rendering
+ * the wrong arm of it.
+ */
+function oneOrMany(
+  discriminator: string | null,
+  variants: readonly FormVariant[],
+): FormNode | null {
+  if (discriminator !== null || variants.length !== 2) return null;
+  const list = variants.find((variant) => variant.node.kind === 'array');
+  const single = variants.find((variant) => variant.node.kind !== 'array');
+  if (list === undefined || single === undefined) return null;
+  if (list.node.kind !== 'array') return null;
+  return Bun.deepEquals(list.node.element, single.node, true)
+    ? list.node
+    : null;
 }
 
 /** The literal value an arm pins its discriminator to. */

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -179,8 +179,15 @@ export function InstallationSettings() {
   );
 }
 
-/** A refusal, kept in the three kinds the command actually draws. */
-function refusalOf(failure: TransportFailure): SaveOutcome {
+/**
+ * A refusal, kept in the three kinds the command actually draws.
+ *
+ * Exported so onboarding refuses in the same three kinds rather than in a
+ * second reading of the same codes: the distinction `NOT_DEPLOYABLE` draws is
+ * the one a form is most likely to flatten, and two screens that flattened it
+ * differently would be two different lies.
+ */
+export function refusalOf(failure: TransportFailure): SaveOutcome {
   switch (failure.code) {
     case 'INVALID_INPUT':
       return { kind: 'invalid', message: failure.message };
@@ -192,7 +199,7 @@ function refusalOf(failure: TransportFailure): SaveOutcome {
 }
 
 /** Server-reported issues, keyed the way the form keys its controls. */
-function issuesOf(failure: TransportFailure): FieldErrors {
+export function issuesOf(failure: TransportFailure): FieldErrors {
   const errors = new Map<string, string[]>();
   for (const issue of failure.issues ?? []) {
     // The dispatch layer paths an issue from the command's *input*, whose one
@@ -394,8 +401,12 @@ function ManifestDivergenceNotice({
  * world, not asked to fix a field, and `NOT_DEPLOYABLE` is that code — a
  * message about a Target that already exists with a different adapter is not
  * something re-typing a value in this form can resolve.
+ *
+ * Exported for the reason {@link refusalOf} is: onboarding writes through the
+ * same command and therefore meets the same three refusals, and it says them in
+ * this markup rather than in a second copy that could drift out of the grammar.
  */
-function Outcome({ outcome }: { readonly outcome: SaveOutcome | null }) {
+export function Outcome({ outcome }: { readonly outcome: SaveOutcome | null }) {
   if (outcome === null) return null;
 
   if (outcome.kind === 'saved') {

--- a/apps/spindrift/src/web/views/auth/onboarding.tsx
+++ b/apps/spindrift/src/web/views/auth/onboarding.tsx
@@ -36,28 +36,43 @@
  * wizard that saved per step would run reconciliation four times over four
  * documents that were each missing something.
  *
+ * **The four are the same four the predicate reads**, which is not a
+ * coincidence and is what keeps this screen coherent:
+ * `isUnconfiguredInstallation` answers over the genuine choices, so answering
+ * them here is what ends onboarding, and a step asking something the predicate
+ * ignores would be a question whose answer changed nothing. Discovery is the
+ * exception and is the reason it is a step rather than a fifth ask: it writes
+ * cloud facts, which are nobody's choice — it is here because confirming them is
+ * cheapest while the operator is already looking at the document.
+ * `secretStore.adapter` is the fourth genuine choice and is deliberately *not*
+ * asked: it is one of two values, both wrong for an installation that has not
+ * decided, and answering the other three is already enough to leave this screen.
+ *
  * **What an operator can authenticate as before any of this.** Nothing here is
  * reachable without a session, and a session is a passkey ceremony scoped to
- * `controlPlane.hostname` — bound once at boot, deliberately (`serve.ts`), and
- * on an unconfigured installation that value is the placeholder's. A browser
- * refuses a ceremony whose relying party is not a suffix of the origin it is
- * on, so an installation that has nothing but the placeholder cannot enrol
- * anybody, and this screen sits behind a door that installation cannot open.
- * That is a real gap and it is not this screen's to close: the hostname is a
- * deployment fact the chart already knows and the manifest is not given, and
- * moving where the relying party resolves from changes which origins ceremonies
- * are accepted at — a change whose only honest proof is a live enrolment. Until
- * that lands, onboarding is reachable exactly for an installation whose
- * hostname is already right and whose remaining values are not.
+ * `controlPlane.hostname` — bound once at boot, deliberately (`serve.ts`). An
+ * installation holding nothing but the placeholder has `spindrift.example.com`
+ * there, and a browser refuses a ceremony whose relying party is not a suffix of
+ * the origin it is on, so *that* installation cannot enrol anybody and this
+ * screen sits behind a door it cannot open. The chart's own default —
+ * `manifest: {}`, which renders no ConfigMap — is exactly that installation.
+ * Closing it is not this screen's: the hostname is a deployment fact the chart
+ * already knows and the manifest is not given, and moving where the relying
+ * party resolves from changes which origins ceremonies are accepted at, a change
+ * whose only honest proof is a live enrolment.
+ *
+ * So what is reachable today is the installation whose declaration seeds the
+ * deployment facts — a real hostname above all — and leaves the genuine choices
+ * at their stand-ins. That one can enrol somebody, and this is what it shows
+ * them first.
  */
 import { CircleAlert, PartyPopper, Rocket } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import { command } from '../../client.ts';
 import type { Path } from '../../forms/document.ts';
-import { manifestFields, manifestIssues } from '../../forms/manifest.ts';
+import { manifestFieldAt, manifestIssues } from '../../forms/manifest.ts';
 import type { FieldErrors } from '../../forms/render.tsx';
 import { SchemaFields } from '../../forms/render.tsx';
-import type { FormField } from '../../forms/schema.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
 import { DiscoveryPanel } from './discovery.tsx';
@@ -131,21 +146,26 @@ export const ONBOARDING_ASKS: readonly OnboardingAsk[] = [
 ];
 
 /**
- * The schema's description of one key, by path.
+ * The step that asks about a value, or `-1` for a value no step asks about.
  *
- * `null` for a path this build's schema does not have, which is rendered as a
- * refusal rather than skipped: a wizard that quietly dropped a question would
- * finish having configured less than it said it did.
+ * A wizard shows one control at a time, so an issue is only actionable on the
+ * step that mounts the control it belongs to. Prefix rather than equality
+ * because an issue names the value that is wrong and a step names the key it
+ * asks for: a bad element of `supplyChain.registry` is reported at
+ * `supplyChain.registry.0`, and the step that can fix it is the one asking for
+ * `supplyChain.registry`.
+ *
+ * `-1` is a real answer and not a miss. Discovery applies cloud facts this
+ * screen never asks for, so a document can be refused over a value with no
+ * control on any step; {@link Onboarding} names those keys in the refusal
+ * instead of navigating to a screen that would not show them.
  */
-export function manifestFieldAt(at: Path): FormField | null {
-  let fields: readonly FormField[] = manifestFields();
-  let found: FormField | null = null;
-  for (const step of at) {
-    found = fields.find((field) => field.key === step) ?? null;
-    if (found === null) return null;
-    fields = found.node.kind === 'object' ? found.node.fields : [];
-  }
-  return found;
+export function stepAsking(path: string): number {
+  return ONBOARDING_ASKS.findIndex((ask) => {
+    if (ask.kind !== 'field') return false;
+    const at = ask.at.join('.');
+    return path === at || path.startsWith(`${at}.`);
+  });
 }
 
 /**
@@ -180,10 +200,26 @@ export function Onboarding({
     // again regardless and is the authority.
     const issues = manifestIssues(document);
     if (issues.size > 0) {
+      const paths = [...issues.keys()];
       setErrors(issues);
+      // Back to the step that asks about the first refused value. This screen
+      // mounts one control at a time, so an issue against `installation` raised
+      // on the last step is an issue rendered against a control three steps
+      // back — the operator is told the manifest was refused and shown nothing
+      // that says what to do. The settings form has no equivalent problem
+      // because every field is mounted at once.
+      //
+      // An issue may still belong to no step: discovery applies cloud facts
+      // this screen never asks for. Naming the keys is what that case has
+      // instead of a control to point at.
+      const asked = paths
+        .map(stepAsking)
+        .filter((at) => at >= 0)
+        .sort((first, second) => first - second);
+      if (asked[0] !== undefined) setStep(asked[0]);
       setOutcome({
         kind: 'invalid',
-        message: 'This installation was not written, because it is not valid.',
+        message: `This installation was not written, because ${paths.join(', ')} ${paths.length === 1 ? 'is' : 'are'} not valid.`,
       });
       return;
     }

--- a/apps/spindrift/src/web/views/auth/onboarding.tsx
+++ b/apps/spindrift/src/web/views/auth/onboarding.tsx
@@ -36,17 +36,21 @@
  * wizard that saved per step would run reconciliation four times over four
  * documents that were each missing something.
  *
- * **The four are the same four the predicate reads**, which is not a
- * coincidence and is what keeps this screen coherent:
- * `isUnconfiguredInstallation` answers over the genuine choices, so answering
- * them here is what ends onboarding, and a step asking something the predicate
- * ignores would be a question whose answer changed nothing. Discovery is the
- * exception and is the reason it is a step rather than a fifth ask: it writes
- * cloud facts, which are nobody's choice — it is here because confirming them is
+ * **This asks three of the four the predicate reads**, which is what keeps the
+ * screen coherent without making it a fourth question:
+ * `isUnconfiguredInstallation` answers over the genuine choices, and because it
+ * is an **and** — unconfigured means all four are still stand-ins — answering
+ * any one of the three asked here is what ends onboarding. A step asking
+ * something the predicate ignores would be a question whose answer changed
+ * nothing, which is why the fourth ask is discovery rather than another key: it
+ * writes cloud facts, nobody's choice, and it is here because confirming them is
  * cheapest while the operator is already looking at the document.
  * `secretStore.adapter` is the fourth genuine choice and is deliberately *not*
  * asked: it is one of two values, both wrong for an installation that has not
- * decided, and answering the other three is already enough to leave this screen.
+ * decided, and answering any of the other three already ends this screen. The
+ * asymmetry is safe only in that direction — a predicate that answered
+ * unconfigured when *any* choice was still a stand-in would hand this
+ * installation, which legitimately keeps two, a wizard instead of its product.
  *
  * **What an operator can authenticate as before any of this.** Nothing here is
  * reachable without a session, and a session is a passkey ceremony scoped to

--- a/apps/spindrift/src/web/views/auth/onboarding.tsx
+++ b/apps/spindrift/src/web/views/auth/onboarding.tsx
@@ -1,0 +1,437 @@
+/**
+ * The first four questions, for an installation nobody has configured (§20).
+ *
+ * `loadStoredManifest` seeds an unseeded row with a placeholder document, and
+ * every value in it is a stand-in — the registry is somebody else's namespace,
+ * the signer names a key ring that does not exist, the control plane is served
+ * at an example hostname. An installation in that state does not *fail*; it
+ * comes up, renders an Overview of nothing, and refuses the first act an
+ * operator attempts, with a message about whichever placeholder that act
+ * happened to read first. This screen is what stands in front of that.
+ *
+ * **Everything else is derived and never asked.** The manifest is three kinds
+ * of value and only one of them is a question: the deployment's own facts are
+ * the chart's, the cloud's facts are discovery's, and what is left — what this
+ * installation is called, whose GitHub App it speaks as, where its artifacts
+ * are published — is nobody's but the operator's. So this asks four things and
+ * the settings surface keeps every key. It is deliberately *not* the settings
+ * form with a progress bar: a first-run screen that opened the whole document
+ * would be asking somebody who has never seen this software to make thirty
+ * decisions before making one.
+ *
+ * **It names manifest keys, and it is the one screen that may.** `installation.tsx`
+ * renders whatever the schema declares and names nothing, which is what keeps it
+ * correct as keys leave and arrive. A wizard cannot be written that way — asking
+ * a chosen four *is* the feature — so the four are named once, in
+ * {@link ONBOARDING_ASKS}, and resolved through `manifestFields()` rather than
+ * rendered by hand. A key that leaves the schema therefore leaves this screen
+ * as a visible refusal rather than as a control writing somewhere nothing
+ * reads, and `test/web/onboarding.test.tsx` walks all four through the schema so
+ * the removal is a failing test rather than a discovery.
+ *
+ * **One write, at the end, through `configureInstallation`.** Every step edits
+ * one document held here; nothing is saved until the last screen. That is not
+ * only about not half-configuring an installation — `writeStoredManifest`
+ * reconciles the Targets a document declares inside the same transaction, so a
+ * wizard that saved per step would run reconciliation four times over four
+ * documents that were each missing something.
+ *
+ * **What an operator can authenticate as before any of this.** Nothing here is
+ * reachable without a session, and a session is a passkey ceremony scoped to
+ * `controlPlane.hostname` — bound once at boot, deliberately (`serve.ts`), and
+ * on an unconfigured installation that value is the placeholder's. A browser
+ * refuses a ceremony whose relying party is not a suffix of the origin it is
+ * on, so an installation that has nothing but the placeholder cannot enrol
+ * anybody, and this screen sits behind a door that installation cannot open.
+ * That is a real gap and it is not this screen's to close: the hostname is a
+ * deployment fact the chart already knows and the manifest is not given, and
+ * moving where the relying party resolves from changes which origins ceremonies
+ * are accepted at — a change whose only honest proof is a live enrolment. Until
+ * that lands, onboarding is reachable exactly for an installation whose
+ * hostname is already right and whose remaining values are not.
+ */
+import { CircleAlert, PartyPopper, Rocket } from 'lucide-react';
+import { type ReactNode, useState } from 'react';
+import { command } from '../../client.ts';
+import type { Path } from '../../forms/document.ts';
+import { manifestFields, manifestIssues } from '../../forms/manifest.ts';
+import type { FieldErrors } from '../../forms/render.tsx';
+import { SchemaFields } from '../../forms/render.tsx';
+import type { FormField } from '../../forms/schema.ts';
+import { Button } from '../../ui/button.tsx';
+import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
+import { DiscoveryPanel } from './discovery.tsx';
+import {
+  issuesOf,
+  Outcome,
+  refusalOf,
+  type SaveOutcome,
+} from './installation.tsx';
+
+/** One screen: a manifest key to confirm, or the cloud to ask. */
+export type OnboardingAsk = {
+  readonly title: string;
+  readonly blurb: string;
+} & (
+  | {
+      readonly kind: 'field';
+      /** Where in the document the answer goes, outermost key first. */
+      readonly at: Path;
+    }
+  | { readonly kind: 'discovery' }
+);
+
+/**
+ * The four questions, in the order they are asked.
+ *
+ * The order is not cosmetic. The name comes first because it is the only answer
+ * that needs nothing — no credential, no cloud, no prior step — so the first
+ * thing an operator does is succeed. GitHub is second because the artifacts
+ * step below it is about publishing what GitHub's repositories produce, and
+ * confirming the client id here is what makes the authorization on the far side
+ * of this screen able to run at all. Discovery is third because it is the only
+ * step that reads the world, and a step that can be slow or refuse belongs after
+ * the ones that cannot. The registry is last because it is the answer most
+ * likely to be a considered choice rather than a confirmation.
+ *
+ * `github.clientId` is the value, not the authorization ceremony:
+ * `beginRepositoryAuthorization` reads the client id off the *stored* manifest,
+ * so a device flow started here would run against the placeholder's. The
+ * ceremony is offered when the document has landed — see {@link OnboardingDone}
+ * — which is also where it already exists, tested, on the connections screen.
+ */
+export const ONBOARDING_ASKS: readonly OnboardingAsk[] = [
+  {
+    kind: 'field',
+    at: ['installation'],
+    title: 'Name this installation',
+    blurb:
+      'A label for this control plane. It appears in the UI and in logs and carries no behaviour, so it is yours to pick.',
+  },
+  {
+    kind: 'field',
+    at: ['github', 'clientId'],
+    title: 'Connect GitHub',
+    blurb:
+      'The GitHub App this installation speaks as. Nothing is authorized yet — that ceremony needs this value stored first, and it is offered as soon as it is.',
+  },
+  {
+    kind: 'discovery',
+    title: 'Confirm what the cloud says',
+    blurb:
+      'Read with the credential this deployment already mounts, so a project, a bucket and a signing key are confirmed rather than typed from memory.',
+  },
+  {
+    kind: 'field',
+    at: ['supplyChain', 'registry'],
+    title: 'Where artifacts are published',
+    blurb:
+      'Every image this installation builds is pushed here and pulled from here by whatever runs it. An installation whose Targets cannot share one names several.',
+  },
+];
+
+/**
+ * The schema's description of one key, by path.
+ *
+ * `null` for a path this build's schema does not have, which is rendered as a
+ * refusal rather than skipped: a wizard that quietly dropped a question would
+ * finish having configured less than it said it did.
+ */
+export function manifestFieldAt(at: Path): FormField | null {
+  let fields: readonly FormField[] = manifestFields();
+  let found: FormField | null = null;
+  for (const step of at) {
+    found = fields.find((field) => field.key === step) ?? null;
+    if (found === null) return null;
+    fields = found.node.kind === 'object' ? found.node.fields : [];
+  }
+  return found;
+}
+
+/**
+ * Ask the four, then write the document once.
+ *
+ * `initial` rather than a read of its own: whoever decided this installation is
+ * unconfigured had to read the manifest to know that, and re-reading it here
+ * would be a second round trip for a document already in hand — and a chance
+ * for the two to disagree about which document is being edited.
+ */
+export function Onboarding({
+  initial,
+  onDone,
+}: {
+  readonly initial: unknown;
+  /**
+   * Configuration landed. `next` is a path to open instead of the product's
+   * own first screen, or `null` for that screen.
+   */
+  onDone(next: string | null): void;
+}) {
+  const [document, setDocument] = useState<unknown>(initial);
+  const [step, setStep] = useState(0);
+  const [errors, setErrors] = useState<FieldErrors>(new Map());
+  const [outcome, setOutcome] = useState<SaveOutcome | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const finish = async () => {
+    // The same earlier-of-two-identical-checks the settings form runs, for the
+    // same reason: the command reports every offending key in one sentence,
+    // which is right for a log and wrong for a form. The command validates
+    // again regardless and is the authority.
+    const issues = manifestIssues(document);
+    if (issues.size > 0) {
+      setErrors(issues);
+      setOutcome({
+        kind: 'invalid',
+        message: 'This installation was not written, because it is not valid.',
+      });
+      return;
+    }
+
+    setSaving(true);
+    setErrors(new Map());
+    try {
+      const result = await command('configureInstallation', {
+        manifest: document,
+      });
+      if (result.ok) {
+        setOutcome({ kind: 'saved', targets: result.value.targets });
+      } else {
+        setOutcome(refusalOf(result.failure));
+        if (result.failure.code === 'INVALID_INPUT') {
+          setErrors(issuesOf(result.failure));
+        }
+      }
+    } catch (cause) {
+      setOutcome({
+        kind: 'failed',
+        message:
+          cause instanceof Error
+            ? cause.message
+            : 'Configuring this installation did not complete.',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <OnboardingView
+      step={step}
+      document={document}
+      errors={errors}
+      outcome={outcome}
+      saving={saving}
+      onChange={(next) => {
+        setDocument(next);
+        setOutcome(null);
+      }}
+      onStep={setStep}
+      onFinish={() => void finish()}
+      onDone={onDone}
+    />
+  );
+}
+
+/**
+ * What is on screen, with nothing to fetch.
+ *
+ * Split from the state above for the reason `InstallationSettingsView` is: every
+ * claim worth making about a wizard is a claim about *what a given step shows*,
+ * and a component that owned its own step could only ever be asserted on its
+ * first one.
+ */
+export function OnboardingView({
+  step,
+  document,
+  errors,
+  outcome,
+  saving,
+  onChange,
+  onStep,
+  onFinish,
+  onDone,
+}: {
+  readonly step: number;
+  readonly document: unknown;
+  readonly errors: FieldErrors;
+  readonly outcome: SaveOutcome | null;
+  readonly saving: boolean;
+  onChange(document: unknown): void;
+  onStep(step: number): void;
+  onFinish(): void;
+  onDone(next: string | null): void;
+}) {
+  // A saved document is the end of this screen's job, whatever step it was on.
+  if (outcome?.kind === 'saved') {
+    return (
+      <OnboardingShell>
+        <OnboardingDone targets={outcome.targets} onDone={onDone} />
+      </OnboardingShell>
+    );
+  }
+
+  const ask = ONBOARDING_ASKS[step];
+  if (ask === undefined) return null;
+  const last = step === ONBOARDING_ASKS.length - 1;
+  const form = { document, errors, disabled: saving, onChange };
+
+  return (
+    <OnboardingShell>
+      <Card>
+        <CardHeader>
+          <Rocket aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+          <div>
+            <p className="text-[11.5px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+              Step {step + 1} of {ONBOARDING_ASKS.length}
+            </p>
+            <CardTitle>{ask.title}</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">{ask.blurb}</p>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {ask.kind === 'discovery' ? (
+            // The same panel the settings surface mounts, editing the same
+            // document through the same `onChange`. A confirmed value is an
+            // unsaved edit here exactly as it is there.
+            <DiscoveryPanel
+              document={document}
+              disabled={saving}
+              onChange={onChange}
+            />
+          ) : (
+            <AskedField at={ask.at} form={form} />
+          )}
+        </CardContent>
+      </Card>
+
+      <Outcome outcome={outcome} />
+
+      <div className="flex items-center justify-between gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          disabled={saving || step === 0}
+          onClick={() => onStep(step - 1)}
+        >
+          Back
+        </Button>
+        {last ? (
+          <Button type="button" disabled={saving} onClick={onFinish}>
+            {saving ? 'Configuring…' : 'Configure this installation'}
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            disabled={saving}
+            onClick={() => onStep(step + 1)}
+          >
+            Continue
+          </Button>
+        )}
+      </div>
+    </OnboardingShell>
+  );
+}
+
+/** One asked key, rendered by the schema rather than by hand. */
+function AskedField({
+  at,
+  form,
+}: {
+  readonly at: Path;
+  readonly form: Parameters<typeof SchemaFields>[0]['form'];
+}) {
+  const field = manifestFieldAt(at);
+  if (field === null) {
+    return (
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground"
+      >
+        <CircleAlert aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+        <div>
+          <p className="font-medium">
+            This build cannot ask that question here.
+          </p>
+          <p className="mt-0.5">
+            The key it asks about is not in this build&apos;s manifest schema,
+            so there is nothing to write. Everything this installation has is
+            editable in Settings once you are through.
+          </p>
+        </div>
+      </div>
+    );
+  }
+  return <SchemaFields fields={[field]} at={at.slice(0, -1)} form={form} />;
+}
+
+/**
+ * Configuration landed, and the one thing that could not happen until it did.
+ *
+ * GitHub's device flow reads `github.clientId` off the stored manifest, so this
+ * is the first moment the authorization an operator was promised on step two
+ * can actually run — and it runs on the connections screen, which already owns
+ * that ceremony and its polling.
+ */
+function OnboardingDone({
+  targets,
+  onDone,
+}: {
+  readonly targets: readonly string[];
+  onDone(next: string | null): void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <PartyPopper aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+        <div>
+          <CardTitle>This installation is configured.</CardTitle>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {targets.length === 0
+              ? 'It declares no Targets yet. Connect one from Settings when there is somewhere to deploy.'
+              : `Targets reconciled, in rank order: ${targets.join(', ')}.`}
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        <p className="text-sm text-muted-foreground">
+          Everything else this installation names — its zones, its Targets, its
+          build routes — is in Settings, and nothing here has to be right
+          forever.
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button type="button" onClick={() => onDone('/settings/connections')}>
+            Authorize GitHub
+          </Button>
+          <Button type="button" variant="outline" onClick={() => onDone(null)}>
+            Open this installation
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * The frame, which is the product's chrome deliberately absent.
+ *
+ * An unconfigured installation has no Apps, no Builds and no Targets, so the
+ * navigation that reaches them would be five links to five empty screens and a
+ * sixth to the settings form this screen exists to stand in front of.
+ */
+function OnboardingShell({ children }: { readonly children: ReactNode }) {
+  return (
+    <main className="mx-auto flex min-h-dvh w-full max-w-[640px] flex-col justify-center gap-6 px-5 py-12">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <span className="font-mono text-xl font-bold tracking-[0.25em] text-foreground">
+          SPINDRIFT
+        </span>
+        <p className="text-xs text-muted-foreground">
+          Nothing here is configured yet. Four answers and it is.
+        </p>
+      </div>
+      {children}
+    </main>
+  );
+}

--- a/apps/spindrift/test/commands/installation-discover.test.ts
+++ b/apps/spindrift/test/commands/installation-discover.test.ts
@@ -22,10 +22,9 @@ import {
   discoverInstallationFacts,
 } from '../../src/commands/installation/discover.ts';
 import type { CommandContext } from '../../src/commands/types.ts';
-import { installationManifestSchema } from '../../src/config/manifest.schema.ts';
 import type { InstallationManifest } from '../../src/config/manifest.ts';
 import type { Database } from '../../src/db/client.ts';
-import { describeObject, type FormField } from '../../src/web/forms/schema.ts';
+import { manifestFieldAt } from '../../src/web/forms/manifest.ts';
 import {
   FakeGcpDiscovery,
   type FakeGcpDiscoveryOptions,
@@ -533,19 +532,15 @@ describe('an installation with no cloud identity', () => {
 });
 
 describe('every path discovery proposes is a path the manifest has', () => {
-  /** Walk the schema the settings form is generated from, key by key. */
+  /**
+   * Walk the schema the settings form is generated from, key by key.
+   *
+   * The wizard's own walk, not a second one: onboarding resolves the keys it
+   * names through `manifestFieldAt`, and a copy here would be a second answer
+   * about one schema that only has to agree by luck.
+   */
   function resolves(path: readonly string[]): boolean {
-    let fields: readonly FormField[] = describeObject(
-      installationManifestSchema,
-    );
-    for (const [index, key] of path.entries()) {
-      const field = fields.find((candidate) => candidate.key === key);
-      if (field === undefined) return false;
-      if (index === path.length - 1) return true;
-      if (field.node.kind !== 'object') return false;
-      fields = field.node.fields;
-    }
-    return false;
+    return manifestFieldAt(path) !== null;
   }
 
   test('the walk rejects a key the schema no longer has', () => {

--- a/apps/spindrift/test/commands/installation-round-trip.test.ts
+++ b/apps/spindrift/test/commands/installation-round-trip.test.ts
@@ -87,6 +87,17 @@ describe('the installation settings round trip', () => {
     ).toBe(true);
   });
 
+  test('a refusal of the document itself is named, not blank', () => {
+    // Strict mode refuses an unrecognized *top-level* key with an empty path,
+    // and both surfaces put these keys into a sentence — "was not written,
+    // because ${paths} are not valid". An empty key is a sentence with a hole
+    // in it, and this is the same word `validateManifest` already prints for
+    // the same issue.
+    const issues = manifestIssues({ ...manifest, unexpected: true });
+
+    expect([...issues.keys()]).toContain('(root)');
+  });
+
   test('the answered document carries no derived key', async () => {
     await seed();
 

--- a/apps/spindrift/test/config/installation-configured.test.ts
+++ b/apps/spindrift/test/config/installation-configured.test.ts
@@ -19,12 +19,21 @@
  * placeholder verbatim, and that document's `controlPlane.hostname` is
  * `spindrift.example.com`. The relying party is bound to it at boot, so no
  * browser will run a passkey ceremony against that installation and onboarding
- * renders only behind a session. The third claim is the state that fixes:
- * a declaration that seeds the deployment facts and leaves the genuine choices
- * alone, which can enrol somebody and is still unconfigured.
+ * renders only behind a session. The seeded-declaration claim below is the state
+ * that fixes — a document with a real hostname whose genuine choices are still
+ * stand-ins can enrol somebody and is still unconfigured — and it is one
+ * document, not a class: nothing in the schema is optional, so that document has
+ * to restate every stand-in by hand. See `isUnconfiguredInstallation`.
+ *
+ * **Each conjunct gets its own claim**, because dropping one from an `&&` is the
+ * false-positive direction and the four-value assertion below cannot see it: it
+ * reads the values, never the predicate. One claim per genuine choice, each
+ * answering that choice alone and asserting configured, is what makes a conjunct
+ * that stops being read a red build rather than a silent widening.
  */
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
+import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
   isUnconfiguredInstallation,
@@ -54,8 +63,25 @@ async function liveDeclaration() {
   return validateManifest(release.spec?.values?.manifest, LIVE_RELEASE);
 }
 
-describe('the live installation renders the product, not the wizard', () => {
-  test('the declaration this repository deploys is configured', async () => {
+/**
+ * **The declaration, which is not the document that governs**, and the name says
+ * so on purpose. `loadStoredManifest` resolves `stored ?? declaration ??
+ * placeholder`, this installation has been seeded for months, and the release's
+ * own header says a declaration seeds and the row governs. So no test in this
+ * file can assert what the live *installation* renders; what it can assert is
+ * that the document this repository declares is not one that would hand an
+ * operator a wizard.
+ *
+ * The two agree today where it matters. The offsite web pod's boot warning
+ * reports the row and the declaration already disagreeing at nine paths —
+ * `charts.app`, and both Targets' `delivery.sourceRef.name`/`.namespace` and
+ * `chartValues.platform.externalAuth.name`/`.port` — and none of the four this
+ * predicate reads is among them. The row's own values are `offsite`,
+ * `Iv1.918d699f36ee7afc`, `["ghcr.io/jonpulsifer", …]` and `onepassword`: the
+ * same two answered, the same two at the stand-in.
+ */
+describe('the declaration this repository deploys is configured', () => {
+  test('it is not a document that would replace the product with a wizard', async () => {
     const manifest = await liveDeclaration();
 
     expect(isUnconfiguredInstallation(manifest)).toBe(false);
@@ -92,10 +118,13 @@ describe('an installation nobody has configured says so', () => {
   });
 
   test('a declaration that seeds only the deployment facts is unconfigured', () => {
-    // The state the wizard is actually reachable in, and the one a whole-document
-    // comparison could not express. Everything corrected here is a fact the chart
-    // knows — the hostname above all, which is what makes a passkey ceremony
-    // possible at all — and every genuine choice is left at its stand-in.
+    // The one state the wizard is reachable in today, and the one a
+    // whole-document comparison could not express. Everything corrected here is
+    // a fact the chart knows — the hostname above all, which is what makes a
+    // passkey ceremony possible at all — and every genuine choice is left at its
+    // stand-in. "Left" is generous: the schema has no optional keys, so this
+    // document restates all four stand-ins by hand, which is why the case is
+    // reachable rather than ordinary.
     const seeded = {
       ...DEFAULT_PLACEHOLDER_MANIFEST,
       controlPlane: { hostname: 'spindrift.substituted.example' },
@@ -113,15 +142,56 @@ describe('an installation nobody has configured says so', () => {
     );
   });
 
-  test('answering one genuine choice is enough to leave onboarding', () => {
-    // Onboarding's first screen, and the smallest act that ends it: naming the
-    // installation. The wizard asks three of the four and this is the one it
-    // asks first, so an operator who gets no further than pressing Continue on
-    // an edited name has still configured this installation.
-    const named = { ...DEFAULT_PLACEHOLDER_MANIFEST, installation: 'offsite' };
+  // One row per conjunct, and four rows rather than one assertion because
+  // dropping a single `&&` is invisible to everything else in this file: the
+  // claim above reads the four values but never routes them through the
+  // predicate, so it cannot watch the predicate stop reading one. Each row
+  // answers exactly one genuine choice and asserts configured — the smallest act
+  // that ends onboarding, which for the first row is an operator pressing
+  // Continue on an edited name and nothing else.
+  const answeringOne: readonly (readonly [string, AuthoredManifest])[] = [
+    [
+      'installation',
+      { ...DEFAULT_PLACEHOLDER_MANIFEST, installation: 'offsite' },
+    ],
+    [
+      'github.clientId',
+      {
+        ...DEFAULT_PLACEHOLDER_MANIFEST,
+        github: {
+          ...DEFAULT_PLACEHOLDER_MANIFEST.github,
+          clientId: 'Iv1.0000000000000000',
+        },
+      },
+    ],
+    [
+      'supplyChain.registry',
+      {
+        ...DEFAULT_PLACEHOLDER_MANIFEST,
+        supplyChain: {
+          ...DEFAULT_PLACEHOLDER_MANIFEST.supplyChain,
+          registry: ['ghcr.io/jonpulsifer'],
+        },
+      },
+    ],
+    [
+      'secretStore.adapter',
+      {
+        ...DEFAULT_PLACEHOLDER_MANIFEST,
+        secretStore: {
+          ...DEFAULT_PLACEHOLDER_MANIFEST.secretStore,
+          adapter: 'gcp-secret-manager',
+        },
+      },
+    ],
+  ];
 
-    expect(isUnconfiguredInstallation(named)).toBe(false);
-  });
+  test.each(answeringOne)(
+    'answering %s and nothing else is enough to leave onboarding',
+    (_choice, manifest) => {
+      expect(isUnconfiguredInstallation(manifest)).toBe(false);
+    },
+  );
 
   test('a registry spelled as a bare string is the list it always was', () => {
     // `supplyChain.registry` accepts either spelling and parses both to a list,

--- a/apps/spindrift/test/config/installation-configured.test.ts
+++ b/apps/spindrift/test/config/installation-configured.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Which application an operator is shown, decided by one predicate.
+ *
+ * `isUnconfiguredInstallation` is the whole of that decision: false renders the
+ * product, true replaces it with a four-question wizard. The two directions are
+ * not symmetric and neither is what a test owes them.
+ *
+ * **A false positive replaces a working installation with a wizard**, which is
+ * why the first claim below reads the *real* declaration out of
+ * `clusters/offsite/apps/spindrift/helm-release.yaml` rather than a fixture. A
+ * fixture asserting the right thing while the repository says something else is
+ * exactly the false positive this file exists to refuse, and the predicate reads
+ * four specific values — two of which this installation legitimately leaves at
+ * the stand-in — so "obviously configured" is not obvious enough to assert from
+ * memory.
+ *
+ * **A false negative is a wizard nobody can reach**, which is what shipped: a
+ * predicate over the whole document answered true for exactly one document, the
+ * placeholder verbatim, and that document's `controlPlane.hostname` is
+ * `spindrift.example.com`. The relying party is bound to it at boot, so no
+ * browser will run a passkey ceremony against that installation and onboarding
+ * renders only behind a session. The third claim is the state that fixes:
+ * a declaration that seeds the deployment facts and leaves the genuine choices
+ * alone, which can enrol somebody and is still unconfigured.
+ */
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  DEFAULT_PLACEHOLDER_MANIFEST,
+  isUnconfiguredInstallation,
+  validateManifest,
+} from '../../src/config/manifest.ts';
+
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+const LIVE_RELEASE = 'clusters/offsite/apps/spindrift/helm-release.yaml';
+
+/**
+ * What Flux's `postBuild` fills in, standing in for the values themselves.
+ *
+ * The zones are read from cluster settings and cluster secrets rather than
+ * written in the release, and restating either here would put a network fact in
+ * a place that is not its source. Neither is a value the predicate reads; what
+ * this substitution is for is letting the rest of the document parse.
+ */
+const SUBSTITUTED = 'substituted.example';
+
+async function liveDeclaration() {
+  const text = (
+    await Bun.file(join(REPO_ROOT, LIVE_RELEASE)).text()
+  ).replaceAll(/\$\{[A-Z_]+\}/g, SUBSTITUTED);
+  const release = Bun.YAML.parse(text) as {
+    spec?: { values?: { manifest?: unknown } };
+  };
+  return validateManifest(release.spec?.values?.manifest, LIVE_RELEASE);
+}
+
+describe('the live installation renders the product, not the wizard', () => {
+  test('the declaration this repository deploys is configured', async () => {
+    const manifest = await liveDeclaration();
+
+    expect(isUnconfiguredInstallation(manifest)).toBe(false);
+  });
+
+  test('two of its four genuine choices really are the stand-in', async () => {
+    // The reason the claim above is worth a test rather than a glance, and the
+    // reason the predicate is "all four" rather than "any": this installation
+    // speaks as the same GitHub App the placeholder names and delivers through
+    // the same one of two store adapters. A predicate that asked whether *any*
+    // genuine choice was still a stand-in would answer unconfigured here, and
+    // an operator signing in to a working installation would be handed a wizard.
+    const manifest = await liveDeclaration();
+
+    expect(manifest.github.clientId).toBe(
+      DEFAULT_PLACEHOLDER_MANIFEST.github.clientId,
+    );
+    expect(manifest.secretStore.adapter).toBe(
+      DEFAULT_PLACEHOLDER_MANIFEST.secretStore.adapter,
+    );
+    // And the two it answers, which are what make it configured.
+    expect(manifest.installation).not.toBe(
+      DEFAULT_PLACEHOLDER_MANIFEST.installation,
+    );
+    expect(manifest.supplyChain.registry).not.toEqual(
+      DEFAULT_PLACEHOLDER_MANIFEST.supplyChain.registry,
+    );
+  });
+});
+
+describe('an installation nobody has configured says so', () => {
+  test('the document an unseeded row is seeded with is unconfigured', () => {
+    expect(isUnconfiguredInstallation(DEFAULT_PLACEHOLDER_MANIFEST)).toBe(true);
+  });
+
+  test('a declaration that seeds only the deployment facts is unconfigured', () => {
+    // The state the wizard is actually reachable in, and the one a whole-document
+    // comparison could not express. Everything corrected here is a fact the chart
+    // knows — the hostname above all, which is what makes a passkey ceremony
+    // possible at all — and every genuine choice is left at its stand-in.
+    const seeded = {
+      ...DEFAULT_PLACEHOLDER_MANIFEST,
+      controlPlane: { hostname: 'spindrift.substituted.example' },
+      dns: {
+        zones: {
+          private: 'substituted.example',
+          public: 'substituted.example',
+        },
+      },
+      charts: { app: 'oci://ghcr.io/example/charts/spindrift-app' },
+    };
+
+    expect(isUnconfiguredInstallation(validateManifest(seeded, 'a seed'))).toBe(
+      true,
+    );
+  });
+
+  test('answering one genuine choice is enough to leave onboarding', () => {
+    // Onboarding's first screen, and the smallest act that ends it: naming the
+    // installation. The wizard asks three of the four and this is the one it
+    // asks first, so an operator who gets no further than pressing Continue on
+    // an edited name has still configured this installation.
+    const named = { ...DEFAULT_PLACEHOLDER_MANIFEST, installation: 'offsite' };
+
+    expect(isUnconfiguredInstallation(named)).toBe(false);
+  });
+
+  test('a registry spelled as a bare string is the list it always was', () => {
+    // `supplyChain.registry` accepts either spelling and parses both to a list,
+    // so the stand-in stays the stand-in however it was written. A predicate
+    // comparing the raw document would answer differently for two documents that
+    // are the same document.
+    const bare = validateManifest(
+      {
+        ...DEFAULT_PLACEHOLDER_MANIFEST,
+        supplyChain: {
+          ...DEFAULT_PLACEHOLDER_MANIFEST.supplyChain,
+          registry: DEFAULT_PLACEHOLDER_MANIFEST.supplyChain.registry[0],
+        },
+      },
+      'a bare registry',
+    );
+
+    expect(isUnconfiguredInstallation(bare)).toBe(true);
+  });
+});

--- a/apps/spindrift/test/harness/dom.ts
+++ b/apps/spindrift/test/harness/dom.ts
@@ -1,0 +1,244 @@
+/**
+ * Just enough DOM for `react-dom/client` to mount into.
+ *
+ * The repo has no jsdom/happy-dom (absent from `package.json`, absent from
+ * `bun.lock`, and the Bun runtime has no DOM global of its own), and adding one
+ * to run a handful of mounted tests is a dependency the suite does not otherwise
+ * need. What follows is not a DOM implementation; it is the subset
+ * `react-dom/client`'s host config and the component trees under test actually
+ * call — `appendChild`/`insertBefore`/`removeChild`,
+ * `setAttribute`/`getAttribute` (Radix reports `data-state` and `hidden`
+ * through these rather than through an IDL property, which is what makes them a
+ * reliable read), `style` as a plain object, a no-op `addEventListener`
+ * (nothing here simulates a click) and a `getBoundingClientRect` that satisfies
+ * a layout effect without a layout.
+ *
+ * **Why a module and not a copy in each file.** Two of them exist now — the
+ * mounted route table and the mounted shell — and the second one arrived
+ * because a whole feature's only wiring was observed by nothing. A second copy
+ * of this shim would be a second answer to "what does React need", and the copy
+ * that fell behind would be the one whose test file mysteriously stopped
+ * mounting.
+ *
+ * **Installed and restored per file, never at import.** These are globals: a
+ * `document` left on `globalThis` flips every `typeof window !== 'undefined'`
+ * feature check in every file that runs afterwards. {@link installDomShim}
+ * captures whatever was there — including the keys a caller passes in `extras`
+ * — and `restore()` puts all of it back, so a file that installs in `beforeAll`
+ * and restores in `afterAll` leaves the suite exactly as it found it.
+ */
+
+export const ELEMENT_NODE = 1;
+export const TEXT_NODE = 3;
+
+/**
+ * `CollapsibleContentImpl` sets a `--radix-collapsible-content-height` custom
+ * property alongside ordinary style keys. React DOM routes any `--`-prefixed
+ * style key through `style.setProperty` rather than a direct assignment (that
+ * split exists for real CSSStyleDeclarations, where custom properties are not
+ * reflected as JS properties) — a plain object supports neither, so this is a
+ * plain object plus that one method.
+ */
+class FakeStyle {
+  [key: string]: unknown;
+  setProperty(name: string, value: string): void {
+    this[name] = value;
+  }
+  removeProperty(name: string): void {
+    delete this[name];
+  }
+}
+
+export class FakeNode {
+  readonly nodeType: number;
+  readonly ownerDocument: FakeDocument;
+  readonly namespaceURI?: string;
+  parentNode: FakeNode | null = null;
+  childNodes: FakeNode[] = [];
+  readonly style = new FakeStyle();
+  readonly tagName: string;
+  private readonly attrs = new Map<string, string>();
+  private text: string;
+
+  constructor(
+    nodeType: number,
+    ownerDocument: FakeDocument,
+    text = '',
+    namespaceURI?: string,
+    tag = '',
+  ) {
+    this.nodeType = nodeType;
+    this.ownerDocument = ownerDocument;
+    this.text = text;
+    this.namespaceURI = namespaceURI;
+    // `getRootHostContext` reads the container's `tagName` (uppercase, per DOM
+    // convention) to seed the SVG/HTML namespace switch; every other fake node
+    // just carries it for parity.
+    this.tagName = tag.toUpperCase();
+  }
+
+  appendChild(child: FakeNode): FakeNode {
+    return this.insertBefore(child, null);
+  }
+
+  insertBefore(child: FakeNode, ref: FakeNode | null): FakeNode {
+    if (child.parentNode) child.parentNode.removeChild(child);
+    const index = ref ? this.childNodes.indexOf(ref) : -1;
+    if (ref && index === -1) {
+      this.childNodes.push(child);
+    } else if (ref) {
+      this.childNodes.splice(index, 0, child);
+    } else {
+      this.childNodes.push(child);
+    }
+    child.parentNode = this;
+    return child;
+  }
+
+  removeChild(child: FakeNode): FakeNode {
+    const index = this.childNodes.indexOf(child);
+    if (index !== -1) this.childNodes.splice(index, 1);
+    child.parentNode = null;
+    return child;
+  }
+
+  contains(node: FakeNode): boolean {
+    for (let n: FakeNode | null = node; n; n = n.parentNode) {
+      if (n === this) return true;
+    }
+    return false;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attrs.set(name, String(value));
+  }
+  getAttribute(name: string): string | null {
+    return this.attrs.has(name) ? (this.attrs.get(name) ?? null) : null;
+  }
+  removeAttribute(name: string): void {
+    this.attrs.delete(name);
+  }
+  hasAttribute(name: string): boolean {
+    return this.attrs.has(name);
+  }
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+
+  getBoundingClientRect() {
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    };
+  }
+
+  get nodeValue(): string | null {
+    return this.nodeType === TEXT_NODE ? this.text : null;
+  }
+  set nodeValue(value: string) {
+    this.text = value;
+  }
+
+  get textContent(): string {
+    return this.nodeType === TEXT_NODE
+      ? this.text
+      : this.childNodes.map((c) => c.textContent).join('');
+  }
+  set textContent(value: string) {
+    this.childNodes = [];
+    if (value)
+      this.appendChild(new FakeNode(TEXT_NODE, this.ownerDocument, value));
+  }
+}
+
+export class FakeDocument {
+  readonly nodeType = 9;
+  // Set to `globalThis` once installed as the global `window` —
+  // `commitBeforeMutationEffects` reads focus through
+  // `container.ownerDocument.defaultView.document`, so `defaultView` has to be
+  // the same object as `globalThis.document`'s owner, not a lookalike.
+  defaultView: typeof globalThis | undefined;
+  // Read by `getActiveElement`; there is no focus in this shim, and `null` says
+  // so instead of leaving the property (and the `|| doc.body` fallback it
+  // feeds) undefined.
+  readonly activeElement: null = null;
+  readonly body: null = null;
+
+  // React registers a handful of document-level listeners (selection,
+  // composition) alongside the per-root ones. Nothing here simulates input, so
+  // these only need to not throw.
+  addEventListener(): void {}
+  removeEventListener(): void {}
+
+  createElement(tag: string): FakeNode {
+    return new FakeNode(ELEMENT_NODE, this, '', undefined, tag);
+  }
+  createElementNS(ns: string, tag: string): FakeNode {
+    return new FakeNode(ELEMENT_NODE, this, '', ns, tag);
+  }
+  createTextNode(text: string): FakeNode {
+    return new FakeNode(TEXT_NODE, this, text);
+  }
+  createComment(text: string): FakeNode {
+    return new FakeNode(8, this, text);
+  }
+}
+
+export interface DomShim {
+  /** The document mounted trees are created from. */
+  readonly document: FakeDocument;
+  /** Put every global this replaced back the way it was. */
+  restore(): void;
+}
+
+/**
+ * Install the shim on `globalThis`.
+ *
+ * `extras` is where a file states the seams its own tree reaches — a `fetch`, a
+ * `WebSocket`, a `location`. They are passed in rather than defaulted because
+ * what a stub is allowed to answer is a claim the test is making, and a default
+ * answer shared between files would be a claim nobody wrote down.
+ */
+export function installDomShim(extras: Record<string, unknown> = {}): DomShim {
+  const document = new FakeDocument();
+  const values: Record<string, unknown> = {
+    document,
+    // `@radix-ui/react-primitive` does a bare `typeof window !== 'undefined'`
+    // feature check on every mount, and react-dom's own focus-restoration pass
+    // reads `container.ownerDocument.defaultView.document` — both need `window`
+    // to be the same object `document` was installed on.
+    window: globalThis,
+    // `@radix-ui/react-presence` reads this to decide whether an open/close
+    // transition is mid CSS-animation. Nothing here has a stylesheet, so
+    // reporting no `animationName` is correct rather than a stub of convenience.
+    getComputedStyle: (node: FakeNode) => node.style,
+    requestAnimationFrame: (cb: () => void) => setTimeout(cb, 0),
+    cancelAnimationFrame: (id: number) => clearTimeout(id),
+    IS_REACT_ACT_ENVIRONMENT: true,
+    // react-dom's focus restoration walks into iframes via
+    // `element instanceof window.HTMLIFrameElement`; nothing here ever is one,
+    // but the right-hand side still has to be a real constructor.
+    HTMLIFrameElement: class {},
+    ...extras,
+  };
+
+  const previous = new Map<string, unknown>();
+  for (const key of Object.keys(values)) {
+    previous.set(key, (globalThis as Record<string, unknown>)[key]);
+  }
+  Object.assign(globalThis, values);
+  document.defaultView = globalThis;
+
+  return {
+    document,
+    restore() {
+      Object.assign(globalThis, Object.fromEntries(previous));
+    },
+  };
+}

--- a/apps/spindrift/test/web/app-mounted.test.tsx
+++ b/apps/spindrift/test/web/app-mounted.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * What a signed-in operator is actually handed, mounted.
+ *
+ * `onboarding.test.tsx` asserts that `SignedIn` renders the wizard when it is
+ * *told* the installation is unconfigured. Nothing asserted the sentence before
+ * that one: that `App` asks, and turns the answer into the state `SignedIn`
+ * branches on. That gap is not a formality — the whole feature hangs off four
+ * lines of one effect, and with them mutated to answer `configured` always, or
+ * deleted outright, the suite stayed green while the wizard became unreachable
+ * and the product became a blank page respectively.
+ *
+ * It is the same defect slice 2 shipped and this ticket's own test header cites:
+ * a discovery panel every test passed around and nothing observed being mounted.
+ * The lesson taken twice is that a claim about a component's *branches* has to
+ * be made against the component, so this mounts `App` itself and answers its two
+ * reads over a stubbed `fetch` — `client.ts` and `auth-client.ts` reach the
+ * network through that one global and nothing else, which is the whole seam.
+ *
+ * Three answers and three screens, and the asymmetry is the point: onboarding
+ * replaces the entire application, so it is the answer that has to be *earned*.
+ * A refusal, a hang, and anything that is not a clear "nobody has configured
+ * this" all resolve to the product, which takes nothing away and leaves Settings
+ * reaching every value the wizard would have asked for.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from 'bun:test';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { DEFAULT_PLACEHOLDER_MANIFEST } from '../../src/config/manifest.ts';
+import { App } from '../../src/web/app.tsx';
+import { type DomShim, installDomShim } from '../harness/dom.ts';
+
+/** The operator the session answers with; `App` only reads the principal. */
+const OPERATOR = { id: 'usr_test', displayName: 'Operator' };
+
+/**
+ * How `getInstallationManifest` answers this test, set per case.
+ *
+ * `null` is the stall: the read never settles, which is a proxy holding a
+ * connection open or a pod mid-rollout, and is the one failure mode a `.catch`
+ * cannot see.
+ */
+let answer:
+  | { readonly kind: 'ok'; readonly configured: boolean }
+  | { readonly kind: 'throws' }
+  | { readonly kind: 'never' } = { kind: 'ok', configured: true };
+
+let dom: DomShim;
+
+beforeAll(() => {
+  dom = installDomShim({
+    // `useRoute` reads the hash through `useSyncExternalStore` and subscribes
+    // with `addEventListener`, which Bun's `globalThis` already implements.
+    location: { hash: '' },
+    // The shell's theme toggle reads a stored preference on mount. Nothing here
+    // is about the theme; an empty store is the "no preference" case and is the
+    // one that needs no opinion.
+    localStorage: {
+      getItem: () => null,
+      setItem: () => undefined,
+    },
+    fetch: async (url: string) => {
+      if (url.endsWith('/session')) {
+        return {
+          json: async () => ({
+            ok: true,
+            value: {
+              principal: OPERATOR,
+              claimed: true,
+              gatewayUnlinked: false,
+            },
+          }),
+        };
+      }
+      if (url.endsWith('getInstallationManifest')) {
+        if (answer.kind === 'throws') throw new Error('the socket went away');
+        if (answer.kind === 'never') return await new Promise(() => {});
+        return {
+          json: async () => ({
+            ok: true,
+            value: {
+              manifest: DEFAULT_PLACEHOLDER_MANIFEST,
+              manifestDivergence: [],
+              configured: answer.kind === 'ok' && answer.configured,
+            },
+          }),
+        };
+      }
+      // Overview's four reads. They are not what is under test and the screen
+      // renders its own loading state until they answer, so they never do.
+      return await new Promise(() => {});
+    },
+  });
+});
+
+afterAll(() => dom.restore());
+
+beforeEach(() => {
+  answer = { kind: 'ok', configured: true };
+});
+
+/** Mount `App` and let both reads settle. */
+async function mount(): Promise<{ text: () => string; unmount: () => void }> {
+  const container = dom.document.createElement('div');
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container as unknown as Element);
+    root.render(<App />);
+  });
+  // The installation read is issued by an effect keyed on the session's answer,
+  // so it is a second turn of the loop rather than part of the first.
+  await act(async () => {});
+  return {
+    text: () => container.textContent,
+    unmount: () => {
+      act(() => root.unmount());
+    },
+  };
+}
+
+describe('the installation decides which application is rendered', () => {
+  test('an installation nobody has configured is handed the wizard', async () => {
+    answer = { kind: 'ok', configured: false };
+
+    const screen = await mount();
+
+    expect(screen.text()).toContain('Step 1 of 4');
+    // And not underneath it: the shell's navigation is the fingerprint of the
+    // product this replaces.
+    expect(screen.text()).not.toContain('Overview');
+
+    screen.unmount();
+  });
+
+  test('a configured installation is handed the product', async () => {
+    answer = { kind: 'ok', configured: true };
+
+    const screen = await mount();
+
+    expect(screen.text()).toContain('Overview');
+    expect(screen.text()).not.toContain('Step 1 of 4');
+
+    screen.unmount();
+  });
+
+  test('a read that fails is the product, not onboarding', async () => {
+    // Onboarding is the more disruptive answer, so a transport failure resolves
+    // to the state that takes nothing away.
+    answer = { kind: 'throws' };
+
+    const screen = await mount();
+
+    expect(screen.text()).toContain('Overview');
+
+    screen.unmount();
+  });
+
+  test('a read that never answers is the product once the deadline passes', async () => {
+    // The failure a `.catch` cannot see. Before the deadline the whole document
+    // is blank — no chrome, no sign-out — for as long as the socket stays open,
+    // which is the state a proxy holding a connection leaves an operator in.
+    answer = { kind: 'never' };
+    jest.useFakeTimers();
+    try {
+      const screen = await mount();
+
+      expect(screen.text()).toBe('');
+
+      await act(async () => {
+        jest.advanceTimersByTime(60_000);
+      });
+
+      expect(screen.text()).toContain('Overview');
+
+      screen.unmount();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/spindrift/test/web/deploy-detail-mounted.test.tsx
+++ b/apps/spindrift/test/web/deploy-detail-mounted.test.tsx
@@ -15,16 +15,10 @@
  *
  * The repo has no jsdom/happy-dom (checked: absent from `package.json`,
  * absent from `bun.lock`, no DOM global in the Bun runtime itself), and
- * adding one is out of scope for a single regression test. What follows is a
- * few dozen lines of the smallest object graph `react-dom/client`'s host
- * config and the `@radix-ui/react-collapsible` tree actually call —
- * `appendChild`/`insertBefore`/`removeChild`, `setAttribute`/`getAttribute`
- * (Radix reports `data-state` and `hidden` through these, never through a
- * direct IDL property, which is what makes them a reliable read here),
- * `style` as a plain object, a no-op `addEventListener` (nothing here
- * simulates a click), and a `getBoundingClientRect` that satisfies
- * `CollapsibleContent`'s layout-effect without a real layout. It is not a DOM
- * implementation; it is the subset this one component tree touches.
+ * adding one is out of scope for a regression test. `test/harness/dom.ts` is
+ * the subset `react-dom/client`'s host config and the
+ * `@radix-ui/react-collapsible` tree actually call, and its own header says
+ * what that subset is and why it is a module rather than a copy per file.
  *
  * The second half of the file mounts the **route table** rather than one view,
  * for the same structural reason: navigating between two Deploys of one App
@@ -33,175 +27,26 @@
  * globals the shim already owns — the client reaches the network through
  * exactly those two and nothing else.
  */
-import { afterAll, beforeEach, describe, expect, test } from 'bun:test';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { Screen } from '../../src/web/app.tsx';
 import type { DeployView } from '../../src/web/model.ts';
 import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
 import { DEPLOY_SCENARIOS } from '../fixtures/scenarios.ts';
-
-const ELEMENT_NODE = 1;
-const TEXT_NODE = 3;
-
-/**
- * `CollapsibleContentImpl` sets a `--radix-collapsible-content-height`
- * custom property alongside ordinary style keys. React DOM routes any
- * `--`-prefixed style key through `style.setProperty` rather than a direct
- * assignment (that split exists for real CSSStyleDeclarations, where custom
- * properties aren't reflected as JS properties) — a plain object supports
- * neither, so this is a plain object plus that one method.
- */
-class FakeStyle {
-  [key: string]: unknown;
-  setProperty(name: string, value: string): void {
-    this[name] = value;
-  }
-  removeProperty(name: string): void {
-    delete this[name];
-  }
-}
-
-class FakeNode {
-  readonly nodeType: number;
-  readonly ownerDocument: FakeDocument;
-  readonly namespaceURI?: string;
-  parentNode: FakeNode | null = null;
-  childNodes: FakeNode[] = [];
-  readonly style = new FakeStyle();
-  readonly tagName: string;
-  private readonly attrs = new Map<string, string>();
-  private text: string;
-
-  constructor(
-    nodeType: number,
-    ownerDocument: FakeDocument,
-    text = '',
-    namespaceURI?: string,
-    tag = '',
-  ) {
-    this.nodeType = nodeType;
-    this.ownerDocument = ownerDocument;
-    this.text = text;
-    this.namespaceURI = namespaceURI;
-    // `getRootHostContext` reads the container's `tagName` (uppercase, per
-    // DOM convention) to seed the SVG/HTML namespace switch; every other
-    // fake node just carries it for parity.
-    this.tagName = tag.toUpperCase();
-  }
-
-  appendChild(child: FakeNode): FakeNode {
-    return this.insertBefore(child, null);
-  }
-
-  insertBefore(child: FakeNode, ref: FakeNode | null): FakeNode {
-    if (child.parentNode) child.parentNode.removeChild(child);
-    const index = ref ? this.childNodes.indexOf(ref) : -1;
-    if (ref && index === -1) {
-      this.childNodes.push(child);
-    } else if (ref) {
-      this.childNodes.splice(index, 0, child);
-    } else {
-      this.childNodes.push(child);
-    }
-    child.parentNode = this;
-    return child;
-  }
-
-  removeChild(child: FakeNode): FakeNode {
-    const index = this.childNodes.indexOf(child);
-    if (index !== -1) this.childNodes.splice(index, 1);
-    child.parentNode = null;
-    return child;
-  }
-
-  contains(node: FakeNode): boolean {
-    for (let n: FakeNode | null = node; n; n = n.parentNode) {
-      if (n === this) return true;
-    }
-    return false;
-  }
-
-  setAttribute(name: string, value: string): void {
-    this.attrs.set(name, String(value));
-  }
-  getAttribute(name: string): string | null {
-    return this.attrs.has(name) ? (this.attrs.get(name) ?? null) : null;
-  }
-  removeAttribute(name: string): void {
-    this.attrs.delete(name);
-  }
-  hasAttribute(name: string): boolean {
-    return this.attrs.has(name);
-  }
-
-  addEventListener(): void {}
-  removeEventListener(): void {}
-
-  getBoundingClientRect() {
-    return {
-      x: 0,
-      y: 0,
-      top: 0,
-      left: 0,
-      right: 0,
-      bottom: 0,
-      width: 0,
-      height: 0,
-    };
-  }
-
-  get nodeValue(): string | null {
-    return this.nodeType === TEXT_NODE ? this.text : null;
-  }
-  set nodeValue(value: string) {
-    this.text = value;
-  }
-
-  get textContent(): string {
-    return this.nodeType === TEXT_NODE
-      ? this.text
-      : this.childNodes.map((c) => c.textContent).join('');
-  }
-  set textContent(value: string) {
-    this.childNodes = [];
-    if (value)
-      this.appendChild(new FakeNode(TEXT_NODE, this.ownerDocument, value));
-  }
-}
-
-class FakeDocument {
-  readonly nodeType = 9;
-  // Set to `globalThis` once the test installs it as the global `window` —
-  // `commitBeforeMutationEffects` reads focus through
-  // `container.ownerDocument.defaultView.document`, so `defaultView` has to
-  // be the same object as `globalThis.document`'s owner, not a lookalike.
-  defaultView: typeof globalThis | undefined;
-  // Read by `getActiveElement`; there is no focus in this shim, and `null`
-  // says so instead of leaving the property (and the `|| doc.body` fallback
-  // it feeds) undefined.
-  readonly activeElement: null = null;
-  readonly body: null = null;
-
-  // React registers a handful of document-level listeners (selection,
-  // composition) alongside the per-root ones. Nothing here simulates input,
-  // so these only need to not throw.
-  addEventListener(): void {}
-  removeEventListener(): void {}
-
-  createElement(tag: string): FakeNode {
-    return new FakeNode(ELEMENT_NODE, this, '', undefined, tag);
-  }
-  createElementNS(ns: string, tag: string): FakeNode {
-    return new FakeNode(ELEMENT_NODE, this, '', ns, tag);
-  }
-  createTextNode(text: string): FakeNode {
-    return new FakeNode(TEXT_NODE, this, text);
-  }
-  createComment(text: string): FakeNode {
-    return new FakeNode(8, this, text);
-  }
-}
+import {
+  type DomShim,
+  ELEMENT_NODE,
+  type FakeNode,
+  installDomShim,
+} from '../harness/dom.ts';
 
 /** Depth-first search for the first element whose text passes `match`. */
 function findButton(
@@ -222,31 +67,6 @@ function findButton(
   }
   return null;
 }
-
-/**
- * The shim is installed for the whole file rather than one `describe`, because
- * more than one claim needs a mounted tree and installing it twice would leave
- * the second restore holding the first shim as its "previous". Restoring at all
- * is what keeps the rest of the suite honest: a `document` left on `globalThis`
- * flips every `typeof window !== 'undefined'` feature check in the files that
- * run after this one.
- */
-const fakeDocument = new FakeDocument();
-const previousDocument = (globalThis as { document?: unknown }).document;
-const previousWindow = (globalThis as { window?: unknown }).window;
-const previousGetComputedStyle = (globalThis as { getComputedStyle?: unknown })
-  .getComputedStyle;
-const previousRaf = (globalThis as { requestAnimationFrame?: unknown })
-  .requestAnimationFrame;
-const previousCancelRaf = (globalThis as { cancelAnimationFrame?: unknown })
-  .cancelAnimationFrame;
-const previousActEnv = (globalThis as { IS_REACT_ACT_ENVIRONMENT?: unknown })
-  .IS_REACT_ACT_ENVIRONMENT;
-const previousHTMLIFrameElement = (
-  globalThis as { HTMLIFrameElement?: unknown }
-).HTMLIFrameElement;
-const previousWebSocket = (globalThis as { WebSocket?: unknown }).WebSocket;
-const previousFetch = globalThis.fetch;
 
 /**
  * What the mounted route table is allowed to answer with.
@@ -280,56 +100,36 @@ async function answer(id: number, deploy: DeployView): Promise<void> {
   });
 }
 
-Object.assign(globalThis, {
-  document: fakeDocument,
-  // `@radix-ui/react-primitive` does a bare `typeof window !== 'undefined'`
-  // feature-check on every mount, and react-dom's own focus-restoration
-  // pass reads `container.ownerDocument.defaultView.document` — both need
-  // `window` to be the same object `document` was installed on.
-  window: globalThis,
-  // `@radix-ui/react-presence` reads this to decide whether an open/close
-  // transition is mid CSS-animation. Nothing here has a stylesheet, so
-  // reporting no `animationName` is correct, not a stub of convenience.
-  getComputedStyle: (node: FakeNode) => node.style,
-  requestAnimationFrame: (cb: () => void) => setTimeout(cb, 0),
-  cancelAnimationFrame: (id: number) => clearTimeout(id),
-  IS_REACT_ACT_ENVIRONMENT: true,
-  // react-dom's focus restoration walks into iframes via
-  // `element instanceof window.HTMLIFrameElement`; nothing here ever is
-  // one, but the right-hand side still has to be a real constructor.
-  HTMLIFrameElement: class {},
-  // `subscribeAttempt` opens one of these as soon as the first read returns.
-  // Nothing here pushes events — the claims below are about the read — so it
-  // only has to be constructible and closeable.
-  WebSocket: class {
-    onmessage: unknown = null;
-    onclose: unknown = null;
-    onerror: unknown = null;
-    close(): void {}
-  },
-  // Every command goes through this, and the id it is asking about is in the
-  // body rather than the path: `pathFor` names the command, not the object.
-  fetch: async (_url: string, init?: { body?: string }) => {
-    const { id } = JSON.parse(init?.body ?? '{}') as { id?: number };
-    if (id === undefined) throw new Error('a command asked for no id');
-    return await answerFor(id);
-  },
-});
-fakeDocument.defaultView = globalThis;
+/**
+ * Installed in `beforeAll` rather than at import, because these are globals and
+ * a file's imports are evaluated before the file that installed them last has
+ * restored: capturing the previous values at the moment this file's tests start
+ * is what keeps two mounted-test files from restoring each other's shim.
+ */
+let dom: DomShim;
 
-afterAll(() => {
-  Object.assign(globalThis, {
-    document: previousDocument,
-    window: previousWindow,
-    getComputedStyle: previousGetComputedStyle,
-    requestAnimationFrame: previousRaf,
-    cancelAnimationFrame: previousCancelRaf,
-    IS_REACT_ACT_ENVIRONMENT: previousActEnv,
-    HTMLIFrameElement: previousHTMLIFrameElement,
-    WebSocket: previousWebSocket,
-    fetch: previousFetch,
+beforeAll(() => {
+  dom = installDomShim({
+    // `subscribeAttempt` opens one of these as soon as the first read returns.
+    // Nothing here pushes events — the claims below are about the read — so it
+    // only has to be constructible and closeable.
+    WebSocket: class {
+      onmessage: unknown = null;
+      onclose: unknown = null;
+      onerror: unknown = null;
+      close(): void {}
+    },
+    // Every command goes through this, and the id it is asking about is in the
+    // body rather than the path: `pathFor` names the command, not the object.
+    fetch: async (_url: string, init?: { body?: string }) => {
+      const { id } = JSON.parse(init?.body ?? '{}') as { id?: number };
+      if (id === undefined) throw new Error('a command asked for no id');
+      return await answerFor(id);
+    },
   });
 });
+
+afterAll(() => dom.restore());
 
 describe('Transcript re-derives open on a build status change', () => {
   test('a running LIVE_TEXT build that turns failed springs the transcript open', () => {
@@ -343,7 +143,7 @@ describe('Transcript re-derives open on a build status change', () => {
     };
     const failedView: DeployView = DEPLOY_SCENARIOS.buildFailed;
 
-    const container = fakeDocument.createElement('div');
+    const container = dom.document.createElement('div');
     let root!: Root;
     act(() => {
       root = createRoot(container as unknown as Element);
@@ -409,7 +209,7 @@ describe('the mounted Deploy screen replaces what a newer view says', () => {
     const building: DeployView = DEPLOY_SCENARIOS.building;
     const failed: DeployView = DEPLOY_SCENARIOS.buildFailed;
 
-    const container = fakeDocument.createElement('div');
+    const container = dom.document.createElement('div');
     let root!: Root;
     act(() => {
       root = createRoot(container as unknown as Element);
@@ -490,7 +290,7 @@ describe('switching between two Deploys of one App', () => {
   });
 
   const mount = () => {
-    const container = fakeDocument.createElement('div');
+    const container = dom.document.createElement('div');
     let root!: Root;
     act(() => {
       root = createRoot(container as unknown as Element);

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -26,7 +26,7 @@ import type {
   AuthoredManifest,
   InstallationManifest,
 } from '../../src/config/manifest.schema.ts';
-import { resolveManifest } from '../../src/config/manifest.ts';
+import { DEFAULT_PLACEHOLDER_MANIFEST } from '../../src/config/manifest.ts';
 import {
   currentStoredManifest,
   loadStoredManifest,
@@ -109,6 +109,30 @@ async function seed(): Promise<void> {
   });
 }
 
+/**
+ * Boot with no declaration at all — the state the wizard exists for.
+ *
+ * The real loader rather than an insert of the placeholder constant, because
+ * the claim being tested is about *that function's* placeholder arm: it
+ * resolves `stored ?? declaration ?? placeholder` and then writes whichever arm
+ * it took, so a test that wrote the row itself would prove nothing about what a
+ * fresh installation actually boots holding.
+ */
+async function bootUnconfigured(): Promise<void> {
+  await loadStoredManifest(database().db, {});
+}
+
+async function readInstallation(): Promise<{
+  manifest: AuthoredManifest;
+  configured: boolean;
+}> {
+  const response = await post(authenticated, 'getInstallationManifest', {});
+  const body = (await response.json()) as {
+    value: { manifest: AuthoredManifest; configured: boolean };
+  };
+  return body.value;
+}
+
 async function storedManifest(): Promise<AuthoredManifest | undefined> {
   const [row] = await database().db.select().from(installation);
   return row?.manifest;
@@ -144,6 +168,55 @@ describe('reading this installation from the browser', () => {
     await seed();
     const response = await post(anonymous, 'getInstallationManifest', {});
     expect(response.status).toBe(401);
+  });
+});
+
+/**
+ * Which screen an unconfigured installation gets, decided by the row rather
+ * than by a flag.
+ *
+ * This is the whole of what makes onboarding appear instead of a product with
+ * nothing configured behind it, and it is asserted over the route table for the
+ * same reason the criteria above are: the browser asks this question through
+ * `getInstallationManifest` and acts on the answer, so an answer that were only
+ * right when the handler is called directly would be right nowhere.
+ */
+describe('whether anybody has configured this installation', () => {
+  test('a boot with nothing declared is unconfigured, and says so', async () => {
+    await bootUnconfigured();
+    const { manifest, configured } = await readInstallation();
+    expect(configured).toBe(false);
+    // And the document handed to onboarding is the one the row holds, which is
+    // what makes the first screen a confirmation rather than a blank form.
+    expect(manifest).toEqual(DEFAULT_PLACEHOLDER_MANIFEST);
+  });
+
+  test('a declaration configured this installation, so onboarding never runs', async () => {
+    // The live posture, and the one that would be worst to get wrong: an
+    // installation whose chart mounts a manifest has been configured by
+    // whoever wrote it, and showing them a wizard would be offering to redo
+    // work they already did.
+    await seed();
+    expect((await readInstallation()).configured).toBe(true);
+  });
+
+  test('onboarding’s own write is what ends it', async () => {
+    // Resolved per dispatch, so the read that follows the write sees the row —
+    // which is what lets onboarding stop because the installation is
+    // configured rather than because a screen decided it was finished.
+    await bootUnconfigured();
+    const { manifest } = await readInstallation();
+    const named = withValueAt(
+      manifest,
+      ['installation'],
+      'named-by-onboarding',
+    );
+
+    const saved = await post(authenticated, 'configureInstallation', {
+      manifest: named,
+    });
+    expect(saved.status).toBe(200);
+    expect((await readInstallation()).configured).toBe(true);
   });
 });
 

--- a/apps/spindrift/test/web/onboarding.test.tsx
+++ b/apps/spindrift/test/web/onboarding.test.tsx
@@ -39,12 +39,13 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import type { Principal } from '../../src/commands/types.ts';
 import { DEFAULT_PLACEHOLDER_MANIFEST } from '../../src/config/manifest.ts';
 import { SignedIn } from '../../src/web/app.tsx';
+import { manifestFieldAt } from '../../src/web/forms/manifest.ts';
 import type { FieldErrors } from '../../src/web/forms/render.tsx';
 import type { SaveOutcome } from '../../src/web/views/auth/installation.tsx';
 import {
-  manifestFieldAt,
   ONBOARDING_ASKS,
   OnboardingView,
+  stepAsking,
 } from '../../src/web/views/auth/onboarding.tsx';
 
 /** The document an unconfigured installation actually holds. */
@@ -194,6 +195,22 @@ describe('a refusal is the same three things it is on the settings screen', () =
       errors: new Map([['installation', ['Too small: expected string']]]),
     });
     expect(markup).toContain('Too small: expected string');
+  });
+
+  test('a refused value is traced to the step that can fix it', () => {
+    // The settings form mounts every field at once and can render an issue
+    // wherever it belongs. This one shows a single control, so an issue against
+    // `installation` raised on the last step is an issue rendered against a
+    // control three steps back — the operator is told the manifest was refused
+    // and shown nothing that says what to do. `finish` navigates on this.
+    expect(stepAsking('installation')).toBe(0);
+    expect(stepAsking('github.clientId')).toBe(1);
+    // By prefix: an issue names the value that is wrong, a step names the key it
+    // asks for, and an array control's elements are neither of the other's.
+    expect(stepAsking('supplyChain.registry.0')).toBe(3);
+    // And a value no step asks about is not forced onto one. Discovery writes
+    // cloud facts this screen never offers a control for.
+    expect(stepAsking('sources.defaultBucket')).toBe(-1);
   });
 });
 

--- a/apps/spindrift/test/web/onboarding.test.tsx
+++ b/apps/spindrift/test/web/onboarding.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * What an installation nobody has configured is shown instead of the product.
+ *
+ * Rendered to static markup, which is the right depth for what is claimed:
+ * every rule below is a statement about **what is on screen in a given step**,
+ * and the step is a prop for exactly that reason — a component that owned it
+ * could only ever be asserted on its first screen.
+ *
+ * Four claims, and they are not the same claim:
+ *
+ * 1. **The four questions are four questions this build can answer.** Onboarding
+ *    is the one screen allowed to name manifest keys, and the price of that
+ *    permission is a test that walks every named key through the schema. A key
+ *    that leaves the schema has to fail here rather than become a step that
+ *    renders nothing.
+ * 2. **Each step asks its own question and nothing else.** "Everything else is
+ *    derived and never asked" is the whole shape of this screen; a step that
+ *    also rendered the rest of the document would be the settings form with a
+ *    progress bar, which is what this is not.
+ * 3. **One write, at the end.** Only the last step offers to configure, because
+ *    `writeStoredManifest` reconciles Targets in the same transaction and four
+ *    saves would be four reconciliations of four incomplete documents.
+ * 4. **A refusal is the same three things it is on the settings screen.** The
+ *    two surfaces write through the same command and meet the same refusals, so
+ *    they render them through the same component rather than through two
+ *    readings that could drift apart — `NOT_DEPLOYABLE` above all, which is the
+ *    one a form is most likely to flatten into "fix this field".
+ *
+ * And one claim that is none of those and is the acceptance criterion itself:
+ * **an unconfigured installation is shown onboarding instead of the product.**
+ * That is asserted against `SignedIn` — the real branch `App` renders after a
+ * session exists — rather than against `OnboardingView`, because a wizard
+ * nothing reaches onboards nobody. The discovery panel shipped in exactly that
+ * state: every test around it passed, and deleting the one line that mounted it
+ * on the settings screen changed nothing.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { Principal } from '../../src/commands/types.ts';
+import { DEFAULT_PLACEHOLDER_MANIFEST } from '../../src/config/manifest.ts';
+import { SignedIn } from '../../src/web/app.tsx';
+import type { FieldErrors } from '../../src/web/forms/render.tsx';
+import type { SaveOutcome } from '../../src/web/views/auth/installation.tsx';
+import {
+  manifestFieldAt,
+  ONBOARDING_ASKS,
+  OnboardingView,
+} from '../../src/web/views/auth/onboarding.tsx';
+
+/** The document an unconfigured installation actually holds. */
+const UNCONFIGURED = DEFAULT_PLACEHOLDER_MANIFEST as unknown;
+
+function screen({
+  step = 0,
+  document = UNCONFIGURED,
+  errors = new Map() as FieldErrors,
+  outcome = null as SaveOutcome | null,
+  saving = false,
+} = {}): string {
+  return renderToStaticMarkup(
+    <OnboardingView
+      step={step}
+      document={document}
+      errors={errors}
+      outcome={outcome}
+      saving={saving}
+      onChange={() => undefined}
+      onStep={() => undefined}
+      onFinish={() => undefined}
+      onDone={() => undefined}
+    />,
+  );
+}
+
+/** Every control this build could render for the manifest, by its own name. */
+const CONTROLS = {
+  installation: 'name="installation"',
+  clientId: 'name="github.clientId"',
+  registry: 'name="supplyChain.registry.0"',
+  // Not asked by any step, and the check that step 2 is a step rather than the
+  // whole form: it is a key on the same document that onboarding never offers.
+  frontend: 'name="build.zeroConfigFrontend"',
+} as const;
+
+describe('the four questions are questions this build can answer', () => {
+  test('every key onboarding names resolves in the schema', () => {
+    // The permission this screen has and `installation.tsx` does not, paid for
+    // mechanically. Deployment facts are being taken out of this schema as the
+    // chart absorbs them; a step naming one that has gone must fail here.
+    for (const ask of ONBOARDING_ASKS) {
+      if (ask.kind !== 'field') continue;
+      expect(manifestFieldAt(ask.at)).not.toBeNull();
+    }
+  });
+
+  test('a key the schema does not have resolves to nothing', () => {
+    // A detector nobody has seen fail is not a detector. `dns.apexZone` is a
+    // key this schema really did carry and really did replace, with
+    // `dns.zones`, so it is the honest stale path to prove the walk with.
+    expect(manifestFieldAt(['dns', 'apexZone'])).toBeNull();
+  });
+});
+
+describe('each step asks its own question and nothing else', () => {
+  test('the first asks what this installation is called', () => {
+    const markup = screen({ step: 0 });
+    expect(markup).toContain(CONTROLS.installation);
+    expect(markup).not.toContain(CONTROLS.clientId);
+    expect(markup).not.toContain(CONTROLS.registry);
+    expect(markup).not.toContain(CONTROLS.frontend);
+  });
+
+  test('the second asks which GitHub App this installation speaks as', () => {
+    const markup = screen({ step: 1 });
+    expect(markup).toContain(CONTROLS.clientId);
+    expect(markup).not.toContain(CONTROLS.registry);
+    expect(markup).not.toContain(CONTROLS.frontend);
+  });
+
+  test('the third asks the cloud rather than the operator', () => {
+    // The settings screen's own discovery panel, mounted here rather than
+    // reimplemented: its narrowing inputs are the fingerprint that this is the
+    // real one and not a second ask that could answer differently.
+    const markup = screen({ step: 2 });
+    expect(markup).toContain('name="discovery.project"');
+    expect(markup).toContain('name="discovery.kmsLocation"');
+    expect(markup).not.toContain(CONTROLS.frontend);
+  });
+
+  test('the fourth asks where artifacts are published', () => {
+    const markup = screen({ step: 3 });
+    expect(markup).toContain(CONTROLS.registry);
+    expect(markup).not.toContain(CONTROLS.installation);
+    expect(markup).not.toContain(CONTROLS.frontend);
+  });
+
+  test('what an operator confirms is what this installation already holds', () => {
+    // Confirmation, not authorship: the control arrives carrying the value the
+    // row has, so an operator who agrees with it presses Continue.
+    expect(screen({ step: 0 })).toContain(
+      `value="${DEFAULT_PLACEHOLDER_MANIFEST.installation}"`,
+    );
+  });
+});
+
+describe('one write, at the end', () => {
+  test('no step before the last offers to configure anything', () => {
+    for (let step = 0; step < ONBOARDING_ASKS.length - 1; step += 1) {
+      expect(screen({ step })).not.toContain('Configure this installation');
+    }
+  });
+
+  test('the last step is the one that writes', () => {
+    expect(screen({ step: ONBOARDING_ASKS.length - 1 })).toContain(
+      'Configure this installation',
+    );
+  });
+
+  test('a written document ends the wizard with the ceremony step two deferred', () => {
+    // Step two says the GitHub authorization needs this value stored first.
+    // This is that promise kept: `beginRepositoryAuthorization` reads the
+    // client id off the stored manifest, so the offer appears exactly when the
+    // document has landed and not before.
+    const markup = screen({
+      step: 0,
+      outcome: { kind: 'saved', targets: ['primary'] },
+    });
+    expect(markup).toContain('This installation is configured.');
+    expect(markup).toContain('Authorize GitHub');
+    // And the questions are gone — a saved document is the end of this screen's
+    // job whatever step the save was pressed from.
+    expect(markup).not.toContain(CONTROLS.installation);
+  });
+});
+
+describe('a refusal is the same three things it is on the settings screen', () => {
+  test('a document this installation cannot take is a fact, not a field', () => {
+    const markup = screen({
+      step: 3,
+      outcome: {
+        kind: 'refused',
+        message: 'manifest Target primary uses cloudrun, but the stored Target',
+      },
+    });
+    expect(markup).toContain('This installation cannot take that manifest.');
+    expect(markup).toContain(
+      'This is a fact about the installation, not a field to correct',
+    );
+  });
+
+  test('an invalid value is shown against the control that produced it', () => {
+    const markup = screen({
+      step: 0,
+      errors: new Map([['installation', ['Too small: expected string']]]),
+    });
+    expect(markup).toContain('Too small: expected string');
+  });
+});
+
+describe('an unconfigured installation is shown onboarding, not the product', () => {
+  const OPERATOR: Principal = { id: 'usr_test', displayName: 'Operator' };
+
+  function signedIn(
+    installation: Parameters<typeof SignedIn>[0]['installation'],
+  ) {
+    return renderToStaticMarkup(
+      <SignedIn
+        principal={OPERATOR}
+        installation={installation}
+        path="/"
+        onNavigate={() => undefined}
+        onConfigured={() => undefined}
+        onSignOut={() => undefined}
+      />,
+    );
+  }
+
+  test('the wizard is what an unconfigured installation renders', () => {
+    const markup = signedIn({
+      state: 'unconfigured',
+      manifest: UNCONFIGURED,
+    });
+    expect(markup).toContain('Step 1 of 4');
+    expect(markup).toContain(CONTROLS.installation);
+  });
+
+  test('the product is not rendered underneath it', () => {
+    // "Instead of a broken app", not "in front of one". The shell's navigation
+    // is the fingerprint: it is what reaches the six screens an unconfigured
+    // installation has nothing to put on.
+    const unconfigured = signedIn({
+      state: 'unconfigured',
+      manifest: UNCONFIGURED,
+    });
+    const configured = signedIn({ state: 'configured' });
+    expect(configured).toContain('Overview');
+    expect(unconfigured).not.toContain('Overview');
+  });
+
+  test('a configured installation never sees it', () => {
+    expect(signedIn({ state: 'configured' })).not.toContain('Step 1 of 4');
+  });
+});

--- a/apps/spindrift/test/web/schema-form.test.ts
+++ b/apps/spindrift/test/web/schema-form.test.ts
@@ -176,6 +176,30 @@ describe('what a field knows about itself', () => {
     expect(humanize('zeroConfigFrontend')).toBe('Zero config frontend');
     expect(humanize('tunnelHostname')).toBe('Tunnel hostname');
   });
+
+  test('a one-or-many key is the list it always was', () => {
+    // `supplyChain.registry` accepts a bare string so that documents written
+    // before it took several keep parsing, and transforms either spelling into
+    // a list. Read as the union it is declared as, that key answered
+    // `unsupported` — so the one manifest value an operator is most likely to
+    // be asked for first was the one value no form could edit. It is the list.
+    const supplyChain = field(fields, 'supplyChain').node;
+    if (supplyChain.kind !== 'object')
+      throw new Error('supplyChain is not an object');
+    const registry = field(supplyChain.fields, 'registry');
+    expect(registry.node).toEqual({
+      kind: 'array',
+      element: { kind: 'string', format: 'text' },
+    });
+  });
+
+  test('an untagged union of unrelated shapes is left alone', () => {
+    // The collapse above recognises one shape and must not become "pick an
+    // arm". Two arms that are not each other's element stay a union, which the
+    // union control renders as honestly as it can rather than guessing.
+    const node = describeSchema(z.union([z.string(), z.array(z.number())]));
+    expect(node.kind).toBe('union');
+  });
 });
 
 describe('editing the document', () => {


### PR DESCRIPTION
`loadStoredManifest` resolves `stored ?? declaration ?? placeholder`, and an
installation with no declaration and no row takes the third arm — a document
whose registry is somebody else's namespace, whose signer names a key ring that
does not exist, and whose control plane is served at an example hostname. That
installation does not fail. It comes up, renders an Overview of nothing, and
refuses the first act an operator attempts with a message about whichever
placeholder that act happened to read first. Every value in it is correctable
from Settings, which is no help to somebody who has never seen this software and
is looking at a navigation to six empty screens.

## Unconfigured is derived from the row, not recorded

The placeholder arm is the honest signal, but it is not observable by the time
anybody can ask: `loadStoredManifest` writes back whichever arm it took, so
after the first boot the arm is distinguishable only by what it wrote. A column
recording which one ran would be a second copy of a fact the row already carries
whole, and it would go stale the first time a database was restored.

So the answer is derived from the document — and from four values in it, not
from the whole of it. The manifest is three kinds of value: deployment facts the
chart already knows, cloud facts discovery can ask for, and the genuine choices
that are nobody's but the operator's. `isUnconfiguredInstallation`
(`src/config/manifest.ts`) reads exactly those four — `installation`,
`github.clientId`, `supplyChain.registry`, `secretStore.adapter` — against the
stand-ins the placeholder carries.

**Comparing the whole document instead would ship a feature with an empty
reachable set.** `configured: false` would hold for exactly one document, the
placeholder verbatim, whose `controlPlane.hostname` is `spindrift.example.com`.
`serve.ts` binds the passkey relying party to that value at boot, so a browser
refuses every ceremony against that installation, and onboarding renders only
after a session exists. Any declaration correcting the hostname differs from the
placeholder and answers `configured: true`. The wizard would have been a screen
no deployment could reach.

**All four together, and the direction matters**, because a false positive
replaces a working installation with a wizard. Two of the four are legitimately
the stand-in here — this repository's own installation speaks as the same GitHub
App the placeholder names, and `onepassword` is one of two store adapters — so a
predicate asking whether *any* genuine choice is still a stand-in would answer
unconfigured for the live deployment. `test/config/installation-configured.test.ts`
reads the real declaration out of `clusters/offsite/apps/spindrift/helm-release.yaml`
and pins it against exactly that. It pins the **declaration**, which is what the
name now says: `loadStoredManifest` takes the stored row whenever one exists, so
no test in this repository can assert what the live installation renders. The two
agree where it matters — the offsite pod's boot warning reports the row and the
declaration disagreeing at nine paths, and none of the four is among them.

The other direction needs a case per conjunct, because dropping one from an `&&`
widens the predicate silently: the claim asserting the four values never routes
them through the predicate, so it cannot watch the predicate stop reading one.
Four rows, each answering exactly one genuine choice and asserting configured.

Two properties follow that a flag would not have. It is current the moment the
row changes — `CommandContext.manifest` is resolved per dispatch. And a
declaration that answers the four configures an installation, which is right:
whoever chose them has configured this one by definition, and offering them a
wizard would be offering to redo work they already did.

## Four questions, one write

Onboarding asks three of the four genuine choices and nothing else; the fourth,
`secretStore.adapter`, is one of two values and both are wrong for an
installation that has not decided, so answering the other three is already enough
to leave the screen. The settings surface keeps every key.

Nothing is written until the last screen, and it goes through
`configureInstallation` for the reason that command exists: `writeStoredManifest`
reconciles the Targets a document declares inside the same transaction, so a
wizard that saved per step would run reconciliation four times over four
documents that were each missing something.

The GitHub step collects the client id and does not start the device flow.
`beginRepositoryAuthorization` reads the client id off the *stored* manifest, so
a ceremony started mid-wizard would run against the placeholder's. The offer
appears on the completion screen, pointing at the connections screen that
already owns that flow and its polling.

Onboarding is the one screen allowed to name manifest keys — asking a chosen few
is what makes it a wizard rather than the settings form with a progress bar — and
the price of that permission is a test that walks every named key through
`installationManifestSchema`. A key that leaves the schema fails there instead of
becoming a step that renders nothing. A document refused on the last step now
lands on the step that asks about the refused value: this screen mounts one
control at a time, so an issue against `installation` reported on step 4 is an
issue rendered against a control three steps back, with nothing on screen naming
it.

## The one genuine choice no form could edit

`supplyChain.registry` accepts a bare string so documents written before it took
several keep parsing, and transforms either spelling into a list. Zod 4 makes
that a pipe, `describeSchema` had no case for one, and the answer was
`unsupported` — so the value an operator is most likely to be asked for first was
the one value the schema-rendered form could not offer, on the settings screen as
much as here. A pipe is now described by its accepting end, which is what a
document may say and what re-validation runs against, and an untagged union whose
array arm holds the other arm's shape is described as that array. Both are
narrow on purpose: a genuine untagged union of unrelated shapes still answers
`union`, and everything else still answers `unsupported`, because a visible
refusal is a better failure than a control writing somewhere nothing reads.

## What decides which application renders, mounted

The branch that turns `configured: false` into a wizard is four lines of one
effect in `app.tsx`, and nothing observed it: `deploy-detail-mounted.test.tsx`
mounts the route table, `onboarding.test.tsx` hands `SignedIn` a value it built
itself. Mutating the predicate to `false` leaves the wizard permanently
unreachable with the whole suite green; deleting the effect gives every signed-in
operator a blank page, still green. That is the same defect that shipped a
discovery panel no test observed being mounted.
`test/web/app-mounted.test.tsx` mounts `App` over a stubbed `fetch` and asserts
all three answers: unconfigured is the wizard, configured is the product, a
refusal is the product. The DOM shim both mounted files need is now
`test/harness/dom.ts` rather than a copy in each.

There is a fourth case under the third. `SignedIn` renders nothing while the read
is outstanding, and a request that never settles — a proxy holding a connection,
a pod mid-rollout — does not reject, so a `.catch` cannot see it: the whole
product sat behind a read that was allowed never to finish. It now races a
deadline, and a read that has not answered by then means the product for the same
reason a read that failed does.

## The risk that remains, and it is not small

Onboarding sits behind a session, and a session is a passkey ceremony scoped to
`controlPlane.hostname` — bound once at boot, deliberately, because a ceremony
belongs to the origin it began at. On an installation holding only the
placeholder that value is an example hostname, and a browser refuses a ceremony
whose relying party is not a suffix of the origin it is on. The chart's default
of `manifest: {}` renders no ConfigMap at all
(`packages/charts/spindrift/templates/manifest.yaml:12`), which is precisely that
installation, and it stays unreachable. This changes which documents answer
unconfigured; it does not change which installations can enrol anybody.

What it does make reachable is one document: a declaration carrying a real
hostname whose four genuine choices are still the stand-ins. That one can enrol
an operator, answers `configured: false`, and is shown the four questions. **One
document, not a class**, and the difference is worth stating plainly because an
earlier version of this description got it wrong. Nothing in
`installationManifestSchema` is optional — `validateManifest({installation: 'x'},
…)` refuses with twelve keys missing — so an operator cannot *leave* the genuine
choices at their stand-ins. They must type all four, at `installation: default`,
this repository's own production GitHub App id, somebody else's GHCR namespace
and `onepassword`. Nobody authors that on purpose.

So the reachable set went from empty to one deliberately-written document, which
is the whole of what a predicate change can do here. Ordinary reachability is the
chart seeding the deployment facts it already holds — `controlPlane.hostname`
above all — so that the placeholder itself is an installation a browser will
enrol against. Not this PR's, and not fixed by relaxing the schema either:
moving where the relying party resolves from changes which origins ceremonies are
accepted at, and its only honest proof is a live enrolment.

## After merge

Nothing changes for a configured installation: the stored row answers two of the
four genuine choices — `offsite` and `["ghcr.io/jonpulsifer", …]`, read out of
the live database — `configured` is true, and the settings surface is untouched.
The claim worth checking live is still the negative one, and it is a sign-in
rather than a query: confirm the product renders rather than the wizard. The
registry control on the settings screen is newly editable and worth one look at
the same time. There is no migration and no Atlantis apply.

