### PR TITLE
fix(spindrift): an attestation that already exists is done, not a failure

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -510,7 +510,12 @@ jobs:
 
           attest() {
             echo "attesting ${1}@${2}"
-            gcloud beta container binauthz attestations sign-and-create \
+            # `sign-and-create` refuses a second occurrence for the same
+            # artifact-url as a conflict — but an identical rebuild reusing
+            # its digest is this pipeline's ordinary behaviour, and "already
+            # attested" is the condition this step exists to bring about, not
+            # a failure. Any other error still fails the build.
+            output=$(gcloud beta container binauthz attestations sign-and-create \
               --project="$attestor_project" \
               --artifact-url="${1}@${2}" \
               --attestor="$attestor_name" \
@@ -519,7 +524,13 @@ jobs:
               --keyversion-location="$(field locations)" \
               --keyversion-keyring="$(field keyRings)" \
               --keyversion-key="$(field cryptoKeys)" \
-              --keyversion="$version"
+              --keyversion="$version" 2>&1) && { printf '%s\n' "$output"; return 0; }
+            case "$output" in
+              *"is the subject of a conflict"*)
+                echo "already attested: ${1}@${2}" ;;
+              *)
+                printf '%s\n' "$output" >&2; return 1 ;;
+            esac
           }
 
           # Once per destination, and for a sharper reason than the signature:

--- a/apps/spindrift/src/adapters/build/cloud-build.ts
+++ b/apps/spindrift/src/adapters/build/cloud-build.ts
@@ -753,7 +753,12 @@ echo "attesting with key version \${version}"
 
 attest() {
   echo "attesting \${1}@\${2}"
-  gcloud beta container binauthz attestations sign-and-create \\
+  # \`sign-and-create\` refuses a second occurrence for the same artifact-url
+  # as a conflict — but an identical rebuild reusing its digest is this
+  # pipeline's ordinary behaviour, and "already attested" is the condition
+  # this step exists to bring about, not a failure. Any other error still
+  # fails the build.
+  output=$(gcloud beta container binauthz attestations sign-and-create \\
     --project=${attestorProject} \\
     --artifact-url="\${1}@\${2}" \\
     --attestor=${quote(attestor[2] ?? '')} \\
@@ -762,7 +767,13 @@ attest() {
     --keyversion-location=${quote(key.location)} \\
     --keyversion-keyring=${quote(key.keyRing)} \\
     --keyversion-key=${quote(key.key)} \\
-    --keyversion="\${version}"
+    --keyversion="\${version}" 2>&1) && { printf '%s\\n' "\${output}"; return 0; }
+  case "\${output}" in
+    *"is the subject of a conflict"*)
+      echo "already attested: \${1}@\${2}" ;;
+    *)
+      printf '%s\\n' "\${output}" >&2; return 1 ;;
+  esac
 }
 
 # Every manifest the index names, read off the registry.

--- a/apps/spindrift/test/adapters/build-attest-selection.test.ts
+++ b/apps/spindrift/test/adapters/build-attest-selection.test.ts
@@ -67,4 +67,55 @@ describe('the hosted route attests what a runtime can run', () => {
     ]);
     expect(digests).not.toContain(`${DESTINATION}@${ATTACHMENT_DIGEST}`);
   });
+
+  test('an occurrence that already exists is done, not a failure', async () => {
+    // An identical rebuild reuses its digest, and a rerun after a green attest
+    // meets its own occurrence — the condition this step exists to bring
+    // about. Observed live: a rerun died at `sign-and-create … is the subject
+    // of a conflict` with everything already attested.
+    const conflictStub = `case "$*" in
+  *print-access-token*) echo stub-token ;;
+  *sign-and-create*) echo 'ERROR: (gcloud.beta.container.binauthz.attestations.sign-and-create) Resource in projects [trusted-builds] is the subject of a conflict: Could not create occurrence' >&2; exit 1 ;;
+esac
+exit 0`;
+
+    const digests = await attested(
+      await attestScript(),
+      { gcloud: conflictStub, docker: indexStub() },
+      {
+        ATTESTOR,
+        SIGNER,
+        DESTINATIONS: DESTINATION,
+        DIGEST: INDEX_DIGEST,
+        CLOUDSDK_CORE_DISABLE_PROMPTS: '1',
+      },
+    );
+
+    expect(digests).toEqual([
+      `${DESTINATION}@${INDEX_DIGEST}`,
+      `${DESTINATION}@${RUNTIME_DIGEST}`,
+    ]);
+  });
+
+  test('any other signing failure still fails the build', async () => {
+    const brokenStub = `case "$*" in
+  *print-access-token*) echo stub-token ;;
+  *sign-and-create*) echo 'ERROR: PERMISSION_DENIED: no signing for you' >&2; exit 1 ;;
+esac
+exit 0`;
+
+    await expect(
+      attested(
+        await attestScript(),
+        { gcloud: brokenStub, docker: indexStub() },
+        {
+          ATTESTOR,
+          SIGNER,
+          DESTINATIONS: DESTINATION,
+          DIGEST: INDEX_DIGEST,
+          CLOUDSDK_CORE_DISABLE_PROMPTS: '1',
+        },
+      ),
+    ).rejects.toThrow('the attest step failed');
+  });
 });


### PR DESCRIPTION
The rerun after the masking fix met its own predecessor's attestations:

> ERROR: (gcloud.beta.container.binauthz.attestations.sign-and-create)
> Resource in projects [trusted-builds] is the subject of a conflict

`sign-and-create` refuses a second occurrence for the same artifact-url — but
an identical rebuild reusing its digest is this pipeline's ordinary
behaviour, and "already attested" is precisely the state the step exists to
bring about. Both attest copies (the hosted workflow's and the cloud
builder's program) now recognise the conflict as done; any other signing
error still fails the build.

The executed-step tests cover both: a conflict-answering gcloud stub yields
the same attested set, and a PERMISSION_DENIED stub still fails the step.
Workflow-only on the hosted side, so it reaches the next dispatch on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)