### PR TITLE
feat(spindrift): deploy on push for apps that opt in

### DIFF
--- a/apps/spindrift/src/db/migrations/0027_app_auto_deploy.sql
+++ b/apps/spindrift/src/db/migrations/0027_app_auto_deploy.sql
@@ -1,0 +1,5 @@
+-- An App's opt-in to Deploy-on-push (§15).
+--
+-- `false` and NOT NULL: auto-deploy is a developer turning something on, never
+-- a default an App wakes up with because Spindrift shipped a migration.
+ALTER TABLE "apps" ADD COLUMN "auto_deploy" boolean DEFAULT false NOT NULL;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1785374380770,
       "tag": "0026_deploy_desired",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1785374380771,
+      "tag": "0027_app_auto_deploy",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -476,6 +476,15 @@ export const apps = pgTable('apps', {
    */
   buildRoute: text('build_route'),
   /**
+   * Opt in to a Deploy dispatched from a push, with no operator at the
+   * keyboard (§15's webhook, `src/reconciler/auto-deploy.ts`).
+   *
+   * `false` by default and on every App that predates this column: auto-deploy
+   * changes what is live without being asked at that moment, so an App gets it
+   * only by a developer turning it on, never by upgrading Spindrift.
+   */
+  autoDeploy: boolean('auto_deploy').notNull().default(false),
+  /**
    * **No vessel column, deliberately.** An App has placements, and each
    * placement's Target is a surface on a vessel — that is the boundary the App
    * is in, and it is derivable. A column here could only be a second, unchecked

--- a/apps/spindrift/src/reconciler/auto-deploy.ts
+++ b/apps/spindrift/src/reconciler/auto-deploy.ts
@@ -1,0 +1,100 @@
+/**
+ * The dispatcher `repo-loop.ts` left for later (§15).
+ *
+ * That file's header says why it stops at adopting a commit: reconciliation
+ * only has a `RepositoryReconciliation` to report, and a Deploy is a decision
+ * about an App, not about a repository. This module is the other half — it
+ * reads what a pass adopted and, for every App on that repository that has
+ * opted in (`apps.autoDeploy`), calls {@link deployApp}: the same one-button
+ * command a developer reaches from the workspace. A push causes exactly what
+ * pressing that button would, nothing more — this module writes no row of its
+ * own and invents no second admission policy.
+ *
+ * **Opt-in is a property of the App, not of the delivery.** A repository can
+ * carry Apps that watch it silently beside Apps that redeploy on every push,
+ * which is why this reads `apps.autoDeploy` per scope rather than a flag on
+ * the repository or on the webhook route.
+ *
+ * **Called from both the webhook route and the poll loop's periodic pass,
+ * over the same `RepositoryReconciliation[]`.** Neither path is a second
+ * dispatcher — both hand their passes here, which is what keeps a missed
+ * delivery self-healing: the loop's next tick reconciles the same commit and
+ * dispatches exactly as the webhook would have (§15: "a missed delivery
+ * self-heals").
+ */
+import { and, eq, inArray } from 'drizzle-orm';
+import { type DeployAppResult, deployApp } from '../commands/apps/deploy.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandResult,
+  Principal,
+} from '../commands/types.ts';
+import type { InstallationManifest } from '../config/manifest.schema.ts';
+import type { Database } from '../db/client.ts';
+import { apps } from '../db/schema.ts';
+import type { RepositoryReconciliation } from './repo-loop.ts';
+
+/**
+ * Attributed to every push-triggered Deploy: nobody was at the keyboard, and
+ * §"First run and identity" gives every enrolled user one fully privileged
+ * kind rather than a role this dispatcher could borrow instead.
+ */
+export const AUTO_DEPLOY_PRINCIPAL: Principal = {
+  id: 'spindrift:auto-deploy',
+  displayName: 'Spindrift (auto-deploy on push)',
+};
+
+/** What `dispatchAutoDeploys` needs — a `CommandContext` minus the principal. */
+export interface AutoDeployContext {
+  readonly db: Database;
+  readonly clock: Clock;
+  readonly adapters: AdapterRegistry;
+  readonly manifest: InstallationManifest;
+}
+
+/** One opted-in App's dispatch, so a caller can log or assert on it. */
+export interface AutoDeployAttempt {
+  readonly appId: string;
+  readonly result: CommandResult<DeployAppResult>;
+}
+
+/**
+ * Deploy every opted-in App whose repository just adopted a new commit.
+ *
+ * Only `outcome: 'adopted'` passes carry a new commit — `unchanged`, `frozen`,
+ * `rejected`, and `unavailable` all mean nothing landed, so there is nothing
+ * to redeploy. `invalid` scopes never appear beside an `adopted` outcome
+ * (repo-loop.ts refuses the whole commit when one does), so every scope this
+ * reads named a real App.
+ */
+export async function dispatchAutoDeploys(
+  context: AutoDeployContext,
+  passes: readonly RepositoryReconciliation[],
+): Promise<readonly AutoDeployAttempt[]> {
+  const appIds = passes
+    .filter((pass) => pass.outcome === 'adopted')
+    .flatMap((pass) => pass.scopes.map((scope) => scope.appId));
+  if (appIds.length === 0) return [];
+
+  const optedIn = await context.db
+    .select({ id: apps.id })
+    .from(apps)
+    .where(and(inArray(apps.id, appIds), eq(apps.autoDeploy, true)));
+
+  const attempts: AutoDeployAttempt[] = [];
+  for (const app of optedIn) {
+    const result = await deployApp(
+      { name: app.id },
+      {
+        principal: AUTO_DEPLOY_PRINCIPAL,
+        clock: context.clock,
+        db: context.db,
+        adapters: context.adapters,
+        manifest: context.manifest,
+      },
+    );
+    attempts.push({ appId: app.id, result });
+  }
+  return attempts;
+}

--- a/apps/spindrift/src/reconciler/process.ts
+++ b/apps/spindrift/src/reconciler/process.ts
@@ -10,6 +10,7 @@ import type { AdapterRegistry, Clock } from '../commands/types.ts';
 import type { InstallationManifest } from '../config/manifest.schema.ts';
 import type { Database } from '../db/client.ts';
 import { reconcilerLoopDuration } from '../telemetry/index.ts';
+import { dispatchAutoDeploys } from './auto-deploy.ts';
 import { DEFAULT_BUILD_INTERVALS, runBuildLoop } from './build-loop.ts';
 import { DEFAULT_REAP_INTERVAL_MS, runConfigLoop } from './config-loop.ts';
 import { DEFAULT_INTERVALS, runDeployLoop } from './deploy-loop.ts';
@@ -244,7 +245,13 @@ export async function runReconciler(
           {
             intervalMs: DEFAULT_REPOSITORY_INTERVAL_MS,
             signal,
-            onPass: () => passed('repository'),
+            // The poll loop's fallback half of §15's pairing: the webhook route
+            // calls the same `dispatchAutoDeploys` over the same passes, so a
+            // missed delivery still deploys on this loop's next tick.
+            onPass: async (passes) => {
+              passed('repository');
+              await dispatchAutoDeploys(context, passes);
+            },
           },
         ),
     });

