### PR TITLE
feat(platform): give both clusters a Secret Manager store

### DIFF
--- a/clusters/base/flux-system/gcp-secret-manager.yaml
+++ b/clusters/base/flux-system/gcp-secret-manager.yaml
@@ -1,0 +1,28 @@
+---
+# Its own Kustomization rather than a directory added to the operator's, for the
+# reason `onepassword-connect` has one: the operator installs the CRDs, and a
+# `ClusterSecretStore` in the same apply is dry-run against a kind that does not
+# exist yet.
+#
+# `substituteFrom` is what this one adds. The store's federation audience names
+# the cluster it is running in, which is the one fact in it that differs between
+# the two — so it is read from the topology ConfigMap rather than branched per
+# cluster.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: gcp-secret-manager
+  namespace: flux-system
+spec:
+  interval: 1h0m0s
+  path: ./clusters/base/platform/gcp-secret-manager
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: infra
+  dependsOn:
+    - name: external-secrets-operator
+  postBuild:
+    substituteFrom:
+      - kind: ConfigMap
+        name: cluster-topology

--- a/clusters/base/flux-system/kustomization.yaml
+++ b/clusters/base/flux-system/kustomization.yaml
@@ -4,6 +4,7 @@ kind: Kustomization
 resources:
   - arc-system.yaml
   - external-secrets-operator.yaml
+  - gcp-secret-manager.yaml
   - kyverno.yaml
   - onepassword-connect.yaml
   - sandbox.yaml

--- a/clusters/base/platform/gcp-secret-manager/cluster-secret-store.yaml
+++ b/clusters/base/platform/gcp-secret-manager/cluster-secret-store.yaml
@@ -1,0 +1,42 @@
+---
+# The read path into the `bluenose` vessel's Secret Manager, one per cluster.
+#
+# Spindrift writes a config item into the installation's store of record and
+# renders an `ExternalSecret` naming the item and its pinned version; this store
+# is what turns that reference into a Secret the workload reads. Cloud Run
+# resolves a pinned reference out of the same project natively, so with this
+# object present every Target in the fleet reads one store of record over its
+# own access path.
+#
+# **Additive.** `onepassword-connect` beside it stays exactly as it is. A
+# cluster reports every provider it holds, so adding this one widens what each
+# cluster can reach and takes nothing away.
+#
+# No credential: the operator mints a token for the service account beside this
+# file, exchanges it at Google's STS for the cluster's own `fml-pool` provider,
+# and the federated principal holds `roles/secretmanager.secretAccessor` on the
+# project directly. Declared in `terraform/gcp/projects/bluenose/iam.tf`; the
+# per-cluster provider in
+# `terraform/gcp/projects/homelab-ng/workload-identity.tf`.
+#
+# `audience` appears twice on purpose and the two are not the same field: the
+# outer one is what the exchange asks Google for, the inner one is the `aud`
+# claim the projected token is minted with. Google checks the second against the
+# provider and refuses a token minted for anything else — including the API
+# server's own default audience, which is what an omitted `audiences` would give.
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: gcp-secret-manager
+spec:
+  provider:
+    gcpsm:
+      projectID: bluenose
+      auth:
+        workloadIdentityFederation:
+          audience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/${CLUSTER_NAME}
+          serviceAccountRef:
+            name: gcp-secret-manager
+            namespace: external-secrets
+            audiences:
+              - //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/${CLUSTER_NAME}

--- a/clusters/base/platform/gcp-secret-manager/kustomization.yaml
+++ b/clusters/base/platform/gcp-secret-manager/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service-account.yaml
+  - cluster-secret-store.yaml
+namespace: external-secrets

--- a/clusters/base/platform/gcp-secret-manager/service-account.yaml
+++ b/clusters/base/platform/gcp-secret-manager/service-account.yaml
@@ -1,0 +1,15 @@
+---
+# The identity the store below federates as. Its own, rather than the
+# operator's: this name is half of a GCP IAM binding
+# (`terraform/gcp/projects/bluenose/iam.tf`), and the operator's service account
+# is named by the upstream chart, which is free to rename it in a version bump
+# and would silently take the binding's subject with it.
+#
+# It mounts nowhere and no pod runs as it. external-secrets mints a token for it
+# through the TokenRequest API when the store needs one, which is why it needs
+# no secret of its own.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gcp-secret-manager
+  namespace: external-secrets


### PR DESCRIPTION
## Summary

Spindrift's cloud Target resolves a pinned secret reference out of its own project's Secret Manager (`apps/spindrift/src/adapters/deploy/cloudrun/index.ts:205`); the clusters read 1Password. Two stores of record, so a Component with any configuration can be placed on one side or the other but never both — and the cloud Target refuses every non-`website` Component outright.

This adds a `gcpsm` `ClusterSecretStore` in front of the `bluenose` vessel's Secret Manager on both clusters, so every Target in the fleet reads one store of record over its own access path.

**This change is additive and changes nothing that works today.** `onepassword-connect` is untouched, and the Kubernetes adapter reports a list of every provider a cluster holds (`apps/spindrift/src/adapters/deploy/kubernetes/index.ts:121-125, 1130-1151`). After this merges each cluster reports `["onepassword", "gcp-secret-manager"]` instead of `["onepassword"]` — strictly more, so nothing placeable becomes unplaceable.

- **One base component, one Flux `Kustomization`.** Its own rather than folded into the operator's, for the reason `onepassword-connect` has its own: the operator installs the CRDs, and a `ClusterSecretStore` in the same apply is dry-run against a kind that does not exist yet.
- **The federation audience names its cluster**, which is the only fact that differs between the two, so it is `${CLUSTER_NAME}` out of the topology ConfigMap rather than two near-identical files.
- **No stored credential.** external-secrets mints a token for the `gcp-secret-manager` ServiceAccount through the TokenRequest API and exchanges it at Google's STS against the per-cluster `fml-pool` provider (`terraform/gcp/projects/homelab-ng/workload-identity.tf:89`). The `audience` appears twice because they are different fields: the outer one is what the exchange asks for, the inner one is the `aud` claim the projected token carries — omitted, the token is minted for the API server's own audience and Google refuses it.

## Order

The IAM grant this authenticates against must be applied first. Merging this before it leaves a store that exists and cannot read anything — and Spindrift's discovery reports a store by its presence, not its readiness, so the cluster would advertise a store that resolves nothing.

## Validation

`mise run k8s:render-apps` (both clusters), `kubectl kustomize` on both `flux-system` trees and both `apps` trees.

Unverified until merge: that the token exchange is actually accepted. It cannot be exercised without applying the object, and nothing consumes the store yet — the installation still names `onepassword`, so the first thing to check after this reconciles is `kubectl get clustersecretstore gcp-secret-manager` reporting Valid on both clusters.