### PR TITLE
bosun: the Ubuntu hull — sub-second FHS skiffs with no Nix in the guest

### DIFF
--- a/.github/workflows/skiff-smoke.yml
+++ b/.github/workflows/skiff-smoke.yml
@@ -28,6 +28,8 @@ permissions:
 
 jobs:
   skiff:
+    # The NixOS family's assertions; the Ubuntu family has its own job below.
+    if: ${{ !startsWith(inputs.label, 'skiff-ubuntu') }}
     runs-on: ${{ inputs.label }}
     timeout-minutes: 10
     steps:
@@ -56,3 +58,36 @@ jobs:
         run: |
           tr ' ' '\n' < /proc/cmdline | grep '^bosun\.'
           test "$(systemd-detect-virt)" = kvm
+
+  # The Ubuntu hull is the ubuntu-latest-fidelity family: an FHS guest with
+  # no Nix in it, flattened from the same runner image ARC runs. What is
+  # worth asserting is exactly that fidelity — plus the same docker and
+  # identity guarantees every skiff makes.
+  skiff-ubuntu:
+    if: ${{ startsWith(inputs.label, 'skiff-ubuntu') }}
+    runs-on: ${{ inputs.label }}
+    timeout-minutes: 10
+    steps:
+      - name: This is Ubuntu, and apt works
+        run: |
+          . /etc/os-release
+          test "$ID" = ubuntu
+          sudo apt-get update -qq
+          sudo apt-get install -qqy --no-install-recommends sl
+          test -x /usr/games/sl
+
+      - name: The ARC image toolchain is present
+        run: |
+          git --version
+          node --version
+          jq --version
+
+      - name: Docker runs a container
+        run: |
+          docker version --format '{{.Server.Version}}'
+          docker run --rm alpine echo container-ok
+
+      - name: This is a skiff, and it knows which one
+        run: |
+          tr ' ' '\n' < /proc/cmdline | grep '^bosun\.'
+          grep -q 'Cloud Hypervisor' /sys/class/dmi/id/sys_vendor

--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -20,8 +20,12 @@ type hullManifest struct {
 	Devices []hullDevice `json:"devices,omitempty"`
 }
 