--- a/apps/spindrift/src/reconciler/repo-loop.ts
+++ b/apps/spindrift/src/reconciler/repo-loop.ts
@@ -33,10 +33,17 @@
  * running, and what stops is the one thing that genuinely cannot continue,
  * which is reading new source.
  *
- * What this loop does **not** do is dispatch a build. §5 makes default-branch
- * HEAD the trigger, but a Build has to name a route, and the routes arrive with
- * the build adapters. Until then the loop's job ends at adopting a commit and
- * saying which scopes it changed, which is the fact a dispatcher will need.
+ * What this file's own functions do **not** do is dispatch a build or a
+ * Deploy. `reconcileRepository`, `reconcileAllRepositories`, and
+ * `applyWebhookDelivery` end at adopting a commit and saying which scopes it
+ * changed — `./auto-deploy.ts`'s `dispatchAutoDeploys` is the dispatcher that
+ * fact was always for. It reads the `RepositoryReconciliation[]` these
+ * functions return and, for every App on the repository that opted in
+ * (`apps.autoDeploy`), calls `deployApp`. Both the poll loop's periodic pass
+ * and the webhook route call it over the same passes, which is what keeps a
+ * missed delivery self-healing rather than silently skipping a deploy: the
+ * loop's next tick reconciles the same commit and dispatches exactly as the
+ * webhook would have.
  */
 import { eq } from 'drizzle-orm';
 import type { Clock } from '../commands/types.ts';
