### PR TITLE
fix(spindrift): let a first deploy name its Component's Target

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -49,6 +49,7 @@ import {
   builds,
   componentTargetDesired,
   repositories,
+  targets,
 } from '../../db/schema.ts';
 import { repositoryRefOf } from '../../domain/repository.ts';
 import { isFetchableBundleLocation } from '../../storage/archives.ts';
@@ -82,6 +83,16 @@ export const deployAppInput = z
      * way to reach the rest: nothing else inserts a Build for them.
      */
     component: z.string().trim().min(1).optional(),
+    /**
+     * The Target for a Component deploying for the first time, by name or id.
+     *
+     * Only a first deploy needs it: placement is a fact a deploy writes, so a
+     * Component that has never deployed has none to read back — `placeComponent`
+     * migrates configuration, it does not place. Absent, the Component's own
+     * history answers as it always has, and a value that disagrees with that
+     * history is refused rather than silently moving the Component.
+     */
+    target: z.string().trim().min(1).optional(),
   })
   .strict();
 
@@ -324,13 +335,40 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
   }
 
   const latestDeploy = component.deploys[0];
-  const targetId =
+  const placedTargetId =
     latestDeploy?.targetId ?? component.desiredTargets[0]?.targetId;
+
+  let targetId = placedTargetId;
+  if (input.target !== undefined) {
+    const wantsId = z.uuid().safeParse(input.target).success;
+    const [named] = await context.db
+      .select({ id: targets.id })
+      .from(targets)
+      .where(
+        wantsId ? eq(targets.id, input.target) : eq(targets.name, input.target),
+      );
+    if (named === undefined) {
+      return failed('NOT_FOUND', `there is no Target '${input.target}'`);
+    }
+    // History wins where it exists: a deploy that named a different Target
+    // than the one this Component lives on is a move, and moves go through
+    // placement — not through a deploy that quietly lands somewhere new.
+    if (placedTargetId !== undefined && placedTargetId !== named.id) {
+      return failed(
+        'INVALID_INPUT',
+        `Component '${component.name}' is placed elsewhere — deploy without ` +
+          'naming a Target, or move it first',
+        [{ path: 'target', message: 'disagrees with the existing placement' }],
+      );
+    }
+    targetId = named.id;
+  }
 
   if (!targetId) {
     return failed(
       'NOT_FOUND',
-      `Component '${component.name}' has no target placement`,
+      `Component '${component.name}' has no target placement — name one: ` +
+        'a first deploy is what writes it',
     );
   }
 

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -716,6 +716,82 @@ describe('deployApp selects which Component it acts on', () => {
     expect(result.failure.message).toContain(component.name);
   });
 
+  /**
+   * Placement is a fact a deploy writes, so a Component that has never
+   * deployed has none to read back — `placeComponent` migrates configuration,
+   * it does not place. The first deploy is where a Target gets named.
+   */
+  test('a first deploy names the Target that placement will remember', async () => {
+    const { app, target } = await fixture();
+    const db = database().db;
+    const [nightly] = await db
+      .insert(components)
+      .values({
+        appId: app.id,
+        name: 'nightly',
+        kind: 'job',
+        reach: 'none',
+        auth: 'none',
+      })
+      .returning();
+
+    const result = await deployApp(
+      { name: app.name, component: nightly!.name, target: target.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('BUILDING');
+
+    const desired = await desiredRow(nightly!.id, target.id);
+    expect(desired).toBeDefined();
+  });
+
+  test('a Target that disagrees with existing placement is refused', async () => {
+    const { app, component, target } = await fixture();
+    await succeededBuild(component.id, 14);
+    await database().db.insert(componentTargetDesired).values({
+      componentId: component.id,
+      targetId: target.id,
+      updatedAt: FROZEN,
+    });
+    const [elsewhere] = await database()
+      .db.insert(targets)
+      .values(
+        targetValues({
+          name: `cluster-${crypto.randomUUID()}`,
+          adapter: 'kubernetes',
+          discovery: null,
+        }),
+      )
+      .returning();
+
+    const result = await deployApp(
+      { name: app.name, target: elsewhere!.name },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('INVALID_INPUT');
+    expect(result.failure.message).toContain('placed elsewhere');
+  });
+
+  test('an unknown Target is refused by name', async () => {
+    const { app } = await fixture();
+
+    const result = await deployApp(
+      { name: app.name, target: 'no-such-target' },
+      context(registryOf(capableAdapter())),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('no-such-target');
+  });
+
   test('an absent Component still deploys the primary, unchanged', async () => {
     const { app, component, target } = await fixture();
     const build = await succeededBuild(component.id, 13);


### PR DESCRIPTION
The follow-up the first live job Component forced: deploying a named second
Component works now, but only if it has a placement — and placement is a fact
a deploy writes. `placeComponent` migrates configuration between Targets; it
does not place. A fresh Component therefore had no way to acquire its first
placement: target resolution found no history and refused, forever.

`deployApp` gains an optional `target` (name or id), honoured only where the
Component has no placement history. History wins where it exists — naming a
Target that disagrees with the existing placement is refused
(`INVALID_INPUT`, "placed elsewhere") rather than quietly moving the
Component; moves stay placement's business.

Three new tests: the first deploy writes the desired-placement row; a
disagreeing Target is refused; an unknown Target is refused by name.
35 pass in the file, typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)