### PR TITLE
docs(runbooks): point at the dotfiles deploy script where it lives

### DIFF
--- a/docs/pages/Runbooks___Deploy a NixOS Host.md
+++ b/docs/pages/Runbooks___Deploy a NixOS Host.md
@@ -55,7 +55,7 @@ tags:: runbook, nixos
 	  ```
 - # Dotfiles
 	- Dotfiles are mise-managed from the in-repo `dotfiles/` tree. `nix/system/mise-dotfiles.nix` carries that subtree into the system closure and runs `mise run bootstrap` during activation.
-	- Shell tooling (eza, fzf, neovim, bat, ripgrep, fd, delta, jq, gh, btop, sd, 1password-cli) and zsh plugins (pure, fzf-tab, autosuggestions, syntax-highlighting, kube-ps1) come from home-manager for the `jawn` user via `nix/system/home-manager.nix` and `nix/home/jawn.nix`. Activation sets `HM_ACTIVATED=1` so `scripts/deploy-dotfiles.sh` skips deploying `~/.config/zsh` on those hosts.
-	- `mise bootstrap --only dotfiles` no longer exists; the bootstrap task routes by OS.
+	- Shell tooling (eza, fzf, neovim, bat, ripgrep, fd, delta, jq, gh, btop, sd, 1password-cli) and zsh plugins (pure, fzf-tab, autosuggestions, syntax-highlighting, kube-ps1) come from home-manager for the `jawn` user via `nix/system/home-manager.nix` and `nix/home/jawn.nix`. Activation sets `HM_ACTIVATED=1` so `dotfiles/scripts/deploy-dotfiles.sh` skips deploying `~/.config/zsh` on those hosts.
+	- The bootstrap task routes by OS; there is no dotfiles-only bootstrap flag.
 - # Auto-upgrade caveat
 	- Hosts auto-rebuild from GitHub `main`. A config deployed from a branch can be reverted by the next auto-upgrade unless the branch merges promptly. Treat a branch deploy as a test unless it has merged.


### PR DESCRIPTION
## Summary

Two lines in the NixOS deploy runbook fail `docs:check` since the home-manager shell-tooling merge: a reference to `scripts/deploy-dotfiles.sh` (the script lives at `dotfiles/scripts/deploy-dotfiles.sh`) and a past-tense sentence about a removed bootstrap flag. Both rewritten to present-tense fact.

## Validation

`mise run docs:check` passes: wikilinks, repo paths, and archaeology all clean. This unblocks the wiki deploy gate.