@@ -480,8 +487,15 @@ async function repositoriesOf(
 export interface RepoLoopOptions {
   readonly intervalMs: number;
   readonly signal?: AbortSignal;
-  /** Called after each pass — where an installation wires logging or metrics. */
-  readonly onPass?: (passes: readonly RepositoryReconciliation[]) => void;
+  /**
+   * Called after each pass — where an installation wires logging, metrics, or
+   * `./auto-deploy.ts`'s `dispatchAutoDeploys`. May return a `Promise`, which
+   * the loop awaits before sleeping: dispatch is a database write and the
+   * loop's shutdown signal must not race ahead of it.
+   */
+  readonly onPass?: (
+    passes: readonly RepositoryReconciliation[],
+  ) => void | Promise<void>;
 }
 
 /**
@@ -502,7 +516,7 @@ export async function runRepoLoop(
     reconcilerLoopDuration.record((Date.now() - startedAt) / 1000, {
       loop: 'repository',
     });
-    options.onPass?.(passes);
+    await options.onPass?.(passes);
     if (options.signal?.aborted) return;
     await sleep(options.intervalMs, options.signal);
   }

--- a/apps/spindrift/src/web/routes.ts
+++ b/apps/spindrift/src/web/routes.ts
@@ -8,7 +8,7 @@
  * to be inline in `server.ts` next to a top-level `Bun.serve` no test can
  * import. So the table moved here and the entries call it.
  *
- * Six kinds of route exist, and five of the six are generated:
+ * Eight kinds of route exist, and three of the eight are generated:
  *
  * 1. **Commands**, from the registry (`dispatch.ts`).
  * 2. **The client**, from whatever built it — `bundle.ts` reading a directory in
@@ -18,9 +18,14 @@
  *    closed tuple of acts. It contains the pre-session acts that *produce* a
  *    principal and passkey-rooted credential administration; neither belongs
  *    in the product command registry.
- * 4. **Streams**, the two authenticated, purpose-specific WebSocket upgrades.
- * 5. **{@link HEALTH_PATH}**, a liveness probe that consults nothing.
- * 6. **{@link READY_PATH}**, a readiness probe that does — see below.
+ * 4. **Upload**, the archive upload boundary (`upload.ts`) — session-authenticated
+ *    like a command, but it takes bytes rather than JSON, so it cannot be one.
+ * 5. **Streams**, the two authenticated, purpose-specific WebSocket upgrades.
+ * 6. **The webhook** (`webhook-route.ts`), the one route with no session at
+ *    all — its authentication is the GitHub HMAC over the raw body, not a
+ *    cookie, so it cannot go through `DispatchDeps.authenticate` either.
+ * 7. **{@link HEALTH_PATH}**, a liveness probe that consults nothing.
+ * 8. **{@link READY_PATH}**, a readiness probe that does — see below.
  *
  * A further hand-authored route is a decision somebody has to make on purpose,
  * in this file, against a test that names it.
@@ -34,6 +39,7 @@ import type { Database } from '../db/client.ts';
 import { commandRoutes, type DispatchDeps } from './dispatch.ts';
 import { streamRoutes } from './streams.ts';
 import { uploadRoutes } from './upload.ts';
+import { type WebhookRouteDeps, webhookRoutes } from './webhook-route.ts';
 
 /**
  * Liveness: whether this process is still running.
@@ -92,6 +98,7 @@ export function webRoutes<Client extends Record<string, ClientRoute>>(
   client: Client,
   deps: DispatchDeps,
   auth: EnrolmentDeps & GatewayDeps,
+  webhook: WebhookRouteDeps,
 ) {
   return {
     ...client,
@@ -101,5 +108,6 @@ export function webRoutes<Client extends Record<string, ClientRoute>>(
     ...commandRoutes(deps),
     ...streamRoutes(deps),
     ...uploadRoutes(deps),
+    ...webhookRoutes(webhook),
   };
 }

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -35,6 +35,7 @@ import {
 import { createDb } from '../db/client.ts';
 import { type ClientRoute, webRoutes } from './routes.ts';
 import { type StreamSocketData, streamWebSocket } from './streams.ts';
+import { WEBHOOK_SECRET_VAR } from './webhook-route.ts';
 
 /**
  * Where the enrolment token arrives.
@@ -238,6 +239,15 @@ export async function start(
       },
     },
     auth,
+    {
+      db,
+      clock: systemClock,
+      secret: Bun.env[WEBHOOK_SECRET_VAR]?.trim() || null,
+      // Same accessor `context` above reads through: current as of this
+      // request, rebuilt only when `configureInstallation` actually changed
+      // something.
+      current: installationNow,
+    },
   );
 
   const server = Bun.serve<StreamSocketData>({

--- a/apps/spindrift/src/web/webhook-route.ts
+++ b/apps/spindrift/src/web/webhook-route.ts
@@ -1,0 +1,140 @@
+/**
+ * The signed repository webhook, mounted (§15, §21).
+ *
+ * `src/integrations/github/webhook.ts` is the verify-then-classify handler;
+ * this is the one route that reaches it, following `upload.ts`'s shape rather
+ * than `dispatch.ts`'s — a delivery carries no session, so there is no
+ * `deps.authenticate` here at all. **The signature is the only
+ * authentication this route has**, which is why {@link WEBHOOK_SECRET_VAR}
+ * absent refuses every delivery before `handleWebhookDelivery` ever runs,
+ * the same posture `ENROLMENT_TOKEN_VAR` takes in `serve.ts` for the same
+ * reason: an installation nobody has configured a secret for cannot have
+ * signed anything, so there is nothing here for a delivery to prove.
+ *
+ * A verified delivery is classified and handed to `repo-loop.ts`'s
+ * `applyWebhookDelivery` — the loop's own latency optimization, not a second
+ * reconciliation path — and the passes it returns go straight to
+ * `auto-deploy.ts`'s `dispatchAutoDeploys`. The poll loop's periodic pass
+ * calls the same function over the same shape of value, which is what keeps
+ * this route a shortcut: every branch here either does what the next poll
+ * would have done anyway, or does nothing.
+ */
+import type { AdapterRegistry, Clock } from '../commands/types.ts';
+import type { InstallationManifest } from '../config/manifest.schema.ts';
+import type { Database } from '../db/client.ts';
+import {
+  EVENT_HEADER,
+  handleWebhookDelivery,
+  SIGNATURE_HEADER,
+  type WebhookDelivery,
+  WebhookRejected,
+  type WebhookRejectionCode,
+} from '../integrations/github/webhook.ts';
+import { dispatchAutoDeploys } from '../reconciler/auto-deploy.ts';
+import { applyWebhookDelivery } from '../reconciler/repo-loop.ts';
+
+export const WEBHOOK_PATH = '/internal/github/webhook';
+
+/**
+ * Where the webhook secret arrives — mirrors `serve.ts`'s
+ * `ENROLMENT_TOKEN_VAR`: an installation Secret key, read once at boot, never
+ * from the manifest an operator authors and hands around.
+ */
+export const WEBHOOK_SECRET_VAR = 'SPINDRIFT_GITHUB_WEBHOOK_SECRET';
+
+export interface WebhookRouteDeps {
+  readonly db: Database;
+  readonly clock: Clock;
+  /** `null` when this installation has no secret configured. */
+  readonly secret: string | null;
+  /**
+   * Current as of this request — mirrors `DispatchDeps.context`'s reasoning:
+   * `configureInstallation` writes the row this route would otherwise never
+   * re-read.
+   */
+  current(): Promise<{
+    readonly adapters: AdapterRegistry;
+    readonly manifest: InstallationManifest;
+  }>;
+}
+
+export function webhookRoutes(
+  deps: WebhookRouteDeps,
+): Record<string, (request: Request) => Promise<Response>> {
+  return {
+    [WEBHOOK_PATH]: (request: Request) => handleWebhook(request, deps),
+  };
+}
+
+function refuse(status: number, code: string, message: string): Response {
+  return Response.json({ ok: false, failure: { code, message } }, { status });
+}
+
+/** The status a rejection code reads as — an auth failure, or a bad request. */
+const REJECTION_STATUS: Record<WebhookRejectionCode, number> = {
+  SIGNATURE_MISSING: 401,
+  SIGNATURE_MALFORMED: 401,
+  SIGNATURE_MISMATCH: 401,
+  EVENT_MISSING: 400,
+  BODY_MALFORMED: 400,
+};
+
+async function handleWebhook(
+  request: Request,
+  deps: WebhookRouteDeps,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return refuse(405, 'METHOD_NOT_ALLOWED', 'a delivery is a POST');
+  }
+  if (deps.secret === null) {
+    return refuse(
+      503,
+      'NOT_CONFIGURED',
+      'this installation has no GitHub webhook secret configured',
+    );
+  }
+
+  let delivery: WebhookDelivery;
+  try {
+    delivery = await handleWebhookDelivery(
+      {
+        event: request.headers.get(EVENT_HEADER),
+        signature: request.headers.get(SIGNATURE_HEADER),
+        body: new Uint8Array(await request.arrayBuffer()),
+      },
+      deps.secret,
+    );
+  } catch (cause) {
+    if (cause instanceof WebhookRejected) {
+      return refuse(REJECTION_STATUS[cause.code], cause.code, cause.message);
+    }
+    throw cause;
+  }
+
+  const { adapters, manifest } = await deps.current();
+  const host = adapters.repository();
+  // No repository integration configured: there is nothing this delivery
+  // could name that this installation manages, so it is answered exactly as
+  // an `ignored` delivery is — authenticated, and nothing to do.
+  const passes =
+    host === null
+      ? []
+      : await applyWebhookDelivery(
+          { db: deps.db, clock: deps.clock, host },
+          delivery,
+        );
+  if (passes.length > 0) {
+    await dispatchAutoDeploys(
+      { db: deps.db, clock: deps.clock, adapters, manifest },
+      passes,
+    );
+  }
+
+  // §21's module: authenticated deliveries answer 202 whether or not they were
+  // about anything, so an attacker probing this endpoint cannot distinguish
+  // "ignored" from "acted on" any more than GitHub's own retry logic needs to.
+  return Response.json(
+    { ok: true, value: { classified: delivery.kind } },
+    { status: 202 },
+  );
+}

