### PR TITLE
fix(spindrift): seed a chart-only install's own relying party

### DIFF
--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -230,7 +230,7 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * a session exists. A predicate whose one `true` sits behind a door that cannot
  * open is a wizard nobody can be shown.
  *
- * **What that actually makes reachable, and it is not yet the ordinary case.** A
+ * **What that actually makes reachable, and it is now the ordinary case.** A
  * declaration carrying a real `controlPlane.hostname` with these four left at
  * their stand-ins answers `true` and *can* enrol somebody, so the reachable set
  * is no longer empty. It is not a document anybody writes by accident: nothing
@@ -242,9 +242,14 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * the deployment facts it already holds, `controlPlane.hostname` above all, so
  * that the *placeholder* — what an installation with no declaration at all is
  * seeded with — is itself an installation a browser will run a ceremony
- * against. That is a change to the chart, not to this predicate, and until it
- * lands the honest statement is: a seeded declaration reaches the wizard, a bare
- * `manifest: {}` install still cannot sign in to be shown it.
+ * against: a bare `manifest: {}` release with a `hostname` renders
+ * `files/default-manifest.yaml` (`packages/charts/spindrift`) in place of the
+ * stored row's fallback, and that document is this same
+ * `DEFAULT_PLACEHOLDER_MANIFEST` with `controlPlane.hostname` bound to the
+ * release's own instead of `spindrift.example.com`. A seeded declaration and a
+ * bare `manifest: {}` install both reach the wizard now; only a release with
+ * neither a declaration nor a `hostname` — in-cluster-only, nothing to bind a
+ * relying party to — still cannot.
  *
  * **All four, not any**, and a false positive here replaces the whole product
  * with a wizard, so the direction matters. Two of the four are legitimately the

