### PR TITLE
fix(trusted-builds): put the probe's viewer where its first call lands

### DIFF
--- a/terraform/gcp/projects/trusted-builds/kms.tf
+++ b/terraform/gcp/projects/trusted-builds/kms.tf
@@ -60,13 +60,14 @@ resource "google_kms_crypto_key_iam_binding" "signer_metadata" {
 }
 # The home vessel's SIGNER_KEY probe asks a different question from signing:
 # not "may I use this key" but "does a key with the signing purpose exist
-# here" — `cryptoKeys.list` on the ring, then the purpose off each key's
-# metadata. The bindings above are key-scoped, so a lister that can read the
-# signer's metadata still cannot enumerate the ring to find it. Ring-scoped
-# `roles/cloudkms.viewer` is metadata only — list and get, no use — and the
-# member form leaves the attester bindings authoritative over their own roles.
-resource "google_kms_key_ring_iam_member" "spindrift_probe_viewer" {
-  key_ring_id = google_kms_key_ring.keys.id
-  role        = "roles/cloudkms.viewer"
-  member      = local.spindrift_controller_member
+# here" — and it starts by enumerating the rings (`GET /v1/projects/…/
+# keyRings`, `cloud-discovery.ts`), which is `cloudkms.keyRings.list` at
+# project scope. A ring-scoped grant answers the second call and not the
+# first, so the viewer sits on the project: metadata only — list and get on
+# rings, keys and versions, use of nothing. The attester bindings above stay
+# authoritative over the roles that can sign.
+resource "google_project_iam_member" "spindrift_probe_viewer" {
+  project = local.project
+  role    = "roles/cloudkms.viewer"
+  member  = local.spindrift_controller_member
 }


### PR DESCRIPTION
## Summary

The previous grant was one scope too narrow: the `SIGNER_KEY` probe starts with `GET /v1/projects/…/keyRings` — `cloudkms.keyRings.list`, a **project-scoped** permission — before it ever lists a ring's keys. The ring-scoped viewer answered the second call and never the first, so the 403 survived the apply (confirmed live: the binding is on the ring, the refusal is unchanged through several loop passes).

This replaces the ring-scoped member with project-level `roles/cloudkms.viewer` for the controller: list and get on rings, keys and versions, use of nothing. The attester bindings keep sole authority over signing.

## Validation

`tofu fmt -check` clean; `tofu init -backend=false && tofu validate` succeeds. After apply, the standing vessel loop's next pass should flip `SIGNER_KEY` met with no other action — `SOURCE_BUCKET` demonstrated exactly that flow.

## Risk

Metadata-read widening from one ring to the project's KMS metadata; removes the now-redundant ring member; no signing capability changes.