### PR TITLE
test(spindrift): fail when publication stops honouring reach

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -155,7 +155,9 @@ jobs:
             turbo-${{ runner.os }}-main-
             turbo-${{ runner.os }}-
       # The App chart's goldens run `helm template` under `bun test`, where the
-      # chart lives (packages/charts).
+      # chart lives (packages/charts). spindrift's own suite templates the same
+      # chart to assert what the record `reach` publishes ends up being, so the
+      # binary is a requirement of both packages rather than one.
       - name: Set up Helm
         uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
         with:

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -36,10 +36,11 @@ jobs:
       - id: changed-paths
         uses: tj-actions/changed-files@24d32ffd492484c1d75e0c0b894501ddb9d30d62 # v47
         with:
-          # The two `clusters/` paths are here because spindrift's conformance
+          # The `clusters/` paths are here because spindrift's conformance
           # tests read those declarations rather than a fixture: `charts.app`,
-          # a Target's delivery `sourceRef`, and an `OCIRepository` tag are all
-          # things the suite asserts and all things that change only there.
+          # a Target's delivery `sourceRef`, an `OCIRepository` tag, and the
+          # sources the DNS controller runs are all things the suite asserts
+          # and all things that change only there.
           # `turbo.json`'s `spindrift#test` and `spindrift#test:chart-pins`
           # inputs together name the same files — a path missing from all
           # three lists is a guard that cannot run in CI.
