### PR TITLE
feat(spindrift): fire a Cloud Run Job on a schedule

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -15,6 +15,12 @@
  * `job.ts` render the two documents; this file is the only thing that knows both
  * exist.
  *
+ * **Three APIs, though.** A Job carries no cron expression, so a scheduled one
+ * is a Cloud Scheduler job calling `jobs.run` in front of it — `scheduler.ts`
+ * renders that, and it is the one part of a Component this adapter places
+ * outside the runtime's own API. It shares the Job's resource name exactly, so
+ * a `DeployRef` locates both and `destroy` takes the schedule with the Job.
+ *
  * **Never the build-from-source path** (§4). The runtime will happily take a
  * source archive and build it, and taking that offer would give this
  * installation a second build engine — with its own frontends, its own
@@ -44,10 +50,8 @@ import type {
 } from '../../../domain/capabilities.ts';
 import {
   type ArtifactType,
-  type Auth,
   artifactAddress,
   type DesiredState,
-  type Reach,
 } from '../../../domain/desired-state.ts';
 import type { CloudRunAdapterConnection } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
@@ -71,9 +75,11 @@ import type {
   StartedRun,
 } from '../contract.ts';
 import { cloudRunJob } from './job.ts';
+import { cloudSchedulerJob, jobInvokerPolicy, TIME_ZONE } from './scheduler.ts';
 import {
   allowsUnauthenticated,
   cloudRunService,
+  type InvokerPolicy,
   invokerPolicy,
   workloadId,
 } from './service.ts';
@@ -98,11 +104,20 @@ export interface CloudRunAdapterOptions {
   readonly now?: () => number;
   /** Cloud Logging API root; injectable for perimeter endpoints and tests. */
   readonly logsEndpoint?: string;
+  /**
+   * Cloud Scheduler API root — what fires a scheduled job (§7).
+   *
+   * Injectable for the same two reasons the logging root is, and defaulted for
+   * the same reason: it is a property of the cloud rather than of a project, so
+   * unlike the Target's own `endpoint` there is nothing per-Target to carry.
+   */
+  readonly schedulerEndpoint?: string;
 }
 
 const DEFAULT_POLL_MS = 2_000;
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
 const DEFAULT_LOGS_ENDPOINT = 'https://logging.googleapis.com';
+const DEFAULT_SCHEDULER_ENDPOINT = 'https://cloudscheduler.googleapis.com';
 const SERVICE_ID_LIMIT = 63;
 
 /**
@@ -154,6 +169,14 @@ const EXECUTION_PAGE_ASKED = 100;
 
 /** How the operator would name the service in the sentence about enabling it. */
 const SERVICE_NAME = 'Cloud Run';
+
+/**
+ * The reason a cloud API gives for "this service is not turned on here".
+ *
+ * The same code `cloud/checklist.ts` reads, and read here for one narrow
+ * purpose — see {@link CloudRunDeployAdapter.unschedule}.
+ */
+const SERVICE_DISABLED = 'SERVICE_DISABLED';
 
 /**
  * What the runtime runs.
@@ -227,21 +250,29 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     }
 
     const job = desired.kind === 'job';
-    // Place refuses this first: `FIRES_SCHEDULES_BY_ADAPTER` makes a scheduled
-    // job a `NO_SCHEDULER` non-candidate here, in the same words. This is the
-    // backstop for the path that asks for a Deploy without asking Place —
-    // dropping the schedule silently is the one outcome worse than refusing it,
-    // because a Component would report `LIVE` on a cadence nothing keeps.
-    // `REJECTED` because §6 puts it with the refusals a developer answers by
-    // changing the request: drop the schedule, or place it on a Target that
-    // keeps one (**72**).
-    if (job && desired.schedule !== undefined) {
+    // What this job's schedule is, or `null` for every other Component: the one
+    // value the rest of `apply` reads to decide whether anything stands in
+    // front of the Job. A `service` never has one — §6 marks `schedule` as a
+    // job's field — so reading it off the kind here means nothing below has to
+    // ask again.
+    const fires = job ? (desired.schedule ?? null) : null;
+    // A schedule fires *as* an identity or it does not fire: Cloud Scheduler
+    // authenticates the `jobs.run` call it makes, and a scheduler job created
+    // without an account would be created happily and refused on every tick —
+    // a Component reporting `LIVE` on a cadence that lands nowhere, which is
+    // the failure this whole path exists to avoid. The Target's runtime
+    // account is the only identity this controller can act as
+    // (`terraform/gcp/projects/bluenose/iam.tf`), so a Target naming none
+    // cannot hold a scheduled job. `REJECTED` because §6 puts it with the
+    // refusals answered by changing the request: drop the schedule, or place it
+    // where an identity is named.
+    if (fires !== null && connection.serviceAccount === undefined) {
       yield this.status('FAILED', { reason: 'REJECTED' });
       return {
         phase: 'FAILED',
         reason: 'REJECTED',
         detail:
-          'this Target runs a job but has nothing to fire it on a schedule',
+          'this Target names no runtime identity for a schedule to fire as',
       };
     }
 
@@ -252,6 +283,21 @@ export class CloudRunDeployAdapter implements DeployAdapter {
 
     yield this.status('APPLYING', { resource: id });
 
+    // A job that declares no schedule must not keep one a previous deploy
+    // asked for, and the removal happens **before** the Job is written for the
+    // same reason §9 writes a tightening invoker policy first: a gap in which
+    // nothing fires is better than a window in which the old cadence fires the
+    // new template. Asserted on every unscheduled job rather than only where
+    // one was removed — this adapter holds no memory of the last deploy, and
+    // deleting what is not there costs one call and answers `404`.
+    if (job && fires === null) {
+      const stopped = await this.unschedule(connection, id);
+      if (stopped !== null) {
+        yield this.status('FAILED', { resource: id, reason: stopped.reason });
+        return { ...stopped, ref };
+      }
+    }
+
     // §9: "tightening drops public reach first and stays red if the stricter
     // boundary does not come up." So for every non-public exposure the invoker
     // policy is written *before* the Service — a bounded outage is preferred
@@ -261,15 +307,20 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     // written again after the rollout below: the closed state is **asserted**
     // on every deploy rather than inherited from the platform's default.
     //
-    // A job has no exposure to assert in either direction: nothing routes to it
-    // and nothing invokes it, so there is no policy that would mean anything.
+    // A job's invoker policy is not on this path. Nothing routes to a Job, so
+    // its policy answers only *who may run it* — which is the scheduler and
+    // nobody else — and the tightening direction there is the scheduler job
+    // deleted above rather than a binding: a grant with nothing left to use it
+    // invokes nothing. So a job asserts its policy once, after the Job exists
+    // and in whichever direction the schedule now means.
     if (!job && !allowsUnauthenticated(desired.reach, desired.auth)) {
       const tightened = await this.setInvoker(
         http,
         connection,
+        SERVICES,
         id,
-        desired.reach,
-        desired.auth,
+        invokerPolicy(desired.reach, desired.auth),
+        `{reach: ${desired.reach}, auth: ${desired.auth}}`,
       );
       if (tightened !== null) {
         yield this.status('FAILED', { resource: id, reason: tightened.reason });
@@ -313,7 +364,42 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       id,
       ref,
     );
-    if (verdict.phase !== 'LIVE' || job) return verdict;
+    if (verdict.phase !== 'LIVE') return verdict;
+
+    if (job) {
+      // Who may run this Job, asserted in whichever direction the schedule now
+      // means — a binding for the identity the scheduler fires as, or nothing
+      // at all. One call rather than a branch, because "what the policy says"
+      // and "whether there is a schedule" are the same question, and skipping
+      // the write on the unscheduled path is how a grant outlives the schedule
+      // that justified it.
+      const bound = await this.setInvoker(
+        http,
+        connection,
+        JOBS,
+        id,
+        jobInvokerPolicy(
+          fires === null ? null : (connection.serviceAccount ?? null),
+        ),
+        'this job',
+      );
+      if (bound !== null) {
+        yield this.status('FAILED', { resource: id, reason: bound.reason });
+        return { ...bound, ref };
+      }
+      if (fires === null) return verdict;
+
+      // Last, and only now: the binding it fires with is already in place, so
+      // the first tick cannot land on a Job that has not yet been told to
+      // admit it.
+      const scheduled = await this.schedule(connection, id, fires, ref);
+      if (scheduled !== null) {
+        yield this.status('FAILED', { resource: id, reason: scheduled.reason });
+        return { ...scheduled, ref };
+      }
+      yield this.log(`firing job ${id} on "${fires}" (${TIME_ZONE})`, id);
+      return verdict;
+    }
 
     // Now that the Service exists, the policy this exposure means is written
     // whichever direction it moved. Opening can only happen here — granting
@@ -324,9 +410,10 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     const written = await this.setInvoker(
       http,
       connection,
+      SERVICES,
       id,
-      desired.reach,
-      desired.auth,
+      invokerPolicy(desired.reach, desired.auth),
+      `{reach: ${desired.reach}, auth: ${desired.auth}}`,
     );
     if (written !== null) {
       yield this.status('FAILED', { resource: id, reason: written.reason });
@@ -370,6 +457,19 @@ export class CloudRunDeployAdapter implements DeployAdapter {
 
     const { collection, id } = placed;
     const noun = collection === JOBS ? 'job' : 'service';
+    // The schedule goes first, and it goes at all: a scheduler job left behind
+    // would keep calling `jobs.run` on a Job that no longer exists, which is
+    // the orphan §6's idempotence rule is about wearing a second service's
+    // uniform. Ordered first so the window is "nothing fires it yet" rather
+    // than "it fires and 404s".
+    if (collection === JOBS) {
+      const stopped = await this.unschedule(connection, id);
+      if (stopped !== null) {
+        throw new Error(
+          stopped.detail ?? `the schedule on job ${id} could not be removed`,
+        );
+      }
+    }
     const deleted = await this.http(connection).json<unknown>({
       method: 'DELETE',
       path: `/v2/${parentOf(connection)}/${collection}/${encodeURIComponent(id)}`,
@@ -461,9 +561,11 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   /**
    * Start one run of the job this ref names, now (§17).
    *
-   * `jobs.run` is the runtime's own verb and the only one there is: a Job here
-   * carries no schedule and nothing stands in front of it, so an execution
-   * exists exactly when something asked for one. The call answers with an
+   * `jobs.run` is the runtime's own verb, and the same one a schedule fires
+   * through — the scheduler calls exactly this over HTTP, as the identity the
+   * Job's invoker policy names. So an on-demand run and a scheduled one produce
+   * the same kind of execution, which is what makes a job's history one list
+   * rather than two (§17). The call answers with an
    * `Operation` whose `metadata` **is** the Execution being created, which is
    * where the name comes from — an execution named by the runtime rather than
    * by this adapter, for the same reason a Service's `uri` comes back across
@@ -689,27 +791,39 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     }
   }
 
-  /** Write the invoker policy for one exposure, or say why it could not. */
+  /**
+   * Write one resource's whole invoker policy, or say why it could not.
+   *
+   * Takes the policy rather than the exposure it came from, because both
+   * collections have one and they are computed from different things: a
+   * Service's from `{reach, auth}` (§9), a Job's from whether anything fires it
+   * (§7). What is shared is the write and how a refusal is read, and that is
+   * all this holds. `describes` is how the policy is named in the sentence a
+   * failure produces.
+   */
   private async setInvoker(
     http: CloudHttp,
     connection: CloudRunAdapterConnection,
+    collection: Collection,
     id: string,
-    reach: Reach,
-    auth: Auth,
+    policy: InvokerPolicy,
+    describes: string,
   ): Promise<Omit<Extract<DeployVerdict, { phase: 'FAILED' }>, 'ref'> | null> {
     const written = await http.json<unknown>({
       method: 'POST',
-      path: `/v2/${parentOf(connection)}/services/${encodeURIComponent(id)}:setIamPolicy`,
-      body: invokerPolicy(reach, auth),
+      path: `/v2/${parentOf(connection)}/${collection}/${encodeURIComponent(id)}:setIamPolicy`,
+      body: policy,
     });
     if (written.ok) return null;
-    // A Service that does not exist yet cannot have a policy, and on the
-    // tightening path that is the normal case rather than a failure: there is
-    // no public reach to drop from something that was never placed.
+    // A resource that does not exist yet cannot have a policy, and where the
+    // policy grants nothing that is not a failure but a statement already true:
+    // there is no reach to drop from something that was never placed. A policy
+    // that *grants* is a different matter — it did not land, and saying so is
+    // the whole point of writing it after the resource exists.
     if (
       written.kind === 'status' &&
       written.status === 404 &&
-      !allowsUnauthenticated(reach, auth)
+      policy.policy.bindings.length === 0
     ) {
       return null;
     }
@@ -717,7 +831,90 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     return {
       phase: 'FAILED',
       reason: failure.reason,
-      detail: `the invoker policy for {reach: ${reach}, auth: ${auth}} could not be written: ${failure.detail}`,
+      detail: `the invoker policy for ${describes} could not be written: ${failure.detail}`,
+      debug: failure.debug,
+    };
+  }
+
+  // --- what stands in front of a Job ---------------------------------------
+
+  /**
+   * Put this job on its schedule, replacing whatever was there.
+   *
+   * **Delete, then create.** Cloud Scheduler has no create-or-update: its
+   * `jobs.create` refuses a name that exists and its `jobs.patch` refuses one
+   * that does not, so an upsert is two calls whichever order they go in. Doing
+   * the removal first makes the same call the unscheduled path already makes,
+   * which leaves one way for a schedule to stop rather than two — and the gap
+   * it opens is between two writes on a cadence measured in minutes.
+   */
+  private async schedule(
+    connection: CloudRunAdapterConnection,
+    id: string,
+    schedule: string,
+    name: DeployRef,
+  ): Promise<Omit<Extract<DeployVerdict, { phase: 'FAILED' }>, 'ref'> | null> {
+    const replaced = await this.unschedule(connection, id);
+    if (replaced !== null) return replaced;
+
+    const created = await this.scheduler().json<unknown>({
+      method: 'POST',
+      path: `/v1/${parentOf(connection)}/${JOBS}`,
+      body: cloudSchedulerJob(schedule, {
+        connection,
+        name,
+        // Refused before anything was written when the Target names none —
+        // see `apply`. The fallback is unreachable and is here because the
+        // type cannot know that.
+        serviceAccount: connection.serviceAccount ?? '',
+      }),
+    });
+    if (created.ok) return null;
+    const failure = cloudWriteFailure(created, id);
+    return {
+      phase: 'FAILED',
+      reason: failure.reason,
+      detail: `job ${id} could not be put on the schedule "${schedule}": ${failure.detail}`,
+      debug: failure.debug,
+    };
+  }
+
+  /** Take this job off its schedule, whether or not it was on one. */
+  private async unschedule(
+    connection: CloudRunAdapterConnection,
+    id: string,
+  ): Promise<Omit<Extract<DeployVerdict, { phase: 'FAILED' }>, 'ref'> | null> {
+    const removed = await this.scheduler().json<unknown>({
+      method: 'DELETE',
+      path: `/v1/${parentOf(connection)}/${JOBS}/${encodeURIComponent(id)}`,
+    });
+    if (removed.ok) return null;
+    if (removed.kind !== 'status') {
+      return {
+        phase: 'FAILED',
+        reason: 'TARGET_UNREACHABLE',
+        detail: `the schedule on job ${id} could not be removed: ${removed.message}`,
+      };
+    }
+    // Nothing to remove, in the two ways there are to have nothing. A `404` is
+    // the ordinary one. A refusal because the service is switched off in this
+    // project is the other, and it is proof rather than an assumption: an API
+    // that was never enabled has nothing under it that could have created a
+    // scheduler job. Tolerating it narrowly is what keeps a project that never
+    // wanted a schedule from failing every unscheduled job on a call about
+    // schedules; every other `403` is a real refusal and is raised.
+    if (
+      removed.status === 404 ||
+      removed.reason === SERVICE_DISABLED ||
+      removed.body.includes(SERVICE_DISABLED)
+    ) {
+      return null;
+    }
+    const failure = cloudWriteFailure(removed, id);
+    return {
+      phase: 'FAILED',
+      reason: failure.reason,
+      detail: `the schedule on job ${id} could not be removed: ${failure.detail}`,
       debug: failure.debug,
     };
   }
