### PR TITLE
feat(spindrift): pin the whole release document on a Deploy

### DIFF
--- a/apps/spindrift/src/commands/components/reach.ts
+++ b/apps/spindrift/src/commands/components/reach.ts
@@ -104,7 +104,7 @@ export const setComponentReach: Command<
     where: (desired, { eq }) => eq(desired.componentId, row.id),
     with: {
       target: { columns: { name: true } },
-      desiredDeploy: { columns: { reach: true, auth: true } },
+      desiredDeploy: { columns: { desired: true } },
     },
   });
 
@@ -116,8 +116,8 @@ export const setComponentReach: Command<
       .filter(
         ({ desiredDeploy }) =>
           desiredDeploy !== null &&
-          (desiredDeploy.reach !== input.reach ||
-            desiredDeploy.auth !== input.auth),
+          (desiredDeploy.desired.reach !== input.reach ||
+            desiredDeploy.desired.auth !== input.auth),
       )
       .map(({ target }) => target.name)
       .sort(),

--- a/apps/spindrift/src/commands/config/set.ts
+++ b/apps/spindrift/src/commands/config/set.ts
@@ -52,7 +52,11 @@ import {
   VARIABLE_NAME,
 } from '../../domain/config.ts';
 import type { ComponentKind } from '../../domain/desired-state.ts';
