### PR TITLE
fix(spindrift): let deployApp name the component it deploys

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -73,6 +73,15 @@ export const deployAppInput = z
      * for a Build in as many words.
      */
     rebuild: z.boolean().optional(),
+    /**
+     * The Component to act on, by its name or id within this App.
+     *
+     * Absent means the App's primary component (`components[0]`), so every
+     * existing caller keeps its behaviour by saying nothing. An App with more
+     * than one Component — a `job` alongside its `service`, say — has no other
+     * way to reach the rest: nothing else inserts a Build for them.
+     */
+    component: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -296,18 +305,36 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     return failed('NOT_FOUND', `App '${app.name}' has no components to deploy`);
   }
 
-  const latestDeploy = primaryComponent.deploys[0];
+  let component = primaryComponent;
+  if (input.component !== undefined) {
+    const named = app.components.find(
+      (candidate) =>
+        candidate.id === input.component || candidate.name === input.component,
+    );
+    if (!named) {
+      const names = app.components
+        .map((candidate) => candidate.name)
+        .join(', ');
+      return failed(
+        'NOT_FOUND',
+        `App '${app.name}' has no Component '${input.component}' — it has: ${names}`,
+      );
+    }
+    component = named;
+  }
+
+  const latestDeploy = component.deploys[0];
   const targetId =
-    latestDeploy?.targetId ?? primaryComponent.desiredTargets[0]?.targetId;
+    latestDeploy?.targetId ?? component.desiredTargets[0]?.targetId;
 
   if (!targetId) {
     return failed(
       'NOT_FOUND',
-      `Component '${primaryComponent.name}' has no target placement`,
+      `Component '${component.name}' has no target placement`,
     );
   }
 
