### PR TITLE
fix(ci): stop paying for durability spindrift's test database never collects

### DIFF
--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -54,9 +54,14 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: spindrift
-          # Matches typescript.yml: the benchmark runs the same suite, so it
-          # must not be the one that hits the stock connection ceiling.
-          POSTGRES_INITDB_ARGS: -c max_connections=300
+          # Matches typescript.yml, and has to: the benchmark runs the same
+          # suite, so a database configured differently would be measuring a
+          # different thing.
+          POSTGRES_INITDB_ARGS: >-
+            -c max_connections=300
+            -c fsync=off
+            -c synchronous_commit=off
+            -c full_page_writes=off
         ports:
           - 5432:5432
         options: >-

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -97,13 +97,27 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: spindrift
-          # Headroom, not a requirement. spindrift's harness builds a private
-          # schema per test and peaks well under the stock 100 — but a backend
-          # the server has not finished reaping still counts against the limit,
-          # and on a contended runner that lag is what turns into `sorry, too
-          # many clients already`. A service container takes no command, so
-          # this rides in through initdb, which has taken `-c` since PG16.
-          POSTGRES_INITDB_ARGS: -c max_connections=300
+          # This database is destroyed when the job ends, so every guarantee it
+          # makes about surviving a crash is paid for and never collected.
+          # spindrift's harness builds and drops a schema per test — over 1600
+          # of them — and with `fsync` on, each one waits on real disk flushes
+          # for state nothing will ever read again. Measured on one machine,
+          # everything else held constant: 199s → 96s → 31s across the harness
+          # fix and this. It is the difference between a five-second hook having
+          # margin and having none.
+          #
+          # `max_connections` is headroom rather than a requirement: the suite
+          # peaks near 30, but a backend the server has not finished reaping
+          # still counts against the limit, and on a contended runner that lag
+          # is what becomes `sorry, too many clients already`.
+          #
+          # A service container takes no command, so all of it rides in through
+          # initdb, which has accepted `-c` since PG16.
+          POSTGRES_INITDB_ARGS: >-
+            -c max_connections=300
+            -c fsync=off
+            -c synchronous_commit=off
+            -c full_page_writes=off
         ports:
           - 5432:5432
         options: >-


### PR DESCRIPTION
## Summary

Follow-up to #1732, and a correction to its reasoning.

#1732 claimed round trips were "the entire failure surface." They were not. It was a real 2× — but CI wall time barely moved (**384s** before → **379s** and **333s** after), and #1730 tipped over the 5s hook boundary again on a merge ref that provably contained the fix. So I measured the axis I had held constant, and it was the one that mattered: my local Postgres ran `fsync=off`, CI's runs with it on.

## The measurement

One machine, one suite, everything else held constant:

| harness | `fsync` | suite | result |
|---|---|---|---|
| per-statement (pre-#1732) | on | **199.6s** | 2 fail — the CI failure, reproduced locally |
| batched (#1732) | on | **95.7s** | pass |
| batched (#1732) | off | **31.4s** | pass |

The database CI hands the suite is destroyed when the job ends, so every guarantee it makes about surviving a crash is bought and never collected. The harness builds and drops a schema per test — 1600+ of them — and with `fsync` on each waits on real disk flushes for state nothing will ever read.

## Changes

- `fsync=off`, `synchronous_commit=off`, `full_page_writes=off` on the two workflows that run this suite, via the same `POSTGRES_INITDB_ARGS` channel #1732 already used.
- `arc-smoke.yml` untouched — it opens one connection to prove reachability.

## What this does not fix

CI's `validate` job is ~6 minutes and this will not make it ~2. The **runner** dominates wall time, not the database — that is what the 384/379/333 sequence says. What the database governs is the *hook*: five seconds to build a schema, and whether it has margin or none is exactly what separates a green run from a red one. Two PRs failed on that boundary this week and one passed on a rerun with no change at all.

Durability is the only thing given up, and this database has nothing to be durable about. Isolation and locking semantics are untouched — which matters, because they are what the suite actually asserts.

## Test Plan

- [x] `initdb -c max_connections=300 -c fsync=off -c synchronous_commit=off -c full_page_writes=off` → all four land in `postgresql.conf` and a running server reports them
- [x] Both workflows parse; the folded scalar yields one arg string (`yq`)
- [x] Suite passes at `fsync=off`: 1644 pass, 0 fail
- [ ] `validate` green here — note the failure mode is loud: a rejected initdb arg means the service container never becomes healthy, so this PR is its own check
- [ ] #1730 rerun on top

**Not verified locally:** the exact `postgres:18-alpine` image. Docker's daemon is unreachable from this WSL distro, so I checked the mechanism against a real `initdb` (`-c` has existed since PG16) rather than against the image CI pulls.
