### PR TITLE
fix(monitoring): repair otel collector and offsite loki, both broken since 5d04f956

### DIFF
--- a/clusters/base/monitoring/opentelemetry-collector.yaml
+++ b/clusters/base/monitoring/opentelemetry-collector.yaml
@@ -62,7 +62,16 @@ spec:
       service:
         telemetry:
           metrics:
-            address: 0.0.0.0:8888
+            # Collector 0.156.0 (chart 0.165.0) dropped the flat `address`
+            # form in favour of the OpenTelemetry `readers` shape. This is
+            # self-telemetry only — the data-pipeline prometheus exporter
+            # below (port 8889) is untouched.
+            readers:
+              - pull:
+                  exporter:
+                    prometheus:
+                      host: 0.0.0.0
+                      port: 8888
         pipelines:
           traces:
             receivers: [otlp]
@@ -87,7 +96,9 @@ spec:
         containerPort: 4318
         servicePort: 4318
         protocol: TCP
-      metrics:
+      # Named "monitoring" (not "metrics") to match the port name the
+      # opentelemetry-collector-servicemonitor.yaml endpoint selects.
+      monitoring:
         enabled: true
         containerPort: 8888
         servicePort: 8888

--- a/clusters/offsite/monitoring/loki.yaml
+++ b/clusters/offsite/monitoring/loki.yaml
@@ -58,6 +58,15 @@ spec:
         enabled: true
         size: 10Gi
         storageClassName: local-path
+    # Chart 7.2.0 defaults deploymentMode to SimpleScalable, which defaults
+    # backend/read/write to 3 replicas each. Zero them out so only the
+    # single binary above is running, matching deploymentMode: SingleBinary.
+    backend:
+      replicas: 0
+    read:
+      replicas: 0
+    write:
+      replicas: 0
     minio:
       enabled: false
     monitoring:


### PR DESCRIPTION
## Summary

Two live monitoring outages, both introduced by commit `5d04f956`
("feat(monitoring): add Tempo + OTel otlp/prometheus exporters, shared
dashboards") and live since 2026-08-01. They stayed invisible because
offsite's monitoring Kustomization was separately wedged until it was
unblocked, at which point offsite's otel-collector pod started
crash-looping and exposed the underlying config bug for both clusters.

### Fault 1 — OpenTelemetry Collector self-telemetry config rejected by the binary

`clusters/base/monitoring/opentelemetry-collector.yaml` is shared by both
clusters. It pins chart `opentelemetry-collector` 0.165.0 (collector
appVersion 0.156.0). `5d04f956` set:

```yaml
service:
  telemetry:
    metrics:
      address: 0.0.0.0:8888
```

Collector 0.156.0's confmap migration removed the flat `address` key from
self-telemetry metrics config in favour of the `readers`/`pull`/`prometheus`
form. Every pod on this config crashes at startup:

```
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
'service.telemetry.metrics' decoding failed due to the following error(s):
'migration.MetricsConfigV030' has invalid keys: address
```

Folly has had **zero** otel-collector pods since the introducing commit's
Helm upgrade failed and could not self-remediate ("missing target release
for rollback"). Offsite's newer pod was crash-looping while a 4-day-old pod
kept serving traffic — which is why this went unnoticed.

Fixed by migrating to the shape the chart's own 0.165.0 defaults already
use:

```yaml
service:
  telemetry:
    metrics:
      readers:
        - pull:
            exporter:
              prometheus:
                host: 0.0.0.0
                port: 8888
```

The data-pipeline `exporters.prometheus` block (port 8889) is untouched —
that's a separate pipeline from self-telemetry.

While checking the `ports` section against
`opentelemetry-collector-servicemonitor.yaml` (which selects endpoint
`port: monitoring`), found that `5d04f956` added both that ServiceMonitor
and the `ports.metrics` entry (8888) in the same change, but never actually
named a port `monitoring` — so the ServiceMonitor has matched nothing since
it was introduced, a second silent hole in the same self-telemetry pipeline.
Renamed `ports.metrics` to `ports.monitoring` (same 8888 container/service
port) so the ServiceMonitor's endpoint selector now resolves.

### Fault 2 — Loki chart validation failure on offsite

`clusters/offsite/monitoring/loki.yaml` sets `deploymentMode: SingleBinary`
and `singleBinary.replicas: 1`, matching offsite's small two-node,
single-binary intent (same as folly's Loki). But chart 7.2.0 defaults
`deploymentMode` to `SimpleScalable`, which defaults `backend`/`read`/`write`
replicas to 3 each — and `5d04f956` never zeroed those out for offsite. The
chart's own `validate.yaml` refuses to install:

```
execution error at (loki/templates/validate.yaml:31:4): You have more than zero replicas configured for
both the single binary and simple scalable targets. If this was intentional change the deploymentMode
to the transitional 'SingleBinary<->SimpleScalable' mode
```

Zeroed `backend`/`read`/`write` replicas, matching folly's established
single-binary pattern. (Folly's chart source/version differs and defaults
its other distributed-mode replicas to 0 already in this chart version, so
only these three needed the explicit override here — verified against the
chart 7.2.0 defaults, not copied wholesale from folly.)

## Verification

- `mise run k8s:render-apps` passes.
- `kubectl kustomize clusters/base/monitoring` and
  `kubectl kustomize clusters/offsite/monitoring` both render cleanly.
- `helm template` against the real charts (`open-telemetry/opentelemetry-collector`
  @ 0.165.0, `grafana/loki` @ 7.2.0) confirms both HelmReleases render, and that
  Loki's `validate.yaml` assertion no longer trips post-fix (confirmed it *does*
  trip pre-fix, reproducing the reported error exactly, as a negative control).
- For the collector, rendering alone doesn't prove the binary accepts the
  config — Helm treats `values.config` as a freeform map, so a schema-invalid
  config renders without complaint either way. To verify for real: extracted
  the rendered ConfigMap's `data.relay` (the actual collector config) and ran
  it through `otelcol-contrib validate --config=file:...` (fetched via
  `nix shell nixpkgs#opentelemetry-collector-contrib`, version 0.151.0 — 5
  minor versions off the chart's pinned 0.156.0, closest available from the
  nixpkgs binary cache in this sandbox; the `telemetry.metrics.readers` shape
  has been stable across that range).
  - Pre-fix rendered config: `otelcol-contrib validate` fails with the exact
    reported error (`'migration.MetricsConfigV030' has invalid keys: address`) —
    confirms the merged config (chart defaults deep-merge with our override,
    so the old config actually carried both `address` and `readers` under
    `telemetry.metrics`) is what the binary rejects.
  - Post-fix rendered config: `otelcol-contrib validate` exits 0, no errors.

Confidence: high that the collector config is accepted by the binary — this
is a binary-level `validate` run against the exact rendered output, not just
a Helm render, with both a positive and a negative control. The one gap is
the 0.151.0 vs 0.156.0 version delta (no closer version was available from
the nixpkgs cache in this sandbox); the confmap migration this fix targets
was already in place well before 0.151.0.

## Test plan

- [ ] After merge, watch `flux --context folly get helmreleases -A` and
      `flux --context offsite get helmreleases -A` for `opentelemetry-collector`
      and (offsite) `loki` to go `Ready`.
- [ ] Confirm otel-collector pods are running (not crash-looping) on both
      clusters.
- [ ] Confirm the `opentelemetry-collector` ServiceMonitor has active targets
      in each cluster's Prometheus.
- [ ] Confirm offsite's Loki StatefulSet comes up and Grafana can query it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X62KGfgV9sHYNVpfK2ADSv