--- a/apps/spindrift/test/conformance/chart-only-enrolment.test.ts
+++ b/apps/spindrift/test/conformance/chart-only-enrolment.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Ticket 77: a chart-only install seeds a manifest whose relying party is the
+ * hostname it actually serves.
+ *
+ * `packages/charts/spindrift/files/default-manifest.yaml` is a second, chart-side
+ * copy of `DEFAULT_PLACEHOLDER_MANIFEST` — templated with the release's own
+ * `controlPlane.hostname` in place of the code's `spindrift.example.com`, so a
+ * release with no `manifest:` value and a `hostname` seeds a document whose
+ * passkey relying party is the origin the release is actually served at rather
+ * than a name no browser on that origin can complete a ceremony against
+ * (`src/web/serve.ts:210-213` binds the relying party to whichever hostname the
+ * seeded document carries).
+ *
+ * A second copy of the placeholder is exactly the shape 33 spent a ticket
+ * refusing to let drift — every other manifest fact the chart could restate is
+ * instead derived or refused at render time. This one is kept anyway because
+ * `hostname` is the one deployment fact the *code's* placeholder cannot know at
+ * import time (it is a release value, not a constant), so unlike
+ * `cloud.federation` or `controlPlane.hostname` in an operator's own
+ * declaration, there is no credential or Values field this chart renders that
+ * the manifest could instead read back. What is not accepted is the drift: this
+ * suite diffs the chart's file against the code's constant on every run, so a
+ * value changed in one without the other is a red test rather than a wizard
+ * nobody can reach.
+ */
+import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
+import {
+  DEFAULT_PLACEHOLDER_MANIFEST,
+  isUnconfiguredInstallation,
+  validateManifest,
+} from '../../src/config/manifest.ts';
+
+/** The repository root, for reading the chart's copy of the placeholder. */
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+const DEFAULT_MANIFEST_FILE = join(
+  REPO_ROOT,
+  'packages/charts/spindrift/files/default-manifest.yaml',
+);
+
+/**
+ * The chart's file is a Helm template, not standalone YAML — its one
+ * substitution is `{{ .Values.hostname | quote }}` at `controlPlane.hostname`.
+ * Standing in for what `tpl` would render with the code's own placeholder
+ * hostname turns "the chart's copy" and "the code's copy" into the same
+ * document, so a plain deep-equal is the whole check: no Helm binary, no
+ * `helm template` invocation, just the text this repository already carries.
+ */
+async function renderedDefaultManifest(): Promise<unknown> {
+  const raw = await Bun.file(DEFAULT_MANIFEST_FILE).text();
+  const rendered = raw.replace(
+    '{{ .Values.hostname | quote }}',
+    JSON.stringify(DEFAULT_PLACEHOLDER_MANIFEST.controlPlane.hostname),
+  );
+  expect(rendered).not.toContain('{{');
+  return Bun.YAML.parse(rendered);
+}
+
+describe('the chart-only default manifest matches the code copy', () => {
+  test('is byte-for-byte the placeholder once the hostname substitution is applied', async () => {
+    expect(await renderedDefaultManifest()).toEqual(
+      DEFAULT_PLACEHOLDER_MANIFEST,
+    );
+  });
+
+  test('is valid against the schema the process boots with', async () => {
+    // Proves box 1 structurally: nothing in `installationManifestSchema` is
+    // optional, so a chart-side copy that drifted a key out of existence would
+    // refuse here rather than crash-looping a fresh installation instead.
+    const rendered = await renderedDefaultManifest();
+    expect(() =>
+      validateManifest(rendered, 'chart default manifest'),
+    ).not.toThrow();
+  });
+
+  test('still answers isUnconfiguredInstallation, so a chart-only install lands on onboarding', async () => {
+    // Box 2. The four genuine choices — installation, github.clientId,
+    // secretStore.adapter, supplyChain.registry — are untouched by the
+    // hostname substitution, so the seeded document reads exactly as
+    // unconfigured as `DEFAULT_PLACEHOLDER_MANIFEST` itself does.
+    const seeded = validateManifest(
+      await renderedDefaultManifest(),
+      'chart default manifest',
+    );
+    expect(isUnconfiguredInstallation(seeded)).toBe(true);
+  });
+
+  test('a hostname the code placeholder does not carry still reads as unconfigured', async () => {
+    // The substitution above proves equality only at the code's own stand-in
+    // hostname. A real release's hostname is never that string, so this is the
+    // case that actually ships: the relying party changes, the four genuine
+    // choices do not, and the predicate must still answer true.
+    const raw = await Bun.file(DEFAULT_MANIFEST_FILE).text();
+    const rendered = raw.replace(
+      '{{ .Values.hostname | quote }}',
+      JSON.stringify('spindrift.lolwtf.ca'),
+    );
+    const seeded = validateManifest(
+      Bun.YAML.parse(rendered),
+      'chart default manifest',
+    );
+    expect(seeded.controlPlane.hostname).toBe('spindrift.lolwtf.ca');
+    expect(isUnconfiguredInstallation(seeded)).toBe(true);
+  });
+});

