### PR TITLE
fix(hull): give a job the system profile on PATH

### DIFF
--- a/.github/workflows/skiff-smoke.yml
+++ b/.github/workflows/skiff-smoke.yml
@@ -28,9 +28,13 @@ jobs:
     steps:
       - name: The store came from the host, warm
         run: |
-          nix-store -q --requisites /run/current-system | wc -l
-          echo "store entries visible: $(ls /nix/store | wc -l)"
-          test "$(ls /nix/store | wc -l)" -gt 1000
+          # Not through a pipe: a pipeline reports the last command's status,
+          # which would hide nix-store failing outright.
+          registered=$(nix-store -q --requisites /run/current-system | wc -l)
+          visible=$(ls /nix/store | wc -l)
+          echo "registered: $registered   visible: $visible"
+          test "$registered" -gt 100
+          test "$visible" -gt 1000
 
       - name: The overlay takes writes
         run: nix-store --add /etc/hostname

--- a/nix/images/hull-nixos.nix
+++ b/nix/images/hull-nixos.nix
@@ -166,15 +166,10 @@ in
       "run-bosun.mount"
     ];
     wants = [ "network-online.target" ];
-    path = with pkgs; [
-      bash
-      coreutils
-      curl
-      git
-      gnutar
-      gzip
-      docker
-    ];
+    # A job gets what a login shell on this machine would get. Without the
+    # system profile a hull built around a warm /nix/store hands jobs no `nix`
+    # to use it with.
+    path = [ "/run/current-system/sw" ];
     environment = {
       RUNNER_ROOT = runnerRoot;
       HOME = runnerRoot;


### PR DESCRIPTION
## Summary

The skiff smoke job failed with `nix-store: command not found`. The runner unit
carried a hand-listed PATH (`bash coreutils curl git gnutar gzip docker`) with
no `nix` in it — so a hull built entirely around sharing the host's warm
`/nix/store` handed jobs nothing to use it with. A job now gets
`/run/current-system/sw`, i.e. what a login shell on that machine would get.

Also fixes a **spuriously passing assertion** in the smoke workflow: it ran
`nix-store -q ... | wc -l`, and a pipeline reports the *last* command's status,
so `wc` succeeding hid `nix-store` failing outright. It now captures both counts
and tests them.

## Validation

`nix build .#nixosConfigurations.riptide...toplevel` passes. Re-dispatched
against the live pool on riptide after merge — see the run in the conversation.

The previous dispatch already proved the pool loop end to end: GitHub handed the
job to a warm skiff, the skiff ran it and halted, and bosun booted a replacement
without being told anything.