--- a/apps/spindrift/test/reconciler/auto-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/auto-deploy.test.ts
@@ -1,0 +1,205 @@
+/**
+ * `dispatchAutoDeploys` — the opt-in gate (§15).
+ *
+ * `repo-loop.test.ts` proves what a pass over a repository adopts;
+ * `webhook-route.test.ts` proves one delivery reaches this module end to end.
+ * This file is about the one decision that is this module's own: which of
+ * the Apps a pass named actually gets a Deploy. `apps.autoDeploy` is the
+ * whole of that decision, so the passes below are synthetic —
+ * `RepositoryReconciliation` values built by hand rather than produced by a
+ * real reconciliation pass — which is what lets this file assert the gate in
+ * isolation from repository reads.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import {
+  apps,
+  builds,
+  components,
+  componentTargetDesired,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import {
+  type AutoDeployContext,
+  dispatchAutoDeploys,
+} from '../../src/reconciler/auto-deploy.ts';
+import type { RepositoryReconciliation } from '../../src/reconciler/repo-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+const clock = { now: () => NOW };
+
+/** An App with a Component, a connected Target, and a Build ready to deploy. */
+async function deployableApp(autoDeploy: boolean) {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({
+      name: `svc-${crypto.randomUUID()}`,
+      sourceKind: 'archive',
+      autoDeploy,
+    })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
+    .returning();
+  const [target] = await db
+    .insert(targets)
+    .values(targetValues({ name: `cluster-${crypto.randomUUID()}` }))
+    .returning();
+  await db.insert(componentTargetDesired).values({
+    componentId: component!.id,
+    targetId: target!.id,
+    updatedAt: NOW,
+  });
+  const digest = `sha256:${crypto.randomUUID().replaceAll('-', '').padEnd(64, '0')}`;
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: crypto.randomUUID().replaceAll('-', '').padEnd(40, '0'),
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: digest,
+      bundleDigest: digest,
+      bundleLocation: 'https://depot.lolwtf.ca/bundles/1.zip',
+      status: 'SUCCEEDED',
+      verifiedBuildLevel: 2,
+      signature: testSignature(digest, NOW.toISOString()),
+    })
+    .returning();
+  return { app: app!, component: component!, build: build! };
+}
+
+/** A working `AutoDeployContext` — a real `createDeploy` runs behind it. */
+function context(): AutoDeployContext {
+  return {
+    db: database().db,
+    clock,
+    adapters: {
+      deploy: (adapter) =>
+        adapter === 'kubernetes' ? new FakeDeployAdapter({ adapter }) : null,
+      build: () => null,
+      store: () => {
+        throw new Error('auto-deploy dispatch reached the secret store');
+      },
+      repository: () => null,
+      supplyChain: () => new SupplyChainHarness(),
+    },
+    manifest,
+  };
+}
+
+function adoptedPass(appIds: readonly string[]): RepositoryReconciliation {
+  return {
+    repositoryId: crypto.randomUUID(),
+    fullName: 'example/app',
+    outcome: 'adopted',
+    commit: '1'.repeat(40),
+    scopes: appIds.map((appId) => ({
+      scope: '.',
+      appId,
+      outcome: 'absent' as const,
+    })),
+  };
+}
+
+async function deployCountFor(componentId: string): Promise<number> {
+  return (
+    await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.componentId, componentId))
+  ).length;
+}
+
+describe('the opt-in gate', () => {
+  test('an opted-in App is deployed through the same command the workspace button calls', async () => {
+    const { app, component, build } = await deployableApp(true);
+
+    const attempts = await dispatchAutoDeploys(context(), [
+      adoptedPass([app.id]),
+    ]);
+
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]).toMatchObject({ appId: app.id, result: { ok: true } });
+    expect(await deployCountFor(component.id)).toBe(1);
+    const [desired] = await database()
+      .db.select()
+      .from(componentTargetDesired)
+      .where(eq(componentTargetDesired.componentId, component.id));
+    expect(desired?.desiredBuildId).toBe(build.id);
+  });
+
+  test('an App that never opted in is left alone', async () => {
+    const { app, component } = await deployableApp(false);
+
+    const attempts = await dispatchAutoDeploys(context(), [
+      adoptedPass([app.id]),
+    ]);
+
+    expect(attempts).toEqual([]);
+    expect(await deployCountFor(component.id)).toBe(0);
+  });
+
+  test('one repository can carry both — only the opted-in App moves', async () => {
+    const opted = await deployableApp(true);
+    const silent = await deployableApp(false);
+
+    const attempts = await dispatchAutoDeploys(context(), [
+      adoptedPass([opted.app.id, silent.app.id]),
+    ]);
+
+    expect(attempts.map((attempt) => attempt.appId)).toEqual([opted.app.id]);
+    expect(await deployCountFor(opted.component.id)).toBe(1);
+    expect(await deployCountFor(silent.component.id)).toBe(0);
+  });
+
+  test('a pass that adopted nothing dispatches nothing, opted in or not', async () => {
+    const { app, component } = await deployableApp(true);
+    const unchanged: RepositoryReconciliation = {
+      repositoryId: crypto.randomUUID(),
+      fullName: 'example/app',
+      outcome: 'unchanged',
+      commit: '2'.repeat(40),
+    };
+
+    const attempts = await dispatchAutoDeploys(context(), [unchanged]);
+
+    expect(attempts).toEqual([]);
+    expect(await deployCountFor(component.id)).toBe(0);
+    // Confirms the App really was eligible, so the empty result above is the
+    // pass being ignored rather than the fixture being wrong.
+    expect(app.autoDeploy).toBe(true);
+  });
+
+  test('no adopted commit anywhere is not a database round trip', async () => {
+    const unreachable: AutoDeployContext = {
+      db: new Proxy(
+        {},
+        {
+          get: () => {
+            throw new Error(
+              'dispatch reached the database with nothing adopted',
+            );
+          },
+        },
+      ) as AutoDeployContext['db'],
+      clock,
+      adapters: context().adapters,
+      manifest,
+    };
+
+    expect(await dispatchAutoDeploys(unreachable, [])).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/web/auth-routes.test.ts
+++ b/apps/spindrift/test/web/auth-routes.test.ts
@@ -79,6 +79,17 @@ function serve() {
         }) satisfies CommandContext,
     },
     auth,
