### PR TITLE
feat(spindrift): make the installation's home a vessel

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -259,10 +259,18 @@ requires to describe the same place.
 Both reconcile from the mounted declaration **on every boot** and render
 read-only, which narrows — and does not invert — the rule that a declaration
 seeds and does not govern: every other vessel is still seed-once-then-UI-owns.
-Neither can be disconnected, guarded explicitly in the command path because
-neither pointer is a foreign key. **The home vessel's checklist may be red while
-the control plane runs on it**; that is already true of the manifest, and the
-guards are what make it safe.
+Read-only on the screens and refused underneath them: a write that would edit
+either of them names the paths a boot would take back rather than saving a value
+the next restart discards. Neither can be disconnected, guarded explicitly in
+the command path because neither pointer is a foreign key. **The home vessel's
+checklist may be red while the control plane runs on it**; that is already true
+of the manifest, and the guards are what make it safe.
+
+A boot reconciling those two moves the boundary and reassesses the surfaces on
+it; it does not re-assert the manifest's copy of a connection, and it does not
+null a fact the declaration is silent about. Both would undo the connect act on
+every restart, which is the same rule `ManifestWrite` already keeps one noun
+down.
 
 **A vessel has a checklist of its own**, keyed by kind × role the way
 `PREREQUISITES_BY_ADAPTER` keys off adapter

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -246,6 +246,34 @@ that Target's vessel is the boundary the Component runs in. Nothing on the App
 records this, because a second answer to one question can only disagree with the
 first.
 
+**Two vessels are the installation's own**, and the manifest names them:
+`installation.controlPlaneVessel` is where this control plane runs, and
+`installation.homeVessel` is where its shared services live — the source bucket,
+the store of record, the artifacts project and the signer. They are scalar
+pointers rather than a flag, so cardinality is free and "this vessel is
+undeletable" is *something points at it* rather than a column. The home vessel
+carries those services as its own properties (`shared`), which is what stops a
+bucket, a store and a project id from being four unrelated strings that nothing
+requires to describe the same place.
+
+Both reconcile from the mounted declaration **on every boot** and render
+read-only, which narrows — and does not invert — the rule that a declaration
+seeds and does not govern: every other vessel is still seed-once-then-UI-owns.
+Neither can be disconnected, guarded explicitly in the command path because
+neither pointer is a foreign key. **The home vessel's checklist may be red while
+the control plane runs on it**; that is already true of the manifest, and the
+guards are what make it safe.
+
+**A vessel has a checklist of its own**, keyed by kind × role the way
+`PREREQUISITES_BY_ADAPTER` keys off adapter
+(`VESSEL_PREREQUISITES_BY_KIND_AND_ROLE`). The home cloud vessel is asked
+whether its source bucket is there, whether the store answers, whether the
+signer is a key with a signing purpose and whether the artifacts project is
+visible; an app vessel is asked nothing, so it is never shown a green row for
+something nobody checked. `src/reconciler/vessel-loop.ts` is the standing pass,
+and it stores what was observed and never what was concluded — health is derived
+at read time, exactly as a Target's is.
+
 **A Target has no name.** `Target = Vessel × surface` is its identity as well as
 its definition: the pair is naturally unique — a boundary carries one runtime of
 each kind — so it is the unique index, it is what `connectTarget` and
@@ -762,7 +790,16 @@ validated value from Postgres. Boot fails loudly, naming every offending key,
 when a declaration or stored document is invalid, or when both are absent.
 Target connection facts in the document are desired state; omitting them leaves
 an in-product connection untouched. Nothing has a default, because a default
-here would name someone's homelab.
+here would name someone's homelab. The two vessels
+`installation.controlPlaneVessel` and `installation.homeVessel` name are the one
+exception to seeds-but-does-not-govern, for the reason above.
+
+A document written under an older schema is brought forward rather than
+discarded — `src/config/manifest-upgrade.ts`, run inside validation, because a
+row this build cannot parse is a row it treats as unseeded and re-seeds over.
+`test/fixtures/stored-manifests/` holds one frozen snapshot per shape a stored
+document has ever had and every one of them has to boot; the newest must need no
+upgrade at all, which is what makes the next schema change prove itself.
 
 ## Usage
 

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -26,10 +26,11 @@
 
 import { createHash } from 'node:crypto';
 import type { AdapterRegistry } from '../commands/types.ts';
-import type {
-  BuildRouteConfig,
-  StoreAdapter,
-  TargetAdapter,
+import {
+  type BuildRouteConfig,
+  type StoreAdapter,
+  sharedServicesOf,
+  type TargetAdapter,
 } from '../config/manifest.schema.ts';
 import type { InstallationManifest } from '../config/manifest.ts';
 import { CredentialKeyring } from '../crypto/credential-envelope.ts';
@@ -583,17 +584,17 @@ export function createSecretStore(
     token,
     ...(fetch ? { fetch } : {}),
   };
+  // The container is the home vessel's, because that is the boundary the store
+  // of record lives in — one place, whatever reaches it.
+  const { secretStoreContainer } = sharedServicesOf(manifest);
   const adapter = manifest.secretStore.adapter satisfies StoreAdapter;
   switch (adapter) {
     case 'onepassword':
-      return new OnePasswordStore({
-        ...endpoint,
-        vault: manifest.secretStore.container,
-      });
+      return new OnePasswordStore({ ...endpoint, vault: secretStoreContainer });
     case 'gcp-secret-manager':
       return new SecretManagerStore({
         ...endpoint,
-        project: manifest.secretStore.container,
+        project: secretStoreContainer,
       });
   }
 }

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -110,7 +110,10 @@ export const startCreationDraft: Command<
       draft: initialCreationDraft({
         repository: repository?.fullName ?? null,
         targetId: target?.id ?? null,
-        vessel: context.manifest.cloud.homeVesselProject,
+        // The vessel by name rather than by project id: the draft states which
+        // boundary this installation's home is, and a project is one shape a
+        // boundary's address happens to have.
+        vessel: context.manifest.installation.homeVessel,
       }),
       createdAt: now,
       updatedAt: now,

--- a/apps/spindrift/src/commands/installation/configure.ts
+++ b/apps/spindrift/src/commands/installation/configure.ts
@@ -30,7 +30,10 @@ import {
   installationManifestSchema,
 } from '../../config/manifest.schema.ts';
 import { ManifestError, validateManifest } from '../../config/manifest.ts';
-import { writeStoredManifest } from '../../config/manifest-store.ts';
+import {
+  governedSliceRefusal,
+  writeStoredManifest,
+} from '../../config/manifest-store.ts';
 import { targetLabel } from '../../domain/target.ts';
 import { type Command, failed, ok } from '../types.ts';
 
@@ -76,6 +79,18 @@ export const configureInstallation: Command<
       return failed('INVALID_INPUT', cause.message);
     }
     throw cause;
+  }
+
+  // The one slice this screen may not drive. A boot re-applies the declaration
+  // to the two vessels this installation is built on, so taking an edit to them
+  // here would be saving a value the next restart discards — the refusal is
+  // what turns that into something an operator reads before it happens. A
+  // `NOT_DEPLOYABLE` fact rather than an `INVALID_INPUT` field error: nothing
+  // in the document is malformed, and no amount of re-typing makes this
+  // installation take it.
+  const governed = governedSliceRefusal(manifest, context.declaration);
+  if (governed !== null) {
+    return failed('NOT_DEPLOYABLE', governed);
   }
 
   // **Reconciliation makes no refusal of its own.** It used to make exactly one

--- a/apps/spindrift/src/commands/installation/configure.ts
+++ b/apps/spindrift/src/commands/installation/configure.ts
@@ -87,7 +87,7 @@ export const configureInstallation: Command<
   await writeStoredManifest(context.db, manifest);
 
   return ok({
-    installation: manifest.installation,
+    installation: manifest.installation.name,
     targets: manifest.targets.map(targetLabel),
   });
 };

--- a/apps/spindrift/src/commands/installation/discover.ts
+++ b/apps/spindrift/src/commands/installation/discover.ts
@@ -65,17 +65,27 @@ export interface DiscoveredCandidate {
    * What is written at the fact's path when this candidate is chosen, verbatim.
    *
    * Carried rather than derived because the two are not always the same shape:
-   * `sources.buckets` is a list and takes `[name]`, while `sources.defaultBucket`
-   * takes the same name bare. A screen deriving that would be a screen with an
-   * opinion about the schema, which is exactly what it must not have.
+   * `sources.buckets` is a list and takes `[name]`, while the home vessel's
+   * `shared.sourceBucket` takes the same name bare. A screen deriving that
+   * would be a screen with an opinion about the schema, which is exactly what
+   * it must not have.
    */
   readonly value: unknown;
 }
 
 /** One manifest path, and what discovery could say about it. */
 export type DiscoveredFact = {
-  /** Where the chosen value belongs, as `forms/document.ts` addresses it. */
-  readonly path: readonly string[];
+  /**
+   * Where the chosen value belongs, as `forms/document.ts` addresses it.
+   *
+   * Numbers as well as keys, because three of these facts are properties of one
+   * *vessel* rather than of a top-level block: the home vessel is an entry in
+   * `vessels`, and its index is how a document addresses it. `withValueAt`
+   * already distinguishes the two — a numeric step indexes an array and a
+   * string step keys an object — so this is the path type that layer has, not a
+   * second one beside it.
+   */
+  readonly path: readonly (string | number)[];
 } & Discovered<DiscoveredCandidate>;
 
 export interface DiscoverInstallationFactsResult {
@@ -138,23 +148,30 @@ export const discoverInstallationFacts: Command<
       : signingKeysIn(discovery, project, kmsLocation),
   ]);
 
-  const suggestedVessel = homeVesselOf(context.manifest.cloud.federation);
+  const suggestedVessel = credentialProject(context.manifest.cloud.federation);
+  // Three of the five facts are the home vessel's own properties, so they are
+  // addressed through its position in `vessels`. Non-negative because the
+  // document-level refinement refuses a manifest whose `homeVessel` names
+  // nothing declared, so a validated one always resolves.
+  const home = context.manifest.vessels.findIndex(
+    (vessel) => vessel.name === context.manifest.installation.homeVessel,
+  );
 
   return ok({
     facts: [
       withSuggestion(
-        mapped(['cloud', 'homeVesselProject'], projects, plain),
+        mapped(['vessels', home, 'location', 'project'], projects, plain),
         suggestedVessel,
       ),
-      mapped(['cloud', 'artifactsProject'], projects, plain),
+      mapped(['vessels', home, 'shared', 'artifactsProject'], projects, plain),
       // The same one read, answered against both keys: a bucket chosen for one
-      // and not the other leaves a manifest whose default is not among its
-      // buckets, which validates and then stages nowhere.
+      // and not the other leaves a manifest whose staging bucket is not among
+      // its buckets, which validates and then stages nowhere.
       mapped(['sources', 'buckets'], buckets, (name) => ({
         label: name,
         value: [name],
       })),
-      mapped(['sources', 'defaultBucket'], buckets, plain),
+      mapped(['vessels', home, 'shared', 'sourceBucket'], buckets, plain),
       mapped(['supplyChain', 'signer'], signers, plain),
     ],
   });
@@ -207,7 +224,7 @@ async function signingKeysIn(
 
 /** One read, against one manifest path, in whichever arm it came back in. */
 function mapped(
-  path: readonly string[],
+  path: readonly (string | number)[],
   discovered: Discovered<string>,
   to: (value: string) => DiscoveredCandidate,
 ): DiscoveredFact {
@@ -254,13 +271,13 @@ function withSuggestion(
 }
 
 /**
- * The home vessel this installation's own identity lives in, if it says.
+ * The project this installation's own identity lives in, if the credential says.
  *
  * Labelled with its provenance, not with the bare id: what is written is the
  * project, but what is read is where the answer came from — this deployment's
  * own credential rather than anything the cloud was asked.
  */
-function homeVesselOf(
+function credentialProject(
   federation: FederationConfig,
 ): DiscoveredCandidate | null {
   const url = federation.impersonationUrl;

--- a/apps/spindrift/src/commands/installation/discover.ts
+++ b/apps/spindrift/src/commands/installation/discover.ts
@@ -73,20 +73,69 @@ export interface DiscoveredCandidate {
   readonly value: unknown;
 }
 
+/**
+ * The step a path takes to reach the vessel `installation.homeVessel` names.
+ *
+ * A stand-in for that entry's position rather than the position itself. Three of
+ * these facts are properties of one *vessel* — the home vessel is an entry in
+ * `vessels` — and an index computed where the answer was produced is an index
+ * the document may have moved since: the settings form removes array entries,
+ * and adopting a declaration replaces the array whole. A value written at a
+ * stale index lands on whichever boundary slid into it, and `location.project`
+ * carries no refinement that would refuse it.
+ *
+ * {@link placementOf} resolves it against the document being edited, at the
+ * moment a candidate is confirmed. Unambiguous as a string because the segment
+ * before it names an array, and an array is never keyed by a name.
+ */
+export const HOME_VESSEL = 'homeVessel';
+
 /** One manifest path, and what discovery could say about it. */
 export type DiscoveredFact = {
   /**
-   * Where the chosen value belongs, as `forms/document.ts` addresses it.
+   * Where the chosen value belongs, as `forms/document.ts` addresses it, with
+   * {@link HOME_VESSEL} standing in for a position only the document can give.
    *
-   * Numbers as well as keys, because three of these facts are properties of one
-   * *vessel* rather than of a top-level block: the home vessel is an entry in
-   * `vessels`, and its index is how a document addresses it. `withValueAt`
-   * already distinguishes the two — a numeric step indexes an array and a
-   * string step keys an object — so this is the path type that layer has, not a
-   * second one beside it.
+   * Numbers as well as keys, because `withValueAt` already distinguishes the
+   * two — a numeric step indexes an array and a string step keys an object — so
+   * this is the path type that layer has, not a second one beside it.
    */
   readonly path: readonly (string | number)[];
 } & Discovered<DiscoveredCandidate>;
+
+/**
+ * Where a discovered value goes in this document — `null` for one that declares
+ * no home vessel to put it on.
+ *
+ * The whole of what {@link HOME_VESSEL} costs, and it is here rather than on the
+ * screen for the reason the panel states about itself: resolving a pointer to a
+ * position is knowledge about this schema, and a panel that held any would be
+ * the panel that stops working when a key moves.
+ */
+export function placementOf(
+  fact: DiscoveredFact,
+  document: unknown,
+): readonly (string | number)[] | null {
+  const [head, next, ...rest] = fact.path;
+  if (head !== 'vessels' || next !== HOME_VESSEL) return fact.path;
+  const home = homeVesselIndex(document);
+  return home === null ? null : ['vessels', home, ...rest];
+}
+
+/** Where the vessel this document's `homeVessel` names sits in its `vessels`. */
+function homeVesselIndex(document: unknown): number | null {
+  const doc = document as {
+    installation?: { homeVessel?: unknown };
+    vessels?: unknown;
+  } | null;
+  const name = doc?.installation?.homeVessel;
+  const vessels = doc?.vessels;
+  if (typeof name !== 'string' || !Array.isArray(vessels)) return null;
+  const index = vessels.findIndex(
+    (vessel) => (vessel as { name?: unknown })?.name === name,
+  );
+  return index === -1 ? null : index;
+}
 
 export interface DiscoverInstallationFactsResult {
   /** In display order. Empty is not a state this command can produce. */
@@ -150,20 +199,23 @@ export const discoverInstallationFacts: Command<
 
   const suggestedVessel = credentialProject(context.manifest.cloud.federation);
   // Three of the five facts are the home vessel's own properties, so they are
-  // addressed through its position in `vessels`. Non-negative because the
-  // document-level refinement refuses a manifest whose `homeVessel` names
-  // nothing declared, so a validated one always resolves.
-  const home = context.manifest.vessels.findIndex(
-    (vessel) => vessel.name === context.manifest.installation.homeVessel,
-  );
-
+  // addressed through {@link HOME_VESSEL} rather than through the position that
+  // vessel holds in the document this process happens to be holding.
   return ok({
     facts: [
       withSuggestion(
-        mapped(['vessels', home, 'location', 'project'], projects, plain),
+        mapped(
+          ['vessels', HOME_VESSEL, 'location', 'project'],
+          projects,
+          plain,
+        ),
         suggestedVessel,
       ),
-      mapped(['vessels', home, 'shared', 'artifactsProject'], projects, plain),
+      mapped(
+        ['vessels', HOME_VESSEL, 'shared', 'artifactsProject'],
+        projects,
+        plain,
+      ),
       // The same one read, answered against both keys: a bucket chosen for one
       // and not the other leaves a manifest whose staging bucket is not among
       // its buckets, which validates and then stages nowhere.
@@ -171,7 +223,11 @@ export const discoverInstallationFacts: Command<
         label: name,
         value: [name],
       })),
-      mapped(['vessels', home, 'shared', 'sourceBucket'], buckets, plain),
+      mapped(
+        ['vessels', HOME_VESSEL, 'shared', 'sourceBucket'],
+        buckets,
+        plain,
+      ),
       mapped(['supplyChain', 'signer'], signers, plain),
     ],
   });

--- a/apps/spindrift/src/commands/storage/list-buckets.ts
+++ b/apps/spindrift/src/commands/storage/list-buckets.ts
@@ -2,6 +2,7 @@
  * `listSourceBuckets` — list first-party GCS buckets for archive sources and artifacts.
  */
 import { z } from 'zod';
+import { sharedServicesOf } from '../../config/manifest.schema.ts';
 import { type Command, ok } from '../types.ts';
 
 export const listSourceBucketsInput = z.object({}).strict();
@@ -10,6 +11,7 @@ export type ListSourceBucketsInput = z.infer<typeof listSourceBucketsInput>;
 
 export interface ListSourceBucketsResult {
   readonly buckets: readonly string[];
+  /** The home vessel's `shared.sourceBucket` — what a staging picks. */
   readonly defaultBucket: string;
   /**
    * Whether this installation can reach a bucket to check one at all (§13).
@@ -26,10 +28,9 @@ export const listSourceBuckets: Command<
   ListSourceBucketsInput,
   ListSourceBucketsResult
 > = async (_input, context) => {
-  const { buckets, defaultBucket } = context.manifest.sources;
   return ok({
-    buckets,
-    defaultBucket: defaultBucket ?? buckets[0] ?? '',
+    buckets: context.manifest.sources.buckets,
+    defaultBucket: sharedServicesOf(context.manifest).sourceBucket,
     canVerify: context.manifest.cloud.federation !== null,
   });
 };

--- a/apps/spindrift/src/commands/storage/use-bucket.ts
+++ b/apps/spindrift/src/commands/storage/use-bucket.ts
@@ -29,7 +29,10 @@
  * rather than a document this act half-rewrote.
  */
 import { z } from 'zod';
-import type { AuthoredManifest } from '../../config/manifest.schema.ts';
+import {
+  type AuthoredManifest,
+  sharedServicesOf,
+} from '../../config/manifest.schema.ts';
 import { ManifestError, validateManifest } from '../../config/manifest.ts';
 import {
   readStoredManifest,
@@ -117,13 +120,23 @@ export const useSourceBucket: Command<
   const buckets = stored.sources.buckets.includes(input.bucketName)
     ? stored.sources.buckets
     : [...stored.sources.buckets, input.bucketName];
-  const defaultBucket = input.makeDefault
+  // Which bucket a staging picks is a property of the home vessel, so making
+  // one the default is a write to that vessel rather than to `sources`. The
+  // list and the choice therefore move in one document, which is what keeps a
+  // default that is not among the buckets unrepresentable.
+  const shared = sharedServicesOf(stored);
+  const sourceBucket = input.makeDefault
     ? input.bucketName
-    : (stored.sources.defaultBucket ?? buckets[0]);
+    : shared.sourceBucket;
 
   const next: AuthoredManifest = {
     ...stored,
-    sources: { ...stored.sources, buckets, defaultBucket },
+    sources: { ...stored.sources, buckets },
+    vessels: stored.vessels.map((vessel) =>
+      vessel.name === stored.installation.homeVessel
+        ? { ...vessel, shared: { ...shared, sourceBucket } }
+        : vessel,
+    ),
   };
 
   try {
@@ -144,9 +157,7 @@ export const useSourceBucket: Command<
 
   return ok({
     buckets,
-    // Non-null by construction: `sources.buckets` has a minimum of one, and the
-    // bucket just verified is in it.
-    defaultBucket: defaultBucket ?? input.bucketName,
+    defaultBucket: sourceBucket,
     location: verified.location,
     permissions: verified.permissions,
   });

--- a/apps/spindrift/src/commands/storage/use-bucket.ts
+++ b/apps/spindrift/src/commands/storage/use-bucket.ts
@@ -35,6 +35,7 @@ import {
 } from '../../config/manifest.schema.ts';
 import { ManifestError, validateManifest } from '../../config/manifest.ts';
 import {
+  governedSliceRefusal,
   readStoredManifest,
   writeStoredManifest,
 } from '../../config/manifest-store.ts';
@@ -139,21 +140,32 @@ export const useSourceBucket: Command<
     ),
   };
 
+  let updated: AuthoredManifest;
   try {
     // Validated on the way out even though only two keys moved: the document
     // that gets written is the one that has to be valid, and a stored manifest
     // that was already drifting from the schema must not be made durable again
     // by an act that never looked at the rest of it.
-    await writeStoredManifest(
-      context.db,
-      validateManifest(next, 'the updated manifest'),
-    );
+    updated = validateManifest(next, 'the updated manifest');
   } catch (cause) {
     if (cause instanceof ManifestError) {
       return failed('NOT_DEPLOYABLE', cause.message);
     }
     throw cause;
   }
+
+  // Which bucket a staging picks is the home vessel's, and an installation that
+  // mounts a declaration takes that vessel from it on every boot. Making a
+  // default here would then leave the added bucket standing and the choice
+  // reverted — an act half-applied, with nothing on screen saying which half.
+  // Refused whole rather than half-applied: adding without choosing is the
+  // other arm of this same command, and it is still open.
+  const governed = governedSliceRefusal(updated, context.declaration);
+  if (governed !== null) {
+    return failed('NOT_DEPLOYABLE', governed);
+  }
+
+  await writeStoredManifest(context.db, updated);
 
   return ok({
     buckets,

--- a/apps/spindrift/src/commands/targets/disconnect.ts
+++ b/apps/spindrift/src/commands/targets/disconnect.ts
@@ -19,6 +19,7 @@
 import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import {
+  isDeclaredInstallationVessel,
   type TargetAdapter,
   targetAdapterSchema,
 } from '../../config/manifest.schema.ts';
@@ -73,6 +74,24 @@ export const disconnectTarget: Command<
 > = async (input, context) => {
   const now = context.clock.now();
   const confirmed = input.confirm ?? true;
+
+  // The two vessels this installation is built on are not an operator's to
+  // remove. Neither pointer is a foreign key, so nothing below would stop this
+  // the way `targets_vessel_id_vessels_id_fk`'s `restrict` stops a vessel with
+  // surfaces from being dropped — the guard is the substitute for that, and it
+  // is checked before the review as well as before the write, so the impact
+  // screen never offers a button that cannot be pressed.
+  //
+  // Refused rather than warned about, because the bootstrap paradox makes the
+  // failure quiet: disconnecting the boundary the control plane runs on, or the
+  // one holding the source bucket and the store, leaves a process that keeps
+  // serving right up until the next thing it tries to stage or deliver.
+  if (isDeclaredInstallationVessel(context.manifest, input.vessel)) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      `${input.vessel} is a vessel this installation is built on, so its surfaces cannot be disconnected — change the declaration and re-seed instead`,
+    );
+  }
 
   // The pair, not a name: `(vessel, adapter)` is what a Target is, and it is the
   // unique index too, so this resolves at most one row.

--- a/apps/spindrift/src/commands/targets/list.ts
+++ b/apps/spindrift/src/commands/targets/list.ts
@@ -16,12 +16,18 @@ import {
   type OnboardingTargetRow,
   pendingConnections,
 } from '../../domain/target-onboarding.ts';
-import { surfacesToProbe, type VesselLocation } from '../../domain/vessel.ts';
+import {
+  deriveVesselHealth,
+  surfacesToProbe,
+  type VesselLocation,
+  vesselRolesOf,
+} from '../../domain/vessel.ts';
 import type {
   CloudBoundaryFacts,
   PendingTargetConnection,
   TargetListItem,
   TargetOptionView,
+  VesselListItem,
 } from '../../web/model.ts';
 import { type Command, ok } from '../types.ts';
 
@@ -182,6 +188,12 @@ export interface ListTargetsResult {
   readonly options: readonly TargetOptionView[];
   /** Connect acts this installation is waiting on — the onboarding surface. */
   readonly pending: readonly PendingTargetConnection[];
+  /**
+   * The boundaries themselves, with the checklist that is theirs rather than a
+   * surface's. In declaration order, so the two the installation is built on
+   * read where the manifest put them.
+   */
+  readonly vessels: readonly VesselListItem[];
 }
 
 export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
@@ -246,6 +258,7 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
         target.connection,
       ),
       edit: editStart(target, allTargets),
+      vesselRoles: vesselRolesOf(context.manifest, target.vessel.name),
     });
 
     const isConnected = target.status === 'connected';
@@ -333,9 +346,32 @@ export const listTargets: Command<ListTargetsInput, ListTargetsResult> = async (
     }
   }
 
