### PR TITLE
feat(spindrift-demo): add a railpack scope and a job scope

### DIFF
--- a/apps/spindrift-demo/README.md
+++ b/apps/spindrift-demo/README.md
@@ -1,0 +1,56 @@
+# spindrift-demo
+
+Four scopes, one per shape of App worth demonstrating. Each is a directory you
+can point a Component at; nothing here shares code with anything else here, so
+deploying one proves something about exactly one path.
+
+| Scope | Kind | Built by | What it demonstrates |
+| --- | --- | --- | --- |
+| `src/` | website | Dockerfile | A site with a real build step. `build.ts` stamps commit, branch and time into the HTML, so a stale deploy is visible on the page. |
+| `plain/` | website | — | Static files with no build at all. The narrowest possible website. |
+| `railpack/` | service | railpack | Detection picking a frontend on its own, because there is no Dockerfile in the scope. |
+| `job/` | job | railpack | A Component that runs once and stops, on either backend. |
+
+## Why two of them carry no `spindrift.yaml` and one does
+
+`job/` has to declare itself. Detection infers only `service` and `website` —
+`Exclude<ComponentKind, 'job'>` in
+`apps/spindrift/src/domain/detection/ladder.ts` — because nothing about a tree
+of files says whether it should be served or run once. `railpack/` deliberately
+has no such file: it is the demo of detection choosing for itself, and a file
+asserting the answer would remove the thing being demonstrated.
+
+`buildkit.ts` switches frontends on `[ -f Dockerfile ]` **in the scope**, so
+`railpack/` and `job/` staying Dockerfile-free is what routes them through
+railpack. Both are also self-contained — no workspace dependency, no root
+lockfile — because the zero-config arm builds with the scope as its build
+context rather than the repository root.
+
+## `job/`
+
+Three optional env vars, so one image covers every case worth looking at:
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `DURATION_SECONDS` | `15` | How long the run takes. Long enough to watch it go from started to finished; short enough that a `*/5 * * * *` schedule never overlaps itself. |
+| `EXIT_CODE` | `0` | Set it non-zero to see how a failed run surfaces. It writes to stderr on the way out. |
+| `STEPS` | `5` | How many progress lines to emit, spread across the duration. |
+
+It prints which backend it landed on from the environment it was given —
+`CLOUD_RUN_EXECUTION` on Cloud Run, `HOSTNAME` on Kubernetes — so a single run
+says which adapter placed it without anyone opening the UI.
+
+A cadence is not declared here. The same code is a job you press **Run now** on
+and a job that fires every five minutes; which one it is belongs to the
+Component, chosen at Place, not to the directory.
+
+## Running them locally
+
+```
+cd railpack && npm run build && npm start     # :3000, JSON on /, /healthz, /env
+cd job && DURATION_SECONDS=3 npm start        # exits 0
+cd job && EXIT_CODE=7 npm start               # exits 7, writes to stderr
+```
+
+`src/` and `plain/` are served by the `serve.ts` beside them; `bun run dev`
+from this directory builds `src/` and serves it hot.

--- a/apps/spindrift-demo/job/job.js
+++ b/apps/spindrift-demo/job/job.js
@@ -1,0 +1,67 @@
+/**
+ * A job that finishes, on purpose, and says who ran it.
+ *
+ * Detection cannot propose `kind: job` — `ladder.ts` types the inferred kind
+ * as `Exclude<ComponentKind, 'job'>`, because nothing about a tree of files
+ * says "run this once and stop" rather than "serve this". That is why this
+ * scope carries a `spindrift.yaml` and the railpack service demo beside it
+ * does not: the file is not a convenience here, it is the only way to say it.
+ *
+ * Three env vars, all optional, so one image demos every case an operator
+ * wants to look at:
+ *
+ *   DURATION_SECONDS   how long to take (default 15) — long enough to watch
+ *                      a run go from started to finished, short enough that a
+ *                      `*\/5 * * * *` schedule never overlaps itself
+ *   EXIT_CODE          what to exit with (default 0) — set it non-zero to see
+ *                      how a failed run surfaces
+ *   STEPS              how many progress lines to emit (default 5)
+ */
+const duration = Number(process.env.DURATION_SECONDS ?? 15);
+const exitCode = Number(process.env.EXIT_CODE ?? 0);
+const steps = Math.max(1, Number(process.env.STEPS ?? 5));
+
+/**
+ * Which backend is this, in its own words.
+ *
+ * Cloud Run names the execution; a Kubernetes Job leaves the pod name in
+ * `HOSTNAME` and nothing else. Reporting whichever is present is how a single
+ * run tells you which adapter placed it without anybody consulting the UI.
+ */
+function whoAmI() {
+  const execution = process.env.CLOUD_RUN_EXECUTION;
+  if (execution) {
+    const task = process.env.CLOUD_RUN_TASK_INDEX ?? '0';
+    return `cloudrun execution=${execution} task=${task}`;
+  }
+  if (process.env.HOSTNAME) return `kubernetes pod=${process.env.HOSTNAME}`;
+  return 'unknown backend';
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const log = (message) =>
+  console.log(`[${new Date().toISOString()}] ${message}`);
+
+log(`spindrift-demo-job starting — ${whoAmI()}`);
+log(`plan: ${steps} steps over ${duration}s, exiting ${exitCode}`);
+
+// Emitted one at a time rather than all at once: the log pane is supposed to
+// show a run in progress, and a job that printed everything in the first
+// millisecond would look identical to one that had already finished.
+for (let step = 1; step <= steps; step++) {
+  await sleep((duration / steps) * 1000);
+  log(`step ${step}/${steps} done`);
+}
+
+if (exitCode === 0) {
+  log('finished');
+} else {
+  // stderr, because a failing run that only ever wrote to stdout is a failing
+  // run that looks fine in any tool that separates the two.
+  console.error(
+    `[${new Date().toISOString()}] failing on purpose with ${exitCode}`,
+  );
+}
+
+process.exit(exitCode);

--- a/apps/spindrift-demo/job/package.json
+++ b/apps/spindrift-demo/job/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "spindrift-demo-job",
+  "private": true,
+  "type": "module",
+  "description": "A one-shot job demo: runs for a bit, logs progress, exits.",
+  "scripts": {
+    "start": "node job.js"
+  }
+}