+    {
+      db: auth.db,
+      clock: auth.clock,
+      // No secret configured: this file is about the auth surface, not the
+      // webhook, and an unconfigured secret is what keeps the route from
+      // reaching `current` if a test here ever hit it by mistake.
+      secret: null,
+      current: () => {
+        throw new Error('an auth-route test reached installation state');
+      },
+    },
   );
 
   return { auth, routes };

--- a/apps/spindrift/test/web/readyz.test.ts
+++ b/apps/spindrift/test/web/readyz.test.ts
@@ -15,6 +15,7 @@ import type { EnrolmentDeps } from '../../src/auth/enrol.ts';
 import type { GatewayDeps } from '../../src/auth/gateway.ts';
 import { createDb, type Database } from '../../src/db/client.ts';
 import { READY_PATH, webRoutes } from '../../src/web/routes.ts';
+import type { WebhookRouteDeps } from '../../src/web/webhook-route.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 
 const database = withIsolatedDatabase();
@@ -43,8 +44,20 @@ function authDeps(db: Database): EnrolmentDeps & GatewayDeps {
   };
 }
 
+/** Inert: `/readyz` never routes a delivery, so reaching these is the bug. */
+function noWebhook(db: Database): WebhookRouteDeps {
+  return {
+    db,
+    clock: { now: () => new Date('2026-01-01T00:00:00Z') },
+    secret: null,
+    current: () => {
+      throw new Error('a readiness test read installation state');
+    },
+  };
+}
+
 async function readyz(db: Database): Promise<Response> {
-  const routes = webRoutes(CLIENT, noSession, authDeps(db));
+  const routes = webRoutes(CLIENT, noSession, authDeps(db), noWebhook(db));
   const handler = routes[READY_PATH] as () => Promise<Response>;
   return handler();
 }

