### PR TITLE
fix(spindrift): name the project whose API refused the read

### DIFF
--- a/apps/spindrift/src/adapters/cloud-discovery.ts
+++ b/apps/spindrift/src/adapters/cloud-discovery.ts
@@ -338,7 +338,11 @@ function reasonFor(
     failure.reason === SERVICE_DISABLED ||
     failure.body.includes(SERVICE_DISABLED)
   ) {
-    return `the ${subject.service} API is not enabled, so ${subject.scope} could not be listed`;
+    // The refusal's ErrorInfo names the project whose switch is off — the
+    // federated token's own, routinely not the one the call was aimed at.
+    return failure.consumer === null
+      ? `the ${subject.service} API is not enabled, so ${subject.scope} could not be listed`
+      : `the ${subject.service} API is not enabled in ${failure.consumer} — the project this installation's calls bill to — so ${subject.scope} could not be listed`;
   }
   if (failure.status === 401 || failure.status === 403) {
     return `the federated identity may not list ${subject.scope}: ${failure.message}`;

--- a/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
@@ -91,7 +91,7 @@ export function cloudChecklist(
       PLATFORM_API: {
         met: false,
         assessed: true,
-        detail: `the ${subject.service} API is not enabled on ${subject.project}`,
+        detail: `the ${subject.service} API is not enabled on ${disabledProject(probe.consumer, subject)}`,
       },
       OIDC_FEDERATION: notAssessed(subject.service),
       VESSEL: notAssessed(subject.service),
@@ -162,6 +162,17 @@ export function cloudSurfaceProbe(
     probe.reason === SERVICE_DISABLED ||
     probe.body.includes(SERVICE_DISABLED)
   ) {
+    // Only when the switch that is off is this project's. A refusal whose
+    // ErrorInfo names a *different* consumer — the federated token's own
+    // project — establishes nothing about what this vessel carries, and
+    // reading it as an absence would delete a Target over the installation's
+    // own misconfiguration.
+    if (probe.consumer !== null && probe.consumer !== subject.project) {
+      return {
+        kind: 'undetermined',
+        detail: `the ${subject.service} API is not enabled on ${probe.consumer}, the project this installation’s calls bill to — nothing was established about ${subject.project}`,
+      };
+    }
     return {
       kind: 'absent',
       detail: `the ${subject.service} API is not enabled on ${subject.project}, so it carries no ${subject.service} surface`,
@@ -171,6 +182,24 @@ export function cloudSurfaceProbe(
     kind: 'undetermined',
     detail: `${subject.service} answered ${probe.status}: ${probe.message}`,
   };
+}
+
+/**
+ * The project whose switch the refusal is actually about.
+ *
+ * GCP refuses a call whose *consumer* — the project the federated token bills
+ * — has the service off, whatever project the URL names, and its ErrorInfo
+ * names that consumer. Echoing `subject.project` when the two differ sends an
+ * operator to the console to verify an API that was never the problem.
+ */
+function disabledProject(
+  consumer: string | null,
+  subject: CloudChecklistSubject,
+): string {
+  if (consumer === null || consumer === subject.project) {
+    return subject.project;
+  }
+  return `${consumer} — the project this installation’s calls bill to, not ${subject.project}`;
 }
 
 /** Every item unmet, with one sentence — the Target nothing is known about. */

--- a/apps/spindrift/src/adapters/deploy/cloud/http.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/http.ts
@@ -53,6 +53,15 @@ export type CloudResponse<Result> =
       readonly body: string;
       /** The API's own machine-readable reason, where it gave one. */
       readonly reason: string | null;
+      /**
+       * The project the refusal's `ErrorInfo` names as the call's consumer,
+       * where it gave one — the federated token's own project, which is
+       * routinely not the project in the request URL. A `SERVICE_DISABLED`
+       * is about this project's switch, whatever project the call was aimed
+       * at, and a sentence that echoes the URL's project sends an operator
+       * to verify an API that was never the problem.
+       */
+      readonly consumer: string | null;
       readonly message: string;
     }
   | {
@@ -82,7 +91,7 @@ interface CloudError {
   error?: {
     message?: string;
     status?: string;
-    details?: { reason?: string }[];
+    details?: { reason?: string; metadata?: { consumer?: string } }[];
   };
 }
 
@@ -215,12 +224,19 @@ function failureOf<Result>(
       ?.reason ??
     parsed?.error?.status ??
     null;
+  // ErrorInfo writes it as `projects/<id>`; the sentences here name projects
+  // bare, as the manifest and every subject already do.
+  const consumer =
+    parsed?.error?.details
+      ?.find((detail) => detail.metadata?.consumer !== undefined)
+      ?.metadata?.consumer?.replace(/^projects\//, '') ?? null;
   return {
     ok: false,
     kind: 'status',
     status: response.status,
     body,
     reason,
+    consumer,
     message: parsed?.error?.message ?? body ?? response.statusText,
   };
 }

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -530,6 +530,30 @@ describe('§13: one probe, three answers', () => {
     );
   });
 
+  test('a switch off in the billing project is named, and settles nothing here', async () => {
+    // GCP refuses a call whose *consumer* — the project the federated token
+    // bills — has the service off, whatever project the URL names, and its
+    // ErrorInfo names that consumer. The checklist row has to send the
+    // operator there, and the surface stays undetermined: the refusal said
+    // nothing about what example-vessel carries.
+    const { adapter } = adapterFor({
+      refuseList: serviceDisabled('example-billing'),
+    });
+    const inspected = await adapter.inspect(target());
+
+    const platform = inspected.prerequisites.find(
+      (item) => item.name === 'PLATFORM_API',
+    );
+    expect(platform?.met).toBe(false);
+    expect(platform?.detail).toContain('example-billing');
+    expect(platform?.detail).toContain('not example-vessel');
+
+    expect(inspected.surface.kind).toBe('undetermined');
+    expect(
+      inspected.surface.kind === 'undetermined' && inspected.surface.detail,
+    ).toContain('example-billing');
+  });
+
   test('but a refusal establishes nothing about what is here', async () => {
     // The distinction `cloud-discovery.ts` draws between found-empty and
     // unavailable, applied to a surface: neither of these says the runtime is

--- a/apps/spindrift/test/commands/installation-discover.test.ts
+++ b/apps/spindrift/test/commands/installation-discover.test.ts
@@ -196,6 +196,36 @@ describe('a refusal is never an empty answer', () => {
     expect(fact.reason).not.toContain('may not list');
   });
 
+  test('a disabled API names the consumer its ErrorInfo names, not the URL', async () => {
+    // The live shape this pins: Cloud KMS switched on in the project being
+    // read, switched off in the project the federated token bills. GCP
+    // refuses the call over the *consumer's* switch and says so in
+    // ErrorInfo; a sentence echoing the URL's project sends an operator to
+    // the console to verify an API that was never the problem.
+    const { context } = installation({
+      projects: [PROJECT],
+      refuse: {
+        keyManagement: {
+          status: 403,
+          reason: 'SERVICE_DISABLED',
+          consumer: 'example-billing',
+          message: 'Cloud KMS API has not been used in project example-billing',
+        },
+      },
+    });
+
+    const fact = factAt(
+      await discover(context, { project: PROJECT, kmsLocation: 'a-region' }),
+      'supplyChain',
+      'signer',
+    );
+
+    expect(fact.kind).toBe('unavailable');
+    if (fact.kind !== 'unavailable') return;
+    expect(fact.reason).toContain('not enabled in example-billing');
+    expect(fact.reason).not.toContain(`not enabled in ${PROJECT}`);
+  });
+
   test('a project with no buckets is found, with none', async () => {
     const { context } = installation({
       projects: [PROJECT],

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -935,14 +935,27 @@ function notFound(): unknown {
  * service is off — the human message is the part that names one, and no test
  * reads it.
  */
-export function serviceDisabled(): { status: number; body: unknown } {
+export function serviceDisabled(consumer?: string): {
+  status: number;
+  body: unknown;
+} {
   return {
     status: 403,
     body: {
       error: {
         message: 'this API has not been used in this project',
         status: 'PERMISSION_DENIED',
-        details: [{ '@type': ERROR_INFO, reason: 'SERVICE_DISABLED' }],
+        details: [
+          {
+            '@type': ERROR_INFO,
+            reason: 'SERVICE_DISABLED',
+            // ErrorInfo names the project whose switch is off — the call's
+            // consumer, which is not necessarily the project in the URL.
+            ...(consumer === undefined
+              ? {}
+              : { metadata: { consumer: `projects/${consumer}` } }),
+          },
+        ],
       },
     },
   };

--- a/apps/spindrift/test/harness/fakes/gcp-discovery-api.ts
+++ b/apps/spindrift/test/harness/fakes/gcp-discovery-api.ts
@@ -40,6 +40,12 @@ export interface FakeRefusal {
   readonly status: number;
   /** Placed in `error.details[].reason`, as the real APIs place it. */
   readonly reason?: string;
+  /**
+   * Placed in `error.details[].metadata.consumer` as `projects/<id>`, as
+   * ErrorInfo carries it — the project the refused call bills, which is not
+   * necessarily the one the request URL names.
+   */
+  readonly consumer?: string;
   readonly message?: string;
 }
 
@@ -244,21 +250,26 @@ function refusalOf(refusal: FakeRefusal | undefined): Response | null {
   return error(refusal.status, {
     message: refusal.message ?? 'the caller may not act here',
     ...(refusal.reason === undefined ? {} : { reason: refusal.reason }),
+    ...(refusal.consumer === undefined ? {} : { consumer: refusal.consumer }),
   });
 }
 
 function error(
   status: number,
-  detail: { message: string; reason?: string },
+  detail: { message: string; reason?: string; consumer?: string },
 ): Response {
+  const info = {
+    ...(detail.reason === undefined ? {} : { reason: detail.reason }),
+    ...(detail.consumer === undefined
+      ? {}
+      : { metadata: { consumer: `projects/${detail.consumer}` } }),
+  };
   return Response.json(
     {
       error: {
         code: status,
         message: detail.message,
-        ...(detail.reason === undefined
-          ? {}
-          : { details: [{ reason: detail.reason }] }),
+        ...(Object.keys(info).length === 0 ? {} : { details: [info] }),
       },
     },
     { status },


### PR DESCRIPTION
## Summary
Observed live 2026-08-07: the home vessel's `SIGNER_KEY` row reported "the Cloud KMS API is not enabled, so the signing keys in trusted-builds … could not be listed" while trusted-builds had KMS enabled — the disabled API was the *consumer* project's (bluenose), whose quota the federated token bills. GCP refuses such a call whatever project the URL names, and its `ErrorInfo.metadata.consumer` says which project's switch is off.

- `failureOf` (the one place every cloud refusal is parsed) now surfaces the ErrorInfo consumer on the status arm, stripped of its `projects/` prefix.
- The three `SERVICE_DISABLED` sentences — discovery's `reasonFor`, the checklist's `PLATFORM_API` detail, and the surface probe — name that project when it differs from the request's target. Without a consumer in the refusal, every sentence is unchanged.
- One conclusion fix riding the same distinction: a surface probe refused over a *different* consumer's switch now reports `undetermined` rather than `absent` — that refusal says nothing about what the vessel carries, and reading it as absence would delete a Target over the installation's own misconfiguration.

## Validation
- `bun run typecheck`, `biome check` on touched files
- `bun test` on the cloudrun, static, installation-discover, and views suites — 216 pass. New tests pin the consumer-vs-target distinction at both layers (discovery via the real HTTP parse, checklist via the adapter probe). The vessel-loop suite needs the CI Postgres and runs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dy6bHX8DyMQ6gHeR2fRprw