### PR TITLE
feat(spindrift): let an App opt in to deploying on push

### DIFF
--- a/apps/spindrift/src/commands/apps/auto-deploy.ts
+++ b/apps/spindrift/src/commands/apps/auto-deploy.ts
@@ -1,0 +1,112 @@
+/**
+ * `setAppAutoDeploy` — an App opts in to deploying on push (§15).
+ *
+ * `apps.autoDeploy` shipped with the webhook and the dispatcher
+ * (`src/reconciler/auto-deploy.ts`) and with nothing that could ever write it:
+ * the column defaults `false`, `createApp` does not take it, and no command
+ * set it. So the feature was complete and permanently off. This is the switch.
+ *
+ * **A toggle, not a deploy.** Unlike `setComponentReach` and
+ * `setComponentSchedule` — which change what a *release* should look like and
+ * therefore name a `pendingRelease` — this changes nothing about what is
+ * running. It changes what happens the **next** time a commit is adopted, and
+ * nothing about the current release is stale for having been deployed while it
+ * was off. So there is no pending anything to report, and turning it on does
+ * not deploy: §15's dispatcher fires on an adopted commit, and the opt-in is
+ * not itself a commit.
+ *
+ * **An archive App is refused.** `dispatchAutoDeploys` reads the scopes of
+ * repository reconciliation passes, so an App with no repository is not
+ * something the dispatcher can ever reach — the switch would sit `true` and
+ * never fire. §3's rule about refusing where the developer is standing applies
+ * exactly: a toggle that silently does nothing forever is worse than one that
+ * says why.
+ *
+ * **A repo App whose repository is not connected yet is allowed.** That one is
+ * temporary — §15 makes connecting a repository something an operator turns on
+ * afterwards — so the switch becomes live the moment the connection lands,
+ * which is a different thing from never. The result names the repository, or
+ * its absence, so the answer says what will actually trigger it.
+ */
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+import { apps, repositories } from '../../db/schema.ts';
+import { type Command, failed, ok } from '../types.ts';
+
+export const setAppAutoDeployInput = z
+  .object({
+    appId: z.uuid(),
+    /**
+     * Required rather than a toggle-what-is-there, for the same reason
+     * `setComponentSchedule.schedule` is: a caller that sent the wrong state
+     * should write the wrong state, not flip whatever it found. Two clients
+     * racing a toggle both succeed and the App ends up wherever the last one
+     * looked; two clients racing a set both succeed and agree.
+     */
+    autoDeploy: z.boolean(),
+  })
+  .strict();
+
+export type SetAppAutoDeployInput = z.infer<typeof setAppAutoDeployInput>;
+
+export interface SetAppAutoDeployResult {
+  readonly appId: string;
+  readonly autoDeploy: boolean;
+  /**
+   * The repository a push would have to land on, or `null` when this App names
+   * one that nobody has connected yet.
+   *
+   * Present so that "on" is never reported without saying what it is on *for*.
+   */
+  readonly repository: string | null;
+}
+
+export const setAppAutoDeploy: Command<
+  SetAppAutoDeployInput,
+  SetAppAutoDeployResult
+> = async (input, context) => {
+  const [app] = await context.db
+    .select({
+      id: apps.id,
+      name: apps.name,
+      sourceKind: apps.sourceKind,
+      repositoryId: apps.repositoryId,
+    })
+    .from(apps)
+    .where(eq(apps.id, input.appId))
+    .limit(1);
+  if (app === undefined) {
+    return failed('NOT_FOUND', `there is no App with id ${input.appId}`);
+  }
+
+  if (app.sourceKind !== 'repo') {
+    // Same code and shape as `setComponentSchedule`'s "only a job Component
+    // has a schedule": the input is well formed and names a real App, and what
+    // is wrong is which App it names.
+    return failed(
+      'INVALID_INPUT',
+      `'${app.name}' is deployed from an uploaded archive, so no push can ever ` +
+        'reach it — auto-deploy would have nothing to fire on. Recreate it from ' +
+        'a repository if you want deploys on push.',
+      [{ path: 'appId', message: 'not a repository App' }],
+    );
+  }
+
+  const repository =
+    app.repositoryId === null
+      ? null
+      : ((
+          await context.db
+            .select({ name: repositories.fullName })
+            .from(repositories)
+            .where(eq(repositories.id, app.repositoryId))
+            .limit(1)
+        )[0]?.name ?? null);
+
+  await context.db
+    .update(apps)
+    .set({ autoDeploy: input.autoDeploy, updatedAt: context.clock.now() })
+    .where(eq(apps.id, app.id));
+
+  return ok({ appId: app.id, autoDeploy: input.autoDeploy, repository });
+};

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -261,6 +261,7 @@ export const getAppWorkspace: Command<
     datastores: Array.from(datastoresMap.values()),
     activity,
     runtime,
