### PR TITLE
feat(cloudflare): import and onboard embarrassing.ca

### DIFF
--- a/clusters/base/networking/external-dns/helm-release.yaml
+++ b/clusters/base/networking/external-dns/helm-release.yaml
@@ -51,6 +51,7 @@ spec:
       - "${SECRET_DOMAIN}"
       - "${GATEWAY_ZONE}"
       - "${SPINDRIFT_DOMAIN}"
+      - embarrassing.ca
     resources:
       requests:
         memory: 100Mi

--- a/clusters/folly/networking/cert-manager/issuers/letsencrypt-production.yaml
+++ b/clusters/folly/networking/cert-manager/issuers/letsencrypt-production.yaml
@@ -20,3 +20,4 @@ spec:
             - ${SECRET_DOMAIN}
             - ${GATEWAY_ZONE}
             - ${SPINDRIFT_DOMAIN}
+            - embarrassing.ca

--- a/clusters/folly/networking/cert-manager/issuers/letsencrypt-staging.yaml
+++ b/clusters/folly/networking/cert-manager/issuers/letsencrypt-staging.yaml
@@ -18,3 +18,4 @@ spec:
         selector:
           dnsZones:
             - ${SECRET_DOMAIN}
+            - embarrassing.ca

--- a/clusters/offsite/networking/cert-manager/issuers/letsencrypt-production.yaml
+++ b/clusters/offsite/networking/cert-manager/issuers/letsencrypt-production.yaml
@@ -20,3 +20,4 @@ spec:
             - ${CLOUDFLARE_ZONE}
             - ${GATEWAY_ZONE}
             - ${SPINDRIFT_DOMAIN}
+            - embarrassing.ca

--- a/clusters/offsite/networking/cert-manager/issuers/letsencrypt-staging.yaml
+++ b/clusters/offsite/networking/cert-manager/issuers/letsencrypt-staging.yaml
@@ -18,3 +18,4 @@ spec:
         selector:
           dnsZones:
             - ${SECRET_DOMAIN}
+            - embarrassing.ca

--- a/nix/services/coredns-sinkhole.nix
+++ b/nix/services/coredns-sinkhole.nix
@@ -42,7 +42,7 @@ in
           fallthrough
         }
         cache {
-          disable denial ${fleet.dnsZone} lolwtf.dev pulsifer.ca
+          disable denial ${fleet.dnsZone} lolwtf.dev pulsifer.ca embarrassing.ca
         }
         forward . ${lib.concatStringsSep " " (map (upstream: "tls://${upstream}") upstreams)} {
           policy random

--- a/terraform/network/cloudflare/embarrassing.ca.tf
+++ b/terraform/network/cloudflare/embarrassing.ca.tf
@@ -1,0 +1,41 @@
+locals {
+  embarrassing_ca_zone_settings = {
+    always_online            = "on"
+    always_use_https         = "on"
+    brotli                   = "on"
+    http3                    = "on"
+    min_tls_version          = "1.2"
+    opportunistic_encryption = "on"
+    ssl                      = "full"
+    tls_1_3                  = "on"
+    websockets               = "on"
+  }
+}
+
+data "cloudflare_zones" "embarrassing_ca" {
+  name = "embarrassing.ca"
+}
+
+import {
+  to = cloudflare_zone.embarrassing_ca
+  id = data.cloudflare_zones.embarrassing_ca.result[0].id
+}
+
+resource "cloudflare_zone" "embarrassing_ca" {
+  account = {
+    id = local.fml_account_id
+  }
+  name = "embarrassing.ca"
+}
+
+resource "cloudflare_zone_dnssec" "embarrassing_ca_dnssec" {
+  zone_id = cloudflare_zone.embarrassing_ca.id
+  status  = "active"
+}
+
+resource "cloudflare_zone_setting" "embarrassing_ca" {
+  for_each   = local.embarrassing_ca_zone_settings
+  zone_id    = cloudflare_zone.embarrassing_ca.id
+  setting_id = each.key
+  value      = each.value
+}


### PR DESCRIPTION
## Summary
Imports and onboards `embarrassing.ca` into Cloudflare OpenTofu configuration, cert-manager ClusterIssuers, external-dns, and CoreDNS sinkhole.

## Changes
- `feat(cloudflare): import and onboard embarrassing.ca`

## Test Plan
- [x] Run `tofu validate terraform/network/cloudflare` (valid configuration)
- [x] Run `mise run k8s:render-apps` (folly and offsite app overlays & spindrift in-repo charts render clean)
- [x] Run `mise run docs:check` (docs contract passes)