### PR TITLE
fix(spindrift): escape every dollar the build service reads as a substitution

### DIFF
--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -361,16 +361,24 @@ export class CloudBuildRoute implements BuildAdapter {
             entrypoint: 'sh',
             args: [
               '-c',
-              registryAuth(spec.destinations) + program + exportDigest(attest),
+              literalDollars(
+                registryAuth(spec.destinations) +
+                  program +
+                  exportDigest(attest),
+              ),
             ],
             // On the step's environment and never in `args`: the arguments are
             // the program, and the program is what a reader of this build
             // resource sees in full. See REGISTRY_AUTH_VAR.
             ...(dockerConfig === null
               ? {}
-              : { env: [`${REGISTRY_AUTH_VAR}=${dockerConfig}`] }),
+              : {
+                  env: [literalDollars(`${REGISTRY_AUTH_VAR}=${dockerConfig}`)],
+                }),
           },
-          ...(attest === null ? [] : [attest]),
+          ...(attest === null
+            ? []
+            : [{ ...attest, args: attest.args.map(literalDollars) }]),
         ],
         // Read, never pushed: the build writes to the log service and this
         // route polls it. Nothing is posted back to Spindrift (§4).
@@ -600,6 +608,23 @@ function googleRegistryDestinations(
  * credential silently lost the vendor half and 401'd on the artifact registry
  * at the export, after the whole build. One writer, one document, both halves.
  */
+/**
+ * Every dollar in a step's fields, escaped for the build service's template
+ * engine.
+ *
+ * The service expands `$UPPERCASE` and `${UPPERCASE}` in a submitted step as
+ * substitutions and refuses a template naming one it does not know — observed
+ * live: the prelude's `"$SPINDRIFT_REGISTRY_AUTH"` failed the whole submit
+ * with "not a valid built-in substitution". Nothing submitted here *is* a
+ * substitution — the programs are shell, and every dollar is the shell's —
+ * so every dollar is escaped uniformly (`$$` is the service's literal-dollar
+ * escape) rather than this file knowing which spellings the template grammar
+ * happens to claim.
+ */
+function literalDollars(field: string): string {
+  return field.replaceAll('$', '$$$$');
+}
+
 function registryAuth(destinations: readonly string[]): string {
   const hosts = googleRegistryHosts(destinations);
   if (hosts.length === 0) return '';

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -599,7 +599,9 @@ describe('the cloud build route', () => {
     );
     await run(route.build(archiveSource(), cloudSpec));
 
-    const program = api.steps[0]?.[1]?.args?.[1] ?? '';
+    // As the step will run it: the service's template expansion turns the
+    // route's `$$` literal-dollar escape back into `$` before bash sees it.
+    const program = (api.steps[0]?.[1]?.args?.[1] ?? '').replaceAll('$$', '$');
     expect(program).toContain('manifests');
     expect(program).toContain('attest "$destination" "$child"');
     // The vendor's registries and no others: this step holds one metadata

--- a/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
+++ b/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
@@ -167,7 +167,9 @@ describe('the cloud build route', () => {
    * the artifact registry 401'd at the export, after the entire build.
    */
   test('mints its own credential into the same document, never over it', async () => {
-    const program = (await stepFor(AUTH)).args.join('\n');
+    // As the step will run it: the service's template expansion turns the
+    // route's `$$` literal-dollar escape back into `$` before sh sees it.
+    const program = (await stepFor(AUTH)).args.join('\n').replaceAll('$$', '$');
 
     // The prelude contributes to the variable the program is the sole reader of.
     expect(program).toContain(`${REGISTRY_AUTH_VAR}="{\\"auths\\":{`);
@@ -175,6 +177,22 @@ describe('the cloud build route', () => {
     // …and never writes a config of its own for the program to clobber. One
     // `mktemp` is one writer; two was the bug.
     expect(program.split('DOCKER_CONFIG=$(mktemp -d)')).toHaveLength(2);
+  });
+
+  /**
+   * The submit-time regression. The build service expands `$UPPERCASE` and
+   * `${UPPERCASE}` in step fields as substitutions and refuses a template
+   * naming one it does not know — observed live: the prelude's
+   * `"$SPINDRIFT_REGISTRY_AUTH"` failed the whole submit with "not a valid
+   * built-in substitution". Lowercase shell variables are invisible to that
+   * grammar; anything it could claim must arrive `$$`-escaped.
+   */
+  test('submits no unescaped dollar the service reads as a substitution', async () => {
+    const step = await stepFor(AUTH);
+
+    for (const field of [...step.args, ...(step.env ?? [])]) {
+      expect(field).not.toMatch(/(?<!\$)\$\{?[A-Z_][A-Z0-9_]*/);
+    }
   });
 
   test('still mints one when this installation stores nothing', async () => {

--- a/apps/spindrift/test/harness/attest-step.ts
+++ b/apps/spindrift/test/harness/attest-step.ts
@@ -106,7 +106,11 @@ export async function attested(
       await chmod(path, 0o755);
     }
     const path = join(directory, 'step.sh');
-    await writeFile(path, script);
+    // What the build service does to a step before the container sees it:
+    // template expansion turns its `$$` literal-dollar escape back into `$`.
+    // The route escapes every dollar on the way in, so running the submitted
+    // text verbatim would hand bash a program that is not shell.
+    await writeFile(path, script.replaceAll('$$', '$'));
 
     const child = Bun.spawn(['bash', path], {
       stdout: 'pipe',


### PR DESCRIPTION
The first managed-route submit ever made with a stored registry credential —
live today, the new Docker Hub credential — failed before anything ran:

> invalid value for 'build.substitutions': key in the template
> "SPINDRIFT_REGISTRY_AUTH" is not a valid built-in substitution

Cloud Build expands `$UPPERCASE` and `${UPPERCASE}` in step fields as
substitutions and refuses a template naming one it does not know. The
credential-splice prelude's `"$SPINDRIFT_REGISTRY_AUTH"` is exactly that
shape; every lowercase shell variable around it is invisible to the template
grammar, which is why nothing else ever tripped it.

The submit now escapes every dollar in step args and env uniformly with the
service's own `$$` literal-dollar escape — the programs are pure shell, so
nothing submitted is ever a real substitution — rather than the adapter
knowing which spellings the grammar claims. The attest-step harness applies
the same expansion the service does before executing, so it keeps running
exactly what a real worker runs. A regression test asserts no submitted field
contains an unescaped substitution-shaped dollar.

Adapter suites: 312 pass, 0 fail. Typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)