### PR TITLE
fix(monitoring): install the Prometheus Operator CRDs ahead of offsite monitoring

### DIFF
--- a/clusters/base/monitoring-crds/helm-repository-prometheus-crds.yaml
+++ b/clusters/base/monitoring-crds/helm-repository-prometheus-crds.yaml
@@ -1,0 +1,16 @@
+---
+# Deliberately a second HelmRepository for the same URL as
+# `base/monitoring/helm-repository-prometheus.yaml`, under its own name.
+#
+# `monitoring` dependsOn `monitoring-crds`, so anything `monitoring-crds`
+# needs must exist before `monitoring` has reconciled even once. Pointing at
+# the `prometheus` HelmRepository — which `monitoring` owns — would invert
+# that and deadlock the pair on a cluster building from nothing.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: prometheus-crds
+  namespace: flux-system
+spec:
+  interval: 24h
+  url: https://prometheus-community.github.io/helm-charts

--- a/clusters/base/monitoring-crds/kustomization.yaml
+++ b/clusters/base/monitoring-crds/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-repository-prometheus-crds.yaml
+  - prometheus-operator-crds.yaml

--- a/clusters/base/monitoring-crds/prometheus-operator-crds.yaml
+++ b/clusters/base/monitoring-crds/prometheus-operator-crds.yaml
@@ -1,0 +1,43 @@
+---
+# The Prometheus Operator's CRDs, installed ahead of the monitoring
+# Kustomization rather than inside it.
+#
+# Flux server-side dry-runs every object in a Kustomization before applying
+# any of them. `base/monitoring` holds both a raw ServiceMonitor and the
+# kube-prometheus-stack HelmRelease that would create the ServiceMonitor CRD,
+# so on a cluster that does not already have that CRD the dry-run fails, the
+# whole Kustomization is refused, and the chart that would resolve it never
+# installs. Splitting the CRDs into a Kustomization `monitoring` dependsOn is
+# what breaks the cycle.
+#
+# appVersion tracks kube-prometheus-stack's: 31.0.0 and 88.1.x are both
+# prometheus-operator v0.93.0. They must move together.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus-operator-crds
+  # flux-system, not monitoring: what this installs is cluster-scoped, and
+  # the monitoring namespace is created by `base/monitoring` — the very
+  # Kustomization that runs after this one.
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  maxHistory: 2
+  chart:
+    spec:
+      chart: prometheus-operator-crds
+      version: 31.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-crds
+        namespace: flux-system
+      interval: 24h
+  install:
+    remediation:
+      retries: 5
+  upgrade:
+    # CRD schema updates are additive; replacing lets a field land without
+    # a by-hand delete of resources the operator is actively using.
+    crds: CreateReplace
+    remediation:
+      retries: 5

--- a/clusters/offsite/flux-system/kustomization.yaml
+++ b/clusters/offsite/flux-system/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - apps.yaml
   - arc-runners.yaml
   - config.yaml
+  - monitoring-crds.yaml
   - monitoring.yaml
   - networking.yaml
   - oauth2-proxy.yaml

--- a/clusters/offsite/flux-system/monitoring-crds.yaml
+++ b/clusters/offsite/flux-system/monitoring-crds.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: monitoring-crds
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/offsite/monitoring-crds
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra

--- a/clusters/offsite/flux-system/monitoring.yaml
+++ b/clusters/offsite/flux-system/monitoring.yaml
@@ -13,6 +13,11 @@ spec:
     name: infra
   dependsOn:
     - name: storage
+    # base/monitoring holds a raw ServiceMonitor. Flux dry-runs every object
+    # in a Kustomization before applying any, so without the CRD already on
+    # the cluster this one is refused whole — including the
+    # kube-prometheus-stack HelmRelease that would supply the CRD.
+    - name: monitoring-crds
   decryption:
     provider: sops
     secretRef:

