### PR TITLE
ci(typescript): skip digest-only deployments

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -18,9 +18,11 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      has_changes: ${{ steps.changed-paths.outputs.any_changed }}
+      has_changes: ${{ steps.classify.outputs.has_changes }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
       - id: changed-paths
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
@@ -44,6 +46,26 @@ jobs:
             turbo.json
             biome.json
             .github/workflows/typescript.yml
+      - id: classify
+        env:
+          ANY_CHANGED: ${{ steps.changed-paths.outputs.any_changed }}
+          ALL_CHANGED_FILES: ${{ steps.changed-paths.outputs.all_changed_files }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          has_changes="$ANY_CHANGED"
+          release=clusters/offsite/apps/spindrift/helm-release.yaml
+
+          # Continuous delivery only rewrites this image digest. The rest of
+          # the release is a conformance-test input and remains significant.
+          if [[ "$ALL_CHANGED_FILES" == "$release" ]] &&
+            git diff --quiet \
+              --ignore-matching-lines='^[[:space:]]*image: ghcr\.io/jonpulsifer/spindrift:latest@sha256:[[:xdigit:]]{64}$' \
+              "$BASE_SHA" "$HEAD_SHA" -- "$release"; then
+            has_changes=false
+          fi
+
+          echo "has_changes=$has_changes" >> "$GITHUB_OUTPUT"
 
   validate:
     needs: detect


### PR DESCRIPTION
## Summary
Skip the expensive TypeScript validation job for automated Spindrift image-digest-only changes while retaining conformance coverage for meaningful release configuration changes.

## Changes
- classify watched changes after the existing path filter
- ignore only an exact Spindrift image digest rewrite when it is the sole watched file
- fetch the comparison commits so pull-request and push events use the same content-aware check

## Test Plan
- [x] `nix run nixpkgs#actionlint -- .github/workflows/typescript.yml`
- [x] verify PR 1713's digest-only diff is ignored
- [x] verify a semantic HelmRelease diff remains TypeScript-relevant
- [x] `mise run validation-impact:test`
