### PR TITLE
refactor(spindrift): discover a vessel's surfaces instead of deriving them

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -199,9 +199,26 @@ that owns the federation, and that can `404`. A cluster is one. A cloud project
 is one. A **Target** is one runtime surface on a vessel — `Target = Vessel ×
 surface` — and a Target is what an App's Component is placed on.
 
-That is why connecting one cloud project registers two Targets, `cloudrun` and
+That is why connecting one cloud project asks about two surfaces, `cloudrun` and
 `static`: placement determines artifact shape, and a single "Cloud" Target would
 leave a website ambiguous between the Cloud Run rendering and the static one.
+
+**Which surfaces a vessel carries is discovered, not derived from its kind.**
+Connect probes the boundary for each surface and registers a Target for each one
+it finds; a project whose Cloud Run API is switched off gets no `cloudrun`
+Target and a sentence saying why. A `kind` decides one thing — which shape
+`location` has — and the probe list (`PROBED_SURFACES_BY_VESSEL_KIND`) is a list
+of questions rather than an answer, which is what stops a project that runs a
+cluster from needing a `gcp-project-with-gke` kind. "Which surfaces does this
+vessel carry" is a query over `targets`, and there is no second copy of it.
+
+**"Not there" and "could not tell" are different answers.** Only an established
+absence withholds a Target; a refused read, a missing federation or an
+unreachable endpoint registers the Target unhealthy with the sentence attached,
+because a confident absence rendered off a failed read is the one thing worse
+than an unhealthy row. Nothing ever removes a Target that already exists — a
+surface that stops answering keeps its row and fails the checklist, and the
+standing loop refreshes rows without ever creating or deleting one.
 
 The split decides where every fact lives. What is true of the boundary, and
 therefore of every surface on it — where it is, which hosts it serves, which

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -220,6 +220,13 @@ than an unhealthy row. Nothing ever removes a Target that already exists — a
 surface that stops answering keeps its row and fails the checklist, and the
 standing loop refreshes rows without ever creating or deleting one.
 
+**A surface found later joins the vessel when somebody asks again.** The absence
+is deliberately not stored: what a boundary carries is a fact about the
+boundary, and a copy of it here would go stale the moment the API is switched
+on. So the answer to "it exists now" is the connect act run again, which the
+Targets screen offers on a boundary that is already connected, and which changes
+no Target that was already there.
+
 The split decides where every fact lives. What is true of the boundary, and
 therefore of every surface on it — where it is, which hosts it serves, which
 registries it reaches — belongs to the vessel, stated once, where two surfaces

--- a/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
@@ -24,11 +24,17 @@
  * non-candidate with a stated reason, and "not assessed" is a stated reason —
  * whereas reporting it met would be core deciding that what it failed to check
  * was fine.
+ *
+ * That same probe answers a second question — {@link cloudSurfaceProbe} — which
+ * is whether this project carries the runtime at all. It is separate from the
+ * checklist because it decides something the checklist never did: whether there
+ * is a Target here to keep a checklist about.
  */
 import type {
   Prerequisite,
   PrerequisiteResult,
 } from '../../../domain/capabilities.ts';
+import type { SurfaceProbe } from '../../../domain/vessel.ts';
 import type { CloudResponse } from './http.ts';
 
 /** The three items a cloud Target is assessed against, in display order. */
@@ -114,6 +120,48 @@ export function cloudChecklist(
   return allUnmet(
     `${subject.service} answered ${probe.status}: ${probe.message}`,
   );
+}
+
+/**
+ * Whether that same probe established the project carries this runtime.
+ *
+ * One question off the call the checklist already made, because the answer is
+ * in the same refusal. A cloud runtime is a service that is switched on per
+ * project, so **the service being off is the surface not being there** — the
+ * `cloudrun` Target an operator would otherwise get is a row nothing can ever
+ * be placed on, and §14 forbids Spindrift turning the service on to make it
+ * true.
+ *
+ * Every other refusal is `undetermined`, and the `404` is the one worth stating
+ * a reason for: a cloud API answers `404` for a project this identity may not
+ * see as readily as for one that is not there, so reading it as an absence
+ * would delete a Target over a missing IAM grant. It stays a `VESSEL` row on a
+ * Target that exists, where the loop re-checks it.
+ */
+export function cloudSurfaceProbe(
+  probe: CloudResponse<unknown>,
+  subject: CloudChecklistSubject,
+): SurfaceProbe {
+  if (probe.ok) return { kind: 'carried' };
+  if (probe.kind === 'transport') {
+    return {
+      kind: 'undetermined',
+      detail: `${subject.service} could not be reached: ${probe.message}`,
+    };
+  }
+  if (
+    probe.reason === SERVICE_DISABLED ||
+    probe.body.includes(SERVICE_DISABLED)
+  ) {
+    return {
+      kind: 'absent',
+      detail: `the ${subject.service} API is not enabled on ${subject.project}, so it carries no ${subject.service} surface`,
+    };
+  }
+  return {
+    kind: 'undetermined',
+    detail: `${subject.service} answered ${probe.status}: ${probe.message}`,
+  };
 }
 
 /** Every item unmet, with one sentence — the Target nothing is known about. */

--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -58,7 +58,7 @@ import {
   targetLabel,
 } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
-import { cloudChecklist } from '../cloud/checklist.ts';
+import { cloudChecklist, cloudSurfaceProbe } from '../cloud/checklist.ts';
 import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
 import { cloudWriteFailure, orderedChecklist } from '../cloud/verdict.ts';
 import type {
@@ -758,15 +758,19 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       query: { pageSize: '1' },
     });
 
-    const prerequisites = cloudChecklist(probe, {
+    const subject = {
       project: connection.project,
       service: SERVICE_NAME,
       scope: `${connection.project} in ${connection.region}`,
-    });
+    };
 
     return {
-      prerequisites: orderedChecklist(prerequisites, this.adapter),
+      prerequisites: orderedChecklist(
+        cloudChecklist(probe, subject),
+        this.adapter,
+      ),
       discovery: await this.discover(connection),
+      surface: cloudSurfaceProbe(probe, subject),
     };
   }
 

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -648,7 +648,12 @@ export class KubernetesDeployAdapter implements DeployAdapter {
       this.checklist(api, connection),
       this.discover(api, connection),
     ]);
-    return { prerequisites, discovery };
+    // A cluster *is* its `kubernetes` surface — there is no second service to
+    // have switched off — so getting this far is the whole probe. The reads
+    // above throw rather than degrade when the API server does not answer, and
+    // core reads that as `undetermined`, which is the honest arm: nothing was
+    // established about a cluster nobody could reach.
+    return { prerequisites, discovery, surface: { kind: 'carried' } };
   }
 
   /**

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -44,7 +44,7 @@ import {
   targetLabel,
 } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
-import { cloudChecklist } from '../cloud/checklist.ts';
+import { cloudChecklist, cloudSurfaceProbe } from '../cloud/checklist.ts';
 import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
 import {
   type CloudFailure,
@@ -342,17 +342,19 @@ export class StaticDeployAdapter implements DeployAdapter {
       path: `${API_VERSION}/projects/${encodeURIComponent(connection.project)}/sites`,
       query: { pageSize: '1' },
     });
+    const subject = {
+      project: connection.project,
+      service: SERVICE_NAME,
+      scope: connection.project,
+    };
 
     return {
       prerequisites: orderedChecklist(
-        cloudChecklist(probe, {
-          project: connection.project,
-          service: SERVICE_NAME,
-          scope: connection.project,
-        }),
+        cloudChecklist(probe, subject),
         this.adapter,
       ),
       discovery: this.discover(connection),
+      surface: cloudSurfaceProbe(probe, subject),
     };
   }
 

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -14,10 +14,20 @@
  * to look at and nothing for the loop to re-check.
  *
  * **The act is credential-shaped though the noun is flat.** Connecting a cloud
- * project registers *both* of that project's Targets — `cloudrun` and `static` —
- * because placement determines artifact shape and a single "Cloud" Target would
- * leave a website ambiguous between the two renderings. That is also why no
- * `Provider` noun exists: the shared thing is an argument to this command.
+ * project asks about *both* of that project's surfaces — `cloudrun` and
+ * `static` — because placement determines artifact shape and a single "Cloud"
+ * Target would leave a website ambiguous between the two renderings. That is
+ * also why no `Provider` noun exists: the shared thing is an argument to this
+ * command.
+ *
+ * **What it asks about and what it registers are different lists.**
+ * `surfacesToProbe` names the questions; the Targets are the answers. A project
+ * whose Cloud Run API is switched off gets no `cloudrun` Target — it gets a
+ * checklist saying the surface is not there, and connect still succeeds. A
+ * surface the probe could not settle *does* get its Target, unhealthy, with the
+ * sentence attached: withholding a row on a refused read would state an absence
+ * nobody established. Neither arm ever removes a Target that already exists —
+ * a row that has been deployed to is not a probe's to delete.
  *
  * Connect is **idempotent by `(vessel, adapter)`** — which is what a Target is,
  * so there is nothing else it could be idempotent by. Re-running it re-inspects,
@@ -43,7 +53,7 @@ import {
   type TargetHealth,
 } from '../../domain/target.ts';
 import {
-  surfacesOf,
+  surfacesToProbe,
   type VesselKind,
   type VesselLocation,
 } from '../../domain/vessel.ts';
@@ -189,9 +199,32 @@ export interface ConnectedTarget {
   readonly prerequisites: readonly PrerequisiteResult[];
 }
 
+/** A surface this act probed for and established the vessel does not carry. */
+export interface AbsentSurface {
+  readonly vessel: string;
+  readonly adapter: TargetAdapter;
+  /**
+   * The checklist as the probe answered it.
+   *
+   * Every row unmet, and the one that establishes the absence carries the
+   * sentence — the same grammar a registered Target's unmet item has, because
+   * "there is no Cloud Run here" and "Cloud Run here is unhealthy" are the same
+   * kind of thing to read and act on.
+   */
+  readonly prerequisites: readonly PrerequisiteResult[];
+  /** What the probe established, in one sentence. */
+  readonly detail: string;
+}
+
 export interface ConnectTargetResult {
-  /** One entry for a cluster, two for a cloud project (§13). */
+  /** One entry per surface the probe did not rule out (§13). */
   readonly targets: readonly ConnectedTarget[];
+  /**
+   * Surfaces the probe established are not on this vessel, and so were not
+   * registered. Empty is the ordinary case; a non-empty entry is why a project
+   * an operator expected two Targets from produced one.
+   */
+  readonly absent: readonly AbsentSurface[];
   /** Deploys a previous disconnect stranded that are still running (§13). */
   readonly readopted: readonly string[];
 }
@@ -297,6 +330,7 @@ export const connectTarget: Command<
 
   const now = context.clock.now();
   const registered: ConnectedTarget[] = [];
+  const absent: AbsentSurface[] = [];
   const readopted: string[] = [];
 
   // The boundary first, because every surface below is a row that references
@@ -334,7 +368,7 @@ export const connectTarget: Command<
   // Idempotent by `(vessel, adapter)`, which is what a Target *is*: reconnecting
   // re-adopts the surface that is already there rather than registering a second
   // one competing for the same workloads.
-  for (const adapter of surfacesOf(input.kind)) {
+  for (const adapter of surfacesToProbe(input.kind)) {
     const existing = (
       await context.db
         .select()
@@ -359,8 +393,26 @@ export const connectTarget: Command<
     );
     // One pass of the same loop §13 runs on a schedule — not a second notion of
     // what "healthy" means that happens to run at connect time.
-    const { prerequisites, discovery } = await inspectTarget(context, ref);
+    const { prerequisites, discovery, surface } = await inspectTarget(
+      context,
+      ref,
+    );
     const health = deriveHealth(prerequisites, adapter);
+
+    if (surface.kind === 'absent' && existing === undefined) {
+      // The only branch that writes nothing. An established absence is a fact
+      // about this boundary, so registering the surface anyway would put a row
+      // on the placement screen that nothing can ever be placed on — and
+      // §14 forbids the one remediation that would make it true, which is
+      // Spindrift switching the service on.
+      absent.push({
+        vessel: input.vessel,
+        adapter,
+        prerequisites,
+        detail: surface.detail,
+      });
+      continue;
+    }
 
     if (existing === undefined) {
       // §13: "Rank is one global ordered list." A new Target joins the end of
@@ -431,5 +483,5 @@ export const connectTarget: Command<
     });
   }
 
