### PR TITLE
fix(spindrift): a repo Build's subpath is the App's, never an inheritance

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -445,11 +445,16 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
         artifactType: buildToRun?.artifactType ?? 'image',
         bundleDigest: rerun.value.bundleDigest,
         bundleLocation: rerun.value.bundleLocation,
-        // A first Build for this Component inherits the App's own subpath —
-        // the bundle is the staged source root, and '.' would build the
-        // monorepo's root instead of the App.
+        // A repo Build's subpath is the App's declared subpath, never an
+        // inheritance: the bundle is the staged source root, '.' would build
+        // the monorepo's root instead of the App, and a predecessor row that
+        // recorded '.' (a Build created before its Component could stage)
+        // must not pass that lie forward. Archive lineage keeps the uploaded
+        // bundle's own subpath — its bytes carry their own layout.
         bundleSubpath:
-          buildToRun?.bundleSubpath ?? app.sourceRepoSubpath ?? '.',
+          app.sourceKind === 'repo'
+            ? (app.sourceRepoSubpath ?? '.')
+            : (buildToRun?.bundleSubpath ?? '.'),
         status: 'PENDING',
         createdAt: now,
       })

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -317,6 +317,10 @@ describe('the bundle a rerun stages', () => {
       .from(builds)
       .where(eq(builds.id, result.value.buildId));
     expect(row?.bundleLocation).toBe(FRESH_LOCATION);
+    // The predecessor was created before its Component could stage, so its
+    // recorded subpath is the placeholder — the App's declared subpath wins,
+    // observed live as build 52 building a monorepo root.
+    expect(row?.bundleSubpath).toBe('apps/spindrift');
   });
 
   test("a Component's first Build stages the App's source and subpath", async () => {


### PR DESCRIPTION
One-line follow-up to the first-bundle staging fix, from watching it live:
the fresh Component's second build staged correctly but inherited
`bundleSubpath: '.'` from its dead predecessor (a row created before the
Component could stage), and set off building the monorepo root.

A repo Build's subpath now always comes from the App's declared
`sourceRepoSubpath` — a predecessor's placeholder must not pass forward.
Archive lineage keeps the uploaded bundle's own subpath, since its bytes
carry their own layout. The staging regression test now also asserts the
subpath.

Affected suites green; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)