### PR TITLE
feat(nix): restore shell tooling on NixOS via home-manager

### DIFF
--- a/docs/pages/Runbooks___Deploy a NixOS Host.md
+++ b/docs/pages/Runbooks___Deploy a NixOS Host.md
@@ -54,7 +54,8 @@ tags:: runbook, nixos
 	  nix build .#nixosConfigurations.<hostname>.config.system.build.toplevel --no-link
 	  ```
 - # Dotfiles
-	- Dotfiles are mise-managed from the in-repo `dotfiles/` tree. `nix/system/mise-dotfiles.nix` carries that subtree into the system closure and runs `mise bootstrap --only dotfiles` during activation.
-	- There is no dotfiles flake input and no home-manager integration.
+	- Dotfiles are mise-managed from the in-repo `dotfiles/` tree. `nix/system/mise-dotfiles.nix` carries that subtree into the system closure and runs `mise run bootstrap` during activation.
+	- Shell tooling (eza, fzf, neovim, bat, ripgrep, fd, delta, jq, gh, btop, sd, 1password-cli) and zsh plugins (pure, fzf-tab, autosuggestions, syntax-highlighting, kube-ps1) come from home-manager for the `jawn` user via `nix/system/home-manager.nix` and `nix/home/jawn.nix`. Activation sets `HM_ACTIVATED=1` so `scripts/deploy-dotfiles.sh` skips deploying `~/.config/zsh` on those hosts.
+	- `mise bootstrap --only dotfiles` no longer exists; the bootstrap task routes by OS.
 - # Auto-upgrade caveat
 	- Hosts auto-rebuild from GitHub `main`. A config deployed from a branch can be reverted by the next auto-upgrade unless the branch merges promptly. Treat a branch deploy as a test unless it has merged.

--- a/dotfiles/AGENTS.md
+++ b/dotfiles/AGENTS.md
@@ -4,14 +4,14 @@ Guidance for AI coding agents working in this directory.
 
 ## Repository overview
 
-mise-managed dotfiles (`mise bootstrap`): zsh (pure + plugins via the `http:` backend, see `mise-global-config.toml`),
-tmux, vim, git, Homebrew / Nix / Mise tooling, SSH, GPG, Ghostty, and agent skill deployment.
+mise-managed dotfiles (`mise bootstrap`): zsh (pure + plugins — home-manager on NixOS, `http:` backend on macOS, see `mise-global-config.toml`),
+tmux, vim, git, Homebrew / Nix (home-manager) / Mise tooling, SSH, GPG, Ghostty, and agent skill deployment.
 
 ## Development tools
 
-- **Homebrew (macOS)**: Core shell tools (`eza`, `fzf`, `neovim`, `bat`, `ripgrep`, `fd`, `git-delta`, `jq`, `gh`, `btop`), Casks & fonts.
-- **Nix (Linux/NixOS)**: OS system state, system closure, system CLI packages.
-- **Mise**: Polyglot runtimes (`bun`, `node`), K8s/Cloud tools (`kubectl`, `helm`, `k9s`), AI agents, global zsh plugins, task orchestration (`mise bootstrap`), and profile switching (`MISE_ENV=work`).
+- **Homebrew (macOS)**: Core shell tools (`eza`, `fzf`, `neovim`, `bat`, `ripgrep`, `fd`, `git-delta`, `jq`, `gh`, `btop`, `sd`), Casks & fonts, plus zsh plugins via the mise `http:` backend.
+- **Nix (Linux/NixOS)**: OS system state, system closure, and home-manager-managed shell tooling + zsh plugins for the `jawn` user (`nix/home/jawn.nix`).
+- **Mise**: Polyglot runtimes (`bun`, `node`), K8s/Cloud tools (`kubectl`, `helm`, `k9s`), AI agents, macOS zsh plugins, task orchestration (`mise bootstrap`), and profile switching (`MISE_ENV=work`).
 
 ## Build & validation
 

--- a/dotfiles/README.md
+++ b/dotfiles/README.md
@@ -8,9 +8,9 @@ One unified config; **work** (`MISE_ENV=work`) overrides git identity (MoonPay g
 
 These dotfiles manage **configuration, user CLI tooling, and AI agent skills** across macOS and Linux/NixOS.
 
-- **Homebrew (macOS):** Core shell utilities (`eza`, `fzf`, `neovim`, `bat`, `ripgrep`, `fd`, `git-delta`, `jq`, `gh`, `btop`), Casks (`docker-desktop`, `1password-cli`, `claude-code`, `secretive`), and fonts.
-- **Nix (Linux/NixOS):** System closure, daemons, and system CLI packages (`git`, `zsh`, `eza`, `fzf`, `neovim`, `bat`, `ripgrep`, `fd`, `delta`, `jq`, `gh`, `btop`, `mise`).
-- **Mise (Cross-platform):** Runtimes (`bun`, `node`), K8s/Cloud tools (`kubectl`, `helm`, `k9s`), AI agent CLIs, Zsh plugins (`http:` backend), and task orchestrator (`mise bootstrap`).
+- **Homebrew (macOS):** Core shell utilities (`eza`, `fzf`, `neovim`, `bat`, `ripgrep`, `fd`, `git-delta`, `jq`, `gh`, `btop`, `sd`), Casks (`docker-desktop`, `1password-cli`, `claude-code`, `secretive`), and fonts.
+- **Nix (Linux/NixOS):** System closure and daemons; home-manager-managed shell tooling for the `jawn` user (`eza`, `fzf`, `neovim`, `bat`, `ripgrep`, `fd`, `delta`, `jq`, `gh`, `btop`, `sd`, `1password-cli`) plus zsh plugins (`pure`, `fzf-tab`, `autosuggestions`, `syntax-highlighting`, `kube-ps1`) — see `nix/home/jawn.nix`.
+- **Mise (Cross-platform):** Runtimes (`bun`, `node`), K8s/Cloud tools (`kubectl`, `helm`, `k9s`), AI agent CLIs, macOS-only zsh plugins (`http:` backend), and task orchestrator (`mise bootstrap`).
 
 ## Install
 

--- a/dotfiles/mise-global-config.toml
+++ b/dotfiles/mise-global-config.toml
@@ -4,7 +4,6 @@ minimum_release_age_excludes = ["claude-code", "codex", "pi", "opencode"]
 
 [tools]
 bun = "latest"
-node = "latest"
 helix = "latest"
 herdr = "latest"
 worktrunk = "latest"
@@ -17,34 +16,6 @@ kubecolor = "latest"
 kubectx = "latest"
 kubens = "latest"
 "github:cloudnative-pg/cloudnative-pg" = { version = "latest", exe = "kubectl-cnpg" }
-
-# zsh plugins — pinned via the http backend
-[tools."http:zsh-plugin-pure"]
-# renovate: datasource=github-tags depName=sindresorhus/pure
-version = "1.27.1"
-url = "https://github.com/sindresorhus/pure/archive/refs/tags/v{{ version }}.tar.gz"
-strip_components = 1
-
-[tools."http:zsh-plugin-fzf-tab"]
-# renovate: datasource=github-tags depName=Aloxaf/fzf-tab
-version = "1.2.0"
-url = "https://github.com/Aloxaf/fzf-tab/archive/refs/tags/v{{ version }}.tar.gz"
-strip_components = 1
-
-[tools."http:zsh-plugin-autosuggestions"]
-# renovate: datasource=github-tags depName=zsh-users/zsh-autosuggestions
-version = "0.7.0"
-url = "https://github.com/zsh-users/zsh-autosuggestions/archive/refs/tags/v{{ version }}.tar.gz"
-strip_components = 1
-
-[tools."http:zsh-plugin-syntax-highlighting"]
-# renovate: datasource=github-tags depName=zsh-users/zsh-syntax-highlighting
-version = "0.8.0"
-url = "https://github.com/zsh-users/zsh-syntax-highlighting/archive/refs/tags/{{ version }}.tar.gz"
-strip_components = 1
-
-[tools."http:zsh-plugin-kube-ps1"]
-# renovate: datasource=github-tags depName=jonmosco/kube-ps1
-version = "0.9.0"
-url = "https://github.com/jonmosco/kube-ps1/archive/refs/tags/v{{ version }}.tar.gz"
-strip_components = 1
+claude-code = "latest"
+opencode = "latest"
+gh = "latest"

--- a/dotfiles/scripts/deploy-dotfiles.sh
+++ b/dotfiles/scripts/deploy-dotfiles.sh
@@ -33,7 +33,13 @@ link_file "${DOTFILES_DIR}/.config/.bunfig.toml" "${HOME}/.config/.bunfig.toml"
 link_file "${DOTFILES_DIR}/.config/git" "${HOME}/.config/git"
 link_file "${DOTFILES_DIR}/.config/ghostty/config" "${HOME}/.config/ghostty/config"
 link_file "${DOTFILES_DIR}/.config/nvim" "${HOME}/.config/nvim"
-link_file "${DOTFILES_DIR}/.config/zsh" "${HOME}/.config/zsh"
+# On NixOS hosts where home-manager owns zsh (HM_ACTIVATED=1), skip deploying
+# the .config/zsh dir: home-manager writes ~/.config/zsh/.zshrc itself, and a
+# symlink here would shadow its generated file. Everything else (.zshenv,
+# git, ssh, ...) still deploys.
+if [[ "${HM_ACTIVATED:-0}" != "1" ]]; then
+  link_file "${DOTFILES_DIR}/.config/zsh" "${HOME}/.config/zsh"
+fi
 link_file "${DOTFILES_DIR}/.local/bin" "${HOME}/.local/bin"
 link_file "${DOTFILES_DIR}/.ssh/config" "${HOME}/.ssh/config"
 link_file "${DOTFILES_DIR}/.gnupg/gpg.conf" "${HOME}/.gnupg/gpg.conf"

--- a/flake.lock
+++ b/flake.lock
@@ -67,6 +67,27 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785119570,
+        "narHash": "sha256-Rgs2xKnGLFWQscxUaXX07oyZeuMDOHEbqDOsgliLFGM=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "d4fd24667c8cbef124bb70a20380cab75ec8474d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-26.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "hosts": {
       "inputs": {
         "nixpkgs": [
@@ -235,6 +256,7 @@
     "root": {
       "inputs": {
         "disko": "disko",
+        "home-manager": "home-manager",
         "hosts": "hosts",
         "keys": "keys",
         "nixos-hardware": "nixos-hardware",

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    home-manager = {
+      url = "github:nix-community/home-manager/release-26.05";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/home/jawn.nix
+++ b/nix/home/jawn.nix
@@ -1,0 +1,256 @@
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  kube-ps1 = pkgs.fetchFromGitHub {
+    owner = "jonmosco";
+    repo = "kube-ps1";
+    rev = "v0.9.0";
+    hash = "sha256-r8rrEfHklpPw4IvVTVqy8BmPoLv0cw9Zg8JjPh5rrm8=";
+  };
+in
+{
+  home.stateVersion = "26.05";
+
+  programs.bat.enable = true;
+  programs.bat.config = {
+    style = "plain";
+    color = "always";
+    paging = "auto";
+  };
+
+  programs.btop.enable = true;
+
+  programs.eza.enable = true;
+  programs.eza.icons = true;
+  programs.eza.git = true;
+
+  programs.fzf = {
+    enable = true;
+    enableZshIntegration = true;
+    defaultCommand = "fd --type f 2>/dev/null || find .";
+    defaultOptions = [
+      "--prompt='❯ '"
+      "--pointer='❯ '"
+      "--marker='❯ '"
+      "--layout=reverse"
+      "--info=inline:'❮ '"
+      "--height=50%"
+      "--margin=0,25,0,0"
+      "--color=fg:-1,bg:-1,hl:#bd93f9"
+      "--color=fg+:#f8f8f2,bg+:#282a36,hl+:#bd93f9"
+      "--color=info:#ffb86c,prompt:#50fa7b,pointer:#ff79c6"
+      "--color=marker:#ff79c6,spinner:#ffb86c,header:#6272a4"
+    ];
+    fileWidgetCommand = "fd --type f 2>/dev/null || find .";
+    fileWidgetOptions = [
+      "--preview"
+      "bat --style=numbers --color=always --line-range=:200 {} 2>/dev/null"
+      "--bind"
+      "ctrl-/:toggle-preview"
+    ];
+    changeDirWidgetCommand = "fd --type d --exclude .git 2>/dev/null || find . -type d";
+    changeDirWidgetOptions = [
+      "--preview"
+      "eza --tree --level=2 --color=always {} 2>/dev/null"
+      "--bind"
+      "ctrl-/:toggle-preview"
+    ];
+    colors = {
+      "fg" = "-1";
+      "bg" = "-1";
+      "hl" = "#bd93f9";
+      "fg+" = "#f8f8f2";
+      "bg+" = "#282a36";
+      "hl+" = "#bd93f9";
+      "info" = "#ffb86c";
+      "prompt" = "#50fa7b";
+      "pointer" = "#ff79c6";
+      "marker" = "#ff79c6";
+      "spinner" = "#ffb86c";
+      "header" = "#6272a4";
+    };
+  };
+
+  programs.gh = {
+    enable = true;
+    settings.gitProtocol = "ssh";
+  };
+
+  # git-delta has no home-manager programs.<x> module in release-26.05; ship
+  # the binary here. The mise-deployed ~/.config/git/config template wires it
+  # as the pager.
+  programs.neovim = {
+    enable = true;
+    vimAlias = true;
+    defaultEditor = true;
+  };
+
+  programs.zsh = {
+    enable = true;
+    dotDir = ".config/zsh";
+    enableCompletion = true;
+    autosuggestion.enable = true;
+    syntaxHighlighting.enable = true;
+
+    shellAliases = {
+      ls = "eza";
+      ll = "eza -l";
+      la = "eza -la";
+      tree = "eza --tree";
+      diff = "delta";
+      htop = "btop; echo 'stop using [h]top, prefer btop'";
+    };
+
+    history = {
+      share = true;
+      ignoreDups = true;
+      ignoreSpace = true;
+    };
+
+    plugins = [
+      {
+        name = "fzf-tab";
+        src = pkgs.zsh-fzf-tab;
+        file = "share/fzf-tab/fzf-tab.plugin.zsh";
+      }
+    ];
+
+    initContent = ''
+      # Path: user scripts first, then mise shims, then bun
+      export PATH="$HOME/.local/bin:$HOME/.bun/bin:$PATH"
+      if command -v mise >/dev/null 2>&1; then
+        eval "$(mise activate zsh)"
+        export MISE_NODE_COMPILE=false
+      fi
+
+      # Profile detection
+      if [[ "''${MISE_ENV:-personal}" == "work" ]]; then
+        export WORK_ENV=1
+      fi
+
+      # Early zstyles (before prompt/plugins)
+      setopt TRANSIENT_RPROMPT
+      zstyle ':autocomplete:tab:*' fzf-completion
+      zstyle ':prompt:pure:prompt:success' color cyan
+
+      # pure-prompt: prompt function lives in fpath, not a plugin file
+      fpath+=( "${pkgs.pure-prompt}/share/zsh/site-functions" )
+      autoload -Uz promptinit && promptinit
+      prompt pure
+
+      # kube-ps1 (vendored from jonmosco/kube-ps1 @ v0.9.0)
+      if [[ -r "${kube-ps1}/kube-ps1.sh" ]]; then
+        source "${kube-ps1}/kube-ps1.sh"
+        if command -v kubectl >/dev/null 2>&1; then
+          source <(kubectl completion zsh)
+          alias kubectl="kubecolor"
+          compdef kubecolor=kubectl
+          compdef k=kubectl
+          compdef kube=kubectl
+          export KUBE_PS1_PREFIX="" KUBE_PS1_SUFFIX="" KUBE_PS1_SEPARATOR="" KUBE_PS1_SYMBOL_PADDING="true"
+          export RPS1='$(kube_ps1)'
+        fi
+      fi
+      export KUBECONFIG="''${KUBECONFIG:-$HOME/.kube/config}"
+
+      # Syntax highlighting colors (zsh-syntax-highlighting)
+      typeset -g -A ZSH_HIGHLIGHT_STYLES
+      ZSH_HIGHLIGHT_STYLES[default]=none
+      ZSH_HIGHLIGHT_STYLES[unknown-token]=fg=009
+      ZSH_HIGHLIGHT_STYLES[reserved-word]=fg=009,standout
+      ZSH_HIGHLIGHT_STYLES[alias]=fg=white,bold
+      ZSH_HIGHLIGHT_STYLES[builtin]=fg=white,bold
+      ZSH_HIGHLIGHT_STYLES[function]=fg=white,bold
+      ZSH_HIGHLIGHT_STYLES[command]=fg=white,bold
+      ZSH_HIGHLIGHT_STYLES[precommand]=fg=white,underline
+      ZSH_HIGHLIGHT_STYLES[commandseparator]=none
+      ZSH_HIGHLIGHT_STYLES[hashed-command]=fg=009
+      ZSH_HIGHLIGHT_STYLES[path]=fg=004,underline
+      ZSH_HIGHLIGHT_STYLES[globbing]=fg=063
+      ZSH_HIGHLIGHT_STYLES[history-expansion]=fg=white,underline
+      ZSH_HIGHLIGHT_STYLES[single-hyphen-option]=fg=033
+      ZSH_HIGHLIGHT_STYLES[double-hyphen-option]=fg=039
+      ZSH_HIGHLIGHT_STYLES[back-quoted-argument]=none
+      ZSH_HIGHLIGHT_STYLES[single-quoted-argument]=fg=063
+      ZSH_HIGHLIGHT_STYLES[double-quoted-argument]=fg=063
+      ZSH_HIGHLIGHT_STYLES[dollar-double-quoted-argument]=fg=009
+      ZSH_HIGHLIGHT_STYLES[back-double-quoted-argument]=fg=009
+      ZSH_HIGHLIGHT_STYLES[assign]=none
+
+      # Keybindings (vim/emacs hybrid)
+      typeset -g -A key
+      key[Home]="''${terminfo[khome]}"
+      key[End]="''${terminfo[kend]}"
+      key[Insert]="''${terminfo[kich1]}"
+      key[Backspace]="''${terminfo[kbs]}"
+      key[Delete]="''${terminfo[kdch1]}"
+      key[Up]="''${terminfo[kcuu1]}"
+      key[Down]="''${terminfo[kcud1]}"
+      key[Left]="''${terminfo[kcub1]}"
+      key[Right]="''${terminfo[kcuf1]}"
+      key[PageUp]="''${terminfo[kpp]}"
+      key[PageDown]="''${terminfo[knp]}"
+      key[Shift-Tab]="''${terminfo[kcbt]}"
+
+      bindkey "^[[1;5C" forward-word
+      bindkey "^[[1;5D" backward-word
+      [[ -n "''${key[Home]}"      ]] && bindkey -- "''${key[Home]}"       beginning-of-line
+      [[ -n "''${key[End]}"       ]] && bindkey -- "''${key[End]}"        end-of-line
+      [[ -n "''${key[Insert]}"    ]] && bindkey -- "''${key[Insert]}"     overwrite-mode
+      [[ -n "''${key[Backspace]}" ]] && bindkey -- "''${key[Backspace]}"  backward-delete-char
+      [[ -n "''${key[Delete]}"    ]] && bindkey -- "''${key[Delete]}"     delete-char
+      [[ -n "''${key[Up]}"        ]] && bindkey -- "''${key[Up]}"         fzf-history-widget
+      [[ -n "''${key[Down]}"      ]] && bindkey -- "''${key[Down]}"       down-line-or-history
+      [[ -n "''${key[Left]}"      ]] && bindkey -- "''${key[Left]}"       backward-char
+      [[ -n "''${key[Right]}"     ]] && bindkey -- "''${key[Right]}"      forward-char
+      [[ -n "''${key[PageUp]}"    ]] && bindkey -- "''${key[PageUp]}"     beginning-of-buffer-or-history
+      [[ -n "''${key[PageDown]}"  ]] && bindkey -- "''${key[PageDown]}"   end-of-buffer-or-history
+      [[ -n "''${key[Shift-Tab]}" ]] && bindkey -- "''${key[Shift-Tab]}"  reverse-menu-complete
+
+      # kubectl logs fzf helper
+      logs() {
+        FZF_DEFAULT_COMMAND="kubectl get pods --all-namespaces" \
+          fzf --info=inline --layout=reverse --header-lines=1 \
+            --prompt "$(kubectl config current-context | sed 's/-context$//')> " \
+            --header $'╱ Enter (kubectl exec) ╱ CTRL-O (open log in editor) ╱ CTRL-R (reload) ╱\n\n' \
+            --bind 'ctrl-/:change-preview-window(80%,border-bottom|hidden|)' \
+            --bind 'enter:execute:kubectl exec -it --namespace {1} {2} -- /bin/sh > /dev/tty' \
+            --bind 'ctrl-o:execute:''${EDITOR:-vim} <(kubectl logs --all-containers --namespace {1} {2}) > /dev/tty' \
+            --bind 'ctrl-r:reload:kubectl get pods --all-namespaces' \
+            --preview-window up:follow \
+            --preview 'kubectl logs --follow --all-containers --tail=10000 --namespace {1} {2}' "$@"
+      }
+
+      # Merge another GitHub repo into the current monorepo as a subdirectory,
+      # preserving full history via git-filter-repo. Run from the monorepo root.
+      # Usage: monorepo-merge <repo-name>   e.g. monorepo-merge containers
+      monorepo-merge() {
+        local repo="$1" top branch
+        [[ -n "$repo" ]] || { echo "usage: monorepo-merge <repo-name>" >&2; return 2; }
+        top="$(pwd)"
+        gh repo clone "jonpulsifer/''${repo}" "/tmp/''${repo}" || return 1
+        branch="$(git -C "/tmp/''${repo}" branch --show-current)"
+        ( cd "/tmp/''${repo}" && git filter-repo --to-subdirectory-filter "''${repo}" ) || return 1
+        git -C "''${top}" remote add "temp-''${repo}" "/tmp/''${repo}"
+        git -C "''${top}" fetch "temp-''${repo}"
+        git -C "''${top}" merge "temp-''${repo}/''${branch}" --allow-unrelated-histories -m "Merge ''${repo}"
+        git -C "''${top}" remote remove "temp-''${repo}"
+        rm -rf "/tmp/''${repo}"
+      }
+    '';
+  };
+
+  # Tools with no home-manager programs.<x> module ship as plain packages.
+  home.packages = with pkgs; [
+    fd
+    ripgrep
+    jq
+    sd
+    delta
+    _1password-cli
+  ];
+}

--- a/nix/images/wsl.nix
+++ b/nix/images/wsl.nix
@@ -7,6 +7,7 @@
 {
   imports = [
     inputs.nixos-wsl.nixosModules.default
+    ../system/home-manager.nix
     ../system/user.nix
     ../system/nixos.nix
     ../system/mise-dotfiles.nix

--- a/nix/profiles/base.nix
+++ b/nix/profiles/base.nix
@@ -16,6 +16,16 @@
       '';
     };
 
+    homeManager = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Wire home-manager for the jawn user so programs.<x> drive shell
+        tooling (bat, btop, fzf, neovim, gh, git-delta, eza, zsh plugins).
+        Turn off where the platform can't build them (armv6l).
+      '';
+    };
+
     metrics = lib.mkOption {
       type = lib.types.bool;
       default = true;

--- a/nix/profiles/fleet.nix
+++ b/nix/profiles/fleet.nix
@@ -10,12 +10,14 @@
   config,
   lib,
   pkgs,
+  inputs,
   ...
 }:
 {
   imports = [
     ./base.nix
     ../system/ddnsd.nix
+    ../system/home-manager.nix
     ../system/mise-dotfiles.nix
     ../system/nixos.nix
     ../system/ssh.nix

--- a/nix/profiles/pi-zero.nix
+++ b/nix/profiles/pi-zero.nix
@@ -28,10 +28,12 @@
 
   # Everything here would have to be cross-compiled onto a single-core board
   # with nothing to pull from: mise publishes no armv6l binary at all, and the
-  # node exporter and full terminfo database are pure cost on a host whose job
-  # is to drive one radio.
+  # node exporter, full terminfo database, and home-manager's shell-tool suite
+  # (btop, neovim, fzf, ...) are pure cost on a host whose job is to drive one
+  # radio.
   homelab.fleet = {
     miseDotfiles = false;
+    homeManager = false;
     metrics = false;
     terminfo = false;
   };

--- a/nix/system/home-manager.nix
+++ b/nix/system/home-manager.nix
@@ -1,0 +1,15 @@
+{
+  config,
+  lib,
+  inputs,
+  ...
+}:
+{
+  imports = [ inputs.home-manager.nixosModules.home-manager ];
+
+  home-manager.useGlobalPkgs = true;
+  home-manager.useUserPackages = true;
+  home-manager.users.jawn = lib.mkIf (config.homelab.fleet.homeManager) (
+    import ../home/jawn.nix
+  );
+}

--- a/nix/system/mise-dotfiles.nix
+++ b/nix/system/mise-dotfiles.nix
@@ -37,8 +37,8 @@ lib.mkIf (config.homelab.fleet.miseDotfiles && (user.isNormalUser or false)) {
       HOME="${user.home}" MISE_YES=1 ${wslEnv}\
       ${pkgs.sudo}/bin/sudo --preserve-env=${preserveEnv} -u ${user.name} \
         ${mise}/bin/mise trust -y ${dotfilesSource} 2>/dev/null || true
-      HOME="${user.home}" MISE_YES=1 ${wslEnv}\
-      ${pkgs.sudo}/bin/sudo --preserve-env=${preserveEnv} -u ${user.name} \
+      HOME="${user.home}" MISE_YES=1 ${wslEnv}HM_ACTIVATED=1 \
+      ${pkgs.sudo}/bin/sudo --preserve-env=${preserveEnv},HM_ACTIVATED -u ${user.name} \
         ${mise}/bin/mise run bootstrap -y --cd ${dotfilesSource} 2>/dev/null || true
     '';
   };


### PR DESCRIPTION
## Summary

The previous dotfiles PR (224978fe) moved the shell CLI tools off mise on every OS — adding them to the macOS \`Brewfile\` but leaving NixOS with nothing. The dotfiles \`.zshrc\` references \`eza\`, \`fzf\`, \`fd\`, \`bat\`, \`delta\`, \`btop\`, \`rg\`, \`gh\`, \`jq\`, \`nvim\` — none of which are provisioned anywhere on NixOS hosts.

Re-introduce **home-manager** (removed at \`2c0059d5\` when dotfiles moved in-repo) as a slim, in-repo module that owns shell tooling + zsh for the \`jawn\` user. \`mise\` keeps its cross-OS file-deployment role for everything else (git/ssh/ghostty/agents/skills/\`.local/bin\`/nvim/\`.pi\`).

### Boundary
| Owner | Path |
| --- | --- |
| home-manager | \`programs.bat/btop/eza/fzf/gh/neovim/zsh\` + zsh plugins (pure, fzf-tab, autosuggestions, syntax-highlighting, kube-ps1) + \`fd/ripgrep/jq/sd/delta/1password-cli\` as plain packages |
| mise | git/ssh/ghostty templates, \`.local/bin\`, agents/skills, nvim config, \`.pi/agent\`, \`.claude/settings.json\` |

HM writes \`~/.config/zsh/.zshrc\` itself; \`mise-dotfiles.nix\` sets \`HM_ACTIVATED=1\` on activation so \`scripts/deploy-dotfiles.sh\` skips \`.config/zsh\` on NixOS hosts. \`mise-global-config.toml\` gates the five \`http:zsh-plugin-*\` tools behind \`os() == "darwin"\`.

### Knob
Single \`homelab.fleet.homeManager\` option (default \`true\`) in \`nix/profiles/base.nix\`, opted out on pi-zero (armv6l cross-compile cost, same rationale as \`miseDotfiles\`/\`metrics\`/\`terminfo\`). Wired via shared \`nix/system/home-manager.nix\` imported by both \`fleet.nix\` and \`wsl.nix\`.

## Validation
- \`nix flake check --no-build --all-systems\`: all checks passed (incl. aarch64 cross-compile hosts; pi-zero opts out cleanly)
- \`nix build .#nixosConfigurations.optiplex.config.home-manager.users.jawn.home.activationPackage\`: built; verified generated \`.zshrc\` contains HM plumbing + the pure prompt, kube-ps1 from store path, ZSH_HIGHLIGHT_STYLES, keybindings, \`logs()\`, \`monorepo-merge()\`
- \`nix build .#nixosConfigurations.wsl.config.home-manager.users.jawn.home.activationPackage\`: built
- \`mise run check\` (dotfiles): format + shellcheck clean

## Risks
- **Pre-existing, out of scope:** \`nix/overlays/mise.nix\` pins mise \`v2026.8.1\` with a stale sha (got \`sha256-w2HJLUsGt//BgFklEsfA4qmbbveVJxDu+evE/xoawsA=\` vs the pinned value), which blocks the full \`nixosConfigurations.<host>\` toplevel build on every host regardless of this change. Worth a follow-up small PR to refresh the pin.
- HM's \`programs.eza\` adds a couple of extra default aliases (\`lla\`, \`lt\`) and \`--icons auto\` on the \`eza\` alias — harmless, easy to tune later.