+  const vesselRows = await context.db.query.vessels.findMany({
+    orderBy: (vessels, { asc }) => [asc(vessels.createdAt), asc(vessels.name)],
+  });
+
   return ok({
     targets: targetsList,
     options: optionsList,
     pending: pendingConnections(allTargets),
+    vessels: vesselRows.map((vessel) => {
+      const roles = vesselRolesOf(context.manifest, vessel.name);
+      const prerequisites = vessel.prerequisites ?? [];
+      return {
+        name: vessel.name,
+        kind: vessel.kind,
+        roles,
+        // Derived here rather than stored, exactly as a Target's is: the
+        // catalogue can gain a row in a release, and a stored verdict would
+        // keep reading healthy against a question nobody had asked yet.
+        health: deriveVesselHealth(prerequisites, vessel.kind, roles),
+        prerequisites: prerequisites.map((item) => ({
+          name: item.name,
+          met: item.met,
+          ...(item.detail === undefined ? {} : { detail: item.detail }),
+        })),
+        inspectedAt: vessel.inspectedAt?.toISOString() ?? null,
+      };
+    }),
   });
 };

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -184,6 +184,46 @@ function governedByDeclaration(
 }
 
 /**
+ * The sentence refusing a document the next boot would take back, or `null` for
+ * one it would leave standing.
+ *
+ * **The guard every write path owes the governed slice.** `loadStoredManifest`
+ * re-applies {@link governedByDeclaration} on every boot, so an operator edit to
+ * the two pointers or to either vessel they name is accepted, saved, and
+ * reverted at the next pod restart — with the screen that took it then showing
+ * the old values and no reason why. That is the failure `ManifestWrite` records
+ * having already happened once to a Target's connection; refusing here is the
+ * same answer one noun up, and it is what makes the two names safe to govern.
+ *
+ * Derived by running the merge and diffing rather than by a second list of the
+ * governed keys: the check and the governance are then the same code, so a
+ * pointer that starts governing something new cannot start being editable at
+ * the same moment.
+ *
+ * Paths, never values, for the reason {@link diffManifestPaths} gives. `null`
+ * with no declaration mounted, because there is then nothing to govern and the
+ * row is the operator's outright.
+ */
+export function governedSliceRefusal(
+  manifest: AuthoredManifest,
+  declaration: AuthoredManifest | null | undefined,
+): string | null {
+  if (declaration == null) return null;
+  // Both sides through the same parse. The schema normalizes as it validates —
+  // `supplyChain.registry` is authored as a string or a list and comes out a
+  // list — and {@link governedByDeclaration} validates what it merges, so
+  // diffing that against an unnormalized document would report every
+  // normalization as a path a boot reverts and refuse a document nobody edited.
+  const normalized = validateManifest(manifest, 'the submitted manifest');
+  const reverted = diffManifestPaths(
+    governedByDeclaration(normalized, declaration),
+    normalized,
+  );
+  if (reverted.length === 0) return null;
+  return `the vessels this installation is built on are declared, and it reconciles them from the mounted declaration on every boot — so this document would be taken back at: ${reverted.join(', ')}. Change the declaration instead.`;
+}
+
+/**
  * What a write of the stored manifest **is**, which is what decides whether a
  * declared Target connection lands on the row.
  *
@@ -435,13 +475,22 @@ async function reconcileManifestTargets(
       'Declared Target connection is awaiting inspection',
       adapter,
     );
+    // The declaration asserting its own copy of this connection over the row,
+    // which only a `declared` write does — see {@link ManifestWrite}.
+    const connectionAsserted =
+      write === 'declared' &&
+      declaredConnection !== null &&
+      !Bun.deepEquals(existing?.connection, declaredConnection, true);
     // Either half moving invalidates the assessment: the surface's own facts,
-    // or the boundary they are facts about.
-    const hasConnectionChange =
-      vessel.moved ||
-      (write === 'declared' &&
-        declaredConnection !== null &&
-        !Bun.deepEquals(existing?.connection, declaredConnection, true));
+    // or the boundary they are facts about. Only the first of the two moves the
+    // connection, and keeping them apart is what makes a governed vessel safe to
+    // reconcile on a boot: there `declaredConnection` is the stored document's
+    // own copy — `null` for every Target the manifest seeds without connection
+    // facts — so writing it would silently discard the connection an operator
+    // supplied through the connect screen, on the strength of a boundary edit
+    // that said nothing about it. The row would still read `connected` while
+    // `hasTargetConnection` skipped it everywhere.
+    const reassess = vessel.moved || connectionAsserted;
 
     await db
       .insert(targets)
@@ -479,14 +528,29 @@ async function reconcileManifestTargets(
           // declaration can correct a reach without touching the connection,
           // and folded in there that edit would land nothing.
           ...(write === 'declared' ? assertedBySeed(target) : {}),
-          ...(hasConnectionChange
+          ...(connectionAsserted
             ? {
                 ...(existing?.status === 'disconnected'
                   ? {}
                   : { status: 'connected' as const }),
                 connection: declaredConnection,
+              }
+            : {}),
+          ...(reassess
+            ? {
                 health: 'unhealthy' as const,
-                prerequisites: awaitingInspection,
+                // The reason the checklist was thrown away, in the words of
+                // whichever half moved. A boundary that moved under a Target
+                // nobody declared a connection for is not "a declared Target
+                // connection awaiting inspection", and reading that on a
+                // screen would send an operator looking for a declaration
+                // that says nothing about it.
+                prerequisites: connectionAsserted
+                  ? awaitingInspection
+                  : unreachablePrerequisites(
+                      'The boundary this Target is on moved and is awaiting inspection',
+                      adapter,
+                    ),
                 discovery: null,
                 inspectedAt: null,
                 updatedAt: sql`now()`,
@@ -640,9 +704,24 @@ async function reconcileManifestVessels(
         set: asserted
           ? {
               kind: vessel.kind,
-              location: vessel.location,
-              servedHosts: vessel.servedHosts,
-              reachableRegistries: vessel.reachableRegistries,
+              // Stated facts only. Omitted rather than nulled for the reason
+              // {@link assertedBySeed} gives about reach: a declaration that
+              // says nothing about where a boundary is has not said it is
+              // nowhere, and the connect screen is where an address most often
+              // comes from — §13 makes `location` optional on a seed precisely
+              // so a boundary can be declared and addressed later. Nulling here
+              // wiped that address on every boot of a governed vessel. A new
+              // row still gets `null`, because there an unstated fact is
+              // genuinely unknown rather than known elsewhere.
+              ...(vessel.location === null
+                ? {}
+                : { location: vessel.location }),
+              ...(vessel.servedHosts === null
+                ? {}
+                : { servedHosts: vessel.servedHosts }),
+              ...(vessel.reachableRegistries === null
+                ? {}
+                : { reachableRegistries: vessel.reachableRegistries }),
             }
           : // Nothing became anything on a `booted` write of an ungoverned
             // vessel, so the row wins outright. `name` is what the conflict

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -11,10 +11,11 @@ import { installation, targets, vessels } from '../db/schema.ts';
 import { unreachablePrerequisites } from '../domain/capabilities.ts';
 import type { TargetConnection } from '../domain/target.ts';
 import type { VesselKind, VesselLocation } from '../domain/vessel.ts';
-import type {
-  AuthoredManifest,
-  InstallationManifest,
-  TargetSeed,
+import {
+  type AuthoredManifest,
+  type InstallationManifest,
+  isDeclaredInstallationVessel,
+  type TargetSeed,
 } from './manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
@@ -73,7 +74,14 @@ export async function loadStoredManifest(
     console.warn(
       `installation manifest: the stored manifest is not valid for this build, so this installation is being re-seeded from the mounted declaration — anything configured through the UI that the declaration does not carry is lost: ${unreadable.message}`,
     );
-  } else if (stored !== null && declaration !== null) {
+  }
+  const declared =
+    stored === null
+      ? (declaration ?? DEFAULT_PLACEHOLDER_MANIFEST)
+      : declaration === null
+        ? stored
+        : governedByDeclaration(stored, declaration);
+  if (unreadable === null && stored !== null && declaration !== null) {
     // The generic half of this warning has existed since the rule did — "a
     // declaration is mounted and ignored" — and it is not enough. Proven live:
     // a rollout moved a Target's gateway in the declaration; the stored row
@@ -82,14 +90,17 @@ export async function loadStoredManifest(
     // the Target's gateway with it. §6: "drift is detected and surfaced, never
     // silently corrected" — naming the paths is that rule applied to the
     // manifest itself, not just to what it deploys.
-    const divergentPaths = diffManifestPaths(declaration, stored);
+    //
+    // Against the document actually being used rather than against the row, so
+    // the governed slice does not appear as divergence a boot has already
+    // resolved: what this names is what is genuinely ignored.
+    const divergentPaths = diffManifestPaths(declaration, declared);
     console.warn(
       divergentPaths.length === 0
         ? 'installation manifest: a declaration is mounted but this installation is already seeded, so the stored manifest is being used and the declaration is ignored — discard the row to re-seed from it'
         : `installation manifest: a declaration is mounted but this installation is already seeded, so the stored manifest is being used and the declaration is ignored — discard the row to re-seed from it. It now disagrees with the stored row at: ${divergentPaths.join(', ')}`,
     );
   }
-  const declared = stored ?? declaration ?? DEFAULT_PLACEHOLDER_MANIFEST;
   // `booted` exactly when the document being written is the one the
   // installation already had — see {@link ManifestWrite}. A stored row this
   // build could not parse leaves `stored` null, which is right: that boot is
@@ -100,6 +111,76 @@ export async function loadStoredManifest(
     stored === null ? 'declared' : 'booted',
   );
   return resolveManifest(declared, env);
+}
+
+/**
+ * The stored document with the two vessels this installation is built on taken
+ * from the mounted declaration.
+ *
+ * **The one slice a declaration governs.** Everywhere else the row wins, because
+ * configuration is the UI's to drive and a rollout must not revert what an
+ * operator just configured. These two are the exception, and the reason is that
+ * the failure they protect against is not a reverted edit but an installation
+ * that cannot come back: a control plane pointed at a boundary that is not
+ * there, or a home vessel whose bucket, store and signer nobody can reach.
+ *
+ * Both pointers move with the entries, so a declaration may hand the role to a
+ * different boundary in one edit. The old home's `shared` block goes with the
+ * role — the schema admits exactly one vessel carrying it — and a governed
+ * vessel the row does not have yet is added rather than dropped.
+ *
+ * **A merge that will not validate is not applied.** A declaration and the image
+ * that understands it land in separate merges, so a document this build reads
+ * differently is the ordinary shape of a rollout rather than a fault; taking the
+ * row whole is the same fallback `declaredManifest` already makes one step
+ * earlier, and it keeps a healthy installation running.
+ */
+function governedByDeclaration(
+  stored: AuthoredManifest,
+  declaration: AuthoredManifest,
+): AuthoredManifest {
+  const governed = new Set([
+    declaration.installation.controlPlaneVessel,
+    declaration.installation.homeVessel,
+  ]);
+  const declared = new Map(
+    declaration.vessels
+      .filter((vessel) => governed.has(vessel.name))
+      .map((vessel) => [vessel.name, vessel] as const),
+  );
+  const kept = stored.vessels.map((vessel) => {
+    const replacement = declared.get(vessel.name);
+    if (replacement !== undefined) return replacement;
+    // Only the outgoing home can be carrying this, and it is not the home any
+    // more — two vessels declaring the shared services is two answers to one
+    // question and the schema refuses it.
+    const { shared: _handedOver, ...withoutShared } = vessel;
+    return withoutShared;
+  });
+  const merged = {
+    ...stored,
+    installation: {
+      ...stored.installation,
+      controlPlaneVessel: declaration.installation.controlPlaneVessel,
+      homeVessel: declaration.installation.homeVessel,
+    },
+    vessels: [
+      ...kept,
+      ...[...declared.values()].filter(
+        (vessel) =>
+          !stored.vessels.some((existing) => existing.name === vessel.name),
+      ),
+    ],
+  };
+  try {
+    return validateManifest(merged, 'the governed installation vessels');
+  } catch (cause) {
+    if (!(cause instanceof ManifestError)) throw cause;
+    console.warn(
+      `installation manifest: the declaration's installation vessels do not compose with the stored document for this build, so the stored one is being used whole: ${cause.message}`,
+    );
+    return stored;
+  }
 }
 
 /**
@@ -514,7 +595,27 @@ interface ReconciledVessel {
   readonly moved: boolean;
 }
 
-/** Create or update the vessels a manifest describes, and return their ids. */
+/**
+ * Create or update the vessels a manifest describes, and return their ids.
+ *
+ * **Two names are governed and every other vessel is seeded.** The vessel this
+ * control plane runs on and the vessel holding its shared services take the
+ * `declared` treatment on every boot: the row is reconciled from the mounted
+ * declaration whether or not it already exists, and a moved boundary reassesses
+ * its surfaces. Every other vessel keeps the module's own rule — a declaration
+ * seeds and does not govern — so a boot leaves alone whatever an operator
+ * corrected through the connect screen.
+ *
+ * This narrows that rule rather than inverting it, and the narrowing is what
+ * makes the pointers safe: you should not be able to click your way into an
+ * unbootable control plane or a home vessel pointing at nothing, and the two
+ * screens that could do it are the ones that now render these read-only.
+ *
+ * **No prune policy is owed**, which is the other thing scoping it this way
+ * buys. A governed set that can shrink has to answer what "no longer declared"
+ * means, and Spindrift never removes a workload, so the answer would be forced
+ * to orphan anyway. A fixed two-element set never asks the question.
+ */
 async function reconcileManifestVessels(
   db: Pick<Database, 'insert' | 'query'>,
   manifest: AuthoredManifest,
@@ -522,11 +623,13 @@ async function reconcileManifestVessels(
 ): Promise<Map<string, ReconciledVessel>> {
   const reconciled = new Map<string, ReconciledVessel>();
   for (const [name, vessel] of vesselRowsOf(manifest)) {
+    const governed = isDeclaredInstallationVessel(manifest, name);
+    const asserted = write === 'declared' || governed;
     const existing = await db.query.vessels.findFirst({
       where: (vessels, { eq }) => eq(vessels.name, name),
     });
     const moved =
-      write === 'declared' &&
+      asserted &&
       vessel.location !== null &&
       !Bun.deepEquals(existing?.location, vessel.location, true);
     const [row] = await db
@@ -534,12 +637,19 @@ async function reconcileManifestVessels(
       .values({ name, ...vessel })
       .onConflictDoUpdate({
         target: vessels.name,
-        set: {
-          kind: vessel.kind,
-          location: vessel.location,
-          servedHosts: vessel.servedHosts,
-          reachableRegistries: vessel.reachableRegistries,
-        },
+        set: asserted
+          ? {
+              kind: vessel.kind,
+              location: vessel.location,
+              servedHosts: vessel.servedHosts,
+              reachableRegistries: vessel.reachableRegistries,
+            }
+          : // Nothing became anything on a `booted` write of an ungoverned
+            // vessel, so the row wins outright. `name` is what the conflict
+            // matched on, so writing it back changes nothing and is what makes
+            // this a no-op update rather than a statement that needs a second
+            // code path.
+            { name },
       })
       .returning({ id: vessels.id });
     reconciled.set(name, { id: row!.id, moved });

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -48,7 +48,128 @@ function asDocument(value: unknown): Document | null {
  * what is wrong with it rather than reporting what this function made of it.
  */
 export function upgradeManifestDocument(document: unknown): unknown {
-  return dropTargetNames(addDeclaredVessels(document));
+  return nameInstallationVessels(dropTargetNames(addDeclaredVessels(document)));
+}
+
+/**
+ * Turn the four loose strings that described this installation's own two
+ * boundaries into two pointers and one vessel's properties.
+ *
+ * `installation` was an opaque label; it is now the block that names the vessel
+ * the control plane runs on and the vessel holding the shared services.
+ * `cloud.homeVesselProject`, `cloud.artifactsProject`, `sources.defaultBucket`
+ * and `secretStore.container` were four keys that all described the second one
+ * without anything saying so, and they move onto it.
+ *
+ * **Both pointers are recovered rather than guessed, and each from the one
+ * thing the old document actually stated.**
+ *
+ * The home vessel is the boundary whose `location.project` is the project
+ * `cloud.homeVesselProject` named — the two were the same value on every
+ * installation that has one, which is the whole reason the collapse is
+ * expressible. Where they were not, the first `gcp-project` vessel takes the
+ * role: the old key could name a project that was never a declared boundary,
+ * and minting a vessel for it here would recover a boundary from a string,
+ * which is precisely what the `vessels` key exists to stop.
+ *
+ * The control plane is the vessel of the **first** Target. Rank is array
+ * position (`reconcileManifestTargets`), the control plane's own cluster is its
+ * in-cluster destination, and rank 0 is where every document written so far put
+ * it. It is a recovery of one fact from one document shape, run once — after
+ * this the declaration states it and nothing derives it again.
+ *
+ * Runs last, because it reads `vessels` and `targets[].vessel`, which the two
+ * steps above are what put there.
+ */
+function nameInstallationVessels(document: unknown): unknown {
+  const manifest = asDocument(document);
+  if (manifest === null) return document;
+  // Already current: `installation` is the block rather than the label.
+  if (asDocument(manifest.installation) !== null) return document;
+  if (typeof manifest.installation !== 'string') return document;
+
+  const vessels = Array.isArray(manifest.vessels) ? manifest.vessels : null;
+  const targets = Array.isArray(manifest.targets) ? manifest.targets : null;
+  const cloud = asDocument(manifest.cloud);
+  const sources = asDocument(manifest.sources);
+  const secretStore = asDocument(manifest.secretStore);
+  if (vessels === null || targets === null) return document;
+
+  const declared = vessels.flatMap((seed) => {
+    const vessel = asDocument(seed);
+    return vessel === null || typeof vessel.name !== 'string' ? [] : [vessel];
+  });
+  if (declared.length !== vessels.length) return document;
+
+  const home = homeVesselIn(declared, cloud?.homeVesselProject);
+  const controlPlane = asDocument(targets[0])?.vessel;
+  if (home === null || typeof controlPlane !== 'string') return document;
+
+  const buckets = sources?.buckets;
+  const sourceBucket =
+    firstString(sources?.defaultBucket) ??
+    (Array.isArray(buckets) ? firstString(buckets[0]) : null);
+  const artifactsProject = firstString(cloud?.artifactsProject);
+  const secretStoreContainer = firstString(secretStore?.container);
+  if (
+    sourceBucket === null ||
+    artifactsProject === null ||
+    secretStoreContainer === null
+  ) {
+    return document;
+  }
+
+  const { defaultBucket: _moved, ...remainingSources } = sources ?? {};
+  const { container: _held, ...remainingStore } = secretStore ?? {};
+  const { cloud: _derivedNow, ...rest } = manifest;
+  return {
+    ...rest,
+    installation: {
+      name: manifest.installation,
+      controlPlaneVessel: controlPlane,
+      homeVessel: home.name,
+    },
+    sources: remainingSources,
+    secretStore: remainingStore,
+    // Rebuilt in place, in order: nothing reads a vessel's position, but two
+    // documents that differ only by order would diff as changed.
+    vessels: declared.map((vessel) =>
+      vessel === home
+        ? {
+            ...vessel,
+            shared: { sourceBucket, artifactsProject, secretStoreContainer },
+          }
+        : vessel,
+    ),
+  };
+}
+
+/**
+ * Which declared boundary `cloud.homeVesselProject` was describing.
+ *
+ * The project match first, because that is the document stating it. The first
+ * cloud vessel behind it, because the old key was free to name a project no
+ * vessel declared and this upgrade may not invent one.
+ */
+function homeVesselIn(
+  declared: readonly Document[],
+  homeVesselProject: unknown,
+): (Document & { name: string }) | null {
+  const named =
+    typeof homeVesselProject === 'string'
+      ? declared.find(
+          (vessel) =>
+            asDocument(vessel.location)?.project === homeVesselProject,
+        )
+      : undefined;
+  const home =
+    named ?? declared.find((vessel) => vessel.kind === 'gcp-project') ?? null;
+  return home === null ? null : (home as Document & { name: string });
+}
+
+/** A stated string, or `null` for anything that is not one. */
+function firstString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
 }
 
 /**

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -864,6 +864,49 @@ export function isDeclaredInstallationVessel(
 }
 
 /**
+ * Every path in a document a mounted declaration governs, as
+ * `web/forms/document.ts` addresses one — the two pointers, and whichever
+ * entries of `vessels` they name. `[]` when nothing is mounted, which is when
+ * nothing is governed.
+ *
+ * **By name resolved against the document, never by a position carried from
+ * anywhere else.** `vessels` is an array an editing surface adds to and removes
+ * from, so a position computed before an edit addresses a different entry after
+ * it.
+ *
+ * Both arguments are `unknown` because both callers hold one: the declaration
+ * arrives over the wire and the document is mid-edit, and a predicate that only
+ * answered for a document that already validates would stop locking exactly
+ * while a mistake was being typed.
+ */
+export function governedManifestPaths(
+  declaration: unknown,
+  document: unknown,
+): readonly (readonly (string | number)[])[] {
+  const pointers = (declaration as { installation?: Record<string, unknown> })
+    ?.installation;
+  const governed = new Set(
+    (['controlPlaneVessel', 'homeVessel'] as const)
+      .map((key) => pointers?.[key])
+      .filter((name): name is string => typeof name === 'string'),
+  );
+  if (governed.size === 0) return [];
+
+  const declared = (document as { vessels?: unknown })?.vessels;
+  const entries = Array.isArray(declared) ? declared : [];
+  return [
+    ['installation', 'controlPlaneVessel'],
+    ['installation', 'homeVessel'],
+    ...entries.flatMap((vessel, index) => {
+      const name = (vessel as { name?: unknown })?.name;
+      return typeof name === 'string' && governed.has(name)
+        ? [['vessels', index] as readonly (string | number)[]]
+        : [];
+    }),
+  ];
+}
+
+/**
  * Project a resolved manifest back down to the document an operator may write.
  *
  * The inverse of the join `resolveManifest` performs, and it exists because an

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -137,10 +137,52 @@ const reachSchema = z.enum(['none', 'private', 'public']);
  * gets the first of `supplyChain.registry`, which is not the same answer as one
  * that reaches none.
  */
+/**
+ * The installation-wide services one vessel holds for every other.
+ *
+ * These were four unrelated top-level keys — `sources.defaultBucket`,
+ * `cloud.artifactsProject`, `secretStore.container` and
+ * `cloud.homeVesselProject` — that happened to describe one boundary. Nothing
+ * said they had to, so nothing noticed when they stopped: a bucket in one
+ * project, a store in another and a `homeVesselProject` naming a third is a
+ * document that validates and then fails at the first signed URL.
+ *
+ * Stated on the vessel they are one boundary's properties, and the fourth
+ * collapses entirely — where the home vessel *is* is its `location`, which every
+ * vessel already carries and which two keys can no longer disagree about.
+ *
+ * Only the vessel `installation.homeVessel` names may carry this block, and it
+ * must: the document-level refinement below enforces both halves, so a reader
+ * asking for the source bucket resolves exactly one answer.
+ */
+export const sharedServicesSchema = z
+  .object({
+    /** Where archive sources and artifacts are staged before a build (§4). */
+    sourceBucket: nonEmptyString,
+    /**
+     * Project holding immutable build artifacts and signing material, shared
+     * across every vessel (§14). Its own project rather than this vessel's: an
+     * installation may publish artifacts from a project it runs nothing in, and
+     * this one does.
+     */
+    artifactsProject: nonEmptyString,
+    /**
+     * What holds the items inside the secret store: the vessel's project for
+     * Secret Manager, the vault for 1Password.
+     *
+     * One key rather than one per adapter, because the two are the same thing
+     * under different names, and a per-adapter block would let an installation
+     * configure a store it does not use.
+     */
+    secretStoreContainer: nonEmptyString,
+  })
+  .strict();
+
 const vesselFacts = {
   name: targetNameSchema,
   servedHosts: z.array(nonEmptyString).optional(),
   reachableRegistries: z.array(nonEmptyString).optional(),
+  shared: sharedServicesSchema.optional(),
 };
 
 /**
@@ -268,10 +310,45 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
 export const installationManifestSchema = z
   .object({
     /**
-     * Opaque label for this installation. Appears in the UI and in logs; it
-     * carries no behaviour.
+     * What this installation is, and which two vessels it is built on.
+     *
+     * The two pointers are scalars naming a declared vessel, and cardinality
+     * comes free with that: a field that names one vessel has nothing to
+     * constrain, no partial unique index, and no guard that can drift from the
+     * column it guards. An `is_home boolean` could express neither — it would be
+     * true of two rows and say nothing about which.
+     *
+     * "This vessel is undeletable" then stops being a column and becomes
+     * *something points at it*, which is the check `targets`' `restrict` already
+     * performs one noun down. Neither pointer is a foreign key, so the guard is
+     * explicit in the command paths rather than in the schema — see
+     * `disconnectTarget`.
      */
-    installation: nonEmptyString,
+    installation: z
+      .object({
+        /**
+         * Opaque label for this installation. Appears in the UI and in logs; it
+         * carries no behaviour.
+         */
+        name: nonEmptyString,
+        /**
+         * The vessel this control plane runs on (§19).
+         *
+         * Being *also* an ordinary deploy Target is fine and needs no marking:
+         * it is the in-cluster destination, first in `targets` and rank 0, and
+         * an ordinary destination besides.
+         */
+        controlPlaneVessel: targetNameSchema,
+        /**
+         * The vessel holding this installation's shared services — the source
+         * bucket, the secret store, the artifacts project and the signer.
+         *
+         * Where the installer put them, so it is an install-time fact rather
+         * than an operator choice; there is no act that moves it.
+         */
+        homeVessel: targetNameSchema,
+      })
+      .strict(),
 
     controlPlane: z
       .object({
@@ -350,46 +427,33 @@ export const installationManifestSchema = z
       .object({
         /**
          * First-party GCS buckets for staging archive sources and artifacts (§4, §13).
+         *
+         * **No `defaultBucket` beside it.** Which of them staging picks is a
+         * property of the home vessel — `shared.sourceBucket` — because a
+         * default stated here could name a bucket in a project nothing else in
+         * this document mentions.
          */
         buckets: z.array(nonEmptyString).min(1),
-        /**
-         * Default GCS bucket for staging archive sources and artifacts.
-         */
-        defaultBucket: nonEmptyString.optional(),
       })
       .strict(),
 
-    cloud: z
-      .object({
-        /**
-         * Project holding immutable build artifacts and signing material. Shared
-         * across every vessel (§14).
-         */
-        artifactsProject: nonEmptyString,
-        /**
-         * Spindrift's own project, and the default shared vessel for Apps that
-         * do not choose one (§14).
-         */
-        homeVesselProject: nonEmptyString,
-        /**
-         * **No `federation` key, and that is the point.**
-         *
-         * §13's one auth mode — "native OIDC federation, nothing stored" — is
-         * an `external_account` credential document, and the installer chart
-         * already writes one from the workload-identity audience and mount path
-         * a release names. Asking for the same four facts here made a second
-         * copy, by hand, in a document the chart does not render; the two could
-         * disagree, they did, and the failure arrived as a `signBlob` refusal
-         * that read as a code defect.
-         *
-         * It is now resolved from the mounted credential —
-         * `federation-credential.ts` — and appears on {@link
-         * InstallationManifest} without ever being authored. Nullable exactly
-         * as before, and for the same reason: an installation with no cloud
-         * Targets mounts no credential and has no honest value here.
-         */
-      })
-      .strict(),
+    /**
+     * **No `cloud` block at all, and that is now the whole of it.**
+     *
+     * §13's one auth mode — "native OIDC federation, nothing stored" — is an
+     * `external_account` credential document, and the installer chart already
+     * writes one from the workload-identity audience and mount path a release
+     * names. Asking for the same four facts here made a second copy, by hand,
+     * in a document the chart does not render; the two could disagree, they
+     * did, and the failure arrived as a `signBlob` refusal that read as a code
+     * defect. The two keys that stayed — `artifactsProject` and
+     * `homeVesselProject` — are properties of the vessel `installation.homeVessel`
+     * names, so the block has nothing authored left in it.
+     *
+     * `cloud.federation` is resolved from the mounted credential —
+     * `federation-credential.ts` — and appears on {@link InstallationManifest}
+     * without ever being authored.
+     */
 
     charts: z
       .object({
@@ -570,14 +634,11 @@ export const installationManifestSchema = z
          */
         endpoint: z.string().url(),
         /**
-         * What holds the items inside that store: the vessel's project for Secret
-         * Manager, the vault for 1Password.
-         *
-         * One key rather than one per adapter, because the two are the same
-         * thing under different names, and a per-adapter block would let an
-         * installation configure a store it does not use.
+         * **No `container` here.** What holds the items is a property of the
+         * boundary they live in, so it is `shared.secretStoreContainer` on the
+         * home vessel — the same place the source bucket and the artifacts
+         * project moved to, and for the same reason.
          */
-        container: nonEmptyString,
       })
       .strict(),
 
@@ -653,6 +714,43 @@ export const installationManifestSchema = z
         message: `no vessel named ${target.vessel} is declared`,
       });
     });
+
+    // The two the installation itself is built on, resolved the same way a
+    // Target's `vessel` is. A pointer that does not resolve is the one shape of
+    // this document that cannot boot: the home vessel is where the source
+    // bucket, the store and the signer are read from, and nothing below can
+    // pick a fallback that would not be a guess about somebody's cloud.
+    for (const key of ['controlPlaneVessel', 'homeVessel'] as const) {
+      if (declared.has(manifest.installation[key])) continue;
+      context.addIssue({
+        code: 'custom',
+        path: ['installation', key],
+        message: `no vessel named ${manifest.installation[key]} is declared`,
+      });
+    }
+
+    // Exactly one vessel carries the shared services, and it is the one the
+    // pointer names. Both halves, because either alone leaves a reader with a
+    // question: none declared is a source bucket nobody stated, and a second
+    // one declared is two answers to `sourceBucket` with nothing to choose
+    // between them.
+    manifest.vessels.forEach((vessel, index) => {
+      const isHome = vessel.name === manifest.installation.homeVessel;
+      if (isHome && vessel.shared === undefined) {
+        context.addIssue({
+          code: 'custom',
+          path: ['vessels', index, 'shared'],
+          message: `${vessel.name} is this installation's home vessel and must declare its shared services`,
+        });
+      }
+      if (!isHome && vessel.shared !== undefined) {
+        context.addIssue({
+          code: 'custom',
+          path: ['vessels', index, 'shared'],
+          message: `only ${manifest.installation.homeVessel}, this installation's home vessel, may declare shared services`,
+        });
+      }
+    });
   });
 
 export type TargetAdapter = z.infer<typeof targetAdapterSchema>;
@@ -661,6 +759,7 @@ export type BuildRouteAdapter = z.infer<typeof buildRouteAdapterSchema>;
 export type BuildRouteConfig = z.infer<typeof buildRouteSchema>;
 export type TargetSeed = z.infer<typeof targetSeedSchema>;
 export type VesselSeed = z.infer<typeof vesselSeedSchema>;
+export type SharedServices = z.infer<typeof sharedServicesSchema>;
 export type GatewayAuthConfig = z.infer<typeof gatewayAuthSchema>;
 
 /**
@@ -680,12 +779,89 @@ export type AuthoredManifest = z.infer<typeof installationManifestSchema>;
  * derived value is present for readers and unreachable from any write path,
  * which is what makes disagreement impossible rather than merely discouraged.
  */
