### PR TITLE
fix(atlantis): scope org allowlist and repo config to infra only

### DIFF
--- a/clusters/offsite/apps/atlantis/helm-release.yaml
+++ b/clusters/offsite/apps/atlantis/helm-release.yaml
@@ -16,7 +16,7 @@ spec:
     image:
       repository: ghcr.io/jonpulsifer/atlantis
       tag: latest@sha256:35e2eadfb38f5ca8d426170a73e0abcf833dfc001a93b02f0b59c2a0f965b3e1
-    orgAllowlist: github.com/jonpulsifer/*
+    orgAllowlist: github.com/jonpulsifer/infra
     environment:
       ATLANTIS_AUTOMERGE: "true"
       ATLANTIS_ALLOW_COMMANDS: "version,plan,apply,unlock,approve_policies,cancel,import"
@@ -75,7 +75,7 @@ spec:
     repoConfig: |
       ---
       repos:
-      - id: /^github.com/jonpulsifer/.*$/
+      - id: github.com/jonpulsifer/infra
         branch: /^main$/
         apply_requirements: []
         workflow: default


### PR DESCRIPTION
## Summary
- `orgAllowlist` was `github.com/jonpulsifer/*`, matching every repo in the org
- the `repos[]` id in `repoConfig` was `/^github.com/jonpulsifer/.*$/`, same problem
- Atlantis was picking up webhooks/comments on unrelated repos (e.g. `jonpulsifer/wishlist`)
- both now pin to `github.com/jonpulsifer/infra`

## Test plan
- [x] `kustomize build clusters/offsite/apps/atlantis` renders cleanly
- [x] rendered `HelmRelease.spec.values.orgAllowlist` and `repoConfig.repos[0].id` both resolve to `github.com/jonpulsifer/infra`
- [ ] merge to `main`, let Flux reconcile, confirm Atlantis no longer reacts to non-infra repos