### PR TITLE
feat(spindrift): let the wizard offer what detection found

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -132,7 +132,17 @@ choices made while building them:
   Review, defaults carrying every step, preflight folded into Review. The
   server-owned draft survives refresh and rejects stale concurrent edits. An
   unmet prerequisite stops before any App, Component, Build, or Deploy exists,
-  keeps the draft, and names what clears it.
+  keeps the draft, and names what clears it. **It offers what exists rather
+  than deciding from it.** The picker is every repository the GitHub grant
+  carries merged with the ones Spindrift holds rows for, each row saying which
+  it is; detection runs on the repository the draft opens on, and every
+  directory it read is a row — buildable ones selectable with their reason, the
+  rest wearing what was found instead (§3). A sole candidate is a proposal and
+  two are a question, so nothing is picked for anybody. **Selecting writes
+  nothing**: `inspectRepository` is a read, and a repository the grant offers
+  gets §15's row and configuration pull request from `completeCreationDraft`,
+  through `connectRepository` itself — which is what keeps "an abandoned draft
+  leaves nothing behind" literally true rather than nearly true.
 - **Authentication Settings** (`views/auth/settings.tsx`) — additive passkeys
   and the optional Gateway binding. Every mutation requires a fresh passkey
   assertion, and the final account-root passkey cannot be removed.

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -138,8 +138,11 @@ choices made while building them:
   it is; detection runs on the repository the draft opens on, and every
   directory it read is a row — buildable ones selectable with their reason, the
   rest wearing what was found instead (§3). A sole candidate is a proposal and
-  two are a question, so nothing is picked for anybody. **Selecting writes
-  nothing**: `inspectRepository` is a read, and a repository the grant offers
+  two are a question, so nothing is picked for anybody — and a draft somebody
+  has already answered is read again without being re-decided, because the
+  draft records which directory its reason is about and which answers are the
+  operator's. **Selecting writes nothing**: `inspectRepository` is a read, and
+  a repository the grant offers
   gets §15's row and configuration pull request from `completeCreationDraft`,
   through `connectRepository` itself — which is what keeps "an abandoned draft
   leaves nothing behind" literally true rather than nearly true.

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -6,6 +6,7 @@ import {
   components,
   componentTargetDesired,
   creationDrafts,
+  type Repository,
   repositories,
   targets,
 } from '../../db/schema.ts';
@@ -27,8 +28,10 @@ import { repositoryRefOf } from '../../domain/repository.ts';
 import { SUPPLIED_ARTIFACT_TYPE } from '../../domain/source.ts';
 import type { StagedSourceBundle } from '../../domain/source-bundle.ts';
 import { targetRowLabel } from '../../domain/target.ts';
+import { reconcileRepository } from '../../reconciler/repo-loop.ts';
 import { routeForTarget } from '../builds/route.ts';
 import type { CreateAppResult } from '../create-app.ts';
+import { connectRepository } from '../repositories/connect.ts';
 import {
   type Command,
   type CommandContext,
@@ -428,11 +431,19 @@ async function prepareCreation(
     });
   }
 
-  const [repository] = await context.db
-    .select()
-    .from(repositories)
-    .where(eq(repositories.fullName, draft.source.repo))
-    .limit(1);
+  let repository = await repositoryRow(context, draft.source.repo);
+  if (
+    draft.source.connect === true &&
+    (repository?.access !== 'active' || repository.authoritativeCommit === null)
+  ) {
+    const connected = await connectAndAdopt(
+      draft.source.repo,
+      draft.source.subpath,
+      context,
+    );
+    if (!connected.ok) return connected;
+    repository = connected.value;
+  }
   if (
     repository?.access !== 'active' ||
     repository.authoritativeCommit === null
@@ -482,6 +493,55 @@ function noBuildRoute(target: string) {
     'NOT_BUILDABLE',
     `this installation has no eligible build route for ${target}`,
   );
+}
+
+async function repositoryRow(context: CommandContext, fullName: string) {
+  const [row] = await context.db
+    .select()
+    .from(repositories)
+    .where(eq(repositories.fullName, fullName))
+    .limit(1);
+  return row;
+}
+
+/**
+ * Connect the repository this draft deploys from, as part of creating the App.
+ *
+ * The wizard lets an operator read any repository the GitHub grant offers, and
+ * reading writes nothing — so a repository Spindrift holds no row for arrives
+ * here, at the one committing act, and is connected through §15's own command
+ * rather than through a second way of connecting. The scope is the directory
+ * the draft names, so the configuration pull request covers what is about to be
+ * deployed and nothing else.
+ *
+ * The reconcile that follows is what makes the new row stageable: `connect`
+ * adopts nothing by design (§15), and a row with no authoritative commit has no
+ * source to build. Reading the default branch here is the same pass the repo
+ * loop makes on its own schedule, taken now so that creation does not wait a
+ * tick for a commit that is already there.
+ */
+async function connectAndAdopt(
+  fullName: string,
+  subpath: string,
+  context: CommandContext,
+): Promise<CommandResult<Repository>> {
+  const connected = await connectRepository(
+    { fullName, scopes: [subpath] },
+    context,
+  );
+  if (!connected.ok) return connected;
+
+  const row = await repositoryRow(context, fullName);
+  if (row === undefined) {
+    throw new Error(`connecting ${fullName} wrote no repository row`);
+  }
+  const host = context.adapters.repository?.() ?? null;
+  if (host === null) return ok(row);
+  await reconcileRepository(
+    { db: context.db, clock: context.clock, host },
+    row,
+  );
+  return ok((await repositoryRow(context, fullName)) ?? row);
 }
 
 async function completedCreation(
@@ -628,7 +688,7 @@ async function revalidate(
     .map((candidate) => candidate.target.id);
   const blockers = [...blockersFor(draft, candidateIds)];
 
-  if (draft.source.kind === 'repo') {
+  if (draft.source.kind === 'repo' && draft.source.repo !== '') {
     const [repository] = await context.db
       .select({
         access: repositories.access,
@@ -637,20 +697,29 @@ async function revalidate(
       .from(repositories)
       .where(eq(repositories.fullName, draft.source.repo))
       .limit(1);
-    if (repository?.access !== 'active') {
-      blockers.push({
-        code: 'REPOSITORY_UNAVAILABLE',
-        title: `The repository ${draft.source.repo} is no longer available.`,
-        remediation:
-          'Restore the GitHub App installation access or choose another repository. The draft is kept.',
-      });
-    } else if (repository.authoritativeCommit === null) {
-      blockers.push({
-        code: 'SOURCE_UNAVAILABLE',
-        title: `The repository ${draft.source.repo} has no authoritative commit ready.`,
-        remediation:
-          'Wait for default-branch reconciliation, then review this draft again.',
-      });
+    // A repository the GitHub grant offers and this installation holds no row
+    // for is connected by completion itself (§15), so its absence is not a
+    // prerequisite to clear beforehand: `connectRepository`'s own refusal is
+    // what says it could not be. `blockersFor` still refuses a draft that names
+    // no repository at all.
+    const connectsOnDeploy =
+      repository === undefined && draft.source.connect === true;
+    if (!connectsOnDeploy) {
+      if (repository?.access !== 'active') {
+        blockers.push({
+          code: 'REPOSITORY_UNAVAILABLE',
+          title: `The repository ${draft.source.repo} is no longer available.`,
+          remediation:
+            'Restore the GitHub App installation access or choose another repository. The draft is kept.',
+        });
+      } else if (repository.authoritativeCommit === null) {
+        blockers.push({
+          code: 'SOURCE_UNAVAILABLE',
+          title: `The repository ${draft.source.repo} has no authoritative commit ready.`,
+          remediation:
+            'Wait for default-branch reconciliation, then review this draft again.',
+        });
+      }
     }
   }
 

--- a/apps/spindrift/src/commands/repositories/access.ts
+++ b/apps/spindrift/src/commands/repositories/access.ts
@@ -1,0 +1,57 @@
+/**
+ * Why a repository was not read, in a sentence the operator can act on.
+ *
+ * §15's three access codes are three different facts and only one of them is
+ * about this repository, so they refuse differently: a lost grant is a fact
+ * about the installation, a quota refusal is a fact about the hour, and
+ * anything else is a fact about GitHub having a bad time. Collapsing the last
+ * two into `NOT_FOUND` sends somebody to check a repository that is there.
+ *
+ * No response body ever reaches the message. The far side answers a failed read
+ * with JSON or with somebody's proxy error page, and neither is a sentence.
+ *
+ * `ACCESS_LOST` states both of its possibilities because there are two and
+ * GitHub answers identically for them (`integrations/github/http.ts`): a
+ * repository that does not exist and one this installation is not granted are
+ * the same `404`, so naming only the second asserts an existence nothing here
+ * established.
+ *
+ * Shared by `inspectRepository` and `connectRepository` because the creation
+ * flow runs both against the same repository — reading it on selection and
+ * connecting it on Deploy — and two taxonomies for one act would mean the same
+ * quota window reads as a missing repository depending on which button the
+ * operator had reached.
+ */
+import { GitHubAccessError } from '../../integrations/github/http.ts';
+import { type CommandResult, failed } from '../types.ts';
+
+export function unreadable<Output>(
+  fullName: string,
+  cause: unknown,
+): CommandResult<Output> {
+  if (cause instanceof GitHubAccessError) {
+    switch (cause.code) {
+      case 'ACCESS_LOST':
+        return failed(
+          'NOT_FOUND',
+          `Spindrift cannot reach ${fullName}. GitHub answers the same way for a repository that does not exist and for one this App installation does not select, so it is one of those two: check the name, then the installation's repository selection.`,
+        );
+      case 'RATE_LIMITED':
+        return failed(
+          'NOT_DEPLOYABLE',
+          `GitHub is rate-limiting Spindrift, so ${fullName} was not read. Nothing is wrong with the repository — try again once the quota resets.`,
+        );
+      case 'UNAVAILABLE':
+        return failed(
+          'NOT_DEPLOYABLE',
+          `GitHub answered ${cause.status} for ${fullName}. That is the far side rather than the repository — try again.`,
+        );
+    }
+  }
+  return failed(
+    'NOT_DEPLOYABLE',
+    `Spindrift could not read ${fullName}: ${
+      cause instanceof Error ? cause.message : String(cause)
+    }`,
+  );
+}

--- a/apps/spindrift/src/commands/repositories/connect.ts
+++ b/apps/spindrift/src/commands/repositories/connect.ts
@@ -32,8 +32,8 @@ import {
   configurationTransaction,
   openConfigurationPullRequest,
 } from '../../integrations/github/config-pr.ts';
-import { GitHubAccessError } from '../../integrations/github/http.ts';
 import { type Command, failed, ok } from '../types.ts';
+import { unreadable } from './access.ts';
 
 /** `owner/name` — the only handle the repository API takes. */
 const fullName = z
@@ -221,39 +221,25 @@ export const connectRepository: Command<
   // to nothing.
   const buildWorkflow = context.manifest.github?.buildWorkflow ?? null;
 
+  // Every read below refuses through the one taxonomy (`access.ts`): §15's
+  // lost-access rule reaches back to here — a repository the App cannot see is
+  // a fact about the world, reported as a refusal the operator can act on,
+  // never an exception the dispatch surface turns into a 500 — and the other
+  // two codes are not that fact. The creation wizard reaches this command with
+  // a repository it has just read successfully, so an hour's quota answering
+  // "cannot reach" would contradict the screen that offered the button.
   let ref: ReturnType<typeof repositoryRefOf>;
   try {
     ref = await host.installationFor(input.fullName);
   } catch (cause) {
-    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
-      return failed(
-        'NOT_FOUND',
-        `Spindrift cannot reach ${input.fullName}: authorize GitHub and check that the App installation selects it`,
-      );
-    }
-    return failed(
-      'NOT_FOUND',
-      `Spindrift cannot reach ${input.fullName}: ${cause instanceof Error ? cause.message : String(cause)}`,
-    );
+    return unreadable(input.fullName, cause);
   }
 
   let defaultBranch: string;
   try {
     ({ defaultBranch } = await host.repository(ref, input.fullName));
   } catch (cause) {
-    // §15's lost-access rule reaches back to here: a repository the App cannot
-    // see is a fact about the world, reported as a refusal the operator can act
-    // on, never an exception the dispatch surface turns into a 500.
-    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
-      return failed(
-        'NOT_FOUND',
-        `Spindrift cannot reach ${input.fullName}: check that the App installation still selects it`,
-      );
-    }
-    return failed(
-      'NOT_FOUND',
-      `Spindrift cannot reach ${input.fullName}: ${cause instanceof Error ? cause.message : String(cause)}`,
-    );
+    return unreadable(input.fullName, cause);
   }
 
   let scopes: ConfigurationScope[];
@@ -266,18 +252,7 @@ export const connectRepository: Command<
       defaultBranch,
     ));
   } catch (cause) {
-    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
-      return failed(
-        'NOT_FOUND',
-        `Spindrift lost access to ${input.fullName} while reading it`,
-      );
-    }
-    return failed(
-      'NOT_DEPLOYABLE',
-      `Spindrift could not read ${input.fullName}: ${
-        cause instanceof Error ? cause.message : String(cause)
-      }`,
-    );
+    return unreadable(input.fullName, cause);
   }
 
   if (scopes.length === 0) {

--- a/apps/spindrift/src/commands/repositories/inspect.ts
+++ b/apps/spindrift/src/commands/repositories/inspect.ts
@@ -29,7 +29,7 @@ import { scanRepository } from '../../domain/detection/discover.ts';
 import type { DetectionProposal } from '../../domain/detection/ladder.ts';
 import { gitHubTree } from '../../domain/detection/tree.ts';
 import { GitHubAccessError } from '../../integrations/github/http.ts';
-import { type Command, failed, ok } from '../types.ts';
+import { type Command, type CommandResult, failed, ok } from '../types.ts';
 
 /** `owner/name` — the only handle the repository API takes. */
 const fullName = z
@@ -135,6 +135,55 @@ function viewOf(scope: string, proposal: DetectionProposal): InspectedScope {
   };
 }
 
+/**
+ * Why the repository was not read, in a sentence the operator can act on.
+ *
+ * §15's three access codes are three different facts and only one of them is
+ * about this repository, so they refuse differently: a lost grant is a fact
+ * about the installation, a quota refusal is a fact about the hour, and
+ * anything else is a fact about GitHub having a bad time. Collapsing the last
+ * two into `NOT_FOUND` sends somebody to check a repository that is there.
+ *
+ * No response body ever reaches the message. The far side answers a failed read
+ * with JSON or with somebody's proxy error page, and neither is a sentence.
+ *
+ * `ACCESS_LOST` states both of its possibilities because there are two and
+ * GitHub answers identically for them (`integrations/github/http.ts`): a
+ * repository that does not exist and one this installation is not granted are
+ * the same `404`, so naming only the second asserts an existence nothing here
+ * established.
+ */
+function unreadable<Output>(
+  fullName: string,
+  cause: unknown,
+): CommandResult<Output> {
+  if (cause instanceof GitHubAccessError) {
+    switch (cause.code) {
+      case 'ACCESS_LOST':
+        return failed(
+          'NOT_FOUND',
+          `Spindrift cannot reach ${fullName}. GitHub answers the same way for a repository that does not exist and for one this App installation does not select, so it is one of those two: check the name, then the installation's repository selection.`,
+        );
+      case 'RATE_LIMITED':
+        return failed(
+          'NOT_DEPLOYABLE',
+          `GitHub is rate-limiting Spindrift, so ${fullName} was not read. Nothing is wrong with the repository — try again once the quota resets.`,
+        );
+      case 'UNAVAILABLE':
+        return failed(
+          'NOT_DEPLOYABLE',
+          `GitHub answered ${cause.status} for ${fullName}. That is the far side rather than the repository — try again.`,
+        );
+    }
+  }
+  return failed(
+    'NOT_DEPLOYABLE',
+    `Spindrift could not read ${fullName}: ${
+      cause instanceof Error ? cause.message : String(cause)
+    }`,
+  );
+}
+
 export const inspectRepository: Command<
   InspectRepositoryInput,
   InspectRepositoryResult
@@ -161,16 +210,7 @@ export const inspectRepository: Command<
     ({ defaultBranch } = await host.repository(ref, input.fullName));
     commit = await host.branchHead(ref, input.fullName, defaultBranch);
   } catch (cause) {
-    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
-      return failed(
-        'NOT_FOUND',
-        `Spindrift cannot reach ${input.fullName}: authorize GitHub and check that the App installation selects it`,
-      );
-    }
-    return failed(
-      'NOT_FOUND',
-      `Spindrift cannot reach ${input.fullName}: ${cause instanceof Error ? cause.message : String(cause)}`,
-    );
+    return unreadable(input.fullName, cause);
   }
 
   let scopes: readonly InspectedScope[];
