### PR TITLE
feat(spindrift): select which Component the App workspace shows

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -122,6 +122,11 @@ choices made while building them:
   sections; its three newest Build/Deploy checkpoints link to the attempts they
   came from, while the global ledgers retain the complete cursor-paged history.
   A website states that it has no runtime instead of showing an empty log.
+  **The Components list is the selector**, and the screen's per-Component half
+  — the runtime, the config keys, the placement and the release — is whichever
+  row is pressed: `getAppWorkspace` takes that Component by name and answers
+  with the App's first when none is named, which is how an App's job reaches
+  its run list and its Run now control from behind its service.
 - **Create** (`views/apps/new/`) — Source → Component → Place → Configure →
   Review, defaults carrying every step, preflight folded into Review. The
   server-owned draft survives refresh and rejects stale concurrent edits. An

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -123,10 +123,11 @@ choices made while building them:
   came from, while the global ledgers retain the complete cursor-paged history.
   A website states that it has no runtime instead of showing an empty log.
   **The Components list is the selector**, and the screen's per-Component half
-  — the runtime, the config keys, the placement and the release — is whichever
-  row is pressed: `getAppWorkspace` takes that Component by name and answers
-  with the App's first when none is named, which is how an App's job reaches
-  its run list and its Run now control from behind its service.
+  — the headline, the runtime, the config keys, the placement, the release and
+  the Component `Deploy` and `Rebuild` act on — is whichever row is pressed:
+  `getAppWorkspace` takes that Component by name and answers with the App's
+  first when none is named, which is how an App's job reaches its run list and
+  its Run now control from behind its service.
 - **Create** (`views/apps/new/`) — Source → Component → Place → Configure →
   Review, defaults carrying every step, preflight folded into Review. The
   server-owned draft survives refresh and rejects stale concurrent edits. An

