### PR TITLE
feat(spindrift): run a job now, and show what it did

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -62,10 +62,13 @@ import type {
   DeployTarget,
   DeployVerdict,
   FailureReason,
+  JobExecution,
+  JobRuns,
   ObservedState,
   RuntimeLogPage,
   RuntimeLogSubject,
   RuntimeLogTailOptions,
+  StartedRun,
 } from '../contract.ts';
 import { cloudRunJob } from './job.ts';
 import {
@@ -112,6 +115,26 @@ const SERVICE_ID_LIMIT = 63;
 const SERVICES = 'services';
 const JOBS = 'jobs';
 type Collection = typeof SERVICES | typeof JOBS;
+
+/** The sub-collection a Job's runs live in — the executions §17 names. */
+const EXECUTIONS = 'executions';
+
+/**
+ * What a job's log entries carry where a service's carry a revision (§17).
+ *
+ * A Job's entries are typed `cloud_run_job`, keyed on `job_name`, and labelled
+ * with the execution and task that wrote them — none of which a
+ * `cloud_run_revision` filter matches. That is why a run's logs are a different
+ * question from "what is this Component saying now" rather than the same query
+ * with a different name in it.
+ */
+const JOB_RESOURCE = 'cloud_run_job';
+const SERVICE_RESOURCE = 'cloud_run_revision';
+const EXECUTION_LABEL = 'run.googleapis.com/execution_name';
+const TASK_INDEX_LABEL = 'run.googleapis.com/task_index';
+
+/** How many runs `executions` asks for when nothing says otherwise. */
+const DEFAULT_EXECUTION_PAGE = 20;
 
 /** How the operator would name the service in the sentence about enabling it. */
 const SERVICE_NAME = 'Cloud Run';
@@ -357,7 +380,13 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       return { kind: 'stream', entries: [], cursor: null, reach: 0 };
     }
     const after = cloudLogCursor(options.after);
-    const service = workloadName(subject, SERVICE_ID_LIMIT);
+    const id = workloadName(subject, SERVICE_ID_LIMIT);
+    // A run's entries are keyed on the Job and labelled with the execution, so
+    // naming one narrows the filter twice: to this Component's Job rather than
+    // its Service, and to that run rather than every run it has ever had. The
+    // Component-wide question a service answers has no answer for a job, which
+    // is why there is no third branch here.
+    const run = subject.execution;
     const response = await new CloudHttp({
       baseUrl: this.options.logsEndpoint ?? DEFAULT_LOGS_ENDPOINT,
       token: this.options.token,
@@ -368,9 +397,14 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       body: {
         resourceNames: [`projects/${connection.project}`],
         filter: [
-          'resource.type="cloud_run_revision"',
-          `resource.labels.service_name="${service}"`,
+          `resource.type="${run === undefined ? SERVICE_RESOURCE : JOB_RESOURCE}"`,
+          run === undefined
+            ? `resource.labels.service_name="${id}"`
+            : `resource.labels.job_name="${id}"`,
           `resource.labels.location="${connection.region}"`,
+          ...(run === undefined
+            ? []
+            : [`labels."${EXECUTION_LABEL}"="${run}"`]),
           ...(after === null ? [] : [`timestamp>="${after.at}"`]),
         ].join(' AND '),
         orderBy: 'timestamp asc',
@@ -405,6 +439,126 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       entries,
       cursor: entries.at(-1)?.cursor ?? options.after ?? null,
       reach: connection.logHistorySeconds ?? 0,
+    };
+  }
+
+  /**
+   * Start one run of the job this ref names, now (§17).
+   *
+   * `jobs.run` is the runtime's own verb and the only one there is: a Job here
+   * carries no schedule and nothing stands in front of it, so an execution
+   * exists exactly when something asked for one. The call answers with an
+   * `Operation` whose `metadata` **is** the Execution being created, which is
+   * where the name comes from — an execution named by the runtime rather than
+   * by this adapter, for the same reason a Service's `uri` comes back across
+   * this seam rather than being handed in (§9).
+   *
+   * A ref naming the other collection is refused rather than run: a Service has
+   * no execution, and the alternative to saying so is a 404 from a path that
+   * reads as if it should have worked.
+   */
+  async run(target: DeployTarget, ref: DeployRef): Promise<StartedRun> {
+    const placed = this.placedJob(target, ref);
+    if (placed.kind === 'none') return placed;
+
+    const started = await this.http(placed.connection).json<CloudOperation>({
+      method: 'POST',
+      path: `${placed.path}:run`,
+      body: {},
+    });
+    if (!started.ok) {
+      throw new Error(`running job ${placed.id} failed: ${started.message}`);
+    }
+    const name = started.value?.metadata?.name;
+    return {
+      kind: 'started',
+      execution: {
+        // An operation that named no execution still started one — the runtime
+        // is creating it behind the operation. The Job's own id is the honest
+        // thing to say meanwhile: it names what was run, and the next read of
+        // `executions` replaces it with the run's own name.
+        name: name === undefined ? placed.id : shortName(name),
+        outcome: 'running',
+        startedAt: null,
+      },
+    };
+  }
+
+  /** The runs that have happened, newest first (§17). */
+  async executions(
+    target: DeployTarget,
+    ref: DeployRef,
+    limit = DEFAULT_EXECUTION_PAGE,
+  ): Promise<JobRuns> {
+    const placed = this.placedJob(target, ref);
+    if (placed.kind === 'none') return placed;
+
+    const read = await this.http(placed.connection).json<CloudExecutionPage>({
+      method: 'GET',
+      path: `${placed.path}/${EXECUTIONS}`,
+      query: { pageSize: String(Math.max(1, limit)) },
+    });
+    if (!read.ok) {
+      throw new Error(
+        `reading the runs of job ${placed.id} failed: ${read.message}`,
+      );
+    }
+    // The API answers newest first already; sorting here anyway costs nothing
+    // and means the screen's order is this contract's promise rather than an
+    // undocumented property of one backend.
+    return {
+      kind: 'executions',
+      executions: (read.value?.executions ?? [])
+        .map(cloudRunExecution)
+        .sort((left, right) => startedAtOf(right) - startedAtOf(left)),
+    };
+  }
+
+  /**
+   * The Job this ref names on this connection, or why it names no job.
+   *
+   * Synchronous, because everything it decides is already in the ref: §6 makes
+   * the collection part of the handle precisely so `observe` and `destroy` can
+   * tell a Service from a Job without a Component, and these two verbs get the
+   * same answer from the same place.
+   */
+  private placedJob(
+    target: DeployTarget,
+    ref: DeployRef,
+  ):
+    | {
+        readonly kind: 'job';
+        readonly connection: CloudRunAdapterConnection;
+        readonly id: string;
+        readonly path: string;
+      }
+    | Extract<JobRuns, { kind: 'none' }> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      return {
+        kind: 'none',
+        because: `${target.name} is not a Cloud Run Target`,
+      };
+    }
+    const placed = parseRef(connection, ref);
+    if (placed === null) {
+      return {
+        kind: 'none',
+        because: 'this Deploy carries no handle on what it placed here',
+      };
+    }
+    if (placed.collection !== JOBS) {
+      return {
+        kind: 'none',
+        because:
+          'this ref names a service, which has a runtime tail rather than runs',
+      };
+    }
+    return {
+      kind: 'job',
+      connection,
+      id: placed.id,
+      path: `/v2/${parentOf(connection)}/${JOBS}/${encodeURIComponent(placed.id)}`,
     };
   }
 
@@ -692,6 +846,76 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   }
 }
 
