### PR TITLE
fix(spindrift): keep the build command whole when there are no build args

### DIFF
--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -200,9 +200,14 @@ function zeroConfigArm(input: BuildKitProgramInput): string {
  * payload core cannot decode.
  */
 export function buildKitProgram(input: BuildKitProgramInput): string {
+  // Each entry is a whole line, newline included, so an empty set contributes
+  // nothing at all: a bare `${args}` line in the template would leave a blank
+  // line after the command's `\` continuation, ending it — and the flag on
+  // the next line becomes a command of its own (`sh: --attest=…: not found`,
+  // observed on the first Component built with no build args).
   const args = Object.entries(input.buildArgs)
-    .map(([key, value]) => `  --opt ${quote(`build-arg:${key}=${value}`)} \\`)
-    .join('\n');
+    .map(([key, value]) => `  --opt ${quote(`build-arg:${key}=${value}`)} \\\n`)
+    .join('');
 
   return `set -eu
 workspace=$(mktemp -d)
@@ -268,8 +273,7 @@ ${zeroConfigArm(input)}
 fi
 
 buildctl-daemonless.sh build "$@" \\
-${args}
-  --attest=type=provenance,mode=max \\
+${args}  --attest=type=provenance,mode=max \\
   --attest=type=sbom \\
   --output ${quote(`type=image,${imageNames(input)},push=true`)} \\
   --metadata-file "$workspace/metadata.json"

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -1094,6 +1094,26 @@ describe('the BuildKit program', () => {
     expect(program).toContain(`--opt source='${FRONTEND}'`);
   });
 
+  test('an empty build-arg set leaves no blank continuation line', () => {
+    // A `\` continuation followed by a blank line ends the command there, and
+    // the flag on the next line becomes a command of its own — observed live
+    // as `sh: --attest=type=provenance,mode=max: not found` on the first
+    // Component built with no build args.
+    const bare = buildKitProgram({
+      bundleUrl: 'staged://bundle',
+      bundleDigest: 'sha256:bundle',
+      subpath: 'apps/web',
+      destinations: ['registry.example.test/app'],
+      tags: ['latest'],
+      zeroConfigFrontend: FRONTEND,
+      buildArgs: {},
+    });
+    expect(bare).not.toMatch(/\\\n\s*\n\s*--/);
+    // The populated program holds the same invariant.
+    expect(program).not.toMatch(/\\\n\s*\n\s*--/);
+    expect(bare).toContain('--attest=type=provenance,mode=max');
+  });
+
   test('builds a Dockerfile against the bundle root, not the scope', () => {
     // The scope names the Dockerfile; the root is what it builds. A monorepo
     // App shares a lockfile and sibling packages with the tree above it, and


### PR DESCRIPTION
The shared BuildKit program had never executed for real until today — the
hosted route runs its own workflow and in-cluster is unconfigured — and its
first run found a birth defect: `${args}` interpolates as its own template
line, so a Component with no build args leaves a blank line after the
`buildctl … \` continuation. The blank line ends the command, and the next
flag becomes a command of its own:

> sh: --attest=type=provenance,mode=max: not found

Build-arg entries are now whole lines (newline included) and an empty set
contributes nothing. The program test pins the invariant: no `\` continuation
followed by a blank line then a flag, in either the bare or populated shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)