### PR TITLE
fix(nix): refresh mise fetchurl hashes for 2026.8.1

### DIFF
--- a/.github/scripts/update-mise-hashes.sh
+++ b/.github/scripts/update-mise-hashes.sh
@@ -14,7 +14,7 @@ compute_sri() {
 	local arch="$1"
 	local url="https://github.com/jdx/mise/releases/download/v${VERSION}/mise-v${VERSION}-linux-${arch}.tar.gz"
 	local hash
-	hash=$(curl -fsSL "$url" | openssl dgst -sha256 -binary | base64 -w0) || {
+	hash=$(nix-prefetch-url --type sha256 "$url") || {
 		echo "ERROR: failed to download or hash $arch tarball ($url)" >&2
 		exit 1
 	}
@@ -22,7 +22,7 @@ compute_sri() {
 		echo "ERROR: empty hash for $arch ($url)" >&2
 		exit 1
 	fi
-	echo "sha256-${hash}"
+	nix hash convert --hash-algo sha256 --to sri "$hash"
 }
 
 ARM64_HASH=$(compute_sri "arm64")

--- a/nix/overlays/mise.nix
+++ b/nix/overlays/mise.nix
@@ -40,9 +40,9 @@ in
       url = "https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-linux-${arch}.tar.gz";
       hash =
         if final.stdenv.hostPlatform.isAarch64 then
-          "sha256-bYiLo9C1149nZ3GoSEaIW39oX7TRUz8pJweeubdWM6g="
+          "sha256-uy236Cq68Pm+EykFYpW6bch0Wt0wgcNLKRPiO5aum9s="
         else
-          "sha256-ZBg2A4VPMZt4ZYMFxUWqyuk14JWaOolLd6D5QW6rBHs=";
+          "sha256-w2HJLUsGt//BgFklEsfA4qmbbveVJxDu+evE/xoawsA=";
     };
 
     # The tarball unpacks into ./mise/{bin,man,...}; set sourceRoot so the


### PR DESCRIPTION
## Summary

The mise `2026.8.0 → 2026.8.1` bump landed the version string only. Renovate's custom manager does not cover the two `fetchurl` hashes, so `nix/overlays/mise.nix` kept the 2026.8.0 hashes and every host build fails:

```
error: hash mismatch in fixed-output derivation '...-mise-v2026.8.1-linux-x64.tar.gz.drv':
         specified: sha256-ZBg2A4VPMZt4ZYMFxUWqyuk14JWaOolLd6D5QW6rBHs=
            got:    sha256-w2HJLUsGt//BgFklEsfA4qmbbveVJxDu+evE/xoawsA=
```

Both hashes refreshed via `.github/scripts/update-mise-hashes.sh`.

The script itself shelled out to `openssl`, which nothing in this repo provides — it is not in `shell.nix` and not in the NixOS host closures. It now uses `nix-prefetch-url` + `nix hash convert`, matching the commands the overlay comment already documents.

## Validation

- `nix build .#nixosConfigurations.wsl.config.system.build.toplevel` — succeeds (previously failed on the mismatch)
- `.github/scripts/update-mise-hashes.sh` re-run against the patched file — idempotent, reproduces both hashes

## Risk

The guard that should have caught this did not fire. On the bump PR, `detect` failed after 1h54m with `The job was not acquired by Runner of type hosted even after multiple attempts`, so the `nixos` build job was skipped and the PR automerged on the remaining checks. The manual-hash-refresh workflow is documented as CI-guarded, but that guard is only as good as ARC runner availability plus branch protection actually requiring those jobs. Worth a follow-up.