### PR TITLE
chore(spindrift): bump the installer chart past its templated manifest

### DIFF
--- a/clusters/offsite/apps/spindrift/oci-repository.yaml
+++ b/clusters/offsite/apps/spindrift/oci-repository.yaml
@@ -17,5 +17,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.1.2
+    tag: 0.1.3
   url: oci://ghcr.io/jonpulsifer/charts/spindrift

--- a/packages/charts/spindrift/Chart.yaml
+++ b/packages/charts/spindrift/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spindrift
 description: The Spindrift installer chart — the web and reconciler Deployments, their database, and the route the UI is served on
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "latest"


### PR DESCRIPTION
`5d999ca4` changed four templates under `packages/charts/spindrift/` without
moving `Chart.yaml`, so the chart workflow re-pushes a mutated `0.1.2` over
the artifact both clusters already hold.

That is not inert — `OCIRepository` re-resolves its tag on a `15m` interval,
so the new templates arrive on their own. The cost is that nothing then
distinguishes the chart before that change from the chart after it: no
rollback handle, and no way to tell which of the two a cluster is running
short of comparing digests.

The consumer pin in `clusters/offsite/apps/spindrift/oci-repository.yaml`
moves with it, which is the invariant
`apps/spindrift/test/conformance/second-target-admission.test.ts:428` exists
to hold — a version ahead of the tag ships nothing, a tag ahead of the push
leaves the source object failing to pull. That test asserts the two match; it
does not and cannot notice templates changing underneath a version that
stayed put, which is why this is a separate commit rather than something CI
caught.

🤖 Generated with [Claude Code](https://claude.com/claude-code)