-  return ok({ targets: registered, readopted });
+  return ok({ targets: registered, absent, readopted });
 };

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -13,9 +13,12 @@ import {
 } from '../../domain/placement.ts';
 import {
   connectionProposal,
+  type OnboardingTargetRow,
   pendingConnections,
 } from '../../domain/target-onboarding.ts';
+import { surfacesToProbe, type VesselLocation } from '../../domain/vessel.ts';
 import type {
+  CloudBoundaryFacts,
   PendingTargetConnection,
   TargetListItem,
   TargetOptionView,
@@ -70,6 +73,108 @@ function canonicalBoundary(
   return zones.private === zones.public
     ? `*.${zones.private}`
     : `*.${zones.private} (private) · *.${zones.public} (public)`;
+}
+
+/** A Target row with the boundary it sits on, as {@link editStart} reads it. */
+type SurfaceOnVessel = OnboardingTargetRow & {
+  readonly vessel: OnboardingTargetRow['vessel'] & {
+    readonly location: VesselLocation | null;
+    readonly servedHosts: readonly string[] | null;
+    readonly reachableRegistries: readonly string[] | null;
+  };
+};
+
+/**
+ * The facts a cloud edit has to restate — see `TargetListItem.edit`.
+ *
+ * Read off the boundary and off its runtime surface, because that is where
+ * `connectTarget` put them: one act supplied them once and fanned them out, so
+ * an edit that re-runs the act has to hand them all back or the act deletes
+ * them.
+ */
+function carriedFacts(
+  vessel: SurfaceOnVessel['vessel'],
+  onVessel: readonly SurfaceOnVessel[],
+): CloudBoundaryFacts {
+  const run = onVessel.find(
+    (row) => row.connection?.adapter === 'cloudrun',
+  )?.connection;
+  const runtime = run?.adapter === 'cloudrun' ? run : null;
+  return {
+    ...(runtime?.serviceAccount === undefined
+      ? {}
+      : { serviceAccount: runtime.serviceAccount }),
+    ...(runtime?.logHistorySeconds === undefined
+      ? {}
+      : { logHistorySeconds: runtime.logHistorySeconds }),
+    ...(vessel.servedHosts === null
+      ? {}
+      : { servedHosts: [...vessel.servedHosts] }),
+    ...(vessel.reachableRegistries === null
+      ? {}
+      : { reachableRegistries: [...vessel.reachableRegistries] }),
+  };
+}
+
+/**
+ * Where an edit of this Target's connection starts — `TargetListItem.edit`.
+ *
+ * A cluster's values come from this Target alone, which is the whole difference
+ * between an edit and a connect: `connectionProposal` prefers a healthy donor
+ * of the same adapter, and given a list of one there is only this row to read.
+ * A donor's values on an edit screen would be the second cluster's address
+ * problem with the Targets the other way round.
+ *
+ * A cloud edit reads this boundary's surfaces **together**, because one connect
+ * writes them together: the region and the runtime endpoint are on `cloudrun`
+ * and the hosting endpoint on `static`, so an edit opened from either that read
+ * only itself would drop the other one's fact. Behind them come the
+ * installation's other cloud Targets, because those three values are
+ * installation-wide rather than this project's — and that is what makes the
+ * edit usable as the re-probe: a vessel whose runtime surface the last probe
+ * did not find has no `cloudrun` row of its own to read an endpoint off.
+ *
+ * Offered only for a surface the boundary's connect act probes for. Editing is
+ * that act run again, so a surface outside its list is one this form would not
+ * write — and a control that does not touch the row it hangs off is worse than
+ * none.
+ */
+function editStart(
+  target: SurfaceOnVessel,
+  allTargets: readonly SurfaceOnVessel[],
+): TargetListItem['edit'] {
+  const location = target.vessel.location;
+  if (target.connection === null || location === null) return null;
+  if (!surfacesToProbe(location.kind).includes(target.adapter)) return null;
+
+  const onVessel = allTargets.filter(
+    (row) => row.vessel.id === target.vessel.id,
+  );
+  // The address is the vessel's, not the surface's — which is exactly why an
+  // edit may state it where a proposal may not.
+  return location.kind === 'cluster'
+    ? {
+        kind: 'cluster',
+        apiServer: location.apiServer,
+        proposal: connectionProposal([target], 'cluster'),
+      }
+    : {
+        kind: 'gcp-project',
+        project: location.project,
+        carried: carriedFacts(target.vessel, onVessel),
+        // This boundary's own surfaces first, the installation's others behind
+        // them: a region and two API endpoints are installation-wide facts a
+        // fresh connect already carries from any working cloud Target, so the
+        // vessel whose runtime surface is not registered *yet* is exactly the
+        // case where another project's are the right thing to offer.
+        proposal: connectionProposal(
+          [
+            ...onVessel,
+            ...allTargets.filter((row) => row.vessel.id !== target.vessel.id),
+          ],
+          'gcp-project',
+        ),
+      };
 }
 
 export interface ListTargetsResult {
@@ -140,21 +245,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
         ),
         target.connection,
       ),
-      // Carried from this Target alone, which is the whole difference between
-      // an edit and a connect: `connectionProposal` prefers a healthy donor of
-      // the same adapter, and given a list of one there is only this row to
-      // read. A donor's values on an edit screen would be the second cluster's
-      // address problem with the Targets the other way round.
-      edit:
-        target.adapter === 'kubernetes' &&
-        target.connection?.adapter === 'kubernetes' &&
-        target.vessel.location?.kind === 'cluster'
-          ? {
-              // The cluster's address is the vessel's, not the surface's.
-              apiServer: target.vessel.location.apiServer,
-              proposal: connectionProposal([target], 'cluster'),
-            }
-          : null,
+      edit: editStart(target, allTargets),
     });
 
     const isConnected = target.status === 'connected';

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -28,11 +28,7 @@
  * and boots each one; adding a shape to that corpus is how a future schema
  * change proves it did not make the re-seed reachable.
  */
-import {
-  unionOfClaims,
-  type VesselKind,
-  vesselKindFor,
-} from '../domain/vessel.ts';
+import { unionOfClaims, type VesselKind } from '../domain/vessel.ts';
 
 /** A JSON object, as a document is before anything has validated it. */
 type Document = Record<string, unknown>;
