### PR TITLE
fix(ci): never cancel a superseded run on main

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -7,10 +7,15 @@ on:
     branches:
       - main
 
-# Cancel superseded runs on the same ref instead of letting them pile up.
+# Cancel superseded runs on a pull request instead of letting them pile up.
+# **Never on `main`**: this workflow builds from a changed-files matrix, so a
+# cancelled push run's images are never built by any later one — the next
+# commit's matrix contains only what *it* changed. A push landing seconds after
+# another would otherwise silently drop the earlier commit's images, and the
+# only symptom is a stale digest nobody bumped. Queue them instead.
 concurrency:
   group: containers-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/pulsifer-ca.yml
+++ b/.github/workflows/pulsifer-ca.yml
@@ -14,7 +14,7 @@ on:
 
 concurrency:
   group: pulsifer-ca-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   deploy:

--- a/.github/workflows/rackstat.yml
+++ b/.github/workflows/rackstat.yml
@@ -15,7 +15,7 @@ on:
 
 concurrency:
   group: rackstat-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/spindrift-charts.yml
+++ b/.github/workflows/spindrift-charts.yml
@@ -40,10 +40,13 @@ on:
       - 'packages/charts/spindrift-app/**'
       - '.github/workflows/spindrift-charts.yml'
 
-# Cancel superseded runs on the same ref instead of letting them pile up.
+# Cancel superseded runs on a pull request instead of letting them pile up.
+# **Never on `main`**: a cancelled push run leaves the chart version in its
+# Chart.yaml unpublished, and the consumer that pins that version by tag then
+# fails to pull with nothing here saying why. Queue them instead.
 concurrency:
   group: spindrift-charts-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/view-counter.yml
+++ b/.github/workflows/view-counter.yml
@@ -16,7 +16,7 @@ env:
 
 concurrency:
   group: view-counter-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   deploy:

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -28,7 +28,7 @@ on:
 
 concurrency:
   group: wiki-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
`cancel-in-progress: true` is correct on a pull request and wrong on `main`
for every workflow that produces an artifact from a changed-files matrix or a
`paths:` filter.

The next commit's matrix contains only what *that* commit changed, so a
cancelled push run's output is never picked up by any later run. Two pushes
landing seconds apart silently drop the earlier one's images, charts or
deploy. There is no failure anywhere — the run reads `cancelled`, the next
one reads green, and the only symptom surfaces days later as a digest nobody
bumped, on a control plane running code that was merged and reviewed.

It happened twice within forty minutes on `containers` alone: `2e6e6cb6` was
taken by `569dd6bd` two seconds later, and `d5947aae` by `fab3803f` fourteen
seconds later. The second cost a merged feature its deployment; recovering it
needed a manual `gh run rerun`, which is not something a person thinks to do
when nothing reports an error.

Changed in the six workflows whose output is an artifact or a deploy —
`containers`, `spindrift-charts`, `wiki`, `pulsifer-ca`, `rackstat`,
`view-counter`. Runs on `main` now queue behind each other instead of
cancelling; pull requests are unaffected.

`terraform`, `typescript`, `oidc`, `dotfiles` and `pixlet-preview` are left
alone deliberately: losing a check run costs nothing, because the next run
re-checks a superset of what the cancelled one would have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)