### PR TITLE
fix(ci): recreate the digest branch when a stale ref carries a workflow diff

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -203,7 +203,21 @@ jobs:
           git add -- "${targets[@]}"
           git commit -m "fix(cd): update ${IMAGE_NAME} image digest to ${DIGEST}"
 
-          git push origin "$BRANCH_NAME" --force
+          if ! git push origin "$BRANCH_NAME" --force; then
+            # A prior run that failed after pushing leaves this branch cut from
+            # an older main, so the next push introduces every commit in
+            # between — and GITHUB_TOKEN may never write one that touched
+            # .github/workflows/, whatever this job's `permissions:` say.
+            # Recreating the ref reduces the push to the single manifest-only
+            # commit above. Only on failure, so an open PR keeps its identity
+            # and its running checks in the ordinary case.
+            echo "Push refused; recreating $BRANCH_NAME so it carries only this commit."
+            git push origin --delete "$BRANCH_NAME" || true
+            git push origin "$BRANCH_NAME" || {
+              echo "::error::Cannot push $BRANCH_NAME even as a fresh ref carrying one manifest-only commit. Delete the remote branch and any open pull request for it, then re-run this job."
+              exit 1
+            }
+          fi
 
           # An **open** one, not any one. `gh pr view <branch>` answers with the
           # most recent pull request for that head whatever its state, so once


### PR DESCRIPTION
The containers workflow builds an image, rewrites the digest in its deploy
manifests, and pushes `cd/update-<image>-digest` for automerge. That push was
refused on the run for `710f6990`:

```text
! [remote rejected] cd/update-spindrift-digest -> cd/update-spindrift-digest
(refusing to allow a GitHub App to create or update workflow
`.github/workflows/typescript.yml` without `workflows` permission)
```

The digest commit touches one manifest and nothing else. The refusal is about
the *ref update*, not the commit: when a previous run failed after pushing, the
remote branch tip survives, cut from an older `main`. Force-pushing over that
stale tip introduces every commit merged in between — and one of them had
edited a workflow file.

Granting the permission is not an option. The credential is
`secrets.GITHUB_TOKEN` (`.github/workflows/containers.yml:131`), and no
`permissions:` key gives a `GITHUB_TOKEN` the right to write a workflow file.
Rebasing onto `origin/main` before pushing does not help either: the refused
range is measured from the stale *remote* tip, not from the local base.

So: try the force-push exactly as before, and only when it is refused, delete
the ref and push it fresh. Recreating the branch makes the introduced range the
single manifest-only commit. Deleting unconditionally would also work, but it
closes an open digest PR and discards its running checks on every ordinary run
in order to fix a case that only arises after a failed one. If the fresh push
is refused too, the log says what to do instead of leaving a bare
`remote rejected`.

## Verification

The range arithmetic is the whole fix, and it reproduces against local bare
repos — a stale digest branch, an interleaved commit touching
`.github/workflows/typescript.yml`, then a new digest commit:

```text
force push (today) introduces:   fix(cd): digest ccc  clusters/hr.yaml
                                 change runner        .github/workflows/typescript.yml
after delete + fresh push:       fix(cd): digest ccc  clusters/hr.yaml
```

The first line is the refusal quoted above. Not added as a test: it asserts
git's own reachability rules rather than anything in this repo. `shellcheck`
is clean on the step.

The fallback path itself cannot be proven by a green run on an ordinary merge —
it executes only when a workflow-touching merge interleaves a *failed* prior
digest run. The next time that coincidence lands, the bump PR should open by
itself rather than needing a by-hand one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X62KGfgV9sHYNVpfK2ADSv