### PR TITLE
fix(spindrift): remove Bun runtime from browser schema

### DIFF
--- a/apps/spindrift/src/web/forms/schema.ts
+++ b/apps/spindrift/src/web/forms/schema.ts
@@ -284,7 +284,10 @@ function oneOrMany(
   const single = variants.find((variant) => variant.node.kind !== 'array');
   if (list === undefined || single === undefined) return null;
   if (list.node.kind !== 'array') return null;
-  return Bun.deepEquals(list.node.element, single.node, true)
+  // FormNodes are plain, acyclic data built above in one canonical property
+  // order, so their JSON representation is their structural identity. Keep
+  // this browser-owned module independent of Bun's server runtime.
+  return JSON.stringify(list.node.element) === JSON.stringify(single.node)
     ? list.node
     : null;
 }

--- a/apps/spindrift/test/web/client-bundle.test.ts
+++ b/apps/spindrift/test/web/client-bundle.test.ts
@@ -80,6 +80,18 @@ const built = await buildClient();
 const DIST = join(APP, 'dist');
 
 describe('the client bundle', () => {
+  test('does not depend on the Bun runtime in a browser', async () => {
+    const files = await readdir(DIST);
+    const entry = files.find((file) => file.endsWith('.js'));
+    expect(entry).toBeDefined();
+    const text = await Bun.file(join(DIST, entry!)).text();
+
+    // `Bun.build` leaves unknown globals intact. A `Bun.*` call can therefore
+    // compile and pass Bun-hosted unit tests, then throw `Bun is not defined`
+    // when a browser reaches it. The client must use browser APIs only.
+    expect(text).not.toMatch(/\bBun\./);
+  });
+
   test('carries no fingerprint of the command layer it used to pull in', async () => {
     const files = await readdir(DIST);
     const entry = files.find((file) => file.endsWith('.js'));


### PR DESCRIPTION
## Summary

Prevent the Spindrift web UI from crashing with `Bun is not defined` while projecting the installation schema in a browser.

## Changes

- Replace the browser-owned schema projector's `Bun.deepEquals` call with structural comparison over its canonical JSON-like `FormNode` data.
- Add a production client-bundle regression test that rejects runtime `Bun.*` references.

## Test Plan

- [x] `bun test test/web/schema-form.test.ts`
- [x] `bun test test/web/client-bundle.test.ts`
- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:45433/spindrift bun test --dots` — 1,612 pass, 0 fail
- [x] `mise run ts:check`
- [x] Changed-files Biome check

## Context

- `.agent/context/context.md` (local, gitignored diagnosis handoff)
