### PR TITLE
feat(spindrift): carry public reach as the Service's own field, not an allUsers binding

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -81,9 +81,9 @@ import { cloudRunJob } from './job.ts';
 import { cloudSchedulerJob, jobInvokerPolicy, TIME_ZONE } from './scheduler.ts';
 import {
   allowsUnauthenticated,
+  CLOSED_INVOKER_POLICY,
   cloudRunService,
   type InvokerPolicy,
-  invokerPolicy,
   workloadId,
 } from './service.ts';
 import {
@@ -326,6 +326,11 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     // written again after the rollout below: the closed state is **asserted**
     // on every deploy rather than inherited from the platform's default.
     //
+    // The *open* half does not travel through IAM at all: `{public, none}` is
+    // the Service document's own `invokerIamDisabled`, so it tightens in the
+    // same PATCH that rolls the template — the field and the revision flip
+    // together, and no principal an org policy could refuse is ever named.
+    //
     // A job's invoker policy is not on this path. Nothing routes to a Job, so
     // its policy answers only *who may run it* — which is the scheduler and
     // nobody else — and the tightening direction there is the scheduler job
@@ -338,7 +343,7 @@ export class CloudRunDeployAdapter implements DeployAdapter {
         connection,
         SERVICES,
         id,
-        invokerPolicy(desired.reach, desired.auth),
+        CLOSED_INVOKER_POLICY,
         `{reach: ${desired.reach}, auth: ${desired.auth}}`,
       );
       if (tightened !== null) {
@@ -437,18 +442,19 @@ export class CloudRunDeployAdapter implements DeployAdapter {
       return verdict;
     }
 
-    // Now that the Service exists, the policy this exposure means is written
-    // whichever direction it moved. Opening can only happen here — granting
-    // invoke on something that is not there is not a call the API takes — and
-    // tightening repeats a write it may already have made, which is idempotent
-    // and is what makes "no non-public mode has a bypassable origin" this
-    // adapter's guarantee rather than the platform default's.
+    // Now that the Service exists, the closed policy is asserted on every
+    // exposure. Tightening repeats a write it may already have made, which is
+    // idempotent and is what makes "no non-public mode has a bypassable
+    // origin" this adapter's guarantee rather than the platform default's. On
+    // the public cell the write earns its place differently: openness is the
+    // document field above, and the empty policy strips the `allUsers`
+    // binding earlier versions of this adapter minted.
     const written = await this.setInvoker(
       http,
       connection,
       SERVICES,
       id,
-      invokerPolicy(desired.reach, desired.auth),
+      CLOSED_INVOKER_POLICY,
       `{reach: ${desired.reach}, auth: ${desired.auth}}`,
     );
     if (written !== null) {

--- a/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/service.ts
@@ -86,9 +86,9 @@ export function ingressFor(reach: Reach): string {
  * Whether anyone at all may invoke the Service (§9).
  *
  * Both halves have to say so. `auth: none` alone is not enough, because it is
- * also what a Component with no route says, and binding `allUsers` on the
- * strength of that would open the invoker check on the one Component that asked
- * to be unroutable. Only a deliberately public and deliberately unauthenticated
+ * also what a Component with no route says, and disabling the invoker check on
+ * the strength of that would open it on the one Component that asked to be
+ * unroutable. Only a deliberately public and deliberately unauthenticated
  * Component relaxes it; every other cell keeps the runtime's own invoker check,
  * which is the authenticated edge §9 wants and the reason no non-public cell has
  * a bypassable origin here.
@@ -121,6 +121,15 @@ export function cloudRunService(
   return {
     labels,
     ingress: ingressFor(desired.reach),
+    // §9's open cell, carried by the Service itself rather than by an IAM
+    // binding. `allUsers` is a principal no org policy admits — bluenose holds
+    // two documented overrides just to let it through — where this field is
+    // the runtime's own way of saying "no invoker check", constrained by
+    // `run.managed.requireInvokerIam` (org default ALLOW). Written explicitly
+    // in both directions, never omitted: tightening must flip it in the same
+    // PATCH that rolls the template, so there is no revision the old openness
+    // could outlive.
+    invokerIamDisabled: allowsUnauthenticated(desired.reach, desired.auth),
     ...(context.useProjectAdmissionPolicy
       ? { binaryAuthorization: { useDefault: true } }
       : {}),
@@ -239,13 +248,19 @@ export interface InvokerPolicy {
 }
 
 /**
- * The IAM policy that matches one exposure state.
+ * The IAM policy every Service carries: nobody may invoke through IAM.
  *
  * A whole policy rather than a binding to add, because the verb this is handed
  * to replaces what is there: §9's "transitions fail closed" needs the *removal*
- * of public reach to be as expressible as the grant, and a client that could
- * only add would leave a tightened Component reachable by the binding nobody
- * took away.
+ * of a grant to be as expressible as one, and a client that could only add
+ * would leave a tightened Component reachable by the binding nobody took away.
+ *
+ * Constant, because the open cell no longer lives here: `{public, none}` is
+ * the Service's own `invokerIamDisabled` (see {@link cloudRunService}), so no
+ * exposure state puts a principal in this policy — which is what lets the org
+ * keep domain-restricted sharing enforced over the vessel. Asserting the empty
+ * policy on the public cell is still load-bearing once: it strips the
+ * `allUsers` binding earlier versions of this adapter minted.
  *
  * **A named gap, in the direction that fails closed.** §9 gives `Private` "one
  * admin-configured Private audience per Target", and no Target carries one yet
@@ -255,15 +270,9 @@ export interface InvokerPolicy {
  * treats the authenticated edge as the largest non-Spindrift dependency (Risk
  * 2), and the audience belongs with it rather than being invented here.
  */
-export function invokerPolicy(reach: Reach, auth: Auth): InvokerPolicy {
-  return {
-    policy: {
-      bindings: allowsUnauthenticated(reach, auth)
-        ? [{ role: 'roles/run.invoker', members: ['allUsers'] }]
-        : [],
-    },
-  };
-}
+export const CLOSED_INVOKER_POLICY: InvokerPolicy = {
+  policy: { bindings: [] },
+};
 
 /**
  * The longest name the runtime accepts for a Service or a Job — the same

--- a/apps/spindrift/test/adapters/cloudrun.test.ts
+++ b/apps/spindrift/test/adapters/cloudrun.test.ts
@@ -162,7 +162,13 @@ describe('§9: reach and auth reach the runtime as two mechanisms', () => {
     expect(ingressFor('public')).toBe(INGRESS.all);
   });
 
-  test('only a public reach with no auth leaves an open invoker', async () => {
+  test('only a public reach with no auth disables the invoker check', async () => {
+    // The open cell travels as the Service's own `invokerIamDisabled`, never
+    // as an IAM binding: `allUsers` is a principal the org's
+    // domain-restricted sharing refuses (the fake refuses it the same way),
+    // so a public Component that reached for the binding would be red in a
+    // vessel. Every cell still asserts the closed policy — the empty write is
+    // what strips a binding an earlier version of this adapter minted.
     for (const [reach, auth] of [
       ['none', 'none'],
       ['private', 'proxy'],
@@ -174,13 +180,14 @@ describe('§9: reach and auth reach the runtime as two mechanisms', () => {
       );
       expect(verdict.phase).toBe('LIVE');
 
+      const document = api.service('shop-web');
+      expect(document?.invokerIamDisabled).toBe(
+        reach === 'public' && auth === 'none',
+      );
       const policy = api.policy('shop-web') as {
         policy: { bindings: { members: string[] }[] };
       };
-      const members = policy.policy.bindings.flatMap(
-        (binding) => binding.members,
-      );
-      expect(members.includes('allUsers')).toBe(reach === 'public');
+      expect(policy.policy.bindings).toEqual([]);
     }
   });
 
@@ -220,7 +227,10 @@ describe('§9: reach and auth reach the runtime as two mechanisms', () => {
     expect(grantAt).toBeGreaterThan(placedAt);
   });
 
-  test('a public deploy whose grant fails is red, not quietly private', async () => {
+  test('a deploy whose policy assert fails is red, not quietly open', async () => {
+    // The empty policy is still load-bearing on the public cell: it is what
+    // strips an `allUsers` binding an earlier adapter minted, so a refusal to
+    // write it cannot be shrugged off as cosmetic.
     const { adapter } = adapterFor({ refuseIam: permissionDenied() });
     const { verdict } = await drain(
       adapter.apply(target(), desired({ reach: 'public', auth: 'none' })),
@@ -234,33 +244,37 @@ describe('§9: reach and auth reach the runtime as two mechanisms', () => {
   test('a 404 excuses a policy that grants nothing, and only that one', async () => {
     // The adapter forgives `404` on a policy write, because a resource that is
     // not there yet cannot have one and an empty policy is a statement already
-    // true of it. A *granting* policy is the opposite case: it did not land,
-    // and going green on it would report a public Component as reachable when
-    // nothing was ever opened.
+    // true of it. A Service's policy never grants — public reach is the
+    // document's own field — so a `404` on either direction of a Service
+    // deploy is the ordinary case and the deploy proceeds.
+    for (const exposure of [
+      { reach: 'public', auth: 'none' },
+      { reach: 'private', auth: 'none' },
+    ] as const) {
+      const { adapter } = adapterFor({
+        refuseIam: { status: 404, body: { error: { status: 'NOT_FOUND' } } },
+      });
+      const { verdict } = await drain(
+        adapter.apply(target(), desired(exposure)),
+      );
+      expect(verdict.phase).toBe('LIVE');
+    }
+
+    // The *granting* policy that must not be excused is a scheduled Job's:
+    // its binding is what admits the scheduler's identity, and going green
+    // without it would report a cadence nothing can ever fire.
     const granting = adapterFor({
       refuseIam: { status: 404, body: { error: { status: 'NOT_FOUND' } } },
     });
-    const opened = await drain(
+    const scheduled = await drain(
       granting.adapter.apply(
-        target(),
-        desired({ reach: 'public', auth: 'none' }),
+        target({
+          serviceAccount: 'runtime@example-vessel.iam.gserviceaccount.com',
+        }),
+        desired({ kind: 'job', reach: 'none', schedule: '0 3 * * *' }),
       ),
     );
-    expect(opened.verdict.phase).toBe('FAILED');
-
-    // The same refusal on the write that closes: the tightening pass runs
-    // before the Service exists, so `404` there is the ordinary case rather
-    // than a failure, and the deploy goes on to place it.
-    const closing = adapterFor({
-      refuseIam: { status: 404, body: { error: { status: 'NOT_FOUND' } } },
-    });
-    const tightened = await drain(
-      closing.adapter.apply(
-        target(),
-        desired({ reach: 'private', auth: 'none' }),
-      ),
-    );
-    expect(tightened.verdict.phase).toBe('LIVE');
+    expect(scheduled.verdict.phase).toBe('FAILED');
   });
 });
 

--- a/apps/spindrift/test/harness/fakes/cloudrun-api.ts
+++ b/apps/spindrift/test/harness/fakes/cloudrun-api.ts
@@ -648,6 +648,24 @@ export class FakeCloudRun {
       if (this.options.refuseIam !== undefined) {
         return json(this.options.refuseIam.status, this.options.refuseIam.body);
       }
+      // The org's domain-restricted sharing, verbatim from the live refusal:
+      // `allUsers` belongs to no permitted customer, so a policy naming it is
+      // rejected wherever this installation runs. Modeled unconditionally
+      // because public reach must travel as the Service's own
+      // `invokerIamDisabled` — an adapter that reaches for the binding again
+      // has to fail here the way it fails in a vessel.
+      const bindings =
+        (body as { policy?: { bindings?: { members?: string[] }[] } })?.policy
+          ?.bindings ?? [];
+      if (bindings.some((binding) => binding.members?.includes('allUsers'))) {
+        return json(403, {
+          error: {
+            status: 'PERMISSION_DENIED',
+            message:
+              'One or more users named in the policy do not belong to a permitted customer, perhaps due to an organization policy.',
+          },
+        });
+      }
       if (!this.resources.has(key)) return json(404, notFound());
       this.policies.set(key, body);
       return json(200, (body as { policy?: unknown })?.policy ?? {});


### PR DESCRIPTION
## Summary
`{reach: public, auth: none}` Cloud Run Components now set the Service's own `invokerIamDisabled` field instead of binding `roles/run.invoker` to `allUsers`. The binding was the one grant the org's domain-restricted sharing refuses — `terraform/gcp/projects/bluenose/policy.tf` documents the two project-level org-policy overrides that exist solely to admit it, and names this exact change as the exit.

- The field is written explicitly in both directions, so tightening flips it in the same PATCH that rolls the revision template — the openness and the revision change atomically, no window where the new revision serves under the old exposure.
- The invoker policy every Service carries is now constantly closed (`CLOSED_INVOKER_POLICY`). Asserting it on the public cell is still load-bearing once: it strips the `allUsers` binding earlier versions of the adapter minted.
- The Cloud Run fake now refuses any policy naming `allUsers` with the org's verbatim refusal sentence, so a regression that reaches for the binding again fails in tests the way it fails in a vessel.
- Job scheduler bindings (per-Job OIDC invoker) are unchanged.

**Follow-up, deliberately not in this PR:** after this image rolls and every public Component redeploys once, the two org-policy overrides in bluenose's `policy.tf` (`allow_public_cloud_run_invoker`, `allow_public_cloud_run_domains`) can be deleted, restoring domain-restricted sharing as the backstop over the vessel. Removing them before the rollout would break the next public deploy from the old image.

## Validation
- `bun run typecheck`, `biome check` clean
- `bun test` over adapters/web/conformance/config/domain/crypto/extraction: 1147 pass, 129 fail — every failure verified `DATABASE_URL is not set` (no local Postgres; CI provides one)
- cloudrun suite: 68 pass, including new assertions that the document field flips per exposure cell and no policy ever names `allUsers`

## Risks
- `invokerIamDisabled` requires `run.services.setIamPolicy`-adjacent permission? No — it travels in the Service document under existing `run.admin`. The org's `run.managed.requireInvokerIam` constraint is unset (default ALLOW), which `policy.tf` already verified.
- Existing public Services keep serving through their stale `allUsers` binding until their next deploy sets the field and clears the binding; no outage window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dy6bHX8DyMQ6gHeR2fRprw