### PR TITLE
feat(spindrift): carry registry credentials to the hosted route sealed

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -30,6 +30,16 @@ on:
         description: The build request, as JSON.
         required: true
         type: string
+    secrets:
+      # Optional, because a caller that passes nothing still runs every build
+      # that carries no credential. Present, it is the private half of the
+      # manifest's `sealPublicKey` — the only thing that can open what
+      # `GitHubActionsBuildRoute.sealRegistryAuth` sealed into `spec`, and
+      # asked for here by name so a caller can pass it explicitly or with
+      # `secrets: inherit`. A connected repository's caller does neither (see
+      # "Log in with sealed credentials" below for what that means for it).
+      SPINDRIFT_BUILD_SEAL_KEY:
+        required: false
   workflow_dispatch:
     inputs:
       spec:
@@ -87,6 +97,12 @@ jobs:
             # signature is the thing that says so.
             printf 'signer=%s\n'       "$(read_key '.signer // ""')"
             printf 'attestor=%s\n'     "$(read_key '.attestor // ""')"
+            # Empty on every build whose destinations this route already
+            # authorizes itself — most of them (§13). Present, it is this
+            # build's held registry credential, sealed to `sealPublicKey` and
+            # opened by "Log in with sealed credentials" below; nothing about
+            # it is readable in this output or anywhere this step touches.
+            printf 'sealedRegistryAuth=%s\n' "$(read_key '.sealedRegistryAuth // ""')"
             # One login per distinct registry host. The GitHub token below only
             # authenticates to GHCR; anything else is a cloud registry the
             # `Authenticate to Google Cloud` step already federates for, so the
@@ -269,6 +285,79 @@ jobs:
         env:
           HOSTS: ${{ steps.request.outputs.googleHosts }}
         run: gcloud auth configure-docker --quiet "$HOSTS"
+
+      # §16's Docker Hub exception, opened rather than sent in the clear. The
+      # credential travelled inside `spec` sealed to this route's
+      # `sealPublicKey` (`GitHubActionsBuildRoute.sealRegistryAuth`) precisely
+      # because `workflow_dispatch` renders every other input of this run in
+      # its header — nothing about it was readable before this step, and the
+      # only key that opens it is this repository's own
+      # `SPINDRIFT_BUILD_SEAL_KEY` secret. What comes out goes straight into
+      # `docker login`'s stdin and nowhere this workflow can be read from —
+      # not `$GITHUB_OUTPUT`, not a file, not a log line. This repository is
+      # public, and its run log is treated as though it already is.
+      - name: Log in with sealed credentials
+        if: steps.request.outputs.sealedRegistryAuth != ''
+        env:
+          SEALED: ${{ steps.request.outputs.sealedRegistryAuth }}
+          SEAL_KEY: ${{ secrets.SPINDRIFT_BUILD_SEAL_KEY }}
+        run: |
+          set -euo pipefail
+          # This build carries a sealed credential, so failing to open it here
+          # has to be loud: reaching `docker login` with nothing would instead
+          # fail several steps later, at the push, for a reason this sentence
+          # already knows.
+          if [ -z "${SEAL_KEY:-}" ]; then
+            echo "::error::this build carries a sealed registry credential, but SPINDRIFT_BUILD_SEAL_KEY is not set on this repository — set it to the private half of the manifest's sealPublicKey, or every push below fails instead, with a worse error." >&2
+            exit 1
+          fi
+          node <<'SPINDRIFT_SEAL_SCRIPT'
+          const crypto = require('node:crypto');
+          const { execFileSync } = require('node:child_process');
+
+          const envelope = JSON.parse(
+            Buffer.from(process.env.SEALED, 'base64').toString('utf8'),
+          );
+          const wrappedKey = Buffer.from(envelope.k, 'base64');
+          const iv = Buffer.from(envelope.iv, 'base64');
+          const combined = Buffer.from(envelope.c, 'base64');
+          // WebCrypto's AES-GCM appends its 16-byte tag to the ciphertext
+          // rather than returning it separately — `sealRegistryAuth` never
+          // split the two, so this is the split back apart.
+          const tag = combined.subarray(combined.length - 16);
+          const ciphertext = combined.subarray(0, combined.length - 16);
+
+          const aesKey = crypto.privateDecrypt(
+            {
+              key: process.env.SEAL_KEY,
+              padding: crypto.constants.RSA_PKCS1_OAEP_PADDING,
+              oaepHash: 'sha256',
+            },
+            wrappedKey,
+          );
+
+          const decipher = crypto.createDecipheriv('aes-256-gcm', aesKey, iv);
+          decipher.setAuthTag(tag);
+          const plaintext = Buffer.concat([
+            decipher.update(ciphertext),
+            decipher.final(),
+          ]);
+          const auth = JSON.parse(plaintext.toString('utf8'));
+
+          // Masked before this step prints anything else, including the
+          // logins below — whose own output could otherwise echo them back.
+          for (const entry of auth) {
+            console.log(`::add-mask::${entry.username}`);
+            console.log(`::add-mask::${entry.secret}`);
+          }
+          for (const entry of auth) {
+            execFileSync(
+              'docker',
+              ['login', entry.host, '-u', entry.username, '--password-stdin'],
+              { input: entry.secret, stdio: ['pipe', 'inherit', 'inherit'] },
+            );
+          }
+          SPINDRIFT_SEAL_SCRIPT
 
       - name: Build and push
         id: push

