### PR TITLE
fix(spindrift): stage a repo Component's first bundle instead of starting dead

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -168,11 +168,18 @@ async function sourceForRerun(
     previous?.bundleDigest ?? app.sourceArchiveDigest ?? null;
   const inherited = previous?.bundleLocation ?? null;
 
-  if (inherited === null || isFetchableBundleLocation(inherited)) {
+  if (
+    inherited !== null
+      ? isFetchableBundleLocation(inherited)
+      : app.sourceKind !== 'repo'
+  ) {
     // Either there is a durable bundle to reuse — a `gs://` object is immutable
-    // and shared, so the same commit wants the same one — or there was never a
-    // bundle here to begin with, which is a Build dispatch already refuses for
-    // its own reasons rather than a stale handle to retire.
+    // and shared, so the same commit wants the same one — or this is an archive
+    // App whose Component never had a bundle, which is a Build dispatch already
+    // refuses for its own reasons rather than a stale handle to retire. A
+    // *repo* Component with no bundle is different: its first Build is exactly
+    // the "stage the exact commit once" act, so it falls through to staging
+    // rather than writing a Build nothing can dispatch.
     return ok({
       commit: baseCommit,
       bundleDigest: inheritedDigest,
@@ -190,11 +197,18 @@ async function sourceForRerun(
     );
   }
 
+  // On this path `inherited` is a stale unfetchable handle — or, for a
+  // Component's first Build, nothing at all. The refusals below say which.
+  const was =
+    inherited === null
+      ? 'never staged for this Component'
+      : `staged at ${inherited}, which no build route can fetch`;
+
   const stager = context.adapters.source?.() ?? null;
   if (stager === null) {
     return failed(
       'NOT_BUILDABLE',
-      `${app.name}'s bundle was staged at ${inherited}, which no build route can fetch, and this installation configures no source depot to stage a fresh one into`,
+      `${app.name}'s bundle was ${was}, and this installation configures no source depot to stage a fresh one into`,
     );
   }
 
@@ -209,13 +223,13 @@ async function sourceForRerun(
   if (repository === undefined) {
     return failed(
       'NOT_BUILDABLE',
-      `${app.name}'s bundle was staged at ${inherited}, which no build route can fetch, and ${app.name} has no connected repository to stage a fresh one from — connect its repository to make it buildable`,
+      `${app.name}'s bundle was ${was}, and ${app.name} has no connected repository to stage a fresh one from — connect its repository to make it buildable`,
     );
   }
   if (repository.access !== 'active') {
     return failed(
       'NOT_BUILDABLE',
-      `${app.name}'s bundle was staged at ${inherited}, which no build route can fetch, and ${repository.fullName} is ${repository.access}, so no fresh bundle can be staged: ${repository.frozenReason ?? 'access to it was lost'}`,
+      `${app.name}'s bundle was ${was}, and ${repository.fullName} is ${repository.access}, so no fresh bundle can be staged: ${repository.frozenReason ?? 'access to it was lost'}`,
     );
   }
 
@@ -228,7 +242,7 @@ async function sourceForRerun(
   if (commit === null) {
     return failed(
       'NOT_BUILDABLE',
-      `${app.name}'s bundle was staged at ${inherited}, which no build route can fetch, and ${repository.fullName} has no authoritative commit ready to stage a fresh one from`,
+      `${app.name}'s bundle was ${was}, and ${repository.fullName} has no authoritative commit ready to stage a fresh one from`,
     );
   }
 
@@ -431,7 +445,11 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
         artifactType: buildToRun?.artifactType ?? 'image',
         bundleDigest: rerun.value.bundleDigest,
         bundleLocation: rerun.value.bundleLocation,
-        bundleSubpath: buildToRun?.bundleSubpath ?? '.',
+        // A first Build for this Component inherits the App's own subpath —
+        // the bundle is the staged source root, and '.' would build the
+        // monorepo's root instead of the App.
+        bundleSubpath:
+          buildToRun?.bundleSubpath ?? app.sourceRepoSubpath ?? '.',
         status: 'PENDING',
         createdAt: now,
       })

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -87,6 +87,8 @@ describe('the bundle a rerun stages', () => {
     connectRepository?: boolean;
     status?: 'FAILED' | 'SUCCEEDED';
     artifactDigest?: string;
+    /** `false` seeds a Component that has never built at all. */
+    previousBuild?: boolean;
   }) {
     const name = `rerun-${crypto.randomUUID().slice(0, 8)}`;
     const [repository] = options.connectRepository
@@ -121,6 +123,9 @@ describe('the bundle a rerun stages', () => {
     await ctx.db
       .insert(componentTargetDesired)
       .values({ componentId: component!.id, targetId: target!.id });
+    if (options.previousBuild === false) {
+      return { app: app!, component: component!, build: null };
+    }
     const [build] = await ctx.db
       .insert(builds)
       .values({
@@ -195,7 +200,7 @@ describe('the bundle a rerun stages', () => {
     // was staged for it, and the handle that predates the depot is not in it.
     expect(rerun!.bundleLocation).toBe(FRESH_LOCATION);
     expect(rerun!.bundleDigest).toBe(FRESH_DIGEST);
-    expect(rerun!.id).not.toBe(seeded.build.id);
+    expect(rerun!.id).not.toBe(seeded.build!.id);
 
     // The exact commit, once — the rerun suffix is a uniqueness device on the
     // row and never travels into staging.
@@ -290,10 +295,10 @@ describe('the bundle a rerun stages', () => {
     expect(result.failure.message).toContain(COMMIT);
   });
 
-  test('a Build with no bundle at all is still started, as it always was', async () => {
-    // Nothing stale to retire here: dispatch already refuses a Build with no
-    // staged bundle, with its own sentence. This ticket narrows what is
-    // inherited, not when a Build may be created.
+  test('a repo Build with no bundle stages one instead of starting dead', async () => {
+    // A repo Component whose previous Build never had a bundle used to get
+    // another Build with none — a row dispatch then refused, forever. The
+    // repository is right there; staging it is what a first bundle is.
     const seeded = await seedFailedBuild({
       location: null,
       connectRepository: true,
@@ -303,7 +308,42 @@ describe('the bundle a rerun stages', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.phase).toBe('BUILDING');
-    expect(stager.staged).toHaveLength(0);
+    expect(stager.staged).toEqual([
+      { repository: `jonpulsifer/${seeded.app.name}`, commit: COMMIT },
+    ]);
+
+    const [row] = await ctx.db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    expect(row?.bundleLocation).toBe(FRESH_LOCATION);
+  });
+
+  test("a Component's first Build stages the App's source and subpath", async () => {
+    // The live shape this pins: a freshly created second Component has no
+    // Build history at all. Its first Build stages the repository at the
+    // authoritative commit and carries the App's own subpath — '.' would
+    // build the monorepo root instead of the App.
+    const seeded = await seedFailedBuild({
+      location: null,
+      connectRepository: true,
+      previousBuild: false,
+    });
+
+    const result = await deployApp({ name: seeded.app.name }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.phase).toBe('BUILDING');
+    expect(stager.staged).toEqual([
+      { repository: `jonpulsifer/${seeded.app.name}`, commit: COMMIT },
+    ]);
+
+    const [row] = await ctx.db
+      .select()
+      .from(builds)
+      .where(eq(builds.id, result.value.buildId));
+    expect(row?.bundleLocation).toBe(FRESH_LOCATION);
+    expect(row?.bundleSubpath).toBe('apps/spindrift');
   });
 
   /**
@@ -334,7 +374,7 @@ describe('the bundle a rerun stages', () => {
       // no intent to navigate to.
       expect(result.value.phase).toBe('BUILDING');
       expect(result.value.deployId).toBeNull();
-      expect(result.value.buildId).not.toBe(seeded.build.id);
+      expect(result.value.buildId).not.toBe(seeded.build!.id);
 
       const rows = await ctx.db
         .select()
@@ -352,7 +392,7 @@ describe('the bundle a rerun stages', () => {
 
       // The row edit this ticket exists to end: the succeeded Build still says
       // it succeeded, and still names what it produced.
-      const succeeded = rows.find((row) => row.id === seeded.build.id);
+      const succeeded = rows.find((row) => row.id === seeded.build!.id);
       expect(succeeded?.status).toBe('SUCCEEDED');
       expect(succeeded?.artifactDigest).toBe(`sha256:${'b'.repeat(64)}`);
     });

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -50,6 +50,15 @@ const noAdapters: AdapterRegistry = {
   },
   repository: () => null,
   supplyChain: () => supplyChainHarness,
+  // A repo Component's first bundle is staged at Build creation now, so the
+  // deploy tests below need a depot; none of them asserts on its contents.
+  source: () => ({
+    stageRepository: async () => ({
+      digest: `sha256:${'d'.repeat(64)}`,
+      location: `gs://depot.example.test/${'d'.repeat(64)}.tgz`,
+      retention: 'ephemeral' as const,
+    }),
+  }),
 };
 
 function context(clock: Clock = frozenClock): CommandContext {
@@ -1744,6 +1753,10 @@ describe('deployApp command', () => {
       targetShape: 'image',
       artifactType: 'image',
       status: 'FAILED',
+      // Durable, so the rerun inherits it: this test is about Build-vs-intent,
+      // and an app with no connected repository has nothing to stage from.
+      bundleDigest: `sha256:${'e'.repeat(64)}`,
+      bundleLocation: `gs://depot.example.test/${'e'.repeat(64)}.tgz`,
     });
 
     const result = await deployApp({ name: appName }, ctx);


### PR DESCRIPTION
The last blocker in the first-job-Component chain, observed live: the
Component's first Build was written with no bundle and dispatch refused it
forever ("Build 51 has no staged bundle, so no route can be given one").

`sourceForRerun` conflated "no stale handle to retire" with "nothing ever
staged" and returned early on a null inheritance. For a repo App the null
case is precisely the staging act — §15's "fetch the exact commit once" —
so it now falls through: stages the repository at the authoritative commit,
and the new Build row carries the App's own `sourceRepoSubpath` ('.' would
build the monorepo root). Archive Apps keep the early return and dispatch's
existing refusal — their bytes cannot be staged again from anything Spindrift
holds.

Also: a repo Build whose *previous* row had no bundle now stages instead of
producing another dead row (the old test pinning that behaviour is updated to
the new truth), and the staging-path refusals say "never staged for this
Component" rather than interpolating a null handle.

Affected suites all green; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)