### PR TITLE
ci(typescript): run TypeScript validation on offsite ARC runner and add benchmark workflow

### DIFF
--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -1,0 +1,112 @@
+name: TypeScript Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Runner target to test (all runs offsite, folly, and ubuntu-latest in parallel matrix)'
+        type: choice
+        options:
+          - all
+          - infra-offsite
+          - infra-folly
+          - ubuntu-latest
+        default: all
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  configure:
+    runs-on: ubuntu-latest
+    outputs:
+      runners: ${{ steps.set-runners.outputs.runners }}
+    steps:
+      - id: set-runners
+        run: |
+          if [ "${{ inputs.target }}" = "all" ]; then
+            echo 'runners=["infra-offsite", "infra-folly", "ubuntu-latest"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'runners=["${{ inputs.target }}"]' >> "$GITHUB_OUTPUT"
+          fi
+
+  benchmark:
+    needs: configure
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ${{ fromJson(needs.configure.outputs.runners) }}
+    name: benchmark (${{ matrix.runner }})
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+    timeout-minutes: 15
+    env:
+      NEXT_TELEMETRY_DISABLED: 1
+      TURBO_TELEMETRY_DISABLED: 1
+      DATABASE_URL: postgres://postgres:postgres@localhost:5432/spindrift
+    services:
+      postgres:
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: spindrift
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/github
+          project_id: homelab-ng
+          create_credentials_file: true
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: 1.3.14
+      - name: Cache Bun store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-store-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-store-${{ runner.os }}-
+      - name: Cache Turborepo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            .turbo
+            node_modules/.cache/turbo
+            apps/*/.turbo
+            packages/*/.turbo
+            apps/*/.next/cache
+          key: turbo-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('bun.lock') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('bun.lock') }}-
+            turbo-${{ runner.os }}-${{ github.ref_name }}-
+            turbo-${{ runner.os }}-main-
+            turbo-${{ runner.os }}-
+      - name: Set up Helm
+        uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+        with:
+          install_args: helm
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+      - name: Lint
+        run: bun run lint
+      - name: Typecheck
+        run: bun run typecheck
+      - name: Build
+        run: bun run build
+      - name: Test
+        run: bun run test

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -5,6 +5,16 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: 'Runner target (infra-offsite, infra-folly, ubuntu-latest)'
+        type: choice
+        options:
+          - infra-offsite
+          - infra-folly
+          - ubuntu-latest
+        default: infra-offsite
 
 permissions:
   contents: read
@@ -69,8 +79,8 @@ jobs:
 
   validate:
     needs: detect
-    if: needs.detect.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
+    if: needs.detect.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ${{ inputs.runner || 'infra-offsite' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary
- Switches default `runs-on` in `typescript.yml` to `infra-offsite` (self-hosted ARC runner pool).
- Adds `workflow_dispatch` trigger with runner choices (`infra-offsite`, `infra-folly`, `ubuntu-latest`).
- Adds `typescript-benchmark.yml` for side-by-side benchmark testing across all runner pools.

## Verification
- Triggered workflow run on `infra-offsite`: https://github.com/jonpulsifer/infra/actions/runs/30959307988