### PR TITLE
feat(spindrift): notice a Cloud Run schedule that stopped firing

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -473,10 +473,27 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     if (read === null) return null;
 
     const status = cloudRunStatus(read);
+    // A Job's placement has a second half nothing else reads. Asked on every
+    // job rather than only scheduled ones, because the whole question is
+    // whether the schedule is *absent*, and only core knows whether that is the
+    // honest answer — an adapter that skipped the read for jobs it believed
+    // unscheduled could only ever believe what it just read.
+    //
+    // ponytail: one extra Cloud Scheduler GET per job per drift pass
+    // (`DEFAULT_DRIFT_INTERVAL_MS`, five minutes). Carry the desired cadence
+    // across the seam instead if a vessel ever holds enough jobs to make that a
+    // real cost.
+    const schedule =
+      placed.collection === JOBS
+        ? await this.observeSchedule(connection, placed.id)
+        : undefined;
     return {
       ref,
       phase: status.phase,
       artifactDigest: servingDigest(read),
+      // Omitted rather than `undefined`: absent is a third state on this field
+      // and a key holding `undefined` is not it.
+      ...(schedule === undefined ? {} : { schedule }),
       ...(status.reason === undefined ? {} : { reason: status.reason }),
       ...(status.detail === undefined ? {} : { detail: status.detail }),
     };
@@ -945,6 +962,39 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       detail: `job ${id} could not be put on the schedule "${schedule}": ${failure.detail}`,
       debug: failure.debug,
     };
+  }
+
+  /**
+   * What is firing this job, or `null` where nothing is.
+   *
+   * **A read that cannot fail into a lie.** `null` here is what makes core
+   * report a stopped schedule, so every way of not knowing has to be `null`'s
+   * opposite — an unreachable API, an expired token, a `403` — or a five
+   * minute uplink blip would announce that a cadence stopped. Only the two
+   * answers that *prove* absence produce `null`: a `404`, and the service
+   * being switched off in this project, which is `unschedule`'s reasoning in
+   * the other direction.
+   */
+  private async observeSchedule(
+    connection: CloudRunAdapterConnection,
+    id: string,
+  ): Promise<string | null | undefined> {
+    const read = await this.scheduler().json<{ schedule?: unknown }>({
+      method: 'GET',
+      path: `/v1/${parentOf(connection)}/${JOBS}/${encodeURIComponent(id)}`,
+    });
+    if (read.ok) {
+      return typeof read.value?.schedule === 'string'
+        ? read.value.schedule
+        : null;
+    }
+    if (
+      read.kind === 'status' &&
+      (read.status === 404 || read.reason === SERVICE_DISABLED)
+    ) {
+      return null;
+    }
+    return undefined;
   }
 
   /** Take this job off its schedule, whether or not it was on one. */

--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -261,6 +261,30 @@ export interface ObservedState {
   artifactDigest: string;
   reason?: FailureReason;
   detail?: string;
+  /**
+   * The cadence something is actually firing this placement on (§6, §7).
+   *
+   * A placement is not always one object. On `cloudrun` a scheduled job is a
+   * Job *and* a Cloud Scheduler job in front of it, and the second one can be
+   * deleted out of band while the first still reads back perfectly — so a
+   * digest is not the whole answer to "is what was asked for still there".
+   *
+   * Three states, and the third is the reason this is optional rather than
+   * `string | null`:
+   *
+   * - a **string** — the expression the backend holds.
+   * - **`null`** — the backend was asked, and nothing fires it.
+   * - **absent** — there is no separate firing half to be absent. Every
+   *   service, and every Kubernetes placement: a CronJob lives inside the
+   *   release Flux reconciles, so it is already covered by the digest read,
+   *   and reporting `null` for it would mark every service drifted forever.
+   *
+   * **Reported, never judged.** Whether `null` is the honest state or a
+   * schedule somebody deleted is a comparison against the Component's
+   * declaration, which only core holds — the same rule `inspect` follows, so
+   * that two adapters cannot draw the conclusion differently.
+   */
+  schedule?: string | null;
 }
 
 /** The Component-following runtime pipe (§17), distinct from attempt events. */

