### PR TITLE
feat(spindrift): let a job Component's schedule be changed or removed

### DIFF
--- a/apps/spindrift/src/commands/apps/delete.ts
+++ b/apps/spindrift/src/commands/apps/delete.ts
@@ -22,7 +22,10 @@
  * bookkeeping was being tidied would be the most destructive possible reading of
  * the request. What the operator gets instead is the list, before they confirm
  * and again afterwards, because after the rows are gone that list is the only
- * record that those workloads exist.
+ * record that those workloads exist — and each entry says whether it keeps
+ * *acting*, not merely sitting: a stranded service is inert, but a stranded
+ * `kind: job` Component with a `schedule` bills on every tick, forever, in a
+ * vessel project nobody is watching (`StrandedWorkload.firing`).
  *
  * **It does reap the config store**, and that is not the same thing. §10's
  * store items are per-key material this App put there and nothing else will ever
@@ -73,6 +76,18 @@ export interface StrandedWorkload {
   /** Where it is still running — the operator has to go there by hand. */
   readonly target: string;
   readonly url: string | null;
+  /**
+   * Whether this stranded workload keeps *acting* rather than merely sitting.
+   *
+   * A stranded service is inert until something calls it; a stranded
+   * `kind: job` Component with a `schedule` has a Cloud Scheduler job in front
+   * of it that fires on every tick forever, billed in a vessel project nobody
+   * is watching — the cost this review exists to make visible before the rows
+   * that name it are gone. Derived from the Component, not the Deploy: the
+   * cadence lives on `components.schedule`, and it is what fires regardless of
+   * which Build is live.
+   */
+  readonly firing: boolean;
 }
 
 /** What deleting this App does, whether or not it has been done yet. */
@@ -174,6 +189,8 @@ export const deleteApp: Command<DeleteAppInput, DeleteAppResult> = async (
             url: deploys.url,
             component: components.name,
             target: targets.name,
+            componentKind: components.kind,
+            schedule: components.schedule,
           })
           .from(deploys)
           .innerJoin(components, eq(deploys.componentId, components.id))
