### PR TITLE
feat(spindrift): edit config vars from the app page

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -18,6 +18,7 @@ import type {
   Runtime,
   WorkspaceView,
 } from '../../web/model.ts';
+import { configuredKeys } from '../config/set.ts';
 import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
 export const getAppWorkspaceInput = z.object({
@@ -127,6 +128,21 @@ export const getAppWorkspace: Command<
       });
     }
   }
+
+  // Keys only, never values (§10) — `configuredKeys` is the same read
+  // `setConfig` itself uses to know what is already there, and it is the
+  // only shape a screen is allowed to show: core's store has no verb that
+  // returns a value. Scoped to the same pair the rest of this screen already
+  // picked — `workspaceTarget`, not every Target the Component might be
+  // placed on — because that pair is what a `Set variable` here would act on.
+  const configKeys =
+    primaryComponent && workspaceTarget
+      ? await configuredKeys(
+          context.db,
+          primaryComponent.id,
+          workspaceTarget.id,
+        )
+      : [];
 
   // Status events only — the checkpoints, not the transcript.
   //
@@ -241,6 +257,7 @@ export const getAppWorkspace: Command<
         ? `Build ${primaryComponent.builds[0].id}`
         : 'none',
     components,
+    configKeys,
     datastores: Array.from(datastoresMap.values()),
     activity,
     runtime,

--- a/apps/spindrift/src/commands/config/set.ts
+++ b/apps/spindrift/src/commands/config/set.ts
@@ -92,7 +92,23 @@ export const setConfigInput = z
   .object({
     componentId: z.uuid(),
     targetId: z.uuid(),
-    entries: z.array(configEntry).min(1),
+    /** Absent or empty on a call that only removes (below). */
+    entries: z.array(configEntry).optional(),
+    /**
+     * Keys to remove, named and nothing more.
+     *
+     * `applyConfigChange` already takes removals as their own list — this is
+     * the one place that list is exposed past this file. It is deliberately
+     * not `replaceConfig`'s diff: that upload is a stand-in for values core
+     * cannot read back, so it has to restate every key an operator means to
+     * keep. A removal does not, because deleting one key was never a claim
+     * about any other key's value.
+     */
+    removals: z
+      .array(
+        z.string().regex(VARIABLE_NAME, 'must be an environment variable name'),
+      )
+      .optional(),
   })
   .strict();
 