@@ -805,6 +1002,25 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   private http(connection: CloudRunAdapterConnection): CloudHttp {
     return new CloudHttp({
       baseUrl: connection.endpoint,
+      token: this.options.token,
+      ...(this.options.fetch === undefined
+        ? {}
+        : { fetch: this.options.fetch }),
+    });
+  }
+
+  /**
+   * The Cloud Scheduler API, which is not the Target's endpoint.
+   *
+   * A second root rather than a second connection field: the Target names where
+   * *its own* control plane is, and the service that fires its jobs is the
+   * cloud's, addressed the same way from every project. Same shape as the
+   * logging root `tail` reaches for, and the same token — §13's federation is
+   * one identity across every API it touches.
+   */
+  private scheduler(): CloudHttp {
+    return new CloudHttp({
+      baseUrl: this.options.schedulerEndpoint ?? DEFAULT_SCHEDULER_ENDPOINT,
       token: this.options.token,
       ...(this.options.fetch === undefined
         ? {}
@@ -1027,6 +1243,11 @@ function parentOf(connection: CloudRunAdapterConnection): string {
  * already stored says `services`, and reading the collection out of the ref
  * rather than deriving it from a kind is what keeps those readable instead of
  * orphaning every running Service.
+ *
+ * A third thing falls out of the shape rather than being designed into it: a
+ * Cloud Scheduler job is named `projects/…/locations/…/jobs/…` too, so this
+ * string **is** the scheduler job's own resource name at a different API root.
+ * That is why nothing has to store where a schedule went.
  */
 function refOf(
   connection: CloudRunAdapterConnection,

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -107,9 +107,10 @@ export interface CloudRunAdapterOptions {
   /**
    * Cloud Scheduler API root — what fires a scheduled job (§7).
    *
-   * Injectable for the same two reasons the logging root is, and defaulted for
-   * the same reason: it is a property of the cloud rather than of a project, so
-   * unlike the Target's own `endpoint` there is nothing per-Target to carry.
+   * Injected only by a test: `adapters/registry.ts` passes this adapter a token
+   * and a transport and nothing else. Defaulted rather than carried on the
+   * connection because it is a property of the cloud rather than of a project —
+   * unlike the Target's own `endpoint`, there is nothing per-Target to say.
    */
   readonly schedulerEndpoint?: string;
 }
@@ -290,11 +291,26 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     // new template. Asserted on every unscheduled job rather than only where
     // one was removed — this adapter holds no memory of the last deploy, and
     // deleting what is not there costs one call and answers `404`.
+    //
+    // **Said, not fatal.** Which is the difference between this call and the
+    // one in `destroy`: here it is a cleanup for a schedule most jobs never
+    // had, and failing on it would make every Cloud Run job — including one
+    // that has never declared a cadence — depend on Cloud Scheduler being
+    // enabled, permitted and reachable. Two ways that bites without anything
+    // being wrong: Cloud Scheduler serves a strict subset of Cloud Run's
+    // regions, and a project's IAM is eventually consistent after the terraform
+    // that grants the role. What actually stops a schedule firing is the empty
+    // invoker policy written further down, and that is a Cloud Run call: a
+    // scheduler job that survived this lands on a Job that no longer admits it.
+    // So the residue is a ticking job producing nothing — stated on the
+    // timeline so it is not silent, and raised for real by `destroy`.
     if (job && fires === null) {
       const stopped = await this.unschedule(connection, id);
       if (stopped !== null) {
-        yield this.status('FAILED', { resource: id, reason: stopped.reason });
-        return { ...stopped, ref };
+        yield this.log(
+          `${stopped.detail ?? `the schedule on job ${id} could not be removed`} — this Component declares none, so the deploy continues and the grant below is what stops it firing`,
+          id,
+        );
       }
     }
 
@@ -394,6 +410,23 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       // admit it.
       const scheduled = await this.schedule(connection, id, fires, ref);
       if (scheduled !== null) {
+        // And taken back when nothing came to use it. Writing the grant first
+        // is right on the path that succeeds and wrong on the path that does
+        // not: the runtime account is one identity shared by every workload in
+        // the vessel — which is the whole reason the binding is per-Job — so a
+        // grant left behind by a visibly failed deploy is a Job anything in the
+        // vessel may run, uncleaned until someone deploys this Component
+        // successfully. Best effort, and deliberately not allowed to replace
+        // the verdict: what the operator has to see is why the schedule did not
+        // land, not a second failure about tidying up after it.
+        await this.setInvoker(
+          http,
+          connection,
+          JOBS,
+          id,
+          jobInvokerPolicy(null),
+          'this job',
+        );
         yield this.status('FAILED', { resource: id, reason: scheduled.reason });
         return { ...scheduled, ref };
       }
@@ -841,12 +874,17 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   /**
    * Put this job on its schedule, replacing whatever was there.
    *
-   * **Delete, then create.** Cloud Scheduler has no create-or-update: its
-   * `jobs.create` refuses a name that exists and its `jobs.patch` refuses one
-   * that does not, so an upsert is two calls whichever order they go in. Doing
-   * the removal first makes the same call the unscheduled path already makes,
-   * which leaves one way for a schedule to stop rather than two — and the gap
-   * it opens is between two writes on a cadence measured in minutes.
+   * **Patch, then create on `404`.** Cloud Scheduler has no create-or-update —
+   * `jobs.create` refuses a name that exists and `jobs.patch` refuses one that
+   * does not — so one of the two has to go first, and the choice is not a wash.
+   * Patching first costs **one** call in the steady state, which is every
+   * re-deploy of a Component whose cadence has not changed, and it never leaves
+   * a moment with nothing scheduled. Deleting first would cost two always and
+   * open that window on every deploy, including ones that change nothing: a
+   * create that then failed — a transient `500`, a quota — would have destroyed
+   * a working cadence, and core keeps the earlier deploy `LIVE`
+   * (`reconciler/deploy-loop.ts`), so nothing in the product would say the
+   * firing had stopped.
    */
   private async schedule(
     connection: CloudRunAdapterConnection,
@@ -854,23 +892,36 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     schedule: string,
     name: DeployRef,
   ): Promise<Omit<Extract<DeployVerdict, { phase: 'FAILED' }>, 'ref'> | null> {
-    const replaced = await this.unschedule(connection, id);
-    if (replaced !== null) return replaced;
-
-    const created = await this.scheduler().json<unknown>({
-      method: 'POST',
-      path: `/v1/${parentOf(connection)}/${JOBS}`,
-      body: cloudSchedulerJob(schedule, {
-        connection,
-        name,
-        // Refused before anything was written when the Target names none —
-        // see `apply`. The fallback is unreachable and is here because the
-        // type cannot know that.
-        serviceAccount: connection.serviceAccount ?? '',
-      }),
+    const document = cloudSchedulerJob(schedule, {
+      connection,
+      name,
+      // Refused before anything was written when the Target names none —
+      // see `apply`. The fallback is unreachable and is here because the
+      // type cannot know that.
+      serviceAccount: connection.serviceAccount ?? '',
     });
-    if (created.ok) return null;
-    const failure = cloudWriteFailure(created, id);
+    const path = `/v1/${parentOf(connection)}/${JOBS}`;
+    const patched = await this.scheduler().json<unknown>({
+      method: 'PATCH',
+      path: `${path}/${encodeURIComponent(id)}`,
+      // Named rather than omitted: an absent mask means "replace the whole
+      // resource" to some of this family's APIs and "update what was sent" to
+      // others, and the fields this adapter writes are the only ones it should
+      // be able to clear. `name` is the identity and is not in it.
+      query: { updateMask: 'schedule,timeZone,httpTarget' },
+      body: document,
+    });
+    if (patched.ok) return null;
+    const written =
+      patched.kind === 'status' && patched.status === 404
+        ? await this.scheduler().json<unknown>({
+            method: 'POST',
+            path,
+            body: document,
+          })
+        : patched;
+    if (written.ok) return null;
+    const failure = cloudWriteFailure(written, id);
     return {
       phase: 'FAILED',
       reason: failure.reason,
@@ -900,14 +951,15 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     // the ordinary one. A refusal because the service is switched off in this
     // project is the other, and it is proof rather than an assumption: an API
     // that was never enabled has nothing under it that could have created a
-    // scheduler job. Tolerating it narrowly is what keeps a project that never
-    // wanted a schedule from failing every unscheduled job on a call about
-    // schedules; every other `403` is a real refusal and is raised.
-    if (
-      removed.status === 404 ||
-      removed.reason === SERVICE_DISABLED ||
-      removed.body.includes(SERVICE_DISABLED)
-    ) {
+    // scheduler job.
+    //
+    // Read off `reason` and nothing else. `cloud/http.ts` lifts that out of the
+    // ErrorInfo the API attaches, which is how Google says "this service is
+    // off" machine-readably; scanning the *body* for the same string would
+    // tolerate a genuine `IAM_PERMISSION_DENIED` whose human message happens to
+    // mention it — swallowing the one refusal that must be raised, on the path
+    // whose whole job is to make sure a schedule really stopped.
+    if (removed.status === 404 || removed.reason === SERVICE_DISABLED) {
       return null;
     }
     const failure = cloudWriteFailure(removed, id);

--- a/apps/spindrift/src/adapters/deploy/cloudrun/job.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/job.ts
@@ -5,15 +5,16 @@
  * describes, the adapter renders**, and a pure function returning a plain
  * object is a document a test can assert whole without a fake API standing by.
  *
- * **What a job on this backend is.** A Job resource that exists and is triggered
- * by nothing. That is the exact analogue of the Kubernetes side, where
+ * **What a job on this backend is.** A Job resource, and nothing in it that says
+ * when to run. That is the exact analogue of the Kubernetes side, where
  * `packages/charts/spindrift-app/templates/cronjob.yaml` renders a CronJob with
  * `suspend: true` and a date that never occurs for an unscheduled job — the
- * object has to exist for anything to have something to trigger. Cloud Run
- * reaches the same state by having no scheduler in front of it, because a Job
- * carries no schedule of its own: firing one on a cadence is a separate service
- * (**72**), and running one on demand is `DeployAdapter.run`, which here is the
- * runtime's own `jobs.run`.
+ * object has to exist for anything to have something to trigger. The difference
+ * is where the cadence lives: a CronJob carries its own and a Job carries none,
+ * so a schedule here is a Cloud Scheduler job standing in front of this one —
+ * `scheduler.ts`, applied by the adapter and not rendered into this document.
+ * Running one on demand is `DeployAdapter.run`, the runtime's own `jobs.run`,
+ * which is also the call a schedule makes.
  *
  * **The template nests twice.** `Job.template` is an `ExecutionTemplate` and
  * `ExecutionTemplate.template` is a `TaskTemplate`; the containers live in the
@@ -23,10 +24,9 @@
  * holds the closed Job schema that makes that mistake fail here rather than in
  * a vessel.
  *
- * **Nothing Service-only is rendered.** `ingress`, `containerPort` and the
- * invoker policy are all answers to "who may reach this", and a Job is reached
- * by nobody: the resource has no `ingress` member and nothing routes to it. So
- * a job's `reach` is `none`, which
+ * **Nothing Service-only is rendered.** `ingress` and `containerPort` are
+ * answers to "who may route to this", and nothing routes to a Job: the resource
+ * has no `ingress` member at all. So a job's `reach` is `none`, which
  * `ASSERTED_REACHES_BY_ADAPTER.cloudrun` already serves, and the chart says the
  * same thing one layer over — `spindrift-app.serving` is "a job is the only
  * workload branch and never serves".

--- a/apps/spindrift/src/adapters/deploy/cloudrun/scheduler.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/scheduler.ts
@@ -1,0 +1,130 @@
+/**
+ * What fires a Cloud Run Job at the times its `schedule` names (§6, §7).
+ *
+ * A Cloud Run Job carries no cron expression: the resource has no field for
+ * one, and `jobs.run` is a verb somebody has to call. So where the App chart
+ * renders a CronJob and the cluster's own controller fires it, this backend
+ * needs a **second service standing in front of the Job** — Cloud Scheduler,
+ * calling `jobs.run` over HTTP on a cadence. That is the whole asymmetry, and
+ * it is why a schedule is the one part of a job this adapter does not render
+ * into the Job document.
+ *
+ * Written as pure functions beside `service.ts` and `job.ts` for the same
+ * reason those are: **core describes, the adapter renders**, and a document a
+ * test can assert whole is worth more than one only a fake can catch.
+ *
+ * **The two documents here are one idea.** The scheduler job says *when* and
+ * *as whom*; the invoker policy says *whether that identity may*. Neither is
+ * any use without the other — a schedule with no binding fires and is refused
+ * `403` on every tick, and a binding with no schedule grants an invoke nobody
+ * makes — so they are built in one place, from one argument, and asserted
+ * together on every apply.
+ */
+import type { CloudRunAdapterConnection } from '../../../domain/target.ts';
+import type { InvokerPolicy } from './service.ts';
+
+/**
+ * The time zone every schedule is read in.
+ *
+ * Stated rather than left to the platform, because the two backends have to
+ * agree: a Kubernetes CronJob with no `timeZone` runs in the controller's, and
+ * `packages/charts/spindrift-app/templates/cronjob.yaml` names none. UTC is
+ * what that is in both clusters, and a Component whose "0 3 * * *" meant two
+ * different hours depending on where it was placed would be a placement
+ * decision quietly changing what the developer asked for.
+ */
+export const TIME_ZONE = 'UTC';
+
+/**
+ * The scope the fire's token carries.
+ *
+ * `jobs.run` is a Google API rather than a service of the developer's, so the
+ * call authenticates with an **OAuth** token and not an OIDC one: OIDC is for
+ * an endpoint that verifies an audience, and the Cloud Run control plane
+ * verifies an IAM permission. The platform-wide scope is the only one that API
+ * accepts; the narrowing that matters is done by the IAM policy below, which is
+ * the thing that actually decides what this token may do.
+ */
+const RUN_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+
+/** What a schedule needs that `DesiredState` does not carry. */
+export interface SchedulerContext {
+  /** Where the Job it fires is addressed — the Target's own API root. */
+  readonly connection: CloudRunAdapterConnection;
+  /** The Job's resource name, which is also this scheduler job's own. */
+  readonly name: string;
+  /** The identity the fire authenticates as. */
+  readonly serviceAccount: string;
+}
+
+/**
+ * One Cloud Scheduler job, ready to be created.
+ *
+ * **It shares the Job's resource name, deliberately.** Both APIs name a job
+ * `projects/…/locations/…/jobs/…`, so the handle `apply` already hands core —
+ * see `refOf` — is byte-for-byte the scheduler job's name at a different API
+ * root. That is what lets `destroy` take the schedule with the Job while
+ * holding nothing but a `DeployRef`: there is no second name to store, so there
+ * is no second name to lose. The alternative — widening the ref to carry a
+ * scheduler name — would have to be readable in every ref written before
+ * schedules existed, and would buy a freedom nothing wants.
+ *
+ * **No `retryConfig`.** Cloud Scheduler's default is not to retry a failed
+ * attempt but to wait for the next occurrence, which is what the chart's
+ * `backoffLimit: 0` says on the other backend. Note what is being retried
+ * either way: this is the `jobs.run` *call*, which returns as soon as the
+ * execution is created — a container that exits non-zero has already succeeded
+ * as far as the scheduler is concerned, and `maxRetries: 0` on the Job is what
+ * decides that half.
+ *
+ * **No `body`.** `jobs.run` takes overrides it does not need; sending none is
+ * how this fires the Job exactly as it was rendered.
+ */
+export function cloudSchedulerJob(
+  schedule: string,
+  context: SchedulerContext,
+): Record<string, unknown> {
+  return {
+    name: context.name,
+    schedule,
+    timeZone: TIME_ZONE,
+    httpTarget: {
+      uri: `${context.connection.endpoint}/v2/${context.name}:run`,
+      httpMethod: 'POST',
+      oauthToken: {
+        serviceAccountEmail: context.serviceAccount,
+        scope: RUN_SCOPE,
+      },
+    },
+  };
+}
+
+/**
+ * Who may run this Job — the whole policy, as `:setIamPolicy` takes one (§9).
+ *
+ * A whole policy rather than a binding to add, for the same reason
+ * `invokerPolicy` is one: the removal of a schedule has to be as expressible as
+ * the grant. Passing `null` is a Component that declares no schedule, and it
+ * writes an **empty** policy rather than skipping the call — the grant outlives
+ * the schedule otherwise, leaving every workload in the vessel able to run a
+ * Job nobody asked to be runnable.
+ *
+ * `roles/run.invoker` and no wider role: it carries `run.jobs.run` and nothing
+ * that could change the Job. Bound **on the Job** rather than on the project,
+ * so the identity that fires one Component's job cannot fire another's.
+ */
+export function jobInvokerPolicy(serviceAccount: string | null): InvokerPolicy {
+  return {
+    policy: {
+      bindings:
+        serviceAccount === null
+          ? []
+          : [
+              {
+                role: 'roles/run.invoker',
+                members: [`serviceAccount:${serviceAccount}`],
+              },
+            ],
+    },
+  };
+}

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -221,6 +221,24 @@ function resourceLimits(desired: DesiredState): Record<string, string> | null {
 }
 
 /**
+ * A whole IAM policy, as `:setIamPolicy` takes one.
+ *
+ * Typed rather than `Record<string, unknown>` because one property of it is
+ * load-bearing at the call site: a policy with **no** bindings asserts nothing
+ * about a resource that is not there, so writing one at a resource that does
+ * not exist is already true and its `404` is not a failure. That rule reads as
+ * arbitrary against an opaque blob and obvious against this.
+ */
+export interface InvokerPolicy {
+  readonly policy: {
+    readonly bindings: readonly {
+      readonly role: string;
+      readonly members: readonly string[];
+    }[];
+  };
+}
+
+/**
  * The IAM policy that matches one exposure state.
  *
  * A whole policy rather than a binding to add, because the verb this is handed
@@ -237,10 +255,7 @@ function resourceLimits(desired: DesiredState): Record<string, string> | null {
  * treats the authenticated edge as the largest non-Spindrift dependency (Risk
  * 2), and the audience belongs with it rather than being invented here.
  */
-export function invokerPolicy(
-  reach: Reach,
-  auth: Auth,
-): Record<string, unknown> {
+export function invokerPolicy(reach: Reach, auth: Auth): InvokerPolicy {
   return {
     policy: {
       bindings: allowsUnauthenticated(reach, auth)

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -150,6 +150,19 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
       hostingEndpoint: z.url(),
       /** Where this project's admission policy is read from (§16). */
       policyEndpoint: z.url().optional(),
+      /**
+       * The identity a revision runs as, and the one a schedule fires as (§7).
+       *
+       * Accepted here because the declared form already carries it
+       * (`config/manifest.schema.ts`) and the two shapes must not disagree about
+       * what a Cloud Run connection is. It decides a capability rather than only
+       * a runtime detail: a Cloud Scheduler job authenticates the `jobs.run`
+       * call it makes, so a Target naming none is a `NO_SCHEDULER`
+       * non-candidate for a scheduled job — see `firesSchedulesOn` in
+       * `domain/capabilities.ts`. Optional, because a project used only for
+       * services needs no identity of its own.
+       */
+      serviceAccount: z.string().trim().min(1).optional(),
       /** §33's static reachability input, and §3's stated capabilities. */
       servedHosts: z.array(z.string().trim().min(1)).optional(),
       reachableRegistries: z.array(z.string().trim().min(1)).optional(),
@@ -218,6 +231,11 @@ function connectionFor(
       ...(input.policyEndpoint === undefined
         ? {}
         : { policyEndpoint: input.policyEndpoint }),
+      // Only this surface runs anything, so only this one has an identity to
+      // run it as — static hosting serves files and authenticates nothing.
+      ...(input.serviceAccount === undefined
+        ? {}
+        : { serviceAccount: input.serviceAccount }),
       // Only this surface has a runtime to have produced output; static
       // hosting gets §17's honest empty state rather than a duration.
       ...(input.logHistorySeconds === undefined

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -271,18 +271,14 @@ export interface TargetCapabilities {
  * *mean* public" (§13) a consequence of the model rather than a rule bolted on
  * top of it.
  *
- * **A job on `cloudrun` is a Job resource that exists and is triggered by
- * nothing**, which is the same thing a job is on `kubernetes`: the App chart
- * renders an unscheduled job as a *suspended* CronJob, because the object has
- * to exist for anything to have something to trigger. Cloud Run reaches that
- * state by having no scheduler in front of the Job rather than by suspending
- * it, since a Job carries no schedule of its own.
- *
- * One thing a job here does not have, and it is a filed ticket rather than a
- * silence: **a schedule**, which needs Cloud Scheduler standing in front of the
- * Job and an API this vessel has not enabled (**72**) and is therefore a
- * non-candidate at Place — see {@link FIRES_SCHEDULES_BY_ADAPTER}. An on-demand
- * run is `DeployAdapter.run`, which both backends answer.
+ * **A job on `cloudrun` is a Job resource with no cadence of its own**, which is
+ * the same thing a job is on `kubernetes` until something schedules it: the App
+ * chart renders an unscheduled job as a *suspended* CronJob, because the object
+ * has to exist for anything to have something to trigger. Cloud Run reaches
+ * that state by having no scheduler in front of the Job rather than by
+ * suspending it. Put one there and both rows run the same Component the same
+ * way — see {@link FIRES_SCHEDULES_BY_ADAPTER}. An on-demand run is
+ * `DeployAdapter.run`, which both backends answer.
  */
 export const KINDS_BY_ADAPTER = {
   kubernetes: ['service', 'website', 'job'],
@@ -294,20 +290,26 @@ export const KINDS_BY_ADAPTER = {
  * Which adapters fire a job at the times its `schedule` names.
  *
  * From the adapter type for the same reason {@link KINDS_BY_ADAPTER} is: what
- * the code driving the Target renders. The App chart renders a CronJob, and the
- * cluster's own controller fires it. Cloud Run's Job resource carries no cron
- * expression at all — firing one is Cloud Scheduler standing in front of it,
- * which needs an API this vessel has not enabled and an invoker binding nothing
- * creates (**72**).
+ * the code driving the Target renders. Both backends that render a job now fire
+ * one, by quite different machinery — the App chart renders a CronJob and the
+ * cluster's own controller fires it, while a Cloud Run Job carries no cron
+ * expression at all and the adapter puts a Cloud Scheduler job in front of it
+ * (`adapters/deploy/cloudrun/scheduler.ts`). Which is exactly why this is a
+ * capability and not an assumption: the *kind* being renderable says nothing
+ * about whether anything keeps a cadence, and the two facts came true on this
+ * backend a release apart.
  *
- * It is a row of its own rather than a second kind because the *kind* is
- * rendered here and the *schedule* is not: §3's grammar refuses a scheduled job
- * at Place with a sentence saying which of the two is missing, so a developer
- * hears it before a build rather than after one.
+ * It is a row of its own rather than a second kind for that same reason, and
+ * §3's grammar is what it buys: a Target that runs a job and fires no schedule
+ * is a `NO_SCHEDULER` non-candidate at Place with a sentence naming which of
+ * the two is missing, so a developer hears it before a build rather than after
+ * one. The only `false` row left is `static`, which renders no job at all and
+ * therefore never reaches that sentence — so the mechanism is dormant here
+ * rather than dead, and it is what the next backend is measured against.
  */
 export const FIRES_SCHEDULES_BY_ADAPTER = {
   kubernetes: true,
-  cloudrun: false,
+  cloudrun: true,
   static: false,
 } as const satisfies Record<TargetAdapter, boolean>;
 

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -237,6 +237,11 @@ export function deployPathReferences(
 export interface TargetCapabilities {
   // From the adapter type.
   kinds: readonly ComponentKind[];
+  /**
+   * From the adapter type **and** from this Target's connection: the code has
+   * to fire a schedule and the Target has to give it something to fire as. See
+   * {@link FIRES_SCHEDULES_BY_ADAPTER} and `CapabilityContext.firesSchedules`.
+   */
   firesSchedules: boolean;
   artifactTypes: readonly ArtifactType[];
 
@@ -306,6 +311,13 @@ export const KINDS_BY_ADAPTER = {
  * one. The only `false` row left is `static`, which renders no job at all and
  * therefore never reaches that sentence — so the mechanism is dormant here
  * rather than dead, and it is what the next backend is measured against.
+ *
+ * **Not the whole answer for one Target, though.** This says what the code can
+ * do; a Cloud Run Target that names no runtime identity has nothing for a
+ * schedule to authenticate as, whatever its adapter is capable of. That half
+ * arrives on the connection — see `CapabilityContext.firesSchedules` — and the
+ * two are ANDed, so the row stays a property of the code and the Target's own
+ * configuration can only ever subtract.
  */
 export const FIRES_SCHEDULES_BY_ADAPTER = {
   kubernetes: true,
@@ -415,6 +427,12 @@ export interface CapabilityContext {
   /** `null` or empty both mean no authenticated edge has been claimed. */
   authReaches: readonly Reach[] | null;
   deployPath: DeployPathReferences;
+  /**
+   * Where this Target's own connection can stop it firing one, even though its
+   * adapter fires them. Absent means nothing about it does — see
+   * {@link FIRES_SCHEDULES_BY_ADAPTER}, which is the only other input.
+   */
+  firesSchedules?: boolean;
 }
 
 /** Fold one inspection into the capabilities §3 describes. */
@@ -424,7 +442,9 @@ export function resolveCapabilities(
 ): TargetCapabilities {
   return {
     kinds: KINDS_BY_ADAPTER[context.adapter],
-    firesSchedules: FIRES_SCHEDULES_BY_ADAPTER[context.adapter],
+    firesSchedules:
+      FIRES_SCHEDULES_BY_ADAPTER[context.adapter] &&
+      (context.firesSchedules ?? true),
     artifactTypes: context.artifactTypes,
 
     arch: discovery.arch,
@@ -506,7 +526,10 @@ export function noCapabilities(context: CapabilityContext): TargetCapabilities {
  * reason, never silently dropped.
  */
 export function capabilitiesOfRow(
-  target: Pick<TargetRow, 'adapter' | 'discovery' | 'reaches' | 'authReaches'>,
+  target: Pick<
+    TargetRow,
+    'adapter' | 'discovery' | 'reaches' | 'authReaches' | 'connection'
+  >,
   options: {
     /** The adapter instance, or `null` when this installation ships none. */
     readonly artifactTypes: readonly ArtifactType[] | null;
@@ -519,10 +542,30 @@ export function capabilitiesOfRow(
     reaches: target.reaches,
     authReaches: target.authReaches,
     deployPath: deployPathReferences(options.manifest),
+    firesSchedules: firesSchedulesOn(target.connection),
   };
   return target.discovery === null || options.artifactTypes === null
     ? noCapabilities(context)
     : resolveCapabilities(target.discovery, context);
+}
+
+/**
+ * Whether this Target's own connection lets a schedule fire, as opposed to its
+ * adapter's code being able to.
+ *
+ * The one case, and the reason this is not purely from-the-adapter-type: a
+ * Cloud Scheduler job authenticates the `jobs.run` call it makes, so a Cloud
+ * Run Target that names no runtime identity has nothing for a schedule to fire
+ * *as* — the adapter refuses it at apply, and §3's grammar says a refusal a
+ * Target's own configuration already decides belongs at Place, before a build,
+ * rather than after one. Every other flavour answers `true`: nothing in a
+ * cluster connection or a static one can withdraw a cadence its adapter keeps.
+ */
+function firesSchedulesOn(connection: TargetRow['connection']): boolean {
+  return (
+    connection?.adapter !== 'cloudrun' ||
+    connection.serviceAccount !== undefined
+  );
 }
 
 /** The columns {@link capabilitiesOfRow} reads, without importing the schema. */
@@ -531,6 +574,15 @@ interface TargetRow {
   discovery: TargetDiscovery | null;
   reaches: readonly Reach[] | null;
   authReaches: readonly Reach[] | null;
+  /**
+   * `adapter` is named so this is not a weak type, exactly as
+   * `placement.ts`'s own view of the same column is; `serviceAccount` is the
+   * one member read here and most flavours carry none.
+   */
+  connection: {
+    readonly adapter: TargetAdapter;
+    readonly serviceAccount?: string;
+  } | null;
 }
 
 /**

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -201,10 +201,14 @@ interface RankedTargetRow {
    * `adapter` is named here only so this is not a weak type: a shape whose every
    * property is optional accepts nothing structurally, and the connection
    * flavours that carry no `chartValues` are most of them.
+   *
+   * `serviceAccount` is not read here — it is what `capabilitiesOfRow` reads
+   * off the same column — and is named so this row satisfies that shape.
    */
   connection: {
     readonly adapter: TargetAdapter;
     readonly chartValues?: Record<string, unknown>;
+    readonly serviceAccount?: string;
   } | null;
 }
 
@@ -433,10 +437,13 @@ export function exclusionsFor(
 
   reasons.push(...reachExclusions(can, requirements));
 
-  // The kind is rendered here and the schedule is not, so this is its own
-  // reason rather than KIND_UNSUPPORTED: Cloud Run runs the Job and has nothing
-  // to fire it, and saying "this Target does not run jobs" would be false in
-  // the sentence a developer reads. Refused at Place because §3 refuses a
+  // Rendering a job and keeping a cadence are two facts, so this is its own
+  // reason rather than KIND_UNSUPPORTED: a Target that runs the Job and has
+  // nothing to fire it would be described by "this Target does not run jobs"
+  // falsely, in the sentence a developer reads. Both backends that render a job
+  // now fire one, and they came true a release apart on Cloud Run — which is
+  // exactly why the two are separate rows rather than one assumption (see
+  // `FIRES_SCHEDULES_BY_ADAPTER`). Refused at Place because §3 refuses a
   // non-candidate there — the alternative is a build and a Deploy that end in
   // the adapter's REJECTED.
   //

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -99,6 +99,7 @@ function adapterFor(options: FakeCloudRunOptions = {}): {
     adapter: new CloudRunDeployAdapter({
       token: api.token,
       fetch: api.fetch,
+      schedulerEndpoint: api.schedulerEndpoint,
       pollIntervalMs: 1,
       sleep: async () => {},
     }),
@@ -647,7 +648,7 @@ describe('the reach a Target rejects is a state, not a crash', () => {
   });
 });
 
-describe('§3: a job is a Job that exists and is triggered by nothing', () => {
+describe('§3: a job is a Job with no cadence of its own', () => {
   /** A job, with the only reach nothing routing to it can honestly claim. */
   const job = (overrides: Partial<DesiredState> = {}) =>
     desired({
@@ -731,21 +732,17 @@ describe('§3: a job is a Job that exists and is triggered by nothing', () => {
     });
   });
 
-  test('nothing that answers "who may reach this" is rendered or written', async () => {
-    // `ingress`, a container port and the invoker policy are all Service
-    // concepts: the Job resource has no `ingress` member, nothing routes to a
-    // Job, and nothing invokes one. The fake's closed Job schema refuses the
-    // first two; the request log is what proves the third never happened.
+  test('nothing that answers "who may route to this" is rendered', async () => {
+    // `ingress` and a container port are Service concepts: the Job resource has
+    // no `ingress` member and nothing routes to a Job. The fake's closed Job
+    // schema is what refuses them if a renderer reaches for one anyway.
     const document = cloudRunJob(job(), RENDER);
     expect(document).not.toHaveProperty('ingress');
     expect(JSON.stringify(document)).not.toContain('containerPort');
 
-    const { api, adapter } = adapterFor();
+    const { adapter } = adapterFor();
     const { verdict } = await drain(adapter.apply(target(), job()));
     expect(verdict.phase).toBe('LIVE');
-    expect(
-      api.requests.filter((request) => request.path.endsWith(':setIamPolicy')),
-    ).toEqual([]);
   });
 
   test('the runtime accepts it, and reports no address for it', async () => {
@@ -784,26 +781,242 @@ describe('§3: a job is a Job that exists and is triggered by nothing', () => {
     );
   });
 
-  test('a schedule is refused rather than dropped', async () => {
-    // A Cloud Run Job carries no schedule, and nothing in this vessel fires one
-    // (**72**). Rendering the Job and saying nothing would leave a Component
-    // reporting LIVE on a cadence nothing keeps — the same failure shape as a
-    // declared change that reaches storage and never reaches what acts on it.
+  test('an unscheduled job is invokable by nobody, and nothing fires it', async () => {
     const { api, adapter } = adapterFor();
-    const { verdict } = await drain(
-      adapter.apply(target(), job({ schedule: '0 3 * * *' })),
+    const { verdict } = await drain(adapter.apply(target(), job()));
+    expect(verdict.phase).toBe('LIVE');
+
+    // Nothing stands in front of it, and the closed state is *asserted* rather
+    // than inherited: an empty policy is what makes "removing a schedule
+    // removes the grant" true on the next deploy as well as this one.
+    expect(api.scheduled()).toEqual([]);
+    expect(api.jobPolicy('shop-nightly')).toEqual({ policy: { bindings: [] } });
+    expect(await api.tick()).toEqual([]);
+  });
+});
+
+describe('§7: a schedule on this backend is a second service in front of the Job', () => {
+  const RUNTIME = 'runtime@example-vessel.iam.gserviceaccount.com';
+
+  /** A Target that names the identity a fire can authenticate as. */
+  const scheduling = () => target({ serviceAccount: RUNTIME });
+
+  const nightly = (overrides: Partial<DesiredState> = {}) =>
+    desired({
+      component: 'nightly',
+      kind: 'job',
+      reach: 'none',
+      auth: 'none',
+      schedule: '0 3 * * *',
+      ...overrides,
+    });
+
+  test('the scheduler job calls jobs.run as the runtime account', async () => {
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(scheduling(), nightly()));
+    expect(verdict.phase).toBe('LIVE');
+
+    // Asserted whole, the way the two rendered documents are: what makes this
+    // right is as much what is absent — no OIDC token aimed at an audience
+    // nothing verifies, no Pub/Sub target, no body overriding the Job that was
+    // just rendered — as what is present.
+    expect(api.schedule('shop-nightly')).toEqual({
+      name: 'projects/example-vessel/locations/somewhere/jobs/shop-nightly',
+      schedule: '0 3 * * *',
+      timeZone: 'UTC',
+      httpTarget: {
+        uri: `${CLOUD_ENDPOINTS.run}/v2/projects/example-vessel/locations/somewhere/jobs/shop-nightly:run`,
+        httpMethod: 'POST',
+        oauthToken: {
+          serviceAccountEmail: RUNTIME,
+          scope: 'https://www.googleapis.com/auth/cloud-platform',
+        },
+      },
+    });
+  });
+
+  test('an execution appears that nobody asked for', async () => {
+    // The criterion, as close as a fake gets to it: the fire goes through the
+    // same transport as every other call, carrying the scheduler's identity
+    // rather than the controller's, and it is admitted only because the Job's
+    // own policy admits that account.
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(scheduling(), nightly()));
+
+    expect(api.jobPolicy('shop-nightly')).toEqual({
+      policy: {
+        bindings: [
+          { role: 'roles/run.invoker', members: [`serviceAccount:${RUNTIME}`] },
+        ],
+      },
+    });
+
+    const before = await adapter.executions(
+      scheduling(),
+      verdict.ref as string,
     );
+    expect(before).toEqual({ kind: 'executions', executions: [] });
+
+    expect(await api.tick()).toEqual([200]);
+
+    const after = await adapter.executions(scheduling(), verdict.ref as string);
+    expect(after.kind).toBe('executions');
+    if (after.kind === 'executions') {
+      expect(after.executions).toHaveLength(1);
+      expect(after.executions[0]?.name).toBe('shop-nightly-1');
+    }
+  });
+
+  test('the grant is on the Job, so it cannot run another Component', async () => {
+    // "on the Job and on nothing wider". The runtime account is one identity
+    // shared by every workload in the vessel, so a project-level grant would
+    // let one App's schedule fire another App's job.
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(scheduling(), nightly()));
+    await drain(
+      adapter.apply(
+        scheduling(),
+        nightly({ component: 'other', schedule: undefined }),
+      ),
+    );
+
+    expect(api.jobPolicy('shop-other')).toEqual({ policy: { bindings: [] } });
+    const ran = await api.fetch(
+      new Request(
+        `${api.endpoint}/v2/projects/example-vessel/locations/somewhere/jobs/shop-other:run`,
+        { method: 'POST', headers: { authorization: `Bearer sa:${RUNTIME}` } },
+      ),
+    );
+    expect(ran.status).toBe(403);
+  });
+
+  test('dropping the schedule stops the firing, and clears the grant', async () => {
+    // The failure this whole path is shaped against, mirrored: a thing that
+    // keeps acting after nobody declares it. The scheduler job is deleted
+    // *before* the new template lands, so there is no window in which the old
+    // cadence fires the new revision.
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(scheduling(), nightly()));
+    expect(api.scheduled()).toHaveLength(1);
+
+    api.requests.length = 0;
+    await drain(adapter.apply(scheduling(), nightly({ schedule: undefined })));
+
+    expect(api.scheduled()).toEqual([]);
+    expect(api.jobPolicy('shop-nightly')).toEqual({ policy: { bindings: [] } });
+    expect(await api.tick()).toEqual([]);
+
+    const removed = api.requests.findIndex(
+      (request) =>
+        request.method === 'DELETE' &&
+        request.path ===
+          '/v1/projects/example-vessel/locations/somewhere/jobs/shop-nightly',
+    );
+    const patched = api.requests.findIndex(
+      (request) =>
+        request.method === 'PATCH' && request.path.includes('/jobs/'),
+    );
+    expect(removed).toBe(0);
+    expect(removed).toBeLessThan(patched);
+  });
+
+  test('destroy takes the schedule with the Job', async () => {
+    // A scheduler job left behind would keep calling `jobs.run` on something
+    // that is not there — an orphan wearing a second service's uniform.
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(scheduling(), nightly()));
+
+    await adapter.destroy(scheduling(), verdict.ref as string);
+    expect(api.job('shop-nightly')).toBeUndefined();
+    expect(api.scheduled()).toEqual([]);
+  });
+
+  test('re-deploying replaces the schedule rather than colliding with it', async () => {
+    // Cloud Scheduler has no create-or-update: its `jobs.create` answers `409`
+    // for a name that exists. An adapter that only ever created would go green
+    // on the first deploy and fail on every one after it.
+    const { api, adapter } = adapterFor();
+    await drain(adapter.apply(scheduling(), nightly()));
+    const { verdict } = await drain(
+      adapter.apply(scheduling(), nightly({ schedule: '30 4 * * 1' })),
+    );
+
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.scheduled()).toHaveLength(1);
+    expect(api.schedule('shop-nightly')?.schedule).toBe('30 4 * * 1');
+  });
+
+  test('a Target naming no identity is refused before anything is written', async () => {
+    // A scheduler job with no account is created happily and refused on every
+    // tick — a Component reporting LIVE on a cadence that lands nowhere, which
+    // is the silent drop one indirection further out.
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), nightly()));
+
     expect(verdict.phase).toBe('FAILED');
     if (verdict.phase === 'FAILED') {
       expect(verdict.reason).toBe('REJECTED');
       expect(blameFor(verdict.reason)).toBe('developer');
-      expect(verdict.detail).toContain('schedule');
+      expect(verdict.detail).toContain('identity');
     }
-    // Nothing was placed: a refusal that had already written the Job would be
-    // the silent drop wearing an error message.
     expect(
       api.requests.filter((request) => request.method === 'PATCH'),
     ).toEqual([]);
+  });
+
+  test('a schedule the far side refuses fails the deploy rather than the Job', async () => {
+    // A cron expression Cloud Scheduler cannot parse is `400 INVALID_ARGUMENT`,
+    // which §6 puts under REJECTED and blames the developer. The Job is up by
+    // then — this is deliberately the last thing `apply` does — so what the
+    // verdict has to say is that the *schedule* did not land.
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(
+      adapter.apply(scheduling(), nightly({ schedule: 'every tuesday' })),
+    );
+
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('REJECTED');
+      expect(verdict.detail).toContain('every tuesday');
+    }
+    expect(api.scheduled()).toEqual([]);
+  });
+
+  test('a project with Cloud Scheduler switched off still deploys a plain job', async () => {
+    // The service being off is proof there is no scheduler job in the project,
+    // so the removal a plain job asserts is already true. Any other refusal is
+    // raised — a deploy that shrugged at `403 IAM_PERMISSION_DENIED` could
+    // leave a schedule firing at a Component that no longer asks for one.
+    const disabled = adapterFor({
+      refuseScheduler: {
+        status: 403,
+        body: {
+          error: {
+            message: 'Cloud Scheduler API has not been used in this project',
+            status: 'PERMISSION_DENIED',
+            details: [
+              {
+                '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
+                reason: 'SERVICE_DISABLED',
+              },
+            ],
+          },
+        },
+      },
+    });
+    const { verdict } = await drain(
+      disabled.adapter.apply(scheduling(), nightly({ schedule: undefined })),
+    );
+    expect(verdict.phase).toBe('LIVE');
+
+    const refused = adapterFor({ refuseScheduler: permissionDenied() });
+    const stopped = await drain(
+      refused.adapter.apply(scheduling(), nightly({ schedule: undefined })),
+    );
+    expect(stopped.verdict.phase).toBe('FAILED');
+    if (stopped.verdict.phase === 'FAILED') {
+      expect(stopped.verdict.detail).toContain('could not be removed');
+    }
   });
 });
 

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -230,6 +230,38 @@ describe('§9: reach and auth reach the runtime as two mechanisms', () => {
       expect(verdict.detail).toContain('invoker policy');
     }
   });
+
+  test('a 404 excuses a policy that grants nothing, and only that one', async () => {
+    // The adapter forgives `404` on a policy write, because a resource that is
+    // not there yet cannot have one and an empty policy is a statement already
+    // true of it. A *granting* policy is the opposite case: it did not land,
+    // and going green on it would report a public Component as reachable when
+    // nothing was ever opened.
+    const granting = adapterFor({
+      refuseIam: { status: 404, body: { error: { status: 'NOT_FOUND' } } },
+    });
+    const opened = await drain(
+      granting.adapter.apply(
+        target(),
+        desired({ reach: 'public', auth: 'none' }),
+      ),
+    );
+    expect(opened.verdict.phase).toBe('FAILED');
+
+    // The same refusal on the write that closes: the tightening pass runs
+    // before the Service exists, so `404` there is the ordinary case rather
+    // than a failure, and the deploy goes on to place it.
+    const closing = adapterFor({
+      refuseIam: { status: 404, body: { error: { status: 'NOT_FOUND' } } },
+    });
+    const tightened = await drain(
+      closing.adapter.apply(
+        target(),
+        desired({ reach: 'private', auth: 'none' }),
+      ),
+    );
+    expect(tightened.verdict.phase).toBe('LIVE');
+  });
 });
 
 describe('§6: phases come from the revision', () => {
@@ -931,12 +963,15 @@ describe('§7: a schedule on this backend is a second service in front of the Jo
     expect(api.scheduled()).toEqual([]);
   });
 
-  test('re-deploying replaces the schedule rather than colliding with it', async () => {
-    // Cloud Scheduler has no create-or-update: its `jobs.create` answers `409`
-    // for a name that exists. An adapter that only ever created would go green
-    // on the first deploy and fail on every one after it.
+  test('re-deploying patches the schedule rather than replacing it', async () => {
+    // Cloud Scheduler has no create-or-update: `jobs.create` answers `409` for
+    // a name that exists and `jobs.patch` answers `404` for one that does not.
+    // An adapter that only ever created would go green on the first deploy and
+    // fail on every one after it.
     const { api, adapter } = adapterFor();
     await drain(adapter.apply(scheduling(), nightly()));
+
+    api.requests.length = 0;
     const { verdict } = await drain(
       adapter.apply(scheduling(), nightly({ schedule: '30 4 * * 1' })),
     );
@@ -944,6 +979,16 @@ describe('§7: a schedule on this backend is a second service in front of the Jo
     expect(verdict.phase).toBe('LIVE');
     expect(api.scheduled()).toHaveLength(1);
     expect(api.schedule('shop-nightly')?.schedule).toBe('30 4 * * 1');
+    // And in **one** call, with no DELETE among them. That is the property, not
+    // the call count: deleting first would mean every re-deploy of an unchanged
+    // Component has a window with nothing scheduled, and a create that then
+    // failed would have destroyed a working cadence while core kept the earlier
+    // deploy LIVE — a schedule that silently stopped.
+    expect(
+      api.requests
+        .filter((request) => request.path.startsWith('/v1/'))
+        .map((request) => request.method),
+    ).toEqual(['PATCH']);
   });
 
   test('a Target naming no identity is refused before anything is written', async () => {
@@ -964,7 +1009,7 @@ describe('§7: a schedule on this backend is a second service in front of the Jo
     ).toEqual([]);
   });
 
-  test('a schedule the far side refuses fails the deploy rather than the Job', async () => {
+  test('a schedule the far side refuses fails the deploy and takes the grant back', async () => {
     // A cron expression Cloud Scheduler cannot parse is `400 INVALID_ARGUMENT`,
     // which §6 puts under REJECTED and blames the developer. The Job is up by
     // then — this is deliberately the last thing `apply` does — so what the
@@ -980,24 +1025,114 @@ describe('§7: a schedule on this backend is a second service in front of the Jo
       expect(verdict.detail).toContain('every tuesday');
     }
     expect(api.scheduled()).toEqual([]);
+    // And the binding written a moment earlier does not outlive the schedule
+    // that justified it. The runtime account is shared by every workload in the
+    // vessel, so leaving it would leave a Job anything in the vessel may run,
+    // put there by a deploy that visibly failed.
+    expect(api.jobPolicy('shop-nightly')).toEqual({ policy: { bindings: [] } });
+    const ran = await api.fetch(
+      new Request(
+        `${api.endpoint}/v2/projects/example-vessel/locations/somewhere/jobs/shop-nightly:run`,
+        { method: 'POST', headers: { authorization: `Bearer sa:${RUNTIME}` } },
+      ),
+    );
+    expect(ran.status).toBe(403);
   });
 
-  test('a project with Cloud Scheduler switched off still deploys a plain job', async () => {
-    // The service being off is proof there is no scheduler job in the project,
-    // so the removal a plain job asserts is already true. Any other refusal is
-    // raised — a deploy that shrugged at `403 IAM_PERMISSION_DENIED` could
-    // leave a schedule firing at a Component that no longer asks for one.
-    const disabled = adapterFor({
+  test('a job that declares no schedule does not depend on Cloud Scheduler', async () => {
+    // The regression this must not become: before schedules existed, deploying
+    // a Cloud Run job made no scheduler call at all. Asserting the removal on
+    // every unscheduled job is right — the adapter holds no memory of the last
+    // deploy — but *failing* on it would make every plain job depend on Cloud
+    // Scheduler being enabled, permitted and reachable. Both are real: Cloud
+    // Scheduler serves a strict subset of Cloud Run's regions, and the project
+    // IAM that grants the role is eventually consistent after its apply.
+    const refusals = [
+      // The service being off is proof there was no scheduler job to remove,
+      // so there is no residue and nothing to say about one.
+      { refuseScheduler: serviceDisabled(), residue: false },
+      { refuseScheduler: permissionDenied(), residue: true },
+      {
+        refuseScheduler: {
+          status: 400,
+          body: { error: { message: 'unsupported location' } },
+        },
+        residue: true,
+      },
+    ];
+    for (const { refuseScheduler, residue } of refusals) {
+      const { api, adapter } = adapterFor({ refuseScheduler });
+      const { verdict, events } = await drain(
+        adapter.apply(scheduling(), nightly({ schedule: undefined })),
+      );
+
+      expect(verdict.phase).toBe('LIVE');
+      expect(api.job('shop-nightly')).toBeDefined();
+      // And the grant is gone whatever the scheduler said, which is what makes
+      // the firing stop even where the scheduler job survived: a tick lands on
+      // a Job that no longer admits it.
+      expect(api.jobPolicy('shop-nightly')).toEqual({
+        policy: { bindings: [] },
+      });
+      // Tolerated is not the same as unsaid: a residue this deploy could not
+      // clear is on the timeline, which is where an operator finds out.
+      expect(
+        events.some(
+          (event) =>
+            event.type === 'log' && event.line.includes('could not be removed'),
+        ),
+      ).toBe(residue);
+    }
+  });
+
+  test('destroy raises what apply tolerates', async () => {
+    // The other side of the same call, and the reason it is one function with
+    // two callers rather than two: `destroy` is the act that has to leave
+    // nothing behind, so a refusal there is a scheduler job that will keep
+    // calling `jobs.run` at a Job that is gone.
+    const { adapter } = adapterFor({ refuseScheduler: permissionDenied() });
+    const { verdict } = await drain(adapter.apply(scheduling(), nightly()));
+    expect(verdict.phase).toBe('FAILED');
+
+    const ref = 'projects/example-vessel/locations/somewhere/jobs/shop-nightly';
+    await expect(adapter.destroy(scheduling(), ref)).rejects.toThrow(
+      'could not be removed',
+    );
+  });
+
+  test('a project with Cloud Scheduler switched off destroys a plain job', async () => {
+    // The service being off is proof there is no scheduler job in the project:
+    // an API that was never enabled has nothing under it that could have
+    // created one.
+    const { api, adapter } = adapterFor({ refuseScheduler: serviceDisabled() });
+    const { verdict } = await drain(
+      adapter.apply(scheduling(), nightly({ schedule: undefined })),
+    );
+    expect(verdict.phase).toBe('LIVE');
+
+    await adapter.destroy(scheduling(), verdict.ref as string);
+    expect(api.job('shop-nightly')).toBeUndefined();
+  });
+
+  test('and a refusal that only mentions the words does not count', async () => {
+    // That tolerance is read off the ErrorInfo `reason` and nowhere else.
+    // Google says "this service is off" machine-readably; a refusal whose
+    // reason is `IAM_PERMISSION_DENIED` is a real one however its human message
+    // reads, and swallowing it here would leave the scheduler job firing at a
+    // Job `destroy` went on to delete.
+    const denied = permissionDenied();
+    const { adapter } = adapterFor({
       refuseScheduler: {
-        status: 403,
+        status: denied.status,
         body: {
           error: {
-            message: 'Cloud Scheduler API has not been used in this project',
+            message:
+              'the caller does not have permission; check whether SERVICE_DISABLED applies',
             status: 'PERMISSION_DENIED',
             details: [
               {
                 '@type': 'type.googleapis.com/google.rpc.ErrorInfo',
-                reason: 'SERVICE_DISABLED',
+                reason: 'IAM_PERMISSION_DENIED',
               },
             ],
           },
@@ -1005,18 +1140,13 @@ describe('§7: a schedule on this backend is a second service in front of the Jo
       },
     });
     const { verdict } = await drain(
-      disabled.adapter.apply(scheduling(), nightly({ schedule: undefined })),
+      adapter.apply(scheduling(), nightly({ schedule: undefined })),
     );
     expect(verdict.phase).toBe('LIVE');
 
-    const refused = adapterFor({ refuseScheduler: permissionDenied() });
-    const stopped = await drain(
-      refused.adapter.apply(scheduling(), nightly({ schedule: undefined })),
-    );
-    expect(stopped.verdict.phase).toBe('FAILED');
-    if (stopped.verdict.phase === 'FAILED') {
-      expect(stopped.verdict.detail).toContain('could not be removed');
-    }
+    await expect(
+      adapter.destroy(scheduling(), verdict.ref as string),
+    ).rejects.toThrow('could not be removed');
   });
 });
 

--- a/apps/spindrift/test/commands/placement.test.ts
+++ b/apps/spindrift/test/commands/placement.test.ts
@@ -178,7 +178,7 @@ describe('resolution is derived, and it is a query', () => {
     expect(run.artifactType).toBe('image');
   });
 
-  test("a job's schedule is derived, and refuses the backend that fires none", async () => {
+  test("a job's schedule is derived, and both runtimes keep one", async () => {
     const registry = fakes();
     await connectEverything(registry);
     const { component } = await seedComponent(
@@ -188,20 +188,24 @@ describe('resolution is derived, and it is a query', () => {
       '0 3 * * *',
     );
 
-    // The Cloud Run adapter renders the Job and nothing fires it, so the
-    // schedule is what excludes it — and it is excluded here rather than after
-    // a build, which is what §3 puts resolution before the build for.
+    // Two machineries, one row: the cluster's own controller fires the CronJob
+    // the chart renders, and the Cloud Run adapter puts a Cloud Scheduler job
+    // in front of the Job it renders. What the schedule still decides is the
+    // *static* Target, which renders no job at all.
     const placement = await place(registry, component.id);
     const run = placement.options.find((o) => o.name === 'vessel-cloudrun')!;
-    expect(run.candidate).toBe(false);
-    expect(run.reasons).toEqual(['NO_SCHEDULER']);
-    expect(run.detail).toEqual([
-      'this Target runs a job but has nothing to fire it on a schedule',
-    ]);
-    // The cluster's own controller fires the CronJob the chart renders.
-    expect(placement.suggestedTargetId).toBe(
-      placement.options.find((o) => o.name === 'cluster')!.targetId,
-    );
+    expect(run.candidate).toBe(true);
+    expect(run.reasons).toEqual([]);
+    const cluster = placement.options.find((o) => o.name === 'cluster')!;
+    expect(cluster.candidate).toBe(true);
+    // Rank is the tie-break §3 leaves to a human, and the cluster ranks first.
+    expect(placement.suggestedTargetId).toBe(cluster.targetId);
+    const cdn = placement.options.find((o) => o.name === 'vessel-static')!;
+    expect(cdn.candidate).toBe(false);
+    expect(cdn.reasons).toContain('KIND_UNSUPPORTED');
+    // NO_SCHEDULER's sentence opens by granting that this Target runs a job, so
+    // it never rides along beside the reason that says it does not.
+    expect(cdn.reasons).not.toContain('NO_SCHEDULER');
   });
 
   test('nowhere fits is returned, with a reason for every Target', async () => {

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -222,11 +222,13 @@ describe('the act is credential-shaped though the noun is flat', () => {
     expect(result.value.targets.map((t) => t.rank)).toEqual([0, 1]);
 
     // Each Target keeps only the endpoint its own adapter drives: one connect
-    // act asked for both, and neither Target carries the other's.
+    // act asked for both, and neither Target carries the other's. The runtime
+    // identity splits the same way — only this surface runs anything.
     expect((await targetRow('vessel-cloudrun'))?.connection).toEqual({
       adapter: 'cloudrun',
       region: 'here',
       endpoint: CLOUD_ENDPOINTS.run,
+      serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
     });
     expect((await targetRow('vessel-static'))?.connection).toEqual({
       adapter: 'static',

--- a/apps/spindrift/test/domain/capabilities.test.ts
+++ b/apps/spindrift/test/domain/capabilities.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, test } from 'bun:test';
 import { targetAdapterSchema } from '../../src/config/manifest.schema.ts';
 import {
   type CapabilityContext,
+  capabilitiesOfRow,
   deriveHealth,
   deriveOfflineDeploy,
   deriveVerifiedDeploy,
@@ -26,6 +27,10 @@ import {
   type TargetDiscovery,
 } from '../../src/domain/capabilities.ts';
 import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+/** Read once: nothing here asserts on the manifest, only through it. */
+const MANIFEST = await fixtureManifest();
 
 /** A deploy path served entirely by the Target itself. */
 const LOCAL_PATH = {
@@ -152,6 +157,53 @@ describe('the provenances that are not discovered', () => {
     // The direction that fails closed: claiming auth nobody wired would put a
     // Component behind a filter that is not there.
     expect(resolveCapabilities(discovery(), context()).authReaches).toEqual([]);
+  });
+
+  test('firing a schedule takes the adapter and the Target both', () => {
+    // §3's grammar: a refusal a Target's own configuration already decides
+    // belongs at Place rather than after a build. A Cloud Scheduler job
+    // authenticates the `jobs.run` call it makes, so a Cloud Run Target naming
+    // no runtime identity has nothing for a schedule to fire *as* — and the
+    // adapter refuses it at apply, which is the after-the-build refusal this
+    // row exists to avoid.
+    const cloud = { adapter: 'cloudrun', project: 'vessel' } as const;
+    const capable = capabilitiesOfRow(
+      {
+        adapter: 'cloudrun',
+        discovery: discovery(),
+        reaches: null,
+        authReaches: null,
+        connection: { ...cloud, serviceAccount: 'runtime@vessel.test' },
+      },
+      { artifactTypes: ['image'], manifest: MANIFEST },
+    );
+    expect(capable.firesSchedules).toBe(true);
+
+    const anonymous = capabilitiesOfRow(
+      {
+        adapter: 'cloudrun',
+        discovery: discovery(),
+        reaches: null,
+        authReaches: null,
+        connection: cloud,
+      },
+      { artifactTypes: ['image'], manifest: MANIFEST },
+    );
+    expect(anonymous.firesSchedules).toBe(false);
+    // And it subtracts only: a cluster connection has nothing that could
+    // withdraw the cadence its adapter keeps.
+    expect(
+      capabilitiesOfRow(
+        {
+          adapter: 'kubernetes',
+          discovery: discovery(),
+          reaches: null,
+          authReaches: null,
+          connection: { adapter: 'kubernetes' },
+        },
+        { artifactTypes: ['image'], manifest: MANIFEST },
+      ).firesSchedules,
+    ).toBe(true);
   });
 
   test('a Target nothing could be discovered about is capable of nothing', () => {

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -484,12 +484,37 @@ describe('§3: a kind an adapter does not render is refused at Place', () => {
     ).toEqual([]);
   });
 
-  test('a schedule nothing fires is refused at Place, and only a schedule', () => {
-    // The kind is rendered on this backend and the schedule is not, so the
-    // refusal is its own reason and lands at Place — a scheduled job accepted
-    // here would be refused by the adapter after a build and a Deploy, which is
-    // the direction §3 exists to prevent.
-    const cloud = target({ adapter: 'cloudrun' });
+  test('both backends that render a job also fire one', () => {
+    // Two quite different machineries reaching the same answer: the cluster's
+    // own controller fires the CronJob the chart renders, and the Cloud Run
+    // adapter puts a Cloud Scheduler job in front of the Job it renders. The
+    // capability is what makes those one row rather than a special case.
+    const scheduled = requirements({
+      kind: 'job',
+      reach: 'none',
+      auth: 'none',
+      schedule: '0 3 * * *',
+    });
+    expect(exclusionsFor(target({ adapter: 'cloudrun' }), scheduled)).toEqual(
+      [],
+    );
+    expect(exclusionsFor(target({ adapter: 'kubernetes' }), scheduled)).toEqual(
+      [],
+    );
+  });
+
+  test('a schedule nothing fires is still refused at Place, and only a schedule', () => {
+    // No connected adapter is in this state today, which is exactly why it is
+    // constructed: the guard is what the *next* backend is measured against,
+    // and a rule with no test is a rule that rots. The kind is rendered and the
+    // schedule is not, so the refusal is its own reason and lands at Place — a
+    // scheduled job accepted here would be refused after a build and a Deploy,
+    // which is the direction §3 exists to prevent.
+    const capable = target({ adapter: 'kubernetes' });
+    const cadenceless: PlacementTarget = {
+      ...capable,
+      capabilities: { ...capable.capabilities, firesSchedules: false },
+    };
     const unscheduled = requirements({
       kind: 'job',
       reach: 'none',
@@ -497,13 +522,8 @@ describe('§3: a kind an adapter does not render is refused at Place', () => {
     });
     const scheduled = { ...unscheduled, schedule: '0 3 * * *' };
 
-    expect(exclusionsFor(cloud, scheduled)).toEqual(['NO_SCHEDULER']);
-    expect(exclusionsFor(cloud, unscheduled)).toEqual([]);
-    // The cluster's own controller fires the CronJob the chart renders, so the
-    // same Component is a candidate there.
-    expect(exclusionsFor(target({ adapter: 'kubernetes' }), scheduled)).toEqual(
-      [],
-    );
+    expect(exclusionsFor(cadenceless, scheduled)).toEqual(['NO_SCHEDULER']);
+    expect(exclusionsFor(cadenceless, unscheduled)).toEqual([]);
     // A backend that renders no job at all says so once. NO_SCHEDULER's
     // sentence opens by granting that this Target runs a job, so beside
     // KIND_UNSUPPORTED it would contradict it on a single row — and

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -686,11 +686,12 @@ export class FakeCloudRun {
   }
 
   /**
-   * Cloud Scheduler, as much of it as an adapter that only ever creates and
+   * Cloud Scheduler, as much of it as an adapter that creates, updates and
    * deletes needs.
    *
    * **No create-or-update, deliberately.** The real `jobs.create` refuses a
-   * name that already exists with `409 ALREADY_EXISTS`, and modelling that is
+   * name that already exists with `409 ALREADY_EXISTS` and the real
+   * `jobs.patch` refuses one that does not with `404`, and modelling both is
    * what keeps an adapter honest about the fact that this API has no upsert —
    * one that assumed otherwise would pass here and leave a Component's second
    * deploy silently on its first schedule.
@@ -703,14 +704,23 @@ export class FakeCloudRun {
       );
     }
     const parent = `/v1/${this.parent()}/jobs`;
+    const addressed = url.pathname.startsWith(`${parent}/`)
+      ? url.pathname.slice('/v1/'.length)
+      : null;
     if (method === 'DELETE') {
-      if (!url.pathname.startsWith(`${parent}/`)) return json(404, notFound());
-      const name = url.pathname.slice('/v1/'.length);
-      if (!this.schedules.has(name)) return json(404, notFound());
-      this.schedules.delete(name);
+      if (addressed === null || !this.schedules.has(addressed)) {
+        return json(404, notFound());
+      }
+      this.schedules.delete(addressed);
       return json(200, {});
     }
-    if (method !== 'POST' || url.pathname !== parent) {
+    // `patch` addresses the job and `create` addresses its parent — the only
+    // difference between the two, other than which of them refuses.
+    if (method === 'PATCH') {
+      if (addressed === null || !this.schedules.has(addressed)) {
+        return json(404, notFound());
+      }
+    } else if (method !== 'POST' || url.pathname !== parent) {
       return json(404, notFound());
     }
 
@@ -738,7 +748,7 @@ export class FakeCloudRun {
         },
       });
     }
-    if (this.schedules.has(name)) {
+    if (method === 'POST' && this.schedules.has(name)) {
       return json(409, {
         error: { code: 409, status: 'ALREADY_EXISTS', message: 'job exists' },
       });
@@ -902,13 +912,20 @@ function notFound(): unknown {
   return { error: { message: 'not found', status: 'NOT_FOUND' } };
 }
 
-/** A refusal because the service is switched off in this project. */
+/**
+ * A refusal because the service is switched off in this project.
+ *
+ * One definition for both APIs this fake stands in for, because what the
+ * adapter reads is the ErrorInfo `reason` and that is identical whichever
+ * service is off — the human message is the part that names one, and no test
+ * reads it.
+ */
 export function serviceDisabled(): { status: number; body: unknown } {
   return {
     status: 403,
     body: {
       error: {
-        message: 'Cloud Run API has not been used in this project',
+        message: 'this API has not been used in this project',
         status: 'PERMISSION_DENIED',
         details: [{ '@type': ERROR_INFO, reason: 'SERVICE_DISABLED' }],
       },

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -31,6 +31,11 @@
  *   §9's fail-closed ordering rather than only that a call was made.
  * - **The admission policy lives at its own endpoint**, which is how a Target
  *   that names none is distinguishable from one whose policy admits everything.
+ * - **Cloud Scheduler is a third API in the same project**, because what fires a
+ *   Job is not the runtime. It is here rather than in a fake of its own for the
+ *   reason {@link FakeCloudRun.tick} exists: the only interesting thing about a
+ *   scheduler job is whether the call it makes is *admitted*, and answering that
+ *   needs the Job's IAM policy — which lives here.
  */
 import type { Fetcher } from '../../../src/adapters/deploy/cloud/http.ts';
 import { CLOUD_ENDPOINTS } from '../installation.ts';
@@ -57,6 +62,8 @@ export interface FakeCloudRunOptions {
   readonly refuseList?: { status: number; body: unknown };
   /** When set, `:setIamPolicy` is refused with this. */
   readonly refuseIam?: { status: number; body: unknown };
+  /** When set, every Cloud Scheduler write is refused with this. */
+  readonly refuseScheduler?: { status: number; body: unknown };
   /** The admission policy this project reports, or `null` for none at all. */
   readonly admissionPolicy?: Record<string, unknown> | null;
   /**
@@ -221,6 +228,58 @@ const SCHEMAS: Record<string, ServiceSchema> = {
   jobs: JOB_SCHEMA,
 };
 
+/**
+ * A Cloud Scheduler v1 `Job`, closed the same way and for the same reason.
+ *
+ * Note the two targets that are here and unused: `pubsubTarget` and
+ * `oidcToken`. They are the shapes a renderer might reach for by analogy — one
+ * fires a topic rather than a Job, and the other authenticates to an endpoint
+ * that verifies an audience rather than to an API that verifies a permission —
+ * so a document naming them is accepted by the schema and then fails
+ * {@link FakeCloudRun.tick}, which is where the mistake actually shows.
+ */
+const SCHEDULER_JOB_SCHEMA: ServiceSchema = {
+  name: true,
+  description: true,
+  schedule: true,
+  timeZone: true,
+  retryConfig: true,
+  attemptDeadline: true,
+  pubsubTarget: true,
+  appEngineHttpTarget: true,
+  httpTarget: {
+    uri: true,
+    httpMethod: true,
+    headers: true,
+    body: true,
+    oauthToken: { serviceAccountEmail: true, scope: true },
+    oidcToken: { serviceAccountEmail: true, audience: true },
+  },
+};
+
+/**
+ * A unix-cron expression, as loosely as this needs to check one.
+ *
+ * Five whitespace-separated fields. The real API parses each of them and
+ * refuses `400 INVALID_ARGUMENT` for a field it cannot read; what matters here
+ * is only that a schedule reaches the far side as a schedule rather than as
+ * something the adapter mangled on the way.
+ */
+const CRON = /^\S+(\s+\S+){4}$/;
+
+/**
+ * How this fake is told a call is being made by a service account.
+ *
+ * The controller's own token is the one every other call carries. A scheduled
+ * fire is made by a *different* identity — the account the scheduler job names
+ * — which is the whole thing criterion "on the Job and on nothing wider" is
+ * about, so it has to be distinguishable here or the IAM policy is decoration.
+ */
+const SERVICE_ACCOUNT_TOKEN = 'sa:';
+
+/** The one role that lets an identity run a Job. */
+const INVOKER = 'roles/run.invoker';
+
 /** The one collection that has runs. Named, because `:run` is refused elsewhere. */
 const JOBS_COLLECTION = 'jobs';
 
@@ -311,6 +370,7 @@ const READY: ServiceScript = (reads) =>
 export class FakeCloudRun {
   readonly endpoint = CLOUD_ENDPOINTS.run;
   readonly policyEndpoint = CLOUD_ENDPOINTS.policy;
+  readonly schedulerEndpoint = CLOUD_ENDPOINTS.scheduler;
   readonly requests: RecordedCloudRequest[] = [];
   /** Every Operation a write answered with, in order — what a poll would use. */
   readonly operations: { name: string; done: boolean }[] = [];
@@ -323,6 +383,15 @@ export class FakeCloudRun {
    * would hide exactly the case `parseRef` exists to get right.
    */
   private readonly resources = new Map<string, Record<string, unknown>>();
+  /**
+   * What Cloud Scheduler holds, by full resource name.
+   *
+   * A separate map rather than a third collection in `resources`, because it is
+   * a separate *service*: a scheduler job and a Cloud Run Job share a resource
+   * name, and collapsing them would hide the one interesting property of that
+   * — that the same string addresses two things.
+   */
+  private readonly schedules = new Map<string, Record<string, unknown>>();
   /** Invoker policies, by `<collection>/<id>` — the surface for exposure. */
   private readonly policies = new Map<string, unknown>();
   private readonly reads = new Map<string, number>();
@@ -377,6 +446,64 @@ export class FakeCloudRun {
     return this.policies.get(`services/${id}`);
   }
 
+  /** The same, for a Job — which is where a schedule's grant lands. */
+  jobPolicy(id: string): unknown {
+    return this.policies.get(`jobs/${id}`);
+  }
+
+  /** The Cloud Scheduler job standing in front of one Job, if any is. */
+  schedule(id: string): Record<string, unknown> | undefined {
+    return this.schedules.get(`${this.parent()}/jobs/${id}`);
+  }
+
+  /** Every scheduler job in the project, by name — nothing should be orphaned. */
+  scheduled(): string[] {
+    return [...this.schedules.keys()].sort();
+  }
+
+  /**
+   * Let every scheduler job fire once, the way Cloud Scheduler would.
+   *
+   * The point is not that the fake can call itself: it is that the call goes
+   * through the same `fetch` as everything else, carrying **the identity the
+   * scheduler job names** rather than the controller's token. So a fire is
+   * admitted only if that account holds `roles/run.invoker` on that Job — which
+   * makes the IAM policy the adapter writes load-bearing instead of decorative,
+   * and makes an execution here mean the same thing it means in a vessel:
+   * something ran that nobody asked for by hand.
+   *
+   * Returns each fire's status, in scheduler-job name order.
+   */
+  async tick(): Promise<number[]> {
+    const fired: number[] = [];
+    for (const name of this.scheduled()) {
+      const job = this.schedules.get(name) as {
+        httpTarget?: {
+          uri?: string;
+          httpMethod?: string;
+          oauthToken?: { serviceAccountEmail?: string };
+        };
+      };
+      const target = job.httpTarget;
+      if (target?.uri === undefined) {
+        fired.push(400);
+        continue;
+      }
+      const response = await this.fetch(
+        new Request(target.uri, {
+          method: target.httpMethod ?? 'POST',
+          headers: {
+            authorization: `Bearer ${SERVICE_ACCOUNT_TOKEN}${
+              target.oauthToken?.serviceAccountEmail ?? ''
+            }`,
+          },
+        }),
+      );
+      fired.push(response.status);
+    }
+    return fired;
+  }
+
   /** Requests the adapter made, in order — what § Seam 2 asserts on. */
   pathsOf(method: string): string[] {
     return this.requests
@@ -386,10 +513,14 @@ export class FakeCloudRun {
 
   fetch: Fetcher = async (request) => {
     const url = new URL(request.url);
-    const body =
+    // A POST with no body at all is legal and is what `jobs.run` is fired with
+    // — the scheduler sends no overrides. Read as text first so that an empty
+    // body is `null` rather than a parse error thrown out of the transport.
+    const sent =
       request.method === 'GET' || request.method === 'DELETE'
-        ? null
-        : await request.clone().json();
+        ? ''
+        : await request.clone().text();
+    const body = sent === '' ? null : (JSON.parse(sent) as unknown);
     this.requests.push({
       method: request.method,
       url: `${url.pathname}${url.search}`,
@@ -397,12 +528,24 @@ export class FakeCloudRun {
       body,
     });
 
-    if (request.headers.get('authorization') !== `Bearer ${this.token()}`) {
+    // Who is calling. Almost always the controller, holding the token §13's
+    // federation minted; a scheduled fire is the one call made by somebody
+    // else, and `tick` says so in the header rather than by being let in
+    // through a side door.
+    const authorization = request.headers.get('authorization') ?? '';
+    const caller = authorization.startsWith(`Bearer ${SERVICE_ACCOUNT_TOKEN}`)
+      ? authorization.slice(`Bearer ${SERVICE_ACCOUNT_TOKEN}`.length)
+      : null;
+    if (caller === null && authorization !== `Bearer ${this.token()}`) {
       return json(401, { error: { message: 'unauthenticated' } });
     }
 
     if (url.origin === new URL(this.policyEndpoint).origin) {
       return this.admissionResponse();
+    }
+
+    if (url.origin === new URL(this.schedulerEndpoint).origin) {
+      return this.schedulerResponse(request.method, url, body);
     }
 
     const parent = `/v2/projects/${this.project}/locations/${this.region}/`;
@@ -473,6 +616,14 @@ export class FakeCloudRun {
       if (collection !== JOBS_COLLECTION || !this.resources.has(key)) {
         return json(404, notFound());
       }
+      // The controller holds `roles/run.admin` on the project, which carries
+      // this. Every other identity has to have been granted it **on this Job**,
+      // which is what makes a schedule that was removed stop firing even if
+      // something still calls: the binding is what the policy says now, not
+      // what it said when the scheduler job was written.
+      if (caller !== null && !this.mayRun(key, caller)) {
+        return json(permissionDenied().status, permissionDenied().body);
+      }
       const started = `${name}-${this.nextRun++}`;
       this.executions.set(name, [
         { name: `${this.parent()}/jobs/${name}/executions/${started}` },
@@ -521,6 +672,92 @@ export class FakeCloudRun {
         });
     }
   };
+
+  /** Whether one service account may run one Job, per that Job's own policy. */
+  private mayRun(key: string, serviceAccount: string): boolean {
+    const written = this.policies.get(key) as
+      | { policy?: { bindings?: { role?: string; members?: string[] }[] } }
+      | undefined;
+    return (written?.policy?.bindings ?? []).some(
+      (binding) =>
+        binding.role === INVOKER &&
+        (binding.members ?? []).includes(`serviceAccount:${serviceAccount}`),
+    );
+  }
+
+  /**
+   * Cloud Scheduler, as much of it as an adapter that only ever creates and
+   * deletes needs.
+   *
+   * **No create-or-update, deliberately.** The real `jobs.create` refuses a
+   * name that already exists with `409 ALREADY_EXISTS`, and modelling that is
+   * what keeps an adapter honest about the fact that this API has no upsert —
+   * one that assumed otherwise would pass here and leave a Component's second
+   * deploy silently on its first schedule.
+   */
+  private schedulerResponse(method: string, url: URL, body: unknown): Response {
+    if (this.options.refuseScheduler !== undefined) {
+      return json(
+        this.options.refuseScheduler.status,
+        this.options.refuseScheduler.body,
+      );
+    }
+    const parent = `/v1/${this.parent()}/jobs`;
+    if (method === 'DELETE') {
+      if (!url.pathname.startsWith(`${parent}/`)) return json(404, notFound());
+      const name = url.pathname.slice('/v1/'.length);
+      if (!this.schedules.has(name)) return json(404, notFound());
+      this.schedules.delete(name);
+      return json(200, {});
+    }
+    if (method !== 'POST' || url.pathname !== parent) {
+      return json(404, notFound());
+    }
+
+    const document = body as Record<string, unknown>;
+    const unknown = unknownMember(document, SCHEDULER_JOB_SCHEMA);
+    if (unknown !== null) {
+      return json(400, {
+        error: {
+          code: 400,
+          status: 'INVALID_ARGUMENT',
+          message: `Invalid JSON payload received. Unknown name "${unknown}" at 'job'.`,
+        },
+      });
+    }
+    const name = document.name;
+    if (
+      typeof name !== 'string' ||
+      !name.startsWith(`${this.parent()}/jobs/`)
+    ) {
+      return json(400, {
+        error: {
+          code: 400,
+          status: 'INVALID_ARGUMENT',
+          message: 'the job name must be under the parent it is created in',
+        },
+      });
+    }
+    if (this.schedules.has(name)) {
+      return json(409, {
+        error: { code: 409, status: 'ALREADY_EXISTS', message: 'job exists' },
+      });
+    }
+    if (
+      typeof document.schedule !== 'string' ||
+      !CRON.test(document.schedule)
+    ) {
+      return json(400, {
+        error: {
+          code: 400,
+          status: 'INVALID_ARGUMENT',
+          message: `"${String(document.schedule)}" is not a valid cron expression`,
+        },
+      });
+    }
+    this.schedules.set(name, document);
+    return json(200, { ...document, state: 'ENABLED' });
+  }
 
   /** Everything stored in one collection. */
   private held(collection: string): Record<string, unknown>[] {

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -164,6 +164,10 @@ export function cloudInput(
     region: 'somewhere',
     runEndpoint: CLOUD_ENDPOINTS.run,
     hostingEndpoint: CLOUD_ENDPOINTS.hosting,
+    // The vessel names one — see `clusters/offsite/apps/spindrift/`. A fixture
+    // that left it out would be a Target no scheduled job can be placed on,
+    // which is a real state but not the ordinary one.
+    serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
     ...overrides,
   };
 }
@@ -204,6 +208,9 @@ export function connectionFor(adapter: TargetAdapter): TargetConnection {
         region: input.region,
         endpoint: input.runEndpoint,
         policyEndpoint: CLOUD_ENDPOINTS.policy,
+        ...(input.serviceAccount === undefined
+          ? {}
+          : { serviceAccount: input.serviceAccount }),
       };
     }
     case 'static': {

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -149,6 +149,8 @@ export const CLOUD_ENDPOINTS = {
   run: 'https://run.example.test',
   hosting: 'https://hosting.example.test',
   policy: 'https://admission.example.test',
+  /** What fires a scheduled job — not the Target's own control plane. */
+  scheduler: 'https://scheduler.example.test',
 } as const;
 
 /** The connect input a cloud project takes, with anything overridden. */

--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -46,10 +46,10 @@ locals {
   spindrift_project_roles = toset([
     "roles/cloudsql.admin",
     # A Cloud Run Job carries no cron expression, so a scheduled Component is a
-    # Cloud Scheduler job the controller creates and deletes beside the Job.
+    # Cloud Scheduler job the controller keeps beside the Job.
     # `roles/run.admin` covers `run.jobs.*` and nothing scheduler-shaped, and
-    # this is the narrowest predefined role covering the only two verbs the
-    # adapter calls — `cloudscheduler.jobs.create` and `.delete`. Neither
+    # this is the narrowest predefined role covering the three verbs the adapter
+    # calls — `cloudscheduler.jobs.create`, `.update` and `.delete`. Neither
     # narrower role reaches them: `roles/cloudscheduler.viewer` only reads, and
     # `roles/cloudscheduler.jobRunner` only forces a run of a job somebody else
     # created. Nothing wider, either: an editor-shaped role would carry every

--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -32,6 +32,10 @@ resource "google_service_account_iam_member" "spindrift_controller_token_creator
   member             = local.spindrift_principal
 }
 
+# Attaching an identity to something is a separate permission from creating the
+# something. The controller writes both a Cloud Run revision and a Cloud
+# Scheduler job that authenticate as the runtime account, and neither call is
+# admitted without `iam.serviceAccounts.actAs` on it.
 resource "google_service_account_iam_member" "spindrift_act_as_runtime" {
   service_account_id = google_service_account.spindrift_runtime.name
   role               = "roles/iam.serviceAccountUser"
@@ -41,6 +45,16 @@ resource "google_service_account_iam_member" "spindrift_act_as_runtime" {
 locals {
   spindrift_project_roles = toset([
     "roles/cloudsql.admin",
+    # A Cloud Run Job carries no cron expression, so a scheduled Component is a
+    # Cloud Scheduler job the controller creates and deletes beside the Job.
+    # `roles/run.admin` covers `run.jobs.*` and nothing scheduler-shaped, and
+    # this is the narrowest predefined role covering the only two verbs the
+    # adapter calls — `cloudscheduler.jobs.create` and `.delete`. Neither
+    # narrower role reaches them: `roles/cloudscheduler.viewer` only reads, and
+    # `roles/cloudscheduler.jobRunner` only forces a run of a job somebody else
+    # created. Nothing wider, either: an editor-shaped role would carry every
+    # other API in the project along with it.
+    "roles/cloudscheduler.admin",
     "roles/compute.networkUser",
     "roles/firebasehosting.admin",
     "roles/iap.admin",

--- a/terraform/gcp/projects/bluenose/services.tf
+++ b/terraform/gcp/projects/bluenose/services.tf
@@ -3,6 +3,11 @@ resource "google_project_service" "service" {
     "artifactregistry.googleapis.com",
     "binaryauthorization.googleapis.com",
     "cloudresourcemanager.googleapis.com",
+    # A Cloud Run Job holds no cron expression, so a Component that declares a
+    # schedule is a Cloud Scheduler job calling `jobs.run` in front of it.
+    # Enabling this also creates the Cloud Scheduler service agent, which is
+    # what mints the token that call carries.
+    "cloudscheduler.googleapis.com",
     "compute.googleapis.com",
     "firebase.googleapis.com",
     "firebasehosting.googleapis.com",


### PR DESCRIPTION
Stacked on #1707, which added the Cloud Run Job and the `run`/`executions` verbs; open against that branch and GitHub will retarget it to `main` when #1707 merges.

A Cloud Run Job holds no cron expression. Until now that meant a Component declaring a schedule and picking the cloud runtime was refused twice: `FIRES_SCHEDULES_BY_ADAPTER.cloudrun` made it a `NO_SCHEDULER` non-candidate at Place, and the adapter carried an apply-time `REJECTED` behind that for the path that asks for a Deploy without asking Place. Both were the honest thing to do — a Component reporting `LIVE` on a cadence nothing keeps is worse than one that will not deploy — but they left the same Component behaving differently on the two runtimes for a reason the developer could do nothing about.

Firing one is a second Google service standing in front of the Job. The adapter now creates a Cloud Scheduler job that calls `jobs.run` over HTTP as the Target's runtime account, and binds `roles/run.invoker` to that account on that Job and nowhere else. The role carries `run.jobs.run` and nothing that could change the Job; binding it per-Job rather than per-project is what stops one App's schedule being able to fire another App's, since the runtime account is one identity shared by every workload in the vessel.

Nothing stores where the schedule went, because nothing needs to. Both APIs name a job `projects/…/locations/…/jobs/…`, so the `DeployRef` `apply` already hands core is byte-for-byte the scheduler job's own resource name at a different API root (`apps/spindrift/src/adapters/deploy/cloudrun/index.ts:1304`). That is what lets `destroy` take the schedule with the Job while holding nothing but a ref, and it is why no ref shape changed and every ref already in the database still parses.

**Re-deploying patches the schedule rather than replacing it.** Cloud Scheduler has no create-or-update — `jobs.create` refuses a name that exists, `jobs.patch` refuses one that does not — so one of them goes first, and the choice is not a wash. Patching first costs one call in the steady state, which is every re-deploy of a Component whose cadence has not changed, and it never leaves a moment with nothing scheduled. Deleting first would cost two always and open that window on every deploy including the ones that change nothing; a create that then hit a transient `500` would have destroyed a working cadence, and core keeps the earlier deploy `LIVE`, so nothing in the product would have said the firing stopped.

The removal direction is the half worth reading twice, because it is the mirror of the failure the refusal was avoiding: a thing that keeps acting after nobody declares it. A job that declares no schedule deletes the scheduler job *before* the new template lands — the same ordering §9 gives a tightening invoker policy, so there is no window in which the old cadence fires the new revision — and it does so on every deploy rather than only where a schedule was removed, because this adapter holds no memory of the last one. The Job's invoker policy is asserted in the same breath and in whichever direction the schedule now means, and a schedule that fails to land takes the grant back with it rather than leaving a Job every workload in the vessel may run.

**That removal is said, not fatal, and only on this path.** Failing the deploy on it would make every Cloud Run job — including one that has never declared a cadence — depend on Cloud Scheduler being enabled, permitted and reachable, which #1707's plain job path did not. Two ways that bites without anything being wrong: Cloud Scheduler serves a strict subset of Cloud Run's regions, and project IAM is eventually consistent after the apply that grants the role. What actually stops a schedule firing is the empty invoker policy written afterwards, which is a Cloud Run call — a scheduler job that survived lands on a Job that no longer admits it — so the residue is a ticking job producing nothing, stated on the deploy timeline. `destroy` raises the same refusal for real, because there the point is to leave nothing behind. The one refusal read specially is `SERVICE_DISABLED`, off the ErrorInfo `reason` and never off the message body: an API that was never enabled has nothing under it that could have created a scheduler job, and a substring scan would have swallowed a genuine `IAM_PERMISSION_DENIED` whose human text happened to mention it.

A Target that names no runtime identity cannot hold a scheduled job — a scheduler job with no account is created happily and refused on every tick, which is the silent drop one indirection further out — and that is now a Place-side refusal as well as the adapter's. `firesSchedules` is the adapter's row ANDed with the Target's own connection, so such a Target is a `NO_SCHEDULER` non-candidate rather than a candidate that gets `REJECTED` after a build. `connectTarget` accepts `serviceAccount` for the same reason: the declared form already carried it, and the two shapes of a Cloud Run connection must not disagree about what one is. A cron expression Cloud Scheduler will not parse still fails the deploy, with the expression in the message.

`terraform/gcp/projects/bluenose` enables `cloudscheduler.googleapis.com` and grants the controller `roles/cloudscheduler.admin`. That is the narrowest predefined role covering the three verbs the adapter calls — `cloudscheduler.jobs.create`, `.update` and `.delete`. `roles/cloudscheduler.viewer` only reads, and `roles/cloudscheduler.jobRunner` only forces a run of a job somebody else created, so neither reaches. The `actAs` edge a scheduler job needs on `spindrift-runtime` already existed for the Cloud Run revision and is unchanged.

The Cloud Run fake grows the third API and a `tick()`, which fires each scheduler job through the same transport carrying **the identity that job names** rather than the controller's token. A fire is therefore admitted only because the Job's own policy admits that account, which makes the binding load-bearing in the tests instead of decorative: an execution appearing after `tick()` means the same thing it means in a vessel.

**What does not stop a schedule, stated plainly.** The adapter removes one the moment something asks it to; nothing in core asks. `components.schedule` is written once at create and there is no update command, so a Component cannot have its cadence changed or dropped through any surface. `DeployAdapter.destroy` has no caller in core — `deleteApp` deliberately strands workloads rather than tearing them down — so deleting an App leaves the Job and its scheduler job running. A Component that changes Target, or changes kind from `job` to `service`, orphans the old Job with whatever fires it. Those are pre-existing core gaps, but this PR is what turns a stranded inert Job into a stranded thing that acts and bills, so they are named here rather than left to be discovered. Separately, `observe` reads the Cloud Run resource and nothing else, so a scheduler job deleted out of band leaves the Component `LIVE` and undrifted; `observe` is handed a ref and no desired state, so it cannot tell that absence from an unscheduled job's, and closing it is a contract question rather than an adapter one. Both are filed.

The risk that remains is the part no fake reaches. Cloud Scheduler's locations are not guaranteed to be the same set as Cloud Run's regions, and a `northamerica-northeast1` scheduler job is asserted only by this change being applied. The `create` also depends on the Cloud Scheduler service agent, which enabling the API provisions — if that grant is slow to land, the first scheduled deploy fails with an IAM message naming an account nobody configured, and re-deploying is the fix. Concurrency is the one behavioural asymmetry left standing: the chart's CronJob sets `concurrencyPolicy: Forbid` and Cloud Run Jobs have no equivalent, so a scheduled run that overlaps a previous one starts a second execution on this backend and is skipped on the other.

After merge the operator needs `atlantis apply` on this PR before any of it does anything — the API is off in `bluenose` and the controller holds no scheduler role until then. A scheduled job deployed before that apply fails on `cloudscheduler.jobs.create`, visibly, with the refusal in the verdict.
