### PR TITLE
feat(spindrift): declare the Docker Hub registry the installation publishes to

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -400,6 +400,10 @@ spec:
         # second one, and its `registry_namespace` output is this exact value.
         registry:
           - ghcr.io/jonpulsifer
+          # Docker Hub, added live in Settings with its stored credential; the
+          # declaration follows so the two documents agree. Only routes that
+          # can carry the credential publish here (§16).
+          - docker.io/jonpulsifer
           - northamerica-northeast1-docker.pkg.dev/trusted-builds/i
         verifier: ghcr.io/jonpulsifer/spindrift-verifier
         # The authority bluenose's Binary Authorization policy requires an


### PR DESCRIPTION
The installation publishes to three registries now — docker.io/jonpulsifer was
added live in Settings with its stored credential — and the Settings screen
correctly reports that the mounted declaration no longer matches
(`supplyChain.registry.1`, `supplyChain.registry.2`). The declaration follows
the stored document; on merge the divergence banner clears.

Ordering matches the stored manifest (ghcr first — it stays the tie-break for
a Target that declares no reachable registries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)