### PR TITLE
Surface the mounted declaration and let an operator adopt it

### DIFF
--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -28,16 +28,32 @@
  * variant of any route or connection carries key material — so the document is
  * platform configuration, and the surface is session-authenticated regardless.
  *
- * **`manifestDivergence` rides along for the same reason `manifest` does.**
+ * **`declarationDivergence` rides along for the same reason `manifest` does.**
  * `loadStoredManifest` already detects a mounted declaration that disagrees
  * with the stored row and says so — once, in a pod log, at boot. §6: "drift is
  * detected and surfaced, never silently corrected" does not stop at the log;
  * an operator who opens this screen weeks after the rollout that caused the
  * disagreement is exactly who needed to see it and exactly who cannot. It is
- * read off `context.manifestDivergence` rather than recomputed here for the
+ * read off `context.declarationDivergence` rather than recomputed here for the
  * same reason `manifest` is: recomputing it would mean reading the mounted
  * declaration a second time, which needs `Bun.file` and puts this command back
- * in the shape it exists to avoid.
+ * in the shape it exists to avoid. Named `declarationDivergence` rather than
+ * `manifestDivergence` because `targets/list.ts:135`'s `connectionDivergence`
+ * used to share that name for a different comparison — a Target's row against
+ * its own manifest entry, not this pair.
+ *
+ * **`declaration` answers the same document as a whole, not only the paths it
+ * disagrees at.** That is what turns "an operator can see a merge did not
+ * land" into "an operator can put it on the row": the whole document is
+ * exactly `configureInstallation`'s input type, so a caller of both commands
+ * in sequence adopts the mounted declaration with no assembly of its own —
+ * `views/auth/installation.tsx`'s adopt action is exactly that sequence. This
+ * does not weaken the paths-only promise `declarationDivergence` keeps —
+ * `diffManifestPaths` still only ever answers a path — it rests instead on the
+ * guarantee the paragraph above already spends: §13 keeps every manifest
+ * variant credential-free by construction, which is the whole reason this
+ * command may answer `manifest` itself rather than only facts about it. Two
+ * documents under that one guarantee, not two guarantees.
  */
 import { z } from 'zod';
 import {
@@ -56,12 +72,25 @@ export type GetInstallationManifestInput = z.infer<
 export interface GetInstallationManifestResult {
   readonly manifest: AuthoredManifest;
   /**
-   * Dotted paths where a mounted declaration disagrees with the manifest
-   * above, or `[]` when nothing is mounted or the two agree. Paths only —
-   * see `manifest-store.ts`'s `diffManifestPaths` for why a value never rides
+   * The mounted declaration, whole — or `null` where none is mounted, one is
+   * unreadable, or this installation runs with no declaration at all.
+   *
+   * `configureInstallation` takes exactly this type, so this is the whole of
+   * what an adopt action needs: read this command, send its `declaration`
+   * straight to that one. Not projected or reduced the way `manifest` is
+   * documented above not to need — `context.declaration` is already parsed
+   * into `AuthoredManifest`, the type this command's own `manifest` field is
+   * and the type `configureInstallation` accepts, so there is nothing here
+   * for a round trip to disagree about.
+   */
+  readonly declaration: AuthoredManifest | null;
+  /**
+   * Dotted paths where {@link declaration} disagrees with the manifest above,
+   * or `[]` when nothing is mounted or the two agree. Paths only — see
+   * `manifest-store.ts`'s `diffManifestPaths` for why a value never rides
    * along with one.
    */
-  readonly manifestDivergence: readonly string[];
+  readonly declarationDivergence: readonly string[];
   /**
    * Whether anybody has answered this installation's genuine choices, or they
    * are still the stand-ins `loadStoredManifest` seeds an unseeded row with.
@@ -95,7 +124,8 @@ export const getInstallationManifest: Command<
   const manifest = toAuthoredManifest(context.manifest);
   return ok({
     manifest,
-    manifestDivergence: context.manifestDivergence ?? [],
+    declaration: context.declaration ?? null,
+    declarationDivergence: context.declarationDivergence ?? [],
     // The authored document, not the resolved one: the deployment's federation
     // is joined onto `context.manifest` per read, and the predicate reads keys
     // an authored document is the only place to state.

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -132,7 +132,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
       status: target.status,
       configured: target.connection !== null,
       inspectedAt: target.inspectedAt?.toISOString() ?? null,
-      manifestDivergence: targetConnectionDivergence(
+      connectionDivergence: targetConnectionDivergence(
         context.manifest.targets.find((seed) => seed.name === target.name),
         target.connection,
       ),

--- a/apps/spindrift/src/commands/types.ts
+++ b/apps/spindrift/src/commands/types.ts
@@ -25,6 +25,7 @@ import type { DatastoreAdapter } from '../adapters/datastore/contract.ts';
 import type { DeployAdapter } from '../adapters/deploy/contract.ts';
 import type { SecretStore } from '../adapters/store/contract.ts';
 import type {
+  AuthoredManifest,
   InstallationManifest,
   StoreAdapter,
   TargetAdapter,
@@ -195,7 +196,28 @@ export interface CommandContext {
    */
   readonly manifest: InstallationManifest;
   /**
-   * Dotted paths where a mounted declaration disagrees with `manifest`, from
+   * The mounted declaration, whole — or `null` where none is mounted, one is
+   * unreadable, or a caller has not computed one. `undefined` for the same
+   * reason `declarationDivergence` below is: every production context reads
+   * this once at boot (`src/web/serve.ts`'s `declaration`) and carries it
+   * along, and a test context that does not care is not required to.
+   *
+   * Answering a whole document here, rather than only the paths it disagrees
+   * with, rests on the same guarantee `getInstallationManifest` already leans
+   * on to answer `manifest` itself: §13 keeps every manifest variant
+   * credential-free by construction, so nothing this field can hold is
+   * secret. It does not weaken {@link diffManifestPaths}'s paths-only promise
+   * below — that walk stays generic over whatever the schema is next asked to
+   * carry regardless of what else the context exposes. Two documents resting
+   * on one guarantee, not two guarantees.
+   *
+   * `configureInstallation` takes exactly this type, which is what makes this
+   * field the whole of what a surface needs to put the declaration onto the
+   * stored row — see `src/commands/installation/get.ts`.
+   */
+  readonly declaration?: AuthoredManifest | null;
+  /**
+   * Dotted paths where {@link declaration} disagrees with `manifest`, from
    * {@link diffManifestPaths}. `undefined` where a caller has not computed
    * one — every production context does; a test context that does not care is
    * not required to.
@@ -212,9 +234,14 @@ export interface CommandContext {
    * **Paths only, exactly as {@link diffManifestPaths} promises — never a
    * value.** A command that reads this must not append a value onto a path
    * before handing it back; doing so would defeat the one property this
-   * field exists to keep.
+   * field exists to keep. Named `declarationDivergence` rather than
+   * `manifestDivergence` because `targets/list.ts` answers a different
+   * question under a name that used to collide with this one — a Target's
+   * row against its own manifest entry, not the declaration against the
+   * stored manifest. Same walk, same word `diffManifestPaths` produces,
+   * different pair of documents.
    */
-  readonly manifestDivergence?: readonly string[];
+  readonly declarationDivergence?: readonly string[];
 }
 
 /**

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -83,7 +83,24 @@ type Gatekeeping =
 export type Configuration =
   | { readonly state: 'asking' }
   | { readonly state: 'unconfigured'; readonly manifest: unknown }
-  | { readonly state: 'configured' };
+  | {
+      readonly state: 'configured';
+      /**
+       * Dotted paths where the mounted declaration disagrees with this
+       * installation, from the same read that decided this state — never
+       * recomputed, so it is only as fresh as the sign-in that fetched it.
+       *
+       * Carried this far up rather than left to the Settings screen alone
+       * (`views/auth/installation.tsx`) so a disagreement is visible on every
+       * screen `AppShell` wraps, not only one an operator has to think to
+       * open — an installation nobody opens Settings on otherwise never
+       * learns a merge did not reach the row. `[]` for every path that
+       * resolved this state without a real answer: a failed or timed-out
+       * read, or the write onboarding just made, none of which has an
+       * opinion sharper than "nothing to report".
+       */
+      readonly declarationDivergence: readonly string[];
+    };
 
 /**
  * How long the whole product waits on the read below before rendering anyway.
@@ -172,11 +189,18 @@ export function App() {
         setInstallation(
           result?.ok && !result.value.configured
             ? { state: 'unconfigured', manifest: result.value.manifest }
-            : { state: 'configured' },
+            : {
+                state: 'configured',
+                declarationDivergence: result?.ok
+                  ? result.value.declarationDivergence
+                  : [],
+              },
         );
       })
       .catch(() => {
-        if (live) setInstallation({ state: 'configured' });
+        if (live) {
+          setInstallation({ state: 'configured', declarationDivergence: [] });
+        }
       })
       .finally(() => clearTimeout(deadline));
     return () => {
@@ -203,7 +227,11 @@ export function App() {
       installation={installation}
       path={route.path}
       onNavigate={route.navigate}
-      onConfigured={() => setInstallation({ state: 'configured' })}
+      onConfigured={() =>
+        // Onboarding's own write just seeded this installation, so there is
+        // nothing yet for a declaration to disagree with — see `Configuration`.
+        setInstallation({ state: 'configured', declarationDivergence: [] })
+      }
       onSignOut={() => {
         void signOut().then(() =>
           setGate({
@@ -270,6 +298,7 @@ export function SignedIn({
       principal={principal}
       themeControl={<ThemeToggle />}
       onSignOut={onSignOut}
+      declarationDivergence={installation.declarationDivergence}
     >
       <Screen path={path} onNavigate={onNavigate} />
     </AppShell>

--- a/apps/spindrift/src/web/components/shell.tsx
+++ b/apps/spindrift/src/web/components/shell.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   Boxes,
   Hammer,
   LayoutDashboard,
@@ -58,6 +59,7 @@ export function AppShell({
   onNavigate,
   onSignOut,
   themeControl,
+  declarationDivergence = [],
   children,
 }: {
   readonly path: string;
@@ -65,6 +67,19 @@ export function AppShell({
   readonly onNavigate: (path: string) => void;
   readonly onSignOut: () => void;
   readonly themeControl: ReactNode;
+  /**
+   * Dotted paths where the mounted declaration disagrees with this
+   * installation (`views/auth/installation.tsx` says why a value never rides
+   * along with one). Optional and defaulted to `[]` so every existing caller
+   * — none of which had an opinion about a declaration — keeps asserting
+   * nothing about a fact it does not exercise.
+   *
+   * Rendered here, under the header rather than only on the Settings screen,
+   * because this is the one component every screen in the product passes
+   * through: an installation nobody opens Settings on otherwise never learns
+   * a merge did not reach the row.
+   */
+  readonly declarationDivergence?: readonly string[];
   readonly children: ReactNode;
 }) {
   const navigation = (
@@ -141,6 +156,28 @@ export function AppShell({
             </Button>
           </div>
         </header>
+        {declarationDivergence.length > 0 ? (
+          <div
+            role="alert"
+            className="flex items-center gap-2 border-b border-warning/40 bg-warning-soft px-4 py-2 text-xs sm:px-6"
+          >
+            <AlertTriangle
+              aria-hidden="true"
+              className="size-3.5 shrink-0 text-warning"
+            />
+            <span>
+              The mounted declaration no longer matches this installation.{' '}
+              <button
+                type="button"
+                className="underline underline-offset-2 hover:no-underline"
+                onClick={() => onNavigate('/settings/installation')}
+              >
+                Review it in Settings
+              </button>
+              .
+            </span>
+          </div>
+        ) : null}
         <main className="min-w-0 pb-20 md:pb-0">{children}</main>
       </div>
 

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -709,8 +709,15 @@ export interface TargetListItem {
    * is what a Target owes an operator before they save Settings and take their
    * own edit back. Empty is the ordinary case — and is also what a Target the
    * manifest declares no connection for correctly reports.
+   *
+   * Named `connectionDivergence` rather than `manifestDivergence` — the name
+   * this field used to share with `GetInstallationManifestResult`'s field —
+   * because the two answer different questions over the same
+   * `diffManifestPaths` walk: this one compares a Target's row against its own
+   * manifest entry; that one compares the mounted declaration against the
+   * stored manifest.
    */
-  readonly manifestDivergence: readonly string[];
+  readonly connectionDivergence: readonly string[];
   /**
    * Where an edit of this Target's connection starts, or `null` on an adapter
    * the product has no edit surface for.

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -147,14 +147,18 @@ export async function start(
    *
    * `loadStoredManifest` already read this file at boot to decide whether to
    * seed from it, and already logs when it disagrees with what got stored —
-   * this is a second, best-effort read of the same file so `manifestDivergence`
+   * this is a second, best-effort read of the same file so `declarationDivergence`
    * below can answer the same question on demand rather than only once, to a
-   * log line, at the moment nobody was watching. `null` for "unreadable" as
-   * well as "absent": an invalid declaration is already reported by that boot
-   * warning, and this is a display concern, not a second place to be fatal
-   * about it. Not re-read per request — the ConfigMap volume it lives on does
-   * not change without a pod restart in the ordinary case, which is the same
-   * reasoning `relyingParty` below rests on.
+   * log line, at the moment nobody was watching. It also rides the context
+   * whole, as `declaration` itself — not only as the paths it disagrees at —
+   * which is what lets a surface put it on the stored row without a second
+   * reader (`src/commands/installation/get.ts` and `configure.ts` say why that
+   * is safe). `null` for "unreadable" as well as "absent": an invalid
+   * declaration is already reported by that boot warning, and this is a
+   * display concern, not a second place to be fatal about it. Not re-read per
+   * request — the ConfigMap volume it lives on does not change without a pod
+   * restart in the ordinary case, which is the same reasoning `relyingParty`
+   * below rests on.
    */
   const declaration = await loadManifestIfPresent().catch(() => null);
 
@@ -166,7 +170,7 @@ export async function start(
    * is one `select` per command; the adapters are rebuilt only when the
    * document actually changed, which is what makes doing this per request
    * affordable — `createAdapterRegistry` is pure assembly whose credentials are
-   * providers called per request, so rebuilding opens nothing. `manifestDivergence`
+   * providers called per request, so rebuilding opens nothing. `declarationDivergence`
    * is recomputed on that same change, against the one-time `declaration`
    * above — cheap, because `diffManifestPaths` is a pure walk over two
    * documents already in memory.
@@ -179,7 +183,7 @@ export async function start(
   let current = {
     manifest,
     adapters,
-    manifestDivergence:
+    declarationDivergence:
       declaration === null
         ? []
         : diffManifestPaths(declaration, toAuthoredManifest(manifest)),
@@ -196,7 +200,7 @@ export async function start(
         db,
         clock: systemClock,
       }),
-      manifestDivergence:
+      declarationDivergence:
         declaration === null
           ? []
           : diffManifestPaths(declaration, toAuthoredManifest(stored)),
@@ -228,7 +232,8 @@ export async function start(
           db,
           adapters: installation.adapters,
           manifest: installation.manifest,
-          manifestDivergence: installation.manifestDivergence,
+          declaration,
+          declarationDivergence: installation.declarationDivergence,
         };
       },
     },

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -67,12 +67,20 @@ export function InstallationSettings() {
   const [outcome, setOutcome] = useState<SaveOutcome | null>(null);
   const [saving, setSaving] = useState(false);
   const [divergence, setDivergence] = useState<readonly string[]>([]);
+  /**
+   * The mounted declaration, whole — what an "Adopt this declaration" press
+   * sends to `configureInstallation` unedited. `null` until the first load
+   * answers, and whenever nothing is mounted; `ManifestDivergenceNotice` does
+   * not offer the act without it.
+   */
+  const [declaration, setDeclaration] = useState<unknown>(null);
 
   const load = useCallback(async () => {
     const result = await command('getInstallationManifest', {});
     if (result.ok) {
       setDocument(result.value.manifest);
-      setDivergence(result.value.manifestDivergence);
+      setDivergence(result.value.declarationDivergence);
+      setDeclaration(result.value.declaration);
       setLoadError(null);
     } else {
       setLoadError(result.failure.message);
@@ -165,12 +173,22 @@ export function InstallationSettings() {
       outcome={outcome}
       saving={saving}
       divergence={divergence}
+      declaration={declaration}
       onChange={(next) => {
         setDocument(next);
         setOutcome(null);
       }}
       onSave={() => void save()}
       onReload={() => {
+        setErrors(new Map());
+        setOutcome(null);
+        void load();
+      }}
+      onAdopted={() => {
+        // The row changed under this screen exactly as a `configureInstallation`
+        // save does, so it is re-read the same way: what the write left, not
+        // what was sent, and any local edit below it is discarded along with
+        // it — the notice says so before the press that causes it.
         setErrors(new Map());
         setOutcome(null);
         void load();
@@ -222,9 +240,11 @@ export function InstallationSettingsView({
   outcome,
   saving,
   divergence = [],
+  declaration = null,
   onChange,
   onSave,
   onReload,
+  onAdopted,
 }: {
   readonly fields: readonly FormField[];
   readonly document: unknown;
@@ -239,9 +259,25 @@ export function InstallationSettingsView({
    * fact it is not exercising.
    */
   readonly divergence?: readonly string[];
+  /**
+   * The mounted declaration itself, from the same command as `divergence` —
+   * `getInstallationManifest`'s `declaration`. What "Adopt this declaration"
+   * sends to `configureInstallation`, unedited. Optional and defaulted to
+   * `null` for the same reason `divergence` is; the notice offers no adopt
+   * act without it, which a test asserting only `divergence` is still
+   * entitled to leave unset.
+   */
+  readonly declaration?: unknown;
   onChange(document: unknown): void;
   onSave(): void;
   onReload(): void;
+  /**
+   * The row changed underneath this screen by a route other than `onSave` —
+   * an adopt press. Optional because a caller that never passes a
+   * `declaration` has no act to report finishing; `ManifestDivergenceNotice`
+   * does not render the button that would need it.
+   */
+  onAdopted?(): void;
 }) {
   const form = { document, errors, disabled: saving, onChange };
   // Sections are whichever keys have structure. Derived rather than listed, so
@@ -259,7 +295,11 @@ export function InstallationSettingsView({
         onSave();
       }}
     >
-      <ManifestDivergenceNotice paths={divergence} />
+      <ManifestDivergenceNotice
+        paths={divergence}
+        declaration={declaration}
+        onAdopted={onAdopted}
+      />
 
       {/* Above the form, because it is the step that comes before editing: a
           value confirmed from the cloud is a value nobody has to type, and one
@@ -362,13 +402,60 @@ export function InstallationSettingsView({
  * **Paths only**, exactly as `getInstallationManifest` answers them: the list
  * says where the two documents disagree, never what either one says at that
  * path.
+ *
+ * **Adopting sends `declaration` whole, the same way `onSave` sends the
+ * edited document.** `declaration` is already an `AuthoredManifest` —
+ * `configureInstallation`'s own input type — so this is not a patch applied
+ * at `paths`: "apply only the diverging paths" would let a partially valid
+ * document through, which is exactly what a manifest must never be. The cost
+ * is stated next to the button that causes it, before the press rather than
+ * after: a `declared` write resets the assessment of every Target whose
+ * connection moves to an unhealthy, awaiting-inspection checklist
+ * (`manifest-store.ts`'s `reconcileManifestTargets`) — which is what most of
+ * a divergence like this one actually is, because a Target's connection is
+ * exactly what a rollout to `helm-release.yaml` most often moves. Said
+ * plainly rather than behind a second confirming click: the sentence is the
+ * same regardless of which paths differ, so a click that only reveals it
+ * would cost an operator a step without giving them anything to decide with
+ * that they could not already read.
  */
 function ManifestDivergenceNotice({
   paths,
+  declaration,
+  onAdopted,
 }: {
   readonly paths: readonly string[];
+  /** The document an adopt press submits, whole. `null` offers no press. */
+  readonly declaration?: unknown;
+  onAdopted?(): void;
 }) {
+  const [adopting, setAdopting] = useState(false);
+  const [adoptError, setAdoptError] = useState<string | null>(null);
+
   if (paths.length === 0) return null;
+
+  const adopt = async () => {
+    setAdopting(true);
+    setAdoptError(null);
+    try {
+      const result = await command('configureInstallation', {
+        manifest: declaration,
+      });
+      if (result.ok) {
+        onAdopted?.();
+      } else {
+        setAdoptError(result.failure.message);
+      }
+    } catch (cause) {
+      setAdoptError(
+        cause instanceof Error
+          ? cause.message
+          : 'Adopting the declaration failed.',
+      );
+    } finally {
+      setAdopting(false);
+    }
+  };
 
   return (
     <div
@@ -376,18 +463,42 @@ function ManifestDivergenceNotice({
       className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground"
     >
       <CircleAlert aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
-      <div>
+      <div className="w-full">
         <p className="font-medium">
           The mounted declaration no longer matches this installation.
         </p>
         <p className="mt-0.5">
           Configuration is this screen's to drive, so what is stored below is
-          what is running — the declaration was only ever the seed. Discard the
-          row to re-seed from it instead of editing here.
+          what is running — the declaration was only ever the seed.
         </p>
         <p className="mt-1 text-muted-foreground">
           Differs at: {paths.join(', ')}.
         </p>
+
+        {declaration === null || declaration === undefined ? null : (
+          <div className="mt-2 flex flex-col gap-2">
+            <p className="text-xs text-muted-foreground">
+              Adopting replaces the document below with the declaration above,
+              whole — discarding any unsaved edit here along with it. Every
+              Target whose connection moves is reset to unhealthy, with an
+              awaiting-inspection checklist, until it is re-inspected.
+            </p>
+            {adoptError !== null ? (
+              <p className="text-terminal-destructive">{adoptError}</p>
+            ) : null}
+            <div>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                disabled={adopting}
+                onClick={() => void adopt()}
+              >
+                {adopting ? 'Adopting…' : 'Adopt this declaration'}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -544,7 +544,7 @@ function TargetCard({
           Paths, never values: a connection is credential-free today and this
           line does not lean on it staying that way.
         */}
-        {target.manifestDivergence.length > 0 ? (
+        {target.connectionDivergence.length > 0 ? (
           <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
             <AlertTriangle
               aria-hidden="true"
@@ -554,7 +554,7 @@ function TargetCard({
               This Target's connection differs from what the installation
               manifest declares for it, at{' '}
               <span className="font-mono">
-                {target.manifestDivergence.join(', ')}
+                {target.connectionDivergence.join(', ')}
               </span>
               . The row is what deploys render from and a restart leaves it
               alone; saving the manifest in Settings replaces it.

--- a/apps/spindrift/test/commands/installation-adopt.test.ts
+++ b/apps/spindrift/test/commands/installation-adopt.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Adopting the mounted declaration onto the stored row (ticket 78).
+ *
+ * `getInstallationManifest` and `configureInstallation` already round-trip a
+ * whole document — `installation-round-trip.test.ts` proves that pair. What
+ * neither of those files proves is that a *declaration* is one of the
+ * documents that can ride that pair: before this ticket, `manifestDivergence`
+ * (now `declarationDivergence`) named only the paths a mounted declaration
+ * disagreed at, and the declaration itself never left the process that read
+ * it. An operator who wanted to adopt it had nothing to send.
+ *
+ * Two claims:
+ *
+ * 1. **`getInstallationManifest` answers the declaration as a document**, the
+ *    same `AuthoredManifest` shape `manifest` is and `configureInstallation`
+ *    accepts — not only the list of paths it differs at.
+ * 2. **Sending that document straight to `configureInstallation` — with no
+ *    assembly of the caller's own — clears the divergence.** This is
+ *    criterion 2's mechanism, proven against a hand-built divergence rather
+ *    than the live offsite installation: nothing in this repository can
+ *    reach that installation, and the ticket says so.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  configureInstallation,
+  getInstallationManifest,
+} from '../../src/commands/index.ts';
+import type { Clock, CommandContext } from '../../src/commands/types.ts';
+import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
+import { diffManifestPaths } from '../../src/config/manifest-store.ts';
+import { installation } from '../../src/db/schema.ts';
+import { withValueAt } from '../../src/web/forms/document.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { authoredFixture, fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const fixture = await authoredFixture();
+const resolved = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+/**
+ * A context for the fixture installation, with `declaration` and
+ * `declarationDivergence` set the way `serve.ts` sets them — by hand here,
+ * because this file's claim is about what a command does with those two
+ * fields, not about how `serve.ts` computes them (`installation-surface.test.ts`
+ * already drives the real route table for that half).
+ */
+function context(extra: Partial<CommandContext> = {}): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    manifest: resolved,
+    adapters: {
+      deploy: () => null,
+      build: () => null,
+      store: () => null,
+      repository: () => null,
+      supplyChain: () => {
+        throw new Error('adopting a declaration reached the supply chain');
+      },
+    } as unknown as CommandContext['adapters'],
+    ...extra,
+  };
+}
+
+async function seed(manifest: AuthoredManifest): Promise<void> {
+  await database()
+    .db.insert(installation)
+    .values({ id: 1, manifest })
+    .onConflictDoUpdate({ target: installation.id, set: { manifest } });
+}
+
+async function storedManifest(): Promise<AuthoredManifest> {
+  const [row] = await database().db.select().from(installation);
+  if (row === undefined) throw new Error('no installation row');
+  return row.manifest as AuthoredManifest;
+}
+
+/** A declaration that diverges from `fixture` at one path. */
+function divergentDeclaration(): AuthoredManifest {
+  return withValueAt(
+    fixture,
+    ['build', 'zeroConfigFrontend'],
+    'registry.example.test/zero-config:merged',
+  ) as AuthoredManifest;
+}
+
+describe('reading the mounted declaration', () => {
+  test('answers it as a document, not only the paths it differs at', async () => {
+    await seed(fixture);
+    const declaration = divergentDeclaration();
+
+    const result = await getInstallationManifest(
+      {},
+      context({
+        declaration,
+        declarationDivergence: diffManifestPaths(declaration, fixture),
+      }),
+    );
+    if (!result.ok) throw new Error('getInstallationManifest refused');
+
+    // Whole, not a projection: an adopt action forwards this value straight
+    // to `configureInstallation`, so a reader that dropped a key here would
+    // make an adopt press delete it.
+    expect(result.value.declaration).toEqual(declaration);
+    expect(result.value.declarationDivergence).toEqual([
+      'build.zeroConfigFrontend',
+    ]);
+  });
+
+  test('a context with no declaration answers null and no paths', async () => {
+    await seed(fixture);
+    const result = await getInstallationManifest({}, context());
+    if (!result.ok) throw new Error('getInstallationManifest refused');
+    expect(result.value.declaration).toBeNull();
+    expect(result.value.declarationDivergence).toEqual([]);
+  });
+});
+
+describe('adopting the declaration', () => {
+  test('sending what the read answered clears the divergence', async () => {
+    await seed(fixture);
+    const declaration = divergentDeclaration();
+
+    // What the surface does, in order: read the declaration off
+    // `getInstallationManifest`, then send exactly that value to
+    // `configureInstallation`. No path from `declarationDivergence` is
+    // touched — the whole document travels, per §20's "the whole document or
+    // nothing" rule cited in `configure.ts`.
+    const read = await getInstallationManifest(
+      {},
+      context({
+        declaration,
+        declarationDivergence: diffManifestPaths(declaration, fixture),
+      }),
+    );
+    if (!read.ok) throw new Error('getInstallationManifest refused');
+    expect(read.value.declarationDivergence.length).toBeGreaterThan(0);
+
+    const written = await configureInstallation(
+      { manifest: read.value.declaration },
+      context(),
+    );
+    expect(written.ok).toBe(true);
+
+    const stored = await storedManifest();
+    expect(stored.build.zeroConfigFrontend).toBe(
+      'registry.example.test/zero-config:merged',
+    );
+
+    // Criterion 2's whole claim, mechanically: re-reading against the row the
+    // write just left answers no divergence, because the declaration and the
+    // stored manifest now agree at the path that used to separate them.
+    const after = await getInstallationManifest(
+      {},
+      context({
+        declaration,
+        declarationDivergence: diffManifestPaths(declaration, stored),
+      }),
+    );
+    if (!after.ok) throw new Error('getInstallationManifest refused');
+    expect(after.value.declarationDivergence).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -436,11 +436,11 @@ describe('an operator’s Target correction outlives the next boot', () => {
     );
     if (!listed.ok) throw new Error('listTargets refused');
     const cluster = listed.value.targets.find((t) => t.name === 'cluster');
-    expect(cluster?.manifestDivergence).toEqual([
+    expect(cluster?.connectionDivergence).toEqual([
       'connection.chartValues.platform.gateway.name',
       'connection.chartValues.platform.gateway.namespace',
     ]);
-    expect(JSON.stringify(cluster?.manifestDivergence)).not.toContain(
+    expect(JSON.stringify(cluster?.connectionDivergence)).not.toContain(
       'gateway-that-moved',
     );
 
@@ -470,7 +470,7 @@ describe('an operator’s Target correction outlives the next boot', () => {
     if (!listed.ok) throw new Error('listTargets refused');
     expect(
       listed.value.targets.find((t) => t.name === 'cluster')
-        ?.manifestDivergence,
+        ?.connectionDivergence,
     ).toEqual([]);
   });
 });

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -894,7 +894,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     // cluster's gateway through the connect form and the manifest still
     // declares the old one. The row is what deploys render from, so the notice
     // is a warning about Settings rather than about the Target.
-    manifestDivergence: [
+    connectionDivergence: [
       'connection.chartValues.platform.gateway.name',
       'connection.chartValues.platform.gateway.namespace',
     ],
@@ -915,7 +915,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     status: 'connected',
     configured: true,
     inspectedAt: '2026-08-02T12:00:00.000Z',
-    manifestDivergence: [],
+    connectionDivergence: [],
     // A cloud project has no `platform` values and no probe to read itself
     // back through, so there is nothing here for an edit form to open onto.
     edit: null,
@@ -932,7 +932,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     status: 'connected',
     configured: true,
     inspectedAt: '2026-08-02T12:00:00.000Z',
-    manifestDivergence: [],
+    connectionDivergence: [],
     // A cloud project has no `platform` values and no probe to read itself
     // back through, so there is nothing here for an edit form to open onto.
     edit: null,
@@ -961,7 +961,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     status: 'connected',
     configured: true,
     inspectedAt: '2026-08-02T12:00:00.000Z',
-    manifestDivergence: [],
+    connectionDivergence: [],
     edit: {
       apiServer: 'https://secondary.example:6443',
       proposal: { carriedFrom: 'Secondary', namespace: 'apps' },

--- a/apps/spindrift/test/web/app-mounted.test.tsx
+++ b/apps/spindrift/test/web/app-mounted.test.tsx
@@ -48,7 +48,11 @@ const OPERATOR = { id: 'usr_test', displayName: 'Operator' };
  * cannot see.
  */
 let answer:
-  | { readonly kind: 'ok'; readonly configured: boolean }
+  | {
+      readonly kind: 'ok';
+      readonly configured: boolean;
+      readonly declarationDivergence?: readonly string[];
+    }
   | { readonly kind: 'throws' }
   | { readonly kind: 'never' } = { kind: 'ok', configured: true };
 
@@ -87,7 +91,11 @@ beforeAll(() => {
             ok: true,
             value: {
               manifest: DEFAULT_PLACEHOLDER_MANIFEST,
-              manifestDivergence: [],
+              declaration: null,
+              declarationDivergence:
+                answer.kind === 'ok'
+                  ? (answer.declarationDivergence ?? [])
+                  : [],
               configured: answer.kind === 'ok' && answer.configured,
             },
           }),
@@ -183,5 +191,46 @@ describe('the installation decides which application is rendered', () => {
     } finally {
       jest.useRealTimers();
     }
+  });
+});
+
+/**
+ * Ticket 78's fourth criterion: a disagreement is visible somewhere an
+ * operator passes anyway, not only on the Settings screen.
+ *
+ * `AppShell` wraps every screen `Screen` renders, and this is the read that
+ * already decides `configured` vs `unconfigured` — so a divergence answered
+ * in the same breath costs nothing further to show on every one of them. The
+ * claim is about `App`/`SignedIn`, the same components the tests above mount,
+ * for the same reason those are asserted against the real branch rather than
+ * against `AppShell` handed a divergence directly: a banner nothing wires
+ * confirms nothing.
+ */
+describe('a divergent declaration is announced on the product surface', () => {
+  test('a non-empty declarationDivergence is shown, unprompted', async () => {
+    answer = {
+      kind: 'ok',
+      configured: true,
+      declarationDivergence: ['build.zeroConfigFrontend'],
+    };
+
+    const screen = await mount();
+
+    expect(screen.text()).toContain(
+      'The mounted declaration no longer matches this installation.',
+    );
+    expect(screen.text()).toContain('Review it in Settings');
+
+    screen.unmount();
+  });
+
+  test('an empty declarationDivergence says nothing', async () => {
+    answer = { kind: 'ok', configured: true, declarationDivergence: [] };
+
+    const screen = await mount();
+
+    expect(screen.text()).not.toContain('mounted declaration');
+
+    screen.unmount();
   });
 });

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -5,7 +5,7 @@
  * every rule below is a statement about **what is on the screen in a given
  * state**, and none is about interaction.
  *
- * Two things are being asserted, and they are not the same thing:
+ * Three things are being asserted, and they are not the same thing:
  *
  * 1. **A control exists for every manifest value**, derived from the schema, so
  *    a key an operator has to correct is reachable. This is the half seven
@@ -16,6 +16,9 @@
  *    `configureInstallation` distinguishes "your document is wrong" from "this
  *    installation cannot take it", and flattening the second into a form error
  *    would tell an operator to fix a field that is not wrong.
+ * 3. **An adopt act is offered exactly when there is a declaration to adopt**
+ *    (ticket 78). The cost is stated before the press: what a `declared` write
+ *    does to a Target whose connection moves.
  */
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -32,6 +35,8 @@ function screen({
   errors = new Map() as FieldErrors,
   outcome = null as SaveOutcome | null,
   saving = false,
+  divergence = [] as readonly string[],
+  declaration = null as unknown,
 } = {}): string {
   return renderToStaticMarkup(
     <InstallationSettingsView
@@ -40,9 +45,12 @@ function screen({
       errors={errors}
       outcome={outcome}
       saving={saving}
+      divergence={divergence}
+      declaration={declaration}
       onChange={() => undefined}
       onSave={() => undefined}
       onReload={() => undefined}
+      onAdopted={() => undefined}
     />,
   );
 }
@@ -152,5 +160,40 @@ describe('a refusal reads as what it is', () => {
     });
     expect(markup).toContain('This installation was configured.');
     expect(markup).toContain('cluster, cloud-cloudrun');
+  });
+});
+
+describe('adopting a divergent declaration', () => {
+  test('no divergence, no notice and no adopt act', () => {
+    const markup = screen();
+    expect(markup).not.toContain(
+      'The mounted declaration no longer matches this installation.',
+    );
+    expect(markup).not.toContain('Adopt this declaration');
+  });
+
+  test('a divergence with nothing to adopt says so, but offers no press', () => {
+    // Reachable when a caller has paths but no document for them — a test
+    // context that computed one without the other. The notice still names
+    // the disagreement; it just cannot act on it.
+    const markup = screen({ divergence: ['build.zeroConfigFrontend'] });
+    expect(markup).toContain(
+      'The mounted declaration no longer matches this installation.',
+    );
+    expect(markup).toContain('Differs at: build.zeroConfigFrontend.');
+    expect(markup).not.toContain('Adopt this declaration');
+  });
+
+  test('a divergence with a declaration offers the adopt act, and its cost', () => {
+    const markup = screen({
+      divergence: ['build.zeroConfigFrontend'],
+      declaration: manifest,
+    });
+    expect(markup).toContain('Adopt this declaration');
+    // The cost, named beside the button rather than after the press: a
+    // `declared` write is what resets a moved Target connection to unhealthy
+    // pending inspection (`manifest-store.ts`'s `reconcileManifestTargets`).
+    expect(markup).toContain('reset to unhealthy');
+    expect(markup).toContain('awaiting-inspection checklist');
   });
 });

--- a/apps/spindrift/test/web/onboarding.test.tsx
+++ b/apps/spindrift/test/web/onboarding.test.tsx
@@ -249,12 +249,17 @@ describe('an unconfigured installation is shown onboarding, not the product', ()
       state: 'unconfigured',
       manifest: UNCONFIGURED,
     });
-    const configured = signedIn({ state: 'configured' });
+    const configured = signedIn({
+      state: 'configured',
+      declarationDivergence: [],
+    });
     expect(configured).toContain('Overview');
     expect(unconfigured).not.toContain('Overview');
   });
 
   test('a configured installation never sees it', () => {
-    expect(signedIn({ state: 'configured' })).not.toContain('Step 1 of 4');
+    expect(
+      signedIn({ state: 'configured', declarationDivergence: [] }),
+    ).not.toContain('Step 1 of 4');
   });
 });


### PR DESCRIPTION
## Summary

- `getInstallationManifest` now answers the mounted declaration as a whole `AuthoredManifest` document (`declaration`), not only the dotted paths it disagrees at (`declarationDivergence`) — carried on `CommandContext` the same way the divergence already was, read once at boot the same way `serve.ts` already reads the file.
- The Settings screen sends that document straight to `configureInstallation` on an "Adopt this declaration" press — the same write a manual save makes, on a different document, with the write's cost (a `declared` write resets every Target whose connection moves to unhealthy, awaiting-inspection) stated next to the button before the press.
- The same divergence now renders as a banner in the product shell (`AppShell`), present on every screen an operator passes through — not only a Settings screen nobody has a reason to open.
- The two fields that used to share the name `manifestDivergence` are renamed to say which pair of documents each compares: `declarationDivergence` (the mounted declaration vs. the stored manifest, on `CommandContext` and `getInstallationManifest`) and `connectionDivergence` (a Target's row vs. its own manifest entry, on `listTargets`).

## Test plan

- [x] `bun test` — 1620 pass, 0 fail (`apps/spindrift`)
- [x] `bun run typecheck`
- [x] `bun run lint` (only two pre-existing, unrelated findings remain — confirmed via `git diff` against `main` that neither touched file is part of this change)
- [x] `mise run ts:check` (workspace-wide)
- [x] New/changed tests reverted and re-run to confirm they fail without the fix: `getInstallationManifest`'s `declaration` field, the shell banner wiring, and the Settings adopt button — each named test went red on its own revert and green again once restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)