### PR TITLE
fix(spindrift): make the wizard's edits safe

### DIFF
--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -146,6 +146,16 @@ choices made while building them:
   gets §15's row and configuration pull request from `completeCreationDraft`,
   through `connectRepository` itself — which is what keeps "an abandoned draft
   leaves nothing behind" literally true rather than nearly true.
+  **Editing it cannot strand the operator.** Writes coalesce behind a trailing
+  debounce and still go one at a time, so the revision guard keeps its ordering
+  while typing a name costs one round trip; leaving the screen sends what is
+  scheduled. Deploy flushes those writes and answers with the save that failed
+  rather than completing a draft the server does not have, and a save refused
+  as stale re-reads the draft, resyncs the revision and says another tab won.
+  A name the schema will refuse is marked at the field from that same schema, a
+  repository nothing could be read from is a prerequisite rather than a
+  sentence, and the id appearing in `/apps/new/<id>` is a rewrite rather than a
+  navigation — which is why that one screen is keyed on its route.
 - **Authentication Settings** (`views/auth/settings.tsx`) — additive passkeys
   and the optional Gateway binding. Every mutation requires a fresh passkey
   assertion, and the final account-root passkey cannot be removed.

--- a/apps/spindrift/README.md
+++ b/apps/spindrift/README.md
@@ -150,12 +150,15 @@ choices made while building them:
   debounce and still go one at a time, so the revision guard keeps its ordering
   while typing a name costs one round trip; leaving the screen sends what is
   scheduled. Deploy flushes those writes and answers with the save that failed
-  rather than completing a draft the server does not have, and a save refused
-  as stale re-reads the draft, resyncs the revision and says another tab won.
-  A name the schema will refuse is marked at the field from that same schema, a
-  repository nothing could be read from is a prerequisite rather than a
-  sentence, and the id appearing in `/apps/new/<id>` is a rewrite rather than a
-  navigation — which is why that one screen is keyed on its route.
+  rather than completing a draft the server does not have, and a stale revision
+  — found by a save or by the press itself — re-reads the draft, resyncs the
+  revision, drops the edits that version had queued and says another tab won.
+  A completion that never came back says the App may exist rather than leaving
+  the button creating something forever. A name the schema will refuse is
+  marked at the field from that same schema, a repository nothing could be read
+  from is a prerequisite until something reads it, and the id appearing in
+  `/apps/new/<id>` is a rewrite rather than a navigation — which is why that one
+  screen is keyed on its route.
 - **Authentication Settings** (`views/auth/settings.tsx`) — additive passkeys
   and the optional Gateway binding. Every mutation requires a fresh passkey
   assertion, and the final account-root passkey cannot be removed.

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -16,6 +16,7 @@ import {
   type CreationDraftView,
   creationDraftSchema,
   initialCreationDraft,
+  storedDraft,
 } from '../../domain/creation-draft.ts';
 import type { ArtifactType } from '../../domain/desired-state.ts';
 import {
@@ -56,18 +57,15 @@ export const saveCreationDraftInput = z
     draft: creationDraftSchema,
   })
   .strict();
-export const reviewCreationDraftInput = versionedIdentity;
 export const completeCreationDraftInput = versionedIdentity;
 
 export type StartCreationDraftInput = z.infer<typeof startCreationDraftInput>;
 export type GetCreationDraftInput = z.infer<typeof getCreationDraftInput>;
 export type SaveCreationDraftInput = z.infer<typeof saveCreationDraftInput>;
-export type ReviewCreationDraftInput = z.infer<typeof reviewCreationDraftInput>;
 export type CompleteCreationDraftInput = z.infer<
   typeof completeCreationDraftInput
 >;
 
-export interface ReviewCreationDraftResult extends CreationDraftView {}
 export interface CompleteCreationDraftResult {
   readonly draft: CreationDraftView;
   readonly app: CompletedCreation | null;
@@ -175,24 +173,6 @@ export const saveCreationDraft: Command<
     .returning();
 
   if (!row) return conflictOrMissing(input.id, input.revision, context);
-  return ok(await viewOf(row, context));
-};
-
-export const reviewCreationDraft: Command<
-  ReviewCreationDraftInput,
-  ReviewCreationDraftResult
-> = async (input, context) => {
-  const row = await owned(input.id, context);
-  if (!row) {
-    return failed(
-      'NOT_FOUND',
-      `there is no creation draft with id ${input.id}`,
-    );
-  }
-  if (row.revision !== input.revision) return stale();
-
-  // Review is intentionally read-only. Issue 05 consumes a ready review and
-  // atomically creates the Component, Build, and first dispatch.
   return ok(await viewOf(row, context));
 };
 
