### PR TITLE
fix(spindrift): build a test schema in one round trip, not 137

### DIFF
--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -54,6 +54,9 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: spindrift
+          # Matches typescript.yml: the benchmark runs the same suite, so it
+          # must not be the one that hits the stock connection ceiling.
+          POSTGRES_INITDB_ARGS: -c max_connections=300
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -97,6 +97,13 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: spindrift
+          # Headroom, not a requirement. spindrift's harness builds a private
+          # schema per test and peaks well under the stock 100 — but a backend
+          # the server has not finished reaping still counts against the limit,
+          # and on a contended runner that lag is what turns into `sorry, too
+          # many clients already`. A service container takes no command, so
+          # this rides in through initdb, which has taken `-c` since PG16.
+          POSTGRES_INITDB_ARGS: -c max_connections=300
         ports:
           - 5432:5432
         options: >-

--- a/apps/spindrift/test/harness/db.ts
+++ b/apps/spindrift/test/harness/db.ts
@@ -58,8 +58,30 @@ const BREAKPOINT = '--> statement-breakpoint';
  */
 const QUALIFIER = '"public".';
 
-/** The committed migrations, in filename order, rewritten to target `schema`. */
-async function migrationStatements(schema: string): Promise<string[]> {
+/**
+ * The committed DDL, read once and joined once.
+ *
+ * Read once because the files do not change while the process runs, and there
+ * is one schema built **per test**: re-reading twenty-five files before each of
+ * them is a thousandfold of the same syscalls for a string that was already in
+ * memory.
+ *
+ * Joined once because the cost that matters is round trips, not bytes. The
+ * breakpoints exist so drizzle-kit can write one statement per line, not
+ * because Postgres needs them apart — sending them separately spends one
+ * network round trip per statement, per test, and that is what makes a schema
+ * build take long enough on a loaded runner for a five-second hook to time out.
+ * Sent together they are one simple-query round trip, and Postgres runs them in
+ * one implicit transaction, so a schema is either built whole or not at all.
+ *
+ * Splitting on the breakpoint before rejoining is not a no-op: it is what drops
+ * comment-only fragments and normalizes whitespace, and it is what keeps the
+ * rewrite below operating on the same units the committed file declares.
+ */
+let committedDdl: string | null = null;
+
+async function migrationDdl(): Promise<string> {
+  if (committedDdl !== null) return committedDdl;
   const files = (await readdir(MIGRATIONS))
     .filter((name) => name.endsWith('.sql'))
     .sort();
@@ -67,11 +89,44 @@ async function migrationStatements(schema: string): Promise<string[]> {
   for (const file of files) {
     const sql = await Bun.file(join(MIGRATIONS, file)).text();
     for (const statement of sql.split(BREAKPOINT)) {
-      const trimmed = statement.replaceAll(QUALIFIER, `"${schema}".`).trim();
+      const trimmed = statement.trim();
       if (trimmed.length > 0) statements.push(trimmed);
     }
   }
-  return statements;
+  committedDdl = statements.join(';\n');
+  return committedDdl;
+}
+
+/** The committed migrations, as one script targeting `schema`. */
+async function migrationScript(schema: string): Promise<string> {
+  return (await migrationDdl()).replaceAll(QUALIFIER, `"${schema}".`);
+}
+
+/**
+ * The one session that creates and drops schemas, for the whole process.
+ *
+ * It is shared because it holds no isolated state: `CREATE SCHEMA` and
+ * `DROP SCHEMA` name their target, so nothing about them belongs to the test
+ * that asked. What was per-test was the *connection* — a pool opened and closed
+ * for a single DDL statement, twice per test, which at four figures of tests is
+ * several thousand connection lifecycles Postgres has to set up and reap. A
+ * server still reaping them when the next test asks for one is a server that
+ * answers `sorry, too many clients already`, and that is the shape the failure
+ * takes on a loaded runner.
+ *
+ * Never closed. It lives exactly as long as the test process, and there is no
+ * later point at which closing it would be more correct than exiting.
+ *
+ * Shareable under concurrency because it is a pool, not a connection —
+ * `isolation.test.ts` builds two schemas inside one `Promise.all`, which is the
+ * case that would break a single session. Its own `search_path` is deliberately
+ * left alone: every statement it runs names the schema it operates on.
+ */
+let admin: SQL | null = null;
+
+function adminSession(): SQL {
+  admin ??= createClient();
+  return admin;
 }
 
 /**
@@ -150,9 +205,7 @@ export function defaultVesselId(kind: VesselKind): string {
 export async function createIsolatedDatabase(): Promise<IsolatedDatabase> {
   const schema = schemaName();
 
-  const admin = createClient();
-  await admin.unsafe(`CREATE SCHEMA "${schema}"`);
-  await admin.close();
+  await adminSession().unsafe(`CREATE SCHEMA "${schema}"`);
 
   const url = schemaUrl(schema);
   const opened: SQL[] = [];
@@ -163,9 +216,7 @@ export async function createIsolatedDatabase(): Promise<IsolatedDatabase> {
   };
 
   const client = connect();
-  for (const statement of await migrationStatements(schema)) {
-    await client.unsafe(statement);
-  }
+  await client.unsafe(await migrationScript(schema));
 
   const db = createDb(client);
   const seeded = await db
@@ -195,9 +246,7 @@ export async function createIsolatedDatabase(): Promise<IsolatedDatabase> {
     connect,
     async close() {
       for (const open of opened) await open.close();
-      const dropper = createClient();
-      await dropper.unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
-      await dropper.close();
+      await adminSession().unsafe(`DROP SCHEMA IF EXISTS "${schema}" CASCADE`);
     },
   };
 }


### PR DESCRIPTION
## Summary

CI failed on two unrelated spindrift PRs within an hour of each other, in two different shapes:

- **#1729** — `a beforeEach/afterEach hook timed out` (5000ms), two tests, different files
- **#1730** — `PostgresError: sorry, too many clients already` (53300), cascading into ~500 failures

Same root cause. The test harness builds a private Postgres schema per test, and it was paying for that one round trip per DDL statement: **137 statements × 1644 tests ≈ 225,000 round trips**, plus 25 file reads and 2 connection lifecycles per test. Locally that costs a minute. On a contended runner it is the entire failure surface — the same suite took **384s in CI vs 60s locally**, and at that speed a 5s hook budget is reachable and backends pile up faster than Postgres reaps them.

## Changes

- **The committed DDL is read once per process and sent as one script.** Postgres runs a multi-statement simple query in one implicit transaction, so a schema is now built whole or not at all. Verified equivalent, not assumed: columns, constraints, indexes and enums fingerprint byte-identical against the statement-at-a-time replay.
- **`CREATE SCHEMA` / `DROP SCHEMA` move to one shared admin pool.** They name their target, so they belong to no test in particular; per-test they were two pool lifecycles opened and closed for a single statement each — ~5,000 per run, which is what piles up as unreaped backends.
- **Connection headroom on the two workflows that run this suite.** Not what fixes the flake and not load-bearing. A service container takes no command, so `max_connections` rides in through `POSTGRES_INITDB_ARGS`, which works because initdb has accepted `-c` since PG16 (verified against a real server, not inferred from docs).

`arc-smoke.yml` is left alone — it opens one connection to prove reachability.

## Test Plan

- [x] Reproduced the environment: Postgres at CI's stock `max_connections=100`
- [x] `bun test` — 1644 pass, 0 fail, **60.6s → 31.4s**
- [x] Peak concurrent connections sampled during the run: 27 before, 36 after (both far under 100 — the ceiling is hit by reap lag, not by steady-state demand)
- [x] Schema equivalence: `information_schema.columns` + `pg_constraint` + `pg_indexes` + `pg_enum` fingerprints match between per-statement and batched replay
- [x] `initdb -c max_connections=300` verified to land in `postgresql.conf` and report `300` from a running server
- [ ] CI green on this PR, then #1729 and #1730 rerun clean on top of it
