### PR TITLE
fix(spindrift): match a reachable registry the same way at placement and deploy

### DIFF
--- a/apps/spindrift/src/domain/desired-state.ts
+++ b/apps/spindrift/src/domain/desired-state.ts
@@ -87,13 +87,27 @@ export function artifactAddress(
   return artifact.refs.find((ref) => pullableFrom(ref, reachable)) ?? null;
 }
 
-/** Whether one reference sits under any of the registries a Target named. */
-function pullableFrom(ref: string, reachable: readonly string[]): boolean {
+/**
+ * Whether one reference sits under any of the registries a Target named.
+ *
+ * The one predicate for "can this Target pull this": `artifactAddress` above
+ * calls it with a concrete pull address, and `exclusionsFor` in
+ * `placement.ts` calls it with the registry namespace itself, before a Build
+ * exists to produce an address — which is exactly what the equality branch is
+ * for, since a real reference always carries more path than its registry and
+ * never needs it.
+ */
+export function pullableFrom(
+  ref: string,
+  reachable: readonly string[],
+): boolean {
   return reachable.some(
     (registry) =>
+      ref === registry ||
       // The namespace spelling, which is the ordinary one. The trailing slash
       // is what stops `…/i` from claiming a reference in `…/images`.
-      ref.startsWith(`${registry}/`) || registryHostOf(ref) === registry,
+      ref.startsWith(`${registry}/`) ||
+      registryHostOf(ref) === registry,
   );
 }
 

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -31,17 +31,17 @@ import type {
 } from '../config/manifest.schema.ts';
 import {
   capabilitiesOfRow,
-  hostOf,
   type TargetCapabilities,
   type TargetDiscovery,
 } from './capabilities.ts';
-import type {
-  ArtifactType,
-  Auth,
-  ComponentKind,
-  Platform,
-  Reach,
-  Resources,
+import {
+  type ArtifactType,
+  type Auth,
+  type ComponentKind,
+  type Platform,
+  pullableFrom,
+  type Reach,
+  type Resources,
 } from './desired-state.ts';
 
 /**
@@ -529,7 +529,7 @@ export function exclusionsFor(
     artifactTypeFor(requirements.kind, target) === 'image' &&
     can.reachableRegistries.length > 0 &&
     !requirements.registries.some((registry) =>
-      can.reachableRegistries.includes(hostOf(registry)),
+      pullableFrom(registry, can.reachableRegistries),
     )
   ) {
     reasons.push('REGISTRY_UNREACHABLE');

--- a/apps/spindrift/src/domain/vessel.ts
+++ b/apps/spindrift/src/domain/vessel.ts
@@ -121,7 +121,15 @@ export interface Vessel {
    * sits on, which is why it is stated once here rather than per surface.
    */
   readonly servedHosts: readonly string[];
-  /** §3, and boundary-shaped for the same reason. */
+  /**
+   * §3, and boundary-shaped for the same reason.
+   *
+   * An entry is a bare host (`ghcr.io`) or a host/namespace (`ghcr.io/owner`),
+   * and both spellings are accepted everywhere this is read —
+   * {@link import('./desired-state.ts').pullableFrom} is the one predicate
+   * that decides it, for both a Build's pull address and, before a Build
+   * exists, the registry namespace itself.
+   */
   readonly reachableRegistries: readonly string[];
 }
 

--- a/apps/spindrift/test/domain/artifact-address.test.ts
+++ b/apps/spindrift/test/domain/artifact-address.test.ts
@@ -52,6 +52,11 @@ describe('the address a Target pulls an artifact by', () => {
    * `ghcr.io/jonpulsifer`. That never equals `ghcr.io`, so the artifact was
    * refused with "carries no address this Target can pull it by" while sitting
    * in the exact registry the Target had named.
+   *
+   * `test/domain/placement.test.ts`'s "a Target declaring host/namespace is a
+   * candidate for that same registry" pins the same `ghcr.io/jonpulsifer`
+   * spelling through `exclusionsFor`, so a fix here alone is not enough to go
+   * green — both call sites share `pullableFrom` and both tests have to pass.
    */
   test('matches the namespace spelling an operator actually writes', () => {
     expect(

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -313,6 +313,20 @@ describe('registry reachability at Place', () => {
     ).toEqual([]);
   });
 
+  test('a Target declaring host/namespace is a candidate for that same registry', () => {
+    // The live bug: `folly` declares `ghcr.io/jonpulsifer` (a namespace, not a
+    // bare host) because its packages are public and need no credential. This
+    // is `artifactAddress`'s "matches the namespace spelling an operator
+    // actually writes" (`test/domain/artifact-address.test.ts`), pinned here
+    // too so the two call sites cannot drift apart again.
+    expect(
+      exclusionsFor(
+        target({ discovery: { reachableRegistries: ['ghcr.io/jonpulsifer'] } }),
+        requirements({ registries: ['ghcr.io/jonpulsifer'] }),
+      ),
+    ).toEqual([]);
+  });
+
   test('declaring nothing is no restriction, not "reaches nothing"', () => {
     // Every Target on this installation, until an operator says otherwise —
     // reading an empty list as a refusal would exclude all of them.


### PR DESCRIPTION
## Summary

`reachableRegistries` had two readers implementing different matching rules. The deploy path (`pullableFrom`, reached through `artifactAddress`) deliberately accepts both a bare host (`ghcr.io`) and a host/namespace (`ghcr.io/owner`) spelling. The placement path (`exclusionsFor`) compared only against the bare host extracted from the reference, so a Target that declares a host/namespace entry matched nothing — excluded from every image-artifact Component regardless of whether it could actually pull the artifact.

- Export `pullableFrom` from `desired-state.ts` and call it from `exclusionsFor` in `placement.ts`, deleting the old `hostOf`-based comparison.
- Add an exact-match branch to `pullableFrom`: `exclusionsFor` calls it with the bare registry namespace itself (pre-build, before any pull address exists), while `artifactAddress` calls it with a concrete pull address — a real reference always carries more path than its registry and never needed this branch, but the namespace-only caller does.
- Document the accepted spellings once, on the `Vessel.reachableRegistries` field that owns the value, pointing at `pullableFrom` as the predicate that decides it.

## Validation

- `bun test` — 1731 pass, 0 fail (real Postgres per the README's Testing section)
- `bun run typecheck` — clean
- `bun run lint` — clean
- Added a regression test in `test/domain/placement.test.ts` reproducing the exact failure (a Target declaring `host/namespace` matching a registry of the same spelling); confirmed it fails against the old comparison (`REGISTRY_UNREACHABLE`) and passes against the new one. A companion note in `test/domain/artifact-address.test.ts` cross-references it so the two call sites can't drift apart silently again.

## Risks

- `pullableFrom`'s new exact-match branch only ever fires for the namespace-only caller (`exclusionsFor`); a concrete pull address from a real Build always carries more path than its registry, so deploy-time matching is unchanged.
- No declared Target configuration changes — the fix is purely in the shared predicate and its callers.