--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -288,6 +288,11 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
         : eqOp(appsTable.name, input.name),
     with: {
       components: {
+        // Oldest first, the same order `getAppWorkspace` reads them in: "the
+        // App's first Component" is what a deploy that names none acts on and
+        // what the screen shows by default, and an unordered read makes those
+        // two the same sentence about different Components.
+        orderBy: (componentsTable, { asc }) => [asc(componentsTable.createdAt)],
         with: {
           deploys: {
             orderBy: (deploysTable, { desc }) => [desc(deploysTable.createdAt)],

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -241,6 +241,14 @@ export const getAppWorkspace: Command<
     });
   }
 
+  // The address the selected Component answers on. A job answers on none — no
+  // adapter puts a url on a job's Deploy — and the App's vanity domain is not
+  // one either: the fallback is for a Component that will serve that domain and
+  // has not deployed yet, which a job never is.
+  const url =
+    latestDeploy?.url ??
+    (selected?.kind === 'job' ? '' : (app.vanityDomain ?? ''));
+
   let runtime: Runtime;
   if (selected?.kind === 'website' && latestTarget?.adapter === 'static') {
     runtime = {
@@ -282,8 +290,11 @@ export const getAppWorkspace: Command<
       ? workspaceTarget.health === 'healthy'
       : false,
     phase: phaseFor(latestDeploy?.phase, selected?.builds[0]?.status),
-    url: latestDeploy?.url ?? app.vanityDomain ?? '',
-    urlLive: latestDeploy?.phase === 'LIVE',
+    url,
+    // An address that is serving, which is not the same as a release that is
+    // live: a placed job is LIVE with nothing to open, and this is the fact the
+    // screen's link and its headline hang off.
+    urlLive: url !== '' && latestDeploy?.phase === 'LIVE',
     release: latestDeploy
       ? `Deploy ${latestDeploy.id}`
       : selected?.builds[0]

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -25,6 +25,21 @@ import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
 export const getAppWorkspaceInput = z.object({
   name: z.string().min(1),
+  /**
+   * Which Component the screen is showing, by name.
+   *
+   * The App-first view is one screen with a selection in it, not a screen per
+   * Component — so this narrows what the per-Component half of
+   * {@link WorkspaceView} is read from and nothing else. Absent is the App's
+   * first Component, which is what a screen opened without a selection shows.
+   *
+   * A name rather than an id because `components` is unique per App and this is
+   * a read of one App: the name is enough to resolve, and it is what the row a
+   * person pressed says. It is its own field rather than a pair with a Target
+   * for the same reason — a second dimension is a second field here, not a
+   * different shape.
+   */
+  component: z.string().min(1).optional(),
 });
 export type GetAppWorkspaceInput = z.infer<typeof getAppWorkspaceInput>;
 
@@ -41,6 +56,10 @@ export const getAppWorkspace: Command<
     with: {
       repository: true,
       components: {
+        // Oldest first, so "the App's first Component" names one Component
+        // rather than whichever row the planner returned first — the default
+        // selection is read from this order on every load of the screen.
+        orderBy: (comps, { asc }) => [asc(comps.createdAt)],
         with: {
           deploys: {
             orderBy: (deploys, { desc }) => [desc(deploys.createdAt)],
@@ -86,10 +105,24 @@ export const getAppWorkspace: Command<
     },
   });
 
-  const primaryComponent = app.components[0];
-  const latestDeploy = primaryComponent?.deploys[0];
+  // The Component the screen is showing. Every per-Component read below hangs
+  // off this one — its runtime, the Target it is placed on, its config — so a
+  // job behind a service is reachable by naming it rather than by being first.
+  const selected =
+    input.component === undefined
+      ? app.components[0]
+      : app.components.find((comp) => comp.name === input.component);
+
+  if (input.component !== undefined && selected === undefined) {
+    return failed(
+      'NOT_FOUND',
+      `App '${app.name}' has no Component '${input.component}'`,
+    );
+  }
+
+  const latestDeploy = selected?.deploys[0];
   const latestTarget = latestDeploy?.target;
-  const desiredTarget = primaryComponent?.desiredTargets[0]?.target;
+  const desiredTarget = selected?.desiredTargets[0]?.target;
   const workspaceTarget = latestTarget ?? desiredTarget;
 
   const components: ComponentView[] = app.components.map((comp) => {
@@ -114,7 +147,11 @@ export const getAppWorkspace: Command<
       name: ds.name,
       engine: ds.engine,
       provenance: ds.provenance,
-      attachedTo: primaryComponent?.name ?? app.name,
+      // A Datastore is attached to the App (§11), so the Component named here
+      // is the App's first and never the selection: the same store reporting
+      // two different attachments as the selection moves is a second answer to
+      // a question that has one.
+      attachedTo: app.components[0]?.name ?? app.name,
       target: targetRowLabel(ds.target),
     });
   }
@@ -135,15 +172,12 @@ export const getAppWorkspace: Command<
   // `setConfig` itself uses to know what is already there, and it is the
   // only shape a screen is allowed to show: core's store has no verb that
   // returns a value. Scoped to the same pair the rest of this screen already
-  // picked — `workspaceTarget`, not every Target the Component might be
-  // placed on — because that pair is what a `Set variable` here would act on.
+  // picked — the selected Component and `workspaceTarget`, not every Target it
+  // might be placed on — because that pair is what a `Set variable` here would
+  // act on.
   const configKeys =
-    primaryComponent && workspaceTarget
-      ? await configuredKeys(
-          context.db,
-          primaryComponent.id,
-          workspaceTarget.id,
-        )
+    selected && workspaceTarget
+      ? await configuredKeys(context.db, selected.id, workspaceTarget.id)
       : [];
 
   // Status events only — the checkpoints, not the transcript.
@@ -208,25 +242,22 @@ export const getAppWorkspace: Command<
   }
 
   let runtime: Runtime;
-  if (
-    primaryComponent?.kind === 'website' &&
-    latestTarget?.adapter === 'static'
-  ) {
+  if (selected?.kind === 'website' && latestTarget?.adapter === 'static') {
     runtime = {
       kind: 'none',
       because: 'Static files are served by the Target.',
     };
-  } else if (primaryComponent?.kind === 'job') {
+  } else if (selected?.kind === 'job') {
     runtime = await executionsOf(
       context,
-      primaryComponent.id,
+      selected.id,
       latestDeploy ?? null,
       now,
     );
-  } else if (primaryComponent && latestTarget) {
+  } else if (selected && latestTarget) {
     runtime = {
       kind: 'stream',
-      componentId: primaryComponent.id,
+      componentId: selected.id,
       targetId: latestTarget.id,
       lines: [],
       reach: reachOf(latestTarget.discovery?.logHistorySeconds ?? 0),
@@ -241,22 +272,22 @@ export const getAppWorkspace: Command<
   const workspace: WorkspaceView = {
     app: app.name,
     appId: app.id,
-    componentId: primaryComponent?.id,
+    componentId: selected?.id,
     targetId: workspaceTarget?.id,
     latestDeployId: latestDeploy?.id,
-    latestBuildId: primaryComponent?.builds[0]?.id,
+    latestBuildId: selected?.builds[0]?.id,
     target: workspaceTarget?.adapter ?? 'none',
     vessel: workspaceTarget?.vessel.name ?? 'none',
     prerequisitesMet: workspaceTarget
       ? workspaceTarget.health === 'healthy'
       : false,
-    phase: phaseFor(latestDeploy?.phase, primaryComponent?.builds[0]?.status),
+    phase: phaseFor(latestDeploy?.phase, selected?.builds[0]?.status),
     url: latestDeploy?.url ?? app.vanityDomain ?? '',
     urlLive: latestDeploy?.phase === 'LIVE',
     release: latestDeploy
       ? `Deploy ${latestDeploy.id}`
-      : primaryComponent?.builds[0]
-        ? `Build ${primaryComponent.builds[0].id}`
+      : selected?.builds[0]
+        ? `Build ${selected.builds[0].id}`
         : 'none',
     components,
     configKeys,

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -904,6 +904,41 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
   );
 }
 
+/**
+ * A refreshed workspace, keeping the log lines the socket has accumulated.
+ *
+ * A read carries only the server's first page of a runtime tail — every line
+ * after it arrived over a socket and lives in this screen's state — so taking
+ * `runtime` wholesale would wipe the log on every refresh.
+ *
+ * The lines are kept only where both reads are about the same Component on the
+ * same Target. The selection can move while a refresh is in flight, and a
+ * Component's output rendered under another Component's name is a worse answer
+ * than the empty card the next socket page fills.
+ *
+ * Exported for `test/web/workspace-refresh.test.ts`: this is where the
+ * selection and the socket meet, and reaching it through the mounted screen
+ * means pressing a row, which the DOM shim does not simulate.
+ */
+export function refreshedWorkspace(
+  current: WorkspaceView,
+  fresh: WorkspaceView,
+): WorkspaceView {
+  const accumulated = current.runtime;
+  if (
+    accumulated.kind !== 'stream' ||
+    fresh.runtime.kind !== 'stream' ||
+    accumulated.componentId !== fresh.runtime.componentId ||
+    accumulated.targetId !== fresh.runtime.targetId
+  ) {
+    return fresh;
+  }
+  return {
+    ...fresh,
+    runtime: { ...fresh.runtime, lines: accumulated.lines },
+  };
+}
+
 function WorkspaceScreen({
   appName,
   onNavigate,
@@ -996,6 +1031,11 @@ function WorkspaceScreen({
     state.type === 'success' && isInFlight(state.workspace.phase);
   useEffect(() => {
     if (!appName) return;
+    // Dropped by the cleanup, the same way the read above drops its own: the
+    // interval is re-armed whenever the selection moves, so a response still in
+    // flight across that press is about a Component this screen has left, and
+    // writing it would put that Component back on screen until the next tick.
+    let live = true;
     const timer = setInterval(
       () => {
         // With the selection, or the refresh would put the App's first
@@ -1005,30 +1045,15 @@ function WorkspaceScreen({
           ...(component === null ? {} : { component }),
         })
           .then((result) => {
-            if (!result.ok) return;
+            if (!live || !result.ok) return;
             const fresh = result.value.workspace;
-            setState((current) => {
-              // The runtime tail is accumulated by a socket, not by this read —
-              // a fresh workspace carries only the server's first page of it,
-              // so taking it wholesale would wipe the log every few seconds.
-              if (
-                current.type === 'success' &&
-                current.workspace.runtime.kind === 'stream' &&
-                fresh.runtime.kind === 'stream'
-              ) {
-                return {
-                  type: 'success',
-                  workspace: {
-                    ...fresh,
-                    runtime: {
-                      ...fresh.runtime,
-                      lines: current.workspace.runtime.lines,
-                    },
-                  },
-                };
-              }
-              return { type: 'success', workspace: fresh };
-            });
+            setState((current) => ({
+              type: 'success',
+              workspace:
+                current.type === 'success'
+                  ? refreshedWorkspace(current.workspace, fresh)
+                  : fresh,
+            }));
           })
           // A failed refresh is not a reason to replace a workspace that is on
           // screen and readable with an error page. The next tick tries again.
@@ -1036,7 +1061,10 @@ function WorkspaceScreen({
       },
       inFlight ? 2_000 : 20_000,
     );
-    return () => clearInterval(timer);
+    return () => {
+      live = false;
+      clearInterval(timer);
+    };
   }, [appName, component, inFlight]);
 
   const runtime =

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -922,6 +922,16 @@ function WorkspaceScreen({
   /** Bumped when an act changed state the workspace has already read. */
   const [reloadToken, setReloadToken] = useState(0);
   /**
+   * Which Component the screen is showing, or `null` for the App's first.
+   *
+   * Held here rather than in the URL: picking a Component is inspection within
+   * one screen, the same call the object explorers make. It is `null` rather
+   * than the first Component's name because the server answers that question —
+   * a client that named a default would be a second answer to it, wrong for
+   * every App whose Components are not in the order this guessed.
+   */
+  const [component, setComponent] = useState<string | null>(null);
+  /**
    * Which run's output is open, and the lines read so far (§17).
    *
    * Held here rather than in the card because the socket is: a job's tail is
@@ -941,7 +951,10 @@ function WorkspaceScreen({
       setState({ type: 'not-found', message: 'No App name provided' });
       return;
     }
-    command('getAppWorkspace', { name: appName })
+    command('getAppWorkspace', {
+      name: appName,
+      ...(component === null ? {} : { component }),
+    })
       .then((result) => {
         if (!live) return;
         if (result.ok) {
@@ -964,7 +977,7 @@ function WorkspaceScreen({
     return () => {
       live = false;
     };
-  }, [appName, reloadToken]);
+  }, [appName, component, reloadToken]);
 
   /**
    * Keep the workspace current while something is moving.
@@ -985,7 +998,12 @@ function WorkspaceScreen({
     if (!appName) return;
     const timer = setInterval(
       () => {
-        void command('getAppWorkspace', { name: appName })
+        // With the selection, or the refresh would put the App's first
+        // Component back on screen every few seconds.
+        void command('getAppWorkspace', {
+          name: appName,
+          ...(component === null ? {} : { component }),
+        })
           .then((result) => {
             if (!result.ok) return;
             const fresh = result.value.workspace;
@@ -1019,7 +1037,7 @@ function WorkspaceScreen({
       inFlight ? 2_000 : 20_000,
     );
     return () => clearInterval(timer);
-  }, [appName, inFlight]);
+  }, [appName, component, inFlight]);
 
   const runtime =
     state.type === 'success' && state.workspace.runtime.kind === 'stream'
@@ -1276,6 +1294,18 @@ function WorkspaceScreen({
   };
 
   /**
+   * Show another Component of this App.
+   *
+   * The open run tail is dropped with the same press: an execution name belongs
+   * to the Component that produced it, so carrying one across the selection
+   * would subscribe to a run the newly selected Component has never had.
+   */
+  const handleSelectComponent = (name: string) => {
+    setFollowing(null);
+    setComponent(name);
+  };
+
+  /**
    * Start one run (§17), then re-read: the list on the screen was written
    * before the run existed, and a run that does not appear reads as a press
    * that did nothing.
@@ -1334,6 +1364,7 @@ function WorkspaceScreen({
         onSetReach={handleSetReach}
         onSetAutoDeploy={handleSetAutoDeploy}
         onSetConfig={handleSetConfig}
+        onSelectComponent={handleSelectComponent}
         {...(runs === null
           ? {}
           : {

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -1184,6 +1184,12 @@ function WorkspaceScreen({
       const result = await command('deployApp', {
         name: state.workspace.appId ?? appName,
         rebuild,
+        // A deploy is a press on one Component, and the header these buttons
+        // sit in reads the selected Component's kind, phase and placement — so
+        // it is that Component's release they start, not the App's first one's.
+        ...(state.workspace.componentId === undefined
+          ? {}
+          : { component: state.workspace.componentId }),
       });
       if (result.ok) {
         // Both arms navigate. §4 makes "a Build started" a different act from

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -520,6 +520,15 @@ export interface ComponentView {
 export interface WorkspaceView {
   readonly app: string;
   readonly appId?: string;
+  /**
+   * Which of {@link components} this view's per-Component half is about — its
+   * runtime, its placement, its release and its config keys.
+   *
+   * The selection the read resolved, echoed rather than assumed: a screen that
+   * asked for no Component is answered with the App's first, so the list can
+   * mark the row it is showing without holding a second idea of which one that
+   * is. Absent for an App with no Components at all.
+   */
   readonly componentId?: string;
   readonly targetId?: string;
   readonly latestDeployId?: number;

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -538,7 +538,12 @@ export interface WorkspaceView {
   readonly vessel: string;
   readonly prerequisitesMet: boolean;
   readonly phase: DeployPhase;
+  /**
+   * Where {@link componentId} answers, empty for a Component that answers
+   * nowhere — every job, and anything not deployed under a vanity domain.
+   */
   readonly url: string;
+  /** That {@link url} is being served. Never true without one. */
   readonly urlLive: boolean;
   readonly release: string;
   readonly components: readonly ComponentView[];

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -126,6 +126,7 @@ export function Workspace({
   deletion,
   onSetReach,
   onSetConfig,
+  onSelectComponent,
   onRunJob,
   onSetAutoDeploy,
   onFollowExecution,
@@ -164,6 +165,15 @@ export function Workspace({
    */
   onSetConfig?: SetConfig;
   /**
+   * Show another Component of this App, by name.
+   *
+   * The Components list is the selector, because it is already the list of what
+   * there is to look at. Absent where the screen reads a fixed view — a row
+   * that could be pressed and changed nothing would be worse than a row that
+   * cannot.
+   */
+  onSelectComponent?: (component: string) => void;
+  /**
    * Start one run of this App's job (§17). Absent where the screen wires no
    * acts, and absent for every Component that is not a job — the runtime card
    * is what decides, because it is the only branch with runs to start.
@@ -181,14 +191,23 @@ export function Workspace({
   /** The lines of whichever run is being followed. */
   executionLines?: readonly LogLine[];
 }) {
-  const primary = view.components[0];
+  /*
+    Which Component the rest of this screen is about — its runtime, its config
+    keys, its placement and its release. `componentId` is the selection the
+    read resolved; a view carrying none is showing the App's first Component,
+    which is the same answer, so this is a lookup rather than a second guess at
+    what the card below belongs to.
+  */
+  const selected =
+    view.components.find((component) => component.id === view.componentId) ??
+    view.components[0];
 
   return (
     <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-4 px-5 py-6">
       <header className="flex flex-wrap items-end gap-4">
         <div>
           <Eyebrow>
-            {primary ? `${primary.kind} · ${primary.name}` : 'app'}
+            {selected ? `${selected.kind} · ${selected.name}` : 'app'}
           </Eyebrow>
           <h1 className="text-2xl font-semibold tracking-tight">{view.app}</h1>
         </div>
@@ -236,13 +255,16 @@ export function Workspace({
       <div className="grid gap-4 md:grid-cols-2">
         <Components
           components={view.components}
+          {...(selected === undefined ? {} : { selectedId: selected.id })}
           {...(onSetReach === undefined ? {} : { onSetReach })}
+          {...(onSelectComponent === undefined ? {} : { onSelectComponent })}
         />
         <Datastores datastores={view.datastores} />
       </div>
 
       <ConfigSection
         configKeys={view.configKeys}
+        {...(selected === undefined ? {} : { component: selected.name })}
         {...(onSetConfig === undefined ? {} : { onSetConfig })}
       />
 
@@ -256,6 +278,7 @@ export function Workspace({
         <Activity entries={view.activity} onNavigate={onNavigate} />
         <Runtime
           view={view}
+          {...(selected === undefined ? {} : { component: selected.name })}
           onNavigate={onNavigate}
           {...(onRunJob ? { onRun: onRunJob } : {})}
           {...(onFollowExecution ? { onFollowExecution } : {})}
@@ -454,19 +477,53 @@ function Row({
   title,
   detail,
   trailing,
+  onSelect,
+  selected,
 }: {
   badge: ReactNode;
   title: string;
   detail: string;
   trailing?: ReactNode;
+  /**
+   * Make the row itself the act of picking it.
+   *
+   * The badge and the two lines become the button and `trailing` stays outside
+   * it, because a row's own act sits there — nesting one button inside another
+   * is not something a browser renders, so the region that selects has to stop
+   * short of it.
+   */
+  onSelect?: () => void;
+  selected?: boolean;
 }) {
-  return (
-    <div className="flex items-center gap-3 border-b border-border-soft py-2.5 last:border-b-0">
+  const body = (
+    <>
       {badge}
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium">{title}</p>
         <p className="truncate text-xs text-muted-foreground">{detail}</p>
       </div>
+    </>
+  );
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 border-b border-border-soft py-2.5 last:border-b-0',
+        selected && 'border-l-2 border-l-accent pl-2',
+      )}
+    >
+      {onSelect ? (
+        <button
+          type="button"
+          aria-pressed={selected}
+          onClick={onSelect}
+          className="flex min-w-0 flex-1 items-center gap-3 rounded-sm text-left hover:bg-secondary/40"
+        >
+          {body}
+        </button>
+      ) : (
+        body
+      )}
       {trailing ?? (
         <ChevronRight
           aria-hidden="true"
@@ -477,12 +534,27 @@ function Row({
   );
 }
 
+/**
+ * Every Component of this App, and which one the screen is showing.
+ *
+ * **The list is the selector.** The runtime card, the Run now control and the
+ * config keys all belong to one Component, and this is the only place that says
+ * which — an App whose `job` sits behind its `service` reaches that job's runs
+ * by the row being pressed here, and reaches them nowhere else. The row being
+ * shown is marked, because a screen rendering a second Component's runs with
+ * nothing saying whose they are is worse than one that cannot render them.
+ */
 function Components({
   components,
+  selectedId,
   onSetReach,
+  onSelectComponent,
 }: {
   components: readonly ComponentView[];
+  /** The row this screen's runtime, config and placement are about. */
+  selectedId?: string;
   onSetReach?: SetReach;
+  onSelectComponent?: (component: string) => void;
 }) {
   const [editing, setEditing] = useState<string | null>(null);
 
@@ -500,6 +572,10 @@ function Components({
               badge={<Badge tone="accent">{component.kind}</Badge>}
               title={component.name}
               detail={`${component.phase} · ${component.reach}${component.auth === 'proxy' ? ' + auth' : ''} · ${component.artifact}`}
+              selected={component.id === selectedId}
+              {...(onSelectComponent === undefined
+                ? {}
+                : { onSelect: () => onSelectComponent(component.name) })}
               trailing={
                 onSetReach ? (
                   <Button
@@ -702,7 +778,7 @@ function Datastores({ datastores }: { datastores: readonly DatastoreView[] }) {
 }
 
 /**
- * The App's environment configuration (§10).
+ * The selected Component's environment configuration (§10).
  *
  * Keys only, ever — the same posture core's config commands take, kept all
  * the way to the screen: nothing here has ever been handed a value, so there
@@ -710,12 +786,19 @@ function Datastores({ datastores }: { datastores: readonly DatastoreView[] }) {
  * "Set variable" is the one form underneath, because `setConfig` upserts —
  * naming a key that already exists overwrites it, so add and edit are one
  * act, not two the operator has to choose between.
+ *
+ * The Component is named above the list because config is scoped to one
+ * (Component, Target) pair and this App may have several: a heading that said
+ * only "Config" was the same list claiming to be the App's.
  */
 function ConfigSection({
   configKeys,
+  component,
   onSetConfig,
 }: {
   configKeys: readonly string[];
+  /** Whose keys these are. Absent for an App with no Components yet. */
+  component?: string;
   onSetConfig?: SetConfig;
 }) {
   const [adding, setAdding] = useState(false);
@@ -724,7 +807,11 @@ function ConfigSection({
   return (
     <Card>
       <SectionHeader
-        eyebrow="App configuration"
+        eyebrow={
+          component === undefined
+            ? 'App configuration'
+            : `Configuration for ${component}`
+        }
         title="Config"
         {...(onSetConfig
           ? {
@@ -1077,12 +1164,19 @@ function ActivityRow({
  */
 function Runtime({
   view,
+  component,
   onNavigate,
   onRun,
   onFollowExecution,
   executionLines,
 }: {
   view: WorkspaceView;
+  /**
+   * Whose output this is. An App has as many runtimes as it has Components and
+   * this card shows one of them, so the card says which — "Recent runs" over an
+   * App with a service and two jobs names none of them.
+   */
+  component?: string;
   onNavigate?: (path: string) => void;
   /**
    * Start one run (§17). Absent where the screen has no act wired — the
@@ -1124,7 +1218,11 @@ function Runtime({
   return (
     <Card>
       <SectionHeader
-        eyebrow="Component output"
+        eyebrow={
+          component === undefined
+            ? 'Component output'
+            : `Output of ${component}`
+        }
         title={TITLE[runtime.kind]}
         action={ACTION[runtime.kind]}
         onAction={

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -223,11 +223,15 @@ export function Workspace({
               label
             />
           ) : null}
-          <Button variant="outline" asChild>
-            <a href={normaliseUrl(view.url)}>
-              Open app <ExternalLink aria-hidden="true" />
-            </a>
-          </Button>
+          {/* Only where the selected Component answers somewhere: a job has no
+              address, and `Open app` on an empty one reloads this screen. */}
+          {view.url === '' ? null : (
+            <Button variant="outline" asChild>
+              <a href={normaliseUrl(view.url)}>
+                Open app <ExternalLink aria-hidden="true" />
+              </a>
+            </Button>
+          )}
           {onRebuild ? (
             <Button variant="outline" onClick={onRebuild} disabled={deploying}>
               Rebuild
@@ -248,6 +252,7 @@ export function Workspace({
 
       <Hero
         view={view}
+        {...(selected === undefined ? {} : { component: selected })}
         onNavigate={onNavigate}
         {...(onSetAutoDeploy === undefined ? {} : { onSetAutoDeploy })}
       />
@@ -289,13 +294,42 @@ export function Workspace({
   );
 }
 
+/**
+ * What the hero says about the Component the screen is showing.
+ *
+ * Named rather than called "Your App", because everything beside this sentence
+ * — the phase pill, the address, the release, the placement — is one
+ * Component's: an App whose `job` sits behind a serving `service` would
+ * otherwise read "Your App has no release serving yet" over a service that is
+ * serving, and "Your App is live" over a CronJob the moment it is placed.
+ *
+ * A Component with no address is stated as deployed rather than as serving.
+ * Every job is one, and so is a service kept off the network — neither of them
+ * has anything an operator could open, and "no release serving yet" reads as a
+ * release that failed rather than one that was never meant to serve.
+ */
+function heroHeadline(view: WorkspaceView, component?: ComponentView): string {
+  const subject = component?.name ?? 'Your App';
+  if (view.url === '') {
+    return view.phase === 'LIVE'
+      ? `${subject} is deployed`
+      : `${subject} has no release yet`;
+  }
+  return view.urlLive
+    ? `${subject} is live`
+    : `${subject} has no release serving yet`;
+}
+
 /** Live state and URL on the left; placement on the right. */
 function Hero({
   view,
+  component,
   onNavigate,
   onSetAutoDeploy,
 }: {
   view: WorkspaceView;
+  /** The Component this card is about. Absent for an App with none yet. */
+  component?: ComponentView;
   onNavigate?: (path: string) => void;
   onSetAutoDeploy?: SetAutoDeploy;
 }) {
@@ -304,21 +338,23 @@ function Hero({
       <div className="flex flex-col gap-2">
         <PhasePill phase={view.phase}>{view.phase}</PhasePill>
         <p className="text-xl font-semibold tracking-tight">
-          {view.urlLive
-            ? 'Your App is live'
-            : 'Your App has no release serving yet'}
+          {heroHeadline(view, component)}
         </p>
-        <a
-          href={normaliseUrl(view.url)}
-          className={cn(
-            'font-mono text-[15px]',
-            view.urlLive
-              ? 'border-b border-current text-accent-foreground'
-              : 'pointer-events-none text-muted-foreground',
-          )}
-        >
-          {view.url}
-        </a>
+        {/* No address, no link: `normaliseUrl('')` is `''`, and an anchor
+            carrying that reloads the screen it is on. */}
+        {view.url === '' ? null : (
+          <a
+            href={normaliseUrl(view.url)}
+            className={cn(
+              'font-mono text-[15px]',
+              view.urlLive
+                ? 'border-b border-current text-accent-foreground'
+                : 'pointer-events-none text-muted-foreground',
+            )}
+          >
+            {view.url}
+          </a>
+        )}
         {/*
           The release is a link because it is a thing, not a label: §2's Deploy
           is Heroku's Release, and the attempt that produced what is running is

--- a/apps/spindrift/test/commands/workspace-component-selection.test.ts
+++ b/apps/spindrift/test/commands/workspace-component-selection.test.ts
@@ -13,9 +13,11 @@
  * own, and every claim below is about the second one being reachable by name.
  */
 import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
 import { createApp } from '../../src/commands/create-app.ts';
 import {
   createComponent,
+  deployApp,
   getAppWorkspace,
   runComponent,
 } from '../../src/commands/index.ts';
@@ -33,7 +35,10 @@ import {
 } from '../../src/db/schema.ts';
 import { defaultVesselName, withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
-import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
 import {
   fixtureManifest,
   insertVessel,
@@ -86,6 +91,7 @@ async function placed(
 
   await ctx.db.insert(componentTargetDesired).values({ componentId, targetId });
 
+  const artifactDigest = `sha256:${'a'.repeat(64)}`;
   const [build] = await ctx.db
     .insert(builds)
     .values({
@@ -93,9 +99,14 @@ async function placed(
       commit: 'abc1234',
       targetShape: 'image',
       artifactType: 'image',
-      artifactDigest: `sha256:${'a'.repeat(64)}`,
+      artifactDigest,
       status: 'SUCCEEDED',
       runner: 'hosted runner',
+      // What §16's gate admits. A Build without provenance and a signature over
+      // its artifact is one no press on Deploy could ever release, so a fixture
+      // carrying none could not state what Deploy does with the selection.
+      verifiedBuildLevel: 2,
+      signature: testSignature(artifactDigest),
     })
     .returning();
 
@@ -357,6 +368,66 @@ describe('an App whose job sits behind its service', () => {
 
     expect(started.ok).toBe(true);
     expect(backend.runsStarted).toEqual(['fake-deploy-nightly']);
+  });
+
+  test('deploys the Component it is showing, not the App’s first', async () => {
+    // The Deploy button sits in the header that states the selection's kind,
+    // phase, placement and release, and it writes an intent for one Component:
+    // `deployApp` takes the App's first unless it is told which, so the id the
+    // screen is showing is the one it has to press with. A press that built
+    // `web` from a screen reading `job · nightly` is the failure.
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const view = await getAppWorkspace(
+      { name: app.appName, component: 'nightly' },
+      ctx,
+    );
+    expect(view.ok).toBe(true);
+    if (!view.ok) return;
+    const showing = view.value.workspace.componentId;
+    if (showing === undefined) throw new Error('the screen shows no Component');
+
+    const pressed = await deployApp(
+      { name: app.appName, component: showing },
+      ctx,
+    );
+
+    expect(pressed.ok).toBe(true);
+    if (!pressed.ok) return;
+    expect(pressed.value.deployId).not.toBeNull();
+    const [written] = await ctx.db
+      .select()
+      .from(deploys)
+      .where(eq(deploys.id, pressed.value.deployId as number));
+    expect(written?.componentId).toBe(app.nightly.componentId);
+    expect(written?.targetId).toBe(app.nightly.targetId);
+  });
+
+  test('names the same first Component a deploy that names none acts on', async () => {
+    // "The App's first Component" is said twice — by the screen that opens with
+    // no selection and by a deploy that names none — and a row order is not a
+    // fact SQL hands out for free, so both commands order by `createdAt` and
+    // this is the claim that they agree. Two answers here is the same defect
+    // read backwards: the header describing one Component, Deploy pressing
+    // another.
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const view = await getAppWorkspace({ name: app.appName }, ctx);
+    const pressed = await deployApp({ name: app.appName }, ctx);
+
+    expect(view.ok).toBe(true);
+    expect(pressed.ok).toBe(true);
+    if (!view.ok || !pressed.ok) return;
+    const [written] = await ctx.db
+      .select()
+      .from(deploys)
+      .where(eq(deploys.id, pressed.value.deployId as number));
+    expect(view.value.workspace.componentId).toBe(app.web.componentId);
+    expect(written?.componentId).toBe(app.web.componentId);
   });
 
   test('refuses a Component this App does not have', async () => {

--- a/apps/spindrift/test/commands/workspace-component-selection.test.ts
+++ b/apps/spindrift/test/commands/workspace-component-selection.test.ts
@@ -1,0 +1,379 @@
+/**
+ * The App workspace, on an App with more than one Component (§17, §18).
+ *
+ * Every App that had ever exercised a job surface had exactly one Component,
+ * and that is what kept this invisible: the screen read `components[0]` for the
+ * runtime, the placement and the config keys while listing every Component, so
+ * an App whose job sits behind its service had no surface for that job at all —
+ * no run list, no Run now, no config. `runComponent` took the pair happily; the
+ * only screen that could call it was bound to a Component that was not a job.
+ *
+ * So the fixture here is the shape that was never tested: `components[0]` is a
+ * `service` and the second Component is a `job`, each placed on a Target of its
+ * own, and every claim below is about the second one being reachable by name.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createApp } from '../../src/commands/create-app.ts';
+import {
+  createComponent,
+  getAppWorkspace,
+  runComponent,
+} from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  builds,
+  componentTargetDesired,
+  configItems,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import { defaultVesselName, withIsolatedDatabase } from '../harness/db.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
+
+const manifest = await fixtureManifest();
+const database = withIsolatedDatabase();
+
+const NOW = new Date('2026-08-06T12:00:00.000Z');
+const clock: Clock = { now: () => NOW };
+const supplyChain = new SupplyChainHarness();
+
+function context(deploy: FakeDeployAdapter): CommandContext {
+  const adapters: AdapterRegistry = {
+    deploy: () => deploy,
+    build: () => null,
+    store: () => null,
+    repository: () => null,
+    supplyChain: () => supplyChain,
+  };
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** A Component, placed on a Target of its own and deployed there. */
+async function placed(
+  ctx: CommandContext,
+  backend: FakeDeployAdapter,
+  componentId: string,
+  ref: string,
+  vesselId?: string,
+): Promise<{ targetId: string; deployId: number }> {
+  const [target] = await ctx.db
+    .insert(targets)
+    .values(
+      targetValues({
+        adapter: 'kubernetes',
+        ...(vesselId === undefined ? {} : { vesselId }),
+      }),
+    )
+    .returning();
+  const targetId = target?.id as string;
+
+  await ctx.db.insert(componentTargetDesired).values({ componentId, targetId });
+
+  const [build] = await ctx.db
+    .insert(builds)
+    .values({
+      componentId,
+      commit: 'abc1234',
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: `sha256:${'a'.repeat(64)}`,
+      status: 'SUCCEEDED',
+      runner: 'hosted runner',
+    })
+    .returning();
+
+  const [deploy] = await ctx.db
+    .insert(deploys)
+    .values({
+      componentId,
+      desired: aDesiredDocument(),
+      targetId,
+      buildId: build?.id as number,
+      phase: 'LIVE',
+      ref,
+    })
+    .returning();
+
+  // The workload the Deploy says is there. Every run verb refuses a ref with
+  // nothing behind it, which is a different state from this one.
+  backend.place(ref, {
+    ref,
+    phase: 'LIVE',
+    artifactDigest: `sha256:${'a'.repeat(64)}`,
+  });
+
+  return { targetId, deployId: deploy?.id as number };
+}
+
+/**
+ * One App, a `service` first and a `job` second, each on its own Target.
+ *
+ * The job's Target sits on a vessel of its own, because the placement the
+ * screen states is per Component: an App is not in a vessel, so a selection
+ * that did not move the boundary would be reading the wrong Target's row.
+ */
+async function serviceThenJob(ctx: CommandContext, backend: FakeDeployAdapter) {
+  const name = `two-${crypto.randomUUID().slice(0, 8)}`;
+  const app = await createApp(
+    {
+      name,
+      sourceKind: 'repo',
+      repoUrl: 'https://vcs.example/acme/thing.git',
+    },
+    ctx,
+  );
+  if (!app.ok) throw new Error(app.failure.message);
+
+  const web = await createComponent(
+    {
+      appId: app.value.appId,
+      name: 'web',
+      kind: 'service',
+      expose: true,
+      reach: 'private',
+      auth: 'proxy',
+    },
+    ctx,
+  );
+  if (!web.ok) throw new Error(web.failure.message);
+
+  const nightly = await createComponent(
+    {
+      appId: app.value.appId,
+      name: 'nightly',
+      kind: 'job',
+      reach: 'none',
+      auth: 'none',
+    },
+    ctx,
+  );
+  if (!nightly.ok) throw new Error(nightly.failure.message);
+
+  const service = await placed(
+    ctx,
+    backend,
+    web.value.componentId,
+    'fake-deploy-web',
+  );
+  const jobVessel = await insertVessel(ctx.db, 'kubernetes');
+  const job = await placed(
+    ctx,
+    backend,
+    nightly.value.componentId,
+    'fake-deploy-nightly',
+    jobVessel.id,
+  );
+
+  await ctx.db.insert(configItems).values([
+    {
+      componentId: web.value.componentId,
+      targetId: service.targetId,
+      key: 'PORT',
+      storeRef: 'store/port',
+      storeVersion: '1',
+    },
+    {
+      componentId: nightly.value.componentId,
+      targetId: job.targetId,
+      key: 'BUCKET',
+      storeRef: 'store/bucket',
+      storeVersion: '1',
+    },
+  ]);
+
+  return {
+    appName: name,
+    web: { componentId: web.value.componentId, ...service },
+    nightly: {
+      componentId: nightly.value.componentId,
+      ...job,
+      vessel: jobVessel.name,
+    },
+  };
+}
+
+/** A run nothing here started — the schedule's, read back off the platform. */
+function withARun(): FakeDeployAdapter {
+  const backend = new FakeDeployAdapter();
+  backend.ran('fake-deploy-nightly', {
+    name: 'nightly-scheduled',
+    outcome: 'passed',
+    startedAt: new Date('2026-08-06T11:00:00.000Z'),
+    detail: '1,284 objects copied',
+  });
+  return backend;
+}
+
+describe('an App whose job sits behind its service', () => {
+  test('shows the first Component with nothing selected', async () => {
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const result = await getAppWorkspace({ name: app.appName }, ctx);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const view = result.value.workspace;
+    // Unchanged for every caller that names no Component: the service is what
+    // an App-first screen opens on, and it is a `stream` rather than a list.
+    expect(view.componentId).toBe(app.web.componentId);
+    expect(view.runtime.kind).toBe('stream');
+    expect(view.configKeys).toEqual(['PORT']);
+    expect(view.vessel).toBe(defaultVesselName('cluster'));
+  });
+
+  test('shows the job when the job is the Component named', async () => {
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const result = await getAppWorkspace(
+      { name: app.appName, component: 'nightly' },
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const runtime = result.value.workspace.runtime;
+    // `{kind: 'executions'}` is what renders the run list and the Run now
+    // control, and it was unreachable for this Component at any URL.
+    expect(runtime.kind).toBe('executions');
+    if (runtime.kind !== 'executions') return;
+    expect(runtime.componentId).toBe(app.nightly.componentId);
+    expect(runtime.targetId).toBe(app.nightly.targetId);
+    expect(runtime.executions).toEqual([
+      {
+        name: 'nightly-scheduled',
+        outcome: 'passed',
+        detail: '1,284 objects copied',
+        when: '1h ago',
+      },
+    ]);
+  });
+
+  test('lists every Component whichever one it is showing', async () => {
+    // The selection is a selection within one screen, not a screen per
+    // Component: an App-first view that could only see the Component it was
+    // showing would have nowhere to select the next one from.
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const result = await getAppWorkspace(
+      { name: app.appName, component: 'nightly' },
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.workspace.components.map((c) => c.name)).toEqual([
+      'web',
+      'nightly',
+    ]);
+    expect(result.value.workspace.app).toBe(app.appName);
+  });
+
+  test('scopes the config keys to the Component it is showing', async () => {
+    // `configKeys` is scoped to the pair a `Set variable` here would act on, so
+    // it has to be the *selected* pair: the same list showing the service's
+    // keys under the job would be one press away from writing them there.
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const result = await getAppWorkspace(
+      { name: app.appName, component: 'nightly' },
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.workspace.configKeys).toEqual(['BUCKET']);
+    expect(result.value.workspace.componentId).toBe(app.nightly.componentId);
+    expect(result.value.workspace.targetId).toBe(app.nightly.targetId);
+  });
+
+  test('states the placement of the Component it is showing', async () => {
+    // An App is not in a vessel — its Components are placed — so the boundary
+    // the screen names moves with the selection rather than staying on
+    // whichever Component happens to be first.
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const result = await getAppWorkspace(
+      { name: app.appName, component: 'nightly' },
+      ctx,
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.workspace.vessel).toBe(app.nightly.vessel);
+    expect(result.value.workspace.latestDeployId).toBe(app.nightly.deployId);
+  });
+
+  test('hands the Run now control ids that start this job', async () => {
+    // The whole point of the surface: `runComponent` always accepted any
+    // Component's pair, and until now no screen could hand it a job's. The ids
+    // the card presses with are the ones the runtime carries.
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const result = await getAppWorkspace(
+      { name: app.appName, component: 'nightly' },
+      ctx,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const runtime = result.value.workspace.runtime;
+    if (runtime.kind !== 'executions') throw new Error('no runs to press');
+    if (runtime.componentId === undefined || runtime.targetId === undefined) {
+      throw new Error('the card would render no button');
+    }
+
+    const started = await runComponent(
+      { componentId: runtime.componentId, targetId: runtime.targetId },
+      ctx,
+    );
+
+    expect(started.ok).toBe(true);
+    expect(backend.runsStarted).toEqual(['fake-deploy-nightly']);
+  });
+
+  test('refuses a Component this App does not have', async () => {
+    // A selection that names nothing is not the App's first Component: the
+    // screen asked for something specific and there is no such thing.
+    const backend = withARun();
+    const ctx = context(backend);
+    const app = await serviceThenJob(ctx, backend);
+
+    const result = await getAppWorkspace(
+      { name: app.appName, component: 'cloudcron' },
+      ctx,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('cloudcron');
+  });
+});

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -661,6 +661,10 @@ export const WORKSPACE_SCENARIOS = {
    * that Component's while the list still holds both. Until a Component could
    * be selected there was no view of this App in which the job had a run list
    * or a Run now control at all.
+   *
+   * The job answers nowhere, so the address is empty and `urlLive` is false
+   * while the release is LIVE — a placed CronJob is exactly that, and the
+   * App's own vanity domain is the service's address, not this Component's.
    */
   jobBehindService: {
     app: 'quay',
@@ -669,7 +673,7 @@ export const WORKSPACE_SCENARIOS = {
     vessel: 'driftwood',
     prerequisitesMet: true,
     phase: 'LIVE',
-    url: `quay.${APEX}`,
+    url: '',
     urlLive: false,
     release: 'Deploy 61',
     autoDeploy: true,

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -652,6 +652,77 @@ export const WORKSPACE_SCENARIOS = {
       ],
     },
   },
+
+  /**
+   * The App the workspace could not show: a `job` behind a `service`.
+   *
+   * `componentId` is the job's, so this is the screen after somebody pressed
+   * the second row — the runtime, the config keys and the placement are all
+   * that Component's while the list still holds both. Until a Component could
+   * be selected there was no view of this App in which the job had a run list
+   * or a Run now control at all.
+   */
+  jobBehindService: {
+    app: 'quay',
+    componentId: 'component-quay-nightly',
+    target: 'Kubernetes',
+    vessel: 'driftwood',
+    prerequisitesMet: true,
+    phase: 'LIVE',
+    url: `quay.${APEX}`,
+    urlLive: false,
+    release: 'Deploy 61',
+    autoDeploy: true,
+    components: [
+      {
+        id: 'component-quay-web',
+        name: 'web',
+        kind: 'service',
+        phase: 'LIVE',
+        artifact: 'image · sha256:41ba…c7d0',
+        reach: 'private',
+        auth: 'proxy',
+      },
+      {
+        id: 'component-quay-nightly',
+        name: 'nightly',
+        kind: 'job',
+        phase: 'LIVE',
+        artifact: 'image · sha256:41ba…c7d0',
+        reach: 'none',
+        auth: 'none',
+      },
+    ],
+    // The job's, not the service's — the pair a `Set variable` on this screen
+    // would write to is the pair the screen is showing.
+    configKeys: ['RETENTION_DAYS'],
+    datastores: [],
+    activity: [
+      {
+        kind: 'deploy',
+        title: 'Deploy 61 live',
+        detail: 'CronJob reconciled; nothing triggers it but a person.',
+        when: '3h ago',
+        status: 'ok',
+        deployId: 61,
+        buildId: null,
+      },
+    ],
+    runtime: {
+      kind: 'executions',
+      componentId: 'component-quay-nightly',
+      targetId: 'target-quay-metal',
+      retained: 10,
+      executions: [
+        {
+          name: 'nightly-29154360',
+          outcome: 'passed',
+          detail: '412 rows pruned in 0m11s',
+          when: '3h ago',
+        },
+      ],
+    },
+  },
 } as const satisfies Record<string, WorkspaceView>;
 
 export type WorkspaceScenarioName = keyof typeof WORKSPACE_SCENARIOS;

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -779,6 +779,41 @@ describe('the App workspace', () => {
       // control whose press cannot be answered is worse than no control.
       expect(workspace(view)).not.toContain('aria-pressed');
     });
+
+    test('states the selected Component, not the App, above its release', () => {
+      // The phase pill, the address and the release beside this sentence are
+      // all the job's. "Your App has no release serving yet" over an App whose
+      // service is serving is a sentence about a Component, told about the App.
+      const markup = workspace(view);
+
+      expect(markup).not.toContain('Your App');
+      expect(markup).toContain('nightly is deployed');
+    });
+
+    test('offers nothing to open for a Component that answers nowhere', () => {
+      // A job has no address, and `normaliseUrl('')` is `''` — an `Open app`
+      // anchor carrying that reloads the workspace instead of opening
+      // anything, which reads as a press that did nothing.
+      const markup = workspace(view);
+
+      expect(markup).not.toContain('href=""');
+      expect(markup).not.toContain('Open app');
+    });
+
+    test('still opens the address of a Component that has one', () => {
+      // The other half of the same rule: the service's URL is still a link,
+      // and it is still the headline the screen leads with.
+      const serving: WorkspaceView = {
+        ...view,
+        componentId: 'component-quay-web',
+        url: 'quay.apps.example',
+        urlLive: true,
+      };
+      const markup = workspace(serving);
+
+      expect(markup).toContain('Open app');
+      expect(markup).toContain('web is live');
+    });
   });
 
   test('a service states how far its log reaches', () => {

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -726,6 +726,61 @@ describe('the App workspace', () => {
     expect(withAct).toContain('Run now');
   });
 
+  describe('an App whose job is not its first Component', () => {
+    // The defect this fixture exists for: the screen listed every Component and
+    // could act on none but the first, so an App shaped like this one had no
+    // surface for its job at all — no run list, no Run now, no config of its
+    // own — while `runComponent` would have taken its pair happily.
+    const view = WORKSPACE_SCENARIOS.jobBehindService;
+
+    test('shows the runs of the Component it is showing, not of the first', () => {
+      const markup = workspace(view);
+
+      expect(markup).toContain('Recent runs');
+      expect(markup).toContain('nightly-29154360');
+      // And says whose runs they are. An App with a service and two jobs has
+      // three runtimes, and a card headed only "Recent runs" names none of them.
+      expect(markup).toContain('Output of nightly');
+      expect(markup).toContain('Configuration for nightly');
+      expect(markup).toContain('RETENTION_DAYS');
+    });
+
+    test('offers Run now for that job', () => {
+      // `{kind: 'executions'}` is what renders the control, and it was
+      // unreachable for a job behind a service at any URL.
+      const markup = renderToStaticMarkup(
+        <Workspace view={view} onRunJob={async () => ({ ok: true })} />,
+      );
+      expect(markup).toContain('Run now');
+    });
+
+    test('leads with the selected Component rather than the first', () => {
+      // The eyebrow over the App's name says what is being looked at, and the
+      // hero underneath it is that Component's placement and release.
+      expect(workspace(view)).toContain('job · nightly');
+    });
+
+    test('makes the Components list the selector, and marks the selection', () => {
+      const markup = renderToStaticMarkup(
+        <Workspace view={view} onSelectComponent={() => undefined} />,
+      );
+
+      // Both rows are pressable — the list is what there is to look at, so it
+      // is also how another one is chosen — and exactly one is pressed.
+      expect(markup.split('aria-pressed="true"').length - 1).toBe(1);
+      expect(markup.split('aria-pressed="false"').length - 1).toBe(1);
+      for (const component of view.components) {
+        expect(markup).toContain(component.name);
+      }
+    });
+
+    test('renders no selector where the screen wires no selection', () => {
+      // The same rule the reach, config and auto-deploy controls follow: a
+      // control whose press cannot be answered is worse than no control.
+      expect(workspace(view)).not.toContain('aria-pressed');
+    });
+  });
+
   test('a service states how far its log reaches', () => {
     // §17: `logHistory` "is how far back `since` can honestly reach... so a
     // Target never *lacks* logs; it only has a shorter memory, and the UI

--- a/apps/spindrift/test/web/workspace-refresh.test.ts
+++ b/apps/spindrift/test/web/workspace-refresh.test.ts
@@ -1,0 +1,88 @@
+/**
+ * What a refresh of the App workspace is allowed to keep.
+ *
+ * The screen holds two sources for one card: the poll re-reads the workspace
+ * every few seconds, and a socket appends log lines to whatever the last read
+ * returned. Keeping the accumulated lines across a refresh is what stops the
+ * log being wiped on every tick — and it is exactly the step that has to notice
+ * the selection, because the Component the card is about can change between the
+ * read being issued and its answer landing.
+ *
+ * Asserted against the merge itself rather than the mounted screen: reaching it
+ * there means pressing a Component row, and `test/harness/dom.ts` states that
+ * it simulates no clicks.
+ */
+import { describe, expect, test } from 'bun:test';
+import { refreshedWorkspace } from '../../src/web/app.tsx';
+import type { WorkspaceView } from '../../src/web/model.ts';
+import { WORKSPACE_SCENARIOS } from '../fixtures/scenarios.ts';
+
+const SERVICE: WorkspaceView = WORKSPACE_SCENARIOS.service;
+
+/** The same workspace as the server writes it: one page of lines, or none. */
+function firstPage(view: WorkspaceView): WorkspaceView {
+  if (view.runtime.kind !== 'stream') throw new Error('not a stream runtime');
+  return { ...view, runtime: { ...view.runtime, lines: [] } };
+}
+
+describe('refreshing the App workspace', () => {
+  test('keeps the lines the socket accumulated for the same Component', () => {
+    const merged = refreshedWorkspace(SERVICE, firstPage(SERVICE));
+
+    if (merged.runtime.kind !== 'stream') throw new Error('lost the stream');
+    if (SERVICE.runtime.kind !== 'stream') throw new Error('bad fixture');
+    // Without this the tail on screen is emptied every tick, which is the whole
+    // reason the merge exists.
+    expect(merged.runtime.lines).toEqual(SERVICE.runtime.lines);
+  });
+
+  test('drops them when the refresh is about a different Component', () => {
+    // Two service Components of one App: the selection moved while a read was
+    // in flight, so the answer describes the other Component's stream. Its
+    // output under this Component's name is the one thing the card must not
+    // say, and the socket refills it on the next page.
+    const other = firstPage({
+      ...SERVICE,
+      componentId: 'component-beacon-worker',
+      runtime: {
+        kind: 'stream',
+        componentId: 'component-beacon-worker',
+        targetId: '00000000-0000-4000-8000-000000000042',
+        lines: [],
+        reach: '7 days',
+      },
+    });
+
+    const merged = refreshedWorkspace(SERVICE, other);
+
+    if (merged.runtime.kind !== 'stream') throw new Error('lost the stream');
+    expect(merged.runtime.lines).toEqual([]);
+    expect(merged.runtime.componentId).toBe('component-beacon-worker');
+  });
+
+  test('drops them when the same Component moved to another Target', () => {
+    const moved = firstPage({
+      ...SERVICE,
+      runtime: {
+        kind: 'stream',
+        componentId: '00000000-0000-4000-8000-000000000041',
+        targetId: '00000000-0000-4000-8000-000000000099',
+        lines: [],
+        reach: '7 days',
+      },
+    });
+
+    const merged = refreshedWorkspace(SERVICE, moved);
+
+    if (merged.runtime.kind !== 'stream') throw new Error('lost the stream');
+    expect(merged.runtime.lines).toEqual([]);
+  });
+
+  test('takes a runtime of another kind whole', () => {
+    // A job selected while a service was on screen: there are no lines to keep
+    // and the run list is the whole answer.
+    const job = WORKSPACE_SCENARIOS.jobBehindService;
+
+    expect(refreshedWorkspace(SERVICE, job)).toEqual(job);
+  });
+});


### PR DESCRIPTION
## Summary

The App workspace shows the Component a person selected instead of always `components[0]`. An App whose `job` sits behind its `service` — `statty`'s `nightly` and `cloudcron` — previously had no surface for that job at all: no run list, no Run now, no log tail.

- `getAppWorkspace` takes an optional `component` name. Every per-Component read follows the selection — `latestDeploy`, `workspaceTarget`, `configKeys`, and the runtime discriminant that renders the Run now control and run list. Absent selection keeps today's first-Component behaviour; an unknown name is `NOT_FOUND`, not a silent fallback.
- The Components list is the selector. The header eyebrow, hero, runtime card, and config card all name the Component they are about; the 2s/20s refresh carries the selection so polling does not snap back to the first Component.
- Deploy and Rebuild act on the selected Component rather than `components[0]`, so the buttons do what the header above them says.
- Datastores stay anchored to the App's first Component — a Datastore is attached to the App, so its attachment does not move with the selection.
- `components` are ordered oldest-first in both `getAppWorkspace` and `deployApp`, so "the App's first Component" names one Component instead of whichever row the planner returned.

No Target selection and no unplace control were built; the selection is a single named field so a Target dimension can be added as a second one later.

## Validation

- `bun run typecheck` clean; `bun run lint` clean.
- `bun test`: 1755 pass / 0 relevant fail (the only failures are pre-existing environmental ones in `test/adapters/` that shell out to `node`/`jq`, absent from the sandbox PATH; those files are untouched).
- New coverage: `test/commands/workspace-component-selection.test.ts` builds a service-first / job-second App across two Targets and asserts selection reaches runtime, config, placement, and the ids Run now presses; `test/web/views.test.tsx` gains a `jobBehindService` scenario group; `test/web/workspace-refresh.test.ts` covers the poll merge keeping accumulated log lines with the Component they were read for.

## Risk

Behaviour change: pressing Deploy/Rebuild while a non-first Component is selected now deploys that Component. That is the fix — previously the screen could show one Component and deploy another.
