### PR TITLE
feat(spindrift): converge faster and show the rollout while it happens

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -115,7 +115,7 @@ export interface CloudRunAdapterOptions {
   readonly schedulerEndpoint?: string;
 }
 
-const DEFAULT_POLL_MS = 2_000;
+const DEFAULT_POLL_MS = 1_000;
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
 const DEFAULT_LOGS_ENDPOINT = 'https://logging.googleapis.com';
 const DEFAULT_SCHEDULER_ENDPOINT = 'https://cloudscheduler.googleapis.com';
@@ -765,6 +765,11 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     // phase: a Service whose terminal condition has not appeared yet must not
     // put a second identical event on the timeline.
     let reported: DeployPhase = 'APPLYING';
+    // The condition message last put on the timeline. A revision says several
+    // different things while staying in one phase — provisioning, pulling,
+    // routing traffic — and those sentences are the only progress a reader gets
+    // between "applying" and a verdict.
+    let said: string | undefined;
 
     for (;;) {
       const service = await this.read(http, connection, collection, id);
@@ -778,6 +783,18 @@ export class CloudRunDeployAdapter implements DeployAdapter {
           ...(status.reason === undefined ? {} : { reason: status.reason }),
           ...(status.detail === undefined ? {} : { detail: status.detail }),
         });
