### PR TITLE
fix(spindrift): honour a bare-host registry declaration when routing builds

### DIFF
--- a/apps/spindrift/src/commands/apps/build-route.ts
+++ b/apps/spindrift/src/commands/apps/build-route.ts
@@ -145,7 +145,17 @@ export const setAppBuildRoute: Command<
         reachable.length > 0
           ? reachable
           : context.manifest.supplyChain.registry.slice(0, 1);
-      if (!published.some((registry) => pullable.includes(registry))) {
+      // A reachable list speaks two spellings — the `ghcr.io/owner` namespace,
+      // and the bare host for a Target that reaches every namespace on one
+      // registry (`domain/desired-state.ts` sets that vocabulary). Published
+      // entries are always namespaces, so a bare host claims one as a prefix;
+      // equality alone would refuse every host-declared Target.
+      const meets = published.some((registry) =>
+        pullable.some(
+          (reach) => registry === reach || registry.startsWith(`${reach}/`),
+        ),
+      );
+      if (!meets) {
         return failed(
           'NOT_BUILDABLE',
           `${input.route} publishes to ${published.join(' and ') || 'no registry this installation configures'}, ` +

--- a/apps/spindrift/test/commands/app-build-route.test.ts
+++ b/apps/spindrift/test/commands/app-build-route.test.ts
@@ -218,6 +218,27 @@ describe('an App choosing its build route', () => {
   });
 
   /**
+   * The other spelling a reachable list is allowed to use: a bare host, for a
+   * Target that reaches every namespace on one registry. The route publishes
+   * to a namespace under that host, so the two meet — refusing here was the
+   * bug this test pins, because live Targets declare hosts.
+   */
+  test('a Target declaring a bare registry host accepts a route publishing a namespace under it', async () => {
+    await ctx.db
+      .update(targets)
+      .set({
+        discovery: {
+          reachableRegistries: ['registry.example.test'],
+        } as never,
+      })
+      .where(eq(targets.id, targetId));
+
+    const result = await setAppBuildRoute({ appId, route: 'managed' }, ctx);
+
+    expect(result.ok).toBe(true);
+  });
+
+  /**
    * The Target's threshold is the Target's, so raising it takes the choice away
    * — which is the direction being wrong has to fail in.
    */


### PR DESCRIPTION
A Target's reachable-registry list legally speaks two spellings — the
`ghcr.io/owner` namespace, and the bare host for a Target that reaches every
namespace on one registry (`domain/desired-state.ts` sets that vocabulary for
pull addresses, and says why: "Comparing it to `registryHostOf(ref)` compares
a namespace to a host and never matches").

`setAppBuildRoute`'s publish/pull intersection didn't speak the second
spelling: it compared published namespaces to the declared list by string
equality. A host-declared Target could therefore never meet any route, and the
refusal it produced was self-contradictory — observed live today:

> managed publishes to … northamerica-northeast1-docker.pkg.dev/trusted-builds/i,
> and bluenose-cloudrun pulls from northamerica-northeast1-docker.pkg.dev — so a
> build … would produce an artifact bluenose-cloudrun cannot pull.

Two of the three live vessels declare bare hosts, so this refused every route
choice for Apps placed on them.

The intersection now claims a namespace by host prefix as well as equality.
Revert-proven: the new test fails against the equality check (8 pass / 1 fail
on the old code, 9 pass with the fix).

Full suite: 1663 pass; the 2 `test/db/migrate.test.ts` failures are a
pre-existing hook-timeout flake on this machine, identical on clean main.
Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)