### PR TITLE
fix(spindrift): re-gate expired sessions and show connection state

### DIFF
--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -27,6 +27,7 @@ import type {
 } from './model.ts';
 import { isInFlight } from './model.ts';
 import { useRoute } from './router.ts';
+import { SESSION_EXPIRED_EVENT } from './session-events.ts';
 import { subscribeAttempt, subscribeRuntime } from './stream-client.ts';
 import { type Theme, useTheme } from './theme.ts';
 import { Button } from './ui/button.tsx';
@@ -147,6 +148,21 @@ export function App() {
     return () => {
       live = false;
     };
+  }, []);
+
+  /**
+   * Re-gate on the one signal `client.ts`, the archive upload, and
+   * `stream-client.ts` all raise the same way: a 24h session that expired
+   * mid-visit, read as `UNAUTHENTICATED` by a transport with nothing sensible
+   * to render for it. The reset is the same shape `onSignOut` below already
+   * uses — this installation is still claimed, and nothing here suggests the
+   * linked Gateway went anywhere.
+   */
+  useEffect(() => {
+    const onExpired = () =>
+      setGate({ state: 'anonymous', claimed: true, gatewayUnlinked: false });
+    addEventListener(SESSION_EXPIRED_EVENT, onExpired);
+    return () => removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
   }, []);
 
   /**

--- a/apps/spindrift/src/web/client.ts
+++ b/apps/spindrift/src/web/client.ts
@@ -14,6 +14,7 @@
 import type { commandRegistry } from '../commands/registry.ts';
 import type { CommandResult } from '../commands/types.ts';
 import { pathFor, type TransportFailureCode } from './command-path.ts';
+import { reportSessionExpired } from './session-events.ts';
 
 type Registry = typeof commandRegistry;
 
@@ -77,5 +78,14 @@ export async function command<Name extends keyof Registry & string>(
     );
   }
 
-  return body as ClientResult<OutputOf<Name>>;
+  const result = body as ClientResult<OutputOf<Name>>;
+  // The 24h session this request rode has expired mid-visit. The view that
+  // called `command()` did not ask "is my session still good" — it asked for
+  // an App or a Build — so it has nothing sensible to render for this refusal
+  // beyond the raw sentence. Re-gating to sign-in is the one answer that is
+  // right for every caller, which is why it happens here rather than in each.
+  if (!result.ok && result.failure.code === 'UNAUTHENTICATED') {
+    reportSessionExpired();
+  }
+  return result;
 }

--- a/apps/spindrift/src/web/components/shell.tsx
+++ b/apps/spindrift/src/web/components/shell.tsx
@@ -6,9 +6,12 @@ import {
   LogOut,
   Rocket,
   Settings,
+  WifiOff,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
+import { useSyncExternalStore } from 'react';
 import type { Principal } from '../../commands/types.ts';
+import { isReconnecting, onConnectionChange } from '../connection-status.ts';
 import { Button } from '../ui/button.tsx';
 import { cn } from '../ui/utils.ts';
 
@@ -103,6 +106,16 @@ export function AppShell({
   readonly declarationDivergence?: readonly string[];
   readonly children: ReactNode;
 }) {
+  // `isReconnecting` doubles as its own server snapshot: unlike
+  // `router.ts`'s hash, this store's state is `Set.size`, which reads the
+  // same — always `false` — with or without a `window`. React still requires
+  // the third argument from any `useSyncExternalStore` reached during a
+  // server render, so it is passed rather than left to the default.
+  const reconnecting = useSyncExternalStore(
+    onConnectionChange,
+    isReconnecting,
+    isReconnecting,
+  );
   const navigation = (
     <>
       {NAVIGATION.map(({ path: destination, label, icon: Icon, roots }) => {
@@ -197,6 +210,21 @@ export function AppShell({
               </button>
               .
             </span>
+          </div>
+        ) : null}
+        {reconnecting ? (
+          // Silent forever was the bug (`stream-client.ts`'s header explains
+          // the retry loop this reports on): a live pane that has stopped
+          // updating and says nothing looks identical to one with nothing new
+          // to show. This is the one place every screen with a stream passes
+          // through, the same reason `declarationDivergence` renders here
+          // rather than on each screen that could show it.
+          <div
+            role="status"
+            className="flex items-center gap-2 border-b border-border bg-muted/60 px-4 py-1.5 text-xs text-muted-foreground sm:px-6"
+          >
+            <WifiOff aria-hidden="true" className="size-3.5 shrink-0" />
+            <span>Disconnected, retrying…</span>
           </div>
         ) : null}
         <main className="min-w-0 pb-20 md:pb-0">{children}</main>

--- a/apps/spindrift/src/web/connection-status.ts
+++ b/apps/spindrift/src/web/connection-status.ts
@@ -1,0 +1,43 @@
+/**
+ * Whether any realtime stream this browser opened is between connections right
+ * now — read the same way `router.ts` reads the hash: an external store,
+ * subscribed to with `useSyncExternalStore` rather than an effect, because a
+ * socket can drop between render and commit the same way the hash can change
+ * mid-transition.
+ *
+ * Membership in a `Set` rather than a counter. A socket can close more than
+ * once before its next successful message — the network dropping twice in a
+ * row while `stream-client.ts` backs off is the ordinary case, not an edge
+ * case — and a counter incremented on every close would drift above the
+ * number of streams actually retrying. Each subscription owns one `symbol` for
+ * its lifetime, so marking it twice or once reads the same.
+ */
+
+const reconnecting = new Set<symbol>();
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+/** A stream this browser opened is retrying a dropped connection. */
+export function markReconnecting(id: symbol): void {
+  if (reconnecting.has(id)) return;
+  reconnecting.add(id);
+  notify();
+}
+
+/** That stream connected again, or gave up — either way it is done retrying. */
+export function markSettled(id: symbol): void {
+  if (!reconnecting.delete(id)) return;
+  notify();
+}
+
+export function isReconnecting(): boolean {
+  return reconnecting.size > 0;
+}
+
+export function onConnectionChange(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/spindrift/src/web/session-events.ts
+++ b/apps/spindrift/src/web/session-events.ts
@@ -1,0 +1,21 @@
+/**
+ * The one signal every transport raises when the session it trusted turns out
+ * to be gone.
+ *
+ * Dispatch (`client.ts`), the archive upload (`views/apps/new/index.tsx`), and
+ * the stream reconnect loop (`stream-client.ts`) are three different
+ * transports reachable from anywhere in the tree, and none of them owns the
+ * shell's gate — `App` in `app.tsx` does. Threading a callback down to every
+ * caller of `command()`, every upload row, and every stream subscription would
+ * make the gate a prop the whole tree carries for one rare event. This is the
+ * seam they call back through instead: the same `dispatchEvent`/
+ * `addEventListener` idiom `router.ts` already uses for the hash, because
+ * `window` is a channel every one of these already runs on.
+ */
+
+export const SESSION_EXPIRED_EVENT = 'spindrift:session-expired';
+
+/** A transport just read `UNAUTHENTICATED` off an otherwise-ordinary response. */
+export function reportSessionExpired(): void {
+  dispatchEvent(new Event(SESSION_EXPIRED_EVENT));
+}

--- a/apps/spindrift/src/web/stream-client.ts
+++ b/apps/spindrift/src/web/stream-client.ts
@@ -6,7 +6,24 @@
  * transport, and `streams.ts` pulls in `db/schema.ts`, `db/notify.ts`, and
  * `drizzle-orm` as values. `test/web/client-bundle.test.ts` guards against
  * this file reaching those instead.
+ *
+ * A dropped socket used to retry every `retryMs` forever, silently — including
+ * when the drop is a stream refusing the reconnect's own upgrade with a 401,
+ * which is a session that expired mid-visit rather than a network blip. A
+ * native `WebSocket` has no way to read that: a failed handshake fires
+ * `onerror`/`onclose` with no status the browser will hand back, by spec, so
+ * the two causes are indistinguishable from inside this file's own events.
+ * What is distinguishable is `readSession()` — the same session read `app.tsx`
+ * already uses to gate the whole product — so once a run of drops is long
+ * enough that a network blip stops being the likely story, this asks that
+ * instead of the socket. A `false` answer stops the loop and raises
+ * {@link reportSessionExpired}; every other case backs off and keeps trying,
+ * which is also what turns the retry from a flat interval into one that
+ * actually eases off rather than hammering a link that is not coming back.
  */
+import { readSession } from './auth-client.ts';
+import { markReconnecting, markSettled } from './connection-status.ts';
+import { reportSessionExpired } from './session-events.ts';
 import {
   ATTEMPT_STREAM_PATH,
   type AttemptStreamMessage,
@@ -26,10 +43,71 @@ export type SocketFactory = (url: string) => BrowserSocket;
 interface SubscribeOptions {
   readonly createSocket?: SocketFactory;
   readonly retryMs?: number;
+  /**
+   * Overridable for tests. Defaults to asking the server whether this browser
+   * is still signed in — network failure reads as "still signed in", because
+   * an inconclusive answer is a reason to keep backing off, not a reason to
+   * throw a live session away.
+   */
+  readonly checkSession?: () => Promise<boolean>;
 }
+
+/** How long a drop backs off before the reconnect that checks the session. */
+const CONSECUTIVE_DROPS_BEFORE_SESSION_CHECK = 3;
+/** A ceiling on the backoff, so "still gone" settles into a slow poll rather than a growing wait. */
+const MAX_RETRY_MS = 8_000;
 
 const browserSocket: SocketFactory = (url) =>
   new WebSocket(url) as BrowserSocket;
+
+async function stillSignedIn(): Promise<boolean> {
+  try {
+    return (await readSession()).principal !== null;
+  } catch {
+    return true;
+  }
+}
+
+/** Capped exponential backoff, not a flat interval — see the module header. */
+function backoff(attempt: number, base: number): number {
+  return Math.min(base * 2 ** (attempt - 1), MAX_RETRY_MS);
+}
+
+/**
+ * What both `onclose` handlers below do with a drop, factored out so the two
+ * streams cannot drift on how a drop is retried. `attempt` is this drop's
+ * 1-based count since the last successful message.
+ */
+function scheduleReconnect(params: {
+  readonly id: symbol;
+  readonly options: SubscribeOptions;
+  readonly attempt: number;
+  readonly reconnect: () => void;
+  readonly giveUp: () => void;
+  readonly setRetry: (handle: ReturnType<typeof setTimeout>) => void;
+}): void {
+  const { id, options, attempt, reconnect, giveUp, setRetry } = params;
+  markReconnecting(id);
+  const delay = backoff(attempt, options.retryMs ?? 500);
+  if (attempt < CONSECUTIVE_DROPS_BEFORE_SESSION_CHECK) {
+    setRetry(setTimeout(reconnect, delay));
+    return;
+  }
+  const checkSession = options.checkSession ?? stillSignedIn;
+  setRetry(
+    setTimeout(() => {
+      void checkSession().then((signedIn) => {
+        if (signedIn) {
+          reconnect();
+          return;
+        }
+        giveUp();
+        markSettled(id);
+        reportSessionExpired();
+      });
+    }, delay),
+  );
+}
 
 export function subscribeAttempt(
   input: { readonly buildId: number; readonly deployId?: number },
@@ -41,6 +119,8 @@ export function subscribeAttempt(
   let terminal = false;
   let socket: BrowserSocket | null = null;
   let retry: ReturnType<typeof setTimeout> | null = null;
+  let attempts = 0;
+  const id = Symbol('attempt-stream');
   const createSocket = options.createSocket ?? browserSocket;
 
   const connect = () => {
@@ -56,14 +136,27 @@ export function subscribeAttempt(
       if (message.kind !== 'attempt') return;
       cursor = message.cursor;
       terminal = message.terminal;
+      attempts = 0;
+      markSettled(id);
       onMessage(message);
     };
     socket.onerror = () => socket?.close();
     socket.onclose = () => {
       socket = null;
-      if (!stopped && !terminal) {
-        retry = setTimeout(connect, options.retryMs ?? 500);
-      }
+      if (stopped || terminal) return;
+      attempts += 1;
+      scheduleReconnect({
+        id,
+        options,
+        attempt: attempts,
+        reconnect: connect,
+        giveUp: () => {
+          stopped = true;
+        },
+        setRetry: (handle) => {
+          retry = handle;
+        },
+      });
     };
   };
 
@@ -71,6 +164,7 @@ export function subscribeAttempt(
   return () => {
     stopped = true;
     if (retry !== null) clearTimeout(retry);
+    markSettled(id);
     socket?.close();
   };
 }
@@ -89,6 +183,8 @@ export function subscribeRuntime(
   let stopped = false;
   let socket: BrowserSocket | null = null;
   let retry: ReturnType<typeof setTimeout> | null = null;
+  let attempts = 0;
+  const id = Symbol('runtime-stream');
   const createSocket = options.createSocket ?? browserSocket;
 
   const connect = () => {
@@ -103,12 +199,27 @@ export function subscribeRuntime(
     socket.onmessage = (event) => {
       const message = JSON.parse(event.data) as RuntimeStreamMessage;
       if (message.kind === 'stream') cursor = message.cursor;
+      attempts = 0;
+      markSettled(id);
       onMessage(message);
     };
     socket.onerror = () => socket?.close();
     socket.onclose = () => {
       socket = null;
-      if (!stopped) retry = setTimeout(connect, options.retryMs ?? 500);
+      if (stopped) return;
+      attempts += 1;
+      scheduleReconnect({
+        id,
+        options,
+        attempt: attempts,
+        reconnect: connect,
+        giveUp: () => {
+          stopped = true;
+        },
+        setRetry: (handle) => {
+          retry = handle;
+        },
+      });
     };
   };
 
@@ -116,6 +227,7 @@ export function subscribeRuntime(
   return () => {
     stopped = true;
     if (retry !== null) clearTimeout(retry);
+    markSettled(id);
     socket?.close();
   };
 }

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -29,9 +29,14 @@ import type {
   CreationDraftView,
   DraftAction,
 } from '../../../../domain/creation-draft.ts';
-import { command, type TransportFailure } from '../../../client.ts';
+import {
+  type ClientResult,
+  command,
+  type TransportFailure,
+} from '../../../client.ts';
 import { RepoPicker } from '../../../components/repo-picker.tsx';
 import type { RepositoryOptionView, TargetOptionView } from '../../../model.ts';
+import { reportSessionExpired } from '../../../session-events.ts';
 import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
 import { Card, Eyebrow } from '../../../ui/card.tsx';
@@ -506,6 +511,49 @@ export function NewApp({
   );
 }
 
+interface UploadValue {
+  readonly digest: string;
+  readonly location: string;
+  readonly filename: string;
+  readonly size: number;
+}
+
+/**
+ * Archive upload, with byte progress.
+ *
+ * `fetch` has no cross-browser way to report how much of a request body has
+ * gone out — the upload side of the streams `ReadableStream` request bodies
+ * would need is not the broadly-supported half. `XMLHttpRequest.upload` has
+ * carried this exact event since it was introduced, so this is the one
+ * remaining reason the screen reaches for it instead of `client.ts`'s `fetch`
+ * wrapper the rest of the app uses.
+ */
+function uploadArchive(
+  file: File,
+  onProgress: (percent: number) => void,
+): Promise<ClientResult<UploadValue>> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', '/internal/upload');
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable) {
+        onProgress(Math.round((event.loaded / event.total) * 100));
+      }
+    };
+    xhr.onerror = () => reject(new Error('Network error during upload'));
+    xhr.onload = () => {
+      try {
+        resolve(JSON.parse(xhr.responseText) as ClientResult<UploadValue>);
+      } catch {
+        reject(new Error('Upload response was not valid JSON'));
+      }
+    };
+    const formData = new FormData();
+    formData.append('file', file);
+    xhr.send(formData);
+  });
+}
+
 /**
  * Source, which is the one row that is genuinely a question.
  *
@@ -529,6 +577,7 @@ function SourceRow({
   onSelectRepo: (fullName: string, url: string) => void;
 }) {
   const [uploading, setUploading] = useState(false);
+  const [uploadPercent, setUploadPercent] = useState<number | null>(null);
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   async function handleFileChange(event: React.ChangeEvent<HTMLInputElement>) {
@@ -537,16 +586,11 @@ function SourceRow({
 
     setUploading(true);
     setUploadError(null);
+    setUploadPercent(0);
     try {
-      const formData = new FormData();
-      formData.append('file', file);
       // No bucket named: which bucket sources stage to is installation
       // configuration and lives on the Storage screen.
-      const response = await fetch('/internal/upload', {
-        method: 'POST',
-        body: formData,
-      });
-      const res = await response.json();
+      const res = await uploadArchive(file, setUploadPercent);
       if (res.ok) {
         dispatch({
           type: 'archive',
@@ -554,8 +598,13 @@ function SourceRow({
           digest: res.value.digest,
           location: res.value.location,
         });
+      } else if (res.failure.code === 'UNAUTHENTICATED') {
+        // The 24h session expired mid-upload. This row has nothing sensible
+        // to render for that beyond the raw refusal — `App` (`app.tsx`) does,
+        // by re-gating to sign-in.
+        reportSessionExpired();
       } else {
-        setUploadError(res.failure?.message || 'Archive upload failed');
+        setUploadError(res.failure.message || 'Archive upload failed');
       }
     } catch (err: unknown) {
       setUploadError(
@@ -563,6 +612,7 @@ function SourceRow({
       );
     } finally {
       setUploading(false);
+      setUploadPercent(null);
     }
   }
 
@@ -625,12 +675,20 @@ function SourceRow({
             <label className="flex cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-border p-4 transition-colors hover:border-primary">
               <span className="text-sm font-medium text-foreground">
                 {uploading
-                  ? 'Uploading archive…'
+                  ? `Uploading archive… ${uploadPercent ?? 0}%`
                   : 'Choose or drop a zip/tar archive'}
               </span>
               <span className="mt-0.5 text-xs text-muted-foreground">
                 Accepts .zip, .tar.gz, .tgz
               </span>
+              {uploading ? (
+                <div className="mt-2 h-1 w-full max-w-56 overflow-hidden rounded-full bg-secondary">
+                  <div
+                    className="h-full rounded-full bg-primary transition-[width] duration-150 ease-out"
+                    style={{ width: `${uploadPercent ?? 0}%` }}
+                  />
+                </div>
+              ) : null}
               <input
                 type="file"
                 accept=".zip,.tar.gz,.tgz,.tar"

--- a/apps/spindrift/test/web/client.test.ts
+++ b/apps/spindrift/test/web/client.test.ts
@@ -1,0 +1,71 @@
+/**
+ * `command()`'s one side effect: an `UNAUTHENTICATED` refusal — the 24h
+ * session gone mid-visit — raises {@link SESSION_EXPIRED_EVENT} rather than
+ * handing the view a refusal it has nothing sensible to render. Every other
+ * refusal is the view's own to show, unchanged.
+ *
+ * Stubs `globalThis.fetch` rather than standing up a server: `command()`
+ * reaches the network through that one global and nothing else, the same
+ * seam `test/web/app-mounted.test.tsx` stubs for the same reason.
+ */
+import { describe, expect, test } from 'bun:test';
+import { command } from '../../src/web/client.ts';
+import { SESSION_EXPIRED_EVENT } from '../../src/web/session-events.ts';
+
+function stubFetch(body: unknown, status: number): typeof fetch {
+  return (async () =>
+    new Response(JSON.stringify(body), {
+      status,
+    })) as unknown as typeof fetch;
+}
+
+async function withStubbedFetch<T>(
+  body: unknown,
+  status: number,
+  run: () => Promise<T>,
+): Promise<T> {
+  const original = globalThis.fetch;
+  globalThis.fetch = stubFetch(body, status);
+  try {
+    return await run();
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+describe('the browser command boundary re-gates on an expired session', () => {
+  test('UNAUTHENTICATED raises the shared session-expired signal', async () => {
+    let fired = false;
+    const onExpired = () => {
+      fired = true;
+    };
+    addEventListener(SESSION_EXPIRED_EVENT, onExpired);
+
+    const result = await withStubbedFetch(
+      { ok: false, failure: { code: 'UNAUTHENTICATED', message: 'expired' } },
+      401,
+      () => command('getInstallationManifest', {}),
+    );
+
+    removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
+    expect(result.ok).toBe(false);
+    expect(fired).toBe(true);
+  });
+
+  test('an ordinary refusal is left for the view to render, not re-gated', async () => {
+    let fired = false;
+    const onExpired = () => {
+      fired = true;
+    };
+    addEventListener(SESSION_EXPIRED_EVENT, onExpired);
+
+    await withStubbedFetch(
+      { ok: false, failure: { code: 'INTERNAL', message: 'boom' } },
+      500,
+      () => command('getInstallationManifest', {}),
+    );
+
+    removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
+    expect(fired).toBe(false);
+  });
+});

--- a/apps/spindrift/test/web/connection-status.test.ts
+++ b/apps/spindrift/test/web/connection-status.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The shared "any stream is retrying" flag `shell.tsx` reads to show a
+ * disconnected banner. The one claim worth a test on its own: membership is
+ * idempotent, so a socket that drops twice before its next message — the
+ * ordinary shape of `stream-client.ts`'s backoff — never leaves the flag
+ * stuck on for one stream while another has long since settled.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  isReconnecting,
+  markReconnecting,
+  markSettled,
+  onConnectionChange,
+} from '../../src/web/connection-status.ts';
+
+describe('the shared reconnecting flag', () => {
+  test('marking the same id twice does not require two settles to clear', () => {
+    const id = Symbol('a');
+    markReconnecting(id);
+    markReconnecting(id);
+    expect(isReconnecting()).toBe(true);
+    markSettled(id);
+    expect(isReconnecting()).toBe(false);
+  });
+
+  test('stays true while any one of several streams is still retrying', () => {
+    const a = Symbol('a');
+    const b = Symbol('b');
+    markReconnecting(a);
+    markReconnecting(b);
+    markSettled(a);
+    expect(isReconnecting()).toBe(true);
+    markSettled(b);
+    expect(isReconnecting()).toBe(false);
+  });
+
+  test('listeners hear only real changes, not repeats', () => {
+    const id = Symbol('a');
+    let notifications = 0;
+    const unsubscribe = onConnectionChange(() => {
+      notifications += 1;
+    });
+    markReconnecting(id);
+    markReconnecting(id);
+    markSettled(id);
+    markSettled(id);
+    unsubscribe();
+    expect(notifications).toBe(2);
+  });
+});

--- a/apps/spindrift/test/web/stream-client.test.ts
+++ b/apps/spindrift/test/web/stream-client.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test';
+import { isReconnecting } from '../../src/web/connection-status.ts';
+import { SESSION_EXPIRED_EVENT } from '../../src/web/session-events.ts';
 import {
   type BrowserSocket,
   type SocketFactory,
@@ -48,6 +50,10 @@ describe('resumable browser stream', () => {
       terminal: false,
     });
     sockets[0]!.drop();
+    // A drop marks the shared "any stream is retrying" flag `shell.tsx`
+    // reads through `connection-status.ts` — before the reconnect resolves,
+    // not after, since that is the window a banner exists to cover.
+    expect(isReconnecting()).toBe(true);
     await Bun.sleep(1);
     expect(urls[1]).toContain('after=41');
 
@@ -57,6 +63,9 @@ describe('resumable browser stream', () => {
       cursor: 42,
       terminal: true,
     });
+    // A message is what clears it — a reconnect that opened but has not yet
+    // heard back is not yet "connected" again.
+    expect(isReconnecting()).toBe(false);
     sockets[1]!.drop();
     await Bun.sleep(1);
     expect(urls).toHaveLength(2);
@@ -98,5 +107,74 @@ describe('resumable browser stream', () => {
     });
     expect(urls[1]).toContain('after=opaque');
     stop();
+  });
+});
+
+describe('a drop the socket cannot explain', () => {
+  // A failed WebSocket upgrade and a network blip fire the identical
+  // `onerror`/`onclose` pair — the browser does not hand back the 401 a
+  // reconnect got refused with. `checkSession` stands in for the real
+  // `readSession()` read `stream-client.ts` falls back to.
+  function harness(checkSession: () => Promise<boolean>) {
+    const urls: string[] = [];
+    const sockets: FakeSocket[] = [];
+    const createSocket: SocketFactory = (url) => {
+      urls.push(url);
+      const socket = new FakeSocket();
+      sockets.push(socket);
+      return socket;
+    };
+    let sessionChecks = 0;
+    const stop = subscribeAttempt({ buildId: 1 }, () => {}, {
+      createSocket,
+      retryMs: 0,
+      checkSession: () => {
+        sessionChecks += 1;
+        return checkSession();
+      },
+    });
+    return {
+      urls,
+      sockets,
+      stop,
+      checks: () => sessionChecks,
+    };
+  }
+
+  test('three drops with nothing heard from in between ask before a fourth try', async () => {
+    const { urls, sockets, stop, checks } = harness(async () => true);
+
+    for (let i = 0; i < 3; i++) {
+      sockets.at(-1)!.drop();
+      await Bun.sleep(1);
+    }
+
+    // A network blip: still signed in, so the loop keeps going rather than
+    // giving up on the first run of bad luck.
+    expect(checks()).toBe(1);
+    expect(urls).toHaveLength(4);
+    stop();
+  });
+
+  test('a session gone by the third drop stops the loop and re-gates', async () => {
+    const events: string[] = [];
+    const onExpired = () => events.push('expired');
+    addEventListener(SESSION_EXPIRED_EVENT, onExpired);
+
+    const { urls, sockets, checks } = harness(async () => false);
+
+    for (let i = 0; i < 3; i++) {
+      sockets.at(-1)!.drop();
+      await Bun.sleep(1);
+    }
+
+    removeEventListener(SESSION_EXPIRED_EVENT, onExpired);
+
+    // No fourth socket: the loop stopped instead of hammering a session that
+    // is not coming back, and the shell's gate hears about it exactly once.
+    expect(checks()).toBe(1);
+    expect(urls).toHaveLength(3);
+    expect(events).toEqual(['expired']);
+    expect(isReconnecting()).toBe(false);
   });
 });


### PR DESCRIPTION
Three web-resilience gaps, one theme: the browser knew something was wrong and
said nothing usable.

- **Expired sessions re-gate instead of rendering a raw error.** `command()`,
  the archive upload, and the stream reconnect loop all funnel
  `UNAUTHENTICATED` into one window-event signal; `App` is its only listener
  and resets the gate to anonymous, the same shape sign-out already uses.
- **Stream reconnects are visible and back off.** The flat silent 500ms-forever
  retry becomes capped exponential backoff; after three consecutive drops the
  loop asks `readSession()` whether the browser is still signed in — a WebSocket
  handshake exposes no HTTP status to JS, so asking the session endpoint is the
  honest 401-vs-blip test. A shell banner shows "Disconnected, retrying…" while
  any stream is down.
- **Archive upload shows byte progress.** The upload is an `XMLHttpRequest` now
  (`upload.onprogress` is the one thing fetch can't do), driving a slim inline
  bar. `StageProgress` stays where it is — it renders discrete stages, not
  bytes.

7 new tests across stream backoff, the shared connection store, and the
UNAUTHENTICATED funnel. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)