### PR TITLE
fix(wsl): skip binfmt setup when unavailable

### DIFF
--- a/nix/images/wsl.nix
+++ b/nix/images/wsl.nix
@@ -23,6 +23,10 @@
   # sdImage outputs on this x86_64 host instead of needing a native aarch64
   # builder or a remote builder.
   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+  # WSL sometimes exposes binfmt_misc read-only. Skip the upstream unit in
+  # that case so a system switch succeeds; it starts normally when WSL makes
+  # the filesystem writable again.
+  systemd.services.systemd-binfmt.unitConfig.ConditionPathIsReadWrite = "/proc/sys/fs/binfmt_misc";
   # NixOS's binfmt module takes over the whole binfmt_misc table on
   # activation; without this, adding the aarch64 registration above wipes
   # out WSL2's own .exe interop handler and breaks running Windows binaries


### PR DESCRIPTION
## Summary
Skip the binfmt setup unit when WSL exposes binfmt_misc as read-only, preventing a failed system switch.

## Changes
- Add a writability condition to systemd-binfmt on the WSL image.

## Test Plan
- [x] `mise run nix:fmt`
- [x] `nix build .#nixosConfigurations.wsl.config.system.build.toplevel --no-link`
