### PR TITLE
feat(spindrift): record loop metrics and probe readiness through the DB

### DIFF
--- a/apps/spindrift/src/commands/builds/list.ts
+++ b/apps/spindrift/src/commands/builds/list.ts
@@ -71,6 +71,7 @@ export const listBuilds: Command<ListBuildsInput, ListBuildsResult> = async (
         when: elapsedSince(row.createdAt, now),
         at: row.createdAt.toISOString(),
         deployId: row.deploys[0]?.id ?? null,
+        dispatchWaitingOn: row.dispatchWaitingOn,
       }),
     ),
     nextBefore: rows.length > limit ? (page.at(-1)?.id ?? null) : null,

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -18,6 +18,12 @@ import {
   componentTargetDesired,
   targets,
 } from '../db/schema.ts';
+import {
+  reconcilerAttemptDuration,
+  reconcilerLoopDuration,
+  reconcilerPickupLatency,
+  reconcilerQueueDepth,
+} from '../telemetry/index.ts';
 
 /**
  * How often to look for a Build to dispatch.
@@ -53,6 +59,10 @@ export async function runBuildPass(
       appId: components.appId,
       componentId: components.id,
       waitingOn: builds.dispatchWaitingOn,
+      // For the pickup-latency metric below — every row here is PENDING by
+      // the `where` clause, so this is the age of a Build still waiting to be
+      // claimed.
+      createdAt: builds.createdAt,
     })
     .from(builds)
     .innerJoin(components, eq(builds.componentId, components.id))
@@ -101,6 +111,10 @@ export async function runBuildPass(
       continue;
     }
     const route = selection.route;
+    // `dispatchBuild` runs the whole attempt — including the adapter's build
+    // stream — to completion before returning, so timing this call is timing
+    // the build itself, not the loop's own bookkeeping around it.
+    const startedAt = Date.now();
     const result = await dispatchBuild(
       {
         buildId: row.buildId,
@@ -109,8 +123,22 @@ export async function runBuildPass(
       },
       context,
     );
-    if (result.ok) dispatched += 1;
+    reconcilerAttemptDuration.record((Date.now() - startedAt) / 1000, {
+      kind: 'build',
+      outcome: result.ok ? 'ok' : 'refused',
+    });
+    if (result.ok) {
+      dispatched += 1;
+      reconcilerPickupLatency.record(
+        (Date.now() - row.createdAt.getTime()) / 1000,
+        { kind: 'build' },
+      );
+    }
   }
+  // `visited` is every distinct Build this pass looked at, all of them
+  // PENDING by the `where` clause — the backlog this pass found, whether or
+  // not it managed to dispatch all of it.
+  reconcilerQueueDepth.record(visited.size, { kind: 'build' });
   return dispatched;
 }
 
@@ -120,7 +148,11 @@ export async function runBuildLoop(
 ): Promise<void> {
   const intervals = options.intervals ?? DEFAULT_BUILD_INTERVALS;
   while (!options.signal.aborted) {
+    const passStartedAt = Date.now();
     const dispatched = await runBuildPass(context);
+    reconcilerLoopDuration.record((Date.now() - passStartedAt) / 1000, {
+      loop: 'build',
+    });
     options.onPass?.();
     await abortableSleep(
       dispatched > 0 ? intervals.activeMs : intervals.idleMs,

--- a/apps/spindrift/src/reconciler/config-loop.ts
+++ b/apps/spindrift/src/reconciler/config-loop.ts
@@ -36,6 +36,7 @@ import {
   targets,
 } from '../db/schema.ts';
 import { CONFIG_RETENTION, configScopeOf, reapable } from '../domain/config.ts';
+import { reconcilerLoopDuration } from '../telemetry/index.ts';
 
 /** What the loop needs. No principal: nobody asked for it to run. */
 export interface ConfigLoopContext {
@@ -121,7 +122,12 @@ export async function runConfigLoop(
 ): Promise<void> {
   const interval = options.intervalMs ?? DEFAULT_REAP_INTERVAL_MS;
   while (!options.signal?.aborted) {
-    options.onPass?.(await runConfigPass(context));
+    const startedAt = Date.now();
+    const reports = await runConfigPass(context);
+    reconcilerLoopDuration.record((Date.now() - startedAt) / 1000, {
+      loop: 'config',
+    });
+    options.onPass?.(reports);
     if (options.signal?.aborted) return;
     await sleep(interval, options.signal);
   }

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -75,6 +75,13 @@ import {
   type TargetWithConnection,
   type VesselRef,
 } from '../domain/target.ts';
+import {
+  reconcilerAttemptDuration,
+  reconcilerDriftedDeploys,
+  reconcilerLoopDuration,
+  reconcilerPickupLatency,
+  reconcilerQueueDepth,
+} from '../telemetry/index.ts';
 
 /** What the loop needs. No principal: nobody asked for it to run. */
 export interface DeployLoopContext {
@@ -224,6 +231,17 @@ export async function claimNextDeploy(
       .for('update', { of: componentTargetDesired, skipLocked: true });
 
     if (row === undefined) return null;
+
+    // Only a fresh `PENDING` intent is a "pickup" in the sense a developer
+    // feels — a reclaimed stale `APPLYING`/`WAITING` lease is a retry, and
+    // timing it against the original Deploy would report the crashed
+    // reconciler's downtime as latency this one caused.
+    if (row.deploy.phase === 'PENDING') {
+      reconcilerPickupLatency.record(
+        (now.getTime() - row.deploy.createdAt.getTime()) / 1000,
+        { kind: 'deploy' },
+      );
+    }
 
     await tx
       .update(deploys)
@@ -723,17 +741,44 @@ export async function runDeployPass(
     // ponytail: unbounded fan-out, bounded in practice by how many distinct
     // Component@Targets are pending at once. Add a pool if that stops holding.
     const outcomes = await Promise.all(
-      claimed.map((deploy) => runAttempt(context, deploy)),
+      claimed.map(async (deploy) => {
+        // `runAttempt` runs the adapter's whole apply stream to a terminal
+        // verdict before returning, so this is the deploy's real duration —
+        // not the loop's own bookkeeping around it.
+        const startedAt = Date.now();
+        const outcome = await runAttempt(context, deploy);
+        reconcilerAttemptDuration.record((Date.now() - startedAt) / 1000, {
+          kind: 'deploy',
+          outcome: outcome?.phase ?? 'skipped',
+        });
+        return outcome;
+      }),
     );
     for (const outcome of outcomes) {
       if (outcome !== null) applied.push(outcome);
     }
   }
 
+  // `null` rather than `[]` when skipped, so a fast tick that does not
+  // observe cannot be mistaken for one that observed zero drifted releases —
+  // §6 wants drift reported on its own slow clock, and recording a false zero
+  // between drift-observing passes would erase the last real count from
+  // anyone scraping between them.
+  const driftReports =
+    options.observe === false ? null : await observeConverged(context);
+  if (driftReports !== null) {
+    reconcilerDriftedDeploys.record(
+      driftReports.filter((report) => report.drifted).length,
+    );
+  }
+
+  const unsettled = await unsettledPhases(context);
+  reconcilerQueueDepth.record(unsettled.length, { kind: 'deploy' });
+
   return {
     applied,
-    drift: options.observe === false ? [] : await observeConverged(context),
-    unsettled: await unsettledPhases(context),
+    drift: driftReports ?? [],
+    unsettled,
   };
 }
 
@@ -753,7 +798,14 @@ export async function runDeployLoop(
     const observe = startedAt >= nextDriftAt;
     if (observe) nextDriftAt = startedAt + driftMs;
 
+    // Wall-clock, not `context.clock` — this measures how long the pass
+    // actually took to run, which is a fact about the machine rather than
+    // about the domain time the injected clock stands in for during tests.
+    const passWallStartedAt = Date.now();
     const pass = await runDeployPass(context, { observe });
+    reconcilerLoopDuration.record((Date.now() - passWallStartedAt) / 1000, {
+      loop: 'deploy',
+    });
     options.onPass?.(pass);
     if (options.signal?.aborted) return;
 

--- a/apps/spindrift/src/reconciler/process.ts
+++ b/apps/spindrift/src/reconciler/process.ts
@@ -9,6 +9,7 @@ import type { SecretStore } from '../adapters/store/contract.ts';
 import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
+import { reconcilerLoopDuration } from '../telemetry/index.ts';
 import { DEFAULT_BUILD_INTERVALS, runBuildLoop } from './build-loop.ts';
 import { DEFAULT_REAP_INTERVAL_MS, runConfigLoop } from './config-loop.ts';
 import { DEFAULT_INTERVALS, runDeployLoop } from './deploy-loop.ts';
@@ -214,7 +215,11 @@ export async function runReconciler(
         const interval =
           options.manifestIntervalMs ?? DEFAULT_MANIFEST_INTERVAL_MS;
         while (!signal.aborted) {
+          const startedAt = Date.now();
           await refresh();
+          reconcilerLoopDuration.record((Date.now() - startedAt) / 1000, {
+            loop: 'manifest',
+          });
           if (signal.aborted) return;
           passed('manifest');
           await abortableSleep(interval, signal);

--- a/apps/spindrift/src/reconciler/repo-loop.ts
+++ b/apps/spindrift/src/reconciler/repo-loop.ts
@@ -52,6 +52,7 @@ import {
 import { SPINDRIFT_FILE } from '../integrations/github/config-pr.ts';
 import { GitHubAccessError } from '../integrations/github/http.ts';
 import type { WebhookDelivery } from '../integrations/github/webhook.ts';
+import { reconcilerLoopDuration } from '../telemetry/index.ts';
 
 /** What the loop needs. No principal: nobody asked for it to run. */
 export interface RepoLoopContext {
@@ -496,7 +497,12 @@ export async function runRepoLoop(
   options: RepoLoopOptions,
 ): Promise<void> {
   while (!options.signal?.aborted) {
-    options.onPass?.(await reconcileAllRepositories(context));
+    const startedAt = Date.now();
+    const passes = await reconcileAllRepositories(context);
+    reconcilerLoopDuration.record((Date.now() - startedAt) / 1000, {
+      loop: 'repository',
+    });
+    options.onPass?.(passes);
     if (options.signal?.aborted) return;
     await sleep(options.intervalMs, options.signal);
   }

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -44,6 +44,7 @@ import {
   hasVesselLocation,
   type TargetHealth,
 } from '../domain/target.ts';
+import { reconcilerLoopDuration } from '../telemetry/index.ts';
 
 /**
  * What the loop needs. Narrower than a `CommandContext` on purpose — the loop
@@ -312,7 +313,11 @@ export async function runTargetLoop(
   options: TargetLoopOptions,
 ): Promise<void> {
   while (!options.signal?.aborted) {
+    const startedAt = Date.now();
     const refreshed = await refreshAllTargets(context);
+    reconcilerLoopDuration.record((Date.now() - startedAt) / 1000, {
+      loop: 'target',
+    });
     options.onPass?.(refreshed);
     if (options.signal?.aborted) return;
     await sleep(options.intervalMs, options.signal);

--- a/apps/spindrift/src/telemetry/index.ts
+++ b/apps/spindrift/src/telemetry/index.ts
@@ -1,12 +1,17 @@
 import {
   type Counter,
+  type Gauge,
   type Histogram,
   type Meter,
   metrics,
   type Tracer,
   trace,
 } from '@opentelemetry/api';
-import { logs, SeverityNumber } from '@opentelemetry/api-logs';
+import {
+  type LogAttributes,
+  logs,
+  SeverityNumber,
+} from '@opentelemetry/api-logs';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-http';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
@@ -128,49 +133,110 @@ export const reconcilerErrorCounter: Counter = meter.createCounter(
   },
 );
 
+/**
+ * How long one build or deploy attempt took, from dispatch to a terminal
+ * outcome — recorded around the same adapter call the build and deploy loops
+ * already block on, so this is real wall time and not the loop's own poll
+ * interval. `kind` distinguishes 'build' from 'deploy'; `outcome` carries
+ * whatever each loop already knows the attempt ended as.
+ */
+export const reconcilerAttemptDuration: Histogram = meter.createHistogram(
+  'reconciler_attempt_duration_seconds',
+  {
+    description: 'Duration of one build or deploy attempt',
+    unit: 's',
+  },
+);
+
+/**
+ * How long a build or deploy row sat before the reconciler first claimed it —
+ * the wait a developer who just pressed the button actually feels.
+ */
+export const reconcilerPickupLatency: Histogram = meter.createHistogram(
+  'reconciler_pickup_latency_seconds',
+  {
+    description:
+      'Time from a build or deploy row being created to the reconciler first claiming it',
+    unit: 's',
+  },
+);
+
+/**
+ * How many build or deploy rows were still unclaimed at the end of one pass.
+ * A gauge, not a counter: the loop reports the level, not an increment.
+ */
+export const reconcilerQueueDepth: Gauge = meter.createGauge(
+  'reconciler_queue_depth',
+  {
+    description: 'Rows still awaiting reconciliation at the end of one pass',
+  },
+);
+
+/**
+ * How many live deploys are currently drifted from their desired artifact, as
+ * of the deploy loop's last drift-observing pass (§6's "visible state").
+ */
+export const reconcilerDriftedDeploys: Gauge = meter.createGauge(
+  'reconciler_drifted_deploys',
+  {
+    description:
+      'Live deploys whose observed artifact no longer matches what is desired',
+  },
+);
+
 const logger = logs.getLogger('spindrift');
 
-export function logInfo(message: string, attributes: Record<string, any> = {}) {
-  console.log(`[INFO] ${message}`, attributes);
+/**
+ * Emit a log record without letting a broken exporter take the caller down.
+ *
+ * `console.*` already ran before this is reached, so the log line itself is
+ * never lost to an OTLP outage — this only guards the second, best-effort
+ * copy. Reported to stderr directly rather than through `logger.emit` again,
+ * which would risk looping back into the same failure.
+ */
+function emitSafely(record: Parameters<typeof logger.emit>[0]): void {
   try {
-    logger.emit({
-      severityNumber: SeverityNumber.INFO,
-      severityText: 'INFO',
-      body: message,
-      attributes,
-    });
-  } catch {}
+    logger.emit(record);
+  } catch (cause) {
+    console.error('[Telemetry] failed to emit log record', cause);
+  }
 }
 
-export function logWarn(message: string, attributes: Record<string, any> = {}) {
+export function logInfo(message: string, attributes: LogAttributes = {}) {
+  console.log(`[INFO] ${message}`, attributes);
+  emitSafely({
+    severityNumber: SeverityNumber.INFO,
+    severityText: 'INFO',
+    body: message,
+    attributes,
+  });
+}
+
+export function logWarn(message: string, attributes: LogAttributes = {}) {
   console.warn(`[WARN] ${message}`, attributes);
-  try {
-    logger.emit({
-      severityNumber: SeverityNumber.WARN,
-      severityText: 'WARN',
-      body: message,
-      attributes,
-    });
-  } catch {}
+  emitSafely({
+    severityNumber: SeverityNumber.WARN,
+    severityText: 'WARN',
+    body: message,
+    attributes,
+  });
 }
 
 export function logError(
   message: string,
   error?: unknown,
-  attributes: Record<string, any> = {},
+  attributes: LogAttributes = {},
 ) {
   console.error(`[ERROR] ${message}`, error, attributes);
-  try {
-    logger.emit({
-      severityNumber: SeverityNumber.ERROR,
-      severityText: 'ERROR',
-      body: `${message}${error instanceof Error ? `: ${error.message}` : ''}`,
-      attributes: {
-        ...attributes,
-        ...(error instanceof Error
-          ? { 'error.stack': error.stack, 'error.message': error.message }
-          : {}),
-      },
-    });
-  } catch {}
+  emitSafely({
+    severityNumber: SeverityNumber.ERROR,
+    severityText: 'ERROR',
+    body: `${message}${error instanceof Error ? `: ${error.message}` : ''}`,
+    attributes: {
+      ...attributes,
+      ...(error instanceof Error
+        ? { 'error.stack': error.stack, 'error.message': error.message }
+        : {}),
+    },
+  });
 }

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -372,6 +372,13 @@ export interface BuildListItem {
   readonly at: string;
   /** The newest Deploy created from this Build, when placement has begun. */
   readonly deployId: number | null;
+  /**
+   * What a PENDING Build is stuck on, in the operator's own words — set by
+   * `recordDispatchWait` (`commands/builds/dispatch.ts`) and cleared the
+   * moment a route actually claims it. `null` covers both "never refused" and
+   * "already running", which is the distinction `status` already carries.
+   */
+  readonly dispatchWaitingOn: string | null;
 }
 
 /** One Deploy in the global placement ledger, including its owning App. */

--- a/apps/spindrift/src/web/routes.ts
+++ b/apps/spindrift/src/web/routes.ts
@@ -8,7 +8,7 @@
  * to be inline in `server.ts` next to a top-level `Bun.serve` no test can
  * import. So the table moved here and the entries call it.
  *
- * Five kinds of route exist, and four of the five are generated:
+ * Six kinds of route exist, and five of the six are generated:
  *
  * 1. **Commands**, from the registry (`dispatch.ts`).
  * 2. **The client**, from whatever built it — `bundle.ts` reading a directory in
@@ -19,28 +19,57 @@
  *    principal and passkey-rooted credential administration; neither belongs
  *    in the product command registry.
  * 4. **Streams**, the two authenticated, purpose-specific WebSocket upgrades.
- * 5. **{@link HEALTH_PATH}**, which is the whole of the rest.
+ * 5. **{@link HEALTH_PATH}**, a liveness probe that consults nothing.
+ * 6. **{@link READY_PATH}**, a readiness probe that does — see below.
  *
  * A further hand-authored route is a decision somebody has to make on purpose,
  * in this file, against a test that names it.
  */
 
+import { sql } from 'drizzle-orm';
 import type { EnrolmentDeps } from '../auth/enrol.ts';
 import type { GatewayDeps } from '../auth/gateway.ts';
 import { authRoutes } from '../auth/routes.ts';
+import type { Database } from '../db/client.ts';
 import { commandRoutes, type DispatchDeps } from './dispatch.ts';
 import { streamRoutes } from './streams.ts';
 import { uploadRoutes } from './upload.ts';
 
 /**
- * The one route that is neither a command nor part of the client bundle.
+ * Liveness: whether this process is still running.
  *
- * It is a constant rather than a handler on purpose: a probe that can consult
+ * A constant rather than a handler on purpose: a probe that can consult
  * something is a probe that can be wrong about something, and §21's "no route
  * may contain domain logic" is easiest to keep when there is no logic to keep
- * out.
+ * out. Deliberately answers "yes" even while the database is unreachable — a
+ * kubelet that restarted this pod for that would kill the one thing capable of
+ * reconnecting once Postgres comes back. {@link READY_PATH} is where that
+ * question actually gets asked.
  */
 export const HEALTH_PATH = '/healthz';
+
+/**
+ * Readiness: whether this pod should currently receive traffic.
+ *
+ * Unlike {@link HEALTH_PATH} this does consult something — a `select 1`
+ * through the same pool every command uses — because "is the process up" and
+ * "can it actually do anything" are different questions, and only the second
+ * one is the Service's to act on. A failure here takes the pod out of
+ * rotation without restarting it, which is the correct response to a database
+ * that is down and will recover on its own.
+ */
+export const READY_PATH = '/readyz';
+
+/** {@link READY_PATH}'s handler: the one hand-authored route that reads the database. */
+async function readyResponse(db: Database): Promise<Response> {
+  try {
+    await db.execute(sql`select 1`);
+    return new Response('ok\n');
+  } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    return new Response(`not ready: ${detail}\n`, { status: 503 });
+  }
+}
 
 /**
  * What a client route may be: a built file's `Response` in production, or Bun's
@@ -66,7 +95,8 @@ export function webRoutes<Client extends Record<string, ClientRoute>>(
 ) {
   return {
     ...client,
-    '/healthz': new Response('ok\n'),
+    [HEALTH_PATH]: new Response('ok\n'),
+    [READY_PATH]: () => readyResponse(auth.db),
     ...authRoutes(auth),
     ...commandRoutes(deps),
     ...streamRoutes(deps),

--- a/apps/spindrift/src/web/views/operations/overview.tsx
+++ b/apps/spindrift/src/web/views/operations/overview.tsx
@@ -31,9 +31,16 @@ interface Concern extends ExplorerItem {
   }[];
 }
 
-function buildTone(status: BuildListItem['status']): ExplorerTone {
-  if (status === 'FAILED') return 'destructive';
-  if (status === 'SUCCEEDED') return 'success';
+function buildTone(
+  build: Pick<BuildListItem, 'status' | 'dispatchWaitingOn'>,
+): ExplorerTone {
+  if (build.status === 'FAILED') return 'destructive';
+  if (build.status === 'SUCCEEDED') return 'success';
+  // A PENDING Build refusing every tick is not "in progress" the way a
+  // RUNNING one is — it needs an operator to configure the thing it is
+  // waiting on, which is what 'warning' already means everywhere else on
+  // this screen.
+  if (build.dispatchWaitingOn !== null) return 'warning';
   return 'accent';
 }
 
@@ -81,6 +88,9 @@ export function Overview({
     (b) => b.status === 'RUNNING' || b.status === 'PENDING',
   ).length;
   const succeededBuilds = builds.filter((b) => b.status === 'SUCCEEDED').length;
+  const waitingBuilds = builds.filter(
+    (b) => b.dispatchWaitingOn !== null,
+  ).length;
 
   const healthyTargets = targets.filter(
     (t) => t.configured && t.status === 'connected' && t.health === 'healthy',
@@ -115,29 +125,38 @@ export function Overview({
         ],
       }),
     ),
-    ...builds.map(
-      (build): Concern => ({
+    ...builds.map((build): Concern => {
+      const waitingOn = build.dispatchWaitingOn;
+      return {
         id: `build:${build.id}`,
         category: 'build',
         title: `Build ${build.id}`,
-        detail: `${build.app} / ${build.component} · ${build.runner ?? 'queued'}`,
-        status: build.status.toLowerCase(),
-        tone: buildTone(build.status),
+        detail:
+          waitingOn !== null
+            ? `${build.app} / ${build.component} · waiting: ${waitingOn}`
+            : `${build.app} / ${build.component} · ${build.runner ?? 'queued'}`,
+        status: waitingOn !== null ? 'waiting' : build.status.toLowerCase(),
+        tone: buildTone(build),
         when: build.when,
         at: build.at,
         active: build.status === 'RUNNING' || build.status === 'PENDING',
         eyebrow: `Build / ${build.id}`,
-        summary: `Commit ${build.commit} is becoming a ${build.artifactType} artifact.`,
+        summary:
+          waitingOn ??
+          `Commit ${build.commit} is becoming a ${build.artifactType} artifact.`,
         path: `/builds/${build.id}`,
         appPath: `/apps/${build.appId}`,
-        search: `${build.commit} ${build.app}`,
+        search: `${build.commit} ${build.app} ${waitingOn ?? ''}`,
         facts: [
           { label: 'Runner', value: build.runner ?? 'waiting' },
           { label: 'Shape', value: build.targetShape, mono: true },
           { label: 'Created', value: build.when, mono: true },
+          ...(waitingOn !== null
+            ? [{ label: 'Waiting on', value: waitingOn }]
+            : []),
         ],
-      }),
-    ),
+      };
+    }),
     ...targets.map(
       (target): Concern => ({
         id: `target:${target.id}`,
@@ -288,6 +307,14 @@ export function Overview({
             ) : (
               `${succeededBuilds} Succeeded`
             )}
+            {waitingBuilds > 0 ? (
+              <>
+                {' · '}
+                <span className="font-semibold text-warning">
+                  {waitingBuilds} Waiting
+                </span>
+              </>
+            ) : null}
           </p>
         </Card>
 

--- a/apps/spindrift/test/web/object-explorer.test.tsx
+++ b/apps/spindrift/test/web/object-explorer.test.tsx
@@ -103,6 +103,7 @@ describe('the global operation ledgers', () => {
     when: '13m ago',
     at: '2026-08-03T12:31:00.000Z',
     deployId: 993,
+    dispatchWaitingOn: null,
   };
   const deploy: DeployLedgerItem = {
     id: 993,

--- a/apps/spindrift/test/web/readyz.test.ts
+++ b/apps/spindrift/test/web/readyz.test.ts
@@ -1,0 +1,77 @@
+/**
+ * `/readyz` — whether this pod can currently reach the database.
+ *
+ * `test/web/routes.test.ts` proves the route-table *shape*, and does it with a
+ * `db` Proxy that throws on any access precisely so those tests never touch a
+ * real connection. This file is the complement: it is the one place that
+ * calls the readiness handler for real, against a healthy Postgres and
+ * against one that cannot be reached — because the whole point of `/readyz`
+ * is telling those two states apart, and a route-table test that never
+ * invokes a handler could not prove that either way.
+ */
+import { describe, expect, test } from 'bun:test';
+import { SQL } from 'bun';
+import type { EnrolmentDeps } from '../../src/auth/enrol.ts';
+import type { GatewayDeps } from '../../src/auth/gateway.ts';
+import { createDb, type Database } from '../../src/db/client.ts';
+import { READY_PATH, webRoutes } from '../../src/web/routes.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+
+/** A stand-in for the client, so this file never depends on a build having run. */
+const CLIENT = { '/': new Response('the client document') };
+
+const noSession = {
+  authenticate: async () => ({ kind: 'anonymous' as const }),
+  context: (): never => {
+    throw new Error('unreachable — /readyz needs no session and no command');
+  },
+};
+
+function authDeps(db: Database): EnrolmentDeps & GatewayDeps {
+  return {
+    db,
+    clock: { now: () => new Date('2026-01-01T00:00:00Z') },
+    relyingParty: {
+      id: 'spindrift.example.test',
+      name: 'example',
+      origin: 'https://spindrift.example.test',
+    },
+    enrolmentToken: null,
+    gateway: null,
+  };
+}
+
+async function readyz(db: Database): Promise<Response> {
+  const routes = webRoutes(CLIENT, noSession, authDeps(db));
+  const handler = routes[READY_PATH] as () => Promise<Response>;
+  return handler();
+}
+
+describe('/readyz', () => {
+  test('answers ok with a live database round trip', async () => {
+    const response = await readyz(database().db);
+    expect(response.status).toBe(200);
+    expect(await response.clone().text()).toBe('ok\n');
+  });
+
+  test('answers 503 when the database cannot be reached', async () => {
+    // Port 1 is a reserved port nothing listens on. Bun's default connection
+    // timeout is 30s, which is far longer than a test should wait to prove a
+    // negative, so it is cut down to keep this fast rather than flaky.
+    const client = new SQL(
+      'postgres://postgres:postgres@127.0.0.1:1/spindrift',
+      {
+        connectionTimeout: 1,
+      },
+    );
+    try {
+      const response = await readyz(createDb(client));
+      expect(response.status).toBe(503);
+      expect(await response.clone().text()).toContain('not ready');
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/apps/spindrift/test/web/routes.test.ts
+++ b/apps/spindrift/test/web/routes.test.ts
@@ -20,7 +20,7 @@ import { commandNames } from '../../src/commands/registry.ts';
 import type { Database } from '../../src/db/client.ts';
 import { BundleMissingError, bundleRoutes } from '../../src/web/bundle.ts';
 import { pathFor } from '../../src/web/dispatch.ts';
-import { HEALTH_PATH, webRoutes } from '../../src/web/routes.ts';
+import { HEALTH_PATH, READY_PATH, webRoutes } from '../../src/web/routes.ts';
 import { STREAM_PATHS } from '../../src/web/streams.ts';
 import { UPLOAD_PATH } from '../../src/web/upload.ts';
 
@@ -68,11 +68,12 @@ const served = webRoutes(CLIENT, noSession, noAuth);
 const AUTH_PATHS = AUTH_ACTS.map(authPathFor);
 
 describe('what the web process serves', () => {
-  test('is the client, the probe, auth, and commands — nothing else', () => {
+  test('is the client, the probes, auth, and commands — nothing else', () => {
     expect(Object.keys(served).sort()).toEqual(
       [
         ...Object.keys(CLIENT),
         HEALTH_PATH,
+        READY_PATH,
         ...AUTH_PATHS,
         ...commandNames.map(pathFor),
         ...STREAM_PATHS,
@@ -81,7 +82,7 @@ describe('what the web process serves', () => {
     );
   });
 
-  test('the hand-authored surface is the probe and auth, and stops there', () => {
+  test('the hand-authored surface is the probes and auth, and stops there', () => {
     // Everything else traces to a generator: a command name, or a file the
     // build emitted. Auth is generated too — from `AUTH_ACTS` — but it is the
     // one generator whose tuple a person writes by hand, so it is counted here
@@ -92,7 +93,13 @@ describe('what the web process serves', () => {
       (path) => !generated.has(path) && !(path in CLIENT),
     );
     expect(handAuthored.sort()).toEqual(
-      [HEALTH_PATH, ...AUTH_PATHS, ...STREAM_PATHS, UPLOAD_PATH].sort(),
+      [
+        HEALTH_PATH,
+        READY_PATH,
+        ...AUTH_PATHS,
+        ...STREAM_PATHS,
+        UPLOAD_PATH,
+      ].sort(),
     );
   });
 

--- a/packages/charts/spindrift/templates/deployment.yaml
+++ b/packages/charts/spindrift/templates/deployment.yaml
@@ -161,11 +161,16 @@ spec:
                 name: {{ . }}
           {{- end }}
           {{- if $process.serves }}
-          # Readiness only. A liveness probe on a process whose slow path is a
-          # database query restarts it exactly when it is least able to recover.
+          # Readiness only, and on purpose: a liveness probe on a process
+          # whose slow path is a database query would restart it exactly when
+          # it is least able to recover. `/readyz` does a real `select 1`
+          # through the app's pool, so a Postgres outage takes the pod out of
+          # the Service without killing the one process that will notice
+          # Postgres come back. `/healthz` stays a bare constant for exactly
+          # that liveness case, should one ever be added here.
           readinessProbe:
             httpGet:
-              path: /healthz
+              path: /readyz
               port: {{ $top.Values.port }}
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -84,7 +84,7 @@ describe('declarative schema ordering', () => {
     const web = one(objects, 'Deployment', 'spindrift-web');
     expect(
       web.spec.template.spec.containers[0].readinessProbe.httpGet.path,
-    ).toBe('/healthz');
+    ).toBe('/readyz');
   });
 });
 


### PR DESCRIPTION
The loops computed durations, pickup latency, queue depth, and drifted counts
and recorded none of it; `/healthz` answered ok with a dead DB pool behind it;
a waiting build was invisible outside its own detail page.

- **Telemetry:** `reconcilerLoopDuration` is finally recorded (every loop pass,
  including the manifest refresh), plus four new instruments: attempt duration,
  pickup latency, queue depth, drifted-deploy count. `logInfo`/`logWarn`/
  `logError` drop `any` for `LogAttributes`, and the swallowed `catch {}` on
  emit now reports to stderr.
- **Readiness:** `/healthz` stays static for liveness; new `/readyz` runs
  `select 1` through the existing pool and answers 503 with the reason when the
  DB is gone. The chart's readinessProbe points at `/readyz` now — the change
  rides the next image digest bump like any other chart move.
- **Overview:** waiting builds show their `dispatchWaitingOn` reason in the
  list row, as a fact, and in search; the Build Pipeline stat card counts them.

`bun test` against real Postgres: 1666 pass, 0 fail. Chart render tests 28
pass. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)