### PR TITLE
fix(bluenose): grant runtime secret access

### DIFF
--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -42,6 +42,15 @@ resource "google_service_account_iam_member" "spindrift_act_as_runtime" {
   member             = google_service_account.spindrift_controller.member
 }
 
+# Cloud Run resolves a revision's secret environment variables as the runtime
+# service account. Spindrift owns the dynamically named secrets in this project,
+# so the runtime needs a project-wide read path that includes future secrets.
+resource "google_project_iam_member" "spindrift_runtime_secret_reader" {
+  project = local.project
+  role    = "roles/secretmanager.secretAccessor"
+  member  = google_service_account.spindrift_runtime.member
+}
+
 locals {
   spindrift_project_roles = toset([
     "roles/cloudsql.admin",


### PR DESCRIPTION
## Summary
Grants the Bluenose Cloud Run runtime account project-wide read access to dynamically managed Secret Manager values.

## Changes
- fix(bluenose): grant runtime secret access

## Test Plan
- [x] `tofu fmt -check terraform/gcp/projects/bluenose/iam.tf`
- [x] `tofu -chdir=terraform/gcp/projects/bluenose validate`