--- a/packages/charts/spindrift/files/default-manifest.yaml
+++ b/packages/charts/spindrift/files/default-manifest.yaml
@@ -1,0 +1,87 @@
+# The chart's own copy of `DEFAULT_PLACEHOLDER_MANIFEST`
+# (apps/spindrift/src/config/manifest.ts), templated with this release's own
+# `controlPlane.hostname` in place of the code's `spindrift.example.com`.
+#
+# `spindrift.manifest.content` (templates/_helpers.tpl) renders this file
+# through `tpl` in place of an operator declaration when a release sets no
+# `manifest` value but does set `hostname` — the chart-only install path
+# ticket 77 exists for. Every key below except `controlPlane.hostname` must
+# stay byte-for-byte the placeholder the code seeds an unseeded installation
+# with, because `isUnconfiguredInstallation` (manifest.ts) reads four of these
+# keys against that exact document to decide whether the first operator lands
+# on onboarding or an Overview of nothing — a value changed here without its
+# twin changing there is a wizard nobody can reach, silently. The conformance
+# test at apps/spindrift/test/conformance/chart-only-enrolment.test.ts diffs
+# this file against the code's copy so that drift is a red test rather than a
+# live surprise.
+installation: default
+controlPlane:
+  hostname: {{ .Values.hostname | quote }}
+auth:
+  gateway: null
+dns:
+  zones:
+    private: example.com
+    public: example.com
+sources:
+  buckets:
+    - bluenose-spindrift-source
+  defaultBucket: bluenose-spindrift-source
+cloud:
+  artifactsProject: spindrift-artifacts
+  homeVesselProject: spindrift-vessel
+charts:
+  app: packages/charts/spindrift-app
+supplyChain:
+  registry:
+    - ghcr.io/spindrift
+  verifier: ghcr.io/spindrift/spindrift-verifier
+  signer: gcpkms://projects/spindrift-artifacts/locations/us-central1/keyRings/keys/cryptoKeys/signer
+github:
+  clientId: Iv1.918d699f36ee7afc
+  oauthBaseUrl: https://github.com
+  apiBaseUrl: https://api.github.com
+  buildWorkflow: spindrift/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
+build:
+  routes:
+    - name: hosted
+      adapter: github-actions
+  # The one value in this document that is not a placeholder — see the doc
+  # comment on `DEFAULT_PLACEHOLDER_MANIFEST.build.zeroConfigFrontend`.
+  zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
+secretStore:
+  adapter: onepassword
+  endpoint: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+  container: spindrift-vault
+vessels:
+  - name: primary
+    kind: cluster
+    location:
+      apiServer: https://kubernetes.default.svc
+  - name: spindrift
+    kind: gcp-project
+    location:
+      project: spindrift-vessel
+targets:
+  - name: primary
+    vessel: primary
+    adapter: kubernetes
+    connection:
+      namespace: spindrift-apps
+      delivery:
+        flavour: flux-helmrelease
+        namespace: spindrift-apps
+        sourceRef:
+          name: infra
+          namespace: flux-system
+  - name: spindrift-cloudrun
+    vessel: spindrift
+    adapter: cloudrun
+    connection:
+      region: spindrift-region
+      endpoint: https://run.googleapis.com
+  - name: spindrift-static
+    vessel: spindrift
+    adapter: static
+    connection:
+      endpoint: https://firebasehosting.googleapis.com

--- a/packages/charts/spindrift/templates/_helpers.tpl
+++ b/packages/charts/spindrift/templates/_helpers.tpl
@@ -44,3 +44,41 @@ unrelated chart revision leaves the completed Job alone.
 {{- $digest := toJson $inputs | sha256sum | trunc 20 -}}
 {{ include "spindrift.fullname" . }}-migrate-{{ $digest }}
 {{- end }}
+
+{{/*
+The manifest document this release seeds, as YAML text — empty when there is
+none.
+
+Two sources, in order. An operator's own declaration (`.Values.manifest`)
+wins whenever it is set. Absent that, a release with a `hostname` seeds
+`files/default-manifest.yaml` instead: the chart's own copy of the code's
+`DEFAULT_PLACEHOLDER_MANIFEST`, templated with this release's own
+`controlPlane.hostname` in place of the code's `spindrift.example.com`.
+
+Ticket 77: a bare `manifest: {}` release used to seed nothing, so
+`loadStoredManifest` fell through to the code's placeholder — whose
+`controlPlane.hostname` is `spindrift.example.com`, not this release's own —
+and `serve.ts` binds the passkey relying party to whatever hostname the seeded
+document carries. A browser refuses a ceremony whose relying-party id is not
+the origin it began at, so the first operator could never sign in far enough
+to reach onboarding. Seeding the deployment's own hostname here, rather than
+correcting it after the fact in the process, keeps one authority for what an
+installation manifest *is* — a document the chart renders or an operator
+authors, never edited by a second writer once it reaches Postgres (`manifest.ts`,
+`isUnconfiguredInstallation`) — at the cost of this second copy of the
+placeholder, which the conformance test at
+`apps/spindrift/test/conformance/chart-only-enrolment.test.ts` diffs against
+the code's own so the two cannot drift apart unnoticed.
+
+No `hostname` and no declaration is still empty, which is the release's own
+"no manifest at all" case: an in-cluster-only installation with neither has no
+origin to seed a relying party at, and every template gated on this stays
+exactly as unrendered as it was before this existed.
+*/}}
+{{- define "spindrift.manifest.content" -}}
+{{- if .Values.manifest -}}
+{{- toYaml .Values.manifest -}}
+{{- else if .Values.hostname -}}
+{{- tpl (.Files.Get "files/default-manifest.yaml") . -}}
+{{- end -}}
+{{- end }}