@@ -109,6 +105,14 @@ function dropTargetNames(document: unknown): unknown {
  * this key existed, so an installation upgraded here gets the same vessel rows
  * it already has: the same names, and the same union of what two surfaces of
  * one boundary each claimed about it.
+ *
+ * **The kind comes from the document, never from the adapter.** What kind of
+ * boundary this is means only what shape its location has, and the old
+ * connection stated that shape directly: an `apiServer` is a cluster and a
+ * `project` is a cloud project. Reading it back off the surface's adapter would
+ * assume each surface belongs to exactly one kind — the assumption a project
+ * that runs a cluster breaks — and would do it inside the one function nothing
+ * else can check.
  */
 function addDeclaredVessels(document: unknown): unknown {
   const manifest = asDocument(document);
@@ -121,7 +125,7 @@ function addDeclaredVessels(document: unknown): unknown {
     string,
     {
       name: string;
-      kind: VesselKind;
+      kind?: VesselKind;
       location?: Document;
       served: (readonly string[] | undefined)[];
       registries: (readonly string[] | undefined)[];
@@ -145,21 +149,18 @@ function addDeclaredVessels(document: unknown): unknown {
       return document;
     }
 
-    const vesselName =
-      adapter === 'kubernetes' ? name : stripSuffix(name, `-${adapter}`);
-    const kind = vesselKindFor(adapter);
+    const vesselName = stripSuffix(name, `-${adapter}`);
     const vessel = vessels.get(vesselName) ?? {
       name: vesselName,
-      kind,
       served: [],
       registries: [],
     };
 
     const connection = asDocument(target.connection);
     if (connection !== null) {
-      // The first surface to state where the boundary is settles it; under the
-      // old schema the pairing rule was what made two surfaces of one project
-      // agree about that.
+      // The first surface to state where the boundary is settles it, and with
+      // it the kind; under the old schema the pairing rule was what made two
+      // surfaces of one project agree about that.
       const {
         apiServer,
         project,
@@ -167,14 +168,11 @@ function addDeclaredVessels(document: unknown): unknown {
         reachableRegistries,
         ...surface
       } = connection;
-      vessel.location ??=
-        kind === 'cluster'
-          ? apiServer === undefined
-            ? undefined
-            : { apiServer }
-          : project === undefined
-            ? undefined
-            : { project };
+      const boundary = boundaryOf(apiServer, project);
+      if (boundary !== null && vessel.kind === undefined) {
+        vessel.kind = boundary.kind;
+        vessel.location = boundary.location;
+      }
       vessel.served.push(asStrings(servedHosts));
       // `static` never carried this key, so it contributes nothing rather than
       // an empty claim — `undefined` is unstated and `[]` is stated-and-empty.
@@ -188,28 +186,34 @@ function addDeclaredVessels(document: unknown): unknown {
     vessels.set(vesselName, vessel);
   }
 
+  const declared: Document[] = [];
+  for (const { name, kind, location, served, registries } of vessels.values()) {
+    // A boundary no surface stated an address for is one this document never
+    // says the shape of. Handed back whole rather than typed by guesswork —
+    // validation then reports the document, which is a fault somebody can read,
+    // where a guessed kind is a location shape nothing would ever check.
+    if (kind === undefined || location === undefined) return document;
+    declared.push({
+      name,
+      kind,
+      location,
+      // The union rather than a winner, matching the backfill: two surfaces
+      // of one boundary *could* state different reach under the old schema,
+      // and silently taking one would be the bug the vessel exists to
+      // prevent. Omitted entirely when no surface stated it, because absent
+      // and `[]` mean different things.
+      ...(served.some((claim) => claim !== undefined)
+        ? { servedHosts: unionOfClaims(served) }
+        : {}),
+      ...(registries.some((claim) => claim !== undefined)
+        ? { reachableRegistries: unionOfClaims(registries) }
+        : {}),
+    });
+  }
+
   return {
     ...manifest,
-    vessels: [...vessels.values()].map(
-      ({ served, registries, location, ...vessel }): Document => ({
-        ...vessel,
-        // Omitted rather than present-and-undefined when no surface said where
-        // the boundary is: the column is nullable for the same reason, and a
-        // key that is there holding nothing is a third state nobody reads.
-        ...(location === undefined ? {} : { location }),
-        // The union rather than a winner, matching the backfill: two surfaces
-        // of one boundary *could* state different reach under the old schema,
-        // and silently taking one would be the bug the vessel exists to
-        // prevent. Omitted entirely when no surface stated it, because absent
-        // and `[]` mean different things.
-        ...(served.some((claim) => claim !== undefined)
-          ? { servedHosts: unionOfClaims(served) }
-          : {}),
-        ...(registries.some((claim) => claim !== undefined)
-          ? { reachableRegistries: unionOfClaims(registries) }
-          : {}),
-      }),
-    ),
+    vessels: declared,
     // Rebuilt in place, in order: `reconcileManifestTargets` reads a Target's
     // rank from its position in this array.
     targets,
@@ -218,6 +222,28 @@ function addDeclaredVessels(document: unknown): unknown {
 
 function stripSuffix(value: string, suffix: string): string {
   return value.endsWith(suffix) ? value.slice(0, -suffix.length) : value;
+}
+
+/**
+ * Which boundary an old connection was describing, from what it stated.
+ *
+ * The kind and the location are one answer rather than two: `kind` is the
+ * discriminant of `VesselLocation`, so whichever address the connection carried
+ * settles both. `null` means the connection said nothing about where the
+ * boundary is, which is not the same as it being a boundary of some default
+ * kind.
+ */
+function boundaryOf(
+  apiServer: unknown,
+  project: unknown,
+): { kind: VesselKind; location: Document } | null {
+  if (typeof apiServer === 'string') {
+    return { kind: 'cluster', location: { apiServer } };
+  }
+  if (typeof project === 'string') {
+    return { kind: 'gcp-project', location: { project } };
+  }
+  return null;
 }
 
 /** A claim about a boundary, or `undefined` for anything that is not one. */

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -106,13 +106,25 @@ function dropTargetNames(document: unknown): unknown {
  * it already has: the same names, and the same union of what two surfaces of
  * one boundary each claimed about it.
  *
- * **The kind comes from the document, never from the adapter.** What kind of
- * boundary this is means only what shape its location has, and the old
+ * **The kind comes from the document wherever the document states it.** What
+ * kind of boundary this is means only what shape its location has, and the old
  * connection stated that shape directly: an `apiServer` is a cluster and a
  * `project` is a cloud project. Reading it back off the surface's adapter would
  * assume each surface belongs to exactly one kind — the assumption a project
  * that runs a cluster breaks — and would do it inside the one function nothing
  * else can check.
+ *
+ * A Target seeded and not yet connected stated no address at all, and that is a
+ * shape the old schema allowed and the current one still does: `location` is
+ * optional on a vessel seed for the same reason the column is nullable. Such a
+ * document says nothing to read a shape off, so the kind falls back to the one
+ * `0022_vessels.sql` wrote on the same evidence — `cluster` for a kubernetes
+ * surface, `gcp-project` for a cloud one. That is not a guess about the
+ * boundary: it is what this installation's vessel row already says, and
+ * disagreeing with it would mint a second vessel beside the migrated one.
+ * Declaring nothing would be worse than either — `vessels` is required, so the
+ * document would fail validation and `loadStoredManifest` would re-seed from
+ * the mounted declaration, which is the loss this module stands between.
  */
 function addDeclaredVessels(document: unknown): unknown {
   const manifest = asDocument(document);
@@ -125,6 +137,8 @@ function addDeclaredVessels(document: unknown): unknown {
     string,
     {
       name: string;
+      /** The kind `0022_vessels.sql` gave this boundary. A fallback only. */
+      backfilled: VesselKind;
       kind?: VesselKind;
       location?: Document;
       served: (readonly string[] | undefined)[];
@@ -149,9 +163,17 @@ function addDeclaredVessels(document: unknown): unknown {
       return document;
     }
 
-    const vesselName = stripSuffix(name, `-${adapter}`);
+    // A cluster's Target keeps its whole name. The suffix existed to tell two
+    // surfaces of one project apart, so a cluster never carried one — which
+    // makes `<name>-kubernetes` a legal name that stripping would rename the
+    // boundary out of. `0022_vessels.sql` derives both names exactly this way,
+    // and agreeing with it is what makes this an upgrade of the rows an
+    // installation has rather than a second set beside them.
+    const vesselName =
+      adapter === 'kubernetes' ? name : stripSuffix(name, `-${adapter}`);
     const vessel = vessels.get(vesselName) ?? {
       name: vesselName,
+      backfilled: adapter === 'kubernetes' ? 'cluster' : 'gcp-project',
       served: [],
       registries: [],
     };
@@ -187,16 +209,23 @@ function addDeclaredVessels(document: unknown): unknown {
   }
 
   const declared: Document[] = [];
-  for (const { name, kind, location, served, registries } of vessels.values()) {
-    // A boundary no surface stated an address for is one this document never
-    // says the shape of. Handed back whole rather than typed by guesswork —
-    // validation then reports the document, which is a fault somebody can read,
-    // where a guessed kind is a location shape nothing would ever check.
-    if (kind === undefined || location === undefined) return document;
+  for (const {
+    name,
+    backfilled,
+    kind,
+    location,
+    served,
+    registries,
+  } of vessels.values()) {
     declared.push({
       name,
-      kind,
-      location,
+      // What the document stated; where it stated nothing, the answer the
+      // backfill already wrote for this row.
+      kind: kind ?? backfilled,
+      // Omitted rather than present-and-undefined when no surface said where
+      // the boundary is: the column is nullable for the same reason, and a key
+      // that is there holding nothing is a third state nobody reads.
+      ...(location === undefined ? {} : { location }),
       // The union rather than a winner, matching the backfill: two surfaces
       // of one boundary *could* state different reach under the old schema,
       // and silently taking one would be the bug the vessel exists to

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -21,10 +21,6 @@
  */
 import { z } from 'zod';
 import type { FederationConfig } from '../adapters/deploy/cloud/federation.ts';
-// `src/domain/vessel.ts` imports `TargetAdapter` back from here, and that is a
-// type-only edge, so the cycle is erased at runtime. Restating the table here
-// to avoid it would be the duplication that table exists to end.
-import { surfacesOf } from '../domain/vessel.ts';
 
 /** A non-empty string with no surrounding whitespace. */
 const nonEmptyString = z.string().trim().min(1);
@@ -597,8 +593,10 @@ export const installationManifestSchema = z
      * hosting several runtimes, so the convention would only get more
      * load-bearing, never less.
      *
-     * Target names keep their suffixes. They are decorative now, which is the
-     * point: nothing parses them.
+     * A vessel states where the boundary is and what it can reach. It does not
+     * state which surfaces are on it — those are the `targets[]` entries that
+     * name it, and what a boundary really carries is established by probing it
+     * at connect.
      */
     vessels: z
       .array(vesselSeedSchema)
@@ -626,8 +624,7 @@ export const installationManifestSchema = z
   })
   .strict()
   /**
-   * Every Target names a declared vessel, and one whose kind carries its
-   * surface.
+   * Every Target names a vessel this document declares.
    *
    * At the document level rather than on `targets`, because it is the one rule
    * in this schema that reads two keys at once. It replaces the
@@ -638,29 +635,23 @@ export const installationManifestSchema = z
    * by name and has nothing honest to do with a Target whose boundary is not
    * in the document.
    *
-   * The kind check is what keeps `SURFACES_BY_VESSEL_KIND` the single statement
-   * of which runtimes a boundary carries: a `cloudrun` Target on a `cluster` is
-   * refused here rather than reaching an adapter that has no way to place it.
+   * **It asks whether this vessel declares this surface, not whether its kind
+   * carries the adapter.** A `targets[]` entry *is* the declaration — the
+   * uniqueness refine above is what keeps a vessel from declaring the same
+   * surface twice — and which runtimes a boundary actually has is established
+   * by probing it at connect. Holding the document to a table of surfaces per
+   * kind would refuse a project that genuinely runs a cluster, and would do it
+   * on the authority of a value whose only job is the shape of `location`.
    */
   .superRefine((manifest, context) => {
-    const kinds = new Map(manifest.vessels.map((v) => [v.name, v.kind]));
+    const declared = new Set(manifest.vessels.map((vessel) => vessel.name));
     manifest.targets.forEach((target, index) => {
-      const kind = kinds.get(target.vessel);
-      if (kind === undefined) {
-        context.addIssue({
-          code: 'custom',
-          path: ['targets', index, 'vessel'],
-          message: `no vessel named ${target.vessel} is declared`,
-        });
-        return;
-      }
-      if (!(surfacesOf(kind) as readonly string[]).includes(target.adapter)) {
-        context.addIssue({
-          code: 'custom',
-          path: ['targets', index, 'vessel'],
-          message: `a ${kind} vessel does not carry a ${target.adapter} surface`,
-        });
-      }
+      if (declared.has(target.vessel)) return;
+      context.addIssue({
+        code: 'custom',
+        path: ['targets', index, 'vessel'],
+        message: `no vessel named ${target.vessel} is declared`,
+      });
     });
   });
 

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -205,10 +205,13 @@ export const targetAdapter = pgEnum('target_adapter', [
  * The tenancy boundary a Target is a surface on — `VesselKind` in
  * `src/domain/vessel.ts`.
  *
- * A different axis from {@link targetAdapter}, which names the runtime: a
- * `gcp-project` carries two adapters, and `kubernetes` is one adapter on a
- * `cluster`. Kept as an independent enum here for the reason the adapter one
- * is.
+ * A different axis from {@link targetAdapter}, which names the runtime, and a
+ * narrower one than it looks: this decides the shape of `vessels.location` and
+ * nothing else. Which runtimes are on a boundary is the set of Targets that
+ * reference it, established by probing at connect — so nothing reads this
+ * column to learn what a vessel carries, and nothing reads an adapter back to
+ * this column either. Kept as an independent enum here for the reason the
+ * adapter one is.
  */
 export const vesselKind = pgEnum('vessel_kind', VESSEL_KINDS);
 

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -46,6 +46,7 @@ import type {
   Reach,
   Resources,
 } from './desired-state.ts';
+import type { SurfaceProbe } from './vessel.ts';
 
 /**
  * Every prerequisite any Target can be asked about (§13).
@@ -194,6 +195,17 @@ export interface TargetDiscovery {
 export interface TargetInspection {
   prerequisites: readonly PrerequisiteResult[];
   discovery: TargetDiscovery;
+  /**
+   * Whether the boundary turned out to carry this surface at all.
+   *
+   * The adapter's to answer rather than core's, for the reason the checklist
+   * is: only the thing that made the call knows whether the runtime answered,
+   * refused, or is not switched on here. Core decides what to *do* about it —
+   * `connectTarget` withholds a Target for an `absent` surface and registers an
+   * `undetermined` one unhealthy — so this stays an observation like every
+   * other field on this type.
+   */
+  surface: SurfaceProbe;
 }
 
 /**

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -29,7 +29,7 @@ import type {
   TargetConnectionProposal,
 } from '../web/model.ts';
 import { type TargetConnection, targetLabel } from './target.ts';
-import { surfacesOf, type VesselKind } from './vessel.ts';
+import { surfacesToProbe, type VesselKind } from './vessel.ts';
 
 /** The donor, spelled the way every other surface names a Target. */
 function labelOf(row: OnboardingTargetRow | undefined): string | null {
@@ -166,12 +166,13 @@ export function pendingConnections(
     return {
       kind: vessel.kind,
       vessel: vessel.name,
-      // Every surface the act will write, whether or not all of them are
-      // unconfigured today: connecting re-registers the whole vessel, and
-      // saying so is what stops the confirmation from under-reporting what it
-      // is about to touch. Read off the vessel's kind rather than recovered
-      // from a name.
-      surfaces: surfacesOf(vessel.kind),
+      // Every surface the act will ask this boundary about, whether or not all
+      // of them are unconfigured today: connecting re-probes the whole vessel,
+      // and saying so is what stops the confirmation from under-reporting what
+      // it is about to touch. What it registers is what the probe finds, which
+      // can be fewer — a project with the runtime API switched off gets a
+      // sentence rather than a Target.
+      surfaces: surfacesToProbe(vessel.kind),
       proposal: connectionProposal(rows, vessel.kind),
     };
   });

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -305,13 +305,49 @@ export function deployTargetOf(
     vessel: vessel.name,
     adapter: target.adapter,
     // The union is discriminated on `adapter`, and the surface half already
-    // carries it, so the spread lands in exactly one arm.
+    // carries it, so the spread lands in exactly one arm. The cast is what
+    // {@link unstatedAddress} exists to check: `where` is the boundary's own
+    // kind's address, and only the compiler is told it is the one this arm
+    // needs.
     connection: {
       ...target.connection,
       ...reach,
       ...where,
     } as AdapterConnection,
   };
+}
+
+/**
+ * The address this surface needs that its vessel's location does not state.
+ *
+ * `null` when {@link deployTargetOf} composed a whole connection, which is the
+ * ordinary case. Each arm of {@link AdapterConnection} requires exactly one
+ * address — `apiServer` for `kubernetes`, `project` for both cloud surfaces —
+ * and a boundary states only its own kind's, so a surface on a boundary of the
+ * other shape composes to a connection with a hole where its address goes.
+ *
+ * **That pairing is a document somebody may write, deliberately.** Which
+ * runtimes a boundary carries is established by probing it rather than by a
+ * table of surfaces per kind, so the manifest no longer refuses a project that
+ * runs a cluster — it just has no way to address one yet. What must not happen
+ * is an adapter being handed the hole: Cloud Run would request
+ * `projects/undefined` on every pass of the loop and report a sentence with
+ * `undefined` in it to the operator. So this is an unmet checklist item
+ * instead, which is §3's grammar for exactly this — a stated reason a Target is
+ * a non-candidate.
+ */
+export function unstatedAddress(target: DeployTargetRef): string | null {
+  const { connection } = target;
+  // `in` rather than a property read: the arm the compiler picked is the one
+  // the cast asserted, so the key is only actually there when the boundary's
+  // location was the matching shape.
+  const stated =
+    target.adapter === 'kubernetes'
+      ? 'apiServer' in connection && connection.apiServer !== ''
+      : 'project' in connection && connection.project !== '';
+  if (stated) return null;
+  const address = target.adapter === 'kubernetes' ? 'apiServer' : 'project';
+  return `this vessel's location states no ${address}, so a ${target.adapter} surface on it has no address to be reached at`;
 }
 
 /**

--- a/apps/spindrift/src/domain/vessel.ts
+++ b/apps/spindrift/src/domain/vessel.ts
@@ -35,50 +35,62 @@ import type { TargetAdapter } from '../config/manifest.schema.ts';
 /**
  * What kind of boundary this is.
  *
+ * **The discriminant {@link VesselLocation} needs, and nothing else.** It says
+ * which shape "where this boundary is" has — `{ apiServer }`, `{ project }`,
+ * later `{ host }` — and it decides no behaviour: it does not say which
+ * surfaces a vessel carries, it is not reversible from an adapter, and it gates
+ * no manifest entry. Which surfaces are on a vessel is what its Targets say,
+ * established by probing the boundary rather than read out of its kind.
+ *
  * Named for the tenancy container itself rather than for the adapter that
- * drives a surface on it, because those are different axes: a `gcp-project`
- * carries two adapters, and `kubernetes` is one adapter on a `cluster`. Every
- * future value is vendor-shaped in the same way, naming one provider's tenancy
- * container, which is what makes them additive.
+ * drives a surface on it, because those are different axes. Every future value
+ * is vendor-shaped in the same way, naming one provider's tenancy container,
+ * which is what makes them additive.
  */
 export const VESSEL_KINDS = ['cluster', 'gcp-project'] as const;
 
 export type VesselKind = (typeof VESSEL_KINDS)[number];
 
 /**
- * The surfaces each kind of vessel carries (§13's split, as a table).
+ * The surfaces a connect act probes a vessel of this kind **for**.
  *
- * This replaces `targetNames()` and `CLOUD_ADAPTERS`. One connect act registers
- * one row per entry here, which is the same behaviour as before — stated as a
- * fact about the vessel kind rather than as a branch on the word "cloud".
+ * A list of questions, not an answer. An entry here means "ask this boundary
+ * whether it carries this runtime"; what it carries is whatever the probe
+ * established, and the Target rows are where that lands. So a project whose
+ * Cloud Run API is switched off is probed for `cloudrun` and has none, and the
+ * same surface may appear under two kinds without either becoming ambiguous —
+ * a probe answers per vessel, and a table cannot.
  *
- * Adding a backend is adding a row — one vessel kind mapped to the surfaces it
- * serves — and needs nothing else in this file.
+ * Adding a backend is adding a row and nothing else in this file.
  */
-export const SURFACES_BY_VESSEL_KIND = {
+export const PROBED_SURFACES_BY_VESSEL_KIND = {
   cluster: ['kubernetes'],
   'gcp-project': ['cloudrun', 'static'],
 } as const satisfies Record<VesselKind, readonly TargetAdapter[]>;
 
-/** The surfaces one connect act registers on a vessel of this kind. */
-export function surfacesOf(kind: VesselKind): readonly TargetAdapter[] {
-  return SURFACES_BY_VESSEL_KIND[kind];
+/** What one connect act asks a vessel of this kind about. */
+export function surfacesToProbe(kind: VesselKind): readonly TargetAdapter[] {
+  return PROBED_SURFACES_BY_VESSEL_KIND[kind];
 }
 
-/** Which kind of vessel carries this surface. */
-export function vesselKindFor(adapter: TargetAdapter): VesselKind {
-  for (const kind of VESSEL_KINDS) {
-    if (
-      (SURFACES_BY_VESSEL_KIND[kind] as readonly string[]).includes(adapter)
-    ) {
-      return kind;
-    }
-  }
-  // Unreachable while the table above covers every adapter, which
-  // `satisfies Record<VesselKind, ...>` and the test in
-  // `test/domain/vessel.test.ts` between them keep true.
-  throw new Error(`no vessel kind carries the ${adapter} surface`);
-}
+/**
+ * What one probe established about one surface on one vessel.
+ *
+ * Three arms rather than a boolean, and the third is the load-bearing one: a
+ * read either produced an answer or it did not, exactly as
+ * `adapters/cloud-discovery.ts` splits `found` from `unavailable`. `absent`
+ * says *this boundary does not carry this runtime* — a fact an operator can act
+ * on, and the one answer that withholds a Target. `undetermined` says nothing
+ * was established, which is what a `403`, a disabled federation or a failed
+ * read produce, and it registers the Target unhealthy with the sentence
+ * attached: rendering a confident absence off a refused read would tell an
+ * operator their project has no Cloud Run when all that happened is nobody
+ * could look.
+ */
+export type SurfaceProbe =
+  | { readonly kind: 'carried' }
+  | { readonly kind: 'absent'; readonly detail: string }
+  | { readonly kind: 'undetermined'; readonly detail: string };
 
 /**
  * Where the boundary is, in its own kind's terms.
@@ -110,10 +122,15 @@ export interface GcpProjectLocation {
  * Everything here is a fact about the boundary — true for every surface on it,
  * and therefore impossible for two of them to disagree about. A fact that is
  * true of one surface and not another belongs on the Target.
+ *
+ * **There is no `surfaces` here.** Which runtimes this boundary carries is the
+ * set of Targets that reference it, and a second copy of that would be a copy
+ * the two can disagree about.
  */
 export interface Vessel {
   readonly id: string;
   readonly name: string;
+  /** {@link VESSEL_KINDS} — the shape of {@link location}, and nothing else. */
   readonly kind: VesselKind;
   readonly location: VesselLocation;
   /**

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -45,6 +45,7 @@ import {
   type TargetHealth,
   targetLabel,
 } from '../domain/target.ts';
+import type { SurfaceProbe } from '../domain/vessel.ts';
 import { reconcilerLoopDuration } from '../telemetry/index.ts';
 
 /**
@@ -62,6 +63,17 @@ export interface TargetInspectionResult {
   readonly prerequisites: readonly PrerequisiteResult[];
   /** `null` when nothing could be discovered — unreachable, or no adapter. */
   readonly discovery: TargetDiscovery | null;
+  /**
+   * What the pass established about the surface itself being there.
+   *
+   * Only `connectTarget` acts on it, and only to withhold a row it was about
+   * to create. **The standing loop never creates or removes a Target from
+   * this**: a row that exists has been placed on, and a probe that failed a
+   * different way on one tick is not a mandate to delete what an operator
+   * connected. A surface a vessel gained since is registered by re-running the
+   * connect, which is an act somebody performed.
+   */
+  readonly surface: SurfaceProbe;
 }
 
 /**
@@ -80,12 +92,15 @@ export async function inspectTarget(
     // Not a fault: an installation is allowed to have a Target whose adapter it
     // does not ship. It is simply a Target nothing can be placed on, and saying
     // so is more useful than refusing to record it.
+    const detail = `this installation has no ${target.adapter} adapter`;
     return {
-      prerequisites: unreachablePrerequisites(
-        `this installation has no ${target.adapter} adapter`,
-        target.adapter,
-      ),
+      prerequisites: unreachablePrerequisites(detail, target.adapter),
       discovery: null,
+      // Undetermined rather than absent, and the distinction is the whole
+      // point: nobody asked the boundary anything, so nothing is known about
+      // what it carries. Reading it as an absence would let an installation
+      // that ships one adapter conclude that no vessel anywhere has the others.
+      surface: { kind: 'undetermined', detail },
     };
   }
   try {
@@ -93,14 +108,14 @@ export async function inspectTarget(
     return {
       prerequisites: inspection.prerequisites,
       discovery: inspection.discovery,
+      surface: inspection.surface,
     };
   } catch (cause) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
     return {
-      prerequisites: unreachablePrerequisites(
-        cause instanceof Error ? cause.message : String(cause),
-        target.adapter,
-      ),
+      prerequisites: unreachablePrerequisites(detail, target.adapter),
       discovery: null,
+      surface: { kind: 'undetermined', detail },
     };
   }
 }
@@ -227,6 +242,11 @@ export interface TargetRefresh {
  * else. In particular it does not touch `status`: connected and disconnected are
  * the operator's statement about a Target, and a loop that could flip them would
  * make a disconnect undo itself the moment the cluster came back.
+ *
+ * It ignores the pass's {@link TargetInspectionResult.surface} for the same
+ * reason. Which surfaces a vessel carries is settled by an act — connect — and
+ * a loop that added or removed rows on a probe would make the set of Targets a
+ * thing that changes while nobody is looking.
  */
 export async function refreshTarget(
   context: TargetLoopContext,

--- a/apps/spindrift/src/reconciler/target-loop.ts
+++ b/apps/spindrift/src/reconciler/target-loop.ts
@@ -44,6 +44,7 @@ import {
   hasVesselLocation,
   type TargetHealth,
   targetLabel,
+  unstatedAddress,
 } from '../domain/target.ts';
 import type { SurfaceProbe } from '../domain/vessel.ts';
 import { reconcilerLoopDuration } from '../telemetry/index.ts';
@@ -101,6 +102,20 @@ export async function inspectTarget(
       // what it carries. Reading it as an absence would let an installation
       // that ships one adapter conclude that no vessel anywhere has the others.
       surface: { kind: 'undetermined', detail },
+    };
+  }
+  const unstated = unstatedAddress(target);
+  if (unstated !== null) {
+    // The vessel's location is of the other kind's shape, so the flat view
+    // this was handed has a hole where the surface's address goes. Asking the
+    // adapter anyway is a request against `projects/undefined` and a sentence
+    // naming `undefined` back to the operator; the checklist says which
+    // address is missing instead. Undetermined for the same reason as above —
+    // nobody asked the boundary anything.
+    return {
+      prerequisites: unreachablePrerequisites(unstated, target.adapter),
+      discovery: null,
+      surface: { kind: 'undetermined', detail: unstated },
     };
   }
   try {

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -1768,6 +1768,14 @@ function TargetsScreen({
   >({ type: 'loading' });
   const [connecting, setConnecting] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  /**
+   * Surfaces the last connect established are not on the boundary it probed.
+   *
+   * Not an error — the connect succeeded — and not readable from the reloaded
+   * list either, because what it says is about a Target that deliberately does
+   * not exist. So it is the one part of the act's answer this screen keeps.
+   */
+  const [absent, setAbsent] = useState<readonly string[]>([]);
   /** Bumped after a connect, because the checklist it produced is the answer. */
   const [reloadToken, setReloadToken] = useState(0);
 
@@ -1801,12 +1809,19 @@ function TargetsScreen({
   const connect = async (input: InputOf<'connectTarget'>) => {
     setConnecting(true);
     setActionError(null);
+    setAbsent([]);
     try {
       const result = await command('connectTarget', input);
       if (!result.ok) {
         setActionError(result.failure.message);
         return;
       }
+      setAbsent(
+        result.value.absent.map(
+          (surface) =>
+            `${surface.vessel}/${surface.adapter} was not registered: ${surface.detail}`,
+        ),
+      );
       // §13: connect always succeeds, and what it produced is a checklist. The
       // list is re-read rather than patched because that checklist is the whole
       // outcome of the act and it came from a pass of the inspection loop.
@@ -1847,6 +1862,7 @@ function TargetsScreen({
       pending={state.pending}
       connecting={connecting}
       error={actionError}
+      absent={absent}
       onConnect={connect}
       onChanged={() => setReloadToken((token) => token + 1)}
       onNavigate={onNavigate}

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -690,6 +690,23 @@ export interface AppListItem {
   readonly artifact: string;
 }
 
+/**
+ * A cloud boundary's own facts, which an edit restates rather than re-derives.
+ *
+ * `connectTarget` writes the whole connection and the whole vessel row, so a
+ * fact the form does not send back is a fact the edit deletes — the identity a
+ * scheduled job fires as, the hosts §33 resolves against, the registries §3
+ * reads. None of them may be *proposed* to a different project, which is
+ * exactly why they travel beside the boundary's own id rather than in
+ * {@link TargetConnectionProposal}.
+ */
+export interface CloudBoundaryFacts {
+  readonly serviceAccount?: string;
+  readonly servedHosts?: string[];
+  readonly reachableRegistries?: string[];
+  readonly logHistorySeconds?: number;
+}
+
 /** A Target as the targets management view lists it. */
 export interface TargetListItem {
   readonly id: string;
@@ -758,24 +775,42 @@ export interface TargetListItem {
    */
   readonly connectionDivergence: readonly string[];
   /**
-   * Where an edit of this Target's connection starts, or `null` on an adapter
-   * the product has no edit surface for.
+   * Where an edit of this Target's connection starts, or `null` where there is
+   * no connection to start from.
    *
-   * Editing is `connectTarget` again — idempotent by name, and already the act
-   * that writes these facts (§13). What it needs that a fresh connect does not
-   * is *this* Target's own address: `TargetConnectionProposal` deliberately
-   * omits `apiServer` because a second cluster prefilled with the first one's
-   * would read as correct and deploy somewhere else, and that reasoning is
-   * exactly inverted here — this is the one Target the address does name.
+   * Editing is `connectTarget` again — idempotent by `(vessel, adapter)`, and
+   * already the act that writes these facts (§13). What it needs that a fresh
+   * connect does not is *this* boundary's own address:
+   * `TargetConnectionProposal` deliberately omits `apiServer` and `project`
+   * because a second boundary prefilled with the first one's would read as
+   * correct and deploy somewhere else, and that reasoning is exactly inverted
+   * here — this is the one boundary the address does name.
    *
-   * `null` for `cloudrun` and `static`: `platform` chart values are a cluster's,
-   * and a cloud project has no probe to read itself back through, so the edit
-   * this field exists for has nothing to offer there.
+   * **It is also the only re-probe an operator has.** One connect asks the
+   * boundary about every surface `surfacesToProbe` names, so re-running it is
+   * how a project whose Cloud Run API was switched off at connect time gets its
+   * `cloudrun` Target the day somebody switches it on. The absence a connect
+   * reported is deliberately not stored — what a boundary carries is a fact
+   * about the boundary, and a copy of it here would be a copy that goes stale
+   * the moment the API is enabled — so being able to ask again is what stands
+   * in for remembering the answer.
+   *
+   * Discriminated on the vessel's kind, because the address the form starts
+   * from is the location's shape.
    */
-  readonly edit: {
-    readonly apiServer: string;
-    readonly proposal: TargetConnectionProposal;
-  } | null;
+  readonly edit:
+    | {
+        readonly kind: 'cluster';
+        readonly apiServer: string;
+        readonly proposal: TargetConnectionProposal;
+      }
+    | {
+        readonly kind: 'gcp-project';
+        readonly project: string;
+        readonly carried: CloudBoundaryFacts;
+        readonly proposal: TargetConnectionProposal;
+      }
+    | null;
 }
 
 /**

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -796,7 +796,13 @@ export interface PendingTargetConnection {
   readonly kind: VesselKind;
   /** What `connectTarget` takes as its `vessel`. */
   readonly vessel: string;
-  /** Every surface on that vessel this one act would configure. */
+  /**
+   * Every surface this one act would probe that vessel for.
+   *
+   * What it registers is what the probe establishes, which may be fewer: a
+   * boundary that turns out not to carry one of these gets a sentence saying
+   * so instead of a Target.
+   */
   readonly surfaces: readonly string[];
   readonly proposal: TargetConnectionProposal;
 }

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -92,7 +92,7 @@ export function ConnectTargetForm(props: {
    * operator to restate the one fact the row is certain of.
    */
   apiServer?: string;
-  /** The surfaces this one act registers on that boundary. */
+  /** The surfaces this one act probes that boundary for. */
   surfaces: readonly string[];
   proposal: TargetConnectionProposal;
   connecting: boolean;
@@ -143,7 +143,7 @@ function Heading({
       </div>
       {surfaces.length > 1 ? (
         <p className="text-xs text-muted-foreground">
-          Registers{' '}
+          Asks for{' '}
           {surfaces.map((surface, index) => (
             <span key={surface}>
               {index > 0 ? ' and ' : ''}
@@ -152,7 +152,7 @@ function Heading({
               </span>
             </span>
           ))}{' '}
-          — one project, both of its surfaces.
+          — one project, and a Target for each one it finds.
         </p>
       ) : null}
     </>

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -54,7 +54,10 @@ import {
 } from '../../../domain/target-onboarding.ts';
 import type { VesselKind } from '../../../domain/vessel.ts';
 import { command, type InputOf, type OutputOf } from '../../client.ts';
-import type { TargetConnectionProposal } from '../../model.ts';
+import type {
+  CloudBoundaryFacts,
+  TargetConnectionProposal,
+} from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import {
@@ -92,6 +95,10 @@ export function ConnectTargetForm(props: {
    * operator to restate the one fact the row is certain of.
    */
   apiServer?: string;
+  /** The same fact for a cloud boundary, on the same one path — an edit. */
+  project?: string;
+  /** What an edit of a cloud boundary restates so the act does not delete it. */
+  carried?: CloudBoundaryFacts;
   /** The surfaces this one act probes that boundary for. */
   surfaces: readonly string[];
   proposal: TargetConnectionProposal;
@@ -641,27 +648,34 @@ function Declaration({
 // --- The cloud flow, unchanged ---------------------------------------------
 
 /**
- * A cloud project's two Targets, in one act (§13).
+ * A cloud project's Targets, in one act (§13).
  *
  * Still a flat form, and not because nobody got to it: a project has no
  * discovery API to enumerate itself through before it is named, so there is
  * nothing here for a probe to read. The two endpoints and the region are
- * carried from a working cloud Target; the project id never is.
+ * carried from a working cloud Target; the project id never is — except on an
+ * edit, where the id is this boundary's own rather than somebody else's, and
+ * pressing the button again is how a surface the last probe did not find gets
+ * asked about a second time.
  */
 function ConnectCloud({
   vessel,
+  project: knownProject = '',
+  carried = {},
   proposal,
   connecting,
   onConnect,
   onCancel,
 }: {
   vessel: string;
+  project?: string;
+  carried?: CloudBoundaryFacts;
   proposal: TargetConnectionProposal;
   connecting: boolean;
   onConnect: (input: ConnectTargetInput) => void;
   onCancel: () => void;
 }) {
-  const [project, setProject] = useState('');
+  const [project, setProject] = useState(knownProject);
   const [region, setRegion] = useState(proposal.region ?? '');
   const [runEndpoint, setRunEndpoint] = useState(proposal.runEndpoint ?? '');
   const [hostingEndpoint, setHostingEndpoint] = useState(
@@ -682,7 +696,11 @@ function ConnectCloud({
           label="Project"
           value={project}
           onChange={(event) => setProject(event.target.value)}
-          hint="Not carried — a second project prefilled with the first one's id would read as correct."
+          hint={
+            knownProject === ''
+              ? "Not carried — a second project prefilled with the first one's id would read as correct."
+              : 'This boundary’s own id. Connecting again re-asks it about every surface.'
+          }
         />
         <Field
           name="region"
@@ -717,6 +735,12 @@ function ConnectCloud({
               ...(proposal.policyEndpoint === undefined
                 ? {}
                 : { policyEndpoint: proposal.policyEndpoint }),
+              // One act writes the whole connection and the whole vessel row,
+              // so what this boundary already states has to go back with it or
+              // the edit deletes it. There is no field for these because they
+              // are not decisions being made again — the fresh-connect path
+              // sends none, having nothing to preserve.
+              ...carried,
             })
           }
         >

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -80,11 +80,30 @@ function kindIcon(kind: ComponentKind) {
   }
 }
 
+/**
+ * What a connect established is not on the boundary it probed.
+ *
+ * Stated rather than left to be inferred from a Target that is not in the list:
+ * "this project has no Cloud Run" and "the connect only half worked" look
+ * identical from a list of what exists, and only one of them is true.
+ */
+function AbsentSurfaces({ absent }: { absent: readonly string[] }) {
+  if (absent.length === 0) return null;
+  return (
+    <div className="rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-sm">
+      {absent.map((sentence) => (
+        <p key={sentence}>{sentence}</p>
+      ))}
+    </div>
+  );
+}
+
 export function TargetList({
   targets,
   pending,
   connecting,
   error,
+  absent = [],
   onConnect,
   onChanged,
   onNavigate,
@@ -94,6 +113,8 @@ export function TargetList({
   pending: readonly PendingTargetConnection[];
   connecting: boolean;
   error: string | null;
+  /** One sentence per surface the last connect found was not there. */
+  absent?: readonly string[];
   onConnect: (input: ConnectTargetInput) => void;
   onChanged?: () => void;
   onNavigate?: (path: string) => void;
@@ -128,6 +149,11 @@ export function TargetList({
       <>
         {error ? (
           <section className="py-4 text-sm text-destructive">{error}</section>
+        ) : null}
+        {absent.length > 0 ? (
+          <section className="py-4">
+            <AbsentSurfaces absent={absent} />
+          </section>
         ) : null}
         <ProviderTargets
           name="Google Cloud"
@@ -224,6 +250,8 @@ export function TargetList({
           {error}
         </div>
       ) : null}
+
+      <AbsentSurfaces absent={absent} />
 
       <TargetCollection
         targets={configured}

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -36,6 +36,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import type { ComponentKind } from '../../../domain/desired-state.ts';
+import { surfacesToProbe } from '../../../domain/vessel.ts';
 import type { LogoName } from '../../client/logos/index.ts';
 import { command, type InputOf, type OutputOf } from '../../client.ts';
 import type { PendingTargetConnection, TargetListItem } from '../../model.ts';
@@ -547,6 +548,10 @@ function TargetCard({
               form was reachable only from an unconfigured seed. It is the same
               form and the same act — §13 makes connect idempotent by name — so
               the edit is a re-connect rather than a second way to write these.
+
+              And a re-connect is a re-probe: it asks the boundary about every
+              surface again, which is how a project whose Cloud Run API was off
+              at connect time gets that Target once it is switched on.
             */}
             {target.edit ? (
               <Button
@@ -593,10 +598,16 @@ function TargetCard({
         {editing && target.edit ? (
           <div className="rounded-md border border-border-soft bg-secondary/40 px-4 py-4">
             <ConnectTargetForm
-              kind="cluster"
+              kind={target.edit.kind}
               vessel={target.vessel}
-              apiServer={target.edit.apiServer}
-              surfaces={[target.adapter]}
+              {...(target.edit.kind === 'cluster'
+                ? { apiServer: target.edit.apiServer }
+                : { project: target.edit.project })}
+              // The whole act, not this card: one connect asks the boundary
+              // about every surface its kind is probed for, and saying so is
+              // what stops the confirmation from under-reporting what it
+              // touches.
+              surfaces={surfacesToProbe(target.edit.kind)}
               proposal={target.edit.proposal}
               connecting={connecting}
               onConnect={onConnect}

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -513,6 +513,39 @@ describe('§13: one probe, three answers', () => {
     expect(vessel?.met).toBe(false);
     expect(vessel?.detail).toContain('never creates a vessel');
   });
+
+  test('and the same probe says whether the project carries this surface', async () => {
+    const { adapter } = adapterFor();
+    expect((await adapter.inspect(target())).surface).toEqual({
+      kind: 'carried',
+    });
+
+    // The service being off in this project *is* the surface not being there:
+    // no revision can ever be placed, and §14 forbids the one remediation.
+    const off = adapterFor({ refuseList: serviceDisabled() });
+    const disabled = (await off.adapter.inspect(target())).surface;
+    expect(disabled.kind).toBe('absent');
+    expect(disabled.kind === 'absent' && disabled.detail).toContain(
+      'not enabled',
+    );
+  });
+
+  test('but a refusal establishes nothing about what is here', async () => {
+    // The distinction `cloud-discovery.ts` draws between found-empty and
+    // unavailable, applied to a surface: neither of these says the runtime is
+    // absent, and reading them that way would delete a Target over an IAM
+    // grant. A cloud API answers `404` for a project this identity may not see
+    // as readily as for one that is not there, which is why it is here too.
+    for (const refuseList of [
+      permissionDenied(),
+      { status: 404, body: { error: { message: 'no project' } } },
+    ]) {
+      const { adapter } = adapterFor({ refuseList });
+      expect((await adapter.inspect(target())).surface.kind).toBe(
+        'undetermined',
+      );
+    }
+  });
 });
 
 describe('§8 and §32: what this Target is honest about', () => {

--- a/apps/spindrift/test/adapters/deploy-contract.test.ts
+++ b/apps/spindrift/test/adapters/deploy-contract.test.ts
@@ -159,6 +159,7 @@ const refuses: DeployAdapter = {
         met: true,
       })),
       discovery: CAPABLE_DISCOVERY,
+      surface: { kind: 'carried' as const },
     };
   },
 };

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -45,6 +45,7 @@ import {
   vessels,
 } from '../../src/db/schema.ts';
 import { deployState } from '../../src/domain/target.ts';
+import { surfacesToProbe } from '../../src/domain/vessel.ts';
 import { restoreDeclaredTargetConnections } from '../../src/reconciler/target-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import {
@@ -321,6 +322,135 @@ describe('the act is credential-shaped though the noun is flat', () => {
     expect((await targetRow('cluster'))?.connection).toEqual(
       connectionFor('kubernetes'),
     );
+  });
+
+  test('and registers only the surfaces the probe found', async () => {
+    // The forcing case, from the other side: a project with no Cloud Run gets
+    // no `cloudrun` Target. Connect still succeeds — the vessel is there, the
+    // surface that answered is there, and the one that is not gets the
+    // checklist that says so.
+    const { registry } = fakes({
+      cloudrun: { surfaceAbsent: 'the Cloud Run API is not enabled on p' },
+    });
+    const result = await connectTarget(
+      cloudInput({ vessel: 'vessel', project: 'p' }),
+      context(registry),
+    );
+
+    if (!result.ok) throw new Error('connect refused');
+    expect(result.value.targets.map((t) => t.adapter)).toEqual(['static']);
+    expect(await targetRow('vessel', 'cloudrun')).toBeUndefined();
+    expect(await targetRow('vessel', 'static')).toBeDefined();
+
+    const [missing] = result.value.absent;
+    expect(missing?.adapter).toBe('cloudrun');
+    expect(missing?.vessel).toBe('vessel');
+    expect(missing?.detail).toContain('not enabled');
+    // A checklist row saying so, in the same grammar an unmet item on a
+    // registered Target has: §13's stated reason, about a surface rather than
+    // about a Target's health.
+    expect(missing?.prerequisites.every((item) => !item.met)).toBe(true);
+  });
+
+  test('but a surface it could not settle is registered, unhealthy', async () => {
+    // "Found nothing" and "could not tell" are different answers. A refused
+    // read establishes no absence, so withholding the Target would put a
+    // confident "this project has no Cloud Run" on screen off a `403` — and
+    // there would then be no row for the loop to re-check when the grant
+    // lands.
+    const { registry } = fakes({
+      cloudrun: { unreachable: 'the federated identity may not act here' },
+    });
+    const result = await connectTarget(
+      cloudInput({ vessel: 'vessel' }),
+      context(registry),
+    );
+
+    if (!result.ok) throw new Error('connect refused');
+    expect(result.value.absent).toEqual([]);
+    expect(result.value.targets.map((t) => t.adapter)).toEqual([
+      'cloudrun',
+      'static',
+    ]);
+    const row = await targetRow('vessel', 'cloudrun');
+    expect(row?.health).toBe('unhealthy');
+    expect(row?.prerequisites?.[0]?.detail).toContain('may not act here');
+  });
+
+  test('the surfaces on a vessel are its rows, not its kind', async () => {
+    // Which runtimes a boundary carries is a query over `targets`, and there
+    // is no second copy of it to disagree: the probe list still asks a cloud
+    // project about both surfaces, and this project answered for one.
+    const { registry } = fakes({
+      cloudrun: { surfaceAbsent: 'the Cloud Run API is not enabled on p' },
+    });
+    await connectTarget(
+      cloudInput({ vessel: 'vessel', project: 'p' }),
+      context(registry),
+    );
+
+    const carried = await database()
+      .db.select({ adapter: targets.adapter })
+      .from(targets)
+      .innerJoin(vessels, eq(targets.vesselId, vessels.id))
+      .where(eq(vessels.name, 'vessel'));
+    expect(carried.map((row) => row.adapter)).toEqual(['static']);
+    expect(surfacesToProbe('gcp-project')).toEqual(['cloudrun', 'static']);
+  });
+
+  test('a surface found later joins the vessel, changing no Target that was there', async () => {
+    // The whole point of a Target being `(vessel, adapter)`: the surface that
+    // was already registered is not renamed, re-ranked or rewritten to make
+    // room for the one that turned up.
+    const off = fakes({
+      cloudrun: { surfaceAbsent: 'the Cloud Run API is not enabled on p' },
+    });
+    await connectTarget(
+      cloudInput({ vessel: 'vessel', project: 'p' }),
+      context(off.registry),
+    );
+    const before = await targetRow('vessel', 'static');
+
+    // Someone enables the API, and the connect is run again.
+    const on = fakes();
+    const result = await connectTarget(
+      cloudInput({ vessel: 'vessel', project: 'p' }),
+      context(on.registry),
+    );
+
+    if (!result.ok) throw new Error('connect refused');
+    expect(await targetRow('vessel', 'static')).toEqual(before);
+    const added = await targetRow('vessel', 'cloudrun');
+    expect(added?.health).toBe('healthy');
+    // It joins the end of the one global rank list rather than displacing the
+    // surface that was connected first.
+    expect(added?.rank).toBe(1);
+    expect(before?.rank).toBe(0);
+  });
+
+  test('a surface that stops answering keeps its Target rather than losing it', async () => {
+    // The asymmetry is deliberate. A row that exists has been placed on, and a
+    // probe is not a mandate to delete what an operator connected — so the
+    // absence lands as an unhealthy checklist, which is a thing to act on
+    // rather than a Target that vanished.
+    await connectTarget(
+      cloudInput({ vessel: 'vessel', project: 'p' }),
+      context(fakes().registry),
+    );
+
+    const { registry } = fakes({
+      cloudrun: { surfaceAbsent: 'the Cloud Run API is not enabled on p' },
+    });
+    const result = await connectTarget(
+      cloudInput({ vessel: 'vessel', project: 'p' }),
+      context(registry),
+    );
+
+    if (!result.ok) throw new Error('connect refused');
+    expect(result.value.absent).toEqual([]);
+    const row = await targetRow('vessel', 'cloudrun');
+    expect(row?.health).toBe('unhealthy');
+    expect(row?.prerequisites?.[0]?.detail).toContain('not enabled');
   });
 
   test('one cloud connect fills its matched manifest-seeded pair', async () => {

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -453,6 +453,74 @@ describe('the act is credential-shaped though the noun is flat', () => {
     expect(row?.prerequisites?.[0]?.detail).toContain('not enabled');
   });
 
+  test('and the screen keeps the act that asks again once it is switched on', async () => {
+    // The absence is deliberately not stored: what a boundary carries is a fact
+    // about the boundary, and a copy of it here would be a copy that goes stale
+    // the moment somebody enables the API. What stands in for remembering the
+    // answer is being able to ask again — which needs a control on a vessel
+    // whose remaining surfaces are already connected, or the only route left is
+    // declaring the surface in Git.
+    await connectTarget(
+      cloudInput({ vessel: 'elsewhere', project: 'other' }),
+      context(fakes().registry),
+    );
+    const off = fakes({
+      cloudrun: { surfaceAbsent: 'the Cloud Run API is not enabled on p' },
+    });
+    await connectTarget(
+      cloudInput({
+        vessel: 'vessel',
+        project: 'p',
+        servedHosts: ['hosting.example.test'],
+      }),
+      context(off.registry),
+    );
+
+    const listed = await listTargets({}, context(off.registry));
+    if (!listed.ok) throw new Error('listTargets refused');
+    const edit = listed.value.targets.find(
+      (target) => target.vessel === 'vessel' && target.adapter === 'static',
+    )?.edit;
+    if (edit?.kind !== 'gcp-project') {
+      throw new Error('the surface that answered offers no edit');
+    }
+    // This boundary's own id, which a fresh connect refuses to propose and an
+    // edit must not make the operator retype. The endpoints and the region are
+    // installation-wide, so the project that does run Cloud Run supplies them.
+    expect(edit.project).toBe('p');
+    expect(edit.proposal.runEndpoint).toBe(CLOUD_ENDPOINTS.run);
+    expect(edit.proposal.region).toBe(cloudInput().region);
+    // And what one act writes that the form has no field to ask for again:
+    // sending the form back without these is the edit deleting them.
+    expect(edit.carried.servedHosts).toEqual(['hosting.example.test']);
+
+    // The same act, from exactly what the screen is holding.
+    const on = fakes();
+    const again = await connectTarget(
+      {
+        kind: 'gcp-project',
+        vessel: 'vessel',
+        project: edit.project,
+        region: edit.proposal.region!,
+        runEndpoint: edit.proposal.runEndpoint!,
+        hostingEndpoint: edit.proposal.hostingEndpoint!,
+        ...edit.carried,
+      },
+      context(on.registry),
+    );
+
+    if (!again.ok) throw new Error('connect refused');
+    expect(again.value.targets.map((target) => target.adapter)).toEqual([
+      'cloudrun',
+      'static',
+    ]);
+    const [boundary] = await database()
+      .db.select({ servedHosts: vessels.servedHosts })
+      .from(vessels)
+      .where(eq(vessels.name, 'vessel'));
+    expect(boundary?.servedHosts).toEqual(['hosting.example.test']);
+  });
+
   test('one cloud connect fills its matched manifest-seeded pair', async () => {
     const { registry } = fakes();
     const vessel = await insertVessel(database().db, 'cloudrun', {
@@ -589,7 +657,10 @@ describe('an operator’s Target correction outlives the next boot', () => {
     // The screen that made the correction possible: the edit opens on this
     // Target's own address, which is the one field a fresh connect refuses to
     // propose and the one field an edit must not make the operator retype.
-    expect(cluster?.edit?.apiServer).toBe(clusterInput().apiServer);
+    expect(cluster?.edit).toMatchObject({
+      kind: 'cluster',
+      apiServer: clusterInput().apiServer,
+    });
     expect(cluster?.edit?.proposal.carriedFrom).toBe('cluster/kubernetes');
   });
 

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -23,7 +23,6 @@ import {
   targets,
 } from '../../src/db/schema.ts';
 import { targetLabel } from '../../src/domain/target.ts';
-import { vesselKindFor } from '../../src/domain/vessel.ts';
 import { defaultVesselName, withIsolatedDatabase } from '../harness/db.ts';
 import {
   SupplyChainHarness,
@@ -31,6 +30,7 @@ import {
 } from '../harness/fakes/supply-chain.ts';
 import {
   fixtureManifest,
+  fixtureVesselKind,
   insertVessel,
   targetValues,
 } from '../harness/installation.ts';
@@ -143,7 +143,7 @@ async function scaffold(
     // `targetValues` leaves `vesselId` at the harness's shared per-kind
     // fixture vessel, so this is the same label a screen reads off the row.
     label: targetLabel({
-      vessel: defaultVesselName(vesselKindFor(adapter)),
+      vessel: defaultVesselName(fixtureVesselKind(adapter)),
       adapter,
     }),
   };

--- a/apps/spindrift/test/config/manifest-upgrade.test.ts
+++ b/apps/spindrift/test/config/manifest-upgrade.test.ts
@@ -216,16 +216,64 @@ describe('the vessels a pre-declaration document is upgraded into', () => {
     ]);
   });
 
-  test('and a boundary no address was stated for gets no invented kind', () => {
-    // No address means the document does not say what shape this boundary has,
-    // and there is nothing left to infer it from. This step declares nothing
-    // rather than guessing, so validation reports the document instead of a
-    // kind nothing would ever check. (`dropTargetNames` still runs — the two
-    // steps are independent.)
+  test('and a boundary no address was stated for keeps the row it has', () => {
+    // A seed with no connection was a legal document — it is the half-ready
+    // state a manifest seeds and an operator finishes in-product — so there is
+    // nothing here to read a shape off. The kind is the one `0022_vessels.sql`
+    // wrote for the same row rather than a fresh guess, and the location is
+    // omitted rather than invented.
     const upgraded = upgradeManifestDocument({
       targets: [{ name: 'nowhere', adapter: 'kubernetes' }],
-    });
-    expect(upgraded).not.toHaveProperty('vessels');
+    }) as { vessels: unknown[] };
+    expect(upgraded.vessels).toEqual([{ name: 'nowhere', kind: 'cluster' }]);
+  });
+
+  test('and one address-less seed does not take the whole document down', () => {
+    // The failure this guards is the module's own: `vessels` is required, so a
+    // document that came back without it fails validation, and
+    // `loadStoredManifest` reads that as an unseeded installation and re-seeds
+    // from the mounted declaration. Every boundary that *did* state an address
+    // would go with it.
+    const seeded = snapshot('01-suffix-paired-vessels.yaml') as {
+      targets: Record<string, unknown>[];
+    };
+    delete seeded.targets[0]?.connection;
+
+    const upgraded = upgradeManifestDocument(seeded) as {
+      vessels: { name: string; location?: unknown }[];
+    };
+    expect(upgraded.vessels.map((vessel) => vessel.name)).toEqual([
+      'cluster',
+      'cloud',
+    ]);
+    expect(upgraded.vessels[0]).not.toHaveProperty('location');
+    expect(() => validateManifest(upgraded, 'test')).not.toThrow();
+  });
+
+  test('and a cluster keeps its whole name, suffix and all', () => {
+    // The suffix told two surfaces of one project apart, so a cluster never
+    // carried one and `<name>-kubernetes` is just a name. Stripping it renames
+    // the boundary away from the row `0022_vessels.sql` created — which
+    // `reconcileManifestVessels` looks up by name, so it would insert a second
+    // vessel and strand the Target already attached to the first.
+    const upgraded = upgradeManifestDocument({
+      targets: [
+        {
+          name: 'folly-kubernetes',
+          adapter: 'kubernetes',
+          connection: {
+            apiServer: 'https://folly.example.test',
+            namespace: 'apps',
+          },
+        },
+      ],
+    }) as { vessels: { name: string }[]; targets: { vessel: string }[] };
+    expect(upgraded.vessels.map((vessel) => vessel.name)).toEqual([
+      'folly-kubernetes',
+    ]);
+    expect(upgraded.targets.map((target) => target.vessel)).toEqual([
+      'folly-kubernetes',
+    ]);
   });
 
   test('is a no-op on a document that already declares them', () => {

--- a/apps/spindrift/test/config/manifest-upgrade.test.ts
+++ b/apps/spindrift/test/config/manifest-upgrade.test.ts
@@ -192,6 +192,42 @@ describe('the vessels a pre-declaration document is upgraded into', () => {
     }
   });
 
+  test('take their kind from the address stated, not from the adapter', () => {
+    // The reverse lookup this step used to make assumed each surface belonged
+    // to exactly one kind of boundary. A project that runs a cluster breaks
+    // that assumption, and the old code would have called this vessel a
+    // `cluster` because its surface is `kubernetes`. What the document
+    // actually says is a project.
+    const upgraded = upgradeManifestDocument({
+      targets: [
+        {
+          name: 'inside-a-project',
+          adapter: 'kubernetes',
+          connection: { project: 'example-vessel', namespace: 'apps' },
+        },
+      ],
+    }) as { vessels: unknown[] };
+    expect(upgraded.vessels).toEqual([
+      {
+        name: 'inside-a-project',
+        kind: 'gcp-project',
+        location: { project: 'example-vessel' },
+      },
+    ]);
+  });
+
+  test('and a boundary no address was stated for gets no invented kind', () => {
+    // No address means the document does not say what shape this boundary has,
+    // and there is nothing left to infer it from. This step declares nothing
+    // rather than guessing, so validation reports the document instead of a
+    // kind nothing would ever check. (`dropTargetNames` still runs — the two
+    // steps are independent.)
+    const upgraded = upgradeManifestDocument({
+      targets: [{ name: 'nowhere', adapter: 'kubernetes' }],
+    });
+    expect(upgraded).not.toHaveProperty('vessels');
+  });
+
   test('is a no-op on a document that already declares them', () => {
     // `02` now upgrades too — `dropTargetNames` still takes its constructed
     // `name` off every entry. `03` is the shape with neither gap, so this is

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -152,20 +152,6 @@ describe('boot fails loudly', () => {
     );
   });
 
-  test('when a Target names a vessel whose kind cannot carry its surface', () => {
-    // `SURFACES_BY_VESSEL_KIND` is the one statement of which runtimes a
-    // boundary carries, and this is where the document is held to it — a
-    // `cloudrun` surface on a cluster is refused here rather than reaching an
-    // adapter that has no way to place it.
-    const document = fixtureText.replace(
-      '  - vessel: cloud\n    adapter: cloudrun',
-      '  - vessel: cluster\n    adapter: cloudrun',
-    );
-    expect(() => parseManifest(document, 'test')).toThrow(
-      /a cluster vessel does not carry a cloudrun surface/,
-    );
-  });
-
   test('on duplicate vessel names', () => {
     const document = fixtureText.replace(
       '  - name: cloud\n',
@@ -178,6 +164,38 @@ describe('boot fails loudly', () => {
     const document = fixtureText.split('targets:')[0] ?? '';
     expect(() => parseManifest(`${document}targets: []\n`, 'test')).toThrow(
       /targets/,
+    );
+  });
+});
+
+/**
+ * The refusal this schema deliberately stopped making.
+ *
+ * A `targets[]` entry **is** how a document declares a surface on a vessel, and
+ * which runtimes a boundary really has is established by probing it at connect.
+ * A vessel's `kind` says only what shape its location has, so holding the
+ * document to a table of surfaces per kind would refuse a project that runs a
+ * cluster on the authority of a value that knows nothing about it.
+ */
+describe('a vessel’s kind is not a list of the runtimes on it', () => {
+  test('a document may declare a surface no table pairs with that kind', () => {
+    const document = fixtureText.replace(
+      '  - vessel: cloud\n    adapter: cloudrun',
+      '  - vessel: cluster\n    adapter: cloudrun',
+    );
+    expect(() => parseManifest(document, 'test')).not.toThrow();
+  });
+
+  test('and the reference itself is still checked', () => {
+    // What survives is the rule that has teeth: `reconcileManifestTargets`
+    // looks a vessel up by name, so a Target naming one the document does not
+    // declare is a seed with nothing to attach to.
+    const document = fixtureText.replace(
+      '  - vessel: cloud\n    adapter: cloudrun',
+      '  - vessel: nowhere\n    adapter: cloudrun',
+    );
+    expect(() => parseManifest(document, 'test')).toThrow(
+      /no vessel named nowhere is declared/,
     );
   });
 });

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -198,6 +198,16 @@ export function deployAdapterSuite(
       }
     });
 
+    test('inspect says whether the boundary carries this surface', async () => {
+      // The question `connectTarget` acts on: a surface the probe establishes
+      // is not there gets no Target at all. Every adapter answers it, because
+      // core holds a `DeployAdapter` without knowing which backend is behind
+      // it — and it answers `carried` here, since the far side these suites
+      // stand up is one that answers.
+      const { surface } = await make().inspect(target);
+      expect(surface).toEqual({ kind: 'carried' });
+    });
+
     test('inspect reports observations, not judgements', async () => {
       const { discovery } = await make().inspect(target);
       // `verifiedDeploy` and `offlineDeploy` are core's conclusions (§32, §33).

--- a/apps/spindrift/test/domain/vessel.test.ts
+++ b/apps/spindrift/test/domain/vessel.test.ts
@@ -1,50 +1,64 @@
 /**
- * The test `src/domain/vessel.ts` says keeps its surface table honest.
+ * The test `src/domain/vessel.ts` says keeps its probe list honest.
  *
- * The file cites this one by name — "`satisfies Record<VesselKind, ...>` and
- * the test in `test/domain/vessel.test.ts` between them keep true" — and it did
- * not exist, so half of what guarded `vesselKindFor`'s unreachable throw was a
- * comment. `satisfies` proves every *kind* has an entry; nothing proved every
- * *adapter* appears in one, which is the direction the throw depends on.
+ * What this file asserted first was that no adapter appeared under two vessel
+ * kinds, because a reverse lookup from a surface to a kind returned the first
+ * match and a surface on two kinds made it a silent coin flip. That lookup is
+ * gone, and with it the constraint: a boundary carries what a probe finds on
+ * it, so the same runtime may be probed for under two kinds without anything
+ * becoming ambiguous. Asserting exclusivity now would re-impose by test the
+ * rule the model dropped.
+ *
+ * So the claims here are the ones that survive it: the list is a list of real
+ * surfaces, every kind has something to ask about, and the answer to "which
+ * surfaces does this vessel carry" is not in this file at all.
  */
 import { describe, expect, test } from 'bun:test';
 import { targetAdapterSchema } from '../../src/config/manifest.schema.ts';
+import * as exports from '../../src/domain/vessel.ts';
 import {
   claimsDisagree,
-  SURFACES_BY_VESSEL_KIND,
-  surfacesOf,
+  surfacesToProbe,
   unionOfClaims,
   VESSEL_KINDS,
-  vesselKindFor,
 } from '../../src/domain/vessel.ts';
 
-describe('every surface is carried by a vessel kind', () => {
-  test.each(targetAdapterSchema.options)(
-    '%s resolves to the kind whose table lists it',
-    (adapter) => {
-      const kind = vesselKindFor(adapter);
-      expect(surfacesOf(kind)).toContain(adapter);
-    },
-  );
-
-  test('no adapter is carried by two kinds', () => {
-    // The reverse lookup returns the first match, so a surface on two kinds
-    // would resolve to whichever `VESSEL_KINDS` happens to list first — a
-    // silent coin flip rather than the exhaustive mapping the throw assumes.
-    const carriers = targetAdapterSchema.options.map((adapter) =>
-      VESSEL_KINDS.filter((kind) =>
-        (SURFACES_BY_VESSEL_KIND[kind] as readonly string[]).includes(adapter),
-      ),
-    );
-    expect(carriers.map((kinds) => kinds.length)).toEqual(
-      targetAdapterSchema.options.map(() => 1),
-    );
+describe('the surfaces a connect probes for', () => {
+  test('every kind has something to ask about', () => {
+    // A kind with an empty list is a boundary a connect would register nothing
+    // for, silently — the act would succeed and produce no Target and no
+    // sentence about why.
+    for (const kind of VESSEL_KINDS) {
+      expect(surfacesToProbe(kind).length).toBeGreaterThan(0);
+    }
   });
 
-  test('every kind carries at least one surface', () => {
+  test('every entry is a surface an adapter actually drives', () => {
+    // The teeth `satisfies Record<VesselKind, readonly TargetAdapter[]>` gives
+    // at compile time, kept at runtime: a probe list naming a runtime nothing
+    // implements sends `connectTarget` to an adapter that does not exist.
     for (const kind of VESSEL_KINDS) {
-      expect(surfacesOf(kind).length).toBeGreaterThan(0);
+      for (const surface of surfacesToProbe(kind)) {
+        expect(targetAdapterSchema.options).toContain(surface);
+      }
     }
+  });
+
+  test('reads in one direction, and there is no other', () => {
+    // The replacement for "no adapter is carried by two kinds". That assertion
+    // guarded a reverse lookup, and the reverse lookup is what a project
+    // running a cluster would have made a coin flip. Its absence is the claim:
+    // this module answers what to ask a kind of boundary and nothing answers
+    // which kind of boundary a surface belongs to, so where that answer is
+    // needed it comes from the Target rows — see
+    // `test/commands/targets.test.ts`, "the surfaces on a vessel are its rows".
+    expect(Object.keys(exports).sort()).toEqual([
+      'PROBED_SURFACES_BY_VESSEL_KIND',
+      'VESSEL_KINDS',
+      'claimsDisagree',
+      'surfacesToProbe',
+      'unionOfClaims',
+    ]);
   });
 });
 

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -908,6 +908,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
       'connection.chartValues.platform.gateway.namespace',
     ],
     edit: {
+      kind: 'cluster',
       apiServer: 'https://primary.example:6443',
       proposal: { carriedFrom: 'primary/kubernetes', namespace: 'apps' },
     },
@@ -972,6 +973,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     inspectedAt: '2026-08-02T12:00:00.000Z',
     connectionDivergence: [],
     edit: {
+      kind: 'cluster',
       apiServer: 'https://secondary.example:6443',
       proposal: { carriedFrom: 'secondary/kubernetes', namespace: 'apps' },
     },

--- a/apps/spindrift/test/harness/fakes/deploy-adapter.ts
+++ b/apps/spindrift/test/harness/fakes/deploy-adapter.ts
@@ -69,6 +69,15 @@ export interface FakeDeployAdapterOptions {
   /** When set, `inspect` throws — the Target that cannot be reached at all. */
   unreachable?: string;
   /**
+   * When set, `inspect` reports the boundary does not carry this surface.
+   *
+   * The far side saying "there is no such runtime here" — a cloud project with
+   * the service switched off — which is a different answer from a refused read
+   * and has to be arrangeable separately from {@link unreachable} for a test to
+   * tell core's two responses apart.
+   */
+  surfaceAbsent?: string;
+  /**
    * When set, `apply` throws instead of returning a verdict.
    *
    * §6 contracts `apply` not to throw — "an adapter that cannot place the
@@ -286,14 +295,21 @@ export class FakeDeployAdapter implements DeployAdapter {
       // the adapter is allowed to fail, and core has to survive it.
       throw new Error(this.options.unreachable);
     }
+    const absent = this.options.surfaceAbsent;
     const unmet = this.options.unmet ?? {};
     return {
       prerequisites: prerequisitesFor(this.adapter).map((name) =>
-        unmet[name] === undefined
-          ? { name, met: true }
-          : { name, met: false, detail: unmet[name] },
+        absent !== undefined
+          ? { name, met: false, detail: absent }
+          : unmet[name] === undefined
+            ? { name, met: true }
+            : { name, met: false, detail: unmet[name] },
       ),
       discovery: { ...CAPABLE_DISCOVERY, ...this.options.discovery },
+      surface:
+        absent === undefined
+          ? { kind: 'carried' }
+          : { kind: 'absent', detail: absent },
     };
   }
 

--- a/apps/spindrift/test/harness/installation.ts
+++ b/apps/spindrift/test/harness/installation.ts
@@ -38,7 +38,7 @@ import {
   deployTargetOf,
   type TargetConnection,
 } from '../../src/domain/target.ts';
-import { vesselKindFor } from '../../src/domain/vessel.ts';
+import type { VesselKind } from '../../src/domain/vessel.ts';
 import { defaultVesselId } from './db.ts';
 
 const FIXTURE = join(import.meta.dir, '../fixtures/installation.example.yaml');
@@ -220,9 +220,28 @@ export function connectionFor(adapter: TargetAdapter): TargetConnection {
   }
 }
 
+/**
+ * Which of the seeded vessels a fixture Target of this adapter sits on.
+ *
+ * A **fixture convention, not a domain rule.** The domain has no reverse lookup
+ * from a surface to a kind of boundary — a project may run a cluster, and which
+ * surfaces a vessel carries is what its Targets say — so this is only the
+ * arrangement `withIsolatedDatabase` seeds, spelled once so every fixture
+ * reaches the same row.
+ */
+const FIXTURE_VESSEL_KIND = {
+  kubernetes: 'cluster',
+  cloudrun: 'gcp-project',
+  static: 'gcp-project',
+} as const satisfies Record<TargetAdapter, VesselKind>;
+
+export function fixtureVesselKind(adapter: TargetAdapter): VesselKind {
+  return FIXTURE_VESSEL_KIND[adapter];
+}
+
 /** The boundary one adapter's surfaces sit on. */
 export function vesselFor(adapter: TargetAdapter): NewVessel {
-  const kind = vesselKindFor(adapter);
+  const kind = fixtureVesselKind(adapter);
   return {
     name: `vessel-${crypto.randomUUID()}`,
     kind,
@@ -282,7 +301,7 @@ export function targetValues(overrides: Partial<NewTarget> = {}): NewTarget {
     rank: 0,
     // The isolated database seeds one vessel per kind; a Target that wants its
     // own passes it. See `defaultVesselId`.
-    vesselId: defaultVesselId(vesselKindFor(adapter)),
+    vesselId: defaultVesselId(fixtureVesselKind(adapter)),
     connection: connectionFor(adapter),
     health: 'healthy',
     // The cluster fixture wires an ExternalAuth backend, so it asserts the edge

--- a/apps/spindrift/test/reconciler/target-loop.test.ts
+++ b/apps/spindrift/test/reconciler/target-loop.test.ts
@@ -208,6 +208,36 @@ describe('one pass over every connected Target', () => {
   });
 });
 
+describe('a surface whose vessel states the other kind of address', () => {
+  test('says which address is missing instead of asking the adapter', async () => {
+    // The manifest allows this pairing on purpose — which runtimes a boundary
+    // carries is established by probing it, not by a table of surfaces per
+    // kind — so a `cloudrun` surface can sit on a cluster. What it must not do
+    // is reach the adapter: composed from a cluster's address the connection
+    // carries no project, and Cloud Run would request `projects/undefined`
+    // every tick and hand the operator a sentence with `undefined` in it.
+    const { registry, of } = fakes();
+    const clock = ticking();
+    const vessel = await insertVessel(database().db, 'kubernetes', {
+      name: 'cluster',
+    });
+    const [row] = await database()
+      .db.insert(targets)
+      .values(targetValues({ adapter: 'cloudrun', vesselId: vessel.id }))
+      .returning();
+
+    const refresh = await refreshTarget(context(registry, clock), row!, vessel);
+
+    expect(refresh.health).toBe('unhealthy');
+    expect(of('cloudrun').inspected).toEqual([]);
+    // §3's grammar: an unmet checklist item carrying the reason, which is what
+    // makes the Target a non-candidate with something an operator can act on.
+    const stored = await targetRow('cluster', 'cloudrun');
+    expect(stored.prerequisites?.[0]?.detail).toContain('states no project');
+    expect(stored.prerequisites?.every((item) => !item.met)).toBe(true);
+  });
+});
+
 describe('a capability flip changes candidacy on the next pass', () => {
   test('without a reconnect', async () => {
     const { registry, of } = fakes();


### PR DESCRIPTION
## Summary

The set of runtime surfaces on a vessel becomes a fact about that vessel, established by probing it at connect, rather than a property of its `kind` read out of a fixed table.

- `DeployAdapter.inspect` answers a third question alongside the checklist and discovery: a `SurfaceProbe` with three arms — `carried` / `absent` / `undetermined`. Only an established absence (`SERVICE_DISABLED`) withholds a Target; a `403`, an absent federation, or a failed read registers the Target unhealthy with the sentence attached, so an unreachable cluster still produces a row and a confident absence is never rendered from a failed read. A `404` is deliberately not an absence — GCP answers one for a project the identity cannot see.
- Connect registers one Target per surface it finds; a surface that already has a row is refreshed, never withdrawn. The standing loop refreshes state on existing rows and never creates one — new Targets come only from an explicit connect act, and a connected cloud boundary can now be asked for its surfaces again from the Targets screen.
- `SURFACES_BY_VESSEL_KIND` demotes to `PROBED_SURFACES_BY_VESSEL_KIND` — what to probe for, not what exists. `vesselKindFor` is deleted; the manifest upgrade resolves each vessel's kind from the document's own stated addresses, falling back to what the vessels migration already wrote for that row when a seed states no address. The manifest refinement asks "does this vessel declare this surface", so a document may declare a `kubernetes` surface on a `gcp-project`; a surface whose vessel's location cannot address it lands unhealthy with the reason instead of issuing `projects/undefined` reads.
- `kind` is documented as the discriminant for `location`'s shape and nothing else. No `vessels.surfaces` column: "which surfaces does this vessel carry" is a query over `targets`.

Out of scope, deliberately: actually probing for GKE on a project (this makes it expressible, nothing more), VM/bare-machine vessels, and enabling anything at the boundary — discovery only reads.

## Validation

- `bun run typecheck` clean; `bun run lint` clean.
- `bun test`: 1754 pass / 0 fail (the only environment-sensitive tests elsewhere shell out to `node`/`jq` and pass with those on PATH; none are touched).
- New coverage: probe arms per adapter, connect withholding only on established absence, the standing loop never creating rows, the upgrade preserving a pre-`vessels` document's vessel rows (address-less seeds included, `<name>-kubernetes` names not renamed), and the unstated-address guard.

## Risk

- No DB migration; Targets appear only through connect acts, so existing rows are untouched on roll.
- The manifest upgrade path was reworked; three defects the first cut introduced there (whole-document abandonment on address-less seeds, suffix-stripping renames) were found in review and are fixed with tests pinning the migrated rows.
- An absence found by a probe is shown in the connect response and not persisted — deliberate, to avoid a second stale copy of "which runtimes does this boundary carry"; the re-probe control is the answer.
