### PR TITLE
fix(spindrift): attest with buildctl's options, not buildx's flags

### DIFF
--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -203,7 +203,7 @@ export function buildKitProgram(input: BuildKitProgramInput): string {
   // Each entry is a whole line, newline included, so an empty set contributes
   // nothing at all: a bare `${args}` line in the template would leave a blank
   // line after the command's `\` continuation, ending it — and the flag on
-  // the next line becomes a command of its own (`sh: --attest=…: not found`,
+  // the next line becomes a command of its own (`sh: --opt: not found`,
   // observed on the first Component built with no build args).
   const args = Object.entries(input.buildArgs)
     .map(([key, value]) => `  --opt ${quote(`build-arg:${key}=${value}`)} \\\n`)
@@ -272,9 +272,12 @@ else
 ${zeroConfigArm(input)}
 fi
 
+# Attestations are frontend options here, not flags. \`--attest=type=…\` is
+# buildx's spelling; \`buildctl build\` has no such flag and refuses the whole
+# invocation with \`Incorrect Usage: flag provided but not defined: -attest\`.
 buildctl-daemonless.sh build "$@" \\
-${args}  --attest=type=provenance,mode=max \\
-  --attest=type=sbom \\
+${args}  --opt attest:provenance=mode=max \\
+  --opt attest:sbom= \\
   --output ${quote(`type=image,${imageNames(input)},push=true`)} \\
   --metadata-file "$workspace/metadata.json"
 

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -596,6 +596,11 @@ describe('the cloud build route', () => {
     expect(api.programs).toHaveLength(1);
     expect(api.programs[0]).toContain('buildctl-daemonless.sh');
     expect(api.programs[0]).toContain(FRONTEND);
+    // Attestations reach `buildctl` as frontend options. `--attest=type=…` is
+    // buildx's flag; passing it here fails the whole invocation before any
+    // step runs, and every managed build did until this was caught live.
+    expect(api.programs[0]).toContain('--opt attest:provenance=mode=max');
+    expect(api.programs[0]).not.toMatch(/^\s*--attest/m);
   });
 
   test('the log arrives while the build runs', async () => {
@@ -1097,8 +1102,8 @@ describe('the BuildKit program', () => {
   test('an empty build-arg set leaves no blank continuation line', () => {
     // A `\` continuation followed by a blank line ends the command there, and
     // the flag on the next line becomes a command of its own — observed live
-    // as `sh: --attest=type=provenance,mode=max: not found` on the first
-    // Component built with no build args.
+    // as `sh: --opt: not found` on the first Component built with no build
+    // args.
     const bare = buildKitProgram({
       bundleUrl: 'staged://bundle',
       bundleDigest: 'sha256:bundle',
@@ -1111,7 +1116,7 @@ describe('the BuildKit program', () => {
     expect(bare).not.toMatch(/\\\n\s*\n\s*--/);
     // The populated program holds the same invariant.
     expect(program).not.toMatch(/\\\n\s*\n\s*--/);
-    expect(bare).toContain('--attest=type=provenance,mode=max');
+    expect(bare).toContain('--opt attest:provenance=mode=max');
   });
 
   test('builds a Dockerfile against the bundle root, not the scope', () => {
@@ -1224,8 +1229,8 @@ describe('the BuildKit program', () => {
 
   test('ends by printing the one line core reads', () => {
     expect(program).toContain('spindrift-result');
-    expect(program).toContain('--attest=type=provenance,mode=max');
-    expect(program).toContain('--attest=type=sbom');
+    expect(program).toContain('--opt attest:provenance=mode=max');
+    expect(program).toContain('--opt attest:sbom=');
     expect(program).toContain('"buildkitProvenanceRef":"%s"');
     expect(program).toContain('"sbomRef":"%s"');
     // A folded payload is a payload core cannot decode.


### PR DESCRIPTION
## What

The BuildKit program passed `--attest=type=provenance,mode=max` and
`--attest=type=sbom`. Those are buildx flags. `buildctl build` has no `--attest`
at any release, so it refused the whole invocation:

```
Incorrect Usage: flag provided but not defined: -attest
error: flag provided but not defined: -attest
```

Attestations are frontend options there: `--opt attest:provenance=mode=max` and
`--opt attest:sbom=`, both as documented for the pinned BuildKit release.

## Evidence

Every build on the `managed` route has failed this way, from the first one to
today's — seven Cloud Build runs, all `FAILURE`, all at build step 0. Every
`SUCCEEDED` build in the installation is `hosted`, which builds with buildx in
Actions and was never affected. The failure lands after railpack prints its
plan, which is why the log looks like a working build until its last line.

## Validation

`bun test test/adapters` — 328 pass. Typecheck clean. Three tests pinned the old
spelling and now pin the new one; one asserts no `--attest` flag survives on a
continuation line.