--- a/packages/charts/spindrift/templates/deployment.yaml
+++ b/packages/charts/spindrift/templates/deployment.yaml
@@ -7,6 +7,11 @@ The reconciler serves nothing, so it gets no port and no probe: a loop that
 claims work with `SELECT … FOR UPDATE SKIP LOCKED` has no readiness to report.
 */}}
 {{- $top := . -}}
+{{/* See spindrift.manifest.content (_helpers.tpl): a declaration verbatim,
+the chart-only seed of files/default-manifest.yaml, or empty. Computed once
+so the checksum, the mount and the env var below all gate on and hash exactly
+what manifest.yaml renders. */}}
+{{- $manifestContent := include "spindrift.manifest.content" $top -}}
 {{- $processes := list (dict "name" "web" "command" "src/web/server.ts" "replicas" .Values.web.replicas "resources" .Values.web.resources "serves" true "federates" true) -}}
 {{- if .Values.reconciler.enabled -}}
 {{- $processes = append $processes (dict "name" "reconciler" "command" "src/reconciler/main.ts" "replicas" .Values.reconciler.replicas "resources" .Values.reconciler.resources "serves" false "federates" true) -}}
@@ -50,11 +55,11 @@ spec:
       {{- include "spindrift.selectorLabels" (dict "Release" $top.Release "Values" $top.Values "Chart" $top.Chart "component" $process.name) | nindent 6 }}
   template:
     metadata:
-      {{- if $top.Values.manifest }}
+      {{- if $manifestContent }}
       annotations:
         # Both processes read the manifest once, at start, so a ConfigMap change
         # has to become a rollout.
-        checksum/manifest: {{ toYaml $top.Values.manifest | sha256sum }}
+        checksum/manifest: {{ $manifestContent | sha256sum }}
       {{- end }}
       labels:
         {{- include "spindrift.labels" $top | nindent 8 }}
@@ -128,7 +133,7 @@ spec:
               value: {{ printf "%s/gcp-credentials.json" $top.Values.serviceAccount.token.mountPath | quote }}
             {{- end }}
             {{- end }}
-            {{- if $top.Values.manifest }}
+            {{- if $manifestContent }}
             # Named explicitly, so a declaration that fails to mount is fatal
             # rather than falling back to the durable row.
             - name: SPINDRIFT_MANIFEST_PATH
@@ -168,7 +173,7 @@ spec:
           volumeMounts:
             - name: tmp
               mountPath: /tmp
-            {{- if $top.Values.manifest }}
+            {{- if $manifestContent }}
             - name: manifest
               mountPath: /etc/spindrift
               readOnly: true
@@ -193,7 +198,7 @@ spec:
       volumes:
         - name: tmp
           emptyDir: {}
-        {{- if $top.Values.manifest }}
+        {{- if $manifestContent }}
         - name: manifest
           configMap:
             name: {{ include "spindrift.fullname" $top }}-manifest

