### PR TITLE
fix(spindrift): fold Docker Hub repositories to the two levels it holds

### DIFF
--- a/apps/spindrift/src/domain/artifact-name.ts
+++ b/apps/spindrift/src/domain/artifact-name.ts
@@ -79,8 +79,15 @@ export function componentRepositories(
 ): readonly string[] | null {
   if (!isPathComponent(parts.app)) return null;
   if (!isPathComponent(parts.component)) return null;
-  return parts.registries.map(
-    (registry) => `${registry}/${parts.app}/${parts.component}`,
+  return parts.registries.map((registry) =>
+    // Docker Hub holds exactly two path levels — namespace, then repository —
+    // so the App and Component fold into one hyphenated segment there. Every
+    // other registry takes the nested form; pushing the nested form to Docker
+    // Hub is "push access denied, repository does not exist" after the whole
+    // build, which is where this was found.
+    registryFlavour(registryHostOf(registry)) === 'dockerHub'
+      ? `${registry}/${parts.app}-${parts.component}`
+      : `${registry}/${parts.app}/${parts.component}`,
   );
 }
 

--- a/apps/spindrift/test/domain/artifact-name.test.ts
+++ b/apps/spindrift/test/domain/artifact-name.test.ts
@@ -64,6 +64,24 @@ describe('a Component’s repository', () => {
     expect(first).not.toEqual(second);
   });
 
+  test('folds to two levels on Docker Hub, which holds no nested namespaces', () => {
+    // Docker Hub is namespace/repository and nothing deeper — the nested form
+    // is "push access denied, repository does not exist" after the whole
+    // build. The fold gives up the unambiguity above on that one registry;
+    // every other registry keeps the canonical nested name, and those are the
+    // refs Deploys pin.
+    expect(
+      componentRepositories({
+        registries: ['docker.io/jonpulsifer', REGISTRY],
+        app: 'statty',
+        component: 'nightly',
+      }),
+    ).toEqual([
+      'docker.io/jonpulsifer/statty-nightly',
+      'ghcr.io/jonpulsifer/statty/nightly',
+    ]);
+  });
+
   test('refuses a name no registry would accept rather than projecting it', () => {
     // Projecting would push two Components to one repository, which is the
     // quiet failure: the second build overwrites the first's tag.


### PR DESCRIPTION
The first hosted build to carry the sealed Docker Hub credential proved the
whole envelope mechanism — ciphertext in the public dispatch inputs, clean
unseal, `Login Succeeded` to both registries — and then died at the export:

> failed to push docker.io/…/statty/nightly: push access denied, repository
> does not exist or may require authorization: insufficient_scope

Docker Hub holds exactly two path levels. `componentRepositories` now folds
app and component into one hyphenated segment for the dockerHub flavour
(`jonpulsifer/statty-nightly`); every other registry keeps the canonical
nested form, which is what Deploys pin. The naming test that documents
nested-over-joined unambiguity gains the Docker Hub case stating the trade
honestly — the fold is that registry's constraint, not a preference.

336 tests across the naming/adapter/destination suites, 0 fail. Typecheck
and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)