--- a/apps/spindrift/src/domain/diagnosis.ts
+++ b/apps/spindrift/src/domain/diagnosis.ts
@@ -114,9 +114,42 @@ export function hasDrifted(args: {
    * on. They agreed when the attempt finished and are free to diverge after.
    */
   readonly observedPhase?: DeployPhase;
+  /** The cadence the Component declares, or `null` when it declares none. */
+  readonly desiredSchedule?: string | null;
+  /** `ObservedState.schedule`, forwarded unjudged. */
+  readonly observedSchedule?: string | null;
 }): boolean {
   if (args.phase !== 'LIVE') return false;
   if (args.observedDigest === null) return true;
   if (args.observedPhase === 'FAILED') return true;
+  if (scheduleDrift(args) !== null) return true;
   return args.observedDigest !== args.desiredDigest;
+}
+
+/**
+ * What the cadence disagrees about, in a sentence, or `null` when it does not.
+ *
+ * **The third way a placement can diverge**, after the digest and the delivery
+ * object's own phase. A Cloud Run Job whose Cloud Scheduler job was deleted
+ * reads back perfectly: right digest, `LIVE`, no cadence, and nothing fires it
+ * again. §6 wants that surfaced, so it is drift like any other and is corrected
+ * by the same re-converge a person presses.
+ *
+ * Absent `observedSchedule` is the backend saying it has no separate firing
+ * half — see `ObservedState.schedule` — so it never disagrees, which is what
+ * keeps every service and every Kubernetes placement out of this.
+ */
+export function scheduleDrift(args: {
+  readonly desiredSchedule?: string | null;
+  readonly observedSchedule?: string | null;
+}): string | null {
+  if (args.observedSchedule === undefined) return null;
+  const desired = args.desiredSchedule ?? null;
+  if (desired === args.observedSchedule) return null;
+  if (args.observedSchedule === null) {
+    return `nothing is firing this job — it declares the schedule "${desired}", and the platform holds none`;
+  }
+  return desired === null
+    ? `this job declares no schedule, and the platform is still firing it on "${args.observedSchedule}"`
+    : `this job declares the schedule "${desired}", and the platform is firing it on "${args.observedSchedule}"`;
 }

--- a/apps/spindrift/src/reconciler/deploy-loop.ts
+++ b/apps/spindrift/src/reconciler/deploy-loop.ts
@@ -66,6 +66,7 @@ import {
   diagnosisOf,
   failureColumns,
   hasDrifted,
+  scheduleDrift,
 } from '../domain/diagnosis.ts';
 import { displayUrl, hostnameFor } from '../domain/naming.ts';
 import {
@@ -572,10 +573,22 @@ async function observeOne(
   }
   const observed = state?.artifactDigest ?? null;
 
+  // The cadence half of the same comparison, where the backend reports one.
+  // Read off the Component rather than the Deploy: `schedule` is what the
+  // developer declares now, and a cadence they changed since this Deploy is a
+  // difference the platform is meant to be asked to converge on, not one this
+  // pass should paper over.
+  const scheduleArgs = {
+    desiredSchedule: subject.component.schedule,
+    ...(state?.schedule === undefined
+      ? {}
+      : { observedSchedule: state.schedule }),
+  };
   const drifted = hasDrifted({
     phase: deploy.phase,
     desiredDigest: subject.build.artifactDigest ?? '',
     observedDigest: observed,
+    ...scheduleArgs,
     ...(state === null ? {} : { observedPhase: state.phase }),
   });
 
@@ -583,8 +596,16 @@ async function observeOne(
   // argument for storing a diagnosis applies here for the same cause: a
   // Helm error naming the value that no longer renders is not recoverable
   // from anywhere once the object is reconciled again.
-  const driftDetail =
-    drifted && state?.phase === 'FAILED' ? (state.detail ?? null) : null;
+  //
+  // A stopped schedule gets core's sentence rather than the platform's,
+  // because the platform said nothing — the finding *is* the absence, and
+  // "nothing fires this any more" is only a sentence somebody holding the
+  // declaration can write.
+  const driftDetail = !drifted
+    ? null
+    : state?.phase === 'FAILED'
+      ? (state.detail ?? null)
+      : scheduleDrift(scheduleArgs);
 
   // §6 wants drift to be "a visible state", and visible means a row: the UI
   // reads rows, so a finding that lived only for the length of this pass

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -1148,6 +1148,90 @@ describe('§7: a schedule on this backend is a second service in front of the Jo
       adapter.destroy(scheduling(), verdict.ref as string),
     ).rejects.toThrow('could not be removed');
   });