@@ -129,10 +145,16 @@ export const setConfig: Command<SetConfigInput, ConfigChangeResult> = async (
   input,
   context,
 ) => {
+  const entries = input.entries ?? [];
+  const removals = input.removals ?? [];
+  if (entries.length === 0 && removals.length === 0) {
+    return failed('INVALID_INPUT', 'nothing to set or remove');
+  }
+
   const subject = await configSubject(context, input);
   if ('failure' in subject) return { ok: false, failure: subject.failure };
 
-  const duplicate = firstDuplicate(input.entries.map((entry) => entry.key));
+  const duplicate = firstDuplicate(entries.map((entry) => entry.key));
   if (duplicate !== null) {
     return failed(
       'INVALID_INPUT',
@@ -140,7 +162,17 @@ export const setConfig: Command<SetConfigInput, ConfigChangeResult> = async (
     );
   }
 
-  return applyConfigChange(context, subject, input.entries, []);
+  const contested = entries
+    .map((entry) => entry.key)
+    .find((key) => removals.includes(key));
+  if (contested !== undefined) {
+    return failed(
+      'INVALID_INPUT',
+      `${contested} is both set and removed in the same call`,
+    );
+  }
+
+  return applyConfigChange(context, subject, entries, removals);
 };
 
 /** Everything a config act needs about what it is acting on. */

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -37,6 +37,7 @@ import { AppList } from './views/apps/list.tsx';
 import { NewApp } from './views/apps/new/index.tsx';
 import {
   type RunJob,
+  type SetConfig,
   type SetReach,
   Workspace,
 } from './views/apps/workspace.tsx';
@@ -1189,6 +1190,49 @@ function WorkspaceScreen({
     }
   };
 
+  // The pair this workspace is showing (§10) — bound here, once, so `SetConfig`
+  // itself does not have to carry it on every call. Re-read on success for the
+  // same reason `handleSetReach` is: `configKeys` is a row this act just
+  // changed, and a key that was just deleted has to actually leave the list
+  // rather than being patched out by a guess about what the write did.
+  const handleSetConfig: SetConfig = async (change) => {
+    const pair =
+      state.type === 'success'
+        ? {
+            componentId: state.workspace.componentId,
+            targetId: state.workspace.targetId,
+          }
+        : { componentId: undefined, targetId: undefined };
+    if (pair.componentId === undefined || pair.targetId === undefined) {
+      return {
+        ok: false,
+        message: 'This App has no Component placed on a Target yet',
+      };
+    }
+    try {
+      const result = await command('setConfig', {
+        componentId: pair.componentId,
+        targetId: pair.targetId,
+        entries: [...change.entries],
+        removals: [...change.removals],
+      });
+      if (!result.ok) return { ok: false, message: result.failure.message };
+      setReloadToken((token) => token + 1);
+      return {
+        ok: true,
+        written: result.value.written,
+        removed: result.value.removed,
+        notDeployed: result.value.notDeployed,
+      };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message:
+          cause instanceof Error ? cause.message : 'Saving config failed',
+      };
+    }
+  };
+
   /**
    * Start one run (§17), then re-read: the list on the screen was written
    * before the run existed, and a run that does not appear reads as a press
@@ -1246,6 +1290,7 @@ function WorkspaceScreen({
         onNavigate={onNavigate}
         deletion={deletion}
         onSetReach={handleSetReach}
+        onSetConfig={handleSetConfig}
         {...(runs === null
           ? {}
           : {

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -524,6 +524,13 @@ export interface WorkspaceView {
   readonly urlLive: boolean;
   readonly release: string;
   readonly components: readonly ComponentView[];
+  /**
+   * Every key configured for this pair (§10), sorted — never a value. Core's
+   * store is write-only, so this is the same read `setConfig` uses to know
+   * what is already there, and it is the only shape the workspace is
+   * allowed to render.
+   */
+  readonly configKeys: readonly string[];
   readonly datastores: readonly DatastoreView[];
   readonly activity: readonly ActivityEntry[];
   /**

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -16,6 +16,10 @@
  * - **A `website` has no runtime**, one level down (§17, §18). Static files are
  *   served by the Target, so there is no process output — an honest empty state,
  *   not a disabled tab.
+ * - **Config shows keys, never values** (§10). Core's store is write-only, so
+ *   the section below Components and Datastores is a list of names and a form
+ *   that writes — there is nothing here that could show a secret it was handed
+ *   by accident, because nothing here is ever handed one.
  */
 import { ChevronRight, ExternalLink } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
