### PR TITLE
refactor(spindrift): identify a Target by its vessel and its surface

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -216,6 +216,13 @@ that Target's vessel is the boundary the Component runs in. Nothing on the App
 records this, because a second answer to one question can only disagree with the
 first.
 
+**A Target has no name.** `Target = Vessel × surface` is its identity as well as
+its definition: the pair is naturally unique — a boundary carries one runtime of
+each kind — so it is the unique index, it is what `connectTarget` and
+`disconnectTarget` take, and it is what the screens show, as
+`<vessel>/<adapter>`. There is nothing to construct and so nothing to rename when
+a vessel turns out to carry a surface nobody had registered.
+
 A Target is flat and has exactly one adapter type. That one connect act asks for
 both control APIs, and each Target keeps only the endpoint its own adapter
 drives: an endpoint is connection material for exactly the reason a cluster's

--- a/apps/spindrift/src/adapters/datastore/gcp.ts
+++ b/apps/spindrift/src/adapters/datastore/gcp.ts
@@ -47,6 +47,7 @@
  * a Target that cannot do a thing: a stated reason, never a silent failure.
  */
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
+import { targetLabel } from '../../domain/target.ts';
 import type { DeployTarget } from '../deploy/contract.ts';
 import type {
   DatastoreAdapter,
@@ -118,7 +119,7 @@ export class CloudDatastoreAdapter implements DatastoreAdapter {
     target: DeployTarget,
     _request: DatastoreRequest,
   ): Promise<DatastoreRef> {
-    throw new CloudDatastoreUnavailableError(target.name);
+    throw new CloudDatastoreUnavailableError(targetLabel(target));
   }
 
   /**

--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -22,7 +22,10 @@
  */
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import { isLabel } from '../../domain/naming.ts';
-import type { KubernetesAdapterConnection } from '../../domain/target.ts';
+import {
+  type KubernetesAdapterConnection,
+  targetLabel,
+} from '../../domain/target.ts';
 import type {
   DeployPhase,
   DeployTarget,
@@ -108,7 +111,7 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
     const connection = connectionOf(target);
     if (connection === null) {
       throw new DatastoreRequestError(
-        `${target.name} is not a Kubernetes Target`,
+        `${targetLabel(target)} is not a Kubernetes Target`,
       );
     }
     if (!isLabel(request.name) || request.name.length > NAME_LIMIT) {

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -53,7 +53,10 @@ import {
   artifactAddress,
   type DesiredState,
 } from '../../../domain/desired-state.ts';
-import type { CloudRunAdapterConnection } from '../../../domain/target.ts';
+import {
+  type CloudRunAdapterConnection,
+  targetLabel,
+} from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
 import { cloudChecklist } from '../cloud/checklist.ts';
 import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
@@ -707,7 +710,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     if (connection === null) {
       return {
         kind: 'none',
-        because: `${target.name} is not a Cloud Run Target`,
+        because: `${targetLabel(target)} is not a Cloud Run Target`,
       };
     }
     const placed = parseRef(connection, ref);
@@ -745,7 +748,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
   async inspect(target: DeployTarget): Promise<TargetInspection> {
     const connection = this.connectionOf(target);
     if (connection === null) {
-      throw new Error(`${target.name} is not a Cloud Run Target`);
+      throw new Error(`${targetLabel(target)} is not a Cloud Run Target`);
     }
     const http = this.http(connection);
 

--- a/apps/spindrift/src/adapters/deploy/contract.ts
+++ b/apps/spindrift/src/adapters/deploy/contract.ts
@@ -33,9 +33,16 @@ import type {
  * is constructed against the connection.
  */
 export interface DeployTarget {
-  /** Stable identifier, unique within the installation. */
-  readonly name: string;
-  /** Exactly one adapter type per Target (§13). */
+  /**
+   * The boundary this Target is a surface on, by name.
+   *
+   * Half of the identity, and the half an adapter never dispatches on. It is
+   * here so an adapter that has to name the Target it was handed can say
+   * `<vessel>/<adapter>` — see `targetLabel` — rather than repeat a string core
+   * had constructed for it.
+   */
+  readonly vessel: string;
+  /** Exactly one adapter type per Target (§13), and the other half of its identity. */
   readonly adapter: TargetAdapter;
   /**
    * How this Target is reached, in its adapter's own terms (§13).

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -37,9 +37,10 @@ import type {
   ArtifactType,
   DesiredState,
 } from '../../../domain/desired-state.ts';
-import type {
-  KubernetesAdapterConnection,
-  KubernetesDelivery,
+import {
+  type KubernetesAdapterConnection,
+  type KubernetesDelivery,
+  targetLabel,
 } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
 import { ENGINE_KINDS as DATASTORE_ENGINE_KINDS } from '../../datastore/kubernetes.ts';
@@ -424,7 +425,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
   async run(target: DeployTarget, ref: DeployRef): Promise<StartedRun> {
     const connection = this.connectionOf(target);
     if (connection === null) {
-      return refuse(`${target.name} is not a Kubernetes Target`);
+      return refuse(`${targetLabel(target)} is not a Kubernetes Target`);
     }
     const api = this.api(connection);
     const placed = await this.placedJob(api, ref);
@@ -536,7 +537,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
   ): Promise<JobRuns> {
     const connection = this.connectionOf(target);
     if (connection === null) {
-      return refuse(`${target.name} is not a Kubernetes Target`);
+      return refuse(`${targetLabel(target)} is not a Kubernetes Target`);
     }
     const api = this.api(connection);
     const placed = await this.placedJob(api, ref);
@@ -639,7 +640,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
   async inspect(target: DeployTarget): Promise<TargetInspection> {
     const connection = this.connectionOf(target);
     if (connection === null) {
-      throw new Error(`${target.name} is not a Kubernetes Target`);
+      throw new Error(`${targetLabel(target)} is not a Kubernetes Target`);
     }
     const api = this.api(connection);
 

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -39,7 +39,10 @@ import {
   artifactAddress,
   type DesiredState,
 } from '../../../domain/desired-state.ts';
-import type { StaticAdapterConnection } from '../../../domain/target.ts';
+import {
+  type StaticAdapterConnection,
+  targetLabel,
+} from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
 import { cloudChecklist } from '../cloud/checklist.ts';
 import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
@@ -331,7 +334,7 @@ export class StaticDeployAdapter implements DeployAdapter {
   async inspect(target: DeployTarget): Promise<TargetInspection> {
     const connection = this.connectionOf(target);
     if (connection === null) {
-      throw new Error(`${target.name} is not a static hosting Target`);
+      throw new Error(`${targetLabel(target)} is not a static hosting Target`);
     }
 
     const probe = await this.http(connection).json<unknown>({

--- a/apps/spindrift/src/commands/apps/build-route.ts
+++ b/apps/spindrift/src/commands/apps/build-route.ts
@@ -38,8 +38,10 @@ import {
   components,
   componentTargetDesired,
   targets,
+  vessels,
 } from '../../db/schema.ts';
 import { publishableRegistries } from '../../domain/artifact-name.ts';
+import { targetLabel } from '../../domain/target.ts';
 import { buildRouteFor, refusalForChosenRoute } from '../builds/route.ts';
 import { type Command, failed, ok } from '../types.ts';
 
@@ -86,7 +88,8 @@ export const setAppBuildRoute: Command<
   const placements = await context.db
     .selectDistinct({
       id: targets.id,
-      name: targets.name,
+      vessel: vessels.name,
+      adapter: targets.adapter,
       // §3's derived half, as the standing loop last reported it — not the
       // connection's declaration, because what a Target can pull from is a fact
       // discovery refreshes and a connect-time snapshot rots.
@@ -98,6 +101,7 @@ export const setAppBuildRoute: Command<
       eq(components.id, componentTargetDesired.componentId),
     )
     .innerJoin(targets, eq(targets.id, componentTargetDesired.targetId))
+    .innerJoin(vessels, eq(vessels.id, targets.vesselId))
     .where(eq(components.appId, app.id));
 
   if (input.route !== null) {
@@ -124,7 +128,7 @@ export const setAppBuildRoute: Command<
       const refusal = refusalForChosenRoute(
         selection.candidates,
         input.route,
-        target.name,
+        targetLabel(target),
       );
       if (refusal !== null) return failed('NOT_BUILDABLE', refusal);
 
@@ -159,10 +163,10 @@ export const setAppBuildRoute: Command<
         return failed(
           'NOT_BUILDABLE',
           `${input.route} publishes to ${published.join(' and ') || 'no registry this installation configures'}, ` +
-            `and ${target.name} pulls from ${pullable.join(' or ')} — ` +
+            `and ${targetLabel(target)} pulls from ${pullable.join(' or ')} — ` +
             `so a build of ${app.name} on that route would produce an artifact ` +
-            `${target.name} cannot pull. Store a registry credential for one ` +
-            `${target.name} reaches, or leave ${app.name} on rank order.`,
+            `${targetLabel(target)} cannot pull. Store a registry credential for one ` +
+            `${targetLabel(target)} reaches, or leave ${app.name} on rank order.`,
         );
       }
     }
@@ -176,6 +180,6 @@ export const setAppBuildRoute: Command<
   return ok({
     appId: app.id,
     route: input.route,
-    targets: placements.map((target) => target.name),
+    targets: placements.map(targetLabel),
   });
 };

--- a/apps/spindrift/src/commands/apps/delete.ts
+++ b/apps/spindrift/src/commands/apps/delete.ts
@@ -46,8 +46,9 @@ import {
   datastores,
   deploys,
   targets,
+  vessels,
 } from '../../db/schema.ts';
-import { STRANDABLE_PHASES } from '../../domain/target.ts';
+import { STRANDABLE_PHASES, targetLabel } from '../../domain/target.ts';
 import { type ConfigSubject, configSubject, reapKey } from '../config/set.ts';
 import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
@@ -188,13 +189,15 @@ export const deleteApp: Command<DeleteAppInput, DeleteAppResult> = async (
             deployId: deploys.id,
             url: deploys.url,
             component: components.name,
-            target: targets.name,
+            vessel: vessels.name,
+            adapter: targets.adapter,
             componentKind: components.kind,
             schedule: components.schedule,
           })
           .from(deploys)
           .innerJoin(components, eq(deploys.componentId, components.id))
           .innerJoin(targets, eq(deploys.targetId, targets.id))
+          .innerJoin(vessels, eq(targets.vesselId, vessels.id))
           .where(
             and(
               inArray(deploys.componentId, componentIds),
@@ -238,7 +241,7 @@ export const deleteApp: Command<DeleteAppInput, DeleteAppResult> = async (
     stranded: strandable.map((deploy) => ({
       deployId: String(deploy.deployId),
       component: deploy.component,
-      target: deploy.target,
+      target: targetLabel(deploy),
       url: deploy.url,
       firing: deploy.componentKind === 'job' && deploy.schedule !== null,
     })),

--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -42,14 +42,16 @@
  * one here would name an artifact that does not exist (§4: "a build records an
  * artifact rather than deploying one").
  */
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
+import { targetAdapterSchema } from '../../config/manifest.schema.ts';
 import {
   type apps,
   builds,
   componentTargetDesired,
   repositories,
   targets,
+  vessels,
 } from '../../db/schema.ts';
 import { repositoryRefOf } from '../../domain/repository.ts';
 import { isFetchableBundleLocation } from '../../storage/archives.ts';
@@ -84,7 +86,8 @@ export const deployAppInput = z
      */
     component: z.string().trim().min(1).optional(),
     /**
-     * The Target for a Component deploying for the first time, by name or id.
+     * The Target for a Component deploying for the first time — its id, or the
+     * two facts that identify it spelled `<vessel>/<adapter>`.
      *
      * Only a first deploy needs it: placement is a fact a deploy writes, so a
      * Component that has never deployed has none to read back — `placeComponent`
@@ -354,13 +357,24 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
 
   let targetId = placedTargetId;
   if (input.target !== undefined) {
-    const wantsId = z.uuid().safeParse(input.target).success;
-    const [named] = await context.db
-      .select({ id: targets.id })
-      .from(targets)
-      .where(
-        wantsId ? eq(targets.id, input.target) : eq(targets.name, input.target),
-      );
+    // Either an id, or the `<vessel>/<adapter>` spelling split back into the
+    // two facts it states. Anything else resolves nothing, which is the honest
+    // answer — half an identity does not name a Target.
+    const [vessel, surface] = input.target.split('/');
+    const adapter = targetAdapterSchema.safeParse(surface);
+    const identifies = z.uuid().safeParse(input.target).success
+      ? eq(targets.id, input.target)
+      : vessel !== undefined && adapter.success
+        ? and(eq(vessels.name, vessel), eq(targets.adapter, adapter.data))
+        : null;
+    const [named] =
+      identifies === null
+        ? []
+        : await context.db
+            .select({ id: targets.id })
+            .from(targets)
+            .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+            .where(identifies);
     if (named === undefined) {
       return failed('NOT_FOUND', `there is no Target '${input.target}'`);
     }

--- a/apps/spindrift/src/commands/apps/list.ts
+++ b/apps/spindrift/src/commands/apps/list.ts
@@ -61,7 +61,7 @@ export const listApps: Command<
       source,
       kind: comp?.kind ?? 'service',
       phase: (deploy?.phase ?? 'PENDING') as DeployPhase,
-      target: target?.name ?? 'none',
+      target: target?.adapter ?? 'none',
       url: deploy?.url ?? app.vanityDomain ?? '',
       urlLive: deploy?.phase === 'LIVE',
       // `deploy.build` is a real Build row whenever `deploy` is — `deploys`

--- a/apps/spindrift/src/commands/apps/resolve-placement.ts
+++ b/apps/spindrift/src/commands/apps/resolve-placement.ts
@@ -26,6 +26,7 @@ import {
   type RequiredDatastore,
   resolvePlacement,
 } from '../../domain/placement.ts';
+import { targetLabel } from '../../domain/target.ts';
 import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
 export const resolveComponentPlacementInput = z
@@ -41,6 +42,7 @@ export type ResolveComponentPlacementInput = z.infer<
 /** One Target the UI renders, candidate or not. */
 export interface PlacementOption {
   readonly targetId: string;
+  /** `<vessel>/<adapter>` — the two facts that identify this Target. */
   readonly name: string;
   readonly rank: number;
   /** Candidates are selectable; non-candidates are listed and disabled (§3). */
@@ -76,10 +78,11 @@ export const resolveComponentPlacement: Command<
     );
   }
 
-  const connected = await context.db
-    .select()
-    .from(targets)
-    .where(eq(targets.status, 'connected'));
+  // With the boundary, because half of what names a Target lives there.
+  const connected = await context.db.query.targets.findMany({
+    where: (targets, { eq }) => eq(targets.status, 'connected'),
+    with: { vessel: true },
+  });
 
   const attached = await context.db
     .select({
@@ -130,7 +133,7 @@ export const resolveComponentPlacement: Command<
   const options: PlacementOption[] = [
     ...placement.candidates.map((candidate) => ({
       targetId: candidate.target.id,
-      name: candidate.target.name,
+      name: targetLabel(candidate.target),
       rank: candidate.target.rank,
       candidate: true,
       artifactType: candidate.artifactType,
@@ -139,7 +142,7 @@ export const resolveComponentPlacement: Command<
     })),
     ...placement.nonCandidates.map((excluded) => ({
       targetId: excluded.target.id,
-      name: excluded.target.name,
+      name: targetLabel(excluded.target),
       rank: excluded.target.rank,
       candidate: false,
       artifactType: null,

--- a/apps/spindrift/src/commands/apps/upload-archive.ts
+++ b/apps/spindrift/src/commands/apps/upload-archive.ts
@@ -27,7 +27,7 @@
  */
 import { and, eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { builds, components, targets } from '../../db/schema.ts';
+import { builds, components } from '../../db/schema.ts';
 import type { ArtifactType } from '../../domain/desired-state.ts';
 import { digestSchema } from '../../domain/digest.ts';
 import { artifactTypeFor, placementTargetOf } from '../../domain/placement.ts';
@@ -92,10 +92,11 @@ export const uploadArchive: Command<
     );
   }
 
-  const [target] = await context.db
-    .select()
-    .from(targets)
-    .where(eq(targets.id, input.targetId));
+  // With the boundary, because half of what names a Target lives there.
+  const target = await context.db.query.targets.findFirst({
+    where: (targets, { eq }) => eq(targets.id, input.targetId),
+    with: { vessel: true },
+  });
   if (target === undefined) {
     return failed('NOT_FOUND', `there is no Target with id ${input.targetId}`);
   }

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -8,6 +8,8 @@ import {
   hasTargetConnection,
   hasVesselLocation,
   type TargetConnection,
+  targetLabel,
+  targetRowLabel,
 } from '../../domain/target.ts';
 import type { VesselLocation } from '../../domain/vessel.ts';
 import type {
@@ -67,7 +69,7 @@ export const getAppWorkspace: Command<
       },
       datastores: {
         with: {
-          target: true,
+          target: { with: { vessel: true } },
         },
       },
     },
@@ -80,7 +82,7 @@ export const getAppWorkspace: Command<
   const unattachedDatastores = await context.db.query.datastores.findMany({
     where: (ds, { isNull }) => isNull(ds.appId),
     with: {
-      target: true,
+      target: { with: { vessel: true } },
     },
   });
 
@@ -113,7 +115,7 @@ export const getAppWorkspace: Command<
       engine: ds.engine,
       provenance: ds.provenance,
       attachedTo: primaryComponent?.name ?? app.name,
-      target: ds.target?.name ?? 'none',
+      target: targetRowLabel(ds.target),
     });
   }
 
@@ -124,7 +126,7 @@ export const getAppWorkspace: Command<
         engine: ds.engine,
         provenance: ds.provenance,
         attachedTo: null,
-        target: ds.target?.name ?? 'none',
+        target: targetRowLabel(ds.target),
       });
     }
   }
@@ -192,7 +194,7 @@ export const getAppWorkspace: Command<
     activity.push({
       kind: 'deploy',
       title: `Deploy ${latestDeploy.id} ${latestDeploy.phase.toLowerCase()}`,
-      detail: latestDeploy.detail ?? `Target: ${latestTarget?.name ?? 'none'}`,
+      detail: latestDeploy.detail ?? `Target: ${targetRowLabel(latestTarget)}`,
       when: elapsedSince(latestDeploy.createdAt, now),
       status:
         latestDeploy.phase === 'LIVE'
@@ -243,7 +245,7 @@ export const getAppWorkspace: Command<
     targetId: workspaceTarget?.id,
     latestDeployId: latestDeploy?.id,
     latestBuildId: primaryComponent?.builds[0]?.id,
-    target: workspaceTarget?.name ?? 'none',
+    target: workspaceTarget?.adapter ?? 'none',
     vessel: workspaceTarget?.vessel.name ?? 'none',
     prerequisitesMet: workspaceTarget
       ? workspaceTarget.health === 'healthy'
@@ -290,10 +292,10 @@ interface PlacedJob {
   readonly ref: string | null;
   readonly target: {
     readonly id: string;
-    readonly name: string;
     readonly adapter: TargetAdapter;
     readonly connection: TargetConnection | null;
     readonly vessel: {
+      readonly name: string;
       readonly location: VesselLocation | null;
       readonly servedHosts: readonly string[] | null;
       readonly reachableRegistries: readonly string[] | null;
@@ -342,7 +344,7 @@ async function executionsOf(
   if (!hasTargetConnection(surface) || !hasVesselLocation(vessel)) {
     return {
       kind: 'none',
-      because: `${surface.name} is not connected, so its runs cannot be read.`,
+      because: `${targetLabel({ vessel: vessel.name, adapter: surface.adapter })} is not connected, so its runs cannot be read.`,
     };
   }
   const adapter = context.adapters.deploy(surface.adapter);
@@ -371,7 +373,7 @@ async function executionsOf(
     return {
       ...runnable,
       executions: [],
-      because: `The runs on ${surface.name} could not be read: ${cause instanceof Error ? cause.message : String(cause)}`,
+      because: `The runs on ${targetLabel({ vessel: vessel.name, adapter: surface.adapter })} could not be read: ${cause instanceof Error ? cause.message : String(cause)}`,
     };
   }
   // A refusal is the adapter saying this ref names no job it can report on —

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -38,6 +38,7 @@ import {
   componentTargetDesired,
   repositories,
   targets,
+  vessels,
 } from '../../db/schema.ts';
 import {
   artifactTags,
@@ -56,6 +57,7 @@ import {
 } from '../../domain/build-route.ts';
 import { DEFAULT_PLATFORM } from '../../domain/placement.ts';
 import { buildOriginOf, type Source } from '../../domain/source.ts';
+import { targetLabel } from '../../domain/target.ts';
 import { isFetchableBundleLocation } from '../../storage/archives.ts';
 import { parseGcsLocation, signedObjectUrl } from '../../storage/signed-url.ts';
 import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
@@ -161,12 +163,17 @@ async function targetBuildPolicy(
 ): Promise<TargetBuildPolicy | null> {
   if (targetId === undefined) return null;
   const [target] = await context.db
-    .select({ name: targets.name, minBuildLevel: targets.minBuildLevel })
+    .select({
+      vessel: vessels.name,
+      adapter: targets.adapter,
+      minBuildLevel: targets.minBuildLevel,
+    })
     .from(targets)
+    .innerJoin(vessels, eq(vessels.id, targets.vesselId))
     .where(eq(targets.id, targetId));
   if (target === undefined) return null;
   return {
-    name: target.name,
+    name: targetLabel(target),
     minimumLevel: (target.minBuildLevel ?? DEFAULT_MINIMUM_BUILD_LEVEL) as
       | 1
       | 2

--- a/apps/spindrift/src/commands/builds/get-detail.ts
+++ b/apps/spindrift/src/commands/builds/get-detail.ts
@@ -14,6 +14,7 @@
  */
 import { z } from 'zod';
 import { elapsedSince } from '../../domain/elapsed.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import type { DeployPhase, DeployView } from '../../web/model.ts';
 import { type Command, failed, ok } from '../types.ts';
 import { buildViewOf, sourceViewOf } from './view.ts';
@@ -52,7 +53,10 @@ export const getBuildDetail: Command<
       component: {
         with: {
           app: true,
-          desiredTargets: { limit: 1, with: { target: true } },
+          desiredTargets: {
+            limit: 1,
+            with: { target: { with: { vessel: true } } },
+          },
         },
       },
       deploys: {
@@ -92,14 +96,14 @@ export const getBuildDetail: Command<
     appId: build.component.app.id,
     app: build.component.app.name,
     component: build.component.name,
-    target: target?.name ?? 'not placed',
+    target: target === undefined ? 'not placed' : targetRowLabel(target),
     commit: build.commit,
     phase: PHASE[build.status],
     phaseWord: buildView === null ? 'Extracted' : PHASE_WORD[build.status],
     headline: headlineFor(
       build.status,
       buildView?.runner ?? null,
-      target?.name ?? null,
+      target === undefined ? null : targetRowLabel(target),
     ),
     url: build.component.app.vanityDomain ?? '',
     // A Build never serves anything: §6's exposure is only ever changed by an

--- a/apps/spindrift/src/commands/components/place.ts
+++ b/apps/spindrift/src/commands/components/place.ts
@@ -23,8 +23,9 @@
 
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { targets } from '../../db/schema.ts';
+import { targets, vessels } from '../../db/schema.ts';
 import { VARIABLE_NAME } from '../../domain/config.ts';
+import { targetLabel } from '../../domain/target.ts';
 import { carryReferences } from '../config/carry.ts';
 import { demandSentence, migrationFor } from '../config/migration.ts';
 import {
@@ -87,12 +88,16 @@ export const placeComponent: Command<
   const missing = migration.demanded.filter((key) => !supplied.has(key));
   if (missing.length > 0) {
     const [target] = await context.db
-      .select({ name: targets.name })
+      .select({ vessel: vessels.name, adapter: targets.adapter })
       .from(targets)
+      .innerJoin(vessels, eq(vessels.id, targets.vesselId))
       .where(eq(targets.id, input.targetId));
     return failed(
       'NOT_DEPLOYABLE',
-      demandSentence(missing, target?.name ?? input.targetId),
+      demandSentence(
+        missing,
+        target === undefined ? input.targetId : targetLabel(target),
+      ),
     );
   }
 

--- a/apps/spindrift/src/commands/components/reach.ts
+++ b/apps/spindrift/src/commands/components/reach.ts
@@ -37,6 +37,7 @@ import {
   authHasARoute,
   type Reach,
 } from '../../domain/desired-state.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import { type Command, failed, ok } from '../types.ts';
 
 export const setComponentReachInput = z
@@ -64,8 +65,8 @@ export interface SetComponentReachResult {
   readonly reach: Reach;
   readonly auth: Auth;
   /**
-   * The Targets whose current release still places the previous answer, by
-   * name and sorted.
+   * The Targets whose current release still places the previous answer, as
+   * `<vessel>/<adapter>` and sorted.
    *
    * Empty means there is nothing to press Deploy for — either this Component
    * has never been placed, or what is desired already asks for what was just
@@ -103,7 +104,10 @@ export const setComponentReach: Command<
   const placed = await context.db.query.componentTargetDesired.findMany({
     where: (desired, { eq }) => eq(desired.componentId, row.id),
     with: {
-      target: { columns: { name: true } },
+      target: {
+        columns: { adapter: true },
+        with: { vessel: { columns: { name: true } } },
+      },
       desiredDeploy: { columns: { desired: true } },
     },
   });
@@ -119,7 +123,7 @@ export const setComponentReach: Command<
           (desiredDeploy.desired.reach !== input.reach ||
             desiredDeploy.desired.auth !== input.auth),
       )
-      .map(({ target }) => target.name)
+      .map(({ target }) => targetRowLabel(target))
       .sort(),
   });
 };

--- a/apps/spindrift/src/commands/components/run.ts
+++ b/apps/spindrift/src/commands/components/run.ts
@@ -27,6 +27,7 @@ import {
   deployTargetOf,
   hasTargetConnection,
   hasVesselLocation,
+  targetLabel,
 } from '../../domain/target.ts';
 import { type Command, failed, ok } from '../types.ts';
 
@@ -94,7 +95,7 @@ export const runComponent: Command<
   ) {
     return failed(
       'NOT_RUNNABLE',
-      `${placed.target.name} is not connected, so nothing can be started on it`,
+      `${targetLabel({ vessel: placed.vessel.name, adapter: placed.target.adapter })} is not connected, so nothing can be started on it`,
     );
   }
   const adapter = context.adapters.deploy(placed.target.adapter);

--- a/apps/spindrift/src/commands/components/schedule.ts
+++ b/apps/spindrift/src/commands/components/schedule.ts
@@ -37,6 +37,7 @@
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
 import { components } from '../../db/schema.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import { type Command, failed, ok } from '../types.ts';
 import { cronExpression } from './create.ts';
 
@@ -94,7 +95,12 @@ export const setComponentSchedule: Command<
 
   const placed = await context.db.query.componentTargetDesired.findMany({
     where: (desired, { eq }) => eq(desired.componentId, row.id),
-    with: { target: { columns: { name: true } } },
+    with: {
+      target: {
+        columns: { adapter: true },
+        with: { vessel: { columns: { name: true } } },
+      },
+    },
   });
 
   return ok({
@@ -106,7 +112,7 @@ export const setComponentSchedule: Command<
     // and nothing is running at those, so nothing there is pending.
     pendingRelease: placed
       .filter((desired) => desired.desiredDeployId !== null)
-      .map(({ target }) => target.name)
+      .map(({ target }) => targetRowLabel(target))
       .sort(),
   });
 };

--- a/apps/spindrift/src/commands/components/unplace.ts
+++ b/apps/spindrift/src/commands/components/unplace.ts
@@ -43,13 +43,13 @@ import {
   components,
   componentTargetDesired,
   deploys,
-  targets,
   vessels,
 } from '../../db/schema.ts';
 import {
   deployTargetOf,
   hasTargetConnection,
   hasVesselLocation,
+  targetRowLabel,
 } from '../../domain/target.ts';
 import { type Command, failed, ok } from '../types.ts';
 
@@ -90,10 +90,11 @@ export const unplaceComponent: Command<
     );
   }
 
-  const [target] = await context.db
-    .select()
-    .from(targets)
-    .where(eq(targets.id, input.targetId));
+  // With the boundary, because half of what names a Target lives there.
+  const target = await context.db.query.targets.findFirst({
+    where: (targets, { eq }) => eq(targets.id, input.targetId),
+    with: { vessel: true },
+  });
   if (target === undefined) {
     return failed('NOT_FOUND', `there is no Target with id ${input.targetId}`);
   }
@@ -110,7 +111,7 @@ export const unplaceComponent: Command<
   if (desired === undefined) {
     return failed(
       'NOT_FOUND',
-      `'${component.name}' is not placed on '${target.name}'`,
+      `'${component.name}' is not placed on ${targetRowLabel(target)}`,
     );
   }
 
@@ -145,7 +146,7 @@ export const unplaceComponent: Command<
     ) {
       return failed(
         'NOT_REMOVABLE',
-        `'${target.name}' is not connected, so nothing can be torn down there`,
+        `${targetRowLabel(target)} is not connected, so nothing can be torn down there`,
       );
     }
     const adapter = context.adapters.deploy(target.adapter);

--- a/apps/spindrift/src/commands/config/pinned.ts
+++ b/apps/spindrift/src/commands/config/pinned.ts
@@ -22,6 +22,7 @@ import {
   configItems,
   PINNED_ENVIRONMENT,
   targets,
+  vessels,
 } from '../../db/schema.ts';
 import { configScopeOf } from '../../domain/config.ts';
 import {
@@ -78,11 +79,13 @@ export async function configScopeFor(
     .select({
       app: apps.name,
       component: components.name,
-      target: targets.name,
+      vessel: vessels.name,
+      adapter: targets.adapter,
     })
     .from(components)
     .innerJoin(apps, eq(components.appId, apps.id))
     .innerJoin(targets, eq(targets.id, targetId))
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
     .where(eq(components.id, componentId));
 
   return row === undefined ? null : configScopeOf(row);

--- a/apps/spindrift/src/commands/config/set.ts
+++ b/apps/spindrift/src/commands/config/set.ts
@@ -42,7 +42,6 @@ import {
   configItems,
   PINNED_ENVIRONMENT,
   type Target,
-  targets,
 } from '../../db/schema.ts';
 import { capabilitiesOfRow } from '../../domain/capabilities.ts';
 import {
@@ -52,6 +51,7 @@ import {
   VARIABLE_NAME,
 } from '../../domain/config.ts';
 import type { ComponentKind } from '../../domain/desired-state.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import {
   checkDeployable,
   deliveringConfig,
@@ -220,10 +220,11 @@ export async function configSubject(
     };
   }
 
-  const [target] = await context.db
-    .select()
-    .from(targets)
-    .where(eq(targets.id, input.targetId));
+  // With the boundary, because half of what names a Target lives there.
+  const target = await context.db.query.targets.findFirst({
+    where: (targets, { eq }) => eq(targets.id, input.targetId),
+    with: { vessel: true },
+  });
   if (target === undefined) {
     return {
       failure: {
@@ -242,7 +243,7 @@ export async function configSubject(
     return {
       failure: {
         code: 'NOT_DEPLOYABLE',
-        message: `${target.name} reaches no secret store this installation can write to, so config set here would be delivered by nobody`,
+        message: `${targetRowLabel(target)} reaches no secret store this installation can write to, so config set here would be delivered by nobody`,
       },
     };
   }

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -26,6 +26,7 @@ import {
 import { repositoryRefOf } from '../../domain/repository.ts';
 import { SUPPLIED_ARTIFACT_TYPE } from '../../domain/source.ts';
 import type { StagedSourceBundle } from '../../domain/source-bundle.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import { routeForTarget } from '../builds/route.ts';
 import type { CreateAppResult } from '../create-app.ts';
 import {
@@ -373,11 +374,11 @@ async function prepareCreation(
   draft: typeof creationDraftSchema._output,
   context: CommandContext,
 ) {
-  const [target] = await context.db
-    .select()
-    .from(targets)
-    .where(eq(targets.id, draft.targetId))
-    .limit(1);
+  // With the boundary, because half of what names a Target lives there.
+  const target = await context.db.query.targets.findFirst({
+    where: (targets, { eq }) => eq(targets.id, draft.targetId),
+    with: { vessel: true },
+  });
   if (!target) {
     return failed<PreparedCreation>(
       'NOT_FOUND',
@@ -410,11 +411,12 @@ async function prepareCreation(
     ) {
       return failed<PreparedCreation>(
         'NOT_DEPLOYABLE',
-        `${target.name} cannot take uploaded finished files`,
+        `${targetRowLabel(target)} cannot take uploaded finished files`,
       );
     }
     const route = supplied ? null : await routeForTarget(target.id, context);
-    if (!supplied && route === null) return noBuildRoute(target.name);
+    if (!supplied && route === null)
+      return noBuildRoute(targetRowLabel(target));
     return ok({
       repositoryId: null,
       commit: draft.source.digest,
@@ -448,7 +450,7 @@ async function prepareCreation(
     );
   }
   const route = await routeForTarget(target.id, context);
-  if (route === null) return noBuildRoute(target.name);
+  if (route === null) return noBuildRoute(targetRowLabel(target));
   let staged: StagedSourceBundle;
   try {
     staged = await stager.stageRepository({
@@ -596,10 +598,10 @@ async function revalidate(
   draft: typeof creationDraftSchema._output,
   context: CommandContext,
 ): Promise<readonly Blocker[]> {
-  const connected = await context.db
-    .select()
-    .from(targets)
-    .where(eq(targets.status, 'connected'));
+  const connected = await context.db.query.targets.findMany({
+    where: (targets, { eq }) => eq(targets.status, 'connected'),
+    with: { vessel: true },
+  });
   const placement = resolvePlacement(
     connected.map((target) =>
       placementTargetOf(target, {
@@ -666,7 +668,7 @@ async function revalidate(
   ) {
     blockers.push({
       code: 'TARGET_UNAVAILABLE',
-      title: `${selectedTarget.name} cannot take uploaded finished files.`,
+      title: `${targetRowLabel(selectedTarget)} cannot take uploaded finished files.`,
       remediation:
         'Choose a static Target for this supplied artifact, or upload source that Spindrift can build for this Target.',
     });
@@ -680,7 +682,7 @@ async function revalidate(
   ) {
     blockers.push({
       code: 'BUILD_ROUTE_UNAVAILABLE',
-      title: `No eligible build route can build for ${selectedTarget.name}.`,
+      title: `No eligible build route can build for ${targetRowLabel(selectedTarget)}.`,
       remediation:
         'Configure a route that clears this Target’s minimum Build Level, then review the draft again.',
     });

--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -41,7 +41,6 @@ import {
   components,
   componentTargetDesired,
   deploys,
-  targets,
 } from '../../db/schema.ts';
 import { DEFAULT_MINIMUM_BUILD_LEVEL } from '../../domain/build-route.ts';
 import type { DesiredDocument } from '../../domain/desired-state.ts';
@@ -52,6 +51,7 @@ import {
   reachExclusions,
   sentence,
 } from '../../domain/placement.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import { demandSentence, migrationFor } from '../config/migration.ts';
 import { type PinnedConfig, readPinnedConfig } from '../config/pinned.ts';
 import {
@@ -321,10 +321,11 @@ export async function checkDeployable(
     return refuse('NOT_FOUND', `Component ${component.name} has no App`);
   }
 
-  const [target] = await context.db
-    .select()
-    .from(targets)
-    .where(eq(targets.id, input.targetId));
+  // With the boundary, because half of what names a Target lives there.
+  const target = await context.db.query.targets.findFirst({
+    where: (targets, { eq }) => eq(targets.id, input.targetId),
+    with: { vessel: true },
+  });
   if (target === undefined) {
     return failed('NOT_FOUND', `there is no Target with id ${input.targetId}`);
   }
@@ -350,7 +351,7 @@ export async function checkDeployable(
   if (target.status !== 'connected') {
     return refuse(
       'NOT_DEPLOYABLE',
-      `${target.name} is disconnected, so nothing new can be placed on it`,
+      `${targetRowLabel(target)} is disconnected, so nothing new can be placed on it`,
     );
   }
 
@@ -378,7 +379,7 @@ export async function checkDeployable(
     if (build.verifiedBuildLevel < requiredLevel) {
       return refuse(
         'NOT_DEPLOYABLE',
-        `Build ${build.id} achieved verified Build Level ${build.verifiedBuildLevel}, and ${target.name} currently requires L${requiredLevel}`,
+        `Build ${build.id} achieved verified Build Level ${build.verifiedBuildLevel}, and ${targetRowLabel(target)} currently requires L${requiredLevel}`,
       );
     }
     // Cryptographically real admission: the recorded signature is re-verified
@@ -412,7 +413,7 @@ export async function checkDeployable(
   if (build.targetShape !== shape) {
     return refuse(
       'NOT_DEPLOYABLE',
-      `Build ${build.id} produced ${build.targetShape}, and ${target.name} takes ${shape} — this placement needs a rebuild`,
+      `Build ${build.id} produced ${build.targetShape}, and ${targetRowLabel(target)} takes ${shape} — this placement needs a rebuild`,
     );
   }
 
@@ -440,7 +441,7 @@ export async function checkDeployable(
       .join('; ');
     return refuse(
       'NOT_DEPLOYABLE',
-      `${target.name} does not serve this Component's ${component.reach} reach — ${why}`,
+      `${targetRowLabel(target)} does not serve this Component's ${component.reach} reach — ${why}`,
     );
   }
 
@@ -458,7 +459,7 @@ export async function checkDeployable(
   if (migration.demanded.length > 0) {
     return refuse(
       'NOT_DEPLOYABLE',
-      demandSentence(migration.demanded, target.name),
+      demandSentence(migration.demanded, targetRowLabel(target)),
     );
   }
 
@@ -474,7 +475,7 @@ export async function checkDeployable(
       desired: {
         app: app.name,
         component: component.name,
-        target: target.name,
+        target: targetRowLabel(target),
         kind: component.kind,
         // Optional on `DesiredState`, so absent rather than null — the chart
         // branches on emptiness and the adapters spread this straight through.

--- a/apps/spindrift/src/commands/deploys/get-detail.ts
+++ b/apps/spindrift/src/commands/deploys/get-detail.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import type { Blame, FailureReason } from '../../adapters/deploy/contract.ts';
 import { elapsedSince } from '../../domain/elapsed.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import type {
   ChecklistItem,
   DeployPhase,
@@ -59,7 +60,7 @@ export const getDeployDetail: Command<
           app: true,
         },
       },
-      target: true,
+      target: { with: { vessel: true } },
       build: true,
     },
   });
@@ -195,13 +196,13 @@ export const getDeployDetail: Command<
         : 'Deploy failed';
   } else if (deploy.phase === 'APPLYING') phaseWord = 'Applying';
 
-  let headline = `Deployed to ${deploy.target.name}`;
+  let headline = `Deployed to ${targetRowLabel(deploy.target)}`;
   if (deploy.phase === 'LIVE') {
-    headline = `Reconciled on ${deploy.target.name}`;
+    headline = `Reconciled on ${targetRowLabel(deploy.target)}`;
   } else if (deploy.phase === 'FAILED') {
     headline = deploy.detail ?? 'Deploy failed';
   } else {
-    headline = `Deploying on ${deploy.target.name}`;
+    headline = `Deploying on ${targetRowLabel(deploy.target)}`;
   }
 
   const view: DeployView = {
@@ -212,7 +213,7 @@ export const getDeployDetail: Command<
     appId: deploy.component.app.id,
     app: deploy.component.app.name,
     component: deploy.component.name,
-    target: deploy.target.name,
+    target: targetRowLabel(deploy.target),
     commit: deploy.build.commit,
     phase: deploy.phase as DeployPhase,
     phaseWord,

--- a/apps/spindrift/src/commands/deploys/list.ts
+++ b/apps/spindrift/src/commands/deploys/list.ts
@@ -18,6 +18,7 @@
 import { inArray } from 'drizzle-orm';
 import { z } from 'zod';
 import { elapsedSince } from '../../domain/elapsed.ts';
+import { targetRowLabel } from '../../domain/target.ts';
 import type { DeployLedgerItem, DeployPhase } from '../../web/model.ts';
 import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
@@ -104,7 +105,7 @@ export async function releasesOf(
     limit: limit + 1,
     with: {
       component: { with: { app: true } },
-      target: true,
+      target: { with: { vessel: true } },
       build: true,
     },
   });
@@ -136,7 +137,7 @@ export async function releasesOf(
       componentId: row.componentId,
       targetId: row.targetId,
       component: row.component.name,
-      target: row.target.name,
+      target: targetRowLabel(row.target),
       commit: row.build.commit,
       phase: row.phase as DeployPhase,
       when: elapsedSince(row.createdAt, now),

--- a/apps/spindrift/src/commands/installation/configure.ts
+++ b/apps/spindrift/src/commands/installation/configure.ts
@@ -31,6 +31,7 @@ import {
 } from '../../config/manifest.schema.ts';
 import { ManifestError, validateManifest } from '../../config/manifest.ts';
 import { writeStoredManifest } from '../../config/manifest-store.ts';
+import { targetLabel } from '../../domain/target.ts';
 import { type Command, failed, ok } from '../types.ts';
 
 export const configureInstallationInput = z
@@ -56,9 +57,9 @@ export interface ConfigureInstallationResult {
   readonly installation: string;
   /**
    * The Targets the written manifest declares, in its own order — which is
-   * §16's admin rank. Returned because writing a manifest is the one act that
-   * can create a Target without anyone naming one, and a confirmation that did
-   * not say so would hide it.
+   * §16's admin rank — each as `<vessel>/<adapter>`. Returned because writing a
+   * manifest is the one act that can create a Target without anyone naming one,
+   * and a confirmation that did not say so would hide it.
    */
   readonly targets: readonly string[];
 }
@@ -77,22 +78,17 @@ export const configureInstallation: Command<
     throw cause;
   }
 
-  try {
-    await writeStoredManifest(context.db, manifest);
-  } catch (cause) {
-    // The one refusal reconciliation makes: a declared Target whose adapter
-    // disagrees with the stored row's. It is a fact about the installation
-    // rather than a malformed field, which is the distinction `NOT_DEPLOYABLE`
-    // draws — the caller is not being told to fix a key.
-    if (cause instanceof ManifestError) {
-      return failed('NOT_DEPLOYABLE', cause.message);
-    }
-    throw cause;
-  }
+  // **Reconciliation makes no refusal of its own.** It used to make exactly one
+  // — a declared Target whose adapter disagreed with the stored row's — and that
+  // state stopped being expressible when the adapter became half of what
+  // identifies a Target: a seed naming a different one names a different Target,
+  // not a redefinition of this one. Everything left that a document can get
+  // wrong is a key, and `validateManifest` above names it.
+  await writeStoredManifest(context.db, manifest);
 
   return ok({
     installation: manifest.installation,
-    targets: manifest.targets.map((target) => target.name),
+    targets: manifest.targets.map(targetLabel),
   });
 };
 

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -19,12 +19,13 @@
  * leave a website ambiguous between the two renderings. That is also why no
  * `Provider` noun exists: the shared thing is an argument to this command.
  *
- * Connect is **idempotent by name**. Re-running it re-inspects, keeps the
- * Target's id and rank, and — if it had been disconnected — re-adopts what it
- * stranded, by asking the adapter to `observe` each orphaned Deploy (§13:
- * "reconnect re-adopts via `observe`").
+ * Connect is **idempotent by `(vessel, adapter)`** — which is what a Target is,
+ * so there is nothing else it could be idempotent by. Re-running it re-inspects,
+ * keeps each Target's id and rank, and — if it had been disconnected — re-adopts
+ * what it stranded, by asking the adapter to `observe` each orphaned Deploy
+ * (§13: "reconnect re-adopts via `observe`").
  */
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { operatorValuesIssues } from '../../adapters/deploy/kubernetes/values.ts';
 import {
@@ -38,11 +39,14 @@ import {
 } from '../../domain/capabilities.ts';
 import {
   deployTargetOf,
-  surfaceNames,
   type TargetConnection,
   type TargetHealth,
 } from '../../domain/target.ts';
-import type { VesselKind, VesselLocation } from '../../domain/vessel.ts';
+import {
+  surfacesOf,
+  type VesselKind,
+  type VesselLocation,
+} from '../../domain/vessel.ts';
 import {
   inspectTarget,
   readoptTargetDeploys,
@@ -113,8 +117,8 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('cluster'),
-      /** The vessel's name. Its one surface takes it unchanged. */
-      name: targetNameSchema,
+      /** The boundary being connected, by name. Every surface on it is registered. */
+      vessel: targetNameSchema,
       /** §13's prerequisite is OIDC against this, not a credential for it. */
       apiServer: z.url(),
       /** Where an App's workloads land. Never created by Spindrift (§7). */
@@ -132,8 +136,8 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('gcp-project'),
-      /** The vessel's name. Both of its surfaces are derived from it. */
-      name: targetNameSchema,
+      /** The boundary being connected, by name. Both of its surfaces are registered. */
+      vessel: targetNameSchema,
       project: z.string().trim().min(1),
       region: z.string().trim().min(1),
       /**
@@ -176,7 +180,8 @@ export type ConnectTargetInput = z.infer<typeof connectTargetInput>;
 /** One registered Target, as the operator's confirmation shows it. */
 export interface ConnectedTarget {
   readonly id: string;
-  readonly name: string;
+  /** The boundary it is a surface on — the two together are what name it. */
+  readonly vessel: string;
   readonly adapter: TargetAdapter;
   readonly rank: number;
   readonly health: TargetHealth;
@@ -300,7 +305,10 @@ export const connectTarget: Command<
   // surfaces would then be split across.
   const desiredVessel = vesselFor(input);
   const existingVessel = (
-    await context.db.select().from(vessels).where(eq(vessels.name, input.name))
+    await context.db
+      .select()
+      .from(vessels)
+      .where(eq(vessels.name, input.vessel))
   )[0];
   const vessel =
     existingVessel === undefined
@@ -308,7 +316,7 @@ export const connectTarget: Command<
           await context.db
             .insert(vessels)
             .values({
-              name: input.name,
+              name: input.vessel,
               ...desiredVessel,
               createdAt: now,
               updatedAt: now,
@@ -323,19 +331,31 @@ export const connectTarget: Command<
             .returning()
         )[0]!;
 
-  for (const { name, adapter } of surfaceNames(input.kind, input.name)) {
+  // Idempotent by `(vessel, adapter)`, which is what a Target *is*: reconnecting
+  // re-adopts the surface that is already there rather than registering a second
+  // one competing for the same workloads.
+  for (const adapter of surfacesOf(input.kind)) {
     const existing = (
-      await context.db.select().from(targets).where(eq(targets.name, name))
+      await context.db
+        .select()
+        .from(targets)
+        .where(
+          and(eq(targets.vesselId, vessel.id), eq(targets.adapter, adapter)),
+        )
     )[0];
 
     const connection = connectionFor(input, adapter);
     // The flat view the adapter takes, composed from the surface just built and
     // the boundary above it — the same composition the loops perform.
     const ref = deployTargetOf(
-      { name, adapter, connection },
+      { adapter, connection },
       // Built from what was just written rather than re-read: `vesselFor`
       // always states a location, which the nullable column cannot know.
-      { ...desiredVessel, location: desiredVessel.location },
+      {
+        ...desiredVessel,
+        name: input.vessel,
+        location: desiredVessel.location,
+      },
     );
     // One pass of the same loop §13 runs on a schedule — not a second notion of
     // what "healthy" means that happens to run at connect time.
@@ -352,7 +372,6 @@ export const connectTarget: Command<
       const [row] = await context.db
         .insert(targets)
         .values({
-          name,
           adapter,
           vesselId: vessel.id,
           connection,
@@ -368,7 +387,7 @@ export const connectTarget: Command<
         .returning();
       registered.push({
         id: row!.id,
-        name,
+        vessel: input.vessel,
         adapter,
         rank: row!.rank,
         health,
@@ -380,10 +399,6 @@ export const connectTarget: Command<
     const [row] = await context.db
       .update(targets)
       .set({
-        // A reconnect may move a surface onto a different vessel — connecting
-        // the same name against another project is a correction, not a second
-        // Target.
-        vesselId: vessel.id,
         connection,
         health,
         prerequisites,
@@ -408,7 +423,7 @@ export const connectTarget: Command<
 
     registered.push({
       id: row!.id,
-      name,
+      vessel: input.vessel,
       adapter,
       rank: row!.rank,
       health,

--- a/apps/spindrift/src/commands/targets/disconnect.ts
+++ b/apps/spindrift/src/commands/targets/disconnect.ts
@@ -18,14 +18,28 @@
  */
 import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { z } from 'zod';
-import { apps, components, deploys, targets } from '../../db/schema.ts';
-import { STRANDABLE_PHASES } from '../../domain/target.ts';
+import {
+  type TargetAdapter,
+  targetAdapterSchema,
+} from '../../config/manifest.schema.ts';
+import {
+  apps,
+  components,
+  deploys,
+  targets,
+  vessels,
+} from '../../db/schema.ts';
+import { STRANDABLE_PHASES, targetLabel } from '../../domain/target.ts';
 import { type Command, failed, ok } from '../types.ts';
 
 export const disconnectTargetInput = z
   .object({
-    /** Targets are addressed by name; the id is core's, not the operator's. */
-    name: z.string().trim().min(1),
+    /**
+     * The Target, as the two facts that identify it: the boundary it is a
+     * surface on and the runtime it is. The id is core's, not the operator's.
+     */
+    vessel: z.string().trim().min(1),
+    adapter: targetAdapterSchema,
     /** False previews the Deploys that confirmation would orphan. */
     confirm: z.boolean().optional(),
   })
@@ -44,7 +58,9 @@ export interface StrandedDeploy {
 
 export interface DisconnectTargetResult {
   readonly targetId: string;
-  readonly name: string;
+  /** The boundary it is a surface on — the two together are what name it. */
+  readonly vessel: string;
+  readonly adapter: TargetAdapter;
   /** False for an impact review; true once the Target was disconnected. */
   readonly disconnected: boolean;
   /** Named, per §13 — this list is the whole point of the confirmation. */
@@ -58,11 +74,19 @@ export const disconnectTarget: Command<
   const now = context.clock.now();
   const confirmed = input.confirm ?? true;
 
+  // The pair, not a name: `(vessel, adapter)` is what a Target is, and it is the
+  // unique index too, so this resolves at most one row.
   const target = (
-    await context.db.select().from(targets).where(eq(targets.name, input.name))
+    await context.db
+      .select({ id: targets.id })
+      .from(targets)
+      .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+      .where(
+        and(eq(vessels.name, input.vessel), eq(targets.adapter, input.adapter)),
+      )
   )[0];
   if (target === undefined) {
-    return failed('NOT_FOUND', `there is no Target named ${input.name}`);
+    return failed('NOT_FOUND', `there is no ${targetLabel(input)} Target`);
   }
 
   // Read before write: the rows to name in the confirmation are exactly the
@@ -107,7 +131,8 @@ export const disconnectTarget: Command<
 
   return ok({
     targetId: target.id,
-    name: target.name,
+    vessel: input.vessel,
+    adapter: input.adapter,
     disconnected: confirmed,
     stranded: strandable.map((deploy) => ({
       deployId: String(deploy.deployId),

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -114,7 +114,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
 
     targetsList.push({
       id: target.id,
-      name: target.name,
+      vessel: target.vessel.name,
       adapter: target.adapter,
       rank: target.rank,
       health: target.health,
@@ -133,7 +133,11 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
       configured: target.connection !== null,
       inspectedAt: target.inspectedAt?.toISOString() ?? null,
       connectionDivergence: targetConnectionDivergence(
-        context.manifest.targets.find((seed) => seed.name === target.name),
+        context.manifest.targets.find(
+          (seed) =>
+            seed.vessel === target.vessel.name &&
+            seed.adapter === target.adapter,
+        ),
         target.connection,
       ),
       // Carried from this Target alone, which is the whole difference between
@@ -182,7 +186,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
         const candidate = placement.candidates[0]!;
         optionsList.push({
           targetId: target.id,
-          name: target.name,
+          vessel: target.vessel.name,
           adapter: target.adapter,
           rank: target.rank,
           candidate: true,
@@ -195,7 +199,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
         const excluded = placement.nonCandidates[0]!;
         optionsList.push({
           targetId: target.id,
-          name: target.name,
+          vessel: target.vessel.name,
           adapter: target.adapter,
           rank: target.rank,
           candidate: false,
@@ -226,7 +230,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
 
       optionsList.push({
         targetId: target.id,
-        name: target.name,
+        vessel: target.vessel.name,
         adapter: target.adapter,
         rank: target.rank,
         candidate: false,

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -336,20 +336,19 @@ async function reconcileManifestTargets(
   const reconciledVessels = await reconcileManifestVessels(db, manifest, write);
 
   for (const [rank, target] of manifest.targets.entries()) {
-    const { name, adapter } = target;
+    const { adapter } = target;
     // Non-null because the document-level refinement in `manifest.schema.ts`
     // refuses a Target whose `vessel` names nothing declared, so a validated
     // manifest cannot reach here with a reference that does not resolve.
     const vessel = reconciledVessels.get(target.vessel)!;
     const declaredConnection = connectionFromSeed(target);
+    // By the pair that identifies a Target, which is also its unique index.
+    // There is no adapter mismatch to check for any more: a seed naming a
+    // different adapter is a different Target, not a redefinition of this one.
     const existing = await db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, name),
+      where: (targets, { and, eq }) =>
+        and(eq(targets.vesselId, vessel.id), eq(targets.adapter, adapter)),
     });
-    if (existing !== undefined && existing.adapter !== adapter) {
-      throw new ManifestError(
-        `manifest Target ${name} uses ${adapter}, but the stored Target uses ${existing.adapter}`,
-      );
-    }
 
     const awaitingInspection = unreachablePrerequisites(
       'Declared Target connection is awaiting inspection',
@@ -366,7 +365,6 @@ async function reconcileManifestTargets(
     await db
       .insert(targets)
       .values({
-        name,
         adapter,
         vesselId: vessel.id,
         rank,
@@ -386,7 +384,7 @@ async function reconcileManifestTargets(
             : awaitingInspection,
       })
       .onConflictDoUpdate({
-        target: targets.name,
+        target: [targets.vesselId, targets.adapter],
         set: {
           rank,
           // §3's asserted half follows the connection, not the rank: a reach is

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -52,7 +52,47 @@ function asDocument(value: unknown): Document | null {
  * what is wrong with it rather than reporting what this function made of it.
  */
 export function upgradeManifestDocument(document: unknown): unknown {
-  return addDeclaredVessels(document);
+  return dropTargetNames(addDeclaredVessels(document));
+}
+
+/**
+ * Take the constructed `name` off every Target entry.
+ *
+ * A Target is `(vessel, adapter)`. Its `name` was those two joined by a hyphen —
+ * or the vessel's name alone where the vessel had only one surface, since the
+ * suffix existed to tell siblings apart. That made it decorative once the vessel
+ * became a key of its own, and made it a rename hazard the moment a vessel could
+ * discover a surface it did not have before.
+ *
+ * **Nothing is derived from it.** The two lines under it were already
+ * authoritative, so this discards the field rather than reading it — which is
+ * also why this step is safe to run over a document {@link addDeclaredVessels}
+ * has just rewritten: that function *put* `vessel` on every entry.
+ *
+ * Runs second for that reason, and returns its argument untouched when no entry
+ * carries the key, which is what keeps this a no-op on a current document.
+ */
+function dropTargetNames(document: unknown): unknown {
+  const manifest = asDocument(document);
+  if (manifest === null) return document;
+
+  const seeds = Array.isArray(manifest.targets) ? manifest.targets : null;
+  if (seeds === null) return document;
+  if (!seeds.some((seed) => asDocument(seed) !== null && 'name' in seed)) {
+    return document;
+  }
+
+  return {
+    ...manifest,
+    // Rebuilt in place, in order: `reconcileManifestTargets` reads a Target's
+    // rank from its position in this array.
+    targets: seeds.map((seed) => {
+      const target = asDocument(seed);
+      if (target === null) return seed;
+      const { name: _discarded, ...rest } = target;
+      return rest;
+    }),
+  };
 }
 
 /**

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -202,12 +202,15 @@ export const vesselSeedSchema = z.discriminatedUnion('kind', [
  * **Only facts true of this runtime surface and not of its neighbours.** Where
  * the boundary is, and what it can reach, are declared once on the vessel this
  * names.
+ *
+ * **There is no `name`.** `vessel` and `adapter` are what identify a Target, so
+ * a third field could only restate them or contradict them — and the spelling it
+ * used to carry was a suffix that appeared only where a vessel had two surfaces,
+ * which made the day a vessel gained one a day the other had to be renamed.
  */
 export const targetSeedSchema = z.discriminatedUnion('adapter', [
   z
     .object({
-      /** Stable identifier, unique within the installation. */
-      name: targetNameSchema,
       /** The vessel this Target is a surface on, by name (§13). */
       vessel: targetNameSchema,
       adapter: z.literal('kubernetes'),
@@ -237,7 +240,6 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
     .strict(),
   z
     .object({
-      name: targetNameSchema,
       vessel: targetNameSchema,
       adapter: z.literal('cloudrun'),
       connection: z
@@ -255,7 +257,6 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
     .strict(),
   z
     .object({
-      name: targetNameSchema,
       vessel: targetNameSchema,
       adapter: z.literal('static'),
       connection: z
@@ -618,8 +619,9 @@ export const installationManifestSchema = z
       .min(1)
       .refine(
         (targets) =>
-          new Set(targets.map((t) => t.name)).size === targets.length,
-        'target names must be unique',
+          new Set(targets.map((t) => `${t.vessel}/${t.adapter}`)).size ===
+          targets.length,
+        'a vessel carries one surface of each kind',
       ),
   })
   .strict()

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -174,7 +174,6 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
   ],
   targets: [
     {
-      name: 'primary',
       vessel: 'primary',
       adapter: 'kubernetes',
       connection: {
@@ -187,7 +186,6 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
       },
     },
     {
-      name: 'spindrift-cloudrun',
       vessel: 'spindrift',
       adapter: 'cloudrun',
       connection: {
@@ -196,7 +194,6 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
       },
     },
     {
-      name: 'spindrift-static',
       vessel: 'spindrift',
       adapter: 'static',
       connection: {

--- a/apps/spindrift/src/db/migrations/0028_target_vessel_surface_identity.sql
+++ b/apps/spindrift/src/db/migrations/0028_target_vessel_surface_identity.sql
@@ -1,0 +1,27 @@
+-- A Target is its vessel and its surface, so it needs no name of its own.
+--
+-- `targets.name` was a constructed string: the vessel's name, plus the adapter
+-- as a suffix where the vessel carried more than one surface. Migration 0022
+-- called slicing that suffix back off "the last time a boundary is recovered
+-- from a name". This is the last time a name is constructed from one.
+--
+-- **Nothing is lost, because nothing was ever stored here that the two
+-- surviving columns do not already state.** `vessel_id` names the boundary and
+-- `adapter` names the runtime on it; the name was those two joined by a hyphen,
+-- or the vessel's name alone where there was only one surface to tell apart.
+-- Every persisted edge into this table is `target_id uuid` — `deploys`,
+-- `component_target_desired`, `datastores`, `config_items` — so dropping the
+-- column moves no foreign key and orphans no row.
+--
+-- The unique index follows the identity rather than the spelling of it. It is
+-- also the stricter constraint: `targets_name_unique` admitted two surfaces of
+-- one vessel with the same adapter as long as somebody had spelled them
+-- differently, which is a state no part of the product has a meaning for. If
+-- this ALTER fails on a live installation, that is the state it found, and
+-- failing is the correct outcome — the rows have to be reconciled by hand
+-- before either one can claim to be *the* Cloud Run surface on that project.
+ALTER TABLE "targets" DROP CONSTRAINT "targets_name_unique";
+--> statement-breakpoint
+ALTER TABLE "targets" DROP COLUMN "name";
+--> statement-breakpoint
+ALTER TABLE "targets" ADD CONSTRAINT "targets_vessel_adapter_unique" UNIQUE("vessel_id","adapter");

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1785374380771,
       "tag": "0027_app_auto_deploy",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1785374380772,
+      "tag": "0028_target_vessel_surface_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -918,7 +918,6 @@ export const targets = pgTable(
   'targets',
   {
     id: uuid('id').primaryKey().defaultRandom(),
-    name: text('name').notNull(),
     adapter: targetAdapter('adapter').notNull(),
     /**
      * The boundary this Target is a surface on.
@@ -984,9 +983,13 @@ export const targets = pgTable(
       .defaultNow(),
   },
   (table) => [
-    // Connect is idempotent by name: reconnecting re-adopts rather than
-    // registering a second Target that would compete for the same workloads.
-    unique('targets_name_unique').on(table.name),
+    // **A Target is its vessel and its surface**, and that pair is naturally
+    // unique — a boundary carries one runtime of each kind. So there is no name
+    // to construct, none to collide, and none to rename when a vessel turns out
+    // to carry a surface nobody knew about. Connect is idempotent by this pair
+    // for the reason it used to be idempotent by name: reconnecting re-adopts
+    // rather than registering a second Target competing for the same workloads.
+    unique('targets_vessel_adapter_unique').on(table.vesselId, table.adapter),
   ],
 );
 

--- a/apps/spindrift/src/domain/config.ts
+++ b/apps/spindrift/src/domain/config.ts
@@ -20,7 +20,8 @@
  *   `destroy`.
  */
 import type { ConfigScope, SecretVersion } from '../adapters/store/contract.ts';
-import type { StoreAdapter } from '../config/manifest.schema.ts';
+import type { StoreAdapter, TargetAdapter } from '../config/manifest.schema.ts';
+import { targetLabel } from './target.ts';
 
 /**
  * §10: "Retention N = 10, the same depth as artifacts."
@@ -41,16 +42,24 @@ export const CONFIG_RETENTION = 10;
  */
 export const VARIABLE_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
-/** The store scope a (App, Component, Target) triple names (§10). */
+/**
+ * The store scope a (App, Component, Target) triple names (§10).
+ *
+ * The Target arrives as the two facts that identify it and is spelled
+ * `<vessel>/<adapter>` here, in the one place that spelling is decided — the
+ * store's item name is derived from this, so a second construction of it
+ * elsewhere would be a second set of items for one scope.
+ */
 export function configScopeOf(names: {
   app: string;
   component: string;
-  target: string;
+  vessel: string;
+  adapter: TargetAdapter;
 }): ConfigScope {
   return {
     app: names.app,
     component: names.component,
-    target: names.target,
+    target: targetLabel(names),
   };
 }
 

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -84,7 +84,8 @@ export type Exclusion = (typeof EXCLUSIONS)[number];
 /** One Target as placement sees it: rank, health, and what it can do. */
 export interface PlacementTarget {
   readonly id: string;
-  readonly name: string;
+  /** The boundary this Target is a surface on — half of what names it. */
+  readonly vessel: string;
   readonly adapter: TargetAdapter;
   /** §13: "Rank is one global ordered list." Lower is considered first. */
   readonly rank: number;
@@ -190,7 +191,8 @@ export interface Placement {
  */
 interface RankedTargetRow {
   id: string;
-  name: string;
+  /** The joined boundary row. A Target is not addressable or nameable without it. */
+  vessel: { name: string };
   adapter: TargetAdapter;
   rank: number;
   health: 'healthy' | 'unhealthy';
@@ -231,7 +233,7 @@ export function placementTargetOf(
 ): PlacementTarget {
   return {
     id: target.id,
-    name: target.name,
+    vessel: target.vessel.name,
     adapter: target.adapter,
     rank: target.rank,
     healthy: target.health === 'healthy',

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -1,7 +1,7 @@
 /**
  * What is left to connect, and what to propose for it (§13).
  *
- * The manifest seeds Target **identities**: a name, an adapter, and a rank,
+ * The manifest seeds Target **identities**: a vessel, an adapter, and a rank,
  * with connection facts optional. A seed with no connection produces a row
  * whose checklist reads "Target connection has not been configured" and whose
  * `connection` column is null — a real, visible, half-ready state, exactly as
@@ -15,10 +15,9 @@
  * Two jobs:
  *
  * 1. **Group Targets back into acts.** Connecting a cloud project registers
- *    both of its Targets (§13), so two unconfigured rows named
- *    `<project>-cloudrun` and `<project>-static` are *one* thing to do, named
- *    `<project>`. A screen listing two cards would reintroduce the second noun
- *    §13 removed.
+ *    both of its Targets (§13), so the `cloudrun` and `static` surfaces of one
+ *    project are *one* thing to do, named for the project. A screen listing two
+ *    cards would reintroduce the second noun §13 removed.
  * 2. **Propose what can honestly be proposed.** See
  *    {@link TargetConnectionProposal} — carried from a working Target of the
  *    same adapter, never from a literal, and never for a value that is
@@ -29,12 +28,18 @@ import type {
   PendingTargetConnection,
   TargetConnectionProposal,
 } from '../web/model.ts';
-import { surfaceNames, type TargetConnection } from './target.ts';
-import type { VesselKind } from './vessel.ts';
+import { type TargetConnection, targetLabel } from './target.ts';
+import { surfacesOf, type VesselKind } from './vessel.ts';
+
+/** The donor, spelled the way every other surface names a Target. */
+function labelOf(row: OnboardingTargetRow | undefined): string | null {
+  return row === undefined
+    ? null
+    : targetLabel({ vessel: row.vessel.name, adapter: row.adapter });
+}
 
 /** The columns this reasoning reads, without importing the table. */
 export interface OnboardingTargetRow {
-  readonly name: string;
   readonly adapter: TargetAdapter;
   readonly connection: TargetConnection | null;
   readonly health: 'healthy' | 'unhealthy';
@@ -76,7 +81,7 @@ function kubernetesProposal(
   // address — `https://kubernetes.default.svc` on an in-cluster install —
   // would read as correct and deploy somewhere else.
   return {
-    carriedFrom: from?.name ?? null,
+    carriedFrom: labelOf(from),
     namespace: connection.namespace,
     deliveryFlavour: connection.delivery.flavour,
     ...(connection.delivery.flavour === 'flux-helmrelease'
@@ -111,7 +116,7 @@ function cloudProposal(
   // cloud project and being handed the first project's id is the one mistake
   // this screen could make that nobody would catch by reading.
   return {
-    carriedFrom: run?.name ?? hosting?.name ?? null,
+    carriedFrom: labelOf(run ?? hosting),
     ...(runConnection === null
       ? {}
       : {
@@ -160,15 +165,13 @@ export function pendingConnections(
     const vessel = group[0]!.vessel;
     return {
       kind: vessel.kind,
-      name: vessel.name,
+      vessel: vessel.name,
       // Every surface the act will write, whether or not all of them are
       // unconfigured today: connecting re-registers the whole vessel, and
       // saying so is what stops the confirmation from under-reporting what it
       // is about to touch. Read off the vessel's kind rather than recovered
       // from a name.
-      targets: surfaceNames(vessel.kind, vessel.name).map(
-        (surface) => surface.name,
-      ),
+      surfaces: surfacesOf(vessel.kind),
       proposal: connectionProposal(rows, vessel.kind),
     };
   });
@@ -190,7 +193,8 @@ type Reach = 'none' | 'private' | 'public';
  * `none` and is a real Target.
  */
 export interface ClusterConnectChoices {
-  readonly name: string;
+  /** The boundary being connected, by name. Its one surface is `kubernetes`. */
+  readonly vessel: string;
   readonly apiServer: string;
   /** Where App workloads land. Never created by Spindrift (§7). */
   readonly namespace: string;
@@ -219,7 +223,8 @@ export interface ClusterConnectChoices {
 /** What `connectTarget` takes for a cluster, assembled from the choices. */
 export interface ClusterConnectPlan {
   readonly kind: 'cluster';
-  readonly name: string;
+  /** The boundary being connected. Its surfaces follow from its kind. */
+  readonly vessel: string;
   readonly apiServer: string;
   readonly namespace: string;
   readonly delivery: {
@@ -290,7 +295,7 @@ export function clusterConnectPlan(
 
   return {
     kind: 'cluster',
-    name: choices.name,
+    vessel: choices.vessel,
     apiServer: choices.apiServer,
     namespace: choices.namespace,
     delivery: {
@@ -351,11 +356,9 @@ export function targetSeedOf(
   plan: ClusterConnectPlan,
 ): Record<string, unknown> {
   return {
-    name: plan.name,
-    // A connected cluster's one surface takes the vessel's name unchanged —
-    // the same rule `vesselFor` applies on the connect path, so the document
-    // and the act name the same boundary.
-    vessel: plan.name,
+    // The two facts that identify a Target, and there is no third. The document
+    // and the act name the same boundary and the same surface on it.
+    vessel: plan.vessel,
     adapter: 'kubernetes',
     ...(plan.reaches.length > 0 ? { reaches: plan.reaches } : {}),
     ...(plan.authReaches.length > 0 ? { authReaches: plan.authReaches } : {}),
@@ -378,7 +381,7 @@ export function vesselSeedOf(
   plan: ClusterConnectPlan,
 ): Record<string, unknown> {
   return {
-    name: plan.name,
+    name: plan.vessel,
     kind: 'cluster',
     location: { apiServer: plan.apiServer },
   };

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -12,6 +12,11 @@
  * project's Targets and the shared thing between them is an argument to a
  * command, not an entity.
  *
+ * **The name is the one clause that did not survive.** §60 gave the boundary a
+ * row, which made the name a string built out of two columns beside it; a Target
+ * is `(vessel, adapter)` and carries no third field. See {@link TargetIdentity}
+ * for why constructing one was worse than merely redundant.
+ *
  * Two states this file owns:
  *
  * - **Health is a standing checklist, not a connect-time verdict.** Connect
@@ -22,7 +27,7 @@
  *   `observe`, and the confirmation names what it strands."
  */
 import type { TargetAdapter } from '../config/manifest.schema.ts';
-import { surfacesOf, type VesselKind, type VesselLocation } from './vessel.ts';
+import type { VesselLocation } from './vessel.ts';
 
 /**
  * How to reach one Target, in whatever terms its adapter needs.
@@ -195,10 +200,14 @@ export type KubernetesDelivery =
       server: string;
     };
 
-/** What the deploy contract's verbs need to name one Target (§6). */
-export interface DeployTargetRef {
-  readonly name: string;
-  readonly adapter: TargetAdapter;
+/**
+ * What the deploy contract's verbs need to name one Target (§6).
+ *
+ * Identity plus how to reach it. The identity is the vessel and the surface —
+ * see {@link TargetIdentity} — which is what an adapter puts in a sentence when
+ * it has to name the Target it was handed.
+ */
+export interface DeployTargetRef extends TargetIdentity {
   readonly connection: AdapterConnection;
 }
 
@@ -245,6 +254,7 @@ export type StaticAdapterConnection = Extract<
 
 /** The Vessel columns {@link deployTargetOf} reads, without importing the row. */
 export interface VesselRef {
+  readonly name: string;
   readonly location: VesselLocation;
   readonly servedHosts: readonly string[] | null;
   readonly reachableRegistries: readonly string[] | null;
@@ -275,7 +285,6 @@ export function hasVesselLocation<
  */
 export function deployTargetOf(
   target: {
-    name: string;
     adapter: TargetAdapter;
     connection: TargetConnection;
   },
@@ -293,7 +302,7 @@ export function deployTargetOf(
       : { project: vessel.location.project };
 
   return {
-    name: target.name,
+    vessel: vessel.name,
     adapter: target.adapter,
     // The union is discriminated on `adapter`, and the surface half already
     // carries it, so the spread lands in exactly one arm.
@@ -356,29 +365,54 @@ export function deployState(deploy: DeployStateInput): DeployState {
 export const STRANDABLE_PHASES = ['APPLYING', 'WAITING', 'LIVE'] as const;
 
 /**
- * The surfaces one connect act registers, and what to call each (§13).
+ * What identifies one Target: the boundary it is on, and the runtime it is.
  *
- * §13's split stands: a cluster is one Target and a cloud project is two, and
- * which two is a fact about the boundary rather than a choice the operator
- * makes. What changed is that the boundary is now a row, so this returns the
- * surfaces of a {@link VesselKind} rather than branching on the word "cloud" —
- * see `SURFACES_BY_VESSEL_KIND` in `vessel.ts`, which is the whole of that fact.
+ * There is no third field, and that is the point. A Target used to carry a
+ * constructed `name` — the vessel's, plus the adapter as a suffix where the
+ * vessel had siblings to tell apart — and that name was decorative the moment
+ * §60 gave the boundary a row of its own. Constructing it was worse than
+ * redundant: the suffix appeared only where a vessel carried more than one
+ * surface, so a vessel *discovering* a second surface would have had to rename
+ * the first, and a Target cannot be renamed.
  *
- * **The suffix is now decorative.** It is a readable name for a surface, and
- * nothing parses it back out: which vessel a Target belongs to is its
- * `vesselId`. A Target named anything at all groups correctly, which is the
- * behaviour `cloudProjectOf` used to deny.
- *
- * A single-surface vessel takes the vessel's own name unchanged: the suffix
- * exists to tell siblings apart, and a vessel with one surface has none.
+ * The pair is naturally unique — a boundary carries one runtime of each kind —
+ * so it is the unique index too (`targets_vessel_adapter_unique`).
  */
-export function surfaceNames(
-  kind: VesselKind,
-  vessel: string,
-): { name: string; adapter: TargetAdapter }[] {
-  const surfaces = surfacesOf(kind);
-  return surfaces.map((adapter) => ({
-    name: surfaces.length === 1 ? vessel : `${vessel}-${adapter}`,
-    adapter,
-  }));
+export interface TargetIdentity {
+  readonly vessel: string;
+  readonly adapter: TargetAdapter;
+}
+
+/**
+ * One Target, spelled for a human: `<vessel>/<adapter>`.
+ *
+ * Two segments where there was one, and legible in a way the flat name was not:
+ * `bluenose` is visibly a boundary and `bluenose/cloudrun` is visibly a surface
+ * on it, rather than two sibling strings that read as peers.
+ *
+ * **Nothing parses this back out.** It is written into sentences and into store
+ * item names; every act that addresses a Target takes its id, or its vessel and
+ * adapter as two fields.
+ */
+export function targetLabel(target: TargetIdentity): string {
+  return `${target.vessel}/${target.adapter}`;
+}
+
+/**
+ * {@link targetLabel} over a `targets` row with its vessel joined.
+ *
+ * The join is the point: a Target row on its own cannot say what it is, because
+ * half of what names it lives on the boundary. `'none'` is the answer for an
+ * absent row — a Component that has never been placed has no Target, which is a
+ * fact rather than a missing lookup.
+ */
+export function targetRowLabel(
+  target:
+    | { adapter: TargetAdapter; vessel: { name: string } }
+    | null
+    | undefined,
+): string {
+  return target == null
+    ? 'none'
+    : targetLabel({ vessel: target.vessel.name, adapter: target.adapter });
 }

--- a/apps/spindrift/src/reconciler/config-loop.ts
+++ b/apps/spindrift/src/reconciler/config-loop.ts
@@ -34,6 +34,7 @@ import {
   configItems,
   PINNED_ENVIRONMENT,
   targets,
+  vessels,
 } from '../db/schema.ts';
 import { CONFIG_RETENTION, configScopeOf, reapable } from '../domain/config.ts';
 import { reconcilerLoopDuration } from '../telemetry/index.ts';
@@ -66,12 +67,14 @@ export async function runConfigPass(
       key: configItems.key,
       app: apps.name,
       component: components.name,
-      target: targets.name,
+      vessel: vessels.name,
+      adapter: targets.adapter,
     })
     .from(configItems)
     .innerJoin(components, eq(configItems.componentId, components.id))
     .innerJoin(apps, eq(components.appId, apps.id))
     .innerJoin(targets, eq(configItems.targetId, targets.id))
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
     .where(eq(configItems.environment, PINNED_ENVIRONMENT));
 
   const reports: ReapReport[] = [];

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -43,6 +43,7 @@ import {
   hasTargetConnection,
   hasVesselLocation,
   type TargetHealth,
+  targetLabel,
 } from '../domain/target.ts';
 import { reconcilerLoopDuration } from '../telemetry/index.ts';
 
@@ -118,7 +119,7 @@ export async function restoreDeclaredTargetConnections(
 ): Promise<readonly string[]> {
   const declared = new Set(
     manifest.targets.flatMap((target) =>
-      target.connection === undefined ? [] : [target.name],
+      target.connection === undefined ? [] : [targetLabel(target)],
     ),
   );
   if (declared.size === 0) return [];
@@ -132,7 +133,9 @@ export async function restoreDeclaredTargetConnections(
 
   for (const { target, vessel } of disconnected) {
     if (
-      !declared.has(target.name) ||
+      !declared.has(
+        targetLabel({ vessel: vessel.name, adapter: target.adapter }),
+      ) ||
       !hasTargetConnection(target) ||
       !hasVesselLocation(vessel)
     ) {
@@ -210,7 +213,8 @@ export async function readoptTargetDeploys(
 /** What one Target's refresh did. */
 export interface TargetRefresh {
   readonly targetId: string;
-  readonly name: string;
+  /** `<vessel>/<adapter>`, for the log line this pass writes. */
+  readonly target: string;
   readonly health: TargetHealth;
   /** Set when this pass changed the Target's health. */
   readonly healthChangedFrom?: TargetHealth;
@@ -226,15 +230,19 @@ export interface TargetRefresh {
  */
 export async function refreshTarget(
   context: TargetLoopContext,
-  target: Pick<Target, 'id' | 'name' | 'adapter' | 'health' | 'connection'>,
-  /** The boundary half of what the adapter is handed. */
-  vessel: Pick<Vessel, 'location' | 'servedHosts' | 'reachableRegistries'>,
+  target: Pick<Target, 'id' | 'adapter' | 'health' | 'connection'>,
+  /** The boundary half of what the adapter is handed, and of what names it. */
+  vessel: Pick<
+    Vessel,
+    'name' | 'location' | 'servedHosts' | 'reachableRegistries'
+  >,
 ): Promise<TargetRefresh> {
+  const label = targetLabel({ vessel: vessel.name, adapter: target.adapter });
   if (!hasTargetConnection(target)) {
-    throw new Error(`Target ${target.name} has no connection to refresh`);
+    throw new Error(`Target ${label} has no connection to refresh`);
   }
   if (!hasVesselLocation(vessel)) {
-    throw new Error(`Target ${target.name} sits on a vessel with no location`);
+    throw new Error(`Target ${label} sits on a vessel with no location`);
   }
   const now = context.clock.now();
   const { prerequisites, discovery } = await inspectTarget(
@@ -256,7 +264,7 @@ export async function refreshTarget(
 
   return {
     targetId: target.id,
-    name: target.name,
+    target: label,
     health,
     ...(health === target.health ? {} : { healthChangedFrom: target.health }),
   };

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -20,6 +20,7 @@
  * step with the first.
  */
 import type { Blame, FailureReason } from '../adapters/deploy/contract.ts';
+import type { TargetAdapter } from '../config/manifest.schema.ts';
 import type {
   ArtifactType,
   Auth,
@@ -523,6 +524,7 @@ export interface WorkspaceView {
   readonly targetId?: string;
   readonly latestDeployId?: number;
   readonly latestBuildId?: number;
+  /** The runtime surface the placed Target is — the boundary is {@link vessel}. */
   readonly target: string;
   readonly vessel: string;
   readonly prerequisitesMet: boolean;
@@ -568,7 +570,9 @@ export interface WorkspaceView {
  */
 export interface TargetOptionView {
   readonly targetId: string;
-  readonly name: string;
+  /** The boundary this Target is a surface on. Half of what names it. */
+  readonly vessel: string;
+  /** The runtime surface it is. The other half. */
   readonly adapter: string;
   readonly rank: number;
   readonly candidate: boolean;
@@ -655,6 +659,10 @@ export interface AppListItem {
   readonly id: string;
   readonly name: string;
   readonly phase: DeployPhase;
+  /**
+   * The runtime surface the placed Target is, beside the boundary it sits on.
+   * The two together are what identify it; neither alone does.
+   */
   readonly target: string;
   /** The boundary the placed Target is a surface on. Empty when unplaced. */
   readonly vessel: string;
@@ -685,8 +693,13 @@ export interface AppListItem {
 /** A Target as the targets management view lists it. */
 export interface TargetListItem {
   readonly id: string;
-  readonly name: string;
-  readonly adapter: string;
+  /** The boundary this Target is a surface on. Half of what names it. */
+  readonly vessel: string;
+  /**
+   * The runtime surface it is. The other half — and the enum rather than a
+   * string, because the screens post this pair back to `disconnectTarget`.
+   */
+  readonly adapter: TargetAdapter;
   readonly rank: number;
   readonly health: 'healthy' | 'unhealthy';
   /** Prerequisite failure details when target is unhealthy. */
@@ -769,22 +782,22 @@ export interface TargetListItem {
  * A connect act this installation is waiting on (§13).
  *
  * **One entry per vessel**, which is the same thing as one per act: connecting
- * a project registers every surface on it, so `bluenose-cloudrun` and
- * `bluenose-static` are one pending connection named `bluenose`. §13 is
+ * a project registers every surface on it, so a project's `cloudrun` and
+ * `static` surfaces are one pending connection named for the project. §13 is
  * explicit that the split is "a consequence of the model, not a decision", and
  * a screen listing two cards would make the operator learn it.
  *
- * The grouping is now a read rather than a reconstruction. These rows share a
- * `vesselId`; nothing recovers the act's name by slicing a suffix off a
- * Target's, which is what used to make an off-convention name unconnectable.
+ * The grouping is a read rather than a reconstruction. These rows share a
+ * `vesselId`, which is what a Target is a surface on — there is no name to
+ * slice a suffix off of.
  */
 export interface PendingTargetConnection {
   /** What `connectTarget` takes as its `kind` — the vessel's kind. */
   readonly kind: VesselKind;
-  /** What `connectTarget` takes as its `name`. */
-  readonly name: string;
-  /** Every Target name this one act would configure. */
-  readonly targets: readonly string[];
+  /** What `connectTarget` takes as its `vessel`. */
+  readonly vessel: string;
+  /** Every surface on that vessel this one act would configure. */
+  readonly surfaces: readonly string[];
   readonly proposal: TargetConnectionProposal;
 }
 

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -312,7 +312,9 @@ export function NewApp({
         <Row
           label="Target"
           unsettled={target === undefined || !target.candidate}
-          value={target?.name ?? 'none'}
+          value={
+            target === undefined ? 'none' : `${target.vessel}/${target.adapter}`
+          }
           tone={
             target === undefined ? null : (
               <TargetHealth healthy={target.candidate} />
@@ -338,7 +340,7 @@ export function NewApp({
                 }
               >
                 <div className="flex flex-wrap items-center gap-2">
-                  <span className="text-sm font-semibold">{option.name}</span>
+                  <span className="text-sm font-semibold">{option.vessel}</span>
                   <Badge tone="idle">{option.adapter}</Badge>
                   {option.candidate && option.artifactType ? (
                     <Badge tone="accent">{option.artifactType}</Badge>

--- a/apps/spindrift/src/web/views/operations/overview.tsx
+++ b/apps/spindrift/src/web/views/operations/overview.tsx
@@ -161,7 +161,7 @@ export function Overview({
       (target): Concern => ({
         id: `target:${target.id}`,
         category: 'target',
-        title: target.name,
+        title: `${target.vessel}/${target.adapter}`,
         detail: `${target.adapter} Target · ${target.status}`,
         status: target.configured ? target.health : 'setup',
         tone:
@@ -174,7 +174,7 @@ export function Overview({
         summary:
           target.prerequisiteFailures?.[0] ??
           (target.configured
-            ? `Target ${target.name} connected via ${target.adapter}.`
+            ? `Target ${target.vessel}/${target.adapter} is connected.`
             : 'This Target still needs its connection completed.'),
         path: '/settings/connections',
         search: `${target.adapter} ${target.prerequisiteFailures?.join(' ') ?? ''}`,

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -77,9 +77,10 @@ type Scan =
 
 export function ConnectTargetForm(props: {
   kind: VesselKind;
-  name: string;
-  /** True on the "add a Target" path, where no manifest seed named it. */
-  nameEditable?: boolean;
+  /** The boundary being connected. Every surface on it is registered. */
+  vessel: string;
+  /** True on the "add a Vessel" path, where no manifest seed named it. */
+  vesselEditable?: boolean;
   /**
    * The address to start from, which is only ever *this* Target's own.
    *
@@ -91,7 +92,8 @@ export function ConnectTargetForm(props: {
    * operator to restate the one fact the row is certain of.
    */
   apiServer?: string;
-  targets: readonly string[];
+  /** The surfaces this one act registers on that boundary. */
+  surfaces: readonly string[];
   proposal: TargetConnectionProposal;
   connecting: boolean;
   onConnect: (input: ConnectTargetInput) => void;
@@ -111,13 +113,13 @@ export function ConnectTargetForm(props: {
 
 function Heading({
   kind,
-  name,
-  targets,
+  vessel,
+  surfaces,
   proposal,
 }: {
   kind: VesselKind;
-  name: string;
-  targets: readonly string[];
+  vessel: string;
+  surfaces: readonly string[];
   proposal: TargetConnectionProposal;
 }) {
   return (
@@ -128,7 +130,7 @@ function Heading({
         ) : (
           <Layers aria-hidden="true" className="size-4 text-muted-foreground" />
         )}
-        <span className="font-mono text-sm font-semibold">{name}</span>
+        <span className="font-mono text-sm font-semibold">{vessel}</span>
         <Badge tone="idle">
           {kind === 'cluster' ? 'cluster' : 'cloud project'}
         </Badge>
@@ -139,16 +141,18 @@ function Heading({
           </span>
         ) : null}
       </div>
-      {targets.length > 1 ? (
+      {surfaces.length > 1 ? (
         <p className="text-xs text-muted-foreground">
           Registers{' '}
-          {targets.map((target, index) => (
-            <span key={target}>
+          {surfaces.map((surface, index) => (
+            <span key={surface}>
               {index > 0 ? ' and ' : ''}
-              <span className="font-mono">{target}</span>
+              <span className="font-mono">
+                {vessel}/{surface}
+              </span>
             </span>
           ))}{' '}
-          — one project, both of its Targets.
+          — one project, both of its surfaces.
         </p>
       ) : null}
     </>
@@ -158,23 +162,23 @@ function Heading({
 // --- The cluster flow -------------------------------------------------------
 
 function ConnectCluster({
-  name,
-  nameEditable = false,
+  vessel,
+  vesselEditable = false,
   apiServer: knownApiServer = '',
   proposal,
   connecting,
   onConnect,
   onCancel,
 }: {
-  name: string;
-  nameEditable?: boolean;
+  vessel: string;
+  vesselEditable?: boolean;
   apiServer?: string;
   proposal: TargetConnectionProposal;
   connecting: boolean;
   onConnect: (input: ConnectTargetInput) => void;
   onCancel: () => void;
 }) {
-  const [targetName, setTargetName] = useState(name);
+  const [vesselName, setVesselName] = useState(vessel);
   // Per-instance, so never proposed *from another Target*: this is the one field
   // that names *this* cluster, and a second cluster prefilled with the first
   // one's address would read as correct and deploy somewhere else. The caller
@@ -206,18 +210,18 @@ function ConnectCluster({
     }
   };
 
-  const addressed = targetName.trim() !== '' && apiServer.trim() !== '';
+  const addressed = vesselName.trim() !== '' && apiServer.trim() !== '';
 
   return (
     <div className="flex flex-col gap-4">
       <div className="grid gap-4 md:grid-cols-2">
-        {nameEditable ? (
+        {vesselEditable ? (
           <Field
-            name="target-name"
-            label="Target name"
-            value={targetName}
-            onChange={(event) => setTargetName(event.target.value)}
-            hint="What this Target is called here. Placement and rank use it."
+            name="vessel-name"
+            label="Vessel name"
+            value={vesselName}
+            onChange={(event) => setVesselName(event.target.value)}
+            hint="What this boundary is called here. Every surface on it is named for it."
           />
         ) : null}
         <Field
@@ -274,7 +278,7 @@ function ConnectCluster({
       {scan.state === 'read' ? (
         <ClusterComponents
           key={reads}
-          name={targetName.trim()}
+          vessel={vesselName.trim()}
           apiServer={apiServer.trim()}
           probed={scan.probed}
           proposal={proposal}
@@ -295,7 +299,7 @@ function ConnectCluster({
  * a stale pick that the new probe no longer offers.
  */
 function ClusterComponents({
-  name,
+  vessel,
   apiServer,
   probed,
   proposal,
@@ -303,7 +307,7 @@ function ClusterComponents({
   onConnect,
   onCancel,
 }: {
-  name: string;
+  vessel: string;
   apiServer: string;
   probed: Probed;
   proposal: TargetConnectionProposal;
@@ -364,7 +368,7 @@ function ClusterComponents({
     null;
 
   const choices: ClusterConnectChoices = {
-    name,
+    vessel,
     apiServer,
     namespace,
     deliveryNamespace,
@@ -393,7 +397,7 @@ function ClusterComponents({
 
   const servesFlux = probe.deliveryFlavours.includes('flux-helmrelease');
   const ready =
-    name !== '' &&
+    vessel !== '' &&
     namespace !== '' &&
     deliveryNamespace !== '' &&
     chosenSource !== null;
@@ -645,13 +649,13 @@ function Declaration({
  * carried from a working cloud Target; the project id never is.
  */
 function ConnectCloud({
-  name,
+  vessel,
   proposal,
   connecting,
   onConnect,
   onCancel,
 }: {
-  name: string;
+  vessel: string;
   proposal: TargetConnectionProposal;
   connecting: boolean;
   onConnect: (input: ConnectTargetInput) => void;
@@ -705,7 +709,7 @@ function ConnectCloud({
           onClick={() =>
             onConnect({
               kind: 'gcp-project',
-              name,
+              vessel,
               project: project.trim(),
               region: region.trim(),
               runEndpoint: runEndpoint.trim(),

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -174,7 +174,7 @@ export function TargetList({
                     <span className="grid size-6 place-items-center rounded-sm bg-secondary font-mono text-xs text-muted-foreground">
                       {target.rank}
                     </span>
-                    <span className="font-medium">{target.name}</span>
+                    <span className="font-medium">{target.vessel}</span>
                     <span className="ml-auto text-xs text-muted-foreground">
                       {target.adapter}
                     </span>
@@ -327,9 +327,9 @@ function TargetCollection({
           <CardContent>
             <ConnectTargetForm
               kind="cluster"
-              name=""
-              nameEditable
-              targets={[]}
+              vessel=""
+              vesselEditable
+              surfaces={[]}
               proposal={clusterProposal}
               connecting={connecting}
               onConnect={onConnect}
@@ -383,14 +383,14 @@ function PendingConnections({
       <Eyebrow>Waiting to be connected</Eyebrow>
       <Card className="divide-y divide-border border-warning/40">
         {pending.map((entry) => (
-          <div key={entry.name}>
+          <div key={entry.vessel}>
             <div className="flex flex-wrap items-center gap-3 px-4 py-3">
               <AlertTriangle
                 aria-hidden="true"
                 className="size-4 shrink-0 text-warning"
               />
               <span className="font-mono text-sm font-medium">
-                {entry.name}
+                {entry.vessel}
               </span>
               <Badge tone="idle">
                 {entry.kind === 'cluster' ? 'cluster' : 'cloud project'}
@@ -400,23 +400,23 @@ function PendingConnections({
               </span>
               <Button
                 size="sm"
-                variant={open === entry.name ? 'ghost' : 'default'}
+                variant={open === entry.vessel ? 'ghost' : 'default'}
                 className="ml-auto"
                 onClick={() =>
                   setOpen((current) =>
-                    current === entry.name ? null : entry.name,
+                    current === entry.vessel ? null : entry.vessel,
                   )
                 }
               >
-                {open === entry.name ? 'Cancel' : 'Finish setup'}
+                {open === entry.vessel ? 'Cancel' : 'Finish setup'}
               </Button>
             </div>
-            {open === entry.name ? (
+            {open === entry.vessel ? (
               <div className="border-t border-border-soft bg-secondary/40 px-4 py-4">
                 <ConnectTargetForm
                   kind={entry.kind}
-                  name={entry.name}
-                  targets={entry.targets}
+                  vessel={entry.vessel}
+                  surfaces={entry.surfaces}
                   proposal={entry.proposal}
                   connecting={connecting}
                   onConnect={onConnect}
@@ -474,7 +474,7 @@ function TargetCard({
             )}
             <div className="min-w-0">
               <div className="flex flex-wrap items-center gap-2">
-                <span className="text-sm font-semibold">{target.name}</span>
+                <span className="text-sm font-semibold">{target.vessel}</span>
                 <Badge tone={unhealthy ? 'destructive' : 'success'}>
                   <Dot />
                   {target.health}
@@ -566,9 +566,9 @@ function TargetCard({
           <div className="rounded-md border border-border-soft bg-secondary/40 px-4 py-4">
             <ConnectTargetForm
               kind="cluster"
-              name={target.name}
+              vessel={target.vessel}
               apiServer={target.edit.apiServer}
-              targets={[target.name]}
+              surfaces={[target.adapter]}
               proposal={target.edit.proposal}
               connecting={connecting}
               onConnect={onConnect}
@@ -657,7 +657,8 @@ function DisconnectTargetControl({
     setState({ type: 'reviewing' });
     try {
       const result = await command('disconnectTarget', {
-        name: target.name,
+        vessel: target.vessel,
+        adapter: target.adapter,
         confirm: false,
       });
       setState(
@@ -677,7 +678,8 @@ function DisconnectTargetControl({
     setState({ type: 'disconnecting', impact });
     try {
       const result = await command('disconnectTarget', {
-        name: target.name,
+        vessel: target.vessel,
+        adapter: target.adapter,
         confirm: true,
       });
       if (!result.ok) {
@@ -728,7 +730,7 @@ function DisconnectTargetControl({
     <div className="basis-full rounded-sm border border-warning/50 bg-warning-soft p-3 text-sm">
       <p className="font-semibold">
         {state.type === 'done'
-          ? `${target.name} is disconnected.`
+          ? `${target.vessel}/${target.adapter} is disconnected.`
           : `Disconnecting will orphan ${count} current Deploy${count === 1 ? '' : 's'}.`}
       </p>
       {count > 0 ? (

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -61,7 +61,7 @@ function target(
   overrides: Partial<CloudRunAdapterConnection> = {},
 ): DeployTarget {
   return {
-    name: 'cloud',
+    vessel: 'cloud',
     adapter: 'cloudrun',
     connection: { ...CONNECTION, ...overrides },
   };

--- a/apps/spindrift/test/adapters/datastore.test.ts
+++ b/apps/spindrift/test/adapters/datastore.test.ts
@@ -35,7 +35,7 @@ import {
 
 function targetOn(fake: FakeKubernetes): DeployTarget {
   return {
-    name: 'metal',
+    vessel: 'metal',
     adapter: 'kubernetes',
     connection: {
       adapter: 'kubernetes',
@@ -284,7 +284,7 @@ describe('the cloud adapter', () => {
   test('refuses to provision and names the fact it is missing', async () => {
     const adapter = new CloudDatastoreAdapter();
     const target: DeployTarget = {
-      name: 'bluenose',
+      vessel: 'bluenose',
       adapter: 'cloudrun',
       connection: {
         adapter: 'cloudrun',

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -111,7 +111,7 @@ const desired: DesiredState = {
   deploy: 'deploy-1',
   app: 'app',
   component: 'web',
-  target: target.name,
+  target: target.vessel,
   kind: 'service',
   artifact: { type: 'image', digest: 'sha256:beef', refs: [] },
   expose: true,

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -118,7 +118,7 @@ function target(
   connectionOverrides: Partial<KubernetesAdapterConnection> = {},
 ): DeployTarget {
   return {
-    name: 'cluster',
+    vessel: 'cluster',
     adapter: 'kubernetes',
     connection: connection(connectionOverrides),
   };

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -51,7 +51,7 @@ const CONNECTION: StaticAdapterConnection = {
 };
 
 const TARGET: DeployTarget = {
-  name: 'hosting',
+  vessel: 'hosting',
   adapter: 'static',
   connection: CONNECTION,
 };

--- a/apps/spindrift/test/commands/app-build-route.test.ts
+++ b/apps/spindrift/test/commands/app-build-route.test.ts
@@ -26,12 +26,17 @@ import {
   componentTargetDesired,
   targets,
   users,
+  vessels,
 } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const baseManifest = await fixtureManifest();
@@ -59,15 +64,21 @@ describe('an App choosing its build route', () => {
     await db.delete(components);
     await db.delete(apps);
     await db.delete(targets);
+    // `seed` can run more than once per test (a test that raises the Target's
+    // level calls it again), so the vessel it mints has to go with the Target
+    // it belonged to — `vessels_name_unique` would otherwise refuse the second
+    // insert of the same fixture name.
+    await db.delete(vessels).where(eq(vessels.name, 'target-a'));
     await db.delete(users);
 
     const [operator] = await db
       .insert(users)
       .values({ displayName: 'Operator' })
       .returning();
+    const vessel = await insertVessel(db, 'kubernetes', { name: 'target-a' });
     const [target] = await db
       .insert(targets)
-      .values(targetValues({ name: 'target-a', rank: 1, minBuildLevel }))
+      .values(targetValues({ vesselId: vessel.id, rank: 1, minBuildLevel }))
       .returning();
     targetId = target!.id;
     const [app] = await db

--- a/apps/spindrift/test/commands/app-list-artifact.test.ts
+++ b/apps/spindrift/test/commands/app-list-artifact.test.ts
@@ -36,7 +36,11 @@ import {
 } from '../../src/db/schema.ts';
 import { configVersionOf } from '../../src/domain/config-version.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const manifest = await fixtureManifest();
@@ -99,9 +103,15 @@ async function seedLiveApp(
   );
   if (!component.ok) throw new Error(component.failure.message);
 
+  // Each App gets its own vessel: this fixture is called more than once per
+  // test, and a Target's identity is now `(vessel, adapter)` rather than a
+  // generated name, so sharing the default vessel would collide on it.
+  const vessel = await insertVessel(ctx.db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await ctx.db
     .insert(targets)
-    .values(targetValues({ adapter: 'kubernetes' }))
+    .values(targetValues({ adapter: 'kubernetes', vesselId: vessel.id }))
     .returning();
   await ctx.db.insert(componentTargetDesired).values({
     componentId: component.value.componentId,

--- a/apps/spindrift/test/commands/artifacts.test.ts
+++ b/apps/spindrift/test/commands/artifacts.test.ts
@@ -25,7 +25,11 @@ import {
   targets,
 } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
@@ -93,9 +97,12 @@ async function seed(
     .returning();
 
   for (let index = 0; index < (input.placements ?? 0); index += 1) {
+    const vessel = await insertVessel(ctx.db, 'kubernetes', {
+      name: `${input.name}-target-${index}`,
+    });
     const [target] = await ctx.db
       .insert(targets)
-      .values(targetValues({ name: `${input.name}-target-${index}` }))
+      .values(targetValues({ vesselId: vessel.id }))
       .returning();
     await ctx.db.insert(deploys).values({
       componentId: component!.id,

--- a/apps/spindrift/test/commands/build-args.test.ts
+++ b/apps/spindrift/test/commands/build-args.test.ts
@@ -44,7 +44,11 @@ import {
 } from '../harness/fakes/deploy-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -103,12 +107,15 @@ async function fixture(
     .insert(components)
     .values({ appId: app!.id, name: 'web', kind, expose: true })
     .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
     .values(
       targetValues({
-        name: `cluster-${crypto.randomUUID()}`,
         adapter: 'kubernetes',
+        vesselId: vessel.id,
         ...(options.minBuildLevel === undefined
           ? {}
           : { minBuildLevel: options.minBuildLevel }),

--- a/apps/spindrift/test/commands/build-bundle-location.test.ts
+++ b/apps/spindrift/test/commands/build-bundle-location.test.ts
@@ -27,7 +27,11 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const baseManifest = await fixtureManifest();
@@ -120,9 +124,10 @@ describe('the bundle location a route is dispatched with', () => {
       .insert(users)
       .values({ displayName: 'Operator' })
       .returning();
+    const vessel = await insertVessel(db, 'kubernetes', { name: 'target-a' });
     await db
       .insert(targets)
-      .values(targetValues({ name: 'target-a', rank: 1 }));
+      .values(targetValues({ vesselId: vessel.id, rank: 1 }));
 
     route = new FakeBuildAdapter();
     const adapters: AdapterRegistry = {

--- a/apps/spindrift/test/commands/build-destination.test.ts
+++ b/apps/spindrift/test/commands/build-destination.test.ts
@@ -28,7 +28,11 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const baseManifest = await fixtureManifest();
@@ -101,9 +105,10 @@ describe('the destination dispatch hands a route', () => {
       .insert(users)
       .values({ displayName: 'Operator' })
       .returning();
+    const vessel = await insertVessel(db, 'kubernetes', { name: 'target-a' });
     await db
       .insert(targets)
-      .values(targetValues({ name: 'target-a', rank: 1 }));
+      .values(targetValues({ vesselId: vessel.id, rank: 1 }));
 
     ctx = {
       client,

--- a/apps/spindrift/test/commands/build-dispatch-followups.test.ts
+++ b/apps/spindrift/test/commands/build-dispatch-followups.test.ts
@@ -29,7 +29,11 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -52,14 +56,16 @@ describe('build dispatch follow-ups', () => {
       .values({ displayName: 'Operator' })
       .returning();
 
+    const vesselA = await insertVessel(db, 'kubernetes', { name: 'target-a' });
     const [_targetA] = await db
       .insert(targets)
-      .values(targetValues({ name: 'target-a', rank: 1 }))
+      .values(targetValues({ vesselId: vesselA.id, rank: 1 }))
       .returning();
 
+    const vesselB = await insertVessel(db, 'kubernetes', { name: 'target-b' });
     const [_targetB] = await db
       .insert(targets)
-      .values(targetValues({ name: 'target-b', rank: 2 }))
+      .values(targetValues({ vesselId: vesselB.id, rank: 2 }))
       .returning();
 
     const fakeBuildAdapter = new FakeBuildAdapter();

--- a/apps/spindrift/test/commands/build-dispatch-refusal.test.ts
+++ b/apps/spindrift/test/commands/build-dispatch-refusal.test.ts
@@ -36,7 +36,11 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const baseManifest = await fixtureManifest();
@@ -171,9 +175,10 @@ describe('a dispatch refusal the operator can see', () => {
       .insert(users)
       .values({ displayName: 'Operator' })
       .returning();
+    const vessel = await insertVessel(db, 'kubernetes', { name: 'target-a' });
     const [target] = await db
       .insert(targets)
-      .values(targetValues({ name: 'target-a', rank: 1 }))
+      .values(targetValues({ vesselId: vessel.id, rank: 1 }))
       .returning();
     targetId = target!.id;
 

--- a/apps/spindrift/test/commands/build-registry-auth.test.ts
+++ b/apps/spindrift/test/commands/build-registry-auth.test.ts
@@ -40,7 +40,11 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const baseManifest = await fixtureManifest();
@@ -161,9 +165,10 @@ describe('a build whose destination needs a stored credential', () => {
       .insert(users)
       .values({ displayName: 'Operator' })
       .returning();
+    const vessel = await insertVessel(db, 'kubernetes', { name: 'target-a' });
     const [target] = await db
       .insert(targets)
-      .values(targetValues({ name: 'target-a', rank: 1 }))
+      .values(targetValues({ vesselId: vessel.id, rank: 1 }))
       .returning();
     targetId = target!.id;
 

--- a/apps/spindrift/test/commands/build-run-url.test.ts
+++ b/apps/spindrift/test/commands/build-run-url.test.ts
@@ -26,7 +26,11 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const baseManifest = await fixtureManifest();
@@ -98,9 +102,10 @@ describe('the run link dispatch records', () => {
       .insert(users)
       .values({ displayName: 'Operator' })
       .returning();
+    const vessel = await insertVessel(db, 'kubernetes', { name: 'target-a' });
     await db
       .insert(targets)
-      .values(targetValues({ name: 'target-a', rank: 1 }));
+      .values(targetValues({ vesselId: vessel.id, rank: 1 }));
 
     ctx = {
       client,

--- a/apps/spindrift/test/commands/component-reach.test.ts
+++ b/apps/spindrift/test/commands/component-reach.test.ts
@@ -33,6 +33,7 @@ import {
   targets,
 } from '../../src/db/schema.ts';
 import { AUTH_NEEDS_A_ROUTE } from '../../src/domain/desired-state.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import {
   type DeployLoopContext,
   runDeployPass,
@@ -43,7 +44,11 @@ import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -108,12 +113,15 @@ async function fixture(
       auth,
     })
     .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
     .values(
       targetValues({
-        name: `cluster-${crypto.randomUUID()}`,
         adapter: 'kubernetes',
+        vesselId: vessel.id,
         discovery: null,
       }),
     )
@@ -133,7 +141,13 @@ async function fixture(
       signature: testSignature(DIGEST, FROZEN.toISOString()),
     })
     .returning();
-  return { app: app!, component: component!, target: target!, build: build! };
+  return {
+    app: app!,
+    component: component!,
+    target: target!,
+    build: build!,
+    label: targetLabel({ vessel: vessel.name, adapter: 'kubernetes' }),
+  };
 }
 
 async function componentRow(id: string) {
@@ -203,7 +217,7 @@ describe('the edit writes a Component and leaves a Deploy to be pressed', () => 
   });
 
   test('a Target still placing the previous answer is named, and nothing is deployed', async () => {
-    const { component, target, build } = await fixture();
+    const { component, target, build, label } = await fixture();
     const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
     const adapters = registryOf(adapter);
     await createDeploy(
@@ -220,7 +234,7 @@ describe('the edit writes a Component and leaves a Deploy to be pressed', () => 
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.pendingRelease).toEqual([target.name]);
+    expect(result.value.pendingRelease).toEqual([label]);
     // §9 keeps exposure out of the mutable-in-place category: the act wrote a
     // row and asked the platform for nothing. A second `apply` here would be
     // this command deciding to re-place a live release nobody pressed Deploy

--- a/apps/spindrift/test/commands/component-schedule.test.ts
+++ b/apps/spindrift/test/commands/component-schedule.test.ts
@@ -31,6 +31,7 @@ import type {
   CommandContext,
 } from '../../src/commands/types.ts';
 import { apps, builds, components, targets } from '../../src/db/schema.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import {
   type DeployLoopContext,
   runDeployPass,
@@ -41,7 +42,11 @@ import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -106,12 +111,15 @@ async function fixture(
       auth: 'none',
     })
     .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cloudrun-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
     .values(
       targetValues({
-        name: `cloudrun-${crypto.randomUUID()}`,
         adapter: 'kubernetes',
+        vesselId: vessel.id,
         discovery: null,
       }),
     )
@@ -131,7 +139,13 @@ async function fixture(
       signature: testSignature(DIGEST, FROZEN.toISOString()),
     })
     .returning();
-  return { app: app!, component: component!, target: target!, build: build! };
+  return {
+    app: app!,
+    component: component!,
+    target: target!,
+    build: build!,
+    label: targetLabel({ vessel: vessel.name, adapter: 'kubernetes' }),
+  };
 }
 
 async function componentRow(id: string) {
@@ -189,7 +203,10 @@ describe('the edit writes a Component and leaves a Deploy to be pressed', () => 
   });
 
   test('a Target already placed is named, and nothing is deployed', async () => {
-    const { component, target, build } = await fixture('job', '0 3 * * *');
+    const { component, target, build, label } = await fixture(
+      'job',
+      '0 3 * * *',
+    );
     const adapter = new FakeDeployAdapter({ adapter: 'kubernetes' });
     const adapters = registryOf(adapter);
     await createDeploy(
@@ -206,7 +223,7 @@ describe('the edit writes a Component and leaves a Deploy to be pressed', () => 
 
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.value.pendingRelease).toEqual([target.name]);
+    expect(result.value.pendingRelease).toEqual([label]);
     // Same rule as `setComponentReach`: writing the row asks the platform for
     // nothing. A second `apply` here would be this command re-placing a live
     // release nobody pressed Deploy for.

--- a/apps/spindrift/test/commands/component-unplace.test.ts
+++ b/apps/spindrift/test/commands/component-unplace.test.ts
@@ -38,7 +38,11 @@ import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -111,12 +115,16 @@ async function fixture(options: {
       auth: 'none',
     })
     .returning();
+  // Its own vessel: a Target is (vessel, adapter), so two fixtures sharing the
+  // harness default would collide on that pair rather than on a name.
+  const adapter = options.adapter ?? 'kubernetes';
+  const vessel = await insertVessel(db, adapter);
   const [target] = await db
     .insert(targets)
     .values(
       targetValues({
-        name: `target-${crypto.randomUUID()}`,
-        adapter: options.adapter ?? 'kubernetes',
+        adapter,
+        vesselId: vessel.id,
         discovery: null,
       }),
     )

--- a/apps/spindrift/test/commands/config.test.ts
+++ b/apps/spindrift/test/commands/config.test.ts
@@ -43,6 +43,7 @@ import {
   targets,
   users,
 } from '../../src/db/schema.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import { runConfigPass } from '../../src/reconciler/config-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import {
@@ -54,7 +55,11 @@ import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -150,12 +155,16 @@ async function fixture(
 async function connectedTarget(
   options: { name?: string; reachableSecretStores?: readonly string[] } = {},
 ) {
+  const vesselName = options.name ?? `cluster-${crypto.randomUUID()}`;
+  const vessel = await insertVessel(database().db, 'kubernetes', {
+    name: vesselName,
+  });
   const [target] = await database()
     .db.insert(targets)
     .values(
       targetValues({
-        name: options.name ?? `cluster-${crypto.randomUUID()}`,
         adapter: 'kubernetes',
+        vesselId: vessel.id,
         discovery: {
           ...CAPABLE_DISCOVERY,
           reachableSecretStores: (options.reachableSecretStores ?? [
@@ -165,7 +174,10 @@ async function connectedTarget(
       }),
     )
     .returning();
-  return target!;
+  return {
+    ...target!,
+    label: targetLabel({ vessel: vesselName, adapter: 'kubernetes' }),
+  };
 }
 
 type TargetStores = (typeof CAPABLE_DISCOVERY)['reachableSecretStores'];
@@ -831,7 +843,7 @@ describe('retention is core’s, at a depth a rollback can reach', () => {
       },
     ]);
     const left = await store.versions(
-      { app: 'shop', component: 'web', target: target.name },
+      { app: 'shop', component: 'web', target: target.label },
       'TOKEN',
     );
     expect(left).toHaveLength(2);

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -28,7 +28,11 @@ import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const builder = new FakeBuildAdapter({ name: 'hosted' });
@@ -95,8 +99,9 @@ async function context(
 }
 
 async function seedCapabilities(
-  targetOverrides: Parameters<typeof targetValues>[0] = {},
+  targetOverrides: Parameters<typeof targetValues>[0] & { name?: string } = {},
 ) {
+  const { name = 'cluster', ...overrides } = targetOverrides;
   const [repository] = await database()
     .db.insert(repositories)
     .values({
@@ -107,15 +112,20 @@ async function seedCapabilities(
       access: 'active',
     })
     .returning();
+  const vessel = await insertVessel(
+    database().db,
+    overrides.adapter ?? 'kubernetes',
+    { name },
+  );
   const [target] = await database()
     .db.insert(targets)
     .values(
       targetValues({
-        name: 'cluster',
+        vesselId: vessel.id,
         rank: 1,
         reaches: ['none', 'private', 'public'],
         discovery: CAPABLE_DISCOVERY,
-        ...targetOverrides,
+        ...overrides,
       }),
     )
     .returning();

--- a/apps/spindrift/test/commands/delete-app.test.ts
+++ b/apps/spindrift/test/commands/delete-app.test.ts
@@ -40,7 +40,11 @@ import {
 } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
@@ -94,11 +98,18 @@ function context(registry: AdapterRegistry): CommandContext {
   };
 }
 
-/** A connected Target to hang Deploys off. */
+/** A connected Target to hang Deploys off, on its own named vessel. */
 async function seedTarget(name: string) {
+  const vessel = await insertVessel(database().db, 'kubernetes', { name });
   const [target] = await database()
     .db.insert(targets)
-    .values(targetValues({ name, adapter: 'kubernetes', health: 'healthy' }))
+    .values(
+      targetValues({
+        vesselId: vessel.id,
+        adapter: 'kubernetes',
+        health: 'healthy',
+      }),
+    )
     .returning();
   return target!;
 }
@@ -289,7 +300,7 @@ describe('a live workload is named and left running', () => {
       {
         deployId: String(seeded.deploy!.id),
         component: 'web',
-        target: 'folly',
+        target: 'folly/kubernetes',
         url: 'web.example.test',
         firing: false,
       },

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -43,6 +43,7 @@ import {
   targets,
 } from '../../src/db/schema.ts';
 import { configVersionOf } from '../../src/domain/config-version.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import { policyDrift } from '../../src/supply-chain/posture.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
@@ -51,7 +52,11 @@ import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
@@ -141,17 +146,28 @@ async function fixture(
       ...(options.auth === undefined ? {} : { auth: options.auth }),
     })
     .returning();
+  const adapter = options.adapter ?? 'kubernetes';
+  const vessel = await insertVessel(db, adapter, {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
     .values(
       targetValues({
-        name: `cluster-${crypto.randomUUID()}`,
-        adapter: options.adapter ?? 'kubernetes',
+        adapter,
+        vesselId: vessel.id,
         discovery: null,
       }),
     )
     .returning();
-  return { app: app!, component: component!, target: target! };
+  return {
+    app: app!,
+    component: component!,
+    target: target!,
+    // `<vessel>/<adapter>` — the same label `targetRowLabel` renders into a
+    // refusal message, precomputed here because the row alone cannot say it.
+    label: targetLabel({ vessel: vessel.name, adapter }),
+  };
 }
 
 /** A Build that is ready to deploy: succeeded, with an artifact of one shape. */
@@ -281,7 +297,7 @@ describe('createDeploy writes an intent, and only an intent', () => {
     // this Target when the developer was offered it; nothing re-asked when the
     // Deploy was created, so "the Target says it cannot and it happened anyway"
     // was the whole of the defect — a declared boundary that was advisory.
-    const { component, target } = await fixture();
+    const { component, target, label } = await fixture();
     // `auth: 'none'` so this is a claim about reach alone — the authenticated
     // edge is the test below, and a Component carrying both would be refused
     // twice and prove neither.
@@ -303,7 +319,7 @@ describe('createDeploy writes an intent, and only an intent', () => {
     expect(refused.ok).toBe(false);
     if (refused.ok) return;
     expect(refused.failure.code).toBe('NOT_DEPLOYABLE');
-    expect(refused.failure.message).toContain(target.name);
+    expect(refused.failure.message).toContain(label);
     expect(refused.failure.message).toContain(
       'no way to serve a public address',
     );
@@ -426,7 +442,7 @@ describe('createDeploy writes an intent, and only an intent', () => {
   });
 
   test('raised policy leaves LIVE serving but blocks every new placement', async () => {
-    const { component, target } = await fixture();
+    const { component, target, label } = await fixture();
     const build = await succeededBuild(component.id, 4);
     const first = await createDeploy(
       { componentId: component.id, targetId: target.id, buildId: build.id },
@@ -469,7 +485,7 @@ describe('createDeploy writes an intent, and only an intent', () => {
       ok: false,
       failure: {
         code: 'NOT_DEPLOYABLE',
-        message: `Build ${build.id} achieved verified Build Level 2, and ${target.name} currently requires L3`,
+        message: `Build ${build.id} achieved verified Build Level 2, and ${label} currently requires L3`,
       },
     });
   });
@@ -571,12 +587,15 @@ describe('createDeploy writes an intent, and only an intent', () => {
 
   test('Cloud Run image deploys share the same admission gate (§16)', async () => {
     const { component } = await fixture({ adapter: 'cloudrun' });
+    const cloudVessel = await insertVessel(database().db, 'cloudrun', {
+      name: `cloud-${crypto.randomUUID()}`,
+    });
     const [cloudTarget] = await database()
       .db.insert(targets)
       .values(
         targetValues({
-          name: `cloud-${crypto.randomUUID()}`,
           adapter: 'cloudrun',
+          vesselId: cloudVessel.id,
           discovery: null,
         }),
       )
@@ -736,7 +755,7 @@ describe('deployApp selects which Component it acts on', () => {
       .returning();
 
     const result = await deployApp(
-      { name: app.name, component: nightly!.name, target: target.name },
+      { name: app.name, component: nightly!.name, target: target.id },
       context(registryOf(capableAdapter())),
     );
 
@@ -756,19 +775,22 @@ describe('deployApp selects which Component it acts on', () => {
       targetId: target.id,
       updatedAt: FROZEN,
     });
+    const elsewhereVessel = await insertVessel(database().db, 'kubernetes', {
+      name: `cluster-${crypto.randomUUID()}`,
+    });
     const [elsewhere] = await database()
       .db.insert(targets)
       .values(
         targetValues({
-          name: `cluster-${crypto.randomUUID()}`,
           adapter: 'kubernetes',
+          vesselId: elsewhereVessel.id,
           discovery: null,
         }),
       )
       .returning();
 
     const result = await deployApp(
-      { name: app.name, target: elsewhere!.name },
+      { name: app.name, target: elsewhere!.id },
       context(registryOf(capableAdapter())),
     );
 
@@ -1158,7 +1180,7 @@ describe('§6: rollback is an ordinary deploy', () => {
   });
 
   test('rollback cannot bypass the Target’s current build policy', async () => {
-    const { component, target } = await fixture();
+    const { component, target, label } = await fixture();
     const older = await succeededBuild(component.id, 42);
     const newer = await succeededBuild(component.id, 43, 'image', 3);
     const deployed = await createDeploy(
@@ -1181,7 +1203,7 @@ describe('§6: rollback is an ordinary deploy', () => {
       ok: false,
       failure: {
         code: 'NOT_DEPLOYABLE',
-        message: `Build ${older.id} achieved verified Build Level 2, and ${target.name} currently requires L3`,
+        message: `Build ${older.id} achieved verified Build Level 2, and ${label} currently requires L3`,
       },
     });
   });

--- a/apps/spindrift/test/commands/installation-configure.test.ts
+++ b/apps/spindrift/test/commands/installation-configure.test.ts
@@ -14,12 +14,10 @@
 import { describe, expect, test } from 'bun:test';
 import { configureInstallation } from '../../src/commands/index.ts';
 import type { Clock, CommandContext } from '../../src/commands/types.ts';
-import type {
-  AuthoredManifest,
-  InstallationManifest,
-} from '../../src/config/manifest.schema.ts';
+import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
 import { loadStoredManifest } from '../../src/config/manifest-store.ts';
 import { installation } from '../../src/db/schema.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { authoredFixture, fixtureManifest } from '../harness/installation.ts';
 
@@ -83,16 +81,19 @@ describe('configuring an installation', () => {
     // The act that can create a Target without anyone naming one. A write that
     // skipped reconciliation would leave it declared and absent.
     const rows = await database().db.query.targets.findMany({
+      with: { vessel: true },
       orderBy: (targets, { asc }) => [asc(targets.rank)],
     });
-    expect(rows.map((row) => row.name)).toEqual(
-      manifest.targets.map((target) => target.name),
-    );
+    expect(
+      rows.map((row) =>
+        targetLabel({ vessel: row.vessel.name, adapter: row.adapter }),
+      ),
+    ).toEqual(manifest.targets.map((target) => targetLabel(target)));
 
     const result = await configureInstallation({ manifest }, context());
     expect(result.ok).toBe(true);
     expect((result.ok ? result.value.targets : []).slice()).toEqual(
-      manifest.targets.map((target) => target.name),
+      manifest.targets.map((target) => targetLabel(target)),
     );
   });
 
@@ -127,30 +128,6 @@ describe('configuring an installation', () => {
     );
 
     expect(await storedManifest()).toEqual(before);
-  });
-
-  test('refuses a Target whose adapter disagrees with the stored one', async () => {
-    await seed();
-    // Schema-valid — a Target may be declared with no connection — so the
-    // refusal has to come from reconciliation meeting the stored row, which is
-    // the only place the disagreement is visible.
-    const swapped = {
-      ...manifest,
-      targets: [
-        { name: 'cluster', vessel: 'cluster', adapter: 'kubernetes' },
-        { name: 'cloud-cloudrun', vessel: 'cluster', adapter: 'kubernetes' },
-      ],
-    } as InstallationManifest;
-
-    const result = await configureInstallation(
-      { manifest: swapped },
-      context(),
-    );
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.failure.code).toBe('NOT_DEPLOYABLE');
-    // One transaction: the refused Target takes the manifest write with it.
-    expect((await storedManifest())?.installation).toBe(manifest.installation);
   });
 });
 

--- a/apps/spindrift/test/commands/operation-ledgers.test.ts
+++ b/apps/spindrift/test/commands/operation-ledgers.test.ts
@@ -14,7 +14,11 @@ import type {
 } from '../../src/commands/types.ts';
 import { builds, deploys, targets } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
@@ -140,9 +144,12 @@ describe('global operation ledgers', () => {
     const ctx = context();
     const first = await appComponent(ctx, 'alpha');
     const second = await appComponent(ctx, 'bravo');
+    const follyVessel = await insertVessel(ctx.db, 'kubernetes', {
+      name: 'Folly',
+    });
     const [target] = await ctx.db
       .insert(targets)
-      .values(targetValues({ name: 'Folly' }))
+      .values(targetValues({ vesselId: follyVessel.id }))
       .returning();
 
     const written: number[] = [];
@@ -188,7 +195,7 @@ describe('global operation ledgers', () => {
     expect(listed.value.deploys[0]).toMatchObject({
       appId: second.appId,
       component: 'web',
-      target: 'Folly',
+      target: 'Folly/kubernetes',
       phase: 'APPLYING',
       buildId: expect.any(Number),
     });
@@ -197,9 +204,12 @@ describe('global operation ledgers', () => {
   test('Deploy cursor keeps older rollback entries reachable', async () => {
     const ctx = context();
     const owner = await appComponent(ctx, 'many-deploys');
+    const manyVessel = await insertVessel(ctx.db, 'kubernetes', {
+      name: 'Many',
+    });
     const [target] = await ctx.db
       .insert(targets)
-      .values(targetValues({ name: 'Many' }))
+      .values(targetValues({ vesselId: manyVessel.id }))
       .returning();
     const [build] = await ctx.db
       .insert(builds)

--- a/apps/spindrift/test/commands/placement.test.ts
+++ b/apps/spindrift/test/commands/placement.test.ts
@@ -11,7 +11,7 @@
  * recorded a placement would make asking the question change the App.
  */
 import { describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import {
   connectTarget,
   resolveComponentPlacement,
@@ -29,8 +29,10 @@ import {
   datastores,
   deploys,
   targets,
+  vessels,
 } from '../../src/db/schema.ts';
 import type { ComponentKind } from '../../src/domain/desired-state.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import {
@@ -82,13 +84,20 @@ function context(registry: AdapterRegistry): CommandContext {
 
 /** The cluster and the two cloud Targets, in rank order, all healthy. */
 async function connectEverything(registry: AdapterRegistry) {
-  await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+  await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
   await connectTarget(
-    cloudInput({ name: 'vessel', region: 'here' }),
+    cloudInput({ vessel: 'vessel', region: 'here' }),
     context(registry),
   );
-  const rows = await database().db.select().from(targets);
-  return new Map(rows.map((row) => [row.name, row]));
+  const rows = await database().db.query.targets.findMany({
+    with: { vessel: true },
+  });
+  return new Map(
+    rows.map((row) => [
+      targetLabel({ vessel: row.vessel.name, adapter: row.adapter }),
+      row,
+    ]),
+  );
 }
 
 async function seedComponent(
@@ -125,13 +134,15 @@ describe('resolution is derived, and it is a query', () => {
     const { component } = await seedComponent();
 
     const placement = await place(registry, component.id);
-    expect(placement.suggestedTargetId).toBe(connected.get('cluster')!.id);
+    expect(placement.suggestedTargetId).toBe(
+      connected.get('cluster/kubernetes')!.id,
+    );
     // Every Target appears, candidate or not, in one rank-ordered list — §3's
     // grammar of listed-and-annotated rather than quietly filtered away.
     expect(placement.options.map((option) => option.name)).toEqual([
-      'cluster',
-      'vessel-cloudrun',
-      'vessel-static',
+      'cluster/kubernetes',
+      'vessel/cloudrun',
+      'vessel/static',
     ]);
     // Only the cluster. A `private` reach is an address on the operator's own
     // network, and neither cloud backend has one to publish — which is a
@@ -149,7 +160,7 @@ describe('resolution is derived, and it is a query', () => {
     const { component } = await seedComponent();
 
     const placement = await place(registry, component.id);
-    const cdn = placement.options.find((o) => o.name === 'vessel-static')!;
+    const cdn = placement.options.find((o) => o.name === 'vessel/static')!;
     expect(cdn.candidate).toBe(false);
     expect(cdn.artifactType).toBeNull();
     expect(cdn.reasons).toContain('KIND_UNSUPPORTED');
@@ -160,20 +171,27 @@ describe('resolution is derived, and it is a query', () => {
     const registry = fakes();
     await connectEverything(registry);
     // A reach the operator states, because §3 says nothing reports one (§13).
+    const staticTarget = (
+      await database()
+        .db.select({ id: targets.id })
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(and(eq(vessels.name, 'vessel'), eq(targets.adapter, 'static')))
+    )[0]!;
     await database()
       .db.update(targets)
       .set({ reaches: ['none', 'private', 'public'] })
-      .where(eq(targets.name, 'vessel-static'));
+      .where(eq(targets.id, staticTarget.id));
     const { component } = await seedComponent('website', 'public', 'none');
 
     const placement = await place(registry, component.id);
-    const cdn = placement.options.find((o) => o.name === 'vessel-static')!;
+    const cdn = placement.options.find((o) => o.name === 'vessel/static')!;
     expect(cdn.candidate).toBe(true);
     expect(cdn.artifactType).toBe('files');
     // The cloud runtime serves a public reach too — its own URL, no tunnel
     // needed — so what separates the two here is artifact shape rather than
     // candidacy, and rank is the tie-break §3 leaves to a human.
-    const run = placement.options.find((o) => o.name === 'vessel-cloudrun')!;
+    const run = placement.options.find((o) => o.name === 'vessel/cloudrun')!;
     expect(run.candidate).toBe(true);
     expect(run.artifactType).toBe('image');
   });
@@ -193,14 +211,16 @@ describe('resolution is derived, and it is a query', () => {
     // in front of the Job it renders. What the schedule still decides is the
     // *static* Target, which renders no job at all.
     const placement = await place(registry, component.id);
-    const run = placement.options.find((o) => o.name === 'vessel-cloudrun')!;
+    const run = placement.options.find((o) => o.name === 'vessel/cloudrun')!;
     expect(run.candidate).toBe(true);
     expect(run.reasons).toEqual([]);
-    const cluster = placement.options.find((o) => o.name === 'cluster')!;
+    const cluster = placement.options.find(
+      (o) => o.name === 'cluster/kubernetes',
+    )!;
     expect(cluster.candidate).toBe(true);
     // Rank is the tie-break §3 leaves to a human, and the cluster ranks first.
     expect(placement.suggestedTargetId).toBe(cluster.targetId);
-    const cdn = placement.options.find((o) => o.name === 'vessel-static')!;
+    const cdn = placement.options.find((o) => o.name === 'vessel/static')!;
     expect(cdn.candidate).toBe(false);
     expect(cdn.reasons).toContain('KIND_UNSUPPORTED');
     // NO_SCHEDULER's sentence opens by granting that this Target runs a job, so
@@ -224,7 +244,7 @@ describe('resolution is derived, and it is a query', () => {
         engine: 'postgres',
         provenance: 'managed',
         appId: app.id,
-        targetId: connected.get('cluster')!.id,
+        targetId: connected.get('cluster/kubernetes')!.id,
       });
 
     const placement = await place(registry, component.id);
@@ -284,14 +304,14 @@ describe('an attached cluster-local Datastore constrains the App', () => {
         engine: 'postgres',
         provenance: 'managed',
         appId: app.id,
-        targetId: connected.get('cluster')!.id,
+        targetId: connected.get('cluster/kubernetes')!.id,
       });
 
     const placement = await place(registry, component.id);
     expect(
       placement.options.filter((o) => o.candidate).map((o) => o.name),
-    ).toEqual(['cluster']);
-    const cloud = placement.options.find((o) => o.name === 'vessel-cloudrun')!;
+    ).toEqual(['cluster/kubernetes']);
+    const cloud = placement.options.find((o) => o.name === 'vessel/cloudrun')!;
     expect(cloud.reasons).toEqual(['DATASTORE_IS_CLUSTER_LOCAL']);
   });
 
@@ -309,7 +329,7 @@ describe('an attached cluster-local Datastore constrains the App', () => {
         engine: 'postgres',
         provenance: 'managed',
         appId: null,
-        targetId: connected.get('cluster')!.id,
+        targetId: connected.get('cluster/kubernetes')!.id,
       });
 
     const placement = await place(registry, component.id);

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -28,7 +28,11 @@ import type {
 } from '../../src/domain/source-bundle.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -116,9 +120,12 @@ describe('the bundle a rerun stages', () => {
       .insert(components)
       .values({ appId: app!.id, name: 'web', kind: 'service' })
       .returning();
+    const vessel = await insertVessel(ctx.db, 'kubernetes', {
+      name: `target-${name}`,
+    });
     const [target] = await ctx.db
       .insert(targets)
-      .values(targetValues({ name: `target-${name}`, adapter: 'kubernetes' }))
+      .values(targetValues({ vesselId: vessel.id, adapter: 'kubernetes' }))
       .returning();
     await ctx.db
       .insert(componentTargetDesired)

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -17,7 +17,7 @@
  * it never wrote would pass a test of its own output.
  */
 import { describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
 import {
   connectTarget,
@@ -42,10 +42,11 @@ import {
   components,
   deploys,
   targets,
+  vessels,
 } from '../../src/db/schema.ts';
 import { deployState } from '../../src/domain/target.ts';
 import { restoreDeclaredTargetConnections } from '../../src/reconciler/target-loop.ts';
-import { defaultVesselId, withIsolatedDatabase } from '../harness/db.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
 import {
   FakeDeployAdapter,
   type FakeDeployAdapterOptions,
@@ -56,6 +57,7 @@ import {
   clusterInput,
   connectionFor,
   fixtureManifest,
+  insertVessel,
 } from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
@@ -111,13 +113,17 @@ function context(registry: AdapterRegistry): CommandContext {
   };
 }
 
-/** The Target row as the database holds it. */
-async function targetRow(name: string) {
+/** The Target row as the database holds it, addressed by `(vessel, adapter)`. */
+async function targetRow(
+  vessel: string,
+  adapter: TargetAdapter = 'kubernetes',
+) {
   const rows = await database()
     .db.select()
     .from(targets)
-    .where(eq(targets.name, name));
-  return rows[0];
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+    .where(and(eq(vessels.name, vessel), eq(targets.adapter, adapter)));
+  return rows[0]?.targets;
 }
 
 /** An App -> Component -> Build -> Deploy chain, live on one Target. */
@@ -159,7 +165,7 @@ describe('connect always succeeds', () => {
   test('a reachable cluster is registered healthy, at the end of the rank', async () => {
     const { registry, of } = fakes();
     const result = await connectTarget(
-      clusterInput({ name: 'cluster' }),
+      clusterInput({ vessel: 'cluster' }),
       context(registry),
     );
 
@@ -178,7 +184,7 @@ describe('connect always succeeds', () => {
       kubernetes: { unreachable: 'dial tcp: no route to host' },
     });
     const result = await connectTarget(
-      clusterInput({ name: 'cluster' }),
+      clusterInput({ vessel: 'cluster' }),
       context(registry),
     );
 
@@ -195,7 +201,7 @@ describe('connect always succeeds', () => {
   test('a Target whose adapter this installation does not ship', async () => {
     const { registry } = fakes({ kubernetes: null });
     const result = await connectTarget(
-      clusterInput({ name: 'cluster' }),
+      clusterInput({ vessel: 'cluster' }),
       context(registry),
     );
 
@@ -210,7 +216,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
   test('connecting a cloud project registers both of its Targets', async () => {
     const { registry } = fakes();
     const result = await connectTarget(
-      cloudInput({ name: 'vessel', region: 'here' }),
+      cloudInput({ vessel: 'vessel', region: 'here' }),
       context(registry),
     );
 
@@ -226,13 +232,13 @@ describe('the act is credential-shaped though the noun is flat', () => {
     // Each Target keeps only the endpoint its own adapter drives: one connect
     // act asked for both, and neither Target carries the other's. The runtime
     // identity splits the same way — only this surface runs anything.
-    expect((await targetRow('vessel-cloudrun'))?.connection).toEqual({
+    expect((await targetRow('vessel', 'cloudrun'))?.connection).toEqual({
       adapter: 'cloudrun',
       region: 'here',
       endpoint: CLOUD_ENDPOINTS.run,
       serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
     });
-    expect((await targetRow('vessel-static'))?.connection).toEqual({
+    expect((await targetRow('vessel', 'static'))?.connection).toEqual({
       adapter: 'static',
       endpoint: CLOUD_ENDPOINTS.hosting,
     });
@@ -240,10 +246,10 @@ describe('the act is credential-shaped though the noun is flat', () => {
 
   test('connect is idempotent by name and keeps the rank', async () => {
     const { registry } = fakes();
-    const input = clusterInput({ name: 'cluster' });
+    const input = clusterInput({ vessel: 'cluster' });
 
     await connectTarget(
-      cloudInput({ name: 'vessel', project: 'p', region: 'r' }),
+      cloudInput({ vessel: 'vessel', project: 'p', region: 'r' }),
       context(registry),
     );
     const first = await connectTarget(input, context(registry));
@@ -260,7 +266,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
 
   test('a reconnect updates what the operator asserted about reach', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
     expect((await targetRow('cluster'))?.reaches).toBeNull();
 
     // The connect screen derives both of these — `reaches` from the gateway's
@@ -272,7 +278,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
     // discarded and no way to see why.
     await connectTarget(
       clusterInput({
-        name: 'cluster',
+        vessel: 'cluster',
         reaches: ['none', 'private', 'public'],
         authReaches: ['private'],
       }),
@@ -286,12 +292,16 @@ describe('the act is credential-shaped though the noun is flat', () => {
 
   test('connect fills a manifest-seeded Target without changing its rank', async () => {
     const { registry } = fakes();
+    // The vessel a manifest seed already declared, by name — connect must
+    // re-adopt it rather than mint a second one under the same name.
+    const vessel = await insertVessel(database().db, 'kubernetes', {
+      name: 'cluster',
+    });
     const [seed] = await database()
       .db.insert(targets)
       .values({
-        name: 'cluster',
         adapter: 'kubernetes',
-        vesselId: defaultVesselId('cluster'),
+        vesselId: vessel.id,
         rank: 4,
         status: 'disconnected',
         connection: null,
@@ -300,7 +310,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
       .returning();
 
     const result = await connectTarget(
-      clusterInput({ name: 'cluster' }),
+      clusterInput({ vessel: 'cluster' }),
       context(registry),
     );
 
@@ -315,22 +325,23 @@ describe('the act is credential-shaped though the noun is flat', () => {
 
   test('one cloud connect fills its matched manifest-seeded pair', async () => {
     const { registry } = fakes();
+    const vessel = await insertVessel(database().db, 'cloudrun', {
+      name: 'vessel',
+    });
     const seeds = await database()
       .db.insert(targets)
       .values([
         {
-          name: 'vessel-cloudrun',
           adapter: 'cloudrun',
-          vesselId: defaultVesselId('gcp-project'),
+          vesselId: vessel.id,
           rank: 2,
           status: 'disconnected',
           connection: null,
           health: 'unhealthy',
         },
         {
-          name: 'vessel-static',
           adapter: 'static',
-          vesselId: defaultVesselId('gcp-project'),
+          vesselId: vessel.id,
           rank: 3,
           status: 'disconnected',
           connection: null,
@@ -340,7 +351,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
       .returning();
 
     const result = await connectTarget(
-      cloudInput({ name: 'vessel' }),
+      cloudInput({ vessel: 'vessel' }),
       context(registry),
     );
 
@@ -368,7 +379,7 @@ describe('the act is credential-shaped though the noun is flat', () => {
 describe('an operator’s Target correction outlives the next boot', () => {
   /** The manifest as Git declares it, naming whichever gateway it still names. */
   function declaredWithGateway(gateway: { name: string; namespace: string }) {
-    const input = clusterInput({ name: 'cluster' });
+    const input = clusterInput({ vessel: 'cluster' });
     const platform = input.chartValues?.platform as Record<string, unknown>;
     return {
       ...toAuthoredManifest(manifest),
@@ -381,7 +392,6 @@ describe('an operator’s Target correction outlives the next boot', () => {
       ],
       targets: [
         {
-          name: 'cluster',
           vessel: 'cluster',
           adapter: 'kubernetes' as const,
           connection: {
@@ -413,7 +423,7 @@ describe('an operator’s Target correction outlives the next boot', () => {
 
     // The correction, through the only act there is for it.
     const connected = await connectTarget(
-      clusterInput({ name: 'cluster' }),
+      clusterInput({ vessel: 'cluster' }),
       context(registry),
     );
     expect(connected.ok).toBe(true);
@@ -437,7 +447,7 @@ describe('an operator’s Target correction outlives the next boot', () => {
       { ...context(registry), manifest: booted },
     );
     if (!listed.ok) throw new Error('listTargets refused');
-    const cluster = listed.value.targets.find((t) => t.name === 'cluster');
+    const cluster = listed.value.targets.find((t) => t.vessel === 'cluster');
     expect(cluster?.connectionDivergence).toEqual([
       'connection.chartValues.platform.gateway.name',
       'connection.chartValues.platform.gateway.namespace',
@@ -450,7 +460,7 @@ describe('an operator’s Target correction outlives the next boot', () => {
     // Target's own address, which is the one field a fresh connect refuses to
     // propose and the one field an edit must not make the operator retype.
     expect(cluster?.edit?.apiServer).toBe(clusterInput().apiServer);
-    expect(cluster?.edit?.proposal.carriedFrom).toBe('cluster');
+    expect(cluster?.edit?.proposal.carriedFrom).toBe('cluster/kubernetes');
   });
 
   test('a Target whose row matches its manifest entry reports no divergence', async () => {
@@ -463,7 +473,7 @@ describe('an operator’s Target correction outlives the next boot', () => {
     const booted = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: JSON.stringify(declared),
     });
-    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
 
     const listed = await listTargets(
       {},
@@ -471,7 +481,7 @@ describe('an operator’s Target correction outlives the next boot', () => {
     );
     if (!listed.ok) throw new Error('listTargets refused');
     expect(
-      listed.value.targets.find((t) => t.name === 'cluster')
+      listed.value.targets.find((t) => t.vessel === 'cluster')
         ?.connectionDivergence,
     ).toEqual([]);
   });
@@ -480,12 +490,12 @@ describe('an operator’s Target correction outlives the next boot', () => {
 describe('disconnect strands rather than stops', () => {
   test('an impact review names Deploys without changing state', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
     const target = (await targetRow('cluster'))!;
     const { app, component } = await seedLiveDeploy(target.id, 'preview-ref');
 
     const result = await disconnectTarget(
-      { name: 'cluster', confirm: false },
+      { vessel: 'cluster', adapter: 'kubernetes', confirm: false },
       context(registry),
     );
     if (!result.ok) throw new Error('disconnect review refused');
@@ -504,12 +514,12 @@ describe('disconnect strands rather than stops', () => {
 
   test('live Deploys go orphaned and are named, and nothing is destroyed', async () => {
     const { registry, of } = fakes();
-    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
     const target = (await targetRow('cluster'))!;
     const { app, component } = await seedLiveDeploy(target.id, 'ref-1');
 
     const result = await disconnectTarget(
-      { name: 'cluster' },
+      { vessel: 'cluster', adapter: 'kubernetes' },
       context(registry),
     );
 
@@ -544,9 +554,9 @@ describe('disconnect strands rather than stops', () => {
 
   test('disconnecting a Target with nothing on it strands nothing', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'cluster' }), context(registry));
+    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
     const result = await disconnectTarget(
-      { name: 'cluster' },
+      { vessel: 'cluster', adapter: 'kubernetes' },
       context(registry),
     );
     if (!result.ok) throw new Error('disconnect refused');
@@ -556,7 +566,7 @@ describe('disconnect strands rather than stops', () => {
   test('an unknown Target is a refusal with an identity', async () => {
     const { registry } = fakes();
     const result = await disconnectTarget(
-      { name: 'nowhere' },
+      { vessel: 'nowhere', adapter: 'kubernetes' },
       context(registry),
     );
     expect(result.ok).toBe(false);
@@ -568,12 +578,15 @@ describe('disconnect strands rather than stops', () => {
 describe('reconnect re-adopts via observe', () => {
   test('a workload the adapter still sees is adopted back', async () => {
     const { registry, of } = fakes();
-    const input = clusterInput({ name: 'cluster' });
+    const input = clusterInput({ vessel: 'cluster' });
 
     await connectTarget(input, context(registry));
     const target = (await targetRow('cluster'))!;
     await seedLiveDeploy(target.id, 'ref-1');
-    await disconnectTarget({ name: 'cluster' }, context(registry));
+    await disconnectTarget(
+      { vessel: 'cluster', adapter: 'kubernetes' },
+      context(registry),
+    );
 
     // The adapter is the authority on what is still running. Teach the fake
     // that the workload survived the disconnect.
@@ -600,12 +613,15 @@ describe('reconnect re-adopts via observe', () => {
 
   test('a workload that is gone stays orphaned rather than resurrected', async () => {
     const { registry } = fakes();
-    const input = clusterInput({ name: 'cluster' });
+    const input = clusterInput({ vessel: 'cluster' });
 
     await connectTarget(input, context(registry));
     const target = (await targetRow('cluster'))!;
     await seedLiveDeploy(target.id, 'ref-1');
-    await disconnectTarget({ name: 'cluster' }, context(registry));
+    await disconnectTarget(
+      { vessel: 'cluster', adapter: 'kubernetes' },
+      context(registry),
+    );
 
     // The fake was never told about `ref-1`, so `observe` reports nothing —
     // which is the honest state, and core must not overwrite it with memory.
@@ -622,11 +638,14 @@ describe('reconnect re-adopts via observe', () => {
 
   test('a declarative reconnect waits for adapters, then re-adopts', async () => {
     const { registry, of } = fakes();
-    const input = clusterInput({ name: 'cluster' });
+    const input = clusterInput({ vessel: 'cluster' });
     await connectTarget(input, context(registry));
     const target = (await targetRow('cluster'))!;
     await seedLiveDeploy(target.id, 'ref-1');
-    await disconnectTarget({ name: 'cluster' }, context(registry));
+    await disconnectTarget(
+      { vessel: 'cluster', adapter: 'kubernetes' },
+      context(registry),
+    );
     of('kubernetes').place('ref-1', {
       ref: 'ref-1',
       phase: 'LIVE',
@@ -636,15 +655,14 @@ describe('reconnect re-adopts via observe', () => {
       ...manifest,
       vessels: [
         {
-          name: input.name,
+          name: input.vessel,
           kind: 'cluster',
           location: { apiServer: input.apiServer },
         },
       ],
       targets: [
         {
-          name: input.name,
-          vessel: input.name,
+          vessel: input.vessel,
           adapter: 'kubernetes',
           connection: {
             namespace: input.namespace,
@@ -688,9 +706,12 @@ describe('listTargets', () => {
 
   test('lists connected targets with rank, health, and candidate placement options', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
     await connectTarget(
-      cloudInput({ name: 'cloudrun-app' }),
+      clusterInput({ vessel: 'folly-k8s' }),
+      context(registry),
+    );
+    await connectTarget(
+      cloudInput({ vessel: 'cloudrun-app' }),
       context(registry),
     );
 
@@ -701,19 +722,22 @@ describe('listTargets', () => {
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.value.targets).toHaveLength(3); // 1 k8s + 2 cloud (cloudrun, static)
-      expect(result.value.targets[0]?.name).toBe('folly-k8s');
+      expect(result.value.targets[0]?.vessel).toBe('folly-k8s');
       expect(result.value.targets[0]?.health).toBe('healthy');
       expect(result.value.options.length).toBeGreaterThan(0);
-      const option = result.value.options.find((o) => o.name === 'folly-k8s');
+      const option = result.value.options.find((o) => o.vessel === 'folly-k8s');
       expect(option?.candidate).toBe(true);
     }
   });
 
   test('resolves placement against the requirements it was given, not a default', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
     await connectTarget(
-      cloudInput({ name: 'cloudrun-app' }),
+      clusterInput({ vessel: 'folly-k8s' }),
+      context(registry),
+    );
+    await connectTarget(
+      cloudInput({ vessel: 'cloudrun-app' }),
       context(registry),
     );
 
@@ -742,7 +766,10 @@ describe('listTargets', () => {
 
   test('says nothing about placement when it is not told what is being placed', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
+    await connectTarget(
+      clusterInput({ vessel: 'folly-k8s' }),
+      context(registry),
+    );
 
     // A partial triple is not a partial answer: placement needs all three, and
     // filling the gaps with plausible values is what made this command answer
@@ -757,8 +784,11 @@ describe('listTargets', () => {
 
   test('states the real naming boundary, never a fabricated domain', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
-    await connectTarget(cloudInput({ name: 'vessel' }), context(registry));
+    await connectTarget(
+      clusterInput({ vessel: 'folly-k8s' }),
+      context(registry),
+    );
+    await connectTarget(cloudInput({ vessel: 'vessel' }), context(registry));
 
     const result = await listTargets(
       { kind: 'website', reach: 'public', auth: 'none' },
@@ -800,7 +830,10 @@ describe('listTargets', () => {
     // point both reaches at the same zone. Two identical clauses joined by
     // " · " would be true but unreadable, so this pins the collapse.
     const { registry } = fakes();
-    await connectTarget(clusterInput({ name: 'folly-k8s' }), context(registry));
+    await connectTarget(
+      clusterInput({ vessel: 'folly-k8s' }),
+      context(registry),
+    );
 
     const oneZoneManifest = {
       ...manifest,

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -22,16 +22,18 @@ import {
   deploys,
   targets,
 } from '../../src/db/schema.ts';
-import {
-  defaultVesselId,
-  defaultVesselName,
-  withIsolatedDatabase,
-} from '../harness/db.ts';
+import { targetLabel } from '../../src/domain/target.ts';
+import { vesselKindFor } from '../../src/domain/vessel.ts';
+import { defaultVesselName, withIsolatedDatabase } from '../harness/db.ts';
 import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const manifest = await fixtureManifest();
@@ -122,9 +124,10 @@ async function scaffold(
   );
   if (!component.ok) throw new Error(component.failure.message);
 
+  const adapter = options.adapter ?? 'kubernetes';
   const [target] = await ctx.db
     .insert(targets)
-    .values(targetValues({ adapter: options.adapter ?? 'kubernetes' }))
+    .values(targetValues({ adapter }))
     .returning();
 
   await ctx.db.insert(componentTargetDesired).values({
@@ -137,6 +140,12 @@ async function scaffold(
     appId: app.value.appId,
     componentId: component.value.componentId,
     target: target!,
+    // `targetValues` leaves `vesselId` at the harness's shared per-kind
+    // fixture vessel, so this is the same label a screen reads off the row.
+    label: targetLabel({
+      vessel: defaultVesselName(vesselKindFor(adapter)),
+      adapter,
+    }),
   };
 }
 
@@ -146,7 +155,7 @@ describe('getBuildDetail command', () => {
     // the build loop to dispatch, and that is the whole act". The press still
     // has to land somewhere, and this is what it lands on.
     const ctx = context();
-    const { componentId, target, appName } = await scaffold(ctx, {
+    const { componentId, appName, label } = await scaffold(ctx, {
       prefix: 'queued',
     });
 
@@ -173,7 +182,7 @@ describe('getBuildDetail command', () => {
     expect(attempt.app).toBe(appName);
     // The desired row is what says where a Component belongs before any intent
     // has named a Target.
-    expect(attempt.target).toBe(target.name);
+    expect(attempt.target).toBe(label);
     expect(attempt.headline).toContain('Building on hosted runner');
     // No intent means nothing was placed and nothing can be rolled back to.
     expect(attempt.resources).toEqual([]);
@@ -555,7 +564,7 @@ describe('getAppWorkspace command', () => {
     if (!createdComp.ok) throw new Error(createdComp.failure.message);
     const [target] = await database()
       .db.insert(targets)
-      .values(targetValues({ adapter: 'static', name: 'cdn' }))
+      .values(targetValues({ adapter: 'static' }))
       .returning();
     await database().db.insert(componentTargetDesired).values({
       componentId: createdComp.value.componentId,
@@ -578,7 +587,7 @@ describe('getAppWorkspace command', () => {
       ok: true,
       value: {
         workspace: {
-          target: 'cdn',
+          target: 'static',
           phase: 'WAITING',
           release: expect.stringMatching(/^Build /),
           components: [
@@ -837,12 +846,14 @@ describe('getDeployDetail command', () => {
     expect(createdComp.ok).toBe(true);
     if (!createdComp.ok) return;
 
+    const metalVessel = await insertVessel(ctx.db, 'kubernetes', {
+      name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
+    });
     const [targetRow] = await ctx.db
       .insert(targets)
       .values({
-        name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
         adapter: 'kubernetes',
-        vesselId: defaultVesselId('cluster'),
+        vesselId: metalVessel.id,
         health: 'healthy',
         rank: 1,
         connection: {
@@ -895,7 +906,9 @@ describe('getDeployDetail command', () => {
     const { deploy } = result.value;
     expect(deploy.app).toBe(appName);
     expect(deploy.component).toBe('web');
-    expect(deploy.target).toBe(targetRow.name);
+    expect(deploy.target).toBe(
+      targetLabel({ vessel: metalVessel.name, adapter: 'kubernetes' }),
+    );
     expect(deploy.commit).toBe('7f3d2c1');
     expect(deploy.phase).toBe('LIVE');
     expect(deploy.urlLive).toBe(true);
@@ -930,12 +943,14 @@ describe('getDeployDetail command', () => {
     expect(createdComp.ok).toBe(true);
     if (!createdComp.ok) return;
 
+    const metalVessel = await insertVessel(ctx.db, 'kubernetes', {
+      name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
+    });
     const [targetRow] = await ctx.db
       .insert(targets)
       .values({
-        name: `Metal-${crypto.randomUUID().slice(0, 6)}`,
         adapter: 'kubernetes',
-        vesselId: defaultVesselId('cluster'),
+        vesselId: metalVessel.id,
         health: 'healthy',
         rank: 1,
         connection: {
@@ -1650,7 +1665,12 @@ describe('deployApp command', () => {
     if (result.ok) return;
 
     expect(result.failure.code).toBe('NOT_DEPLOYABLE');
-    expect(result.failure.message).toContain(targetRow!.name);
+    expect(result.failure.message).toContain(
+      targetLabel({
+        vessel: defaultVesselName('cluster'),
+        adapter: 'kubernetes',
+      }),
+    );
     expect(result.failure.message).toContain('disconnected');
 
     // Nothing was written behind the refusal: no second Build, no intent.

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
-import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
+import { and, eq } from 'drizzle-orm';
+import type {
+  AuthoredManifest,
+  TargetAdapter,
+} from '../../src/config/manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
   MANIFEST_INLINE_VAR,
@@ -13,7 +16,7 @@ import {
   writeStoredManifest,
 } from '../../src/config/manifest-store.ts';
 import { createDb } from '../../src/db/client.ts';
-import { installation, targets } from '../../src/db/schema.ts';
+import { installation, targets, vessels } from '../../src/db/schema.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import {
   connectionFor,
@@ -21,6 +24,19 @@ import {
 } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
+
+/** The `targets.id` for the surface named by `(vessel, adapter)`. */
+async function targetIdOf(
+  vessel: string,
+  adapter: TargetAdapter = 'kubernetes',
+): Promise<string> {
+  const [row] = await database()
+    .db.select({ id: targets.id })
+    .from(targets)
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+    .where(and(eq(vessels.name, vessel), eq(targets.adapter, adapter)));
+  return row!.id;
+}
 const FIXTURE = new URL(
   '../fixtures/installation.example.yaml',
   import.meta.url,
@@ -43,7 +59,6 @@ const connectedManifest = {
   ],
   targets: [
     {
-      name: 'cluster',
       vessel: 'cluster',
       adapter: 'kubernetes',
       connection: {
@@ -56,7 +71,6 @@ const connectedManifest = {
       },
     },
     {
-      name: 'cloud-cloudrun',
       vessel: 'cloud',
       adapter: 'cloudrun',
       connection: {
@@ -65,7 +79,6 @@ const connectedManifest = {
       },
     },
     {
-      name: 'cloud-static',
       vessel: 'cloud',
       adapter: 'static',
       connection: {
@@ -92,11 +105,12 @@ describe('the stored installation manifest', () => {
     });
 
     const rows = await database().db.query.targets.findMany({
+      with: { vessel: true },
       orderBy: (targets, { asc }) => [asc(targets.rank)],
     });
     expect(
-      rows.map(({ name, adapter, rank, status, health, connection }) => ({
-        name,
+      rows.map(({ vessel, adapter, rank, status, health, connection }) => ({
+        vessel: vessel.name,
         adapter,
         rank,
         status,
@@ -105,7 +119,7 @@ describe('the stored installation manifest', () => {
       })),
     ).toEqual([
       {
-        name: 'cluster',
+        vessel: 'cluster',
         adapter: 'kubernetes',
         rank: 0,
         status: 'disconnected',
@@ -113,7 +127,7 @@ describe('the stored installation manifest', () => {
         connection: null,
       },
       {
-        name: 'cloud-cloudrun',
+        vessel: 'cloud',
         adapter: 'cloudrun',
         rank: 1,
         status: 'disconnected',
@@ -121,7 +135,7 @@ describe('the stored installation manifest', () => {
         connection: null,
       },
       {
-        name: 'cloud-static',
+        vessel: 'cloud',
         adapter: 'static',
         rank: 2,
         status: 'disconnected',
@@ -137,17 +151,18 @@ describe('the stored installation manifest', () => {
     });
 
     const rows = await database().db.query.targets.findMany({
+      with: { vessel: true },
       orderBy: (targets, { asc }) => [asc(targets.rank)],
     });
     expect(
-      rows.map(({ name, status, connection }) => ({
-        name,
+      rows.map(({ vessel, status, connection }) => ({
+        vessel: vessel.name,
         status,
         connection,
       })),
     ).toEqual([
       {
-        name: 'cluster',
+        vessel: 'cluster',
         status: 'connected',
         connection: {
           adapter: 'kubernetes',
@@ -160,7 +175,7 @@ describe('the stored installation manifest', () => {
         },
       },
       {
-        name: 'cloud-cloudrun',
+        vessel: 'cloud',
         status: 'connected',
         connection: {
           adapter: 'cloudrun',
@@ -169,7 +184,7 @@ describe('the stored installation manifest', () => {
         },
       },
       {
-        name: 'cloud-static',
+        vessel: 'cloud',
         status: 'connected',
         connection: {
           adapter: 'static',
@@ -215,7 +230,7 @@ describe('the stored installation manifest', () => {
     await database()
       .db.update(targets)
       .set({ health: 'healthy', updatedAt: old })
-      .where(eq(targets.name, 'cluster'));
+      .where(eq(targets.id, await targetIdOf('cluster')));
     const changed = {
       ...connectedManifest,
       vessels: connectedManifest.vessels.map((vessel) =>
@@ -237,9 +252,15 @@ describe('the stored installation manifest', () => {
     // was asserting this behaviour through the one path that no longer has it.
     await writeStoredManifest(database().db, changed);
 
-    const cluster = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const cluster = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     // The address moved to the boundary, so that is where the edit lands —
     // and the surface it carries is still reassessed, because what changed is
     // still where this Target is.
@@ -282,7 +303,7 @@ describe('the stored installation manifest', () => {
     await database()
       .db.update(targets)
       .set({ connection: corrected, health: 'healthy' })
-      .where(eq(targets.name, 'cluster'));
+      .where(eq(targets.id, await targetIdOf('cluster')));
 
     // The restart. It used to be the whole defect: `loadStoredManifest` writes
     // the stored document back on every boot, and reconciliation re-asserted
@@ -290,9 +311,15 @@ describe('the stored installation manifest', () => {
     // edit lasted exactly until the next pod rolled, silently.
     await loadStoredManifest(database().db, {});
 
-    const cluster = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const cluster = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     expect(cluster?.connection).toEqual(corrected);
     // Nothing was re-declared, so nothing about the Target's assessment was
     // invalidated either — a boot that reset this to unhealthy would make every
@@ -321,14 +348,20 @@ describe('the stored installation manifest', () => {
     await database()
       .db.update(targets)
       .set({ connection: connectionFor('kubernetes'), status: 'connected' })
-      .where(eq(targets.name, 'cluster'));
+      .where(eq(targets.id, await targetIdOf('cluster')));
 
-    const cluster = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const cluster = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     expect(
       targetConnectionDivergence(
-        fixtureManifest.targets.find((target) => target.name === 'cluster'),
+        fixtureManifest.targets.find((target) => target.vessel === 'cluster'),
         cluster?.connection ?? null,
       ),
     ).toEqual([]);
@@ -378,9 +411,15 @@ describe('the stored installation manifest', () => {
     await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,
     });
-    const before = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const before = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     await database()
       .db.update(targets)
       .set({
@@ -395,7 +434,7 @@ describe('the stored installation manifest', () => {
           },
         },
       })
-      .where(eq(targets.name, 'cluster'));
+      .where(eq(targets.id, await targetIdOf('cluster')));
 
     const changed = fixtureText.replace(
       'installation: example',
@@ -405,9 +444,15 @@ describe('the stored installation manifest', () => {
       [MANIFEST_INLINE_VAR]: changed,
     });
 
-    const after = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const after = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     expect(after?.id).toBe(before?.id);
     expect(after?.status).toBe('connected');
     expect(after?.connection).toEqual({
@@ -510,48 +555,19 @@ describe('the stored installation manifest', () => {
     );
   });
 
-  test('an incompatible Target declaration rolls back manifest and rank changes', async () => {
-    await loadStoredManifest(database().db, {
-      [MANIFEST_INLINE_VAR]: fixtureText,
-    });
-    await database()
-      .db.update(targets)
-      .set({ rank: 99 })
-      .where(eq(targets.name, 'cluster'));
-    // Re-seeding is where a declaration can still meet Target rows it did not
-    // create: discarding the installation row leaves the Targets behind.
-    await database().db.delete(installation);
-    const incompatible = {
-      ...fixtureManifest,
-      installation: 'incompatible',
-      targets: [
-        { name: 'cluster', vessel: 'cluster', adapter: 'kubernetes' },
-        { name: 'cloud-cloudrun', vessel: 'cluster', adapter: 'kubernetes' },
-      ],
-    } satisfies AuthoredManifest;
-
-    await expect(
-      loadStoredManifest(database().db, {
-        [MANIFEST_INLINE_VAR]: JSON.stringify(incompatible),
-      }),
-    ).rejects.toThrow(/stored Target uses cloudrun/);
-
-    // The whole seed is one transaction, so a refused Target leaves no
-    // half-seeded installation behind and no rank change from the attempt.
-    expect(await database().db.select().from(installation)).toEqual([]);
-    const cluster = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
-    expect(cluster?.rank).toBe(99);
-  });
-
   test('a declared write updates an existing Target’s asserted reaches, and a boot does not', async () => {
     await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
     });
-    const seeded = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const seeded = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     // Nobody has said, so the row asserts nothing and the adapter's floor is
     // the whole answer — §3's asserted half is stated, never reported.
     expect(seeded?.reaches).toBeNull();
@@ -574,9 +590,15 @@ describe('the stored installation manifest', () => {
     } as AuthoredManifest;
     await writeStoredManifest(database().db, asserting);
 
-    const declared = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const declared = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     expect(declared?.reaches).toEqual(['none', 'private', 'public']);
     expect(declared?.authReaches).toEqual(['private']);
 
@@ -587,12 +609,18 @@ describe('the stored installation manifest', () => {
     await database()
       .db.update(targets)
       .set({ reaches: ['none'] })
-      .where(eq(targets.name, 'cluster'));
+      .where(eq(targets.id, await targetIdOf('cluster')));
     await writeStoredManifest(database().db, asserting, 'booted');
 
-    const booted = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const booted = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     expect(booted?.reaches).toEqual(['none']);
   });
 
@@ -603,13 +631,19 @@ describe('the stored installation manifest', () => {
     await database()
       .db.update(targets)
       .set({ rank: 99 })
-      .where(eq(targets.name, 'cluster'));
+      .where(eq(targets.id, await targetIdOf('cluster')));
 
     await loadStoredManifest(database().db, {});
 
-    const cluster = await database().db.query.targets.findFirst({
-      where: (targets, { eq }) => eq(targets.name, 'cluster'),
-    });
+    const cluster = (
+      await database()
+        .db.select()
+        .from(targets)
+        .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+        .where(
+          and(eq(vessels.name, 'cluster'), eq(targets.adapter, 'kubernetes')),
+        )
+    )[0]?.targets;
     expect(cluster?.rank).toBe(0);
   });
 

--- a/apps/spindrift/test/config/manifest-upgrade.test.ts
+++ b/apps/spindrift/test/config/manifest-upgrade.test.ts
@@ -166,18 +166,23 @@ describe('the vessels a pre-declaration document is upgraded into', () => {
 
   test('leave the Targets in order, carrying only their own surface', () => {
     // Rank is read from this array's order, so a rewrite that reordered it
-    // would silently re-rank the installation.
+    // would silently re-rank the installation. `01` predates the
+    // `dropTargetNames` step too, so the chained upgrade also takes the
+    // constructed `name` off every entry — asserted below as its own claim
+    // rather than folded into this array, since that is the newer step's
+    // whole job.
     const upgraded = upgradeManifestDocument(document) as {
-      targets: { name: string; vessel: string; connection?: object }[];
+      targets: { vessel: string; adapter: string; connection?: object }[];
     };
     expect(
-      upgraded.targets.map((target) => [target.name, target.vessel]),
+      upgraded.targets.map((target) => [target.vessel, target.adapter]),
     ).toEqual([
-      ['cluster', 'cluster'],
-      ['cloud-cloudrun', 'cloud'],
-      ['cloud-static', 'cloud'],
+      ['cluster', 'kubernetes'],
+      ['cloud', 'cloudrun'],
+      ['cloud', 'static'],
     ]);
     for (const target of upgraded.targets) {
+      expect(target).not.toHaveProperty('name');
       expect(Object.keys(target.connection ?? {})).not.toContain('apiServer');
       expect(Object.keys(target.connection ?? {})).not.toContain('project');
       expect(Object.keys(target.connection ?? {})).not.toContain('servedHosts');
@@ -188,7 +193,10 @@ describe('the vessels a pre-declaration document is upgraded into', () => {
   });
 
   test('is a no-op on a document that already declares them', () => {
-    const current = snapshot('02-declared-vessels.yaml');
+    // `02` now upgrades too — `dropTargetNames` still takes its constructed
+    // `name` off every entry. `03` is the shape with neither gap, so this is
+    // where "already current" moved.
+    const current = snapshot('03-target-is-vessel-and-surface.yaml');
     expect(upgradeManifestDocument(current)).toEqual(current);
   });
 });

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -125,12 +125,16 @@ describe('boot fails loudly', () => {
     );
   });
 
-  test('on duplicate target names', () => {
+  test('on a Target that repeats another’s vessel and adapter', () => {
+    // A Target has no name of its own — `(vessel, adapter)` is the pair that
+    // identifies it, and it is the pair a document cannot repeat.
     const document = fixtureText.replace(
-      'name: cloud-cloudrun\n',
-      'name: cluster\n',
+      '  - vessel: cloud\n    adapter: static',
+      '  - vessel: cluster\n    adapter: kubernetes',
     );
-    expect(() => parseManifest(document, 'test')).toThrow(/unique/);
+    expect(() => parseManifest(document, 'test')).toThrow(
+      /a vessel carries one surface of each kind/,
+    );
   });
 
   test('when a Target names a vessel the document does not declare', () => {
@@ -140,8 +144,8 @@ describe('boot fails loudly', () => {
     // which is what `reconcileManifestTargets` needs, since it looks a vessel
     // up by name and has nothing honest to do without one.
     const document = fixtureText.replace(
-      '    vessel: cloud\n    adapter: static',
-      '    vessel: hosting\n    adapter: static',
+      '  - vessel: cloud\n    adapter: static',
+      '  - vessel: hosting\n    adapter: static',
     );
     expect(() => parseManifest(document, 'test')).toThrow(
       /targets\.2\.vessel: no vessel named hosting is declared/,
@@ -154,8 +158,8 @@ describe('boot fails loudly', () => {
     // `cloudrun` surface on a cluster is refused here rather than reaching an
     // adapter that has no way to place it.
     const document = fixtureText.replace(
-      '    vessel: cloud\n    adapter: cloudrun',
-      '    vessel: cluster\n    adapter: cloudrun',
+      '  - vessel: cloud\n    adapter: cloudrun',
+      '  - vessel: cluster\n    adapter: cloudrun',
     );
     expect(() => parseManifest(document, 'test')).toThrow(
       /a cluster vessel does not carry a cloudrun surface/,

--- a/apps/spindrift/test/conformance/archive-to-live.test.ts
+++ b/apps/spindrift/test/conformance/archive-to-live.test.ts
@@ -77,7 +77,11 @@ import {
   FakeDeployAdapter,
 } from '../harness/fakes/deploy-adapter.ts';
 import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const baseManifest = await fixtureManifest();
@@ -146,11 +150,14 @@ async function installation(options: { sourceCommit?: string } = {}) {
   // test is about is the chain and not placement's exclusion rules — those have
   // their own tests, and a Target excluded here would fail this one somewhere
   // unrelated to why.
+  const offsiteVessel = await insertVessel(db, 'kubernetes', {
+    name: 'offsite',
+  });
   const [target] = await db
     .insert(targets)
     .values(
       targetValues({
-        name: 'offsite',
+        vesselId: offsiteVessel.id,
         rank: 0,
         reaches: ['none', 'private', 'public'],
         discovery: CAPABLE_DISCOVERY,

--- a/apps/spindrift/test/conformance/second-target-admission.test.ts
+++ b/apps/spindrift/test/conformance/second-target-admission.test.ts
@@ -57,6 +57,7 @@ import {
 import {
   clusterInput,
   fixtureManifest,
+  insertVessel,
   targetValues,
 } from '../harness/installation.ts';
 
@@ -148,12 +149,12 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
     const ctx = context(harnessRegistry(adapterMap));
 
     // Connect target 1 (primary)
-    const primaryInput = clusterInput({ name: 'primary-k8s' });
+    const primaryInput = clusterInput({ vessel: 'primary-k8s' });
     const res1 = await connectTarget(primaryInput, ctx);
     expect(res1.ok).toBe(true);
 
     // Connect target 2 (secondary)
-    const secondaryInput = clusterInput({ name: 'secondary-k8s' });
+    const secondaryInput = clusterInput({ vessel: 'secondary-k8s' });
     const res2 = await connectTarget(secondaryInput, ctx);
     expect(res2.ok).toBe(true);
 
@@ -163,7 +164,7 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
     if (!listRes.ok) return;
 
     expect(listRes.value.targets).toHaveLength(2);
-    const targetNames = listRes.value.targets.map((t) => t.name);
+    const targetNames = listRes.value.targets.map((t) => t.vessel);
     expect(targetNames).toContain('primary-k8s');
     expect(targetNames).toContain('secondary-k8s');
 
@@ -182,8 +183,8 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
     ]);
     const ctx = context(harnessRegistry(adapterMap));
 
-    await connectTarget(clusterInput({ name: 'primary-k8s' }), ctx);
-    await connectTarget(clusterInput({ name: 'secondary-k8s' }), ctx);
+    await connectTarget(clusterInput({ vessel: 'primary-k8s' }), ctx);
+    await connectTarget(clusterInput({ vessel: 'secondary-k8s' }), ctx);
 
     await database()
       .db.update(targets)
@@ -196,7 +197,9 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
         },
       });
 
-    const allTargets = await database().db.select().from(targets);
+    const allTargets = await database().db.query.targets.findMany({
+      with: { vessel: true },
+    });
 
     const placementTargets = allTargets.map((t) =>
       placementTargetOf(t, { artifactTypes: ['image'], manifest }),
@@ -240,15 +243,27 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
       .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
       .returning();
 
-    // Connect both Targets using targetValues helper
+    // Connect both Targets using targetValues helper, each on its own vessel.
+    const primaryVessel = await insertVessel(database().db, 'kubernetes', {
+      name: 'primary-k8s',
+    });
+    const secondaryVessel = await insertVessel(database().db, 'kubernetes', {
+      name: 'secondary-k8s',
+    });
     const [t1] = await database()
       .db.insert(targets)
-      .values(targetValues({ name: 'primary-k8s', adapter: 'kubernetes' }))
+      .values(
+        targetValues({ adapter: 'kubernetes', vesselId: primaryVessel.id }),
+      )
       .returning();
     const [t2] = await database()
       .db.insert(targets)
       .values(
-        targetValues({ name: 'secondary-k8s', adapter: 'kubernetes', rank: 1 }),
+        targetValues({
+          adapter: 'kubernetes',
+          vesselId: secondaryVessel.id,
+          rank: 1,
+        }),
       )
       .returning();
 
@@ -487,10 +502,17 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
       .db.insert(components)
       .values({ appId: app!.id, name: 'web', kind: 'service' })
       .returning();
+    const secondaryVessel = await insertVessel(database().db, 'kubernetes', {
+      name: 'secondary-k8s',
+    });
     const [t2] = await database()
       .db.insert(targets)
       .values(
-        targetValues({ name: 'secondary-k8s', adapter: 'kubernetes', rank: 1 }),
+        targetValues({
+          adapter: 'kubernetes',
+          vesselId: secondaryVessel.id,
+          rank: 1,
+        }),
       )
       .returning();
 
@@ -543,9 +565,12 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
     const ctx = context(harnessRegistry(adapterMap, supplyChain));
 
     // 1. Target connection
-    const c1 = await connectTarget(clusterInput({ name: 'primary-k8s' }), ctx);
+    const c1 = await connectTarget(
+      clusterInput({ vessel: 'primary-k8s' }),
+      ctx,
+    );
     const c2 = await connectTarget(
-      clusterInput({ name: 'secondary-k8s' }),
+      clusterInput({ vessel: 'secondary-k8s' }),
       ctx,
     );
     expect(c1.ok).toBe(true);

--- a/apps/spindrift/test/domain/placement.test.ts
+++ b/apps/spindrift/test/domain/placement.test.ts
@@ -40,7 +40,7 @@ const ARTIFACT_TYPES = {
 function target(
   overrides: {
     id?: string;
-    name?: string;
+    vessel?: string;
     adapter?: CapabilityContext['adapter'];
     rank?: number;
     healthy?: boolean;
@@ -54,7 +54,7 @@ function target(
   const adapter = overrides.adapter ?? 'kubernetes';
   return {
     id: overrides.id ?? `target-${adapter}`,
-    name: overrides.name ?? adapter,
+    vessel: overrides.vessel ?? adapter,
     adapter,
     rank: overrides.rank ?? 0,
     healthy: overrides.healthy ?? true,
@@ -99,8 +99,8 @@ describe('the suggestion follows rank', () => {
   test('the first candidate by global rank is suggested', () => {
     const placement = resolvePlacement(
       [
-        target({ id: 'second', name: 'cloud', adapter: 'cloudrun', rank: 5 }),
-        target({ id: 'first', name: 'cluster', rank: 1 }),
+        target({ id: 'second', vessel: 'cloud', adapter: 'cloudrun', rank: 5 }),
+        target({ id: 'first', vessel: 'cluster', rank: 1 }),
       ],
       // A reach both serve: rank is what this test is about, and a Target
       // filtered out on reach would make it pass for the wrong reason.
@@ -417,8 +417,8 @@ describe('§9: a Private website takes the server-image rendering', () => {
     // the server-image rendering."
     const placement = resolvePlacement(
       [
-        target({ id: 'cdn', name: 'hosting', adapter: 'static', rank: 0 }),
-        target({ id: 'cluster', name: 'cluster', rank: 1 }),
+        target({ id: 'cdn', vessel: 'hosting', adapter: 'static', rank: 0 }),
+        target({ id: 'cluster', vessel: 'cluster', rank: 1 }),
       ],
       requirements({ kind: 'website', reach: 'private', auth: 'proxy' }),
     );
@@ -442,8 +442,8 @@ describe('§9: a Private website takes the server-image rendering', () => {
   test('the same website going public reaches static hosting as files', () => {
     const placement = resolvePlacement(
       [
-        target({ id: 'cdn', name: 'hosting', adapter: 'static', rank: 0 }),
-        target({ id: 'cluster', name: 'cluster', rank: 1 }),
+        target({ id: 'cdn', vessel: 'hosting', adapter: 'static', rank: 0 }),
+        target({ id: 'cluster', vessel: 'cluster', rank: 1 }),
       ],
       requirements({ kind: 'website', reach: 'public', auth: 'none' }),
     );

--- a/apps/spindrift/test/domain/target-connect-plan.test.ts
+++ b/apps/spindrift/test/domain/target-connect-plan.test.ts
@@ -33,7 +33,7 @@ import {
 } from '../../src/domain/target-onboarding.ts';
 
 const BASE: ClusterConnectChoices = {
-  name: 'metal',
+  vessel: 'metal',
   apiServer: 'https://cluster.invalid:6443',
   namespace: 'apps',
   deliveryNamespace: 'apps',
@@ -147,7 +147,6 @@ describe('a cluster connect plan', () => {
     if (parsed.data.adapter !== 'kubernetes') {
       throw new Error(`declared a ${parsed.data.adapter} Target`);
     }
-    expect(parsed.data.name).toBe('metal');
     expect(parsed.data.vessel).toBe('metal');
     expect(parsed.data.reaches).toEqual(plan.reaches);
     expect(parsed.data.connection?.chartValues).toEqual(plan.chartValues);

--- a/apps/spindrift/test/domain/target-onboarding.test.ts
+++ b/apps/spindrift/test/domain/target-onboarding.test.ts
@@ -8,6 +8,7 @@
  * API server reads as correct and points somewhere else.
  */
 import { describe, expect, test } from 'bun:test';
+import type { TargetAdapter } from '../../src/config/manifest.schema.ts';
 import {
   connectionProposal,
   type OnboardingTargetRow,
@@ -26,7 +27,6 @@ const BLUENOSE_VESSEL = {
 } as const;
 
 const CLUSTER: OnboardingTargetRow = {
-  name: 'offsite',
   adapter: 'kubernetes',
   health: 'healthy',
   vessel: OFFSITE_VESSEL,
@@ -42,7 +42,6 @@ const CLUSTER: OnboardingTargetRow = {
 };
 
 const CLOUD_RUN: OnboardingTargetRow = {
-  name: 'bluenose-cloudrun',
   adapter: 'cloudrun',
   health: 'healthy',
   vessel: BLUENOSE_VESSEL,
@@ -55,7 +54,6 @@ const CLOUD_RUN: OnboardingTargetRow = {
 };
 
 const CLOUD_STATIC: OnboardingTargetRow = {
-  name: 'bluenose-static',
   adapter: 'static',
   health: 'healthy',
   vessel: BLUENOSE_VESSEL,
@@ -66,13 +64,12 @@ const CLOUD_STATIC: OnboardingTargetRow = {
 };
 
 function unconfigured(
-  name: string,
-  adapter: OnboardingTargetRow['adapter'],
+  adapter: TargetAdapter,
   vessel: OnboardingTargetRow['vessel'] = adapter === 'kubernetes'
     ? OFFSITE_VESSEL
     : BLUENOSE_VESSEL,
 ): OnboardingTargetRow {
-  return { name, adapter, health: 'unhealthy', connection: null, vessel };
+  return { adapter, health: 'unhealthy', connection: null, vessel };
 }
 
 describe('what is still waiting to be connected', () => {
@@ -90,61 +87,33 @@ describe('what is still waiting to be connected', () => {
 
   test('a cloud project is one act naming both of its Targets', () => {
     const pending = pendingConnections([
-      unconfigured('bluenose-cloudrun', 'cloudrun'),
-      unconfigured('bluenose-static', 'static'),
+      unconfigured('cloudrun'),
+      unconfigured('static'),
     ]);
 
     expect(pending).toHaveLength(1);
     expect(pending[0]).toMatchObject({
       kind: 'gcp-project',
-      name: 'bluenose',
-      targets: ['bluenose-cloudrun', 'bluenose-static'],
+      vessel: 'bluenose',
+      surfaces: ['cloudrun', 'static'],
     });
   });
 
   test('half a cloud project still names both Targets the act would write', () => {
-    const pending = pendingConnections([
-      CLOUD_RUN,
-      unconfigured('bluenose-static', 'static'),
-    ]);
+    const pending = pendingConnections([CLOUD_RUN, unconfigured('static')]);
 
     // Connecting re-registers the pair. Listing only the unconfigured half
     // would under-report what the button is about to touch.
-    expect(pending[0]?.targets).toEqual([
-      'bluenose-cloudrun',
-      'bluenose-static',
-    ]);
-  });
-
-  test('a Target whose name carries no adapter suffix is still offered', () => {
-    // This used to be dropped: the act's name was recovered by slicing the
-    // adapter suffix off the row's, so a row that carried none was
-    // unconnectable — a Target the screen listed nowhere and no button could
-    // reach. The boundary is a row now, so the name is read rather than
-    // reconstructed and the convention binds nothing.
-    expect(
-      pendingConnections([unconfigured('anything-at-all', 'cloudrun')]),
-    ).toEqual([
-      {
-        kind: 'gcp-project',
-        name: BLUENOSE_VESSEL.name,
-        targets: [
-          `${BLUENOSE_VESSEL.name}-cloudrun`,
-          `${BLUENOSE_VESSEL.name}-static`,
-        ],
-        proposal: { carriedFrom: null },
-      },
-    ]);
+    expect(pending[0]?.surfaces).toEqual(['cloudrun', 'static']);
   });
 
   test('a cluster is one act named for the vessel it sits on', () => {
-    expect(pendingConnections([unconfigured('folly', 'kubernetes')])).toEqual([
+    expect(pendingConnections([unconfigured('kubernetes')])).toEqual([
       {
         kind: 'cluster',
-        name: OFFSITE_VESSEL.name,
-        // One surface, so it takes the vessel's name unchanged: the suffix
-        // exists to tell siblings apart and there are none.
-        targets: [OFFSITE_VESSEL.name],
+        vessel: OFFSITE_VESSEL.name,
+        // One surface, so it is the whole list §13 gives a cluster.
+        surfaces: ['kubernetes'],
         proposal: { carriedFrom: null },
       },
     ]);
@@ -163,7 +132,7 @@ describe('what a connect may be prefilled with', () => {
     const proposal = connectionProposal([CLUSTER], 'cluster');
 
     expect(proposal).toEqual({
-      carriedFrom: 'offsite',
+      carriedFrom: 'offsite/kubernetes',
       namespace: 'spindrift-apps',
       deliveryFlavour: 'flux-helmrelease',
       sourceRef: { name: 'infra', namespace: 'flux-system' },
@@ -179,7 +148,7 @@ describe('what a connect may be prefilled with', () => {
     );
 
     expect(proposal).toEqual({
-      carriedFrom: 'bluenose-cloudrun',
+      carriedFrom: 'bluenose/cloudrun',
       region: 'northamerica-northeast1',
       runEndpoint: 'https://run.googleapis.example',
       policyEndpoint: 'https://binaryauthorization.googleapis.example',
@@ -189,23 +158,19 @@ describe('what a connect may be prefilled with', () => {
   });
 
   test('it prefers a healthy Target to copy from', () => {
-    const broken: OnboardingTargetRow = {
-      ...CLUSTER,
-      name: 'broken',
-      health: 'unhealthy',
-    };
+    const broken: OnboardingTargetRow = { ...CLUSTER, health: 'unhealthy' };
 
     // Copying a Target that does not work forward is the fastest way to turn
     // one broken Target into two.
     expect(connectionProposal([broken, CLUSTER], 'cluster')).toMatchObject({
-      carriedFrom: 'offsite',
+      carriedFrom: 'offsite/kubernetes',
     });
   });
 
   test('it falls back to an unhealthy Target rather than proposing nothing', () => {
     const broken: OnboardingTargetRow = { ...CLUSTER, health: 'unhealthy' };
     expect(connectionProposal([broken], 'cluster')).toMatchObject({
-      carriedFrom: 'offsite',
+      carriedFrom: 'offsite/kubernetes',
     });
   });
 });

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -76,10 +76,10 @@ secretStore:
   endpoint: https://secrets.example.test
   container: example-secrets
 
-# The tenancy boundaries. Named, so nothing has to recover one from the shared
-# prefix of two Target names — the cloud vessel below carries two surfaces and
-# says so once. No `location` on either: this fixture seeds identity and rank
-# and leaves how to reach them to the connect act, which is the half-ready state
+# The tenancy boundaries. Named, so nothing has to recover one from a Target's
+# vessel and adapter — the cloud vessel below carries two surfaces and says so
+# once. No `location` on either: this fixture seeds identity and rank and
+# leaves how to reach them to the connect act, which is the half-ready state
 # §13 intends to be visible.
 vessels:
   - name: cluster
@@ -87,14 +87,12 @@ vessels:
   - name: cloud
     kind: gcp-project
 
-# Rank order: placement considers these top to bottom.
+# Rank order: placement considers these top to bottom. A Target has no name of
+# its own — `vessel` and `adapter` are what identify it.
 targets:
-  - name: cluster
-    vessel: cluster
+  - vessel: cluster
     adapter: kubernetes
-  - name: cloud-cloudrun
-    vessel: cloud
+  - vessel: cloud
     adapter: cloudrun
-  - name: cloud-static
-    vessel: cloud
+  - vessel: cloud
     adapter: static

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -670,7 +670,7 @@ export const WORKSPACE_SCENARIO_NAMES = Object.keys(
 export const TARGET_OPTIONS: readonly TargetOptionView[] = [
   {
     targetId: 'metal',
-    name: 'Metal',
+    vessel: 'metal',
     adapter: 'kubernetes',
     rank: 1,
     candidate: true,
@@ -681,7 +681,7 @@ export const TARGET_OPTIONS: readonly TargetOptionView[] = [
   },
   {
     targetId: 'cloud',
-    name: 'Cloud Run',
+    vessel: 'vessel-a',
     adapter: 'cloudrun',
     rank: 2,
     candidate: true,
@@ -692,7 +692,7 @@ export const TARGET_OPTIONS: readonly TargetOptionView[] = [
   },
   {
     targetId: 'static',
-    name: 'Static hosting',
+    vessel: 'vessel-a',
     adapter: 'static',
     rank: 3,
     candidate: false,
@@ -703,7 +703,7 @@ export const TARGET_OPTIONS: readonly TargetOptionView[] = [
   },
   {
     targetId: 'remote',
-    name: 'Remote cluster',
+    vessel: 'remote',
     adapter: 'kubernetes',
     rank: 4,
     candidate: false,
@@ -889,7 +889,7 @@ const CLOUD_CHECKLIST = [
 export const TARGET_LIST: readonly TargetListItem[] = [
   {
     id: 'target-primary',
-    name: 'Primary',
+    vessel: 'primary',
     adapter: 'kubernetes',
     rank: 1,
     health: 'healthy',
@@ -909,12 +909,12 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     ],
     edit: {
       apiServer: 'https://primary.example:6443',
-      proposal: { carriedFrom: 'Primary', namespace: 'apps' },
+      proposal: { carriedFrom: 'primary/kubernetes', namespace: 'apps' },
     },
   },
   {
     id: 'target-cloudrun',
-    name: 'Cloud Run · vessel-a',
+    vessel: 'vessel-a',
     adapter: 'cloudrun',
     rank: 2,
     health: 'healthy',
@@ -931,7 +931,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
   },
   {
     id: 'target-static',
-    name: 'Firebase · vessel-a',
+    vessel: 'vessel-a',
     adapter: 'static',
     rank: 3,
     health: 'healthy',
@@ -948,7 +948,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
   },
   {
     id: 'target-secondary',
-    name: 'Secondary',
+    vessel: 'secondary',
     adapter: 'kubernetes',
     rank: 4,
     health: 'unhealthy',
@@ -973,7 +973,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     connectionDivergence: [],
     edit: {
       apiServer: 'https://secondary.example:6443',
-      proposal: { carriedFrom: 'Secondary', namespace: 'apps' },
+      proposal: { carriedFrom: 'secondary/kubernetes', namespace: 'apps' },
     },
   },
 ];

--- a/apps/spindrift/test/fixtures/stored-manifests/03-target-is-vessel-and-surface.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/03-target-is-vessel-and-surface.yaml
@@ -1,0 +1,115 @@
+# A stored manifest as this build writes one: a Target is its vessel and its
+# surface, and carries no name of its own.
+#
+# `02` gave a Target both — a `vessel` reference *and* a constructed `name` that
+# was the vessel's, plus the adapter as a suffix where the vessel carried more
+# than one surface. The suffix was decorative from the moment the vessel became
+# a row, and worse than redundant: it appeared only where there were siblings to
+# tell apart, so a vessel discovering a second surface would have had to rename
+# the first. `manifest-upgrade.ts` drops the field rather than deriving anything
+# from it, because the two lines under it were already authoritative.
+#
+# **The newest file in this corpus, and the test asserts this build needs no
+# upgrade to read it.** That is the forcing function: change the manifest schema
+# in any way that stops accepting this document, and the assertion fails. The
+# fix is never to edit this file — it is to copy it to the next number, edit
+# *that* to the new shape, and teach `manifest-upgrade.ts` how to get from here
+# to there. Doing it the other way round is exactly how a schema change reaches
+# production able to discard a configured installation.
+#
+# `installation` differs from every declaration this suite mounts, for the
+# reason `01` gives.
+installation: stored-without-target-names
+
+controlPlane:
+  hostname: spindrift.example.test
+
+auth:
+  gateway: null
+
+dns:
+  zones:
+    private: apps.example.test
+    public: example.test
+
+sources:
+  buckets:
+    - example-source-bucket
+  defaultBucket: example-source-bucket
+
+cloud:
+  artifactsProject: example-artifacts
+  homeVesselProject: example-home
+
+charts:
+  app: example/spindrift-app
+
+supplyChain:
+  registry: registry.example.test/artifacts
+  verifier: verifier.example.test
+  signer: gcpkms://projects/example-artifacts/locations/example-region/keyRings/keys/cryptoKeys/signer
+
+github:
+  clientId: Iv1.example
+  oauthBaseUrl: https://git.example.test
+  apiBaseUrl: https://api.git.example.test
+  buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
+
+build:
+  routes:
+    - name: hosted
+      adapter: github-actions
+  zeroConfigFrontend: registry.example.test/zero-config:pinned
+
+secretStore:
+  adapter: gcp-secret-manager
+  endpoint: https://secrets.example.test
+  container: example-secrets
+
+vessels:
+  - name: cluster
+    kind: cluster
+    location:
+      apiServer: https://cluster.example.test
+    reachableRegistries:
+      - registry.example.test
+    servedHosts:
+      - apps.example.test
+  - name: cloud
+    kind: gcp-project
+    location:
+      project: example-vessel
+    reachableRegistries:
+      - mirror.example.test
+    servedHosts:
+      - hosting.example.test
+      - run.example.test
+
+targets:
+  - vessel: cluster
+    adapter: kubernetes
+    reaches: [none, private]
+    authReaches: [private]
+    connection:
+      namespace: apps
+      delivery:
+        flavour: flux-helmrelease
+        namespace: apps
+        sourceRef:
+          name: infra
+          namespace: flux-system
+      chartValues:
+        platform:
+          gateway:
+            name: cluster-gateway
+            namespace: gateway
+  - vessel: cloud
+    adapter: cloudrun
+    connection:
+      region: example-region
+      endpoint: https://run.example.test
+      serviceAccount: runtime@example-vessel.iam.gserviceaccount.com
+  - vessel: cloud
+    adapter: static
+    connection:
+      endpoint: https://hosting.example.test

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -98,7 +98,7 @@ export function clusterInput(
 ): KubernetesConnectInput {
   return {
     kind: 'cluster',
-    name: 'cluster',
+    vessel: 'cluster',
     apiServer: 'https://cluster.example.test',
     namespace: 'apps',
     delivery: {
@@ -159,7 +159,7 @@ export function cloudInput(
 ): CloudConnectInput {
   return {
     kind: 'gcp-project',
-    name: 'cloud',
+    vessel: 'cloud',
     project: 'example-vessel',
     region: 'somewhere',
     runEndpoint: CLOUD_ENDPOINTS.run,
@@ -260,12 +260,13 @@ export async function insertVessel(
  */
 export function deployTargetFor(
   adapter: TargetAdapter,
-  name = `target-${adapter}`,
+  vesselName = `vessel-${adapter}`,
 ): DeployTargetRef {
   const vessel = vesselFor(adapter);
   return deployTargetOf(
-    { name, adapter, connection: connectionFor(adapter) },
+    { adapter, connection: connectionFor(adapter) },
     {
+      name: vesselName,
       location: vessel.location!,
       servedHosts: vessel.servedHosts ?? null,
       reachableRegistries: vessel.reachableRegistries ?? null,
@@ -277,7 +278,6 @@ export function deployTargetFor(
 export function targetValues(overrides: Partial<NewTarget> = {}): NewTarget {
   const adapter = overrides.adapter ?? 'kubernetes';
   return {
-    name: `target-${crypto.randomUUID()}`,
     adapter,
     rank: 0,
     // The isolated database seeds one vessel per kind; a Target that wants its

--- a/apps/spindrift/test/reconciler/auto-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/auto-deploy.test.ts
@@ -31,7 +31,11 @@ import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -53,9 +57,12 @@ async function deployableApp(autoDeploy: boolean) {
     .insert(components)
     .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
     .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
-    .values(targetValues({ name: `cluster-${crypto.randomUUID()}` }))
+    .values(targetValues({ vesselId: vessel.id }))
     .returning();
   await db.insert(componentTargetDesired).values({
     componentId: component!.id,

--- a/apps/spindrift/test/reconciler/deploy-loop.test.ts
+++ b/apps/spindrift/test/reconciler/deploy-loop.test.ts
@@ -33,6 +33,7 @@ import {
   deploys,
   targets,
 } from '../../src/db/schema.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import {
   claimNextDeploy,
   DEFAULT_CLAIM_TIMEOUT_MS,
@@ -47,7 +48,11 @@ import {
   FakeDeployAdapter,
   type ScriptedAttempt,
 } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
@@ -96,14 +101,13 @@ async function pendingDeploy(
       ...(options.schedule === undefined ? {} : { schedule: options.schedule }),
     })
     .returning();
+  const adapter = options.adapter ?? 'kubernetes';
+  const vessel = await insertVessel(db, adapter, {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
-    .values(
-      targetValues({
-        name: `cluster-${crypto.randomUUID()}`,
-        adapter: options.adapter ?? 'kubernetes',
-      }),
-    )
+    .values(targetValues({ vesselId: vessel.id, adapter }))
     .returning();
   const [build] = await db
     .insert(builds)
@@ -125,7 +129,7 @@ async function pendingDeploy(
       desired: aDesiredDocument({
         app: app!.name,
         component: component!.name,
-        target: target!.name,
+        target: targetLabel({ vessel: vessel.name, adapter }),
         reach: options.reach ?? 'private',
         auth: options.auth ?? 'proxy',
       }),

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -36,6 +36,7 @@ import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import {
   FIXTURE_DEPLOYMENT_ENV,
   fixtureManifest,
+  insertVessel,
   targetValues,
 } from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
@@ -401,14 +402,12 @@ async function pendingBuildNoRouteSatisfies() {
     .insert(components)
     .values({ appId: app!.id, name: 'web', kind: 'service' })
     .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
-    .values(
-      targetValues({
-        name: `cluster-${crypto.randomUUID()}`,
-        adapter: 'kubernetes',
-      }),
-    )
+    .values(targetValues({ vesselId: vessel.id, adapter: 'kubernetes' }))
     .returning();
   await db
     .insert(componentTargetDesired)
@@ -439,14 +438,12 @@ async function pendingDeploy() {
       auth: 'proxy',
     })
     .returning();
+  const vessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
   const [target] = await db
     .insert(targets)
-    .values(
-      targetValues({
-        name: `cluster-${crypto.randomUUID()}`,
-        adapter: 'kubernetes',
-      }),
-    )
+    .values(targetValues({ vesselId: vessel.id, adapter: 'kubernetes' }))
     .returning();
   const [build] = await db
     .insert(builds)

--- a/apps/spindrift/test/reconciler/repo-loop.test.ts
+++ b/apps/spindrift/test/reconciler/repo-loop.test.ts
@@ -42,7 +42,7 @@ import {
 } from '../../src/reconciler/repo-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeGitHub } from '../harness/fakes/github-api.ts';
-import { targetValues } from '../harness/installation.ts';
+import { insertVessel, targetValues } from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
@@ -125,9 +125,10 @@ async function liveDeploy(appId: string) {
     .insert(components)
     .values({ appId, name: 'api', kind: 'service', expose: true })
     .returning();
+  const vessel = await insertVessel(db, 'kubernetes', { name: 'cluster' });
   const [target] = await db
     .insert(targets)
-    .values(targetValues({ name: 'cluster', rank: 1 }))
+    .values(targetValues({ vesselId: vessel.id, rank: 1 }))
     .returning();
   const [build] = await db
     .insert(builds)

--- a/apps/spindrift/test/reconciler/target-loop.test.ts
+++ b/apps/spindrift/test/reconciler/target-loop.test.ts
@@ -9,7 +9,7 @@
  * other test in this file could still pass.
  */
 import { describe, expect, test } from 'bun:test';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import {
   connectTarget,
   resolveComponentPlacement,
@@ -32,6 +32,7 @@ import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
 import {
   clusterInput,
   fixtureManifest,
+  insertVessel,
   targetValues,
 } from '../harness/installation.ts';
 
@@ -86,12 +87,31 @@ function context(registry: AdapterRegistry, clock: Clock): CommandContext {
   };
 }
 
-async function targetRow(name: string) {
+/** The Target row for the surface named by `(vessel, adapter)`. */
+async function targetRow(
+  vessel: string,
+  adapter: TargetAdapter = 'kubernetes',
+) {
   const rows = await database()
     .db.select()
     .from(targets)
-    .where(eq(targets.name, name));
-  return rows[0]!;
+    .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+    .where(and(eq(vessels.name, vessel), eq(targets.adapter, adapter)));
+  return rows[0]!.targets;
+}
+
+/** A Target row on its own, freshly named vessel — what `targetValues({ name })` used to give it. */
+async function insertNamedTarget(
+  name: string,
+  overrides: Partial<Parameters<typeof targetValues>[0]> = {},
+) {
+  const adapter = overrides.adapter ?? 'kubernetes';
+  const vessel = await insertVessel(database().db, adapter, { name });
+  const [row] = await database()
+    .db.insert(targets)
+    .values(targetValues({ ...overrides, adapter, vesselId: vessel.id }))
+    .returning();
+  return row!;
 }
 
 /** The boundary a Target sits on — half of what `refreshTarget` inspects. */
@@ -107,9 +127,7 @@ describe('one pass over every connected Target', () => {
   test('writes the checklist, the discovery, and the derived health', async () => {
     const { registry, of } = fakes();
     const clock = ticking();
-    await database()
-      .db.insert(targets)
-      .values(targetValues({ name: 'cluster' }));
+    await insertNamedTarget('cluster');
 
     clock.advance();
     const [refresh] = await refreshAllTargets(context(registry, clock));
@@ -121,15 +139,15 @@ describe('one pass over every connected Target', () => {
       prerequisitesFor('kubernetes').length,
     );
     expect(row.inspectedAt).toEqual(clock.now());
-    expect(of('kubernetes').inspected.map((t) => t.name)).toEqual(['cluster']);
+    expect(of('kubernetes').inspected.map((t) => t.vessel)).toEqual([
+      'cluster',
+    ]);
   });
 
   test('a disconnected Target is not polled', async () => {
     const { registry, of } = fakes();
     const clock = ticking();
-    await database()
-      .db.insert(targets)
-      .values(targetValues({ name: 'gone', status: 'disconnected' }));
+    await insertNamedTarget('gone', { status: 'disconnected' });
 
     expect(await refreshAllTargets(context(registry, clock))).toEqual([]);
     // Continuing to poll a Target the operator removed would keep someone
@@ -140,9 +158,7 @@ describe('one pass over every connected Target', () => {
   test('the loop never flips connected or disconnected', async () => {
     const { registry } = fakes();
     const clock = ticking();
-    await database()
-      .db.insert(targets)
-      .values(targetValues({ name: 'cluster', health: 'unhealthy' }));
+    await insertNamedTarget('cluster', { health: 'unhealthy' });
 
     await refreshAllTargets(context(registry, clock));
     // Connected and disconnected are the operator's statement. A loop that
@@ -154,9 +170,7 @@ describe('one pass over every connected Target', () => {
   test('health changing is reported, and health staying is not', async () => {
     const { registry, of } = fakes();
     const clock = ticking();
-    await database()
-      .db.insert(targets)
-      .values(targetValues({ name: 'cluster', health: 'unhealthy' }));
+    await insertNamedTarget('cluster', { health: 'unhealthy' });
 
     const [first] = await refreshAllTargets(context(registry, clock));
     expect(first?.healthChangedFrom).toBe('unhealthy');
@@ -175,23 +189,20 @@ describe('one pass over every connected Target', () => {
       adapter: 'kubernetes',
       unreachable: 'the API server is not answering',
     });
-    const [row] = await database()
-      .db.insert(targets)
-      .values(targetValues({ name: 'cluster' }))
-      .returning();
+    const row = await insertNamedTarget('cluster');
 
     const down: AdapterRegistry = { ...registry, deploy: () => unreachable };
     await refreshTarget(
       context(down, clock),
-      row!,
-      await vesselOf(row!.vesselId),
+      row,
+      await vesselOf(row.vesselId),
     );
     expect((await targetRow('cluster')).health).toBe('unhealthy');
 
     await refreshTarget(
       context(registry, clock),
       await targetRow('cluster'),
-      await vesselOf(row!.vesselId),
+      await vesselOf(row.vesselId),
     );
     expect((await targetRow('cluster')).health).toBe('healthy');
   });
@@ -203,7 +214,7 @@ describe('a capability flip changes candidacy on the next pass', () => {
     const clock = ticking();
     const ctx = () => context(registry, clock);
 
-    await connectTarget(clusterInput({ name: 'cluster' }), ctx());
+    await connectTarget(clusterInput({ vessel: 'cluster' }), ctx());
 
     const [app] = await database()
       .db.insert(apps)
@@ -253,9 +264,7 @@ describe('the loop itself', () => {
   test('runs passes until aborted', async () => {
     const { registry, of } = fakes();
     const clock = ticking();
-    await database()
-      .db.insert(targets)
-      .values(targetValues({ name: 'cluster' }));
+    await insertNamedTarget('cluster');
 
     const controller = new AbortController();
     let passes = 0;
@@ -276,9 +285,7 @@ describe('the loop itself', () => {
   test('an already-aborted signal runs no pass at all', async () => {
     const { registry, of } = fakes();
     const clock = ticking();
-    await database()
-      .db.insert(targets)
-      .values(targetValues({ name: 'cluster' }));
+    await insertNamedTarget('cluster');
 
     await runTargetLoop(context(registry, clock), {
       intervalMs: 1,

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -161,7 +161,7 @@ describe('non-candidate Targets are listed rather than hidden', () => {
 
   test('every connected Target appears, candidate or not', () => {
     for (const target of TARGET_OPTIONS) {
-      expect(markup).toContain(target.name);
+      expect(markup).toContain(target.vessel);
     }
   });
 

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -69,9 +69,10 @@ describe('every manifest value is reachable', () => {
 
   test('a nested key is reached by its own path', () => {
     // Dotted paths are what let a Zod issue be rendered against the input that
-    // caused it. `targets.0.name` names one row of one array.
+    // caused it. `targets.0.vessel` names one row of one array — a Target has
+    // no name of its own, so `vessel` is the field this now pins.
     expect(markup).toContain('name="dns.zones.private"');
-    expect(markup).toContain('name="targets.0.name"');
+    expect(markup).toContain('name="targets.0.vessel"');
   });
 
   test('the pinned zero-config frontend is one of them', () => {

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -32,6 +32,7 @@ import {
   loadStoredManifest,
 } from '../../src/config/manifest-store.ts';
 import { installation } from '../../src/db/schema.ts';
+import { targetLabel } from '../../src/domain/target.ts';
 import {
   commandRoutes,
   type DispatchDeps,
@@ -287,11 +288,21 @@ describe('configuring this installation from the browser', () => {
     // reached a different writer would leave a Target declared in the document
     // and absent from the table.
     await seed();
-    const declared = [
-      ...fixture.targets,
-      { name: 'spare', vessel: 'cluster', adapter: 'kubernetes' },
+    // The vessel every existing Target already sits on carries a full set of
+    // surfaces, so a genuinely new Target needs a genuinely new vessel too.
+    const declaredVessels = [
+      ...fixture.vessels,
+      { name: 'spare', kind: 'cluster' as const },
     ];
-    const edited = withValueAt(fixture, ['targets'], declared);
+    const declaredTargets = [
+      ...fixture.targets,
+      { vessel: 'spare', adapter: 'kubernetes' as const },
+    ];
+    const edited = withValueAt(
+      withValueAt(fixture, ['vessels'], declaredVessels),
+      ['targets'],
+      declaredTargets,
+    );
 
     const saved = await post(authenticated, 'configureInstallation', {
       manifest: edited,
@@ -299,15 +310,18 @@ describe('configuring this installation from the browser', () => {
     expect(saved.status).toBe(200);
 
     const rows = await database().db.query.targets.findMany({
+      with: { vessel: true },
       orderBy: (targets, { asc }) => [asc(targets.rank)],
     });
-    expect(rows.map((row) => row.name)).toEqual(
-      declared.map((target) => target.name),
-    );
+    expect(
+      rows.map((row) =>
+        targetLabel({ vessel: row.vessel.name, adapter: row.adapter }),
+      ),
+    ).toEqual(declaredTargets.map((target) => targetLabel(target)));
     // A Target nobody named through the product exists because the manifest
     // said so, which is the whole reason the write and the reconcile are one
     // transaction.
-    expect(rows.some((row) => row.name === 'spare')).toBe(true);
+    expect(rows.some((row) => row.vessel.name === 'spare')).toBe(true);
   });
 
   test('an invalid document is a 422 naming every offending key', async () => {
@@ -329,27 +343,5 @@ describe('configuring this installation from the browser', () => {
     expect(body.failure.code).toBe('INVALID_INPUT');
     expect(body.failure.message).toContain('zones.private');
     expect(await storedManifest()).toEqual(before);
-  });
-
-  test('a document this installation cannot take is a 409, not a field error', async () => {
-    // The distinction the screen renders. 409 rather than 422 because the
-    // request is well formed and the caller has nothing to fix in it — §3's
-    // disabled-with-reasons grammar, over HTTP.
-    await seed();
-    const swapped = withValueAt(
-      fixture,
-      ['targets'],
-      [
-        { name: 'cluster', vessel: 'cluster', adapter: 'kubernetes' },
-        { name: 'cloud-cloudrun', vessel: 'cluster', adapter: 'kubernetes' },
-      ],
-    );
-
-    const response = await post(authenticated, 'configureInstallation', {
-      manifest: swapped,
-    });
-    expect(response.status).toBe(409);
-    const body = (await response.json()) as { failure: { code: string } };
-    expect(body.failure.code).toBe('NOT_DEPLOYABLE');
   });
 });

--- a/apps/spindrift/test/web/streams.test.ts
+++ b/apps/spindrift/test/web/streams.test.ts
@@ -23,7 +23,11 @@ import {
 } from '../../src/web/streams.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 import { aDesiredDocument } from '../harness/release.ts';
 
 const database = withIsolatedDatabase();
@@ -41,9 +45,12 @@ async function seedAttempt() {
     .db.insert(components)
     .values({ appId: app!.id, name: 'web', kind: 'service' })
     .returning();
+  const vessel = await insertVessel(database().db, 'kubernetes', {
+    name: 'cluster',
+  });
   const [target] = await database()
     .db.insert(targets)
-    .values(targetValues({ name: 'cluster' }))
+    .values(targetValues({ vesselId: vessel.id }))
     .returning();
   const [build] = await database()
     .db.insert(builds)
@@ -231,9 +238,9 @@ describe('authenticated attempt stream', () => {
         kind: 'runtime',
         adapter: new ThrowingAdapter(),
         target: {
-          name: 'cluster',
+          vessel: 'cluster',
           adapter: 'kubernetes',
-          connection: targetValues({ name: 'cluster' }).connection!,
+          connection: targetValues({ adapter: 'kubernetes' }).connection!,
         },
         subject: { app: 'live-app', component: 'web' },
         cursor: 'durable-cursor',

--- a/apps/spindrift/test/web/target-repo-routes.test.ts
+++ b/apps/spindrift/test/web/target-repo-routes.test.ts
@@ -91,7 +91,7 @@ describe('listTargets and listRepositories over route boundary', () => {
 
   test('listTargets returns persisted targets and options for authenticated user', async () => {
     const ctx = await makeContext(null);
-    await connectTarget(clusterInput({ name: 'folly-cluster' }), ctx);
+    await connectTarget(clusterInput({ vessel: 'folly-cluster' }), ctx);
 
     const routes = serve(ctx, true);
     // The requirements travel in the payload, so options over the route
@@ -111,15 +111,19 @@ describe('listTargets and listRepositories over route boundary', () => {
     };
     expect(body.ok).toBe(true);
     expect(body.value.targets).toHaveLength(1);
-    expect(body.value.targets[0].name).toBe('folly-cluster');
+    expect(body.value.targets[0].vessel).toBe('folly-cluster');
     expect(body.value.options).toHaveLength(1);
-    expect(body.value.options[0].name).toBe('folly-cluster');
+    expect(body.value.options[0].vessel).toBe('folly-cluster');
   });
 
   test('listTargets reports prerequisite failure details for unhealthy targets over HTTP', async () => {
     const ctx = await makeContext(null);
-    await connectTarget(clusterInput({ name: 'unhealthy-cluster' }), ctx);
+    await connectTarget(clusterInput({ vessel: 'unhealthy-cluster' }), ctx);
 
+    const [unhealthyVessel] = await ctx.db
+      .select({ id: schema.vessels.id })
+      .from(schema.vessels)
+      .where(eq(schema.vessels.name, 'unhealthy-cluster'));
     await ctx.db
       .update(schema.targets)
       .set({
@@ -132,7 +136,7 @@ describe('listTargets and listRepositories over route boundary', () => {
           },
         ],
       })
-      .where(eq(schema.targets.name, 'unhealthy-cluster'));
+      .where(eq(schema.targets.vesselId, unhealthyVessel!.id));
 
     const routes = serve(ctx, true);
     const res = await routes[pathFor('listTargets')]!(

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -863,10 +863,10 @@ describe('the Targets surface', () => {
     const markup = targets([
       {
         kind: 'gcp-project',
-        name: 'a-project',
-        targets: ['a-project-cloudrun', 'a-project-static'],
+        vessel: 'a-project',
+        surfaces: ['cloudrun', 'static'],
         proposal: {
-          carriedFrom: 'other-cloudrun',
+          carriedFrom: 'other/cloudrun',
           region: 'somewhere',
           runEndpoint: 'https://run.example.test',
           hostingEndpoint: 'https://hosting.example.test',

--- a/apps/spindrift/test/web/webhook-route.test.ts
+++ b/apps/spindrift/test/web/webhook-route.test.ts
@@ -36,7 +36,11 @@ import {
   SupplyChainHarness,
   testSignature,
 } from '../harness/fakes/supply-chain.ts';
-import { fixtureManifest, targetValues } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
@@ -192,9 +196,12 @@ describe('a push that reaches an opted-in App', () => {
       .insert(components)
       .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
       .returning();
+    const vessel = await insertVessel(db, 'kubernetes', {
+      name: `cluster-${crypto.randomUUID()}`,
+    });
     const [target] = await db
       .insert(targets)
-      .values(targetValues({ name: `cluster-${crypto.randomUUID()}` }))
+      .values(targetValues({ vesselId: vessel.id }))
       .returning();
     await db.insert(componentTargetDesired).values({
       componentId: component!.id,

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -244,8 +244,7 @@ spec:
           reachableRegistries:
             - northamerica-northeast1-docker.pkg.dev
       targets:
-        - name: offsite
-          vessel: offsite
+        - vessel: offsite
           # Every reach: this cluster has a load-balancer address on the lab net
           # and a Cloudflare tunnel in front of it.
           reaches: [none, private, public]
@@ -314,8 +313,7 @@ spec:
                   # itself, which the chart always admits as a sibling.
                   allowedNamespaces:
                     - oauth2-proxy
-        - name: folly
-          vessel: folly
+        - vessel: folly
           # No tunnel of its own is named to Spindrift, so this Target serves
           # what its gateway's RFC1918 address reaches and nothing beyond it.
           # Adding one is this list plus `dns.tunnelHostname`, either here or on
@@ -384,8 +382,7 @@ spec:
                   # always admits as a sibling.
                   allowedNamespaces:
                     - oauth2-proxy
-        - name: bluenose-cloudrun
-          vessel: bluenose
+        - vessel: bluenose
           adapter: cloudrun
           connection:
             region: northamerica-northeast1
@@ -403,8 +400,7 @@ spec:
             # the controller's `actAs` on it are declared in
             # terraform/gcp/projects/bluenose/iam.tf for exactly this.
             serviceAccount: spindrift-runtime@bluenose.iam.gserviceaccount.com
-        - name: bluenose-static
-          vessel: bluenose
+        - vessel: bluenose
           adapter: static
           connection:
             endpoint: https://firebasehosting.googleapis.com

--- a/packages/charts/spindrift/files/default-manifest.yaml
+++ b/packages/charts/spindrift/files/default-manifest.yaml
@@ -63,8 +63,7 @@ vessels:
     location:
       project: spindrift-vessel
 targets:
-  - name: primary
-    vessel: primary
+  - vessel: primary
     adapter: kubernetes
     connection:
       namespace: spindrift-apps
@@ -74,14 +73,12 @@ targets:
         sourceRef:
           name: infra
           namespace: flux-system
-  - name: spindrift-cloudrun
-    vessel: spindrift
+  - vessel: spindrift
     adapter: cloudrun
     connection:
       region: spindrift-region
       endpoint: https://run.googleapis.com
-  - name: spindrift-static
-    vessel: spindrift
+  - vessel: spindrift
     adapter: static
     connection:
       endpoint: https://firebasehosting.googleapis.com


### PR DESCRIPTION
## Summary

`targets.name` stops being an identifier. A Target is `(vessel_id, adapter)` — naturally unique, because a boundary carries one runtime of each kind — so there is no suffix to construct and none to collide.

The name was a constructed string: the vessel's name, plus the adapter as a suffix *only where the vessel carried more than one surface*. That made it a rename hazard as well as redundant — a vessel discovering a second surface would have needed the first one renamed, and a Target cannot be renamed.

- `unique(vessel_id, adapter)` replaces `targets_name_unique`; `surfaceNames` and its `<vessel>-<adapter>` construction are gone.
- `connectTarget` and `disconnectTarget` take the pair. Connect is idempotent by it, which is the only thing it could be idempotent by now.
- The manifest's `targets[]` entries carry `vessel` and `adapter` and no `name`. Uniqueness is over the pair.
- Every screen and every sentence spells a Target `<vessel>/<adapter>` (`targetLabel` / `targetRowLabel`). The App list and the App workspace already showed the vessel beside the Target, so those two now show the surface rather than repeating the boundary.
- `configureInstallation` loses its `NOT_DEPLOYABLE` arm: the one refusal reconciliation made was a declared adapter disagreeing with the stored row's, and that state stopped being expressible once the adapter became half of what identifies a Target.

The offsite declaration and the installer chart's placeholder manifest drop `name:` from their target seeds; both were verified to validate against the new schema.

## Migration

`0028_target_vessel_surface_identity.sql` drops the constraint, drops the column, and adds the pair index.

**No data is lost and no foreign key moves.** Every persisted edge into `targets` is already `target_id uuid` — `deploys`, `component_target_desired`, `datastores`, `config_items` — and the two surviving columns state everything the name did. The live rows are `offsite/kubernetes`, `folly/kubernetes`, `bluenose/cloudrun`, `bluenose/static`: four distinct pairs, so the new unique index takes. If it ever did not, failing is the correct outcome — two surfaces of one vessel with one adapter is a state nothing in the product has a meaning for.

The upgrade path for stored documents is `manifest-upgrade.ts`'s new `dropTargetNames` step, with `03-target-is-vessel-and-surface.yaml` added to the frozen corpus. `01` and `02` are untouched.

## Two stored strings that embed a Target label

Called out because "no stored row references a Target by name" deserves to be precise rather than approximately true. Neither of these *resolves* a Target — both are snapshots — and both now carry a spelling that cannot be renamed, which is the hazard this change exists to remove:

1. **`deploys.desired.target`** (JSONB). What was delivered, replayed verbatim by a rollback. Nothing reads it back; it is not a lookup key.
2. **The secret store's item name**, via `ConfigScope.target` — a Secret Manager secret id and a 1Password item title embed the scope. Core cannot rewrite these, structurally: it never reads a value back (§10), so it cannot migrate one.

The migration rewrites neither. The consequence on a live installation with existing config: pinned references in `config_items.store_ref` keep resolving, so nothing stops being delivered, but a `set` after this lands writes under the new id and retention stops reaping the old versions. Worth a follow-up if that installation turns out to have any.

## Validation

From `apps/spindrift/`, against real Postgres:

- `bun test` — 1738 pass, 0 fail, 130 files
- `bun run typecheck` — clean
- `bun run lint` — clean
- The offsite `helm-release.yaml` manifest re-validated against the new schema out of band: `offsite/kubernetes, folly/kubernetes, bluenose/cloudrun, bluenose/static`

## Risks

- **The unique index is stricter than what it replaces.** `targets_name_unique` admitted two surfaces of one vessel with the same adapter as long as they were spelled differently. The migration fails loudly on such a pair rather than picking one.
- **Four tests were removed rather than rewritten**, all with the same subject: the adapter-mismatch refusal, and the suffix-reconstruction rule `surfaceNames` implemented. Neither has a code path left to exercise. The transactionality of `writeStoredManifest` loses its one trigger with them — there is no longer a reachable mid-transaction failure to assert a rollback from.
- `unplaceComponent` landed on `main` during this work and was updated to speak the pair.