+
+  // --- §6: what `observe` can say about the half in front of the Job --------
+
+  test('observe reports the cadence the platform is actually holding', async () => {
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(scheduling(), nightly()));
+
+    const observed = await adapter.observe(scheduling(), verdict.ref as string);
+    expect(observed?.schedule).toBe('0 3 * * *');
+  });
+
+  test('a scheduler job deleted out of band reads back as no cadence', async () => {
+    // The whole ticket, in three lines. The Job is untouched — right digest,
+    // `LIVE`, nothing to see — and nothing will ever fire it again. A pass
+    // that read only the Cloud Run resource calls this converged.
+    const { api, adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(scheduling(), nightly()));
+    expect(await api.tick()).toHaveLength(1);
+
+    api.deschedule('shop-nightly');
+    expect(await api.tick()).toEqual([]);
+
+    const observed = await adapter.observe(scheduling(), verdict.ref as string);
+    expect(observed?.phase).toBe('LIVE');
+    expect(observed?.artifactDigest).toBe('sha256:abc');
+    expect(observed?.schedule).toBeNull();
+  });
+
+  test('a job that declares no schedule reads back the same way', async () => {
+    // Deliberately indistinguishable from the test above: the API answers one
+    // `404` for both, and an adapter that guessed which was which would have to
+    // guess from state it does not hold. §6 puts the judgement in core, which
+    // has the declaration to compare against.
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(
+      adapter.apply(scheduling(), nightly({ schedule: undefined })),
+    );
+    expect(
+      (await adapter.observe(scheduling(), verdict.ref as string))?.schedule,
+    ).toBeNull();
+  });
+
+  test('a service reports no cadence at all, rather than an absent one', async () => {
+    // Absent, not `null`. A Service has no firing half, so `null` would say
+    // "something that should be firing this is gone" about every website in
+    // the installation, forever.
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(adapter.apply(target(), desired()));
+
+    const observed = await adapter.observe(target(), verdict.ref as string);
+    expect(observed?.phase).toBe('LIVE');
+    expect('schedule' in (observed ?? {})).toBe(false);
+  });
+
+  test('a refusal that does not prove absence is not reported as absence', async () => {
+    // `null` is what makes core announce that a cadence stopped, so only the
+    // two answers that *prove* nothing is there may produce it. A `403`, an
+    // expired token, an unreachable API: every one of those is "I could not
+    // tell", and reporting it as absence would turn a blip into a false alarm
+    // about a schedule that is still firing perfectly well.
+    const api = new FakeCloudRun();
+    const denied = permissionDenied();
+    const adapter = new CloudRunDeployAdapter({
+      token: api.token,
+      schedulerEndpoint: api.schedulerEndpoint,
+      pollIntervalMs: 1,
+      sleep: async () => {},
+      fetch: async (request) => {
+        const url = new URL(request.url);
+        return url.origin === new URL(api.schedulerEndpoint).origin &&
+          request.method === 'GET'
+          ? new Response(JSON.stringify(denied.body), {
+              status: denied.status,
+              headers: { 'content-type': 'application/json' },
+            })
+          : api.fetch(request);
+      },
+    });
+    const { verdict } = await drain(adapter.apply(scheduling(), nightly()));
+
+    const observed = await adapter.observe(scheduling(), verdict.ref as string);
+    expect(observed?.phase).toBe('LIVE');
+    expect('schedule' in (observed ?? {})).toBe(false);
+  });
 });
 
 describe('the ref an adapter hands back names its own collection', () => {

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -456,6 +456,11 @@ export class FakeCloudRun {
     return this.schedules.get(`${this.parent()}/jobs/${id}`);
   }
 
+  /** Somebody deleted the schedule out of band and told nobody. */
+  deschedule(id: string): void {
+    this.schedules.delete(`${this.parent()}/jobs/${id}`);
+  }
+
   /** Every scheduler job in the project, by name — nothing should be orphaned. */
   scheduled(): string[] {
     return [...this.schedules.keys()].sort();
@@ -713,6 +718,16 @@ export class FakeCloudRun {
       }
       this.schedules.delete(addressed);
       return json(200, {});
+    }
+    // What `observe` asks, and the only read this API serves. A job that was
+    // never scheduled and one whose scheduler job was deleted answer the same
+    // `404` here — which is the point: the API cannot tell them apart either.
+    if (method === 'GET') {
+      const held =
+        addressed === null ? undefined : this.schedules.get(addressed);
+      return held === undefined
+        ? json(404, notFound())
+        : json(200, { ...held, state: 'ENABLED' });
     }
     // `patch` addresses the job and `create` addresses its parent — the only
     // difference between the two, other than which of them refuses.

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -74,6 +74,9 @@ async function pendingDeploy(
     auth?: 'none' | 'proxy';
     /** The backend this lands on, which decides who mints the name (§9). */
     adapter?: 'kubernetes' | 'cloudrun';
+    kind?: 'service' | 'job';
+    /** The cadence the Component declares — the desired half of §6's drift. */
+    schedule?: string;
   } = {},
 ) {
   const db = database().db;
@@ -86,10 +89,11 @@ async function pendingDeploy(
     .values({
       appId: app!.id,
       name: 'web',
-      kind: 'service',
+      kind: options.kind ?? 'service',
       expose: true,
       reach: options.reach ?? 'private',
       auth: options.auth ?? 'proxy',
+      ...(options.schedule === undefined ? {} : { schedule: options.schedule }),
     })
     .returning();
   const [target] = await db
@@ -671,6 +675,89 @@ describe('drift is surfaced, never corrected (§6)', () => {
     const row = await deployRow(deploy.id);
     expect(row?.driftedAt).toBeNull();
     expect(row?.driftDetail).toBeNull();
+  });
+
+  test('a schedule that stopped firing is drift, digest and phase or not', async () => {
+    const { deploy } = await pendingDeploy({
+      kind: 'job',
+      schedule: '0 3 * * *',
+    });
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'jobs/nightly' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    // Everything the old pass looked at still agrees: the Job is there, it is
+    // `LIVE`, and it carries the digest that was asked for. What is gone is the
+    // only thing that ever ran it.
+    adapter.place('jobs/nightly', {
+      ref: 'jobs/nightly',
+      phase: 'LIVE',
+      artifactDigest: DIGEST,
+      schedule: null,
+    });
+
+    const pass = await runDeployPass(context(adapter));
+    expect(
+      pass.drift.find((entry) => entry.deployId === deploy.id)?.drifted,
+    ).toBe(true);
+
+    // And it says which of the two halves disagreed. A bare flag on a row whose
+    // digest matches is the operator reading "drifted" beside three fields that
+    // all look right.
+    const row = await deployRow(deploy.id);
+    expect(row?.driftedAt).toEqual(FROZEN);
+    expect(row?.driftDetail).toContain('0 3 * * *');
+    expect(row?.driftDetail).toContain('nothing is firing this job');
+
+    // Surfaced, not corrected — §6 holds here exactly as it does for a digest.
+    expect(adapter.applied).toHaveLength(1);
+  });
+
+  test('a job nobody scheduled is not drifted for having no schedule', async () => {
+    // The honest state for most jobs, and the one a naive fix marks drifted
+    // forever: nothing fires it because nothing was ever asked to.
+    const { deploy } = await pendingDeploy({ kind: 'job' });
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'jobs/nightly' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    adapter.place('jobs/nightly', {
+      ref: 'jobs/nightly',
+      phase: 'LIVE',
+      artifactDigest: DIGEST,
+      schedule: null,
+    });
+
+    const pass = await runDeployPass(context(adapter));
+    expect(
+      pass.drift.find((entry) => entry.deployId === deploy.id)?.drifted,
+    ).toBe(false);
+    expect((await deployRow(deploy.id))?.driftedAt).toBeNull();
+  });
+
+  test('a backend that reports no cadence is never drifted for one', async () => {
+    // Every service, and every Kubernetes placement. The field is absent rather
+    // than `null`, and absent has to mean "not applicable" — the alternative is
+    // every website in the installation permanently drifted.
+    const { deploy } = await pendingDeploy();
+    const adapter = new FakeDeployAdapter({
+      script: [{ verdict: { phase: 'LIVE', ref: 'hr/apps/web' } }],
+    });
+    await runDeployPass(context(adapter));
+
+    adapter.place('hr/apps/web', {
+      ref: 'hr/apps/web',
+      phase: 'LIVE',
+      artifactDigest: DIGEST,
+    });
+
+    const pass = await runDeployPass(context(adapter));
+    expect(
+      pass.drift.find((entry) => entry.deployId === deploy.id)?.drifted,
+    ).toBe(false);
+    expect((await deployRow(deploy.id))?.driftedAt).toBeNull();
   });
 
   test('drift fixed out of band stops being reported, with no dismissal', async () => {


### PR DESCRIPTION
A Cloud Run Job and the Cloud Scheduler job in front of it are one placement in two resources. `observe` read only the first, so a scheduler job deleted out of band left the Component `LIVE`, undrifted, with nothing firing it and nothing anywhere saying so.

## The contract answer

`ObservedState.schedule` — three states, and the third is why it is optional rather than `string | null`:

| value | means |
| --- | --- |
| a string | the expression the backend holds |
| `null` | the backend was asked, and nothing fires it |
| absent | there is no separate firing half to be absent |

Absent is every service and every Kubernetes placement, whose CronJob is inside the release Flux reconciles. Reporting `null` there would mark every website in the installation permanently drifted.

The judgement stays in core (`scheduleDrift`, beside the digest and phase comparisons), which also writes the sentence — the platform said nothing, the finding *is* the absence. The Cloud Scheduler API answers one `404` both for a schedule somebody deleted and for a job that never had one, which is precisely why an adapter cannot decide this.

`null` is load-bearing, so the read is paranoid: only a `404` and `SERVICE_DISABLED` produce it. A `403`, an expired token, an unreachable API report absent — a five minute uplink blip must not announce that a cadence stopped.

## Validation

```
bun test        1715 pass, 0 fail (128 files)
bun run typecheck   clean
bun run lint        clean
```

Five adapter tests and three core tests. The pair worth naming asserts the **same** observation for a deleted schedule and for a job that declares none — deliberately, because that is the whole reason the judgement is core's.

Revert-and-fail proof — dropping the `scheduleDrift` call from `hasDrifted`:

```
(fail) a schedule that stopped firing is drift, digest and phase or not
  expect(pass.drift.find(…)?.drifted).toBe(true)  →  Received: undefined
```

## Risks

- One Cloud Scheduler `GET` per job per drift pass (five minutes), including jobs that declare no schedule — the whole question is whether the schedule is absent, so an adapter that skipped the read for jobs it *believed* unscheduled could only believe what it just read. Marked with its upgrade path. Services pay nothing.
- Proven against the API fake and the contract fake, not against Google. The live observation needs a `kind: job` Component on a `cloudrun` Target with a schedule, which nothing has yet.