--- a/apps/spindrift/test/web/routes.test.ts
+++ b/apps/spindrift/test/web/routes.test.ts
@@ -23,6 +23,10 @@ import { pathFor } from '../../src/web/dispatch.ts';
 import { HEALTH_PATH, READY_PATH, webRoutes } from '../../src/web/routes.ts';
 import { STREAM_PATHS } from '../../src/web/streams.ts';
 import { UPLOAD_PATH } from '../../src/web/upload.ts';
+import {
+  WEBHOOK_PATH,
+  type WebhookRouteDeps,
+} from '../../src/web/webhook-route.ts';
 
 const APP = join(import.meta.dir, '../..');
 
@@ -60,10 +64,36 @@ const noAuth: EnrolmentDeps & GatewayDeps = {
   gateway: null,
 };
 
+/**
+ * Webhook deps that would throw if reached, and a secret that is never
+ * configured — this file asserts over the *shape* of the table, so a delivery
+ * actually reaching `applyWebhookDelivery` here would mean the assertion had
+ * gone wrong.
+ */
+const noWebhook: WebhookRouteDeps = {
+  db: new Proxy(
+    {},
+    {
+      get: () => {
+        throw new Error('a route-table test reached the database');
+      },
+    },
+  ) as Database,
+  clock: {
+    now: () => {
+      throw new Error('a route-table test read the clock');
+    },
+  },
+  secret: null,
+  current: () => {
+    throw new Error('a route-table test read installation state');
+  },
+};
+
 /** A stand-in for the client, so this file never depends on a build having run. */
 const CLIENT = { '/': new Response('the client document') };
 
-const served = webRoutes(CLIENT, noSession, noAuth);
+const served = webRoutes(CLIENT, noSession, noAuth, noWebhook);
 
 const AUTH_PATHS = AUTH_ACTS.map(authPathFor);
 