@@ -190,18 +230,7 @@ export const inspectRepository: Command<
           },
     );
   } catch (cause) {
-    if (cause instanceof GitHubAccessError && cause.code === 'ACCESS_LOST') {
-      return failed(
-        'NOT_FOUND',
-        `Spindrift lost access to ${input.fullName} while reading it`,
-      );
-    }
-    return failed(
-      'NOT_DEPLOYABLE',
-      `Spindrift could not read ${input.fullName} at ${commit.slice(0, 7)}: ${
-        cause instanceof Error ? cause.message : String(cause)
-      }`,
-    );
+    return unreadable(input.fullName, cause);
   }
 
   return ok({

--- a/apps/spindrift/src/commands/repositories/inspect.ts
+++ b/apps/spindrift/src/commands/repositories/inspect.ts
@@ -28,8 +28,8 @@ import { declaredPlanner } from '../../domain/detection/declared.ts';
 import { scanRepository } from '../../domain/detection/discover.ts';
 import type { DetectionProposal } from '../../domain/detection/ladder.ts';
 import { gitHubTree } from '../../domain/detection/tree.ts';
-import { GitHubAccessError } from '../../integrations/github/http.ts';
-import { type Command, type CommandResult, failed, ok } from '../types.ts';
+import { type Command, failed, ok } from '../types.ts';
+import { unreadable } from './access.ts';
 
 /** `owner/name` — the only handle the repository API takes. */
 const fullName = z
@@ -133,55 +133,6 @@ function viewOf(scope: string, proposal: DetectionProposal): InspectedScope {
         .map((option) => [option.kind, option.reason]),
     ),
   };
-}
-
-/**
- * Why the repository was not read, in a sentence the operator can act on.
- *
- * §15's three access codes are three different facts and only one of them is
- * about this repository, so they refuse differently: a lost grant is a fact
- * about the installation, a quota refusal is a fact about the hour, and
- * anything else is a fact about GitHub having a bad time. Collapsing the last
- * two into `NOT_FOUND` sends somebody to check a repository that is there.
- *
- * No response body ever reaches the message. The far side answers a failed read
- * with JSON or with somebody's proxy error page, and neither is a sentence.
- *
- * `ACCESS_LOST` states both of its possibilities because there are two and
- * GitHub answers identically for them (`integrations/github/http.ts`): a
- * repository that does not exist and one this installation is not granted are
- * the same `404`, so naming only the second asserts an existence nothing here
- * established.
- */
-function unreadable<Output>(
-  fullName: string,
-  cause: unknown,
-): CommandResult<Output> {
-  if (cause instanceof GitHubAccessError) {
-    switch (cause.code) {
-      case 'ACCESS_LOST':
-        return failed(
-          'NOT_FOUND',
-          `Spindrift cannot reach ${fullName}. GitHub answers the same way for a repository that does not exist and for one this App installation does not select, so it is one of those two: check the name, then the installation's repository selection.`,
-        );
-      case 'RATE_LIMITED':
-        return failed(
-          'NOT_DEPLOYABLE',
-          `GitHub is rate-limiting Spindrift, so ${fullName} was not read. Nothing is wrong with the repository — try again once the quota resets.`,
-        );
-      case 'UNAVAILABLE':
-        return failed(
-          'NOT_DEPLOYABLE',
-          `GitHub answered ${cause.status} for ${fullName}. That is the far side rather than the repository — try again.`,
-        );
-    }
-  }
-  return failed(
-    'NOT_DEPLOYABLE',
-    `Spindrift could not read ${fullName}: ${
-      cause instanceof Error ? cause.message : String(cause)
-    }`,
-  );
 }
 
 export const inspectRepository: Command<

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -114,6 +114,17 @@ const detection = z
     reason: z.string().min(1),
     available: z.array(componentKind),
     unavailable: z.partialRecord(componentKind, z.string().min(1)),
+    /**
+     * The directory the sentence above is about.
+     *
+     * Absent means nothing has read one — which is what a fresh draft means by
+     * "until detection says otherwise", and what every draft written before
+     * `inspectRepository` existed means too. Present, it is what makes the
+     * reason checkable against the directory the draft names: a sentence about
+     * `apps/hub` shown under a root directory reading `docs` is a sentence
+     * about somewhere else.
+     */
+    scope: z.string().min(1).optional(),
   })
   .strict();
 
@@ -165,6 +176,16 @@ export const creationDraftSchema = z
      * re-deriving over it is the flow overwriting a decision it asked for.
      */
     appNameByOperator: z.boolean().optional(),
+    /**
+     * Whether the directory is the operator's word rather than a proposal.
+     *
+     * The same discipline as `appNameByOperator`, and durable for the same
+     * reason: a draft is a row somebody comes back to, so a flag that lived
+     * only in the open tab would let reopening the draft move a directory they
+     * typed. Cleared whenever the repository changes, because a path is a
+     * statement about one tree.
+     */
+    scopeByOperator: z.boolean().optional(),
     /**
      * Which step of the old rail this draft was left on.
      *
@@ -385,6 +406,7 @@ export function draftReducer(draft: Draft, action: DraftAction): Draft {
           reason: action.reason,
           available,
           unavailable: action.unavailable,
+          scope: action.scope,
         },
         // A detected scope names the Component: `apps/api` is `api`, and a
         // root scope keeps whatever the repository is called.
@@ -413,13 +435,20 @@ export function draftReducer(draft: Draft, action: DraftAction): Draft {
           ...(action.connect === true ? { connect: true as const } : {}),
         },
         appName: draft.appNameByOperator ? draft.appName : name,
+        // The directory went back to the root with the tree it named, so
+        // whoever typed the old one has not typed this one.
+        scopeByOperator: undefined,
       };
     }
+    // Typing a directory is the operator answering where the App is, so it
+    // stands however detection reads it (story 32) and it survives the draft
+    // being closed and reopened.
     case 'subpath':
       return draft.source.kind === 'repo'
         ? {
             ...draft,
             source: { ...draft.source, subpath: action.subpath },
+            scopeByOperator: true,
           }
         : draft;
     case 'archive':

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -24,7 +24,7 @@ export const ENTRIES = [
   {
     id: 'discover',
     label: 'Discover',
-    note: 'Propose Apps from a connected repo',
+    note: 'List every directory a repo can deploy',
   },
 ] as const;
 
@@ -70,9 +70,27 @@ const source = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('repo'),
-      repo: z.string().min(1),
-      url: z.url(),
+      /**
+       * Empty until one is picked.
+       *
+       * "Deploy from a repository, and I have not said which" is a state the
+       * flow genuinely has — the `Link repo` and `Discover` tiles open on it
+       * from an upload draft — and a schema that could not hold it would make
+       * those tiles unable to switch the source at all. `blockersFor` refuses
+       * to create anything while it is empty.
+       */
+      repo: z.string(),
+      url: z.union([z.url(), z.literal('')]),
       subpath: z.string().min(1),
+      /**
+       * Whether creating the App also connects the repository (§15).
+       *
+       * Set when the operator picks a repository GitHub grants and Spindrift
+       * holds no row for. Browsing one writes nothing; Deploy is the committing
+       * act, and it is there that the row and the configuration PR appear. An
+       * abandoned draft leaves neither.
+       */
+      connect: z.boolean().optional(),
     })
     .strict(),
   z
@@ -128,6 +146,26 @@ export const creationDraftSchema = z
     auth,
     config: z.array(configKey),
     /**
+     * The source the last tile switch put down.
+     *
+     * Pressing `Upload` on a repository draft and then `Link repo` again is
+     * somebody looking rather than changing their mind, and a tile that costs
+     * them a staged archive or a chosen repository for the look is a tile
+     * nobody presses twice. Optional, and unset on a draft that has never
+     * switched.
+     */
+    stashed: source.optional(),
+    /**
+     * Whether the App name is the operator's word rather than a derivation.
+     *
+     * Optional because drafts are durable rows and an older one predates the
+     * flag; absent reads as "nothing has been typed", which is what every one
+     * of those drafts means. Once set, choosing another repository or another
+     * scope leaves the name alone: a name somebody typed is an answer, and
+     * re-deriving over it is the flow overwriting a decision it asked for.
+     */
+    appNameByOperator: z.boolean().optional(),
+    /**
      * Which step of the old rail this draft was left on.
      *
      * Optional, unread, and still here: drafts are durable rows, and a strict
@@ -153,7 +191,7 @@ export type DraftAction =
   | { type: 'target'; targetId: string }
   | { type: 'reach'; reach: Reach }
   | { type: 'auth'; auth: Auth }
-  | { type: 'repo'; fullName: string; url: string }
+  | { type: 'repo'; fullName: string; url: string; connect?: boolean }
   | { type: 'subpath'; subpath: string }
   /**
    * What the detector found, applied.
@@ -254,17 +292,68 @@ export function initialCreationDraft(input: {
   };
 }
 
+/** An archive nobody has staged yet — what the `Upload` tile opens on. */
+function emptyArchive(): DraftSource {
+  return {
+    kind: 'archive',
+    filename: 'upload.zip',
+    digest: `sha256:${'0'.repeat(64)}`,
+    location: null,
+    contents: 'source',
+    subpath: '.',
+  };
+}
+
+/**
+ * The kind of source a tile is about, or `null` when it is about the kind of
+ * Component instead — `Service` and `Website` name what is being deployed and
+ * never where it comes from.
+ */
+function sourceKindFor(entry: EntryId): DraftSource['kind'] | null {
+  if (entry === 'upload') return 'archive';
+  return entry === 'repo' || entry === 'discover' ? 'repo' : null;
+}
+
+/** Neither an archive nor a repository yet — what a switched tile opens on. */
+function blankSource(kind: DraftSource['kind']): DraftSource {
+  return kind === 'archive'
+    ? emptyArchive()
+    : { kind: 'repo', repo: '', url: '', subpath: '.' };
+}
+
 export function draftReducer(draft: Draft, action: DraftAction): Draft {
   switch (action.type) {
+    // A tile that names a source switches to it, whatever the draft was on
+    // before: a tile that changes a label and leaves the surface underneath it
+    // belonging to the other kind of source is a tile that lies. The source it
+    // switches away from is kept, so that pressing the other tile and coming
+    // back is a look rather than a loss.
     case 'entry': {
       const kind =
         action.entry === 'service' || action.entry === 'website'
           ? action.entry
           : draft.detection.kind;
-      return { ...draft, entry: action.entry, kind };
+      const wanted = sourceKindFor(action.entry);
+      if (wanted === null || wanted === draft.source.kind) {
+        return { ...draft, entry: action.entry, kind };
+      }
+      return {
+        ...draft,
+        entry: action.entry,
+        kind,
+        source:
+          draft.stashed?.kind === wanted ? draft.stashed : blankSource(wanted),
+        stashed: draft.source,
+      };
     }
     case 'field':
-      return { ...draft, [action.field]: action.value };
+      return {
+        ...draft,
+        [action.field]: action.value,
+        // Typing the App name is the operator answering the question, so
+        // nothing derives it again afterwards.
+        ...(action.field === 'appName' ? { appNameByOperator: true } : {}),
+      };
     case 'kind':
       return { ...draft, kind: action.kind };
     case 'target':
@@ -317,9 +406,13 @@ export function draftReducer(draft: Draft, action: DraftAction): Draft {
           kind: 'repo',
           repo: action.fullName,
           url: action.url,
-          subpath: draft.source.kind === 'repo' ? draft.source.subpath : '.',
+          // Back to the root: the directory the draft named is a statement
+          // about the repository that was selected before this one, and
+          // carrying it over would name a path in a tree nobody has read.
+          subpath: '.',
+          ...(action.connect === true ? { connect: true as const } : {}),
         },
-        appName: name,
+        appName: draft.appNameByOperator ? draft.appName : name,
       };
     }
     case 'subpath':
@@ -373,6 +466,15 @@ export function blockersFor(
       title: 'The chosen Target is not a candidate for this Component.',
       remediation:
         'Pick a Target listed as a candidate, or clear the reason this one was excluded. Targets state their own reasons.',
+    });
+  }
+
+  if (draft.source.kind === 'repo' && draft.source.repo === '') {
+    blockers.push({
+      code: 'SOURCE_UNAVAILABLE',
+      title: 'No repository is chosen.',
+      remediation:
+        'Pick one under Source. Every repository the GitHub App installation grants is listed there, whether Spindrift has connected it or not.',
     });
   }
 