+// hullDevice is one declared guest device: exactly one of its fields is set.
+// A share is a virtiofs directory bosun runs a virtiofsd for; a disk is a
+// file the hull ships, handed to the guest as a virtio-blk device.
 type hullDevice struct {
-	Share hullShare `json:"share"`
+	Share *hullShare `json:"share,omitempty"`
+	Disk  *hullDisk  `json:"disk,omitempty"`
 }
 
 type hullShare struct {
@@ -30,12 +34,18 @@ type hullShare struct {
 	RO   bool   `json:"ro"`
 }
 
+type hullDisk struct {
+	Path string `json:"path"` // relative to the hull directory, like kernel and initrd
+	RO   bool   `json:"ro"`
+}
+
 // hull is a loaded manifest plus the digest bosun computed for it. id is
 // deliberately absent from hull.json — a digest cannot live inside the file
 // it digests — so bosun computes it here: sha256 over hull.json's bytes plus
-// the kernel and initrd files it names, in that order. Device share hosts
-// are not hashed: they are host-side bind targets (e.g. /nix/store), not
-// content the hull ships.
+// the kernel and initrd files it names, then each disk in declaration order.
+// Device share hosts are not hashed: they are host-side bind targets (e.g.
+// /nix/store), not content the hull ships. Disks are hashed: a rootfs image
+// is exactly the content a hull ships.
 type hull struct {
 	dir      string
 	manifest hullManifest
@@ -55,9 +65,25 @@ func loadHull(dir string) (*hull, error) {
 		return nil, fmt.Errorf("hull manifest %s: kernel, initrd, and cmdline are required", dir)
 	}
 
+	shipped := []string{m.Kernel, m.Initrd}
+	for i, dev := range m.Devices {
+		switch {
+		case dev.Share != nil && dev.Disk == nil:
+		case dev.Disk != nil && dev.Share == nil:
+			if dev.Disk.Path == "" {
+				return nil, fmt.Errorf("hull manifest %s: devices[%d].disk.path is required", dir, i)
+			}
+			shipped = append(shipped, dev.Disk.Path)
+		default:
+			return nil, fmt.Errorf("hull manifest %s: devices[%d] must declare exactly one of share or disk", dir, i)
+		}
+	}
+
+	// ponytail: hashes every shipped file (a rootfs disk is GBs) on each
+	// spawn; cache by (path, mtime) if refill latency ever matters.
 	h := sha256.New()
 	h.Write(raw)
-	for _, name := range []string{m.Kernel, m.Initrd} {
+	for _, name := range shipped {
 		if err := hashFile(h, filepath.Join(dir, name)); err != nil {
 			return nil, fmt.Errorf("hashing hull file %s: %w", name, err)
 		}
@@ -116,8 +142,13 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 	if p.apiSock, err = sockPath(runtimeDir, id+".api"); err != nil {
 		return skiffPaths{}, err
 	}
+	// Parallel to devices; a disk needs no helper daemon, so its slot stays
+	// empty.
 	p.deviceSocks = make([]string, len(devices))
 	for i, dev := range devices {
+		if dev.Share == nil {
+			continue
+		}
 		if p.deviceSocks[i], err = sockPath(runtimeDir, id+"."+dev.Share.Tag+".fs"); err != nil {
 			return skiffPaths{}, err
 		}
@@ -138,7 +169,16 @@ func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 		"--fs", fmt.Sprintf("tag=bosun,socket=%s", p.credSock),
 	}
 	for i, dev := range h.manifest.Devices {
-		args = append(args, "--fs", fmt.Sprintf("tag=%s,socket=%s", dev.Share.Tag, p.deviceSocks[i]))
+		switch {
+		case dev.Share != nil:
+			args = append(args, "--fs", fmt.Sprintf("tag=%s,socket=%s", dev.Share.Tag, p.deviceSocks[i]))
+		case dev.Disk != nil:
+			ro := "off"
+			if dev.Disk.RO {
+				ro = "on"
+			}
+			args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=%s", filepath.Join(h.dir, dev.Disk.Path), ro))
+		}
 	}
 	args = append(args,
 		"--net", fmt.Sprintf("vhost_user=on,socket=%s", p.netSock),

--- a/apps/bosun/hull_test.go
+++ b/apps/bosun/hull_test.go
@@ -76,7 +76,7 @@ func TestChArgsWithDevices(t *testing.T) {
 		dir: "/hulls/nixos",
 		manifest: hullManifest{
 			Kernel: "vmlinux", Initrd: "initrd", Cmdline: "console=ttyS0",
-			Devices: []hullDevice{{Share: hullShare{Tag: "ro-store", Host: "/nix/store", RO: true}}},
+			Devices: []hullDevice{{Share: &hullShare{Tag: "ro-store", Host: "/nix/store", RO: true}}},
 		},
 		digest: "deadbeef",
 	}
@@ -99,6 +99,40 @@ func TestChArgsWithDevices(t *testing.T) {
 		"--console", "off",
 		"--serial", "file=/var/log/bosun/sk02.log",
 		"--cmdline", "console=ttyS0 bosun.skiff=sk02 bosun.hull=sha256:deadbeef",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("argv mismatch:\n got:  %v\n want: %v", got, want)
+	}
+}
+
+func TestChArgsWithDisk(t *testing.T) {
+	h := &hull{
+		dir: "/hulls/ubuntu",
+		manifest: hullManifest{
+			Kernel: "vmlinux", Initrd: "initrd", Cmdline: "console=ttyS0",
+			Devices: []hullDevice{{Disk: &hullDisk{Path: "rootfs.img", RO: true}}},
+		},
+		digest: "deadbeef",
+	}
+	class := Class{VCPUs: 2, Memory: "2048M"}
+	paths, err := resolvePaths("/run/bosun", "/var/log/bosun", "sk03", h.manifest.Devices)
+	if err != nil {
+		t.Fatalf("resolvePaths: %v", err)
+	}
+
+	got := chArgs(h, class, "sk03", paths)
+	want := []string{
+		"--kernel", "/hulls/ubuntu/vmlinux",
+		"--initramfs", "/hulls/ubuntu/initrd",
+		"--cpus", "boot=2",
+		"--memory", "size=2048M,shared=on",
+		"--fs", "tag=bosun,socket=/run/bosun/sk03.fs",
+		"--disk", "path=/hulls/ubuntu/rootfs.img,readonly=on",
+		"--net", "vhost_user=on,socket=/run/bosun/sk03.net",
+		"--api-socket", "/run/bosun/sk03.api",
+		"--console", "off",
+		"--serial", "file=/var/log/bosun/sk03.log",
+		"--cmdline", "console=ttyS0 bosun.skiff=sk03 bosun.hull=sha256:deadbeef",
 	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("argv mismatch:\n got:  %v\n want: %v", got, want)
@@ -192,6 +226,45 @@ func TestHullDigestStableAndCoversNamedFiles(t *testing.T) {
 	}
 	if h5.digest == h1.digest {
 		t.Fatal("digest did not change when cmdline changed")
+	}
+}
+
+func TestHullDigestCoversDiskContent(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "vmlinux"), "kernel-bytes")
+	writeFile(t, filepath.Join(dir, "initrd"), "initrd-bytes")
+	writeFile(t, filepath.Join(dir, "rootfs.img"), "rootfs-bytes")
+	manifest := `{"kernel":"vmlinux","initrd":"initrd","cmdline":"console=ttyS0","devices":[{"disk":{"path":"rootfs.img","ro":true}}]}`
+	writeFile(t, filepath.Join(dir, "hull.json"), manifest)
+
+	h1, err := loadHull(dir)
+	if err != nil {
+		t.Fatalf("loadHull: %v", err)
+	}
+	writeFile(t, filepath.Join(dir, "rootfs.img"), "different-rootfs-bytes")
+	h2, err := loadHull(dir)
+	if err != nil {
+		t.Fatalf("loadHull: %v", err)
+	}
+	if h1.digest == h2.digest {
+		t.Fatal("digest did not change when disk content changed")
+	}
+}
+
+func TestLoadHullRejectsMalformedDevices(t *testing.T) {
+	for name, devices := range map[string]string{
+		"neither":      `[{}]`,
+		"both":         `[{"share":{"tag":"t","host":"/h"},"disk":{"path":"d.img"}}]`,
+		"missing path": `[{"disk":{"ro":true}}]`,
+	} {
+		dir := t.TempDir()
+		writeFile(t, filepath.Join(dir, "vmlinux"), "kernel-bytes")
+		writeFile(t, filepath.Join(dir, "initrd"), "initrd-bytes")
+		writeFile(t, filepath.Join(dir, "hull.json"),
+			`{"kernel":"vmlinux","initrd":"initrd","cmdline":"console=ttyS0","devices":`+devices+`}`)
+		if _, err := loadHull(dir); err == nil {
+			t.Fatalf("%s: expected error", name)
+		}
 	}
 }
 

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -190,6 +190,9 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 	s.helpers = append(s.helpers, credProc)
 
 	for i, dev := range h.manifest.Devices {
+		if dev.Share == nil {
+			continue // a disk rides cloud-hypervisor's own --disk; no helper
+		}
 		dp, err := p.launch.Start(virtiofsd, virtiofsdArgs(s.paths.deviceSocks[i], dev.Share.Host, dev.Share.RO), helpersLog, helpersLog)
 		if err != nil {
 			return fmt.Errorf("start device virtiofsd %s: %w", dev.Share.Tag, err)

--- a/flake.nix
+++ b/flake.nix
@@ -79,7 +79,7 @@
       );
 
       fleet = import ./nix/lib/registry.nix {
-        inherit lib;
+        inherit lib pkgsFor;
         registry = import ./nix/hosts;
         inherit
           (import ./nix/lib/mkHost.nix {

--- a/nix/hosts/default.nix
+++ b/nix/hosts/default.nix
@@ -9,8 +9,10 @@
 #   tags          Tailscale ACL tags. For a k8s node, the cluster tag ("folly"
 #                 or "offsite") is also what selects its cluster — see
 #                 ../profiles/k8s-node.nix.
-#   kind          "host" (deployable, gets the fleet baseline) or "image"
-#                 (built and flashed/imported, gets only ../profiles/base.nix)
+#   kind          "host" (deployable, gets the fleet baseline), "image"
+#                 (built and flashed/imported, gets only ../profiles/base.nix),
+#                 or "package" (a plain derivation, no NixOS closure at all:
+#                 `module` is callPackage'd and `artifact` does not apply)
 #   baseline      override the baseline implied by `kind`
 #   module        the configuration (default ./<name>.nix)
 #   artifact      attribute under config.system.build to expose as a package
@@ -128,5 +130,12 @@
     kind = "image";
     module = ../images/hull-nixos.nix;
     artifact = "hull";
+  };
+
+  # The FHS skiff: kernel, initrd, and a flattened runner-image rootfs disk.
+  # Not a NixOS closure — the guest carries no Nix at all.
+  hull-ubuntu = {
+    kind = "package";
+    module = ../images/hull-ubuntu.nix;
   };
 }

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -24,5 +24,14 @@
       memory = "2048M";
       warm = 1;
     };
+    # The FHS family: apt, dockerd, and the ARC image's toolchain, no Nix.
+    # More memory than skiff-nixos because jobs here apt-get and docker build
+    # inside the guest rather than leaning on a warm host store.
+    classes.skiff-ubuntu = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 4;
+      memory = "4096M";
+      warm = 1;
+    };
   };
 }

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -130,6 +130,10 @@ let
     $bb ip link set eth0 up
     $bb udhcpc -i eth0 -q -n -s /opt/bosun/udhcpc-script
 
+    # A plain tmpfs: docker's overlayfs snapshotter cannot put upper/work
+    # dirs on the root overlay itself (EINVAL on mount).
+    $bb mkdir -p /var/lib/docker
+    $bb mount -t tmpfs -o mode=0710 tmpfs /var/lib/docker
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
       dockerd >/var/log/dockerd.log 2>&1 &
     echo "skiff-mark setup-done $($bb cut -d' ' -f1 /proc/uptime)"
@@ -196,7 +200,7 @@ let
               rm -rf "root/$dir/''${name#.wh.}"
             fi
           done
-          tar -xf "$layer" -C root --no-same-owner --exclude='*/.wh.*'
+          tar -xf "$layer" -C root --no-same-owner --exclude='*/.wh.*' --exclude='.wh.*'
         done
 
         # dockerd, containerd, runc and friends.
@@ -214,23 +218,13 @@ let
         # kmod; busybox answers.
         [ -e root/sbin/modprobe ] || ln -sf /opt/bosun/busybox root/sbin/modprobe
 
-        # Jobs written for ubuntu-latest say `sudo apt-get`; this guest runs
-        # them as root already, and the runner image ships no sudo.
-        # ponytail: flag-stripping shim; real sudo debs if a job ever needs -u
-        if [ ! -e root/usr/bin/sudo ]; then
-          cat > root/usr/bin/sudo <<'EOF'
-        #!/bin/sh
-        while [ $# -gt 0 ]; do
-          case "$1" in
-            --) shift; break ;;
-            -*) shift ;;
-            *) break ;;
-          esac
-        done
-        exec "$@"
-        EOF
-          chmod 755 root/usr/bin/sudo
-        fi
+        # Jobs written for ubuntu-latest say `sudo apt-get`, and they run as
+        # root here. The image's sudoers grants only the `sudo` group (the
+        # runner user) and includes no sudoers.d, so root needs its own line
+        # in the main file.
+        chmod u+w root/etc/sudoers
+        echo 'root ALL=(ALL:ALL) NOPASSWD:ALL' >> root/etc/sudoers
+        chmod 440 root/etc/sudoers
 
         mkdir -p root/opt/bosun root/run/bosun
         install -m755 ${busybox}/bin/busybox root/opt/bosun/busybox
