### PR TITLE
fix(nix): update mise 2026.8.0 hashes

### DIFF
--- a/nix/overlays/mise.nix
+++ b/nix/overlays/mise.nix
@@ -40,9 +40,9 @@ in
       url = "https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-linux-${arch}.tar.gz";
       hash =
         if final.stdenv.hostPlatform.isAarch64 then
-          "sha256-DbAwUjf9CHhiroIXXWGdKI0yG64hauEQHMczFXqAtpM="
+          "sha256-bYiLo9C1149nZ3GoSEaIW39oX7TRUz8pJweeubdWM6g="
         else
-          "sha256-LK6NxUgS+mC/ZS5uvcac/uEQZgzdsnBT9UQv3tGdvH0=";
+          "sha256-ZBg2A4VPMZt4ZYMFxUWqyuk14JWaOolLd6D5QW6rBHs=";
     };
 
     # The tarball unpacks into ./mise/{bin,man,...}; set sourceRoot so the


### PR DESCRIPTION
## Summary

- refresh the `arm64` and `x64` SRI hashes for mise 2026.8.0
- follow up on #1712, which auto-merged before the checksum repair could be pushed

## Validation

- `.github/scripts/update-mise-hashes.sh` (with OpenSSL supplied by Nix)
- `mise run nix:check`
- `git diff --check`