@@ -600,7 +580,7 @@ async function completedCreation(
     draft: {
       id: row.id,
       revision: row.revision,
-      draft: row.draft,
+      draft: storedDraft(row.draft),
       blockers: [],
       ready: true,
     },
@@ -656,11 +636,15 @@ async function viewOf(
   row: typeof creationDrafts.$inferSelect,
   context: CommandContext,
 ): Promise<CreationDraftView> {
-  const blockers = await revalidate(row.draft, context);
+  // Read through `storedDraft`, so a row written before a key was retired
+  // hands the browser only keys the save schema still names — the browser
+  // returns whatever it was given, and a strict schema would refuse it.
+  const draft = storedDraft(row.draft);
+  const blockers = await revalidate(draft, context);
   return {
     id: row.id,
     revision: row.revision,
-    draft: row.draft,
+    draft,
     blockers,
     ready: blockers.length === 0,
   };

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -24,7 +24,7 @@ import {
   placementTargetOf,
   resolvePlacement,
 } from '../../domain/placement.ts';
-import { repositoryRefOf } from '../../domain/repository.ts';
+import { cloneUrlFor, repositoryRefOf } from '../../domain/repository.ts';
 import { SUPPLIED_ARTIFACT_TYPE } from '../../domain/source.ts';
 import type { StagedSourceBundle } from '../../domain/source-bundle.ts';
 import { targetRowLabel } from '../../domain/target.ts';
@@ -111,7 +111,16 @@ export const startCreationDraft: Command<
       id,
       userId: context.principal.id,
       draft: initialCreationDraft({
-        repository: repository?.fullName ?? null,
+        repository:
+          repository === undefined
+            ? null
+            : {
+                fullName: repository.fullName,
+                cloneUrl: cloneUrlFor(
+                  context.manifest.github.oauthBaseUrl,
+                  repository.fullName,
+                ),
+              },
         targetId: target?.id ?? null,
         // The vessel by name rather than by project id: the draft states which
         // boundary this installation's home is, and a project is one shape a

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -39,7 +39,6 @@ export { setConfig } from './config/set.ts';
 export {
   completeCreationDraft,
   getCreationDraft,
-  reviewCreationDraft,
   saveCreationDraft,
   startCreationDraft,
 } from './creation-drafts/lifecycle.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -66,8 +66,6 @@ import {
   completeCreationDraftInput,
   getCreationDraft,
   getCreationDraftInput,
-  reviewCreationDraft,
-  reviewCreationDraftInput,
   saveCreationDraft,
   saveCreationDraftInput,
   startCreationDraft,
@@ -208,10 +206,6 @@ export const commandRegistry = {
   saveCreationDraft: {
     input: saveCreationDraftInput,
     handler: saveCreationDraft,
-  },
-  reviewCreationDraft: {
-    input: reviewCreationDraftInput,
-    handler: reviewCreationDraft,
   },
   completeCreationDraft: {
     input: completeCreationDraftInput,

--- a/apps/spindrift/src/commands/repositories/list.ts
+++ b/apps/spindrift/src/commands/repositories/list.ts
@@ -29,20 +29,38 @@ export const listRepositories: Command<
   ListRepositoriesResult
 > = async (_input, context) => {
   const host = context.adapters.repository?.() ?? null;
+  // Refreshed together rather than one after another. This read is on the
+  // creation screen's critical path and every active repository was a serial
+  // round trip to the host, so the screen waited for the sum of them — and a
+  // slow one made the wizard look broken rather than busy.
+  const staleReasons = new Map<string, string>();
   if (host !== null) {
     const existing = await context.db.query.repositories.findMany();
-    for (const repo of existing) {
-      if (repo.access === 'active') {
-        try {
-          await reconcileRepository(
-            { db: context.db, clock: context.clock, host },
-            repo,
-          );
-        } catch {
-          // ignore individual repo reconciliation error during list
-        }
-      }
-    }
+    await Promise.all(
+      existing
+        .filter((repo) => repo.access === 'active')
+        .map(async (repo) => {
+          // One repository the host would not answer about does not empty the
+          // list — but the row it happened to says so, because the alternative
+          // is a commit from an hour ago rendered as current. `unavailable` is
+          // the loop's own word for that, and a throw is the same fact
+          // arriving as an exception.
+          try {
+            const pass = await reconcileRepository(
+              { db: context.db, clock: context.clock, host },
+              repo,
+            );
+            if (pass.outcome === 'unavailable') {
+              staleReasons.set(repo.id, pass.detail);
+            }
+          } catch (cause) {
+            staleReasons.set(
+              repo.id,
+              cause instanceof Error ? cause.message : String(cause),
+            );
+          }
+        }),
+    );
   }
 
   const allRepos = await context.db.query.repositories.findMany({
@@ -92,6 +110,7 @@ export const listRepositories: Command<
       health: isConnected ? 'connected' : 'connection_lost',
       error: repo.frozenReason ?? null,
       lastReconciledSha: repo.authoritativeCommit ?? null,
+      staleReason: staleReasons.get(repo.id) ?? null,
       appSubpaths,
     });
   }

--- a/apps/spindrift/src/commands/repositories/list.ts
+++ b/apps/spindrift/src/commands/repositories/list.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { RepositoryAuthorizationRequiredError } from '../../domain/repository.ts';
 import { reconcileRepository } from '../../reconciler/repo-loop.ts';
 import type {
+  GrantedRepositoryView,
   LinkedRepoView,
   RepositoryConnectorView,
   RepositoryOptionView,
@@ -16,7 +17,7 @@ export interface ListRepositoriesResult {
   /** Durable connections consumed by the App creation flow. */
   readonly options: readonly RepositoryOptionView[];
   /** Repositories GitHub currently grants, consumed by the connector form. */
-  readonly available: readonly RepositoryOptionView[];
+  readonly available: readonly GrantedRepositoryView[];
   readonly connector: RepositoryConnectorView;
 }
 
@@ -126,17 +127,17 @@ export const listRepositories: Command<
   const connectedByName = new Map(
     reposList.map((repo) => [repo.fullName, repo] as const),
   );
-  const availableList: RepositoryOptionView[] = available.map((repo) => ({
+  const availableList: GrantedRepositoryView[] = available.map((repo) => ({
     repositoryId: repo.repositoryId,
     fullName: repo.fullName,
     defaultBranch: repo.defaultBranch,
-    connected: connectedByName.has(repo.fullName),
+    rowExists: connectedByName.has(repo.fullName),
   }));
   const optionsList: RepositoryOptionView[] = allRepos.map((repo) => ({
     repositoryId: repo.id,
     fullName: repo.fullName,
     defaultBranch: repo.defaultBranch,
-    connected: subpathsByRepoId.has(repo.id),
+    alreadyDeploys: subpathsByRepoId.has(repo.id),
   }));
 
   return ok({

--- a/apps/spindrift/src/commands/repositories/list.ts
+++ b/apps/spindrift/src/commands/repositories/list.ts
@@ -1,5 +1,8 @@
 import { z } from 'zod';
-import { RepositoryAuthorizationRequiredError } from '../../domain/repository.ts';
+import {
+  cloneUrlFor,
+  RepositoryAuthorizationRequiredError,
+} from '../../domain/repository.ts';
 import { reconcileRepository } from '../../reconciler/repo-loop.ts';
 import type {
   GrantedRepositoryView,
@@ -127,16 +130,19 @@ export const listRepositories: Command<
   const connectedByName = new Map(
     reposList.map((repo) => [repo.fullName, repo] as const),
   );
+  const webBaseUrl = context.manifest.github.oauthBaseUrl;
   const availableList: GrantedRepositoryView[] = available.map((repo) => ({
     repositoryId: repo.repositoryId,
     fullName: repo.fullName,
     defaultBranch: repo.defaultBranch,
+    cloneUrl: cloneUrlFor(webBaseUrl, repo.fullName),
     rowExists: connectedByName.has(repo.fullName),
   }));
   const optionsList: RepositoryOptionView[] = allRepos.map((repo) => ({
     repositoryId: repo.id,
     fullName: repo.fullName,
     defaultBranch: repo.defaultBranch,
+    cloneUrl: cloneUrlFor(webBaseUrl, repo.fullName),
     alreadyDeploys: subpathsByRepoId.has(repo.id),
   }));
 

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -28,27 +28,6 @@ export const ENTRIES = [
   },
 ] as const;
 
-/**
- * The five decisions, as the flow used to walk them.
- *
- * Kept as vocabulary and no longer as a rail. §18 named the sequence Source →
- * Component → Place → Configure → Review, and stories 31 and 32 say what that
- * sequence is *for*: "defaults carrying every step" and "corrections and
- * configuration hidden behind progressive disclosure". Five screens with a
- * Continue button under each is one way to render that, and it turned out to
- * be the way that made every default look like a question.
- *
- * So the decisions still exist, in this order, as the order of the summary
- * rows on one screen. What went away is the walking.
- */
-export const DECISIONS = [
-  'Source',
-  'Component',
-  'Place',
-  'Configure',
-  'Review',
-] as const;
-
 // Exported because §3's requirements are derived from exactly these three, so
 // any command that resolves placement validates them against the same words the
 // draft does.
@@ -201,17 +180,25 @@ export const creationDraftSchema = z
      * statement about one tree.
      */
     scopeByOperator: z.boolean().optional(),
-    /**
-     * Which step of the old rail this draft was left on.
-     *
-     * Optional, unread, and still here: drafts are durable rows, and a strict
-     * schema that dropped the key would refuse every draft saved before the
-     * flow became one screen. It costs a line to keep and a migration to
-     * remove.
-     */
-    step: z.number().int().min(0).optional(),
   })
   .strict();
+
+/**
+ * The same document, read from a stored row.
+ *
+ * Drafts are durable jsonb, so a row written before a key was retired still
+ * carries it — and the strict schema above, which is what a save is validated
+ * against, would refuse the operator's own draft the moment they touched it.
+ * Reading through this drops what is no longer named, so the browser never
+ * receives a key it would hand straight back. That is the whole migration: the
+ * column is jsonb and every retired key was optional.
+ */
+const storedDraftSchema = z.object(creationDraftSchema.shape);
+
+export function storedDraft(draft: Draft): Draft {
+  const parsed = storedDraftSchema.safeParse(draft);
+  return parsed.success ? (parsed.data as Draft) : draft;
+}
 
 export type Draft = z.infer<typeof creationDraftSchema>;
 export type EntryId = Draft['entry'];

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -264,12 +264,16 @@ export interface CreationDraftView {
 
 /** Defaults are selected from current persisted installation capabilities. */
 export function initialCreationDraft(input: {
-  readonly repository: string | null;
+  /** The repository to open on, with the clone URL its host serves it at. */
+  readonly repository: {
+    readonly fullName: string;
+    readonly cloneUrl: string;
+  } | null;
   readonly targetId: string | null;
   readonly vessel: string;
 }): Draft {
   const name =
-    (input.repository?.split('/').pop() ?? 'app')
+    (input.repository?.fullName.split('/').pop() ?? 'app')
       .toLowerCase()
       .replaceAll(/[^a-z0-9-]/g, '-')
       .replaceAll(/^-+|-+$/g, '') || 'app';
@@ -279,8 +283,8 @@ export function initialCreationDraft(input: {
     source: repo
       ? {
           kind: 'repo',
-          repo,
-          url: `https://github.com/${repo}.git`,
+          repo: repo.fullName,
+          url: repo.cloneUrl,
           subpath: '.',
         }
       : {

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -264,6 +264,24 @@ export interface CreationDraftView {
   readonly ready: boolean;
 }
 
+/**
+ * What a draft claims about a repository nothing has read.
+ *
+ * One statement of it, because two states mean it: a draft that has just been
+ * created, and a draft that has just been pointed at another repository. Both
+ * have read nothing about the tree they name, and `scope: undefined` is what
+ * says so — it is the flag the browser's read consults before proposing.
+ */
+function openingDetection(): Detection {
+  return {
+    kind: 'service',
+    reason:
+      'the default is a long-running service until detection says otherwise',
+    available: ['service', 'website', 'job'],
+    unavailable: {},
+  };
+}
+
 /** Defaults are selected from current persisted installation capabilities. */
 export function initialCreationDraft(input: {
   /** The repository to open on, with the clone URL its host serves it at. */
@@ -299,13 +317,7 @@ export function initialCreationDraft(input: {
         },
     appName: name,
     componentName: 'web',
-    detection: {
-      kind: 'service',
-      reason:
-        'the default is a long-running service until detection says otherwise',
-      available: ['service', 'website', 'job'],
-      unavailable: {},
-    },
+    detection: openingDetection(),
     kind: 'service',
     vessel: {
       name: input.vessel,
@@ -444,6 +456,12 @@ export function draftReducer(draft: Draft, action: DraftAction): Draft {
         // The directory went back to the root with the tree it named, so
         // whoever typed the old one has not typed this one.
         scopeByOperator: undefined,
+        // And so did the read. The sentence, the ruled-out kinds and the scope
+        // are all statements about the previous repository, and the scope is
+        // what makes a draft count as answered — carried over, the read of the
+        // repository just chosen finds the question already settled and applies
+        // nothing, leaving the rows below describing somewhere else.
+        detection: openingDetection(),
       };
     }
     // Typing a directory is the operator answering where the App is, so it

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -56,15 +56,30 @@ export const componentKind = z.enum(['service', 'website', 'job']);
 export const reach = z.enum(['none', 'private', 'public']);
 export const auth = z.enum(['none', 'proxy']);
 const entry = z.enum(['service', 'website', 'upload', 'repo', 'discover']);
-const appName = z
+
+/**
+ * The App name's rule, exported because the screen checks it too.
+ *
+ * One statement of the rule, read from both ends: the browser marks the field
+ * as the operator types and the command refuses the document, and a second copy
+ * of the regex is how those two come to disagree. The messages are written for
+ * a reader because this is the one schema whose complaints are rendered beside
+ * an input rather than logged.
+ */
+export const appNameSchema = z
   .string()
   .trim()
-  .min(1)
-  .max(63)
+  .min(1, 'the App needs a name')
+  .max(63, 'at most 63 characters — it is one DNS label')
   .regex(
     /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/,
     'must be lowercase letters, digits and hyphens',
   );
+
+/** The Component name's rule. Read beside the field for the same reason. */
+export const componentNameSchema = z
+  .string()
+  .min(1, 'the Component needs a name');
 
 const source = z.discriminatedUnion('kind', [
   z
@@ -147,8 +162,8 @@ export const creationDraftSchema = z
   .object({
     entry,
     source,
-    appName,
-    componentName: z.string().min(1),
+    appName: appNameSchema,
+    componentName: componentNameSchema,
     detection,
     kind: componentKind,
     vessel,

--- a/apps/spindrift/src/domain/repository.ts
+++ b/apps/spindrift/src/domain/repository.ts
@@ -203,3 +203,15 @@ export function repositoryRefOf(row: {
 }): RepositoryRef {
   return { installationId: row.installationId };
 }
+
+/**
+ * Where a repository is cloned from.
+ *
+ * `webBaseUrl` is the repository host's web origin, which §20 keeps in the
+ * installation manifest because an enterprise deployment serves its own. A
+ * template with the public host written into it is a clone URL that is right
+ * here by accident and wrong for every other installation.
+ */
+export function cloneUrlFor(webBaseUrl: string, fullName: string): string {
+  return `${webBaseUrl}/${fullName}.git`;
+}

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -5,7 +5,7 @@
  * here is chrome that exists to reach them.
  */
 import { Monitor, Moon, Sun } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Principal } from '../commands/types.ts';
 import { readSession, signOut } from './auth-client.ts';
 import { command, type InputOf, type OutputOf } from './client.ts';
@@ -37,7 +37,12 @@ import { Eyebrow } from './ui/card.tsx';
 import { cn } from './ui/utils.ts';
 import { DeployDetail } from './views/apps/deploy-detail.tsx';
 import { AppList } from './views/apps/list.tsx';
-import { NewApp } from './views/apps/new/index.tsx';
+import {
+  type CreationLoad,
+  CreationLoadFailure,
+  CreationSkeleton,
+  NewApp,
+} from './views/apps/new/index.tsx';
 import {
   type RunJob,
   type SetAutoDeploy,
@@ -382,14 +387,16 @@ export function Screen({
     return <SourcesScreen onNavigate={onNavigate} />;
   if (path.startsWith('/artifacts'))
     return <ArtifactsScreen onNavigate={onNavigate} />;
+  // The one screen keyed on the route rather than on the object in it, because
+  // it is the one screen that *names* its object partway through: a draft
+  // starts, the path is rewritten to `/apps/new/<id>`, and a key reading that
+  // id would tear down the screen that just created it. `NewAppScreen` keeps
+  // its own record of which draft is loaded and keys `NewApp` on it, so a
+  // different draft still resets everything a different draft should.
   if (path.startsWith('/apps/new')) {
     const draftId = path.replace(/^\/apps\/new\/?/, '') || null;
     return (
-      <NewAppScreen
-        key={draftId ?? 'new'}
-        draftId={draftId}
-        onNavigate={onNavigate}
-      />
+      <NewAppScreen key="apps-new" draftId={draftId} onNavigate={onNavigate} />
     );
   }
   if (path.startsWith('/deploys')) {
@@ -2248,7 +2255,7 @@ function NewAppScreen({
   onNavigate: (path: string) => void;
 }) {
   const [state, setState] = useState<
-    | { type: 'loading' }
+    | { type: 'loading'; phase: CreationLoad }
     | { type: 'error'; message: string }
     | {
         type: 'success';
@@ -2257,16 +2264,32 @@ function NewAppScreen({
         repoGrant: readonly GrantedRepositoryView[];
         draft: import('../domain/creation-draft.ts').CreationDraftView;
       }
-  >({ type: 'loading' });
+  >({ type: 'loading', phase: 'draft' });
+  const [attempt, setAttempt] = useState(0);
   // React Strict Mode replays effects in development. Supplying the identity
   // makes both starts the same authenticated act instead of leaving an orphan.
-  const [startId] = useState(() => crypto.randomUUID());
+  const startId = useRef(crypto.randomUUID());
+  /** The draft on screen, so this screen's own URL rewrite is not navigation. */
+  const loaded = useRef<string | null>(null);
 
   useEffect(() => {
+    // The path naming the draft this screen started is the rewrite below
+    // arriving back through the router. Reloading for it would re-run both
+    // reads and throw away everything typed since — which is the whole of what
+    // remounting on the id used to cost.
+    if (draftId !== null && draftId === loaded.current) return;
+    if (draftId === null && loaded.current !== null) {
+      // `New App` pressed while a draft is open: a genuinely new one needs an
+      // identity of its own, or `startCreationDraft` idempotently answers with
+      // the draft already on screen.
+      startId.current = crypto.randomUUID();
+      loaded.current = null;
+    }
     let live = true;
+    setState({ type: 'loading', phase: 'draft' });
     const draftRequest =
       draftId === null
-        ? command('startCreationDraft', { id: startId })
+        ? command('startCreationDraft', { id: startId.current })
         : command('getCreationDraft', { id: draftId });
     // The Targets read follows the draft rather than racing it: placement is
     // derived from what is being created (§3), so asking before the draft
@@ -2279,6 +2302,7 @@ function NewAppScreen({
         setState({ type: 'error', message: draftRes.failure.message });
         return;
       }
+      setState({ type: 'loading', phase: 'options' });
       const { kind, reach, auth } = draftRes.value.draft;
       const [targetRes, repoRes] = await Promise.all([
         command('listTargets', { kind, reach, auth }),
@@ -2293,6 +2317,7 @@ function NewAppScreen({
         setState({ type: 'error', message: repoRes.failure.message });
         return;
       }
+      loaded.current = draftRes.value.id;
       setState({
         type: 'success',
         targetOptions: targetRes.value.options,
@@ -2313,26 +2338,16 @@ function NewAppScreen({
     return () => {
       live = false;
     };
-  }, [draftId, onNavigate, startId]);
+  }, [draftId, onNavigate, attempt]);
 
-  if (state.type === 'loading') {
-    return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <p className="text-sm text-muted-foreground animate-pulse">
-          Loading creation options...
-        </p>
-      </div>
-    );
-  }
+  if (state.type === 'loading') return <CreationSkeleton phase={state.phase} />;
 
   if (state.type === 'error') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="text-sm font-medium">Failed to load creation options</p>
-          <p className="text-sm mt-1">{state.message}</p>
-        </div>
-      </div>
+      <CreationLoadFailure
+        message={state.message}
+        onRetry={() => setAttempt((value) => value + 1)}
+      />
     );
   }
 

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -16,6 +16,7 @@ import type {
   BuildListItem,
   DeployLedgerItem,
   DeployView,
+  GrantedRepositoryView,
   LinkedRepoView,
   LogLine,
   PendingTargetConnection,
@@ -2050,7 +2051,7 @@ function RepositoriesScreen({ embedded = false }: { embedded?: boolean }) {
         type: 'success';
         repos: readonly LinkedRepoView[];
         options: readonly RepositoryOptionView[];
-        available: readonly RepositoryOptionView[];
+        available: readonly GrantedRepositoryView[];
         connector: RepositoryConnectorView;
       }
   >({ type: 'loading' });
@@ -2253,7 +2254,7 @@ function NewAppScreen({
         type: 'success';
         targetOptions: readonly TargetOptionView[];
         repoOptions: readonly RepositoryOptionView[];
-        repoGrant: readonly RepositoryOptionView[];
+        repoGrant: readonly GrantedRepositoryView[];
         draft: import('../domain/creation-draft.ts').CreationDraftView;
       }
   >({ type: 'loading' });

--- a/apps/spindrift/src/web/components/repo-picker.tsx
+++ b/apps/spindrift/src/web/components/repo-picker.tsx
@@ -40,6 +40,9 @@ export type RepositoryChoiceState =
 export interface RepositoryChoice {
   readonly fullName: string;
   readonly defaultBranch: string;
+  /** Carried from the response rather than templated: the host is the
+   * installation's, and this component has no way to know it. */
+  readonly cloneUrl: string;
   readonly state: RepositoryChoiceState;
 }
 
@@ -70,6 +73,7 @@ export function repositoryChoices(
     rows.set(repo.fullName, {
       fullName: repo.fullName,
       defaultBranch: repo.defaultBranch,
+      cloneUrl: repo.cloneUrl,
       state: repo.alreadyDeploys ? 'deploys' : 'connected',
     });
   }
@@ -78,6 +82,7 @@ export function repositoryChoices(
     rows.set(repo.fullName, {
       fullName: repo.fullName,
       defaultBranch: repo.defaultBranch,
+      cloneUrl: repo.cloneUrl,
       state: 'grant-only',
     });
   }
@@ -94,7 +99,7 @@ export function RepoPicker({
   repos: readonly RepositoryChoice[];
   /** The fullName of the currently selected repo, or `null`. */
   selected: string | null;
-  onSelect: (repo: RepositoryChoice, url: string) => void;
+  onSelect: (repo: RepositoryChoice) => void;
 }) {
   const [filter, setFilter] = useState('');
   const normalised = filter.toLowerCase();
@@ -138,9 +143,7 @@ export function RepoPicker({
               <button
                 key={repo.fullName}
                 type="button"
-                onClick={() =>
-                  onSelect(repo, `https://github.com/${repo.fullName}.git`)
-                }
+                onClick={() => onSelect(repo)}
                 className={cn(
                   'flex items-center gap-2.5 rounded-md px-3 py-2 text-left transition-colors',
                   isSelected

--- a/apps/spindrift/src/web/components/repo-picker.tsx
+++ b/apps/spindrift/src/web/components/repo-picker.tsx
@@ -23,7 +23,7 @@
  */
 import { GitBranch, Search } from 'lucide-react';
 import { useState } from 'react';
-import type { RepositoryOptionView } from '../model.ts';
+import type { GrantedRepositoryView, RepositoryOptionView } from '../model.ts';
 import { Badge } from '../ui/badge.tsx';
 import { cn } from '../ui/utils.ts';
 
@@ -55,22 +55,22 @@ const STATE_BADGE = {
 /**
  * The grant and the connections, as one list.
  *
- * The two `connected` booleans on the response mean different things — on a
- * connection it means an App deploys from it, on a grant entry it means a row
- * exists — so neither is read as a state here. The state is derived from which
- * list a repository is in and what its own list says about it, which is the
- * only reading that cannot be wrong about the other list.
+ * A connection knows whether an App deploys from it and a grant entry knows
+ * whether a row exists, which are two different facts about two different
+ * lists — so a row's state is derived from which list it came from and the
+ * fact that list actually holds, and neither boolean is ever read off the
+ * other's row.
  */
 export function repositoryChoices(
   connections: readonly RepositoryOptionView[],
-  grant: readonly RepositoryOptionView[],
+  grant: readonly GrantedRepositoryView[],
 ): readonly RepositoryChoice[] {
   const rows = new Map<string, RepositoryChoice>();
   for (const repo of connections) {
     rows.set(repo.fullName, {
       fullName: repo.fullName,
       defaultBranch: repo.defaultBranch,
-      state: repo.connected ? 'deploys' : 'connected',
+      state: repo.alreadyDeploys ? 'deploys' : 'connected',
     });
   }
   for (const repo of grant) {

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -639,6 +639,14 @@ interface RepositoryIdentityView {
   readonly fullName: string;
   /** The branch Spindrift watches. */
   readonly defaultBranch: string;
+  /**
+   * Where this repository is cloned from.
+   *
+   * Composed here rather than in the browser because the repository host is an
+   * installation fact (§20) and the browser reads no manifest: a client-side
+   * template would name the public host on an installation that has its own.
+   */
+  readonly cloneUrl: string;
 }
 
 /**

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -706,6 +706,15 @@ export interface LinkedRepoView {
   readonly error: string | null;
   /** The last commit SHA Spindrift reconciled. */
   readonly lastReconciledSha: string | null;
+  /**
+   * Why the last refresh of this row from the host failed, if it did.
+   *
+   * Separate from `error`, which is about access being lost. This one is a row
+   * that is still connected and whose commit is older than it looks: listing
+   * every repository refreshes them all, and one the host would not answer
+   * about is a stale row rather than a missing one.
+   */
+  readonly staleReason: string | null;
   /** App subpaths connected to this repository. */
   readonly appSubpaths: readonly string[];
 }

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -631,22 +631,43 @@ export interface TargetOptionView {
   readonly detail: readonly string[];
 }
 
-/**
- * A connected repository as the repository picker lists it.
- *
- * §20: `Link repo` lists repositories currently granted to the installation.
- * Spindrift stores installation and stable repository IDs; the display fields
- * (fullName, defaultBranch) are refreshable.
- */
-export interface RepositoryOptionView {
+/** Everything both repository lists say about one repository. */
+interface RepositoryIdentityView {
   /** GitHub's stable numeric or UUID repository ID, used as the selection key. */
   readonly repositoryId: string | number;
   /** The owner/name a human reads — e.g. `example-org/hub`. */
   readonly fullName: string;
   /** The branch Spindrift watches. */
   readonly defaultBranch: string;
-  /** Whether this repository already has an App connected to it. */
-  readonly connected: boolean;
+}
+
+/**
+ * A repository Spindrift holds a connection row for.
+ *
+ * §20: Spindrift stores installation and stable repository IDs; the display
+ * fields (fullName, defaultBranch) are refreshable.
+ */
+export interface RepositoryOptionView extends RepositoryIdentityView {
+  /**
+   * Whether an App already deploys from this repository.
+   *
+   * Named for what it is because the grant list carries a boolean about the
+   * same repository meaning something else entirely: two fields called
+   * `connected` on one response, rendered with one green badge, is a badge that
+   * claims whichever of the two the reader happens to assume.
+   */
+  readonly alreadyDeploys: boolean;
+}
+
+/**
+ * A repository the GitHub App installation currently grants.
+ *
+ * The grant is a fact about GitHub, so the only thing this list knows about
+ * Spindrift is whether a row for it exists here yet.
+ */
+export interface GrantedRepositoryView extends RepositoryIdentityView {
+  /** Whether Spindrift already holds a connection row for it. */
+  readonly rowExists: boolean;
 }
 
 /** Whether the repository connector can currently call GitHub for this user. */

--- a/apps/spindrift/src/web/ui/field.tsx
+++ b/apps/spindrift/src/web/ui/field.tsx
@@ -49,6 +49,7 @@ export function Field({
   name,
   label,
   hint,
+  issue,
   className,
   children,
   ...props
@@ -56,13 +57,38 @@ export function Field({
   name: string;
   label: string;
   hint?: string;
+  /**
+   * What is wrong with the value, said here rather than at the bottom of the
+   * page.
+   *
+   * A rule the form already knows is a rule the form can state where the value
+   * is: a transport refusal listing `appName` under a Deploy button is the same
+   * fact delivered where nobody can act on it. `aria-invalid` carries it to
+   * anyone not reading the sentence.
+   */
+  issue?: string | null;
   children?: ReactNode;
 }) {
   return (
     <div className={cn('flex flex-col gap-1.5', className)}>
       <Label htmlFor={name}>{label}</Label>
-      {children ?? <Input id={name} name={name} {...props} />}
-      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+      {children ?? (
+        <Input
+          id={name}
+          name={name}
+          aria-invalid={issue ? true : undefined}
+          aria-describedby={issue ? `${name}-issue` : undefined}
+          className={issue ? 'border-destructive' : undefined}
+          {...props}
+        />
+      )}
+      {issue ? (
+        <p id={`${name}-issue`} className="text-xs text-destructive">
+          {issue}
+        </p>
+      ) : hint ? (
+        <p className="text-xs text-muted-foreground">{hint}</p>
+      ) : null}
     </div>
   );
 }

--- a/apps/spindrift/src/web/views/apps/new/deploy.ts
+++ b/apps/spindrift/src/web/views/apps/new/deploy.ts
@@ -1,0 +1,60 @@
+/**
+ * What pressing Deploy does, in the order it has to happen.
+ *
+ * Separate from the screen for the reason `detect.ts` is: the interesting part
+ * is a sequence with one rule in it, and the rule is invisible when it is four
+ * lines inside a click handler.
+ *
+ * The rule is that **Deploy completes the draft the server holds, not the one
+ * on screen**. So the writes are flushed first — a debounce means the last
+ * edit may still be sitting in a timer — and then the question is whether they
+ * landed. If they did not, nothing is sent: the revision would be right and the
+ * document wrong, which produces an App built from an older answer with no sign
+ * that anything was ignored.
+ *
+ * What went wrong before was smaller and worse. The screen cleared the refusal,
+ * awaited the chain, and returned on failure — so a save that had been refused
+ * while nobody was looking made Deploy a button that erased the only sentence
+ * explaining itself and did nothing. The failure is the answer to the press,
+ * and this returns it.
+ */
+import type {
+  ClientResult,
+  OutputOf,
+  TransportFailure,
+} from '../../../client.ts';
+
+type Completion = OutputOf<'completeCreationDraft'>;
+
+/** Said when Deploy is refused by a save nobody watched fail. */
+export const UNSAVED_TITLE = 'Nothing was created — this draft is not saved';
+
+export type DeployOutcome =
+  /** The draft never reached the server, so nothing was completed. */
+  | {
+      readonly act: 'unsaved';
+      readonly failure: TransportFailure;
+      readonly title: string;
+    }
+  /** The completing command itself refused. */
+  | { readonly act: 'refused'; readonly failure: TransportFailure }
+  /** It ran. The App may still be null — a blocked draft creates nothing. */
+  | { readonly act: 'completed'; readonly result: Completion };
+
+export async function deployDraft(steps: {
+  /** Send anything the debounce is holding and wait for the chain to drain. */
+  flush(): Promise<void>;
+  /** What the last write was refused with, once the chain has drained. */
+  unsaved(): TransportFailure | null;
+  complete(): Promise<ClientResult<Completion>>;
+}): Promise<DeployOutcome> {
+  await steps.flush();
+  const failure = steps.unsaved();
+  if (failure !== null) {
+    return { act: 'unsaved', failure, title: UNSAVED_TITLE };
+  }
+  const result = await steps.complete();
+  return result.ok
+    ? { act: 'completed', result: result.value }
+    : { act: 'refused', failure: result.failure };
+}

--- a/apps/spindrift/src/web/views/apps/new/deploy.ts
+++ b/apps/spindrift/src/web/views/apps/new/deploy.ts
@@ -17,6 +17,11 @@
  * while nobody was looking made Deploy a button that erased the only sentence
  * explaining itself and did nothing. The failure is the answer to the press,
  * and this returns it.
+ *
+ * Which is why the outcomes are five rather than three. Two of the ways the
+ * press can end are not refusals to report: a stale revision is the same
+ * recoverable state a refused save is, and a completion that never answered is
+ * not the server saying no — it is nobody knowing what it did.
  */
 import type {
   ClientResult,
@@ -29,6 +34,9 @@ type Completion = OutputOf<'completeCreationDraft'>;
 /** Said when Deploy is refused by a save nobody watched fail. */
 export const UNSAVED_TITLE = 'Nothing was created — this draft is not saved';
 
+/** Said when the completing command never answered at all. */
+export const LOST_TITLE = 'Spindrift did not hear back';
+
 export type DeployOutcome =
   /** The draft never reached the server, so nothing was completed. */
   | {
@@ -36,8 +44,26 @@ export type DeployOutcome =
       readonly failure: TransportFailure;
       readonly title: string;
     }
+  /**
+   * The draft moved under this tab, so completing it is the same recovery a
+   * refused save is: the revision this tab holds is a version that no longer
+   * exists, and pressing again sends it again. Its own arm because it is the
+   * one refusal the screen can answer rather than report.
+   */
+  | { readonly act: 'stale' }
   /** The completing command itself refused. */
   | { readonly act: 'refused'; readonly failure: TransportFailure }
+  /**
+   * It was sent and nothing came back — a dropped connection, or a proxy
+   * answering with its own error page. Distinct from a refusal because the
+   * server may well have created the App: the only honest thing to say is that
+   * this is unknown, which a button stuck on "Creating…" does not say.
+   */
+  | {
+      readonly act: 'lost';
+      readonly failure: TransportFailure;
+      readonly title: string;
+    }
   /** It ran. The App may still be null — a blocked draft creates nothing. */
   | { readonly act: 'completed'; readonly result: Completion };
 
@@ -53,8 +79,21 @@ export async function deployDraft(steps: {
   if (failure !== null) {
     return { act: 'unsaved', failure, title: UNSAVED_TITLE };
   }
-  const result = await steps.complete();
-  return result.ok
-    ? { act: 'completed', result: result.value }
+  let result: ClientResult<Completion>;
+  try {
+    result = await steps.complete();
+  } catch (cause) {
+    return {
+      act: 'lost',
+      failure: {
+        code: 'INTERNAL',
+        message: `${cause instanceof Error ? cause.message : 'the request did not complete'} — nothing here knows whether the App was created. Check Apps before pressing Deploy again.`,
+      },
+      title: LOST_TITLE,
+    };
+  }
+  if (result.ok) return { act: 'completed', result: result.value };
+  return result.failure.code === 'STALE_EDIT'
+    ? { act: 'stale' }
     : { act: 'refused', failure: result.failure };
 }

--- a/apps/spindrift/src/web/views/apps/new/draft.ts
+++ b/apps/spindrift/src/web/views/apps/new/draft.ts
@@ -10,7 +10,6 @@ export {
   CREATION_BLOCKER_CODES,
   type CreationDraftView,
   creationDraftSchema,
-  DECISIONS,
   type Detection,
   type Draft,
   type DraftAction,

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -40,7 +40,11 @@ import {
   type RepositoryChoice,
   repositoryChoices,
 } from '../../../components/repo-picker.tsx';
-import type { RepositoryOptionView, TargetOptionView } from '../../../model.ts';
+import type {
+  GrantedRepositoryView,
+  RepositoryOptionView,
+  TargetOptionView,
+} from '../../../model.ts';
 import { reportSessionExpired } from '../../../session-events.ts';
 import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
@@ -108,7 +112,7 @@ export function NewApp({
   /** Repositories Spindrift holds a row for. */
   repos: readonly RepositoryOptionView[];
   /** Repositories GitHub currently grants this installation. */
-  available: readonly RepositoryOptionView[];
+  available: readonly GrantedRepositoryView[];
   onCreated?: (app: { readonly id: string; readonly name: string }) => void;
 }) {
   const [draft, setDraft] = useState(initial.draft);

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -276,11 +276,11 @@ export function NewApp({
   };
 
   /** Selecting a repository reads it. Nothing is written until Deploy. */
-  const selectRepo = (repo: RepositoryChoice, url: string) => {
+  const selectRepo = (repo: RepositoryChoice) => {
     dispatch({
       type: 'repo',
       fullName: repo.fullName,
-      url,
+      url: repo.cloneUrl,
       connect: repo.state === 'grant-only',
     });
     scopesRef.current = [];
@@ -720,7 +720,7 @@ function SourceRow({
   detectionError: string | null;
   /** Detection is offering candidates and the draft names none of them. */
   unchosen: boolean;
-  onSelectRepo: (repo: RepositoryChoice, url: string) => void;
+  onSelectRepo: (repo: RepositoryChoice) => void;
   onChooseScope: (scope: InspectedScope) => void;
   onSettleSubpath: () => void;
 }) {

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -117,9 +117,41 @@ function unchosenScope(
  * holds nothing buildable is the assertion path §5 keeps open: name the
  * directory, pick the kind, and Spindrift builds what you said.
  */
-export type DetectionTrouble =
-  | { readonly kind: 'unread'; readonly message: string }
-  | { readonly kind: 'unsupported'; readonly message: string };
+export interface DetectionTrouble {
+  readonly kind: 'unread' | 'unsupported';
+  readonly message: string;
+  /** The repository the read was about. */
+  readonly repo: string;
+  /**
+   * The directory it asked about, absent when it asked about the tree.
+   *
+   * What makes the sentence checkable against the draft rather than cleared on
+   * a guess: a complaint about `docs` stops being on screen when the root
+   * directory stops saying `docs`, and one about the repository as a whole does
+   * not, because naming a directory in it did not read it.
+   */
+  readonly scope?: string;
+}
+
+/**
+ * The last read's complaint, while the draft still names what it is about.
+ *
+ * Derived rather than cleared per action, which is the whole of the fix: an
+ * enumeration of the actions that "move the input" cannot tell a sentence about
+ * a directory from a sentence about a repository, and clearing an unreadable
+ * repository on a keystroke in the root directory field re-enables Deploy on
+ * the draft's opening claim — a kind nothing checked, in a tree nothing read.
+ */
+export function standingTrouble(
+  draft: Draft,
+  trouble: DetectionTrouble | null,
+): DetectionTrouble | null {
+  if (trouble === null || draft.source.kind !== 'repo') return null;
+  if (draft.source.repo !== trouble.repo) return null;
+  return trouble.scope === undefined || trouble.scope === draft.source.subpath
+    ? trouble
+    : null;
+}
 
 function unreadRepository(
   draft: Draft,
@@ -134,20 +166,6 @@ function unreadRepository(
     },
   ];
 }
-
-/**
- * The actions that make a sentence about the last read stop being true.
- *
- * Naming the actions rather than clearing everywhere: `kind`, `reach` and the
- * Target do not move the thing that was read, so a refusal that survives them
- * is the refusal still being about the repository on screen.
- */
-const CLEARS_DETECTION = new Set<DraftAction['type']>([
-  'repo',
-  'subpath',
-  'entry',
-  'detect',
-]);
 
 /** Whether anything has answered which directory this draft deploys. */
 function answeredScope(draft: Draft): boolean {
@@ -303,10 +321,11 @@ export function NewApp({
     draft.source.kind === 'repo' &&
     draft.detection.scope !== undefined &&
     draft.detection.scope !== draft.source.subpath;
+  const standing = standingTrouble(draft, trouble);
   const localBlockers = [
     ...blockersFor(draft, candidateIds),
     ...unchosen,
-    ...unreadRepository(draft, trouble),
+    ...unreadRepository(draft, standing),
   ];
   const blockers = [
     ...localBlockers,
@@ -329,29 +348,45 @@ export function NewApp({
    * revision the tab holds is a version that no longer exists, so the next
    * keystroke is refused for the same reason, forever. Re-reading is the whole
    * recovery — the server's draft is the truth by definition here — and what it
-   * costs is whatever was typed into the field the other tab also changed,
-   * which is why it is said out loud rather than done quietly.
+   * costs is whatever was typed since the other tab wrote, which is why it is
+   * said out loud rather than done quietly.
    */
   const resync = async (): Promise<void> => {
-    const recovered = await command('getCreationDraft', { id: initial.id });
-    if (!recovered.ok) {
-      unsaved.current = recovered.failure;
-      setRefusal({ failure: recovered.failure });
-      return;
-    }
-    revisionRef.current = recovered.value.revision;
-    draftRef.current = recovered.value.draft;
-    setDraft(recovered.value.draft);
-    setServerBlockers(recovered.value.blockers);
-    unsaved.current = null;
-    setRefusal({
-      failure: {
-        code: 'STALE_EDIT',
+    try {
+      const recovered = await command('getCreationDraft', { id: initial.id });
+      if (!recovered.ok) {
+        unsaved.current = recovered.failure;
+        setRefusal({ failure: recovered.failure });
+        return;
+      }
+      revisionRef.current = recovered.value.revision;
+      draftRef.current = recovered.value.draft;
+      setDraft(recovered.value.draft);
+      setServerBlockers(recovered.value.blockers);
+      // Whatever the debounce is still holding was written against the version
+      // that just lost, and sending it would put a document nobody is looking
+      // at on the server at the revision just recovered — where it lands,
+      // because the revision is all the guard checks. Dropped after the read
+      // rather than before it, so an edit made while it was in flight goes too.
+      writes.current?.discard();
+      unsaved.current = null;
+      setRefusal({
+        failure: {
+          code: 'STALE_EDIT',
+          message:
+            'Another tab saved this draft first, and its version is what is on screen now. Anything you had typed here since is gone — check the rows above before deploying.',
+        },
+        title: 'This draft was edited somewhere else',
+      });
+    } catch (cause) {
+      const failure: TransportFailure = {
+        code: 'INTERNAL',
         message:
-          'Another tab saved this draft first, and its version is what is on screen now. Anything you had changed on the same field is gone — check the rows above before deploying.',
-      },
-      title: 'This draft was edited somewhere else',
-    });
+          cause instanceof Error ? cause.message : 'the draft was not re-read',
+      };
+      unsaved.current = failure;
+      setRefusal({ failure });
+    }
   };
 
   const persist = async (next: Draft): Promise<void> => {
@@ -396,10 +431,6 @@ export function NewApp({
     const next = draftReducer(previous, action);
     draftRef.current = next;
     setDraft(next);
-    // A sentence about what was read stops being true the moment the input it
-    // was read from moves. Leaving it up is how a repository that cannot be
-    // read keeps blocking a repository that can.
-    if (CLEARS_DETECTION.has(action.type)) setTrouble(null);
     // Compared rather than keyed off the action type: `entry` and `detect`
     // change the kind too, and an enumeration here would drift the first time a
     // new action moves one of the three.
@@ -446,7 +477,14 @@ export function NewApp({
         inspection(fullName, scope),
       );
       if (!result.ok) {
-        setTrouble({ kind: 'unread', message: result.failure.message });
+        // Recorded against the repository and no directory, whichever the
+        // request named: what failed is the reading of the tree, and only
+        // another repository — or another read — is a different answer.
+        setTrouble({
+          kind: 'unread',
+          message: result.failure.message,
+          repo: fullName,
+        });
         return;
       }
       const found = result.value.scopes;
@@ -463,10 +501,16 @@ export function NewApp({
       });
       if (outcome.act === 'detect') dispatch(outcome.action);
       if (outcome.act === 'refuse')
-        setTrouble({ kind: 'unsupported', message: outcome.message });
+        setTrouble({
+          kind: 'unsupported',
+          message: outcome.message,
+          repo: fullName,
+          scope,
+        });
     } catch (cause) {
       setTrouble({
         kind: 'unread',
+        repo: fullName,
         message:
           cause instanceof Error
             ? cause.message
@@ -536,33 +580,46 @@ export function NewApp({
   /** The terminal act: revalidate and create under one database lock. */
   async function start() {
     setSubmitting(true);
-    const outcome = await deployDraft({
-      flush: async () => {
-        await writes.current?.flush();
-      },
-      unsaved: () => unsaved.current,
-      complete: () =>
-        command('completeCreationDraft', {
-          id: initial.id,
-          revision: revisionRef.current,
-        }),
-    });
-    setSubmitting(false);
-    if (outcome.act === 'unsaved') {
-      setRefusal({ failure: outcome.failure, title: outcome.title });
-      return;
+    try {
+      const outcome = await deployDraft({
+        flush: async () => {
+          await writes.current?.flush();
+        },
+        unsaved: () => unsaved.current,
+        complete: () =>
+          command('completeCreationDraft', {
+            id: initial.id,
+            revision: revisionRef.current,
+          }),
+      });
+      if (outcome.act === 'unsaved' || outcome.act === 'lost') {
+        setRefusal({ failure: outcome.failure, title: outcome.title });
+        return;
+      }
+      // The press is as capable of finding the stale revision as a keystroke
+      // is, and it lands there whenever the last edit was already saved: the
+      // flush sends nothing, so the completion is the first thing carrying the
+      // revision another tab has superseded. Reported rather than recovered, it
+      // is a refusal telling the operator to reload with no control that does.
+      if (outcome.act === 'stale') {
+        await resync();
+        return;
+      }
+      if (outcome.act === 'refused') {
+        setRefusal({ failure: outcome.failure });
+        return;
+      }
+      setRefusal(null);
+      setServerBlockers(outcome.result.draft.blockers);
+      if (outcome.result.app === null) return;
+      onCreated?.({
+        id: outcome.result.app.appId,
+        name: outcome.result.app.name,
+      });
+    } finally {
+      // Whatever happened, the button stops saying it is creating something.
+      setSubmitting(false);
     }
-    if (outcome.act === 'refused') {
-      setRefusal({ failure: outcome.failure });
-      return;
-    }
-    setRefusal(null);
-    setServerBlockers(outcome.result.draft.blockers);
-    if (outcome.result.app === null) return;
-    onCreated?.({
-      id: outcome.result.app.appId,
-      name: outcome.result.app.name,
-    });
   }
 
   return (
@@ -589,7 +646,7 @@ export function NewApp({
           repos={choices}
           scopes={scopes}
           detecting={detecting}
-          trouble={trouble}
+          trouble={standing}
           unchosen={unchosen.length > 0}
           onSelectRepo={selectRepo}
           onChooseScope={chooseScope}
@@ -602,7 +659,7 @@ export function NewApp({
           // so the row that holds it opens rather than hiding the field the
           // message is attached to behind a pencil.
           unsettled={
-            trouble !== null ||
+            standing !== null ||
             unchosen.length > 0 ||
             readElsewhere ||
             appNameIssue !== null ||

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -25,10 +25,15 @@
  */
 import { AlertTriangle, Loader2, Rocket } from 'lucide-react';
 import { type Dispatch, useEffect, useRef, useState } from 'react';
+import type { ZodType } from 'zod';
 import type {
   Blocker,
   CreationDraftView,
   DraftAction,
+} from '../../../../domain/creation-draft.ts';
+import {
+  appNameSchema,
+  componentNameSchema,
 } from '../../../../domain/creation-draft.ts';
 import {
   type ClientResult,
@@ -50,6 +55,7 @@ import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
 import { Card, Eyebrow } from '../../../ui/card.tsx';
 import { Field } from '../../../ui/field.tsx';
+import { deployDraft } from './deploy.ts';
 import {
   type InspectedScope,
   inspection,
@@ -70,6 +76,7 @@ import {
   TargetHealth,
   VesselRow,
 } from './summary.tsx';
+import { type DraftWrites, draftWrites } from './writes.ts';
 
 /**
  * What stands between a repository with several Apps in it and a Deploy.
@@ -98,6 +105,65 @@ function unchosenScope(
       remediation: `Detection found ${detected.length} directories it knows how to build. Pick one under Source, or name another yourself.`,
     },
   ];
+}
+
+/**
+ * What went wrong with the read, split on whether there was one.
+ *
+ * The two are different answers and only one of them is a prerequisite. A
+ * repository that could not be read leaves every row below Source standing on
+ * the draft's opening claim — a kind nothing checked, a directory nothing
+ * looked in — so Deploy would build a guess. A repository that *was* read and
+ * holds nothing buildable is the assertion path §5 keeps open: name the
+ * directory, pick the kind, and Spindrift builds what you said.
+ */
+export type DetectionTrouble =
+  | { readonly kind: 'unread'; readonly message: string }
+  | { readonly kind: 'unsupported'; readonly message: string };
+
+function unreadRepository(
+  draft: Draft,
+  trouble: DetectionTrouble | null,
+): readonly Blocker[] {
+  if (draft.source.kind !== 'repo' || trouble?.kind !== 'unread') return [];
+  return [
+    {
+      code: 'REPOSITORY_UNAVAILABLE',
+      title: `Spindrift could not read ${draft.source.repo}.`,
+      remediation: `${trouble.message} Until it can be read, everything below Source is the draft's opening claim rather than anything found in the repository.`,
+    },
+  ];
+}
+
+/**
+ * The actions that make a sentence about the last read stop being true.
+ *
+ * Naming the actions rather than clearing everywhere: `kind`, `reach` and the
+ * Target do not move the thing that was read, so a refusal that survives them
+ * is the refusal still being about the repository on screen.
+ */
+const CLEARS_DETECTION = new Set<DraftAction['type']>([
+  'repo',
+  'subpath',
+  'entry',
+  'detect',
+]);
+
+/** Whether anything has answered which directory this draft deploys. */
+function answeredScope(draft: Draft): boolean {
+  return draft.scopeByOperator === true || draft.detection.scope !== undefined;
+}
+
+/** The schema's own complaint about one value, or `null`. */
+function issueWith(schema: ZodType<string>, value: string): string | null {
+  const parsed = schema.safeParse(value);
+  return parsed.success ? null : (parsed.error.issues[0]?.message ?? null);
+}
+
+/** A refusal, and what the operator was doing when it arrived. */
+interface Refused {
+  readonly failure: TransportFailure;
+  readonly title?: string;
 }
 
 /** The two reads this screen opens with, in the order they are made. */
@@ -202,11 +268,11 @@ export function NewApp({
   // offered the candidates for a `service`.
   const [targets, setTargets] = useState(initialTargets);
   const [serverBlockers, setServerBlockers] = useState(initial.blockers);
-  const [refusal, setRefusal] = useState<TransportFailure | null>(null);
+  const [refusal, setRefusal] = useState<Refused | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [saving, setSaving] = useState(false);
   const [detecting, setDetecting] = useState(false);
-  const [detectionError, setDetectionError] = useState<string | null>(null);
+  const [trouble, setTrouble] = useState<DetectionTrouble | null>(null);
   // Everything the last read said about this repository, unsummarized. The
   // wizard's job is to offer it, so it is kept as it arrived: dropping the
   // scopes detection could not make sense of would leave "why not here"
@@ -215,9 +281,8 @@ export function NewApp({
   const scopesRef = useRef<readonly InspectedScope[]>([]);
   const draftRef = useRef(initial.draft);
   const revisionRef = useRef(initial.revision);
-  const saves = useRef(Promise.resolve());
-  const pendingSaves = useRef(0);
-  const saveFailed = useRef(false);
+  /** What the last write was refused with, or `null` once one has landed. */
+  const unsaved = useRef<TransportFailure | null>(null);
 
   const candidateIds = targets
     .filter((target) => target.candidate)
@@ -238,7 +303,11 @@ export function NewApp({
     draft.source.kind === 'repo' &&
     draft.detection.scope !== undefined &&
     draft.detection.scope !== draft.source.subpath;
-  const localBlockers = [...blockersFor(draft, candidateIds), ...unchosen];
+  const localBlockers = [
+    ...blockersFor(draft, candidateIds),
+    ...unchosen,
+    ...unreadRepository(draft, trouble),
+  ];
   const blockers = [
     ...localBlockers,
     ...serverBlockers.filter(
@@ -247,12 +316,90 @@ export function NewApp({
   ];
   const target = targets.find((option) => option.targetId === draft.targetId);
   const choices = repositoryChoices(repos, available);
+  const appNameIssue = issueWith(appNameSchema, draft.appName);
+  const componentNameIssue = issueWith(
+    componentNameSchema,
+    draft.componentName,
+  );
+
+  /**
+   * Put the server's copy of the draft back on screen.
+   *
+   * The revision guard means one refused save refuses every save after it: the
+   * revision the tab holds is a version that no longer exists, so the next
+   * keystroke is refused for the same reason, forever. Re-reading is the whole
+   * recovery — the server's draft is the truth by definition here — and what it
+   * costs is whatever was typed into the field the other tab also changed,
+   * which is why it is said out loud rather than done quietly.
+   */
+  const resync = async (): Promise<void> => {
+    const recovered = await command('getCreationDraft', { id: initial.id });
+    if (!recovered.ok) {
+      unsaved.current = recovered.failure;
+      setRefusal({ failure: recovered.failure });
+      return;
+    }
+    revisionRef.current = recovered.value.revision;
+    draftRef.current = recovered.value.draft;
+    setDraft(recovered.value.draft);
+    setServerBlockers(recovered.value.blockers);
+    unsaved.current = null;
+    setRefusal({
+      failure: {
+        code: 'STALE_EDIT',
+        message:
+          'Another tab saved this draft first, and its version is what is on screen now. Anything you had changed on the same field is gone — check the rows above before deploying.',
+      },
+      title: 'This draft was edited somewhere else',
+    });
+  };
+
+  const persist = async (next: Draft): Promise<void> => {
+    try {
+      const result = await command('saveCreationDraft', {
+        id: initial.id,
+        revision: revisionRef.current,
+        draft: next,
+      });
+      if (result.ok) {
+        revisionRef.current = result.value.revision;
+        unsaved.current = null;
+        setServerBlockers(result.value.blockers);
+        setRefusal(null);
+        return;
+      }
+      if (result.failure.code === 'STALE_EDIT') {
+        await resync();
+        return;
+      }
+      unsaved.current = result.failure;
+      setRefusal({ failure: result.failure });
+    } catch (cause) {
+      const failure: TransportFailure = {
+        code: 'MALFORMED_REQUEST',
+        message:
+          cause instanceof Error ? cause.message : 'the draft could not save',
+      };
+      unsaved.current = failure;
+      setRefusal({ failure });
+    }
+  };
+
+  const writes = useRef<DraftWrites<Draft> | null>(null);
+  writes.current ??= draftWrites<Draft>({
+    save: persist,
+    onWriting: setSaving,
+  });
 
   const dispatch: Dispatch<DraftAction> = (action) => {
     const previous = draftRef.current;
     const next = draftReducer(previous, action);
     draftRef.current = next;
     setDraft(next);
+    // A sentence about what was read stops being true the moment the input it
+    // was read from moves. Leaving it up is how a repository that cannot be
+    // read keeps blocking a repository that can.
+    if (CLEARS_DETECTION.has(action.type)) setTrouble(null);
     // Compared rather than keyed off the action type: `entry` and `detect`
     // change the kind too, and an enumeration here would drift the first time a
     // new action moves one of the three.
@@ -272,37 +419,7 @@ export function NewApp({
           setTargets(result.value.options);
       });
     }
-    pendingSaves.current += 1;
-    setSaving(true);
-    saves.current = saves.current
-      .then(async () => {
-        const result = await command('saveCreationDraft', {
-          id: initial.id,
-          revision: revisionRef.current,
-          draft: next,
-        });
-        if (!result.ok) {
-          saveFailed.current = true;
-          setRefusal(result.failure);
-          return;
-        }
-        revisionRef.current = result.value.revision;
-        saveFailed.current = false;
-        setServerBlockers(result.value.blockers);
-        setRefusal(null);
-      })
-      .catch((cause: unknown) => {
-        saveFailed.current = true;
-        setRefusal({
-          code: 'MALFORMED_REQUEST',
-          message:
-            cause instanceof Error ? cause.message : 'the draft could not save',
-        });
-      })
-      .finally(() => {
-        pendingSaves.current -= 1;
-        setSaving(pendingSaves.current > 0);
-      });
+    writes.current?.edit(next);
   };
 
   /**
@@ -322,14 +439,14 @@ export function NewApp({
    */
   const inspect = async (fullName: string, scope?: string) => {
     setDetecting(true);
-    setDetectionError(null);
+    setTrouble(null);
     try {
       const result = await command(
         'inspectRepository',
         inspection(fullName, scope),
       );
       if (!result.ok) {
-        setDetectionError(result.failure.message);
+        setTrouble({ kind: 'unread', message: result.failure.message });
         return;
       }
       const found = result.value.scopes;
@@ -345,11 +462,16 @@ export function NewApp({
         merged,
       });
       if (outcome.act === 'detect') dispatch(outcome.action);
-      if (outcome.act === 'refuse') setDetectionError(outcome.message);
+      if (outcome.act === 'refuse')
+        setTrouble({ kind: 'unsupported', message: outcome.message });
     } catch (cause) {
-      setDetectionError(
-        cause instanceof Error ? cause.message : 'the repository was not read',
-      );
+      setTrouble({
+        kind: 'unread',
+        message:
+          cause instanceof Error
+            ? cause.message
+            : 'the repository was not read',
+      });
     } finally {
       setDetecting(false);
     }
@@ -401,34 +523,46 @@ export function NewApp({
     void inspect(source.repo);
   }, []);
 
+  // A debounce that drops the last edit when the screen goes away is a
+  // debounce that loses work: navigating off within the window would leave the
+  // draft one keystroke behind what was on screen. Leaving sends it.
+  useEffect(
+    () => () => {
+      void writes.current?.flush();
+    },
+    [],
+  );
+
   /** The terminal act: revalidate and create under one database lock. */
   async function start() {
     setSubmitting(true);
-    setRefusal(null);
-    await saves.current;
-    if (saveFailed.current) {
-      setSubmitting(false);
-      return;
-    }
-    const result = await command('completeCreationDraft', {
-      id: initial.id,
-      revision: revisionRef.current,
-    });
-    if (!result.ok) {
-      setRefusal(result.failure);
-      setSubmitting(false);
-      return;
-    }
-    setServerBlockers(result.value.draft.blockers);
-    if (result.value.app === null) {
-      setSubmitting(false);
-      return;
-    }
-    onCreated?.({
-      id: result.value.app.appId,
-      name: result.value.app.name,
+    const outcome = await deployDraft({
+      flush: async () => {
+        await writes.current?.flush();
+      },
+      unsaved: () => unsaved.current,
+      complete: () =>
+        command('completeCreationDraft', {
+          id: initial.id,
+          revision: revisionRef.current,
+        }),
     });
     setSubmitting(false);
+    if (outcome.act === 'unsaved') {
+      setRefusal({ failure: outcome.failure, title: outcome.title });
+      return;
+    }
+    if (outcome.act === 'refused') {
+      setRefusal({ failure: outcome.failure });
+      return;
+    }
+    setRefusal(null);
+    setServerBlockers(outcome.result.draft.blockers);
+    if (outcome.result.app === null) return;
+    onCreated?.({
+      id: outcome.result.app.appId,
+      name: outcome.result.app.name,
+    });
   }
 
   return (
@@ -455,7 +589,7 @@ export function NewApp({
           repos={choices}
           scopes={scopes}
           detecting={detecting}
-          detectionError={detectionError}
+          trouble={trouble}
           unchosen={unchosen.length > 0}
           onSelectRepo={selectRepo}
           onChooseScope={chooseScope}
@@ -464,8 +598,15 @@ export function NewApp({
 
         <Row
           label="Component"
+          // A name the schema will refuse is an answer nobody has given yet,
+          // so the row that holds it opens rather than hiding the field the
+          // message is attached to behind a pencil.
           unsettled={
-            detectionError !== null || unchosen.length > 0 || readElsewhere
+            trouble !== null ||
+            unchosen.length > 0 ||
+            readElsewhere ||
+            appNameIssue !== null ||
+            componentNameIssue !== null
           }
           value={`${draft.componentName} · ${draft.kind}`}
           why={
@@ -492,6 +633,7 @@ export function NewApp({
                     value: event.target.value,
                   })
                 }
+                issue={appNameIssue}
                 hint="Lowercase DNS label — it appears in the canonical hostname."
               />
               <Field
@@ -505,6 +647,7 @@ export function NewApp({
                     value: event.target.value,
                   })
                 }
+                issue={componentNameIssue}
               />
             </div>
             <div className="grid gap-2 sm:grid-cols-3">
@@ -709,7 +852,9 @@ export function NewApp({
         </div>
       ) : null}
 
-      {refusal ? <Refusal failure={refusal} /> : null}
+      {refusal ? (
+        <Refusal failure={refusal.failure} title={refusal.title} />
+      ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
         <Button
@@ -785,7 +930,7 @@ function SourceRow({
   repos,
   scopes,
   detecting,
-  detectionError,
+  trouble,
   unchosen,
   onSelectRepo,
   onChooseScope,
@@ -797,7 +942,7 @@ function SourceRow({
   /** What the last read said, or `null` before anything has been read. */
   scopes: readonly InspectedScope[] | null;
   detecting: boolean;
-  detectionError: string | null;
+  trouble: DetectionTrouble | null;
   /** Detection is offering candidates and the draft names none of them. */
   unchosen: boolean;
   onSelectRepo: (repo: RepositoryChoice) => void;
@@ -847,13 +992,18 @@ function SourceRow({
   return (
     <Row
       label="Source"
-      // Opens itself on anything unresolved, because §3's grammar only works
-      // when the alternatives are visible: a sentence about a directory
-      // Spindrift could not build is unreadable while the list of directories
-      // it did read is behind a disclosure.
+      // Open whenever the source is still the question — which includes a
+      // repository whose directory nothing has answered for yet, not only one
+      // that went wrong. §3's grammar only works when the alternatives are
+      // visible: a sentence about a directory Spindrift could not build is
+      // unreadable while the list of directories it did read is behind a
+      // pencil. A settled source collapses, because then the list is noise.
       unsettled={
         draft.source.kind === 'repo'
-          ? draft.source.repo === '' || unchosen || detectionError !== null
+          ? draft.source.repo === '' ||
+            unchosen ||
+            trouble !== null ||
+            !answeredScope(draft)
           : !draft.source.location
       }
       value={
@@ -872,7 +1022,7 @@ function SourceRow({
         ) : null
       }
       why={
-        detectionError ??
+        trouble?.message ??
         (draft.source.kind === 'archive' && !draft.source.location
           ? 'Not staged yet.'
           : undefined)
@@ -1021,10 +1171,23 @@ function ScopeChooser({
  * The code is shown alongside the sentence because it is a closed vocabulary
  * and therefore searchable — the same reason §6 keeps its eight failure reasons
  * rather than writing friendlier prose.
+ *
+ * `title` is what the operator was doing when it arrived. A refusal from a save
+ * nobody watched, still on screen when Deploy is pressed, otherwise reads as
+ * the answer to the press — and the two want different sentences.
  */
-function Refusal({ failure }: { failure: TransportFailure }) {
+function Refusal({
+  failure,
+  title,
+}: {
+  failure: TransportFailure;
+  title?: string;
+}) {
   return (
     <div className="rounded-md border border-destructive bg-destructive-soft px-3 py-2.5">
+      {title ? (
+        <p className="text-sm font-semibold text-destructive">{title}</p>
+      ) : null}
       <p className="font-mono text-xs font-semibold text-destructive">
         {failure.code}
       </p>

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -100,6 +100,86 @@ function unchosenScope(
   ];
 }
 
+/** The two reads this screen opens with, in the order they are made. */
+export type CreationLoad = 'draft' | 'options';
+
+const LOADING_NOTE = {
+  draft: 'Recovering the draft…',
+  options: 'Reading the Targets and repositories it can use…',
+} as const satisfies Record<CreationLoad, string>;
+
+/**
+ * The screen's own shape, while the two reads it opens with are in flight.
+ *
+ * A screen that is a card of decided rows loads as a card of rows: one pulsing
+ * sentence says a page is coming and nothing about what will be on it, and the
+ * layout shift when the real rows arrive is the reader losing their place. The
+ * caption names the read actually outstanding, because the second one cannot
+ * start until the first has answered — the draft says what to resolve placement
+ * for (§3) — so "still loading" has two different meanings here.
+ */
+export function CreationSkeleton({ phase }: { phase: CreationLoad }) {
+  return (
+    <div
+      aria-busy="true"
+      className="mx-auto flex w-full max-w-[760px] flex-col gap-5 px-5 py-6"
+    >
+      <header>
+        <Eyebrow>New App</Eyebrow>
+        <div className="mt-2 h-7 w-64 animate-pulse rounded-md bg-secondary" />
+        <p className="mt-2 text-sm text-muted-foreground">
+          {LOADING_NOTE[phase]}
+        </p>
+      </header>
+      <Card>
+        {['Source', 'Component', 'Target', 'URL', 'Reach', 'Vessel'].map(
+          (label) => (
+            <div
+              key={label}
+              className="flex items-center gap-3 border-b border-border-soft px-4 py-3 last:border-b-0"
+            >
+              <span className="w-[84px] shrink-0 text-xs text-muted-foreground">
+                {label}
+              </span>
+              <span className="h-4 flex-1 animate-pulse rounded bg-secondary" />
+            </div>
+          ),
+        )}
+      </Card>
+    </div>
+  );
+}
+
+/**
+ * Neither read answered, so there is no draft to show.
+ *
+ * Every one of the three reads behind this screen is idempotent — a start
+ * replays onto the draft id it was handed, and the other two are queries — so
+ * the retry is free, and without it a transient failure left the operator on a
+ * screen with a sentence and nothing to press.
+ */
+export function CreationLoadFailure({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-[760px] flex-col gap-3 px-5 py-6">
+      <div className="rounded-sm border border-destructive/50 bg-destructive/10 p-4 text-destructive">
+        <p className="text-sm font-medium">Failed to load creation options</p>
+        <p className="mt-1 text-sm">{message}</p>
+      </div>
+      <div>
+        <Button variant="outline" onClick={onRetry}>
+          Try again
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function NewApp({
   initial,
   targets: initialTargets,

--- a/apps/spindrift/src/web/views/apps/new/writes.ts
+++ b/apps/spindrift/src/web/views/apps/new/writes.ts
@@ -1,0 +1,84 @@
+/**
+ * The draft's write side: a trailing debounce in front of a serialized chain.
+ *
+ * The draft is server-owned and guarded by a revision, so **order is not
+ * negotiable** — two saves in flight at once means the second carries a
+ * revision the first is about to invalidate, and the loser is refused as a
+ * stale edit the operator never made. That is what the chain is for, and it is
+ * why the debounce sits in *front* of it rather than replacing it: coalescing
+ * decides how many saves are sent, and the chain decides that they are sent one
+ * at a time.
+ *
+ * What the debounce buys is the other half. Every keystroke in a name was one
+ * round trip and one revision bump, so typing `almanac-staging` wrote sixteen
+ * versions of a draft nobody had finished writing — and the button underneath
+ * flipped disabled and back on every one of them.
+ *
+ * `save` owns its own refusals and must not reject; a rejection is still
+ * absorbed here, because a chain that stays rejected is a draft that silently
+ * never saves again.
+ */
+
+export interface DraftWrites<Draft> {
+  /**
+   * Record an edit. The newest one wins, and nothing is sent while edits keep
+   * arriving.
+   */
+  edit(draft: Draft): void;
+  /** Send whatever is scheduled now, and resolve once the chain has drained. */
+  flush(): Promise<void>;
+}
+
+/** Long enough to swallow a burst of typing, short enough to feel immediate. */
+export const WRITE_DELAY = 350;
+
+export function draftWrites<Draft>({
+  save,
+  onWriting,
+  delay = WRITE_DELAY,
+}: {
+  save: (draft: Draft) => Promise<void>;
+  /**
+   * Called `true` when a save leaves and `false` when the chain drains.
+   *
+   * At the debounce boundary rather than per edit, which is what keeps Deploy
+   * from flickering through a burst: while edits are only scheduled there is
+   * nothing in flight to report, and pressing Deploy flushes them anyway.
+   */
+  onWriting: (writing: boolean) => void;
+  delay?: number;
+}): DraftWrites<Draft> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let scheduled: { draft: Draft } | null = null;
+  let chain = Promise.resolve();
+  let inFlight = 0;
+
+  const send = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (scheduled === null) return;
+    const { draft } = scheduled;
+    scheduled = null;
+    inFlight += 1;
+    onWriting(true);
+    const settle = () => {
+      inFlight -= 1;
+      if (inFlight === 0) onWriting(false);
+    };
+    chain = chain.then(() => save(draft)).then(settle, settle);
+  };
+
+  return {
+    edit(draft) {
+      scheduled = { draft };
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(send, delay);
+    },
+    async flush() {
+      send();
+      await chain;
+    },
+  };
+}

--- a/apps/spindrift/src/web/views/apps/new/writes.ts
+++ b/apps/spindrift/src/web/views/apps/new/writes.ts
@@ -27,6 +27,18 @@ export interface DraftWrites<Draft> {
   edit(draft: Draft): void;
   /** Send whatever is scheduled now, and resolve once the chain has drained. */
   flush(): Promise<void>;
+  /**
+   * Drop every edit that has not reached the server yet.
+   *
+   * For the one case where sending them would be worse than losing them: the
+   * draft on screen has been replaced by the server's, so an edit written
+   * against the version before it is not a newer answer, it is an older
+   * document about to be written at the newer revision — and it would land,
+   * because the revision guard is all the server checks. Both the timer and
+   * anything already queued behind the save in flight, since the save that
+   * recovers is itself in that chain.
+   */
+  discard(): void;
 }
 
 /** Long enough to swallow a burst of typing, short enough to feel immediate. */
@@ -52,6 +64,14 @@ export function draftWrites<Draft>({
   let scheduled: { draft: Draft } | null = null;
   let chain = Promise.resolve();
   let inFlight = 0;
+  /**
+   * Which run of edits the queue is on.
+   *
+   * A queued save is a closure the chain has already accepted, so `discard`
+   * cannot reach into it — it moves the count instead, and a save whose count
+   * has been left behind resolves without being sent.
+   */
+  let run = 0;
 
   const send = () => {
     if (timer !== null) {
@@ -60,6 +80,7 @@ export function draftWrites<Draft>({
     }
     if (scheduled === null) return;
     const { draft } = scheduled;
+    const sending = run;
     scheduled = null;
     inFlight += 1;
     onWriting(true);
@@ -67,7 +88,9 @@ export function draftWrites<Draft>({
       inFlight -= 1;
       if (inFlight === 0) onWriting(false);
     };
-    chain = chain.then(() => save(draft)).then(settle, settle);
+    chain = chain
+      .then(() => (sending === run ? save(draft) : undefined))
+      .then(settle, settle);
   };
 
   return {
@@ -79,6 +102,14 @@ export function draftWrites<Draft>({
     async flush() {
       send();
       await chain;
+    },
+    discard() {
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      scheduled = null;
+      run += 1;
     },
   };
 }

--- a/apps/spindrift/src/web/views/repos/list.tsx
+++ b/apps/spindrift/src/web/views/repos/list.tsx
@@ -701,6 +701,20 @@ function ConnectedRepositories({
                   <p className="text-sm">{repo.error}</p>
                 </div>
               ) : null}
+              {/* Still connected, and the commit beside it is older than it
+                  looks: listing refreshes every row, and one the host would
+                  not answer about says so rather than passing for current. */}
+              {repo.staleReason ? (
+                <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-warning">
+                  <AlertTriangle
+                    aria-hidden="true"
+                    className="mt-0.5 size-4 text-warning"
+                  />
+                  <p className="text-sm">
+                    This row was not refreshed: {repo.staleReason}
+                  </p>
+                </div>
+              ) : null}
               {repo.appSubpaths.length > 0 ? (
                 <div className="flex flex-wrap gap-1.5">
                   {repo.appSubpaths.map((subpath) => (

--- a/apps/spindrift/src/web/views/repos/list.tsx
+++ b/apps/spindrift/src/web/views/repos/list.tsx
@@ -42,9 +42,9 @@ import { useState } from 'react';
 import type { ComponentKind } from '../../../domain/desired-state.ts';
 import { command, type InputOf, type OutputOf } from '../../client.ts';
 import type {
+  GrantedRepositoryView,
   LinkedRepoView,
   RepositoryConnectorView,
-  RepositoryOptionView,
 } from '../../model.ts';
 import { Badge, Dot } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
@@ -94,7 +94,7 @@ export function RepositoryList({
   embedded = false,
 }: {
   repos: readonly LinkedRepoView[];
-  options: readonly RepositoryOptionView[];
+  options: readonly GrantedRepositoryView[];
   connector: RepositoryConnectorView;
   authorization: RepositoryAuthorizationView | null;
   connecting: boolean;
@@ -373,7 +373,7 @@ function AvailableRepositories({
   connecting,
   onConnect,
 }: {
-  options: readonly RepositoryOptionView[];
+  options: readonly GrantedRepositoryView[];
   connecting: boolean;
   onConnect: (input: ConnectRepositoryInput) => void;
 }) {
@@ -430,7 +430,7 @@ function RepositoryRow({
   onToggle,
   onConnect,
 }: {
-  option: RepositoryOptionView;
+  option: GrantedRepositoryView;
   open: boolean;
   connecting: boolean;
   onToggle: () => void;
@@ -470,14 +470,14 @@ function RepositoryRow({
         <span className="font-mono text-xs text-muted-foreground">
           {option.defaultBranch}
         </span>
-        {option.connected ? <Badge tone="success">connected</Badge> : null}
+        {option.rowExists ? <Badge tone="success">connected</Badge> : null}
         <Button
           size="sm"
           variant={open ? 'ghost' : 'outline'}
           className="ml-auto"
           onClick={toggle}
         >
-          {open ? 'Cancel' : option.connected ? 'Reconnect' : 'Connect'}
+          {open ? 'Cancel' : option.rowExists ? 'Reconnect' : 'Connect'}
         </Button>
       </div>
 

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -159,6 +159,21 @@ describe('creation drafts', () => {
     expect(row?.count).toBe(1);
   });
 
+  test('the draft it opens on clones from the host the manifest names', async () => {
+    // The public host is a value this installation could have and not a
+    // template to write into the source: an enterprise deployment serves its
+    // own, and a draft carrying the wrong one stages nothing.
+    await seedCapabilities();
+    const started = await startCreationDraft({}, await context());
+    expect(started.ok).toBe(true);
+    if (!started.ok) return;
+    expect(started.value.draft.source).toMatchObject({
+      kind: 'repo',
+      repo: 'example/app',
+      url: 'https://git.example.test/example/app.git',
+    });
+  });
+
   test('refresh recovers the same server-owned draft for its operator', async () => {
     await seedCapabilities();
     const ctx = await context();

--- a/apps/spindrift/test/commands/creation-drafts.test.ts
+++ b/apps/spindrift/test/commands/creation-drafts.test.ts
@@ -3,7 +3,6 @@ import { count, eq } from 'drizzle-orm';
 import {
   completeCreationDraft,
   getCreationDraft,
-  reviewCreationDraft,
   saveCreationDraft,
   startCreationDraft,
 } from '../../src/commands/creation-drafts/lifecycle.ts';
@@ -193,6 +192,36 @@ describe('creation drafts', () => {
     expect(stored?.revision).toBe(0);
   });
 
+  test('a draft written before a key was retired is still editable', async () => {
+    // Drafts are durable jsonb rows somebody comes back to. The save schema is
+    // strict, and the browser sends back what it was given — so a retired key
+    // handed out on read is a draft that refuses its own next keystroke. The
+    // read drops it, which is the whole migration a jsonb column needs.
+    await seedCapabilities();
+    const ctx = await context();
+    const started = await startCreationDraft({}, ctx);
+    if (!started.ok) throw new Error(started.failure.message);
+    await database()
+      .db.update(creationDrafts)
+      .set({ draft: { ...started.value.draft, step: 4 } as never })
+      .where(eq(creationDrafts.id, started.value.id));
+
+    const recovered = await getCreationDraft({ id: started.value.id }, ctx);
+    expect(recovered.ok).toBe(true);
+    if (!recovered.ok) return;
+    expect(recovered.value.draft).not.toHaveProperty('step');
+
+    const saved = await saveCreationDraft(
+      {
+        id: started.value.id,
+        revision: recovered.value.revision,
+        draft: { ...recovered.value.draft, appName: 'still-editable' },
+      },
+      ctx,
+    );
+    expect(saved.ok && saved.value.draft.appName).toBe('still-editable');
+  });
+
   test('serializes edits with an optimistic revision and rejects a stale tab', async () => {
     await seedCapabilities();
     const ctx = await context();
@@ -202,7 +231,6 @@ describe('creation drafts', () => {
     const changed = {
       ...started.value.draft,
       appName: 'renamed',
-      step: 2,
     };
     const saved = await saveCreationDraft(
       { id: started.value.id, revision: 0, draft: changed },
@@ -252,10 +280,7 @@ describe('creation drafts', () => {
       .set({ health: 'unhealthy' })
       .where(eq(targets.id, target.id));
 
-    const reviewed = await reviewCreationDraft(
-      { id: started.value.id, revision: started.value.revision },
-      ctx,
-    );
+    const reviewed = await getCreationDraft({ id: started.value.id }, ctx);
     expect(reviewed.ok).toBe(true);
     if (!reviewed.ok) return;
     expect(reviewed.value.ready).toBe(false);
@@ -283,21 +308,18 @@ describe('creation drafts', () => {
       {
         id: started.value.id,
         revision: started.value.revision,
-        draft: { ...started.value.draft, step: 4 },
+        draft: { ...started.value.draft },
       },
       ctx,
     );
     if (!saved.ok) throw new Error(saved.failure.message);
 
-    const reviewed = await reviewCreationDraft(
-      { id: saved.value.id, revision: saved.value.revision },
-      ctx,
-    );
+    const reviewed = await getCreationDraft({ id: saved.value.id }, ctx);
     expect(reviewed.ok).toBe(true);
     if (!reviewed.ok) return;
     expect(reviewed.value.ready).toBe(true);
     expect(reviewed.value.blockers).toEqual([]);
-    expect(reviewed.value.draft.step).toBe(4);
+    expect(reviewed.value.draft.componentName).toBe('web');
     const completed = await completeCreationDraft(
       { id: saved.value.id, revision: saved.value.revision },
       ctx,
@@ -435,7 +457,7 @@ describe('creation drafts', () => {
       {
         id: started.value.id,
         revision: started.value.revision,
-        draft: { ...started.value.draft, step: 4 },
+        draft: { ...started.value.draft },
       },
       ctx,
     );
@@ -488,7 +510,6 @@ describe('creation drafts', () => {
             contents: 'source',
             subpath: 'service',
           },
-          step: 4,
         },
       },
       ctx,
@@ -546,7 +567,6 @@ describe('creation drafts', () => {
           reach: 'public',
           auth: 'none',
           targetId: target.id,
-          step: 4,
         },
       },
       ctx,
@@ -597,7 +617,6 @@ describe('creation drafts', () => {
           reach: 'public',
           auth: 'none',
           targetId: target.id,
-          step: 4,
         },
       },
       ctx,
@@ -637,7 +656,6 @@ describe('creation drafts', () => {
             contents: 'source',
             subpath: '.',
           },
-          step: 4,
         },
       },
       ctx,

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -720,6 +720,9 @@ describe('listRepositories', () => {
         repositoryId: '99',
         fullName: 'example/available',
         defaultBranch: 'trunk',
+        // The manifest's repository host, not the public one: an enterprise
+        // installation clones from its own, and the browser reads no manifest.
+        cloneUrl: 'https://git.example.test/example/available.git',
         rowExists: false,
       },
     ]);

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -678,6 +678,25 @@ describe('listRepositories', () => {
     }
   });
 
+  test('a repository the host would not answer about is listed, and says so', async () => {
+    // Listing refreshes every connected repository from the host. One that
+    // fails must not empty the screen — and must not pass for current either,
+    // because the commit beside it is then older than it looks.
+    const fake = new FakeGitHub();
+    fake.commitFiles('main', { 'README.md': 'unconnected' });
+    await connectRepository(input(fake), await context(fake));
+
+    const offline = await context(fake, (() => {
+      throw new Error('the repository host is unreachable');
+    }) as unknown as typeof fetch);
+    const result = await listRepositories({}, offline);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.repos).toHaveLength(1);
+    expect(result.value.repos[0]?.staleReason).toContain('unreachable');
+  });
+
   test('keeps GitHub-granted repositories separate from durable connections', async () => {
     const base = await context(null);
     const result = await listRepositories(

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -720,7 +720,7 @@ describe('listRepositories', () => {
         repositoryId: '99',
         fullName: 'example/available',
         defaultBranch: 'trunk',
-        connected: false,
+        rowExists: false,
       },
     ]);
   });

--- a/apps/spindrift/test/conformance/archive-to-live.test.ts
+++ b/apps/spindrift/test/conformance/archive-to-live.test.ts
@@ -42,7 +42,7 @@ import { describe, expect, test } from 'bun:test';
 import { asc, eq } from 'drizzle-orm';
 import {
   completeCreationDraft,
-  reviewCreationDraft,
+  getCreationDraft,
   saveCreationDraft,
   startCreationDraft,
 } from '../../src/commands/creation-drafts/lifecycle.ts';
@@ -304,10 +304,7 @@ async function createThroughDraft(
   );
   if (!saved.ok) throw new Error(saved.failure.message);
 
-  const reviewed = await reviewCreationDraft(
-    { id: saved.value.id, revision: saved.value.revision },
-    context,
-  );
+  const reviewed = await getCreationDraft({ id: saved.value.id }, context);
   if (!reviewed.ok) throw new Error(reviewed.failure.message);
   // Read back rather than assumed: a blocker here is the product refusing the
   // draft, and it names which of §3's conditions this installation failed.

--- a/apps/spindrift/test/db/jsonb-documents.test.ts
+++ b/apps/spindrift/test/db/jsonb-documents.test.ts
@@ -29,7 +29,10 @@ const MIGRATION = join(
 
 const draftValues = () =>
   initialCreationDraft({
-    repository: 'jonpulsifer/infra',
+    repository: {
+      fullName: 'jonpulsifer/infra',
+      cloneUrl: 'https://vcs.example/jonpulsifer/infra.git',
+    },
     targetId: crypto.randomUUID(),
     vessel: 'bluenose',
   });

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -829,36 +829,49 @@ export const INITIAL_DRAFT: Draft = {
   step: 0,
 };
 
+/**
+ * The repository host this fixture installation runs against.
+ *
+ * Deliberately not the public one: a clone URL composed from the manifest is
+ * indistinguishable from a hardcoded template while the fixture agrees with it.
+ */
+const VCS = 'https://vcs.example';
+
 /** Repositories Spindrift holds a row for, two of which have an App on them. */
 export const REPOSITORY_OPTIONS: readonly RepositoryOptionView[] = [
   {
     repositoryId: 100001,
     fullName: 'example-org/infra',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/infra.git`,
     alreadyDeploys: true,
   },
   {
     repositoryId: 100002,
     fullName: 'example-org/hub',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/hub.git`,
     alreadyDeploys: true,
   },
   {
     repositoryId: 100003,
     fullName: 'example-org/site',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/site.git`,
     alreadyDeploys: false,
   },
   {
     repositoryId: 100004,
     fullName: 'example-org/api',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/api.git`,
     alreadyDeploys: true,
   },
   {
     repositoryId: 100005,
     fullName: 'example-org/weather-card',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/weather-card.git`,
     alreadyDeploys: false,
   },
 ];
@@ -874,24 +887,28 @@ export const REPOSITORY_GRANT: readonly GrantedRepositoryView[] = [
     repositoryId: 100001,
     fullName: 'example-org/infra',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/infra.git`,
     rowExists: true,
   },
   {
     repositoryId: 100003,
     fullName: 'example-org/site',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/site.git`,
     rowExists: true,
   },
   {
     repositoryId: 200001,
     fullName: 'example-org/almanac',
     defaultBranch: 'main',
+    cloneUrl: `${VCS}/example-org/almanac.git`,
     rowExists: false,
   },
   {
     repositoryId: 200002,
     fullName: 'example-org/ledger',
     defaultBranch: 'trunk',
+    cloneUrl: `${VCS}/example-org/ledger.git`,
     rowExists: false,
   },
 ];

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -826,7 +826,6 @@ export const INITIAL_DRAFT: Draft = {
     { name: 'LOG_LEVEL', supplied: true },
     { name: 'DATABASE_URL', supplied: false },
   ],
-  step: 0,
 };
 
 /**

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -921,6 +921,7 @@ export const LINKED_REPOS: readonly LinkedRepoView[] = [
     health: 'connected',
     error: null,
     lastReconciledSha: 'a1b2c3d',
+    staleReason: null,
     appSubpaths: ['apps/hub', 'apps/api', 'apps/wiki'],
   },
   {
@@ -930,6 +931,7 @@ export const LINKED_REPOS: readonly LinkedRepoView[] = [
     health: 'connected',
     error: null,
     lastReconciledSha: 'e4f5g6h',
+    staleReason: null,
     appSubpaths: ['.'],
   },
   {
@@ -940,6 +942,7 @@ export const LINKED_REPOS: readonly LinkedRepoView[] = [
     error:
       'Installation suspended — the GitHub App installation was suspended by the account owner.',
     lastReconciledSha: 'i7j8k9l',
+    staleReason: null,
     appSubpaths: ['.'],
   },
 ];

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -23,6 +23,7 @@ import type {
   AppListItem,
   ChecklistItem,
   DeployView,
+  GrantedRepositoryView,
   LinkedRepoView,
   LogLine,
   RepositoryOptionView,
@@ -828,77 +829,70 @@ export const INITIAL_DRAFT: Draft = {
   step: 0,
 };
 
-/**
- * Repositories Spindrift holds a row for. `connected` here means an App
- * already deploys from it — `listRepositories`'s own reading of the word on
- * this list.
- */
+/** Repositories Spindrift holds a row for, two of which have an App on them. */
 export const REPOSITORY_OPTIONS: readonly RepositoryOptionView[] = [
   {
     repositoryId: 100001,
     fullName: 'example-org/infra',
     defaultBranch: 'main',
-    connected: true,
+    alreadyDeploys: true,
   },
   {
     repositoryId: 100002,
     fullName: 'example-org/hub',
     defaultBranch: 'main',
-    connected: true,
+    alreadyDeploys: true,
   },
   {
     repositoryId: 100003,
     fullName: 'example-org/site',
     defaultBranch: 'main',
-    connected: false,
+    alreadyDeploys: false,
   },
   {
     repositoryId: 100004,
     fullName: 'example-org/api',
     defaultBranch: 'main',
-    connected: true,
+    alreadyDeploys: true,
   },
   {
     repositoryId: 100005,
     fullName: 'example-org/weather-card',
     defaultBranch: 'main',
-    connected: false,
+    alreadyDeploys: false,
   },
 ];
 
 /**
- * Repositories the GitHub App installation currently grants. `connected` here
- * means Spindrift holds a row for it — the other reading of the same word, on
- * the other list of the same response, which is why the picker derives a state
- * instead of rendering either boolean.
+ * Repositories the GitHub App installation currently grants.
  *
  * Two of them are on no other list: a grant Spindrift has never connected is
  * the ordinary state of a fresh installation.
  */
-export const REPOSITORY_GRANT: readonly RepositoryOptionView[] = [
+export const REPOSITORY_GRANT: readonly GrantedRepositoryView[] = [
   {
     repositoryId: 100001,
     fullName: 'example-org/infra',
     defaultBranch: 'main',
-    connected: true,
+    rowExists: true,
   },
   {
     repositoryId: 100003,
     fullName: 'example-org/site',
     defaultBranch: 'main',
-    connected: true,
+    rowExists: true,
   },
   {
     repositoryId: 200001,
     fullName: 'example-org/almanac',
     defaultBranch: 'main',
-    connected: false,
+    rowExists: false,
   },
   {
     repositoryId: 200002,
     fullName: 'example-org/ledger',
     defaultBranch: 'trunk',
-    connected: false,
+    rowExists: false,
   },
 ];
 

--- a/apps/spindrift/test/web/creation-detection.test.tsx
+++ b/apps/spindrift/test/web/creation-detection.test.tsx
@@ -33,7 +33,7 @@ import {
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { Draft } from '../../src/domain/creation-draft.ts';
-import { blockersFor } from '../../src/domain/creation-draft.ts';
+import { blockersFor, draftReducer } from '../../src/domain/creation-draft.ts';
 import type { ComponentKind } from '../../src/domain/desired-state.ts';
 import {
   type InspectedScope,
@@ -381,6 +381,36 @@ describe('a draft somebody already answered', () => {
     expect(saved).toEqual([]);
 
     screen.unmount();
+  });
+
+  test('but choosing another repository is not a reopen', async () => {
+    // The guard is durable state, which is what makes it survive the reload it
+    // exists for — and what made it survive the picker. A second repository
+    // arrived already answered by the first one's read, so nothing was applied
+    // to it: the kind, the sentence and the ruled-out kinds stayed the previous
+    // repository's, with no blocker and Deploy enabled.
+    const answered = draftReducer(clean, {
+      type: 'detect',
+      scope: 'apps/api',
+      kind: 'job',
+      reason: 'a job is declared in spindrift.yaml',
+      unavailable: { website: 'no static output is emitted here' },
+    });
+    const switched = draftReducer(answered, {
+      type: 'repo',
+      fullName: 'example/ledger',
+      url: 'https://github.com/example/ledger.git',
+    });
+    const found = [detected('.', 'website', 'Astro — `astro` is a dependency')];
+
+    expect(
+      outcomeOf(switched, {
+        fullName: 'example/ledger',
+        scope: undefined,
+        found,
+        merged: found,
+      }).act,
+    ).toBe('detect');
   });
 
   test('a reason read elsewhere says which directory it is about', async () => {

--- a/apps/spindrift/test/web/creation-edits.test.tsx
+++ b/apps/spindrift/test/web/creation-edits.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * Editing a draft cannot strand, mislead, or silently drop what was typed.
+ *
+ * The defects here are one family: state the screen holds and state the server
+ * holds drifting apart with no way back. Each one is observed at the seam it
+ * lives at — the Deploy sequence as a decision, the recovery through the
+ * mounted screen's own effect, the read failure as a prerequisite — because the
+ * DOM shim has no event system and typing is not something a test can do here.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Draft } from '../../src/domain/creation-draft.ts';
+import { blockersFor } from '../../src/domain/creation-draft.ts';
+import type { TransportFailure } from '../../src/web/client.ts';
+import {
+  deployDraft,
+  UNSAVED_TITLE,
+} from '../../src/web/views/apps/new/deploy.ts';
+import type { InspectedScope } from '../../src/web/views/apps/new/detect.ts';
+import { NewApp } from '../../src/web/views/apps/new/index.tsx';
+import { WRITE_DELAY } from '../../src/web/views/apps/new/writes.ts';
+import {
+  INITIAL_DRAFT,
+  REPOSITORY_GRANT,
+  REPOSITORY_OPTIONS,
+  TARGET_OPTIONS,
+} from '../fixtures/scenarios.ts';
+import { type DomShim, installDomShim } from '../harness/dom.ts';
+
+const CANDIDATES = TARGET_OPTIONS.filter((target) => target.candidate).map(
+  (target) => target.targetId,
+);
+
+const REFUSED: TransportFailure = {
+  code: 'INTERNAL',
+  message: 'the draft could not be written',
+};
+
+describe('Deploy after a save that failed', () => {
+  const held = { flushed: 0, completed: 0 };
+  const steps = (unsaved: TransportFailure | null) => ({
+    flush: async () => {
+      held.flushed += 1;
+    },
+    unsaved: () => unsaved,
+    complete: async () => {
+      held.completed += 1;
+      return { ok: true as const, value: { draft: null, app: null } as never };
+    },
+  });
+
+  beforeEach(() => {
+    held.flushed = 0;
+    held.completed = 0;
+  });
+
+  test('answers with what failed, and creates nothing', async () => {
+    // The press used to clear the refusal, await the chain, and return — so the
+    // one sentence explaining why nothing happened was erased by the act that
+    // did nothing.
+    const outcome = await deployDraft(steps(REFUSED));
+
+    expect(outcome).toEqual({
+      act: 'unsaved',
+      failure: REFUSED,
+      title: UNSAVED_TITLE,
+    });
+    expect(held.completed).toBe(0);
+  });
+
+  test('flushes the pending write before deciding', async () => {
+    // The debounce means the last edit may still be in a timer. Completing
+    // before it lands creates an App from the answer before the last one.
+    await deployDraft(steps(null));
+
+    expect(held.flushed).toBe(1);
+    expect(held.completed).toBe(1);
+  });
+
+  test('a refusal from the completing command is its own answer', async () => {
+    const outcome = await deployDraft({
+      flush: async () => {},
+      unsaved: () => null,
+      complete: async () => ({ ok: false as const, failure: REFUSED }),
+    });
+
+    expect(outcome).toEqual({ act: 'refused', failure: REFUSED });
+  });
+});
+
+/** What `inspectRepository` answers with, per test. */
+let scopes: readonly InspectedScope[] = [];
+/** Command names to refuse once, and with what. */
+let refuse = new Map<string, TransportFailure>();
+/** Every command the screen called, in order. */
+let called: string[] = [];
+/** Every draft the screen wrote back. */
+let saved: Draft[] = [];
+/** What `getCreationDraft` answers a resync with. */
+let stored: Draft = INITIAL_DRAFT;
+
+let dom: DomShim;
+
+beforeAll(() => {
+  dom = installDomShim({
+    fetch: async (url: string, init: { body: string }) => {
+      const name = url.split('/').pop() ?? '';
+      called.push(name);
+      const refusal = refuse.get(name);
+      if (refusal !== undefined) {
+        refuse.delete(name);
+        return { json: async () => ({ ok: false, failure: refusal }) };
+      }
+      if (name === 'inspectRepository') {
+        return {
+          json: async () => ({
+            ok: true,
+            value: {
+              fullName: 'example/almanac',
+              defaultBranch: 'main',
+              commit: 'a'.repeat(40),
+              scopes,
+              canConnect: true,
+            },
+          }),
+        };
+      }
+      if (name === 'saveCreationDraft') {
+        saved.push((JSON.parse(init.body) as { draft: Draft }).draft);
+        return {
+          json: async () => ({
+            ok: true,
+            value: { id: 'draft', revision: 9, draft: null, blockers: [] },
+          }),
+        };
+      }
+      if (name === 'getCreationDraft') {
+        return {
+          json: async () => ({
+            ok: true,
+            value: {
+              id: 'draft',
+              revision: 12,
+              draft: stored,
+              blockers: [],
+              ready: true,
+            },
+          }),
+        };
+      }
+      return {
+        json: async () => ({ ok: true, value: { options: TARGET_OPTIONS } }),
+      };
+    },
+  });
+});
+
+afterAll(() => dom.restore());
+
+beforeEach(() => {
+  scopes = [];
+  refuse = new Map();
+  called = [];
+  saved = [];
+  stored = INITIAL_DRAFT;
+});
+
+const clean: Draft = {
+  ...INITIAL_DRAFT,
+  config: INITIAL_DRAFT.config.map((key) => ({ ...key, supplied: true })),
+};
+
+const repoDraft: Draft = {
+  ...clean,
+  source: {
+    kind: 'repo',
+    repo: 'example/almanac',
+    url: 'https://vcs.example/example/almanac.git',
+    subpath: '.',
+  },
+};
+
+async function mount(draft: Draft) {
+  const container = dom.document.createElement('div');
+  let root!: Root;
+  await act(async () => {
+    root = createRoot(container as unknown as Element);
+    root.render(
+      <NewApp
+        initial={{
+          id: crypto.randomUUID(),
+          revision: 0,
+          draft,
+          blockers: blockersFor(draft, CANDIDATES),
+          ready: false,
+        }}
+        targets={TARGET_OPTIONS}
+        repos={REPOSITORY_OPTIONS}
+        available={REPOSITORY_GRANT}
+      />,
+    );
+  });
+  await act(async () => {});
+  return {
+    text: () => container.textContent,
+    /** Let the trailing debounce fire and its save land. */
+    settleWrites: () =>
+      act(async () => {
+        await new Promise((done) => setTimeout(done, WRITE_DELAY + 60));
+      }),
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+const detected = (scope: string): InspectedScope => ({
+  scope,
+  outcome: 'detected',
+  kind: 'service',
+  reason: 'Go — go.mod is in this directory',
+  frontend: 'railpack',
+  dockerfile: null,
+  outputDirectory: null,
+  watchPaths: [scope],
+  configured: false,
+  unavailable: {},
+});
+
+describe('an edit the server refused as stale', () => {
+  test('re-reads the draft and says another tab won', async () => {
+    // The revision guard makes one refused save refuse every save after it:
+    // the tab holds a version that no longer exists, so the next keystroke is
+    // refused for the same reason, forever.
+    scopes = [detected('apps/only')];
+    stored = { ...repoDraft, componentName: 'renamed-elsewhere' };
+    refuse.set('saveCreationDraft', {
+      code: 'STALE_EDIT',
+      message: 'this creation draft changed in another browser',
+    });
+
+    const screen = await mount(repoDraft);
+    await screen.settleWrites();
+
+    // One write attempt, not one per state change on the way in.
+    expect(called.filter((call) => call === 'saveCreationDraft')).toHaveLength(
+      1,
+    );
+    expect(called).toContain('getCreationDraft');
+    // The server's draft is on screen, and the screen says why it moved.
+    expect(screen.text()).toContain('renamed-elsewhere · service');
+    expect(screen.text()).toContain('This draft was edited somewhere else');
+    expect(screen.text()).toContain('STALE_EDIT');
+    // And no draft of this tab's reached the server, so what is on screen is
+    // the other tab's version rather than a merge of the two.
+    expect(saved).toEqual([]);
+
+    screen.unmount();
+  });
+});
+
+describe('a repository nothing could be read from', () => {
+  test('blocks Deploy rather than staying deployable on a stale claim', async () => {
+    // Everything under Source is the draft's opening claim until something has
+    // read the repository — a kind nothing checked, a directory nothing looked
+    // in. Deploying that builds a guess.
+    refuse.set('inspectRepository', {
+      code: 'NOT_FOUND',
+      message: 'no repository example/almanac is available to this operator',
+    });
+
+    const screen = await mount(repoDraft);
+
+    expect(screen.text()).toContain('could not read example/almanac');
+    expect(screen.text()).toContain('Spindrift stops before Build #1');
+
+    screen.unmount();
+  });
+
+  test('a repository that was read and holds nothing buildable does not', async () => {
+    // The other half of the same split: this one was read, and §5 keeps the
+    // assertion path open — name the directory, pick the kind.
+    scopes = [{ scope: '.', outcome: 'unsupported', detail: 'just prose.' }];
+
+    const screen = await mount(repoDraft);
+
+    expect(screen.text()).toContain('does not know how to build');
+    expect(screen.text()).not.toContain('could not read example/almanac');
+    expect(screen.text()).not.toContain('Spindrift stops before Build #1');
+
+    screen.unmount();
+  });
+});
+
+describe('the Source row', () => {
+  test('opens while nothing has answered which directory to deploy', async () => {
+    // The repository is chosen and the directory is not, which is the state a
+    // fresh draft opens in — the question is the row, so the row is open.
+    scopes = [detected('apps/one'), detected('apps/two')];
+
+    const screen = await mount(repoDraft);
+
+    expect(screen.text()).toContain('Directories Spindrift read');
+
+    screen.unmount();
+  });
+
+  test('collapses once the directory is somebody’s answer', async () => {
+    // Settled, so the alternatives are noise.
+    scopes = [detected('apps/one'), detected('apps/two')];
+
+    const screen = await mount({
+      ...repoDraft,
+      scopeByOperator: true,
+      source: {
+        kind: 'repo',
+        repo: 'example/almanac',
+        url: 'https://vcs.example/example/almanac.git',
+        subpath: 'apps/one',
+      },
+    });
+
+    expect(screen.text()).not.toContain('Directories Spindrift read');
+
+    screen.unmount();
+  });
+});

--- a/apps/spindrift/test/web/creation-edits.test.tsx
+++ b/apps/spindrift/test/web/creation-edits.test.tsx
@@ -18,14 +18,19 @@ import {
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import type { Draft } from '../../src/domain/creation-draft.ts';
-import { blockersFor } from '../../src/domain/creation-draft.ts';
+import { blockersFor, draftReducer } from '../../src/domain/creation-draft.ts';
 import type { TransportFailure } from '../../src/web/client.ts';
 import {
   deployDraft,
+  LOST_TITLE,
   UNSAVED_TITLE,
 } from '../../src/web/views/apps/new/deploy.ts';
 import type { InspectedScope } from '../../src/web/views/apps/new/detect.ts';
-import { NewApp } from '../../src/web/views/apps/new/index.tsx';
+import {
+  type DetectionTrouble,
+  NewApp,
+  standingTrouble,
+} from '../../src/web/views/apps/new/index.tsx';
 import { WRITE_DELAY } from '../../src/web/views/apps/new/writes.ts';
 import {
   INITIAL_DRAFT,
@@ -93,6 +98,49 @@ describe('Deploy after a save that failed', () => {
     });
 
     expect(outcome).toEqual({ act: 'refused', failure: REFUSED });
+  });
+
+  test('a stale revision is the press to recover from, not one to report', async () => {
+    // The press finds it whenever the last edit had already been saved: the
+    // flush sends nothing, so completing is the first thing carrying the
+    // revision the other tab superseded. Reported, it renders the server's
+    // own "reload it before saving" with no control that reloads, and every
+    // press after it fails identically.
+    const outcome = await deployDraft({
+      flush: async () => {},
+      unsaved: () => null,
+      complete: async () => ({
+        ok: false as const,
+        failure: {
+          code: 'STALE_EDIT',
+          message: 'this creation draft changed in another browser',
+        },
+      }),
+    });
+
+    expect(outcome).toEqual({ act: 'stale' });
+  });
+
+  test('a completion that never answered says the App may exist', async () => {
+    // A dropped connection or a proxy's own error page: `command` throws
+    // rather than resolving, and the press used to leave the button disabled
+    // reading "Creating…" with nothing on screen and no way back.
+    const outcome = await deployDraft({
+      flush: async () => {},
+      unsaved: () => null,
+      complete: async () => {
+        throw new Error(
+          'dispatch of completeCreationDraft answered 502 with no command result',
+        );
+      },
+    });
+
+    expect(outcome.act).toBe('lost');
+    expect(outcome.act === 'lost' && outcome.title).toBe(LOST_TITLE);
+    expect(outcome.act === 'lost' && outcome.failure.message).toContain('502');
+    expect(outcome.act === 'lost' && outcome.failure.message).toContain(
+      'Check Apps',
+    );
   });
 });
 
@@ -295,6 +343,71 @@ describe('a repository nothing could be read from', () => {
     expect(screen.text()).not.toContain('Spindrift stops before Build #1');
 
     screen.unmount();
+  });
+});
+
+/**
+ * How long the sentence a read left stays on screen.
+ *
+ * The blocker above is derived from it, so this is what decides whether a
+ * repository nothing could read keeps Deploy off. Exercised as the decision it
+ * is: the shim has no event system, and every one of these is an edit.
+ */
+describe('the sentence a read left', () => {
+  const unread: DetectionTrouble = {
+    kind: 'unread',
+    repo: 'example/almanac',
+    message: 'GitHub is rate-limiting Spindrift.',
+  };
+
+  test('survives an edit that cannot have made the repository readable', () => {
+    // Both of these used to clear it, and neither reads anything: the
+    // directory field re-reads on blur, and the tile is the same source again.
+    // Cleared, Deploy is enabled on a kind nothing checked in a tree nothing
+    // looked in — which is the whole of what the blocker exists to stop.
+    const typed = draftReducer(repoDraft, {
+      type: 'subpath',
+      subpath: 'apps/a',
+    });
+    const looked = draftReducer(repoDraft, { type: 'entry', entry: 'repo' });
+
+    expect(standingTrouble(typed, unread)).toBe(unread);
+    expect(standingTrouble(looked, unread)).toBe(unread);
+  });
+
+  test('goes when the draft names another repository', () => {
+    const switched = draftReducer(repoDraft, {
+      type: 'repo',
+      fullName: 'example/ledger',
+      url: 'https://vcs.example/example/ledger.git',
+    });
+
+    expect(standingTrouble(switched, unread)).toBeNull();
+  });
+
+  test('and when the source stops being a repository at all', () => {
+    const uploading = draftReducer(repoDraft, {
+      type: 'entry',
+      entry: 'upload',
+    });
+
+    expect(standingTrouble(uploading, unread)).toBeNull();
+  });
+
+  test('one about a directory goes when the directory does', () => {
+    // The other half: this one *was* read, and it is a statement about
+    // `docs` — which the next keystroke in that field makes untrue.
+    const about: DetectionTrouble = {
+      kind: 'unsupported',
+      repo: 'example/almanac',
+      scope: 'docs',
+      message: 'Spindrift does not know how to build docs in example/almanac',
+    };
+    const named = draftReducer(repoDraft, { type: 'subpath', subpath: 'docs' });
+    const moved = draftReducer(named, { type: 'subpath', subpath: 'apps/web' });
+
+    expect(standingTrouble(named, about)).toBe(about);
+    expect(standingTrouble(moved, about)).toBeNull();
   });
 });
 

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -19,7 +19,11 @@ import {
   type Draft,
   draftReducer,
 } from '../../src/web/views/apps/new/draft.ts';
-import { NewApp } from '../../src/web/views/apps/new/index.tsx';
+import {
+  CreationLoadFailure,
+  CreationSkeleton,
+  NewApp,
+} from '../../src/web/views/apps/new/index.tsx';
 import {
   INITIAL_DRAFT,
   REPOSITORY_GRANT,
@@ -150,6 +154,53 @@ describe('the whole plan is on one screen', () => {
 
   test('the vessel is marked immutable while it is still a choice', () => {
     expect(markup).toContain('immutable once created');
+  });
+});
+
+describe('while the screen is still loading', () => {
+  test('the placeholder is the rows that are coming, not one pulsing line', () => {
+    // A card of six rows arrives as a card of six rows. The alternative is a
+    // sentence that says nothing about what will be on the screen, followed by
+    // a layout shift that costs the reader their place.
+    const markup = renderToStaticMarkup(<CreationSkeleton phase="draft" />);
+    for (const label of [
+      'Source',
+      'Component',
+      'Target',
+      'URL',
+      'Reach',
+      'Vessel',
+    ]) {
+      expect(markup).toContain(label);
+    }
+    expect(markup).toContain('aria-busy="true"');
+  });
+
+  test('it names which of the two reads is outstanding', () => {
+    // The second read cannot start until the first has answered — placement is
+    // resolved for the draft (§3) — so "loading" means two different waits.
+    expect(renderToStaticMarkup(<CreationSkeleton phase="draft" />)).toContain(
+      'Recovering the draft',
+    );
+    expect(
+      renderToStaticMarkup(<CreationSkeleton phase="options" />),
+    ).toContain('Targets and repositories');
+  });
+});
+
+describe('when neither read answered', () => {
+  const markup = renderToStaticMarkup(
+    <CreationLoadFailure
+      message="the database was unreachable"
+      onRetry={() => {}}
+    />,
+  );
+
+  test('the failure is named and retryable', () => {
+    // Every read behind this screen is idempotent, so a dead end here is a
+    // choice rather than a consequence.
+    expect(markup).toContain('the database was unreachable');
+    expect(markup).toContain('Try again');
   });
 });
 

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -188,6 +188,31 @@ describe('while the screen is still loading', () => {
   });
 });
 
+describe('a field the schema will refuse', () => {
+  // The rule is one statement, in `creationDraftSchema`, read from both ends.
+  // Before this the only surface for it was the transport refusal the save
+  // came back with, rendered under the Deploy button as `appName: must be
+  // lowercase…` — the right fact, as far from the input as the page allows.
+  const markup = render({ ...clean, appName: 'Almanac Staging' });
+
+  test('is marked where the value is', () => {
+    expect(markup).toContain('aria-invalid="true"');
+    expect(markup).toContain('must be lowercase letters, digits and hyphens');
+  });
+
+  test('and a good one is not', () => {
+    expect(render(clean)).not.toContain('aria-invalid');
+  });
+
+  test('the Component name carries the schema’s rule too', () => {
+    // Whatever rule the schema states, and no rule it does not: an empty name
+    // is the only thing `componentName` refuses.
+    expect(render({ ...clean, componentName: '' })).toContain(
+      'the Component needs a name',
+    );
+  });
+});
+
 describe('when neither read answered', () => {
   const markup = renderToStaticMarkup(
     <CreationLoadFailure

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -450,6 +450,30 @@ describe('the draft reducer', () => {
     expect(next.scopeByOperator).toBeUndefined();
   });
 
+  test('another repository is another read, so the detection resets', () => {
+    // The scope is what `outcomeOf` reads to decide a draft has been answered.
+    // Carried across a repository change, the read of the repository just
+    // chosen applies nothing and the rows below keep describing the previous
+    // one — a kind, a sentence, and ruled-out kinds from somewhere else.
+    const read = draftReducer(INITIAL_DRAFT, {
+      type: 'detect',
+      scope: 'apps/api',
+      kind: 'job',
+      reason: 'a job is declared in spindrift.yaml',
+      unavailable: { website: 'no static output is emitted here' },
+    });
+    const next = draftReducer(read, {
+      type: 'repo',
+      fullName: 'example/ledger',
+      url: 'https://github.com/example/ledger.git',
+    });
+
+    expect(next.detection.scope).toBeUndefined();
+    expect(next.detection.unavailable).toEqual({});
+    expect(next.detection.available).toEqual(['service', 'website', 'job']);
+    expect(next.detection.reason).not.toContain('spindrift.yaml');
+  });
+
   test('a directory the operator typed is recorded as theirs', () => {
     // Durable rather than session state, because the guard it feeds is about
     // the read that runs when a saved draft is reopened.

--- a/apps/spindrift/test/web/creation-screen-mounted.test.tsx
+++ b/apps/spindrift/test/web/creation-screen-mounted.test.tsx
@@ -153,7 +153,7 @@ describe('a draft becoming addressable', () => {
     expect(count('inspectRepository')).toBe(1);
 
     // Still the screen, rather than the placeholder a reload puts back.
-    expect(screen.text()).toContain(INITIAL_DRAFT.appName);
+    expect(screen.text()).toContain(INITIAL_DRAFT.detection.reason);
     expect(screen.text()).not.toContain('Recovering the draft');
 
     screen.unmount();
@@ -168,7 +168,7 @@ describe('a draft becoming addressable', () => {
 
     expect(count('getCreationDraft')).toBe(1);
     expect(count('startCreationDraft')).toBe(0);
-    expect(screen.text()).toContain(INITIAL_DRAFT.appName);
+    expect(screen.text()).toContain(INITIAL_DRAFT.detection.reason);
 
     screen.unmount();
   });

--- a/apps/spindrift/test/web/creation-screen-mounted.test.tsx
+++ b/apps/spindrift/test/web/creation-screen-mounted.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * The creation screen names its own object partway through, and survives it.
+ *
+ * `/apps/new` has no id until the draft exists, so the screen starts one and
+ * then rewrites the path to `/apps/new/<id>`. Every other screen in the route
+ * table is keyed on the id in its path — for the reason `Screen`'s own header
+ * gives — and this is the one place that rule turns on itself: the id appearing
+ * is not navigation to another draft, it is this draft becoming addressable.
+ * Keyed on it, the screen that just started the draft is unmounted and rebuilt,
+ * re-reading the draft, the Targets, the repositories and the repository
+ * detection, and discarding whatever had been typed in between.
+ *
+ * So this mounts the route table rather than the screen: the claim is about the
+ * key the table writes, and a test rendering `NewAppScreen` itself would supply
+ * that key and assert its own prop.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+} from 'bun:test';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Screen } from '../../src/web/app.tsx';
+import {
+  INITIAL_DRAFT,
+  REPOSITORY_GRANT,
+  REPOSITORY_OPTIONS,
+  TARGET_OPTIONS,
+} from '../fixtures/scenarios.ts';
+import { type DomShim, installDomShim } from '../harness/dom.ts';
+
+const DRAFT_ID = '3a2b1c00-0000-4000-8000-00000000beef';
+
+const DRAFT_VIEW = {
+  id: DRAFT_ID,
+  revision: 4,
+  draft: INITIAL_DRAFT,
+  blockers: [],
+  ready: true,
+};
+
+/** Every command the mounted table called, in order. */
+let called: string[] = [];
+/** Command names to refuse once, so a retry can be observed answering. */
+let refuseOnce = new Set<string>();
+
+let dom: DomShim;
+
+beforeAll(() => {
+  dom = installDomShim({
+    fetch: async (url: string) => {
+      const name = url.split('/').pop() ?? '';
+      called.push(name);
+      if (refuseOnce.delete(name)) {
+        return {
+          json: async () => ({
+            ok: false,
+            failure: { code: 'INTERNAL', message: 'the database was asleep' },
+          }),
+        };
+      }
+      switch (name) {
+        case 'startCreationDraft':
+        case 'getCreationDraft':
+          return { json: async () => ({ ok: true, value: DRAFT_VIEW }) };
+        case 'listTargets':
+          return {
+            json: async () => ({
+              ok: true,
+              value: { options: TARGET_OPTIONS },
+            }),
+          };
+        case 'listRepositories':
+          return {
+            json: async () => ({
+              ok: true,
+              value: {
+                repos: [],
+                options: REPOSITORY_OPTIONS,
+                available: REPOSITORY_GRANT,
+                connector: { state: 'unavailable' },
+              },
+            }),
+          };
+        default:
+          return {
+            json: async () => ({
+              ok: true,
+              value: {
+                fullName: 'example/almanac',
+                defaultBranch: 'main',
+                commit: 'a'.repeat(40),
+                scopes: [],
+                canConnect: true,
+              },
+            }),
+          };
+      }
+    },
+  });
+});
+
+afterAll(() => dom.restore());
+
+beforeEach(() => {
+  called = [];
+  refuseOnce = new Set();
+});
+
+/** The route table, with the hash router's navigation modelled as a re-render. */
+function mount(initial: string) {
+  const container = dom.document.createElement('div');
+  let root!: Root;
+  let path = initial;
+  const navigate = (next: string) => {
+    path = next;
+    root.render(<Screen path={path} onNavigate={navigate} />);
+  };
+  return {
+    text: () => container.textContent,
+    path: () => path,
+    open: () =>
+      act(async () => {
+        root = createRoot(container as unknown as Element);
+        root.render(<Screen path={path} onNavigate={navigate} />);
+      }),
+    settle: () => act(async () => {}),
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+const count = (name: string) => called.filter((call) => call === name).length;
+
+describe('a draft becoming addressable', () => {
+  test('the rewritten path reads nothing a second time', async () => {
+    const screen = mount('/apps/new');
+    await screen.open();
+    await screen.settle();
+
+    // The rewrite happened: the draft has an id and the path names it.
+    expect(screen.path()).toBe(`/apps/new/${DRAFT_ID}`);
+    // And every read behind the screen was made exactly once. A remount here
+    // costs a second `getCreationDraft`, a second placement resolution, a
+    // second repository list and a second read of the repository.
+    expect(count('startCreationDraft')).toBe(1);
+    expect(count('getCreationDraft')).toBe(0);
+    expect(count('listTargets')).toBe(1);
+    expect(count('listRepositories')).toBe(1);
+    expect(count('inspectRepository')).toBe(1);
+
+    // Still the screen, rather than the placeholder a reload puts back.
+    expect(screen.text()).toContain(INITIAL_DRAFT.appName);
+    expect(screen.text()).not.toContain('Recovering the draft');
+
+    screen.unmount();
+  });
+
+  test('an addressed draft is read once, without starting one', async () => {
+    // The other direction: opening the URL directly resumes rather than
+    // creating, which is what makes the draft a durable row worth addressing.
+    const screen = mount(`/apps/new/${DRAFT_ID}`);
+    await screen.open();
+    await screen.settle();
+
+    expect(count('getCreationDraft')).toBe(1);
+    expect(count('startCreationDraft')).toBe(0);
+    expect(screen.text()).toContain(INITIAL_DRAFT.appName);
+
+    screen.unmount();
+  });
+});
+
+describe('a load that failed', () => {
+  test('says what failed instead of a screen with nothing on it', async () => {
+    refuseOnce.add('startCreationDraft');
+    const screen = mount('/apps/new');
+    await screen.open();
+    await screen.settle();
+
+    expect(screen.text()).toContain('the database was asleep');
+    expect(screen.text()).toContain('Try again');
+    // And the path was never rewritten, because there is no draft to name.
+    expect(screen.path()).toBe('/apps/new');
+
+    screen.unmount();
+  });
+});

--- a/apps/spindrift/test/web/draft-writes.test.ts
+++ b/apps/spindrift/test/web/draft-writes.test.ts
@@ -87,6 +87,23 @@ describe('a burst of edits', () => {
 
     expect(saved).toEqual(['almanac']);
   });
+
+  test('and the flush after a discard sends nothing', async () => {
+    const saved: string[] = [];
+    const writes = draftWrites<string>({
+      save: async (draft) => {
+        saved.push(draft);
+      },
+      onWriting: () => {},
+      delay: 10_000,
+    });
+
+    writes.edit('almanac');
+    writes.discard();
+    await writes.flush();
+
+    expect(saved).toEqual([]);
+  });
 });
 
 describe('two saves', () => {
@@ -114,6 +131,41 @@ describe('two saves', () => {
 
     recorded.release();
     await writes.flush();
+  });
+
+  test('one refused as stale takes the edits behind it with it', async () => {
+    // What the screen's recovery needs. The draft on screen has just been
+    // replaced by the server's, so an edit written against the version that
+    // lost is not a newer answer — it is an older document, and sending it
+    // writes it at the revision just recovered, where the guard accepts it.
+    // The edit is already in the chain by then, because the save that
+    // recovers is the link in front of it.
+    const recorded = recorder();
+    const writes = draftWrites<string>({
+      save: recorded.save,
+      onWriting: () => {},
+      delay: 5,
+    });
+
+    writes.edit('local-a');
+    await tick(15);
+    expect(recorded.saved).toEqual(['local-a']);
+
+    writes.edit('local-ab');
+    await tick(15);
+    writes.discard();
+    recorded.release();
+    await writes.flush();
+
+    expect(recorded.saved).toEqual(['local-a']);
+
+    // And only what was pending: the next edit is an answer about the draft
+    // now on screen, so it saves.
+    writes.edit('recovered-and-edited');
+    await tick(15);
+    recorded.release();
+    await writes.flush();
+    expect(recorded.saved).toEqual(['local-a', 'recovered-and-edited']);
   });
 
   test('a save that throws does not wedge every save after it', async () => {

--- a/apps/spindrift/test/web/draft-writes.test.ts
+++ b/apps/spindrift/test/web/draft-writes.test.ts
@@ -1,0 +1,139 @@
+/**
+ * The draft's write side, as a decision rather than a rendering.
+ *
+ * Two properties that pull against each other, which is why they are one
+ * module and one test rather than a debounce somebody added on top of a chain:
+ *
+ * - **Coalescing.** A name typed a character at a time was a round trip and a
+ *   revision bump per character, and a Deploy button that flipped disabled and
+ *   back on every one of them.
+ * - **Order.** The draft is guarded by a revision, so two writes in flight at
+ *   once means the second carries a version the first is about to invalidate —
+ *   and the operator is told their own edit is a stale one from another tab.
+ *
+ * Deliberately not driven through the screen: the mounted harness has no event
+ * system (`test/harness/dom.ts`), and typing is exactly what this coalesces.
+ */
+import { describe, expect, test } from 'bun:test';
+import { draftWrites } from '../../src/web/views/apps/new/writes.ts';
+
+const tick = (ms: number) => new Promise((done) => setTimeout(done, ms));
+
+/** A save that records what it was handed and finishes when told. */
+function recorder() {
+  const saved: string[] = [];
+  const gates: (() => void)[] = [];
+  return {
+    saved,
+    /** Let the save that is waiting finish. */
+    release: () => gates.shift()?.(),
+    save: async (draft: string) => {
+      saved.push(draft);
+      await new Promise<void>((done) => gates.push(done));
+    },
+  };
+}
+
+describe('a burst of edits', () => {
+  test('is one save, carrying the last one', async () => {
+    const saved: string[] = [];
+    const writes = draftWrites<string>({
+      save: async (draft) => {
+        saved.push(draft);
+      },
+      onWriting: () => {},
+      delay: 20,
+    });
+
+    for (const value of ['a', 'al', 'alm', 'alma']) writes.edit(value);
+    expect(saved).toEqual([]);
+
+    await tick(40);
+    expect(saved).toEqual(['alma']);
+  });
+
+  test('reports one stretch of writing rather than one per edit', async () => {
+    // The Deploy button reads this. Flipping it per keystroke is the flicker
+    // the debounce exists to remove, so `true` may not arrive until a save
+    // actually leaves.
+    const writing: boolean[] = [];
+    const writes = draftWrites<string>({
+      save: async () => {},
+      onWriting: (value) => writing.push(value),
+      delay: 20,
+    });
+
+    for (const value of ['a', 'al', 'alm']) writes.edit(value);
+    expect(writing).toEqual([]);
+
+    await tick(40);
+    expect(writing).toEqual([true, false]);
+  });
+
+  test('the flush Deploy makes sends what is still scheduled', async () => {
+    // Pressing Deploy inside the debounce window would otherwise complete the
+    // draft the server holds, which is the one before the last edit.
+    const saved: string[] = [];
+    const writes = draftWrites<string>({
+      save: async (draft) => {
+        saved.push(draft);
+      },
+      onWriting: () => {},
+      delay: 10_000,
+    });
+
+    writes.edit('almanac');
+    await writes.flush();
+
+    expect(saved).toEqual(['almanac']);
+  });
+});
+
+describe('two saves', () => {
+  test('never overlap, whatever order the edits arrived in', async () => {
+    const recorded = recorder();
+    const writes = draftWrites<string>({
+      save: recorded.save,
+      onWriting: () => {},
+      delay: 5,
+    });
+
+    writes.edit('first');
+    await tick(15);
+    expect(recorded.saved).toEqual(['first']);
+
+    // A second burst while the first save is still in flight. Nothing may go
+    // out until the first has answered with the revision the second needs.
+    writes.edit('second');
+    await tick(15);
+    expect(recorded.saved).toEqual(['first']);
+
+    recorded.release();
+    await tick(15);
+    expect(recorded.saved).toEqual(['first', 'second']);
+
+    recorded.release();
+    await writes.flush();
+  });
+
+  test('a save that throws does not wedge every save after it', async () => {
+    // The chain is a promise, and a rejected one stays rejected: the draft
+    // would quietly stop saving for the rest of the session.
+    const saved: string[] = [];
+    const writes = draftWrites<string>({
+      save: async (draft) => {
+        saved.push(draft);
+        if (draft === 'boom') throw new Error('the network went away');
+      },
+      onWriting: () => {},
+      delay: 5,
+    });
+
+    writes.edit('boom');
+    await tick(15);
+    writes.edit('after');
+    await writes.flush();
+
+    expect(saved).toEqual(['boom', 'after']);
+  });
+});

--- a/apps/spindrift/test/web/repo-picker.test.tsx
+++ b/apps/spindrift/test/web/repo-picker.test.tsx
@@ -7,9 +7,9 @@
  * the operator has granted repositories and connected none, that reads "no
  * repositories" beside a GitHub App that is working.
  *
- * The two lists each carry a `connected` boolean and they do not mean the same
- * thing, which is why the state on each row is derived here rather than read
- * off either one.
+ * Each list carries its own boolean about Spindrift — `alreadyDeploys` on a
+ * connection, `rowExists` on a grant entry — which is why the state on each row
+ * is derived here rather than read off either one.
  */
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
@@ -53,10 +53,11 @@ describe('what the picker offers', () => {
     expect(stateOf('example-org/ledger')).toBe('grant-only');
   });
 
-  test("the grant's own `connected` flag never decides a row", () => {
-    // `available[].connected` means "a row exists" while `options[].connected`
-    // means "an App deploys from it". Reading the first as a state is how a
-    // connected repository with no App reads as one that has one.
+  test("the grant's own row-exists flag never decides a row", () => {
+    // A grant entry knows only that Spindrift holds a row; whether an App
+    // deploys from it is the connection's own fact. Reading the first as the
+    // second is how a connected repository with no App reads as one that has
+    // one.
     const grantOnly = repositoryChoices(
       [],
       [
@@ -64,11 +65,22 @@ describe('what the picker offers', () => {
           repositoryId: '1',
           fullName: 'example-org/site',
           defaultBranch: 'main',
-          connected: true,
+          rowExists: true,
         },
       ],
     );
     expect(grantOnly[0]?.state).toBe('grant-only');
+  });
+
+  test('a repository on both lists is read off the connection', () => {
+    // `example-org/site` has a row and no App: the grant says a row exists and
+    // the connection says nothing deploys from it. Only the second is an answer
+    // to the question the row is asking.
+    expect(
+      REPOSITORY_GRANT.find((repo) => repo.fullName === 'example-org/site')
+        ?.rowExists,
+    ).toBe(true);
+    expect(stateOf('example-org/site')).toBe('connected');
   });
 });
 

--- a/apps/spindrift/test/web/repo-picker.test.tsx
+++ b/apps/spindrift/test/web/repo-picker.test.tsx
@@ -65,6 +65,7 @@ describe('what the picker offers', () => {
           repositoryId: '1',
           fullName: 'example-org/site',
           defaultBranch: 'main',
+          cloneUrl: 'https://vcs.example/example-org/site.git',
           rowExists: true,
         },
       ],

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -200,7 +200,7 @@ describe('the GitHub repository connector', () => {
             repositoryId: '99',
             fullName: 'example/app',
             defaultBranch: 'main',
-            connected: false,
+            rowExists: false,
           },
         ]}
         connector={{

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -200,6 +200,7 @@ describe('the GitHub repository connector', () => {
             repositoryId: '99',
             fullName: 'example/app',
             defaultBranch: 'main',
+            cloneUrl: 'https://vcs.example/example/app.git',
             rowExists: false,
           },
         ]}


### PR DESCRIPTION
## Summary

Editing a creation draft stops being able to strand, mislead, or silently drop the operator's input. All ten of the wizard's remaining edit-safety and feel defects, in one stacked change on the detection work:

- **Writes coalesce** behind a 350ms trailing debounce in front of the existing serialized save chain, flushing on unmount — typing a name is one write per pause, and the Deploy button stops flickering per keystroke.
- **Deploy answers honestly:** it flushes pending writes and shows the save that failed instead of clearing the refusal and silently returning; a `STALE_EDIT` on either save or Deploy refetches the draft, resyncs the revision, discards the writes the old revision had queued (a run-counter, so a scheduled write cannot overwrite the recovered draft), and says another tab won; a thrown completion returns a "did not hear back" outcome instead of stranding the button at "Creating…".
- **Inline validation** from the same zod schema the command runs, beside the field with `aria-invalid` — the bottom-of-page transport refusal stops being the only surface.
- **Detection troubles are scoped to what they were about:** they clear when the repo, subpath, or entry that caused them changes, an unread repository blocks Deploy distinctly from one that was read and holds nothing buildable, and choosing a second repository forgets the first one's read.
- **The screen stays mounted** when its URL learns the draft id (the rewrite no longer remounts and re-fetches everything); loading renders skeleton rows naming which read is outstanding; a failed load offers a retry.
- **Repository rows tell the truth:** the two `connected` booleans become `alreadyDeploys` / `rowExists`; clone URLs derive from the host the installation's manifest names; `listRepositories` reconciles rows in parallel and marks the row it could not reconcile with its reason instead of swallowing the error.
- **Dead surfaces removed** deliberately: `reviewCreationDraft` (registered, tested, read by nothing), the unused `DECISIONS` export, and the persisted-but-unread `step` key (stripped on read; jsonb, no migration).

## Validation

- `bun run typecheck` clean; `bun run lint` clean; `docs:check` clean.
- `bun test`: 1968 pass / 0 fail (142 files), re-run after rebasing onto current `main`.
- New coverage: write coalescing and the discard/run-counter semantics, `deployDraft`'s four outcomes, `STALE_EDIT` resync through a mounted screen, unread-vs-unbuildable blockers, the remount fix (verified to fail with the fix reverted), skeletons, retry, inline validation, the renamed booleans, and a legacy `step`-carrying row staying editable.

## Risk

- Reviewer-caught and fixed pre-push: two races where a write scheduled before a stale-recovery could overwrite the server's draft, a second repository keeping the first's detection, the unread blocker clearing on a keystroke, and Deploy stranding on a thrown completion.
- Removing `reviewCreationDraft` is an API removal from the command registry; nothing in the product or tests calls it after this change.
