### PR TITLE
feat(bluenose): let each cluster's external-secrets read this vessel's Secret Manager

### DIFF
--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -82,3 +82,34 @@ resource "google_project_iam_member" "spindrift" {
   role    = each.key
   member  = google_service_account.spindrift_controller.member
 }
+
+# The delivery half of the same store. Spindrift writes a config item here with
+# `roles/secretmanager.admin` above; the Target the Component runs on fetches it
+# back, and for a Kubernetes Target that fetch is external-secrets, not
+# Spindrift. So each cluster's operator needs its own read path into this
+# vessel's Secret Manager, or a Component placed on a cluster resolves nothing.
+#
+# `roles/secretmanager.secretAccessor` and no wider: the chart renders an
+# `ExternalSecret` naming a secret id and a pinned version number, which is
+# `secretmanager.versions.access` alone. Nothing here lists, creates or
+# describes — `roles/secretmanager.viewer` would only add metadata reads nobody
+# makes.
+#
+# The principal is federated directly rather than through a service account.
+# There is nothing for one to carry: the grant is a single read role on a single
+# project, so an impersonated account would be an extra identity holding exactly
+# the permissions the principal already holds. The Kubernetes service account
+# each subject names is declared in `clusters/base/platform/gcp-secret-manager`,
+# and the per-cluster provider that mints its token in
+# terraform/gcp/projects/homelab-ng/workload-identity.tf.
+locals {
+  cluster_secret_readers = toset(["folly", "offsite"])
+}
+
+resource "google_project_iam_member" "cluster_secret_reader" {
+  for_each = local.cluster_secret_readers
+
+  project = local.project
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "principal://${local.fml_pool}/subject/${each.key}:system:serviceaccount:external-secrets:gcp-secret-manager"
+}

--- a/terraform/gcp/projects/bluenose/versions.tf
+++ b/terraform/gcp/projects/bluenose/versions.tf
@@ -4,7 +4,11 @@ locals {
 
   vessel_topology = jsondecode(file("${path.module}/config/vessel-topology.json"))
 
-  spindrift_principal = "principal://iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/subject/offsite:system:serviceaccount:spindrift:spindrift"
+  # The pool every cluster workload federates through, one provider per cluster.
+  # Declared in terraform/gcp/projects/homelab-ng/workload-identity.tf.
+  fml_pool = "iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool"
+
+  spindrift_principal = "principal://${local.fml_pool}/subject/offsite:system:serviceaccount:spindrift:spindrift"
 }
 
 data "google_project" "current" {


### PR DESCRIPTION
## Summary

Spindrift writes a config item into the installation's store of record; the Target the Component runs on fetches it back over its own access path. On a Kubernetes Target that fetch is external-secrets, not Spindrift — so a Secret Manager store in this vessel is only half usable until each cluster's operator can read from it.

Grants `roles/secretmanager.secretAccessor` on `bluenose` to the federated principal of a `gcp-secret-manager` Kubernetes service account in each cluster's `external-secrets` namespace, through the per-cluster `fml-pool` provider that already exists (`terraform/gcp/projects/homelab-ng/workload-identity.tf:89`).

- **`secretAccessor` and no wider.** The App chart renders an `ExternalSecret` naming a secret id and a pinned version number (`packages/charts/spindrift-app/templates/externalsecret.yaml:47-53`), which is `secretmanager.versions.access` alone. Nothing lists or describes.
- **Direct principal, no impersonation.** One read role on one project; an impersonated service account would be a second identity holding exactly what the principal already holds. `terraform/gcp/projects/bluenose/iam.tf:18` uses impersonation because that account carries a dozen unrelated grants — this one carries one.
- The controller's write half is already in place (`roles/secretmanager.admin`, `iam.tf:63`), and `secretmanager.googleapis.com` is already enabled (`services.tf`).

Also folds the repeated pool resource name in `versions.tf` into a `local`, since a second principal would otherwise be a third copy of it.

This grant is inert on its own: nothing in either cluster references it until the `ClusterSecretStore` that uses these service accounts lands. It goes first so the store works the moment it exists rather than sitting unauthenticated.

## Validation

`mise run tf:fmt`, `mise run tf:validate` — every root valid.

## Risks

Additive IAM only. No existing binding changes.