--- a/packages/charts/spindrift/templates/manifest.yaml
+++ b/packages/charts/spindrift/templates/manifest.yaml
@@ -1,13 +1,21 @@
 {{/*
-The installation manifest, declared by the release.
+The installation manifest, declared by the release — or, absent a
+declaration, seeded from `files/default-manifest.yaml` when this release has
+a `hostname` to bind the passkey relying party to. See
+`spindrift.manifest.content` in `_helpers.tpl` for which case applies, and
+ticket 77 for why the seeded case exists.
 
 **A declaration seeds; it does not govern.** `loadStoredManifest` takes the
 stored row whenever one exists and this document only when none does, so
-editing it does nothing to a seeded installation. Empty declares nothing.
+editing it does nothing to a seeded installation. Rendering neither declares
+nothing.
 
 **A declaration may not restate what this chart already renders.** The refusals
-below reject a manifest carrying a fact this chart owns, at render time — the
-earliest the two copies can be compared and the only place being wrong is free.
+below reject an operator's manifest carrying a fact this chart owns, at render
+time — the earliest the two copies can be compared and the only place being
+wrong is free. They run only against `.Values.manifest`: the seeded default
+document is this chart's own copy of the placeholder, built to already agree
+with `.Values.hostname`, so there is nothing for it to disagree with.
 */}}
 {{- if .Values.manifest }}
 {{- if dig "cloud" "federation" nil .Values.manifest }}
@@ -20,6 +28,9 @@ earliest the two copies can be compared and the only place being wrong is free.
 {{- if and .Values.hostname $declaredHostname (ne $declaredHostname .Values.hostname) }}
 {{- fail (printf "manifest.controlPlane.hostname is %q but this release serves the control plane at %q. It is the passkey relying-party id, so the disagreement would enrol nobody: a ceremony is scoped to the origin it began at, and the origin is the one the HTTPRoute answers on." $declaredHostname .Values.hostname) }}
 {{- end }}
+{{- end }}
+{{- $manifestContent := include "spindrift.manifest.content" . }}
+{{- if $manifestContent }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -32,5 +43,5 @@ data:
   # The filename the process looks for. It is mounted at the directory so the
   # key lands at the path `DEFAULT_MANIFEST_PATH` names.
   manifest.yaml: |-
-    {{- toYaml .Values.manifest | nindent 4 }}
+    {{- $manifestContent | nindent 4 }}
 {{- end }}

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -488,6 +488,77 @@ describe('the relying party and the front door cannot disagree', () => {
   });
 });
 
