### PR TITLE
fix(bosun): keep per-skiff state across a restart

### DIFF
--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -193,6 +193,12 @@ in
 
         RuntimeDirectory = "bosun";
         RuntimeDirectoryMode = "0700";
+        # systemd removes a RuntimeDirectory when the service stops, which
+        # would delete the per-skiff state on the way down -- exactly what
+        # sweep-on-start reads to deregister runners whose VMM was killed with
+        # the cgroup and never got to tear itself down. Without this, every
+        # restart leaks a ghost registration.
+        RuntimeDirectoryPreserve = "yes";
         LogsDirectory = "bosun";
 
         # Every skiff is a child of this unit, so one filter covers the whole


### PR DESCRIPTION
## Summary

`RuntimeDirectory=` is removed by systemd when the service stops, so `/run/bosun`
and every skiff's `runner-id` went with it on the way down. That is exactly the
state sweep-on-start reads in order to deregister runners whose VMM was killed
with the cgroup and never got a chance to tear itself down — so the sweep could
never do its job, and every restart leaked a ghost registration.

Observed live on riptide: two restarts left runners 146 and 147 behind, both
`offline` and uncollectable. This is the failure mode the design already refuses
to trust GitHub's runner list for; the fix makes the local bookkeeping actually
survive to be swept.

`RuntimeDirectoryPreserve = "yes"` keeps the directory across restarts. `/run` is
still tmpfs, so a reboot clears it, which remains correct.

## Validation

`nix build .#nixosConfigurations.riptide...toplevel` passes. Deployed to riptide
and verified a restart no longer leaks a registration.