### PR TITLE
test(ci): let the skiff smoke job target any class

### DIFF
--- a/.github/workflows/skiff-smoke.yml
+++ b/.github/workflows/skiff-smoke.yml
@@ -17,13 +17,18 @@ name: Skiff Smoke
 
 on:
   workflow_dispatch:
+    inputs:
+      label:
+        description: Which class to run on
+        type: string
+        default: skiff-nixos
 
 permissions:
   contents: read
 
 jobs:
   skiff:
-    runs-on: skiff-nixos
+    runs-on: ${{ inputs.label }}
     timeout-minutes: 10
     steps:
       - name: The store came from the host, warm


### PR DESCRIPTION
Makes the smoke job's target a `workflow_dispatch` input defaulting to `skiff-nixos`, the same shape `arc-smoke.yml` uses for its `cluster` input.

Needed in order to aim a job at one specific skiff: a branch-only workflow cannot be dispatched at all, because `workflow_dispatch` resolves the workflow on the default branch and `--ref` only chooses which version runs.