--- a/apps/spindrift/src/domain/detection/discover.ts
+++ b/apps/spindrift/src/domain/detection/discover.ts
@@ -81,10 +81,14 @@ function ignored(path: string): boolean {
 /**
  * Candidate directories, in the order a screen should list them.
  *
- * Workspace membership wins when the repository declares it: a Bun, npm, yarn
- * or pnpm workspace has already said where its packages are, and guessing past
- * a declaration would be inventing an answer somebody wrote down. Everything
- * else falls back to a bounded walk for a directory carrying a manifest.
+ * Two questions, both asked, and the answers merged. A Bun, npm, yarn or pnpm
+ * workspace has already said where its packages are, so a declared package goes
+ * first: somebody wrote it down, and a walk's guess does not outrank that. But a
+ * declaration is a statement about one ecosystem's packages and never about the
+ * repository — a Go service beside a JS workspace is declared by nothing, and
+ * treating the workspace list as the whole answer is how a monorepo offers four
+ * of its seventeen directories. So the bounded manifest walk runs as well, and
+ * what it finds beyond the declaration is appended.
  *
  * The root is **not** included. The caller has already asked about it — that is
  * the first question detection answers — and discovery is what happens when the
@@ -96,18 +100,19 @@ export async function discoverScopes(
   const declared = (await workspaceDirectories(tree)).filter(
     (directory) => !ignored(directory),
   );
-  if (declared.length > 0) return declared.slice(0, MAX_CANDIDATES);
 
-  const candidates = new Set<string>();
+  const walked = new Set<string>();
   for (const path of await tree.paths()) {
     if (ignored(path)) continue;
     const segments = path.split('/');
     const file = segments.pop();
     if (file === undefined || !CANDIDATE_MANIFESTS.has(file)) continue;
     if (segments.length === 0 || segments.length > MAX_DEPTH) continue;
-    candidates.add(segments.join('/'));
+    walked.add(segments.join('/'));
   }
-  return [...candidates].sort().slice(0, MAX_CANDIDATES);
+  for (const directory of declared) walked.delete(directory);
+
+  return [...declared, ...[...walked].sort()].slice(0, MAX_CANDIDATES);
 }
 
 /**

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -2249,6 +2249,7 @@ function NewAppScreen({
         type: 'success';
         targetOptions: readonly TargetOptionView[];
         repoOptions: readonly RepositoryOptionView[];
+        repoGrant: readonly RepositoryOptionView[];
         draft: import('../domain/creation-draft.ts').CreationDraftView;
       }
   >({ type: 'loading' });
@@ -2291,6 +2292,7 @@ function NewAppScreen({
         type: 'success',
         targetOptions: targetRes.value.options,
         repoOptions: repoRes.value.options,
+        repoGrant: repoRes.value.available,
         draft: draftRes.value,
       });
       if (draftId === null) {
@@ -2335,6 +2337,7 @@ function NewAppScreen({
       initial={state.draft}
       targets={state.targetOptions}
       repos={state.repoOptions}
+      available={state.repoGrant}
       onCreated={(app) => onNavigate(`/apps/${app.id}`)}
     />
   );

--- a/apps/spindrift/src/web/components/repo-picker.tsx
+++ b/apps/spindrift/src/web/components/repo-picker.tsx
@@ -1,16 +1,25 @@
 /**
  * The repository picker for the creation flow's Source step (§20, Task 24).
  *
- * Lists repositories currently granted to the authorized GitHub App
- * installation. A developer selects one, and the selection populates the
- * draft's source with the repo's fullName and a composed clone URL. The picker
- * does not create connections—a missing repository is authorized and connected
- * from the Repositories screen first.
+ * **It lists the grant, not the database.** `listRepositories` answers with two
+ * lists on one response — the durable connections Spindrift holds rows for, and
+ * the repositories GitHub currently grants this installation — and a picker
+ * showing only the first is a picker that reads "No repositories available" on
+ * a fresh install where the operator has already granted five. So the two are
+ * merged here, and every row says which of the three it is, because they are
+ * three different things to press: one already has an App deploying from it,
+ * one is connected and has none, and one is offered by GitHub and connects when
+ * the App is created.
+ *
+ * Selecting writes nothing either way. Reading a repository is
+ * `inspectRepository`, which writes nothing at all; Deploy is the committing
+ * act, and it is there that a grant-only repository gets its row and its
+ * configuration pull request.
  *
  * The filter is a client-side substring match against fullName. It is fast
  * enough for the single-operator scale v1 targets, and the picker never
- * fetches — the list arrives as a prop from the same API call that populated
- * the creation flow.
+ * fetches — the lists arrive as props from the same API call that populated the
+ * creation flow.
  */
 import { GitBranch, Search } from 'lucide-react';
 import { useState } from 'react';
@@ -18,15 +27,74 @@ import type { RepositoryOptionView } from '../model.ts';
 import { Badge } from '../ui/badge.tsx';
 import { cn } from '../ui/utils.ts';
 
+/** What one row is, in the operator's terms. */
+export type RepositoryChoiceState =
+  /** An App already deploys from it. */
+  | 'deploys'
+  /** Spindrift holds a row for it and nothing deploys from it yet. */
+  | 'connected'
+  /** GitHub grants it and Spindrift holds no row: Deploy connects it. */
+  | 'grant-only';
+
+/** One repository, as a row an operator can read the state of. */
+export interface RepositoryChoice {
+  readonly fullName: string;
+  readonly defaultBranch: string;
+  readonly state: RepositoryChoiceState;
+}
+
+const STATE_BADGE = {
+  deploys: { tone: 'success', label: 'already deploys' },
+  connected: { tone: 'accent', label: 'connected' },
+  'grant-only': { tone: 'idle', label: 'connects on Deploy' },
+} as const satisfies Record<
+  RepositoryChoiceState,
+  { tone: 'success' | 'accent' | 'idle'; label: string }
+>;
+
+/**
+ * The grant and the connections, as one list.
+ *
+ * The two `connected` booleans on the response mean different things — on a
+ * connection it means an App deploys from it, on a grant entry it means a row
+ * exists — so neither is read as a state here. The state is derived from which
+ * list a repository is in and what its own list says about it, which is the
+ * only reading that cannot be wrong about the other list.
+ */
+export function repositoryChoices(
+  connections: readonly RepositoryOptionView[],
+  grant: readonly RepositoryOptionView[],
+): readonly RepositoryChoice[] {
+  const rows = new Map<string, RepositoryChoice>();
+  for (const repo of connections) {
+    rows.set(repo.fullName, {
+      fullName: repo.fullName,
+      defaultBranch: repo.defaultBranch,
+      state: repo.connected ? 'deploys' : 'connected',
+    });
+  }
+  for (const repo of grant) {
+    if (rows.has(repo.fullName)) continue;
+    rows.set(repo.fullName, {
+      fullName: repo.fullName,
+      defaultBranch: repo.defaultBranch,
+      state: 'grant-only',
+    });
+  }
+  return [...rows.values()].sort((left, right) =>
+    left.fullName.localeCompare(right.fullName),
+  );
+}
+
 export function RepoPicker({
   repos,
   selected,
   onSelect,
 }: {
-  repos: readonly RepositoryOptionView[];
+  repos: readonly RepositoryChoice[];
   /** The fullName of the currently selected repo, or `null`. */
   selected: string | null;
-  onSelect: (fullName: string, url: string) => void;
+  onSelect: (repo: RepositoryChoice, url: string) => void;
 }) {
   const [filter, setFilter] = useState('');
   const normalised = filter.toLowerCase();
@@ -60,20 +128,18 @@ export function RepoPicker({
           <p className="px-2 py-4 text-center text-sm text-muted-foreground">
             {filter
               ? 'No repositories match that filter.'
-              : 'No repositories available.'}
+              : 'GitHub grants this installation no repositories. Authorize GitHub, or add repositories to the App installation, from Settings → Connections.'}
           </p>
         ) : (
           filtered.map((repo) => {
             const isSelected = selected === repo.fullName;
+            const badge = STATE_BADGE[repo.state];
             return (
               <button
-                key={repo.repositoryId}
+                key={repo.fullName}
                 type="button"
                 onClick={() =>
-                  onSelect(
-                    repo.fullName,
-                    `https://github.com/${repo.fullName}.git`,
-                  )
+                  onSelect(repo, `https://github.com/${repo.fullName}.git`)
                 }
                 className={cn(
                   'flex items-center gap-2.5 rounded-md px-3 py-2 text-left transition-colors',
@@ -92,11 +158,9 @@ export function RepoPicker({
                 <Badge tone="idle" className="shrink-0">
                   {repo.defaultBranch}
                 </Badge>
-                {repo.connected ? (
-                  <Badge tone="success" className="shrink-0">
-                    connected
-                  </Badge>
-                ) : null}
+                <Badge tone={badge.tone} className="shrink-0">
+                  {badge.label}
+                </Badge>
               </button>
             );
           })
@@ -104,7 +168,9 @@ export function RepoPicker({
       </div>
 
       <p className="text-xs text-muted-foreground">
-        Missing a repository? Authorize or connect it from Repositories first.
+        Selecting reads the repository and writes nothing. A repository GitHub
+        grants gets its row and its configuration pull request when the App is
+        created, and never before.
       </p>
     </div>
   );

--- a/apps/spindrift/src/web/views/apps/new/detect.ts
+++ b/apps/spindrift/src/web/views/apps/new/detect.ts
@@ -1,0 +1,138 @@
+/**
+ * What one read of a repository asks, and what the draft may take from it.
+ *
+ * Separate from the screen because the interesting part is a decision rather
+ * than a rendering: which of the directories that came back — if any — the
+ * draft is allowed to adopt. Two mistakes live here whenever this is a few
+ * lines inside an effect, and both are silent:
+ *
+ * - A read nobody asked for **re-deciding a draft somebody already answered**.
+ *   Drafts are durable rows reachable by URL, so the read that fills in a fresh
+ *   draft runs again on every reopen; applying its proposal the second time
+ *   reverts the kind, the Component name and the directory the operator
+ *   corrected, and the save that follows makes it permanent.
+ * - A read **about one directory answering with another**. A settled root
+ *   directory asks about the path it now names; falling back to some other
+ *   candidate moves the path out from under the operator, and leaving the old
+ *   sentence standing describes a directory nobody named.
+ */
+import type { Draft, DraftAction } from '../../../../domain/creation-draft.ts';
+import type { InputOf, OutputOf } from '../../../client.ts';
+
+/** One directory `inspectRepository` had something to say about. */
+export type InspectedScope = OutputOf<'inspectRepository'>['scopes'][number];
+export type DetectedScope = Extract<InspectedScope, { outcome: 'detected' }>;
+
+/**
+ * The read to issue: the whole repository, or the one directory named.
+ *
+ * §5's "named, never searched" is a property of the request, not of the
+ * rendering — a subpath edit that re-read the whole tree would answer about
+ * directories the operator did not ask about and leave the named one to be
+ * found among them.
+ */
+export function inspection(
+  fullName: string,
+  scope?: string,
+): InputOf<'inspectRepository'> {
+  return scope === undefined ? { fullName } : { fullName, scopes: [scope] };
+}
+
+/** A fresh answer about one directory, in place, with the rest left alone. */
+export function mergeScopes(
+  current: readonly InspectedScope[],
+  found: readonly InspectedScope[],
+): readonly InspectedScope[] {
+  const replaced = new Map(found.map((scope) => [scope.scope, scope] as const));
+  const merged = current.map((scope) => replaced.get(scope.scope) ?? scope);
+  const seen = new Set(current.map((scope) => scope.scope));
+  return [...merged, ...found.filter((scope) => !seen.has(scope.scope))];
+}
+
+/**
+ * The one candidate, or nothing.
+ *
+ * §5's discovery is "a list for a human to choose from", and one entry is the
+ * case where choosing is not a decision anybody makes differently. Two is.
+ */
+function soleDetected(scopes: readonly InspectedScope[]): DetectedScope | null {
+  const detected = scopes.filter((scope) => scope.outcome === 'detected');
+  return detected.length === 1 ? detected[0]! : null;
+}
+
+/** What the screen does with what came back. */
+export type ReadOutcome =
+  /** Detection proposed something the draft can take. */
+  | { readonly act: 'detect'; readonly action: DraftAction }
+  /** The list is the answer — the chooser below states it better than a sentence. */
+  | { readonly act: 'offer' }
+  /** Nothing here is deployable, said about the directory that was asked about. */
+  | { readonly act: 'refuse'; readonly message: string };
+
+function detected(scope: DetectedScope): ReadOutcome {
+  return {
+    act: 'detect',
+    action: {
+      type: 'detect',
+      scope: scope.scope,
+      kind: scope.kind,
+      reason: scope.reason,
+      unavailable: scope.unavailable,
+    },
+  };
+}
+
+/**
+ * Whether anything on this draft is already an answer about what to deploy.
+ *
+ * Both halves are durable, which is the point: session state resets on the
+ * reopen this guard exists for.
+ */
+function answered(draft: Draft): boolean {
+  return draft.scopeByOperator === true || draft.detection.scope !== undefined;
+}
+
+export function outcomeOf(
+  draft: Draft,
+  read: {
+    readonly fullName: string;
+    /** The directory this read asked about, or undefined for the repository. */
+    readonly scope: string | undefined;
+    /** What came back from this read. */
+    readonly found: readonly InspectedScope[];
+    /** Everything known about the repository once this read is folded in. */
+    readonly merged: readonly InspectedScope[];
+  },
+): ReadOutcome {
+  if (read.scope !== undefined) {
+    const named = read.found.find((scope) => scope.scope === read.scope);
+    if (named?.outcome === 'detected') return detected(named);
+    return {
+      act: 'refuse',
+      message:
+        named?.outcome === 'unsupported'
+          ? `Spindrift does not know how to build ${read.scope} in ${read.fullName}: ${named.detail} Name another directory, or pick the kind yourself.`
+          : `Spindrift read nothing about ${read.scope} in ${read.fullName}. Name another directory, or pick the kind yourself.`,
+    };
+  }
+
+  // A whole-repository read fills in a draft nobody has answered, and only
+  // that. Reopening a draft is not a correction of it.
+  if (answered(draft)) return { act: 'offer' };
+
+  const named = read.found.find(
+    (scope) => scope.scope === draft.source.subpath,
+  );
+  if (named?.outcome === 'detected') return detected(named);
+  const sole = soleDetected(read.merged);
+  if (sole !== null) return detected(sole);
+  if (read.merged.some((scope) => scope.outcome === 'detected'))
+    return { act: 'offer' };
+  return {
+    act: 'refuse',
+    message:
+      named?.outcome === 'unsupported'
+        ? `Spindrift does not know how to build ${named.scope} in ${read.fullName}: ${named.detail} Name another directory, or pick the kind yourself.`
+        : `Spindrift found nothing it knows how to build in ${read.fullName}. Every directory it read is listed below with what it found instead — name one yourself and pick the kind, or add a spindrift.yaml.`,
+  };
+}

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -24,17 +24,23 @@
  * found.
  */
 import { AlertTriangle, Loader2, Rocket } from 'lucide-react';
-import { type Dispatch, useRef, useState } from 'react';
+import { type Dispatch, useEffect, useRef, useState } from 'react';
 import type {
+  Blocker,
   CreationDraftView,
   DraftAction,
 } from '../../../../domain/creation-draft.ts';
 import {
   type ClientResult,
   command,
+  type OutputOf,
   type TransportFailure,
 } from '../../../client.ts';
-import { RepoPicker } from '../../../components/repo-picker.tsx';
+import {
+  RepoPicker,
+  type RepositoryChoice,
+  repositoryChoices,
+} from '../../../components/repo-picker.tsx';
 import type { RepositoryOptionView, TargetOptionView } from '../../../model.ts';
 import { reportSessionExpired } from '../../../session-events.ts';
 import { Badge } from '../../../ui/badge.tsx';
@@ -56,15 +62,74 @@ import {
   VesselRow,
 } from './summary.tsx';
 
+/** One directory `inspectRepository` had something to say about. */
+type InspectedScope = OutputOf<'inspectRepository'>['scopes'][number];
+type DetectedScope = Extract<InspectedScope, { outcome: 'detected' }>;
+
+/** A fresh answer about one directory, in place, with the rest left alone. */
+function mergeScopes(
+  current: readonly InspectedScope[],
+  found: readonly InspectedScope[],
+): readonly InspectedScope[] {
+  const replaced = new Map(found.map((scope) => [scope.scope, scope] as const));
+  const merged = current.map((scope) => replaced.get(scope.scope) ?? scope);
+  const seen = new Set(current.map((scope) => scope.scope));
+  return [...merged, ...found.filter((scope) => !seen.has(scope.scope))];
+}
+
+/**
+ * The one candidate, or nothing.
+ *
+ * §5's discovery is "a list for a human to choose from", and one entry is the
+ * case where choosing is not a decision anybody makes differently. Two is.
+ */
+function soleDetected(scopes: readonly InspectedScope[]): DetectedScope | null {
+  const detected = scopes.filter((scope) => scope.outcome === 'detected');
+  return detected.length === 1 ? detected[0]! : null;
+}
+
+/**
+ * What stands between a repository with several Apps in it and a Deploy.
+ *
+ * The draft names a directory from the moment it exists — the root — and
+ * deploying that because nobody corrected it is the silent first-hit this
+ * screen refuses to make. So while detection is offering more than one
+ * candidate and the draft names none of them, there is a prerequisite to clear,
+ * stated the way every other unmet prerequisite on this screen is.
+ *
+ * A directory the operator typed is an answer, however detection reads it, and
+ * a repository detection could make nothing of leaves the assertion path open:
+ * §5's ladder proposes, and story 32 keeps the escape hatch.
+ */
+function unchosenScope(
+  draft: Draft,
+  detected: readonly InspectedScope[],
+  named: boolean,
+): readonly Blocker[] {
+  if (draft.source.kind !== 'repo' || named || detected.length < 2) return [];
+  if (detected.some((scope) => scope.scope === draft.source.subpath)) return [];
+  return [
+    {
+      code: 'SOURCE_UNAVAILABLE',
+      title: `Nothing is chosen to deploy from ${draft.source.repo}.`,
+      remediation: `Detection found ${detected.length} directories it knows how to build. Pick one under Source, or name another yourself.`,
+    },
+  ];
+}
+
 export function NewApp({
   initial,
   targets: initialTargets,
   repos,
+  available,
   onCreated,
 }: {
   initial: CreationDraftView;
   targets: readonly TargetOptionView[];
+  /** Repositories Spindrift holds a row for. */
   repos: readonly RepositoryOptionView[];
+  /** Repositories GitHub currently grants this installation. */
+  available: readonly RepositoryOptionView[];
   onCreated?: (app: { readonly id: string; readonly name: string }) => void;
 }) {
   const [draft, setDraft] = useState(initial.draft);
@@ -79,6 +144,16 @@ export function NewApp({
   const [saving, setSaving] = useState(false);
   const [detecting, setDetecting] = useState(false);
   const [detectionError, setDetectionError] = useState<string | null>(null);
+  // Everything the last read said about this repository, unsummarized. The
+  // wizard's job is to offer it, so it is kept as it arrived: dropping the
+  // scopes detection could not make sense of would leave "why not here"
+  // unanswerable, and dropping the ones it could would leave the screen picking.
+  const [scopes, setScopes] = useState<readonly InspectedScope[] | null>(null);
+  const scopesRef = useRef<readonly InspectedScope[]>([]);
+  // Whether the operator typed the directory rather than choosing one. Their
+  // name stands even where detection has nothing to say about it — §5's ladder
+  // is a proposal, and story 32 keeps the assertion available.
+  const [subpathNamed, setSubpathNamed] = useState(false);
   const draftRef = useRef(initial.draft);
   const revisionRef = useRef(initial.revision);
   const saves = useRef(Promise.resolve());
@@ -88,7 +163,11 @@ export function NewApp({
   const candidateIds = targets
     .filter((target) => target.candidate)
     .map((target) => target.targetId);
-  const localBlockers = blockersFor(draft, candidateIds);
+  const detected = (scopes ?? []).filter(
+    (scope) => scope.outcome === 'detected',
+  );
+  const unchosen = unchosenScope(draft, detected, subpathNamed);
+  const localBlockers = [...blockersFor(draft, candidateIds), ...unchosen];
   const blockers = [
     ...localBlockers,
     ...serverBlockers.filter(
@@ -96,6 +175,7 @@ export function NewApp({
     ),
   ];
   const target = targets.find((option) => option.targetId === draft.targetId);
+  const choices = repositoryChoices(repos, available);
 
   const dispatch: Dispatch<DraftAction> = (action) => {
     const previous = draftRef.current;
@@ -155,39 +235,68 @@ export function NewApp({
   };
 
   /**
-   * Choosing a repository is choosing everything the repository implies.
+   * Read a repository and offer what is in it.
    *
    * One read of the real default branch, through the same ladder that writes
-   * `spindrift.yaml`. Failing to detect is not failing to select — the repo is
-   * still the source, the kind is still correctable, and the sentence says
-   * which of the two happened.
+   * `spindrift.yaml`. Every directory it answered about is kept and shown; a
+   * proposal is applied **only** when detection found exactly one thing to
+   * propose, or when the draft already names one of the directories it found.
+   * Two candidates is a choice, and a screen that picks the alphabetically
+   * first of them has searched and then decided, which is the worst of both.
+   *
+   * `scope` names one directory, which is what an edited subpath asks about —
+   * §5's "named, never searched". Its answer replaces that directory's row and
+   * leaves the rest of the list alone, so correcting a path does not throw away
+   * the candidates beside it.
+   *
+   * Failing to read is not failing to select: the repo is still the source, the
+   * kind is still correctable, and the sentence says which of the two happened.
    */
-  const selectRepo = async (fullName: string, url: string) => {
-    dispatch({ type: 'repo', fullName, url });
+  const inspect = async (fullName: string, scope?: string) => {
     setDetecting(true);
     setDetectionError(null);
     try {
-      const result = await command('inspectRepository', { fullName });
+      const result = await command(
+        'inspectRepository',
+        scope === undefined ? { fullName } : { fullName, scopes: [scope] },
+      );
       if (!result.ok) {
         setDetectionError(result.failure.message);
         return;
       }
-      const found = result.value.scopes.find(
-        (scope) => scope.outcome === 'detected',
+      const found = result.value.scopes;
+      const merged =
+        scope === undefined ? found : mergeScopes(scopesRef.current, found);
+      scopesRef.current = merged;
+      setScopes(merged);
+
+      // The directory the draft names wins when detection has an answer for
+      // it, so a subpath edit is answered about the directory it named. A sole
+      // candidate is the only other thing safe to apply: one is a proposal,
+      // two is a question.
+      const named = found.find(
+        (candidate) => candidate.scope === draftRef.current.source.subpath,
       );
-      if (found === undefined || found.outcome !== 'detected') {
-        setDetectionError(
-          `Spindrift found nothing it knows how to build in ${fullName}. Pick the kind yourself, or add a spindrift.yaml.`,
-        );
+      const proposal =
+        named?.outcome === 'detected' ? named : soleDetected(merged);
+      if (proposal !== null) {
+        dispatch({
+          type: 'detect',
+          scope: proposal.scope,
+          kind: proposal.kind,
+          reason: proposal.reason,
+          unavailable: proposal.unavailable,
+        });
         return;
       }
-      dispatch({
-        type: 'detect',
-        scope: found.scope,
-        kind: found.kind,
-        reason: found.reason,
-        unavailable: found.unavailable,
-      });
+      // More than one candidate: the chooser below is the answer, and saying
+      // anything else here would be an error message about a working repo.
+      if (merged.some((candidate) => candidate.outcome === 'detected')) return;
+      setDetectionError(
+        named?.outcome === 'unsupported'
+          ? `Spindrift does not know how to build ${named.scope} in ${fullName}: ${named.detail} Name another directory, or pick the kind yourself.`
+          : `Spindrift found nothing it knows how to build in ${fullName}. Every directory it read is listed below with what it found instead — name one yourself and pick the kind, or add a spindrift.yaml.`,
+      );
     } catch (cause) {
       setDetectionError(
         cause instanceof Error ? cause.message : 'the repository was not read',
@@ -196,6 +305,53 @@ export function NewApp({
       setDetecting(false);
     }
   };
+
+  /** Selecting a repository reads it. Nothing is written until Deploy. */
+  const selectRepo = (repo: RepositoryChoice, url: string) => {
+    dispatch({
+      type: 'repo',
+      fullName: repo.fullName,
+      url,
+      connect: repo.state === 'grant-only',
+    });
+    scopesRef.current = [];
+    setScopes(null);
+    setSubpathNamed(false);
+    void inspect(repo.fullName);
+  };
+
+  const chooseScope = (scope: InspectedScope) => {
+    if (scope.outcome !== 'detected') return;
+    setSubpathNamed(false);
+    dispatch({
+      type: 'detect',
+      scope: scope.scope,
+      kind: scope.kind,
+      reason: scope.reason,
+      unavailable: scope.unavailable,
+    });
+  };
+
+  /** A settled subpath edit asks about the directory it now names. */
+  const settleSubpath = () => {
+    const source = draftRef.current.source;
+    if (source.kind !== 'repo' || source.repo === '' || !source.subpath) return;
+    void inspect(source.repo, source.subpath);
+  };
+
+  // Detection runs for the repository the draft opens on, before anybody
+  // presses anything. A draft claims a kind from the moment it exists, and a
+  // screen that renders that claim without ever asking is the screen this
+  // whole flow was supposed to replace. Reading writes nothing, so the only
+  // thing it costs a draft nobody finishes is one request.
+  const opened = useRef(false);
+  useEffect(() => {
+    if (opened.current) return;
+    opened.current = true;
+    const source = initial.draft.source;
+    if (source.kind !== 'repo' || source.repo === '') return;
+    void inspect(source.repo);
+  }, []);
 
   /** The terminal act: revalidate and create under one database lock. */
   async function start() {
@@ -232,9 +388,11 @@ export function NewApp({
       <header>
         <Eyebrow>New App</Eyebrow>
         <h1 className="mt-1 text-2xl font-semibold tracking-tight">
-          {draft.source.kind === 'repo'
-            ? `Deploy from ${draft.source.repo}`
-            : 'Deploy an upload'}
+          {draft.source.kind !== 'repo'
+            ? 'Deploy an upload'
+            : draft.source.repo === ''
+              ? 'Deploy from a repository'
+              : `Deploy from ${draft.source.repo}`}
         </h1>
         <p className="mt-1 max-w-prose text-sm text-muted-foreground">
           Everything below already has an answer. Read down, correct what is
@@ -246,15 +404,20 @@ export function NewApp({
         <SourceRow
           draft={draft}
           dispatch={dispatch}
-          repos={repos}
+          repos={choices}
+          scopes={scopes}
           detecting={detecting}
           detectionError={detectionError}
+          unchosen={unchosen.length > 0}
           onSelectRepo={selectRepo}
+          onChooseScope={chooseScope}
+          onSettleSubpath={settleSubpath}
+          onNameSubpath={() => setSubpathNamed(true)}
         />
 
         <Row
           label="Component"
-          unsettled={detectionError !== null}
+          unsettled={detectionError !== null || unchosen.length > 0}
           value={`${draft.componentName} · ${draft.kind}`}
           why={draft.detection.reason}
           tone={
@@ -567,16 +730,28 @@ function SourceRow({
   draft,
   dispatch,
   repos,
+  scopes,
   detecting,
   detectionError,
+  unchosen,
   onSelectRepo,
+  onChooseScope,
+  onSettleSubpath,
+  onNameSubpath,
 }: {
   draft: Draft;
   dispatch: Dispatch<DraftAction>;
-  repos: readonly RepositoryOptionView[];
+  repos: readonly RepositoryChoice[];
+  /** What the last read said, or `null` before anything has been read. */
+  scopes: readonly InspectedScope[] | null;
   detecting: boolean;
   detectionError: string | null;
-  onSelectRepo: (fullName: string, url: string) => void;
+  /** Detection is offering candidates and the draft names none of them. */
+  unchosen: boolean;
+  onSelectRepo: (repo: RepositoryChoice, url: string) => void;
+  onChooseScope: (scope: InspectedScope) => void;
+  onSettleSubpath: () => void;
+  onNameSubpath: () => void;
 }) {
   const [uploading, setUploading] = useState(false);
   const [uploadPercent, setUploadPercent] = useState<number | null>(null);
@@ -621,11 +796,21 @@ function SourceRow({
   return (
     <Row
       label="Source"
-      unsettled={draft.source.kind === 'archive' && !draft.source.location}
-      value={
+      // Opens itself on anything unresolved, because §3's grammar only works
+      // when the alternatives are visible: a sentence about a directory
+      // Spindrift could not build is unreadable while the list of directories
+      // it did read is behind a disclosure.
+      unsettled={
         draft.source.kind === 'repo'
-          ? `${draft.source.repo} · ${draft.source.subpath}`
-          : draft.source.filename
+          ? draft.source.repo === '' || unchosen || detectionError !== null
+          : !draft.source.location
+      }
+      value={
+        draft.source.kind !== 'repo'
+          ? draft.source.filename
+          : draft.source.repo === ''
+            ? 'no repository chosen'
+            : `${draft.source.repo} · ${draft.source.subpath}`
       }
       tone={
         detecting ? (
@@ -659,17 +844,30 @@ function SourceRow({
           <div className="flex flex-col gap-3">
             <RepoPicker
               repos={repos}
-              selected={draft.source.repo}
+              selected={draft.source.repo === '' ? null : draft.source.repo}
               onSelect={onSelectRepo}
+            />
+            <ScopeChooser
+              subpath={draft.source.subpath}
+              scopes={scopes}
+              onChoose={onChooseScope}
             />
             <Field
               name="subpath"
               label="Root directory"
               value={draft.source.subpath}
-              onChange={(event) =>
-                dispatch({ type: 'subpath', subpath: event.target.value })
-              }
-              hint="Named, never searched — Spindrift does not roam the tree. Detection filled this in."
+              onChange={(event) => {
+                onNameSubpath();
+                dispatch({ type: 'subpath', subpath: event.target.value });
+              }}
+              // Settled rather than per-keystroke: the reason on screen is a
+              // statement about one directory, and re-reading `apps/w` on the
+              // way to `apps/web` would describe a directory nobody named.
+              onBlur={onSettleSubpath}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') onSettleSubpath();
+              }}
+              hint="Named, never searched — Spindrift does not roam the tree. Leave the field to read the directory it now names."
             />
           </div>
         ) : (
@@ -715,6 +913,55 @@ function SourceRow({
         )}
       </div>
     </Row>
+  );
+}
+
+/**
+ * Every directory the repository was read for, as a list to choose from.
+ *
+ * §5 says discovery "proposes a list of candidate directories for a human to
+ * choose from", and this is that list rather than a summary of it. A directory
+ * detection knows how to build is selectable and wears the kind and the
+ * sentence behind it; one it does not is here too, disabled, wearing what it
+ * found instead — §3's grammar, which only works if the alternatives are
+ * visible. An empty list means nothing has been read yet, which is a different
+ * thing from a repository with nothing in it.
+ */
+function ScopeChooser({
+  subpath,
+  scopes,
+  onChoose,
+}: {
+  subpath: string;
+  scopes: readonly InspectedScope[] | null;
+  onChoose: (scope: InspectedScope) => void;
+}) {
+  if (scopes === null || scopes.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <Eyebrow>Directories Spindrift read</Eyebrow>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {scopes.map((scope) => (
+          <Choice
+            key={scope.scope}
+            selected={scope.outcome === 'detected' && scope.scope === subpath}
+            disabled={scope.outcome !== 'detected'}
+            title={scope.scope}
+            note={
+              scope.outcome === 'detected'
+                ? `${scope.kind} — ${scope.reason}`
+                : scope.detail
+            }
+            onClick={() => onChoose(scope)}
+          />
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        Choosing one detects that directory and names the Component after it.
+        Nothing is picked for you when there is more than one.
+      </p>
+    </div>
   );
 }
 

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -33,7 +33,6 @@ import type {
 import {
   type ClientResult,
   command,
-  type OutputOf,
   type TransportFailure,
 } from '../../../client.ts';
 import {
@@ -47,6 +46,12 @@ import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
 import { Card, Eyebrow } from '../../../ui/card.tsx';
 import { Field } from '../../../ui/field.tsx';
+import {
+  type InspectedScope,
+  inspection,
+  mergeScopes,
+  outcomeOf,
+} from './detect.ts';
 import { blockersFor, type Draft, draftReducer, ENTRIES } from './draft.ts';
 import {
   Advanced,
@@ -61,32 +66,6 @@ import {
   TargetHealth,
   VesselRow,
 } from './summary.tsx';
-
-/** One directory `inspectRepository` had something to say about. */
-type InspectedScope = OutputOf<'inspectRepository'>['scopes'][number];
-type DetectedScope = Extract<InspectedScope, { outcome: 'detected' }>;
-
-/** A fresh answer about one directory, in place, with the rest left alone. */
-function mergeScopes(
-  current: readonly InspectedScope[],
-  found: readonly InspectedScope[],
-): readonly InspectedScope[] {
-  const replaced = new Map(found.map((scope) => [scope.scope, scope] as const));
-  const merged = current.map((scope) => replaced.get(scope.scope) ?? scope);
-  const seen = new Set(current.map((scope) => scope.scope));
-  return [...merged, ...found.filter((scope) => !seen.has(scope.scope))];
-}
-
-/**
- * The one candidate, or nothing.
- *
- * §5's discovery is "a list for a human to choose from", and one entry is the
- * case where choosing is not a decision anybody makes differently. Two is.
- */
-function soleDetected(scopes: readonly InspectedScope[]): DetectedScope | null {
-  const detected = scopes.filter((scope) => scope.outcome === 'detected');
-  return detected.length === 1 ? detected[0]! : null;
-}
 
 /**
  * What stands between a repository with several Apps in it and a Deploy.
@@ -150,10 +129,6 @@ export function NewApp({
   // unanswerable, and dropping the ones it could would leave the screen picking.
   const [scopes, setScopes] = useState<readonly InspectedScope[] | null>(null);
   const scopesRef = useRef<readonly InspectedScope[]>([]);
-  // Whether the operator typed the directory rather than choosing one. Their
-  // name stands even where detection has nothing to say about it — §5's ladder
-  // is a proposal, and story 32 keeps the assertion available.
-  const [subpathNamed, setSubpathNamed] = useState(false);
   const draftRef = useRef(initial.draft);
   const revisionRef = useRef(initial.revision);
   const saves = useRef(Promise.resolve());
@@ -166,7 +141,19 @@ export function NewApp({
   const detected = (scopes ?? []).filter(
     (scope) => scope.outcome === 'detected',
   );
-  const unchosen = unchosenScope(draft, detected, subpathNamed);
+  const unchosen = unchosenScope(
+    draft,
+    detected,
+    draft.scopeByOperator === true,
+  );
+  // The sentence under Component is a statement about one directory, and the
+  // draft can name another one — an edit that has not settled yet, or a
+  // directory detection could make nothing of. Saying which is what keeps the
+  // reason from reading as though it were about the path on screen.
+  const readElsewhere =
+    draft.source.kind === 'repo' &&
+    draft.detection.scope !== undefined &&
+    draft.detection.scope !== draft.source.subpath;
   const localBlockers = [...blockersFor(draft, candidateIds), ...unchosen];
   const blockers = [
     ...localBlockers,
@@ -238,11 +225,8 @@ export function NewApp({
    * Read a repository and offer what is in it.
    *
    * One read of the real default branch, through the same ladder that writes
-   * `spindrift.yaml`. Every directory it answered about is kept and shown; a
-   * proposal is applied **only** when detection found exactly one thing to
-   * propose, or when the draft already names one of the directories it found.
-   * Two candidates is a choice, and a screen that picks the alphabetically
-   * first of them has searched and then decided, which is the worst of both.
+   * `spindrift.yaml`. Every directory it answered about is kept and shown, and
+   * `outcomeOf` decides what — if anything — the draft may take from it.
    *
    * `scope` names one directory, which is what an edited subpath asks about —
    * §5's "named, never searched". Its answer replaces that directory's row and
@@ -258,7 +242,7 @@ export function NewApp({
     try {
       const result = await command(
         'inspectRepository',
-        scope === undefined ? { fullName } : { fullName, scopes: [scope] },
+        inspection(fullName, scope),
       );
       if (!result.ok) {
         setDetectionError(result.failure.message);
@@ -270,33 +254,14 @@ export function NewApp({
       scopesRef.current = merged;
       setScopes(merged);
 
-      // The directory the draft names wins when detection has an answer for
-      // it, so a subpath edit is answered about the directory it named. A sole
-      // candidate is the only other thing safe to apply: one is a proposal,
-      // two is a question.
-      const named = found.find(
-        (candidate) => candidate.scope === draftRef.current.source.subpath,
-      );
-      const proposal =
-        named?.outcome === 'detected' ? named : soleDetected(merged);
-      if (proposal !== null) {
-        dispatch({
-          type: 'detect',
-          scope: proposal.scope,
-          kind: proposal.kind,
-          reason: proposal.reason,
-          unavailable: proposal.unavailable,
-        });
-        return;
-      }
-      // More than one candidate: the chooser below is the answer, and saying
-      // anything else here would be an error message about a working repo.
-      if (merged.some((candidate) => candidate.outcome === 'detected')) return;
-      setDetectionError(
-        named?.outcome === 'unsupported'
-          ? `Spindrift does not know how to build ${named.scope} in ${fullName}: ${named.detail} Name another directory, or pick the kind yourself.`
-          : `Spindrift found nothing it knows how to build in ${fullName}. Every directory it read is listed below with what it found instead — name one yourself and pick the kind, or add a spindrift.yaml.`,
-      );
+      const outcome = outcomeOf(draftRef.current, {
+        fullName,
+        scope,
+        found,
+        merged,
+      });
+      if (outcome.act === 'detect') dispatch(outcome.action);
+      if (outcome.act === 'refuse') setDetectionError(outcome.message);
     } catch (cause) {
       setDetectionError(
         cause instanceof Error ? cause.message : 'the repository was not read',
@@ -316,13 +281,11 @@ export function NewApp({
     });
     scopesRef.current = [];
     setScopes(null);
-    setSubpathNamed(false);
     void inspect(repo.fullName);
   };
 
   const chooseScope = (scope: InspectedScope) => {
     if (scope.outcome !== 'detected') return;
-    setSubpathNamed(false);
     dispatch({
       type: 'detect',
       scope: scope.scope,
@@ -343,7 +306,8 @@ export function NewApp({
   // presses anything. A draft claims a kind from the moment it exists, and a
   // screen that renders that claim without ever asking is the screen this
   // whole flow was supposed to replace. Reading writes nothing, so the only
-  // thing it costs a draft nobody finishes is one request.
+  // thing it costs a draft nobody finishes is one request — and `outcomeOf`
+  // is what keeps a reopened draft reading rather than re-deciding.
   const opened = useRef(false);
   useEffect(() => {
     if (opened.current) return;
@@ -412,14 +376,19 @@ export function NewApp({
           onSelectRepo={selectRepo}
           onChooseScope={chooseScope}
           onSettleSubpath={settleSubpath}
-          onNameSubpath={() => setSubpathNamed(true)}
         />
 
         <Row
           label="Component"
-          unsettled={detectionError !== null || unchosen.length > 0}
+          unsettled={
+            detectionError !== null || unchosen.length > 0 || readElsewhere
+          }
           value={`${draft.componentName} · ${draft.kind}`}
-          why={draft.detection.reason}
+          why={
+            readElsewhere && draft.source.kind === 'repo'
+              ? `${draft.detection.reason} — read in ${draft.detection.scope}, and the root directory now names ${draft.source.subpath}.`
+              : draft.detection.reason
+          }
           tone={
             draft.kind === draft.detection.kind ? null : (
               <Badge tone="warning">corrected</Badge>
@@ -737,7 +706,6 @@ function SourceRow({
   onSelectRepo,
   onChooseScope,
   onSettleSubpath,
-  onNameSubpath,
 }: {
   draft: Draft;
   dispatch: Dispatch<DraftAction>;
@@ -751,7 +719,6 @@ function SourceRow({
   onSelectRepo: (repo: RepositoryChoice, url: string) => void;
   onChooseScope: (scope: InspectedScope) => void;
   onSettleSubpath: () => void;
-  onNameSubpath: () => void;
 }) {
   const [uploading, setUploading] = useState(false);
   const [uploadPercent, setUploadPercent] = useState<number | null>(null);
@@ -856,10 +823,9 @@ function SourceRow({
               name="subpath"
               label="Root directory"
               value={draft.source.subpath}
-              onChange={(event) => {
-                onNameSubpath();
-                dispatch({ type: 'subpath', subpath: event.target.value });
-              }}
+              onChange={(event) =>
+                dispatch({ type: 'subpath', subpath: event.target.value })
+              }
               // Settled rather than per-keystroke: the reason on screen is a
               // statement about one directory, and re-reading `apps/w` on the
               // way to `apps/web` would describe a directory nobody named.

--- a/apps/spindrift/test/commands/creation-draft-connect.test.ts
+++ b/apps/spindrift/test/commands/creation-draft-connect.test.ts
@@ -1,0 +1,232 @@
+/**
+ * Deploying from a repository Spindrift has not connected yet (§15, story 24).
+ *
+ * The creation flow lists every repository the GitHub App installation grants,
+ * not only the ones with rows, and selecting one is a **read**:
+ * `inspectRepository` writes nothing, so browsing five repositories leaves five
+ * of nothing behind. That is the promise the draft itself makes on screen —
+ * "Nothing has been created. This draft is kept." — and a wizard that opened a
+ * configuration pull request per repository somebody looked at would leave a
+ * trail of PRs for Apps that never existed.
+ *
+ * So the connect happens inside the one committing act. Pressing Deploy writes
+ * the `repositories` row and opens §15's one configuration pull request, and it
+ * does it through `connectRepository` rather than through a second way of
+ * connecting a repository — the alternative is two acts that can disagree about
+ * what connecting means.
+ *
+ * Both halves are asserted here, and the first one is the load-bearing one: an
+ * abandoned draft leaves no row and no pull request.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  completeCreationDraft,
+  saveCreationDraft,
+  startCreationDraft,
+} from '../../src/commands/creation-drafts/lifecycle.ts';
+import type {
+  AdapterRegistry,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import { apps, repositories, targets, users } from '../../src/db/schema.ts';
+import { GitHubApp } from '../../src/integrations/github/app.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { CAPABLE_DISCOVERY } from '../harness/fakes/deploy-adapter.ts';
+import { FakeGitHub } from '../harness/fakes/github-api.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const builder = new FakeBuildAdapter({ name: 'hosted' });
+const supplyChain = new SupplyChainHarness();
+
+/** A repository the operator has granted and Spindrift has never connected. */
+function grantedRepository() {
+  const fake = new FakeGitHub();
+  fake.commitFiles('main', {
+    'README.md': 'granted, unconnected',
+    'go.mod': 'module example.com/app\n',
+  });
+  return fake;
+}
+
+async function context(fake: FakeGitHub): Promise<CommandContext> {
+  const [principal] = await database()
+    .db.insert(users)
+    .values({ displayName: 'Operator' })
+    .returning();
+  const host = new GitHubApp({
+    baseUrl: fake.baseUrl,
+    authorization: () => 'Bearer test-user-token',
+    fetch: fake.fetch,
+  });
+  const adapters: AdapterRegistry = {
+    deploy: (adapter) => ({
+      adapter,
+      artifactTypes: ['image'],
+      apply: async function* () {
+        yield {
+          type: 'status',
+          at: new Date('2026-08-07T12:00:00.000Z'),
+          phase: 'APPLYING',
+        };
+        return { phase: 'FAILED', reason: 'INTERNAL' };
+      },
+      observe: async () => null,
+      destroy: async () => {},
+      inspect: async () => {
+        throw new Error('creation drafts do not inspect the far side');
+      },
+      tail: async () => ({
+        kind: 'stream',
+        entries: [],
+        cursor: null,
+        reach: 0,
+      }),
+      run: async () => ({ kind: 'none', because: 'nothing runs here' }),
+      executions: async () => ({ kind: 'none', because: 'nothing runs here' }),
+    }),
+    build: (name) => (name === builder.name ? builder : null),
+    store: () => null,
+    repository: () => host,
+    source: () => ({
+      async stageRepository(input) {
+        return {
+          digest: `sha256:${'b'.repeat(64)}`,
+          location: `https://bundles.example.test/${input.commit}.tar.gz`,
+          retention: 'ephemeral',
+        };
+      },
+    }),
+    supplyChain: () => supplyChain,
+  };
+  return {
+    principal: { id: principal!.id, displayName: principal!.displayName },
+    clock: { now: () => new Date('2026-08-07T12:00:00.000Z') },
+    db: database().db,
+    adapters,
+    manifest: await fixtureManifest(),
+  };
+}
+
+async function seedTarget() {
+  const vessel = await insertVessel(database().db, 'kubernetes');
+  const [target] = await database()
+    .db.insert(targets)
+    .values(
+      targetValues({
+        vesselId: vessel.id,
+        rank: 1,
+        reaches: ['none', 'private', 'public'],
+        discovery: CAPABLE_DISCOVERY,
+      }),
+    )
+    .returning();
+  return target!;
+}
+
+/** A draft that deploys from the granted repository, saved and not completed. */
+async function draftOn(fake: FakeGitHub, ctx: CommandContext) {
+  const target = await seedTarget();
+  const started = await startCreationDraft({}, ctx);
+  if (!started.ok) throw new Error(started.failure.message);
+  const saved = await saveCreationDraft(
+    {
+      id: started.value.id,
+      revision: started.value.revision,
+      draft: {
+        ...started.value.draft,
+        appName: 'granted',
+        source: {
+          kind: 'repo',
+          repo: fake.fullName,
+          url: `https://github.com/${fake.fullName}.git`,
+          subpath: '.',
+          connect: true,
+        },
+        targetId: target.id,
+      },
+    },
+    ctx,
+  );
+  if (!saved.ok) throw new Error(saved.failure.message);
+  return saved.value;
+}
+
+describe('a draft on a repository the grant offers', () => {
+  test('is not blocked by the row it does not have yet', async () => {
+    const fake = grantedRepository();
+    const ctx = await context(fake);
+
+    const draft = await draftOn(fake, ctx);
+
+    expect(draft.blockers).toEqual([]);
+    expect(draft.ready).toBe(true);
+  });
+
+  test('leaves no row and no pull request while it is abandoned', async () => {
+    const fake = grantedRepository();
+    const ctx = await context(fake);
+
+    await draftOn(fake, ctx);
+
+    expect(await database().db.select().from(repositories)).toEqual([]);
+    expect(fake.pulls).toEqual([]);
+  });
+
+  test('connects the repository and opens the one PR when the App is created', async () => {
+    const fake = grantedRepository();
+    const ctx = await context(fake);
+    const draft = await draftOn(fake, ctx);
+
+    const completed = await completeCreationDraft(
+      { id: draft.id, revision: draft.revision },
+      ctx,
+    );
+
+    expect(completed.ok).toBe(true);
+    if (!completed.ok || completed.value.app === null) {
+      throw new Error('the App was not created');
+    }
+    // §15's transaction, opened once, by the same command the Repositories
+    // screen presses.
+    expect(fake.pulls).toHaveLength(1);
+    const [row] = await database().db.select().from(repositories);
+    expect(row).toMatchObject({
+      fullName: fake.fullName,
+      access: 'active',
+      configPullRequest: 1,
+    });
+    // And the App is on that row rather than on a repository URL nothing
+    // resolves to.
+    const [app] = await database().db.select().from(apps);
+    expect(app?.repositoryId).toBe(row!.id);
+    expect(completed.value.app.buildStatus).toBe('PENDING');
+  });
+
+  test('a repository nothing can be built in refuses, and creates nothing', async () => {
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'just prose' });
+    const ctx = await context(fake);
+    const draft = await draftOn(fake, ctx);
+
+    const completed = await completeCreationDraft(
+      { id: draft.id, revision: draft.revision },
+      ctx,
+    );
+
+    expect(completed.ok).toBe(false);
+    if (completed.ok) return;
+    expect(completed.failure.message).toContain(
+      'nothing it knows how to build',
+    );
+    expect(await database().db.select().from(repositories)).toEqual([]);
+    expect(await database().db.select().from(apps)).toEqual([]);
+    expect(fake.pulls).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -334,11 +334,15 @@ describe('connecting a repository without being told what is in it', () => {
     // `apps/lib` is a library. It is passed over rather than connected, and
     // passing over seven of nine directories is the ordinary monorepo case —
     // refusing the whole connect over them would make discovery useless.
+    //
+    // `apps/api` is a Go service and the workspace declaration says nothing
+    // about it, which is exactly why discovery does not stop at that
+    // declaration: a repository is not one ecosystem's package list.
     expect(
       Object.keys(written)
         .filter((path) => path.endsWith(SPINDRIFT_FILE))
         .sort(),
-    ).toEqual([`apps/web/${SPINDRIFT_FILE}`]);
+    ).toEqual([`apps/api/${SPINDRIFT_FILE}`, `apps/web/${SPINDRIFT_FILE}`]);
   });
 
   test('an in-repo spindrift.yaml is what gets written back, unchanged', async () => {
@@ -536,6 +540,52 @@ describe('inspecting a repository before connecting it', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.failure.code).toBe('NOT_FOUND');
+    // GitHub answers a repository that does not exist and one the installation
+    // does not select identically, so the sentence names both rather than
+    // asserting an existence nothing established.
+    expect(result.failure.message).toContain('does not exist');
+    expect(result.failure.message).toContain('repository selection');
+  });
+
+  test('a quota refusal is not a missing repository', async () => {
+    // §15 splits `RATE_LIMITED` from `ACCESS_LOST` precisely so that an hour's
+    // quota is never read as a repository that is gone. Collapsing them here
+    // sends an operator to check an installation that is fine.
+    const fake = new FakeGitHub();
+    fake.rateLimited = true;
+
+    const result = await inspectRepository(
+      { fullName: fake.fullName },
+      await context(fake),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).not.toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('rate-limiting');
+    // And no response body: the far side answers a refusal with JSON or with
+    // somebody's error page, and neither is a sentence.
+    expect(result.failure.message).not.toContain('rate limit exceeded');
+    expect(result.failure.message).not.toContain('failed with');
+  });
+
+  test('a far side having a bad time says so, without its body', async () => {
+    const fake = new FakeGitHub();
+    const failing = (async () =>
+      new Response('<html>upstream connect error</html>', {
+        status: 502,
+      })) as unknown as typeof fetch;
+
+    const result = await inspectRepository(
+      { fullName: fake.fullName },
+      await context(fake, failing),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).not.toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('502');
+    expect(result.failure.message).not.toContain('upstream connect error');
   });
 
   test('reads the tree once however many scopes it inspects', async () => {

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -166,8 +166,51 @@ describe('connecting a repository', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.failure.code).toBe('NOT_FOUND');
-    expect(result.failure.message).toContain('installation selects it');
+    // GitHub answers a repository that does not exist and one the installation
+    // does not select identically, so the sentence names both rather than
+    // asserting an existence nothing established.
+    expect(result.failure.message).toContain('does not exist');
+    expect(result.failure.message).toContain('repository selection');
     // Nothing was written on the way to refusing.
+    expect(await database().db.select().from(repositories)).toEqual([]);
+  });
+
+  // The creation wizard connects on Deploy, against a repository it has
+  // already read successfully on this screen. A quota window answering
+  // `NOT_FOUND` there contradicts the list the operator picked from, and a raw
+  // HTTP body is not a sentence anybody can act on.
+  test('a quota refusal is not a missing repository', async () => {
+    const fake = new FakeGitHub();
+    fake.rateLimited = true;
+
+    const result = await connectRepository(input(fake), await context(fake));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).not.toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('rate-limiting');
+    expect(result.failure.message).not.toContain('rate limit exceeded');
+    expect(result.failure.message).not.toContain('failed with');
+    expect(await database().db.select().from(repositories)).toEqual([]);
+  });
+
+  test('a far side having a bad time says so, without its body', async () => {
+    const fake = new FakeGitHub();
+    const failing = (async () =>
+      new Response('<html>upstream connect error</html>', {
+        status: 502,
+      })) as unknown as typeof fetch;
+
+    const result = await connectRepository(
+      input(fake),
+      await context(fake, failing),
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).not.toBe('NOT_FOUND');
+    expect(result.failure.message).toContain('502');
+    expect(result.failure.message).not.toContain('upstream connect error');
     expect(await database().db.select().from(repositories)).toEqual([]);
   });
 

--- a/apps/spindrift/test/domain/repository-scan.test.ts
+++ b/apps/spindrift/test/domain/repository-scan.test.ts
@@ -198,6 +198,40 @@ describe('discovering what is in a repository', () => {
     ]);
   });
 
+  test('a declared workspace does not hide what is beside it', async () => {
+    // The defect: a repository that declares JS workspaces answered with its
+    // JS packages and nothing else, so a Go service in the same `apps/`
+    // directory was not a candidate — not even an unsupported one. A
+    // declaration says where one ecosystem's packages are; it says nothing
+    // about the repository.
+    const found = await discoverScopes(
+      memoryTree({
+        'package.json': PACKAGE({ workspaces: ['apps/*'] }),
+        'apps/web/package.json': PACKAGE({
+          name: 'web',
+          dependencies: { next: '15.0.0' },
+        }),
+        'apps/ddnsd/go.mod': 'module ddnsd\n',
+        'apps/rackstat/Dockerfile': 'FROM scratch\n',
+      }),
+    );
+
+    // Declared packages keep their priority, and what the walk found beyond
+    // them follows.
+    expect(found).toEqual(['apps/web', 'apps/ddnsd', 'apps/rackstat']);
+  });
+
+  test('a declared package is offered once, not twice', async () => {
+    const found = await discoverScopes(
+      memoryTree({
+        'package.json': PACKAGE({ workspaces: ['apps/*'] }),
+        'apps/web/package.json': PACKAGE({ name: 'web' }),
+      }),
+    );
+
+    expect(found).toEqual(['apps/web']);
+  });
+
   test('a repository with no workspace declaration is walked, but not deeply', async () => {
     const found = await discoverScopes(
       memoryTree({

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -827,7 +827,11 @@ export const INITIAL_DRAFT: Draft = {
   step: 0,
 };
 
-/** Available repositories from the GitHub App installation. */
+/**
+ * Repositories Spindrift holds a row for. `connected` here means an App
+ * already deploys from it — `listRepositories`'s own reading of the word on
+ * this list.
+ */
 export const REPOSITORY_OPTIONS: readonly RepositoryOptionView[] = [
   {
     repositoryId: 100001,
@@ -857,6 +861,42 @@ export const REPOSITORY_OPTIONS: readonly RepositoryOptionView[] = [
     repositoryId: 100005,
     fullName: 'example-org/weather-card',
     defaultBranch: 'main',
+    connected: false,
+  },
+];
+
+/**
+ * Repositories the GitHub App installation currently grants. `connected` here
+ * means Spindrift holds a row for it — the other reading of the same word, on
+ * the other list of the same response, which is why the picker derives a state
+ * instead of rendering either boolean.
+ *
+ * Two of them are on no other list: a grant Spindrift has never connected is
+ * the ordinary state of a fresh installation.
+ */
+export const REPOSITORY_GRANT: readonly RepositoryOptionView[] = [
+  {
+    repositoryId: 100001,
+    fullName: 'example-org/infra',
+    defaultBranch: 'main',
+    connected: true,
+  },
+  {
+    repositoryId: 100003,
+    fullName: 'example-org/site',
+    defaultBranch: 'main',
+    connected: true,
+  },
+  {
+    repositoryId: 200001,
+    fullName: 'example-org/almanac',
+    defaultBranch: 'main',
+    connected: false,
+  },
+  {
+    repositoryId: 200002,
+    fullName: 'example-org/ledger',
+    defaultBranch: 'trunk',
     connected: false,
   },
 ];

--- a/apps/spindrift/test/web/creation-detection.test.tsx
+++ b/apps/spindrift/test/web/creation-detection.test.tsx
@@ -7,7 +7,7 @@
  * default nobody chose. A static render cannot observe an effect, so this file
  * mounts the screen and answers its one read.
  *
- * Three properties, and they are the three ways this went wrong before:
+ * Four properties, and they are the four ways this went wrong before:
  *
  * 1. **It asks.** A draft carries `detection` from the moment it exists, with
  *    the sentence "until detection says otherwise" — so a screen that never
@@ -18,6 +18,9 @@
  * 3. **It does not choose.** One candidate is a proposal; two is a question,
  *    and taking the alphabetically first is a decision nobody can see being
  *    made.
+ * 4. **It does not re-choose.** The same read runs on every reopen of a
+ *    durable draft, and applying its proposal a second time reverts — durably,
+ *    through the save that follows — what somebody already corrected.
  */
 import {
   afterAll,
@@ -31,6 +34,13 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { Draft } from '../../src/domain/creation-draft.ts';
 import { blockersFor } from '../../src/domain/creation-draft.ts';
+import type { ComponentKind } from '../../src/domain/desired-state.ts';
+import {
+  type InspectedScope,
+  inspection,
+  mergeScopes,
+  outcomeOf,
+} from '../../src/web/views/apps/new/detect.ts';
 import { NewApp } from '../../src/web/views/apps/new/index.tsx';
 import {
   INITIAL_DRAFT,
@@ -44,7 +54,11 @@ const CANDIDATES = TARGET_OPTIONS.filter((target) => target.candidate).map(
   (target) => target.targetId,
 );
 
-const detected = (scope: string, kind: string, reason: string) => ({
+const detected = (
+  scope: string,
+  kind: ComponentKind,
+  reason: string,
+): InspectedScope => ({
   scope,
   outcome: 'detected',
   kind,
@@ -57,22 +71,24 @@ const detected = (scope: string, kind: string, reason: string) => ({
   unavailable: { job: 'jobs are asserted, never inferred' },
 });
 
-const unsupported = (scope: string, detail: string) => ({
+const unsupported = (scope: string, detail: string): InspectedScope => ({
   scope,
   outcome: 'unsupported',
   detail,
 });
 
 /** What `inspectRepository` answers, per test. */
-let scopes: readonly unknown[] = [];
+let scopes: readonly InspectedScope[] = [];
 /** Every command the screen called, in order. */
 let called: string[] = [];
+/** Every draft the screen wrote back, in order. */
+let saved: Draft[] = [];
 
 let dom: DomShim;
 
 beforeAll(() => {
   dom = installDomShim({
-    fetch: async (url: string) => {
+    fetch: async (url: string, init: { body: string }) => {
       const name = url.split('/').pop() ?? '';
       called.push(name);
       if (name === 'inspectRepository') {
@@ -90,6 +106,9 @@ beforeAll(() => {
         };
       }
       if (name === 'saveCreationDraft') {
+        // Recorded rather than counted: what the screen decided on its own is
+        // only visible in what it wrote back.
+        saved.push((JSON.parse(init.body) as { draft: Draft }).draft);
         return {
           json: async () => ({
             ok: true,
@@ -111,6 +130,7 @@ afterAll(() => dom.restore());
 beforeEach(() => {
   scopes = [];
   called = [];
+  saved = [];
 });
 
 async function mount(draft: Draft) {
@@ -290,5 +310,216 @@ describe('every directory it read is on the screen', () => {
     expect(text).toContain('a library rather than an App.');
 
     screen.unmount();
+  });
+});
+
+/**
+ * Reopening a draft is not correcting it.
+ *
+ * Drafts are durable rows reachable by URL (`/apps/new/:draftId`), so the read
+ * that fills in a fresh draft runs again on every reload and every back
+ * navigation. Applying its proposal the second time reverts what somebody
+ * already decided — and the save that follows every action makes the reversion
+ * permanent, which is what turns a cosmetic flicker into a draft that deploys a
+ * different directory than the one on screen.
+ */
+describe('a draft somebody already answered', () => {
+  test('a corrected kind and a typed Component survive the read on open', async () => {
+    scopes = [
+      detected('apps/api', 'service', 'Bun — a start script is declared'),
+    ];
+
+    const screen = await mount({
+      ...clean,
+      kind: 'job',
+      componentName: 'api-worker',
+      detection: {
+        kind: 'service',
+        reason: 'Bun — a start script is declared',
+        available: ['service', 'website', 'job'],
+        unavailable: {},
+        scope: 'apps/api',
+      },
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://github.com/example/almanac.git',
+        subpath: 'apps/api',
+      },
+    });
+
+    // It still asks — the directories stay on screen to choose from.
+    expect(called).toContain('inspectRepository');
+    expect(screen.text()).toContain('api-worker · job');
+    // And it wrote nothing, because it decided nothing.
+    expect(saved).toEqual([]);
+
+    screen.unmount();
+  });
+
+  test('a directory the operator typed is not swapped for the one candidate', async () => {
+    // The sole-candidate proposal is the right answer for a draft nobody has
+    // answered. Here somebody named `apps/ddnsd` — a directory this read has
+    // nothing to say about — and moving them to `apps/hub` would deploy
+    // somewhere they never asked for.
+    scopes = [
+      detected('apps/hub', 'service', 'Bun — a start script is declared'),
+    ];
+
+    const screen = await mount({
+      ...clean,
+      scopeByOperator: true,
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://github.com/example/almanac.git',
+        subpath: 'apps/ddnsd',
+      },
+    });
+
+    expect(screen.text()).toContain('example/almanac · apps/ddnsd');
+    expect(saved).toEqual([]);
+
+    screen.unmount();
+  });
+
+  test('a reason read elsewhere says which directory it is about', async () => {
+    // The draft names `docs` and the sentence under Component was read in
+    // `apps/api`. Rendering it bare would describe a directory nobody named.
+    scopes = [
+      detected('apps/api', 'service', 'Bun — a start script is declared'),
+    ];
+
+    const screen = await mount({
+      ...clean,
+      scopeByOperator: true,
+      detection: {
+        kind: 'service',
+        reason: 'Bun — a start script is declared',
+        available: ['service', 'website', 'job'],
+        unavailable: {},
+        scope: 'apps/api',
+      },
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://github.com/example/almanac.git',
+        subpath: 'docs',
+      },
+    });
+
+    expect(screen.text()).toContain('read in apps/api');
+    expect(screen.text()).toContain('root directory now names docs');
+
+    screen.unmount();
+  });
+});
+
+/**
+ * A read about one directory answers about that directory.
+ *
+ * This is the settled-subpath path — `onBlur`/Enter on the root directory
+ * field — and the property is the whole of it: whatever comes back is about
+ * the path that was named, so the reason on screen can never be a sentence
+ * about somewhere else. The decision is exercised here rather than through the
+ * mounted screen because the DOM shim deliberately has no event system
+ * (`test/harness/dom.ts`); the request shape and the decision are what a
+ * settled edit *is*.
+ */
+describe('a read about one directory', () => {
+  const repo: Draft = {
+    ...clean,
+    source: {
+      kind: 'repo',
+      repo: 'example/almanac',
+      url: 'https://github.com/example/almanac.git',
+      subpath: 'docs',
+    },
+    scopeByOperator: true,
+  };
+  const known = [
+    detected('apps/hub', 'service', 'Bun — a start script is declared'),
+    detected('apps/site', 'website', 'Astro — `astro` is a dependency'),
+  ];
+
+  test('it names the directory rather than searching the tree', () => {
+    expect(inspection('example/almanac', 'docs')).toEqual({
+      fullName: 'example/almanac',
+      scopes: ['docs'],
+    });
+    expect(inspection('example/almanac')).toEqual({
+      fullName: 'example/almanac',
+    });
+  });
+
+  test('its answer replaces that one row and leaves the rest standing', () => {
+    const merged = mergeScopes(known, [
+      detected('apps/hub', 'website', 'Astro — `astro` is a dependency'),
+      unsupported('docs', 'just prose in this directory.'),
+    ]);
+
+    expect(merged.map((scope) => scope.scope)).toEqual([
+      'apps/hub',
+      'apps/site',
+      'docs',
+    ]);
+    expect(merged[0]).toMatchObject({ kind: 'website' });
+    expect(merged[1]).toEqual(known[1]!);
+  });
+
+  test('a directory it can build is what the draft takes', () => {
+    const found = [
+      detected('docs', 'website', 'Astro — `astro` is a dependency'),
+    ];
+
+    expect(
+      outcomeOf(repo, {
+        fullName: 'example/almanac',
+        scope: 'docs',
+        found,
+        merged: mergeScopes(known, found),
+      }),
+    ).toEqual({
+      act: 'detect',
+      action: {
+        type: 'detect',
+        scope: 'docs',
+        kind: 'website',
+        reason: 'Astro — `astro` is a dependency',
+        unavailable: { job: 'jobs are asserted, never inferred' },
+      },
+    });
+  });
+
+  test('one it cannot says so about that directory, and moves nothing', () => {
+    const found = [unsupported('docs', 'just prose in this directory.')];
+    const outcome = outcomeOf(repo, {
+      fullName: 'example/almanac',
+      scope: 'docs',
+      found,
+      merged: mergeScopes(known, found),
+    });
+
+    expect(outcome.act).toBe('refuse');
+    expect(outcome.act === 'refuse' && outcome.message).toContain('docs');
+    expect(outcome.act === 'refuse' && outcome.message).toContain(
+      'just prose in this directory.',
+    );
+  });
+
+  test('a sole candidate elsewhere is not an answer about the named directory', () => {
+    // The snap-back: with one candidate in the repository, a settled edit to a
+    // directory detection cannot build used to fall through to the candidate
+    // and rewrite the path out from under whoever typed it.
+    const found = [unsupported('docs', 'just prose in this directory.')];
+
+    expect(
+      outcomeOf(repo, {
+        fullName: 'example/almanac',
+        scope: 'docs',
+        found,
+        merged: mergeScopes([known[0]!], found),
+      }).act,
+    ).toBe('refuse');
   });
 });

--- a/apps/spindrift/test/web/creation-detection.test.tsx
+++ b/apps/spindrift/test/web/creation-detection.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * What the creation screen does with what detection found, mounted.
+ *
+ * These are claims about the screen's *behaviour* rather than its markup, and
+ * behaviour here is one effect and one command call: the wizard opens claiming
+ * a kind, and until something asks `inspectRepository` that claim is the
+ * default nobody chose. A static render cannot observe an effect, so this file
+ * mounts the screen and answers its one read.
+ *
+ * Three properties, and they are the three ways this went wrong before:
+ *
+ * 1. **It asks.** A draft carries `detection` from the moment it exists, with
+ *    the sentence "until detection says otherwise" — so a screen that never
+ *    asks renders a claim about a repository nobody read.
+ * 2. **It offers everything it was told.** `inspectRepository` answers about
+ *    every directory it looked at, unsupported ones included with the reason,
+ *    and §5 makes that a list for a human to choose from.
+ * 3. **It does not choose.** One candidate is a proposal; two is a question,
+ *    and taking the alphabetically first is a decision nobody can see being
+ *    made.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Draft } from '../../src/domain/creation-draft.ts';
+import { blockersFor } from '../../src/domain/creation-draft.ts';
+import { NewApp } from '../../src/web/views/apps/new/index.tsx';
+import {
+  INITIAL_DRAFT,
+  REPOSITORY_GRANT,
+  REPOSITORY_OPTIONS,
+  TARGET_OPTIONS,
+} from '../fixtures/scenarios.ts';
+import { type DomShim, installDomShim } from '../harness/dom.ts';
+
+const CANDIDATES = TARGET_OPTIONS.filter((target) => target.candidate).map(
+  (target) => target.targetId,
+);
+
+const detected = (scope: string, kind: string, reason: string) => ({
+  scope,
+  outcome: 'detected',
+  kind,
+  reason,
+  frontend: 'railpack',
+  dockerfile: null,
+  outputDirectory: null,
+  watchPaths: [scope],
+  configured: false,
+  unavailable: { job: 'jobs are asserted, never inferred' },
+});
+
+const unsupported = (scope: string, detail: string) => ({
+  scope,
+  outcome: 'unsupported',
+  detail,
+});
+
+/** What `inspectRepository` answers, per test. */
+let scopes: readonly unknown[] = [];
+/** Every command the screen called, in order. */
+let called: string[] = [];
+
+let dom: DomShim;
+
+beforeAll(() => {
+  dom = installDomShim({
+    fetch: async (url: string) => {
+      const name = url.split('/').pop() ?? '';
+      called.push(name);
+      if (name === 'inspectRepository') {
+        return {
+          json: async () => ({
+            ok: true,
+            value: {
+              fullName: 'example/almanac',
+              defaultBranch: 'main',
+              commit: 'a'.repeat(40),
+              scopes,
+              canConnect: true,
+            },
+          }),
+        };
+      }
+      if (name === 'saveCreationDraft') {
+        return {
+          json: async () => ({
+            ok: true,
+            value: { id: 'draft', revision: 1, draft: null, blockers: [] },
+          }),
+        };
+      }
+      // `listTargets` re-resolves placement whenever a detection moves the
+      // kind. Answering with the same options keeps that off these assertions.
+      return {
+        json: async () => ({ ok: true, value: { options: TARGET_OPTIONS } }),
+      };
+    },
+  });
+});
+
+afterAll(() => dom.restore());
+
+beforeEach(() => {
+  scopes = [];
+  called = [];
+});
+
+async function mount(draft: Draft) {
+  const container = dom.document.createElement('div');
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container as unknown as Element);
+    root.render(
+      <NewApp
+        initial={{
+          id: crypto.randomUUID(),
+          revision: 0,
+          draft,
+          blockers: blockersFor(draft, CANDIDATES),
+          ready: false,
+        }}
+        targets={TARGET_OPTIONS}
+        repos={REPOSITORY_OPTIONS}
+        available={REPOSITORY_GRANT}
+      />,
+    );
+  });
+  // The read is issued from a first-render effect, so its answer lands on the
+  // turn after the mount.
+  await act(async () => {});
+  return {
+    text: () => container.textContent,
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+const clean: Draft = {
+  ...INITIAL_DRAFT,
+  config: INITIAL_DRAFT.config.map((key) => ({ ...key, supplied: true })),
+};
+
+describe('the screen reads the repository it opens on', () => {
+  test('detection runs without anybody pressing anything', async () => {
+    scopes = [
+      detected('apps/web', 'website', 'Astro — `astro` is a dependency'),
+    ];
+
+    const screen = await mount(clean);
+
+    expect(called).toContain('inspectRepository');
+    // And the answer replaces the default the draft was carrying.
+    expect(screen.text()).toContain('astro');
+    expect(screen.text()).not.toContain('until detection says otherwise');
+
+    screen.unmount();
+  });
+
+  test('an upload draft reads nothing, because there is nothing to read', async () => {
+    const screen = await mount({
+      ...clean,
+      entry: 'upload',
+      source: {
+        kind: 'archive',
+        filename: 'dist.zip',
+        digest: `sha256:${'0'.repeat(64)}`,
+        location: 'https://bundles.example.test/dist.zip',
+        contents: 'source',
+        subpath: '.',
+      },
+    });
+
+    expect(called).not.toContain('inspectRepository');
+
+    screen.unmount();
+  });
+});
+
+describe('every directory it read is on the screen', () => {
+  test('a repository with several candidates offers them all, and picks none', async () => {
+    scopes = [
+      unsupported(
+        '.',
+        'no package.json, go.mod or Dockerfile in this directory.',
+      ),
+      detected('apps/hub', 'service', 'Bun — a start script is declared'),
+      detected('apps/ddnsd', 'service', 'Go — go.mod is in this directory'),
+      detected('apps/site', 'website', 'Astro — `astro` is a dependency'),
+    ];
+
+    const screen = await mount({
+      ...clean,
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://github.com/example/almanac.git',
+        subpath: '.',
+      },
+    });
+    const text = screen.text();
+
+    for (const scope of ['apps/hub', 'apps/ddnsd', 'apps/site']) {
+      expect(text).toContain(scope);
+    }
+    // The one it could not make sense of is here too, wearing what it found
+    // instead of a sentence about the repository as a whole.
+    expect(text).toContain('no package.json, go.mod or Dockerfile');
+    // And nothing was chosen: the alphabetically first candidate is not the
+    // answer, and Deploy waits for one.
+    expect(text).toContain('Nothing is chosen to deploy from example/almanac');
+    expect(text).toContain('Spindrift stops before Build #1');
+
+    screen.unmount();
+  });
+
+  test('a sole candidate is a proposal rather than a question', async () => {
+    scopes = [
+      unsupported('.', 'nothing in the root'),
+      detected('apps/only', 'service', 'Go — go.mod is in this directory'),
+    ];
+
+    const screen = await mount({
+      ...clean,
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://github.com/example/almanac.git',
+        subpath: '.',
+      },
+    });
+    const text = screen.text();
+
+    expect(text).toContain('go.mod is in this directory');
+    expect(text).not.toContain('Nothing is chosen');
+    // The Component the proposal names, taken from the scope it was found in.
+    expect(text).toContain('only');
+
+    screen.unmount();
+  });
+
+  test('a directory it cannot build says what it found there instead', async () => {
+    scopes = [unsupported('.', 'just prose in this directory.')];
+
+    const screen = await mount({
+      ...clean,
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://github.com/example/almanac.git',
+        subpath: '.',
+      },
+    });
+    const text = screen.text();
+
+    // The detail, not a generic sentence about the repository — and the row
+    // opens itself so the list it refers to is on screen rather than behind an
+    // Edit button.
+    expect(text).toContain('does not know how to build . in example/almanac');
+    expect(text).toContain('just prose in this directory.');
+    expect(text).toContain('Directories Spindrift read');
+
+    screen.unmount();
+  });
+
+  test('a repository it can build nothing in says so, with every directory listed', async () => {
+    scopes = [
+      unsupported('.', 'nothing in the root.'),
+      unsupported('packages/ui', 'a library rather than an App.'),
+    ];
+
+    const screen = await mount({
+      ...clean,
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://github.com/example/almanac.git',
+        subpath: 'apps/web',
+      },
+    });
+    const text = screen.text();
+
+    expect(text).toContain('found nothing it knows how to build');
+    expect(text).toContain('a library rather than an App.');
+
+    screen.unmount();
+  });
+});

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -22,6 +22,7 @@ import {
 import { NewApp } from '../../src/web/views/apps/new/index.tsx';
 import {
   INITIAL_DRAFT,
+  REPOSITORY_GRANT,
   REPOSITORY_OPTIONS,
   TARGET_OPTIONS,
 } from '../fixtures/scenarios.ts';
@@ -48,6 +49,7 @@ const render = (draft: Draft) =>
       }}
       targets={TARGET_OPTIONS}
       repos={REPOSITORY_OPTIONS}
+      available={REPOSITORY_GRANT}
     />,
   );
 
@@ -190,6 +192,9 @@ describe('the draft reducer', () => {
       entry: 'website',
     });
     expect(next.kind).toBe('website');
+    // …and leaves the source alone: `Service` and `Website` name a kind, not a
+    // place to get the code from.
+    expect(next.source).toEqual(INITIAL_DRAFT.source);
   });
 
   test("a tile that names no kind leaves detection's proposal standing", () => {
@@ -198,6 +203,76 @@ describe('the draft reducer', () => {
       entry: 'upload',
     });
     expect(next.kind).toBe(INITIAL_DRAFT.detection.kind);
+  });
+
+  test('the Upload tile switches the source to an archive', () => {
+    // The defect this pins: the tile set an entry and a kind and nothing else,
+    // so pressing it from a repository draft left the repository picker on
+    // screen and the draft still deploying from a repository.
+    const next = draftReducer(INITIAL_DRAFT, {
+      type: 'entry',
+      entry: 'upload',
+    });
+    expect(next.source.kind).toBe('archive');
+  });
+
+  /** A draft that has only ever been an upload — the fresh-install shape. */
+  const uploadOnly: Draft = {
+    ...INITIAL_DRAFT,
+    entry: 'upload',
+    source: {
+      kind: 'archive',
+      filename: 'upload.zip',
+      digest: `sha256:${'0'.repeat(64)}`,
+      location: null,
+      contents: 'source',
+      subpath: '.',
+    },
+  };
+
+  test('the repo tiles open on a picker when no repository has been named', () => {
+    const linking = draftReducer(uploadOnly, { type: 'entry', entry: 'repo' });
+
+    expect(linking.source).toMatchObject({ kind: 'repo', repo: '' });
+    // Which is a draft nothing can be created from, said out loud rather than
+    // discovered at Deploy.
+    expect(
+      blockersFor(linking, CANDIDATES).map((blocker) => blocker.title),
+    ).toContain('No repository is chosen.');
+  });
+
+  test('discovering is linking a repo, with its directories to choose from', () => {
+    const next = draftReducer(uploadOnly, { type: 'entry', entry: 'discover' });
+    expect(next.source.kind).toBe('repo');
+  });
+
+  test('a staged archive survives a look at the repo tiles', () => {
+    // Pressing the other tile is a look. Costing somebody a staged upload for
+    // it is how a tile becomes one nobody presses twice.
+    const staged = draftReducer(uploadOnly, {
+      type: 'archive',
+      filename: 'dist.zip',
+      digest: `sha256:${'a'.repeat(64)}`,
+      location: 'https://bundles.example.test/dist.zip',
+    });
+    const back = draftReducer(
+      draftReducer(staged, { type: 'entry', entry: 'repo' }),
+      { type: 'entry', entry: 'upload' },
+    );
+
+    expect(back.source).toMatchObject({
+      kind: 'archive',
+      location: 'https://bundles.example.test/dist.zip',
+    });
+  });
+
+  test('and so does the repository that was picked', () => {
+    const back = draftReducer(
+      draftReducer(INITIAL_DRAFT, { type: 'entry', entry: 'upload' }),
+      { type: 'entry', entry: 'repo' },
+    );
+
+    expect(back.source).toEqual(INITIAL_DRAFT.source);
   });
 
   test('a detection replaces the proposal, the kind, and the scope together', () => {
@@ -218,7 +293,10 @@ describe('the draft reducer', () => {
     expect(next.source.kind === 'repo' && next.source.subpath).toBe('apps/web');
   });
 
-  test('a detection overrides a correction, because it is about a new directory', () => {
+  test('a detection overrides a corrected kind, because it is about a new directory', () => {
+    // Still true of the *kind*, and deliberately not of the App name below: a
+    // kind is an answer about a directory, so an answer about a different
+    // directory replaces it. A name is an answer about the App.
     const corrected = draftReducer(INITIAL_DRAFT, {
       type: 'kind',
       kind: 'job',
@@ -232,5 +310,56 @@ describe('the draft reducer', () => {
     });
 
     expect(next.kind).toBe('website');
+  });
+
+  test('a repository nobody named derives the App name from it', () => {
+    const next = draftReducer(INITIAL_DRAFT, {
+      type: 'repo',
+      fullName: 'example/ledger',
+      url: 'https://github.com/example/ledger.git',
+    });
+    expect(next.appName).toBe('ledger');
+  });
+
+  test('an App name the operator typed survives re-selecting the repository', () => {
+    const named = draftReducer(INITIAL_DRAFT, {
+      type: 'field',
+      field: 'appName',
+      value: 'almanac-staging',
+    });
+    const reselected = draftReducer(named, {
+      type: 'repo',
+      fullName: 'example/ledger',
+      url: 'https://github.com/example/ledger.git',
+    });
+    const redetected = draftReducer(reselected, {
+      type: 'detect',
+      scope: 'apps/api',
+      kind: 'service',
+      reason: 'a fresh read',
+      unavailable: {},
+    });
+
+    expect(reselected.appName).toBe('almanac-staging');
+    expect(redetected.appName).toBe('almanac-staging');
+  });
+
+  test('selecting a repository the grant offers marks it to connect on Deploy', () => {
+    const next = draftReducer(INITIAL_DRAFT, {
+      type: 'repo',
+      fullName: 'example/ledger',
+      url: 'https://github.com/example/ledger.git',
+      connect: true,
+    });
+    expect(next.source).toMatchObject({ connect: true, subpath: '.' });
+  });
+
+  test('another repository is another tree, so the directory resets', () => {
+    const next = draftReducer(INITIAL_DRAFT, {
+      type: 'repo',
+      fullName: 'example/ledger',
+      url: 'https://github.com/example/ledger.git',
+    });
+    expect(next.source.kind === 'repo' && next.source.subpath).toBe('.');
   });
 });

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -291,6 +291,10 @@ describe('the draft reducer', () => {
     // The scope names the Component, and the source follows it.
     expect(next.componentName).toBe('web');
     expect(next.source.kind === 'repo' && next.source.subpath).toBe('apps/web');
+    // And the reason records the directory it is about, so a draft reopened
+    // later can tell "already read" from "never asked" without a string match
+    // on the placeholder sentence.
+    expect(next.detection.scope).toBe('apps/web');
   });
 
   test('a detection overrides a corrected kind, because it is about a new directory', () => {
@@ -355,11 +359,28 @@ describe('the draft reducer', () => {
   });
 
   test('another repository is another tree, so the directory resets', () => {
-    const next = draftReducer(INITIAL_DRAFT, {
+    const named = draftReducer(INITIAL_DRAFT, {
+      type: 'subpath',
+      subpath: 'apps/ddnsd',
+    });
+    const next = draftReducer(named, {
       type: 'repo',
       fullName: 'example/ledger',
       url: 'https://github.com/example/ledger.git',
     });
     expect(next.source.kind === 'repo' && next.source.subpath).toBe('.');
+    // With the claim on it: the root is nobody's word, so the next read of the
+    // new tree is free to propose one.
+    expect(next.scopeByOperator).toBeUndefined();
+  });
+
+  test('a directory the operator typed is recorded as theirs', () => {
+    // Durable rather than session state, because the guard it feeds is about
+    // the read that runs when a saved draft is reopened.
+    const next = draftReducer(INITIAL_DRAFT, {
+      type: 'subpath',
+      subpath: 'apps/ddnsd',
+    });
+    expect(next.scopeByOperator).toBe(true);
   });
 });

--- a/apps/spindrift/test/web/repo-picker.test.tsx
+++ b/apps/spindrift/test/web/repo-picker.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * The repository picker lists the GitHub grant (§20, story 24).
+ *
+ * `listRepositories` answers with two lists — the rows Spindrift holds and the
+ * repositories GitHub currently grants — and the defect this pins is a picker
+ * that renders the first and drops the second: on a fresh installation, where
+ * the operator has granted repositories and connected none, that reads "no
+ * repositories" beside a GitHub App that is working.
+ *
+ * The two lists each carry a `connected` boolean and they do not mean the same
+ * thing, which is why the state on each row is derived here rather than read
+ * off either one.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  RepoPicker,
+  repositoryChoices,
+} from '../../src/web/components/repo-picker.tsx';
+import { REPOSITORY_GRANT, REPOSITORY_OPTIONS } from '../fixtures/scenarios.ts';
+
+const choices = repositoryChoices(REPOSITORY_OPTIONS, REPOSITORY_GRANT);
+const stateOf = (fullName: string) =>
+  choices.find((choice) => choice.fullName === fullName)?.state;
+
+describe('what the picker offers', () => {
+  test('every repository on either list is offered exactly once', () => {
+    const names = choices.map((choice) => choice.fullName);
+    expect(new Set(names).size).toBe(names.length);
+    for (const repo of [...REPOSITORY_OPTIONS, ...REPOSITORY_GRANT]) {
+      expect(names).toContain(repo.fullName);
+    }
+  });
+
+  test('a repository the grant offers and nothing connected is still offered', () => {
+    // The whole point: `options` is empty on a fresh installation and the
+    // grant is not.
+    expect(
+      repositoryChoices([], REPOSITORY_GRANT).map((c) => c.fullName),
+    ).toEqual(
+      [...REPOSITORY_GRANT]
+        .map((repo) => repo.fullName)
+        .sort((left, right) => left.localeCompare(right)),
+    );
+    expect(stateOf('example-org/almanac')).toBe('grant-only');
+  });
+
+  test('each row says which of the three it is', () => {
+    // An App deploys from `infra`; `site` has a row and no App; `ledger` is
+    // only a grant. Three different presses, so three different rows.
+    expect(stateOf('example-org/infra')).toBe('deploys');
+    expect(stateOf('example-org/site')).toBe('connected');
+    expect(stateOf('example-org/ledger')).toBe('grant-only');
+  });
+
+  test("the grant's own `connected` flag never decides a row", () => {
+    // `available[].connected` means "a row exists" while `options[].connected`
+    // means "an App deploys from it". Reading the first as a state is how a
+    // connected repository with no App reads as one that has one.
+    const grantOnly = repositoryChoices(
+      [],
+      [
+        {
+          repositoryId: '1',
+          fullName: 'example-org/site',
+          defaultBranch: 'main',
+          connected: true,
+        },
+      ],
+    );
+    expect(grantOnly[0]?.state).toBe('grant-only');
+  });
+});
+
+describe('what the picker says', () => {
+  const markup = renderToStaticMarkup(
+    <RepoPicker
+      repos={choices}
+      selected="example-org/infra"
+      onSelect={() => {}}
+    />,
+  );
+
+  test('the state of every row is on the row', () => {
+    expect(markup).toContain('already deploys');
+    expect(markup).toContain('connected');
+    expect(markup).toContain('connects on Deploy');
+  });
+
+  test('selecting is stated to write nothing', () => {
+    // The promise the draft makes — "Nothing has been created" — is only true
+    // if browsing repositories does not open a pull request per look.
+    expect(markup).toContain('writes nothing');
+  });
+
+  test('an empty grant names what to do about it', () => {
+    const empty = renderToStaticMarkup(
+      <RepoPicker repos={[]} selected={null} onSelect={() => {}} />,
+    );
+    expect(empty).toContain('grants this installation no repositories');
+  });
+});


### PR DESCRIPTION
## Summary

The creation wizard shows the operator what exists — the repositories GitHub actually grants, and every scope detection actually found — instead of a DB-only picker and a silent commitment to the first hit.

- **The picker renders the GitHub grant.** `listRepositories.available` merges with the connected rows, each row stating its state — deploys / connected / grant-only — derived explicitly rather than from either existing `connected` boolean. A fresh App-install grant appears immediately instead of "No repositories available."
- **Connect on Deploy, never on selection.** Selecting a grant-only repo only inspects (a read); `completeCreationDraft` connects it inside the same committing act that creates the App, reusing `connectRepository`'s machinery. An abandoned draft leaves no repository row and no PR — tested literally.
- **Every scope renders as a chooser.** Detected scopes selectable with kind and reason; unsupported ones visible with their `detail`. Nothing auto-picks: a proposal applies only when it is the sole detected scope; with two or more, Deploy blocks until the operator chooses. Editing the root directory re-inspects that path on a settled edit, so the reason shown never describes a different directory.
- **Discovery stops truncating monorepos.** A declared workspace no longer short-circuits the manifest walk — declared packages keep priority, and Go services or Dockerfile directories beside a JS workspace are appended as candidates (previously: 4 of 17 real directories surfaced on this repo).
- **The entry tiles work.** `upload` / `repo` / `discover` switch the source for real, and toggling between them stashes the source switched away from, so a staged archive survives a look at the repo list.
- **Refusals tell the truth.** `RATE_LIMITED` and `UNAVAILABLE` stop surfacing as `NOT_FOUND` with raw HTTP bodies, on both `inspectRepository` and `connectRepository`; not-found messages state both possibilities GitHub answers identically for instead of asserting the repo exists. An operator-typed App name survives repo and scope re-selection.

## Validation

- `bun run typecheck` clean; `bun run lint` clean.
- `bun test`: 1833 pass / 0 relevant fail (the one failure is the pre-existing environmental `node`-not-on-PATH test in `test/adapters/`, untouched by this change; it passes with node on PATH).
- New coverage: the scan merge (Go + Dockerfile beside a declared workspace), connect-on-complete (abandoned draft leaves nothing; completion writes exactly one row + one PR; unbuildable repo refuses and creates nothing), the scope chooser and its choose-before-Deploy blocker, subpath re-inspect (including the settled-edit-onto-undetectable case, which was broken until tested), resumed drafts keeping operator corrections, the picker's three row states, and the refusal taxonomy.

## Risk

- The draft schema gains only optional keys (jsonb) — drafts written before this change still parse; no migration.
- Reviewer-caught and fixed pre-merge: mount detection could overwrite a resumed draft's stored corrections (the proposal decision is now a pure seam that never re-decides a draft the operator already settled).