--- a/apps/spindrift-demo/job/spindrift.yaml
+++ b/apps/spindrift-demo/job/spindrift.yaml
@@ -1,0 +1,22 @@
+# Managed by Spindrift, and yours to edit.
+#
+# This scope has to say `kind: job` because nothing can work it out: detection
+# infers only `service` and `website` (`Exclude<ComponentKind, 'job'>` in
+# apps/spindrift/src/domain/detection/ladder.ts), since a tree of files does
+# not say whether it should be served or run once. The sibling `railpack/`
+# scope deliberately carries no such file — it is the demo of detection
+# choosing for itself.
+#
+# There is no `schedule` key here on purpose. A cadence belongs to a
+# Component, not to a directory: the same code is a job you press Run on and a
+# job that fires every five minutes, and which one it is is the operator's
+# choice at Place, not the repository's.
+version: 1
+component:
+  kind: job
+build:
+  frontend: railpack
+  command: null
+  outputDirectory: null
+watchPaths:
+  - apps/spindrift-demo/job

--- a/apps/spindrift-demo/railpack/.gitignore
+++ b/apps/spindrift-demo/railpack/.gitignore
@@ -1,0 +1,1 @@
+build-stamp.json

--- a/apps/spindrift-demo/railpack/build.js
+++ b/apps/spindrift-demo/railpack/build.js
@@ -1,0 +1,27 @@
+/**
+ * Write down what the build saw, so the running service can prove it ran.
+ *
+ * The point of this file is that it is not optional decoration: railpack runs
+ * `npm run build` because package.json declares it, and if the build phase
+ * never happened `build-stamp.json` is missing and the server says so on `/`.
+ * A demo that looked identical whether or not it was built would not
+ * demonstrate anything.
+ */
+import { writeFileSync } from 'node:fs';
+
+const stamp = {
+  builtAt: new Date().toISOString(),
+  node: process.version,
+  // railpack sets neither of these; they are here to show what a build-time
+  // environment actually carried, which is the question people ask first.
+  platform: `${process.platform}/${process.arch}`,
+};
+
+writeFileSync(
+  new URL('./build-stamp.json', import.meta.url),
+  `${JSON.stringify(stamp, null, 2)}\n`,
+);
+
+console.log(
+  `spindrift-demo-railpack built at ${stamp.builtAt} on ${stamp.node}`,
+);

--- a/apps/spindrift-demo/railpack/package.json
+++ b/apps/spindrift-demo/railpack/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "spindrift-demo-railpack",
+  "private": true,
+  "type": "module",
+  "description": "Zero-config service demo: no Dockerfile, so Spindrift builds it with railpack.",
+  "scripts": {
+    "build": "node build.js",
+    "start": "node server.js"
+  }
+}

