### PR TITLE
fix(trusted-builds): delete untagged artifacts, not every artifact

### DIFF
--- a/terraform/gcp/projects/trusted-builds/artifact-registry.tf
+++ b/terraform/gcp/projects/trusted-builds/artifact-registry.tf
@@ -12,6 +12,11 @@ resource "google_artifact_registry_repository" "images" {
     id     = "delete-untagged"
     action = "DELETE"
     condition {
+      # Without this the provider sends `ANY`, and the policy this id promises
+      # is one that deletes every artifact a day after it is built — including
+      # the tagged one a live Service is running, which then cannot redeploy
+      # or roll back because its digest no longer resolves.
+      tag_state  = "UNTAGGED"
       older_than = "24h"
     }
   }


### PR DESCRIPTION
## What

`cleanup_policies.condition` omitted `tag_state`. The provider sends `ANY` for an
omitted value, so the policy named `delete-untagged` deletes **every** artifact
24 hours after it is built — tagged included.

## Evidence

`trusted-builds/i` is empty (`Repository Size: 0.000MB`), and the live policy
reads `tagState: ANY`. Redeploying a running Cloud Run Service on its current
artifact fails with `Image 'northamerica-northeast1-docker.pkg.dev/trusted-builds/i/plainboi/web@sha256:103ab…' not found` — the revision keeps serving
only because Cloud Run already holds the image.

## Validation

`tofu validate` clean. Needs `atlantis apply` on this PR; the policy change
takes effect on the repository immediately, and nothing recovers the artifacts
already deleted — those Components rebuild.