@@ -223,6 +240,7 @@ export const deleteApp: Command<DeleteAppInput, DeleteAppResult> = async (
       component: deploy.component,
       target: deploy.target,
       url: deploy.url,
+      firing: deploy.componentKind === 'job' && deploy.schedule !== null,
     })),
     detachedDatastores: attached.map((datastore) => datastore.name),
     configKeys: pinned.map(

--- a/apps/spindrift/src/commands/components/create.ts
+++ b/apps/spindrift/src/commands/components/create.ts
@@ -45,7 +45,7 @@ const componentName = z
  * parser here would be a second implementation of something core does not run,
  * and the two would eventually disagree about a Sunday.
  */
-const cronExpression = z
+export const cronExpression = z
   .string()
   .trim()
   .regex(

--- a/apps/spindrift/src/commands/components/schedule.ts
+++ b/apps/spindrift/src/commands/components/schedule.ts
@@ -1,0 +1,112 @@
+/**
+ * `setComponentSchedule` — change or remove a `kind: job` Component's cadence
+ * after creation (§2).
+ *
+ * `createComponent` writes `schedule` once, at creation, and nothing else ever
+ * wrote it — so the Cloud Run adapter's removal branch (`apply` unscheduling a
+ * job whose `desired.schedule` is absent, `src/adapters/deploy/cloudrun/index.ts:287-311`)
+ * was correct and unreachable: no command could ever produce a re-deploy whose
+ * `desired.schedule` differed from the one set at creation. This is that
+ * command, and it is deliberately narrow — the one field `createComponent`
+ * could not make editable without becoming an edit command itself.
+ *
+ * **Same shape as `setComponentReach`, for the same reasons.** This is a
+ * deploy, not a settings toggle: `desiredStateFor`
+ * (`src/reconciler/deploy-loop.ts:280`) reads `component.schedule` fresh on
+ * every attempt, so writing this row changes nothing that is currently
+ * running — the Cloud Scheduler job in front of a live Deploy keeps firing on
+ * the old cadence until somebody presses Deploy again. `pendingRelease` names
+ * where that is still true.
+ *
+ * **`null` removes it, and is required rather than optional.** `createComponent`
+ * defaults an absent `schedule` to "unscheduled" because that is what silence
+ * means at creation; an edit has no such fallback; §9's `setComponentReach`
+ * comment is the same argument — an omitted field on an edit reads as "leave
+ * it alone", so removing a schedule has to be said, not implied by leaving it
+ * out.
+ *
+ * **Unlike `reach`/`auth`, there is no `deploys.schedule` pin to diff
+ * against** — no attempt ever needed one, because nothing about a job's
+ * cadence has to survive a rollback the way a released reach does. So
+ * `pendingRelease` cannot tell "this Target's live release already fires on
+ * the new cadence" from "it does not" the way `setComponentReach` can; it
+ * conservatively names every Target this Component is placed on. Pressing
+ * Deploy on a Target that happened to already match is a no-op release, not a
+ * wrong one.
+ */
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { components } from '../../db/schema.ts';
+import { type Command, failed, ok } from '../types.ts';
+import { cronExpression } from './create.ts';
+
+export const setComponentScheduleInput = z
+  .object({
+    componentId: z.uuid(),
+    /** The new cron expression, or `null` to leave the job unscheduled. */
+    schedule: cronExpression.nullable(),
+  })
+  .strict();
+
+export type SetComponentScheduleInput = z.infer<
+  typeof setComponentScheduleInput
+>;
+
+export interface SetComponentScheduleResult {
+  readonly componentId: string;
+  readonly schedule: string | null;
+  /**
+   * The Targets this Component is placed on, by name and sorted — press
+   * Deploy on each to put the new cadence (or its removal) in front of what is
+   * currently running there. See the module comment for why this cannot be
+   * narrowed the way `setComponentReach`'s equivalent is.
+   */
+  readonly pendingRelease: readonly string[];
+}
+
+export const setComponentSchedule: Command<
+  SetComponentScheduleInput,
+  SetComponentScheduleResult
+> = async (input, context) => {
+  const [row] = await context.db
+    .select()
+    .from(components)
+    .where(eq(components.id, input.componentId));
+  if (row === undefined) {
+    return failed(
+      'NOT_FOUND',
+      `there is no Component with id ${input.componentId}`,
+    );
+  }
+  if (row.kind !== 'job') {
+    return failed(
+      'INVALID_INPUT',
+      `'${row.name}' is a ${row.kind}, and only a job Component has a schedule`,
+      [{ path: 'componentId', message: 'not a job Component' }],
+    );
+  }
+
+  const [updated] = await context.db
+    .update(components)
+    .set({ schedule: input.schedule, updatedAt: context.clock.now() })
+    .where(eq(components.id, input.componentId))
+    .returning();
+
+  const placed = await context.db.query.componentTargetDesired.findMany({
+    where: (desired, { eq }) => eq(desired.componentId, row.id),
+    with: { target: { columns: { name: true } } },
+  });
+
+  return ok({
+    componentId: updated!.id,
+    schedule: updated!.schedule,
+    // Only a pair a Deploy actually reached — `componentTargetDesired` also
+    // holds rows `createDeploy` inserted and then left with `desiredDeployId`
+    // null because that first attempt was vetoed (`src/commands/deploys/create.ts:185-211`),
+    // and nothing is running at those, so nothing there is pending.
+    pendingRelease: placed
+      .filter((desired) => desired.desiredDeployId !== null)
+      .map(({ target }) => target.name)
+      .sort(),
+  });
+};

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -30,6 +30,7 @@ export { createComponent } from './components/create.ts';
 export { placeComponent } from './components/place.ts';
 export { setComponentReach } from './components/reach.ts';
 export { runComponent } from './components/run.ts';
+export { setComponentSchedule } from './components/schedule.ts';
 export { replaceConfig } from './config/replace.ts';
 export { setConfig } from './config/set.ts';
 export {

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -49,6 +49,10 @@ import {
   setComponentReachInput,
 } from './components/reach.ts';
 import { runComponent, runComponentInput } from './components/run.ts';
+import {
+  setComponentSchedule,
+  setComponentScheduleInput,
+} from './components/schedule.ts';
 import { replaceConfig, replaceConfigInput } from './config/replace.ts';
 import { setConfig, setConfigInput } from './config/set.ts';
 import {
@@ -209,6 +213,10 @@ export const commandRegistry = {
     handler: setComponentReach,
   },
   runComponent: { input: runComponentInput, handler: runComponent },
+  setComponentSchedule: {
+    input: setComponentScheduleInput,
+    handler: setComponentSchedule,
+  },
   setConfig: { input: setConfigInput, handler: setConfig },
   configureInstallation: {
     input: configureInstallationInput,

--- a/apps/spindrift/test/commands/component-schedule.test.ts
+++ b/apps/spindrift/test/commands/component-schedule.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Changing or removing a `kind: job` Component's cadence after creation (75,
+ * §2, §6).
+ *
+ * `components.schedule` was write-once — `createComponent` was its only
+ * writer — so the Cloud Run adapter's removal branch (an `apply` whose
+ * `desired.schedule` is absent, `src/adapters/deploy/cloudrun/index.ts:287-311`)
+ * could never be reached by any command: nothing could ever produce a
+ * re-deploy whose schedule differed from the one set at creation. Three claims
+ * here, and the last is the one that answers the ticket's own criterion:
+ *
+ * - **A non-job Component has nothing to schedule.** The refusal is a
+ *   `NOT_FOUND`-shaped `INVALID_INPUT`, matching `runComponent`'s.
+ * - **The edit writes the Component and leaves a Deploy to be pressed.**
+ *   Nothing already running changes — `pendingRelease` names where it has not
+ *   yet.
+ * - **A re-deploy after removing the schedule reaches the adapter with
+ *   `desired.schedule` absent.** This is the box: the removal branch that used
+ *   to be unreachable through any command is now reachable through this one.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import {
+  createDeploy,
+  setComponentSchedule,
+} from '../../src/commands/index.ts';
+import { dispatch } from '../../src/commands/registry.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { apps, builds, components, targets } from '../../src/db/schema.ts';
+import {
+  type DeployLoopContext,
+  runDeployPass,
+} from '../../src/reconciler/deploy-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+const DIGEST = `sha256:${'a'.repeat(64)}`;
+
+function registryOf(deployAdapter: FakeDeployAdapter): AdapterRegistry {
+  const chain = new SupplyChainHarness();
+  return {
+    deploy: (adapter) =>
+      adapter === deployAdapter.adapter ? deployAdapter : null,
+    build: () => {
+      throw new Error('a schedule edit must not reach a builder');
+    },
+    store: () => {
+      throw new Error('a schedule edit must not reach the secret store');
+    },
+    repository: () => null,
+    supplyChain: () => chain,
+  };
+}
+
+function context(adapters: AdapterRegistry): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+function loopContext(adapter: FakeDeployAdapter): DeployLoopContext {
+  return {
+    db: database().db,
+    adapters: { deploy: (name) => (name === adapter.adapter ? adapter : null) },
+    clock,
+    manifest,
+  };
+}
+
+/** An App with one Component of the given kind, a cluster Target, a Build. */
+async function fixture(
+  kind: 'job' | 'service' = 'job',
+  schedule: string | null = '0 3 * * *',
+) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'batch', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({
+      appId: app!.id,
+      name: 'nightly',
+      kind,
+      schedule: kind === 'job' ? schedule : null,
+      reach: 'none',
+      auth: 'none',
+    })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        name: `cloudrun-${crypto.randomUUID()}`,
+        adapter: 'kubernetes',
+        discovery: null,
+      }),
+    )
+    .returning();
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'abcdef0',
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: DIGEST,
+      bundleDigest: DIGEST,
+      bundleLocation: 'https://depot.example.test/bundles/1.zip',
+      status: 'SUCCEEDED',
+      verifiedBuildLevel: 2,
+      signature: testSignature(DIGEST, FROZEN.toISOString()),
+    })
+    .returning();
+  return { app: app!, component: component!, target: target!, build: build! };
+}
+
+async function componentRow(id: string) {
+  const [row] = await database()
+    .db.select()
+    .from(components)
+    .where(eq(components.id, id));
+  return row;
+}
+
+describe('only a job Component has a schedule to change', () => {
+  test('a service is refused, naming the field', async () => {
+    const { component } = await fixture('service', null);
+
+    const refused = await dispatch(
+      'setComponentSchedule',
+      { componentId: component.id, schedule: '0 3 * * *' },
+      context(registryOf(new FakeDeployAdapter())),
+    );
+
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.failure.code).toBe('INVALID_INPUT');
+  });
+
+  test('an unknown Component is a refusal with an identity', async () => {
+    const missing = crypto.randomUUID();
+    const result = await setComponentSchedule(
+      { componentId: missing, schedule: null },
+      context(registryOf(new FakeDeployAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+    expect(result.failure.message).toContain(missing);
+  });
+});
+
+describe('the edit writes a Component and leaves a Deploy to be pressed', () => {
+  test('a Component that has never been placed has nothing serving the old cadence', async () => {
+    const { component } = await fixture('job', '0 3 * * *');
+
+    const result = await setComponentSchedule(
+      { componentId: component.id, schedule: null },
+      context(registryOf(new FakeDeployAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pendingRelease).toEqual([]);
+    const row = await componentRow(component.id);
+    expect(row?.schedule).toBeNull();
+    expect(row?.updatedAt).toEqual(FROZEN);
+  });
+
+  test('a Target already placed is named, and nothing is deployed', async () => {
+    const { component, target, build } = await fixture('job', '0 3 * * *');
+    const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
+    const adapters = registryOf(adapter);
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    await runDeployPass(loopContext(adapter));
+    expect(adapter.applied).toHaveLength(1);
+
+    const result = await setComponentSchedule(
+      { componentId: component.id, schedule: null },
+      context(adapters),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.pendingRelease).toEqual([target.name]);
+    // Same rule as `setComponentReach`: writing the row asks the platform for
+    // nothing. A second `apply` here would be this command re-placing a live
+    // release nobody pressed Deploy for.
+    expect(adapter.applied).toHaveLength(1);
+  });
+});
+
+describe('a re-deploy is what reaches the adapter (75)', () => {
+  test('removing the schedule and pressing Deploy hands the adapter an absent schedule', async () => {
+    const { component, target, build } = await fixture('job', '0 3 * * *');
+    const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
+    const adapters = registryOf(adapter);
+
+    const first = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    expect(first.ok).toBe(true);
+    await runDeployPass(loopContext(adapter));
+    expect(adapter.applied).toHaveLength(1);
+    // The Component still declares its schedule at the first attempt: proves
+    // the fixture, not the fix.
+    expect(adapter.applied[0]?.desired.schedule).toBe('0 3 * * *');
+
+    const edited = await setComponentSchedule(
+      { componentId: component.id, schedule: null },
+      context(adapters),
+    );
+    expect(edited.ok).toBe(true);
+
+    const second = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    expect(second.ok).toBe(true);
+    await runDeployPass(loopContext(adapter));
+
+    expect(adapter.applied).toHaveLength(2);
+    // The removal branch: no command could ever produce this before —
+    // `components.schedule` was write-once, so `desired.schedule` could never
+    // differ from what `createComponent` set. Revert this file's registration
+    // (drop `setComponentSchedule` from the registry, or make its input
+    // schema default `schedule` to the old value) and this assertion is what
+    // goes red, because nothing would ever have written `null` onto the row.
+    expect(adapter.applied[1]?.desired.schedule).toBeUndefined();
+  });
+
+  test('setting a new cadence and pressing Deploy hands the adapter the new one', async () => {
+    const { component, target, build } = await fixture('job', '0 3 * * *');
+    const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
+    const adapters = registryOf(adapter);
+
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    await runDeployPass(loopContext(adapter));
+
+    const edited = await setComponentSchedule(
+      { componentId: component.id, schedule: '0 9 * * 1' },
+      context(adapters),
+    );
+    expect(edited.ok).toBe(true);
+    if (!edited.ok) return;
+    expect(edited.value.schedule).toBe('0 9 * * 1');
+
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: build.id },
+      context(adapters),
+    );
+    await runDeployPass(loopContext(adapter));
+
+    expect(adapter.applied).toHaveLength(2);
+    expect(adapter.applied[1]?.desired.schedule).toBe('0 9 * * 1');
+  });
+});

--- a/apps/spindrift/test/commands/delete-app.test.ts
+++ b/apps/spindrift/test/commands/delete-app.test.ts
@@ -109,7 +109,12 @@ async function seedTarget(name: string) {
  */
 async function seedApp(
   name: string,
-  options: { targetId?: string; phase?: 'LIVE' | 'FAILED' } = {},
+  options: {
+    targetId?: string;
+    phase?: 'LIVE' | 'FAILED';
+    kind?: 'service' | 'job';
+    schedule?: string | null;
+  } = {},
 ) {
   const db = database().db;
   const [app] = await db
@@ -118,7 +123,12 @@ async function seedApp(
     .returning();
   const [component] = await db
     .insert(components)
-    .values({ appId: app!.id, name: 'web', kind: 'service' })
+    .values({
+      appId: app!.id,
+      name: 'web',
+      kind: options.kind ?? 'service',
+      schedule: options.schedule ?? null,
+    })
     .returning();
 
   if (options.targetId === undefined) {
@@ -279,6 +289,7 @@ describe('a live workload is named and left running', () => {
         component: 'web',
         target: 'folly',
         url: 'web.example.test',
+        firing: false,
       },
     ]);
 
@@ -295,6 +306,44 @@ describe('a live workload is named and left running', () => {
     // §13's rule, verbatim: no adapter was ever constructed, so nothing was
     // torn down.
     expect(built().size).toBe(0);
+  });
+
+  test('a scheduled job is named as one that keeps firing', async () => {
+    const target = await seedTarget('folly');
+    await seedApp('bills-forever', {
+      targetId: target.id,
+      kind: 'job',
+      schedule: '0 3 * * *',
+    });
+    const { registry } = fakes();
+
+    const review = await deleteApp(
+      { name: 'bills-forever', confirm: false },
+      context(registry),
+    );
+
+    expect(review.ok).toBe(true);
+    if (!review.ok) return;
+    // The point of this box: a stranded schedule is not merely sitting there
+    // like a stranded service — it bills on every tick, so the review has to
+    // say so before the rows that name it are gone.
+    expect(review.value.stranded).toHaveLength(1);
+    expect(review.value.stranded[0]?.firing).toBe(true);
+  });
+
+  test('an unscheduled job is stranded but not firing', async () => {
+    const target = await seedTarget('folly');
+    await seedApp('idle-job', { targetId: target.id, kind: 'job' });
+    const { registry } = fakes();
+
+    const review = await deleteApp(
+      { name: 'idle-job', confirm: false },
+      context(registry),
+    );
+
+    expect(review.ok).toBe(true);
+    if (!review.ok) return;
+    expect(review.value.stranded[0]?.firing).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- `components.schedule` was write-once — `createComponent` was its only writer — so the Cloud Run adapter's removal branch (`apply` unscheduling a job whose `desired.schedule` is absent, `apps/spindrift/src/adapters/deploy/cloudrun/index.ts:287-311`) was correct but unreachable through any command.
- Adds `setComponentSchedule` (`apps/spindrift/src/commands/components/schedule.ts`), shaped like `setComponentReach`: it writes the Component's `schedule` (or `null` to remove it) and names the Targets a fresh Deploy is needed on. `desiredStateFor` (`apps/spindrift/src/reconciler/deploy-loop.ts:280`) already reads `component.schedule` fresh on every attempt, so no reconciler or adapter change was needed — pressing Deploy after this edit is what reaches the adapter's existing removal branch.
- `deleteApp`'s stranding review (`apps/spindrift/src/commands/apps/delete.ts`) now names which stranded workloads keep *firing*: a stranded service is inert, but a stranded `kind: job` Component with a `schedule` has a Cloud Scheduler job in front of it that bills on every tick, forever, in a vessel project nobody is watching. `StrandedWorkload` gains a `firing` field derived from the Component's `kind` and `schedule`.

## Test plan

- [x] `bun test` — 1620 pass, 2 pre-existing `test/db/migrate.test.ts` hook-timeout flakes unrelated to this change (reproduces on `main`)
- [x] `bun run typecheck`
- [x] `bun run lint` — clean on every file this PR touches; two pre-existing findings in files this PR does not touch (`test/adapters/publishable-registries.test.ts`, `src/commands/builds/route.ts`)
- [x] `mise run ts:check` from the repo root
- [x] Reverted the write in `setComponentSchedule` and watched `test/commands/component-schedule.test.ts` go red (3 of 6 tests failed, including the one asserting the adapter receives an absent schedule on re-deploy)
- [x] Reverted the `firing` derivation in `deleteApp` and watched the new `test/commands/delete-app.test.ts` case go red

🤖 Generated with [Claude Code](https://claude.com/claude-code)