--- a/apps/spindrift-demo/railpack/server.js
+++ b/apps/spindrift-demo/railpack/server.js
@@ -1,0 +1,68 @@
+/**
+ * A service with no Dockerfile, which is the whole point.
+ *
+ * `buildkit.ts` switches frontends on `[ -f Dockerfile ]` in the scope, so
+ * this directory staying Dockerfile-free is what routes it through railpack.
+ * It is also self-contained — no workspace dependency, no root lockfile —
+ * because the zero-config arm builds with the *scope* as its context, not the
+ * repository root.
+ *
+ * Node built-ins only, deliberately. A dependency here would prove railpack
+ * can install one, but it would also make the demo fail for a reason that has
+ * nothing to do with Spindrift the first time a registry is slow.
+ */
+
+import { readFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+
+const port = Number(process.env.PORT) || 3000;
+const startedAt = new Date();
+
+/** What the build wrote, or null if the build phase never ran. */
+function buildStamp() {
+  try {
+    return JSON.parse(
+      readFileSync(new URL('./build-stamp.json', import.meta.url), 'utf-8'),
+    );
+  } catch {
+    return null;
+  }
+}
+
+const routes = {
+  '/': () => {
+    const stamp = buildStamp();
+    return {
+      service: 'spindrift-demo-railpack',
+      builtBy: 'railpack (no Dockerfile in this scope)',
+      build: stamp ?? 'MISSING — `npm run build` never ran',
+      startedAt: startedAt.toISOString(),
+      uptimeSeconds: Math.round((Date.now() - startedAt.getTime()) / 1000),
+    };
+  },
+  // A liveness answer that is cheap and says nothing else, so a probe pointed
+  // at it does not depend on the build having succeeded.
+  '/healthz': () => ({ ok: true }),
+  '/env': () => ({
+    // Only the names. Printing a value here would make the obvious demo of
+    // "wire a secret to this App" the same thing as leaking it.
+    names: Object.keys(process.env).sort(),
+  }),
+};
+
+createServer((req, res) => {
+  const path = new URL(req.url, `http://${req.headers.host}`).pathname;
+  const handler = routes[path];
+  res.writeHead(handler ? 200 : 404, {
+    'content-type': 'application/json; charset=utf-8',
+  });
+  res.end(
+    `${JSON.stringify(
+      handler ? handler() : { error: 'not found', routes: Object.keys(routes) },
+      null,
+      2,
+    )}\n`,
+  );
+}).listen(port, () => {
+  console.log(`spindrift-demo-railpack listening on :${port}`);
+});


### PR DESCRIPTION
`spindrift-demo` had two website scopes — `src/` with a build step and
`plain/` without one — and no way to demonstrate either of the two paths
people ask about first: a build with no Dockerfile in it, and a Component that
runs once and stops.

| Scope | Kind | Built by | Demonstrates |
| --- | --- | --- | --- |
| `railpack/` | service | railpack | Detection picking a frontend on its own |
| `job/` | job | railpack | A Component that runs once and stops, on either backend |

## `railpack/`

No Dockerfile, which is the whole of what makes it a railpack build —
`apps/spindrift/src/adapters/build/buildkit.ts:264` switches frontends on
`[ -f Dockerfile ]` in the scope. It carries no `spindrift.yaml` on purpose:
asserting the answer would remove the thing being demonstrated.

The build step is load-bearing rather than decorative. `npm run build` writes a
stamp the server reads back, so a build phase that silently never ran says so
on `/` instead of looking identical to one that did.

Serves JSON on `/`, `/healthz` and `/env`. `/env` returns variable *names*
only — printing values would make the obvious "wire a secret to this App" demo
the same thing as leaking it.

## `job/`

This scope has to declare `kind: job`. Detection infers only `service` and
`website` — `Exclude<ComponentKind, 'job'>` in
`apps/spindrift/src/domain/detection/ladder.ts:25` — because nothing about a
tree of files says whether it should be served or run once. So `job/` carries a
`spindrift.yaml` and `railpack/` deliberately does not.

Three optional env vars cover every case worth looking at from one image:

| Variable | Default | Effect |
| --- | --- | --- |
| `DURATION_SECONDS` | `15` | Long enough to watch a run go from started to finished; short enough that a `*/5 * * * *` schedule never overlaps itself |
| `EXIT_CODE` | `0` | Non-zero to see how a failed run surfaces; it writes to stderr on the way out |
| `STEPS` | `5` | Progress lines, spread across the duration, emitted one at a time so a run in progress does not look like one that already finished |

It reports whichever of `CLOUD_RUN_EXECUTION` or `HOSTNAME` it was given, so a
single run says which adapter placed it without anyone opening the UI.

No cadence is declared in the file. The same code is a job somebody presses
**Run now** on and a job that fires every five minutes; which one it is belongs
to the Component, chosen at Place, not to the directory.

## Both

Self-contained, Node built-ins only. The zero-config arm builds with the scope
as its build context rather than the repository root, so a workspace dependency
would not resolve — and a registry dependency would add a way for the demo to
fail for reasons that are not Spindrift's.

## Checks

`spindrift.yaml` parsed with the repo's own `parseSpindriftFile`, which returns
`kind: job`, `frontend: railpack`. Both scopes run locally: the service builds,
serves and 404s correctly; the job exits `0` and exits `7` on demand. Biome
clean. A `README.md` beside them describes all four scopes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)