--- a/.github/workflows/spindrift.yml
+++ b/.github/workflows/spindrift.yml
@@ -38,5 +38,14 @@ permissions:
 jobs:
   build:
     uses: ./.github/workflows/spindrift-build.yml
+    # A `workflow_call` passes no secret it is not told to, even locally — so
+    # without this, `SPINDRIFT_BUILD_SEAL_KEY` set on this repository would sit
+    # unreachable one `uses:` away from the step that needs it. `inherit`
+    # rather than naming it: this repository is the only caller of its own
+    # build workflow that can hold the key at all (a connected repository's
+    # generated caller passes no secrets — see `buildWorkflowCaller`), so there
+    # is nothing here `inherit` could leak that this repository does not
+    # already hold.
+    secrets: inherit
     with:
       spec: ${{ inputs.spec }}

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -326,15 +326,16 @@ export interface BuildAdapter {
    * A property of the route's *mechanism*, not a policy. The two routes that
    * run the BuildKit program in a container of their own can take a secret
    * through an environment variable scoped to that container. The hosted route
-   * cannot: it is dispatched by a `workflow_dispatch` whose inputs GitHub
-   * renders in the run header, so a token in the request would be published to
-   * anyone who can see the run — including a repository the installation does
-   * not own.
+   * is dispatched by a `workflow_dispatch` whose inputs GitHub renders in the
+   * run header, so a token in the request would be published to anyone who can
+   * see the run — including a repository the installation does not own — and
+   * it answers `true` only where it has somewhere else to put one: see
+   * `GitHubActionsBuildRoute.carriesRegistryCredential` for the sealed
+   * mechanism that opens up.
    *
-   * The correct mechanism there is a repository Actions secret, which needs a
-   * libsodium sealed box to write and therefore a dependency §20 has not taken.
-   * Until it exists this is `false` and `dispatchBuild` refuses, which is the
-   * direction being wrong has to fail in.
+   * A route with nowhere configured to carry one answers `false`, and
+   * `dispatchBuild` refuses a build that needs a stored credential on it —
+   * which is the direction being wrong has to fail in.
    */
   readonly carriesRegistryCredential: boolean;
   /**

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -36,6 +36,7 @@ import {
   CALLER_WORKFLOW_FILE,
   RUN_NAME_PREFIX,
 } from '../../integrations/github/config-pr.ts';
+import type { RegistryAuth } from '../../storage/registry-credentials.ts';
 import type {
   BuildAdapter,
   BuildEvent,
@@ -154,6 +155,13 @@ export interface GitHubActionsRouteOptions extends PollingOptions {
   readonly signer: string;
   /** The attestor a cloud Target's admission asks. See `BuildRequestSpec.attestor`. */
   readonly attestor: string;
+  /**
+   * SPKI PEM, matching the manifest's `build.routes[].sealPublicKey`.
+   *
+   * Its presence is what turns on `carriesRegistryCredential`. Absent, this
+   * route composes exactly the dispatch it always has.
+   */
+  readonly sealPublicKey?: string;
   /** Injected so a test can pin the correlation it asserts on. */
   readonly correlation?: () => string;
   /** How long to keep looking for the run a dispatch started. */
@@ -238,6 +246,20 @@ export interface BuildRequestSpec {
    * two verifiers, two artifacts.
    */
   readonly attestor: string;
+  /**
+   * The installation's held registry credential, sealed to `sealPublicKey`
+   * (`sealRegistryAuth` below) — absent wherever {@link BuildSpec.registryAuth}
+   * is empty, which is the ordinary case (§16).
+   *
+   * Never the credential itself. `workflow_dispatch` renders every other field
+   * of this request in the run header, so the plaintext travels no further
+   * than the process that composed this object — see
+   * `carriesRegistryCredential` for the rest of the reasoning. The reusable
+   * workflow's "Log in with sealed credentials" step is the only place that
+   * ever opens it, and it does so with the private key on the other side of
+   * this pair, held as this repository's `SPINDRIFT_BUILD_SEAL_KEY` secret.
+   */
+  readonly sealedRegistryAuth?: string;
 }
 
 export class GitHubActionsBuildRoute implements BuildAdapter {
@@ -246,18 +268,31 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
   readonly provenanceBuilderId =
     'https://github.com/actions/runner/github-hosted';
   /**
-   * **No.** This route is dispatched through `workflow_dispatch`, and GitHub
-   * renders a dispatch's inputs in the run header — so a credential travelling
-   * in the spec would be published to everyone who can see the run, in a
-   * repository §15 deliberately does not require the installation to own.
+   * **Only where a seal key is configured.** This route is dispatched through
+   * `workflow_dispatch`, and GitHub renders a dispatch's inputs in the run
+   * header — so a credential travelling in the spec in the clear would be
+   * published to everyone who can see the run, in a repository §15
+   * deliberately does not require the installation to own. That is still true
+   * and is still why nothing here ever sends one unsealed.
    *
-   * The right mechanism is a repository Actions secret, which is written
-   * through a libsodium sealed box and therefore wants a dependency this
-   * package has not taken. Until then `dispatchBuild` refuses a build that
-   * needs a stored credential on this route, which is a route an operator can
-   * change rather than a token an operator cannot un-publish.
+   * What changed is the mechanism for carrying one anyway. A repository
+   * Actions secret written through a libsodium sealed box would have needed a
+   * dependency this package has not taken — the alternative actually built is
+   * the reverse of that write: this route seals a held credential to
+   * `sealPublicKey` (`sealRegistryAuth` below) *before* it ever reaches the
+   * dispatch inputs, so what the run header renders is ciphertext. The only
+   * key that opens it is the matching private key, and its only home is the
+   * platform repository's `SPINDRIFT_BUILD_SEAL_KEY` Actions secret — never
+   * this manifest, never git, and not a connected repository's own secrets
+   * either: a caller in a connected repository passes none, so a build that
+   * runs there carries no credential regardless of what this route declares.
+   *
+   * A route with no `sealPublicKey` configured answers `false` here exactly as
+   * before, and `dispatchBuild` refuses a build that needs a stored credential
+   * on it — a route an operator can change, rather than a token an operator
+   * cannot un-publish.
    */
-  readonly carriesRegistryCredential = false;
+  readonly carriesRegistryCredential: boolean;
   /**
    * Both, because the run holds two identities at once and the pinned workflow
    * uses each: `docker/login-action` against `ghcr.io` with the run's own
@@ -284,6 +319,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
   constructor(private readonly options: GitHubActionsRouteOptions) {
     this.name = options.name;
     this.platformRepository = reusableWorkflowRepository(options.buildWorkflow);
+    this.carriesRegistryCredential = options.sealPublicKey !== undefined;
   }
 
   async *build(
@@ -330,6 +366,24 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     )();
     const runName = `${RUN_NAME_PREFIX} ${correlation}`;
 
+    // `dispatchBuild` already refused a build that needs one where
+    // `carriesRegistryCredential` is false, so a seal key is here whenever
+    // `spec.registryAuth` is not empty — the throw below is for a caller that
+    // skipped that refusal, which is a programming error rather than a
+    // configuration one (the same posture `reusableWorkflowRepository` takes).
+    let sealedRegistryAuth: string | undefined;
+    if (spec.registryAuth.length > 0) {
+      if (this.options.sealPublicKey === undefined) {
+        throw new TypeError(
+          'build received a registry credential but this route has no sealPublicKey configured',
+        );
+      }
+      sealedRegistryAuth = await sealRegistryAuth(
+        spec.registryAuth,
+        this.options.sealPublicKey,
+      );
+    }
+
     const request: BuildRequestSpec = {
       bundleDigest: source.bundleDigest,
       origin: source.origin,
@@ -342,6 +396,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       zeroConfigFrontend: this.options.zeroConfigFrontend,
       signer: this.options.signer,
       attestor: this.options.attestor,
+      ...(sealedRegistryAuth !== undefined ? { sealedRegistryAuth } : {}),
     };
 
     let repository: string | null = null;
@@ -541,6 +596,75 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       report,
     });
   }
+}
+
+/**
+ * Seals a held registry credential to `sealPublicKey`, so it can travel inside
+ * `workflow_dispatch`'s inputs without arriving in the clear
+ * (`carriesRegistryCredential` above says why that would otherwise matter).
+ *
+ * Hybrid rather than RSA-OAEP alone: OAEP has no room for more than a couple
+ * hundred bytes of plaintext under a 2048-bit key, and a registry login is not
+ * bounded that way. A fresh AES-256-GCM key encrypts the payload; RSA-OAEP
+ * wraps only that key.
+ *
+ * The envelope is `base64(JSON.stringify({k, iv, c}))` — the wrapped AES key,
+ * the GCM nonce, and the ciphertext with WebCrypto's own 16-byte tag already
+ * appended to it, each base64 on its own. Exported so a test can decrypt what
+ * this produces with the *exact* algorithm the reusable workflow runs — see
+ * `.github/workflows/spindrift-build.yml`'s "Log in with sealed credentials"
+ * step, the other half of this pair and the one the wire format actually has
+ * to agree with.
+ */
+export async function sealRegistryAuth(
+  auth: readonly RegistryAuth[],
+  sealPublicKey: string,
+): Promise<string> {
+  const publicKey = await crypto.subtle.importKey(
+    'spki',
+    spkiPemToDer(sealPublicKey),
+    { name: 'RSA-OAEP', hash: 'SHA-256' },
+    false,
+    ['encrypt'],
+  );
+
+  const aesKey = await crypto.subtle.generateKey(
+    { name: 'AES-GCM', length: 256 },
+    true,
+    ['encrypt'],
+  );
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv },
+    aesKey,
+    new TextEncoder().encode(JSON.stringify(auth)),
+  );
+  const rawKey = await crypto.subtle.exportKey('raw', aesKey);
+  const wrappedKey = await crypto.subtle.encrypt(
+    { name: 'RSA-OAEP' },
+    publicKey,
+    rawKey,
+  );
+
+  const envelope = {
+    k: Buffer.from(wrappedKey).toString('base64'),
+    iv: Buffer.from(iv).toString('base64'),
+    c: Buffer.from(ciphertext).toString('base64'),
+  };
+  return Buffer.from(JSON.stringify(envelope)).toString('base64');
+}
+
+/** The DER bytes inside an SPKI PEM, which is what WebCrypto's `importKey` takes. */
+function spkiPemToDer(pem: string): Uint8Array<ArrayBuffer> {
+  const body = pem
+    .replace(/-{5}BEGIN PUBLIC KEY-{5}/, '')
+    .replace(/-{5}END PUBLIC KEY-{5}/, '')
+    .replace(/\s+/g, '');
+  // Copied into a fresh `Uint8Array<ArrayBuffer>` rather than returned as the
+  // `Buffer` itself: `Buffer`'s type admits `ArrayBufferLike`, which WebCrypto's
+  // `BufferSource` does not, and a cast here would paper over the one call site
+  // that actually needs the narrower type.
+  return new Uint8Array(Buffer.from(body, 'base64'));
 }
 
 /**

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -507,6 +507,10 @@ function createBuildRoute(
         zeroConfigFrontend,
         signer: manifest.supplyChain.signer,
         attestor: manifest.supplyChain.attestor ?? '',
+        // Absent unless the manifest configured one, which is what keeps
+        // `carriesRegistryCredential` false and `dispatchBuild` refusing a
+        // stored credential on this route until an operator pastes a key in.
+        sealPublicKey: route.sealPublicKey,
       });
     }
     case 'cloud-build':

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -117,6 +117,20 @@ export const buildRouteSchema = z.discriminatedUnion('adapter', [
       /** What this route is called, as `Target.buildRoutes` names it. */
       name: nonEmptyString,
       adapter: z.literal('github-actions'),