--- a/clusters/offsite/monitoring-crds/kustomization.yaml
+++ b/clusters/offsite/monitoring-crds/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/monitoring-crds

--- a/clusters/offsite/monitoring/kube-prometheus.yaml
+++ b/clusters/offsite/monitoring/kube-prometheus.yaml
@@ -28,6 +28,11 @@ spec:
     remediation:
       retries: 5
   values:
+    # The CRDs come from the monitoring-crds Kustomization this one dependsOn,
+    # so they already exist and belong to another release by the time this
+    # installs. Leaving this true makes Helm refuse to adopt them.
+    crds:
+      enabled: false
     defaultRules:
       rules:
         etcd: false


### PR DESCRIPTION
Offsite's `monitoring` Kustomization has applied nothing since **2026-08-01**.
Its last applied revision is `ec237554` (2026-07-31); every reconcile since has
failed the same way:

```text
ServiceMonitor/monitoring/opentelemetry-collector dry-run failed:
no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1"
```

Live state confirms it: offsite has zero `monitoring.coreos.com` CRDs, and
`prom-stack` is absent from its HelmRelease list entirely — only
`metrics-server`, `opentelemetry-collector` and `vector` are installed.

## Why

`clusters/base/monitoring/` holds a raw `ServiceMonitor`, shared by both
clusters. Offsite's `monitoring` Kustomization pulls in that file *and*
`kube-prometheus.yaml`, the HelmRelease that supplies the ServiceMonitor CRD.
Flux server-side dry-runs every object in a Kustomization before applying any
of them, so the ServiceMonitor fails validation, the whole Kustomization is
refused, and the chart that would create the CRD it needs never installs.

Folly is unaffected only because its CRDs predate that ServiceMonitor.

## The fix

A `monitoring-crds` Kustomization that `monitoring` `dependsOn`, installing the
`prometheus-operator-crds` chart. 31.0.0 and kube-prometheus-stack 88.1.x are
both prometheus-operator `v0.93.0`; they must move together.

It carries its own `HelmRepository` under a distinct name rather than reusing
the `prometheus` one. That one is owned by `monitoring` — the Kustomization
that now runs *after* this — so pointing at it would invert the dependency and
deadlock the pair again on a cluster building from nothing.

`kube-prometheus-stack` gets `crds.enabled: false`. It ships its ten CRDs in a
Helm `crds/` **directory**, which Helm installs without ownership metadata and
never upgrades. Taking them from a templates-based chart gives them a single
owner and lets a schema change actually land.

## Folly is deliberately not wired up

Folly has the same latent deadlock — a from-scratch rebuild would wedge
identically — but it cannot take this chart as-is. Its CRDs already exist and
carry no Helm ownership metadata:

```text
labels:            helm.toolkit.fluxcd.io/name: prom-stack
                   helm.toolkit.fluxcd.io/namespace: monitoring
helm annotations:  (none)
```

No `app.kubernetes.io/managed-by: Helm`, no `meta.helm.sh/release-*` — the
`crds/`-directory behaviour above is exactly why. A templates-based chart
cannot adopt them, so wiring folly here would break a cluster that currently
works. Closing that gap needs a one-time ownership stamp on the ten CRDs first,
which is a live mutation and belongs in its own change.

## Verification

- `mise run k8s:render-apps` passes.
- `kubectl kustomize` renders `base/monitoring-crds`, `offsite/monitoring-crds`
  and `offsite/flux-system`; `monitoring` resolves `dependsOn: [storage,
  monitoring-crds]`.
- `helm template prometheus-operator-crds 31.0.0` renders 10 CRDs including
  `servicemonitors.monitoring.coreos.com`, the one the failing dry-run names.
- `offsite/monitoring` still builds with the `crds.enabled` change.

Note that CI would not have caught this: `k8s:render-apps` covers folly
monitoring but not offsite, and either way the failure is a server-side
dry-run against a live cluster, not a render error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X62KGfgV9sHYNVpfK2ADSv