### PR TITLE
chore(flux): reconcile spindrift within five minutes

### DIFF
--- a/clusters/offsite/bootstrap/flux-values.yaml
+++ b/clusters/offsite/bootstrap/flux-values.yaml
@@ -13,4 +13,4 @@ instance:
     ref: "refs/heads/main"
     path: "clusters/offsite/flux-system"
     pullSecret: "flux-github-app-credentials"
-    interval: "1h"
+    interval: "5m"

--- a/clusters/offsite/flux-system/apps.yaml
+++ b/clusters/offsite/flux-system/apps.yaml
@@ -5,7 +5,7 @@ metadata:
   name: apps
   namespace: flux-system
 spec:
-  interval: 1h0m0s
+  interval: 5m0s
   path: ./clusters/offsite/apps
   prune: true
   sourceRef:


### PR DESCRIPTION
## What gates pickup today

Live intervals observed on the offsite cluster (context `offsite`):

- `GitRepository/infra` (flux-system): `spec.interval: 1h` — polls `main` hourly.
- `Kustomization/apps` (flux-system, applies `clusters/offsite/apps`, which
  contains the spindrift `HelmRelease`): `spec.interval: 1h0m0s`.
- `HelmRelease/spindrift` (namespace `spindrift`): `spec.interval: 5m0s`,
  already at target, unchanged. It tracks its chart via `chartRef` to
  `OCIRepository/spindrift`, `spec.interval: 15m` — that repository polls the
  published chart artifact in `ghcr.io/jonpulsifer/charts/spindrift`, not the
  infra repo itself, so it's outside the "merged commit reaches the
  HelmRelease" path and is left alone.
- The root `Kustomization/infra` that applies `clusters/offsite/flux-system`
  runs at `10m0s`, but that value isn't declared anywhere in this repo — the
  `FluxInstance` CRD only exposes a single `sync.interval` (which sets the
  `GitRepository` interval); the root Kustomization's interval is an internal
  flux-operator default. It's not on the hot path either: kustomize-controller
  requeues dependents as soon as their source's artifact revision changes,
  independent of the dependent's own interval, so this isn't a lever available
  here.

Net effect: a merge to `main` could sit for up to an hour before
source-controller even noticed the new commit, which is why a manual
`flux reconcile` was needed after every merge.

## What changed

- `clusters/offsite/bootstrap/flux-values.yaml`: `instance.sync.interval`
  `1h` → `5m` (sets the `GitRepository/infra` interval; applied via
  `helm_release.flux` through Atlantis, not Flux).
- `clusters/offsite/flux-system/apps.yaml`: `Kustomization/apps`
  `spec.interval` `1h0m0s` → `5m0s`.

Nothing else moved. `HelmRelease/spindrift` was already at 5m, and the chart's
`OCIRepository` interval is a separate concern (new chart artifact pickup, not
infra-repo merges).

## Validation

- `kustomize build clusters/offsite/flux-system` — renders clean, confirms
  `Kustomization/apps` carries `interval: 5m0s`.
- `kustomize build clusters/offsite/apps` — renders clean (unaffected,
  sanity check).
- `tofu -chdir=clusters/offsite/bootstrap init -backend=false && tofu validate`
  — succeeds (one pre-existing deprecation warning on
  `kubernetes_secret.main`, unrelated to this change).