+      /**
+       * The public half of this route's sealing keypair, SPKI PEM.
+       *
+       * A dispatch's inputs are rendered in the run header (§15), so a stored
+       * registry credential cannot travel to this route in the clear —
+       * `GitHubActionsBuildRoute.carriesRegistryCredential` says why at
+       * length. Present, that credential is sealed to this key before it ever
+       * reaches the dispatch, and the reusable workflow opens it with the
+       * matching private key, which lives only as this repository's
+       * `SPINDRIFT_BUILD_SEAL_KEY` Actions secret — never here, never in git.
+       * Absent, this route carries no credential and `dispatchBuild` keeps
+       * refusing a build that needs one.
+       */
+      sealPublicKey: nonEmptyString.optional(),
     })
     .strict(),
   z

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -17,6 +17,7 @@
  * - **`in-cluster` is L1**, which is what makes an L2 Target refuse it.
  */
 import { describe, expect, test } from 'bun:test';
+import { generateKeyPairSync } from 'node:crypto';
 import { buildKitProgram } from '../../src/adapters/build/buildkit.ts';
 import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
 import type {
@@ -28,6 +29,7 @@ import type {
 import {
   GitHubActionsBuildRoute,
   reusableWorkflowRepository,
+  sealRegistryAuth,
 } from '../../src/adapters/build/github-actions.ts';
 import {
   InClusterBuildRoute,
@@ -44,6 +46,7 @@ import {
   buildWorkflowCaller,
   RUN_NAME_PREFIX,
 } from '../../src/integrations/github/config-pr.ts';
+import type { RegistryAuth } from '../../src/storage/registry-credentials.ts';
 import {
   ATTACHMENT_DIGEST,
   attested,
@@ -71,6 +74,13 @@ const FRONTEND = 'registry.example.test/zero-config:pinned';
 const SIGNER =
   'gcpkms://projects/example/locations/global/keyRings/keys/cryptoKeys/signer';
 const ATTESTOR = 'projects/example/attestors/provenance';
+
+/** Generated once — every sealing test opens envelopes with the same pair. */
+const SEAL_KEYPAIR = generateKeyPairSync('rsa', {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: 'spki', format: 'pem' },
+  privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+});
 
 const spec: BuildSpec = {
   artifactType: 'image',
@@ -168,6 +178,7 @@ function text(events: readonly BuildEvent[]): string {
 function hostedRoute(
   options: FakeGitHubOptions = {},
   pacing: { discoveryMs?: number; timeoutMs?: number } = {},
+  sealPublicKey?: string,
 ): {
   host: FakeGitHub;
   route: GitHubActionsBuildRoute;
@@ -187,11 +198,54 @@ function hostedRoute(
       signer: SIGNER,
       attestor: ATTESTOR,
       correlation: () => 'fixed-correlation',
+      ...(sealPublicKey !== undefined ? { sealPublicKey } : {}),
       ...PACING,
       ...pacing,
       ...fakeClock(),
     }),
   };
+}
+
+/**
+ * The decrypt half of the reusable workflow's "Log in with sealed
+ * credentials" step, lifted from the workflow file itself rather than
+ * retyped — so the round-trip test below proves the algorithm this repository
+ * actually runs, not a copy of it that could quietly drift out of step.
+ *
+ * Sliced at `const auth = …` — the point where the workflow's own script has
+ * finished decrypting and has nothing further to prove — with one line of the
+ * test's own appended so the spawned process has something to report back.
+ * `docker login` never runs under this cut.
+ */
+async function workflowDecryptScript(): Promise<string> {
+  const text = await Bun.file(
+    new URL(
+      '../../../../.github/workflows/spindrift-build.yml',
+      import.meta.url,
+    ),
+  ).text();
+  const workflow = Bun.YAML.parse(text) as {
+    jobs: { build: { steps: { name?: string; run?: string }[] } };
+  };
+  const step = workflow.jobs.build.steps.find(
+    (candidate) => candidate.name === 'Log in with sealed credentials',
+  );
+  // The bash preamble sits before the heredoc and is not JavaScript, so the
+  // slice starts *after* the line that opens it — not at the top of `run`.
+  const heredocStart = step?.run?.indexOf("<<'SPINDRIFT_SEAL_SCRIPT'\n");
+  const scriptStart =
+    heredocStart === undefined || heredocStart === -1
+      ? -1
+      : heredocStart + "<<'SPINDRIFT_SEAL_SCRIPT'\n".length;
+  const marker = "const auth = JSON.parse(plaintext.toString('utf8'));";
+  const cut =
+    scriptStart === -1 ? -1 : (step?.run?.indexOf(marker, scriptStart) ?? -1);
+  if (step?.run === undefined || scriptStart === -1 || cut === -1) {
+    throw new Error(
+      'could not find the sealed-credential decrypt algorithm in spindrift-build.yml',
+    );
+  }
+  return `${step.run.slice(scriptStart, cut + marker.length)}\nconsole.log(JSON.stringify(auth));\n`;
 }
 
 describe('the hosted build route', () => {
@@ -432,6 +486,70 @@ describe('the hosted build route', () => {
     // syntax and the linter cannot tell which one this file meant.
     const expression = ['${', '{ inputs.correlation }', '}'].join('');
     expect(caller).toContain(`run-name: ${RUN_NAME_PREFIX} ${expression}`);
+  });
+
+  test('carries a registry credential only where a seal key is configured', () => {
+    expect(hostedRoute().route.carriesRegistryCredential).toBe(false);
+    expect(
+      hostedRoute({}, {}, SEAL_KEYPAIR.publicKey).route
+        .carriesRegistryCredential,
+    ).toBe(true);
+  });
+
+  test('a held credential travels sealed, never as a username or secret in the clear', async () => {
+    const held = {
+      host: 'registry-1.docker.io',
+      username: 'an-owner',
+      secret: 'a-token',
+    };
+    const { host, route } = hostedRoute({}, {}, SEAL_KEYPAIR.publicKey);
+    await run(route.build(archiveSource(), { ...spec, registryAuth: [held] }));
+
+    // The whole request, not just the field it should have landed in — the
+    // one thing this test cannot afford to miss is the secret showing up
+    // somewhere `sealedRegistryAuth` was not, in a request GitHub renders in
+    // the run header.
+    const raw = host.dispatches[0]?.inputs.spec ?? '{}';
+    expect(raw).not.toContain(held.secret);
+    expect(raw).not.toContain(held.username);
+
+    const request = JSON.parse(raw);
+    expect(typeof request.sealedRegistryAuth).toBe('string');
+    expect((request.sealedRegistryAuth as string).length).toBeGreaterThan(0);
+  });
+
+  test('carries no sealedRegistryAuth key at all where nothing is held', async () => {
+    const { host, route } = hostedRoute({}, {}, SEAL_KEYPAIR.publicKey);
+    await run(route.build(archiveSource(), spec));
+
+    const request = JSON.parse(host.dispatches[0]?.inputs.spec ?? '{}');
+    expect(request).not.toHaveProperty('sealedRegistryAuth');
+  });
+
+  test('the sealed envelope opens with the exact algorithm the workflow runs', async () => {
+    const auth: RegistryAuth[] = [
+      { host: 'registry-1.docker.io', username: 'an-owner', secret: 'a-token' },
+      { host: 'ghcr.io', username: 'other-owner', secret: 'a-second-token' },
+    ];
+    const sealed = await sealRegistryAuth(auth, SEAL_KEYPAIR.publicKey);
+
+    const proc = Bun.spawn(['node', '-e', await workflowDecryptScript()], {
+      env: {
+        ...process.env,
+        SEALED: sealed,
+        SEAL_KEY: SEAL_KEYPAIR.privateKey,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode, stderr).toBe(0);
+    expect(JSON.parse(stdout)).toEqual(auth);
   });
 });
 


### PR DESCRIPTION
The hosted route refuses to dispatch while the installation holds a stored
registry credential, because `workflow_dispatch` inputs render publicly in
the run header. That refusal now has an exit that keeps the credential's only
home in Spindrift: the dispatch carries `sealedRegistryAuth` — AES-256-GCM
over the credential list, the AES key wrapped RSA-OAEP(SHA-256) to a
`sealPublicKey` declared on the route in the manifest — and the workflow
decrypts with the private half held as the one repo Actions secret
(`SPINDRIFT_BUILD_SEAL_KEY`). WebCrypto on the sealing side, Node's stdlib on
the unsealing side; no new dependencies.

- `carriesRegistryCredential` is true exactly when a seal key is declared, so
  installations without one keep today's refusal.
- The unseal step masks every value before `docker login --password-stdin`,
  and fails loudly naming the missing secret rather than dying later at the
  push.
- `spindrift.yml` gains `secrets: inherit` — a `workflow_call` passes no
  secret unasked. Connected repos' generated caller stays secret-free, and a
  test asserts that.
- The round-trip test extracts the actual Node script out of
  `spindrift-build.yml` and runs it, so both sides provably speak the same
  algorithm.

Full suite 1684 pass, typecheck and lint clean.

Rollout note: the keypair exists; the repo secret and the manifest's
`sealPublicKey` land separately (operator acts), then hosted builds carry the
docker.io credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)