### PR TITLE
fix(bluenose): enable cloud build for the controller's quota project

### DIFF
--- a/terraform/gcp/projects/bluenose/services.tf
+++ b/terraform/gcp/projects/bluenose/services.tf
@@ -2,6 +2,10 @@ resource "google_project_service" "service" {
   for_each = toset([
     "artifactregistry.googleapis.com",
     "binaryauthorization.googleapis.com",
+    # The build submit targets trusted-builds, but the controller's federated
+    # token bills its quota here — and GCP refuses a call whose consumer
+    # project has not enabled the API, whatever project the URL names.
+    "cloudbuild.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     # A Cloud Run Job holds no cron expression, so a Component that declares a
     # schedule is a Cloud Scheduler job calling `jobs.run` in front of it.


### PR DESCRIPTION
Every managed-route build submit fails with `SERVICE_DISABLED` naming
bluenose's project number (`558198215187`) even though the URL targets
`trusted-builds`, where `cloudbuild.googleapis.com` is enabled and Terraform
confirms no drift. The distinction is consumer vs resource project: the
controller's federated token bills its quota to bluenose, and GCP refuses a
call whose consumer project has not enabled the API, whatever project the URL
names.

One service added to bluenose's enablement list, with a comment saying why it
is here when nothing in bluenose runs Cloud Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)