-  const latestBuild = primaryComponent.builds[0];
+  const latestBuild = component.builds[0];
 
   if (
     !input.rebuild &&
@@ -317,7 +344,7 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
   ) {
     const deployAttempt = await createDeploy(
       {
-        componentId: primaryComponent.id,
+        componentId: component.id,
         targetId,
         buildId: latestBuild.id,
       },
@@ -360,7 +387,7 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     const [newBuild] = await context.db
       .insert(builds)
       .values({
-        componentId: primaryComponent.id,
+        componentId: component.id,
         commit: commitRef,
         targetShape: buildToRun?.targetShape ?? 'image',
         artifactType: buildToRun?.artifactType ?? 'image',
@@ -394,7 +421,7 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
   await context.db
     .insert(componentTargetDesired)
     .values({
-      componentId: primaryComponent.id,
+      componentId: component.id,
       targetId,
       updatedAt: now,
     })

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -20,6 +20,7 @@
 import { describe, expect, test } from 'bun:test';
 import { and, eq } from 'drizzle-orm';
 import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
+import { deployApp } from '../../src/commands/apps/deploy.ts';
 import { placeIntent } from '../../src/commands/deploys/create.ts';
 import {
   createDeploy,
@@ -605,6 +606,142 @@ describe('createDeploy writes an intent, and only an intent', () => {
       },
     });
     expect(refusing.signatureChecks.admissions).toHaveLength(1);
+  });
+});
+
+describe('deployApp selects which Component it acts on', () => {
+  /**
+   * A second Component on the fixture's App — a `job` alongside the fixture's
+   * `service`, the shape that had no path to a Build at all before `deployApp`
+   * could be told which Component it meant. Placed on the fixture's own Target
+   * so `desiredTargets` — not a Deploy history that does not exist yet — is
+   * what resolves `targetId`.
+   */
+  async function secondComponent(appId: string, targetId: string) {
+    const db = database().db;
+    const [component] = await db
+      .insert(components)
+      .values({
+        appId,
+        name: 'worker',
+        kind: 'job',
+        reach: 'none',
+        auth: 'none',
+      })
+      .returning();
+    await db
+      .insert(componentTargetDesired)
+      .values({ componentId: component!.id, targetId, updatedAt: FROZEN });
+    return component!;
+  }
+
+  test('a fresh second Component gets its own Build, not the primary’s', async () => {
+    const { app, component, target } = await fixture();
+    const primaryBuild = await succeededBuild(component.id, 10);
+    const worker = await secondComponent(app.id, target.id);
+
+    const result = await deployApp(
+      { name: app.name, component: worker.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Nothing was deployable yet for `worker`, so this is the Build-starting
+    // act, not the deploy one.
+    expect(result.value.phase).toBe('BUILDING');
+    expect(result.value.deployId).toBeNull();
+
+    const [started] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    expect(started?.componentId).toBe(worker.id);
+
+    // The primary's own Build is untouched — a different Component's deploy
+    // wrote nothing onto it.
+    const primaryRows = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.componentId, component.id));
+    expect(primaryRows).toEqual([primaryBuild]);
+  });
+
+  test('a named second Component with an artifact gets its own Deploy, not the primary’s', async () => {
+    const { app, component, target } = await fixture();
+    await succeededBuild(component.id, 11);
+    const worker = await secondComponent(app.id, target.id);
+    const workerBuild = await succeededBuild(worker.id, 12);
+
+    const result = await deployApp(
+      { name: app.name, component: worker.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('PENDING');
+    expect(result.value.buildId).toBe(workerBuild.id);
+
+    const [deploy] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, result.value.deployId!));
+    expect(deploy?.componentId).toBe(worker.id);
+
+    // The primary Component gets no Deploy out of an intent aimed at `worker`.
+    const primaryDeploys = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, component.id));
+    expect(primaryDeploys).toHaveLength(0);
+
+    const desired = await desiredRow(worker.id, target.id);
+    expect(desired?.desiredBuildId).toBe(workerBuild.id);
+    expect(desired?.desiredDeployId).toBe(result.value.deployId);
+  });
+
+  test('an unknown Component name is refused, naming what the App actually has', async () => {
+    const { app, component } = await fixture();
+
+    const result = await deployApp(
+      { name: app.name, component: 'no-such-component' },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('no-such-component');
+    expect(result.failure.message).toContain(component.name);
+  });
+
+  test('an absent Component still deploys the primary, unchanged', async () => {
+    const { app, component, target } = await fixture();
+    const build = await succeededBuild(component.id, 13);
+    await database()
+      .db.insert(componentTargetDesired)
+      .values({
+        componentId: component.id,
+        targetId: target.id,
+        updatedAt: FROZEN,
+      });
+
+    const result = await deployApp(
+      { name: app.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('PENDING');
+    expect(result.value.buildId).toBe(build.id);
+
+    const [deploy] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, result.value.deployId!));
+    expect(deploy?.componentId).toBe(component.id);
   });
 });
 

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -719,13 +719,11 @@ describe('deployApp selects which Component it acts on', () => {
   test('an absent Component still deploys the primary, unchanged', async () => {
     const { app, component, target } = await fixture();
     const build = await succeededBuild(component.id, 13);
-    await database()
-      .db.insert(componentTargetDesired)
-      .values({
-        componentId: component.id,
-        targetId: target.id,
-        updatedAt: FROZEN,
-      });
+    await database().db.insert(componentTargetDesired).values({
+      componentId: component.id,
+      targetId: target.id,
+      updatedAt: FROZEN,
+    });
 
     const result = await deployApp(
       { name: app.name },


### PR DESCRIPTION
An App can hold several Components and the domain keys Builds per Component —
but every path that mints a Build row is pinned to `app.components[0]`.
Observed live today: a freshly created second Component (a `kind: job`) can
never obtain a Build or a Deploy. `createDeploy` refuses a foreign buildId
("that Build belongs to a different Component"), so `runComponent` refuses
`NOT_RUNNABLE` forever — the Component exists and nothing can ever run it.

The minimal exit: `deployApp` gains an optional `component` (name or id
within the App). Absent means the primary component, so every existing caller
keeps its behaviour by saying nothing. Given, the selected component flows
through the existing target-resolution, build-reuse/creation, and
desired-placement logic unchanged — `sourceForRerun` was already keyed on the
App, so a component with zero builds stages the App's source correctly.

Four new tests: a second component gets its own Build (primary untouched), a
second component with its own succeeded Build gets its own Deploy, an unknown
name is refused naming what exists, and the absent-input path still deploys
the primary. 32 pass in the file; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)