### PR TITLE
fix(bluenose): let the home vessel's probes see what they check

### DIFF
--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -51,6 +51,25 @@ resource "google_project_iam_member" "spindrift_runtime_secret_reader" {
   member  = google_service_account.spindrift_runtime.member
 }
 
+# Connect-time discovery offers this project's buckets as staging candidates,
+# and the home vessel's SOURCE_BUCKET probe asks the same question. Both are
+# `storage.buckets.list` and nothing else — object access stays per-bucket
+# (`storage.tf` grants it on the one bucket Spindrift stages into), and no
+# predefined role carries the list permission without dragging object reads
+# along, so this is a custom role rather than `roles/viewer`.
+resource "google_project_iam_custom_role" "bucket_lister" {
+  role_id     = "spindriftBucketLister"
+  title       = "Spindrift bucket lister"
+  description = "List the project's buckets, nothing else"
+  permissions = ["storage.buckets.list"]
+}
+
+resource "google_project_iam_member" "spindrift_bucket_lister" {
+  project = local.project
+  role    = google_project_iam_custom_role.bucket_lister.id
+  member  = google_service_account.spindrift_controller.member
+}
+
 locals {
   spindrift_project_roles = toset([
     "roles/cloudsql.admin",

--- a/terraform/gcp/projects/bluenose/services.tf
+++ b/terraform/gcp/projects/bluenose/services.tf
@@ -6,6 +6,11 @@ resource "google_project_service" "service" {
     # token bills its quota here — and GCP refuses a call whose consumer
     # project has not enabled the API, whatever project the URL names.
     "cloudbuild.googleapis.com",
+    # The signer keys live in trusted-builds, but the controller's federated
+    # token bills its quota here — same rule as cloudbuild above. Without this,
+    # the home vessel's SIGNER_KEY probe answers SERVICE_DISABLED for a keyring
+    # that exists and is listable, because the refusal names the consumer.
+    "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     # A Cloud Run Job holds no cron expression, so a Component that declares a
     # schedule is a Cloud Scheduler job calling `jobs.run` in front of it.


### PR DESCRIPTION
## Summary

The home-vessel checklist's first live read reported two unmet prerequisites on `bluenose`, and both are real boundary gaps, not probe defects:

- **`SIGNER_KEY`**: `cloudkms.googleapis.com` is enabled in `trusted-builds` (the keyring exists and is listable there) but not in `bluenose` — and the controller's federated token bills its quota here, so GCP refuses the list with `SERVICE_DISABLED` naming the consumer. Same rule `services.tf` already documents for `cloudbuild`. Enabled.
- **`SOURCE_BUCKET`**: the controller cannot `storage.buckets.list`, which also degrades connect-time bucket discovery. No predefined role carries the list permission without dragging object reads along, so this is a single-permission custom role plus a member grant; object access stays per-bucket as `storage.tf` already grants it.

## Validation

`tofu fmt -check` clean; `tofu init -backend=false && tofu validate` succeeds. Atlantis plan on this PR is the authority; after apply, the standing vessel loop should turn both rows green with no further action — that observation is the point of the checklist.

## Risk

Two additive grants scoped as narrowly as GCP allows; no existing resource changes.