@@ -50,6 +51,8 @@ jobs:
             packages/charts/**
             clusters/base/platform/spindrift-target/**
             clusters/offsite/apps/spindrift/**
+            clusters/*/networking/external-dns/helm-release.yaml
+            clusters/*/networking/external-dns/kustomization.yaml
             packages/k6/**
             packages/typescript-config/**
             package.json

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -590,6 +590,15 @@ its gateway's own address are pinned apart there: live they are equal, which is
 what made a record derived from the gateway and a record the chart stated
 indistinguishable.
 
+Which sources that controller runs is the other half of the mechanism and is not
+Spindrift's to declare, so it is read from `clusters/` rather than assumed
+(`test/harness/external-dns-installation.ts`), once for every cluster a
+Component can be placed on. A sources list that loses `crd` is a `DNSEndpoint`
+nobody reads while every route is still held out — no source claims the name and
+`--policy=sync` deletes the record — with each rendered object still exactly
+right. Any argument that model does not account for fails there rather than
+being approximated.
+
 The live-from-creation status name and a vanity leg standing in front of a
 backend that cannot carry the name itself still have no `DNSEndpoint` to
 render, because both need a name before any Component exists to hang one on.

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -578,6 +578,18 @@ hostname off the shared gateway's own address — a route can never state its ow
 per-Component target, so letting both sources publish raced the same name at
 two record types.
 
+**What the objects become is asserted, not the objects.** A rendering golden is
+green whenever the manifests are right, and they were right throughout the life
+of the defect that split these two objects apart — the controller published
+something else. `test/conformance/reach-publication.test.ts` runs a
+`DesiredState` through the real adapter, renders the chart with the values that
+reach the cluster, and reads the result through a model of the controller's two
+sources (`test/harness/fakes/external-dns.ts`), so what is asserted is the
+record rather than the document asking for it. The Target's private address and
+its gateway's own address are pinned apart there: live they are equal, which is
+what made a record derived from the gateway and a record the chart stated
+indistinguishable.
+
 The live-from-creation status name and a vanity leg standing in front of a
 backend that cannot carry the name itself still have no `DNSEndpoint` to
 render, because both need a name before any Component exists to hang one on.

--- a/apps/spindrift/test/conformance/reach-publication.test.ts
+++ b/apps/spindrift/test/conformance/reach-publication.test.ts
@@ -1,0 +1,294 @@
+/**
+ * `reach` decides the record a Component's name answers to (§9).
+ *
+ * **Why this is not a chart golden.** The chart's goldens assert what a release
+ * *asks* for, and they were green throughout the whole life of the defect they
+ * now describe: a route asked for a proxied name at the Target's tunnel, the
+ * controller published an unproxied address at the shared gateway instead, and
+ * every manifest in the cluster was exactly what it should have been. The
+ * decision is only observable one step further down, where the objects become
+ * records — so that step is modelled (`test/harness/fakes/external-dns.ts`) and
+ * the record is what gets asserted.
+ *
+ * **The whole chain runs, and nothing in it is stubbed on our side.** A
+ * `DesiredState` at one reach goes through the real Kubernetes adapter, which
+ * writes a real values blob onto a delivery object in the fake cluster; that
+ * blob — not a baseline, not a fixture — is what the real chart is rendered
+ * with; the rendered objects are what the modelled controller reads. So this
+ * fails whether `reach` stops reaching the values, stops deciding the record,
+ * or stops being the only thing that does.
+ *
+ * The last one is the sharp edge, and it is why the gateway's own address is
+ * pinned *apart* from the Target's private address here. Live they are equal —
+ * the Target publishes the address of the gateway its routes attach to — which
+ * is precisely what made a record derived from the gateway indistinguishable
+ * from a record the chart stated. They are independent inputs, so the fixture
+ * separates them and the assertion names which one the record came from.
+ */
+import { describe, expect, test } from 'bun:test';
+import type {
+  DeployEvent,
+  DeployTarget,
+  DeployVerdict,
+} from '../../src/adapters/deploy/contract.ts';
+import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/index.ts';
+import type { DesiredState } from '../../src/domain/desired-state.ts';
+import { type RenderedObject, renderAppChart } from '../harness/app-chart.ts';
+import {
+  CONTROLLER,
+  type GatewayStatus,
+  publish,
+} from '../harness/fakes/external-dns.ts';
+import { FakeKubernetes } from '../harness/fakes/kubernetes-api.ts';
+
+/** The Apps gateway every route in the namespace attaches to. */
+const GATEWAY: GatewayStatus = {
+  name: 'spindrift-apps',
+  namespace: 'spindrift-apps',
+  // Its own load-balancer address, which is the only thing the route source can
+  // ever publish, and deliberately not the address below.
+  addresses: ['10.89.0.68'],
+};
+
+/** The two addresses `reach` chooses between, per Target. */
+const PRIVATE_ADDRESS = '10.89.0.69';
+const TUNNEL_HOSTNAME = 'tunnel.example.test';
+
+const CANONICAL = 'blog-web.apps.example.test';
+const VANITY = 'blog.vanity.example.test';
+
+/** The operator's class, as a connected Target carries it. */
+const CHART_VALUES = {
+  platform: {
+    gateway: { name: GATEWAY.name, namespace: GATEWAY.namespace },
+    externalAuth: {
+      name: 'oauth2-proxy-authz',
+      namespace: 'oauth2-proxy',
+      port: 4181,
+    },
+    dns: {
+      privateAddress: PRIVATE_ADDRESS,
+      tunnelHostname: TUNNEL_HOSTNAME,
+    },
+    networkPolicy: { allowedNamespaces: ['oauth2-proxy'] },
+  },
+};
+
+const TARGET: DeployTarget = {
+  vessel: 'cluster',
+  adapter: 'kubernetes',
+  connection: {
+    adapter: 'kubernetes',
+    apiServer: 'https://cluster.example.test',
+    namespace: GATEWAY.namespace,
+    delivery: {
+      flavour: 'flux-helmrelease',
+      namespace: GATEWAY.namespace,
+      sourceRef: { name: 'spindrift-app', namespace: GATEWAY.namespace },
+    },
+    chartValues: CHART_VALUES,
+  },
+};
+
+function desiredState(overrides: Partial<DesiredState> = {}): DesiredState {
+  return {
+    deploy: 'deploy-1',
+    app: 'blog',
+    component: 'web',
+    target: 'cluster',
+    kind: 'service',
+    artifact: {
+      type: 'image',
+      digest: 'sha256:feed',
+      refs: ['registry.example.test/blog/web@sha256:feed'],
+    },
+    expose: true,
+    reach: 'private',
+    auth: 'none',
+    config: [],
+    requirements: {
+      platform: { os: 'linux', arch: 'amd64' },
+      resources: {},
+    },
+    hostname: { canonical: CANONICAL },
+    ...overrides,
+  };
+}
+
+/**
+ * What a cluster would hold for this Component, through the real adapter.
+ *
+ * The values are read back off the applied delivery object rather than composed
+ * here, because "what the adapter wrote" and "what the chart is rendered with"
+ * being the same document is half of what this suite is asserting.
+ */
+async function renderRelease(
+  overrides: Partial<DesiredState> = {},
+): Promise<RenderedObject[]> {
+  const cluster = new FakeKubernetes({
+    servedKinds: { 'helm.toolkit.fluxcd.io/v2': ['HelmRelease'] },
+  });
+  const adapter = new KubernetesDeployAdapter({
+    chart: 'oci://registry.example.test/charts/spindrift-app',
+    token: cluster.token,
+    fetch: cluster.fetch,
+    pollIntervalMs: 1,
+    sleep: async () => {},
+  });
+  const verdict = await drain(adapter.apply(TARGET, desiredState(overrides)));
+  expect(verdict.phase).toBe('LIVE');
+
+  const release = cluster.get(`helmreleases/${GATEWAY.namespace}/blog-web`)
+    ?.spec as { values?: unknown } | undefined;
+  if (release?.values === undefined) {
+    throw new Error('expected the HelmRelease to carry inline values');
+  }
+  return renderAppChart(release.values, GATEWAY.namespace);
+}
+
+/** Drive a deploy stream to its verdict. */
+async function drain(
+  stream: AsyncGenerator<DeployEvent, DeployVerdict, void>,
+): Promise<DeployVerdict> {
+  let step = await stream.next();
+  while (!step.done) step = await stream.next();
+  return step.value;
+}
+
+describe('reach decides the record that is published', () => {
+  test('private is an unproxied address record at the Target’s own address', async () => {
+    const publication = publish(await renderRelease({ reach: 'private' }), [
+      GATEWAY,
+    ]);
+
+    // The address is the Target's, not the gateway's — `10.89.0.68` is what a
+    // record derived from the parent would have carried, and it appears
+    // nowhere. Unproxied because the value is RFC1918: the record type is the
+    // boundary, so nothing has to be attached to it to keep it one.
+    expect(publication.records).toEqual([
+      {
+        dnsName: CANONICAL,
+        recordType: 'A',
+        targets: [PRIVATE_ADDRESS],
+        proxied: false,
+        claimedBy: 'crd/blog-web',
+      },
+    ]);
+    expect(publication.contended).toEqual([]);
+  });
+
+  test('public is a proxied CNAME at the Target’s tunnel', async () => {
+    const publication = publish(await renderRelease({ reach: 'public' }), [
+      GATEWAY,
+    ]);
+
+    // A hostname can only ever be a CNAME, which is the half the route source
+    // structurally could not express: it publishes an address, and asking the
+    // zone provider to proxy one is the refusal that soft-errored a whole-zone
+    // sync every five minutes.
+    expect(publication.records).toEqual([
+      {
+        dnsName: CANONICAL,
+        recordType: 'CNAME',
+        targets: [TUNNEL_HOSTNAME],
+        proxied: true,
+        claimedBy: 'crd/blog-web',
+      },
+    ]);
+    expect(publication.contended).toEqual([]);
+  });
+
+  test('none publishes nothing at all', async () => {
+    // A Component with no reach has no route, so there is no name to answer
+    // for. A record here would be an alternate origin it asked not to have.
+    const publication = publish(await renderRelease({ reach: 'none' }), [
+      GATEWAY,
+    ]);
+    expect(publication.records).toEqual([]);
+  });
+
+  test('every name the route serves is published at the one reach', async () => {
+    // The canonical name and the vanity name are the same Component at the same
+    // reach. A record covering only the first leaves the second answered by
+    // whatever wildcard the zone still has, which is the failure retiring one
+    // was supposed to end.
+    const publication = publish(
+      await renderRelease({
+        reach: 'public',
+        hostname: { canonical: CANONICAL, vanity: VANITY },
+      }),
+      [GATEWAY],
+    );
+    expect(publication.records.map((record) => record.dnsName)).toEqual([
+      CANONICAL,
+      VANITY,
+    ]);
+    for (const record of publication.records) {
+      expect(record.recordType).toBe('CNAME');
+      expect(record.targets).toEqual([TUNNEL_HOSTNAME]);
+      expect(record.proxied).toBe(true);
+    }
+    expect(publication.contended).toEqual([]);
+  });
+});
+
+/**
+ * A guard nobody has seen fail is not a guard.
+ *
+ * Each mutation below is applied to what the chart actually rendered, so it
+ * stands in for the publication mechanism regressing rather than for a fixture
+ * someone typed. The assertions are the ones above, run against the damage.
+ */
+describe('publication that stops honouring reach fails here', () => {
+  /** The route stops holding itself out of the route source. */
+  function unheldOut(objects: readonly RenderedObject[]): RenderedObject[] {
+    return objects.map((object) => {
+      if (object.kind !== 'HTTPRoute') return object;
+      const { [CONTROLLER]: _held, ...annotations } =
+        object.metadata.annotations ?? {};
+      return { ...object, metadata: { ...object.metadata, annotations } };
+    });
+  }
+
+  /** The chart stops stating the record. */
+  function unstated(objects: readonly RenderedObject[]): RenderedObject[] {
+    return objects.filter((object) => object.kind !== 'DNSEndpoint');
+  }
+
+  test('a route that stops holding itself out claims its own name a second time', async () => {
+    const rendered = await renderRelease({ reach: 'public' });
+    const publication = publish(unheldOut(rendered), [GATEWAY]);
+
+    // Two sources, one name, two record types — the state that fails a
+    // whole-zone sync rather than one record.
+    expect(publication.contended).toEqual([CANONICAL]);
+    expect(publication.records).toHaveLength(2);
+  });
+
+  test('a Component whose record is no longer stated answers off the gateway', async () => {
+    const rendered = await renderRelease({ reach: 'public' });
+    const publication = publish(unheldOut(unstated(rendered)), [GATEWAY]);
+
+    // Nothing is contended and nothing errors: one source, one record, and a
+    // `public` Component answering an RFC1918 address on the public internet.
+    // Reach was ignored and the zone is perfectly healthy about it, which is
+    // the shape of failure this suite exists for.
+    expect(publication.contended).toEqual([]);
+    expect(publication.records).toEqual([
+      {
+        dnsName: CANONICAL,
+        recordType: 'A',
+        targets: GATEWAY.addresses,
+        proxied: false,
+        claimedBy: 'httproute/blog-web',
+      },
+    ]);
+  });
+
+  test('a record nothing states and nothing derives is no record', async () => {
+    // The hold-out on its own is not a fix: with the DNSEndpoint gone it is
+    // just a name that resolves nowhere. Both halves are the mechanism.
+    const rendered = await renderRelease({ reach: 'public' });
+    expect(publish(unstated(rendered), [GATEWAY]).records).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/conformance/reach-publication.test.ts
+++ b/apps/spindrift/test/conformance/reach-publication.test.ts
@@ -24,8 +24,15 @@
  * is precisely what made a record derived from the gateway indistinguishable
  * from a record the chart stated. They are independent inputs, so the fixture
  * separates them and the assertion names which one the record came from.
+ *
+ * **The controller is not our side either, and it is half the mechanism.** A
+ * `DNSEndpoint` nobody reads and a route held out of a source nobody runs is a
+ * Component whose name goes dark, with every object in the cluster still
+ * rendered exactly right. So the controller's configuration is read out of
+ * `clusters/` rather than assumed, once per cluster Spindrift deploys through.
  */
 import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
 import type {
   DeployEvent,
   DeployTarget,
@@ -35,11 +42,22 @@ import { KubernetesDeployAdapter } from '../../src/adapters/deploy/kubernetes/in
 import type { DesiredState } from '../../src/domain/desired-state.ts';
 import { type RenderedObject, renderAppChart } from '../harness/app-chart.ts';
 import {
+  controllerFor,
+  installedControllers,
+} from '../harness/external-dns-installation.ts';
+import {
   CONTROLLER,
   type GatewayStatus,
   publish,
 } from '../harness/fakes/external-dns.ts';
 import { FakeKubernetes } from '../harness/fakes/kubernetes-api.ts';
+
+/** Every cluster's controller, as that cluster declares it. */
+const CONTROLLERS = await installedControllers();
+
+/** The declaration naming the clusters a Component can be placed on. */
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+const LIVE_RELEASE = 'clusters/offsite/apps/spindrift/helm-release.yaml';
 
 /** The Apps gateway every route in the namespace attaches to. */
 const GATEWAY: GatewayStatus = {
@@ -155,82 +173,97 @@ async function drain(
   return step.value;
 }
 
-describe('reach decides the record that is published', () => {
-  test('private is an unproxied address record at the Target’s own address', async () => {
-    const publication = publish(await renderRelease({ reach: 'private' }), [
-      GATEWAY,
-    ]);
+/** One run per cluster, because each runs its own controller. */
+const PER_CLUSTER = CONTROLLERS.map(
+  (controller) => [controller.cluster, controller] as const,
+);
 
-    // The address is the Target's, not the gateway's — `10.89.0.68` is what a
-    // record derived from the parent would have carried, and it appears
-    // nowhere. Unproxied because the value is RFC1918: the record type is the
-    // boundary, so nothing has to be attached to it to keep it one.
-    expect(publication.records).toEqual([
-      {
-        dnsName: CANONICAL,
-        recordType: 'A',
-        targets: [PRIVATE_ADDRESS],
-        proxied: false,
-        claimedBy: 'crd/blog-web',
-      },
-    ]);
-    expect(publication.contended).toEqual([]);
-  });
+describe.each(PER_CLUSTER)(
+  'reach decides the record published on %s',
+  (_cluster, controller) => {
+    test('private is an unproxied address record at the Target’s own address', async () => {
+      const publication = publish(
+        await renderRelease({ reach: 'private' }),
+        [GATEWAY],
+        controller,
+      );
 
-  test('public is a proxied CNAME at the Target’s tunnel', async () => {
-    const publication = publish(await renderRelease({ reach: 'public' }), [
-      GATEWAY,
-    ]);
+      // The address is the Target's, not the gateway's — `10.89.0.68` is what a
+      // record derived from the parent would have carried, and it appears
+      // nowhere. Unproxied because the value is RFC1918: the record type is the
+      // boundary, so nothing has to be attached to it to keep it one.
+      expect(publication.records).toEqual([
+        {
+          dnsName: CANONICAL,
+          recordType: 'A',
+          targets: [PRIVATE_ADDRESS],
+          proxied: false,
+          claimedBy: 'crd/blog-web',
+        },
+      ]);
+      expect(publication.contended).toEqual([]);
+    });
 
-    // A hostname can only ever be a CNAME, which is the half the route source
-    // structurally could not express: it publishes an address, and asking the
-    // zone provider to proxy one is the refusal that soft-errored a whole-zone
-    // sync every five minutes.
-    expect(publication.records).toEqual([
-      {
-        dnsName: CANONICAL,
-        recordType: 'CNAME',
-        targets: [TUNNEL_HOSTNAME],
-        proxied: true,
-        claimedBy: 'crd/blog-web',
-      },
-    ]);
-    expect(publication.contended).toEqual([]);
-  });
+    test('public is a proxied CNAME at the Target’s tunnel', async () => {
+      const publication = publish(
+        await renderRelease({ reach: 'public' }),
+        [GATEWAY],
+        controller,
+      );
 
-  test('none publishes nothing at all', async () => {
-    // A Component with no reach has no route, so there is no name to answer
-    // for. A record here would be an alternate origin it asked not to have.
-    const publication = publish(await renderRelease({ reach: 'none' }), [
-      GATEWAY,
-    ]);
-    expect(publication.records).toEqual([]);
-  });
+      // A hostname can only ever be a CNAME, which is the half the route source
+      // structurally could not express: it publishes an address, and asking the
+      // zone provider to proxy one is the refusal that soft-errored a whole-zone
+      // sync every five minutes.
+      expect(publication.records).toEqual([
+        {
+          dnsName: CANONICAL,
+          recordType: 'CNAME',
+          targets: [TUNNEL_HOSTNAME],
+          proxied: true,
+          claimedBy: 'crd/blog-web',
+        },
+      ]);
+      expect(publication.contended).toEqual([]);
+    });
 
-  test('every name the route serves is published at the one reach', async () => {
-    // The canonical name and the vanity name are the same Component at the same
-    // reach. A record covering only the first leaves the second answered by
-    // whatever wildcard the zone still has, which is the failure retiring one
-    // was supposed to end.
-    const publication = publish(
-      await renderRelease({
-        reach: 'public',
-        hostname: { canonical: CANONICAL, vanity: VANITY },
-      }),
-      [GATEWAY],
-    );
-    expect(publication.records.map((record) => record.dnsName)).toEqual([
-      CANONICAL,
-      VANITY,
-    ]);
-    for (const record of publication.records) {
-      expect(record.recordType).toBe('CNAME');
-      expect(record.targets).toEqual([TUNNEL_HOSTNAME]);
-      expect(record.proxied).toBe(true);
-    }
-    expect(publication.contended).toEqual([]);
-  });
-});
+    test('none publishes nothing at all', async () => {
+      // A Component with no reach has no route, so there is no name to answer
+      // for. A record here would be an alternate origin it asked not to have.
+      const publication = publish(
+        await renderRelease({ reach: 'none' }),
+        [GATEWAY],
+        controller,
+      );
+      expect(publication.records).toEqual([]);
+    });
+
+    test('every name the route serves is published at the one reach', async () => {
+      // The canonical name and the vanity name are the same Component at the same
+      // reach. A record covering only the first leaves the second answered by
+      // whatever wildcard the zone still has, which is the failure retiring one
+      // was supposed to end.
+      const publication = publish(
+        await renderRelease({
+          reach: 'public',
+          hostname: { canonical: CANONICAL, vanity: VANITY },
+        }),
+        [GATEWAY],
+        controller,
+      );
+      expect(publication.records.map((record) => record.dnsName)).toEqual([
+        CANONICAL,
+        VANITY,
+      ]);
+      for (const record of publication.records) {
+        expect(record.recordType).toBe('CNAME');
+        expect(record.targets).toEqual([TUNNEL_HOSTNAME]);
+        expect(record.proxied).toBe(true);
+      }
+      expect(publication.contended).toEqual([]);
+    });
+  },
+);
 
 /**
  * A guard nobody has seen fail is not a guard.
@@ -239,56 +272,139 @@ describe('reach decides the record that is published', () => {
  * stands in for the publication mechanism regressing rather than for a fixture
  * someone typed. The assertions are the ones above, run against the damage.
  */
-describe('publication that stops honouring reach fails here', () => {
-  /** The route stops holding itself out of the route source. */
-  function unheldOut(objects: readonly RenderedObject[]): RenderedObject[] {
-    return objects.map((object) => {
-      if (object.kind !== 'HTTPRoute') return object;
-      const { [CONTROLLER]: _held, ...annotations } =
-        object.metadata.annotations ?? {};
-      return { ...object, metadata: { ...object.metadata, annotations } };
+describe.each(PER_CLUSTER)(
+  'publication on %s that stops honouring reach fails here',
+  (_cluster, controller) => {
+    /** The route stops holding itself out of the route source. */
+    function unheldOut(objects: readonly RenderedObject[]): RenderedObject[] {
+      return objects.map((object) => {
+        if (object.kind !== 'HTTPRoute') return object;
+        const { [CONTROLLER]: _held, ...annotations } =
+          object.metadata.annotations ?? {};
+        return { ...object, metadata: { ...object.metadata, annotations } };
+      });
+    }
+
+    /** The chart stops stating the record. */
+    function unstated(objects: readonly RenderedObject[]): RenderedObject[] {
+      return objects.filter((object) => object.kind !== 'DNSEndpoint');
+    }
+
+    test('a route that stops holding itself out claims its own name a second time', async () => {
+      const rendered = await renderRelease({ reach: 'public' });
+      const publication = publish(unheldOut(rendered), [GATEWAY], controller);
+
+      // Two sources, one name, two record types — the state that fails a
+      // whole-zone sync rather than one record. It is also what says the hold-out
+      // is load-bearing on this cluster: a controller not running the route
+      // source could not contend, and this would fail.
+      expect(publication.contended).toEqual([CANONICAL]);
+      expect(publication.records).toHaveLength(2);
     });
-  }
 
-  /** The chart stops stating the record. */
-  function unstated(objects: readonly RenderedObject[]): RenderedObject[] {
-    return objects.filter((object) => object.kind !== 'DNSEndpoint');
-  }
+    test('a Component whose record is no longer stated answers off the gateway', async () => {
+      const rendered = await renderRelease({ reach: 'public' });
+      const publication = publish(
+        unheldOut(unstated(rendered)),
+        [GATEWAY],
+        controller,
+      );
 
-  test('a route that stops holding itself out claims its own name a second time', async () => {
-    const rendered = await renderRelease({ reach: 'public' });
-    const publication = publish(unheldOut(rendered), [GATEWAY]);
+      // Nothing is contended and nothing errors: one source, one record, and a
+      // `public` Component answering an RFC1918 address on the public internet.
+      // Reach was ignored and the zone is perfectly healthy about it, which is
+      // the shape of failure this suite exists for.
+      expect(publication.contended).toEqual([]);
+      expect(publication.records).toEqual([
+        {
+          dnsName: CANONICAL,
+          recordType: 'A',
+          targets: GATEWAY.addresses,
+          proxied: false,
+          claimedBy: 'httproute/blog-web',
+        },
+      ]);
+    });
 
-    // Two sources, one name, two record types — the state that fails a
-    // whole-zone sync rather than one record.
-    expect(publication.contended).toEqual([CANONICAL]);
-    expect(publication.records).toHaveLength(2);
+    test('a record nothing states and nothing derives is no record', async () => {
+      // The hold-out on its own is not a fix: with the DNSEndpoint gone it is
+      // just a name that resolves nowhere. Both halves are the mechanism.
+      const rendered = await renderRelease({ reach: 'public' });
+      expect(
+        publish(unstated(rendered), [GATEWAY], controller).records,
+      ).toEqual([]);
+    });
+
+    test('a controller that stops reading stated records publishes nothing', async () => {
+      // The half of the mechanism that is not Spindrift's code, mutated where it
+      // is declared: drop `crd` from this cluster's sources and the DNSEndpoint
+      // is read by nobody while the route is still held out, so no source claims
+      // the name — and `--policy=sync` then deletes the record already there.
+      // Every object the chart renders is untouched and still correct.
+      const rendered = await renderRelease({ reach: 'public' });
+      const deaf = {
+        ...controller,
+        sources: controller.sources.filter((source) => source !== 'crd'),
+      };
+      expect(publish(rendered, [GATEWAY], deaf).records).toEqual([]);
+    });
+  },
+);
+
+/**
+ * The controller these tests model is the one the clusters declare.
+ *
+ * Reading it is only worth anything if it is read for every cluster a Component
+ * can land on, and if an installation the model does not actually cover fails
+ * rather than being quietly approximated. Both are asserted here.
+ */
+describe('the modelled controller is the declared one', () => {
+  test('every Kubernetes Target runs a controller read off its own cluster', async () => {
+    const release = Bun.YAML.parse(
+      await Bun.file(join(REPO_ROOT, LIVE_RELEASE)).text(),
+    ) as {
+      spec?: {
+        values?: {
+          manifest?: { targets?: { vessel?: string; adapter?: string }[] };
+        };
+      };
+    };
+    const clusters = (release.spec?.values?.manifest?.targets ?? [])
+      .filter((target) => target.adapter === 'kubernetes')
+      .map((target) => target.vessel)
+      .filter((vessel) => vessel !== undefined);
+
+    expect(clusters.length).toBeGreaterThan(0);
+    for (const cluster of clusters) {
+      expect(CONTROLLERS.map((controller) => controller.cluster)).toContain(
+        cluster,
+      );
+    }
   });
 
-  test('a Component whose record is no longer stated answers off the gateway', async () => {
-    const rendered = await renderRelease({ reach: 'public' });
-    const publication = publish(unheldOut(unstated(rendered)), [GATEWAY]);
-
-    // Nothing is contended and nothing errors: one source, one record, and a
-    // `public` Component answering an RFC1918 address on the public internet.
-    // Reach was ignored and the zone is perfectly healthy about it, which is
-    // the shape of failure this suite exists for.
-    expect(publication.contended).toEqual([]);
-    expect(publication.records).toEqual([
-      {
-        dnsName: CANONICAL,
-        recordType: 'A',
-        targets: GATEWAY.addresses,
-        proxied: false,
-        claimedBy: 'httproute/blog-web',
-      },
-    ]);
-  });
-
-  test('a record nothing states and nothing derives is no record', async () => {
-    // The hold-out on its own is not a fix: with the DNSEndpoint gone it is
-    // just a name that resolves nowhere. Both halves are the mechanism.
-    const rendered = await renderRelease({ reach: 'public' });
-    expect(publish(unstated(rendered), [GATEWAY]).records).toEqual([]);
+  test('an argument the model does not account for is refused, not ignored', () => {
+    // `--annotation-prefix` renames every annotation key, including the one the
+    // route holds itself out with. A model that shrugged at an unfamiliar
+    // argument would keep holding the route out of a source that had stopped
+    // seeing the hold-out — one name, two record types, whole-zone sync down.
+    const overlay = {
+      resources: ['../../../base/networking/external-dns'],
+      patches: [
+        {
+          target: { kind: 'HelmRelease', name: 'external-dns' },
+          patch:
+            '- op: add\n' +
+            '  path: /spec/values/extraArgs/-\n' +
+            '  value: --annotation-prefix=dns.example.test/\n',
+        },
+      ],
+    };
+    expect(() =>
+      controllerFor(
+        'somewhere',
+        { spec: { values: { sources: ['crd'], extraArgs: [] } } },
+        overlay,
+      ),
+    ).toThrow(/--annotation-prefix/);
   });
 });

--- a/apps/spindrift/test/harness/app-chart.ts
+++ b/apps/spindrift/test/harness/app-chart.ts
@@ -1,0 +1,74 @@
+/**
+ * The App chart, rendered with the values a Target was actually applied.
+ *
+ * The chart's own goldens live where the chart does
+ * (`packages/charts/spindrift-app/tests/`) and render over a baseline of
+ * representative values. This renders over **no** baseline: what goes in is the
+ * inline blob the adapter wrote onto the delivery object and nothing else, so a
+ * value core stopped rendering is a chart that falls back to `values.yaml`
+ * rather than a merge that hides it.
+ */
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/** The chart this installation deploys every Component through. */
+const CHART = join(
+  import.meta.dir,
+  '../../../../packages/charts/spindrift-app',
+);
+
+/** One rendered object, as loosely typed as YAML actually is. */
+export interface RenderedObject {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    annotations?: Record<string, string>;
+  };
+  spec?: any;
+}
+
+/** `helm template` over the chart, parsed, with `values` as the whole input. */
+export async function renderAppChart(
+  values: unknown,
+  namespace = 'spindrift-apps',
+): Promise<RenderedObject[]> {
+  const file = join(tmpdir(), `spindrift-values-${crypto.randomUUID()}.json`);
+  await Bun.write(file, JSON.stringify(values));
+  try {
+    const helm = Bun.spawn(
+      [
+        'helm',
+        'template',
+        'release',
+        CHART,
+        '--namespace',
+        namespace,
+        '--values',
+        file,
+      ],
+      { stdout: 'pipe', stderr: 'pipe' },
+    );
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(helm.stdout).text(),
+      new Response(helm.stderr).text(),
+      helm.exited,
+    ]);
+    if (code !== 0) {
+      throw new Error(`helm template failed (${code}): ${stderr}`);
+    }
+    const documents = Bun.YAML.parse(stdout) as unknown;
+    const list = Array.isArray(documents) ? documents : [documents];
+    return list.filter(
+      (document): document is RenderedObject =>
+        typeof document === 'object' &&
+        document !== null &&
+        typeof (document as RenderedObject).kind === 'string',
+    );
+  } finally {
+    await Bun.file(file)
+      .delete()
+      .catch(() => {});
+  }
+}

--- a/apps/spindrift/test/harness/external-dns-installation.ts
+++ b/apps/spindrift/test/harness/external-dns-installation.ts
@@ -1,0 +1,176 @@
+/**
+ * The DNS controller each cluster runs, read off the cluster manifests (§9).
+ *
+ * Publication is a two-party mechanism and Spindrift owns one party: the App
+ * chart states a record in a `DNSEndpoint` and holds its own route out of the
+ * route source. Both halves are inert unless the controller is configured to
+ * read the first and to be the thing the second is held out of, and that
+ * configuration is declared in `clusters/`, not here. So it is read from
+ * `clusters/`: a model that hardcodes `--source=crd` keeps agreeing with itself
+ * after the sources list loses `crd`, and that installation publishes nothing
+ * at all — the routes are still held out, no source claims an App's name, and
+ * `--policy=sync` deletes the records that are already there.
+ *
+ * **What this refuses to model matters as much as what it reads.** An argument
+ * outside {@link INERT_ARGUMENTS} fails here rather than being ignored, because
+ * the arguments that would change the answer — which namespaces a source reads,
+ * what an annotation key is called, which kind the `crd` source reads — are not
+ * enumerable, and a model that shrugs at an argument it has not seen is the
+ * hardcoded premise again with more steps.
+ */
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import type { Controller } from './fakes/external-dns.ts';
+
+const REPO_ROOT = join(import.meta.dir, '../../../..');
+
+/** The one declaration of what the controller runs, shared by every cluster. */
+const RELEASE = 'clusters/base/networking/external-dns/helm-release.yaml';
+
+/** Where a cluster builds on it. */
+const overlayPath = (cluster: string) =>
+  `clusters/${cluster}/networking/external-dns/kustomization.yaml`;
+
+/**
+ * Arguments that change nothing this model reads.
+ *
+ * `--fqdn-template` only names a hostname for an object that has none
+ * (`source/gateway.go`, `hosts()`), and every route the App chart renders
+ * carries its own. That holds only while `--combine-fqdn-annotation` is absent
+ * — which is itself an argument, so this list is what keeps it absent.
+ */
+const INERT_ARGUMENTS = [/^--fqdn-template=/];
+
+export interface ExternalDnsRelease {
+  spec?: { values?: { sources?: unknown; extraArgs?: unknown } };
+}
+
+export interface ExternalDnsOverlay {
+  resources?: unknown;
+  patches?: unknown;
+}
+
+interface Patch {
+  target?: { kind?: string; name?: string };
+  patch?: string;
+}
+
+interface PatchOperation {
+  op?: string;
+  path?: string;
+  value?: unknown;
+}
+
+/** Every cluster that builds on {@link RELEASE}, as it configures it. */
+export async function installedControllers(): Promise<Controller[]> {
+  const release = (await parse(RELEASE)) as ExternalDnsRelease;
+  const controllers: Controller[] = [];
+  for (const entry of await readdir(join(REPO_ROOT, 'clusters'), {
+    withFileTypes: true,
+  })) {
+    if (!entry.isDirectory() || entry.name === 'base') continue;
+    const overlay = overlayPath(entry.name);
+    if (!(await Bun.file(join(REPO_ROOT, overlay)).exists())) continue;
+    controllers.push(
+      controllerFor(
+        entry.name,
+        release,
+        (await parse(overlay)) as ExternalDnsOverlay,
+      ),
+    );
+  }
+  if (controllers.length === 0) {
+    throw new Error(`no cluster builds on ${RELEASE}: the paths have moved`);
+  }
+  return controllers;
+}
+
+/**
+ * One cluster's controller, from the shared release and that cluster's overlay.
+ *
+ * Kept apart from the reading so the refusals below can be shown failing: a
+ * guard only ever handed the manifest it agrees with is a guard nobody has seen
+ * work.
+ */
+export function controllerFor(
+  cluster: string,
+  release: ExternalDnsRelease,
+  overlay: ExternalDnsOverlay,
+): Controller {
+  const origin = overlayPath(cluster);
+  if (!buildsOnRelease(overlay)) {
+    throw new Error(`${origin} declares an external-dns of its own`);
+  }
+  const argued = [
+    ...strings(release.spec?.values?.extraArgs, `${RELEASE} extraArgs`),
+    ...appendedArguments(overlay, origin),
+  ];
+  for (const argument of argued) {
+    if (INERT_ARGUMENTS.some((inert) => inert.test(argument))) continue;
+    throw new Error(
+      `${cluster}'s external-dns runs ${argument}, which this model does not ` +
+        'account for: model what it changes about a published record, or list ' +
+        'it as inert once it is known to change nothing',
+    );
+  }
+  return {
+    cluster,
+    sources: strings(release.spec?.values?.sources, `${RELEASE} sources`),
+  };
+}
+
+/** Arguments a cluster appends to the shared list, as a JSON patch does. */
+function appendedArguments(
+  overlay: ExternalDnsOverlay,
+  origin: string,
+): string[] {
+  const appended: string[] = [];
+  for (const patch of asArray<Patch>(overlay.patches)) {
+    if (patch.target?.kind !== 'HelmRelease') continue;
+    if (patch.target?.name !== 'external-dns') continue;
+    const operations = Bun.YAML.parse(patch.patch ?? '');
+    if (!Array.isArray(operations)) {
+      throw new Error(`${origin} patches external-dns by merge, not by op`);
+    }
+    for (const operation of operations as PatchOperation[]) {
+      const path = operation.path ?? '';
+      if (operation.op === 'add' && path === '/spec/values/extraArgs/-') {
+        appended.push(String(operation.value));
+        continue;
+      }
+      if (
+        path.startsWith('/spec/values/extraArgs') ||
+        path.startsWith('/spec/values/sources')
+      ) {
+        throw new Error(`${origin} ${operation.op}s ${path}, which is unread`);
+      }
+    }
+  }
+  return appended;
+}
+
+function buildsOnRelease(overlay: ExternalDnsOverlay): boolean {
+  return asArray<unknown>(overlay.resources).some(
+    (resource) =>
+      typeof resource === 'string' &&
+      resource.replace(/\/+$/, '').endsWith('base/networking/external-dns'),
+  );
+}
+
+function asArray<T>(value: unknown): T[] {
+  return Array.isArray(value) ? (value as T[]) : [];
+}
+
+function strings(value: unknown, what: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    value.some((entry) => typeof entry !== 'string')
+  ) {
+    throw new Error(`${what} is not a list of strings`);
+  }
+  return value;
+}
+
+async function parse(path: string): Promise<unknown> {
+  return Bun.YAML.parse(await Bun.file(join(REPO_ROOT, path)).text());
+}

--- a/apps/spindrift/test/harness/fakes/external-dns.ts
+++ b/apps/spindrift/test/harness/fakes/external-dns.ts
@@ -8,8 +8,9 @@
  * a route asked for a proxied name at its tunnel and the zone was given an
  * unproxied address at the shared gateway instead.
  *
- * Two sources, because the installation runs both (`--source=crd
- * --source=gateway-httproute`) and the whole defect was that the second one
+ * Two sources are modelled, and **which of them the controller runs is read off
+ * the cluster manifests** rather than assumed here — see {@link Controller} and
+ * `../external-dns-installation.ts`. The whole defect was that the second
  * answered for names the first was written to state:
  *
  * - **`crd`** passes `spec.endpoints` through as written, which is what makes a
@@ -32,6 +33,24 @@
  * hostname on an attached route matches one, and modelling the negotiation
  * would only re-derive that.
  */
+
+/**
+ * The controller as an installation configures it, not as this file assumes.
+ *
+ * Only the source list, because that is the whole of what the installation
+ * decides about a record here: `crd` is what reads the record the chart states,
+ * `gateway-httproute` is the one the route holds itself out of, and either
+ * leaving the list changes what a Component's name answers to without changing
+ * a single thing Spindrift renders. Everything else the controller is passed is
+ * refused rather than modelled, upstream of this — see
+ * `../external-dns-installation.ts`.
+ */
+export interface Controller {
+  /** The cluster whose declaration this is, so a failure names it. */
+  readonly cluster: string;
+  /** `--source=…`, as that cluster declares them. */
+  readonly sources: readonly string[];
+}
 
 /** One object a source reads, as loosely typed as the API's own JSON. */
 export interface ClusterObject {
@@ -79,7 +98,14 @@ export interface Publication {
 /** The annotation a source honours to leave an object alone. */
 export const CONTROLLER = 'external-dns.alpha.kubernetes.io/controller';
 
-/** The only value that means "this one is mine". */
+/**
+ * The only value that means "this one is mine".
+ *
+ * Upstream's `ControllerValue` constant and not a thing an installation sets —
+ * no flag changes it. The annotation *key* is `AnnotationKeyPrefix +
+ * "controller"` and that prefix is settable, which is one of the reasons an
+ * argument this model has not accounted for is refused rather than ignored.
+ */
 export const CONTROLLER_ID = 'dns-controller';
 
 const TARGET = 'external-dns.alpha.kubernetes.io/target';
@@ -91,8 +117,14 @@ const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
 export function publish(
   objects: readonly ClusterObject[],
   gateways: readonly GatewayStatus[],
+  controller: Controller,
 ): Publication {
-  const records = [...fromEndpoints(objects), ...fromRoutes(objects, gateways)];
+  const records = [
+    ...(controller.sources.includes('crd') ? fromEndpoints(objects) : []),
+    ...(controller.sources.includes('gateway-httproute')
+      ? fromRoutes(objects, gateways)
+      : []),
+  ];
   const claimants = new Map<string, number>();
   for (const record of records) {
     claimants.set(record.dnsName, (claimants.get(record.dnsName) ?? 0) + 1);

--- a/apps/spindrift/test/harness/fakes/external-dns.ts
+++ b/apps/spindrift/test/harness/fakes/external-dns.ts
@@ -1,0 +1,194 @@
+/**
+ * The DNS controller's source layer, as far as a record depends on it (§9).
+ *
+ * **Fake the far side, never our side.** Spindrift renders objects and a
+ * controller turns them into records; the turning is the far side, and it is
+ * the half nothing here could otherwise observe. A rendering golden asserts
+ * what a Component *asks* to publish, which is exactly what stayed green while
+ * a route asked for a proxied name at its tunnel and the zone was given an
+ * unproxied address at the shared gateway instead.
+ *
+ * Two sources, because the installation runs both (`--source=crd
+ * --source=gateway-httproute`) and the whole defect was that the second one
+ * answered for names the first was written to state:
+ *
+ * - **`crd`** passes `spec.endpoints` through as written, which is what makes a
+ *   `DNSEndpoint` a statement rather than a hint.
+ * - **`gateway-httproute`** derives an endpoint per route hostname, taking its
+ *   targets from the parent **Gateway** — its `…/target` annotation if it
+ *   carries one, else its `status.addresses` — and reading provider config off
+ *   the *route*. A route can never state its own target, so every Component on
+ *   one shared gateway gets that gateway's address whatever its reach is.
+ *
+ * Both are modelled skipping any object whose {@link CONTROLLER} annotation
+ * names something other than {@link CONTROLLER_ID}. The route source is where
+ * that check is documented, and applying it to the CRD source too is the
+ * conservative direction: it makes the model publish *less* than the
+ * controller would, so a record this model drops is a test that fails rather
+ * than a name that quietly resolves.
+ *
+ * What is deliberately not modelled: listener matching. The Gateway a Target
+ * names carries a wildcard listener covering the whole App zone, so every
+ * hostname on an attached route matches one, and modelling the negotiation
+ * would only re-derive that.
+ */
+
+/** One object a source reads, as loosely typed as the API's own JSON. */
+export interface ClusterObject {
+  apiVersion: string;
+  kind: string;
+  metadata: {
+    name: string;
+    namespace?: string;
+    annotations?: Record<string, string>;
+  };
+  spec?: any;
+}
+
+/** A Gateway a route parents onto, as the API reports it. */
+export interface GatewayStatus {
+  name: string;
+  namespace: string;
+  /** `status.addresses[*].value` — the route source's fallback target. */
+  addresses: readonly string[];
+  annotations?: Record<string, string>;
+}
+
+/** One record the zone provider would be asked to write. */
+export interface PublishedRecord {
+  dnsName: string;
+  recordType: string;
+  targets: readonly string[];
+  proxied: boolean;
+  /** The source that claimed the name, and the object it read it from. */
+  claimedBy: string;
+}
+
+export interface Publication {
+  readonly records: readonly PublishedRecord[];
+  /**
+   * Names more than one source claimed.
+   *
+   * Never an empty formality: two sources claiming one name at two record
+   * types is the state that soft-errors a whole-zone sync, and it is what the
+   * route's hold-out exists to prevent.
+   */
+  readonly contended: readonly string[];
+}
+
+/** The annotation a source honours to leave an object alone. */
+export const CONTROLLER = 'external-dns.alpha.kubernetes.io/controller';
+
+/** The only value that means "this one is mine". */
+export const CONTROLLER_ID = 'dns-controller';
+
+const TARGET = 'external-dns.alpha.kubernetes.io/target';
+const PROXIED = 'external-dns.alpha.kubernetes.io/cloudflare-proxied';
+
+const IPV4 = /^\d{1,3}(\.\d{1,3}){3}$/;
+
+/** What the controller would publish for one namespace's objects. */
+export function publish(
+  objects: readonly ClusterObject[],
+  gateways: readonly GatewayStatus[],
+): Publication {
+  const records = [...fromEndpoints(objects), ...fromRoutes(objects, gateways)];
+  const claimants = new Map<string, number>();
+  for (const record of records) {
+    claimants.set(record.dnsName, (claimants.get(record.dnsName) ?? 0) + 1);
+  }
+  return {
+    records,
+    contended: [...claimants]
+      .filter(([, count]) => count > 1)
+      .map(([name]) => name),
+  };
+}
+
+/** The `crd` source: `spec.endpoints`, verbatim. */
+function fromEndpoints(objects: readonly ClusterObject[]): PublishedRecord[] {
+  const records: PublishedRecord[] = [];
+  for (const object of objects) {
+    if (object.kind !== 'DNSEndpoint' || heldOut(object)) continue;
+    for (const endpoint of object.spec?.endpoints ?? []) {
+      records.push({
+        dnsName: endpoint.dnsName,
+        recordType: endpoint.recordType,
+        targets: endpoint.targets ?? [],
+        proxied: proxied(
+          Object.fromEntries(
+            (endpoint.providerSpecific ?? []).map(
+              (entry: { name: string; value: string }) => [
+                entry.name,
+                entry.value,
+              ],
+            ),
+          ),
+        ),
+        claimedBy: `crd/${object.metadata.name}`,
+      });
+    }
+  }
+  return records;
+}
+
+/** The `gateway-httproute` source: one endpoint per hostname, off the parent. */
+function fromRoutes(
+  objects: readonly ClusterObject[],
+  gateways: readonly GatewayStatus[],
+): PublishedRecord[] {
+  const records: PublishedRecord[] = [];
+  for (const object of objects) {
+    if (object.kind !== 'HTTPRoute' || heldOut(object)) continue;
+    const targets = parentTargets(object, gateways);
+    if (targets.length === 0) continue;
+    for (const hostname of object.spec?.hostnames ?? []) {
+      records.push({
+        dnsName: hostname,
+        // One record type for the whole set, as the source picks it: the
+        // targets come from one parent, so they are all addresses or all names.
+        recordType: suitableType(targets[0] as string),
+        targets,
+        proxied: proxied(object.metadata.annotations),
+        claimedBy: `httproute/${object.metadata.name}`,
+      });
+    }
+  }
+  return records;
+}
+
+/** The Gateway's stated target, else the address it reports for itself. */
+function parentTargets(
+  route: ClusterObject,
+  gateways: readonly GatewayStatus[],
+): readonly string[] {
+  const targets: string[] = [];
+  for (const parent of route.spec?.parentRefs ?? []) {
+    const gateway = gateways.find(
+      (candidate) =>
+        candidate.name === parent.name &&
+        candidate.namespace === (parent.namespace ?? route.metadata.namespace),
+    );
+    if (gateway === undefined) continue;
+    const stated = gateway.annotations?.[TARGET];
+    targets.push(
+      ...(stated === undefined ? gateway.addresses : stated.split(',')),
+    );
+  }
+  return targets;
+}
+
+function heldOut(object: ClusterObject): boolean {
+  const claimed = object.metadata.annotations?.[CONTROLLER];
+  return claimed !== undefined && claimed !== CONTROLLER_ID;
+}
+
+function proxied(config: Record<string, string> | undefined): boolean {
+  return config?.[PROXIED] === 'true';
+}
+
+/** An address is an address record; anything else is a name. */
+function suitableType(target: string): string {
+  if (IPV4.test(target)) return 'A';
+  return target.includes(':') ? 'AAAA' : 'CNAME';
+}

--- a/turbo.json
+++ b/turbo.json
@@ -46,6 +46,8 @@
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/charts/spindrift-app/Chart.yaml",
+        "$TURBO_ROOT$/packages/charts/spindrift-app/values.yaml",
+        "$TURBO_ROOT$/packages/charts/spindrift-app/templates/**",
         "$TURBO_ROOT$/clusters/offsite/apps/spindrift/helm-release.yaml"
       ],
       "env": ["DATABASE_URL"],

--- a/turbo.json
+++ b/turbo.json
@@ -48,7 +48,9 @@
         "$TURBO_ROOT$/packages/charts/spindrift-app/Chart.yaml",
         "$TURBO_ROOT$/packages/charts/spindrift-app/values.yaml",
         "$TURBO_ROOT$/packages/charts/spindrift-app/templates/**",
-        "$TURBO_ROOT$/clusters/offsite/apps/spindrift/helm-release.yaml"
+        "$TURBO_ROOT$/clusters/offsite/apps/spindrift/helm-release.yaml",
+        "$TURBO_ROOT$/clusters/base/networking/external-dns/helm-release.yaml",
+        "$TURBO_ROOT$/clusters/*/networking/external-dns/kustomization.yaml"
       ],
       "env": ["DATABASE_URL"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]


### PR DESCRIPTION
## Summary

Something now fails if publication stops honouring `reach`. Publication is a two-party mechanism: the App chart states a record in a `DNSEndpoint` and holds its own routes out of the route source; the external-dns controller declared in `clusters/` reads the first and ignores the second. Both halves are now under test, driven by the real rendering code and the real cluster manifests rather than restated premises.

- `test/conformance/reach-publication.test.ts` renders the chart through the real code for `reach: public` and `reach: private` and asserts the record each publishes: a proxied CNAME at the tunnel hostname for public, unproxied A records at the gateway address for private, and the controller annotation that keeps the route source out of it. A mutation that stops `reach` driving any of that fails.
- The controller's own configuration is read off `clusters/base/networking/external-dns/helm-release.yaml` and each cluster's overlay instead of being hardcoded in the fake — a sources list that loses `crd` publishes nothing and `--policy=sync` would delete the records already there, so the model agreeing with itself was half the mechanism unguarded. An `extraArgs` entry the model does not account for is refused, not ignored.
- `turbo.json`'s `spindrift#test` inputs gain the external-dns manifests, so CI reruns these tests when the controller declaration changes.

## Validation

- `bun run typecheck` clean; `bun run lint` clean.
- `bun test`: 1756 pass / 0 fail (131 files). The only environment-sensitive failures elsewhere (`test/adapters/` shelling out to `node`/`jq`) are untouched and pass with those tools on PATH.
- Negative halves proven in-test: dropping `crd` from the sources publishes nothing; an unknown controller argument is refused; a controller reading route sources would double-publish and fails.

## Risk

Cross-tree coupling, deliberate: `apps/spindrift` tests now read `clusters/**/networking/external-dns/*`. That is the point of the guard — the two halves of publication live in two trees, and the test is what notices when they stop agreeing.
