### PR TITLE
fix(trusted-builds): let the signer probe enumerate the ring

### DIFF
--- a/terraform/gcp/projects/trusted-builds/kms.tf
+++ b/terraform/gcp/projects/trusted-builds/kms.tf
@@ -58,3 +58,15 @@ resource "google_kms_crypto_key_iam_binding" "signer_metadata" {
   role          = "roles/cloudkms.viewer"
   members       = local.attester_principals
 }
+# The home vessel's SIGNER_KEY probe asks a different question from signing:
+# not "may I use this key" but "does a key with the signing purpose exist
+# here" — `cryptoKeys.list` on the ring, then the purpose off each key's
+# metadata. The bindings above are key-scoped, so a lister that can read the
+# signer's metadata still cannot enumerate the ring to find it. Ring-scoped
+# `roles/cloudkms.viewer` is metadata only — list and get, no use — and the
+# member form leaves the attester bindings authoritative over their own roles.
+resource "google_kms_key_ring_iam_member" "spindrift_probe_viewer" {
+  key_ring_id = google_kms_key_ring.keys.id
+  role        = "roles/cloudkms.viewer"
+  member      = local.spindrift_controller_member
+}


### PR DESCRIPTION
## Summary

Follow-up to the bluenose consumer-project enablement: with `cloudkms.googleapis.com` billable, the home vessel's `SIGNER_KEY` probe now reaches `trusted-builds` and gets a 403 — the controller has key-scoped grants on the signer key but nothing that can enumerate the ring to find it. The probe's question is "does a key with the signing purpose exist here", which is `cryptoKeys.list` plus metadata.

One grant: ring-scoped `roles/cloudkms.viewer` (list and get, no use of any version) for the controller, as an `iam_member` so the attester bindings stay authoritative over their roles.

## Validation

`tofu fmt -check` clean; `tofu init -backend=false && tofu validate` succeeds. After apply, the standing vessel loop should flip `SIGNER_KEY` green on its own — `SOURCE_BUCKET` already did exactly that after the previous apply, with no recheck action.

## Risk

Additive metadata-read grant; no existing binding changes.