### PR TITLE
fix(ci): mask only the sealed secret, not the username inside every ref

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -346,8 +346,12 @@ jobs:
 
           // Masked before this step prints anything else, including the
           // logins below — whose own output could otherwise echo them back.
+          // The secret only: the runner also masks the base64 form of a
+          // masked value, and the username is inside every image reference —
+          // masking it punched `***` through the base64 build report and the
+          // route refused a green run it could no longer parse. A username is
+          // the public half of the pair; it is in the refs by design.
           for (const entry of auth) {
-            console.log(`::add-mask::${entry.username}`);
             console.log(`::add-mask::${entry.secret}`);
           }
           for (const entry of auth) {


### PR DESCRIPTION
The first fully green sealed-credential build still came back FAILED in
Spindrift, and the reason is delightful: the unseal step `::add-mask::`ed the
credential's username as well as its secret. The runner masks base64-encoded
forms of masked values too — and the username is inside every image
reference — so the base64 `spindrift-result` payload came out with the
encoded username punched to `***`. The route then refused a green run whose
report it could no longer parse, exactly as §16 wants it to when a report is
unreadable.

The username is the public half of the pair and appears in the refs by
design; only the secret is masked now. Workflow-only change — callers pin the
default branch, so it reaches the next dispatch with no image roll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)