### PR TITLE
fix(bluenose): say why run.invoker is not a project role here

### DIFF
--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -65,6 +65,16 @@ locals {
   ])
 }
 
+# `roles/run.invoker` is deliberately absent from the list above, and the
+# absence is the design rather than a gap. A scheduled Component's Cloud
+# Scheduler job calls `jobs.run` under an OIDC identity that is granted the
+# role **on the one Job it fires**, by the controller, at deploy time:
+# `apps/spindrift/src/adapters/deploy/cloudrun/scheduler.ts:112-124` sets the
+# whole policy on that resource and says why nothing wider reaches it.
+# Granting it here instead would hand the controller the right to invoke every
+# Cloud Run resource in the project, for the life of the project, to save a
+# per-Job call it already makes.
+
 resource "google_project_iam_member" "spindrift" {
   for_each = local.spindrift_project_roles
 


### PR DESCRIPTION
## What this is really for

`cloudscheduler.googleapis.com` and `roles/cloudscheduler.admin` have been
declared in this root since the schedules work merged, and were never applied
— that PR carried an `atlantis plan` comment and no `atlantis apply`. Atlantis
applies on the pull request, so a merged PR is not somewhere the apply can be
run from, and this root has had no diff since to autoplan on.

**So this PR exists to carry that apply.** Please run:

```
atlantis apply -d terraform/gcp/projects/bluenose
```

Until it does, a scheduled Cloud Run deploy fails visibly on
`cloudscheduler.jobs.create` — the API is off and the controller holds no
scheduler role.

## The change itself

Rather than a no-op diff, the comment is one that is worth having and stays
true after the apply.

A reader checking that a scheduled Cloud Run Job can actually be invoked finds
`roles/cloudscheduler.admin` in `spindrift_project_roles` and no
`roles/run.invoker`, and the obvious conclusion — that the grant was forgotten
— is wrong. The controller sets `roles/run.invoker` on the individual Job at
deploy time, on the one Job the scheduler fires
(`apps/spindrift/src/adapters/deploy/cloudrun/scheduler.ts:112-124`), which is
exactly why it is not a project role. Granting it here would hand the
controller the right to invoke every Cloud Run resource in the project for the
life of the project, to save a per-Job call it already makes.

`tofu fmt -check` clean, `tofu validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)