-export type InstallationManifest = Omit<AuthoredManifest, 'cloud'> & {
-  readonly cloud: AuthoredManifest['cloud'] & {
+export type InstallationManifest = AuthoredManifest & {
+  readonly cloud: {
     /** Resolved from the credential the deployment mounts, never authored. */
     readonly federation: FederationConfig | null;
   };
 };
+
+/** The document both halves of a pointer are resolved against. */
+type PointedAt = Pick<AuthoredManifest, 'installation' | 'vessels'>;
+
+/**
+ * The vessel one of the installation's two pointers names.
+ *
+ * Total, because the document-level refinement above already refused a pointer
+ * that resolves to nothing — so a validated manifest cannot reach here without
+ * an answer, and the throw is the assertion of that rather than a case a caller
+ * has to handle.
+ */
+function pointedVessel(manifest: PointedAt, name: string): VesselSeed {
+  const vessel = manifest.vessels.find((declared) => declared.name === name);
+  if (vessel === undefined) {
+    throw new Error(`no vessel named ${name} is declared`);
+  }
+  return vessel;
+}
+
+/** The vessel holding this installation's shared services. */
+export function homeVesselOf(manifest: PointedAt): VesselSeed {
+  return pointedVessel(manifest, manifest.installation.homeVessel);
+}
+
+/** The vessel this control plane runs on (§19). */
+export function controlPlaneVesselOf(manifest: PointedAt): VesselSeed {
+  return pointedVessel(manifest, manifest.installation.controlPlaneVessel);
+}
+
+/**
+ * The source bucket, the artifacts project and the store container, read off
+ * the one vessel that holds them.
+ *
+ * Total for the same reason {@link pointedVessel} is: the refinement requires
+ * the home vessel to declare this block and forbids every other vessel from
+ * carrying one, so there is exactly one answer and it is present.
+ */
+export function sharedServicesOf(manifest: PointedAt): SharedServices {
+  const home = homeVesselOf(manifest);
+  if (home.shared === undefined) {
+    throw new Error(`${home.name} declares no shared services`);
+  }
+  return home.shared;
+}
+
+/**
+ * The project the home vessel is, or `null` where the declaration seeds its
+ * identity without saying where it is.
+ *
+ * `null` rather than a throw because that half-ready state is one §13 intends to
+ * be visible: `location` is optional on a vessel seed for the same reason the
+ * column is nullable, and a bucket check against `undefined` is worse than a
+ * stated absence.
+ */
+export function homeVesselProjectOf(manifest: PointedAt): string | null {
+  const location = homeVesselOf(manifest).location;
+  return location !== undefined && 'project' in location
+    ? location.project
+    : null;
+}
+
+/**
+ * Whether this vessel is one the installation itself is built on.
+ *
+ * The predicate every guard and every read-only screen asks. Neither pointer is
+ * a foreign key, so this is what stands in for one.
+ */
+export function isDeclaredInstallationVessel(
+  manifest: Pick<AuthoredManifest, 'installation'>,
+  vessel: string,
+): boolean {
+  return (
+    vessel === manifest.installation.homeVessel ||
+    vessel === manifest.installation.controlPlaneVessel
+  );
+}
 
 /**
  * Project a resolved manifest back down to the document an operator may write.
@@ -704,6 +880,6 @@ export type InstallationManifest = Omit<AuthoredManifest, 'cloud'> & {
 export function toAuthoredManifest(
   manifest: InstallationManifest,
 ): AuthoredManifest {
-  const { federation: _derived, ...cloud } = manifest.cloud;
-  return { ...manifest, cloud };
+  const { cloud: _derived, ...authored } = manifest;
+  return authored;
 }

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -100,7 +100,11 @@ export const DEFAULT_MANIFEST_PATH = '/etc/spindrift/manifest.yaml';
 
 /** High-trust default placeholder manifest used when initializing an unseeded installation. */
 export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
-  installation: 'default',
+  installation: {
+    name: 'default',
+    controlPlaneVessel: 'primary',
+    homeVessel: 'spindrift',
+  },
   controlPlane: {
     hostname: 'spindrift.example.com',
   },
@@ -115,11 +119,6 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
   },
   sources: {
     buckets: ['bluenose-spindrift-source'],
-    defaultBucket: 'bluenose-spindrift-source',
-  },
-  cloud: {
-    artifactsProject: 'spindrift-artifacts',
-    homeVesselProject: 'spindrift-vessel',
   },
   charts: {
     app: 'packages/charts/spindrift-app',
@@ -158,7 +157,6 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
     adapter: 'onepassword',
     endpoint:
       'http://onepassword-connect.external-secrets.svc.cluster.local:8080',
-    container: 'spindrift-vault',
   },
   vessels: [
     {
@@ -170,6 +168,11 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
       name: 'spindrift',
       kind: 'gcp-project',
       location: { project: 'spindrift-vessel' },
+      shared: {
+        sourceBucket: 'bluenose-spindrift-source',
+        artifactsProject: 'spindrift-artifacts',
+        secretStoreContainer: 'spindrift-vault',
+      },
     },
   ],
   targets: [
@@ -271,7 +274,7 @@ export function isUnconfiguredInstallation(
 ): boolean {
   const stand = DEFAULT_PLACEHOLDER_MANIFEST;
   return (
-    manifest.installation === stand.installation &&
+    manifest.installation.name === stand.installation.name &&
     manifest.github.clientId === stand.github.clientId &&
     manifest.secretStore.adapter === stand.secretStore.adapter &&
     // The one that is a list. A bare string is the same document as a
@@ -348,10 +351,7 @@ export async function resolveManifest(
 ): Promise<InstallationManifest> {
   return {
     ...manifest,
-    cloud: {
-      ...manifest.cloud,
-      federation: await loadDeploymentFederation(env),
-    },
+    cloud: { federation: await loadDeploymentFederation(env) },
   };
 }
 

--- a/apps/spindrift/src/db/migrations/0029_vessel_checklist.sql
+++ b/apps/spindrift/src/db/migrations/0029_vessel_checklist.sql
@@ -1,0 +1,22 @@
+-- A vessel gets a standing checklist of its own.
+--
+-- §13's checklist was written about a Target, and four of this installation's
+-- prerequisites are not a Target's: the source bucket a build stages into
+-- before any placement is known, the artifacts project shared across every
+-- vessel (§14), the store of record every Target reads one copy of, and the
+-- signer core calls rather than a Target does. They belong to the boundary that
+-- holds them, which is the vessel `installation.homeVessel` names.
+--
+-- Which rows a vessel is asked is `VESSEL_PREREQUISITES_BY_KIND_AND_ROLE` in
+-- `src/domain/vessel.ts` — kind times role, the way `PREREQUISITES_BY_ADAPTER`
+-- keys off adapter. An app vessel is asked nothing and stores nothing here, so
+-- it is never shown a green row for something nobody checked.
+--
+-- **Additive and nullable, so it is safe on a running installation.** Null is
+-- "never assessed", which is what every existing row honestly is until the
+-- standing loop has been round once; health is derived from these rows at read
+-- time rather than stored, for the reason `target-loop.ts` gives about stored
+-- derivations.
+ALTER TABLE "vessels" ADD COLUMN "prerequisites" jsonb;
+--> statement-breakpoint
+ALTER TABLE "vessels" ADD COLUMN "inspected_at" timestamp with time zone;

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1785374380772,
       "tag": "0028_target_vessel_surface_identity",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1785374380773,
+      "tag": "0029_vessel_checklist",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -51,7 +51,11 @@ import type {
 import type { Draft } from '../domain/creation-draft.ts';
 import type { DesiredDocument } from '../domain/desired-state.ts';
 import type { TargetConnection } from '../domain/target.ts';
-import { VESSEL_KINDS, type VesselLocation } from '../domain/vessel.ts';
+import {
+  VESSEL_KINDS,
+  type VesselLocation,
+  type VesselPrerequisiteResult,
+} from '../domain/vessel.ts';
 import type { CoreSignature } from '../supply-chain/sign.ts';
 import type { BackendProvenanceAssessment } from '../supply-chain/verify.ts';
 
@@ -902,6 +906,27 @@ export const vessels = pgTable(
     servedHosts: text('served_hosts').array(),
     /** §3, and boundary-shaped for the same reason. */
     reachableRegistries: text('reachable_registries').array(),
+    /**
+     * The standing checklist for the boundary itself, as
+     * `VESSEL_PREREQUISITES_BY_KIND_AND_ROLE` decides its rows.
+     *
+     * Not a second copy of a Target's: these are the four facts that are true of
+     * one boundary and of no runtime on it — the source bucket, the store
+     * container, the artifacts project and the signer. Null means never
+     * assessed, which is a different state from assessed-and-empty: an app
+     * vessel is asked nothing and so stores an empty list once the loop has been
+     * past it.
+     *
+     * Health is not a column. It is every catalogued row met, derived at read
+     * time for the reason `target-loop.ts` gives — a stored derivation can be
+     * stale in a way nothing notices.
+     */
+    prerequisites:
+      jsonbDocument('prerequisites').$type<
+        readonly VesselPrerequisiteResult[]
+      >(),
+    /** When the standing pass last ran against this boundary. */
+    inspectedAt: timestamp('inspected_at', { withTimezone: true }),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/apps/spindrift/src/domain/vessel.ts
+++ b/apps/spindrift/src/domain/vessel.ts
@@ -30,7 +30,10 @@
  * so `DeployAdapter`, `DeployTarget`, and every conformance test are untouched.
  * This is a core-side normalization, not a change to §6's contract.
  */
-import type { TargetAdapter } from '../config/manifest.schema.ts';
+import type {
+  AuthoredManifest,
+  TargetAdapter,
+} from '../config/manifest.schema.ts';
 
 /**
  * What kind of boundary this is.
@@ -71,6 +74,155 @@ export const PROBED_SURFACES_BY_VESSEL_KIND = {
 /** What one connect act asks a vessel of this kind about. */
 export function surfacesToProbe(kind: VesselKind): readonly TargetAdapter[] {
   return PROBED_SURFACES_BY_VESSEL_KIND[kind];
+}
+
+/**
+ * What one vessel is to this installation, as opposed to what it is made of.
+ *
+ * The second axis of the prerequisite catalogue below. `kind` says what shape a
+ * boundary's address has; this says what the installation asks of it — and the
+ * two are independent, which is why they are two axes rather than more kinds.
+ *
+ * A vessel can hold more than one role: nothing stops an installation whose
+ * control plane runs on the same boundary its shared services live in, and a
+ * scalar role would have to pick one and drop the other's rows.
+ */
+export const VESSEL_ROLES = ['home', 'controlPlane', 'app'] as const;
+
+export type VesselRole = (typeof VESSEL_ROLES)[number];
+
+/**
+ * Which roles this installation's manifest puts on one vessel, by name.
+ *
+ * `app` is the answer for everything the two pointers do not name — not an
+ * absence, because an ordinary deploy boundary is a role rather than the lack of
+ * one, and the catalogue has to be able to key off it.
+ */
+export function vesselRolesOf(
+  manifest: Pick<AuthoredManifest, 'installation'>,
+  vessel: string,
+): readonly VesselRole[] {
+  const roles: VesselRole[] = [];
+  if (vessel === manifest.installation.homeVessel) roles.push('home');
+  if (vessel === manifest.installation.controlPlaneVessel) {
+    roles.push('controlPlane');
+  }
+  return roles.length === 0 ? ['app'] : roles;
+}
+
+/**
+ * Every prerequisite a vessel can be asked about, as distinct from a surface on
+ * one (§13's checklist is `PREREQUISITES` in `capabilities.ts`).
+ *
+ * These are the four the home vessel exists to hold, and none of them belongs to
+ * a Target: a source bucket is where a build's bytes are staged before any
+ * placement is known, an artifacts project is shared across every vessel (§14),
+ * the store of record is one place whatever reaches it, and the signer is a key
+ * core calls rather than a Target does. Assessing them on a Target would put the
+ * same row on three screens and let them disagree.
+ */
+export const VESSEL_PREREQUISITES = [
+  'SOURCE_BUCKET',
+  'SECRET_STORE',
+  'SIGNER_KEY',
+  'ARTIFACTS_PROJECT',
+] as const;
+
+export type VesselPrerequisite = (typeof VESSEL_PREREQUISITES)[number];
+
+/**
+ * The checklist one vessel is assessed against, by kind **and** role.
+ *
+ * `PREREQUISITES_BY_ADAPTER` keys off adapter for the reason `capabilities.ts`
+ * states — "a checklist row that can never fail is a row that teaches a reader
+ * the wrong thing about what was checked" — and the same argument runs one axis
+ * over. An app vessel has no source bucket, no store container and no signer of
+ * its own; showing it four permanently-green rows would say those were checked
+ * when nothing looked.
+ *
+ * Kind matters as well as role because every one of these reads is a cloud API
+ * call. A cluster that somehow held the shared services would be assessed
+ * against nothing rather than against four questions no code here knows how to
+ * ask it — which is the honest answer until something does.
+ */
+export const VESSEL_PREREQUISITES_BY_KIND_AND_ROLE = {
+  cluster: { home: [], controlPlane: [], app: [] },
+  'gcp-project': {
+    home: ['SOURCE_BUCKET', 'SECRET_STORE', 'SIGNER_KEY', 'ARTIFACTS_PROJECT'],
+    controlPlane: [],
+    app: [],
+  },
+} as const satisfies Record<
+  VesselKind,
+  Record<VesselRole, readonly VesselPrerequisite[]>
+>;
+
+/**
+ * What a vessel of this kind in these roles is asked, in display order.
+ *
+ * The union over its roles rather than one row, so a boundary that is both the
+ * home and the control plane is asked everything either role owes. Ordered by
+ * {@link VESSEL_PREREQUISITES} so two vessels never show the same rows in
+ * different orders.
+ */
+export function vesselPrerequisitesFor(
+  kind: VesselKind,
+  roles: readonly VesselRole[],
+): readonly VesselPrerequisite[] {
+  const asked = new Set(
+    roles.flatMap((role) => [
+      ...VESSEL_PREREQUISITES_BY_KIND_AND_ROLE[kind][role],
+    ]),
+  );
+  return VESSEL_PREREQUISITES.filter((name) => asked.has(name));
+}
+
+/** One checklist item on a vessel, and the sentence behind an unmet one. */
+export interface VesselPrerequisiteResult {
+  readonly name: VesselPrerequisite;
+  readonly met: boolean;
+  /** Why it is unmet. §3's grammar: an exclusion carries its reason. */
+  readonly detail?: string;
+}
+
+/**
+ * The checklist for a vessel nothing could be asked about.
+ *
+ * The vessel-level twin of `unreachablePrerequisites`: an installation with no
+ * federation, or a process with no cloud client, produces every catalogued row
+ * unmet with the fault stated rather than no rows at all.
+ */
+export function unreachableVesselPrerequisites(
+  detail: string,
+  kind: VesselKind,
+  roles: readonly VesselRole[],
+): readonly VesselPrerequisiteResult[] {
+  return vesselPrerequisitesFor(kind, roles).map((name) => ({
+    name,
+    met: false,
+    detail,
+  }));
+}
+
+/**
+ * Healthy is every catalogued item met — including the vacuous case.
+ *
+ * An app vessel is asked nothing and is therefore healthy, which is the right
+ * answer rather than a loophole: it holds nothing this installation depends on,
+ * so there is nothing about it that can be broken here. The Targets on it carry
+ * their own checklist and fail on their own terms.
+ */
+export function deriveVesselHealth(
+  prerequisites: readonly VesselPrerequisiteResult[],
+  kind: VesselKind,
+  roles: readonly VesselRole[],
+): 'healthy' | 'unhealthy' {
+  const met = new Set(
+    prerequisites.filter((item) => item.met).map((i) => i.name),
+  );
+  return vesselPrerequisitesFor(kind, roles).every((name) => met.has(name))
+    ? 'healthy'
+    : 'unhealthy';
 }
 
 /**

--- a/apps/spindrift/src/reconciler/main.ts
+++ b/apps/spindrift/src/reconciler/main.ts
@@ -18,7 +18,9 @@ try {
   await startReconciler({
     signal: shutdown.signal,
     onStarted: (manifest) =>
-      console.log(`spindrift reconciler → running (${manifest.installation})`),
+      console.log(
+        `spindrift reconciler → running (${manifest.installation.name})`,
+      ),
     onEvent: report,
   });
 } finally {

--- a/apps/spindrift/src/reconciler/process.ts
+++ b/apps/spindrift/src/reconciler/process.ts
@@ -16,9 +16,11 @@ import { DEFAULT_REAP_INTERVAL_MS, runConfigLoop } from './config-loop.ts';
 import { DEFAULT_INTERVALS, runDeployLoop } from './deploy-loop.ts';
 import { runRepoLoop } from './repo-loop.ts';
 import { runTargetLoop } from './target-loop.ts';
+import { runVesselLoop } from './vessel-loop.ts';
 
 export type ReconcilerLoopName =
   | 'target'
+  | 'vessel'
   | 'repository'
   | 'config'
   | 'build'
@@ -163,6 +165,19 @@ export async function runReconciler(
           intervalMs: DEFAULT_TARGET_INTERVAL_MS,
           signal,
           onPass: () => passed('target'),
+        }),
+    },
+    {
+      // The boundary's own checklist, at the Target loop's cadence and for the
+      // same reason: a connect-time snapshot rots, and a bucket that stopped
+      // being writable is a fact that has to be re-established rather than
+      // remembered.
+      name: 'vessel',
+      run: (signal) =>
+        runVesselLoop(context, {
+          intervalMs: DEFAULT_TARGET_INTERVAL_MS,
+          signal,
+          onPass: () => passed('vessel'),
         }),
     },
     {

--- a/apps/spindrift/src/reconciler/vessel-loop.ts
+++ b/apps/spindrift/src/reconciler/vessel-loop.ts
@@ -1,0 +1,296 @@
+/**
+ * The Vessel loop — the standing checklist for a boundary rather than for a
+ * surface on one (§13, §14).
+ *
+ * §13's checklist was written about a Target, and this installation depends on
+ * four facts that are not any Target's: the bucket a build stages into before a
+ * placement is even known, the artifacts project shared across every vessel, the
+ * one store of record every Target reads a copy of, and the signer core calls.
+ * They belong to the vessel `installation.homeVessel` names, and until this loop
+ * ran nothing checked any of them — the failure mode `cloud-discovery.ts` names:
+ *
+ * > A mistyped project or bucket is invisible until a build stages a source
+ * > archive and fails on a signed URL.
+ *
+ * A separate loop from the Target one rather than a second pass inside it,
+ * because it asks entirely different far sides — Cloud Storage, Resource
+ * Manager, Cloud KMS and the secret store — rather than a deploy adapter. §13's
+ * "one loop, not two" is an argument about health and capabilities being one
+ * question of one adapter, and that argument does not reach across the seam.
+ *
+ * **What it asks is the catalogue, and nothing else.**
+ * `VESSEL_PREREQUISITES_BY_KIND_AND_ROLE` decides which rows a vessel gets, so
+ * an app vessel is asked nothing and stores an empty checklist — never a green
+ * row for something nobody checked. It stores what was observed and never what
+ * was concluded: health is derived at read time, exactly as a Target's is.
+ */
+import { eq } from 'drizzle-orm';
+import type { Discovered } from '../adapters/cloud-discovery.ts';
+import type { SecretStore } from '../adapters/store/contract.ts';
+import type { AdapterRegistry, Clock } from '../commands/types.ts';
+import {
+  type InstallationManifest,
+  sharedServicesOf,
+} from '../config/manifest.schema.ts';
+import type { Database } from '../db/client.ts';
+import { type Vessel, vessels } from '../db/schema.ts';
+import {
+  deriveVesselHealth,
+  unreachableVesselPrerequisites,
+  type VesselPrerequisite,
+  type VesselPrerequisiteResult,
+  type VesselRole,
+  vesselPrerequisitesFor,
+  vesselRolesOf,
+} from '../domain/vessel.ts';
+import { reconcilerLoopDuration } from '../telemetry/index.ts';
+
+/** What the loop needs. No principal: nobody asked for it to run. */
+export interface VesselLoopContext {
+  readonly db: Database;
+  readonly adapters: Pick<AdapterRegistry, 'discovery' | 'store'>;
+  readonly clock: Clock;
+  readonly manifest: InstallationManifest;
+}
+
+/**
+ * A KMS key reference as `supplyChain.signer` carries it, split into the two
+ * segments Cloud KMS lists keys by.
+ *
+ * Parsed rather than asked for separately: the manifest already names the key in
+ * full, and a second pair of keys beside it would be two values that can
+ * disagree about one.
+ */
+const SIGNER_REFERENCE =
+  /^gcpkms:\/\/projects\/([^/]+)\/locations\/([^/]+)\/keyRings\//;
+
+/**
+ * The scope a store reachability probe reads under.
+ *
+ * A listing rather than a write, and of a key that has never been written: both
+ * stores answer an absent item with an empty list and answer an unreachable
+ * endpoint, a refused credential or a container that does not exist by throwing.
+ * That difference is the whole probe — it exercises the exact path core writes
+ * over, credential included, without putting anything in the store.
+ */
+const STORE_PROBE = {
+  scope: { app: 'spindrift', component: 'checklist', target: 'vessel' },
+  key: 'REACHABILITY',
+} as const;
+
+/** One vessel's checklist, and the row it was written to. */
+export interface VesselRefresh {
+  readonly vesselId: string;
+  readonly vessel: string;
+  readonly health: 'healthy' | 'unhealthy';
+  /** Set when this pass changed what the boundary reports. */
+  readonly healthChangedFrom?: 'healthy' | 'unhealthy';
+}
+
+/**
+ * Ask one boundary the questions its kind and roles put to it.
+ *
+ * Never throws, for the reason `inspectTarget` does not: the far sides here are
+ * other people's APIs, and one refusing must produce an unmet row with its
+ * sentence rather than stop the pass.
+ */
+export async function inspectVessel(
+  context: VesselLoopContext,
+  vessel: Pick<Vessel, 'name' | 'kind' | 'location'>,
+  roles: readonly VesselRole[],
+): Promise<readonly VesselPrerequisiteResult[]> {
+  const asked = vesselPrerequisitesFor(vessel.kind, roles);
+  if (asked.length === 0) return [];
+
+  const discovery = context.adapters.discovery?.() ?? null;
+  if (discovery === null) {
+    return unreachableVesselPrerequisites(
+      'this process cannot reach a cloud API, so nothing about this boundary could be established',
+      vessel.kind,
+      roles,
+    );
+  }
+  const location = vessel.location;
+  if (location === null || location.kind !== 'gcp-project') {
+    // The catalogue only asks these of a `gcp-project`, so this is a boundary
+    // whose row does not yet say where it is — the half-ready state §13 intends
+    // to be visible rather than one to fabricate a project id for.
+    return unreachableVesselPrerequisites(
+      `${vessel.name} states no project, so its shared services could not be looked for`,
+      vessel.kind,
+      roles,
+    );
+  }
+
+  const shared = sharedServicesOf(context.manifest);
+  const signer = SIGNER_REFERENCE.exec(context.manifest.supplyChain.signer);
+  // Four independent reads, each folded into its own row. Never one `try` and
+  // never one rejection path: `GcpDiscovery` returns its failures, so a single
+  // catch would turn three good answers into four refusals.
+  const [buckets, projects, keys, store] = await Promise.all([
+    discovery.buckets(location.project),
+    discovery.projects(),
+    signer === null
+      ? notAskable(
+          'supplyChain.signer is not a Cloud KMS key reference, so no key location could be read from it',
+        )
+      : discovery.signingKeys(signer[1]!, signer[2]!),
+    storeReach(context.adapters.store(context.manifest.secretStore.adapter)),
+  ]);
+
+  const answers: Record<VesselPrerequisite, VesselPrerequisiteResult> = {
+    SOURCE_BUCKET: holds(
+      'SOURCE_BUCKET',
+      buckets,
+      shared.sourceBucket,
+      `${shared.sourceBucket} is not a bucket in ${location.project}`,
+    ),
+    SECRET_STORE: store,
+    SIGNER_KEY: holds(
+      'SIGNER_KEY',
+      keys,
+      context.manifest.supplyChain.signer,
+      'no signing key with that reference is in this location, or its purpose is not signing',
+    ),
+    ARTIFACTS_PROJECT: holds(
+      'ARTIFACTS_PROJECT',
+      projects,
+      shared.artifactsProject,
+      `${shared.artifactsProject} is not a project this identity can see`,
+    ),
+  };
+  return asked.map((name) => answers[name]);
+}
+
+/** A read that was never made, in the arm a refused one comes back in. */
+function notAskable(reason: string): Promise<Discovered<string>> {
+  return Promise.resolve({ kind: 'unavailable', reason });
+}
+
+/**
+ * One checklist row from one listing.
+ *
+ * The two arms stay apart all the way to the row: an established absence says
+ * the value is not there, and a refused read says nothing was established.
+ * Collapsing them would report a mistyped bucket and an unreachable API with the
+ * same sentence, which is the laundering `cloud-discovery.ts` exists to prevent.
+ */
+function holds(
+  name: VesselPrerequisite,
+  listed: Discovered<string>,
+  value: string,
+  absent: string,
+): VesselPrerequisiteResult {
+  if (listed.kind === 'unavailable') {
+    return { name, met: false, detail: listed.reason };
+  }
+  return listed.candidates.includes(value)
+    ? { name, met: true }
+    : { name, met: false, detail: absent };
+}
+
+/** Whether the configured store answered at all. */
+async function storeReach(
+  store: SecretStore | null,
+): Promise<VesselPrerequisiteResult> {
+  if (store === null) {
+    return {
+      name: 'SECRET_STORE',
+      met: false,
+      detail:
+        'this installation has no adapter for the secret store its manifest names',
+    };
+  }
+  try {
+    await store.versions(STORE_PROBE.scope, STORE_PROBE.key);
+    return { name: 'SECRET_STORE', met: true };
+  } catch (cause) {
+    return {
+      name: 'SECRET_STORE',
+      met: false,
+      detail: cause instanceof Error ? cause.message : String(cause),
+    };
+  }
+}
+
+/**
+ * One pass over every vessel.
+ *
+ * Every one of them, not only the two the installation is built on: an app
+ * vessel is asked nothing, so its pass is one write of an empty checklist, and
+ * that empty list is what makes "assessed and asked nothing" a different stored
+ * state from "never assessed".
+ */
+export async function refreshAllVessels(
+  context: VesselLoopContext,
+): Promise<readonly VesselRefresh[]> {
+  const rows = await context.db.select().from(vessels);
+  const refreshed: VesselRefresh[] = [];
+
+  for (const vessel of rows) {
+    const roles = vesselRolesOf(context.manifest, vessel.name);
+    const before =
+      vessel.prerequisites === null
+        ? null
+        : deriveVesselHealth(vessel.prerequisites, vessel.kind, roles);
+    // Sequential rather than concurrent, exactly as the Target loop is: the far
+    // sides are other people's control planes, and a fleet refreshing in
+    // lockstep is a thundering herd against every one of them at once.
+    const prerequisites = await inspectVessel(context, vessel, roles);
+    const now = context.clock.now();
+    await context.db
+      .update(vessels)
+      .set({ prerequisites, inspectedAt: now, updatedAt: now })
+      .where(eq(vessels.id, vessel.id));
+
+    const health = deriveVesselHealth(prerequisites, vessel.kind, roles);
+    refreshed.push({
+      vesselId: vessel.id,
+      vessel: vessel.name,
+      health,
+      ...(before === null || before === health
+        ? {}
+        : { healthChangedFrom: before }),
+    });
+  }
+  return refreshed;
+}
+
+/** How often the loop runs, and how to stop it. */
+export interface VesselLoopOptions {
+  readonly intervalMs: number;
+  readonly signal?: AbortSignal;
+  readonly onPass?: (refreshed: readonly VesselRefresh[]) => void;
+}
+
+/** Run the loop until aborted. Poll, not watch — see `target-loop.ts`. */
+export async function runVesselLoop(
+  context: VesselLoopContext,
+  options: VesselLoopOptions,
+): Promise<void> {
+  while (!options.signal?.aborted) {
+    const startedAt = Date.now();
+    const refreshed = await refreshAllVessels(context);
+    reconcilerLoopDuration.record((Date.now() - startedAt) / 1000, {
+      loop: 'vessel',
+    });
+    options.onPass?.(refreshed);
+    if (options.signal?.aborted) return;
+    await sleep(options.intervalMs, options.signal);
+  }
+}
+
+/** A sleep that wakes early on abort rather than holding the loop open. */
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    signal?.addEventListener(
+      'abort',
+      () => {
+        clearTimeout(timer);
+        resolve();
+      },
+      { once: true },
+    );
+  });
+}

--- a/apps/spindrift/src/storage/archives.ts
+++ b/apps/spindrift/src/storage/archives.ts
@@ -21,6 +21,7 @@ import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { FederationOptions } from '../adapters/deploy/cloud/federation.ts';
+import { sharedServicesOf } from '../config/manifest.schema.ts';
 import type { InstallationManifest } from '../config/manifest.ts';
 import { uploadToGcsBucket } from './cloud.ts';
 
@@ -66,12 +67,17 @@ export const ARTIFACTS_BUCKET_VAR = 'SPINDRIFT_ARTIFACTS_BUCKET';
  * this process outside its chart rather than a caller of it.
  */
 export function sourceDepotFor(
-  manifest: Pick<InstallationManifest, 'sources' | 'cloud'> | null | undefined,
+  manifest:
+    | Pick<InstallationManifest, 'installation' | 'vessels' | 'cloud'>
+    | null
+    | undefined,
 ): SourceDepot | null {
   const bucket =
     process.env[ARTIFACTS_BUCKET_VAR]?.trim() ||
-    manifest?.sources?.defaultBucket?.trim() ||
-    manifest?.sources?.buckets?.[0]?.trim();
+    // The home vessel's, because that is where the bucket is: a default stated
+    // beside `sources.buckets` could name one in a project nothing else in the
+    // document mentions, which is invisible until a build stages an archive.
+    (manifest == null ? undefined : sharedServicesOf(manifest).sourceBucket);
   const federation = manifest?.cloud?.federation ?? null;
   if (!bucket || federation === null) return null;
   return { bucket, federation };

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -23,6 +23,7 @@ import type {
   RepositoryOptionView,
   TargetListItem,
   TargetOptionView,
+  VesselListItem,
   WorkspaceView,
 } from './model.ts';
 import { isInFlight } from './model.ts';
@@ -1829,6 +1830,7 @@ function TargetsScreen({
         type: 'success';
         targets: readonly TargetListItem[];
         pending: readonly PendingTargetConnection[];
+        vessels: readonly VesselListItem[];
       }
   >({ type: 'loading' });
   const [connecting, setConnecting] = useState(false);
@@ -1854,6 +1856,7 @@ function TargetsScreen({
             type: 'success',
             targets: result.value.targets,
             pending: result.value.pending,
+            vessels: result.value.vessels,
           });
         } else {
           setState({ type: 'error', message: result.failure.message });
@@ -1925,6 +1928,7 @@ function TargetsScreen({
     <TargetList
       targets={state.targets}
       pending={state.pending}
+      vessels={state.vessels}
       connecting={connecting}
       error={actionError}
       absent={absent}

--- a/apps/spindrift/src/web/forms/manifest.ts
+++ b/apps/spindrift/src/web/forms/manifest.ts
@@ -13,7 +13,7 @@
 import { installationManifestSchema } from '../../config/manifest.schema.ts';
 import type { Path } from './document.ts';
 import type { FieldErrors } from './render.tsx';
-import { describeObject, type FormField } from './schema.ts';
+import { describeObject, type FormField, type FormNode } from './schema.ts';
 
 /**
  * The manifest's top-level keys, as fields, in the order the schema declares
@@ -40,14 +40,37 @@ export function manifestFields(): readonly FormField[] {
  * the one that drifted would be the one nobody was reading.
  */
 export function manifestFieldAt(at: Path): FormField | null {
-  let fields: readonly FormField[] = FIELDS;
-  let found: FormField | null = null;
-  for (const step of at) {
-    found = fields.find((field) => field.key === step) ?? null;
-    if (found === null) return null;
-    fields = found.node.kind === 'object' ? found.node.fields : [];
+  return fieldAt({ kind: 'object', fields: FIELDS }, at);
+}
+
+/**
+ * The field one path names inside one node.
+ *
+ * Two things beyond walking object keys, and both are what a path into
+ * `vessels` needs. A **numeric** step descends into an array's element, which
+ * is a shape and not a field — so a path that ends on one answers null rather
+ * than naming the array. A **union** is tried arm by arm, with the whole
+ * remaining path against each: a vessel's `location` exists on both arms and
+ * carries a different key on each, so an arm that merely has the first segment
+ * is not the arm that has the path.
+ */
+function fieldAt(node: FormNode, path: Path): FormField | null {
+  const [step, ...rest] = path;
+  if (step === undefined) return null;
+  if (node.kind === 'union') {
+    for (const variant of node.variants) {
+      const found = fieldAt(variant.node, path);
+      if (found !== null) return found;
+    }
+    return null;
   }
-  return found;
+  if (typeof step === 'number') {
+    return node.kind === 'array' ? fieldAt(node.element, rest) : null;
+  }
+  if (node.kind !== 'object') return null;
+  const field = node.fields.find((each) => each.key === step);
+  if (field === undefined) return null;
+  return rest.length === 0 ? field : fieldAt(field.node, rest);
 }
 
 /**

--- a/apps/spindrift/src/web/forms/render.tsx
+++ b/apps/spindrift/src/web/forms/render.tsx
@@ -35,7 +35,30 @@ export interface FormProps {
   readonly document: unknown;
   readonly errors: FieldErrors;
   readonly disabled: boolean;
+  /**
+   * Whether one path is somebody else's to write — read-only rather than
+   * saving-right-now, which is what `disabled` says.
+   *
+   * A predicate over paths rather than a flag on a field, because the answer is
+   * a fact about the *document* and this file has none: which value a screen
+   * may not drive depends on what the document says elsewhere, and a field
+   * carrying it would be the schema describing a screen. The caller answers for
+   * a path and everything under it; omitted means nothing is locked.
+   */
+  locked?(at: Path): boolean;
   onChange(document: unknown): void;
+}
+
+/**
+ * Whether a control at this path may not be written — either reason.
+ *
+ * The two are one word to a control and two words to a reader: `disabled` is
+ * "not right now, a save is in flight" and `locked` is "not here, ever". The
+ * sentence explaining the second belongs on the screen that knows it, not on
+ * every input.
+ */
+function isFrozen(form: FormProps, at: Path): boolean {
+  return form.disabled || form.locked?.(at) === true;
 }
 
 /** Every key of an object schema, in the order the schema declares them. */
@@ -82,6 +105,7 @@ function SchemaFieldControl({
   const present = value !== undefined && value !== null;
   const togglable = field.optional || field.nullable;
   const id = pathKey(at);
+  const frozen = isFrozen(form, at);
 
   const toggle = (on: boolean) => {
     if (on) {
@@ -109,7 +133,7 @@ function SchemaFieldControl({
             id={`${id}--present`}
             name={`${id}--present`}
             checked={present}
-            disabled={form.disabled}
+            disabled={frozen}
             onChange={(event) => toggle(event.currentTarget.checked)}
             className="size-3.5 accent-accent"
             aria-label={`Configure ${field.label}`}
@@ -144,6 +168,7 @@ export function SchemaControl({
 }) {
   const value = valueAt(form.document, at);
   const id = pathKey(at);
+  const frozen = isFrozen(form, at);
   const set = (next: unknown) =>
     form.onChange(withValueAt(form.document, at, next));
 
@@ -155,7 +180,7 @@ export function SchemaControl({
           name={id}
           type={node.format === 'url' ? 'url' : 'text'}
           value={typeof value === 'string' ? value : ''}
-          disabled={form.disabled}
+          disabled={frozen}
           onChange={(event) => set(event.currentTarget.value)}
         />
       );
@@ -167,7 +192,7 @@ export function SchemaControl({
           type="number"
           step={node.integer ? 1 : 'any'}
           value={typeof value === 'number' ? String(value) : ''}
-          disabled={form.disabled}
+          disabled={frozen}
           onChange={(event) => {
             const parsed = Number(event.currentTarget.value);
             set(event.currentTarget.value === '' ? undefined : parsed);
@@ -181,7 +206,7 @@ export function SchemaControl({
           id={id}
           name={id}
           checked={value === true}
-          disabled={form.disabled}
+          disabled={frozen}
           onChange={(event) => set(event.currentTarget.checked)}
           className="size-4 accent-accent"
         />
@@ -191,7 +216,7 @@ export function SchemaControl({
         <Select
           id={id}
           value={typeof value === 'string' ? value : ''}
-          disabled={form.disabled}
+          disabled={frozen}
           onChange={set}
           options={node.values.map((each) => ({ value: each, label: each }))}
         />
@@ -251,7 +276,10 @@ function ArrayControl({
             type="button"
             size="sm"
             variant="ghost"
-            disabled={form.disabled}
+            // Per item, not per array: an array may hold one entry somebody else
+            // declares and others a screen owns outright, and locking the whole
+            // control for the first would take the second away too.
+            disabled={isFrozen(form, [...at, index])}
             aria-label={`Remove item ${index + 1}`}
             onClick={() =>
               form.onChange(withoutValueAt(form.document, [...at, index]))
@@ -307,7 +335,7 @@ function UnionControl({
           <Select
             id={`${id}--variant`}
             value={active?.tag ?? ''}
-            disabled={form.disabled}
+            disabled={isFrozen(form, at)}
             onChange={(next) => {
               const chosen = node.variants.find((each) => each.tag === next);
               if (chosen === undefined) return;

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -28,7 +28,7 @@ import type {
   Reach,
 } from '../domain/desired-state.ts';
 import type { Exclusion } from '../domain/placement.ts';
-import type { VesselKind } from '../domain/vessel.ts';
+import type { VesselKind, VesselRole } from '../domain/vessel.ts';
 
 /**
  * §6's phases, verbatim: `PENDING → APPLYING → WAITING → LIVE | FAILED`.
@@ -825,6 +825,46 @@ export interface TargetListItem {
         readonly proposal: TargetConnectionProposal;
       }
     | null;
+  /**
+   * What this Target's boundary is to the installation, from
+   * `vesselRolesOf` — `['app']` for an ordinary one.
+   *
+   * The screen reads it to decide whether this Target is the operator's to
+   * change. A boundary the installation itself is built on reconciles from the
+   * declaration on every boot, so an edit here would be reverted by the next
+   * restart with nothing on screen saying why; the honest surface is one that
+   * does not offer the control, and says where the values come from instead.
+   */
+  readonly vesselRoles: readonly VesselRole[];
+}
+
+/**
+ * One tenancy boundary, as the Targets screen shows it.
+ *
+ * A peer of {@link TargetListItem} rather than a field on it, because a
+ * boundary's checklist is one fact and a vessel may carry two surfaces — folded
+ * into the Target rows it would be the same four answers rendered twice, which
+ * is the duplication the vessel noun exists to remove.
+ */
+export interface VesselListItem {
+  readonly name: string;
+  /** The shape of its address, and nothing else — see `domain/vessel.ts`. */
+  readonly kind: VesselKind;
+  /** What the installation asks of it. `['app']` is an ordinary boundary. */
+  readonly roles: readonly VesselRole[];
+  readonly health: 'healthy' | 'unhealthy';
+  /**
+   * The whole standing checklist for the boundary, met rows included — and
+   * empty for a vessel the catalogue asks nothing of, which is not the same as
+   * a vessel that passed.
+   */
+  readonly prerequisites: readonly {
+    readonly name: string;
+    readonly met: boolean;
+    readonly detail?: string;
+  }[];
+  /** When the standing pass last ran against it, ISO-8601, or null if never. */
+  readonly inspectedAt: string | null;
 }
 
 /**

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -214,7 +214,7 @@ export async function start(
     clock: systemClock,
     relyingParty: {
       id: manifest.controlPlane.hostname,
-      name: manifest.installation,
+      name: manifest.installation.name,
       origin: `https://${manifest.controlPlane.hostname}`,
     },
     enrolmentToken: Bun.env[ENROLMENT_TOKEN_VAR]?.trim() || null,
@@ -257,8 +257,8 @@ export async function start(
     websocket: streamWebSocket,
   });
 
-  logInfo(`spindrift web → ${server.url} (${manifest.installation})`, {
+  logInfo(`spindrift web → ${server.url} (${manifest.installation.name})`, {
     url: String(server.url),
-    installation: manifest.installation,
+    installation: manifest.installation.name,
   });
 }

--- a/apps/spindrift/src/web/views/auth/discovery.tsx
+++ b/apps/spindrift/src/web/views/auth/discovery.tsx
@@ -28,7 +28,9 @@ import type {
   DiscoveredCandidate,
   DiscoveredFact,
 } from '../../../commands/installation/discover.ts';
+import { placementOf } from '../../../commands/installation/discover.ts';
 import { command } from '../../client.ts';
+import type { Path } from '../../forms/document.ts';
 import { withValueAt } from '../../forms/document.ts';
 import { humanize } from '../../forms/schema.ts';
 import { Button } from '../../ui/button.tsx';
@@ -92,10 +94,22 @@ export async function askInstallationCloud(narrowing: {
 export function DiscoveryPanel({
   document,
   disabled = false,
+  locked,
   onChange,
 }: {
   readonly document: unknown;
   readonly disabled?: boolean;
+  /**
+   * Whether the value at a path is somebody else's to write — the same
+   * predicate the form below this panel locks its controls with.
+   *
+   * Offering a value for a field a save would refuse is the shape of button
+   * `commands/targets/disconnect.ts` refuses to render: an act that cannot
+   * happen, shown as one that can. The reason is said in place of the
+   * candidates rather than by greying them, because a disabled button with no
+   * sentence reads as a cloud that answered nothing.
+   */
+  locked?(at: Path): boolean;
   onChange(document: unknown): void;
 }) {
   const [project, setProject] = useState('');
@@ -159,6 +173,7 @@ export function DiscoveryPanel({
           <DiscoveredFactList
             facts={facts}
             disabled={disabled || busy}
+            unwritable={(fact) => unwritable(fact, document, locked)}
             onApply={(fact, candidate) =>
               onChange(applyDiscovered(document, fact, candidate))
             }
@@ -210,7 +225,34 @@ export function applyDiscovered(
   fact: DiscoveredFact,
   candidate: DiscoveredCandidate,
 ): unknown {
-  return withValueAt(document, fact.path, candidate.value);
+  const at = placementOf(fact, document);
+  // A document with nowhere to put this is left alone rather than written at
+  // the position the answer was produced for: an entry removed between the ask
+  // and the press would make that position address a different boundary.
+  if (at === null) return document;
+  return withValueAt(document, at, candidate.value);
+}
+
+/**
+ * Why a confirmed value would not land, or `null` when it would.
+ *
+ * Two ways of not landing and one sentence each, because they send an operator
+ * to two different places: a document the answer has no home in is something to
+ * fix in the form below, and a value the declaration owns is something to fix
+ * in the declaration.
+ */
+export function unwritable(
+  fact: DiscoveredFact,
+  document: unknown,
+  locked?: (at: Path) => boolean,
+): string | null {
+  const at = placementOf(fact, document);
+  if (at === null) {
+    return 'the vessel this answers for is not declared in the document below';
+  }
+  return locked?.(at) === true
+    ? 'this is declared by the mounted declaration and reconciled from it on every boot, so it is not written here'
+    : null;
 }
 
 /**
@@ -223,10 +265,13 @@ export function applyDiscovered(
 export function DiscoveredFactList({
   facts,
   disabled = false,
+  unwritable,
   onApply,
 }: {
   readonly facts: readonly DiscoveredFact[];
   readonly disabled?: boolean;
+  /** {@link unwritable}, threaded by the panel. Omitted answers everything writable. */
+  unwritable?(fact: DiscoveredFact): string | null;
   onApply(fact: DiscoveredFact, candidate: DiscoveredCandidate): void;
 }) {
   return (
@@ -245,6 +290,8 @@ export function DiscoveredFactList({
           <dd className="text-sm">
             {fact.kind === 'unavailable' ? (
               <span className="text-muted-foreground">{fact.reason}</span>
+            ) : unwritable?.(fact) ? (
+              <span className="text-muted-foreground">{unwritable(fact)}</span>
             ) : fact.candidates.length === 0 ? (
               <span className="text-muted-foreground">
                 Nothing of this kind exists here.

--- a/apps/spindrift/src/web/views/auth/discovery.tsx
+++ b/apps/spindrift/src/web/views/auth/discovery.tsx
@@ -240,7 +240,7 @@ export function DiscoveredFactList({
             {/* The last segment, humanized. Never a key written here — the
                 path came from the command, and the schema owns which keys
                 exist. */}
-            {humanize(fact.path[fact.path.length - 1] ?? '')}
+            {humanize(String(fact.path[fact.path.length - 1] ?? ''))}
           </dt>
           <dd className="text-sm">
             {fact.kind === 'unavailable' ? (

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -38,10 +38,19 @@
  * next edit starts from the row rather than from a stale copy. Reload discards
  * local edits for the same reason.
  */
-import { CircleAlert, CircleCheck, RotateCcw, Sliders } from 'lucide-react';
+import {
+  CircleAlert,
+  CircleCheck,
+  RotateCcw,
+  Server,
+  Sliders,
+} from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
+import { governedManifestPaths } from '../../../config/manifest.schema.ts';
 import type { TransportFailure } from '../../client.ts';
 import { command } from '../../client.ts';
+import type { Path } from '../../forms/document.ts';
+import { pathKey } from '../../forms/document.ts';
 import { manifestFields, manifestIssues } from '../../forms/manifest.ts';
 import type { FieldErrors } from '../../forms/render.tsx';
 import { SchemaFields } from '../../forms/render.tsx';
@@ -279,7 +288,18 @@ export function InstallationSettingsView({
    */
   onAdopted?(): void;
 }) {
-  const form = { document, errors, disabled: saving, onChange };
+  // The slice the mounted declaration takes back on every boot. Read-only here
+  // rather than accepted and reverted: `configureInstallation` refuses a
+  // document that edits it, and a field an operator can type into but not save
+  // is a field that teaches them the wrong thing about who owns it. Still no
+  // key named in this file — the paths come from the schema module that owns
+  // them, resolved against the document being edited.
+  const governed = governedManifestPaths(declaration, document).map(pathKey);
+  const locked = (at: Path) => {
+    const here = pathKey(at);
+    return governed.some((key) => here === key || here.startsWith(`${key}.`));
+  };
+  const form = { document, errors, disabled: saving, locked, onChange };
   // Sections are whichever keys have structure. Derived rather than listed, so
   // a key that changes shape moves itself between the two halves.
   const nested = fields.filter(
@@ -301,6 +321,8 @@ export function InstallationSettingsView({
         onAdopted={onAdopted}
       />
 
+      <GovernedSliceNotice locked={governed.length > 0} />
+
       {/* Above the form, because it is the step that comes before editing: a
           value confirmed from the cloud is a value nobody has to type, and one
           typed here is a value nothing checked. It edits the same document
@@ -309,6 +331,7 @@ export function InstallationSettingsView({
       <DiscoveryPanel
         document={document}
         disabled={saving}
+        locked={locked}
         onChange={onChange}
       />
 
@@ -379,6 +402,40 @@ export function InstallationSettingsView({
         </Button>
       </div>
     </form>
+  );
+}
+
+/**
+ * Why some of the fields below cannot be typed into.
+ *
+ * The sentence rather than a tooltip on each control, and the same sentence
+ * `views/targets/list.tsx` renders on a governed Target's card: these two
+ * boundaries reconcile from the mounted declaration on every boot, so an edit
+ * accepted here would survive exactly until the next restart — with the screen
+ * that accepted it then showing the old values and no reason. A lock with no
+ * sentence beside it reads as a bug in the form.
+ *
+ * Not a refusal: nothing failed and nothing here is wrong to fix, so it takes
+ * the neutral voice `Outcome`'s `refused` arm uses rather than the destructive
+ * one.
+ */
+function GovernedSliceNotice({ locked }: { readonly locked: boolean }) {
+  if (!locked) return null;
+  return (
+    <div className="flex items-start gap-2 rounded-md border border-border bg-secondary p-3 text-sm text-foreground">
+      <Server aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
+      <div>
+        <p className="font-medium">
+          The vessels this installation is built on are declared, not configured
+          here.
+        </p>
+        <p className="mt-0.5 text-muted-foreground">
+          This installation reconciles them from the mounted declaration on
+          every boot, so they are read-only below and a save that changed one
+          would be refused. Change the declaration instead.
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/apps/spindrift/src/web/views/auth/onboarding.tsx
+++ b/apps/spindrift/src/web/views/auth/onboarding.tsx
@@ -122,7 +122,7 @@ export type OnboardingAsk = {
 export const ONBOARDING_ASKS: readonly OnboardingAsk[] = [
   {
     kind: 'field',
-    at: ['installation'],
+    at: ['installation', 'name'],
     title: 'Name this installation',
     blurb:
       'A label for this control plane. It appears in the UI and in logs and carries no behaviour, so it is yours to pick.',

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -36,10 +36,14 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import type { ComponentKind } from '../../../domain/desired-state.ts';
-import { surfacesToProbe } from '../../../domain/vessel.ts';
+import { surfacesToProbe, type VesselRole } from '../../../domain/vessel.ts';
 import type { LogoName } from '../../client/logos/index.ts';
 import { command, type InputOf, type OutputOf } from '../../client.ts';
-import type { PendingTargetConnection, TargetListItem } from '../../model.ts';
+import type {
+  PendingTargetConnection,
+  TargetListItem,
+  VesselListItem,
+} from '../../model.ts';
 import { Badge, Dot } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, Eyebrow } from '../../ui/card.tsx';
@@ -102,6 +106,7 @@ function AbsentSurfaces({ absent }: { absent: readonly string[] }) {
 export function TargetList({
   targets,
   pending,
+  vessels,
   connecting,
   error,
   absent = [],
@@ -112,6 +117,8 @@ export function TargetList({
 }: {
   targets: readonly TargetListItem[];
   pending: readonly PendingTargetConnection[];
+  /** The boundaries themselves, with the checklist that is theirs. */
+  vessels: readonly VesselListItem[];
   connecting: boolean;
   error: string | null;
   /** One sentence per surface the last connect found was not there. */
@@ -156,6 +163,7 @@ export function TargetList({
             <AbsentSurfaces absent={absent} />
           </section>
         ) : null}
+        <VesselChecklists vessels={vessels} />
         <ProviderTargets
           name="Google Cloud"
           logo="google-cloud"
@@ -253,6 +261,8 @@ export function TargetList({
       ) : null}
 
       <AbsentSurfaces absent={absent} />
+
+      <VesselChecklists vessels={vessels} />
 
       <TargetCollection
         targets={configured}
@@ -395,6 +405,90 @@ function TargetCollection({
   );
 }
 
+/**
+ * The boundaries themselves, with the checklist that is theirs.
+ *
+ * A section of its own rather than rows inside each Target card, because a
+ * vessel may carry two surfaces and this is one fact about the boundary — folded
+ * into the Targets it would be the same four answers rendered twice, which is
+ * the duplication the vessel noun exists to remove.
+ *
+ * **Only the boundaries something is asked of appear here.** An app vessel's
+ * catalogue is empty, so it has no rows, and a section listing it with nothing
+ * under it would say something was checked when nothing was.
+ */
+function VesselChecklists({
+  vessels,
+}: {
+  readonly vessels: readonly VesselListItem[];
+}) {
+  const assessed = vessels.filter(
+    (vessel) => vessel.prerequisites.length > 0 || declaredRole(vessel.roles),
+  );
+  if (assessed.length === 0) return null;
+
+  return (
+    <section className="flex flex-col gap-2">
+      <Eyebrow>Boundaries this installation is built on</Eyebrow>
+      <Card className="divide-y divide-border">
+        {assessed.map((vessel) => (
+          <div key={vessel.name} className="flex flex-col gap-2 px-4 py-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <Server aria-hidden="true" className="size-4 shrink-0" />
+              <span className="text-sm font-semibold">{vessel.name}</span>
+              <Badge tone="idle">{vessel.kind}</Badge>
+              {vessel.prerequisites.length > 0 ? (
+                <Badge
+                  tone={vessel.health === 'healthy' ? 'success' : 'destructive'}
+                >
+                  <Dot />
+                  {vessel.health}
+                </Badge>
+              ) : null}
+              <span className="text-xs text-muted-foreground">
+                {declaredRole(vessel.roles) ?? 'an ordinary deploy boundary'}
+              </span>
+            </div>
+            {vessel.prerequisites.map((item) => (
+              <div
+                key={item.name}
+                className="flex items-start gap-2 px-1 text-xs"
+              >
+                {item.met ? (
+                  <Check
+                    aria-hidden="true"
+                    className="mt-0.5 size-3.5 shrink-0 text-success"
+                  />
+                ) : (
+                  <X
+                    aria-hidden="true"
+                    className="mt-0.5 size-3.5 shrink-0 text-destructive"
+                  />
+                )}
+                <span className="font-mono">{item.name}</span>
+                {item.detail ? (
+                  <span className="text-muted-foreground">— {item.detail}</span>
+                ) : null}
+              </div>
+            ))}
+            {/*
+              Labelled as of-a-moment, for the reason a Target's checklist is:
+              this is the last pass of the loop, and saying when stops it from
+              being read as now. A boundary nobody has been past yet says so
+              rather than reading as four questions that passed.
+            */}
+            <p className="text-[11px] text-subtle">
+              {vessel.inspectedAt === null
+                ? 'never inspected'
+                : `last checked ${new Date(vessel.inspectedAt).toLocaleString()}`}
+            </p>
+          </div>
+        ))}
+      </Card>
+    </section>
+  );
+}
+
 /** The unfinished half, at the top, with the form that finishes it. */
 function PendingConnections({
   pending,
@@ -460,6 +554,25 @@ function PendingConnections({
   );
 }
 
+/**
+ * What this Target's boundary is to the installation, as a sentence fragment —
+ * `null` for an ordinary one.
+ *
+ * Both roles when a boundary carries both, because an installation whose
+ * control plane runs where its shared services live is one boundary doing two
+ * jobs, and naming only the first would leave the other unexplained.
+ */
+function declaredRole(roles: readonly VesselRole[]): string | null {
+  const named = roles.flatMap((role) =>
+    role === 'home'
+      ? ['this installation’s home vessel']
+      : role === 'controlPlane'
+        ? ['where this control plane runs']
+        : [],
+  );
+  return named.length === 0 ? null : named.join(' and ');
+}
+
 function TargetCard({
   target,
   connecting,
@@ -476,6 +589,7 @@ function TargetCard({
   const [editing, setEditing] = useState(false);
   const met = target.prerequisites.filter((item) => item.met).length;
   const logo = ADAPTER_LOGO[target.adapter];
+  const declared = declaredRole(target.vesselRoles);
 
   return (
     <Card className={cn(unhealthy && 'border-destructive/40')}>
@@ -553,7 +667,7 @@ function TargetCard({
               surface again, which is how a project whose Cloud Run API was off
               at connect time gets that Target once it is switched on.
             */}
-            {target.edit ? (
+            {declared === null && target.edit ? (
               <Button
                 variant={editing ? 'ghost' : 'outline'}
                 size="sm"
@@ -562,7 +676,7 @@ function TargetCard({
                 {editing ? 'Cancel' : 'Edit connection'}
               </Button>
             ) : null}
-            {target.status === 'connected' ? (
+            {declared === null && target.status === 'connected' ? (
               <DisconnectTargetControl target={target} onChanged={onChanged} />
             ) : null}
           </div>
@@ -594,6 +708,27 @@ function TargetCard({
             </span>
           </div>
         ) : null}
+
+        {declared === null ? null : (
+          /*
+            Read-only, and the sentence is why rather than a disabled button.
+            This boundary reconciles from the mounted declaration on every boot,
+            so an edit made here would survive exactly until the next restart —
+            with the screen that accepted it then showing the old values and no
+            reason. Disconnect is refused for the same reason one level down:
+            `disconnectTarget` guards it, because neither pointer is a foreign
+            key and nothing else would stop it.
+          */
+          <div className="flex items-start gap-2 rounded-md border border-border-soft bg-secondary/40 px-3 py-2 text-xs text-muted-foreground">
+            <Server aria-hidden="true" className="mt-0.5 size-3.5 shrink-0" />
+            <span>
+              {target.vessel} is {declared}. It is declared by the installation
+              manifest and reconciled from it on every boot, so its connection
+              is edited there rather than here — and its surfaces cannot be
+              disconnected.
+            </span>
+          </div>
+        )}
 
         {editing && target.edit ? (
           <div className="rounded-md border border-border-soft bg-secondary/40 px-4 py-4">

--- a/apps/spindrift/test/commands/installation-discover.test.ts
+++ b/apps/spindrift/test/commands/installation-discover.test.ts
@@ -97,10 +97,24 @@ function installation(options: FakeGcpDiscoveryOptions = {}) {
   return { fake, context: contextFor(fake) };
 }
 
+/**
+ * Where the home vessel sits in the fixture's `vessels`.
+ *
+ * Three of the five facts are that vessel's own properties, so their paths run
+ * through its position. Resolved from the pointer rather than written as `1`:
+ * an index typed here would agree with the fixture only by luck.
+ */
+const HOME = [
+  'vessels',
+  fixture.vessels.findIndex(
+    (vessel) => vessel.name === fixture.installation.homeVessel,
+  ),
+] as const;
+
 /** One fact by the manifest path it proposes a value for. */
 function factAt(
   facts: readonly DiscoveredFact[],
-  ...path: string[]
+  ...path: (string | number)[]
 ): DiscoveredFact {
   const found = facts.find((fact) => fact.path.join('.') === path.join('.'));
   if (found === undefined) {
@@ -212,7 +226,9 @@ describe('a refusal is never an empty answer', () => {
 
     const facts = await discover(context, { project: PROJECT });
 
-    expect(factAt(facts, 'cloud', 'artifactsProject').kind).toBe('found');
+    expect(factAt(facts, ...HOME, 'shared', 'artifactsProject').kind).toBe(
+      'found',
+    );
     expect(factAt(facts, 'sources', 'buckets').kind).toBe('found');
     expect(factAt(facts, 'supplyChain', 'signer').kind).toBe('unavailable');
   });
@@ -227,7 +243,7 @@ describe('what the reads answer', () => {
 
     const facts = await discover(context, { project: PROJECT });
     const buckets = factAt(facts, 'sources', 'buckets');
-    const fallback = factAt(facts, 'sources', 'defaultBucket');
+    const fallback = factAt(facts, ...HOME, 'shared', 'sourceBucket');
 
     expect(buckets.kind).toBe('found');
     expect(fallback.kind).toBe('found');
@@ -309,7 +325,9 @@ describe('what the reads answer', () => {
 
     const facts = await discover(context);
 
-    expect(factAt(facts, 'cloud', 'artifactsProject').kind).toBe('found');
+    expect(factAt(facts, ...HOME, 'shared', 'artifactsProject').kind).toBe(
+      'found',
+    );
     for (const path of [
       ['sources', 'buckets'],
       ['supplyChain', 'signer'],
@@ -331,7 +349,12 @@ describe('what the reads answer', () => {
       deletedProjects: ['example-retired'],
     });
 
-    const fact = factAt(await discover(context), 'cloud', 'artifactsProject');
+    const fact = factAt(
+      await discover(context),
+      ...HOME,
+      'shared',
+      'artifactsProject',
+    );
 
     expect(fact.kind).toBe('found');
     if (fact.kind !== 'found') return;
@@ -348,7 +371,12 @@ describe('truncation is not silence', () => {
       pageSize: 1,
     });
 
-    const fact = factAt(await discover(context), 'cloud', 'artifactsProject');
+    const fact = factAt(
+      await discover(context),
+      ...HOME,
+      'shared',
+      'artifactsProject',
+    );
 
     expect(fact.kind).toBe('found');
     if (fact.kind !== 'found') return;
@@ -370,7 +398,12 @@ describe('truncation is not silence', () => {
       pageSize: 1,
     });
 
-    const fact = factAt(await discover(context), 'cloud', 'artifactsProject');
+    const fact = factAt(
+      await discover(context),
+      ...HOME,
+      'shared',
+      'artifactsProject',
+    );
 
     expect(fact.kind).toBe('unavailable');
     if (fact.kind !== 'unavailable') return;
@@ -417,7 +450,12 @@ describe('the credential answers what it can without a call', () => {
       }),
     );
 
-    const fact = factAt(await discover(context), 'cloud', 'homeVesselProject');
+    const fact = factAt(
+      await discover(context),
+      ...HOME,
+      'location',
+      'project',
+    );
 
     expect(fact.kind).toBe('found');
     if (fact.kind !== 'found') return;
@@ -441,7 +479,12 @@ describe('the credential answers what it can without a call', () => {
       }),
     );
 
-    const fact = factAt(await discover(context), 'cloud', 'homeVesselProject');
+    const fact = factAt(
+      await discover(context),
+      ...HOME,
+      'location',
+      'project',
+    );
 
     expect(fact.kind).toBe('found');
     if (fact.kind !== 'found') return;
@@ -454,7 +497,12 @@ describe('the credential answers what it can without a call', () => {
     // fragment of a project name presented as an answer.
     const { context } = installation({ projects: [] });
 
-    const fact = factAt(await discover(context), 'cloud', 'homeVesselProject');
+    const fact = factAt(
+      await discover(context),
+      ...HOME,
+      'location',
+      'project',
+    );
 
     expect(fact.kind).toBe('found');
     if (fact.kind !== 'found') return;
@@ -479,7 +527,7 @@ describe('the credential answers what it can without a call', () => {
     );
 
     const facts = await discover(context);
-    const home = factAt(facts, 'cloud', 'homeVesselProject');
+    const home = factAt(facts, ...HOME, 'location', 'project');
 
     expect(home.kind).toBe('found');
     if (home.kind !== 'found') return;
@@ -492,7 +540,9 @@ describe('the credential answers what it can without a call', () => {
     expect(home.candidates[0]?.value).toBe(PROJECT);
     // And the key it cannot suggest anything for stays honest about the same
     // refusal, rather than borrowing the answer.
-    expect(factAt(facts, 'cloud', 'artifactsProject').kind).toBe('unavailable');
+    expect(factAt(facts, ...HOME, 'shared', 'artifactsProject').kind).toBe(
+      'unavailable',
+    );
   });
 });
 
@@ -539,7 +589,7 @@ describe('every path discovery proposes is a path the manifest has', () => {
    * names through `manifestFieldAt`, and a copy here would be a second answer
    * about one schema that only has to agree by luck.
    */
-  function resolves(path: readonly string[]): boolean {
+  function resolves(path: readonly (string | number)[]): boolean {
     return manifestFieldAt(path) !== null;
   }
 

--- a/apps/spindrift/test/commands/installation-discover.test.ts
+++ b/apps/spindrift/test/commands/installation-discover.test.ts
@@ -20,6 +20,8 @@ import { createAdapterRegistry } from '../../src/adapters/registry.ts';
 import {
   type DiscoveredFact,
   discoverInstallationFacts,
+  HOME_VESSEL,
+  placementOf,
 } from '../../src/commands/installation/discover.ts';
 import type { CommandContext } from '../../src/commands/types.ts';
 import type { InstallationManifest } from '../../src/config/manifest.ts';
@@ -98,18 +100,13 @@ function installation(options: FakeGcpDiscoveryOptions = {}) {
 }
 
 /**
- * Where the home vessel sits in the fixture's `vessels`.
+ * How the home vessel is addressed in a discovered path.
  *
- * Three of the five facts are that vessel's own properties, so their paths run
- * through its position. Resolved from the pointer rather than written as `1`:
- * an index typed here would agree with the fixture only by luck.
+ * Three of the five facts are that vessel's own properties, and they name it
+ * rather than the position it holds — the position is the document's to give,
+ * at the moment a value is applied to it.
  */
-const HOME = [
-  'vessels',
-  fixture.vessels.findIndex(
-    (vessel) => vessel.name === fixture.installation.homeVessel,
-  ),
-] as const;
+const HOME = ['vessels', HOME_VESSEL] as const;
 
 /** One fact by the manifest path it proposes a value for. */
 function factAt(
@@ -593,6 +590,15 @@ describe('every path discovery proposes is a path the manifest has', () => {
     return manifestFieldAt(path) !== null;
   }
 
+  /** The same walk, over a fact placed on a document the way the panel places it. */
+  function placed(fact: DiscoveredFact): readonly (string | number)[] {
+    const at = placementOf(fact, fixture);
+    if (at === null) {
+      throw new Error(`nothing in the fixture holds ${fact.path.join('.')}`);
+    }
+    return at;
+  }
+
   test('the walk rejects a key the schema no longer has', () => {
     // The exact staleness this test exists to catch: `dns.apexZone` was the
     // key when discovery was first specified, and `dns.zones.private` is the
@@ -622,10 +628,54 @@ describe('every path discovery proposes is a path the manifest has', () => {
 
     expect(facts.length).toBeGreaterThan(0);
     for (const fact of facts) {
-      expect([fact.path.join('.'), resolves(fact.path)]).toEqual([
+      expect([fact.path.join('.'), resolves(placed(fact))]).toEqual([
         fact.path.join('.'),
         true,
       ]);
     }
+  });
+
+  test('a vessel path is placed by name, so an edited array cannot misplace it', async () => {
+    // The whole reason a discovered path names the home vessel rather than
+    // carrying its position: the settings form removes entries from `vessels`
+    // between the ask and the press, and `location.project` carries no
+    // refinement that would refuse a value written onto the wrong boundary.
+    const { context } = installation({ projects: [PROJECT] });
+    const fact = factAt(
+      await discover(context, { project: PROJECT }),
+      ...HOME,
+      'location',
+      'project',
+    );
+
+    const shifted = {
+      ...fixture,
+      vessels: [
+        { name: 'a-boundary-added-since', kind: 'cluster' as const },
+        ...fixture.vessels,
+      ],
+    };
+    expect(placementOf(fact, shifted)).toEqual([
+      'vessels',
+      fixture.vessels.findIndex(
+        (vessel) => vessel.name === fixture.installation.homeVessel,
+      ) + 1,
+      'location',
+      'project',
+    ]);
+  });
+
+  test('a document that declares no home vessel is placed nowhere', async () => {
+    // Rather than at the position the answer was produced for, which after a
+    // removal is whichever boundary slid into it.
+    const { context } = installation({ projects: [PROJECT] });
+    const fact = factAt(
+      await discover(context, { project: PROJECT }),
+      ...HOME,
+      'location',
+      'project',
+    );
+
+    expect(placementOf(fact, { ...fixture, vessels: [] })).toBeNull();
   });
 });

--- a/apps/spindrift/test/commands/installation-round-trip.test.ts
+++ b/apps/spindrift/test/commands/installation-round-trip.test.ts
@@ -59,10 +59,10 @@ function context(): CommandContext {
 }
 
 async function seed(): Promise<void> {
-  const { federation: _derived, ...cloud } = manifest.cloud;
+  const { cloud: _derived, ...authored } = manifest;
   await database()
     .db.insert(installation)
-    .values({ id: 1, manifest: { ...manifest, cloud } })
+    .values({ id: 1, manifest: authored })
     .onConflictDoNothing();
 }
 
@@ -105,7 +105,7 @@ describe('the installation settings round trip', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
 
-    expect('federation' in result.value.manifest.cloud).toBe(false);
+    expect(result.value.manifest).not.toHaveProperty('cloud');
   });
 
   test('a value edited on what the read answers writes back', async () => {

--- a/apps/spindrift/test/commands/installation-round-trip.test.ts
+++ b/apps/spindrift/test/commands/installation-round-trip.test.ts
@@ -26,14 +26,18 @@ import {
   getInstallationManifest,
 } from '../../src/commands/index.ts';
 import type { Clock, CommandContext } from '../../src/commands/types.ts';
-import { installationManifestSchema } from '../../src/config/manifest.schema.ts';
+import {
+  installationManifestSchema,
+  sharedServicesOf,
+} from '../../src/config/manifest.schema.ts';
 import { installation } from '../../src/db/schema.ts';
 import { manifestIssues } from '../../src/web/forms/manifest.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { fixtureManifest } from '../harness/installation.ts';
+import { authoredFixture, fixtureManifest } from '../harness/installation.ts';
 
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
+const declaration = await authoredFixture();
 
 const FROZEN = new Date('2024-06-01T00:00:00.000Z');
 const clock: Clock = { now: () => FROZEN };
@@ -135,5 +139,85 @@ describe('the installation settings round trip', () => {
     expect(row?.manifest.build.zeroConfigFrontend).toBe(
       'ghcr.io/railwayapp/railpack-frontend:v0.35.0',
     );
+  });
+});
+
+/**
+ * The one slice this screen does not drive.
+ *
+ * `loadStoredManifest` re-applies the mounted declaration to the two vessels
+ * this installation is built on at every boot. Taking an edit to them here would
+ * be saving a value the next pod restart discards — the same failure
+ * `ManifestWrite` records having already happened to a Target's connection, one
+ * noun up. So it is refused, and the paths a boot would take back are named.
+ */
+describe('an installation that mounts a declaration', () => {
+  /** The same context a chart-installed pod's dispatch builds. */
+  function declared(): CommandContext {
+    return { ...context(), declaration };
+  }
+
+  /** The home vessel's shared services, edited as the settings form edits them. */
+  const withSourceBucket = (bucket: string) => ({
+    ...declaration,
+    vessels: declaration.vessels.map((vessel) =>
+      vessel.name === declaration.installation.homeVessel &&
+      vessel.shared !== undefined
+        ? { ...vessel, shared: { ...vessel.shared, sourceBucket: bucket } }
+        : vessel,
+    ),
+  });
+
+  test('an edit to a governed vessel is refused, and nothing is written', async () => {
+    await seed();
+
+    const result = await configureInstallation(
+      { manifest: withSourceBucket('operator-chosen') },
+      declared(),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // A fact about the installation, not a field to correct — the distinction
+    // this screen keeps three refusals apart for. Re-typing the value in the
+    // form changes nothing about it.
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('shared.sourceBucket');
+
+    const [row] = await database().db.select().from(installation);
+    expect(sharedServicesOf(row!.manifest).sourceBucket).toBe(
+      'example-source-bucket',
+    );
+  });
+
+  test('adopting the declaration whole is not an edit to it', async () => {
+    // The act `ManifestDivergenceNotice` offers. It submits the declaration
+    // unchanged, so there is nothing in the governed slice for a boot to
+    // revert and the guard has to let it through.
+    await seed();
+    const result = await configureInstallation(
+      { manifest: declaration },
+      declared(),
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  test('everything else on the screen still writes', async () => {
+    await seed();
+    const result = await configureInstallation(
+      {
+        manifest: {
+          ...declaration,
+          sources: {
+            ...declaration.sources,
+            buckets: [...declaration.sources.buckets, 'another-bucket'],
+          },
+        },
+      },
+      declared(),
+    );
+    expect(result.ok).toBe(true);
+
+    const [row] = await database().db.select().from(installation);
+    expect(row?.manifest.sources.buckets).toContain('another-bucket');
   });
 });

--- a/apps/spindrift/test/commands/source-buckets.test.ts
+++ b/apps/spindrift/test/commands/source-buckets.test.ts
@@ -14,6 +14,7 @@ import type {
   AdapterRegistry,
   CommandContext,
 } from '../../src/commands/types.ts';
+import { sharedServicesOf } from '../../src/config/manifest.schema.ts';
 import {
   readStoredManifest,
   writeStoredManifest,
@@ -99,9 +100,21 @@ async function context(bucketStatus = 200): Promise<CommandContext> {
   };
 }
 
+/**
+ * The declared list and the one staging picks, read back from the row.
+ *
+ * Two keys from two places now, and deliberately asserted together: the list is
+ * `sources.buckets` and the choice is the home vessel's `shared.sourceBucket`,
+ * so a write that moved one without the other is a manifest whose staging
+ * bucket is not among its buckets.
+ */
 async function storedBuckets() {
   const stored = await readStoredManifest(database().db);
-  return stored?.sources;
+  if (stored === null) return null;
+  return {
+    buckets: stored.sources.buckets,
+    defaultBucket: sharedServicesOf(stored).sourceBucket,
+  };
 }
 
 describe('declaring a source bucket', () => {

--- a/apps/spindrift/test/commands/source-buckets.test.ts
+++ b/apps/spindrift/test/commands/source-buckets.test.ts
@@ -217,3 +217,48 @@ describe('declaring a source bucket', () => {
     expect(without.ok && without.value.canVerify).toBe(false);
   });
 });
+
+/**
+ * Which bucket a staging picks is a property of the home vessel, and an
+ * installation that mounts a declaration takes that vessel from it on every
+ * boot. So the choice is the declaration's there, and this command has to say
+ * so rather than write it.
+ */
+describe('an installation whose home vessel is declared', () => {
+  async function declared(): Promise<CommandContext> {
+    return { ...(await context()), declaration: await authoredFixture() };
+  }
+
+  test('adding a bucket is still this screen’s to do', async () => {
+    // `sources.buckets` is not the home vessel's, so nothing about it moves
+    // with the declaration and the ordinary act stays open.
+    const result = await useSourceBucket(
+      { bucketName: 'a-second-bucket', makeDefault: false },
+      await declared(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(await storedBuckets()).toMatchObject({
+      buckets: ['example-source-bucket', 'a-second-bucket'],
+    });
+  });
+
+  test('moving the default is refused rather than half-applied', async () => {
+    // Accepted, it would leave the bucket added and the choice reverted at the
+    // next restart — one act, half of it standing, and nothing on screen
+    // saying which half.
+    const result = await useSourceBucket(
+      { bucketName: 'a-second-bucket', makeDefault: true },
+      await declared(),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('shared.sourceBucket');
+    expect(await storedBuckets()).toMatchObject({
+      buckets: ['example-source-bucket'],
+      defaultBucket: 'example-source-bucket',
+    });
+  });
+});

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -31,6 +31,7 @@ import type {
 } from '../../src/commands/types.ts';
 import {
   type InstallationManifest,
+  sharedServicesOf,
   type TargetAdapter,
   toAuthoredManifest,
 } from '../../src/config/manifest.schema.ts';
@@ -581,11 +582,20 @@ describe('an operator’s Target correction outlives the next boot', () => {
     const platform = input.chartValues?.platform as Record<string, unknown>;
     return {
       ...toAuthoredManifest(manifest),
+      // One declared boundary, so it is both of the two the installation is
+      // built on. `shared` follows the pointer rather than the kind: only the
+      // vessel `homeVessel` names may carry it, and it must.
+      installation: {
+        ...manifest.installation,
+        controlPlaneVessel: 'cluster',
+        homeVessel: 'cluster',
+      },
       vessels: [
         {
           name: 'cluster',
           kind: 'cluster' as const,
           location: { apiServer: input.apiServer },
+          shared: sharedServicesOf(manifest),
         },
       ],
       targets: [
@@ -691,12 +701,15 @@ describe('an operator’s Target correction outlives the next boot', () => {
 describe('disconnect strands rather than stops', () => {
   test('an impact review names Deploys without changing state', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
-    const target = (await targetRow('cluster'))!;
+    await connectTarget(
+      clusterInput({ vessel: 'app-cluster' }),
+      context(registry),
+    );
+    const target = (await targetRow('app-cluster'))!;
     const { app, component } = await seedLiveDeploy(target.id, 'preview-ref');
 
     const result = await disconnectTarget(
-      { vessel: 'cluster', adapter: 'kubernetes', confirm: false },
+      { vessel: 'app-cluster', adapter: 'kubernetes', confirm: false },
       context(registry),
     );
     if (!result.ok) throw new Error('disconnect review refused');
@@ -710,17 +723,20 @@ describe('disconnect strands rather than stops', () => {
       .from(deploys)
       .where(eq(deploys.targetId, target.id));
     expect(row?.orphanedAt).toBeNull();
-    expect((await targetRow('cluster'))?.status).toBe('connected');
+    expect((await targetRow('app-cluster'))?.status).toBe('connected');
   });
 
   test('live Deploys go orphaned and are named, and nothing is destroyed', async () => {
     const { registry, of } = fakes();
-    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
-    const target = (await targetRow('cluster'))!;
+    await connectTarget(
+      clusterInput({ vessel: 'app-cluster' }),
+      context(registry),
+    );
+    const target = (await targetRow('app-cluster'))!;
     const { app, component } = await seedLiveDeploy(target.id, 'ref-1');
 
     const result = await disconnectTarget(
-      { vessel: 'cluster', adapter: 'kubernetes' },
+      { vessel: 'app-cluster', adapter: 'kubernetes' },
       context(registry),
     );
 
@@ -746,7 +762,7 @@ describe('disconnect strands rather than stops', () => {
     expect(
       deployState({ phase: row!.phase, orphanedAt: row!.orphanedAt }),
     ).toBe('orphaned');
-    expect((await targetRow('cluster'))?.status).toBe('disconnected');
+    expect((await targetRow('app-cluster'))?.status).toBe('disconnected');
 
     // A cluster being removed from the platform is exactly when tearing down
     // what runs on it would be the most destructive reading of the request.
@@ -755,13 +771,49 @@ describe('disconnect strands rather than stops', () => {
 
   test('disconnecting a Target with nothing on it strands nothing', async () => {
     const { registry } = fakes();
-    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
+    await connectTarget(
+      clusterInput({ vessel: 'app-cluster' }),
+      context(registry),
+    );
     const result = await disconnectTarget(
-      { vessel: 'cluster', adapter: 'kubernetes' },
+      { vessel: 'app-cluster', adapter: 'kubernetes' },
       context(registry),
     );
     if (!result.ok) throw new Error('disconnect refused');
     expect(result.value.stranded).toEqual([]);
+  });
+
+  test('a vessel the installation is built on cannot be disconnected', async () => {
+    // Neither pointer is a foreign key, so nothing else would stop this the way
+    // `targets_vessel_id_vessels_id_fk`'s `restrict` stops a vessel with
+    // surfaces from being dropped. The bootstrap paradox is what makes it worth
+    // an explicit guard: disconnecting the boundary this control plane runs on
+    // leaves a process that keeps serving until the next thing it tries to do.
+    const { registry } = fakes();
+    await connectTarget(clusterInput({ vessel: 'cluster' }), context(registry));
+
+    for (const vessel of [
+      manifest.installation.controlPlaneVessel,
+      manifest.installation.homeVessel,
+    ]) {
+      const result = await disconnectTarget(
+        { vessel, adapter: 'kubernetes' },
+        context(registry),
+      );
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+      expect(result.failure.message).toContain('built on');
+    }
+
+    // And refused before the review, so the impact screen never offers a
+    // button that cannot be pressed.
+    const review = await disconnectTarget(
+      { vessel: 'cluster', adapter: 'kubernetes', confirm: false },
+      context(registry),
+    );
+    expect(review.ok).toBe(false);
+    expect((await targetRow('cluster'))?.status).toBe('connected');
   });
 
   test('an unknown Target is a refusal with an identity', async () => {
@@ -779,13 +831,13 @@ describe('disconnect strands rather than stops', () => {
 describe('reconnect re-adopts via observe', () => {
   test('a workload the adapter still sees is adopted back', async () => {
     const { registry, of } = fakes();
-    const input = clusterInput({ vessel: 'cluster' });
+    const input = clusterInput({ vessel: 'app-cluster' });
 
     await connectTarget(input, context(registry));
-    const target = (await targetRow('cluster'))!;
+    const target = (await targetRow('app-cluster'))!;
     await seedLiveDeploy(target.id, 'ref-1');
     await disconnectTarget(
-      { vessel: 'cluster', adapter: 'kubernetes' },
+      { vessel: 'app-cluster', adapter: 'kubernetes' },
       context(registry),
     );
 
@@ -814,13 +866,13 @@ describe('reconnect re-adopts via observe', () => {
 
   test('a workload that is gone stays orphaned rather than resurrected', async () => {
     const { registry } = fakes();
-    const input = clusterInput({ vessel: 'cluster' });
+    const input = clusterInput({ vessel: 'app-cluster' });
 
     await connectTarget(input, context(registry));
-    const target = (await targetRow('cluster'))!;
+    const target = (await targetRow('app-cluster'))!;
     await seedLiveDeploy(target.id, 'ref-1');
     await disconnectTarget(
-      { vessel: 'cluster', adapter: 'kubernetes' },
+      { vessel: 'app-cluster', adapter: 'kubernetes' },
       context(registry),
     );
 
@@ -839,12 +891,12 @@ describe('reconnect re-adopts via observe', () => {
 
   test('a declarative reconnect waits for adapters, then re-adopts', async () => {
     const { registry, of } = fakes();
-    const input = clusterInput({ vessel: 'cluster' });
+    const input = clusterInput({ vessel: 'app-cluster' });
     await connectTarget(input, context(registry));
-    const target = (await targetRow('cluster'))!;
+    const target = (await targetRow('app-cluster'))!;
     await seedLiveDeploy(target.id, 'ref-1');
     await disconnectTarget(
-      { vessel: 'cluster', adapter: 'kubernetes' },
+      { vessel: 'app-cluster', adapter: 'kubernetes' },
       context(registry),
     );
     of('kubernetes').place('ref-1', {
@@ -854,11 +906,17 @@ describe('reconnect re-adopts via observe', () => {
     });
     const declared = {
       ...manifest,
+      installation: {
+        ...manifest.installation,
+        controlPlaneVessel: input.vessel,
+        homeVessel: input.vessel,
+      },
       vessels: [
         {
           name: input.vessel,
           kind: 'cluster',
           location: { apiServer: input.apiServer },
+          shared: sharedServicesOf(manifest),
         },
       ],
       targets: [
@@ -878,14 +936,14 @@ describe('reconnect re-adopts via observe', () => {
       // is the deployment's, and the schema refuses a document restating it.
       [MANIFEST_INLINE_VAR]: JSON.stringify(toAuthoredManifest(declared)),
     });
-    expect((await targetRow('cluster'))?.status).toBe('disconnected');
+    expect((await targetRow('app-cluster'))?.status).toBe('disconnected');
 
     const readopted = await restoreDeclaredTargetConnections(
       context(registry),
       declared,
     );
     expect(readopted).toHaveLength(1);
-    expect((await targetRow('cluster'))?.status).toBe('connected');
+    expect((await targetRow('app-cluster'))?.status).toBe('connected');
     const [row] = await database()
       .db.select()
       .from(deploys)

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -46,7 +46,10 @@ import {
   vessels,
 } from '../../src/db/schema.ts';
 import { deployState } from '../../src/domain/target.ts';
-import { surfacesToProbe } from '../../src/domain/vessel.ts';
+import {
+  surfacesToProbe,
+  vesselPrerequisitesFor,
+} from '../../src/domain/vessel.ts';
 import { restoreDeclaredTargetConnections } from '../../src/reconciler/target-loop.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import {
@@ -1108,5 +1111,59 @@ describe('listTargets', () => {
     if (!result.ok) return;
     const k8s = result.value.targets.find((t) => t.adapter === 'kubernetes');
     expect(k8s?.canonical).toBe('*.apps.example.test');
+  });
+
+  test('answers the boundaries themselves, with the role each carries', async () => {
+    // The seam between the vessel catalogue and the screen. Both ends are well
+    // covered on their own; without this the payload the Targets surface reads
+    // its checklist section out of is asserted by nothing.
+    const { registry } = fakes();
+    await connectTarget(cloudInput({ vessel: 'cloud' }), context(registry));
+
+    const result = await listTargets({}, context(registry));
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const home = result.value.vessels.find((vessel) => vessel.name === 'cloud');
+    expect(home?.roles).toEqual(['home']);
+    expect(home?.inspectedAt).toBeNull();
+  });
+
+  test('a vessel’s health is derived from its rows, not read off one', async () => {
+    // Health is not a column, for the reason `target-loop.ts` gives about a
+    // stored derivation going stale. Asserted through the catalogue rather than
+    // by mirroring it: an unmet row is unhealthy, and every row met is healthy.
+    const { registry } = fakes();
+    await connectTarget(cloudInput({ vessel: 'cloud' }), context(registry));
+
+    const catalogue = vesselPrerequisitesFor('gcp-project', ['home']);
+    expect(catalogue).toContain('SOURCE_BUCKET');
+
+    await database()
+      .db.update(vessels)
+      .set({
+        prerequisites: catalogue.map((name) => ({
+          name,
+          met: name !== 'SIGNER_KEY',
+        })),
+      })
+      .where(eq(vessels.name, 'cloud'));
+    const unhealthy = await listTargets({}, context(registry));
+    expect(unhealthy.ok).toBe(true);
+    if (!unhealthy.ok) return;
+    expect(
+      unhealthy.value.vessels.find((vessel) => vessel.name === 'cloud')?.health,
+    ).toBe('unhealthy');
+
+    await database()
+      .db.update(vessels)
+      .set({ prerequisites: catalogue.map((name) => ({ name, met: true })) })
+      .where(eq(vessels.name, 'cloud'));
+    const healthy = await listTargets({}, context(registry));
+    expect(healthy.ok).toBe(true);
+    if (!healthy.ok) return;
+    expect(
+      healthy.value.vessels.find((vessel) => vessel.name === 'cloud')?.health,
+    ).toBe('healthy');
   });
 });

--- a/apps/spindrift/test/config/federation-credential.test.ts
+++ b/apps/spindrift/test/config/federation-credential.test.ts
@@ -102,11 +102,9 @@ describe('the credential the deployment mounts', () => {
 
 describe('the manifest cannot restate it', () => {
   test('there is no key to write it into', () => {
-    const cloud = installationManifestSchema.shape.cloud;
-    expect(Object.keys(cloud.shape).sort()).toEqual([
-      'artifactsProject',
-      'homeVesselProject',
-    ]);
+    // Not even a block to hang it off any more: the two keys that used to sit
+    // beside it are properties of the home vessel, so `cloud` is derived whole.
+    expect(installationManifestSchema.shape).not.toHaveProperty('cloud');
     expect(Object.keys(installationManifestSchema.shape.charts.shape)).toEqual([
       'app',
     ]);
@@ -123,7 +121,6 @@ describe('the manifest cannot restate it', () => {
     const restated = {
       ...document,
       cloud: {
-        ...(document.cloud as Record<string, unknown>),
         federation: {
           audience: '//iam.stale.test/pools/stale',
           tokenUrl: 'https://sts.stale.test/v1/token',
@@ -139,7 +136,7 @@ describe('the manifest cannot restate it', () => {
 
     expect(() =>
       parseManifest(JSON.stringify(restated), 'a stale document'),
-    ).toThrow(/federation/);
+    ).toThrow(/cloud/);
   });
 
   test('what readers get is the deployment’s copy, joined on at resolve', async () => {
@@ -153,6 +150,6 @@ describe('the manifest cannot restate it', () => {
     );
     // And the authored document is untouched by the join, so a write path
     // holding one cannot round-trip a derived value back into the row.
-    expect(authored.cloud).not.toHaveProperty('federation');
+    expect(authored).not.toHaveProperty('cloud');
   });
 });

--- a/apps/spindrift/test/config/installation-configured.test.ts
+++ b/apps/spindrift/test/config/installation-configured.test.ts
@@ -155,8 +155,14 @@ describe('an installation nobody has configured says so', () => {
   // Continue on an edited name and nothing else.
   const answeringOne: readonly (readonly [string, AuthoredManifest])[] = [
     [
-      'installation',
-      { ...DEFAULT_PLACEHOLDER_MANIFEST, installation: 'offsite' },
+      'installation.name',
+      {
+        ...DEFAULT_PLACEHOLDER_MANIFEST,
+        installation: {
+          ...DEFAULT_PLACEHOLDER_MANIFEST.installation,
+          name: 'offsite',
+        },
+      },
     ],
     [
       'github.clientId',

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../src/config/manifest.ts';
 import {
   diffManifestPaths,
+  governedSliceRefusal,
   loadStoredManifest,
   targetConnectionDivergence,
   writeStoredManifest,
@@ -926,5 +927,148 @@ describe('the two vessels the installation is built on are governed', () => {
       .where(eq(targets.id, id));
     expect(row?.health).toBe('unhealthy');
     expect(row?.inspectedAt).toBeNull();
+  });
+
+  /** The fixture, with a home vessel a declaration can move. */
+  function homeAt(project: string) {
+    return JSON.stringify({
+      ...fixtureManifest,
+      vessels: fixtureManifest.vessels.map((vessel) =>
+        vessel.name === fixtureManifest.installation.homeVessel
+          ? { ...vessel, location: { project } }
+          : vessel,
+      ),
+    });
+  }
+
+  test('a boot that moves the home vessel keeps the connection an operator made', async () => {
+    // The fixture seeds its Targets with no connection — §13's half-ready state
+    // — so on a boot the manifest's copy of one is `null`. Re-asserting it
+    // because the boundary moved would discard what the connect screen wrote
+    // while leaving the row reading `connected`, which is a Target every loop
+    // and every deploy path silently skips.
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: homeAt('before'),
+    });
+    const id = await targetIdOf('cloud', 'cloudrun');
+    const connection = connectionFor('cloudrun');
+    await database()
+      .db.update(targets)
+      .set({
+        status: 'connected',
+        connection,
+        health: 'healthy',
+        inspectedAt: new Date(),
+      })
+      .where(eq(targets.id, id));
+
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: homeAt('after'),
+    });
+
+    const [row] = await database()
+      .db.select()
+      .from(targets)
+      .where(eq(targets.id, id));
+    expect(row?.status).toBe('connected');
+    expect(row?.connection).toEqual(connection);
+    // Reassessed, though: every claim on the checklist was about the old place.
+    expect(row?.health).toBe('unhealthy');
+    expect(row?.inspectedAt).toBeNull();
+    // And it says which half moved. "Declared Target connection is awaiting
+    // inspection" would send an operator to a declaration that says nothing
+    // about this Target's connection.
+    expect(row?.prerequisites?.[0]?.detail).toContain('boundary');
+  });
+
+  test('a boot leaves an address the declaration does not state', async () => {
+    // The fixture declares both boundaries and neither location, which is the
+    // half-ready state §13 intends to be visible: the address comes from the
+    // connect act. Nulling the row on the strength of a declaration that said
+    // nothing about it undid that act on every restart.
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+    const located = {
+      kind: 'gcp-project' as const,
+      project: 'typed-at-connect',
+    };
+    await database()
+      .db.update(vessels)
+      .set({ location: located })
+      .where(eq(vessels.name, 'cloud'));
+
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: fixtureText,
+    });
+
+    expect(await locationOf('cloud')).toEqual(located);
+  });
+});
+
+/**
+ * The other half of governing those two: a write into the governed slice is
+ * refused rather than accepted and reverted at the next boot.
+ */
+describe('a write the next boot would take back is refused', () => {
+  /** The home vessel's shared services, edited the way the product edits them. */
+  function withSourceBucket(bucket: string): AuthoredManifest {
+    return {
+      ...connectedManifest,
+      vessels: connectedManifest.vessels.map((vessel) =>
+        vessel.name === connectedManifest.installation.homeVessel &&
+        vessel.shared !== undefined
+          ? { ...vessel, shared: { ...vessel.shared, sourceBucket: bucket } }
+          : vessel,
+      ),
+    } as AuthoredManifest;
+  }
+
+  test('the paths a boot would revert are named', () => {
+    const refusal = governedSliceRefusal(
+      withSourceBucket('operator-chosen'),
+      connectedManifest,
+    );
+    expect(refusal).toContain('vessels.1.shared.sourceBucket');
+    expect(refusal).toContain('Change the declaration');
+    // Paths, never values, for the reason `diffManifestPaths` gives.
+    expect(refusal).not.toContain('operator-chosen');
+  });
+
+  test('a re-pointed pointer is named too', () => {
+    const refusal = governedSliceRefusal(
+      {
+        ...connectedManifest,
+        installation: {
+          ...connectedManifest.installation,
+          controlPlaneVessel: 'cloud',
+        },
+      },
+      connectedManifest,
+    );
+    expect(refusal).toContain('installation.controlPlaneVessel');
+  });
+
+  test('everything outside the governed slice is still this screen’s to drive', () => {
+    expect(
+      governedSliceRefusal(
+        {
+          ...connectedManifest,
+          sources: {
+            ...connectedManifest.sources,
+            buckets: [...connectedManifest.sources.buckets, 'another-bucket'],
+          },
+        },
+        connectedManifest,
+      ),
+    ).toBeNull();
+  });
+
+  test('with no declaration mounted there is nothing to govern', () => {
+    // An installation running with no declaration owns its own document
+    // outright, which is the state the shared services are configured in.
+    expect(
+      governedSliceRefusal(withSourceBucket('operator-chosen'), null),
+    ).toBeNull();
   });
 });

--- a/apps/spindrift/test/config/manifest-store.test.ts
+++ b/apps/spindrift/test/config/manifest-store.test.ts
@@ -55,6 +55,12 @@ const connectedManifest = {
       name: 'cloud',
       kind: 'gcp-project',
       location: { project: 'example-vessel' },
+      // Carried from the fixture rather than restated: the home vessel is the
+      // one that must declare these, and which vessel that is comes from the
+      // fixture's own `installation.homeVessel`.
+      shared: fixtureManifest.vessels.find(
+        (vessel) => vessel.name === fixtureManifest.installation.homeVessel,
+      )?.shared,
     },
   ],
   targets: [
@@ -93,7 +99,7 @@ describe('the stored installation manifest', () => {
     const first = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,
     });
-    expect(first.installation).toBe('example');
+    expect(first.installation.name).toBe('example');
 
     const later = await loadStoredManifest(database().db, {});
     expect(later).toEqual(first);
@@ -371,11 +377,8 @@ describe('the stored installation manifest', () => {
     const first = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,
     });
-    expect(first.installation).toBe('example');
-    const changed = fixtureText.replace(
-      'installation: example',
-      'installation: replacement',
-    );
+    expect(first.installation.name).toBe('example');
+    const changed = fixtureText.replace('name: example', 'name: replacement');
 
     // A rollout must not revert what an operator just configured, so the row
     // wins over the declaration that seeded it.
@@ -383,17 +386,14 @@ describe('the stored installation manifest', () => {
       [MANIFEST_INLINE_VAR]: changed,
     });
     expect(later).toEqual(first);
-    expect(later.installation).toBe('example');
+    expect(later.installation.name).toBe('example');
   });
 
   test('discarding the row re-seeds from the declaration', async () => {
     await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: fixtureText,
     });
-    const changed = fixtureText.replace(
-      'installation: example',
-      'installation: replacement',
-    );
+    const changed = fixtureText.replace('name: example', 'name: replacement');
 
     // The deliberate act that makes a declaration apply again. It is also the
     // whole of the tear-down-and-redeploy loop: an installation that lost its
@@ -403,7 +403,7 @@ describe('the stored installation manifest', () => {
     const reseeded = await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: changed,
     });
-    expect(reseeded.installation).toBe('replacement');
+    expect(reseeded.installation.name).toBe('replacement');
     expect(await loadStoredManifest(database().db, {})).toEqual(reseeded);
   });
 
@@ -436,10 +436,7 @@ describe('the stored installation manifest', () => {
       })
       .where(eq(targets.id, await targetIdOf('cluster')));
 
-    const changed = fixtureText.replace(
-      'installation: example',
-      'installation: replacement',
-    );
+    const changed = fixtureText.replace('name: example', 'name: replacement');
     await loadStoredManifest(database().db, {
       [MANIFEST_INLINE_VAR]: changed,
     });
@@ -515,10 +512,7 @@ describe('the stored installation manifest', () => {
     // though the operator had declared nothing at all.
     await expect(
       loadStoredManifest(database().db, {
-        [MANIFEST_INLINE_VAR]: fixtureText.replace(
-          'installation: example',
-          'installation: ""',
-        ),
+        [MANIFEST_INLINE_VAR]: fixtureText.replace('name: example', 'name: ""'),
       }),
     ).rejects.toThrow(ManifestError);
   });
@@ -658,7 +652,7 @@ describe('the stored installation manifest', () => {
       }),
     ]);
     expect(second).toEqual(first);
-    expect(first.installation).toBe('example');
+    expect(first.installation.name).toBe('example');
     expect(await database().db.select().from(targets)).toHaveLength(3);
   });
 
@@ -695,7 +689,7 @@ describe('the stored installation manifest', () => {
     // what an installation with no cloud Targets honestly has.
     expect(loaded).toEqual({
       ...DEFAULT_PLACEHOLDER_MANIFEST,
-      cloud: { ...DEFAULT_PLACEHOLDER_MANIFEST.cloud, federation: null },
+      cloud: { federation: null },
     });
   });
 
@@ -783,15 +777,30 @@ describe('naming where a declaration disagrees with the stored row', () => {
   });
 
   test('the startup warning names the differing path, and still no value', async () => {
+    // An ordinary boundary, deliberately: the two the installation is built on
+    // are reconciled from the declaration on every boot, so a difference there
+    // is one a boot resolves rather than one to warn about.
+    const seeded = {
+      ...connectedManifest,
+      vessels: [
+        ...connectedManifest.vessels,
+        {
+          name: 'elsewhere',
+          kind: 'cluster' as const,
+          location: { apiServer: 'https://elsewhere.example.test' },
+        },
+      ],
+    } satisfies AuthoredManifest;
     await loadStoredManifest(database().db, {
-      [MANIFEST_INLINE_VAR]: JSON.stringify(connectedManifest),
+      [MANIFEST_INLINE_VAR]: JSON.stringify(seeded),
     });
     const declared = {
-      ...connectedManifest,
-      vessels: connectedManifest.vessels.map((vessel) =>
-        vessel.kind === 'cluster'
+      ...seeded,
+      vessels: seeded.vessels.map((vessel) =>
+        vessel.name === 'elsewhere'
           ? {
-              ...vessel,
+              name: 'elsewhere',
+              kind: 'cluster' as const,
               location: {
                 apiServer: 'https://declared-elsewhere.example.test',
               },
@@ -821,11 +830,101 @@ describe('naming where a declaration disagrees with the stored row', () => {
     const messages = calls.map((call) => String(call[0]));
     expect(
       messages.some((message) =>
-        message.includes('vessels.0.location.apiServer'),
+        message.includes('vessels.2.location.apiServer'),
       ),
     ).toBe(true);
     expect(
       messages.some((message) => message.includes('declared-elsewhere')),
     ).toBe(false);
+  });
+});
+
+/**
+ * The one exception to "a declaration seeds and does not govern".
+ *
+ * It is a narrowing rather than an inversion: the vessel this control plane runs
+ * on and the vessel holding its shared services reconcile from the mounted
+ * declaration on every boot, because you should not be able to click your way
+ * into an unbootable control plane or a home pointing at nothing. Every other
+ * vessel keeps the rule exactly.
+ */
+describe('the two vessels the installation is built on are governed', () => {
+  /** A declaration with a third, ordinary boundary beside the fixture's two. */
+  function withAppVessel(apiServer: string, homeProject: string) {
+    return JSON.stringify({
+      ...connectedManifest,
+      vessels: [
+        ...connectedManifest.vessels.map((vessel) =>
+          vessel.name === 'cloud'
+            ? { ...vessel, location: { project: homeProject } }
+            : vessel,
+        ),
+        { name: 'elsewhere', kind: 'cluster', location: { apiServer } },
+      ],
+      targets: [
+        ...connectedManifest.targets,
+        { vessel: 'elsewhere', adapter: 'kubernetes' },
+      ],
+    });
+  }
+
+  async function locationOf(name: string) {
+    const [row] = await database()
+      .db.select({ location: vessels.location })
+      .from(vessels)
+      .where(eq(vessels.name, name));
+    return row?.location;
+  }
+
+  test('a boot moves the home vessel and leaves an ordinary one alone', async () => {
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: withAppVessel(
+        'https://elsewhere.example.test',
+        'first-home',
+      ),
+    });
+
+    // Both edited in the declaration, and only one of them is the
+    // declaration's to move on a boot.
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: withAppVessel(
+        'https://moved.example.test',
+        'second-home',
+      ),
+    });
+
+    expect(await locationOf('cloud')).toEqual({
+      kind: 'gcp-project',
+      project: 'second-home',
+    });
+    expect(await locationOf('elsewhere')).toEqual({
+      kind: 'cluster',
+      apiServer: 'https://elsewhere.example.test',
+    });
+  });
+
+  test('moving the home vessel reassesses the surfaces on it', async () => {
+    // A Target's checklist is a set of claims about a place. Move the place and
+    // every one of them is about somewhere else — the same reason a `declared`
+    // write resets them.
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: withAppVessel('https://a.example.test', 'before'),
+    });
+    const id = await targetIdOf('cloud', 'cloudrun');
+    await database()
+      .db.update(targets)
+      .set({ health: 'healthy', inspectedAt: new Date() })
+      .where(eq(targets.id, id));
+
+    await loadStoredManifest(database().db, {
+      [MANIFEST_INLINE_VAR]: withAppVessel('https://a.example.test', 'after'),
+    });
+
+    const [row] = await database()
+      .db.select()
+      .from(targets)
+      .where(eq(targets.id, id));
+    expect(row?.health).toBe('unhealthy');
+    expect(row?.inspectedAt).toBeNull();
   });
 });

--- a/apps/spindrift/test/config/manifest-upgrade.test.ts
+++ b/apps/spindrift/test/config/manifest-upgrade.test.ts
@@ -92,7 +92,15 @@ describe('every stored manifest this project has ever written', () => {
     // The document that was stored is the document that was loaded. If a schema
     // change made this row unreadable, `installation` would read `example` —
     // the declaration's — and everything the operator configured would be gone.
-    expect(loaded.installation).toBe(document.installation as string);
+    // The `installation` block on the row, whatever shape the snapshot wrote
+    // it in: a document from before the pointers existed carried the label
+    // bare, and the upgrade is what turns it into the block with the two
+    // vessels named beside it.
+    expect(loaded.installation.name).toBe(
+      typeof document.installation === 'string'
+        ? document.installation
+        : (document.installation as { name: string }).name,
+    );
     expect(warnings.filter((message) => message.includes('re-seeded'))).toEqual(
       [],
     );
@@ -160,6 +168,15 @@ describe('the vessels a pre-declaration document is upgraded into', () => {
         // taking one would be the bug the vessel exists to prevent.
         servedHosts: ['hosting.example.test', 'run.example.test'],
         reachableRegistries: ['mirror.example.test'],
+        // The four keys that described this boundary without saying so.
+        // `cloud.homeVesselProject` named `example-home`, which was never a
+        // declared vessel, so the first cloud boundary takes the role rather
+        // than a second one being minted out of the string.
+        shared: {
+          sourceBucket: 'example-source-bucket',
+          artifactsProject: 'example-artifacts',
+          secretStoreContainer: 'example-secrets',
+        },
       },
     ]);
   });
@@ -277,10 +294,101 @@ describe('the vessels a pre-declaration document is upgraded into', () => {
   });
 
   test('is a no-op on a document that already declares them', () => {
-    // `02` now upgrades too — `dropTargetNames` still takes its constructed
-    // `name` off every entry. `03` is the shape with neither gap, so this is
-    // where "already current" moved.
-    const current = snapshot('03-target-is-vessel-and-surface.yaml');
+    // `03` now upgrades too — it still states the home vessel's properties as
+    // four loose keys. `04` is the shape with none of the three gaps, so this
+    // is where "already current" moved.
+    const current = snapshot('04-installation-home-vessel.yaml');
     expect(upgradeManifestDocument(current)).toEqual(current);
+  });
+});
+
+/**
+ * The four loose strings, collapsed onto the boundary they were describing.
+ *
+ * The hazard the upgrade removes is not that the old document was unreadable —
+ * it is that nothing said `cloud.homeVesselProject`, `cloud.artifactsProject`,
+ * `sources.defaultBucket` and `secretStore.container` were four properties of
+ * one place, so nothing noticed when they stopped being.
+ */
+describe('the two vessels an installation is built on, recovered once', () => {
+  test('the home vessel is the boundary the old project id named', () => {
+    // `03` names `example-home`, which no vessel declares, so the first cloud
+    // boundary takes the role. Minting a vessel out of the string would be
+    // recovering a boundary from a name, which is what `vessels` exists to stop.
+    const upgraded = upgradeManifestDocument(
+      snapshot('03-target-is-vessel-and-surface.yaml'),
+    ) as {
+      installation: {
+        name: string;
+        controlPlaneVessel: string;
+        homeVessel: string;
+      };
+      vessels: { name: string; shared?: unknown }[];
+      sources: Record<string, unknown>;
+      secretStore: Record<string, unknown>;
+      cloud?: unknown;
+    };
+
+    expect(upgraded.installation).toEqual({
+      name: 'stored-without-target-names',
+      // Rank 0: the control plane's own boundary is its in-cluster
+      // destination, and array position is rank.
+      controlPlaneVessel: 'cluster',
+      homeVessel: 'cloud',
+    });
+    expect(
+      upgraded.vessels.find((vessel) => vessel.name === 'cloud')?.shared,
+    ).toEqual({
+      sourceBucket: 'example-source-bucket',
+      artifactsProject: 'example-artifacts',
+      secretStoreContainer: 'example-secrets',
+    });
+    // And exactly one vessel carries them, which is what the refinement needs.
+    expect(
+      upgraded.vessels.filter((vessel) => vessel.shared !== undefined),
+    ).toHaveLength(1);
+
+    // The keys they came from are gone rather than duplicated: a value in two
+    // places is a value two readers can disagree about.
+    expect(upgraded.cloud).toBeUndefined();
+    expect(upgraded.sources).not.toHaveProperty('defaultBucket');
+    expect(upgraded.secretStore).not.toHaveProperty('container');
+  });
+
+  test('a document whose home project is a declared boundary keeps that one', () => {
+    // The live shape: `cloud.homeVesselProject` and the vessel's own
+    // `location.project` were the same value, which is the whole reason the
+    // collapse is expressible at all.
+    const document = snapshot('03-target-is-vessel-and-surface.yaml') as Record<
+      string,
+      unknown
+    >;
+    const cloud = document.cloud as Record<string, unknown>;
+    const upgraded = upgradeManifestDocument({
+      ...document,
+      cloud: { ...cloud, homeVesselProject: 'example-vessel' },
+    }) as { installation: { homeVessel: string } };
+    expect(upgraded.installation.homeVessel).toBe('cloud');
+  });
+
+  test('a document with no staging default takes the first declared bucket', () => {
+    // `sources.defaultBucket` was optional and `sources.buckets` has a minimum
+    // of one, so the fallback the old readers applied is the one carried
+    // forward — the alternative is a document that fails validation and takes
+    // the re-seed path this module exists to keep unreachable.
+    const document = snapshot('03-target-is-vessel-and-surface.yaml') as Record<
+      string,
+      unknown
+    >;
+    const sources = document.sources as Record<string, unknown>;
+    const { defaultBucket: _dropped, ...withoutDefault } = sources;
+    const upgraded = upgradeManifestDocument({
+      ...document,
+      sources: withoutDefault,
+    }) as { vessels: { name: string; shared?: { sourceBucket: string } }[] };
+    expect(
+      upgraded.vessels.find((vessel) => vessel.name === 'cloud')?.shared
+        ?.sourceBucket,
+    ).toBe('example-source-bucket');
   });
 });

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
 import {
+  controlPlaneVesselOf,
+  homeVesselOf,
+  homeVesselProjectOf,
+  isDeclaredInstallationVessel,
+  sharedServicesOf,
+} from '../../src/config/manifest.schema.ts';
+import {
   assertTrustedGatewayBoundary,
   loadManifest,
   MANIFEST_INLINE_VAR,
@@ -16,7 +23,7 @@ const fixtureText = await Bun.file(FIXTURE).text();
 describe('the fixture installation', () => {
   test('boots clean from a file', async () => {
     const manifest = await loadManifest({ [MANIFEST_PATH_VAR]: FIXTURE });
-    expect(manifest.installation).toBe('example');
+    expect(manifest.installation.name).toBe('example');
     expect(manifest.auth.gateway).toBeNull();
     expect(manifest.dns.zones.private).toBe('apps.example.test');
     expect(manifest.secretStore.adapter).toBe('gcp-secret-manager');
@@ -29,15 +36,15 @@ describe('the fixture installation', () => {
 
   test('boots clean from an inline document', async () => {
     const manifest = await loadManifest({ [MANIFEST_INLINE_VAR]: fixtureText });
-    expect(manifest.installation).toBe('example');
+    expect(manifest.installation.name).toBe('example');
   });
 
   test('is read from the path when both are set', async () => {
     const manifest = await loadManifest({
       [MANIFEST_PATH_VAR]: FIXTURE,
-      [MANIFEST_INLINE_VAR]: 'installation: inline',
+      [MANIFEST_INLINE_VAR]: 'installation:\n  name: inline',
     });
-    expect(manifest.installation).toBe('example');
+    expect(manifest.installation.name).toBe('example');
   });
 });
 
@@ -94,7 +101,7 @@ describe('boot fails loudly', () => {
     }
     expect(message).toContain('dns');
     expect(message).toContain('auth');
-    expect(message).toContain('cloud');
+    expect(message).toContain('vessels');
     expect(message).toContain('charts');
     expect(message).toContain('github');
     expect(message).toContain('secretStore');
@@ -102,10 +109,7 @@ describe('boot fails loudly', () => {
   });
 
   test('on a required key that is present but empty', () => {
-    const document = fixtureText.replace(
-      'installation: example',
-      "installation: ''",
-    );
+    const document = fixtureText.replace('name: example', "name: ''");
     expect(() => parseManifest(document, 'test')).toThrow(/installation/);
   });
 
@@ -239,5 +243,95 @@ describe('the reusable build workflow ref', () => {
       'test',
     );
     expect(manifest.github.buildWorkflow).toBeNull();
+  });
+});
+
+/**
+ * The two pointers, resolved the way a Target's `vessel` already is.
+ *
+ * Both are scalars naming a declared vessel, so cardinality comes free and the
+ * only thing left to check is that the reference resolves — which is the same
+ * document-level rule `targets[].vessel` goes through, and the same reason:
+ * nothing below has anything honest to do with a name that is not there.
+ */
+describe('the vessels this installation is built on', () => {
+  const fixture = Bun.YAML.parse(fixtureText) as Record<string, unknown>;
+
+  function withInstallation(
+    installation: Record<string, unknown>,
+    vessels: unknown = fixture.vessels,
+  ) {
+    return JSON.stringify({ ...fixture, installation, vessels });
+  }
+
+  test('a pointer naming nothing declared is refused, by path', () => {
+    expect(() =>
+      parseManifest(
+        withInstallation({
+          name: 'example',
+          controlPlaneVessel: 'nowhere',
+          homeVessel: 'cloud',
+        }),
+        'test',
+      ),
+    ).toThrow(/installation.controlPlaneVessel: no vessel named nowhere/);
+  });
+
+  test('the home vessel must declare the shared services', () => {
+    // `cluster` declares no `shared`, so pointing `homeVessel` at it leaves the
+    // source bucket, the store container and the artifacts project unstated —
+    // three values with no second place to read them from.
+    expect(() =>
+      parseManifest(
+        withInstallation({
+          name: 'example',
+          controlPlaneVessel: 'cluster',
+          homeVessel: 'cluster',
+        }),
+        'test',
+      ),
+    ).toThrow(/must declare its shared services/);
+  });
+
+  test('no other vessel may declare them', () => {
+    // The other half, and the one that keeps the read total: two vessels
+    // carrying a `sourceBucket` is two answers with nothing to choose between.
+    const vessels = (fixture.vessels as Record<string, unknown>[]).map(
+      (vessel) => ({
+        ...vessel,
+        shared: {
+          sourceBucket: 'a-bucket',
+          artifactsProject: 'a-project',
+          secretStoreContainer: 'a-container',
+        },
+      }),
+    );
+    expect(() =>
+      parseManifest(
+        withInstallation(
+          fixture.installation as Record<string, unknown>,
+          vessels,
+        ),
+        'test',
+      ),
+    ).toThrow(/may declare shared services/);
+  });
+
+  test('what a reader gets is the home vessel’s, resolved once', async () => {
+    const manifest = await loadManifest({ [MANIFEST_PATH_VAR]: FIXTURE });
+    expect(homeVesselOf(manifest).name).toBe('cloud');
+    expect(controlPlaneVesselOf(manifest).name).toBe('cluster');
+    expect(sharedServicesOf(manifest)).toEqual({
+      sourceBucket: 'example-source-bucket',
+      artifactsProject: 'example-artifacts',
+      secretStoreContainer: 'example-secrets',
+    });
+    // Absent rather than a throw: this fixture seeds identity and rank and
+    // leaves how to reach each boundary to the connect act.
+    expect(homeVesselProjectOf(manifest)).toBeNull();
+    expect(isDeclaredInstallationVessel(manifest, 'cloud')).toBe(true);
+    expect(isDeclaredInstallationVessel(manifest, 'somewhere-else')).toBe(
+      false,
+    );
   });
 });

--- a/apps/spindrift/test/domain/vessel.test.ts
+++ b/apps/spindrift/test/domain/vessel.test.ts
@@ -18,9 +18,15 @@ import { targetAdapterSchema } from '../../src/config/manifest.schema.ts';
 import * as exports from '../../src/domain/vessel.ts';
 import {
   claimsDisagree,
+  deriveVesselHealth,
   surfacesToProbe,
   unionOfClaims,
+  unreachableVesselPrerequisites,
   VESSEL_KINDS,
+  VESSEL_PREREQUISITES,
+  VESSEL_ROLES,
+  vesselPrerequisitesFor,
+  vesselRolesOf,
 } from '../../src/domain/vessel.ts';
 
 describe('the surfaces a connect probes for', () => {
@@ -55,9 +61,16 @@ describe('the surfaces a connect probes for', () => {
     expect(Object.keys(exports).sort()).toEqual([
       'PROBED_SURFACES_BY_VESSEL_KIND',
       'VESSEL_KINDS',
+      'VESSEL_PREREQUISITES',
+      'VESSEL_PREREQUISITES_BY_KIND_AND_ROLE',
+      'VESSEL_ROLES',
       'claimsDisagree',
+      'deriveVesselHealth',
       'surfacesToProbe',
       'unionOfClaims',
+      'unreachableVesselPrerequisites',
+      'vesselPrerequisitesFor',
+      'vesselRolesOf',
     ]);
   });
 });
@@ -82,5 +95,112 @@ describe('reconciling what two surfaces claimed about one boundary', () => {
       ]),
     ).toBe(false);
     expect(claimsDisagree([['a.test'], ['b.test']])).toBe(true);
+  });
+});
+
+/**
+ * The catalogue's second axis.
+ *
+ * `PREREQUISITES_BY_ADAPTER` keys off adapter because "a checklist row that can
+ * never fail is a row that teaches a reader the wrong thing about what was
+ * checked". These are the same claim one axis over: what the installation asks
+ * of a boundary depends on what that boundary is *to it*, not only on what it is
+ * made of, and an app vessel is asked nothing.
+ */
+describe('what a vessel is asked, by kind and by role', () => {
+  test('the home cloud vessel carries the four the installation depends on', () => {
+    expect(vesselPrerequisitesFor('gcp-project', ['home'])).toEqual([
+      'SOURCE_BUCKET',
+      'SECRET_STORE',
+      'SIGNER_KEY',
+      'ARTIFACTS_PROJECT',
+    ]);
+  });
+
+  test('an app vessel is asked nothing, whatever its kind', () => {
+    // The point of the axis: four permanently green rows on an ordinary deploy
+    // boundary would say those were checked when nothing looked at them.
+    for (const kind of VESSEL_KINDS) {
+      expect(vesselPrerequisitesFor(kind, ['app'])).toEqual([]);
+    }
+  });
+
+  test('a cluster is asked nothing even as the home', () => {
+    // Honest rather than aspirational: a source bucket, a store container and a
+    // signing key are reads no code here knows how to make against a cluster.
+    expect(vesselPrerequisitesFor('cluster', ['home'])).toEqual([]);
+  });
+
+  test('a boundary in two roles is asked what either role owes, once', () => {
+    // An installation whose control plane runs where its shared services live
+    // is one boundary doing two jobs. A scalar role would have to pick one.
+    expect(
+      vesselPrerequisitesFor('gcp-project', ['home', 'controlPlane']),
+    ).toEqual([...VESSEL_PREREQUISITES]);
+  });
+
+  test('every catalogued row is a prerequisite this module has a name for', () => {
+    for (const kind of VESSEL_KINDS) {
+      for (const role of VESSEL_ROLES) {
+        for (const name of vesselPrerequisitesFor(kind, [role])) {
+          expect(VESSEL_PREREQUISITES).toContain(name);
+        }
+      }
+    }
+  });
+
+  test('a vessel neither pointer names is an app vessel', () => {
+    const manifest = {
+      installation: {
+        name: 'a-test',
+        controlPlaneVessel: 'here',
+        homeVessel: 'home',
+      },
+    };
+    expect(vesselRolesOf(manifest, 'home')).toEqual(['home']);
+    expect(vesselRolesOf(manifest, 'here')).toEqual(['controlPlane']);
+    expect(vesselRolesOf(manifest, 'elsewhere')).toEqual(['app']);
+    expect(
+      vesselRolesOf(
+        { installation: { ...manifest.installation, homeVessel: 'here' } },
+        'here',
+      ),
+    ).toEqual(['home', 'controlPlane']);
+  });
+});
+
+describe('a vessel’s health is every catalogued row met', () => {
+  test('an unreachable pass answers every row unmet, never no rows', () => {
+    const unmet = unreachableVesselPrerequisites(
+      'nobody could look',
+      'gcp-project',
+      ['home'],
+    );
+    expect(unmet.map((item) => item.name)).toEqual([...VESSEL_PREREQUISITES]);
+    expect(unmet.every((item) => !item.met && item.detail)).toBe(true);
+    expect(deriveVesselHealth(unmet, 'gcp-project', ['home'])).toBe(
+      'unhealthy',
+    );
+  });
+
+  test('an app vessel is healthy because nothing about it can be broken here', () => {
+    // Vacuously, and that is the right answer rather than a loophole: it holds
+    // nothing this installation depends on. Its Targets fail on their own terms.
+    expect(deriveVesselHealth([], 'gcp-project', ['app'])).toBe('healthy');
+  });
+
+  test('a checklist that answered fewer rows than it was asked is unhealthy', () => {
+    // The same rule `deriveHealth` applies to a Target: a pass that silently
+    // stopped reporting a row must not make a boundary look healthier.
+    expect(
+      deriveVesselHealth(
+        [
+          { name: 'SOURCE_BUCKET', met: true },
+          { name: 'SECRET_STORE', met: true },
+        ],
+        'gcp-project',
+        ['home'],
+      ),
+    ).toBe('unhealthy');
   });
 });

--- a/apps/spindrift/test/fixtures/installation.example.yaml
+++ b/apps/spindrift/test/fixtures/installation.example.yaml
@@ -4,7 +4,13 @@
 # Spindrift installation appears here and nowhere in src/. If a new
 # installation-specific value is added to the schema, this file is where it
 # gets a value, and the extraction test is what notices when it does not.
-installation: example
+installation:
+  name: example
+  # The two vessels this installation is itself built on. Scalars naming a
+  # declared vessel, so cardinality is free: there is one control plane and one
+  # home, and neither can be a list of two.
+  controlPlaneVessel: cluster
+  homeVessel: cloud
 
 # Where this control plane serves its own UI. A passkey is scoped to it, and it
 # is how one process tells a request for itself from a request for an App.
@@ -24,15 +30,12 @@ dns:
 sources:
   buckets:
     - example-source-bucket
-  defaultBucket: example-source-bucket
 
-cloud:
-  artifactsProject: example-artifacts
-  homeVesselProject: example-home
-  # No `federation` block. §13's one auth mode is an external_account credential
-  # the installer chart renders, and the process reads it from there — see
-  # gcp-credentials.json beside this file, which is the fixture deployment's
-  # copy. A second one here could disagree with the pod it runs in.
+# No `cloud` block. §13's one auth mode is an external_account credential the
+# installer chart renders, and the process reads it from there — see
+# gcp-credentials.json beside this file, which is the fixture deployment's copy.
+# A second one here could disagree with the pod it runs in. The two keys that
+# used to sit beside it are properties of the home vessel below.
 
 charts:
   app: example/spindrift-app
@@ -74,7 +77,6 @@ build:
 secretStore:
   adapter: gcp-secret-manager
   endpoint: https://secrets.example.test
-  container: example-secrets
 
 # The tenancy boundaries. Named, so nothing has to recover one from a Target's
 # vessel and adapter — the cloud vessel below carries two surfaces and says so
@@ -86,6 +88,13 @@ vessels:
     kind: cluster
   - name: cloud
     kind: gcp-project
+    # This installation's shared services, stated once on the boundary that
+    # holds them. `installation.homeVessel` names this vessel, so this block is
+    # required here and refused on every other.
+    shared:
+      sourceBucket: example-source-bucket
+      artifactsProject: example-artifacts
+      secretStoreContainer: example-secrets
 
 # Rank order: placement considers these top to bottom. A Target has no name of
 # its own — `vessel` and `adapter` are what identify it.

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -28,6 +28,7 @@ import type {
   RepositoryOptionView,
   TargetListItem,
   TargetOptionView,
+  VesselListItem,
   WorkspaceView,
 } from '../../src/web/model.ts';
 import type { Draft } from '../../src/web/views/apps/new/draft.ts';
@@ -987,6 +988,11 @@ export const TARGET_LIST: readonly TargetListItem[] = [
       apiServer: 'https://primary.example:6443',
       proposal: { carriedFrom: 'primary/kubernetes', namespace: 'apps' },
     },
+    // The boundary this control plane runs on, so the card renders read-only:
+    // no edit, no disconnect, and the sentence saying where its values come
+    // from. It is an ordinary deploy Target besides, which is why it is here
+    // rather than in a list of its own.
+    vesselRoles: ['controlPlane'],
   },
   {
     id: 'target-cloudrun',
@@ -1004,6 +1010,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     // A cloud project has no `platform` values and no probe to read itself
     // back through, so there is nothing here for an edit form to open onto.
     edit: null,
+    vesselRoles: ['home'],
   },
   {
     id: 'target-static',
@@ -1021,6 +1028,7 @@ export const TARGET_LIST: readonly TargetListItem[] = [
     // A cloud project has no `platform` values and no probe to read itself
     // back through, so there is nothing here for an edit form to open onto.
     edit: null,
+    vesselRoles: ['home'],
   },
   {
     id: 'target-secondary',
@@ -1052,5 +1060,48 @@ export const TARGET_LIST: readonly TargetListItem[] = [
       apiServer: 'https://secondary.example:6443',
       proposal: { carriedFrom: 'secondary/kubernetes', namespace: 'apps' },
     },
+    vesselRoles: ['app'],
+  },
+];
+
+/** Vessel demo data — the boundaries the Targets above are surfaces on. */
+export const VESSEL_LIST: readonly VesselListItem[] = [
+  {
+    name: 'primary',
+    kind: 'cluster',
+    roles: ['controlPlane'],
+    health: 'healthy',
+    // The catalogue asks a cluster nothing, whatever its role: a source bucket,
+    // a store container, an artifacts project and a signing key are reads no
+    // code here knows how to make against a cluster, and four permanently green
+    // rows would say otherwise.
+    prerequisites: [],
+    inspectedAt: '2026-08-02T12:00:00.000Z',
+  },
+  {
+    name: 'vessel-a',
+    kind: 'gcp-project',
+    roles: ['home'],
+    health: 'unhealthy',
+    prerequisites: [
+      { name: 'SOURCE_BUCKET', met: true },
+      { name: 'SECRET_STORE', met: true },
+      {
+        name: 'SIGNER_KEY',
+        met: false,
+        detail:
+          'no signing key with that reference is in this location, or its purpose is not signing',
+      },
+      { name: 'ARTIFACTS_PROJECT', met: true },
+    ],
+    inspectedAt: '2026-08-02T12:00:00.000Z',
+  },
+  {
+    name: 'secondary',
+    kind: 'cluster',
+    roles: ['app'],
+    health: 'healthy',
+    prerequisites: [],
+    inspectedAt: '2026-08-02T12:00:00.000Z',
   },
 ];

--- a/apps/spindrift/test/fixtures/stored-manifests/04-installation-home-vessel.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/04-installation-home-vessel.yaml
@@ -1,0 +1,121 @@
+# A stored manifest as this build writes one: the two vessels this installation
+# is built on are named by the installation itself, and the four keys that
+# described the second one without saying so are its properties.
+#
+# `03` stated `cloud.homeVesselProject`, `cloud.artifactsProject`,
+# `sources.defaultBucket` and `secretStore.container` as four unrelated
+# top-level values. Nothing said they described one boundary, so nothing noticed
+# when they stopped describing the same one. `manifest-upgrade.ts` recovers the
+# home vessel by matching `cloud.homeVesselProject` against a declared vessel's
+# project — and, where the old document named a project no vessel declared,
+# takes the first cloud vessel rather than minting a boundary out of a string.
+# The control plane is the vessel of the rank-0 Target, which is where every
+# document written so far put it.
+#
+# **The newest file in this corpus, and the test asserts this build needs no
+# upgrade to read it.** That is the forcing function: change the manifest schema
+# in any way that stops accepting this document, and the assertion fails. The
+# fix is never to edit this file — it is to copy it to the next number, edit
+# *that* to the new shape, and teach `manifest-upgrade.ts` how to get from here
+# to there. Doing it the other way round is exactly how a schema change reaches
+# production able to discard a configured installation.
+#
+# `installation.name` differs from every declaration this suite mounts, for the
+# reason `01` gives.
+installation:
+  name: stored-with-installation-vessels
+  controlPlaneVessel: cluster
+  homeVessel: cloud
+
+controlPlane:
+  hostname: spindrift.example.test
+
+auth:
+  gateway: null
+
+dns:
+  zones:
+    private: apps.example.test
+    public: example.test
+
+sources:
+  buckets:
+    - example-source-bucket
+
+charts:
+  app: example/spindrift-app
+
+supplyChain:
+  registry: registry.example.test/artifacts
+  verifier: verifier.example.test
+  signer: gcpkms://projects/example-artifacts/locations/example-region/keyRings/keys/cryptoKeys/signer
+
+github:
+  clientId: Iv1.example
+  oauthBaseUrl: https://git.example.test
+  apiBaseUrl: https://api.git.example.test
+  buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
+
+build:
+  routes:
+    - name: hosted
+      adapter: github-actions
+  zeroConfigFrontend: registry.example.test/zero-config:pinned
+
+secretStore:
+  adapter: gcp-secret-manager
+  endpoint: https://secrets.example.test
+
+vessels:
+  - name: cluster
+    kind: cluster
+    location:
+      apiServer: https://cluster.example.test
+    reachableRegistries:
+      - registry.example.test
+    servedHosts:
+      - apps.example.test
+  - name: cloud
+    kind: gcp-project
+    location:
+      project: example-vessel
+    reachableRegistries:
+      - mirror.example.test
+    servedHosts:
+      - hosting.example.test
+      - run.example.test
+    # The shared services, on the one vessel that holds them. Only the vessel
+    # `installation.homeVessel` names may carry this block, and it must.
+    shared:
+      sourceBucket: example-source-bucket
+      artifactsProject: example-artifacts
+      secretStoreContainer: example-secrets
+
+targets:
+  - vessel: cluster
+    adapter: kubernetes
+    reaches: [none, private]
+    authReaches: [private]
+    connection:
+      namespace: apps
+      delivery:
+        flavour: flux-helmrelease
+        namespace: apps
+        sourceRef:
+          name: infra
+          namespace: flux-system
+      chartValues:
+        platform:
+          gateway:
+            name: cluster-gateway
+            namespace: gateway
+  - vessel: cloud
+    adapter: cloudrun
+    connection:
+      region: example-region
+      endpoint: https://run.example.test
+      serviceAccount: runtime@example-vessel.iam.gserviceaccount.com
+  - vessel: cloud
+    adapter: static
+    connection:
+      endpoint: https://hosting.example.test

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -146,7 +146,7 @@ describe('reconciler loop composition', () => {
         .filter((event) => event.type === 'pass')
         .map((event) => event.loop)
         .sort(),
-    ).toEqual(['build', 'config', 'deploy', 'target']);
+    ).toEqual(['build', 'config', 'deploy', 'target', 'vessel']);
     expect(events.find((event) => event.type === 'disabled')).toEqual({
       type: 'disabled',
       loop: 'repository',
@@ -188,6 +188,7 @@ describe('reconciler loop composition', () => {
       'deploy',
       'repository',
       'target',
+      'vessel',
     ]);
   });
 });

--- a/apps/spindrift/test/reconciler/vessel-loop.test.ts
+++ b/apps/spindrift/test/reconciler/vessel-loop.test.ts
@@ -1,0 +1,290 @@
+/**
+ * The standing checklist a boundary is assessed against.
+ *
+ * The claim is the one `cloud-discovery.ts` states and nothing acted on until
+ * this loop: "a mistyped project or bucket is invisible until a build stages a
+ * source archive and fails on a signed URL". A red row on a screen is what turns
+ * that into something an operator can see before a build.
+ *
+ * The far side is faked at the HTTP seam (§ Seam 2), so the real client, its
+ * real resource names and its real key-purpose filter all run — which is what
+ * makes "the signer is not a signing key here" a fact this suite can produce
+ * rather than one it can only stub.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createAdapterRegistry } from '../../src/adapters/registry.ts';
+import type { SecretStore } from '../../src/adapters/store/contract.ts';
+import type { AdapterRegistry } from '../../src/commands/types.ts';
+import type { InstallationManifest } from '../../src/config/manifest.schema.ts';
+import { vessels } from '../../src/db/schema.ts';
+import type { VesselPrerequisiteResult } from '../../src/domain/vessel.ts';
+import { deriveVesselHealth } from '../../src/domain/vessel.ts';
+import {
+  inspectVessel,
+  refreshAllVessels,
+} from '../../src/reconciler/vessel-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import {
+  FakeGcpDiscovery,
+  type FakeGcpDiscoveryOptions,
+} from '../harness/fakes/gcp-discovery-api.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const NOW = new Date('2026-08-07T00:00:00.000Z');
+const TOKEN = 'federated-token';
+
+const fixture = await fixtureManifest();
+
+/** The home vessel as this suite declares it: a project with a signer in it. */
+const HOME_PROJECT = 'example-vessel';
+const SIGNER_LOCATION = 'example-region';
+
+/**
+ * The fixture installation with the home vessel actually located somewhere.
+ *
+ * The document ships without a `location` on either boundary — that half-ready
+ * state is one §13 intends to be visible — and a checklist against a project
+ * nobody stated is the one answer this loop must not fabricate. So the tests
+ * that assert a green row supply one, and the test that asserts the honest
+ * refusal leaves it off.
+ */
+function installationWith(project: string | null): InstallationManifest {
+  return {
+    ...fixture,
+    vessels: fixture.vessels.map((vessel) =>
+      vessel.name === fixture.installation.homeVessel
+        ? {
+            ...vessel,
+            ...(project === null
+              ? {}
+              : { location: { project } as { project: string } }),
+          }
+        : vessel,
+    ),
+  } as InstallationManifest;
+}
+
+/** A store that answers a listing, or refuses the way an unreachable one does. */
+function store(reachable: boolean): SecretStore {
+  return {
+    adapter: fixture.secretStore.adapter,
+    pinning: 'NATIVE',
+    put: () => Promise.reject(new Error('not used')),
+    describe: () => Promise.resolve(null),
+    versions: () =>
+      reachable
+        ? Promise.resolve([])
+        : Promise.reject(new Error('the secret store refused: 403')),
+    destroy: () => Promise.resolve(),
+  };
+}
+
+interface Wiring {
+  readonly manifest?: InstallationManifest;
+  readonly storeReachable?: boolean;
+  readonly discovery?: FakeGcpDiscoveryOptions | null;
+}
+
+function context(wiring: Wiring = {}) {
+  const manifest = wiring.manifest ?? installationWith(HOME_PROJECT);
+  const real = createAdapterRegistry({
+    manifest,
+    env: {},
+    cloudToken: () => TOKEN,
+    fetch: new FakeGcpDiscovery({
+      token: TOKEN,
+      projects: [HOME_PROJECT, 'example-artifacts'],
+      buckets: { [HOME_PROJECT]: ['example-source-bucket'] },
+      keys: [
+        {
+          project: 'example-artifacts',
+          location: SIGNER_LOCATION,
+          ring: 'keys',
+          name: 'signer',
+        },
+      ],
+      ...(wiring.discovery ?? {}),
+    }).fetch,
+  });
+  const adapters: Pick<AdapterRegistry, 'discovery' | 'store'> = {
+    discovery: () => (wiring.discovery === null ? null : real.discovery!()),
+    store: () => store(wiring.storeReachable ?? true),
+  };
+  return { db: database().db, clock: { now: () => NOW }, adapters, manifest };
+}
+
+/** The checklist for the home vessel, keyed so a row is read by name. */
+async function homeChecklist(
+  wiring: Wiring = {},
+): Promise<Map<string, VesselPrerequisiteResult>> {
+  const ctx = context(wiring);
+  const home = ctx.manifest.vessels.find(
+    (vessel) => vessel.name === ctx.manifest.installation.homeVessel,
+  )!;
+  const answered = await inspectVessel(
+    ctx,
+    {
+      name: home.name,
+      kind: home.kind,
+      location:
+        home.location === undefined
+          ? null
+          : ({ kind: home.kind, ...home.location } as never),
+    },
+    ['home'],
+  );
+  return new Map(answered.map((item) => [item.name, item]));
+}
+
+describe('the four the home vessel carries', () => {
+  test('a boundary that holds all four reports every row met', async () => {
+    const checklist = await homeChecklist();
+    expect([...checklist.keys()]).toEqual([
+      'SOURCE_BUCKET',
+      'SECRET_STORE',
+      'SIGNER_KEY',
+      'ARTIFACTS_PROJECT',
+    ]);
+    expect([...checklist.values()].every((item) => item.met)).toBe(true);
+  });
+
+  test('a bucket that is not in the project is the row it should be', async () => {
+    // The exact failure this exists for: a mistyped bucket, said out loud on a
+    // screen instead of at a signed URL minutes into a build.
+    const checklist = await homeChecklist({
+      discovery: { buckets: { [HOME_PROJECT]: ['some-other-bucket'] } },
+    });
+    const bucket = checklist.get('SOURCE_BUCKET')!;
+    expect(bucket.met).toBe(false);
+    expect(bucket.detail).toContain('example-source-bucket');
+    // And only that row: three independent reads, so one absence is not four.
+    expect(checklist.get('SIGNER_KEY')?.met).toBe(true);
+    expect(checklist.get('ARTIFACTS_PROJECT')?.met).toBe(true);
+  });
+
+  test('a refused read is a different sentence from an absence', async () => {
+    // `cloud-discovery.ts`'s rule, carried all the way to the row: a `403` says
+    // nothing was established, and reporting it as "your bucket is not there"
+    // would put a confident absence on screen off a failed read.
+    const checklist = await homeChecklist({
+      discovery: { refuse: { storage: { status: 403, message: 'no' } } },
+    });
+    const bucket = checklist.get('SOURCE_BUCKET')!;
+    expect(bucket.met).toBe(false);
+    expect(bucket.detail).toContain('may not list');
+    expect(bucket.detail).not.toContain('is not a bucket');
+  });
+
+  test('a key of the wrong purpose is not a signer', async () => {
+    // Run through the real filter: a symmetric key produces a `signer` that
+    // validates, saves, reconciles, and fails at the first cosign call.
+    const checklist = await homeChecklist({
+      discovery: {
+        keys: [
+          {
+            project: 'example-artifacts',
+            location: SIGNER_LOCATION,
+            ring: 'keys',
+            name: 'signer',
+            purpose: 'ENCRYPT_DECRYPT',
+          },
+        ],
+      },
+    });
+    expect(checklist.get('SIGNER_KEY')?.met).toBe(false);
+  });
+
+  test('a store that refuses carries what it said', async () => {
+    const checklist = await homeChecklist({ storeReachable: false });
+    const item = checklist.get('SECRET_STORE')!;
+    expect(item.met).toBe(false);
+    expect(item.detail).toContain('403');
+  });
+
+  test('a home vessel with no project is not looked for anyway', async () => {
+    // Rather than a probe against `projects/undefined` and a sentence naming
+    // `undefined` back to the operator.
+    const checklist = await homeChecklist({
+      manifest: installationWith(null),
+    });
+    expect([...checklist.values()].every((item) => !item.met)).toBe(true);
+    expect(checklist.get('SOURCE_BUCKET')?.detail).toContain(
+      'states no project',
+    );
+  });
+
+  test('a process with no cloud client says so on every row', async () => {
+    const checklist = await homeChecklist({ discovery: null });
+    expect([...checklist.values()].every((item) => !item.met)).toBe(true);
+    expect(checklist.get('ARTIFACTS_PROJECT')?.detail).toContain(
+      'cannot reach a cloud API',
+    );
+  });
+});
+
+describe('one pass over the boundaries', () => {
+  test('writes the checklist and leaves an app vessel asked nothing', async () => {
+    const manifest = installationWith(HOME_PROJECT);
+    await database()
+      .db.insert(vessels)
+      .values([
+        {
+          name: manifest.installation.homeVessel,
+          kind: 'gcp-project',
+          location: { kind: 'gcp-project', project: HOME_PROJECT },
+        },
+        {
+          name: 'elsewhere',
+          kind: 'gcp-project',
+          location: { kind: 'gcp-project', project: 'somewhere-else' },
+        },
+      ]);
+
+    // Every vessel, not only the two the installation is built on: an app
+    // vessel's pass is one write of an empty checklist, and that empty list is
+    // what makes assessed-and-asked-nothing a stored state of its own.
+    const refreshed = await refreshAllVessels(context({ manifest }));
+    expect(refreshed.map((pass) => pass.vessel)).toContain('cloud');
+    expect(refreshed.map((pass) => pass.vessel)).toContain('elsewhere');
+
+    const rows = await database().db.select().from(vessels);
+    const home = rows.find((row) => row.name === 'cloud')!;
+    const app = rows.find((row) => row.name === 'elsewhere')!;
+
+    expect(home.prerequisites).toHaveLength(4);
+    expect(deriveVesselHealth(home.prerequisites!, home.kind, ['home'])).toBe(
+      'healthy',
+    );
+    // Assessed and asked nothing, which is a different stored state from never
+    // assessed — and never a green row for something nobody checked.
+    expect(app.prerequisites).toEqual([]);
+    expect(app.inspectedAt).toEqual(NOW);
+  });
+
+  test('a pass reports the health it changed', async () => {
+    const manifest = installationWith(HOME_PROJECT);
+    await database()
+      .db.insert(vessels)
+      .values({
+        name: manifest.installation.homeVessel,
+        kind: 'gcp-project',
+        location: { kind: 'gcp-project', project: HOME_PROJECT },
+      });
+
+    const home = (passes: Awaited<ReturnType<typeof refreshAllVessels>>) =>
+      passes.find((pass) => pass.vessel === manifest.installation.homeVessel)!;
+
+    // The first pass has nothing to compare against — never assessed is not a
+    // verdict that changed.
+    expect(
+      home(await refreshAllVessels(context({ manifest }))),
+    ).not.toHaveProperty('healthChangedFrom');
+
+    expect(
+      home(
+        await refreshAllVessels(context({ manifest, storeReachable: false })),
+      ),
+    ).toMatchObject({ health: 'unhealthy', healthChangedFrom: 'healthy' });
+  });
+});

--- a/apps/spindrift/test/storage/source-depot.test.ts
+++ b/apps/spindrift/test/storage/source-depot.test.ts
@@ -31,15 +31,24 @@ const federation = {
 };
 
 const manifest = {
-  sources: {
-    buckets: ['bluenose-spindrift-source'],
-    defaultBucket: 'bluenose-spindrift-source',
+  installation: {
+    name: 'a-test',
+    controlPlaneVessel: 'here',
+    homeVessel: 'home',
   },
-  cloud: {
-    artifactsProject: 'artifacts',
-    homeVesselProject: 'vessel',
-    federation,
-  },
+  vessels: [
+    {
+      name: 'home',
+      kind: 'gcp-project',
+      location: { project: 'vessel' },
+      shared: {
+        sourceBucket: 'bluenose-spindrift-source',
+        artifactsProject: 'artifacts',
+        secretStoreContainer: 'vessel',
+      },
+    },
+  ],
+  cloud: { federation },
 } as unknown as Parameters<typeof sourceDepotFor>[0];
 
 /** A far side that answers the token exchange, the upload, and `signBlob`. */

--- a/apps/spindrift/test/web/installation-discovery.test.tsx
+++ b/apps/spindrift/test/web/installation-discovery.test.tsx
@@ -27,21 +27,24 @@ import type {
   DiscoveredCandidate,
   DiscoveredFact,
 } from '../../src/commands/installation/discover.ts';
+import { HOME_VESSEL } from '../../src/commands/installation/discover.ts';
 import { manifestFields } from '../../src/web/forms/manifest.ts';
 import {
   applyDiscovered,
   askInstallationCloud,
   DiscoveredFactList,
   DiscoveryRefusal,
+  unwritable,
 } from '../../src/web/views/auth/discovery.tsx';
 import { InstallationSettingsView } from '../../src/web/views/auth/installation.tsx';
 import { fixtureManifest } from '../harness/installation.ts';
 
 const FACTS: readonly DiscoveredFact[] = [
   {
-    // The home vessel's own project, addressed through its position in
-    // `vessels` — three of the five facts are that boundary's properties now.
-    path: ['vessels', 1, 'location', 'project'],
+    // The home vessel's own project, addressed by the pointer that names it —
+    // three of the five facts are that boundary's properties now, and the
+    // position it holds is the document's to give at the moment of the press.
+    path: ['vessels', HOME_VESSEL, 'location', 'project'],
     kind: 'found',
     candidates: [{ label: 'example-home', value: 'example-home' }],
     suggested: { label: 'example-home', value: 'example-home' },
@@ -91,7 +94,11 @@ describe('what the panel shows', () => {
 
 describe('confirming a value edits the document at the path it came with', () => {
   const document = {
-    vessels: [{ name: 'cluster' }, { location: { project: 'typed-by-hand' } }],
+    installation: { homeVessel: 'home' },
+    vessels: [
+      { name: 'cluster' },
+      { name: 'home', location: { project: 'typed-by-hand' } },
+    ],
     sources: { buckets: [] },
   };
 
@@ -102,9 +109,54 @@ describe('confirming a value edits the document at the path it came with', () =>
     // rather than by an expectation.
     if (fact.kind !== 'found') throw new Error('the fixture lost its arm');
     expect(applyDiscovered(document, fact, fact.candidates[0]!)).toEqual({
-      vessels: [{ name: 'cluster' }, { location: { project: 'example-home' } }],
+      installation: { homeVessel: 'home' },
+      vessels: [
+        { name: 'cluster' },
+        { name: 'home', location: { project: 'example-home' } },
+      ],
       sources: { buckets: [] },
     });
+  });
+
+  test('the vessel is found by name, not at the position the answer carried', () => {
+    // An entry removed between the ask and the press moves every entry after
+    // it. A position carried from the server would then address whichever
+    // boundary slid into it, and `location.project` has no refinement that
+    // would refuse the value.
+    const fact = FACTS[0]!;
+    if (fact.kind !== 'found') throw new Error('the fixture lost its arm');
+    const shifted = { ...document, vessels: [document.vessels[1]!] };
+    expect(applyDiscovered(shifted, fact, fact.candidates[0]!)).toEqual({
+      ...document,
+      vessels: [{ name: 'home', location: { project: 'example-home' } }],
+    });
+  });
+
+  test('a document with nowhere to put the answer is left alone', () => {
+    const fact = FACTS[0]!;
+    if (fact.kind !== 'found') throw new Error('the fixture lost its arm');
+    const homeless = { ...document, vessels: [{ name: 'cluster' }] };
+    expect(applyDiscovered(homeless, fact, fact.candidates[0]!)).toBe(homeless);
+    expect(unwritable(fact, homeless)).toContain('not declared');
+  });
+
+  test('a value the declaration owns is said, not offered', () => {
+    // The panel edits the same document the form below it locks, so a candidate
+    // for a governed path is a button whose only outcome is a refused save.
+    const fact = FACTS[0]!;
+    if (fact.kind !== 'found') throw new Error('the fixture lost its arm');
+    const reason = unwritable(fact, document, (at) => at[0] === 'vessels');
+    expect(reason).toContain('mounted declaration');
+
+    const markup = renderToStaticMarkup(
+      <DiscoveredFactList
+        facts={[fact]}
+        unwritable={() => reason}
+        onApply={() => undefined}
+      />,
+    );
+    expect(markup).toContain('mounted declaration');
+    expect(markup).not.toContain('example-home');
   });
 
   test('a list-valued key takes the shape its candidate carried', () => {

--- a/apps/spindrift/test/web/installation-discovery.test.tsx
+++ b/apps/spindrift/test/web/installation-discovery.test.tsx
@@ -39,7 +39,9 @@ import { fixtureManifest } from '../harness/installation.ts';
 
 const FACTS: readonly DiscoveredFact[] = [
   {
-    path: ['cloud', 'homeVesselProject'],
+    // The home vessel's own project, addressed through its position in
+    // `vessels` — three of the five facts are that boundary's properties now.
+    path: ['vessels', 1, 'location', 'project'],
     kind: 'found',
     candidates: [{ label: 'example-home', value: 'example-home' }],
     suggested: { label: 'example-home', value: 'example-home' },
@@ -82,15 +84,15 @@ describe('what the panel shows', () => {
   });
 
   test('headings are the schema keys humanized, not written here', () => {
-    expect(markup).toContain('Home vessel project');
+    expect(markup).toContain('Project');
     expect(markup).toContain('Signer');
   });
 });
 
 describe('confirming a value edits the document at the path it came with', () => {
   const document = {
-    cloud: { homeVesselProject: 'typed-by-hand' },
-    sources: { buckets: [], defaultBucket: 'typed-by-hand' },
+    vessels: [{ name: 'cluster' }, { location: { project: 'typed-by-hand' } }],
+    sources: { buckets: [] },
   };
 
   test('the value lands at the path, and nothing else moves', () => {
@@ -100,15 +102,15 @@ describe('confirming a value edits the document at the path it came with', () =>
     // rather than by an expectation.
     if (fact.kind !== 'found') throw new Error('the fixture lost its arm');
     expect(applyDiscovered(document, fact, fact.candidates[0]!)).toEqual({
-      cloud: { homeVesselProject: 'example-home' },
-      sources: { buckets: [], defaultBucket: 'typed-by-hand' },
+      vessels: [{ name: 'cluster' }, { location: { project: 'example-home' } }],
+      sources: { buckets: [] },
     });
   });
 
   test('a list-valued key takes the shape its candidate carried', () => {
     // The reason a candidate carries a value at all: `sources.buckets` is a
-    // list and `sources.defaultBucket` is not, and a panel deriving that would
-    // be a panel with an opinion about the schema.
+    // list and the home vessel's `shared.sourceBucket` is not, and a panel
+    // deriving that would be a panel with an opinion about the schema.
     const bucket: DiscoveredCandidate = {
       label: 'a-bucket',
       value: ['a-bucket'],
@@ -155,7 +157,7 @@ describe('the panel is part of the settings surface', () => {
     // Order, not just presence: a confirmation offered underneath the field it
     // would have saved a typo in is a confirmation nobody reaches first.
     expect(markup.indexOf('name="discovery.project"')).toBeLessThan(
-      markup.indexOf('name="cloud.homeVesselProject"'),
+      markup.indexOf('name="sources.buckets.0"'),
     );
   });
 });

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -164,6 +164,64 @@ describe('a refusal reads as what it is', () => {
   });
 });
 
+/**
+ * Ticket 81's second clause: the two vessels the installation is built on
+ * reconcile from the mounted declaration on boot **and render read-only**.
+ *
+ * The lock is the point rather than the refusal behind it. `loadStoredManifest`
+ * re-applies the declaration to those two entries at every restart, so a field
+ * an operator can type into here is a field that accepts a value and loses it —
+ * which is the failure `views/targets/list.tsx` renders its own sentence for.
+ */
+describe('the vessels this installation is built on are read-only', () => {
+  /** The fixture plus a boundary neither pointer names. */
+  const withAppVessel = {
+    ...manifest,
+    vessels: [...manifest.vessels, { name: 'elsewhere', kind: 'cluster' }],
+  };
+
+  /** Whether the control with this `name` is rendered disabled. */
+  function locked(markup: string, name: string): boolean {
+    const control = new RegExp(`<[^>]*name="${name}"[^>]*>`).exec(markup)?.[0];
+    if (control === undefined) throw new Error(`no control named ${name}`);
+    return control.includes('disabled=""');
+  }
+
+  test('a declaration locks the pointers and the entries they name', () => {
+    const markup = screen({ document: withAppVessel, declaration: manifest });
+
+    expect(locked(markup, 'installation.controlPlaneVessel')).toBe(true);
+    expect(locked(markup, 'installation.homeVessel')).toBe(true);
+    // Everything under a governed entry, not only its name: the shared services
+    // are the half a boot most often takes back, and the half three commands
+    // used to write.
+    expect(locked(markup, 'vessels.1.name')).toBe(true);
+    expect(locked(markup, 'vessels.1.shared.sourceBucket')).toBe(true);
+    // By name, resolved against the document. The third boundary is nobody's
+    // but this screen's, and so is every ordinary key.
+    expect(locked(markup, 'vessels.2.name')).toBe(false);
+    expect(locked(markup, 'build.zeroConfigFrontend')).toBe(false);
+  });
+
+  test('the lock carries the sentence saying why', () => {
+    // A disabled input with nothing beside it reads as a bug in the form.
+    expect(
+      screen({ document: withAppVessel, declaration: manifest }),
+    ).toContain('are declared, not configured here');
+  });
+
+  test('with no declaration mounted the whole document is this screen’s', () => {
+    // Governance is what a declaration does on a boot. An installation running
+    // without one owns its document outright — which is how the shared services
+    // are configured at all on an install that mounts nothing.
+    const markup = screen({ document: withAppVessel });
+
+    expect(locked(markup, 'installation.homeVessel')).toBe(false);
+    expect(locked(markup, 'vessels.1.shared.sourceBucket')).toBe(false);
+    expect(markup).not.toContain('are declared, not configured here');
+  });
+});
+
 describe('adopting a divergent declaration', () => {
   test('no divergence, no notice and no adopt act', () => {
     const markup = screen();

--- a/apps/spindrift/test/web/installation-surface.test.ts
+++ b/apps/spindrift/test/web/installation-surface.test.ts
@@ -209,7 +209,7 @@ describe('whether anybody has configured this installation', () => {
     const { manifest } = await readInstallation();
     const named = withValueAt(
       manifest,
-      ['installation'],
+      ['installation', 'name'],
       'named-by-onboarding',
     );
 

--- a/apps/spindrift/test/web/onboarding.test.tsx
+++ b/apps/spindrift/test/web/onboarding.test.tsx
@@ -75,7 +75,7 @@ function screen({
 
 /** Every control this build could render for the manifest, by its own name. */
 const CONTROLS = {
-  installation: 'name="installation"',
+  installation: 'name="installation.name"',
   clientId: 'name="github.clientId"',
   registry: 'name="supplyChain.registry.0"',
   // Not asked by any step, and the check that step 2 is a step rather than the
@@ -139,7 +139,7 @@ describe('each step asks its own question and nothing else', () => {
     // Confirmation, not authorship: the control arrives carrying the value the
     // row has, so an operator who agrees with it presses Continue.
     expect(screen({ step: 0 })).toContain(
-      `value="${DEFAULT_PLACEHOLDER_MANIFEST.installation}"`,
+      `value="${DEFAULT_PLACEHOLDER_MANIFEST.installation.name}"`,
     );
   });
 });
@@ -192,7 +192,7 @@ describe('a refusal is the same three things it is on the settings screen', () =
   test('an invalid value is shown against the control that produced it', () => {
     const markup = screen({
       step: 0,
-      errors: new Map([['installation', ['Too small: expected string']]]),
+      errors: new Map([['installation.name', ['Too small: expected string']]]),
     });
     expect(markup).toContain('Too small: expected string');
   });
@@ -203,14 +203,14 @@ describe('a refusal is the same three things it is on the settings screen', () =
     // `installation` raised on the last step is an issue rendered against a
     // control three steps back — the operator is told the manifest was refused
     // and shown nothing that says what to do. `finish` navigates on this.
-    expect(stepAsking('installation')).toBe(0);
+    expect(stepAsking('installation.name')).toBe(0);
     expect(stepAsking('github.clientId')).toBe(1);
     // By prefix: an issue names the value that is wrong, a step names the key it
     // asks for, and an array control's elements are neither of the other's.
     expect(stepAsking('supplyChain.registry.0')).toBe(3);
     // And a value no step asks about is not forced onto one. Discovery writes
     // cloud facts this screen never offers a control for.
-    expect(stepAsking('sources.defaultBucket')).toBe(-1);
+    expect(stepAsking('secretStore.endpoint')).toBe(-1);
   });
 });
 

--- a/apps/spindrift/test/web/schema-form.test.ts
+++ b/apps/spindrift/test/web/schema-form.test.ts
@@ -115,9 +115,12 @@ describe('what a field knows about itself', () => {
   });
 
   test('an optional key is marked optional', () => {
-    const sources = field(fields, 'sources').node;
-    if (sources.kind !== 'object') throw new Error('sources is not an object');
-    expect(field(sources.fields, 'defaultBucket').optional).toBe(true);
+    const supplyChain = field(fields, 'supplyChain').node;
+    if (supplyChain.kind !== 'object') {
+      throw new Error('supplyChain is not an object');
+    }
+    expect(field(supplyChain.fields, 'attestor').optional).toBe(true);
+    expect(field(supplyChain.fields, 'signer').optional).toBe(false);
   });
 
   test('an enum becomes its own members, read from the schema', () => {

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -997,6 +997,80 @@ describe('the Targets surface', () => {
     // all the way onto the screen.
     expect(markup).not.toContain('spindrift-apps');
   });
+
+  /** One card at a time, because the two claims below are about one card each. */
+  const card = (id: string) =>
+    renderToStaticMarkup(
+      <TargetList
+        targets={TARGET_LIST.filter((target) => target.id === id)}
+        pending={[]}
+        vessels={VESSEL_LIST}
+        connecting={false}
+        error={null}
+        onConnect={() => undefined}
+      />,
+    );
+
+  test('a surface on a vessel the installation is built on offers neither act', () => {
+    // That boundary reconciles from the mounted declaration on every boot, so
+    // an edit made here would survive exactly until the next restart — and a
+    // disconnect is refused one layer down, because neither pointer is a
+    // foreign key and nothing else would stop it.
+    const markup = words(card('target-primary'));
+    expect(markup).not.toContain('Edit connection');
+    expect(markup).not.toContain('Disconnect');
+    // And the sentence saying why, rather than a disabled button saying nothing.
+    expect(markup).toContain('where this control plane runs');
+    expect(markup).toContain('cannot be disconnected');
+  });
+
+  test('an ordinary Target keeps both acts', () => {
+    // The other side of the same claim: the lock is by role, not by screen.
+    const markup = words(card('target-secondary'));
+    expect(markup).toContain('Edit connection');
+    expect(markup).toContain('Disconnect');
+    expect(markup).not.toContain('cannot be disconnected');
+  });
+
+  test('the boundaries carry a checklist of their own, and say which they are', () => {
+    const markup = words(targets());
+    expect(markup).toContain('Boundaries this installation is built on');
+    // The four the home vessel exists to hold. None of them belongs to a
+    // Target, and none is asked of an app vessel.
+    for (const item of [
+      'SOURCE_BUCKET',
+      'SECRET_STORE',
+      'SIGNER_KEY',
+      'ARTIFACTS_PROJECT',
+    ]) {
+      expect(markup).toContain(item);
+    }
+    expect(markup).toContain('home vessel');
+    expect(markup).toContain('where this control plane runs');
+    // Red where a row failed — a boundary's health is every catalogued row met.
+    expect(markup).toContain('unhealthy');
+  });
+
+  test('a boundary nobody has been past says so rather than reading as passed', () => {
+    // §18's rule in reverse: a snapshot has to say when, and never-assessed is
+    // a different state from assessed-and-everything-met.
+    const markup = words(
+      renderToStaticMarkup(
+        <TargetList
+          targets={TARGET_LIST}
+          pending={[]}
+          vessels={VESSEL_LIST.map((vessel) => ({
+            ...vessel,
+            inspectedAt: null,
+          }))}
+          connecting={false}
+          error={null}
+          onConnect={() => undefined}
+        />,
+      ),
+    );
+    expect(markup).toContain('never inspected');
+  });
 });
 
 describe('changing how a Component is reached (§9)', () => {

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -29,6 +29,7 @@ import {
   BUILD_ATTEMPT,
   DEPLOY_SCENARIOS,
   TARGET_LIST,
+  VESSEL_LIST,
   WORKSPACE_SCENARIOS,
 } from '../fixtures/scenarios.ts';
 
@@ -908,6 +909,7 @@ describe('the Targets surface', () => {
       <TargetList
         targets={TARGET_LIST}
         pending={pending}
+        vessels={VESSEL_LIST}
         connecting={false}
         error={null}
         onConnect={() => undefined}
@@ -936,6 +938,7 @@ describe('the Targets surface', () => {
       <TargetList
         targets={TARGET_LIST}
         pending={[]}
+        vessels={VESSEL_LIST}
         connecting={false}
         error={null}
         onConnect={() => undefined}

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -97,7 +97,14 @@ spec:
     # from cluster-settings, `SECRET_DOMAIN` from cluster-secrets — so the zone
     # is read rather than restated, the same way `hostname` above reads it.
     manifest:
-      installation: offsite
+      # What this installation is, and the two vessels it is built on. Both
+      # pointers name a vessel declared below: `offsite` is where this control
+      # plane runs — and an ordinary deploy Target besides — and `bluenose`
+      # holds the shared services every Target reads through.
+      installation:
+        name: offsite
+        controlPlaneVessel: offsite
+        homeVessel: bluenose
       controlPlane:
         hostname: spindrift.${SECRET_DOMAIN}
       dns:
@@ -166,12 +173,11 @@ spec:
         # version rather than a moving tag: it is the only input to a
         # zero-config build that no digest covers.
         zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
-      cloud:
-        # Federation is not a manifest key: it is read from the
-        # `external_account` credential the chart renders from the two
-        # serviceAccount.token values above.
-        artifactsProject: trusted-builds
-        homeVesselProject: bluenose
+      # No `cloud` block. Federation is not a manifest key: it is read from the
+      # `external_account` credential the chart renders from the two
+      # serviceAccount.token values above. The two keys that used to sit beside
+      # it — the artifacts project and the home vessel's own project — are
+      # properties of `bluenose` below, where nothing can disagree with them.
       charts:
         # The App chart as an artifact, which is what makes every Target's
         # release independent of a checkout of this repository. The reference
@@ -187,9 +193,12 @@ spec:
         oauthBaseUrl: https://github.com
         buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
       sources:
+        # Which of these staging picks is `shared.sourceBucket` on the home
+        # vessel: the bucket lives in that project, so stating it anywhere else
+        # is a default that can name a bucket in a project this document does
+        # not otherwise mention.
         buckets:
           - bluenose-spindrift-source
-        defaultBucket: bluenose-spindrift-source
       # The tenancy boundaries this installation deploys into. Where a boundary
       # is, and what it can reach, are facts about the boundary and are stated
       # here once — a Target below states only what is true of its own runtime
@@ -230,6 +239,21 @@ spec:
           kind: gcp-project
           location:
             project: bluenose
+          # The shared services, on the boundary that holds them.
+          # `installation.homeVessel` names this vessel, so this block is
+          # required here and refused on every other.
+          #
+          # `secretStoreContainer` is this project: `bluenose` holds the secrets
+          # for every Target, including the two clusters — the store of record
+          # is one place, and where it lives is a property of the store, not of
+          # who reads it. `artifactsProject` is deliberately *not* this project:
+          # artifacts and signing material live in `trusted-builds` beside the
+          # registry, and collapsing the two would be the one place this vessel
+          # is asked to be somewhere it is not.
+          shared:
+            sourceBucket: bluenose-spindrift-source
+            artifactsProject: trusted-builds
+            secretStoreContainer: bluenose
           # The artifact registry and nothing else. Cloud Run pulls through a
           # cache mirror that cannot parse the OCI index pushed to GHCR, so
           # naming the registry it *can* read is what keeps a Deploy here from
@@ -415,10 +439,8 @@ spec:
       # (`clusters/base/platform/gcp-secret-manager`), which is what the two
       # Targets above name.
       #
-      # `container` is the vessel's project. `bluenose` holds the secrets for
-      # every Target, including the two clusters — the store of record is one
-      # place, and where it lives is a property of the store, not of who reads
-      # it.
+      # Which container holds the items is `shared.secretStoreContainer` on the
+      # home vessel, because it is a property of that boundary.
       #
       # No credential here. Core writes over the same federation every cloud
       # Target already goes through (`storeTokenFor` in
@@ -427,7 +449,6 @@ spec:
       secretStore:
         adapter: gcp-secret-manager
         endpoint: https://secretmanager.googleapis.com
-        container: bluenose
       supplyChain:
         # northamerica-northeast1, which is where the key is:
         # `google_kms_crypto_key.signer` takes `local.region`, and

--- a/packages/charts/spindrift/files/default-manifest.yaml
+++ b/packages/charts/spindrift/files/default-manifest.yaml
@@ -14,7 +14,10 @@
 # test at apps/spindrift/test/conformance/chart-only-enrolment.test.ts diffs
 # this file against the code's copy so that drift is a red test rather than a
 # live surprise.
-installation: default
+installation:
+  name: default
+  controlPlaneVessel: primary
+  homeVessel: spindrift
 controlPlane:
   hostname: {{ .Values.hostname | quote }}
 auth:
@@ -26,10 +29,6 @@ dns:
 sources:
   buckets:
     - bluenose-spindrift-source
-  defaultBucket: bluenose-spindrift-source
-cloud:
-  artifactsProject: spindrift-artifacts
-  homeVesselProject: spindrift-vessel
 charts:
   app: packages/charts/spindrift-app
 supplyChain:
@@ -52,7 +51,6 @@ build:
 secretStore:
   adapter: onepassword
   endpoint: http://onepassword-connect.external-secrets.svc.cluster.local:8080
-  container: spindrift-vault
 vessels:
   - name: primary
     kind: cluster
@@ -62,6 +60,10 @@ vessels:
     kind: gcp-project
     location:
       project: spindrift-vessel
+    shared:
+      sourceBucket: bluenose-spindrift-source
+      artifactsProject: spindrift-artifacts
+      secretStoreContainer: spindrift-vault
 targets:
   - vessel: primary
     adapter: kubernetes

--- a/packages/charts/spindrift/templates/manifest.yaml
+++ b/packages/charts/spindrift/templates/manifest.yaml
@@ -18,8 +18,8 @@ document is this chart's own copy of the placeholder, built to already agree
 with `.Values.hostname`, so there is nothing for it to disagree with.
 */}}
 {{- if .Values.manifest }}
-{{- if dig "cloud" "federation" nil .Values.manifest }}
-{{- fail "manifest.cloud.federation is not a manifest key: federation is read from the external_account credential this chart renders. Set serviceAccount.token.gcpAudience and serviceAccount.token.gcpImpersonationUrl instead." }}
+{{- if hasKey .Values.manifest "cloud" }}
+{{- fail "manifest.cloud is not a manifest key. Federation is read from the external_account credential this chart renders — set serviceAccount.token.gcpAudience and serviceAccount.token.gcpImpersonationUrl instead — and the artifacts project and the home vessel's own project are properties of the vessel installation.homeVessel names." }}
 {{- end }}
 {{- if dig "charts" "installer" nil .Values.manifest }}
 {{- fail "manifest.charts.installer is not a manifest key: nothing reads it. Remove it." }}

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -418,7 +418,22 @@ describe('the credential is the only copy of the federation', () => {
           cloud: { federation: { audience: '//iam.stale.test/pools/stale' } },
         },
       }),
-    ).rejects.toThrow('manifest.cloud.federation is not a manifest key');
+    ).rejects.toThrow('manifest.cloud is not a manifest key');
+  });
+
+  test('refuses a declaration that states the home vessel’s projects', async () => {
+    // The whole `cloud` key, not the federation alone: the artifacts project
+    // and the project the home vessel is are properties of the vessel
+    // `installation.homeVessel` names, so a document restating them there is
+    // two answers to one question and is refused at render time.
+    await expect(
+      render({
+        manifest: {
+          installation: 'declared',
+          cloud: { artifactsProject: 'stale-artifacts' },
+        },
+      }),
+    ).rejects.toThrow('properties of the vessel installation.homeVessel names');
   });
 
   test('refuses a declaration that names the chart it was installed from', async () => {
@@ -509,7 +524,16 @@ describe('a chart-only install seeds its own relying party', () => {
     // The genuine choices stay at their stand-ins, so the seeded document is
     // still one `isUnconfiguredInstallation` (apps/spindrift/src/config/manifest.ts)
     // reads as unconfigured.
-    expect(seeded.installation).toBe('default');
+    const installation = seeded.installation as Record<string, string>;
+    expect(installation.name).toBe('default');
+    // And both pointers name vessels this same document declares. A chart-only
+    // install boots from nothing else, so a pointer that resolves to nothing
+    // here is an installation that refuses its own seed.
+    const declared = (seeded.vessels as { name: string }[]).map(
+      (vessel) => vessel.name,
+    );
+    expect(declared).toContain(installation.controlPlaneVessel);
+    expect(declared).toContain(installation.homeVessel);
     expect((seeded.github as { clientId?: string }).clientId).toBe(
       'Iv1.918d699f36ee7afc',
     );

--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -532,8 +532,8 @@ describe('a chart-only install seeds its own relying party', () => {
     const declared = (seeded.vessels as { name: string }[]).map(
       (vessel) => vessel.name,
     );
-    expect(declared).toContain(installation.controlPlaneVessel);
-    expect(declared).toContain(installation.homeVessel);
+    expect(declared).toContain(installation.controlPlaneVessel ?? '');
+    expect(declared).toContain(installation.homeVessel ?? '');
     expect((seeded.github as { clientId?: string }).clientId).toBe(
       'Iv1.918d699f36ee7afc',
     );


### PR DESCRIPTION
## Summary

The two vessels this installation is built on stop being loose strings and become declared, governed rows. `installation` becomes a block — `{name, controlPlaneVessel, homeVessel}` — with both pointers resolved by the document-level refinement the way a Target's `vessel` already is. The four keys that all happened to say where the shared services live (`cloud.homeVesselProject`, `cloud.artifactsProject`, `sources.defaultBucket`, `secretStore.container`) collapse into a `shared` block on the home vessel; the `cloud` block has nothing authored left and is derived. A manifest-upgrade step carries existing stored documents forward; a new fixture snapshots the shape; no dual-read path.

- **Governance, narrowly.** The two named vessels (and the pointers) reconcile from the mounted declaration on every boot and render read-only everywhere — the Targets screen and the manifest editor, which now refuses edits into the governed slice instead of accepting writes a boot would silently revert. Every other vessel genuinely keeps seed-once-then-UI-owns: a booted write no longer touches an existing ungoverned row at all, and no longer discards the connection facts the connect screen wrote.
- **Guards.** Neither named vessel can be disconnected; the Targets screen says which role a boundary holds instead of offering the controls.
- **The catalogue gains a second axis.** Prerequisites key off kind × role: a `gcp-project` home owes `SOURCE_BUCKET`, `SECRET_STORE`, `SIGNER_KEY`, `ARTIFACTS_PROJECT`; an app vessel is asked nothing and never shows a green row nobody checked. A standing vessel loop probes the home vessel's four through the existing discovery reads and renders a "Boundaries this installation is built on" section.
- **Declaration and chart move together.** `clusters/offsite/apps/spindrift/helm-release.yaml`, the chart's default manifest, and its render-time refusal all move in this change; chart goldens updated.

## Validation

- `bun run typecheck` clean; `bun run lint` clean.
- `bun test`: 1847 pass / 0 fail (134 files), re-run after rebasing onto current `main`.
- New coverage: the vessel loop against a faked cloud (met rows, a mistyped bucket, refused-read vs absence, wrong-purpose key, no project, empty checklist for an app vessel), both pointer refinements, the upgrade derivation, boot governance of exactly the two named vessels (and non-governance of an ordinary one), the disconnect guard, the read-only Target card, and the governed-slice refusal.

## Risk and merge sequencing

- **DB migration** `0029_vessel_checklist.sql`: two additive nullable columns; runs on the image roll; safe on the live database.
- **The declaration changes shape.** The stored manifest row takes precedence over the mounted ConfigMap, so after merge and image roll the installation must be told to adopt the new declaration (`configureInstallation`) — until then it runs on the upgraded stored document, which the manifest-upgrade step produces from the old keys. Both paths are tested; the adopt step is the operator's call on timing.
- A re-pointed home vessel reassesses its surfaces on boot (`moved` treatment) — deliberate, tested, and only reachable by editing the declaration.