+    autoDeploy: app.sourceKind === 'repo' ? app.autoDeploy : null,
   };
 
   return ok({ workspace });

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -16,6 +16,7 @@
  * named commands and arrive with the milestones that implement them.
  */
 
+export { setAppAutoDeploy } from './apps/auto-deploy.ts';
 export { setAppBuildRoute } from './apps/build-route.ts';
 export { deleteApp } from './apps/delete.ts';
 export { deployApp } from './apps/deploy.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -29,6 +29,7 @@
  * nothing left for a route to decide.
  */
 import type { z } from 'zod';
+import { setAppAutoDeploy, setAppAutoDeployInput } from './apps/auto-deploy.ts';
 import { setAppBuildRoute, setAppBuildRouteInput } from './apps/build-route.ts';
 import { deleteApp, deleteAppInput } from './apps/delete.ts';
 import { deployApp, deployAppInput } from './apps/deploy.ts';
@@ -163,6 +164,10 @@ export type AnyCommandDescriptor = CommandDescriptor<any, any>;
 export const commandRegistry = {
   deleteApp: { input: deleteAppInput, handler: deleteApp },
   deployApp: { input: deployAppInput, handler: deployApp },
+  setAppAutoDeploy: {
+    input: setAppAutoDeployInput,
+    handler: setAppAutoDeploy,
+  },
   setAppBuildRoute: { input: setAppBuildRouteInput, handler: setAppBuildRoute },
   getAppWorkspace: { input: getAppWorkspaceInput, handler: getAppWorkspace },
   getDeployDetail: { input: getDeployDetailInput, handler: getDeployDetail },

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -38,6 +38,7 @@ import { AppList } from './views/apps/list.tsx';
 import { NewApp } from './views/apps/new/index.tsx';
 import {
   type RunJob,
+  type SetAutoDeploy,
   type SetConfig,
   type SetReach,
   Workspace,
@@ -1206,6 +1207,31 @@ function WorkspaceScreen({
     }
   };
 
+  // Deploy on push (§15). No re-read of the workspace: the toggle already
+  // holds the answer it just wrote, and the reload `handleSetReach` needs is
+  // because reach changes a *derived* row. This changes exactly the field the
+  // control is showing.
+  const handleSetAutoDeploy: SetAutoDeploy = async (autoDeploy) => {
+    const appId = state.type === 'success' ? state.workspace.appId : undefined;
+    if (appId === undefined) {
+      return { ok: false, message: 'This App has no id to set the switch on' };
+    }
+    try {
+      const result = await command('setAppAutoDeploy', { appId, autoDeploy });
+      return result.ok
+        ? { ok: true }
+        : { ok: false, message: result.failure.message };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message:
+          cause instanceof Error
+            ? cause.message
+            : 'Saving deploy-on-push failed',
+      };
+    }
+  };
+
   // The pair this workspace is showing (§10) — bound here, once, so `SetConfig`
   // itself does not have to carry it on every call. Re-read on success for the
   // same reason `handleSetReach` is: `configKeys` is a row this act just
@@ -1306,6 +1332,7 @@ function WorkspaceScreen({
         onNavigate={onNavigate}
         deletion={deletion}
         onSetReach={handleSetReach}
+        onSetAutoDeploy={handleSetAutoDeploy}
         onSetConfig={handleSetConfig}
         {...(runs === null
           ? {}

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -547,6 +547,15 @@ export interface WorkspaceView {
    * list of executions rather than a tail it has nothing to put in.
    */
   readonly runtime: Runtime;
+  /**
+   * Whether a push to this App's repository redeploys it (§15).
+   *
+   * `null` for an App deployed from an uploaded archive: no push can reach it,
+   * so "off" would be a state it could be turned out of and this is not one.
+   * The screen renders the absence, never a disabled switch pretending there
+   * is a choice.
+   */
+  readonly autoDeploy: boolean | null;
 }
 
 /**

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -68,6 +68,20 @@ export type SetReach = (change: {
 >;
 
 /**
+ * Turning deploy-on-push on or off for this App (§15).
+ *
+ * Sends the state it wants rather than "flip it", which is what
+ * `setAppAutoDeploy` takes and for the reason stated there: two presses racing
+ * a toggle disagree about where they left it, and two presses racing a set do
+ * not.
+ */
+export type SetAutoDeploy = (
+  autoDeploy: boolean,
+) => Promise<
+  { readonly ok: true } | { readonly ok: false; readonly message: string }
+>;
+
+/**
  * Starting one run of a job, as the screen above needs it answered (§17).
  *
  * The same shape {@link SetReach} takes and for the same reason: the press has
@@ -113,6 +127,7 @@ export function Workspace({
   onSetReach,
   onSetConfig,
   onRunJob,
+  onSetAutoDeploy,
   onFollowExecution,
   executionLines,
 }: {
@@ -154,6 +169,13 @@ export function Workspace({
    * is what decides, because it is the only branch with runs to start.
    */
   onRunJob?: RunJob;
+  /**
+   * Absent where deploy-on-push is not editable from here, for the same reason
+   * {@link onSetReach} is. Also absent for an archive App — but that one the
+   * view already says with `autoDeploy: null`, so the control is not rendered
+   * at all rather than rendered dead.
+   */
+  onSetAutoDeploy?: SetAutoDeploy;
   /** Follow one run's output, or nothing when the name is `null`. */
   onFollowExecution?: (execution: string | null) => void;
   /** The lines of whichever run is being followed. */
@@ -205,7 +227,11 @@ export function Workspace({
         </div>
       </header>
 
-      <Hero view={view} onNavigate={onNavigate} />
+      <Hero
+        view={view}
+        onNavigate={onNavigate}
+        {...(onSetAutoDeploy === undefined ? {} : { onSetAutoDeploy })}
+      />
 
       <div className="grid gap-4 md:grid-cols-2">
         <Components
@@ -244,9 +270,11 @@ export function Workspace({
 function Hero({
   view,
   onNavigate,
+  onSetAutoDeploy,
 }: {
   view: WorkspaceView;
   onNavigate?: (path: string) => void;
+  onSetAutoDeploy?: SetAutoDeploy;
 }) {
   return (
     <Card className="flex flex-wrap items-start gap-6 px-5 py-5">
@@ -297,8 +325,88 @@ function Hero({
             ? 'All prerequisites passing'
             : 'A prerequisite is unmet'}
         </p>
+        {/*
+          Beside placement rather than in the header, because it is not an act:
+          the header holds the two buttons that make something happen now, and
+          a switch that changes what happens *next time* sitting between them
+          is the one misread that costs a surprise deploy.
+
+          Rendered only where the App can receive a push at all — `autoDeploy`
+          is `null` for an archive App, and a disabled switch would offer a
+          choice that does not exist.
+        */}
+        {view.autoDeploy !== null && onSetAutoDeploy ? (
+          <AutoDeployToggle
+            autoDeploy={view.autoDeploy}
+            onSetAutoDeploy={onSetAutoDeploy}
+          />
+        ) : null}
       </div>
     </Card>
+  );
+}
+
+/**
+ * Deploy on push, on or off (§15).
+ *
+ * **Optimistic, and it says so when it was wrong.** The press flips the label
+ * immediately and puts it back if the command refuses — a switch that waits for
+ * a round trip before moving reads as broken, and this one is cheap to undo.
+ *
+ * No confirmation. Turning it *on* is the direction with consequences, and the
+ * consequence is a deploy that would have happened anyway the moment somebody
+ * pressed Deploy — §15's dispatcher calls the same `deployApp`, so nothing here
+ * can do something the button above it could not.
+ */
+function AutoDeployToggle({
+  autoDeploy,
+  onSetAutoDeploy,
+}: {
+  autoDeploy: boolean;
+  onSetAutoDeploy: SetAutoDeploy;
+}) {
+  const [on, setOn] = useState(autoDeploy);
+  const [saving, setSaving] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  const flip = async () => {
+    const wanted = !on;
+    setOn(wanted);
+    setSaving(true);
+    setRefusal(null);
+    try {
+      const result = await onSetAutoDeploy(wanted);
+      if (!result.ok) {
+        setOn(!wanted);
+        setRefusal(result.message);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="mt-1 flex flex-col items-end gap-1">
+      <button
+        type="button"
+        onClick={flip}
+        disabled={saving}
+        aria-pressed={on}
+        className={cn(
+          'rounded-md border px-2 py-1 text-xs transition-colors',
+          on
+            ? 'border-accent/40 bg-accent-soft text-accent-foreground'
+            : 'border-border-soft text-muted-foreground hover:text-foreground',
+        )}
+      >
+        Deploy on push: {on ? 'on' : 'off'}
+      </button>
+      {refusal ? (
+        <p className="max-w-[22rem] text-left text-xs text-destructive">
+          {refusal}
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/spindrift/test/commands/app-auto-deploy.test.ts
+++ b/apps/spindrift/test/commands/app-auto-deploy.test.ts
@@ -1,0 +1,197 @@
+/**
+ * An App opting in to deploying on push (§15).
+ *
+ * `apps.autoDeploy` shipped with its reader (`reconciler/auto-deploy.ts`) and
+ * its trigger (the webhook route) and with **no writer at all** — the column
+ * defaults `false`, `createApp` does not take it, and no command set it. So
+ * deploy-on-push was complete, merged, and permanently off. Three claims:
+ *
+ * - **The switch actually moves the column**, which is the whole gap.
+ * - **An archive App is refused**, because `dispatchAutoDeploys` reads the
+ *   scopes of repository reconciliation passes — an App with no repository is
+ *   not something it can ever reach, so `true` there would be a switch that
+ *   sits on and never fires.
+ * - **The dispatcher deploys what this turned on, and only that.** The reader
+ *   and the writer meet here or they do not meet anywhere: a test that only
+ *   asserted the column would pass just as well against a column nothing reads.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { setAppAutoDeploy } from '../../src/commands/apps/auto-deploy.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { apps, repositories, users } from '../../src/db/schema.ts';
+import { dispatchAutoDeploys } from '../../src/reconciler/auto-deploy.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2026-08-06T12:00:00.000Z');
+
+const adapters: AdapterRegistry = {
+  deploy: () => null,
+  build: () => null,
+  store: () => null,
+  supplyChain: () => null,
+  repository: () => null,
+} as unknown as AdapterRegistry;
+
+describe('deploy on push, turned on and off', () => {
+  let ctx: CommandContext;
+  let repoAppId: string;
+  let archiveAppId: string;
+
+  beforeEach(async () => {
+    const { client, db } = database();
+    await db.delete(apps);
+    await db.delete(repositories);
+    await db.delete(users);
+
+    const [operator] = await db
+      .insert(users)
+      .values({ displayName: 'Operator' })
+      .returning();
+    const [repository] = await db
+      .insert(repositories)
+      .values({
+        fullName: 'jonpulsifer/infra',
+        installationId: '1',
+        defaultBranch: 'main',
+      })
+      .returning();
+    const [repoApp] = await db
+      .insert(apps)
+      .values({
+        name: 'statty',
+        sourceKind: 'repo',
+        sourceRepoUrl: 'jonpulsifer/infra',
+        sourceRepoSubpath: 'apps/statty',
+        repositoryId: repository!.id,
+      })
+      .returning();
+    repoAppId = repoApp!.id;
+    const [archiveApp] = await db
+      .insert(apps)
+      .values({ name: 'archivetest', sourceKind: 'archive' })
+      .returning();
+    archiveAppId = archiveApp!.id;
+
+    ctx = {
+      client,
+      db,
+      adapters,
+      clock: { now: () => FROZEN },
+      manifest,
+      operatorId: operator!.id,
+      principal: { type: 'user', id: operator!.id, displayName: 'Operator' },
+    } as CommandContext;
+  });
+
+  async function autoDeployOf(id: string): Promise<boolean | undefined> {
+    const [row] = await database()
+      .db.select({ autoDeploy: apps.autoDeploy })
+      .from(apps)
+      .where(eq(apps.id, id));
+    return row?.autoDeploy;
+  }
+
+  test('the column every App defaults to, and the one nothing could change', async () => {
+    // The state this ticket is about: shipped, readable, and unreachable.
+    expect(await autoDeployOf(repoAppId)).toBe(false);
+  });
+
+  test('turning it on writes the column and names what it fires on', async () => {
+    const result = await setAppAutoDeploy(
+      { appId: repoAppId, autoDeploy: true },
+      ctx,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value.autoDeploy).toBe(true);
+      // "On" is never reported without saying what it is on *for*.
+      expect(result.value.repository).toBe('jonpulsifer/infra');
+    }
+    expect(await autoDeployOf(repoAppId)).toBe(true);
+  });
+
+  test('turning it off writes the column back', async () => {
+    await setAppAutoDeploy({ appId: repoAppId, autoDeploy: true }, ctx);
+    const result = await setAppAutoDeploy(
+      { appId: repoAppId, autoDeploy: false },
+      ctx,
+    );
+    expect(result.ok).toBe(true);
+    expect(await autoDeployOf(repoAppId)).toBe(false);
+  });
+
+  test('an archive App is refused, because no push can reach it', async () => {
+    const result = await setAppAutoDeploy(
+      { appId: archiveAppId, autoDeploy: true },
+      ctx,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.failure.code).toBe('INVALID_INPUT');
+      expect(result.failure.message).toContain('uploaded archive');
+    }
+    // And it is refused *before* the write, not reported after one.
+    expect(await autoDeployOf(archiveAppId)).toBe(false);
+  });
+
+  test('an App that does not exist is not silently a no-op', async () => {
+    const result = await setAppAutoDeploy(
+      { appId: '00000000-0000-4000-8000-000000000000', autoDeploy: true },
+      ctx,
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.failure.code).toBe('NOT_FOUND');
+  });
+
+  test('the dispatcher deploys the App this turned on, and skips the one it did not', async () => {
+    // The claim that makes the other five worth anything: the writer and the
+    // reader are the same column. `dispatchAutoDeploys` selects on
+    // `apps.autoDeploy = true`, so an App this command has not switched on is
+    // not attempted at all — no `deployApp` call, no adapter needed.
+    const { db } = database();
+    const [second] = await db
+      .insert(apps)
+      .values({
+        name: 'plainboi',
+        sourceKind: 'repo',
+        sourceRepoUrl: 'jonpulsifer/infra',
+        sourceRepoSubpath: 'apps/plainboi',
+      })
+      .returning();
+
+    await setAppAutoDeploy({ appId: repoAppId, autoDeploy: true }, ctx);
+
+    const attempts = await dispatchAutoDeploys(
+      { db, clock: ctx.clock, adapters, manifest },
+      [
+        {
+          outcome: 'adopted',
+          scopes: [{ appId: repoAppId }, { appId: second!.id }],
+        },
+      ] as never,
+    );
+
+    expect(attempts.map((attempt) => attempt.appId)).toEqual([repoAppId]);
+  });
+
+  test('nothing is dispatched from a pass that adopted no commit', async () => {
+    // `unchanged`, `frozen`, `rejected`, `unavailable` all mean nothing landed.
+    // An opted-in App must not redeploy on a pass that found no new commit.
+    await setAppAutoDeploy({ appId: repoAppId, autoDeploy: true }, ctx);
+
+    const attempts = await dispatchAutoDeploys(
+      { db: database().db, clock: ctx.clock, adapters, manifest },
+      [{ outcome: 'unchanged', scopes: [{ appId: repoAppId }] }] as never,
+    );
+
+    expect(attempts).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -432,6 +432,7 @@ export const WORKSPACE_SCENARIOS = {
     url: `beacon.${APEX}`,
     urlLive: true,
     release: 'Deploy 42',
+    autoDeploy: false,
     components: [
       {
         id: 'component-beacon-web',
@@ -527,6 +528,7 @@ export const WORKSPACE_SCENARIOS = {
     url: `almanac.${APEX}`,
     urlLive: true,
     release: 'Deploy 17',
+    autoDeploy: false,
     components: [
       {
         id: 'component-almanac-web',
@@ -580,6 +582,7 @@ export const WORKSPACE_SCENARIOS = {
     url: `ledger.${APEX}`,
     urlLive: false,
     release: 'Execution 118',
+    autoDeploy: false,
     components: [
       {
         id: 'component-ledger-nightly',

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -605,6 +605,42 @@ describe('the App workspace', () => {
     expect(buttons).toBeGreaterThanOrEqual(view.activity.length);
   });
 
+  test('an App that can receive a push offers the switch that makes it', () => {
+    // §15's dispatcher and the webhook both read `apps.autoDeploy`, and until
+    // now nothing anywhere could write it — the feature shipped permanently
+    // off. This is the control that turns it on.
+    const markup = renderToStaticMarkup(
+      <Workspace
+        view={WORKSPACE_SCENARIOS.service}
+        onSetAutoDeploy={async () => ({ ok: true })}
+      />,
+    );
+    expect(markup).toContain('Deploy on push: off');
+  });
+
+  test('an App no push can reach is not offered a dead switch', () => {
+    // `autoDeploy: null` is the archive App: there is no repository, so there
+    // is no state to be turned out of. §3's grammar disables a choice and says
+    // why; this is not a choice at all, so the honest render is nothing.
+    const archive = {
+      ...WORKSPACE_SCENARIOS.service,
+      autoDeploy: null,
+    } as const satisfies WorkspaceView;
+
+    const markup = renderToStaticMarkup(
+      <Workspace view={archive} onSetAutoDeploy={async () => ({ ok: true })} />,
+    );
+    expect(markup).not.toContain('Deploy on push');
+  });
+
+  test('a screen wiring no acts renders no switch either', () => {
+    // The same rule the reach and config editors follow: a control whose Save
+    // cannot be called is worse than no control.
+    expect(workspace(WORKSPACE_SCENARIOS.service)).not.toContain(
+      'Deploy on push',
+    );
+  });
+
   test('a website states that it has no runtime', () => {
     // §17: the `static` adapter gets an honest empty state, and §18 puts it one
     // level down rather than disabling a tab. `kind: 'none'` carries the reason


### PR DESCRIPTION
`apps.auto_deploy` shipped with its reader (`src/reconciler/auto-deploy.ts`) and its trigger (the webhook route) and with **no writer at all** — the column defaults `false`, `createApp` does not take it, and no command set it. Deploy-on-push was complete, merged, and permanently off.

This is the switch, plus the control that reaches it from the App workspace.

## Shape

- **Sets, does not toggle.** `setAppAutoDeploy` takes the state it wants. Two presses racing a toggle disagree about where they left it; two presses racing a set agree.
- **An archive App is refused.** `dispatchAutoDeploys` reads the scopes of repository reconciliation passes, so an App with no repository is not something it can ever reach — `true` there would sit on and never fire. Same `INVALID_INPUT` shape `setComponentSchedule` uses for "only a job Component has a schedule".
- **A repo App whose repository is not connected yet is allowed.** That one is temporary — §15 makes connecting a repository something an operator turns on afterwards — so the switch becomes live when the connection lands. The result names the repository, or its absence, so "on" is never reported without saying what it is on for.
- **The control sits beside placement, not in the header.** The header holds the two buttons that make something happen *now*; a switch that changes what happens *next time* between them is the one misread that costs a surprise deploy.
- **An archive App gets no control**, not a disabled one — `autoDeploy` is `null` in the view, because there is no state to be turned out of. A screen that wires no acts renders no switch either, the same rule the reach and config editors follow.

## Validation

```
bun test        1719 pass, 0 fail (129 files)
bun run typecheck   clean
bun run lint        clean on every file touched
```

Seven command tests and three view tests. The one that makes the others worth anything drives `dispatchAutoDeploys` over two Apps and asserts only the switched-on one is attempted — the writer and the reader are the same column, or a test asserting the column alone would pass against a column nothing reads.

Revert-and-fail proof — dropping `autoDeploy` from the update's `.set({…})`:

```
(fail) turning it on writes the column and names what it fires on
(fail) the dispatcher deploys the App this turned on, and skips the one it did not
```

Two lint findings remain in files this PR does not touch (`src/commands/builds/route.ts`, `test/adapters/publishable-registries.test.ts`), both pre-existing.