@@ -36,6 +40,7 @@ import type {
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, Eyebrow } from '../../ui/card.tsx';
+import { Field } from '../../ui/field.tsx';
 import { cn } from '../../ui/utils.ts';
 import {
   AUTH_NOTE,
@@ -74,6 +79,30 @@ export type RunJob = () => Promise<
   { readonly ok: true } | { readonly ok: false; readonly message: string }
 >;
 
+/**
+ * Writing or removing config for the pair this workspace is showing (§10),
+ * as the screen above needs it answered.
+ *
+ * One call for both, because `setConfig` itself takes entries and removals
+ * together — there is no separate "edit" act, because setting a key that
+ * already exists *is* the edit (core upserts and never reads the old value
+ * back to compare against). `componentId`/`targetId` are not part of this
+ * shape: the workspace has exactly one pair on screen, so the screen above
+ * binds them once rather than asking every call here to restate it.
+ */
+export type SetConfig = (change: {
+  readonly entries: readonly { key: string; value: string }[];
+  readonly removals: readonly string[];
+}) => Promise<
+  | {
+      readonly ok: true;
+      readonly written: readonly string[];
+      readonly removed: readonly string[];
+      readonly notDeployed: string | null;
+    }
+  | { readonly ok: false; readonly message: string }
+>;
+
 export function Workspace({
   view,
   onDeploy,
@@ -82,6 +111,7 @@ export function Workspace({
   onNavigate,
   deletion,
   onSetReach,
+  onSetConfig,
   onRunJob,
   onFollowExecution,
   executionLines,
@@ -112,6 +142,12 @@ export function Workspace({
    * worse than no form.
    */
   onSetReach?: SetReach;
+  /**
+   * Absent where config is not editable from here, for the same reason
+   * {@link onSetReach} is — the fixture screens render this view with no acts
+   * wired, and a form whose Save cannot be called is worse than no form.
+   */
+  onSetConfig?: SetConfig;
   /**
    * Start one run of this App's job (§17). Absent where the screen wires no
    * acts, and absent for every Component that is not a job — the runtime card
@@ -178,6 +214,11 @@ export function Workspace({
         />
         <Datastores datastores={view.datastores} />
       </div>
+
+      <ConfigSection
+        configKeys={view.configKeys}
+        {...(onSetConfig === undefined ? {} : { onSetConfig })}
+      />
 
       <div className="grid gap-4 md:grid-cols-2">
         {/*
@@ -549,6 +590,212 @@ function Datastores({ datastores }: { datastores: readonly DatastoreView[] }) {
         )}
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * The App's environment configuration (§10).
+ *
+ * Keys only, ever — the same posture core's config commands take, kept all
+ * the way to the screen: nothing here has ever been handed a value, so there
+ * is nothing here that could show one by accident.
+ * "Set variable" is the one form underneath, because `setConfig` upserts —
+ * naming a key that already exists overwrites it, so add and edit are one
+ * act, not two the operator has to choose between.
+ */
+function ConfigSection({
+  configKeys,
+  onSetConfig,
+}: {
+  configKeys: readonly string[];
+  onSetConfig?: SetConfig;
+}) {
+  const [adding, setAdding] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  return (
+    <Card>
+      <SectionHeader
+        eyebrow="App configuration"
+        title="Config"
+        {...(onSetConfig
+          ? {
+              action: adding ? 'Close' : 'Set variable',
+              onAction: () => setAdding((current) => !current),
+            }
+          : {})}
+      />
+      <CardContent className="pt-0">
+        {onSetConfig && adding ? (
+          <ConfigVarForm
+            onSetConfig={onSetConfig}
+            onDone={() => setAdding(false)}
+          />
+        ) : null}
+        {deleteError ? (
+          <p className="mb-2 rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-xs text-destructive">
+            {deleteError}
+          </p>
+        ) : null}
+        {configKeys.length === 0 ? (
+          <EmptyState title="No configuration is set.">
+            Values are write-only — Spindrift stores one secret per variable and
+            never reads one back, including here.
+          </EmptyState>
+        ) : (
+          configKeys.map((key) => (
+            <Row
+              key={key}
+              badge={<Badge tone="idle">env</Badge>}
+              title={key}
+              detail="value is write-only"
+              trailing={
+                onSetConfig ? (
+                  <DeleteConfigVarButton
+                    configKey={key}
+                    onSetConfig={onSetConfig}
+                    onError={setDeleteError}
+                  />
+                ) : undefined
+              }
+            />
+          ))
+        )}
+        <p className="pt-2 text-xs text-muted-foreground">
+          A config change redeploys what is running under a new configVersion —
+          or says why nothing was redeployed, the same way Deploy does.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Setting one variable — write-only in, so the value field always starts
+ * blank, even for a key that already has one (§10: nothing above the store
+ * has ever been allowed to read it back).
+ */
+function ConfigVarForm({
+  onSetConfig,
+  onDone,
+}: {
+  onSetConfig: SetConfig;
+  onDone: () => void;
+}) {
+  const [key, setKey] = useState('');
+  const [value, setValue] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [outcome, setOutcome] = useState<
+    | { readonly kind: 'saved'; readonly notDeployed: string | null }
+    | { readonly kind: 'refused'; readonly message: string }
+    | null
+  >(null);
+
+  const save = async () => {
+    setSaving(true);
+    setOutcome(null);
+    try {
+      const result = await onSetConfig({
+        entries: [{ key: key.trim(), value }],
+        removals: [],
+      });
+      if (result.ok) {
+        setOutcome({ kind: 'saved', notDeployed: result.notDeployed });
+        setKey('');
+        setValue('');
+      } else {
+        setOutcome({ kind: 'refused', message: result.message });
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 border-b border-border-soft pb-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        <Field
+          name="config-key"
+          label="Key"
+          value={key}
+          onChange={(event) => setKey(event.target.value)}
+          placeholder="DATABASE_URL"
+        />
+        <Field
+          name="config-value"
+          label="Value"
+          type="password"
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="written once, never shown again"
+        />
+      </div>
+      {outcome?.kind === 'refused' ? (
+        <p className="rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-xs text-destructive">
+          {outcome.message}
+        </p>
+      ) : null}
+      {outcome?.kind === 'saved' ? (
+        <p className="rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
+          {outcome.notDeployed ??
+            'Saved. Redeployed under the new configuration.'}
+        </p>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          disabled={saving || key.trim() === ''}
+          onClick={() => {
+            void save();
+          }}
+        >
+          {saving ? 'Saving…' : 'Save variable'}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onDone} disabled={saving}>
+          {outcome?.kind === 'saved' ? 'Close' : 'Cancel'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Removing one variable, and nothing else.
+ *
+ * `setConfig` takes the key alone — unlike `replaceConfig`'s upload, a
+ * removal never asks this button to restate the values of the keys it is
+ * leaving alone, which is the whole reason deleting one key does not mean
+ * retyping every other one. No local confirmation state: the button has
+ * nowhere on the row to show one, so a refusal is reported to the section
+ * above instead of being lost.
+ *
+ * Exported for `test/web/views.test.tsx`, which calls it directly to prove
+ * what pressing it sends — the same reason `DeleteAppButton` is.
+ */
+export function DeleteConfigVarButton({
+  configKey,
+  onSetConfig,
+  onError,
+}: {
+  configKey: string;
+  onSetConfig: SetConfig;
+  onError: (message: string | null) => void;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      onClick={() => {
+        onError(null);
+        void onSetConfig({ entries: [], removals: [configKey] }).then(
+          (result) => {
+            if (!result.ok) onError(result.message);
+          },
+        );
+      }}
+    >
+      Delete
+    </Button>
   );
 }
 

--- a/apps/spindrift/test/commands/config.test.ts
+++ b/apps/spindrift/test/commands/config.test.ts
@@ -293,6 +293,85 @@ describe('setConfig writes a reference, never a value', () => {
   });
 });
 
+describe('setConfig also removes, naming nothing but the key', () => {
+  test('one key goes, the rest are untouched', async () => {
+    const { component, target } = await fixture();
+    const commands = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [
+          { key: 'TOKEN', value: 'one' },
+          { key: 'DSN', value: 'two' },
+        ],
+      },
+      commands,
+    );
+    const putsBefore = store.puts.length;
+
+    const result = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        removals: ['TOKEN'],
+      },
+      commands,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.removed).toEqual(['TOKEN']);
+    expect(result.value.written).toEqual([]);
+    // DSN's value was never restated, so nothing was written to the store —
+    // a removal is not `replaceConfig`'s upload wearing a shorter name.
+    expect(store.puts.length).toBe(putsBefore);
+
+    const rows = await database()
+      .db.select()
+      .from(configItems)
+      .where(eq(configItems.componentId, component.id));
+    expect(rows.map((row) => row.key)).toEqual(['DSN']);
+  });
+
+  test('a key both set and removed in one call is refused', async () => {
+    const { component, target } = await fixture();
+
+    const result = await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'TOKEN', value: 'one' }],
+        removals: ['TOKEN'],
+      },
+      await context(
+        registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+      ),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+  });
+
+  test('nothing to set and nothing to remove is refused', async () => {
+    const { component, target } = await fixture();
+
+    const result = await setConfig(
+      { componentId: component.id, targetId: target.id },
+      await context(
+        registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+      ),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+  });
+});
+
 describe('a config change produces a new Deploy', () => {
   test('the pair redeploys what is live, under a new configVersion', async () => {
     const { component, target } = await fixture();

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -443,6 +443,7 @@ export const WORKSPACE_SCENARIOS = {
         auth: 'proxy',
       },
     ],
+    configKeys: ['DATABASE_URL', 'PORT'],
     datastores: [
       {
         name: 'primary',
@@ -537,6 +538,10 @@ export const WORKSPACE_SCENARIOS = {
         auth: 'none',
       },
     ],
+    // A website's configuration is baked at build time (§10) — ordinary
+    // rows, not entries in this store, so this list is empty rather than
+    // wrong.
+    configKeys: [],
     // §11: a website cannot attach a Datastore.
     datastores: [],
     activity: [
@@ -586,6 +591,7 @@ export const WORKSPACE_SCENARIOS = {
         auth: 'none',
       },
     ],
+    configKeys: ['BUCKET'],
     datastores: [
       {
         name: 'archive',

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -16,7 +16,11 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { logos } from '../../src/web/client/logos/index.ts';
 import type { DeployView, WorkspaceView } from '../../src/web/model.ts';
 import { DeployDetail } from '../../src/web/views/apps/deploy-detail.tsx';
-import { ReachEditor, Workspace } from '../../src/web/views/apps/workspace.tsx';
+import {
+  DeleteConfigVarButton,
+  ReachEditor,
+  Workspace,
+} from '../../src/web/views/apps/workspace.tsx';
 import { Gate } from '../../src/web/views/auth/gate.tsx';
 import { CredentialSettingsView } from '../../src/web/views/auth/settings.tsx';
 import { RepositoryList } from '../../src/web/views/repos/list.tsx';
@@ -907,5 +911,76 @@ describe('changing how a Component is reached (§9)', () => {
     for (const cell of ['none', 'private', 'public', 'proxy']) {
       expect(markup).toContain(cell);
     }
+  });
+});
+
+describe('editing config from the workspace (§10)', () => {
+  const view = WORKSPACE_SCENARIOS.service;
+
+  test('every configured key is shown, and nothing about its value is', () => {
+    const markup = workspace(view);
+    for (const key of view.configKeys) {
+      expect(markup).toContain(key);
+    }
+    expect(markup).toContain('value is write-only');
+    // The consequence, stated rather than hidden: this is the same posture
+    // `deployChange`'s own comment takes server-side, kept on the screen.
+    expect(markup).toContain(
+      'redeploys what is running under a new configVersion',
+    );
+  });
+
+  test('the affordance is on the section only where an act is wired', () => {
+    // No form whose Save cannot be called — the same rule §9's Reach card
+    // states above.
+    expect(workspace(view)).not.toContain('Set variable');
+
+    const markup = renderToStaticMarkup(
+      <Workspace
+        view={view}
+        onSetConfig={async () => ({
+          ok: true,
+          written: [],
+          removed: [],
+          notDeployed: null,
+        })}
+      />,
+    );
+    expect(markup).toContain('Set variable');
+  });
+
+  test('pressing Delete on a key dispatches setConfig’s removal shape, and nothing else', () => {
+    // Called directly rather than clicked through a mounted tree, for the
+    // same reason `DeleteAppButton`'s own test in `app-list-identity.test.tsx`
+    // is: what is under test is which value the handler closes over, and
+    // `renderToStaticMarkup` — this file's usual depth — cannot click
+    // anything (see this file's own header).
+    const calls: {
+      entries: readonly { key: string; value: string }[];
+      removals: readonly string[];
+    }[] = [];
+    const onSetConfig = async (change: {
+      entries: readonly { key: string; value: string }[];
+      removals: readonly string[];
+    }) => {
+      calls.push(change);
+      return {
+        ok: true as const,
+        written: [],
+        removed: change.removals,
+        notDeployed: null,
+      };
+    };
+
+    const button = DeleteConfigVarButton({
+      configKey: 'DATABASE_URL',
+      onSetConfig,
+      onError: () => undefined,
+    });
+    (button.props as { onClick: () => void }).onClick();
+
+    // The exact shape `setConfig` takes: the key named, nothing about the
+    // keys left alone — a removal never restates a value it cannot read.
+    expect(calls).toEqual([{ entries: [], removals: ['DATABASE_URL'] }]);
   });
 });


### PR DESCRIPTION
`setConfig` and `replaceConfig` shipped with write-only proof tests and no
view calling them — config was only usable through raw command POSTs.

- The workspace now carries `configKeys` (key names only, via the same
  `configuredKeys()` helper the command layer already uses) and the App page
  gets a Config section: set/edit a var, delete a var, following the existing
  `ReachEditor` disclosure pattern.
- `setConfig` gains `removals` — `applyConfigChange` always took a removals
  list; the command just never exposed it. A per-key delete genuinely needed
  it: `replaceConfig`'s diff would require restating every other value, and
  values are write-only.
- Masking is total: no value is ever read back or rendered, matching the
  existing `configuredKeys` posture. The section's copy states the
  consequence — a change redeploys under a new configVersion — using the
  command's own `notDeployed` sentence when nothing redeploys.

`bun test`: 1670 pass, 0 fail. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)