+describe('a chart-only install seeds its own relying party', () => {
+  // Ticket 77: `manifest: {}` with a `hostname` used to render no ConfigMap
+  // at all, so `loadStoredManifest` fell through to the code's own
+  // placeholder — `spindrift.example.com` — and no browser on this release's
+  // real origin can complete a passkey ceremony against it. See
+  // `spindrift.manifest.content` in `_helpers.tpl` for the precedence and
+  // `apps/spindrift/test/conformance/chart-only-enrolment.test.ts` for the
+  // proof that this document still agrees with the code's copy everywhere
+  // except the hostname.
+  test('renders a default manifest naming this release as the relying party, when none is declared', async () => {
+    const objects = await render({ hostname: 'spindrift.example.test' });
+    const configMap = one(objects, 'ConfigMap', 'spindrift-manifest');
+    const seeded = Bun.YAML.parse(
+      configMap.data?.['manifest.yaml'] ?? '',
+    ) as Record<string, unknown>;
+    expect(seeded.controlPlane).toEqual({
+      hostname: 'spindrift.example.test',
+    });
+    // The genuine choices stay at their stand-ins, so the seeded document is
+    // still one `isUnconfiguredInstallation` (apps/spindrift/src/config/manifest.ts)
+    // reads as unconfigured.
+    expect(seeded.installation).toBe('default');
+    expect((seeded.github as { clientId?: string }).clientId).toBe(
+      'Iv1.918d699f36ee7afc',
+    );
+    expect((seeded.secretStore as { adapter?: string }).adapter).toBe(
+      'onepassword',
+    );
+    expect((seeded.supplyChain as { registry?: string[] }).registry).toEqual([
+      'ghcr.io/spindrift',
+    ]);
+
+    const web = one(objects, 'Deployment', 'spindrift-web');
+    const pod = web.spec.template.spec;
+    expect(
+      pod.containers[0].env.some(
+        (item: { name: string }) => item.name === 'SPINDRIFT_MANIFEST_PATH',
+      ),
+    ).toBe(true);
+    expect(
+      pod.volumes.some((v: { name: string }) => v.name === 'manifest'),
+    ).toBe(true);
+  });
+
+  test('renders no manifest ConfigMap for a hostless, undeclared release', async () => {
+    // The in-cluster-only shape stays exactly as unreachable-by-default as it
+    // was: no hostname means no deployment fact to seed a relying party from,
+    // so this release still renders nothing rather than a document naming an
+    // empty string.
+    const objects = await render();
+    expect(
+      objects.some((object) => object.metadata.name === 'spindrift-manifest'),
+    ).toBe(false);
+  });
+
+  test('an explicit declaration still wins over the seeded default', async () => {
+    const objects = await render({
+      hostname: 'spindrift.example.test',
+      manifest: {
+        installation: 'declared',
+        controlPlane: { hostname: 'spindrift.example.test' },
+      },
+    });
+    const configMap = one(objects, 'ConfigMap', 'spindrift-manifest');
+    expect(Bun.YAML.parse(configMap.data?.['manifest.yaml'] ?? '')).toEqual({
+      installation: 'declared',
+      controlPlane: { hostname: 'spindrift.example.test' },
+    });
+  });
+});
+
 describe('the trust store', () => {
   const federated = (caConfigMap?: string) => ({
     reconciler: { enabled: true },


### PR DESCRIPTION
## Summary

- A release deployed with no `manifest:` value and a `hostname` used to render no ConfigMap at all, so `loadStoredManifest` fell through to the code's own placeholder — whose `controlPlane.hostname` is `spindrift.example.com`. The passkey relying party binds to that hostname at boot, and a browser refuses a ceremony whose relying-party id is not the origin it began at, so the first operator could never sign in far enough to reach onboarding.
- The installer chart now seeds `packages/charts/spindrift/files/default-manifest.yaml` — its own copy of `DEFAULT_PLACEHOLDER_MANIFEST`, templated with the release's own `controlPlane.hostname` — whenever a release declares no manifest but has a hostname to bind a relying party to. The four genuine choices (`installation`, `github.clientId`, `secretStore.adapter`, `supplyChain.registry`) stay at their stand-ins, so `isUnconfiguredInstallation` still reads the seeded document as unconfigured and the first signed-in operator lands on onboarding. A release with neither a declaration nor a hostname still renders nothing, exactly as before.
- A new conformance suite (`apps/spindrift/test/conformance/chart-only-enrolment.test.ts`) diffs the chart's copy against the code's `DEFAULT_PLACEHOLDER_MANIFEST` on every run, so the two copies drifting apart is a red test rather than a silent wizard-nobody-can-reach.

## Why a second copy of the placeholder, not a code-side fix

Two shapes were available: have the chart render a full default document (kept one authority for what a manifest *is*, costs a chart-side copy that can drift), or have the process correct the placeholder's deployment facts from its own environment before writing the seed row (keeps one copy, puts a second writer into the seed path an earlier change made single-authority). This PR takes the first: the chart is the only place that renders deployment facts into Kubernetes objects at all — the process reads manifests, it does not derive them — so a second writer in the seed path would be new, while a chart-side copy is the same shape this chart already carries for the federation credential and is guarded the same way, with a conformance test instead of hand review.

## Test plan

- [x] `bun test` (apps/spindrift, with a real Postgres) — 1616/1616 pass; a pre-existing, load-independent 15s hook timeout in `test/db/migrate.test.ts` reproduces identically on the base commit and is unrelated to this change
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (two pre-existing, unrelated findings in files this PR does not touch)
- [x] `mise run ts:check` — clean
- [x] `mise run k8s:render-apps` — clean
- [x] `bun test` in `packages/charts/spindrift` — 28/28 pass, including 3 new cases for the seeded default, the still-empty hostless case, and an explicit declaration still winning
- [x] Reverted the chart template changes and re-ran the new render test: it fails with "expected exactly one ConfigMap spindrift-manifest, got 0", proving the test is load-bearing
- [x] Deliberately drifted one field in the chart's copy of the placeholder and re-ran the conformance suite: all four cases fail, including a schema validation error naming the drifted field, proving the drift guard actually catches drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)