### PR TITLE
fix(spindrift): stop double-prefixing URLs with https://

### DIFF
--- a/apps/spindrift/src/web/ui/utils.ts
+++ b/apps/spindrift/src/web/ui/utils.ts
@@ -19,3 +19,19 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Normalise a URL for an `href` — only prepend `https://` when the value
+ * doesn't already carry a scheme. Backends (Firebase Hosting, Cloud Run)
+ * and `displayUrl()` all return absolute URLs, so prepending
+ * unconditionally would produce `https://https://…`.
+ */
+export function normaliseUrl(raw: string): string {
+  if (!raw) return '';
+  // Already has a proper scheme — return as-is.
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) return raw;
+  // Common typo: `https//…` instead of `https://…`. Fix it.
+  const fixed = raw.replace(/^(https?):?\/\//i, '$1://');
+  if (fixed !== raw) return fixed;
+  return `https://${raw}`;
+}

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -68,7 +68,7 @@ import {
   CollapsibleTrigger,
 } from '../../ui/collapsible.tsx';
 import { Logo } from '../../ui/logo.tsx';
-import { cn } from '../../ui/utils.ts';
+import { cn, normaliseUrl } from '../../ui/utils.ts';
 
 /**
  * The mark and the name for a build route's platform.
@@ -500,7 +500,7 @@ function UrlBlock({ view }: { view: DeployView }) {
     <div className="ml-auto flex flex-col items-end gap-1 text-right">
       <Eyebrow>{serving || previous ? 'Serving' : 'Reserved'}</Eyebrow>
       <a
-        href={`https://${view.url}`}
+        href={normaliseUrl(view.url)}
         className={cn(
           'font-mono text-base',
           serving || previous

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -41,7 +41,7 @@ import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, Eyebrow } from '../../ui/card.tsx';
 import { Field } from '../../ui/field.tsx';
-import { cn } from '../../ui/utils.ts';
+import { cn, normaliseUrl } from '../../ui/utils.ts';
 import {
   AUTH_NOTE,
   AUTHS,
@@ -205,7 +205,7 @@ export function Workspace({
             />
           ) : null}
           <Button variant="outline" asChild>
-            <a href={`https://${view.url}`}>
+            <a href={normaliseUrl(view.url)}>
               Open app <ExternalLink aria-hidden="true" />
             </a>
           </Button>
@@ -286,7 +286,7 @@ function Hero({
             : 'Your App has no release serving yet'}
         </p>
         <a
-          href={`https://${view.url}`}
+          href={normaliseUrl(view.url)}
           className={cn(
             'font-mono text-[15px]',
             view.urlLive


### PR DESCRIPTION
## Summary
Backends (Firebase Hosting, Cloud Run) and `displayUrl()` all produce absolute URLs with the `https://` scheme. The workspace and deploy-detail views were unconditionally prepending `https://` again, producing `https://https://…` on every clickable link.

## Changes
- Move `appHref`'s scheme-guard logic into a shared `normaliseUrl()` in `ui/utils.ts`
- Use it in `workspace.tsx` (two `href` sites) and `deploy-detail.tsx` (one)

## Test Plan
- [ ] Open any app workspace — "Open app" button and URL link should go to the correct address, not `https://https://…`
- [ ] Open a deploy detail — its URL link should go to the correct address
- [ ] App list "Open URL" links should still work (already had `appHref`)