-import { checkDeployable, placeIntent } from '../deploys/create.ts';
+import {
+  checkDeployable,
+  deliveringConfig,
+  placeIntent,
+} from '../deploys/create.ts';
 import {
   type AdapterRegistry,
   type Command,
@@ -463,10 +467,10 @@ async function deployChange(
     return { deployId: null, notDeployed: checked.failure.message };
   }
 
-  const placed = await placeIntent(context, {
-    ...checked.value,
-    config: pinned,
-  });
+  const placed = await placeIntent(
+    context,
+    deliveringConfig(checked.value, pinned),
+  );
   return placed.ok
     ? { deployId: placed.value.deployId, notDeployed: null }
     : { deployId: null, notDeployed: placed.failure.message };

--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -36,6 +36,7 @@
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
 import {
+  apps,
   builds,
   components,
   componentTargetDesired,
@@ -43,6 +44,7 @@ import {
   targets,
 } from '../../db/schema.ts';
 import { DEFAULT_MINIMUM_BUILD_LEVEL } from '../../domain/build-route.ts';
+import type { DesiredDocument } from '../../domain/desired-state.ts';
 import {
   artifactTypeFor,
   DEFAULT_PLATFORM,
@@ -104,16 +106,46 @@ export interface DeployPreconditions {
   readonly componentId: string;
   readonly targetId: string;
   readonly buildId: number;
-  readonly reach: 'none' | 'private' | 'public';
-  readonly auth: 'none' | 'proxy';
   /**
-   * The pinned config document this attempt delivers (§10).
+   * Everything this attempt places, captured here rather than read at apply
+   * time — which is what makes a Deploy "exactly Heroku's Release": what a
+   * rollback comes back up with is what its Deploy recorded, not what the
+   * Component and config rows say today.
    *
-   * Captured here rather than read at apply time, which is what makes a Deploy
-   * "exactly Heroku's Release": what a rollback comes back up with is what its
-   * Deploy recorded, not what the config items say today.
+   * §10 made this argument for the config document alone. It was never specific
+   * to config: a Component's kind, exposure and schedule are read by the same
+   * apply, and re-reading them gives a rollback yesterday's artifact under
+   * today's shape.
    */
-  readonly config: PinnedConfig;
+  readonly desired: DesiredDocument;
+  /** §10's hash over `desired.config`, materialized because the UI lists it. */
+  readonly configVersion: string;
+}
+
+/**
+ * The same preconditions, delivering a different config document.
+ *
+ * Two callers replace exactly this one leg and nothing else: a config change
+ * deploys what was *just written* rather than what `checkDeployable` read a
+ * moment earlier, and a rollback deploys what the release being rolled back to
+ * originally had. Both leave the rest of the shape alone, because the shape a
+ * rollback wants is the Component as it is now — rolling an artifact back is
+ * not a request to undo unrelated edits.
+ *
+ * A function rather than the spread written twice, because the spread is
+ * nested: `{ ...value, config: pinned }` type-checks against nothing and
+ * silently pins the old document, which is the bug this whole column exists to
+ * remove.
+ */
+export function deliveringConfig(
+  value: DeployPreconditions,
+  config: PinnedConfig,
+): DeployPreconditions {
+  return {
+    ...value,
+    configVersion: config.version,
+    desired: { ...value.desired, config: config.document },
+  };
 }
 
 /**
@@ -217,16 +249,11 @@ export async function placeIntent(
         targetId: checked.targetId,
         buildId: checked.buildId,
         phase: 'PENDING',
-        // §9: reach and auth are the Component's settings, captured at intent
-        // time so a later change to the Component does not retroactively
-        // describe what this attempt asked for.
-        reach: checked.reach,
-        auth: checked.auth,
-        // §10, for the same reason and with more at stake: the document is what
-        // this Deploy delivers, so a rollback to it delivers that document
-        // again rather than whatever config was set in the meantime.
-        configVersion: checked.config.version,
-        configDocument: checked.config.document,
+        // The document this Deploy places, captured at intent time so that a
+        // later edit to the Component does not retroactively describe what this
+        // attempt asked for, and so a rollback to it places what it placed.
+        desired: checked.desired,
+        configVersion: checked.configVersion,
         createdAt: now,
         updatedAt: now,
       })
@@ -255,7 +282,7 @@ export async function placeIntent(
     buildId: checked.buildId,
     phase: 'PENDING' as const,
     supersededBuildId: placed.supersededBuildId,
-    configVersion: checked.config.version,
+    configVersion: checked.configVersion,
   });
 }
 
@@ -281,6 +308,17 @@ export async function checkDeployable(
       'NOT_FOUND',
       `there is no Component with id ${input.componentId}`,
     );
+  }
+
+  const [app] = await context.db
+    .select()
+    .from(apps)
+    .where(eq(apps.id, component.appId));
+  if (app === undefined) {
+    // Unreachable while the foreign key holds, which is what makes this a
+    // refusal rather than a `!`: a Component whose App has been deleted is not
+    // a state to compose a release document out of.
+    return refuse('NOT_FOUND', `Component ${component.name} has no App`);
   }
 
   const [target] = await context.db
@@ -424,15 +462,35 @@ export async function checkDeployable(
     );
   }
 
+  const config = await readPinnedConfig(context.db, component.id, target.id);
+
   return {
     ok: true,
     value: {
       componentId: component.id,
       targetId: target.id,
       buildId: build.id,
-      reach: component.reach,
-      auth: component.auth,
-      config: await readPinnedConfig(context.db, component.id, target.id),
+      configVersion: config.version,
+      desired: {
+        app: app.name,
+        component: component.name,
+        target: target.name,
+        kind: component.kind,
+        // Optional on `DesiredState`, so absent rather than null — the chart
+        // branches on emptiness and the adapters spread this straight through.
+        ...(component.expose === null ? {} : { expose: component.expose }),
+        reach: component.reach,
+        auth: component.auth,
+        ...(component.schedule === null
+          ? {}
+          : { schedule: component.schedule }),
+        config: config.document,
+        // §3 keeps core out of scheduling and detection has not landed, so
+        // nothing states a platform or a size yet. Pinned as the constant it
+        // has always been applied as, so that the day something does state one
+        // this is the only place that changes.
+        requirements: { platform: DEFAULT_PLATFORM, resources: {} },
+      },
     },
   };
 }

--- a/apps/spindrift/src/commands/deploys/rollback.ts
+++ b/apps/spindrift/src/commands/deploys/rollback.ts
@@ -29,6 +29,7 @@ import type { Command, CommandContext } from '../types.ts';
 import {
   type CreateDeployResult,
   checkDeployable,
+  deliveringConfig,
   placeIntent,
 } from './create.ts';
 
@@ -65,7 +66,9 @@ export const rollbackDeploy: Command<
   // up unconfigured because history is silent.
   const previous = await lastDeployOf(context, input);
   const value =
-    previous === null ? checked.value : { ...checked.value, config: previous };
+    previous === null
+      ? checked.value
+      : deliveringConfig(checked.value, previous);
 
   // The "is this actually older" question is asked **under the lock**, against
   // the desired row as it is at the moment the intent is written. Asking it
@@ -99,7 +102,7 @@ async function lastDeployOf(
   input: RollbackDeployInput,
 ): Promise<PinnedConfig | null> {
   const [previous] = await context.db
-    .select({ document: deploys.configDocument })
+    .select({ desired: deploys.desired })
     .from(deploys)
     .where(
       and(
@@ -111,11 +114,9 @@ async function lastDeployOf(
     .orderBy(desc(deploys.id))
     .limit(1);
 
-  if (previous?.document === undefined || previous.document === null) {
-    return null;
-  }
+  if (previous === undefined) return null;
   return {
-    document: previous.document,
-    version: await configVersionOf(previous.document),
+    document: previous.desired.config,
+    version: await configVersionOf(previous.desired.config),
   };
 }

--- a/apps/spindrift/src/db/migrations/0026_deploy_desired.sql
+++ b/apps/spindrift/src/db/migrations/0026_deploy_desired.sql
@@ -1,0 +1,56 @@
+-- A Deploy carries the document it places, and every Deploy has one.
+--
+-- §10 pinned `config_document` because "re-reading current config at apply time
+-- would give a rollback the configuration of the release it is rolling away
+-- from". `reach` and `auth` were pinned later for the same reason, stated the
+-- same way. Everything else in the document — kind, expose, schedule, the names
+-- — was still read from `components` at apply time, so a Component edited after
+-- an intent was written retroactively changed what that intent placed, and a
+-- rollback came back up with yesterday's artifact under today's shape.
+--
+-- One column replaces the three. It is NOT NULL on purpose: an intent whose
+-- meaning has to be reassembled from rows that have moved since is not an
+-- intent, and a nullable column would keep the compose-from-rows path alive as
+-- a fallback, which is where the bug would keep living.
+--
+-- What it does not carry — the artifact (immutable on the Build this Deploy
+-- names), the deploy id (this row's own key), and the hostname (a property of
+-- the App, since §9's "one record re-point" only holds if a name outlives the
+-- releases under it) — is why this backfill is computable from these rows
+-- alone.
+ALTER TABLE "deploys" ADD COLUMN "desired" jsonb;
+
+-- Every existing row gets the document it would have been written with.
+-- `jsonb_strip_nulls` is what makes `expose` and `schedule` absent rather than
+-- null, matching the optional fields on `DesiredState`. `requirements` is the
+-- constant `DEFAULT_PLATFORM` with no resources, which is exactly what these
+-- rows were applied with — placement's arch and ceiling joins have never had a
+-- stated value to compare against.
+UPDATE "deploys" AS d
+SET "desired" = jsonb_strip_nulls(
+  jsonb_build_object(
+    'app', a."name",
+    'component', c."name",
+    'target', t."name",
+    'kind', c."kind"::text,
+    'expose', c."expose",
+    'reach', COALESCE(d."reach", c."reach")::text,
+    'auth', COALESCE(d."auth", c."auth")::text,
+    'schedule', c."schedule",
+    'config', COALESCE(d."config_document", '[]'::jsonb),
+    'requirements', jsonb_build_object(
+      'platform', jsonb_build_object('os', 'linux', 'arch', 'amd64'),
+      'resources', '{}'::jsonb
+    )
+  )
+)
+FROM "components" c, "apps" a, "targets" t
+WHERE c."id" = d."component_id"
+  AND a."id" = c."app_id"
+  AND t."id" = d."target_id";
+
+ALTER TABLE "deploys" ALTER COLUMN "desired" SET NOT NULL;
+
+ALTER TABLE "deploys" DROP COLUMN "config_document";
+ALTER TABLE "deploys" DROP COLUMN "reach";
+ALTER TABLE "deploys" DROP COLUMN "auth";

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -183,6 +183,13 @@
       "when": 1785374380769,
       "tag": "0025_drop_app_vessel_ref",
       "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "7",
+      "when": 1785374380770,
+      "tag": "0026_deploy_desired",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -49,7 +49,7 @@ import type {
   TargetDiscovery,
 } from '../domain/capabilities.ts';
 import type { Draft } from '../domain/creation-draft.ts';
-import type { ConfigEntry } from '../domain/desired-state.ts';
+import type { DesiredDocument } from '../domain/desired-state.ts';
 import type { TargetConnection } from '../domain/target.ts';
 import { VESSEL_KINDS, type VesselLocation } from '../domain/vessel.ts';
 import type { CoreSignature } from '../supply-chain/sign.ts';
@@ -692,32 +692,34 @@ export const deploys = pgTable('deploys', {
    */
   ref: text('ref'),
   url: text('url'),
-  /** §10: "a hash over a document of pinned version references." */
+  /**
+   * §10: "a hash over a document of pinned version references."
+   *
+   * Kept beside {@link deploys.desired} rather than recomputed from it: this is
+   * a materialized hash the UI reads on every list, not a second statement of
+   * what is delivered.
+   */
   configVersion: text('config_version'),
   /**
-   * The pinned document itself, captured when this intent was written (§10).
+   * **What this intent places**, captured when it was written (§6, §10).
    *
-   * Stored rather than re-read from `config_items` at apply time, and that is
-   * the whole of what makes a Deploy "exactly Heroku's Release": a rollback is
-   * an ordinary deploy naming an older Build (§6), and it "comes back up with
-   * the configuration it originally had" only because the configuration it had
-   * is on the row. Re-deriving it from current config items would make every
-   * rollback come up with *today's* config, which is the failure §10's pinning
-   * exists to prevent.
+   * `NOT NULL`, and that is the whole design. A Deploy whose meaning has to be
+   * reassembled from Component and config rows that have moved since is not an
+   * intent — it is a query, and it answers with today's shape under yesterday's
+   * artifact. §10 already made this argument for config alone: "re-deriving it
+   * from current config items would make every rollback come up with *today's*
+   * config." The argument was never specific to config.
+   *
+   * So this column **replaces** `config_document`, `reach` and `auth`, which
+   * pinned three fields of one document and left the rest to be re-read. Two
+   * places holding one fact is two places for them to disagree.
    *
    * References, never values — the same posture as `sessions.tokenHash`: a
    * database that cannot produce a credential is a database whose disclosure
-   * does not produce one either.
+   * does not produce one either. See {@link DesiredDocument} for the three
+   * fields this deliberately does not carry.
    */
-  configDocument:
-    jsonbDocument('config_document').$type<readonly ConfigEntry[]>(),
-  /**
-   * What this attempt asked for, pinned the same way `configDocument` is: a
-   * Component edited mid-attempt must not retroactively change what a running
-   * attempt is placing.
-   */
-  reach: reachState('reach'),
-  auth: authMode('auth'),
+  desired: jsonbDocument('desired').$type<DesiredDocument>().notNull(),
   /**
    * §13: "Disconnect always works: live Deploys go `orphaned`, workloads keep
    * running." Set when the Target this Deploy sits on was disconnected, and

--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -253,3 +253,38 @@ export interface DesiredState {
   requirements: Requirements;
   hostname: Hostname;
 }
+
+/**
+ * The part of {@link DesiredState} a Deploy **pins when its intent is written**.
+ *
+ * §10 pinned the config document for a stated reason — "re-reading current
+ * config at apply time would give a rollback the configuration of the release it
+ * is rolling away from" — and the same argument covers the rest of the shape: a
+ * Component edited after an intent was written must not retroactively change
+ * what that intent placed. Pinning three fields and re-reading the others made a
+ * rollback come back up with yesterday's artifact under today's shape.
+ *
+ * **Every Deploy has one.** The column is `NOT NULL`, and that is the point: an
+ * intent whose meaning has to be reassembled from rows that have moved since is
+ * not an intent, it is a query. There is no compose-from-rows path to fall back
+ * to, because a fallback is where the bug would keep living.
+ *
+ * Three fields are deliberately **not** here, each because pinning it would be
+ * wrong rather than merely unnecessary:
+ *
+ * - `deploy` — the Deploy's own id. Storing a row's primary key inside the row
+ *   is a second copy that can disagree with the first.
+ * - `artifact` — carried by the Build, which is immutable once `SUCCEEDED` and
+ *   is what a Deploy names. Copying it here would be a cache of an immutable
+ *   fact.
+ * - `hostname` — a property of the **App**, not of a release. §9 makes moving an
+ *   App between backends "one record re-point", which only holds if a name
+ *   outlives the releases under it; a rollback that restored an older vanity
+ *   name would take away the address somebody bookmarked. It is derived at apply
+ *   time from the App's names, the Target's adapter, and the installation's
+ *   zones, and that is correct.
+ */
+export type DesiredDocument = Omit<
+  DesiredState,
+  'deploy' | 'artifact' | 'hostname'
+>;

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -68,7 +68,6 @@ import {
   hasDrifted,
 } from '../domain/diagnosis.ts';
 import { displayUrl, hostnameFor } from '../domain/naming.ts';
-import { DEFAULT_PLATFORM } from '../domain/placement.ts';
 import {
   deployTargetOf,
   hasTargetConnection,
@@ -273,36 +272,31 @@ export function desiredStateFor(
    */
   vanityIsUnambiguous: boolean,
 ): DesiredState {
-  const { deploy, app, component, build, target } = subject;
+  const { deploy, app, build, target } = subject;
   return {
+    // The row's own key, which is why it is not in the pinned document.
     deploy: String(deploy.id),
-    app: app.name,
-    component: component.name,
-    target: target.name,
-    kind: component.kind,
+    // Everything this intent asked for, exactly as it asked for it. Nothing
+    // here re-reads `components`: an attempt that did would deliver a shape
+    // nobody asked for, and a rollback would come back up with yesterday's
+    // artifact under today's kind, exposure and schedule.
+    ...deploy.desired,
+    // Carried by the Build, which is immutable once `SUCCEEDED` — and a Deploy
+    // cannot be written naming one that is not (`checkDeployable`).
     artifact: {
       type: build.artifactType,
       digest: build.artifactDigest ?? '',
       refs: build.artifactRefs ?? [],
     },
-    ...(component.expose === null ? {} : { expose: component.expose }),
-    // The Deploy's own reach and auth, not the Component's current ones: this
-    // attempt asked for what it asked for, and a Component edited since must
-    // not retroactively change what a running attempt is placing.
-    reach: deploy.reach ?? component.reach,
-    auth: deploy.auth ?? component.auth,
-    ...(component.schedule === null ? {} : { schedule: component.schedule }),
-    // §10: the document this Deploy recorded when its intent was written, not
-    // whatever config says now. An attempt that re-read the items would deliver
-    // a configuration nobody asked for, and a rollback would come back up with
-    // the config of the release it was rolling away from.
-    config: deploy.configDocument ?? [],
-    requirements: { platform: DEFAULT_PLATFORM, resources: {} },
+    // Derived, not pinned: a name is a property of the App rather than of a
+    // release. §9 makes moving an App between backends "one record re-point",
+    // which only holds if the name outlives the releases under it — so a
+    // rollback must not take back the address somebody bookmarked.
     hostname: hostnameFor({
       app: app.name,
-      component: component.name,
+      component: deploy.desired.component,
       adapter: target.adapter,
-      reach: deploy.reach ?? component.reach,
+      reach: deploy.desired.reach,
       zones: manifest.dns.zones,
       vanityLabel: vanityIsUnambiguous ? app.vanityDomain : null,
     }),

--- a/apps/spindrift/test/commands/app-list-artifact.test.ts
+++ b/apps/spindrift/test/commands/app-list-artifact.test.ts
@@ -37,6 +37,7 @@ import {
 import { configVersionOf } from '../../src/domain/config-version.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const manifest = await fixtureManifest();
 const database = withIsolatedDatabase();
@@ -130,6 +131,7 @@ async function seedLiveApp(
     .insert(deploys)
     .values({
       componentId: component.value.componentId,
+      desired: aDesiredDocument(),
       targetId: target!.id,
       buildId: build!.id,
       phase: 'LIVE',

--- a/apps/spindrift/test/commands/artifacts.test.ts
+++ b/apps/spindrift/test/commands/artifacts.test.ts
@@ -26,6 +26,7 @@ import {
 } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 
@@ -98,6 +99,7 @@ async function seed(
       .returning();
     await ctx.db.insert(deploys).values({
       componentId: component!.id,
+      desired: aDesiredDocument(),
       targetId: target!.id,
       buildId: build!.id,
       phase: 'LIVE',

--- a/apps/spindrift/test/commands/component-reach.test.ts
+++ b/apps/spindrift/test/commands/component-reach.test.ts
@@ -299,7 +299,9 @@ describe('a Component edited mid-attempt does not change what is being placed', 
       .from(deploys)
       .where(eq(deploys.componentId, component.id))
       .orderBy(deploys.id);
-    expect(rows.map(({ reach, auth }) => ({ reach, auth }))).toEqual([
+    expect(
+      rows.map(({ desired }) => ({ reach: desired.reach, auth: desired.auth })),
+    ).toEqual([
       { reach: 'private', auth: 'proxy' },
       { reach: 'public', auth: 'none' },
     ]);

--- a/apps/spindrift/test/commands/config.test.ts
+++ b/apps/spindrift/test/commands/config.test.ts
@@ -330,7 +330,7 @@ describe('a config change produces a new Deploy', () => {
       .from(deploys)
       .where(eq(deploys.id, changed.value.deployId!));
     expect(deploy?.buildId).toBe(build.id);
-    const document = deploy?.configDocument ?? [];
+    const document = deploy?.desired.config ?? [];
     expect(document).toHaveLength(1);
     expect(document[0]?.name).toBe('TOKEN');
     // Pinned, not floating: the entry names a version the store minted.
@@ -421,8 +421,8 @@ describe('a rollback comes up with the configuration it originally had', () => {
       .db.select()
       .from(deploys)
       .where(eq(deploys.id, first.value.deployId));
-    expect(restored?.configDocument).toEqual(original!.configDocument!);
-    expect(restored?.configDocument).not.toEqual([]);
+    expect(restored?.desired.config).toEqual(original!.desired.config);
+    expect(restored?.desired.config).not.toEqual([]);
   });
 });
 

--- a/apps/spindrift/test/commands/delete-app.test.ts
+++ b/apps/spindrift/test/commands/delete-app.test.ts
@@ -41,6 +41,7 @@ import {
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -150,6 +151,7 @@ async function seedApp(
     .insert(deploys)
     .values({
       componentId: component!.id,
+      desired: aDesiredDocument(),
       targetId: options.targetId,
       buildId: build!.id,
       phase: options.phase ?? 'LIVE',

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -51,6 +51,7 @@ import {
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -711,11 +712,10 @@ describe('concurrency: the locking read (§6)', () => {
     const preconditions = {
       componentId: component.id,
       targetId: target.id,
-      reach: 'private' as const,
-      auth: 'proxy' as const,
       // Nothing is configured here, and the empty document still has a version
       // (§10) — "no config" is a state a Deploy is pinned to like any other.
-      config: { document: [], version: await configVersionOf([]) },
+      configVersion: await configVersionOf([]),
+      desired: aDesiredDocument({ reach: 'private', auth: 'proxy' }),
     };
 
     let announceRead = (): void => {};

--- a/apps/spindrift/test/commands/job-runs.test.ts
+++ b/apps/spindrift/test/commands/job-runs.test.ts
@@ -32,6 +32,7 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const manifest = await fixtureManifest();
 const database = withIsolatedDatabase();
@@ -116,6 +117,7 @@ async function scaffold(
     .insert(deploys)
     .values({
       componentId: component.value.componentId,
+      desired: aDesiredDocument(),
       targetId: target?.id as string,
       buildId: await buildFor(ctx, component.value.componentId),
       phase: 'LIVE',

--- a/apps/spindrift/test/commands/operation-ledgers.test.ts
+++ b/apps/spindrift/test/commands/operation-ledgers.test.ts
@@ -15,6 +15,7 @@ import type {
 import { builds, deploys, targets } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -162,6 +163,7 @@ describe('global operation ledgers', () => {
         .insert(deploys)
         .values({
           componentId: owner.componentId,
+          desired: aDesiredDocument(),
           targetId: target!.id,
           buildId: build!.id,
           phase: index === 0 ? 'LIVE' : 'APPLYING',
@@ -213,6 +215,7 @@ describe('global operation ledgers', () => {
     await ctx.db.insert(deploys).values(
       Array.from({ length: RELEASE_PAGE + 1 }, () => ({
         componentId: owner.componentId,
+        desired: aDesiredDocument(),
         targetId: target!.id,
         buildId: build!.id,
         phase: 'LIVE' as const,

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -57,6 +57,7 @@ import {
   connectionFor,
   fixtureManifest,
 } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -143,6 +144,7 @@ async function seedLiveDeploy(targetId: string, ref: string) {
     .insert(deploys)
     .values({
       componentId: component!.id,
+      desired: aDesiredDocument(),
       targetId,
       buildId: build!.id,
       phase: 'LIVE',

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -32,6 +32,7 @@ import {
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const manifest = await fixtureManifest();
 const database = withIsolatedDatabase();
@@ -192,6 +193,7 @@ describe('getBuildDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'LIVE',
@@ -284,6 +286,7 @@ describe('listDeploys command', () => {
         .insert(deploys)
         .values({
           componentId,
+          desired: aDesiredDocument(),
           targetId: target.id,
           buildId: build!.id,
           phase: 'LIVE',
@@ -348,6 +351,7 @@ describe('listDeploys command', () => {
         .insert(deploys)
         .values({
           componentId,
+          desired: aDesiredDocument(),
           targetId: target.id,
           buildId: build!.id,
           phase: 'LIVE',
@@ -438,6 +442,7 @@ describe('getAppWorkspace command', () => {
       .returning();
     await database().db.insert(deploys).values({
       componentId: createdComp.value.componentId,
+      desired: aDesiredDocument(),
       targetId: target!.id,
       buildId: build!.id,
       phase: 'LIVE',
@@ -500,6 +505,7 @@ describe('getAppWorkspace command', () => {
       .returning();
     await database().db.insert(deploys).values({
       componentId: createdComp.value.componentId,
+      desired: aDesiredDocument(),
       targetId: target!.id,
       buildId: build!.id,
       phase: 'LIVE',
@@ -644,6 +650,7 @@ describe('the workspace as a way into the system', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'LIVE',
@@ -752,6 +759,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'LIVE',
@@ -861,6 +869,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId: createdComp.value.componentId,
+        desired: aDesiredDocument(),
         targetId: targetRow.id,
         buildId: buildRow.id,
         phase: 'LIVE',
@@ -947,6 +956,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId: createdComp.value.componentId,
+        desired: aDesiredDocument(),
         targetId: targetRow!.id,
         buildId: build1!.id,
         phase: 'LIVE',
@@ -969,6 +979,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId: createdComp.value.componentId,
+        desired: aDesiredDocument(),
         targetId: targetRow!.id,
         buildId: build2!.id,
         phase: 'FAILED',
@@ -1028,6 +1039,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'FAILED',
@@ -1110,6 +1122,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'FAILED',
@@ -1149,6 +1162,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'FAILED',
@@ -1190,6 +1204,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'FAILED',
@@ -1254,6 +1269,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'LIVE',
@@ -1360,6 +1376,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'FAILED',
@@ -1426,6 +1443,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'LIVE',
@@ -1464,6 +1482,7 @@ describe('getDeployDetail command', () => {
       .insert(deploys)
       .values({
         componentId,
+        desired: aDesiredDocument(),
         targetId: target.id,
         buildId: build!.id,
         phase: 'LIVE',

--- a/apps/spindrift/test/db/jsonb-documents.test.ts
+++ b/apps/spindrift/test/db/jsonb-documents.test.ts
@@ -43,13 +43,40 @@ async function seedOperator() {
   return user!;
 }
 
-/** The committed migration, exactly as it ships, as its own statements. */
+/**
+ * The committed migration, exactly as it ships, as its own statements — minus
+ * the ones whose column this schema no longer has.
+ *
+ * 0016 is one independent `UPDATE` per `jsonb` column, and this test replays it
+ * against a **fully migrated** database rather than against the schema of its
+ * own day. So a column dropped by any later migration makes one of these
+ * statements refer to something that is not there: `deploys.config_document`
+ * went that way when a Deploy started carrying its whole release document.
+ *
+ * Skipping is derived from `information_schema` rather than hard-coded, so this
+ * keeps working as columns come and go, and it is narrower than catching the
+ * error would be — an undefined column anywhere else still fails the test.
+ */
 async function migrationStatements() {
   const sql = await readFile(MIGRATION, 'utf8');
-  return sql
+  const statements = sql
     .split('--> statement-breakpoint')
     .map((statement) => statement.trim())
     .filter((statement) => statement.length > 0);
+
+  const present = await Promise.all(
+    statements.map(async (statement) => {
+      const target = /UPDATE\s+"(\w+)"\s+SET\s+"(\w+)"/.exec(statement);
+      if (target === null) return true;
+      const [found] = await database().client`
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = current_schema()
+          AND table_name = ${target[1]!}
+          AND column_name = ${target[2]!}`;
+      return found !== undefined;
+    }),
+  );
+  return statements.filter((_, index) => present[index]);
 }
 
 describe('jsonb columns store documents', () => {

--- a/apps/spindrift/test/domain/attempt-log.test.ts
+++ b/apps/spindrift/test/domain/attempt-log.test.ts
@@ -36,6 +36,7 @@ import {
 } from '../../src/domain/attempt-log.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 
@@ -70,6 +71,7 @@ async function seedAttempt() {
     .db.insert(deploys)
     .values({
       componentId: component!.id,
+      desired: aDesiredDocument(),
       targetId: target!.id,
       buildId: build!.id,
     })

--- a/apps/spindrift/test/harness/release.ts
+++ b/apps/spindrift/test/harness/release.ts
@@ -1,0 +1,34 @@
+/**
+ * A release document for fixtures that insert a Deploy row directly.
+ *
+ * `deploys.desired` is `NOT NULL` because an intent whose meaning has to be
+ * reassembled from rows that have moved since is not an intent. That is a real
+ * constraint rather than a formality, so a fixture has to state one — and most
+ * fixtures do not care what is in it, which is what this is for.
+ *
+ * Anything a test *asserts* on — the names that build a hostname, the reach a
+ * route is rendered at, the config a delivery carries — is passed as an override
+ * rather than defaulted here, because a default that silently disagreed with the
+ * `components` row a test also inserted would make the test pass for the wrong
+ * reason.
+ */
+
+import type { DesiredDocument } from '../../src/domain/desired-state.ts';
+import { DEFAULT_PLATFORM } from '../../src/domain/placement.ts';
+
+export function aDesiredDocument(
+  overrides: Partial<DesiredDocument> = {},
+): DesiredDocument {
+  return {
+    app: 'app',
+    component: 'web',
+    target: 'target',
+    kind: 'service',
+    expose: true,
+    reach: 'private',
+    auth: 'proxy',
+    config: [],
+    requirements: { platform: DEFAULT_PLATFORM, resources: {} },
+    ...overrides,
+  };
+}

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -48,6 +48,7 @@ import {
   type ScriptedAttempt,
 } from '../harness/fakes/deploy-adapter.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -115,11 +116,18 @@ async function pendingDeploy(
     .insert(deploys)
     .values({
       componentId: component!.id,
+      // The document names what this fixture actually created, because the
+      // adapter is handed these names and the hostname is built from them.
+      desired: aDesiredDocument({
+        app: app!.name,
+        component: component!.name,
+        target: target!.name,
+        reach: options.reach ?? 'private',
+        auth: options.auth ?? 'proxy',
+      }),
       targetId: target!.id,
       buildId: build!.id,
       phase: 'PENDING',
-      reach: options.reach ?? 'private',
-      auth: options.auth ?? 'proxy',
     })
     .returning();
   await db.insert(componentTargetDesired).values({
@@ -167,6 +175,7 @@ describe('claiming (§6, SKIP LOCKED)', () => {
       .db.insert(deploys)
       .values({
         componentId: first.component.id,
+        desired: aDesiredDocument(),
         targetId: first.target.id,
         buildId: first.build.id,
         phase: 'PENDING',
@@ -185,6 +194,7 @@ describe('claiming (§6, SKIP LOCKED)', () => {
       .db.insert(deploys)
       .values({
         componentId: first.component.id,
+        desired: aDesiredDocument(),
         targetId: first.target.id,
         buildId: first.build.id,
         phase: 'PENDING',
@@ -300,6 +310,37 @@ describe('phases come from the platform, not from core (§6)', () => {
     expect(desired.hostname.canonical).toBe(
       `shop-web.${manifest.dns.zones.private}`,
     );
+  });
+
+  test('a Component edited after the intent does not change what it places', async () => {
+    const { deploy, component } = await pendingDeploy();
+
+    // Everything the old apply path re-read from `components`, moved. Under
+    // that path this attempt would have placed a suspended CronJob for a
+    // Component the developer had already stopped exposing — yesterday's
+    // artifact under today's shape, which is the same failure §10 pinned the
+    // config document to prevent.
+    await database()
+      .db.update(components)
+      .set({ kind: 'job', expose: false, schedule: '0 3 * * *' })
+      .where(eq(components.id, component.id));
+
+    const adapter = new FakeDeployAdapter();
+    const claimed = await claimNextDeploy(context(adapter));
+    await runAttempt(context(adapter), claimed!);
+
+    const desired = adapter.applied[0]!.desired;
+    expect(desired.kind).toBe('service');
+    expect(desired.expose).toBe(true);
+    expect(desired.schedule).toBeUndefined();
+    expect(desired.deploy).toBe(String(deploy.id));
+
+    // And the row still says so afterwards, which is what a rollback reads.
+    const [row] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, deploy.id));
+    expect(row?.desired.kind).toBe('service');
   });
 });
 
@@ -492,8 +533,8 @@ describe('§9: reach and auth never mutate on red', () => {
     // The App is exactly as reachable as it was: the previous release is still
     // serving, and quietly tightening this would turn one red deploy into an
     // outage nobody asked for.
-    expect(row?.reach).toBe('public');
-    expect(row?.auth).toBe('none');
+    expect(row?.desired.reach).toBe('public');
+    expect(row?.desired.auth).toBe('none');
 
     const [after] = await database()
       .db.select()
@@ -695,6 +736,7 @@ describe('the poll is the correctness path (plan, Transport shape)', () => {
     };
     await database().db.insert(deploys).values({
       componentId: first.component.id,
+      desired: aDesiredDocument(),
       targetId: first.target.id,
       buildId: first.build.id,
       phase: 'PENDING',

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -38,6 +38,7 @@ import {
   fixtureManifest,
   targetValues,
 } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -462,11 +463,10 @@ async function pendingDeploy() {
     .insert(deploys)
     .values({
       componentId: component!.id,
+      desired: aDesiredDocument({ reach: 'private', auth: 'proxy' }),
       targetId: target!.id,
       buildId: build!.id,
       phase: 'PENDING',
-      reach: 'private',
-      auth: 'proxy',
     })
     .returning();
   await db.insert(componentTargetDesired).values({

--- a/apps/spindrift/test/reconciler/repo-loop.test.ts
+++ b/apps/spindrift/test/reconciler/repo-loop.test.ts
@@ -43,6 +43,7 @@ import {
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeGitHub } from '../harness/fakes/github-api.ts';
 import { targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 
@@ -143,6 +144,7 @@ async function liveDeploy(appId: string) {
     .insert(deploys)
     .values({
       componentId: component!.id,
+      desired: aDesiredDocument(),
       targetId: target!.id,
       buildId: build!.id,
       phase: 'LIVE',

--- a/apps/spindrift/test/web/streams.test.ts
+++ b/apps/spindrift/test/web/streams.test.ts
@@ -24,6 +24,7 @@ import {
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
 
@@ -57,6 +58,7 @@ async function seedAttempt() {
     .db.insert(deploys)
     .values({
       componentId: component!.id,
+      desired: aDesiredDocument(),
       targetId: target!.id,
       buildId: build!.id,
     })
@@ -475,6 +477,7 @@ describe('a job tails one run rather than the Component', () => {
       .db.insert(deploys)
       .values({
         componentId: job?.id as string,
+        desired: aDesiredDocument(),
         targetId: seeded.target.id,
         buildId: seeded.build.id,
       });


### PR DESCRIPTION
## Summary

A Deploy pinned `config_document`, `reach` and `auth`, and re-read the rest of its shape from `components` at apply time. So a Component edited after an intent was written retroactively changed what that intent placed, and a rollback came back up with yesterday's artifact under today's kind, exposure and schedule — the failure the config pin exists to prevent, in every field it did not cover.

One `NOT NULL` `jsonb` column, `deploys.desired`, replaces the three. `checkDeployable` composes the release document, `placeIntent` writes it, and `desiredStateFor` spreads it — the deploy loop no longer reads `components` at all.

## Changes

- **`deploys.desired`, `NOT NULL`** — not nullable-with-a-fallback, because a compose-from-rows fallback is where the bug would keep living. That constraint is what forced the question of what a backfill can honestly compute, and the answer is what keeps three fields *out* of the document: `deploy` (the row's own key), `artifact` (carried by the Build, immutable once `SUCCEEDED`), and `hostname` (a property of the App — moving an App between backends is one record re-point, which only holds if a name outlives the releases under it, so a rollback must not take back the address somebody bookmarked).
- **`0025_deploy_desired.sql`** — adds the column, backfills every existing row from the rows themselves, sets `NOT NULL`, drops `config_document`, `reach` and `auth`.
- **`deliveringConfig`** — the two callers that replace only the config leg (a config change, and a rollback) share one function rather than writing the spread twice. The spread is nested, so `{ ...value, config }` type-checks against nothing while silently pinning the old document.
- **`test/db/jsonb-documents.test.ts`** — it replays migration 0016 against a *fully migrated* database, so dropping a column 0016 touches broke it. It now skips statements whose column no longer exists, derived from `information_schema` rather than hard-coded — narrower than catching the error, so an undefined column anywhere else still fails.

## Test Plan

- [x] `bun test` — 1656 pass, 0 fail, against real Postgres
- [x] `mise run ts:check` — typecheck and lint clean
- [x] New check: `test/reconciler/deploy-loop.test.ts` writes an intent, then flips the Component to `kind: 'job', expose: false, schedule: '0 3 * * *'`, and asserts the attempt still places `service` / `expose: true` / no schedule. Mutation-verified — reinstating a single `kind: subject.component.kind` read in `desiredStateFor` makes it fail.
- [x] Migration applied to a clean database end to end: `desired jsonb not null` present, the three columns gone.
- [ ] Reviewer sanity-check on the backfill's `requirements` literal — it pins `DEFAULT_PLATFORM` with no resources, which is exactly what existing rows were applied with, since nothing has ever stated a platform or a size.
