### PR TITLE
fix(bosun): don't kill a skiff on one offline observation

### DIFF
--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -65,6 +65,13 @@ const (
 	// must never claim it.
 	selfHosted = "self-hosted"
 
+	// wedgeThreshold is how many consecutive offline observations it takes to
+	// call a guest wedged. A runner drops its connection whenever the network
+	// hiccups -- observed live, one minute after a transient
+	// "connection reset by peer" on the poll itself -- and killing on the
+	// first observation kills whatever job the skiff was running.
+	wedgeThreshold = 3
+
 	// jitExpiry is how long a generated JIT config is valid if never
 	// consumed. Idle recycling is derived from it: a skiff that never goes
 	// online within this window is holding a dead credential.

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -24,9 +24,10 @@ type skiff struct {
 	paths    skiffPaths
 	mintedAt time.Time // when the JIT config was minted; its ~1h expiry is measured from here
 
-	mu         sync.Mutex
-	everOnline bool      // true once the runner has reported online at least once
-	busySince  time.Time // zero until the runner first reports busy; maxLifetime is measured from here
+	mu            sync.Mutex
+	everOnline    bool      // true once the runner has reported online at least once
+	offlineStreak int       // consecutive offline observations; reset by any other status
+	busySince     time.Time // zero until the runner first reports busy; maxLifetime is measured from here
 
 	helpersLog *os.File
 	helpers    []proc // virtiofsd(s) + passt
@@ -313,9 +314,12 @@ func (p *pool) pollOnce(ctx context.Context) {
 //   - First online observation: revoke the JIT credential host-side. virtiofs
 //     passes the delete through, so it vanishes in-guest with no guest
 //     cooperation, and untrusted job code never sees a live credential again.
-//   - Offline after having been online: the guest is wedged. ch-remote ping
+//   - Offline after having been online: the guest may be wedged. ch-remote ping
 //     cannot tell a hung guest from a healthy one — both answer with a live
-//     VMM — so GitHub's own view of the runner is the only signal.
+//     VMM — so GitHub's own view of the runner is the only signal. It takes
+//     wedgeThreshold consecutive offline observations, because a runner
+//     briefly loses its connection whenever the network hiccups and one
+//     observation is not worth killing a job over.
 //   - Busy transition: recorded once, so maxLifetime is measured from when
 //     the job started, not from boot (which would let warm idle time eat a
 //     job's budget).
@@ -334,6 +338,12 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	if justConnected {
 		s.everOnline = true
 	}
+	if status == "offline" {
+		s.offlineStreak++
+	} else {
+		s.offlineStreak = 0
+	}
+	offlineStreak := s.offlineStreak
 	if busy && s.busySince.IsZero() {
 		s.busySince = time.Now()
 	}
@@ -350,8 +360,8 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	}
 
 	switch {
-	case status == "offline" && everOnline:
-		logger.Warn("wedged guest: went offline with the VMM still alive")
+	case status == "offline" && everOnline && offlineStreak >= wedgeThreshold:
+		logger.Warn("wedged guest: went offline with the VMM still alive", "consecutive_polls", offlineStreak)
 		killBestEffort(s.ch, logger, "wedged cloud-hypervisor")
 	case !busySince.IsZero() && p.exceededLifetime(s.class, busySince):
 		logger.Info("max lifetime exceeded, recycling", "busy_for", time.Since(busySince))

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -192,7 +192,9 @@ func TestWedgedGuestIsKilled(t *testing.T) {
 	p.pollOnce(ctx) // connects, goes busy
 
 	gh.setStatus(first.runnerID, "offline", true)
-	p.pollOnce(ctx) // wedge: offline after having been online
+	for i := 0; i < wedgeThreshold; i++ {
+		p.pollOnce(ctx) // wedge: offline after having been online, repeatedly
+	}
 
 	waitFor(t, "wedged skiff is killed and replaced", func() bool {
 		p.mu.Lock()
@@ -249,5 +251,40 @@ func TestSweepOnEmptyRuntimeDirIsANoop(t *testing.T) {
 	}
 	if len(gh.deleted) != 0 {
 		t.Fatalf("expected no deletes, got %v", gh.deleted)
+	}
+}
+
+// TestTransientOfflineDoesNotKill covers the incident this debounce exists for:
+// a runner briefly lost its connection to GitHub, and killing on the first
+// offline observation destroyed a healthy skiff a minute later. Anything short
+// of wedgeThreshold consecutive observations, or a streak broken by a single
+// online, must leave the skiff alone -- it may be running a job.
+func TestTransientOfflineDoesNotKill(t *testing.T) {
+	p, gh, _ := testPool(t)
+	ctx := context.Background()
+	p.fill(ctx)
+	first := onlySkiff(t, p)
+
+	gh.setStatus(first.runnerID, "online", true)
+	p.pollOnce(ctx)
+
+	for i := 0; i < wedgeThreshold-1; i++ {
+		gh.setStatus(first.runnerID, "offline", true)
+		p.pollOnce(ctx)
+	}
+	// one good observation resets the streak, exactly as a reconnect would
+	gh.setStatus(first.runnerID, "online", true)
+	p.pollOnce(ctx)
+	for i := 0; i < wedgeThreshold-1; i++ {
+		gh.setStatus(first.runnerID, "offline", true)
+		p.pollOnce(ctx)
+	}
+
+	p.mu.Lock()
+	_, stillThere := p.skiffs[first.id]
+	n := len(p.skiffs)
+	p.mu.Unlock()
+	if !stillThere || n != 1 {
+		t.Fatalf("a skiff that never hit %d consecutive offline polls was killed anyway (present=%v, pool=%d)", wedgeThreshold, stillThere, n)
 	}
 }


### PR DESCRIPTION
## What happened

Observed live on riptide within hours of bosun going up:

```
04:51:49 WARN  poll runner status ... read: connection reset by peer
04:52:49 WARN  wedged guest: went offline with the VMM still alive
04:52:49 INFO  skiff halted   error="signal: killed"
```

The poll failed on a transient network error; one minute later the next poll
saw the runner `offline` and bosun killed the skiff. The guest was healthy — the
runner had briefly lost its connection to GitHub along with everything else on
that host at that moment.

**The skiff that died was idle. Had it been busy, the job would have gone with
it** — and `maxLifetime` exists precisely because jobs are supposed to survive.

## The fix

Wedge detection now requires **three consecutive** offline observations, and any
other status resets the streak.

GitHub's view of the runner is still the only signal that can detect a wedged
guest — `ch-remote ping` cannot, because a hung guest with a live VMM answers
ping perfectly well. This only stops a single network hiccup from counting as
proof.

## Validation

`go test ./...` passes, including at `-count=10`. The existing wedge test now
drives the full streak; a new `TestTransientOfflineDoesNotKill` covers the
incident directly, including a streak broken by one reconnect.