### PR TITLE
fix(trusted-builds): keep the staging repository ephemeral, and say so

### DIFF
--- a/terraform/gcp/projects/trusted-builds/artifact-registry.tf
+++ b/terraform/gcp/projects/trusted-builds/artifact-registry.tf
@@ -7,16 +7,26 @@ resource "google_artifact_registry_repository" "images" {
     enablement_config = "DISABLED"
   }
 
+  # Everything goes after a day, tagged included, and that is the point. This
+  # repository is staging for Cloud Run, not an archive: every build pushes one
+  # digest to GHCR, Docker Hub and here, the first two host it for free, and
+  # retaining it in a billed repository is paying twice for the same bytes.
+  #
+  # Nothing serving depends on it — "Cloud Run keeps this copy of the container
+  # image as long as it is used by a serving revision". What it costs is a
+  # redeploy older than a day, which rebuilds; rollbacks here happen well inside
+  # the window. The digest is still in GHCR either way, but Cloud Run cannot
+  # pull that index, which is the whole reason this repository exists.
+  #
+  # `tag_state` is stated rather than defaulted because the default *is* `ANY`,
+  # and a policy that reads `delete-untagged` while deleting everything invites
+  # someone to "fix" it into a bill.
   cleanup_policy_dry_run = false
   cleanup_policies {
-    id     = "delete-untagged"
+    id     = "delete-after-a-day"
     action = "DELETE"
     condition {
-      # Without this the provider sends `ANY`, and the policy this id promises
-      # is one that deletes every artifact a day after it is built — including
-      # the tagged one a live Service is running, which then cannot redeploy
-      # or roll back because its digest no longer resolves.
-      tag_state  = "UNTAGGED"
+      tag_state  = "ANY"
       older_than = "24h"
     }
   }


### PR DESCRIPTION
## What

Reverts today's retention change. The 24h sweep was correct; only its id lied.

`trusted-builds/i` is staging for Cloud Run, not an archive. Every build pushes
the same digest to three registries:

```
ghcr.io/jonpulsifer/<app>/<component>@sha256:…      free
docker.io/jonpulsifer/<app>-<component>@sha256:…    free
…docker.pkg.dev/trusted-builds/i/<app>/<component>@sha256:…   billed
```

Retaining the billed copy pays twice for bytes GHCR already holds. Cloud Run
imports its own copy and "keeps this copy of the container image as long as it
is used by a serving revision", so the sweep cannot break anything serving. The
cost is a redeploy older than a day, which rebuilds; rollbacks happen inside the
window.

`tag_state` is stated rather than defaulted (the default is `ANY`) and the id
now names what the policy does, so a reader does not mistake the sweep for a bug.

## Validation

`tofu plan`: 0 to add, 1 to change, 0 to destroy — the one policy back to
`tag_state = ANY`. Needs `atlantis apply`.