@@ -240,15 +234,30 @@ let
         install -m644 ${inittab} root/etc/inittab
         rm -f root/etc/resolv.conf
 
+        # Modes the sandbox build cannot express on disk: tar umask-masks
+        # sticky bits and chmod'ing setuid is forbidden in the sandbox, so
+        # both are stamped into the squashfs instead of the staging tree.
+        # ponytail: a hardcoded list; generate from the layer tars if more
+        # setuid tools ever matter.
+        printf '%s\n' \
+          'tmp m 1777 0 0' \
+          'var/tmp m 1777 0 0' \
+          'usr/bin/sudo m 4755 0 0' \
+          'usr/bin/su m 4755 0 0' \
+          > pseudo.defs
+
         mkdir $out
         mksquashfs root $out/rootfs.img \
-          -comp zstd -all-root -no-progress -noappend -processors $NIX_BUILD_CORES
+          -comp zstd -all-root -no-progress -noappend -processors $NIX_BUILD_CORES \
+          -pf pseudo.defs
       '';
 
   manifest = {
     kernel = "vmlinux";
     initrd = "initrd";
-    cmdline = "console=ttyS0 panic=-1";
+    # loglevel=4: full dmesg to the serial file costs ~0.3 s of the ~1 s
+    # boot; warnings still land. Raise it when debugging a boot.
+    cmdline = "console=ttyS0 panic=-1 loglevel=4";
     devices = [
       {
         disk = {

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -153,8 +153,8 @@ let
   '';
 
   # Stage 2, line 2: the one job this skiff was booted for. The runner
-  # deregisters itself after one job and exits; inittab's next line then
-  # powers off, which exits the VMM with 0 — the launcher's completion signal.
+  # deregisters itself after one job and exits; this script then powers off,
+  # which exits the VMM with 0 — the launcher's completion signal.
   run = pkgs.writeScript "skiff-run" ''
     #!/opt/bosun/busybox sh
     export HOME=/home/runner
@@ -185,7 +185,6 @@ let
       {
         nativeBuildInputs = with pkgs; [
           jq
-          squashfs-tools-ng
           squashfsTools
         ];
       }

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -1,0 +1,270 @@
+# The Ubuntu hull: an FHS guest with no Nix in it.
+#
+# This is the `ubuntu-latest`-fidelity family and the shape the cloud path
+# boots. The rootfs is the repo's own ARC runner image — the exact filesystem
+# every `runs-on: offsite` job already passes on — flattened into a read-only
+# squashfs handed to the guest as a virtio-blk disk. Writes land in a tmpfs
+# overlay upper, so a skiff still leaves nothing behind.
+#
+# Nix builds all of it, but none of it reaches the guest: no /nix/store, no
+# store share, no Nix database. "No Nix in the cloud" is about the guest, not
+# the builder.
+#
+# There is no systemd in here. PID 1 is busybox init running three inittab
+# lines: bring the machine up, run one job, halt. The guest is a single-use
+# machine running one job as root — the VM boundary is the isolation, not the
+# user boundary inside it (same stance as hull-nixos).
+{
+  lib,
+  pkgs,
+}:
+let
+  # Same kernel derivation the NixOS hull boots, so riptide's store already
+  # has it: the `dev` output's vmlinux carries the PVH entry note
+  # cloud-hypervisor needs, and /lib/modules below comes from the same build.
+  kernel = pkgs.linuxPackages.kernel;
+  # depmod'd module tree from the kernel's split `modules` output: the raw
+  # output carries no modules.dep, which both makeModulesClosure and the
+  # guest's busybox modprobe need.
+  modulesTree = pkgs.aggregateModules [ kernel.modules ];
+
+  # The rootfs source of record: clusters/base/apps/arc/infra.yaml pins this
+  # same image for the ARC runners, so "what does a job need installed?" is
+  # already field-answered. Bump the digest when the cluster pin moves; a
+  # stale pin still pulls, it is just older.
+  runnerImage = pkgs.dockerTools.pullImage {
+    imageName = "ghcr.io/jonpulsifer/actions-runner";
+    imageDigest = "sha256:fcc546f5fb6e4fe048e3b28f0c20f4df2077ce0e51be5e55bf89262c6aa1fecf";
+    sha256 = "sha256-mhFqK3vA/aQ+3ncQ2MNbQLuoPI8XrEEFaU7MevtFz1k=";
+    os = "linux";
+    arch = "amd64";
+  };
+
+  # dockerd inside the guest, version-matched to the NixOS hull's docker so
+  # the two families never diverge on build behaviour. Static binaries: the
+  # guest has Ubuntu's glibc, not nixpkgs', so nothing dynamic from nixpkgs
+  # can run there.
+  dockerStatic = pkgs.fetchurl {
+    url = "https://download.docker.com/linux/static/stable/x86_64/docker-29.6.2.tgz";
+    hash = "sha256-1iBK6pIjjiRT1URciFudLl64+CkVVo7FDt+dvhKjrHQ=";
+  };
+
+  busybox = pkgs.pkgsStatic.busybox;
+  # dockerd shells out to iptables; the container-image rootfs has none.
+  iptables = pkgs.pkgsStatic.iptables;
+
+  # Everything stage-1 needs before there is a rootfs to load modules from.
+  # The full module tree rides inside the rootfs for everything later (docker
+  # pulls netfilter modules in on demand).
+  modulesClosure = pkgs.makeModulesClosure {
+    kernel = modulesTree;
+    firmware = pkgs.emptyDirectory;
+    rootModules = [
+      "virtio_pci"
+      "virtio_blk"
+      "virtio_net"
+      "virtio_rng"
+      "squashfs"
+      "overlay"
+      "fuse"
+      "virtiofs"
+    ];
+    allowMissing = false;
+  };
+
+  # Stage 1: mount the read-only rootfs, put a tmpfs overlay on top, attach
+  # the credential share, and hand PID 1 to busybox init inside the overlay.
+  stage1 = pkgs.writeScript "stage1" ''
+    #!/bin/busybox sh
+    bb=/bin/busybox
+    $bb mount -t proc proc /proc
+    $bb mount -t sysfs sysfs /sys
+    $bb mount -t devtmpfs dev /dev
+    for m in virtio_pci virtio_blk virtio_net virtio_rng squashfs overlay fuse virtiofs; do
+      $bb modprobe $m
+    done
+    $bb mkdir -p /ro /rw /newroot
+    $bb mount -t squashfs -o ro /dev/vda /ro
+    $bb mount -t tmpfs -o mode=0755 tmpfs /rw
+    $bb mkdir -p /rw/upper /rw/work
+    $bb mount -t overlay -o lowerdir=/ro,upperdir=/rw/upper,workdir=/rw/work overlay /newroot
+    $bb mount -t virtiofs -o ro bosun /newroot/run/bosun
+    exec $bb switch_root /newroot /opt/bosun/busybox init
+  '';
+
+  initrd = pkgs.makeInitrd {
+    contents = [
+      {
+        object = stage1;
+        symlink = "/init";
+      }
+      {
+        object = "${busybox}/bin/busybox";
+        symlink = "/bin/busybox";
+      }
+      {
+        object = "${modulesClosure}/lib/modules";
+        symlink = "/lib/modules";
+      }
+    ];
+  };
+
+  # Stage 2, line 1: the machine. Mounts, hostname, DHCP from passt, dockerd
+  # in the background — nothing here may block the runner longer than it must.
+  setup = pkgs.writeScript "skiff-setup" ''
+    #!/opt/bosun/busybox sh
+    bb=/opt/bosun/busybox
+    $bb mount -t proc proc /proc
+    echo "skiff-mark setup-start $($bb cut -d' ' -f1 /proc/uptime)"
+    $bb mount -t sysfs sysfs /sys
+    $bb mount -t devtmpfs dev /dev
+    $bb mkdir -p /dev/pts /dev/shm
+    $bb mount -t devpts devpts /dev/pts
+    $bb mount -t tmpfs shm /dev/shm
+    $bb mount -t cgroup2 cgroup2 /sys/fs/cgroup
+
+    $bb hostname skiff
+    echo "127.0.0.1 localhost skiff" > /etc/hosts
+
+    $bb ip link set lo up
+    $bb ip link set eth0 up
+    $bb udhcpc -i eth0 -q -n -s /opt/bosun/udhcpc-script
+
+    PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+      dockerd >/var/log/dockerd.log 2>&1 &
+    echo "skiff-mark setup-done $($bb cut -d' ' -f1 /proc/uptime)"
+  '';
+
+  udhcpcScript = pkgs.writeScript "udhcpc-script" ''
+    #!/opt/bosun/busybox sh
+    bb=/opt/bosun/busybox
+    case "$1" in
+      bound|renew)
+        $bb ifconfig "$interface" "$ip" netmask "''${subnet:-255.255.255.0}"
+        [ -n "$router" ] && $bb route add default gw "$router" dev "$interface"
+        $bb rm -f /etc/resolv.conf
+        for d in $dns; do echo "nameserver $d" >> /etc/resolv.conf; done
+        ;;
+    esac
+  '';
+
+  # Stage 2, line 2: the one job this skiff was booted for. The runner
+  # deregisters itself after one job and exits; inittab's next line then
+  # powers off, which exits the VMM with 0 — the launcher's completion signal.
+  run = pkgs.writeScript "skiff-run" ''
+    #!/opt/bosun/busybox sh
+    export HOME=/home/runner
+    export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    export RUNNER_ALLOW_RUNASROOT=1
+    # Read rather than passed as an argument: --jitconfig would put the
+    # credential in every process listing inside the guest.
+    export ACTIONS_RUNNER_INPUT_JITCONFIG="$(/opt/bosun/busybox cat /run/bosun/jitconfig)"
+    cd /home/runner
+    echo "skiff-mark runner-exec $(/opt/bosun/busybox cut -d' ' -f1 /proc/uptime)"
+    exec ./bin/Runner.Listener run
+  '';
+
+  inittab = pkgs.writeText "inittab" ''
+    ::sysinit:/opt/bosun/setup
+    ::wait:/opt/bosun/run
+    ::once:/opt/bosun/busybox poweroff -f
+    ::ctrlaltdel:/opt/bosun/busybox poweroff -f
+  '';
+
+  rootfs =
+    pkgs.runCommand "skiff-ubuntu-rootfs"
+      {
+        nativeBuildInputs = with pkgs; [
+          jq
+          squashfs-tools-ng
+          squashfsTools
+        ];
+      }
+      ''
+        mkdir root
+        tar -xf ${runnerImage} -C .
+
+        # Flatten the OCI layers in manifest order, honouring whiteouts.
+        for layer in $(jq -r '.[0].Layers[]' manifest.json); do
+          # `|| true`: a layer with no whiteouts is normal, and stdenv's
+          # pipefail would otherwise kill the build on grep's empty result.
+          tar -tf "$layer" | { grep -E '(^|/)\.wh\.' || true; } | while read -r wh; do
+            dir=$(dirname "$wh"); name=$(basename "$wh")
+            if [ "$name" = ".wh..wh..opq" ]; then
+              rm -rf "root/$dir"/{*,.[!.]*} 2>/dev/null || true
+            else
+              rm -rf "root/$dir/''${name#.wh.}"
+            fi
+          done
+          tar -xf "$layer" -C root --no-same-owner --exclude='*/.wh.*'
+        done
+
+        # dockerd, containerd, runc and friends.
+        tar -xzf ${dockerStatic}
+        install -m755 docker/* root/usr/local/bin/
+
+        # Static iptables where dockerd's PATH will find it.
+        mkdir -p root/usr/local/sbin
+        cp -a ${iptables}/bin/. root/usr/local/sbin/
+
+        # The full module tree, so docker can modprobe netfilter on demand.
+        cp -a ${modulesTree}/lib/modules root/lib/
+        # The kernel's own module loader must exist at the path the kernel
+        # calls (request_module → /sbin/modprobe). The container image has no
+        # kmod; busybox answers.
+        [ -e root/sbin/modprobe ] || ln -sf /opt/bosun/busybox root/sbin/modprobe
+
+        # Jobs written for ubuntu-latest say `sudo apt-get`; this guest runs
+        # them as root already, and the runner image ships no sudo.
+        # ponytail: flag-stripping shim; real sudo debs if a job ever needs -u
+        if [ ! -e root/usr/bin/sudo ]; then
+          cat > root/usr/bin/sudo <<'EOF'
+        #!/bin/sh
+        while [ $# -gt 0 ]; do
+          case "$1" in
+            --) shift; break ;;
+            -*) shift ;;
+            *) break ;;
+          esac
+        done
+        exec "$@"
+        EOF
+          chmod 755 root/usr/bin/sudo
+        fi
+
+        mkdir -p root/opt/bosun root/run/bosun
+        install -m755 ${busybox}/bin/busybox root/opt/bosun/busybox
+        install -m755 ${setup} root/opt/bosun/setup
+        install -m755 ${run} root/opt/bosun/run
+        install -m755 ${udhcpcScript} root/opt/bosun/udhcpc-script
+        install -m644 ${inittab} root/etc/inittab
+        rm -f root/etc/resolv.conf
+
+        mkdir $out
+        mksquashfs root $out/rootfs.img \
+          -comp zstd -all-root -no-progress -noappend -processors $NIX_BUILD_CORES
+      '';
+
+  manifest = {
+    kernel = "vmlinux";
+    initrd = "initrd";
+    cmdline = "console=ttyS0 panic=-1";
+    devices = [
+      {
+        disk = {
+          path = "rootfs.img";
+          ro = true;
+        };
+      }
+    ];
+  };
+in
+# A hull is content-addressed by the launcher over this directory, so it
+# carries no identity of its own.
+pkgs.runCommand "hull-ubuntu" { preferLocalBuild = true; } ''
+  mkdir -p $out
+  ln -s ${kernel.dev}/vmlinux $out/vmlinux
+  ln -s ${initrd}/initrd $out/initrd
+  ln -s ${rootfs}/rootfs.img $out/rootfs.img
+  ln -s ${pkgs.writeText "hull.json" (builtins.toJSON manifest)} $out/hull.json
+''

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -165,13 +165,18 @@ let
     export ACTIONS_RUNNER_INPUT_JITCONFIG="$(/opt/bosun/busybox cat /run/bosun/jitconfig)"
     cd /home/runner
     echo "skiff-mark runner-exec $(/opt/bosun/busybox cut -d' ' -f1 /proc/uptime)"
-    exec ./bin/Runner.Listener run
+    # Not exec'd, and the poweroff lives here rather than in an inittab
+    # `once` entry: measured on riptide, busybox init never reached the
+    # `once` line after this wait entry finished, leaving a deregistered
+    # guest running forever. The shell that ran the runner halts the machine.
+    ./bin/Runner.Listener run
+    echo "skiff-mark runner-exit $(/opt/bosun/busybox cut -d' ' -f1 /proc/uptime)"
+    /opt/bosun/busybox poweroff -f
   '';
 
   inittab = pkgs.writeText "inittab" ''
     ::sysinit:/opt/bosun/setup
     ::wait:/opt/bosun/run
-    ::once:/opt/bosun/busybox poweroff -f
     ::ctrlaltdel:/opt/bosun/busybox poweroff -f
   '';
 

--- a/nix/lib/registry.nix
+++ b/nix/lib/registry.nix
@@ -6,9 +6,14 @@
   lib,
   mkHost,
   registry,
+  pkgsFor,
 }:
 let
   isHost = entry: (entry.kind or "host") == "host";
+  # A plain derivation, not a NixOS closure: callPackage'd straight from its
+  # module. The Ubuntu hull is the first — a guest with no NixOS in it has no
+  # nixosConfiguration to hang an artifact off.
+  isPackage = entry: (entry.kind or "host") == "package";
 
   defaultSystem = "x86_64-linux";
 in
@@ -41,7 +46,7 @@ rec {
       ]
       ++ (crossHostModules.${name} or [ ]);
     }
-  ) registry;
+  ) (lib.filterAttrs (_: entry: !isPackage entry) registry);
 
   # Hosts you can ssh to: what `nix run .` fans out over.
   deployHosts = lib.attrNames (lib.filterAttrs (_: isHost) registry);
@@ -55,9 +60,15 @@ rec {
   # running `nix build`.
   packagesFor =
     system:
-    lib.mapAttrs (name: entry: nixosConfigurations.${name}.config.system.build.${entry.artifact}) (
+    lib.mapAttrs (
+      name: entry:
+      if isPackage entry then
+        pkgsFor.${entry.system or defaultSystem}.callPackage entry.module { }
+      else
+        nixosConfigurations.${name}.config.system.build.${entry.artifact}
+    ) (
       lib.filterAttrs (
-        _: entry: entry ? artifact && (entry.packageSystem or defaultSystem) == system
+        _: entry: (entry ? artifact || isPackage entry) && (entry.packageSystem or defaultSystem) == system
       ) registry
     );
 }

--- a/nix/lib/registry.nix
+++ b/nix/lib/registry.nix
@@ -60,15 +60,17 @@ rec {
   # running `nix build`.
   packagesFor =
     system:
-    lib.mapAttrs (
-      name: entry:
-      if isPackage entry then
-        pkgsFor.${entry.system or defaultSystem}.callPackage entry.module { }
-      else
-        nixosConfigurations.${name}.config.system.build.${entry.artifact}
-    ) (
-      lib.filterAttrs (
-        _: entry: (entry ? artifact || isPackage entry) && (entry.packageSystem or defaultSystem) == system
-      ) registry
-    );
+    lib.mapAttrs
+      (
+        name: entry:
+        if isPackage entry then
+          pkgsFor.${entry.system or defaultSystem}.callPackage entry.module { }
+        else
+          nixosConfigurations.${name}.config.system.build.${entry.artifact}
+      )
+      (
+        lib.filterAttrs (
+          _: entry: (entry ? artifact || isPackage entry) && (entry.packageSystem or defaultSystem) == system
+        ) registry
+      );
 }


### PR DESCRIPTION
## Summary

The second hull family from the bosun map: `runs-on: skiff-ubuntu` boots an FHS guest flattened from this repo's own ARC runner image — no Nix anywhere inside — and reaches `Runner.Listener` exec in **0.68–0.97 s** on riptide.

- `nix/images/hull-ubuntu.nix`: `dockerTools.pullImage` of `ghcr.io/jonpulsifer/actions-runner` (the digest the ARC scale set pins), layers flattened with whiteout handling into a zstd squashfs served read-only over virtio-blk, tmpfs overlay upper. PID 1 is busybox init — no systemd, no cloud-init. docker 29.6.2 static binaries (version-matched to the NixOS hull), `pkgsStatic.iptables`, and the kernel's full module tree ride in the image.
- `apps/bosun`: `hull.json` devices learn a `disk` variant (`--disk path=…,readonly=on`); disk content is hashed into the hull digest; no per-family branching anywhere — the hull contract seam held.
- `nix/lib/registry.nix`: new `kind = "package"` for artifacts that are not NixOS closures; this hull is the first.
- riptide gains the `skiff-ubuntu` class (4 vCPU / 4 GiB / warm 1) beside `skiff-nixos`.
- `skiff-smoke.yml` gains the FHS family's job: apt via sudo, ARC toolchain, docker run, skiff identity.

## Validation

- `go test ./apps/bosun` green; `mise run nix:check` green (fleet evaluates with the registry change).
- Deployed to riptide from this branch: bosun booted both classes warm; smoke run 31185242420 green on `runs-on: skiff-ubuntu`; skiff halted itself after the job (VMM exit 0) and bosun booted a replacement +4 s.
- Boot timeline measured over eight flights: kernel→init 0.5–0.7 s, runner-exec 0.68–0.97 s with the shipped `loglevel=4` cmdline.

## Risks

- The rootfs digest pin goes stale (not broken) when the cluster's ARC image pin moves; bump them together.
- Jobs on this class run as root inside the guest (the VM is the isolation boundary, same stance as the NixOS hull); the runner user + sudoers entries exist if that changes.
- riptide currently runs this branch's config and reverts on its next auto-upgrade from main — merge promptly.