### PR TITLE
fix(spindrift): remove the auth bypass from the gate

### DIFF
--- a/apps/spindrift/src/web/views/auth/gate.tsx
+++ b/apps/spindrift/src/web/views/auth/gate.tsx
@@ -32,11 +32,6 @@ export interface GateProps {
   readonly onSignedIn: (principal: Principal) => void;
 }
 
-const DEV_OPERATOR: Principal = {
-  id: 'usr_dev_operator',
-  displayName: 'Dev Operator',
-};
-
 export function Gate({
   claimed,
   gatewayUnlinked = false,
@@ -64,19 +59,6 @@ export function Gate({
       ) : (
         <Enrol onSignedIn={onSignedIn} />
       )}
-      <div className="rounded-xl border border-border/80 bg-card/60 p-4 text-center backdrop-blur-sm shadow-sm transition-all hover:border-accent/40">
-        <p className="mb-2.5 font-mono text-xs font-semibold text-muted-foreground tracking-wide uppercase">
-          Local Development Seam
-        </p>
-        <Button
-          type="button"
-          variant="outline"
-          className="w-full font-mono text-xs hover:border-accent hover:text-accent"
-          onClick={() => onSignedIn(DEV_OPERATOR)}
-        >
-          Bypass Auth (Sign in as Dev Operator)
-        </Button>
-      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
The gate rendered a "Local Development Seam" card unconditionally, offering a one-click "Sign in as Dev Operator" on every installation — including production, where it was visible on mobile. The bypass was client-side state only (no server session was minted), but a live sign-in screen should not offer a fake principal at all. This removes the card and the hardcoded principal; nothing else referenced them.

## Validation
- `bun run typecheck`, `biome check` on the touched file
- `bun test test/web/views.test.tsx test/web/app-mounted.test.tsx test/web/client-bundle.test.ts` — 105 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dy6bHX8DyMQ6gHeR2fRprw