### PR TITLE
fix(bosun): stop leaking spinning passt processes and zombie helpers

### DIFF
--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -205,9 +205,15 @@ func virtiofsdArgs(sock, sharedDir string, ro bool) []string {
 	return args
 }
 
+// passtArgs builds one skiff's network backend. --foreground keeps passt as
+// bosun's own child so Kill() reaches it, and --one-off makes it quit when
+// its VMM disconnects instead of waiting — and spinning — for a second
+// client that a one-job skiff will never send.
 func passtArgs(sock string) []string {
 	return []string{
 		"--vhost-user",
+		"--foreground",
+		"--one-off",
 		"-s", sock,
 		"--map-host-loopback", "none",
 		"--map-guest-addr", "none",

--- a/apps/bosun/hull_test.go
+++ b/apps/bosun/hull_test.go
@@ -155,7 +155,7 @@ func TestVirtiofsdArgs(t *testing.T) {
 
 func TestPasstArgs(t *testing.T) {
 	got := passtArgs("/run/bosun/sk01.net")
-	want := []string{"--vhost-user", "-s", "/run/bosun/sk01.net", "--map-host-loopback", "none", "--map-guest-addr", "none", "-4", "-D", "1.1.1.1"}
+	want := []string{"--vhost-user", "--foreground", "--one-off", "-s", "/run/bosun/sk01.net", "--map-host-loopback", "none", "--map-guest-addr", "none", "-4", "-D", "1.1.1.1"}
 	if !slices.Equal(got, want) {
 		t.Fatalf("got %v want %v", got, want)
 	}

--- a/apps/bosun/launcher.go
+++ b/apps/bosun/launcher.go
@@ -8,10 +8,10 @@ import (
 // launcher starts a child process. execLauncher is the real adapter; tests
 // substitute a fake that records argv and simulates exit.
 //
-// stdout/stderr are *os.File, not io.Writer: passt daemonizes and holds its
-// inherited stdio open past its own exit, so a piped io.Writer would leave
-// Wait's copy goroutine blocked forever. A real file (or /dev/null) has no
-// such goroutine.
+// stdout/stderr are *os.File, not io.Writer: virtiofsd forks a worker that
+// inherits its stdio and outlives the parent's exit, so a piped io.Writer
+// would leave Wait's copy goroutine blocked on the survivor. A real file (or
+// /dev/null) has no such goroutine.
 type launcher interface {
 	Start(name string, args []string, stdout, stderr *os.File) (proc, error)
 }

--- a/apps/bosun/launcher_test.go
+++ b/apps/bosun/launcher_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -16,13 +17,17 @@ var errFakeKilled = errors.New("fake: killed")
 type fakeProc struct {
 	exitCh chan error
 	once   sync.Once
+	waited atomic.Bool // someone is Wait()ing, so this process gets reaped
 }
 
 func newFakeProc() *fakeProc {
 	return &fakeProc{exitCh: make(chan error, 1)}
 }
 
-func (p *fakeProc) Wait() error { return <-p.exitCh }
+func (p *fakeProc) Wait() error {
+	p.waited.Store(true)
+	return <-p.exitCh
+}
 
 func (p *fakeProc) Kill() error {
 	p.once.Do(func() { p.exitCh <- errFakeKilled })
@@ -66,6 +71,13 @@ func (f *fakeLaunch) last(name string) (fakeCall, bool) {
 		}
 	}
 	return fakeCall{}, false
+}
+
+// all returns every recorded call, oldest first.
+func (f *fakeLaunch) all() []fakeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]fakeCall(nil), f.calls...)
 }
 
 func (f *fakeLaunch) count() int {

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -188,7 +188,11 @@ in
         User = "bosun";
         Group = "bosun";
         SupplementaryGroups = [ "kvm" ];
-        Restart = "on-failure";
+        # always, not on-failure: bosun exits 0 on SIGTERM, and on-failure
+        # reads that as "done" -- leaving the pool empty and every skiff label
+        # unserviced until someone notices. An explicit `systemctl stop` still
+        # stops it.
+        Restart = "always";
         RestartSec = "5s";
 
         RuntimeDirectory = "bosun";

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -183,36 +183,22 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 
 	virtiofsd := binPath(p.cfg.Bin.Virtiofsd, "virtiofsd")
 
-	credProc, err := p.launch.Start(virtiofsd, virtiofsdArgs(s.paths.credSock, s.paths.dir, false), helpersLog, helpersLog)
-	if err != nil {
+	if err := p.startHelper(s, virtiofsd, virtiofsdArgs(s.paths.credSock, s.paths.dir, false)); err != nil {
 		return fmt.Errorf("start credential virtiofsd: %w", err)
 	}
-	s.helpers = append(s.helpers, credProc)
 
 	for i, dev := range h.manifest.Devices {
 		if dev.Share == nil {
 			continue // a disk rides cloud-hypervisor's own --disk; no helper
 		}
-		dp, err := p.launch.Start(virtiofsd, virtiofsdArgs(s.paths.deviceSocks[i], dev.Share.Host, dev.Share.RO), helpersLog, helpersLog)
-		if err != nil {
+		if err := p.startHelper(s, virtiofsd, virtiofsdArgs(s.paths.deviceSocks[i], dev.Share.Host, dev.Share.RO)); err != nil {
 			return fmt.Errorf("start device virtiofsd %s: %w", dev.Share.Tag, err)
 		}
-		s.helpers = append(s.helpers, dp)
 	}
 
-	// passt daemonizes; the real daemon detaches from this process (see
-	// launcher.go). It stays in bosun's cgroup, so KillMode=control-group
-	// still reaps it when bosun itself stops.
-	//
-	// ponytail: an individual skiff recycled mid-run cannot kill the
-	// detached passt process by PID, only its own launch handle (a no-op
-	// past daemonization). Upgrade path: pass --pid and track/kill that PID
-	// if leaked passt processes become a problem in practice.
-	passtProc, err := p.launch.Start(binPath(p.cfg.Bin.Passt, "passt"), passtArgs(s.paths.netSock), helpersLog, helpersLog)
-	if err != nil {
+	if err := p.startHelper(s, binPath(p.cfg.Bin.Passt, "passt"), passtArgs(s.paths.netSock)); err != nil {
 		return fmt.Errorf("start passt: %w", err)
 	}
-	s.helpers = append(s.helpers, passtProc)
 
 	chProc, err := p.launch.Start(binPath(p.cfg.Bin.CloudHypervisor, "cloud-hypervisor"), chArgs(h, class, s.id, s.paths), helpersLog, helpersLog)
 	if err != nil {
@@ -220,6 +206,20 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 	}
 	s.ch = chProc
 
+	return nil
+}
+
+// startHelper launches one side-car on s and reaps it in the background.
+// bosun's lifecycle signal is cloud-hypervisor's exit alone, so nothing else
+// ever Wait()s a helper — and an unwaited child that exits stays a zombie in
+// bosun's process table until bosun itself restarts.
+func (p *pool) startHelper(s *skiff, name string, args []string) error {
+	pr, err := p.launch.Start(name, args, s.helpersLog, s.helpersLog)
+	if err != nil {
+		return err
+	}
+	s.helpers = append(s.helpers, pr)
+	go func() { _ = pr.Wait() }()
 	return nil
 }
 

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -93,6 +93,21 @@ func TestFillBootsWarmCountAndCredentialShareAlwaysPresent(t *testing.T) {
 	}
 }
 
+// Every side-car must be Wait()ed by someone, or it becomes a zombie in
+// bosun's process table the moment it exits — one per helper per recycled
+// skiff, for as long as bosun runs.
+func TestEveryHelperIsReaped(t *testing.T) {
+	p, _, fl := testPool(t)
+	p.fill(context.Background())
+
+	for _, call := range fl.all() {
+		if call.name == "cloud-hypervisor" {
+			continue // awaitExit owns this one
+		}
+		waitFor(t, "helper "+call.name+" is Wait()ed", call.proc.waited.Load)
+	}
+}
+
 func TestPoolReplacesSkiffAfterExit(t *testing.T) {
 	p, _, fl := testPool(t)
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
riptide ran at load 19 on 6 cores for nine hours with two idle skiffs. bosun's
own cgroup accounting names the cost: **1d 6h 7min of CPU over 9h 1min of wall
clock** — ~3.4 cores burned continuously on a host that also runs kubelet.

Three defects, all in the teardown path.

**passt leaked and spun.** It daemonizes and setsids, so the handle bosun holds
is an already-exited parent: `Kill()` is a no-op and the real daemon outlives
its skiff with `ppid 1`, outside even a process-group kill. It then busy-loops
at 100% waiting for a second client that a one-job skiff never sends. 19 had
accumulated, one per recycle. `--foreground` keeps passt as bosun's own child
so `Kill()` reaches it; `--one-off` makes it quit with its VMM. This retires the
`ponytail:` note at `apps/bosun/pool.go:207` — its `--pid`-tracking upgrade path
is unnecessary, passt has native flags for both halves.

**No helper was ever reaped.** `awaitExit` waits on cloud-hypervisor alone, so
every virtiofsd and passt that exited stayed a zombie in bosun's process table —
44 of them. `startHelper` now reaps each in the background.

**`Restart=on-failure` read a clean exit as "done".** bosun exits 0 on SIGTERM,
so the pool sat empty with `skiff-nixos` and `skiff-ubuntu` unserviced and
nothing bringing it back. `Restart=always`; an explicit `systemctl stop` still
stops it.

## Validation

- `go build ./... && go vet ./... && go test ./...` green in `apps/bosun`
- `TestEveryHelperIsReaped` is the regression check; verified it fails when the
  reap goroutine is removed
- `nix eval .#nixosConfigurations.riptide.config.systemd.services.bosun.serviceConfig.Restart` → `always`

## Risk

passt's startup banner moves from the journal to each skiff's
`/var/log/bosun/<id>.helpers.log`, since a foreground passt logs to stderr
rather than syslog. Per-skiff is the better place for it, and it makes the
journal considerably quieter.

Wants a deploy to riptide after merge — bosun is down there now, and the pool
does not refill itself until the unit is running again.