@@ -78,6 +108,7 @@ describe('what the web process serves', () => {
         ...commandNames.map(pathFor),
         ...STREAM_PATHS,
         UPLOAD_PATH,
+        WEBHOOK_PATH,
       ].sort(),
     );
   });
@@ -99,6 +130,7 @@ describe('what the web process serves', () => {
         ...AUTH_PATHS,
         ...STREAM_PATHS,
         UPLOAD_PATH,
+        WEBHOOK_PATH,
       ].sort(),
     );
   });

--- a/apps/spindrift/test/web/webhook-route.test.ts
+++ b/apps/spindrift/test/web/webhook-route.test.ts
@@ -1,0 +1,269 @@
+/**
+ * The mounted webhook route (§15, §21).
+ *
+ * `test/integrations/github/webhook.test.ts` proves the handler's own
+ * verify-then-classify contract; this file proves the thing that used to be
+ * missing — that `webRoutes` actually reaches it, over a real HTTP `Request`,
+ * with the secret and installation state arriving the way `serve.ts` wires
+ * them. The opt-in gate gets its own focused coverage in
+ * `test/reconciler/auto-deploy.test.ts`; the case here is the one only the
+ * mounted route can prove — that a real signed delivery reaches an opted-in
+ * App's Deploy end to end.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import type { AdapterRegistry } from '../../src/commands/types.ts';
+import type { Database } from '../../src/db/client.ts';
+import {
+  apps,
+  builds,
+  components,
+  componentTargetDesired,
+  deploys,
+  repositories,
+  targets,
+} from '../../src/db/schema.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import {
+  WEBHOOK_PATH,
+  type WebhookRouteDeps,
+  webhookRoutes,
+} from '../../src/web/webhook-route.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { FakeGitHub } from '../harness/fakes/github-api.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
+import { fixtureManifest, targetValues } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+const SECRET = 'the installation’s webhook secret';
+const NOW = new Date('2026-07-28T12:00:00.000Z');
+const clock = { now: () => NOW };
+
+async function sign(body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const mac = new Uint8Array(
+    await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(body)),
+  );
+  return `sha256=${Array.from(mac, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+}
+
+async function delivery(
+  event: string,
+  payload: unknown,
+  options: { signed?: boolean } = {},
+): Promise<Request> {
+  const body = JSON.stringify(payload);
+  const headers: Record<string, string> = {
+    'X-GitHub-Event': event,
+    'content-type': 'application/json',
+  };
+  if (options.signed !== false)
+    headers['X-Hub-Signature-256'] = await sign(body);
+  return new Request('https://spindrift.example.test/internal/github/webhook', {
+    method: 'POST',
+    headers,
+    body,
+  });
+}
+
+/** Deps that throw if a webhook that should refuse before reading them touches them. */
+const unreachable: WebhookRouteDeps = {
+  db: new Proxy(
+    {},
+    {
+      get: () => {
+        throw new Error('reached the database');
+      },
+    },
+  ) as Database,
+  clock: {
+    now: () => {
+      throw new Error('read the clock');
+    },
+  },
+  secret: SECRET,
+  current: () => {
+    throw new Error('read installation state');
+  },
+};
+
+function post(deps: WebhookRouteDeps, request: Request): Promise<Response> {
+  return webhookRoutes(deps)[WEBHOOK_PATH]!(request);
+}
+
+describe('the route the earlier handler had nowhere to be reached from', () => {
+  test('refuses a GET', async () => {
+    const response = await post(
+      unreachable,
+      new Request('https://spindrift.example.test/internal/github/webhook'),
+    );
+    expect(response.status).toBe(405);
+  });
+
+  test('refuses every delivery when no secret is configured, before touching anything', async () => {
+    const response = await post(
+      { ...unreachable, secret: null },
+      await delivery('push', { ref: 'refs/heads/main' }),
+    );
+    expect(response.status).toBe(503);
+    expect((await response.json()).failure.code).toBe('NOT_CONFIGURED');
+  });
+
+  test('refuses a bad signature before reading installation state', async () => {
+    const response = await post(
+      unreachable,
+      await delivery('push', { ref: 'refs/heads/main' }, { signed: false }),
+    );
+    expect(response.status).toBe(401);
+    expect((await response.json()).failure.code).toBe('SIGNATURE_MISSING');
+  });
+
+  test('a verified delivery about nothing this installation manages is still a 202', async () => {
+    const response = await post(
+      {
+        db: database().db,
+        clock,
+        secret: SECRET,
+        current: async () => ({
+          adapters: {
+            deploy: () => null,
+            build: () => null,
+            store: () => {
+              throw new Error('unreachable: no App opted in');
+            },
+            repository: () => null,
+            supplyChain: () => {
+              throw new Error('unreachable: no App opted in');
+            },
+          } satisfies AdapterRegistry,
+          manifest,
+        }),
+      },
+      await delivery('push', {
+        ref: 'refs/heads/main',
+        after: '1'.repeat(40),
+        repository: {
+          full_name: 'example/unconnected',
+          default_branch: 'main',
+        },
+      }),
+    );
+    expect(response.status).toBe(202);
+    expect((await response.json()).value).toEqual({ classified: 'push' });
+  });
+});
+
+describe('a push that reaches an opted-in App', () => {
+  test('deploys it end to end, through the same command a developer would press', async () => {
+    const db = database().db;
+    const fake = new FakeGitHub();
+    const commit = fake.commitFiles('main', { 'README.md': 'hello' });
+
+    const [repository] = await db
+      .insert(repositories)
+      .values({
+        fullName: fake.fullName,
+        installationId: fake.installationId,
+        defaultBranch: fake.defaultBranch,
+      })
+      .returning();
+    const [app] = await db
+      .insert(apps)
+      .values({
+        name: 'invoices',
+        sourceKind: 'repo',
+        sourceRepoUrl: `https://git.invalid/${fake.fullName}`,
+        repositoryId: repository!.id,
+        autoDeploy: true,
+      })
+      .returning();
+    const [component] = await db
+      .insert(components)
+      .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
+      .returning();
+    const [target] = await db
+      .insert(targets)
+      .values(targetValues({ name: `cluster-${crypto.randomUUID()}` }))
+      .returning();
+    await db.insert(componentTargetDesired).values({
+      componentId: component!.id,
+      targetId: target!.id,
+      updatedAt: NOW,
+    });
+    const digest = `sha256:${'a'.repeat(64)}`;
+    const [build] = await db
+      .insert(builds)
+      .values({
+        componentId: component!.id,
+        commit: '0'.repeat(40),
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: digest,
+        bundleDigest: digest,
+        bundleLocation: 'https://depot.lolwtf.ca/bundles/1.zip',
+        status: 'SUCCEEDED',
+        verifiedBuildLevel: 2,
+        signature: testSignature(digest, NOW.toISOString()),
+      })
+      .returning();
+    expect(build).toBeDefined();
+
+    const host = new GitHubApp({
+      baseUrl: fake.baseUrl,
+      authorization: () => 'Bearer test-user-token',
+      fetch: fake.fetch,
+    });
+    const supplyChain = new SupplyChainHarness();
+    const response = await post(
+      {
+        db,
+        clock,
+        secret: SECRET,
+        current: async () => ({
+          adapters: {
+            deploy: (adapter) =>
+              adapter === 'kubernetes'
+                ? new FakeDeployAdapter({ adapter })
+                : null,
+            build: () => null,
+            store: () => {
+              throw new Error('unreachable: this Build is already SUCCEEDED');
+            },
+            repository: () => host,
+            supplyChain: () => supplyChain,
+          } satisfies AdapterRegistry,
+          manifest,
+        }),
+      },
+      await delivery('push', {
+        ref: `refs/heads/${fake.defaultBranch}`,
+        after: commit,
+        repository: {
+          full_name: fake.fullName,
+          default_branch: fake.defaultBranch,
+        },
+      }),
+    );
+
+    expect(response.status).toBe(202);
+    const [desired] = await db
+      .select()
+      .from(componentTargetDesired)
+      .where(eq(componentTargetDesired.componentId, component!.id));
+    // The webhook reached the same one-button command a developer presses:
+    // the existing SUCCEEDED Build was deployed, not rebuilt.
+    expect(desired?.desiredBuildId).toBe(build!.id);
+    expect(await db.select().from(deploys)).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
The GitHub webhook handler was complete — HMAC before parse, tested — and
dead: nothing mounted it, and the repo loop deliberately stopped at adopting
commits. This wires both halves of §15 together:

- `webhook-route.ts` mounts the handler into the web server (secret from
  `SPINDRIFT_GITHUB_WEBHOOK_SECRET`, same pattern as the enrolment token),
  verifies, applies the delivery, and dispatches auto-deploys.
- `auto-deploy.ts` is the dispatcher the repo loop's header always promised:
  for every adopted pass it deploys each App that opted in, through the same
  `deployApp` command the workspace button calls. The poll loop calls it too,
  so the webhook stays what §15 says it is — a latency optimization over the
  correctness path.
- Opt-in is a new `apps.auto_deploy` column (migration 0027), default false.
  Nothing had an app-level flag to hang this off. Deliberately not in this PR:
  a command/UI to flip it — the column ships with tests writing it directly,
  and the toggle belongs with the other orphan-field authors (minBuildLevel,
  vanityDomain).

10 new tests including a full signed push→Deploy round trip over real HTTP.
Typecheck clean; the only suite failures are the known shared-Postgres
migrate flakes, reproduced identically with this change reverted.

Note for merge order: touches `repo-loop.ts`/`process.ts`, which #1742 also
touches — whichever lands second may need a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)