+/** The long-running operation a write answers with, as much as is read. */
+interface CloudOperation {
+  /** The resource being created — for `jobs.run`, the Execution itself. */
+  readonly metadata?: { readonly name?: string };
+}
+
+interface CloudExecutionPage {
+  readonly executions?: readonly CloudExecution[];
+}
+
+/** One run, as much of the v2 `Execution` as this adapter reads. */
+interface CloudExecution {
+  readonly name?: string;
+  readonly startTime?: string;
+  readonly createTime?: string;
+  readonly succeededCount?: number;
+  readonly failedCount?: number;
+  readonly conditions?: readonly {
+    readonly type?: string;
+    readonly state?: string;
+    readonly message?: string;
+  }[];
+}
+
+/**
+ * One `Execution` as a run (§17).
+ *
+ * The `Completed` condition is the terminal one, and the counts are the
+ * fallback rather than the primary reading: a run whose condition has not been
+ * written yet but whose task already failed is a failed run, and reporting it
+ * as still going would leave the screen waiting for something that is over.
+ */
+function cloudRunExecution(execution: CloudExecution): JobExecution {
+  const completed = (execution.conditions ?? []).find(
+    (condition) => condition.type === 'Completed',
+  );
+  const at = execution.startTime ?? execution.createTime;
+  const outcome =
+    completed?.state === 'CONDITION_SUCCEEDED' ||
+    (completed === undefined && (execution.succeededCount ?? 0) > 0)
+      ? 'passed'
+      : completed?.state === 'CONDITION_FAILED' ||
+          (execution.failedCount ?? 0) > 0
+        ? 'failed'
+        : 'running';
+  return {
+    name: shortName(execution.name ?? ''),
+    outcome,
+    startedAt: at === undefined ? null : new Date(at),
+    ...(completed?.message === undefined ? {} : { detail: completed.message }),
+  };
+}
+
+/** What a run sorts by. A run with no start time yet is the newest there is. */
+function startedAtOf(execution: JobExecution): number {
+  return execution.startedAt?.getTime() ?? Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * The last segment of a resource path.
+ *
+ * The runtime names an execution in full — `projects/…/jobs/…/executions/x` —
+ * and the log filter's `execution_name` label carries only the `x`. So the
+ * short name is what travels, because it is the one form both the list and the
+ * logs agree on.
+ */
+function shortName(name: string): string {
+  return name.slice(name.lastIndexOf('/') + 1);
+}
+
 interface CloudLogPage {
   readonly entries?: readonly CloudLogEntry[];
 }
@@ -703,6 +927,8 @@ interface CloudLogEntry {
   readonly textPayload?: string;
   readonly jsonPayload?: unknown;
   readonly resource?: { readonly labels?: Record<string, string> };
+  /** Where a job's entries carry which execution and task wrote them. */
+  readonly labels?: Record<string, string>;
 }
 
 interface CloudLogRecord {
@@ -725,8 +951,19 @@ function cloudLogRecord(entry: CloudLogEntry): CloudLogRecord | null {
     at,
     insertId: entry.insertId,
     line,
-    replica: entry.resource?.labels?.revision_name ?? 'unknown',
+    // What wrote the line. A service's replica is a revision; a run's is one of
+    // its tasks, and a run with `taskCount: 1` still names the task rather than
+    // leaving the column reading `unknown` for every line it ever writes.
+    replica:
+      entry.resource?.labels?.revision_name ??
+      taskReplica(entry.labels?.[TASK_INDEX_LABEL]) ??
+      'unknown',
   };
+}
+
+/** The `task N` a task index reads as, or nothing when there is no index. */
+function taskReplica(index: string | undefined): string | undefined {
+  return index === undefined ? undefined : `task ${index}`;
 }
 
 function cloudLogCursor(cursor: string | undefined): CloudLogRecord | null {

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -133,8 +133,24 @@ const SERVICE_RESOURCE = 'cloud_run_revision';
 const EXECUTION_LABEL = 'run.googleapis.com/execution_name';
 const TASK_INDEX_LABEL = 'run.googleapis.com/task_index';
 
-/** How many runs `executions` asks for when nothing says otherwise. */
+/** How many runs `executions` reports when nothing says otherwise. */
 const DEFAULT_EXECUTION_PAGE = 20;
+
+/**
+ * How many the API is asked for, regardless of how many are reported.
+ *
+ * `projects.locations.jobs.executions.list` documents no ordering and takes no
+ * `orderBy`, so a page of ten is ten *some* executions and sorting them
+ * afterwards only orders what arrived. Asking for a page far larger than the
+ * depth any caller wants makes the newest ones be in it whichever end the API
+ * starts from. Google's list APIs clamp a `pageSize` above their own maximum
+ * rather than refusing it, so this is a ceiling request, not a promise.
+ *
+ * ponytail: a job with more executions than this still hides its newest ones if
+ * the API pages oldest-first. Upgrade path is following `nextPageToken` until
+ * it is empty, which is unbounded work for a screen that shows ten rows.
+ */
+const EXECUTION_PAGE_ASKED = 100;
 
 /** How the operator would name the service in the sentence about enabling it. */
 const SERVICE_NAME = 'Cloud Run';
@@ -496,21 +512,23 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     const read = await this.http(placed.connection).json<CloudExecutionPage>({
       method: 'GET',
       path: `${placed.path}/${EXECUTIONS}`,
-      query: { pageSize: String(Math.max(1, limit)) },
+      query: { pageSize: String(EXECUTION_PAGE_ASKED) },
     });
     if (!read.ok) {
       throw new Error(
         `reading the runs of job ${placed.id} failed: ${read.message}`,
       );
     }
-    // The API answers newest first already; sorting here anyway costs nothing
-    // and means the screen's order is this contract's promise rather than an
-    // undocumented property of one backend.
+    // Sort then slice, and in that order: the API documents no ordering, so
+    // a page of `limit` would be `limit` arbitrary runs and sorting them would
+    // put the newest of *those* on top. `limit` is what to report, never what
+    // to look at — see {@link EXECUTION_PAGE_ASKED}.
     return {
       kind: 'executions',
       executions: (read.value?.executions ?? [])
         .map(cloudRunExecution)
-        .sort((left, right) => startedAtOf(right) - startedAtOf(left)),
+        .sort((left, right) => startedAtOf(right) - startedAtOf(left))
+        .slice(0, Math.max(1, limit)),
     };
   }
 

--- a/apps/spindrift/src/adapters/deploy/cloudrun/job.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/job.ts
@@ -11,8 +11,9 @@
  * `suspend: true` and a date that never occurs for an unscheduled job — the
  * object has to exist for anything to have something to trigger. Cloud Run
  * reaches the same state by having no scheduler in front of it, because a Job
- * carries no schedule of its own: firing one is a separate service (**72**) and
- * running one on demand is a `DeployAdapter` verb that does not exist (**73**).
+ * carries no schedule of its own: firing one on a cadence is a separate service
+ * (**72**), and running one on demand is `DeployAdapter.run`, which here is the
+ * runtime's own `jobs.run`.
  *
  * **The template nests twice.** `Job.template` is an `ExecutionTemplate` and
  * `ExecutionTemplate.template` is a `TaskTemplate`; the containers live in the

--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -282,6 +282,13 @@ export interface RuntimeLogSubject {
    * optional rather than a second method. The two differ by one clause in a
    * selector or a filter, and a second method would have had to restate the
    * cursor, the paging and the reach that make this one honest.
+   *
+   * **A run name, checked before it gets here.** Adapters put it into a query
+   * language by concatenation — a Cloud Logging filter, a label selector — so a
+   * caller that lets a request body reach this field unchecked hands the far
+   * side a filter of the caller's choosing. `src/web/streams.ts` is the one
+   * boundary this crosses from a browser and it is checked there; a second
+   * caller owes the same check.
    */
   readonly execution?: string;
 }

--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -267,7 +267,61 @@ export interface ObservedState {
 export interface RuntimeLogSubject {
   readonly app: string;
   readonly component: string;
+  /**
+   * One run of a job, when the question is about a run rather than the
+   * Component (§17).
+   *
+   * A job's output does not belong to the Component the way a service's does.
+   * "What is this Component saying now" has no answer for a job — nothing is
+   * running most of the time — and merging every run's lines into one tail
+   * would answer a question nobody asked, with last night's failure
+   * interleaved into this morning's. So the subject narrows: the name is one
+   * {@link JobExecution}'s, and the page is that run's lines and no other's.
+   *
+   * Absent for a service, which is the ordinary case and the reason this is
+   * optional rather than a second method. The two differ by one clause in a
+   * selector or a filter, and a second method would have had to restate the
+   * cursor, the paging and the reach that make this one honest.
+   */
+  readonly execution?: string;
 }
+
+/**
+ * One run of a job, as the backend reports it (§17).
+ *
+ * §17: "**A job is not a stream but a list of executions.** An execution
+ * terminates, so it is attempt-shaped." Which is why this carries an outcome
+ * rather than a {@link DeployPhase}: a run that ended is not a workload that
+ * went `FAILED`, and borrowing the deploy vocabulary would put "the release is
+ * down" and "last night's backup exited 1" under the same word.
+ *
+ * The `name` is the backend's own and is deliberately not parsed by core: it is
+ * what {@link RuntimeLogSubject.execution} is filled with, so the only thing it
+ * owes anyone is naming the same run twice.
+ */
+export interface JobExecution {
+  /** The backend's own name for this run — what a tail reads its logs by. */
+  readonly name: string;
+  readonly outcome: 'passed' | 'failed' | 'running';
+  /** When the platform says it started, or `null` while it has not. */
+  readonly startedAt: Date | null;
+  /** The sentence a reader gets, where the backend offers one. */
+  readonly detail?: string;
+}
+
+/** What starting a run produced, or why this backend had nothing to start. */
+export type StartedRun =
+  | { readonly kind: 'started'; readonly execution: JobExecution }
+  | { readonly kind: 'none'; readonly because: string };
+
+/** The runs that have happened, or why this backend has none to report. */
+export type JobRuns =
+  | {
+      readonly kind: 'executions';
+      /** Newest first — the order the screen reads them in. */
+      readonly executions: readonly JobExecution[];
+    }
+  | { readonly kind: 'none'; readonly because: string };
 
 /** One line from one replica, with the backend's durable resume position. */
 export interface RuntimeLogEntry {
@@ -375,11 +429,63 @@ export interface DeployAdapter {
   destroy(target: DeployTarget, ref: DeployRef): Promise<void>;
 
   /**
+   * Start one run of the job this ref names, now (§7, §17).
+   *
+   * **Why a verb and not a mode on `apply`.** §7: "a job always renders a
+   * `CronJob`, suspended when unscheduled… `apply` for a job therefore becomes
+   * two acts." `apply` is convergent and core re-applies it whenever desired
+   * state moves, so a run folded into it would fire on a reach change, on a
+   * config edit, on a rollback. The two acts have different arity — the object
+   * is placed once and run any number of times — and one method cannot have
+   * both.
+   *
+   * **Why a ref and not a `DesiredState`.** What is being run is what `apply`
+   * placed, not a description core assembled a second time. Handing this a
+   * `DesiredState` would let a run execute an image the Component is not
+   * serving, which is exactly the kind of divergence storing the ref exists to
+   * prevent.
+   *
+   * **Why it refuses rather than throws.** §13's "connect always succeeds" is
+   * core's promise in one direction and this is the same promise in the other:
+   * an adapter that has no job to run says so in a sentence, the way `tail`'s
+   * `none` arm does, because "a website cannot be run" is a fact about the
+   * backend and not an exception. A far side that *is* asked correctly and
+   * fails — the API refused, the cluster is unreachable — throws, exactly as
+   * `tail` does, because that is a fault and not an answer.
+   */
+  run(target: DeployTarget, ref: DeployRef): Promise<StartedRun>;
+
+  /**
+   * The runs that have happened, newest first (§17).
+   *
+   * The second half of the same seam, split along the line `apply` and
+   * `observe` are already split along: one member acts, one member reads. A run
+   * nobody can see afterwards is not something an operator can be given, so
+   * this is not an extra — it is what makes the verb above mean anything.
+   *
+   * **Read from the platform, never stored.** §17 fixes the history asymmetry
+   * between backends "by rendering a larger history limit, not by storing logs
+   * — configure the platform, don't build it", so the depth is the CronJob's
+   * `successfulJobsHistoryLimit` on one backend and the runtime's own retention
+   * on the other. `limit` is a page size, not that depth: it bounds what is
+   * asked for and says nothing about what is kept.
+   */
+  executions(
+    target: DeployTarget,
+    ref: DeployRef,
+    limit?: number,
+  ): Promise<JobRuns>;
+
+  /**
    * Read a bounded page of service output from the platform (§17).
    *
    * The cursor is platform-owned and survives a web/reconciler restart. Static
    * hosting returns the explicit `none` arm; it never masquerades as an empty
    * stream.
+   *
+   * A subject naming an `execution` asks the narrower question — one run's
+   * lines rather than the Component's — and it is the only way a job's output
+   * is readable, because a job's entries belong to the run that wrote them.
    */
   tail(
     target: DeployTarget,

--- a/apps/spindrift/src/adapters/deploy/kubernetes/api.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/api.ts
@@ -100,7 +100,9 @@ export class KubernetesApi {
 
   /** One object, or `null` when the API says it is not there. */
   async get(ref: ResourceRef): Promise<KubernetesObject | null> {
-    return this.json<KubernetesObject>('GET', resourcePath(ref));
+    return this.json<KubernetesObject>('GET', resourcePath(ref), {
+      tolerate: [404],
+    });
   }
 
   /**
@@ -119,6 +121,7 @@ export class KubernetesApi {
     const list = await this.json<KubernetesList>(
       'GET',
       `${resourcePath(ref)}${search}`,
+      { tolerate: [404] },
     );
     return list === null ? null : (list.items ?? []);
   }
@@ -149,22 +152,42 @@ export class KubernetesApi {
   }
 
   /**
-   * `POST` one object, for the APIs that answer rather than store.
+   * `POST` one object, and answer with what the API server made of it.
    *
-   * `SelfSubjectAccessReview` is the only such call this adapter makes: the
-   * API server replies with what the request's own identity may do, which is
-   * how §13's "OIDC both ways" is checked without holding a credential.
+   * Two callers, and they want opposite things from the reply.
+   * `SelfSubjectAccessReview` answers rather than stores: the API server
+   * replies with what the request's own identity may do, which is how §13's
+   * "OIDC both ways" is checked without holding a credential. A Job stores, and
+   * the object that comes back is the proof it exists.
+   *
+   * **A `404` here is a fault, never an absence.** `POST`ing to a collection
+   * path 404s when the namespace is gone or the group is not served — neither
+   * of which is "there is nothing there", both of which mean nothing was
+   * created. Absence is only an answer for a read, which is why the tolerance
+   * for it is opt-in one method up rather than a default in {@link send}.
    */
   async create(
     ref: ResourceRef,
     object: KubernetesObject,
-  ): Promise<KubernetesObject | null> {
-    return this.json<KubernetesObject>('POST', resourcePath(ref), object);
+  ): Promise<KubernetesObject> {
+    const created = await this.json<KubernetesObject>(
+      'POST',
+      resourcePath(ref),
+      { body: object },
+    );
+    // `send` only answers `null` for a tolerated status and this call tolerates
+    // none, so this is unreachable — asserted rather than assumed because the
+    // whole point of the change above is that a caller must not be able to
+    // treat "created nothing" as "created something".
+    if (created === null) {
+      throw new Error(`POST ${resourcePath(ref)} returned no object`);
+    }
+    return created;
   }
 
   /** Idempotent: deleting what is already gone succeeds (§6). */
   async delete(ref: ResourceRef): Promise<void> {
-    await this.send('DELETE', resourcePath(ref));
+    await this.send('DELETE', resourcePath(ref), { tolerate: [404] });
   }
 
   /**
@@ -207,7 +230,9 @@ export class KubernetesApi {
     const response = await this.send(
       'GET',
       `/api/v1/namespaces/${namespace}/pods/${pod}/log${query}`,
-      { tolerate: [400] },
+      // A pod that has been garbage collected is a `404`, and "there is no log"
+      // is the same honest answer for it as for one that has not started.
+      { tolerate: [400, 404] },
     );
     return response === null ? null : await response.text();
   }
@@ -220,6 +245,9 @@ export class KubernetesApi {
     const resources = await this.json<{ resources?: { kind: string }[] }>(
       'GET',
       path,
+      // A group the cluster does not serve has no discovery document, which is
+      // the answer this asks for rather than a fault.
+      { tolerate: [404] },
     );
     return (resources?.resources ?? []).some(
       (resource) => resource.kind === kind,
@@ -229,13 +257,12 @@ export class KubernetesApi {
   private async json<Result>(
     method: string,
     path: string,
-    body?: unknown,
+    options: {
+      body?: unknown;
+      tolerate?: readonly number[];
+    } = {},
   ): Promise<Result | null> {
-    const response = await this.send(
-      method,
-      path,
-      body === undefined ? {} : { body },
-    );
+    const response = await this.send(method, path, options);
     if (response === null) return null;
     return (await response.json()) as Result;
   }
@@ -246,7 +273,18 @@ export class KubernetesApi {
     options: {
       body?: unknown;
       contentType?: string;
-      /** Statuses the caller has a value for, returned instead of thrown. */
+      /**
+       * Statuses the caller has a value for, returned as `null` rather than
+       * raised.
+       *
+       * `404` is in here for every read and for `delete`, and in here for
+       * nothing that writes. It used to be unconditional, on the reasoning that
+       * absence is an answer every caller has a value for — which was true
+       * until a caller started `POST`ing a Job. A create whose namespace was
+       * deleted 404s, and swallowing that turned "nothing was created" into a
+       * started run: an act that reached nothing and reported success. The
+       * distinction is a property of the verb, so the verb states it.
+       */
       tolerate?: readonly number[];
     } = {},
   ): Promise<Response | null> {
@@ -269,9 +307,6 @@ export class KubernetesApi {
     const send = this.endpoint.fetch ?? ((input: Request) => fetch(input));
     const response = await send(request);
 
-    // Absence is an answer every caller here has a value for, so it comes back
-    // rather than being raised.
-    if (response.status === 404) return null;
     if (options.tolerate?.includes(response.status)) return null;
     if (!response.ok) {
       throw new KubernetesRequestError(

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -395,10 +395,26 @@ export class KubernetesDeployAdapter implements DeployAdapter {
    * scheduled time — which for an unscheduled job is a date that never occurs.
    * And the owner reference is what makes §7's "a scheduled run and a manual
    * run are the same object with a field flipped" true from the reading side:
-   * the CronJob controller counts what it owns, so a manual run lands in the
-   * same history, is pruned by the same limit, and is held off by the same
-   * `concurrencyPolicy: Forbid` — rather than becoming an orphan that outlives
-   * every execution beside it.
+   * `getJobsToBeReconciled` selects the controller ref, so a manual run lands
+   * in `cleanupFinishedJobs` and is pruned by the same history limit rather
+   * than becoming an orphan that outlives every execution beside it.
+   *
+   * **The reference does not make `concurrencyPolicy: Forbid` hold a manual run
+   * off, and nothing here can.** The controller's Forbid check is
+   * `len(cj.Status.Active) > 0`, and `Status.Active` is appended only where the
+   * controller creates a Job itself — it never adopts a foreign Job into it. So
+   * a run started here at 02:59:55 does not stop the `0 3 * * *` fire, and the
+   * two run concurrently even though the policy says never. There is no API
+   * that asks a CronJob to run now; `kubectl create job --from=cronjob/x` does
+   * exactly this and does not set an owner at all. An in-flight check in
+   * `runComponent` would not change it either: the fire that overlaps comes
+   * from the controller, which does not consult Spindrift.
+   *
+   * The known cost of the reference is a `Warning UnexpectedJob "Saw a job that
+   * the controller did not create or forgot"` on every sync until the run
+   * finishes — `syncCronJob`'s `!found && !IsJobFinished(j)` arm. That is a
+   * true statement about a Job the controller did not create, and pruning is
+   * worth it.
    *
    * `blockOwnerDeletion` is deliberately absent from that reference: setting it
    * needs `update` on the owner's `finalizers` subresource wherever the
@@ -478,7 +494,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       spec: template.spec,
     };
 
-    let created: KubernetesObject | null;
+    let created: KubernetesObject;
     try {
       created = await api.create(
         {
@@ -498,10 +514,9 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       }
       throw cause;
     }
-    return {
-      kind: 'started',
-      execution: startingRun(created?.metadata.name ?? name),
-    };
+    // The name the API server stored, not the one that was asked for: `create`
+    // now answers with the object or raises, so this reports a run that exists.
+    return { kind: 'started', execution: startingRun(created.metadata.name) };
   }
 
   /**
@@ -1070,7 +1085,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
           },
         },
       );
-      const status = review?.status as { allowed?: boolean } | undefined;
+      const status = review.status as { allowed?: boolean } | undefined;
       return status?.allowed === true;
     } catch {
       return false;

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -542,15 +542,26 @@ export class KubernetesDeployAdapter implements DeployAdapter {
     const placed = await this.placedJob(api, ref);
     if (placed.kind === 'none') return placed;
 
-    const jobs =
-      (await api.list(
-        {
-          apiVersion: JOB.apiVersion,
-          plural: JOB.plural,
-          namespace: connection.namespace,
-        },
-        { labelSelector: placed.selector },
-      )) ?? [];
+    const jobs = await api.list(
+      {
+        apiVersion: JOB.apiVersion,
+        plural: JOB.plural,
+        namespace: connection.namespace,
+      },
+      { labelSelector: placed.selector },
+    );
+    // `list` answers `null` for a `404`, which {@link KubernetesApi.list} keeps
+    // apart from an empty list on purpose: it means the namespace is gone or
+    // this cluster does not serve `batch/v1`. Neither is "this job has never
+    // run", and `?? []` here would render both as the never-run empty state —
+    // the read half of the same silent-wrong-answer `create` had. Raised so it
+    // lands where a `403` on this call already lands, on `executionsOf`'s
+    // `because` arm: the runs could not be read, and the Run now button stays.
+    if (jobs === null) {
+      throw new Error(
+        `the API server answered 404 listing ${JOB.plural} in ${connection.namespace} — that namespace or ${JOB.apiVersion} is not there`,
+      );
+    }
 
     return {
       kind: 'executions',
@@ -1526,15 +1537,23 @@ function writeFailure(
 ): Extract<DeployVerdict, { phase: 'FAILED' }> {
   if (cause instanceof KubernetesRequestError) {
     // A 4xx is the cluster refusing this object — an admission webhook, a
-    // quota, an invalid spec — which §6 puts under one reason. A 5xx or an
-    // auth failure is the cluster being unavailable to Spindrift, which is a
-    // different blame entirely.
+    // quota, an invalid spec — which §6 puts under one reason and blames on the
+    // developer. Three of them are not that, and a 5xx is not either.
+    //
+    // 401 and 403 are Spindrift's own credential. A **404 on a write is the
+    // address, never the object**: a server-side apply creates what is not
+    // there, so the only things that can be missing are the namespace or the
+    // API group — the Target, which the operator configured, not the spec the
+    // developer wrote. Indicting the developer for a namespace that was deleted
+    // sends them reading their chart values, and §6 calls blame the most useful
+    // thing the UI knows. All three are `TARGET_UNREACHABLE`'s platform.
+    const platformFailure =
+      cause.status === 401 || cause.status === 403 || cause.status === 404;
     const rejected = cause.status >= 400 && cause.status < 500;
-    const authFailure = cause.status === 401 || cause.status === 403;
     return {
       phase: 'FAILED',
       ref,
-      reason: rejected && !authFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
+      reason: rejected && !platformFailure ? 'REJECTED' : 'TARGET_UNREACHABLE',
       detail: cause.body || cause.message,
       debug: { status: cause.status, url: cause.url },
     };

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -52,11 +52,14 @@ import type {
   DeployTarget,
   DeployVerdict,
   FailureReason,
+  JobExecution,
+  JobRuns,
   ObservedState,
   RuntimeLogEntry,
   RuntimeLogPage,
   RuntimeLogSubject,
   RuntimeLogTailOptions,
+  StartedRun,
 } from '../contract.ts';
 import {
   type Fetcher,
@@ -150,6 +153,46 @@ const SECRET_STORE = {
   kind: 'ClusterSecretStore',
   plural: 'clustersecretstores',
 } as const;
+
+/**
+ * The two objects a job's runs are (§7, §17).
+ *
+ * The chart renders a CronJob for every job, scheduled or not, and a run is a
+ * Job it owns — so "start a run" is creating a Job from the CronJob's own
+ * `jobTemplate` rather than un-suspending it. Un-suspending would make the
+ * next *scheduled* time fire, which for an unscheduled job is a date that never
+ * occurs and for a scheduled one is a different act than the operator asked
+ * for.
+ */
+const CRON_JOB = {
+  apiVersion: 'batch/v1',
+  kind: 'CronJob',
+  plural: 'cronjobs',
+} as const;
+
+const JOB = { apiVersion: 'batch/v1', kind: 'Job', plural: 'jobs' } as const;
+
+/**
+ * The label the Job controller stamps on the pods of one run.
+ *
+ * The current one. The unprefixed label of the same name is set beside it and
+ * is deprecated, so keying on this one is what keeps a job's tail reading the
+ * run it was asked about rather than whichever label the cluster stops writing
+ * first.
+ */
+const JOB_NAME_LABEL = 'batch.kubernetes.io/job-name';
+
+/** What `kubectl create job --from` marks a run somebody asked for. */
+const MANUAL_RUN = 'cronjob.kubernetes.io/instantiate';
+
+/**
+ * The longest name a run may carry.
+ *
+ * A Job's pods are named `<job>-<five random characters>`, and a pod's hostname
+ * is a DNS label — so the six characters the Job controller appends have to fit
+ * under 63 or the run starts and can never schedule a pod.
+ */
+const RUN_NAME_LIMIT = 57;
 
 /**
  * What a route attaches to. Read only by {@link KubernetesDeployAdapter.probe}
@@ -264,7 +307,17 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       return { kind: 'stream', entries: [], cursor: null, reach: 0 };
     }
     const api = this.api(connection);
-    const selector = `app.kubernetes.io/name=${subject.component},app.kubernetes.io/part-of=${subject.app}`;
+    // A run's pods carry the Component's labels like every other pod the chart
+    // renders, so the subject narrows by one term rather than by a second
+    // query: with no execution named this is the Component's whole output, and
+    // with one it is that run's and no other run's.
+    const selector = [
+      `app.kubernetes.io/name=${subject.component}`,
+      `app.kubernetes.io/part-of=${subject.app}`,
+      ...(subject.execution === undefined
+        ? []
+        : [`${JOB_NAME_LABEL}=${subject.execution}`]),
+    ].join(',');
     const pods =
       (await api.list(
         { apiVersion: 'v1', plural: 'pods', namespace: connection.namespace },
@@ -330,6 +383,221 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       // cursor in that case would skip the beginning of the new log.
       cursor: entries.at(-1)?.cursor ?? encodeRuntimeCursor(next),
       reach: connection.logHistorySeconds ?? 0,
+    };
+  }
+
+  /**
+   * Start one run of the job this ref placed (§7, §17).
+   *
+   * A Job created from the CronJob's own `jobTemplate`, **owned by that
+   * CronJob**. Both halves are load-bearing. Creating from the template rather
+   * than un-suspending is what makes this run *now* instead of at the next
+   * scheduled time — which for an unscheduled job is a date that never occurs.
+   * And the owner reference is what makes §7's "a scheduled run and a manual
+   * run are the same object with a field flipped" true from the reading side:
+   * the CronJob controller counts what it owns, so a manual run lands in the
+   * same history, is pruned by the same limit, and is held off by the same
+   * `concurrencyPolicy: Forbid` — rather than becoming an orphan that outlives
+   * every execution beside it.
+   *
+   * `blockOwnerDeletion` is deliberately absent from that reference: setting it
+   * needs `update` on the owner's `finalizers` subresource wherever the
+   * `OwnerReferencesPermissionEnforcement` admission plugin is on, and the
+   * garbage collection this wants happens without it.
+   */
+  async run(target: DeployTarget, ref: DeployRef): Promise<StartedRun> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      return refuse(`${target.name} is not a Kubernetes Target`);
+    }
+    const api = this.api(connection);
+    const placed = await this.placedJob(api, ref);
+    if (placed.kind === 'none') return placed;
+
+    const [owner] =
+      (await api.list(
+        {
+          apiVersion: CRON_JOB.apiVersion,
+          plural: CRON_JOB.plural,
+          namespace: connection.namespace,
+        },
+        { labelSelector: placed.selector },
+      )) ?? [];
+    if (owner === undefined) {
+      return refuse(
+        `no ${CRON_JOB.kind} for ${placed.app}/${placed.component} is on this Target yet`,
+      );
+    }
+    const template = (owner.spec as { jobTemplate?: JobTemplate } | undefined)
+      ?.jobTemplate;
+    if (template?.spec === undefined) {
+      return refuse(
+        `${CRON_JOB.kind} ${owner.metadata.name} carries no job template to run`,
+      );
+    }
+
+    // The CronJob controller's own naming, at second rather than minute
+    // resolution: a name derived from when the run was asked for, so a second
+    // press within the same second is the *same* run rather than a second one.
+    // The API server enforces that for free — see the 409 below.
+    const name = workloadName(
+      {
+        app: owner.metadata.name,
+        component: String(Math.floor(this.clock() / 1_000)),
+      },
+      RUN_NAME_LIMIT,
+    );
+    const uid = owner.metadata.uid;
+    const run: KubernetesObject = {
+      apiVersion: JOB.apiVersion,
+      kind: JOB.kind,
+      metadata: {
+        name,
+        namespace: connection.namespace,
+        ...(template.metadata?.labels === undefined
+          ? {}
+          : { labels: template.metadata.labels }),
+        annotations: {
+          ...template.metadata?.annotations,
+          [MANUAL_RUN]: 'manual',
+        },
+        ...(typeof uid === 'string'
+          ? {
+              ownerReferences: [
+                {
+                  apiVersion: CRON_JOB.apiVersion,
+                  kind: CRON_JOB.kind,
+                  name: owner.metadata.name,
+                  uid,
+                  controller: true,
+                },
+              ],
+            }
+          : {}),
+      },
+      spec: template.spec,
+    };
+
+    let created: KubernetesObject | null;
+    try {
+      created = await api.create(
+        {
+          apiVersion: JOB.apiVersion,
+          plural: JOB.plural,
+          namespace: connection.namespace,
+        },
+        run,
+      );
+    } catch (cause) {
+      // The run this press names is already going. Reporting it as started is
+      // the honest answer and the idempotent one: a double press produced one
+      // run, which is what the operator asked for and what §6 asks of `destroy`
+      // for the same reason.
+      if (cause instanceof KubernetesRequestError && cause.status === 409) {
+        return { kind: 'started', execution: startingRun(name) };
+      }
+      throw cause;
+    }
+    return {
+      kind: 'started',
+      execution: startingRun(created?.metadata.name ?? name),
+    };
+  }
+
+  /**
+   * The runs that have happened, newest first (§17).
+   *
+   * Listed by the Component's own labels rather than by ownership, because a
+   * Job the CronJob controller created and a Job this adapter created both
+   * carry the template's labels while only the second is guaranteed to still
+   * have an owner: garbage collection removes the reference before it removes
+   * the object. Listing by label reads both, which is the whole question — what
+   * has this Component run, however it was started.
+   */
+  async executions(
+    target: DeployTarget,
+    ref: DeployRef,
+    limit = 20,
+  ): Promise<JobRuns> {
+    const connection = this.connectionOf(target);
+    if (connection === null) {
+      return refuse(`${target.name} is not a Kubernetes Target`);
+    }
+    const api = this.api(connection);
+    const placed = await this.placedJob(api, ref);
+    if (placed.kind === 'none') return placed;
+
+    const jobs =
+      (await api.list(
+        {
+          apiVersion: JOB.apiVersion,
+          plural: JOB.plural,
+          namespace: connection.namespace,
+        },
+        { labelSelector: placed.selector },
+      )) ?? [];
+
+    return {
+      kind: 'executions',
+      executions: jobs
+        .map(jobExecution)
+        .sort((left, right) => startedAtOf(right) - startedAtOf(left))
+        .slice(0, Math.max(1, limit)),
+    };
+  }
+
+  /**
+   * The job this ref placed, as the labels its objects carry.
+   *
+   * Read off the delivery object's **values** rather than derived from the ref,
+   * because the ref names the release and the workload is named by the chart —
+   * `spindrift-app.fullname` truncates plainly where {@link workloadName} keeps
+   * a digest, so the two names diverge for a long App and deriving one from the
+   * other would be a reimplementation of a chart helper that is free to change.
+   * The values are what Spindrift wrote and what the chart rendered from, so
+   * they are the one place both sides agree.
+   */
+  private async placedJob(
+    api: KubernetesApi,
+    ref: DeployRef,
+  ): Promise<
+    | {
+        readonly kind: 'job';
+        readonly app: string;
+        readonly component: string;
+        readonly selector: string;
+      }
+    | Extract<JobRuns, { kind: 'none' }>
+  > {
+    const parsed = parseRef(ref);
+    if (parsed === null) {
+      return refuse('this Deploy carries no handle on what it placed');
+    }
+    const object = await api.get({
+      apiVersion: apiVersionOf(parsed.flavour),
+      plural: pluralOf(parsed.flavour),
+      namespace: parsed.namespace,
+      name: parsed.name,
+    });
+    if (object === null) {
+      return refuse(`${parsed.name} is no longer on this Target`);
+    }
+    const app = valuesOf(parsed.flavour, object).app as
+      | { name?: unknown; component?: unknown; kind?: unknown }
+      | undefined;
+    if (app?.kind !== 'job') {
+      return refuse('this Component is not a job, so it has no runs');
+    }
+    if (typeof app.name !== 'string' || typeof app.component !== 'string') {
+      return refuse(`${parsed.name} does not say which Component it renders`);
+    }
+    return {
+      kind: 'job',
+      app: app.name,
+      component: app.component,
+      // `spindrift-app.selectorLabels`, which is on every object the chart
+      // renders and on every pod a run of it creates.
+      selector: `app.kubernetes.io/name=${app.component},app.kubernetes.io/part-of=${app.name}`,
     };
   }
 
@@ -999,6 +1267,75 @@ export class KubernetesDeployAdapter implements DeployAdapter {
   }
 }
 
+/** The half of a CronJob a run is made from. */
+interface JobTemplate {
+  readonly metadata?: {
+    readonly labels?: Record<string, string>;
+    readonly annotations?: Record<string, string>;
+  };
+  readonly spec?: Record<string, unknown>;
+}
+
+/** A refusal in the vocabulary both run verbs answer in (§17). */
+function refuse(because: string): Extract<JobRuns, { kind: 'none' }> {
+  return { kind: 'none', because };
+}
+
+/**
+ * A run that has just been asked for.
+ *
+ * `running` with no start time, which is what it is: the API server has the
+ * Job and the controller has not created a pod for it yet. Reporting anything
+ * else would be this adapter guessing at a status it can read a moment later.
+ */
+function startingRun(name: string): JobExecution {
+  return { name, outcome: 'running', startedAt: null };
+}
+
+/**
+ * One Job as a run (§17).
+ *
+ * `Complete` and `Failed` are the only conditions that end a Job; everything
+ * else on the list — `SuccessCriteriaMet`, `FailureTarget`, `Suspended` — is
+ * the controller narrating, and a run narrating is a run still going.
+ */
+function jobExecution(job: KubernetesObject): JobExecution {
+  const status = job.status as
+    | {
+        startTime?: string;
+        conditions?: {
+          type?: string;
+          status?: string;
+          reason?: string;
+          message?: string;
+        }[];
+      }
+    | undefined;
+  const terminal = (status?.conditions ?? []).find(
+    (condition) =>
+      condition.status === 'True' &&
+      (condition.type === 'Complete' || condition.type === 'Failed'),
+  );
+  const at = status?.startTime ?? job.metadata.creationTimestamp;
+  const detail = terminal?.message ?? terminal?.reason;
+  return {
+    name: job.metadata.name,
+    outcome:
+      terminal === undefined
+        ? 'running'
+        : terminal.type === 'Complete'
+          ? 'passed'
+          : 'failed',
+    startedAt: typeof at === 'string' ? new Date(at) : null,
+    ...(detail === undefined ? {} : { detail }),
+  };
+}
+
+/** What a run sorts by. A run with no start time yet is the newest there is. */
+function startedAtOf(execution: JobExecution): number {
+  return execution.startedAt?.getTime() ?? Number.MAX_SAFE_INTEGER;
+}
+
 interface RuntimePosition {
   readonly at: string;
   readonly seen: number;
@@ -1104,13 +1441,26 @@ function statusOf(flavour: Flavour, object: KubernetesObject): DeliveryStatus {
     : helmReleaseStatus(object);
 }
 
+/**
+ * The values the delivery object was applied with — what the chart rendered.
+ *
+ * The one read of them, because the two flavours keep them in different places
+ * and a second branch could only ever read one of the two wrongly.
+ */
+function valuesOf(
+  flavour: Flavour,
+  object: KubernetesObject,
+): Record<string, unknown> {
+  return flavour === 'argo-application'
+    ? applicationValues(object)
+    : helmReleaseValues(object);
+}
+
 /** The digest the delivery object was applied with — what is serving. */
 function appliedDigest(flavour: Flavour, object: KubernetesObject): string {
-  const values =
-    flavour === 'argo-application'
-      ? applicationValues(object)
-      : helmReleaseValues(object);
-  const app = values.app as { artifactDigest?: string } | undefined;
+  const app = valuesOf(flavour, object).app as
+    | { artifactDigest?: string }
+    | undefined;
   return app?.artifactDigest ?? '';
 }
 

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -56,9 +56,11 @@ import type {
   DeployTarget,
   DeployVerdict,
   FailureReason,
+  JobRuns,
   ObservedState,
   RuntimeLogPage,
   RuntimeLogSubject,
+  StartedRun,
 } from '../contract.ts';
 import { BundleError, type BundleFile, readBundle } from './bundle.ts';
 
@@ -82,6 +84,15 @@ const DEPLOY_LABEL = 'spindrift-deploy';
 
 /** A site id is capped well below a DNS label. See `domain/workload-name.ts`. */
 const SITE_ID_LIMIT = 30;
+
+/**
+ * The one sentence every runtime question here is answered with (§17).
+ *
+ * Three questions — what is it saying, run it, what has it run — and one fact
+ * behind all three: files are served, never executed. Written once so the three
+ * refusals cannot drift into three different explanations of the same thing.
+ */
+const NOTHING_RUNS = 'Static files are served by the Target.';
 
 /**
  * The most file hashes one `populateFiles` call may carry.
@@ -292,8 +303,28 @@ export class StaticDeployAdapter implements DeployAdapter {
   ): Promise<RuntimeLogPage> {
     return {
       kind: 'none',
-      because: 'Static files are served by the Target.',
+      because: NOTHING_RUNS,
     };
+  }
+
+  /**
+   * There is nothing here to run, and saying so is the answer (§17).
+   *
+   * `KINDS_BY_ADAPTER.static` is `['website']`, so a job never reaches this
+   * backend and this refusal is unreachable through placement. It is written
+   * anyway, and written as a refusal rather than left unimplemented, for the
+   * same reason `tail` returns its `none` arm rather than an empty page: a
+   * contract every adapter answers is a contract core can call without asking
+   * which one it is holding, and a method that threw would make the one caller
+   * that forgot to check the kind fail as a crash instead of as a sentence.
+   */
+  async run(_target: DeployTarget, _ref: DeployRef): Promise<StartedRun> {
+    return { kind: 'none', because: NOTHING_RUNS };
+  }
+
+  /** The same fact from the reading side: no run ever happened here. */
+  async executions(_target: DeployTarget, _ref: DeployRef): Promise<JobRuns> {
+    return { kind: 'none', because: NOTHING_RUNS };
   }
 
   /** One pass of §13's checklist and §3's discovery, in one call. */

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -1,6 +1,15 @@
 import { z } from 'zod';
+import type { JobRuns } from '../../adapters/deploy/contract.ts';
+import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import { artifactSummary } from '../../domain/artifact-name.ts';
 import { elapsedSince } from '../../domain/elapsed.ts';
+import {
+  deployTargetOf,
+  hasTargetConnection,
+  hasVesselLocation,
+  type TargetConnection,
+} from '../../domain/target.ts';
+import type { VesselLocation } from '../../domain/vessel.ts';
 import type {
   ActivityEntry,
   ComponentView,
@@ -9,7 +18,7 @@ import type {
   Runtime,
   WorkspaceView,
 } from '../../web/model.ts';
-import { type Command, failed, ok } from '../types.ts';
+import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
 export const getAppWorkspaceInput = z.object({
   name: z.string().min(1),
@@ -34,7 +43,9 @@ export const getAppWorkspace: Command<
             orderBy: (deploys, { desc }) => [desc(deploys.createdAt)],
             limit: 1,
             with: {
-              target: true,
+              // The boundary as well as the surface: a job's runs are read
+              // from the platform, and `deployTargetOf` needs both rows.
+              target: { with: { vessel: true } },
               build: true,
             },
           },
@@ -185,11 +196,12 @@ export const getAppWorkspace: Command<
       because: 'Static files are served by the Target.',
     };
   } else if (primaryComponent?.kind === 'job') {
-    runtime = {
-      kind: 'executions',
-      executions: [],
-      retained: 10,
-    };
+    runtime = await executionsOf(
+      context,
+      primaryComponent.id,
+      latestDeploy ?? null,
+      now,
+    );
   } else if (primaryComponent && latestTarget) {
     runtime = {
       kind: 'stream',
@@ -233,6 +245,117 @@ export const getAppWorkspace: Command<
 
   return ok({ workspace });
 };
+
+/**
+ * How many runs the screen offers, and says it keeps (§17).
+ *
+ * §17 fixes N at 10 and the App chart renders exactly that —
+ * `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` in
+ * `packages/charts/spindrift-app/templates/cronjob.yaml`.
+ *
+ * ponytail: it is a page size on every backend and a retention depth on only
+ * one. Cloud Run keeps its own number of executions and reports it nowhere, so
+ * a job there may well have more runs than this asks for and the caption
+ * beneath the list is the chart's promise rather than that project's. Upgrade
+ * path: return the depth from `executions` and let each adapter answer with
+ * what it observes.
+ */
+const RETAINED_RUNS = 10;
+
+/** What {@link executionsOf} reads off the Deploy that placed the job. */
+interface PlacedJob {
+  /** §6's opaque handle. Null until an `apply` placed something. */
+  readonly ref: string | null;
+  readonly target: {
+    readonly id: string;
+    readonly name: string;
+    readonly adapter: TargetAdapter;
+    readonly connection: TargetConnection | null;
+    readonly vessel: {
+      readonly location: VesselLocation | null;
+      readonly servedHosts: readonly string[] | null;
+      readonly reachableRegistries: readonly string[] | null;
+    } | null;
+  } | null;
+}
+
+/**
+ * The runs a job has had, read from the platform (§17).
+ *
+ * §17 keeps a job's history on the backend — "configure the platform, don't
+ * build it" — so this is a live read on every load of the screen rather than a
+ * table Spindrift maintains. A stored history would have to be reconciled
+ * against the CronJob that prunes it, and would be wrong for every run the
+ * scheduler started rather than an operator.
+ *
+ * **Every failure is an empty state, never a failed screen.** A Target that
+ * will not answer is one card's worth of bad news; the App's phase, its URL and
+ * its timeline are all still readable, and taking the workspace down over a
+ * cluster that is momentarily unreachable would hide the very things an
+ * operator opened it to see.
+ */
+async function executionsOf(
+  context: CommandContext,
+  componentId: string,
+  placed: PlacedJob | null,
+  now: Date,
+): Promise<Runtime> {
+  const surface = placed?.target ?? null;
+  const vessel = surface?.vessel ?? null;
+  if (placed?.ref == null || surface === null || vessel === null) {
+    return {
+      kind: 'none',
+      because: 'This job has not been placed on a Target yet.',
+    };
+  }
+  if (!hasTargetConnection(surface) || !hasVesselLocation(vessel)) {
+    return {
+      kind: 'none',
+      because: `${surface.name} is not connected, so its runs cannot be read.`,
+    };
+  }
+  const adapter = context.adapters.deploy(surface.adapter);
+  if (adapter === null) {
+    return {
+      kind: 'none',
+      because: `This installation has no ${surface.adapter} adapter.`,
+    };
+  }
+
+  let runs: JobRuns;
+  try {
+    runs = await adapter.executions(
+      deployTargetOf(surface, vessel),
+      placed.ref,
+      RETAINED_RUNS,
+    );
+  } catch (cause) {
+    return {
+      kind: 'none',
+      because: `The runs on ${surface.name} could not be read: ${cause instanceof Error ? cause.message : String(cause)}`,
+    };
+  }
+  if (runs.kind === 'none') return { kind: 'none', because: runs.because };
+
+  return {
+    kind: 'executions',
+    componentId,
+    targetId: surface.id,
+    executions: runs.executions.map((execution) => ({
+      name: execution.name,
+      outcome: execution.outcome,
+      detail: execution.detail ?? '',
+      // A run the backend has accepted and not started carries no time, and
+      // "just now" is what that is — the same word `elapsedSince` uses for the
+      // first minute, so the column reads consistently either way.
+      when:
+        execution.startedAt === null
+          ? 'just now'
+          : elapsedSince(execution.startedAt, now),
+    })),
+    retained: RETAINED_RUNS,
+  };
+}
 
 /**
  * What a checkpoint is called on the timeline.

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -247,18 +247,19 @@ export const getAppWorkspace: Command<
 };
 
 /**
- * How many runs the screen offers, and says it keeps (§17).
+ * How many runs the screen asks for (§17).
  *
  * §17 fixes N at 10 and the App chart renders exactly that —
  * `successfulJobsHistoryLimit` and `failedJobsHistoryLimit` in
  * `packages/charts/spindrift-app/templates/cronjob.yaml`.
  *
  * ponytail: it is a page size on every backend and a retention depth on only
- * one. Cloud Run keeps its own number of executions and reports it nowhere, so
- * a job there may well have more runs than this asks for and the caption
- * beneath the list is the chart's promise rather than that project's. Upgrade
- * path: return the depth from `executions` and let each adapter answer with
- * what it observes.
+ * one. On `kubernetes` it happens to be both, because the chart Spindrift
+ * renders sets the same number; Cloud Run keeps its own count of executions and
+ * reports it nowhere, so a job there may well have runs beyond this. The
+ * caption beneath the list says only what this is — how many are shown — for
+ * that reason. Upgrade path: return the depth from `executions` and let each
+ * adapter answer with what it observes.
  */
 const RETAINED_RUNS = 10;
 
@@ -293,6 +294,15 @@ interface PlacedJob {
  * its timeline are all still readable, and taking the workspace down over a
  * cluster that is momentarily unreachable would hide the very things an
  * operator opened it to see.
+ *
+ * **A failed read is still a runnable job.** Whether this job can be run is a
+ * fact about the Deploy that placed it, not about whether listing its runs
+ * worked, so a Target that refuses the list answers on the `executions` arm
+ * with the reason on it rather than on `none`. The two are one screen apart:
+ * `none` renders no Run now button, and the first thing an operator meets after
+ * this merges is a cluster whose Role has not reconciled yet, answering `403`
+ * to the list. Hiding the control there hides it exactly where its refusal is
+ * the diagnosis.
  */
 async function executionsOf(
   context: CommandContext,
@@ -322,6 +332,13 @@ async function executionsOf(
     };
   }
 
+  const runnable = {
+    kind: 'executions',
+    componentId,
+    targetId: surface.id,
+    retained: RETAINED_RUNS,
+  } as const;
+
   let runs: JobRuns;
   try {
     runs = await adapter.executions(
@@ -331,16 +348,18 @@ async function executionsOf(
     );
   } catch (cause) {
     return {
-      kind: 'none',
+      ...runnable,
+      executions: [],
       because: `The runs on ${surface.name} could not be read: ${cause instanceof Error ? cause.message : String(cause)}`,
     };
   }
+  // A refusal is the adapter saying this ref names no job it can report on —
+  // a Service's handle, a release that is gone. There is nothing to run either,
+  // so this one does collapse to `none`.
   if (runs.kind === 'none') return { kind: 'none', because: runs.because };
 
   return {
-    kind: 'executions',
-    componentId,
-    targetId: surface.id,
+    ...runnable,
     executions: runs.executions.map((execution) => ({
       name: execution.name,
       outcome: execution.outcome,
@@ -353,7 +372,6 @@ async function executionsOf(
           ? 'just now'
           : elapsedSince(execution.startedAt, now),
     })),
-    retained: RETAINED_RUNS,
   };
 }
 

--- a/apps/spindrift/src/commands/components/run.ts
+++ b/apps/spindrift/src/commands/components/run.ts
@@ -1,0 +1,127 @@
+/**
+ * `runComponent` — start one run of a job, now (§17).
+ *
+ * §7 makes a job's `apply` two acts: the chart renders a CronJob that exists
+ * and is triggered by nothing, and something has to trigger it. This is that
+ * something, and it is a command rather than a mode on `deployApp` for the
+ * reason `DeployAdapter.run` is a verb rather than a mode on `apply` — a deploy
+ * is convergent and happens whenever desired state moves, while a run is an act
+ * an operator asked for once.
+ *
+ * **It writes nothing.** No Deploy row, no attempt, no event. A run is not an
+ * attempt: §6's phases describe placing a workload, and a job that exits 1 is
+ * not a release that went red — the CronJob is still exactly as live as it was.
+ * The runs themselves live on the platform (§17: "configure the platform, don't
+ * build it"), which is where `getAppWorkspace` reads them back from, so a row
+ * here would be a second history that could only disagree with the first.
+ *
+ * **The ref decides what runs.** It is the handle `apply` returned and core
+ * stored (§6), so what starts is the workload that is actually placed — never a
+ * description assembled a second time from rows that may have moved since.
+ */
+import { and, desc, eq } from 'drizzle-orm';
+import { z } from 'zod';
+import type { JobExecution } from '../../adapters/deploy/contract.ts';
+import { deploys, targets, vessels } from '../../db/schema.ts';
+import {
+  deployTargetOf,
+  hasTargetConnection,
+  hasVesselLocation,
+} from '../../domain/target.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const runComponentInput = z
+  .object({
+    componentId: z.uuid(),
+    targetId: z.uuid(),
+  })
+  .strict();
+
+export type RunComponentInput = z.infer<typeof runComponentInput>;
+
+export interface RunComponentResult {
+  /** The run the backend started, in its own name for it. */
+  readonly execution: JobExecution;
+}
+
+export const runComponent: Command<
+  RunComponentInput,
+  RunComponentResult
+> = async (input, context) => {
+  const [component] = await context.db.query.components.findMany({
+    where: (components, { eq }) => eq(components.id, input.componentId),
+    limit: 1,
+  });
+  if (!component) {
+    return failed('NOT_FOUND', 'that Component does not exist');
+  }
+  // The kind is checked here as well as by the adapter, because the two
+  // refusals are different sentences: this one is about the Component a person
+  // is looking at, and the adapter's is about the object a ref names.
+  if (component.kind !== 'job') {
+    return failed(
+      'NOT_RUNNABLE',
+      `${component.name} is a ${component.kind}, and only a job has runs`,
+    );
+  }
+
+  const [placed] = await context.db
+    .select({ ref: deploys.ref, target: targets, vessel: vessels })
+    .from(deploys)
+    .innerJoin(targets, eq(deploys.targetId, targets.id))
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+    .where(
+      and(
+        eq(deploys.componentId, input.componentId),
+        eq(deploys.targetId, input.targetId),
+      ),
+    )
+    // The newest Deploy that placed something. An older ref may name a
+    // workload a re-place has since moved, and running the one that is serving
+    // is the only reading of "run it now" that matches what the screen shows.
+    .orderBy(desc(deploys.id))
+    .limit(1);
+
+  if (!placed || placed.ref === null) {
+    return failed(
+      'NOT_RUNNABLE',
+      `${component.name} has not been placed on that Target yet, so there is nothing to run`,
+    );
+  }
+  if (
+    !hasTargetConnection(placed.target) ||
+    !hasVesselLocation(placed.vessel)
+  ) {
+    return failed(
+      'NOT_RUNNABLE',
+      `${placed.target.name} is not connected, so nothing can be started on it`,
+    );
+  }
+  const adapter = context.adapters.deploy(placed.target.adapter);
+  if (adapter === null) {
+    return failed(
+      'NOT_RUNNABLE',
+      `this installation has no ${placed.target.adapter} adapter`,
+    );
+  }
+
+  // §17: the adapter refuses in a sentence and throws on a fault, so the two
+  // are reported as two things. A refusal is the operator's to act on — the
+  // wrong backend, a workload that is gone — and a fault is the far side's.
+  let started: Awaited<ReturnType<typeof adapter.run>>;
+  try {
+    started = await adapter.run(
+      deployTargetOf(placed.target, placed.vessel),
+      placed.ref,
+    );
+  } catch (cause) {
+    return failed(
+      'NOT_RUNNABLE',
+      cause instanceof Error ? cause.message : String(cause),
+    );
+  }
+  if (started.kind === 'none') {
+    return failed('NOT_RUNNABLE', started.because);
+  }
+  return ok({ execution: started.execution });
+};

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -29,6 +29,7 @@ export { listBuilds } from './builds/list.ts';
 export { createComponent } from './components/create.ts';
 export { placeComponent } from './components/place.ts';
 export { setComponentReach } from './components/reach.ts';
+export { runComponent } from './components/run.ts';
 export { replaceConfig } from './config/replace.ts';
 export { setConfig } from './config/set.ts';
 export {

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -48,6 +48,7 @@ import {
   setComponentReach,
   setComponentReachInput,
 } from './components/reach.ts';
+import { runComponent, runComponentInput } from './components/run.ts';
 import { replaceConfig, replaceConfigInput } from './config/replace.ts';
 import { setConfig, setConfigInput } from './config/set.ts';
 import {
@@ -207,6 +208,7 @@ export const commandRegistry = {
     input: setComponentReachInput,
     handler: setComponentReach,
   },
+  runComponent: { input: runComponentInput, handler: runComponent },
   setConfig: { input: setConfigInput, handler: setConfig },
   configureInstallation: {
     input: configureInstallationInput,

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -246,6 +246,17 @@ export type CommandFailureCode =
    * missing, so a provenance document would have nothing to join against.
    */
   | 'NOT_BUILDABLE'
+  /**
+   * A run was asked for and did not start (§17).
+   *
+   * One code for every reason, because from the screen they are one fact: the
+   * Component is not a job, nothing has been placed on that Target yet, the
+   * Target is disconnected, the backend has nothing to run, or the far side
+   * refused. The sentence differs; what the operator does next — read it and
+   * fix the thing it names — does not, and five codes would only be five ways
+   * to render the same button state.
+   */
+  | 'NOT_RUNNABLE'
   /** The caller saved an older revision than the server currently owns. */
   | 'STALE_EDIT';
 

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -278,12 +278,11 @@ export interface TargetCapabilities {
  * state by having no scheduler in front of the Job rather than by suspending
  * it, since a Job carries no schedule of its own.
  *
- * Two things a job here does not have, and each is a filed ticket rather than
- * a silence: **a schedule**, which needs Cloud Scheduler standing in front of
- * the Job and an API this vessel has not enabled (**72**) and is therefore a
- * non-candidate at Place — see {@link FIRES_SCHEDULES_BY_ADAPTER} — and **an
- * on-demand run**, which needs a verb `DeployAdapter` does not have and every
- * adapter would have to answer (**73**).
+ * One thing a job here does not have, and it is a filed ticket rather than a
+ * silence: **a schedule**, which needs Cloud Scheduler standing in front of the
+ * Job and an API this vessel has not enabled (**72**) and is therefore a
+ * non-candidate at Place — see {@link FIRES_SCHEDULES_BY_ADAPTER}. An on-demand
+ * run is `DeployAdapter.run`, which both backends answer.
  */
 export const KINDS_BY_ADAPTER = {
   kubernetes: ['service', 'website', 'job'],

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -972,7 +972,20 @@ function WorkspaceScreen({
         execution: following,
       },
       (page) => {
-        if (page.kind !== 'stream' || page.entries.length === 0) return;
+        // The two non-stream frames are exactly the cases criterion 4 fails in
+        // — `pods/log` not granted, the pods garbage collected, Cloud Logging
+        // refusing — and dropping them made those look identical to a run that
+        // printed nothing. They are the only thing this pane has to say, so
+        // they replace it rather than being appended to it.
+        if (page.kind === 'none') {
+          setRunLines([{ text: page.because }]);
+          return;
+        }
+        if (page.kind === 'error') {
+          setRunLines([{ text: page.message }]);
+          return;
+        }
+        if (page.entries.length === 0) return;
         setRunLines((lines) => [
           ...lines,
           ...page.entries.map((entry) => ({

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -17,6 +17,7 @@ import type {
   DeployLedgerItem,
   DeployView,
   LinkedRepoView,
+  LogLine,
   PendingTargetConnection,
   RepositoryConnectorView,
   RepositoryOptionView,
@@ -33,7 +34,11 @@ import { cn } from './ui/utils.ts';
 import { DeployDetail } from './views/apps/deploy-detail.tsx';
 import { AppList } from './views/apps/list.tsx';
 import { NewApp } from './views/apps/new/index.tsx';
-import { type SetReach, Workspace } from './views/apps/workspace.tsx';
+import {
+  type RunJob,
+  type SetReach,
+  Workspace,
+} from './views/apps/workspace.tsx';
 import { Gate } from './views/auth/gate.tsx';
 import { InstallationSettings } from './views/auth/installation.tsx';
 import { Onboarding } from './views/auth/onboarding.tsx';
@@ -854,6 +859,16 @@ function WorkspaceScreen({
   const [deployError, setDeployError] = useState<string | null>(null);
   /** Bumped when an act changed state the workspace has already read. */
   const [reloadToken, setReloadToken] = useState(0);
+  /**
+   * Which run's output is open, and the lines read so far (§17).
+   *
+   * Held here rather than in the card because the socket is: a job's tail is
+   * one run's, so switching runs is a different subscription and the lines
+   * start again — which is why they are cleared when the name changes rather
+   * than appended to whatever the last run said.
+   */
+  const [following, setFollowing] = useState<string | null>(null);
+  const [runLines, setRunLines] = useState<readonly LogLine[]>([]);
 
   // There is no workspace left to stand on once the App is gone.
   const deletion = useAppDeletion(() => onNavigate('/apps'));
@@ -938,6 +953,35 @@ function WorkspaceScreen({
       },
     );
   }, [runtime?.componentId, runtime?.targetId]);
+
+  // A job's runs are read the same way a service's output is — one socket, one
+  // cursor — with the run named. §17's two surfaces stay distinct in what they
+  // are subscribed to, not in how they are transported.
+  const runs =
+    state.type === 'success' && state.workspace.runtime.kind === 'executions'
+      ? state.workspace.runtime
+      : null;
+  useEffect(() => {
+    setRunLines([]);
+    if (runs === null || following === null) return;
+    if (runs.componentId === undefined || runs.targetId === undefined) return;
+    return subscribeRuntime(
+      {
+        componentId: runs.componentId,
+        targetId: runs.targetId,
+        execution: following,
+      },
+      (page) => {
+        if (page.kind !== 'stream' || page.entries.length === 0) return;
+        setRunLines((lines) => [
+          ...lines,
+          ...page.entries.map((entry) => ({
+            text: `${entry.replica}  ${entry.line}`,
+          })),
+        ]);
+      },
+    );
+  }, [runs?.componentId, runs?.targetId, following]);
 
   if (state.type === 'loading') {
     return (
@@ -1033,6 +1077,36 @@ function WorkspaceScreen({
     }
   };
 
+  /**
+   * Start one run (§17), then re-read: the list on the screen was written
+   * before the run existed, and a run that does not appear reads as a press
+   * that did nothing.
+   */
+  const handleRunJob: RunJob = async () => {
+    const job =
+      state.type === 'success' && state.workspace.runtime.kind === 'executions'
+        ? state.workspace.runtime
+        : null;
+    if (job?.componentId === undefined || job.targetId === undefined) {
+      return { ok: false, message: 'This job has not been placed on a Target' };
+    }
+    try {
+      const result = await command('runComponent', {
+        componentId: job.componentId,
+        targetId: job.targetId,
+      });
+      if (!result.ok) return { ok: false, message: result.failure.message };
+      setReloadToken((token) => token + 1);
+      return { ok: true };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message:
+          cause instanceof Error ? cause.message : 'Starting the run failed',
+      };
+    }
+  };
+
   return (
     <>
       {deployError ? (
@@ -1060,6 +1134,13 @@ function WorkspaceScreen({
         onNavigate={onNavigate}
         deletion={deletion}
         onSetReach={handleSetReach}
+        {...(runs === null
+          ? {}
+          : {
+              onRunJob: handleRunJob,
+              onFollowExecution: setFollowing,
+              executionLines: runLines,
+            })}
       />
       <DeleteAppDialog deletion={deletion} />
     </>

--- a/apps/spindrift/src/web/dispatch.ts
+++ b/apps/spindrift/src/web/dispatch.ts
@@ -92,6 +92,7 @@ const STATUS = {
   // status that means "not in this state".
   NOT_DEPLOYABLE: 409,
   NOT_BUILDABLE: 409,
+  NOT_RUNNABLE: 409,
   STALE_EDIT: 409,
   UNAUTHENTICATED: 401,
   FORBIDDEN: 403,

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -445,6 +445,17 @@ export type Runtime =
     }
   | {
       readonly kind: 'executions';
+      /**
+       * The two ids a run is acted on by: `runComponent` starts one here, and
+       * the runtime stream reads one run's logs by naming it beside them.
+       *
+       * On this arm as well as on `stream` because a job has both — an act and
+       * a tail — while a `none` has neither. Absent where the Component has
+       * never been placed: there is no Target to run it on, and a button that
+       * could not resolve one would be a button that only ever fails.
+       */
+      readonly componentId?: string;
+      readonly targetId?: string;
       readonly executions: readonly Execution[];
       readonly retained: number;
     }

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -458,6 +458,16 @@ export type Runtime =
       readonly targetId?: string;
       readonly executions: readonly Execution[];
       readonly retained: number;
+      /**
+       * Why this list is empty, when it is empty because the read failed.
+       *
+       * A job that is placed on a Target is runnable whether or not its runs
+       * could be listed, so a failed read stays on this arm rather than
+       * collapsing to `none` — collapsing took the Run now button away in
+       * exactly the state its diagnostics matter, the one where the Target
+       * answers `403` because the Role has not reconciled yet.
+       */
+      readonly because?: string;
     }
   | { readonly kind: 'none'; readonly because: string };
 

--- a/apps/spindrift/src/web/stream-client.ts
+++ b/apps/spindrift/src/web/stream-client.ts
@@ -76,7 +76,12 @@ export function subscribeAttempt(
 }
 
 export function subscribeRuntime(
-  input: { readonly componentId: string; readonly targetId: string },
+  input: {
+    readonly componentId: string;
+    readonly targetId: string;
+    /** One run of a job, whose output is that run's rather than the tail (§17). */
+    readonly execution?: string;
+  },
   onMessage: (message: RuntimeStreamMessage) => void,
   options: SubscribeOptions = {},
 ): () => void {
@@ -92,6 +97,7 @@ export function subscribeRuntime(
       componentId: input.componentId,
       targetId: input.targetId,
     });
+    if (input.execution !== undefined) query.set('execution', input.execution);
     if (cursor !== null) query.set('after', cursor);
     socket = createSocket(streamUrl(`${RUNTIME_STREAM_PATH}?${query}`));
     socket.onmessage = (event) => {

--- a/apps/spindrift/src/web/streams.ts
+++ b/apps/spindrift/src/web/streams.ts
@@ -50,6 +50,17 @@ export {
   type StreamMessage,
 };
 
+/**
+ * What a run may be called, which is what both runtimes already enforce.
+ *
+ * A Cloud Run execution and a Kubernetes Job are both named as an RFC 1123
+ * label: lowercase alphanumerics and dashes, starting and ending alphanumeric,
+ * 63 characters at most. Nothing a backend would answer about is turned away,
+ * and nothing that could end a quoted term in a Cloud Logging filter or a label
+ * selector gets past it.
+ */
+const RUN_NAME = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
 export interface StreamDeps {
   authenticate(request: Request): Promise<RequestAuthentication>;
   /**
@@ -185,6 +196,22 @@ async function upgradeRuntime(
   const after = url.searchParams.get('after');
   /** Which run, for the one kind whose output belongs to a run (§17). */
   const execution = url.searchParams.get('execution');
+  // This value is concatenated into a query language on the far side — a Cloud
+  // Logging filter, a label selector — so it is checked here, at the one place
+  // it enters from a browser, rather than escaped at each of them. Unchecked it
+  // is a read of the whole vessel project: `AND` binds tighter than `OR`, so
+  // `a" OR timestamp>="2020-01-01T00:00:00Z` makes a filter that matches every
+  // entry the project has, other Apps' output and audit logs included, and the
+  // lines land in the run pane of whoever asked.
+  //
+  // The pattern is what both runtimes name a run: a Cloud Run execution and a
+  // Kubernetes Job are both RFC 1123 label-shaped, so nothing legitimate is
+  // turned away and nothing with a quote in it gets through. `?execution=` is
+  // an empty string rather than `null`, which passes the "name one" guard
+  // below, so it is refused here.
+  if (execution !== null && !RUN_NAME.test(execution)) {
+    return refusal(400, 'MALFORMED_REQUEST', 'that is not a run name');
+  }
   if (!componentId || !targetId) {
     return refusal(
       400,

--- a/apps/spindrift/src/web/streams.ts
+++ b/apps/spindrift/src/web/streams.ts
@@ -25,6 +25,7 @@ import {
   type AttemptLogCursor,
   readAttemptStream,
 } from '../domain/attempt-log.ts';
+import { isLabel } from '../domain/naming.ts';
 import {
   deployTargetOf,
   hasTargetConnection,
@@ -49,17 +50,6 @@ export {
   type StreamErrorMessage,
   type StreamMessage,
 };
-
-/**
- * What a run may be called, which is what both runtimes already enforce.
- *
- * A Cloud Run execution and a Kubernetes Job are both named as an RFC 1123
- * label: lowercase alphanumerics and dashes, starting and ending alphanumeric,
- * 63 characters at most. Nothing a backend would answer about is turned away,
- * and nothing that could end a quoted term in a Cloud Logging filter or a label
- * selector gets past it.
- */
-const RUN_NAME = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
 
 export interface StreamDeps {
   authenticate(request: Request): Promise<RequestAuthentication>;
@@ -204,12 +194,23 @@ async function upgradeRuntime(
   // entry the project has, other Apps' output and audit logs included, and the
   // lines land in the run pane of whoever asked.
   //
-  // The pattern is what both runtimes name a run: a Cloud Run execution and a
-  // Kubernetes Job are both RFC 1123 label-shaped, so nothing legitimate is
-  // turned away and nothing with a quote in it gets through. `?execution=` is
-  // an empty string rather than `null`, which passes the "name one" guard
-  // below, so it is refused here.
-  if (execution !== null && !RUN_NAME.test(execution)) {
+  // One DNS label — §9's {@link isLabel}, rather than a sixth copy of the same
+  // grammar — because that is what everything Spindrift starts is called: a
+  // Cloud Run execution name *is* validated as a label, and the Jobs this
+  // adapter creates are named from a release name already shortened to 63.
+  //
+  // It is deliberately narrower than Kubernetes. A Job name is a DNS
+  // *subdomain* — dots are legal, and the ceiling is 253 — and `executions()`
+  // lists by label, so a foreign Job named `blog.nightly-1` can reach the
+  // Recent runs card and be refused when its row is clicked. That is the trade
+  // taken: a name Spindrift cannot have produced does not get to widen a
+  // browser-controlled string on its way into two query languages, and a run
+  // whose logs will not open is a smaller failure than one that opens
+  // everyone's. Widening it means escaping at each concatenation site instead.
+  //
+  // `?execution=` is an empty string rather than `null`, which passes the "name
+  // one" guard below, so it is refused here.
+  if (execution !== null && !isLabel(execution)) {
     return refusal(400, 'MALFORMED_REQUEST', 'that is not a run name');
   }
   if (!componentId || !targetId) {

--- a/apps/spindrift/src/web/streams.ts
+++ b/apps/spindrift/src/web/streams.ts
@@ -183,6 +183,8 @@ async function upgradeRuntime(
   const componentId = url.searchParams.get('componentId');
   const targetId = url.searchParams.get('targetId');
   const after = url.searchParams.get('after');
+  /** Which run, for the one kind whose output belongs to a run (§17). */
+  const execution = url.searchParams.get('execution');
   if (!componentId || !targetId) {
     return refusal(
       400,
@@ -213,11 +215,26 @@ async function upgradeRuntime(
     return refusal(404, 'NOT_FOUND', 'the Component or Target does not exist');
   }
   const { target: surface, vessel } = target;
-  if (component.kind === 'job') {
+  // §17: a job has executions rather than a runtime tail, and the refusal that
+  // used to end here is now answered by the executions it names — one of them
+  // is the subject. Without one there is still nothing to follow: a job is not
+  // running most of the time, and merging every run's output into one stream
+  // would answer a question nobody asked.
+  if (component.kind === 'job' && execution === null) {
     return refusal(
       409,
       'NO_RUNTIME',
-      'a job has executions rather than a runtime tail',
+      'a job has executions rather than a runtime tail: name one to read it',
+    );
+  }
+  // And the other direction: a service has one output and it is not a run's.
+  // Serving a named execution here would hand back the Component's whole tail
+  // under a name that had been silently dropped.
+  if (component.kind !== 'job' && execution !== null) {
+    return refusal(
+      409,
+      'NO_RUNTIME',
+      `${component.name} is a ${component.kind}, and only a job has runs`,
     );
   }
   const [placed] = await authenticated.context.db
@@ -258,7 +275,11 @@ async function upgradeRuntime(
       kind: 'runtime',
       adapter,
       target: deployTargetOf(surface, vessel),
-      subject: { app: app.name, component: component.name },
+      subject: {
+        app: app.name,
+        component: component.name,
+        ...(execution === null ? {} : { execution }),
+      },
       cursor: after,
       closed: false,
     },

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -855,11 +855,17 @@ function Runtime({
               chart's `successfulJobsHistoryLimit` and on `cloudrun` is not the
               retention of anything — saying "the last N are kept" there sends
               an operator looking for a run that `gcloud` still has.
+
+              Not shown at all on a failed read: nothing was shown, so a caption
+              claiming ten of anything is the empty-list lie the sentence above
+              it exists to avoid.
             */}
-            <p className="pt-2 text-xs text-muted-foreground">
-              Showing the last {runtime.retained} runs. The history lives on the
-              Target, not here.
-            </p>
+            {runtime.because ? null : (
+              <p className="pt-2 text-xs text-muted-foreground">
+                Showing the last {runtime.retained} runs. The history lives on
+                the Target, not here.
+              </p>
+            )}
           </>
         ) : (
           <>

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -805,7 +805,17 @@ function Runtime({
                 ) : null}
               </div>
             ) : null}
-            {runtime.executions.length === 0 ? (
+            {/*
+              A read that failed keeps this arm so the button above stays
+              pressable, and says why here. Rendering the empty-list sentence
+              instead would claim the job has never run when what happened is
+              that nobody could find out.
+            */}
+            {runtime.because ? (
+              <EmptyState title="These runs could not be read.">
+                {runtime.because}
+              </EmptyState>
+            ) : runtime.executions.length === 0 ? (
               <EmptyState title="This job has not run yet.">
                 A run started here, or by the schedule, appears in this list.
               </EmptyState>
@@ -839,9 +849,16 @@ function Runtime({
                 ) : null}
               </div>
             ))}
+            {/*
+              What this number is, and nothing more. It is the page size the
+              screen asks for, which on `kubernetes` also happens to be the
+              chart's `successfulJobsHistoryLimit` and on `cloudrun` is not the
+              retention of anything — saying "the last N are kept" there sends
+              an operator looking for a run that `gcloud` still has.
+            */}
             <p className="pt-2 text-xs text-muted-foreground">
-              The last {runtime.retained} executions are kept. Depth is
-              configured on the Target, not stored here.
+              Showing the last {runtime.retained} runs. The history lives on the
+              Target, not here.
             </p>
           </>
         ) : (

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -28,6 +28,7 @@ import type {
   ActivityEntry,
   ComponentView,
   DatastoreView,
+  LogLine,
   WorkspaceView,
 } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
@@ -59,6 +60,18 @@ export type SetReach = (change: {
   | { readonly ok: false; readonly message: string }
 >;
 
+/**
+ * Starting one run of a job, as the screen above needs it answered (§17).
+ *
+ * The same shape {@link SetReach} takes and for the same reason: the press has
+ * exactly one thing to say afterwards — it started, or here is the sentence the
+ * command refused with — and threading that back as two props would put this
+ * card's transient state on the screen that owns the App.
+ */
+export type RunJob = () => Promise<
+  { readonly ok: true } | { readonly ok: false; readonly message: string }
+>;
+
 export function Workspace({
   view,
   onDeploy,
@@ -67,6 +80,9 @@ export function Workspace({
   onNavigate,
   deletion,
   onSetReach,
+  onRunJob,
+  onFollowExecution,
+  executionLines,
 }: {
   view: WorkspaceView;
   onDeploy?: () => void;
@@ -94,6 +110,16 @@ export function Workspace({
    * worse than no form.
    */
   onSetReach?: SetReach;
+  /**
+   * Start one run of this App's job (§17). Absent where the screen wires no
+   * acts, and absent for every Component that is not a job — the runtime card
+   * is what decides, because it is the only branch with runs to start.
+   */
+  onRunJob?: RunJob;
+  /** Follow one run's output, or nothing when the name is `null`. */
+  onFollowExecution?: (execution: string | null) => void;
+  /** The lines of whichever run is being followed. */
+  executionLines?: readonly LogLine[];
 }) {
   const primary = view.components[0];
 
@@ -128,12 +154,15 @@ export function Workspace({
               Rebuild
             </Button>
           ) : null}
+          {/*
+            "Deploy" whatever the kind. This button writes an intent, and for a
+            job that places a CronJob triggered by nothing — it has never made
+            anything run, and calling it `Run now` beside a button that does is
+            the one label a reader cannot recover from. Running is on the
+            runtime card, where the runs are (§17).
+          */}
           <Button onClick={onDeploy} disabled={deploying}>
-            {deploying
-              ? 'Deploying...'
-              : primary?.kind === 'job'
-                ? 'Run now'
-                : 'Deploy'}
+            {deploying ? 'Deploying...' : 'Deploy'}
           </Button>
         </div>
       </header>
@@ -156,7 +185,13 @@ export function Workspace({
           not here reads as applied and is not.
         */}
         <Activity entries={view.activity} onNavigate={onNavigate} />
-        <Runtime view={view} onNavigate={onNavigate} />
+        <Runtime
+          view={view}
+          onNavigate={onNavigate}
+          {...(onRunJob ? { onRun: onRunJob } : {})}
+          {...(onFollowExecution ? { onFollowExecution } : {})}
+          {...(executionLines ? { executionLines } : {})}
+        />
       </div>
     </div>
   );
@@ -686,12 +721,48 @@ function ActivityRow({
 function Runtime({
   view,
   onNavigate,
+  onRun,
+  onFollowExecution,
+  executionLines,
 }: {
   view: WorkspaceView;
   onNavigate?: (path: string) => void;
+  /**
+   * Start one run (§17). Absent where the screen has no act wired — the
+   * fixture renders, and any Component that is not a placed job.
+   */
+  onRun?: RunJob;
+  /**
+   * Follow one run's output, or nothing when the name is `null`.
+   *
+   * The lines come back as {@link executionLines} rather than through this
+   * callback, because the socket outlives any one render and the screen above
+   * owns it — the same split the service tail already has.
+   */
+  onFollowExecution?: (execution: string | null) => void;
+  executionLines?: readonly LogLine[];
 }) {
   const runtime = view.runtime;
   const latestDeployId = view.latestDeployId;
+  /** Which run's output is open. One at a time: this is a list, not a tree. */
+  const [following, setFollowing] = useState<string | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [runError, setRunError] = useState<string | null>(null);
+
+  const follow = (execution: string) => {
+    const next = following === execution ? null : execution;
+    setFollowing(next);
+    onFollowExecution?.(next);
+  };
+
+  const start = async () => {
+    if (!onRun) return;
+    setStarting(true);
+    setRunError(null);
+    const result = await onRun();
+    setStarting(false);
+    if (!result.ok) setRunError(result.message);
+  };
 
   return (
     <Card>
@@ -712,17 +783,61 @@ function Runtime({
           </EmptyState>
         ) : runtime.kind === 'executions' ? (
           <>
+            {/*
+              §17's other half of `apply` for a job: the chart renders a
+              CronJob that is triggered by nothing, so an unscheduled job is
+              only ever run because somebody asked. The button is what asking
+              is, and it sits with the runs rather than beside Deploy because
+              running is not deploying — nothing about what is placed changes.
+            */}
+            {onRun ? (
+              <div className="flex items-center gap-3 pb-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={starting}
+                  onClick={() => void start()}
+                >
+                  {starting ? 'Starting...' : 'Run now'}
+                </Button>
+                {runError ? (
+                  <p className="text-xs text-destructive">{runError}</p>
+                ) : null}
+              </div>
+            ) : null}
+            {runtime.executions.length === 0 ? (
+              <EmptyState title="This job has not run yet.">
+                A run started here, or by the schedule, appears in this list.
+              </EmptyState>
+            ) : null}
             {runtime.executions.map((execution) => (
-              <Row
-                key={execution.name}
-                badge={
-                  <Badge tone={EXECUTION_TONE[execution.outcome]}>
-                    {execution.outcome}
-                  </Badge>
-                }
-                title={execution.name}
-                detail={`${execution.detail} · ${execution.when}`}
-              />
+              <div key={execution.name}>
+                {/*
+                  A run's logs are read by naming the run, so the row is what
+                  names it. Pressing it again closes the pane rather than
+                  leaving the screen holding a socket nobody is reading.
+                */}
+                <button
+                  type="button"
+                  className="w-full text-left"
+                  onClick={
+                    onFollowExecution ? () => follow(execution.name) : undefined
+                  }
+                >
+                  <Row
+                    badge={
+                      <Badge tone={EXECUTION_TONE[execution.outcome]}>
+                        {execution.outcome}
+                      </Badge>
+                    }
+                    title={execution.name}
+                    detail={`${execution.detail} · ${execution.when}`}
+                  />
+                </button>
+                {following === execution.name ? (
+                  <LogPane lines={executionLines ?? []} />
+                ) : null}
+              </div>
             ))}
             <p className="pt-2 text-xs text-muted-foreground">
               The last {runtime.retained} executions are kept. Depth is

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -1035,6 +1035,33 @@ describe('a job is run, and its runs are read', () => {
     expect(runs.executions[1]?.detail).toBe('the task exited 1');
   });
 
+  test('reads past the page it wants, because the API orders nothing', async () => {
+    // `projects.locations.jobs.executions.list` documents no ordering and takes
+    // no `orderBy`, so a page of `limit` is `limit` arbitrary runs. Asking for
+    // exactly what the screen shows and sorting the reply is correct only if
+    // the API happens to answer newest-first: seeded oldest-first, that reads
+    // the same ten stale runs forever and a run started by the button is never
+    // on the list. The page asked for is a ceiling, `limit` is what to report.
+    const oldestFirst = Array.from({ length: 14 }, (_, index) =>
+      execution(`shop-nightly-${index + 1}`, {
+        startTime: `2026-08-${String(index + 1).padStart(2, '0')}T00:00:00Z`,
+        succeededCount: 1,
+      }),
+    );
+    const { adapter } = adapterFor({
+      executions: { 'shop-nightly': oldestFirst },
+    });
+    await drain(adapter.apply(target(), job()));
+
+    const runs = await adapter.executions(target(), JOB_REF, 10);
+
+    expect(runs.kind).toBe('executions');
+    if (runs.kind !== 'executions') return;
+    expect(runs.executions).toHaveLength(10);
+    expect(runs.executions[0]?.name).toBe('shop-nightly-14');
+    expect(runs.executions.at(-1)?.name).toBe('shop-nightly-5');
+  });
+
   test("reads one run's logs with a job filter, not a revision one", async () => {
     const api = new FakeCloudRun();
     const filters: string[] = [];

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -934,3 +934,173 @@ describe('runtime log tail', () => {
     );
   });
 });
+
+/**
+ * A job's runs (§17).
+ *
+ * A Job here is triggered by nothing, so an execution exists exactly when
+ * something asked for one — `jobs.run` is that asking, and its `Operation`
+ * carries the Execution the runtime named. The reading half is the sub-
+ * collection, and the log half is the filter that a Service's would never
+ * match: a run's entries are `cloud_run_job`, keyed on `job_name` and labelled
+ * with the execution, none of which a `cloud_run_revision` filter selects.
+ */
+describe('a job is run, and its runs are read', () => {
+  const JOB_REF =
+    'projects/example-vessel/locations/somewhere/jobs/shop-nightly';
+  const job = () =>
+    desired({ component: 'nightly', kind: 'job', reach: 'none', auth: 'none' });
+
+  /** One `Execution` as the API returns it. */
+  function execution(
+    name: string,
+    fields: Record<string, unknown>,
+  ): Record<string, unknown> {
+    return {
+      name: `projects/example-vessel/locations/somewhere/jobs/shop-nightly/executions/${name}`,
+      ...fields,
+    };
+  }
+
+  test('starts a run through the runtime’s own verb', async () => {
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(target(), job()));
+
+    const started = await adapter.run(target(), JOB_REF);
+
+    expect(started.kind).toBe('started');
+    if (started.kind !== 'started') return;
+    // The short name, which is the only form the log filter's own
+    // `execution_name` label carries.
+    expect(started.execution.name).toBe('shop-nightly-1');
+    expect(started.execution.outcome).toBe('running');
+    expect(api.pathsOf('POST')).toContain(
+      '/v2/projects/example-vessel/locations/somewhere/jobs/shop-nightly:run',
+    );
+  });
+
+  test('refuses a ref that names a service rather than a job', async () => {
+    const { adapter } = adapterFor();
+    await drain(adapter.apply(target(), desired()));
+
+    expect(
+      await adapter.run(
+        target(),
+        'projects/example-vessel/locations/somewhere/services/shop-web',
+      ),
+    ).toEqual({
+      kind: 'none',
+      because:
+        'this ref names a service, which has a runtime tail rather than runs',
+    });
+  });
+
+  test('lists the runs that happened, newest first, with their outcome', async () => {
+    const { adapter } = adapterFor({
+      executions: {
+        'shop-nightly': [
+          execution('shop-nightly-3', {
+            startTime: '2026-08-03T00:00:00Z',
+          }),
+          execution('shop-nightly-2', {
+            startTime: '2026-08-02T00:00:00Z',
+            failedCount: 1,
+            conditions: [
+              {
+                type: 'Completed',
+                state: 'CONDITION_FAILED',
+                message: 'the task exited 1',
+              },
+            ],
+          }),
+          execution('shop-nightly-1', {
+            startTime: '2026-08-01T00:00:00Z',
+            succeededCount: 1,
+            conditions: [{ type: 'Completed', state: 'CONDITION_SUCCEEDED' }],
+          }),
+        ],
+      },
+    });
+    await drain(adapter.apply(target(), job()));
+
+    const runs = await adapter.executions(target(), JOB_REF);
+
+    expect(runs.kind).toBe('executions');
+    if (runs.kind !== 'executions') return;
+    expect(runs.executions.map((run) => [run.name, run.outcome])).toEqual([
+      ['shop-nightly-3', 'running'],
+      ['shop-nightly-2', 'failed'],
+      ['shop-nightly-1', 'passed'],
+    ]);
+    expect(runs.executions[1]?.detail).toBe('the task exited 1');
+  });
+
+  test("reads one run's logs with a job filter, not a revision one", async () => {
+    const api = new FakeCloudRun();
+    const filters: string[] = [];
+    const adapter = new CloudRunDeployAdapter({
+      token: api.token,
+      logsEndpoint: api.endpoint,
+      fetch: async (request) => {
+        if (new URL(request.url).pathname !== '/v2/entries:list') {
+          return api.fetch(request);
+        }
+        const body = (await request.clone().json()) as { filter: string };
+        filters.push(body.filter);
+        return Response.json({
+          entries: [
+            {
+              timestamp: '2026-08-04T12:00:00.000Z',
+              insertId: 'a',
+              textPayload: 'backing up',
+              labels: { 'run.googleapis.com/task_index': '0' },
+            },
+          ],
+        });
+      },
+    });
+
+    const page = await adapter.tail(target(), {
+      app: 'shop',
+      component: 'nightly',
+      execution: 'shop-nightly-2',
+    });
+
+    expect(page.kind).toBe('stream');
+    if (page.kind !== 'stream') return;
+    expect(page.entries.map((entry) => entry.line)).toEqual(['backing up']);
+    // A run has tasks rather than revisions, and a column reading `unknown` for
+    // every line a job ever writes is what a revision-shaped read produces.
+    expect(page.entries[0]?.replica).toBe('task 0');
+    expect(filters[0]).toContain('resource.type="cloud_run_job"');
+    expect(filters[0]).toContain('resource.labels.job_name="shop-nightly"');
+    expect(filters[0]).toContain(
+      'labels."run.googleapis.com/execution_name"="shop-nightly-2"',
+    );
+    expect(filters[0]).not.toContain('cloud_run_revision');
+  });
+
+  test('a service still reads its revisions — the filter did not move', async () => {
+    const api = new FakeCloudRun();
+    const filters: string[] = [];
+    const adapter = new CloudRunDeployAdapter({
+      token: api.token,
+      logsEndpoint: api.endpoint,
+      fetch: async (request) => {
+        if (new URL(request.url).pathname !== '/v2/entries:list') {
+          return api.fetch(request);
+        }
+        filters.push(
+          ((await request.clone().json()) as { filter: string }).filter,
+        );
+        return Response.json({ entries: [] });
+      },
+    });
+
+    await adapter.tail(target(), { app: 'shop', component: 'web' });
+
+    expect(filters[0]).toContain('resource.type="cloud_run_revision"');
+    expect(filters[0]).toContain('resource.labels.service_name="shop-web"');
+    expect(filters[0]).not.toContain('execution_name');
+  });
+});

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -146,6 +146,12 @@ const refuses: DeployAdapter = {
   async tail() {
     return { kind: 'stream', entries: [], cursor: null, reach: 0 };
   },
+  async run() {
+    return { kind: 'none', because: 'nothing was placed here to run' };
+  },
+  async executions() {
+    return { kind: 'none', because: 'nothing was placed here to run' };
+  },
   async inspect() {
     return {
       prerequisites: prerequisitesFor('kubernetes').map((name) => ({

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -607,6 +607,27 @@ describe('a write that never landed', () => {
     expect(blameFor(verdict.reason)).toBe('platform');
   });
 
+  test('an apply the API server 404s is a failure, blamed on the platform', async () => {
+    // The write half of the same question the job `create` test asks. A
+    // server-side apply into a deleted namespace — or one whose delivery CRD is
+    // not installed — answers `404`, and `apply` returns `void`, so a swallowed
+    // one was a deploy that placed nothing and went on to poll for a verdict.
+    //
+    // And it is `TARGET_UNREACHABLE`, not `REJECTED`: an apply creates what is
+    // not there, so nothing missing here is the developer's object. §6 blames
+    // `REJECTED` on the developer, which would send them reading their chart
+    // values for a namespace the operator deleted.
+    const { adapter, cluster } = adapterFor({
+      refuse: { status: 404, body: 'namespaces "apps" not found' },
+    });
+    const { verdict } = await drain(adapter.apply(target(), desiredState()));
+    if (verdict.phase !== 'FAILED') throw new Error('expected a failure');
+    expect(verdict.reason).toBe('TARGET_UNREACHABLE');
+    expect(blameFor(verdict.reason)).toBe('platform');
+    expect(verdict.detail).toBe('namespaces "apps" not found');
+    expect(cluster.all('helmreleases')).toHaveLength(0);
+  });
+
   test('an expired credential is unreachable, not a rejection', async () => {
     const { adapter } = adapterFor({ token: 'a-different-token' });
     const { verdict } = await drain(adapter.apply(target(), desiredState()));
@@ -1593,7 +1614,9 @@ describe('a job is run, and its runs are read', () => {
       now: () => RUN_AT,
     });
 
-    expect(adapter.run(target(), REF)).rejects.toThrow(/404/);
+    // Awaited: unawaited, the second assertion runs before `run` has issued its
+    // `POST` and would pass whatever the adapter did.
+    await expect(adapter.run(target(), REF)).rejects.toThrow(/404/);
     expect(far.all('jobs')).toHaveLength(0);
   });
 
@@ -1668,6 +1691,29 @@ describe('a job is run, and its runs are read', () => {
       ['blog-nightly-1', 'passed'],
     ]);
     expect(runs.executions[1]?.detail).toBe('the container exited 1');
+  });
+
+  test('a list the API server 404s is a fault, not a job that never ran', async () => {
+    // The read half of the `create` test above, and the same failure: `403` on
+    // this call reaches the "these runs could not be read" arm, so a `404` —
+    // the namespace deleted, or a cluster that does not serve `batch/v1` —
+    // reading green and empty is an asymmetry nobody chose. `api.list` answers
+    // `null` for exactly that and `?? []` threw the distinction away.
+    const far = new FakeKubernetes({
+      // `CronJob` served and `Job` not: a `list jobs` here is a `404` while
+      // everything `placedJob` reads still answers, so the failure is this one
+      // call's and not the fixture falling over earlier.
+      servedKinds: { ...SERVED, 'batch/v1': ['CronJob'] },
+      objects: {
+        'helmreleases/delivery/blog-nightly': release,
+        'cronjobs/apps/blog-nightly': cronJob,
+      },
+      status: () => null,
+    });
+
+    await expect(adapterFor(far).executions(target(), REF)).rejects.toThrow(
+      /404/,
+    );
   });
 
   test("reads one run's logs rather than the Component's whole output", async () => {

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -1433,3 +1433,255 @@ function node(arch: string, allocatable: Record<string, string>): FakeObject {
     status: { allocatable },
   };
 }
+
+/**
+ * A job's runs (§7, §17).
+ *
+ * The chart renders every job as a CronJob — suspended when unscheduled — so a
+ * run is a Job created from that CronJob's own `jobTemplate` and owned by it.
+ * Both halves have a failure mode a plausible implementation walks into: a run
+ * built from anything other than the template runs the wrong image, and a run
+ * with no owner outlives every execution beside it because nothing prunes it.
+ */
+describe('a job is run, and its runs are read', () => {
+  const RUN_AT = Date.UTC(2026, 7, 4, 12, 0, 0);
+  const JOB_LABELS = {
+    'app.kubernetes.io/name': 'nightly',
+    'app.kubernetes.io/part-of': 'blog',
+  };
+  const REF = 'flux-helmrelease:delivery/blog-nightly';
+
+  /** The release the chart rendered from, as the adapter reads it back. */
+  const release: FakeObject = {
+    apiVersion: 'helm.toolkit.fluxcd.io/v2',
+    kind: 'HelmRelease',
+    metadata: { name: 'blog-nightly', namespace: 'delivery' },
+    spec: {
+      values: {
+        app: { name: 'blog', component: 'nightly', kind: 'job' },
+      },
+    },
+  };
+
+  const jobTemplate = {
+    metadata: { labels: JOB_LABELS },
+    spec: { backoffLimit: 0, template: { spec: { containers: [] } } },
+  };
+
+  const cronJob: FakeObject = {
+    apiVersion: 'batch/v1',
+    kind: 'CronJob',
+    metadata: {
+      name: 'blog-nightly',
+      namespace: 'apps',
+      uid: 'cron-uid-1',
+      labels: JOB_LABELS,
+    },
+    spec: { suspend: true, schedule: '0 0 31 2 *', jobTemplate },
+  };
+
+  function ranJob(
+    name: string,
+    overrides: { startTime?: string; conditions?: unknown[] } = {},
+  ): FakeObject {
+    return {
+      apiVersion: 'batch/v1',
+      kind: 'Job',
+      metadata: { name, namespace: 'apps', labels: JOB_LABELS },
+      status: {
+        ...(overrides.startTime === undefined
+          ? {}
+          : { startTime: overrides.startTime }),
+        ...(overrides.conditions === undefined
+          ? {}
+          : { conditions: overrides.conditions }),
+      },
+    };
+  }
+
+  function cluster(objects: Record<string, FakeObject> = {}): FakeKubernetes {
+    return new FakeKubernetes({
+      servedKinds: { ...SERVED, 'batch/v1': ['CronJob', 'Job'] },
+      objects: {
+        'helmreleases/delivery/blog-nightly': release,
+        'cronjobs/apps/blog-nightly': cronJob,
+        ...objects,
+      },
+      // Nothing here polls for readiness, and the default script would
+      // otherwise stamp a ready HelmRelease's status onto every Job read.
+      status: () => null,
+    });
+  }
+
+  function adapterFor(far: FakeKubernetes): KubernetesDeployAdapter {
+    return new KubernetesDeployAdapter({
+      chart: CHART,
+      token: far.token,
+      fetch: far.fetch,
+      now: () => RUN_AT,
+    });
+  }
+
+  test('starts a Job from the CronJob template, owned by the CronJob', async () => {
+    const far = cluster();
+    const started = await adapterFor(far).run(target(), REF);
+
+    expect(started.kind).toBe('started');
+    if (started.kind !== 'started') return;
+    expect(started.execution.outcome).toBe('running');
+
+    const created = far.get(`jobs/apps/${started.execution.name}`);
+    expect(created?.kind).toBe('Job');
+    // The template's spec, verbatim: a run that assembled its own would run
+    // something other than what the chart rendered.
+    expect(created?.spec).toEqual(jobTemplate.spec);
+    expect(created?.metadata.labels).toEqual(JOB_LABELS);
+    expect(created?.metadata.annotations).toEqual({
+      'cronjob.kubernetes.io/instantiate': 'manual',
+    });
+    // Owned, so the CronJob's history limits prune it like any other run.
+    expect(created?.metadata.ownerReferences).toEqual([
+      {
+        apiVersion: 'batch/v1',
+        kind: 'CronJob',
+        name: 'blog-nightly',
+        uid: 'cron-uid-1',
+        controller: true,
+      },
+    ]);
+  });
+
+  test('leaves the CronJob suspended — running now is not scheduling', async () => {
+    const far = cluster();
+    await adapterFor(far).run(target(), REF);
+
+    expect(far.get('cronjobs/apps/blog-nightly')?.spec).toEqual({
+      suspend: true,
+      schedule: '0 0 31 2 *',
+      jobTemplate,
+    });
+  });
+
+  test('a second press in the same second is the same run, not a second one', async () => {
+    const far = cluster();
+    const adapter = adapterFor(far);
+    const first = await adapter.run(target(), REF);
+    const second = await adapter.run(target(), REF);
+
+    expect(second.kind).toBe('started');
+    if (first.kind !== 'started' || second.kind !== 'started') return;
+    expect(second.execution.name).toBe(first.execution.name);
+    expect(far.all('jobs')).toHaveLength(1);
+  });
+
+  test('refuses a Component that is not a job, in a sentence', async () => {
+    const far = new FakeKubernetes({
+      servedKinds: { ...SERVED, 'batch/v1': ['CronJob', 'Job'] },
+      objects: {
+        'helmreleases/delivery/blog-web': {
+          apiVersion: 'helm.toolkit.fluxcd.io/v2',
+          kind: 'HelmRelease',
+          metadata: { name: 'blog-web', namespace: 'delivery' },
+          spec: {
+            values: {
+              app: { name: 'blog', component: 'web', kind: 'service' },
+            },
+          },
+        },
+      },
+      status: () => null,
+    });
+    const refused = await adapterFor(far).run(
+      target(),
+      'flux-helmrelease:delivery/blog-web',
+    );
+
+    expect(refused).toEqual({
+      kind: 'none',
+      because: 'this Component is not a job, so it has no runs',
+    });
+  });
+
+  test('lists the runs that happened, newest first, with their outcome', async () => {
+    const far = cluster({
+      'jobs/apps/blog-nightly-1': ranJob('blog-nightly-1', {
+        startTime: '2026-08-01T00:00:00Z',
+        conditions: [
+          {
+            type: 'Complete',
+            status: 'True',
+            reason: 'CompletionsReached',
+            message: 'all tasks completed',
+          },
+        ],
+      }),
+      'jobs/apps/blog-nightly-2': ranJob('blog-nightly-2', {
+        startTime: '2026-08-02T00:00:00Z',
+        conditions: [
+          {
+            type: 'Failed',
+            status: 'True',
+            reason: 'BackoffLimitExceeded',
+            message: 'the container exited 1',
+          },
+        ],
+      }),
+      'jobs/apps/blog-nightly-3': ranJob('blog-nightly-3', {
+        startTime: '2026-08-03T00:00:00Z',
+        // `SuccessCriteriaMet` is the controller narrating, not a verdict.
+        conditions: [{ type: 'SuccessCriteriaMet', status: 'True' }],
+      }),
+    });
+
+    const runs = await adapterFor(far).executions(target(), REF);
+
+    expect(runs.kind).toBe('executions');
+    if (runs.kind !== 'executions') return;
+    expect(
+      runs.executions.map((execution) => [execution.name, execution.outcome]),
+    ).toEqual([
+      ['blog-nightly-3', 'running'],
+      ['blog-nightly-2', 'failed'],
+      ['blog-nightly-1', 'passed'],
+    ]);
+    expect(runs.executions[1]?.detail).toBe('the container exited 1');
+  });
+
+  test("reads one run's logs rather than the Component's whole output", async () => {
+    const far = new FakeKubernetes({
+      servedKinds: { ...SERVED, 'batch/v1': ['CronJob', 'Job'] },
+      lists: {
+        pods: [
+          runPod('blog-nightly-2-xyz', 'blog-nightly-2'),
+          runPod('blog-nightly-1-abc', 'blog-nightly-1'),
+        ],
+      },
+      logs: (name) => `2026-08-04T12:00:00Z from ${name}\n`,
+    });
+    const page = await adapterFor(far).tail(target(), {
+      app: 'blog',
+      component: 'nightly',
+      execution: 'blog-nightly-2',
+    });
+
+    expect(page.kind).toBe('stream');
+    if (page.kind !== 'stream') return;
+    // The cluster filters, not the caller: only the named run's pod comes back.
+    expect(page.entries.map((entry) => entry.line)).toEqual([
+      'from blog-nightly-2-xyz',
+    ]);
+  });
+
+  /** A pod of one run, labelled the way the Job controller labels one. */
+  function runPod(name: string, run: string): FakeObject {
+    return {
+      apiVersion: 'v1',
+      kind: 'Pod',
+      metadata: {
+        name,
+        namespace: 'apps',
+        labels: { ...JOB_LABELS, 'batch.kubernetes.io/job-name': run },
+      },
+    };
+  }
+});

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -1574,6 +1574,29 @@ describe('a job is run, and its runs are read', () => {
     expect(far.all('jobs')).toHaveLength(1);
   });
 
+  test('a create the API server 404s is a fault, not a started run', async () => {
+    // `POST /apis/batch/v1/namespaces/<ns>/jobs` answers `404` when the
+    // namespace has been deleted or the cluster does not serve `batch/v1`.
+    // Nothing is created either way, so a started run reported from it is a
+    // row reading `running` that the next `executions` read never lists —
+    // this repo's signature failure, an act that reached nothing and said it
+    // worked. `create` distinguishes stored from not-stored by raising.
+    const far = cluster();
+    const adapter = new KubernetesDeployAdapter({
+      chart: CHART,
+      token: far.token,
+      fetch: async (request) =>
+        request.method === 'POST' &&
+        new URL(request.url).pathname.endsWith('/jobs')
+          ? new Response('{"kind":"Status","code":404}', { status: 404 })
+          : far.fetch(request),
+      now: () => RUN_AT,
+    });
+
+    expect(adapter.run(target(), REF)).rejects.toThrow(/404/);
+    expect(far.all('jobs')).toHaveLength(0);
+  });
+
   test('refuses a Component that is not a job, in a sentence', async () => {
     const far = new FakeKubernetes({
       servedKinds: { ...SERVED, 'batch/v1': ['CronJob', 'Job'] },

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -382,6 +382,25 @@ describe('§13 and §17: what this Target is honest about', () => {
     });
   });
 
+  test('refuses to run, rather than being unimplemented', async () => {
+    // §17's other direction. `KINDS_BY_ADAPTER.static` is `['website']`, so a
+    // job never reaches this backend and the refusal is unreachable through
+    // placement — which is exactly why it has to be a sentence rather than a
+    // throw: a caller that forgot to check the kind gets an answer it can put
+    // on a screen instead of a stack trace it cannot.
+    const { adapter } = adapterFor();
+    const refusal = {
+      kind: 'none',
+      because: 'Static files are served by the Target.',
+    } as const;
+    expect(await adapter.run(TARGET, 'example/sites/shop-site')).toEqual(
+      refusal,
+    );
+    expect(await adapter.executions(TARGET, 'example/sites/shop-site')).toEqual(
+      refusal,
+    );
+  });
+
   test('a site reaches no store, which is why §10 exempts a website', async () => {
     const { adapter } = adapterFor();
     const { discovery } = await adapter.inspect(TARGET);

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -53,6 +53,14 @@ const adapters: AdapterRegistry = {
       throw new Error('creation drafts do not inspect the far side');
     },
     tail: async () => ({ kind: 'stream', entries: [], cursor: null, reach: 0 }),
+    run: async () => ({
+      kind: 'none',
+      because: 'creation drafts do not run anything',
+    }),
+    executions: async () => ({
+      kind: 'none',
+      because: 'creation drafts do not run anything',
+    }),
   }),
   build: (name) => (name === builder.name ? builder : null),
   store: () => null,

--- a/apps/spindrift/test/commands/job-runs.test.ts
+++ b/apps/spindrift/test/commands/job-runs.test.ts
@@ -307,4 +307,31 @@ describe('the App screen lists the runs that happened', () => {
       because: 'this backend keeps no runs',
     });
   });
+
+  test('a read that failed still says the job can be run', async () => {
+    // The state this feature's first day is in: the Role granting `list` on
+    // batch jobs has not reconciled on the cluster yet, so the read `403`s
+    // while starting a run would have worked. Collapsing that to `kind: 'none'`
+    // takes the ids off the runtime, and the screen renders no Run now button —
+    // the feature hiding itself in exactly the state where pressing it is the
+    // diagnosis. Whether a job is runnable is a fact about the Deploy that
+    // placed it, not about whether listing worked.
+    const backend = new FakeDeployAdapter({
+      executionsThrows: 'jobs.batch is forbidden: User cannot list jobs',
+    });
+    const ctx = context(backend);
+    const { appName } = await scaffold(ctx, backend);
+
+    const workspace = await getAppWorkspace({ name: appName }, ctx);
+
+    expect(workspace.ok).toBe(true);
+    if (!workspace.ok) return;
+    const runtime = workspace.value.workspace.runtime;
+    expect(runtime.kind).toBe('executions');
+    if (runtime.kind !== 'executions') return;
+    expect(runtime.executions).toHaveLength(0);
+    expect(runtime.componentId).toBeDefined();
+    expect(runtime.targetId).toBeDefined();
+    expect(runtime.because).toContain('is forbidden');
+  });
 });

--- a/apps/spindrift/test/commands/job-runs.test.ts
+++ b/apps/spindrift/test/commands/job-runs.test.ts
@@ -1,0 +1,310 @@
+/**
+ * Running a job, and reading what it did (§7, §17).
+ *
+ * Seam 1: the command layer over a fake deploy backend. What is asserted here
+ * is the half the adapter tests cannot see — that a press reaches the far side
+ * with the ref core stored, and that the App screen's list of runs is the far
+ * side's rather than a shape core made up.
+ *
+ * The claim worth stating up front, because it is what the placeholder it
+ * replaces made easy to get wrong: **the workspace reads runs from the
+ * platform**, so the list is the runs that happened, including the ones the
+ * schedule started and nothing here asked for.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createApp } from '../../src/commands/create-app.ts';
+import {
+  createComponent,
+  getAppWorkspace,
+  runComponent,
+} from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  componentTargetDesired,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const manifest = await fixtureManifest();
+const database = withIsolatedDatabase();
+
+const NOW = new Date('2026-08-04T12:00:00.000Z');
+const clock: Clock = { now: () => NOW };
+const supplyChain = new SupplyChainHarness();
+
+function context(deploy: FakeDeployAdapter | null): CommandContext {
+  const adapters: AdapterRegistry = {
+    deploy: () => deploy,
+    build: () => null,
+    store: () => null,
+    repository: () => null,
+    supplyChain: () => supplyChain,
+  };
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/**
+ * One App with one job Component, placed and deployed.
+ *
+ * The workload is put on the fake far side too, because that is what a deploy
+ * did: a ref on a row with nothing behind it is a Component whose workload has
+ * been deleted, and every run verb refuses that on purpose.
+ */
+async function scaffold(
+  ctx: CommandContext,
+  backend: FakeDeployAdapter,
+  options: { kind?: 'job' | 'service'; ref?: string | null } = {},
+) {
+  const name = `runs-${crypto.randomUUID().slice(0, 8)}`;
+  const app = await createApp(
+    {
+      name,
+      sourceKind: 'repo',
+      repoUrl: 'https://vcs.example/acme/thing.git',
+      vesselRef: 'driftwood',
+    },
+    ctx,
+  );
+  if (!app.ok) throw new Error(app.failure.message);
+
+  const component = await createComponent(
+    options.kind === 'service'
+      ? {
+          appId: app.value.appId,
+          name: 'web',
+          kind: 'service',
+          expose: true,
+          reach: 'private',
+          auth: 'proxy',
+        }
+      : {
+          appId: app.value.appId,
+          name: 'nightly',
+          kind: 'job',
+          // A job is reached by nobody: nothing routes to it, so §9's grid
+          // leaves it the one pair that means "no route at all".
+          reach: 'none',
+          auth: 'none',
+        },
+    ctx,
+  );
+  if (!component.ok) throw new Error(component.failure.message);
+
+  const [target] = await ctx.db
+    .insert(targets)
+    .values(targetValues({ adapter: 'kubernetes' }))
+    .returning();
+  await ctx.db.insert(componentTargetDesired).values({
+    componentId: component.value.componentId,
+    targetId: target?.id as string,
+  });
+
+  const [placed] = await ctx.db
+    .insert(deploys)
+    .values({
+      componentId: component.value.componentId,
+      targetId: target?.id as string,
+      buildId: await buildFor(ctx, component.value.componentId),
+      phase: 'LIVE',
+      ref: options.ref === undefined ? 'fake-deploy-1' : options.ref,
+    })
+    .returning();
+
+  if (placed?.ref != null) {
+    backend.place(placed.ref, {
+      ref: placed.ref,
+      phase: 'LIVE',
+      artifactDigest: `sha256:${'a'.repeat(64)}`,
+    });
+  }
+
+  return {
+    appName: name,
+    componentId: component.value.componentId,
+    targetId: target?.id as string,
+    deployId: placed?.id as number,
+  };
+}
+
+/** A green Build, because a Deploy row references one. */
+async function buildFor(
+  ctx: CommandContext,
+  componentId: string,
+): Promise<number> {
+  const { builds } = await import('../../src/db/schema.ts');
+  const [build] = await ctx.db
+    .insert(builds)
+    .values({
+      componentId,
+      commit: 'abc1234',
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: `sha256:${'a'.repeat(64)}`,
+      status: 'SUCCEEDED',
+      runner: 'hosted runner',
+    })
+    .returning();
+  return build?.id as number;
+}
+
+describe('runComponent', () => {
+  test('starts a run against the ref the Deploy stored', async () => {
+    const backend = new FakeDeployAdapter();
+    backend.ran('fake-deploy-1', {
+      name: 'nightly-1',
+      outcome: 'passed',
+      startedAt: new Date('2026-08-03T00:00:00.000Z'),
+    });
+    const ctx = context(backend);
+    const { componentId, targetId } = await scaffold(ctx, backend);
+
+    const started = await runComponent({ componentId, targetId }, ctx);
+
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+    expect(started.value.execution.outcome).toBe('running');
+    // §6's opaque handle, handed straight back: a run assembled from the rows
+    // instead could start a workload the Component is no longer serving.
+    expect(backend.runsStarted).toEqual(['fake-deploy-1']);
+  });
+
+  test('refuses a Component that is not a job, and never reaches the backend', async () => {
+    const backend = new FakeDeployAdapter();
+    const ctx = context(backend);
+    const { componentId, targetId } = await scaffold(ctx, backend, {
+      kind: 'service',
+    });
+
+    const refused = await runComponent({ componentId, targetId }, ctx);
+
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.failure.code).toBe('NOT_RUNNABLE');
+    expect(refused.failure.message).toContain('only a job has runs');
+    expect(backend.runsStarted).toEqual([]);
+  });
+
+  test('refuses a job nothing has placed yet', async () => {
+    const backend = new FakeDeployAdapter();
+    const ctx = context(backend);
+    const { componentId, targetId } = await scaffold(ctx, backend, {
+      ref: null,
+    });
+
+    const refused = await runComponent({ componentId, targetId }, ctx);
+
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.failure.code).toBe('NOT_RUNNABLE');
+    expect(refused.failure.message).toContain('nothing to run');
+  });
+
+  test('a far side that fails is a refusal with its sentence, not a crash', async () => {
+    const backend = new FakeDeployAdapter({
+      runThrows: 'the API server answered 403',
+    });
+    const ctx = context(backend);
+    const { componentId, targetId } = await scaffold(ctx, backend);
+
+    const refused = await runComponent({ componentId, targetId }, ctx);
+
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.failure.code).toBe('NOT_RUNNABLE');
+    expect(refused.failure.message).toBe('the API server answered 403');
+  });
+});
+
+describe('the App screen lists the runs that happened', () => {
+  test('reads them from the platform, newest first, with when and outcome', async () => {
+    const backend = new FakeDeployAdapter();
+    // A run nothing here started — the schedule's. §17 keeps a job's history on
+    // the backend precisely so this one appears without core knowing about it.
+    backend.ran('fake-deploy-1', {
+      name: 'nightly-scheduled',
+      outcome: 'failed',
+      startedAt: new Date('2026-08-04T11:00:00.000Z'),
+      detail: 'the container exited 1',
+    });
+    const ctx = context(backend);
+    const { appName, componentId, targetId } = await scaffold(ctx, backend);
+
+    const workspace = await getAppWorkspace({ name: appName }, ctx);
+
+    expect(workspace.ok).toBe(true);
+    if (!workspace.ok) return;
+    const runtime = workspace.value.workspace.runtime;
+    expect(runtime.kind).toBe('executions');
+    if (runtime.kind !== 'executions') return;
+    expect(runtime.executions).toEqual([
+      {
+        name: 'nightly-scheduled',
+        outcome: 'failed',
+        detail: 'the container exited 1',
+        when: '1h ago',
+      },
+    ]);
+    // The two ids a run is acted on by. Without them the card can offer no
+    // button and open no log, which is the state the empty placeholder left.
+    expect(runtime.componentId).toBe(componentId);
+    expect(runtime.targetId).toBe(targetId);
+    expect(runtime.retained).toBe(10);
+  });
+
+  test('a run started here is on the list the next time the screen is read', async () => {
+    const backend = new FakeDeployAdapter();
+    const ctx = context(backend);
+    const { appName, componentId, targetId } = await scaffold(ctx, backend);
+
+    const before = await getAppWorkspace({ name: appName }, ctx);
+    expect(before.ok).toBe(true);
+    if (before.ok && before.value.workspace.runtime.kind === 'executions') {
+      expect(before.value.workspace.runtime.executions).toEqual([]);
+    }
+
+    await runComponent({ componentId, targetId }, ctx);
+    const after = await getAppWorkspace({ name: appName }, ctx);
+
+    expect(after.ok).toBe(true);
+    if (!after.ok) return;
+    const runtime = after.value.workspace.runtime;
+    expect(runtime.kind).toBe('executions');
+    if (runtime.kind !== 'executions') return;
+    expect(runtime.executions).toHaveLength(1);
+    expect(runtime.executions[0]?.outcome).toBe('running');
+  });
+
+  test('a backend that will not answer is one empty card, not a failed screen', async () => {
+    // The workspace is the screen an operator opens *because* something is
+    // wrong. Taking it down over a Target that is momentarily unreachable would
+    // hide the phase, the URL and the timeline they came to read.
+    const backend = new FakeDeployAdapter({
+      noRuns: 'this backend keeps no runs',
+    });
+    const ctx = context(backend);
+    const { appName } = await scaffold(ctx, backend);
+
+    const workspace = await getAppWorkspace({ name: appName }, ctx);
+
+    expect(workspace.ok).toBe(true);
+    if (!workspace.ok) return;
+    expect(workspace.value.workspace.runtime).toEqual({
+      kind: 'none',
+      because: 'this backend keeps no runs',
+    });
+  });
+});

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -209,6 +209,25 @@ export function deployAdapterSuite(
       expect(Array.isArray(discovery.arch)).toBe(true);
     });
 
+    test('answers both run verbs about a ref it never placed', async () => {
+      // §17's run verbs are part of what every adapter answers, and "throws" is
+      // not an answer this contract accepts: core holds a `DeployAdapter`
+      // without knowing which backend is behind it, so a caller that reached
+      // for a run on a website would crash rather than read a sentence. Every
+      // backend has this case — the ref names nothing, or names something that
+      // is not a job — and every backend has to have words for it.
+      const adapter = make();
+      const answers = [
+        await adapter.run(target, 'never-placed'),
+        await adapter.executions(target, 'never-placed'),
+      ];
+      for (const answer of answers) {
+        expect(answer.kind).toBe('none');
+        if (answer.kind !== 'none') continue;
+        expect(answer.because.length).toBeGreaterThan(0);
+      }
+    });
+
     test('refuses an artifact type it did not declare', async () => {
       const adapter = make();
       expect(adapter.artifactTypes).not.toContain(foreign);

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -60,6 +60,14 @@ export interface FakeCloudRunOptions {
   /** The admission policy this project reports, or `null` for none at all. */
   readonly admissionPolicy?: Record<string, unknown> | null;
   /**
+   * Runs each Job already has, newest first, by job id.
+   *
+   * Seeded rather than only produced by `:run`, because most of a job's history
+   * was written before Spindrift asked for anything — a fake that could only
+   * report what this process started could not test reading one at all.
+   */
+  readonly executions?: Readonly<Record<string, readonly unknown[]>>;
+  /**
    * Reads a newly created Service `404`s for before it becomes readable.
    *
    * One by default rather than zero, because the create-then-`404` window is
@@ -208,6 +216,9 @@ const SCHEMAS: Record<string, ServiceSchema> = {
   jobs: JOB_SCHEMA,
 };
 
+/** The one collection that has runs. Named, because `:run` is refused elsewhere. */
+const JOBS_COLLECTION = 'jobs';
+
 /**
  * The first member the document names that the schema does not, if any.
  *
@@ -313,10 +324,26 @@ export class FakeCloudRun {
   /** Reads a just-created Service still owes before it can be seen. */
   private readonly creating = new Map<string, number>();
   private nextOperation = 1;
+  private nextRun = 1;
+  /** Each Job's runs, newest first — the sub-collection `:run` appends to. */
+  private readonly executions = new Map<string, unknown[]>();
   private readonly options: FakeCloudRunOptions;
 
   constructor(options: FakeCloudRunOptions = {}) {
     this.options = options;
+    for (const [job, runs] of Object.entries(options.executions ?? {})) {
+      this.executions.set(job, [...runs]);
+    }
+  }
+
+  /** `projects/<p>/locations/<r>` — what every name here hangs off. */
+  private parent(): string {
+    return `projects/${this.project}/locations/${this.region}`;
+  }
+
+  /** The runs one Job holds, newest first. */
+  private runsOf(job: string): unknown[] {
+    return this.executions.get(job) ?? [];
   }
 
   get project(): string {
@@ -404,9 +431,48 @@ export class FakeCloudRun {
       return json(200, { [collection]: [...this.held(collection)] });
     }
 
+    // A Job's runs are a sub-collection rather than a resource of their own,
+    // so they are routed before the `<name>[:verb]` split — which would
+    // otherwise read `jobs/<id>/executions` as a resource nobody named.
+    const runs = rest.match(/^([^/:]+)\/executions$/);
+    if (runs !== null) {
+      if (request.method !== 'GET') {
+        return json(405, {
+          error: { message: 'runs are listed, not written' },
+        });
+      }
+      if (!this.resources.has(`${collection}/${runs[1]}`)) {
+        return json(404, notFound());
+      }
+      return json(200, { executions: this.runsOf(runs[1] as string) });
+    }
+
     const [name, verb] = rest.split(':', 2);
     if (name === undefined || name === '') return json(404, notFound());
     const key = `${collection}/${name}`;
+
+    // `jobs.run` is the runtime's own verb: it answers with an `Operation`
+    // whose metadata **is** the Execution being created, and the execution
+    // appears in the job's sub-collection behind it. A fake that only answered
+    // the call would let an adapter that never read the name back pass.
+    if (verb === 'run') {
+      if (collection !== JOBS_COLLECTION || !this.resources.has(key)) {
+        return json(404, notFound());
+      }
+      const started = `${name}-${this.nextRun++}`;
+      this.executions.set(name, [
+        { name: `${this.parent()}/jobs/${name}/executions/${started}` },
+        ...this.runsOf(name),
+      ]);
+      return json(200, {
+        name: `${this.parent()}/operations/op-${this.nextOperation++}`,
+        done: false,
+        metadata: {
+          '@type': 'type.googleapis.com/google.cloud.run.v2.Execution',
+          name: `${this.parent()}/jobs/${name}/executions/${started}`,
+        },
+      });
+    }
 
     if (verb === 'setIamPolicy') {
       if (this.options.refuseIam !== undefined) {

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -60,11 +60,16 @@ export interface FakeCloudRunOptions {
   /** The admission policy this project reports, or `null` for none at all. */
   readonly admissionPolicy?: Record<string, unknown> | null;
   /**
-   * Runs each Job already has, newest first, by job id.
+   * Runs each Job already has, by job id, **in the order the API will list
+   * them**.
    *
    * Seeded rather than only produced by `:run`, because most of a job's history
    * was written before Spindrift asked for anything — a fake that could only
    * report what this process started could not test reading one at all.
+   *
+   * The order is the seeder's because `executions.list` documents none and
+   * takes no `orderBy`. Seed oldest-first to hold an adapter to sorting what it
+   * read rather than trusting the page it was handed.
    */
   readonly executions?: Readonly<Record<string, readonly unknown[]>>;
   /**
@@ -325,7 +330,7 @@ export class FakeCloudRun {
   private readonly creating = new Map<string, number>();
   private nextOperation = 1;
   private nextRun = 1;
-  /** Each Job's runs, newest first — the sub-collection `:run` appends to. */
+  /** Each Job's runs, in list order — the sub-collection `:run` prepends to. */
   private readonly executions = new Map<string, unknown[]>();
   private readonly options: FakeCloudRunOptions;
 
@@ -341,7 +346,7 @@ export class FakeCloudRun {
     return `projects/${this.project}/locations/${this.region}`;
   }
 
-  /** The runs one Job holds, newest first. */
+  /** The runs one Job holds, in the order this fake will list them. */
   private runsOf(job: string): unknown[] {
     return this.executions.get(job) ?? [];
   }
@@ -444,7 +449,16 @@ export class FakeCloudRun {
       if (!this.resources.has(`${collection}/${runs[1]}`)) {
         return json(404, notFound());
       }
-      return json(200, { executions: this.runsOf(runs[1] as string) });
+      // `pageSize` is honoured and the order is whatever this fake was seeded
+      // with, because that is what `executions.list` documents: a page size and
+      // no ordering at all. An adapter that asks for ten and trusts them to be
+      // the newest ten is right only by luck, and a fake that always answered
+      // newest-first is a fake that makes that luck look like a guarantee.
+      const page = Number(url.searchParams.get('pageSize') ?? '0');
+      const held = this.runsOf(runs[1] as string);
+      return json(200, {
+        executions: page > 0 ? held.slice(0, page) : held,
+      });
     }
 
     const [name, verb] = rest.split(':', 2);

--- a/apps/spindrift/test/harness/fakes/deploy-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/deploy-adapter.ts
@@ -87,6 +87,16 @@ export interface FakeDeployAdapterOptions {
   noRuns?: string;
   /** When set, `run` throws — the far side that was asked correctly and failed. */
   runThrows?: string;
+  /**
+   * When set, `executions` throws while `run` still works.
+   *
+   * Separate from {@link runThrows} because that is the state this feature's
+   * first day looks like: `list` on batch jobs is a grant the Role has not
+   * reconciled yet, so reading the runs `403`s while starting one would have
+   * worked. A fake that could only fail both could not tell whether core hid
+   * the button because the job is unrunnable or because nobody could look.
+   */
+  executionsThrows?: string;
 }
 
 /**
@@ -240,6 +250,9 @@ export class FakeDeployAdapter implements DeployAdapter {
   }
 
   async executions(_target: DeployTarget, ref: DeployRef): Promise<JobRuns> {
+    if (this.options.executionsThrows !== undefined) {
+      throw new Error(this.options.executionsThrows);
+    }
     const refusal = this.refusalFor(ref);
     if (refusal !== null) return refusal;
     return {

--- a/apps/spindrift/test/harness/fakes/deploy-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/deploy-adapter.ts
@@ -17,10 +17,13 @@ import type {
   DeployRef,
   DeployTarget,
   DeployVerdict,
+  JobExecution,
+  JobRuns,
   ObservedState,
   RuntimeLogPage,
   RuntimeLogSubject,
   RuntimeLogTailOptions,
+  StartedRun,
 } from '../../../src/adapters/deploy/contract.ts';
 import type { TargetAdapter } from '../../../src/config/manifest.schema.ts';
 import {
@@ -74,6 +77,16 @@ export interface FakeDeployAdapterOptions {
    * has to survive one, so the fake has to be able to be one.
    */
   applyThrows?: string;
+  /**
+   * When set, both run verbs refuse with this sentence — the `static` shape.
+   *
+   * §17 gives a backend that runs nothing an explicit refusal rather than an
+   * empty list, so a test about how core handles one needs a fake that can be
+   * that backend without being a different class.
+   */
+  noRuns?: string;
+  /** When set, `run` throws — the far side that was asked correctly and failed. */
+  runThrows?: string;
 }
 
 /**
@@ -116,11 +129,16 @@ export class FakeDeployAdapter implements DeployAdapter {
   /** Every `inspect`, so a test can prove the loop ran without a reconnect. */
   readonly inspected: DeployTarget[] = [];
 
+  /** Every `run`, in call order — what proves a press reached the backend. */
+  readonly runsStarted: DeployRef[] = [];
+
   private readonly script: readonly ScriptedAttempt[];
   private readonly options: FakeDeployAdapterOptions;
   private attempts = 0;
   /** What `apply` placed, so `observe` can report it back (§6). */
   private readonly placed = new Map<DeployRef, ObservedState>();
+  /** The runs each ref has had, oldest first — the platform's own history. */
+  private readonly runs = new Map<DeployRef, JobExecution[]>();
 
   constructor(options: FakeDeployAdapterOptions = {}) {
     this.options = options;
@@ -193,6 +211,43 @@ export class FakeDeployAdapter implements DeployAdapter {
     this.placed.delete(ref);
   }
 
+  /**
+   * Put a run on the far side that this fake did not start.
+   *
+   * The same reason {@link place} exists: a job's history is the platform's,
+   * and most of it was written by the scheduler rather than by anything core
+   * asked for — so a test about reading runs has to be able to arrange runs
+   * without pressing the button first.
+   */
+  ran(ref: DeployRef, execution: JobExecution): void {
+    this.runs.set(ref, [...(this.runs.get(ref) ?? []), execution]);
+  }
+
+  async run(_target: DeployTarget, ref: DeployRef): Promise<StartedRun> {
+    this.runsStarted.push(ref);
+    if (this.options.runThrows !== undefined) {
+      throw new Error(this.options.runThrows);
+    }
+    const refusal = this.refusalFor(ref);
+    if (refusal !== null) return refusal;
+    const execution: JobExecution = {
+      name: `${ref}-run-${(this.runs.get(ref)?.length ?? 0) + 1}`,
+      outcome: 'running',
+      startedAt: null,
+    };
+    this.ran(ref, execution);
+    return { kind: 'started', execution };
+  }
+
+  async executions(_target: DeployTarget, ref: DeployRef): Promise<JobRuns> {
+    const refusal = this.refusalFor(ref);
+    if (refusal !== null) return refusal;
+    return {
+      kind: 'executions',
+      executions: [...(this.runs.get(ref) ?? [])].reverse(),
+    };
+  }
+
   async tail(
     _target: DeployTarget,
     _subject: RuntimeLogSubject,
@@ -222,6 +277,29 @@ export class FakeDeployAdapter implements DeployAdapter {
       ),
       discovery: { ...CAPABLE_DISCOVERY, ...this.options.discovery },
     };
+  }
+
+  /**
+   * Why this ref has no runs, or `null` when it has.
+   *
+   * A ref nothing was placed under refuses for the same reason `observe`
+   * returns `null` for one: the far side does not have it. Both run verbs share
+   * the answer so a test cannot arrange a fake that would start a run it could
+   * never then list.
+   */
+  private refusalFor(
+    ref: DeployRef,
+  ): Extract<JobRuns, { kind: 'none' }> | null {
+    if (this.options.noRuns !== undefined) {
+      return { kind: 'none' as const, because: this.options.noRuns };
+    }
+    if (!this.placed.has(ref) && !this.runs.has(ref)) {
+      return {
+        kind: 'none' as const,
+        because: `nothing is placed under ${ref}`,
+      };
+    }
+    return null;
   }
 
   /** The last scripted attempt repeats once the script is exhausted. */

--- a/apps/spindrift/test/harness/fakes/kubernetes-api.ts
+++ b/apps/spindrift/test/harness/fakes/kubernetes-api.ts
@@ -273,6 +273,26 @@ export class FakeKubernetes {
     }
 
     if (parsed.name === undefined) {
+      // A `POST` to a collection creates. It is the one write that refuses a
+      // name already taken — a `409`, not an overwrite — which is what makes a
+      // caller relying on that refusal for idempotence testable here rather
+      // than only in a cluster.
+      if (request.method === 'POST') {
+        const object = body as FakeObject;
+        const key = `${parsed.plural}/${parsed.namespace ?? ''}/${object.metadata.name}`;
+        if (this.objects.has(key)) {
+          return json(409, {
+            kind: 'Status',
+            apiVersion: 'v1',
+            status: 'Failure',
+            reason: 'AlreadyExists',
+            code: 409,
+            message: `${parsed.plural} "${object.metadata.name}" already exists`,
+          });
+        }
+        this.objects.set(key, object);
+        return json(201, object);
+      }
       return this.listResponse(parsed, url.searchParams);
     }
 

--- a/apps/spindrift/test/web/streams.test.ts
+++ b/apps/spindrift/test/web/streams.test.ts
@@ -548,6 +548,14 @@ describe('a job tails one run rather than the Component', () => {
       '',
       'Nightly-2',
       'nightly_2',
+      // Deliberately narrower than Kubernetes, which names a Job as a DNS
+      // *subdomain*: dots are legal there, and `executions()` lists by label,
+      // so a Job somebody else created can reach the card under a name this
+      // refuses. That is the trade — a name Spindrift cannot have produced
+      // does not get to widen a browser-controlled string on its way into two
+      // query languages, and one row whose log pane will not open is a smaller
+      // failure than one that opens the whole project's.
+      'blog.nightly-1',
     ]) {
       const { response, upgraded } = await upgrade(
         user,

--- a/apps/spindrift/test/web/streams.test.ts
+++ b/apps/spindrift/test/web/streams.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../src/domain/attempt-log.ts';
 import {
   ATTEMPT_STREAM_PATH,
+  RUNTIME_STREAM_PATH,
   readStreamPage,
   type StreamSocketData,
   streamRoutes,
@@ -446,5 +447,115 @@ describe('in-process attempt event notifications', () => {
 
     expect(wakes).toEqual(['woke']);
     unsub();
+  });
+});
+
+/**
+ * §17's second pipe, aimed at a job.
+ *
+ * A job's output belongs to a run, so the subject the socket carries has to say
+ * which one. Both directions are asserted, because the failure of each is
+ * silent: a job with no run named would tail every run at once, and a service
+ * with one named would drop the name and hand back the Component's whole tail
+ * under it.
+ */
+describe('a job tails one run rather than the Component', () => {
+  async function seedJob(): Promise<{
+    user: { id: string; displayName: string };
+    componentId: string;
+    serviceId: string;
+    targetId: string;
+  }> {
+    const seeded = await seedAttempt();
+    const [job] = await database()
+      .db.insert(components)
+      .values({ appId: seeded.app.id, name: 'nightly', kind: 'job' })
+      .returning();
+    await database()
+      .db.insert(deploys)
+      .values({
+        componentId: job?.id as string,
+        targetId: seeded.target.id,
+        buildId: seeded.build.id,
+      });
+    return {
+      user: seeded.user,
+      componentId: job?.id as string,
+      serviceId: seeded.component.id,
+      targetId: seeded.target.id,
+    };
+  }
+
+  function runtimeRequest(query: string): Request {
+    return new Request(
+      `https://spindrift.example.test${RUNTIME_STREAM_PATH}?${query}`,
+      { headers: { upgrade: 'websocket' } },
+    );
+  }
+
+  async function upgrade(
+    user: { id: string; displayName: string },
+    query: string,
+  ): Promise<{ response: Response | undefined; upgraded: StreamSocketData[] }> {
+    const upgraded: StreamSocketData[] = [];
+    const ctx = await context(user);
+    const response = await streamRoutes({
+      authenticate: async () => ({ kind: 'authenticated', principal: user }),
+      context: () => ctx,
+    })[RUNTIME_STREAM_PATH]?.(runtimeRequest(query), {
+      upgrade: (_request: Request, options: { data: StreamSocketData }) => {
+        upgraded.push(options.data);
+        return true;
+      },
+    } as unknown as Bun.Server<StreamSocketData>);
+    return { response, upgraded };
+  }
+
+  test('a named run becomes the subject the adapter is asked about', async () => {
+    const { user, componentId, targetId } = await seedJob();
+
+    const { response, upgraded } = await upgrade(
+      user,
+      `componentId=${componentId}&targetId=${targetId}&execution=nightly-2`,
+    );
+
+    expect(response).toBeUndefined();
+    const socket = upgraded[0];
+    expect(socket?.kind).toBe('runtime');
+    if (socket?.kind !== 'runtime') return;
+    expect(socket.subject).toEqual({
+      app: 'live-app',
+      component: 'nightly',
+      execution: 'nightly-2',
+    });
+  });
+
+  test('a job with no run named still refuses, and says how to ask', async () => {
+    const { user, componentId, targetId } = await seedJob();
+
+    const { response } = await upgrade(
+      user,
+      `componentId=${componentId}&targetId=${targetId}`,
+    );
+
+    expect(response?.status).toBe(409);
+    const body = (await response?.json()) as {
+      failure: { code: string; message: string };
+    };
+    expect(body.failure.code).toBe('NO_RUNTIME');
+    expect(body.failure.message).toContain('name one to read it');
+  });
+
+  test('a service is refused a run, rather than quietly given its tail', async () => {
+    const { user, serviceId, targetId } = await seedJob();
+
+    const { response } = await upgrade(
+      user,
+      `componentId=${serviceId}&targetId=${targetId}&execution=nightly-2`,
+    );
+
+    expect(response?.status).toBe(409);
+    const body = (await response?.json()) as { failure: { message: string } };
+    expect(body.failure.message).toContain('only a job has runs');
   });
 });

--- a/apps/spindrift/test/web/streams.test.ts
+++ b/apps/spindrift/test/web/streams.test.ts
@@ -530,6 +530,34 @@ describe('a job tails one run rather than the Component', () => {
     });
   });
 
+  test('a run name that is not one is refused before an adapter sees it', async () => {
+    // The Cloud Run adapter concatenates this into a Cloud Logging filter over
+    // `projects/<vessel>`, joining its clauses with ` AND `. `AND` binds
+    // tighter than `OR`, so a value carrying a quote and an `OR` widens the
+    // filter to every entry the project has — other Apps' output, GCP audit
+    // logs — and the lines render in the run pane of whoever asked for them.
+    // The check is here because this is the one place the value crosses in
+    // from a browser.
+    const { user, componentId, targetId } = await seedJob();
+
+    for (const attempt of [
+      'a" OR timestamp>="2020-01-01T00:00:00Z',
+      'nightly-2" OR "x"="x',
+      // `?execution=` is an empty string rather than `null`, so it passes the
+      // "name one to read it" guard and names nothing.
+      '',
+      'Nightly-2',
+      'nightly_2',
+    ]) {
+      const { response, upgraded } = await upgrade(
+        user,
+        `componentId=${componentId}&targetId=${targetId}&execution=${encodeURIComponent(attempt)}`,
+      );
+      expect(response?.status).toBe(400);
+      expect(upgraded).toHaveLength(0);
+    }
+  });
+
   test('a job with no run named still refuses, and says how to ask', async () => {
     const { user, componentId, targetId } = await seedJob();
 

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -627,11 +627,44 @@ describe('the App workspace', () => {
     expect(markup).toContain('Execution 118');
     expect(markup).toContain('passed');
     expect(markup).toContain('failed');
-    // The retention depth is stated, and stated as configured rather than
-    // stored — §17 fixes the platform asymmetry "by rendering a larger history
-    // limit, not by storing logs".
-    expect(markup).toContain('last 10 executions');
-    expect(markup).toContain('configured on the Target');
+    // The caption says how many are shown and where the history lives, and
+    // stops there. `retained` is a page size on both backends and a retention
+    // depth on `kubernetes` only, where it happens to equal the chart's
+    // `successfulJobsHistoryLimit`; a Cloud Run project retains its own number
+    // and reports it nowhere, so "the last 10 are kept" sent an operator
+    // looking for a run `gcloud run jobs executions list` still had.
+    expect(markup).toContain('Showing the last 10 runs');
+    expect(markup).not.toContain('are kept');
+  });
+
+  test('runs that could not be read say so, and stay runnable', () => {
+    // The state this is about is the first one an operator meets after this
+    // merges: the Role granting `list` on batch has not reconciled yet, the
+    // Target answers `403`, and the read fails. Collapsing that to `kind:
+    // 'none'` took the Run now button off the card — the feature hiding itself
+    // in exactly the state where pressing it is the diagnosis.
+    const refused = {
+      ...WORKSPACE_SCENARIOS.job,
+      runtime: {
+        kind: 'executions',
+        componentId: 'component-1',
+        targetId: 'target-1',
+        executions: [],
+        retained: 10,
+        because:
+          'The runs on folly could not be read: GET /apis/batch/v1/... failed with 403',
+      },
+    } as const satisfies WorkspaceView;
+
+    const markup = renderToStaticMarkup(
+      <Workspace view={refused} onRunJob={async () => ({ ok: true })} />,
+    );
+    expect(markup).toContain('Run now');
+    expect(markup).toContain('could not be read');
+    expect(markup).toContain('403');
+    // And not the sentence for a job that has genuinely never run: nobody
+    // found out whether it has.
+    expect(markup).not.toContain('has not run yet');
   });
 
   test('running a job is offered where the runs are, and only there', () => {

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -665,6 +665,8 @@ describe('the App workspace', () => {
     // And not the sentence for a job that has genuinely never run: nobody
     // found out whether it has.
     expect(markup).not.toContain('has not run yet');
+    // Nor the caption, which counts what was shown. Nothing was.
+    expect(markup).not.toContain('Showing the last');
   });
 
   test('running a job is offered where the runs are, and only there', () => {

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -634,6 +634,23 @@ describe('the App workspace', () => {
     expect(markup).toContain('configured on the Target');
   });
 
+  test('running a job is offered where the runs are, and only there', () => {
+    // §7 makes a job's `apply` two acts, and only the second one runs
+    // anything: the header's Deploy button writes an intent that places a
+    // CronJob triggered by nothing. Two buttons that both read `Run now` where
+    // one deploys is the label a reader cannot recover from, so the word
+    // belongs to the act that actually runs something.
+    const job = WORKSPACE_SCENARIOS.job;
+    const withoutAct = workspace(job);
+    expect(withoutAct).toContain('Deploy');
+    expect(withoutAct).not.toContain('Run now');
+
+    const withAct = renderToStaticMarkup(
+      <Workspace view={job} onRunJob={async () => ({ ok: true })} />,
+    );
+    expect(withAct).toContain('Run now');
+  });
+
   test('a service states how far its log reaches', () => {
     // §17: `logHistory` "is how far back `since` can honestly reach... so a
     // Target never *lacks* logs; it only has a shorter memory, and the UI

--- a/clusters/base/platform/spindrift-target/rbac.yaml
+++ b/clusters/base/platform/spindrift-target/rbac.yaml
@@ -91,6 +91,28 @@ rules:
       - pods/log
     verbs:
       - get
+  # A job's runs. The App chart renders every job as a CronJob, so the CronJob
+  # is what a run is created from — its own `jobTemplate`, read here — and the
+  # Jobs are the runs themselves, listed to answer "did last night's run work".
+  #
+  # `create` on jobs and nothing more: Spindrift starts a run and never edits or
+  # deletes one. The CronJob owns what this creates and prunes it under its own
+  # history limits, which is why no `delete` is needed for the history to stay
+  # bounded.
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
   # `CHART_SOURCE`, for the artifact form. The App chart's `OCIRepository` is
   # this namespace's own object (`oci-repository.yaml`), so the grant to read it
   # belongs to the Role this namespace already binds rather than to a second one

--- a/clusters/base/platform/spindrift-target/rbac.yaml
+++ b/clusters/base/platform/spindrift-target/rbac.yaml
@@ -99,13 +99,16 @@ rules:
   # deletes one. The CronJob owns what this creates and prunes it under its own
   # history limits, which is why no `delete` is needed for the history to stay
   # bounded.
+  #
+  # `list` without `get`, because both reads are by label selector — the adapter
+  # never knows an object's name in advance, since the chart names the workload
+  # and Spindrift names the release.
   - apiGroups:
       - batch
     resources:
       - cronjobs
       - jobs
     verbs:
-      - get
       - list
   - apiGroups:
       - batch


### PR DESCRIPTION
A job's Component rendered a CronJob that was triggered by nothing, and a screen
that promised runs it never had. `DeployAdapter` had no way to make something
happen to that object, and `getAppWorkspace` answered a `kind: 'job'` Component
with `{kind: 'executions', executions: [], retained: 10}` — a list that was
honest about being a placeholder and nothing else.

## Two verbs, not one

The obvious shape is one verb that starts a run. It is one member short. `run`
starts one and `executions` reports the runs that happened, split along the same
line `apply` and `observe` are already split along: one member acts, one member
reads. A run nobody can see afterwards is not something an operator can be
given, so the read is not an extra — it is what makes the act mean anything.

Folding the run into `apply` was the real alternative and it fails in a way that
bites. `apply` is convergent and core re-applies it whenever desired state
moves, so a run folded into it fires on a reach change, on a config edit, on a
rollback. The two acts have different arity — the object is placed once and run
any number of times — and one method cannot have both. §7 already says this:
"`apply` for a job therefore becomes two acts."

`run` takes a ref rather than a `DesiredState` for the same reason `observe`
does. What is being run is what `apply` placed, not a description core assembled
a second time, and handing it a fresh description would let a run execute an
image the Component is not serving.

## Refusing is an answer; throwing is not

Every adapter answers both, `static` included, and it answers by refusing in a
sentence. §13's "connect always succeeds" is core's promise in one direction and
this is the same promise in the other: core holds a `DeployAdapter` without
knowing which backend is behind it, so a caller reaching for a run on a website
would crash rather than read something it can put on a screen. `static` has no
job to run and says so with the same `{kind: 'none', because}` its `tail`
already uses, so the three refusals it now makes cannot drift into three
different explanations of one fact. A far side that is asked correctly and fails
still throws, exactly as `tail` does, because that is a fault and not an answer.
The conformance suite asserts the whole claim against every adapter that exists.

## A run on Kubernetes is a Job the CronJob owns

The chart renders every job as a CronJob, suspended when unscheduled, so
starting a run is creating a Job from that CronJob's own `jobTemplate` —
un-suspending would make the next *scheduled* time fire, which for an
unscheduled job is a date that never occurs and for a scheduled one is a
different act than the operator asked for.

The owner reference earns its place on pruning and on nothing else.
`getJobsToBeReconciled` selects on the controller ref, so a manual run reaches
`cleanupFinishedJobs` and is pruned by the same `successfulJobsHistoryLimit`
instead of becoming an orphan that outlives every execution beside it.
`blockOwnerDeletion` is deliberately absent: it needs `update` on the owner's
`finalizers` subresource wherever `OwnerReferencesPermissionEnforcement` is on,
and the garbage collection this wants happens without it.

**It does not make `concurrencyPolicy: Forbid` hold a manual run off.** The
controller's Forbid check is `len(cj.Status.Active) > 0`, and `Status.Active` is
appended only where the controller creates a Job itself — it never adopts a
foreign Job into it. A run started at 02:59:55 does not stop the `0 3 * * *` fire
and the two run concurrently, and nothing in Spindrift can change that: there is
no API that asks a CronJob to run now, the overlapping fire comes from the
controller, and the controller does not consult us. `kubectl create job
--from=cronjob/x` does exactly this and sets no owner at all. The cost the
reference does carry is a `Warning UnexpectedJob "Saw a job that the controller
did not create or forgot"` on every sync until the run finishes — `syncCronJob`'s
`!found && !IsJobFinished(j)` arm — which is a true statement about a Job the
controller did not create.

The Job is named from the second the run was asked for, which is the CronJob
controller's own scheme at finer resolution. A second press inside the same
second gets a 409 from the API server and is reported as the run that is already
going — idempotence bought from the far side rather than from a lock.

What the CronJob and its Jobs are found by is the delivery object's stored
values, not a name derived from the ref: `spindrift-app.fullname` truncates
plainly where `workloadName` keeps a digest, so the two diverge for a long App,
and deriving one from the other would be reimplementing a chart helper that is
free to change (`apps/spindrift/src/adapters/deploy/kubernetes/index.ts:550`).

On Cloud Run it is `jobs.run`, whose `Operation` carries the Execution the
runtime named — an execution named by the platform and read back, for the same
reason a Service's `uri` comes back across this seam rather than being handed
in.

## A create that stored nothing is distinguishable from one that stored something

`KubernetesApi.send` answered `null` for every `404`, on the reasoning that
absence is an answer every caller has a value for. That was true until a caller
started `POST`ing a Job. `POST`ing to `/apis/batch/v1/namespaces/<ns>/jobs`
answers `404` when the namespace has been deleted or the cluster does not serve
`batch/v1` — neither of which is "there is nothing there", both of which mean
nothing was created. `create` passed the `null` through and `run` read
`created?.metadata.name ?? name` off it, so the operator got `{"ok":true}`, a row
reading `running`, and a run the next `executions` read never lists.

The tolerance is opt-in per verb now: on every read and on `delete`, where
absence really is the answer, and on nothing that writes. `apply` had the same
hole — a server-side apply into a missing namespace was reporting success too —
and is closed by the same change, with its own test: swallowed, that apply does
not fail at all, it polls a delivery object that was never stored until the
deadline and reports `TIMEOUT`.

Making a 404 apply reachable put it in the wrong arm of §6's blame table.
`writeFailure` mapped every 4xx that is not 401/403 to `REJECTED`, which §6
blames on the *developer* — "admission webhook, invalid spec, quota, org
policy". A server-side apply creates what is not there, so the only things that
can be missing on a 404 are the namespace or the API group: the Target the
operator configured, not the spec the developer wrote. It is
`TARGET_UNREACHABLE`, whose blame is platform.

The read half had the mirror of it. `executions()` did
`(await api.list(...)) ?? []`, throwing away the distinction `KubernetesApi.list`
returns `null` to preserve — "no Jobs exist" and "this cluster does not serve
`batch/v1`" are different answers. A 403 on that call already reached the "these
runs could not be read" card while a 404 read green and empty. It raises now,
and lands where the 403 lands.

## A run name is checked where it enters

The `execution` query parameter reaches a Cloud Logging filter by string
concatenation over `resourceNames: ['projects/<vessel>']`. `AND` binds tighter
than `OR`, so `?execution=a" OR timestamp>="2020-01-01T00:00:00Z` produced

```
resource.type="cloud_run_job" AND resource.labels.job_name="shop-nightly"
  AND resource.labels.location="somewhere"
  AND labels."run.googleapis.com/execution_name"="a"
  OR timestamp>="2020-01-01T00:00:00Z"
```

— every entry the project has, other Apps' output and GCP audit logs included,
rendered into the run pane of whoever asked. It is checked in
`apps/spindrift/src/web/streams.ts`, the one place it crosses in from a browser,
against one DNS label — §9's `isLabel`, so the grammar has one home rather than
six. `?execution=` is an empty string rather than `null` and had been passing
the "name one to read it" guard; it is refused there too.

That is what everything Spindrift starts is called — a Cloud Run execution name
*is* validated as a label, and a Job created here is named from a release name
already shortened to 63 — but it is **deliberately narrower than Kubernetes**.
Upstream validates a Job name as a DNS *subdomain*: dots are legal and the
ceiling is 253. `executions()` lists by label, on purpose, so a Job somebody
else created named `blog.nightly-1` can reach the Recent runs card and be
refused when its row is clicked. The trade is taken knowingly — a name Spindrift
cannot have produced does not get to widen a browser-controlled string on its
way into two query languages, and one row whose log pane will not open is a
smaller failure than one that opens the whole project's.

## A run's logs are a different question

`RuntimeLogSubject` gains an optional `execution`. A job's output does not
belong to the Component the way a service's does: "what is this Component saying
now" has no answer for a job, which is not running most of the time, and merging
every run's lines into one tail interleaves last night's failure with this
morning's.

With a run named the cluster adapter adds one term to its pod selector, and the
Cloud Run adapter builds the filter a job's entries actually match —
`cloud_run_job`, keyed on `job_name`, with the execution label — none of which a
`cloud_run_revision` filter on `service_name` selects. That was the second,
smaller contract problem, and reverting either half leaves a run's logs
unreadable while everything else still passes. One optional field rather than a
second method, because the two differ by one clause in a selector and a second
method would have had to restate the cursor, the paging and the reach that make
this one honest.

`streams.ts` still refuses a job with no run named, in a sentence that now says
how to ask, and now refuses a service that names one rather than dropping the
name and handing back the Component's whole tail under it.

## The workspace reads the platform, every load

§17 keeps a job's history on the backend — "configure the platform, don't build
it" — so `getAppWorkspace` asks the adapter rather than a table. A stored
history would have to be reconciled against the CronJob that prunes it, and
would be wrong for every run the scheduler started rather than an operator.

Every failure on that path is one empty card carrying its reason, never a failed
screen. The workspace is what an operator opens *because* something is wrong,
and taking it down over a Target that is momentarily unreachable would hide the
phase, the URL and the timeline they came to read.

A failed read is still a runnable job, and stays on the `executions` arm with its
reason rather than collapsing to `none`. Whether a job can be run is a fact about
the Deploy that placed it, not about whether listing worked — and the first state
this feature meets on a real cluster is the Role not yet reconciled and the API
server answering `403` to `list jobs`, which is exactly where the Run now button
has to be pressable for its refusal to be the diagnosis. A `404` on that call
reaches the same card and says the same thing; the caption counting what was
shown is not rendered there, because nothing was.

## Two corrections that came with it

The workspace header's primary button read `Run now` for a job and called
`deployApp`. It has never made anything run — it writes an intent that places a
CronJob triggered by nothing — and two buttons both reading `Run now` where one
deploys is the label a reader cannot recover from. It reads `Deploy` like every
other kind now, and the word moved to the control that does the thing.

`KINDS_BY_ADAPTER`'s comment said an on-demand run "needs a verb `DeployAdapter`
does not have". That sentence has stopped being true.

A run's log pane had been dropping every non-`stream` frame — the
`{kind: 'none', because}` arm and the `{kind: 'error', message}` frame the pump
sends before closing — which are exactly the cases where reading a run's log
fails: `pods/log` not granted, the pods garbage collected, Cloud Logging
refusing. They rendered identically to a run that printed nothing. They are the
only thing the pane has to say in those cases, so they replace it.

## What remains

A manual run overlapping a scheduled one is possible on a job configured never to
overlap, for the reason above, and a run in flight emits an `UnexpectedJob`
warning event until it finishes. Neither is fixable from here.

Cloud Run's `executions.list` documents no ordering and takes no `orderBy`, so
this asks for a page far larger than any caller's depth and slices after sorting.
A job with more executions than that page still hides its newest ones if the API
pages oldest-first; following `nextPageToken` to the end is unbounded work for a
screen that shows ten rows, and the `ponytail:` note in
`apps/spindrift/src/adapters/deploy/cloudrun/index.ts` names it.

The caption under the list says how many runs are shown and that the history
lives on the Target. It does not name a retention depth, because `RETAINED_RUNS`
is one only on `kubernetes`, where it happens to equal the chart's
`successfulJobsHistoryLimit`; a Cloud Run project keeps its own count and reports
it nowhere. The `ponytail:` note in
`apps/spindrift/src/commands/apps/workspace.ts` names the upgrade path: return
the depth from `executions` and let each adapter answer with what it observes.

## After merge

Flux has to reconcile the RBAC before the Kubernetes side works.
`spindrift-target-delivery` gains `list` on `batch` cronjobs and jobs and
`create` on jobs in `spindrift-apps`; until it lands on each cluster, the runs
card reads the API server's 403 and the Run now button is still there to press.
`list` without `get`, because both reads are by label selector — the adapter
never knows an object's name in advance, since the chart names the workload and
Spindrift names the release.
`create` and nothing more is the whole grant — Spindrift starts a run and never
edits or deletes one, and the CronJob prunes what this creates.

On the Cloud Run side the identity the vessel federates needs `run.jobs.run` and
`run.executions.list` in the project.

Neither backend has been driven live from this branch: starting a run mutates
live infrastructure. Nothing here is Terraform, so there is nothing for Atlantis
to apply.



