### PR TITLE
fix(cd): update spindrift image digest to sha256:b82de5d6 (manual)

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -36,7 +36,7 @@ spec:
     # Renovate pins the digest on this line and Flux rolls it out. The image's
     # manifest schema and the chart must agree on which keys a declaration may
     # carry — the manifest below has to satisfy both.
-    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:ed94e52ea43ae9e483c3b1e0efda65412c76077241f3bd1fb724b6d0c6293a66
+    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:b82de5d61b45136cb4ffd2fad920c6824026ddfe76a7e950f0b442e6741c2a92
     # Substituted by the apps Kustomization from the cluster-secrets Secret, so
     # the zone is read rather than restated. external-dns publishes the record
     # from the HTTPRoute and cert-manager issues the certificate, so this line


### PR DESCRIPTION
The containers run for the deploy-fix merge built and pushed the image, then
failed only at its digest-branch push: a concurrent run's history carried
`.github/workflows/typescript.yml` and the App token has no `workflows`
permission, so GitHub refused the whole ref update. `ghcr.io/jonpulsifer/spindrift:latest`
already resolves to this digest — this PR is only the manifest catching up.

Carries #1756 (Cloud Build dollar escape) and #1757 (first-deploy placement),
which the live v1-gate work is waiting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)