### PR TITLE
fix(monitoring): repair Tempo storage config on both clusters

### DIFF
--- a/clusters/folly/monitoring/tempo.yaml
+++ b/clusters/folly/monitoring/tempo.yaml
@@ -36,10 +36,9 @@ spec:
               endpoint: 0.0.0.0:4317
             http:
               endpoint: 0.0.0.0:4318
-      storage:
-        type: filesystem
-      traces_storage:
-        path: /var/tempo/traces
+      # storage.trace defaults to backend: local, local.path: /var/tempo/traces,
+      # wal.path: /var/tempo/wal — exactly the local single-binary intent here,
+      # both under the persistence PVC's /var/tempo mount. No override needed.
     service:
       type: ClusterIP
     persistence:

--- a/clusters/offsite/monitoring/tempo.yaml
+++ b/clusters/offsite/monitoring/tempo.yaml
@@ -37,10 +37,9 @@ spec:
               endpoint: 0.0.0.0:4317
             http:
               endpoint: 0.0.0.0:4318
-      storage:
-        type: filesystem
-      traces_storage:
-        path: /var/tempo/traces
+      # storage.trace defaults to backend: local, local.path: /var/tempo/traces,
+      # wal.path: /var/tempo/wal — exactly the local single-binary intent here,
+      # both under the persistence PVC's /var/tempo mount. No override needed.
     service:
       type: ClusterIP
     persistence:


### PR DESCRIPTION
## Summary

A third live monitoring outage from the same source as the otel-collector and
offsite-Loki fixes merged just before this PR: commit `5d04f956`
("feat(monitoring): add Tempo + OTel otlp/prometheus exporters, shared
dashboards"). Both clusters' Tempo HelmReleases have never started.

`clusters/folly/monitoring/tempo.yaml` and `clusters/offsite/monitoring/tempo.yaml`
carry identical values (chart `tempo` 1.24.4, appVersion 2.9.0):

```yaml
tempo:
  storage:
    type: filesystem
  traces_storage:
    path: /var/tempo/traces
```

Neither key exists in Tempo's `storage.Config` schema. The chart's `config`
template passes `.Values.tempo.storage` straight through to the binary's
`storage:` block via `toYaml`, and Helm's default value merge combines our
override with the chart's own `storage.trace` defaults rather than replacing
them — so the rendered config carries both the valid `trace` block and the
invalid `type` key side by side. The binary rejects it at startup, live on
both clusters right now:

```
failed parsing config: failed to parse configFile /conf/tempo.yaml: yaml: unmarshal errors:
  line 38: field type not found in type storage.Config
```

`traces_storage` isn't consumed by the main config template at all — that key
only exists under `tempo.metricsGenerator.traces_storage`, an unrelated
metrics-generator WAL path — so it was always dead config, not itself the
cause of the crash but noise regardless.

Both HelmReleases report `Helm install failed ... StatefulSet/monitoring/tempo
status: 'Failed'`, and both are additionally Stalled with "missing target
release for rollback: cannot remediate failed release" — the first install
never succeeded, so Flux has nothing to roll back to. Neither cluster has ever
had a running Tempo, which is why the otel-collector's `otlp/tempo` exporter
(clusters/base/monitoring/opentelemetry-collector.yaml) has had nowhere to
send traces since 5d04f956 landed.

## Fix

Deleted both invalid blocks rather than restating the equivalent config. The
chart's defaults are already exactly this deployment's intent:

```yaml
storage:
  trace:
    backend: local
    local:
      path: /var/tempo/traces
    wal:
      path: /var/tempo/wal
```

Verified against the rendered ConfigMap (not assumed) — see below. Both
default paths (`/var/tempo/traces`, `/var/tempo/wal`) sit under the chart's
single PVC mount at `/var/tempo`, which is exactly what `persistence`
(10Gi, `local-path`) in this file already provisions — no mismatch between
where the config writes and what's backed by the PV.

## Verification

- `mise run k8s:render-apps` passes; `kubectl kustomize` on both clusters'
  `monitoring/` overlays renders clean.
- `helm template` against `grafana/tempo` @ 1.24.4 for both pre-fix and
  post-fix values, then extracted the rendered ConfigMap's actual
  `tempo.yaml` config (not just confirmed it renders — Helm treats
  `values.tempo.storage` as a freeform map, so a schema-invalid config
  renders without complaint either way):
  - Pre-fix rendered config: `storage:` carries both `trace: {...}` (chart
    default) and `type: filesystem` (our invalid override) side by side —
    confirms the deep-merge theory above.
  - Post-fix rendered config: only `storage.trace` remains, matching the
    chart defaults exactly.
- Verified at the **binary level**, not just Helm-render level: fetched
  `tempo` via `nix shell nixpkgs#tempo` (2.10.5 — the closest available from
  the nixpkgs binary cache in this sandbox; the chart pins appVersion 2.9.0,
  one minor version off) and ran `tempo -config.file=<rendered> -config.verify=true`
  against both extracted configs as a positive/negative control pair:
  - Pre-fix config: exits 1, reproducing the exact reported error at the same
    line number (`line 38: field type not found in type storage.Config`).
  - Post-fix config: exits 0, no output.

Confidence: high. This is a binary-level config-verify run against the exact
rendered output, with both a positive and a negative control, on both
clusters' files (which are byte-identical, confirmed via diff before editing).
The one gap is the 2.10.5 vs 2.9.0 version delta — no exact-version binary was
available from the nixpkgs cache in this sandbox and Docker isn't available
here either; the `storage.trace` schema and `-config.verify` behavior are
unlikely to have changed across that range.

## Test plan

- [ ] After merge, watch `flux --context folly get helmreleases -A` and
      `flux --context offsite get helmreleases -A` for `tempo` to go `Ready`.
- [ ] Confirm the Tempo StatefulSet comes up (not `Failed`) on both clusters.
- [ ] Confirm the otel-collector's `otlp/tempo` exporter successfully delivers
      traces (no connection errors in collector logs).
- [ ] Confirm folly's Tempo datasource in Grafana (uid: `tempo`) can query traces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X62KGfgV9sHYNVpfK2ADSv