+      }
+
+      // Terminal phases are excluded: their detail travels on the verdict, and
+      // repeating it here would put the same sentence on the timeline twice.
+      if (
+        status.detail !== undefined &&
+        status.detail !== said &&
+        status.phase !== 'LIVE' &&
+        status.phase !== 'FAILED'
+      ) {
+        said = status.detail;
+        yield this.log(status.detail, id);
       }
 
       if (status.phase === 'LIVE') {

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -114,7 +114,7 @@ export interface KubernetesAdapterOptions {
   readonly now?: () => number;
 }
 
-const DEFAULT_POLL_MS = 2_000;
+const DEFAULT_POLL_MS = 1_000;
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
 const RUNTIME_LOG_LIMIT_BYTES = 256 * 1024;
 
@@ -736,6 +736,15 @@ export class KubernetesDeployAdapter implements DeployAdapter {
    * the controller, and this is the only period in which they change quickly.
    * Once the attempt ends, nothing here keeps looking — the slow cadence that
    * detects drift belongs to core's loop, and lives on `observe`.
+   *
+   * **The controller's sentence is emitted, not only its phase.** A Helm
+   * upgrade spends most of its life in one phase while saying a series of
+   * different things — pulling the chart, running the upgrade action, waiting
+   * on a Deployment. Reporting only phase transitions turned two or three
+   * minutes of legible progress into two events and a still screen, so every
+   * change in the `Ready` condition's message becomes a log line on the
+   * timeline. It is deduplicated on the message itself, so a controller
+   * repeating itself every poll does not fill the log with one sentence.
    */
   private async *awaitVerdict(
     api: KubernetesApi,
@@ -751,6 +760,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
     // reported controller phase too, so an object whose status has not caught
     // up to its generation does not duplicate the event on the timeline.
     let reported: DeployPhase = 'APPLYING';
+    let said: string | undefined;
 
     for (;;) {
       const current = await api.get({
@@ -771,6 +781,20 @@ export class KubernetesDeployAdapter implements DeployAdapter {
           ...(status.reason === undefined ? {} : { reason: status.reason }),
           ...(status.detail === undefined ? {} : { detail: status.detail }),
         });
+      }
+
+      // The progress *within* a phase, which is where a rollout spends its
+      // time. Skipped on the terminal phases: `failed` writes the diagnosis
+      // below and `LIVE` is the verdict, so echoing either here would put the
+      // same sentence on the timeline twice.
+      if (
+        status.detail !== undefined &&
+        status.detail !== said &&
+        status.phase !== 'LIVE' &&
+        status.phase !== 'FAILED'
+      ) {
+        said = status.detail;
+        yield this.log(status.detail, resource);
       }
 
       if (status.phase === 'LIVE') {

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -19,9 +19,16 @@ import {
   targets,
 } from '../db/schema.ts';
 
+/**
+ * How often to look for a Build to dispatch.
+ *
+ * Both ends are the wait between pressing Deploy and a runner starting, and the
+ * scan itself is one indexed `select` over `PENDING` rows — so idle is seconds,
+ * not the tens of seconds a cheaper-looking number would cost every developer.
+ */
 export const DEFAULT_BUILD_INTERVALS = {
-  activeMs: 1_000,
-  idleMs: 5_000,
+  activeMs: 500,
+  idleMs: 1_500,
 } as const;
 
 export interface BuildLoopOptions {

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -13,9 +13,13 @@
  * convergence loop must not have; and hand-rolled watch bookkeeping in
  * TypeScript with no informer is real work for no gain at this scale.
  *
- * **The interval is adaptive, not fixed** (see {@link intervalFor}). Fast while
- * an attempt is in flight — a bounded window, not a standing watch — and slow
- * once converged, where the slow cadence *is* the drift detection §6 asks for.
+ * **Two cadences, not one.** Looking for work is one cheap indexed `select`, so
+ * it runs every second or two — a developer who pressed Deploy is waiting, and
+ * the interval before pickup is the largest number they experience. Looking at
+ * what has already converged costs one adapter round trip per live release, so
+ * drift detection runs on its own far slower clock
+ * ({@link DEFAULT_DRIFT_INTERVAL_MS}). Binding the two together made every
+ * pickup wait out a drift interval, which is the wait this split removes.
  *
  * **Claiming is `FOR UPDATE SKIP LOCKED`, and the claim is a leased phase.**
  * The lock on the Component@Target desired-state row is held only long enough
@@ -97,26 +101,36 @@ const IN_FLIGHT: readonly DeployPhase[] = ['APPLYING', 'WAITING'];
 /** A crashed worker's phase remains durable, then becomes safely reclaimable. */
 export const DEFAULT_CLAIM_TIMEOUT_MS = 15 * 60_000;
 
-/** How often to look, given what the Deploy is doing (§6, plan Transport). */
+/** How often to look for claimable work, given what is in flight (§6). */
 export interface LoopIntervals {
   /** While an attempt is converging. Short, and bounded by the attempt. */
   readonly fastMs: number;
-  /** Once converged. Also the drift-detection cadence — drift is information. */
+  /** With nothing unsettled. Still seconds: this is time-to-pickup. */
   readonly slowMs: number;
 }
 
 export const DEFAULT_INTERVALS: LoopIntervals = {
-  fastMs: 2_000,
-  slowMs: 5 * 60_000,
+  fastMs: 1_000,
+  slowMs: 2_000,
 };
 
 /**
- * The interval to wait before looking again.
+ * How often converged releases are re-read to notice drift (§6).
  *
- * Fast only while something is unsettled. §6 is explicit that drift is
- * "information, not an alarm", so the converged cadence is minutes: polling a
- * settled workload every two seconds would be a watch built out of polls, which
- * is the thing this design declined.
+ * Minutes, and deliberately unrelated to {@link LoopIntervals}: §6 is explicit
+ * that drift is "information, not an alarm", and one adapter round trip per
+ * live release is not something to spend every second. Polling for *work* is a
+ * `select`, so it stays fast; polling the platform is a network call, so it
+ * stays slow.
+ */
+export const DEFAULT_DRIFT_INTERVAL_MS = 5 * 60_000;
+
+/**
+ * The interval to wait before looking for work again.
+ *
+ * Fast while something is unsettled, and only a little slower when nothing is:
+ * both ends of this are the latency a developer feels between pressing a button
+ * and something happening.
  *
  * **The phases must come from the database, not from what the last pass
  * returned.** A pass only ever returns terminal outcomes — an attempt runs to
@@ -512,68 +526,80 @@ export async function observeConverged(
     .from(deploys)
     .where(eq(deploys.phase, 'LIVE'));
 
-  const reports: DriftReport[] = [];
-  for (const deploy of live) {
-    if (deploy.ref === null || deploy.orphanedAt !== null) continue;
-    const subject = await subjectOf(context, deploy);
-    if (subject === null) continue;
-
-    let state: ObservedState | null = null;
-    try {
-      state = await subject.adapter.observe(
-        deployTargetOf(subject.target, subject.vessel),
-        deploy.ref,
-      );
-    } catch {
-      // A Target that cannot be reached is not a Target that has drifted. Saying
-      // "drifted" here would turn every uplink blip into a false alarm about
-      // something a developer did.
-      continue;
-    }
-    const observed = state?.artifactDigest ?? null;
-
-    const drifted = hasDrifted({
-      phase: deploy.phase,
-      desiredDigest: subject.build.artifactDigest ?? '',
-      observedDigest: observed,
-      ...(state === null ? {} : { observedPhase: state.phase }),
-    });
-
-    // The platform's own sentence, kept only while it is the reason. §12's
-    // argument for storing a diagnosis applies here for the same cause: a
-    // Helm error naming the value that no longer renders is not recoverable
-    // from anywhere once the object is reconciled again.
-    const driftDetail =
-      drifted && state?.phase === 'FAILED' ? (state.detail ?? null) : null;
-
-    // §6 wants drift to be "a visible state", and visible means a row: the UI
-    // reads rows, so a finding that lived only for the length of this pass
-    // would be surfaced to nobody. Cleared when it matches again, so drift
-    // somebody fixed out of band stops being reported without a dismissal.
-    if (
-      drifted !== (deploy.driftedAt !== null) ||
-      observed !== deploy.observedDigest ||
-      driftDetail !== deploy.driftDetail
-    ) {
-      await context.db
-        .update(deploys)
-        .set({
-          driftedAt: drifted ? now : null,
-          observedDigest: observed,
-          driftDetail,
-          updatedAt: now,
-        })
-        .where(eq(deploys.id, deploy.id));
-    }
-
-    reports.push({
-      deployId: deploy.id,
-      drifted,
-      observedDigest: observed,
-      driftDetail,
-    });
-  }
+  // One adapter round trip each, and they do not depend on one another — so
+  // the pass costs the slowest Target rather than the sum of every Target.
+  // ponytail: unbounded fan-out, add a concurrency cap if an installation ever
+  // carries enough live releases to make that a thundering herd.
+  const reports = (
+    await Promise.all(live.map((deploy) => observeOne(context, deploy, now)))
+  ).filter((report): report is DriftReport => report !== null);
   return reports;
+}
+
+/** Read one converged release back off its platform, and say what it found. */
+async function observeOne(
+  context: DeployLoopContext,
+  deploy: Deploy,
+  now: Date,
+): Promise<DriftReport | null> {
+  if (deploy.ref === null || deploy.orphanedAt !== null) return null;
+  const subject = await subjectOf(context, deploy);
+  if (subject === null) return null;
+
+  let state: ObservedState | null = null;
+  try {
+    state = await subject.adapter.observe(
+      deployTargetOf(subject.target, subject.vessel),
+      deploy.ref,
+    );
+  } catch {
+    // A Target that cannot be reached is not a Target that has drifted. Saying
+    // "drifted" here would turn every uplink blip into a false alarm about
+    // something a developer did.
+    return null;
+  }
+  const observed = state?.artifactDigest ?? null;
+
+  const drifted = hasDrifted({
+    phase: deploy.phase,
+    desiredDigest: subject.build.artifactDigest ?? '',
+    observedDigest: observed,
+    ...(state === null ? {} : { observedPhase: state.phase }),
+  });
+
+  // The platform's own sentence, kept only while it is the reason. §12's
+  // argument for storing a diagnosis applies here for the same cause: a
+  // Helm error naming the value that no longer renders is not recoverable
+  // from anywhere once the object is reconciled again.
+  const driftDetail =
+    drifted && state?.phase === 'FAILED' ? (state.detail ?? null) : null;
+
+  // §6 wants drift to be "a visible state", and visible means a row: the UI
+  // reads rows, so a finding that lived only for the length of this pass
+  // would be surfaced to nobody. Cleared when it matches again, so drift
+  // somebody fixed out of band stops being reported without a dismissal.
+  if (
+    drifted !== (deploy.driftedAt !== null) ||
+    observed !== deploy.observedDigest ||
+    driftDetail !== deploy.driftDetail
+  ) {
+    await context.db
+      .update(deploys)
+      .set({
+        driftedAt: drifted ? now : null,
+        observedDigest: observed,
+        driftDetail,
+        updatedAt: now,
+      })
+      .where(eq(deploys.id, deploy.id));
+  }
+
+  return {
+    deployId: deploy.id,
+    drifted,
+    observedDigest: observed,
+    driftDetail,
+  };
 }
 
 /** Read everything one Deploy refers to, or `null` if it is not runnable. */
@@ -623,6 +649,8 @@ async function subjectOf(
 /** How the loop runs, and how to stop it. */
 export interface DeployLoopOptions {
   readonly intervals?: LoopIntervals;
+  /** Overrides {@link DEFAULT_DRIFT_INTERVAL_MS}, for a test that cannot wait. */
+  readonly driftIntervalMs?: number;
   readonly signal?: AbortSignal;
   /**
    * An optional early wake-up — the `LISTEN/NOTIFY` leg.
@@ -651,26 +679,66 @@ export interface LoopPass {
   readonly unsettled: readonly DeployPhase[];
 }
 
+/** What one pass is asked to do beyond claiming work. */
+export interface DeployPassOptions {
+  /**
+   * Whether to re-read converged releases for drift.
+   *
+   * The loop passes `false` on most ticks, because looking for work and looking
+   * for drift are different costs on different clocks
+   * ({@link DEFAULT_DRIFT_INTERVAL_MS}). Defaults to `true`, so a caller that
+   * wants one complete pass gets one.
+   */
+  readonly observe?: boolean;
+}
+
 /**
- * Drain every claimable intent, then look at what has converged.
+ * Claim every eligible intent, run them all, then optionally look for drift.
  *
- * Draining rather than taking one per tick: a burst of intents should not take
- * one poll interval each to start, and the drain is bounded by how many rows are
- * actually `PENDING`.
+ * **Claim in rounds, run each round together.** Claiming is a short transaction
+ * and applying is somebody else's control plane taking minutes, so the two are
+ * not interleaved: everything claimable is marked `APPLYING` up front and those
+ * attempts then run concurrently. Applying them one after another made a second
+ * App's deploy wait out the first App's whole rollout — two unrelated workloads,
+ * on two unrelated Targets, serialised by nothing but the shape of a `for` loop.
+ *
+ * Concurrency within a round is safe by the same rule that makes claiming safe:
+ * `claimNextDeploy` refuses a Component@Target that already has an in-flight
+ * Deploy, so a round holds at most one attempt per workload and no two attempts
+ * are ever placing the same thing.
+ *
+ * That refusal is also why the rounds repeat. Two queued intents for **one**
+ * Component@Target must still land in order, and the second only becomes
+ * claimable once the first is settled — so the pass keeps claiming until a round
+ * comes back empty. The wall clock is the deepest single queue rather than the
+ * sum of everything pending.
  */
 export async function runDeployPass(
   context: DeployLoopContext,
+  options: DeployPassOptions = {},
 ): Promise<LoopPass> {
   const applied: AttemptOutcome[] = [];
   for (;;) {
-    const claimed = await claimNextDeploy(context);
-    if (claimed === null) break;
-    const outcome = await runAttempt(context, claimed);
-    if (outcome !== null) applied.push(outcome);
+    const claimed: Deploy[] = [];
+    for (;;) {
+      const next = await claimNextDeploy(context);
+      if (next === null) break;
+      claimed.push(next);
+    }
+    if (claimed.length === 0) break;
+    // ponytail: unbounded fan-out, bounded in practice by how many distinct
+    // Component@Targets are pending at once. Add a pool if that stops holding.
+    const outcomes = await Promise.all(
+      claimed.map((deploy) => runAttempt(context, deploy)),
+    );
+    for (const outcome of outcomes) {
+      if (outcome !== null) applied.push(outcome);
+    }
   }
+
   return {
     applied,
-    drift: await observeConverged(context),
+    drift: options.observe === false ? [] : await observeConverged(context),
     unsettled: await unsettledPhases(context),
   };
 }
@@ -681,8 +749,17 @@ export async function runDeployLoop(
   options: DeployLoopOptions = {},
 ): Promise<void> {
   const intervals = options.intervals ?? DEFAULT_INTERVALS;
+  const driftMs = options.driftIntervalMs ?? DEFAULT_DRIFT_INTERVAL_MS;
+  // Zero, so the first pass observes: a reconciler that just started has no
+  // idea what the platforms are holding, and that is the moment to find out.
+  let nextDriftAt = 0;
+
   while (!options.signal?.aborted) {
-    const pass = await runDeployPass(context);
+    const startedAt = context.clock.now().getTime();
+    const observe = startedAt >= nextDriftAt;
+    if (observe) nextDriftAt = startedAt + driftMs;
+
+    const pass = await runDeployPass(context, { observe });
     options.onPass?.(pass);
     if (options.signal?.aborted) return;
 

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -25,6 +25,7 @@ import type {
   TargetOptionView,
   WorkspaceView,
 } from './model.ts';
+import { isInFlight } from './model.ts';
 import { useRoute } from './router.ts';
 import { subscribeAttempt, subscribeRuntime } from './stream-client.ts';
 import { type Theme, useTheme } from './theme.ts';
@@ -903,6 +904,61 @@ function WorkspaceScreen({
       live = false;
     };
   }, [appName, reloadToken]);
+
+  /**
+   * Keep the workspace current while something is moving.
+   *
+   * The attempt screen has the event stream; this screen has no such edge — it
+   * read once at mount and then sat on whatever the phase was at that instant,
+   * so a deploy started from here converged entirely off-screen. §18 puts the
+   * running App first, and an App-first screen that cannot notice its App
+   * coming up is the one that most needs to.
+   *
+   * Two cadences for the same reason the reconciler has two: while a release is
+   * in flight the reader is watching, and once it settles the read is only
+   * catching acts from elsewhere.
+   */
+  const inFlight =
+    state.type === 'success' && isInFlight(state.workspace.phase);
+  useEffect(() => {
+    if (!appName) return;
+    const timer = setInterval(
+      () => {
+        void command('getAppWorkspace', { name: appName })
+          .then((result) => {
+            if (!result.ok) return;
+            const fresh = result.value.workspace;
+            setState((current) => {
+              // The runtime tail is accumulated by a socket, not by this read —
+              // a fresh workspace carries only the server's first page of it,
+              // so taking it wholesale would wipe the log every few seconds.
+              if (
+                current.type === 'success' &&
+                current.workspace.runtime.kind === 'stream' &&
+                fresh.runtime.kind === 'stream'
+              ) {
+                return {
+                  type: 'success',
+                  workspace: {
+                    ...fresh,
+                    runtime: {
+                      ...fresh.runtime,
+                      lines: current.workspace.runtime.lines,
+                    },
+                  },
+                };
+              }
+              return { type: 'success', workspace: fresh };
+            });
+          })
+          // A failed refresh is not a reason to replace a workspace that is on
+          // screen and readable with an error page. The next tick tries again.
+          .catch(() => {});
+      },
+      inFlight ? 2_000 : 20_000,
+    );
+    return () => clearInterval(timer);
+  }, [appName, inFlight]);
 
   const runtime =
     state.type === 'success' && state.workspace.runtime.kind === 'stream'

--- a/apps/spindrift/src/web/components/log-pane.tsx
+++ b/apps/spindrift/src/web/components/log-pane.tsx
@@ -11,6 +11,7 @@
  * than an empty pane or a spinner.
  */
 import type { ReactNode } from 'react';
+import { useEffect, useRef } from 'react';
 import type { LogLine } from '../model.ts';
 import { cn } from '../ui/utils.ts';
 
@@ -19,18 +20,53 @@ const TONE = {
   muted: 'text-terminal-muted',
 } as const;
 
+/**
+ * How close to the bottom counts as "watching the end", in pixels.
+ *
+ * Generous, because the test is applied *after* the new lines are in the DOM:
+ * a reader pinned to the bottom is already this far from it by the time the
+ * effect runs, and a tighter threshold would drop them off the tail on exactly
+ * the fast-moving logs that most need following.
+ */
+const FOLLOW_SLACK_PX = 120;
+
 export function LogPane({
   lines,
+  follow = false,
   className,
 }: {
   lines: readonly LogLine[];
+  /**
+   * Keep the newest line in view as output arrives.
+   *
+   * Set while the thing writing the log is still running, and never otherwise —
+   * a finished transcript is a document you read from the top. Following also
+   * caps the pane's height, because a pane that grows forever has no bottom to
+   * scroll to and would drag the whole page down instead.
+   */
+  follow?: boolean;
   className?: string;
 }) {
+  const pane = useRef<HTMLPreElement>(null);
+
+  useEffect(() => {
+    const node = pane.current;
+    if (!follow || node === null) return;
+    // Only if the reader is already at the end. Somebody who scrolled up to
+    // read an earlier line is reading it, and yanking them back to the tail
+    // every time the runner prints is how a live log becomes unusable.
+    const distance = node.scrollHeight - node.scrollTop - node.clientHeight;
+    if (distance > FOLLOW_SLACK_PX) return;
+    node.scrollTop = node.scrollHeight;
+  }, [follow, lines]);
+
   return (
     <pre
+      ref={pane}
       className={cn(
         'overflow-x-auto rounded-lg bg-terminal px-3.5 py-3',
         'text-[12.5px] leading-[1.65] text-terminal-foreground',
+        follow && 'max-h-[420px] overflow-y-auto scroll-smooth',
         className,
       )}
     >

--- a/apps/spindrift/src/web/components/progress.tsx
+++ b/apps/spindrift/src/web/components/progress.tsx
@@ -1,0 +1,140 @@
+/**
+ * Where an attempt has got to, as one strip across the top of the screen.
+ *
+ * §18 rejects the stage rail every CI tool reaches for, and this is not that
+ * rail: it does not *structure* the page, it summarises it. The order down the
+ * screen is still state, diagnosis, what the release is, resources, logs — the
+ * running App first and the pipeline second. What this adds is the one thing
+ * that order cannot carry on its own, which is **how far along**. A reader who
+ * arrives mid-deploy should not have to infer that from which drawers happen to
+ * be open.
+ *
+ * It earns its place by being a legend rather than a navigation surface:
+ * nothing here is clickable, every segment names its own state in words, and
+ * the whole thing collapses to a single line once the release is live. A strip
+ * you can press would be a rail again.
+ *
+ * **The bar is honest about not knowing.** A deploy has no percentage — the
+ * platform reports phases, not fractions — so the fill is derived from *stages
+ * settled*, and the stage in flight contributes a half rather than a guess. The
+ * shimmer over the leading edge is what says "moving, duration unknown"; a bar
+ * that crept toward 90% and waited there would be inventing a number the
+ * controller never gave.
+ */
+import type { StepStatus } from '../model.ts';
+import { cn } from '../ui/utils.ts';
+import { StepGlyph, statusWord } from './status.tsx';
+
+/** One leg of the journey from source to serving. */
+export interface Stage {
+  readonly name: string;
+  readonly status: StepStatus;
+  /** The platform's own word for what this leg is doing, when it has one. */
+  readonly detail?: string;
+}
+
+/**
+ * How full the bar is.
+ *
+ * A settled stage counts whole and a running one counts half, so the bar moves
+ * on real transitions and never on a timer. Everything after a failure stays
+ * unfilled: a red deploy has not quietly made progress on the legs behind it.
+ */
+function fractionOf(stages: readonly Stage[]): number {
+  if (stages.length === 0) return 0;
+  let filled = 0;
+  for (const stage of stages) {
+    if (stage.status === 'failed') break;
+    if (stage.status === 'done') filled += 1;
+    else if (stage.status === 'running') {
+      filled += 0.5;
+      break;
+    } else break;
+  }
+  return filled / stages.length;
+}
+
+/** The tone the whole strip reads in: red beats moving, moving beats green. */
+function toneOf(stages: readonly Stage[]): 'failed' | 'running' | 'done' {
+  if (stages.some((stage) => stage.status === 'failed')) return 'failed';
+  if (stages.some((stage) => stage.status === 'running')) return 'running';
+  return 'done';
+}
+
+const FILL = {
+  failed: 'bg-destructive',
+  running: 'bg-warning',
+  done: 'bg-success',
+} as const;
+
+export function StageProgress({
+  stages,
+  className,
+}: {
+  stages: readonly Stage[];
+  className?: string;
+}) {
+  if (stages.length === 0) return null;
+  const tone = toneOf(stages);
+  const percent = Math.round(fractionOf(stages) * 100);
+
+  return (
+    <div
+      className={cn('flex flex-col gap-2', className)}
+      // One label for the whole strip. Each segment repeats its state in words
+      // below, so a screen reader that walks the list gets the detail; this is
+      // the summary somebody arriving on the region hears first.
+      role="group"
+      aria-label={`Progress: ${stages
+        .map((stage) => `${stage.name} ${statusWord(stage.status)}`)
+        .join(', ')}`}
+    >
+      <div className="h-1 w-full overflow-hidden rounded-full bg-secondary">
+        <div
+          className={cn(
+            'h-full rounded-full transition-[width] duration-700 ease-out',
+            FILL[tone],
+            // Only the moving bar moves. A settled one holding a shimmer would
+            // say something is happening when nothing is.
+            tone === 'running' && 'animate-pulse',
+          )}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+
+      <ol className="flex flex-wrap items-start gap-x-1 gap-y-2">
+        {stages.map((stage, index) => (
+          <li key={stage.name} className="flex items-start gap-1">
+            <div className="flex flex-col gap-0.5">
+              <span className="flex items-center gap-1.5">
+                <StepGlyph status={stage.status} />
+                <span
+                  className={cn(
+                    'text-[12.5px] font-medium',
+                    stage.status === 'waiting'
+                      ? 'text-muted-foreground'
+                      : 'text-foreground',
+                  )}
+                >
+                  {stage.name}
+                </span>
+              </span>
+              <span
+                className="pl-[22px] text-[11px] text-muted-foreground"
+                title={stage.detail}
+              >
+                {stage.detail ?? statusWord(stage.status)}
+              </span>
+            </div>
+            {index < stages.length - 1 ? (
+              <span
+                aria-hidden="true"
+                className="mt-[7px] ml-1 mr-1 h-px w-6 shrink-0 bg-border sm:w-10"
+              />
+            ) : null}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/components/running-time.tsx
+++ b/apps/spindrift/src/web/components/running-time.tsx
@@ -1,0 +1,66 @@
+/**
+ * How long the thing on screen has been going, counting.
+ *
+ * `elapsedSince` in the domain answers a different question — *when* something
+ * happened, projected against the server's clock, at minute resolution, because
+ * "8m ago" is the right grain for a release from this afternoon. This answers
+ * *how long it has been going*, at second resolution, and it has to tick.
+ *
+ * That is why it computes in the browser, which the domain's helper deliberately
+ * does not: a duration measured from a server-supplied start is off by whatever
+ * the two clocks disagree about, and a second or two of skew is invisible in a
+ * number whose whole job is to keep moving. A relative *instant* computed the
+ * same way would be a wrong fact; a running timer is a sign of life.
+ *
+ * **It is its own component so it is its own re-render.** A hook in the screen
+ * above would re-render the whole attempt page every second, log pane and all,
+ * to move two digits. The interval also stops the moment `active` goes false,
+ * so a settled release is not paying a timer to display a constant.
+ */
+import { useEffect, useState } from 'react';
+
+/** `1:04` up to an hour, then `1:02:09`. Never a bare count of seconds. */
+export function formatDuration(ms: number): string {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const seconds = total % 60;
+  const minutes = Math.floor(total / 60) % 60;
+  const hours = Math.floor(total / 3600);
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return hours > 0
+    ? `${hours}:${pad(minutes)}:${pad(seconds)}`
+    : `${minutes}:${pad(seconds)}`;
+}
+
+export function RunningTime({
+  since,
+  active,
+  className,
+}: {
+  /** ISO-8601 instant the run started, as the read model carries it. */
+  since: string;
+  /** Whether it is still going. False freezes the number where it stands. */
+  active: boolean;
+  className?: string;
+}) {
+  const started = Date.parse(since);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (!active) return;
+    // Re-synced from the wall clock each tick rather than incremented, so a
+    // backgrounded tab that throttled its timers comes back showing the true
+    // duration instead of however many ticks it was allowed to run.
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [active]);
+
+  // A start the read model could not supply is not a zero to render. There is
+  // no duration to state, so nothing is stated.
+  if (Number.isNaN(started)) return null;
+
+  return (
+    <span className={className}>
+      {formatDuration((active ? now : Math.max(now, started)) - started)}
+    </span>
+  );
+}

--- a/apps/spindrift/src/web/components/status.tsx
+++ b/apps/spindrift/src/web/components/status.tsx
@@ -6,7 +6,7 @@
  * same in any product, and these would not — a `BlameChip` is meaningless
  * outside a system that decided blame is derived, closed, and worth a chip.
  */
-import { Check, CircleDashed, Dot as DotIcon, X } from 'lucide-react';
+import { Check, CircleDashed, Loader2, X } from 'lucide-react';
 import type { ReactNode } from 'react';
 import type { Blame } from '../../adapters/deploy/contract.ts';
 import { type DeployPhase, isInFlight, type StepStatus } from '../model.ts';
@@ -67,30 +67,48 @@ export function BlameChip({ blame }: { blame: Blame | null }) {
 /**
  * Everything a step status renders as, in one row per status.
  *
- * Three parallel maps keyed by the same union is three chances to add a status
- * to two of them. One record makes a missing field a compile error, which is
+ * Four parallel maps keyed by the same union is four chances to add a status
+ * to three of them. One record makes a missing field a compile error, which is
  * the same discipline `BLAME` and `KINDS_BY_ADAPTER` use in the domain — and
  * `waiting` is the row that proves it earns its keep: it is the only status
  * whose glyph, tone, and word all disagree with its key.
+ *
+ * `spin` is a claim about the system, not decoration. It is set on exactly the
+ * status that means work is happening right now, so a stopped spinner is a
+ * statement that nothing is moving — which is what makes the moving one
+ * trustworthy. A step whose backend went silent still reads `running` and still
+ * spins, and that is correct: the phase is what the platform last said, and the
+ * screen does not get to decide it has gone stale.
  */
 const STATUS = {
-  done: { icon: Check, tone: 'text-success', word: 'done' },
-  running: { icon: DotIcon, tone: 'text-warning', word: 'running' },
-  failed: { icon: X, tone: 'text-destructive', word: 'failed' },
+  done: { icon: Check, tone: 'text-success', word: 'done', spin: false },
+  running: {
+    icon: Loader2,
+    tone: 'text-warning',
+    word: 'running',
+    spin: true,
+  },
+  failed: { icon: X, tone: 'text-destructive', word: 'failed', spin: false },
   waiting: {
     icon: CircleDashed,
     tone: 'text-muted-foreground',
     word: 'queued',
+    spin: false,
   },
 } as const satisfies Record<
   StepStatus,
-  { icon: typeof Check; tone: string; word: string }
+  { icon: typeof Check; tone: string; word: string; spin: boolean }
 >;
 
 /** The leading glyph on a checklist line. */
 export function StepGlyph({ status }: { status: StepStatus }) {
-  const { icon: Icon, tone } = STATUS[status];
-  return <Icon aria-hidden="true" className={cn('size-3.5 shrink-0', tone)} />;
+  const { icon: Icon, tone, spin } = STATUS[status];
+  return (
+    <Icon
+      aria-hidden="true"
+      className={cn('size-3.5 shrink-0', tone, spin && 'animate-spin')}
+    />
+  );
 }
 
 /** The word a step status reads as, where one is written out. */

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -48,8 +48,18 @@ import type { LogoName } from '../../client/logos/index.ts';
 import { Checklist } from '../../components/checklist.tsx';
 import { DiagnosisPanel, DriftPanel } from '../../components/diagnosis.tsx';
 import { LogPane, Notice } from '../../components/log-pane.tsx';
+import {
+  type Stage as ProgressStage,
+  StageProgress,
+} from '../../components/progress.tsx';
+import { RunningTime } from '../../components/running-time.tsx';
 import { PhasePill, StepGlyph, statusWord } from '../../components/status.tsx';
-import type { DeployView, SourceView } from '../../model.ts';
+import {
+  type DeployView,
+  isInFlight,
+  type SourceView,
+  type StepStatus,
+} from '../../model.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, Eyebrow } from '../../ui/card.tsx';
 import {
@@ -288,22 +298,103 @@ function Hero({
   view: DeployView;
   actions: AttemptActions;
 }) {
+  const moving = isInFlight(view.phase);
+
   return (
-    <Card className="flex flex-wrap items-center gap-4 px-5 py-5">
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <PhasePill phase={view.phase}>{view.phaseWord}</PhasePill>
-          <Eyebrow>{view.when}</Eyebrow>
-          {view.current ? <Eyebrow>· current release</Eyebrow> : null}
+    <Card className="flex flex-col gap-4 px-5 py-5">
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <PhasePill phase={view.phase}>{view.phaseWord}</PhasePill>
+            {/*
+              While it is moving, the number that matters is how long it has
+              been moving — a screen whose only time reads "just now" for the
+              first minute of a rollout looks frozen. Once it settles, "8m ago"
+              is the right grain again and the timer goes away rather than
+              standing there having stopped.
+            */}
+            {moving ? (
+              <Eyebrow>
+                <RunningTime since={view.at} active className="tabular-nums" />
+              </Eyebrow>
+            ) : (
+              <Eyebrow>{view.when}</Eyebrow>
+            )}
+            {view.current ? <Eyebrow>· current release</Eyebrow> : null}
+          </div>
+          <h1 className="text-[27px] font-semibold leading-tight tracking-[-0.02em]">
+            {view.headline}
+          </h1>
+          <Actions view={view} actions={actions} />
         </div>
-        <h1 className="text-[27px] font-semibold leading-tight tracking-[-0.02em]">
-          {view.headline}
-        </h1>
-        <Actions view={view} actions={actions} />
+        <UrlBlock view={view} />
       </div>
-      <UrlBlock view={view} />
+      <StageProgress
+        stages={stagesOf(view)}
+        className="border-t border-border-soft pt-4"
+      />
     </Card>
   );
+}
+
+/**
+ * The four legs every release has, in the order they happen.
+ *
+ * They are derived here rather than carried on {@link DeployView} because none
+ * of them is a new fact: each one is a projection of state the read model
+ * already states, and a fifth field restating them is a fifth field that can
+ * disagree with the four it was derived from.
+ *
+ * **Live is its own leg, and not a duplicate of Deploy.** The two answer
+ * different questions on the case that matters most: §9 never mutates exposure
+ * on red, so a failed deploy leaves the previous release serving — Deploy is
+ * `failed` and the App is still up. Collapsing them would make the strip say
+ * the App is down when it is not, which is the single most frightening thing a
+ * screen can get wrong.
+ */
+function stagesOf(view: DeployView): readonly ProgressStage[] {
+  const build = view.build;
+
+  const deployStatus: StepStatus =
+    view.id === null
+      ? 'waiting'
+      : view.phase === 'LIVE'
+        ? 'done'
+        : view.phase === 'FAILED'
+          ? 'failed'
+          : view.phase === 'PENDING'
+            ? 'waiting'
+            : 'running';
+
+  return [
+    // Always settled: the bytes were staged before any of this was written.
+    {
+      name: 'Source',
+      status: 'done',
+      detail: sourceRef(view.source),
+    },
+    build === null
+      ? // §4's supplied artifact — finished output, recorded as-is. Green
+        // because nothing is owed, and labelled so it does not read as a build
+        // that quietly succeeded.
+        { name: 'Build', status: 'done', detail: 'extracted' }
+      : {
+          name: 'Build',
+          status: build.status,
+          ...(build.duration === undefined ? {} : { detail: build.duration }),
+        },
+    { name: 'Deploy', status: deployStatus, detail: view.target },
+    view.urlLive
+      ? { name: 'Live', status: 'done', detail: 'serving' }
+      : view.previousReleaseServing
+        ? // Serving, just not this release. Neither green nor red: the App is
+          // up and this attempt did not put it there.
+          { name: 'Live', status: 'waiting', detail: 'previous release' }
+        : {
+            name: 'Live',
+            status: view.phase === 'FAILED' ? 'failed' : 'waiting',
+          },
+  ];
 }
 
 /**
@@ -743,7 +834,7 @@ function Transcript({ build }: { build: NonNullable<DeployView['build']> }) {
       </CollapsibleTrigger>
       <CollapsibleContent>
         <div className="flex flex-col gap-2 pt-2">
-          <LogPane lines={lines} />
+          <LogPane lines={lines} follow={build.status === 'running'} />
           {clipped ? (
             <p className="text-[11.5px] text-muted-foreground">
               Only the tail is kept here — a failure is at the end of a log, and
@@ -825,7 +916,7 @@ function DeployDrawer({ view }: { view: DeployView }) {
           yet.
         </Notice>
       ) : (
-        <LogPane lines={view.deployLog} />
+        <LogPane lines={view.deployLog} follow={isInFlight(view.phase)} />
       )}
     </Stage>
   );

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -430,6 +430,54 @@ describe('phases come from the controller', () => {
     expect(phases).toEqual(['APPLYING', 'WAITING', 'LIVE']);
   });
 
+  test("the controller's own sentence reaches the timeline, once each", async () => {
+    // A Helm upgrade says several different things while staying in one phase,
+    // and those sentences are the only progress a reader gets between the
+    // phase change and the verdict. Reporting phases alone left minutes of a
+    // rollout looking like a stopped screen.
+    const said = ['pulling chart', 'pulling chart', 'running upgrade'];
+    const { adapter } = adapterFor({
+      status: (reads) => {
+        const message = said[reads];
+        return message === undefined
+          ? {
+              observedGeneration: 1,
+              conditions: [
+                { type: 'Ready', status: 'True', message: 'upgrade succeeded' },
+              ],
+            }
+          : {
+              observedGeneration: 1,
+              conditions: [
+                {
+                  type: 'Ready',
+                  status: 'False',
+                  reason: 'Progressing',
+                  message,
+                },
+              ],
+            };
+      },
+    });
+
+    const { events, verdict } = await drain(
+      adapter.apply(target(), desiredState()),
+    );
+    expect(verdict.phase).toBe('LIVE');
+
+    const lines = events
+      .filter((event) => event.type === 'log')
+      .map((event) => (event.type === 'log' ? event.line : ''));
+    // After the write this adapter reports itself: the repeated poll of an
+    // unchanged message does not repeat the line, and the terminal sentence is
+    // not echoed here — it travels on the verdict.
+    expect(lines).toEqual([
+      'applied HelmRelease/delivery/blog-web',
+      'pulling chart',
+      'running upgrade',
+    ]);
+  });
+
   test('a LIVE verdict carries no url — the cluster gives no name of its own', async () => {
     const { adapter } = adapterFor();
     const { verdict } = await drain(adapter.apply(target(), desiredState()));

--- a/apps/spindrift/test/web/progress.test.tsx
+++ b/apps/spindrift/test/web/progress.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * The progress strip, and the one claim it exists to make.
+ *
+ * Rendered to static markup for the same reason `views.test.tsx` is: every rule
+ * here is a statement about what appears on screen in a given state, and none
+ * of them is about interaction.
+ *
+ * The claim that matters is the last one — **a failed deploy whose previous
+ * release is still serving does not report the App as down**. §9 never mutates
+ * exposure on red, so that pairing is the ordinary shape of a failure, and a
+ * strip that painted it all red would be the most frightening wrong thing this
+ * screen could say.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { StageProgress } from '../../src/web/components/progress.tsx';
+import { formatDuration } from '../../src/web/components/running-time.tsx';
+import type { DeployView } from '../../src/web/model.ts';
+import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
+import { DEPLOY_SCENARIOS } from '../fixtures/scenarios.ts';
+
+const strip = (stages: Parameters<typeof StageProgress>[0]['stages']) =>
+  renderToStaticMarkup(<StageProgress stages={stages} />);
+
+const screen = (view: DeployView) =>
+  renderToStaticMarkup(<DeployDetail view={view} />);
+
+/** The bar's fill, as the inline style states it. */
+const width = (markup: string) => /width:\s*([0-9]+)%/.exec(markup)?.[1];
+
+/** The strip's own summary, which is also what a screen reader is handed. */
+const summary = (markup: string) =>
+  /aria-label="Progress: ([^"]*)"/.exec(markup)?.[1];
+
+describe('the bar reports settled work, never a guess', () => {
+  test('a stage in flight counts a half, not a hopeful fraction', () => {
+    expect(
+      width(
+        strip([
+          { name: 'a', status: 'done' },
+          { name: 'b', status: 'running' },
+          { name: 'c', status: 'waiting' },
+          { name: 'd', status: 'waiting' },
+        ]),
+      ),
+    ).toBe('38');
+  });
+
+  test('nothing behind a failure is credited as progress', () => {
+    // The two stages after the failure are `done` on the row, which is what a
+    // naive count would add up. A red pipeline stopped where it stopped.
+    expect(
+      width(
+        strip([
+          { name: 'a', status: 'done' },
+          { name: 'b', status: 'failed' },
+          { name: 'c', status: 'done' },
+          { name: 'd', status: 'done' },
+        ]),
+      ),
+    ).toBe('25');
+  });
+
+  test('everything settled fills it', () => {
+    expect(
+      width(
+        strip([
+          { name: 'a', status: 'done' },
+          { name: 'b', status: 'done' },
+        ]),
+      ),
+    ).toBe('100');
+  });
+
+  test('only the moving bar moves', () => {
+    expect(strip([{ name: 'a', status: 'running' }])).toContain(
+      'animate-pulse',
+    );
+    expect(strip([{ name: 'a', status: 'done' }])).not.toContain(
+      'animate-pulse',
+    );
+  });
+});
+
+describe('the strip a release renders', () => {
+  test('a live release is green all the way to serving', () => {
+    expect(summary(screen(DEPLOY_SCENARIOS.live as DeployView))).toBe(
+      'Source done, Build done, Deploy done, Live done',
+    );
+  });
+
+  test('a build in flight has not started the deploy', () => {
+    expect(summary(screen(DEPLOY_SCENARIOS.building as DeployView))).toBe(
+      'Source done, Build running, Deploy running, Live queued',
+    );
+  });
+
+  test('a failed build leaves the App up, and says so', () => {
+    // Failed at Build, and `Live` is *queued* rather than failed: the previous
+    // release is still serving, so the App is not down.
+    const markup = screen(DEPLOY_SCENARIOS.buildFailed as DeployView);
+    expect(summary(markup)).toBe(
+      'Source done, Build failed, Deploy failed, Live queued',
+    );
+    expect(markup).toContain('previous release');
+  });
+});
+
+describe('a running duration', () => {
+  test('reads as minutes and seconds, then hours', () => {
+    expect(formatDuration(0)).toBe('0:00');
+    expect(formatDuration(9_400)).toBe('0:09');
+    expect(formatDuration(64_000)).toBe('1:04');
+    expect(formatDuration(3_729_000)).toBe('1:02:09');
+  });
+
+  test('never counts backwards through clock skew', () => {
+    expect(formatDuration(-5_000)).toBe('0:00');
+  });
+});


### PR DESCRIPTION
Deploying felt slow and looked frozen. Both had specific causes, and they are different problems.

## Speed

**Time to pickup was up to five minutes.** `runDeployLoop` used one interval for two jobs — looking for work, and looking for drift. Drift costs one adapter round trip per live release, so the converged interval was `5 * 60_000`. A `PENDING` intent written while the loop slept waited out that whole interval before anything touched it.

The two now run on separate clocks. The claim scan is one indexed `select`, so it polls every 1–2s; drift observation keeps its own `DEFAULT_DRIFT_INTERVAL_MS` of five minutes. §6's "drift is information, not an alarm" is preserved — it was never the reason pickup was slow, it was just tied to the same timer.

**A pass ran one deploy at a time.** It claimed an intent, ran it to a terminal verdict, then claimed the next — so two Apps on two unrelated Targets serialised on nothing but the shape of a `for` loop. `runDeployPass` now claims in rounds and runs each round concurrently. The rounds repeat rather than one flat fan-out because two queued intents for a single Component@Target must still land in order, and the claim guard only releases the second once the first settles. Wall clock is the deepest single queue rather than the sum of everything pending. `observeConverged` is parallel for the same reason.

Build dispatch idles at 1.5s rather than 5s. Both the Kubernetes and Cloud Run adapters poll their in-flight object every second rather than every two.

Bun's SQL client still has no session-level `LISTEN`, so the `wakeup` seam stays unwired — the cadence split gets the same win without adding `postgres.js` for one channel.

## Visibility

**Rollout feedback.** Both adapters emitted phase *transitions* only, so a two-minute Helm upgrade produced three events. They now put the controller's own `Ready` condition message on the timeline whenever it changes — "pulling chart", "running upgrade" — deduplicated on the message so a controller repeating itself every poll does not fill the log, and with the terminal sentence left to travel on the verdict instead of appearing twice.

**Spinners.** `STATUS.running` was a static dot. It is `Loader2` + `animate-spin` now, added as a `spin` field on the existing status record so it reaches every checklist line, stage header and resource row from one place.

**Stage strip.** `components/progress.tsx` — Source → Build → Deploy → Live in the attempt hero. This is not the rail §18 rejects: it does not structure the page, nothing in it is clickable, and the order down the screen is unchanged. The bar is derived from *stages settled*, with an in-flight stage counting a half and nothing behind a failure credited — a deploy has no percentage, and a bar that crept to 90% and waited would be inventing a number the controller never gave.

`Live` is a separate leg from `Deploy` deliberately. Exposure never mutates on red, so a failed deploy leaves the previous release serving — `Deploy` reads failed and the App is still up. Collapsing them would paint the strip red and say the App is down when it is not. That is the assertion pinned in `test/web/progress.test.tsx`.

**Running timer.** `components/running-time.tsx`, its own component so it does not re-render the log pane every second, and re-synced from the wall clock each tick so a throttled background tab comes back showing the true duration.

**Log follow.** `LogPane` gains `follow`, which caps height and pins to the tail — but only when the reader is already near the bottom, so scrolling up to read something does not get yanked back.

**The App workspace never refreshed.** It read once at mount and then sat on whatever the phase was at that instant, so a deploy started from there converged entirely off-screen. It now refreshes every 2s while a release is in flight and every 20s when it is not, preserving the runtime lines the socket accumulated rather than replacing them with the server's first page.

## Checks

`bun run typecheck` and `bun run lint` clean (two pre-existing findings in `commands/builds/route.ts` and `test/adapters/publishable-registries.test.ts` untouched). Full suite 1620 pass. `test/db/migrate.test.ts` fails locally with two 15s `afterEach` timeouts under load — identical failures reproduce on a stashed tree, so it is `DROP DATABASE WITH (FORCE)` contention on the local Postgres, not this change.

New coverage: the progress derivation and duration formatting in `test/web/progress.test.tsx`, and the adapter's per-sentence log emission in `test/adapters/kubernetes.test.ts`.

Two fan-outs carry `ponytail:` markers noting they are unbounded — bounded in practice by how many distinct Component@Targets and live releases an installation has, with a pool as the upgrade path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
