### PR TITLE
fix(bosun): take riptide's GitHub token out of a hand-placed plaintext file

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -13,6 +13,12 @@ creation_rules:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
           # oldschool (ssh-to-age of its ed25519 host key)
           - age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c
+  - path_regex: nix/secrets/riptide\.sops\.ya?ml
+    key_groups:
+      - age:
+          - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          # riptide (ssh-to-age of its ed25519 host key)
+          - age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
   - path_regex: nix/secrets/optiplex\.sops\.ya?ml
     key_groups:
       - age:

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -1,8 +1,9 @@
 # riptide: folly worker node, rooted on NVMe. Also the first bosun host.
-{ inputs, ... }:
+{ config, inputs, ... }:
 {
   imports = [
     ../profiles/k8s-node.nix
+    ../system/sops.nix
     ../system/tailscale-disable.nix
     ../../apps/bosun/module.nix
   ];
@@ -11,13 +12,24 @@
 
   homelab.disko.device = "/dev/nvme0n1";
 
+  sops.defaultSopsFile = ../secrets/riptide.sops.yaml;
+  # bosun reads this once at startup, so a rotated token needs the unit
+  # bounced -- which is what restartUnits does on the activation that
+  # rewrites the secret.
+  sops.secrets."bosun-github-token" = {
+    owner = "bosun";
+    group = "bosun";
+    mode = "0400";
+    restartUnits = [ "bosun.service" ];
+  };
+
   # A skiff mounts this host's /nix/store, so the hull's closure has to be
   # here rather than merely buildable: naming the package is what puts it in
   # riptide's store.
   services.bosun = {
     enable = true;
     repo = "jonpulsifer/infra";
-    tokenFile = "/var/secrets/bosun-github-token";
+    tokenFile = config.sops.secrets."bosun-github-token".path;
     classes.skiff-nixos = {
       hull = "${inputs.self.packages.x86_64-linux.hull-nixos}";
       vcpus = 4;

--- a/nix/secrets/riptide.sops.yaml
+++ b/nix/secrets/riptide.sops.yaml
@@ -1,0 +1,25 @@
+bosun-github-token: ENC[AES256_GCM,data:hEra3mqZTCE3F/9OwADfo7gKdxe5pR2yyaQBVgiAQQjkowEOTlGOEg==,iv:ceRNU4J/L3OV1CGS9xOFYnrc3WczytFfNJOlbN1xN4s=,tag:S/2S8V14e/qiMJAXWf4N/w==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBzYkZ0eGd4QzNxL25mYzJI
+            cHZacEIyVXlBOXVJTFg5SWVKOUZvWHplajJRCnZ6UEUxbm1hTU15Y2IzVHNsLy9H
+            SW9vRFlhbG9NYThiMWJkcXBqb3lPQnMKLS0tIHBHU0ZaRkhLdUNUUzRPbWJ2TGNO
+            VEU5cGU5NEhhSWlxOUUxczgxTFJJWG8K1U6dFq8UyWc306i9jvmSPPCIfXVq/K/+
+            BfQ7QU8yHqHPzAohQ+QLpJTqh7/cviuP/lo4TXXeED/1ok2xmavz3Q==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqRnNRakVibWJlOVNwZFF5
+            SkhSY0NXWGZZTlBtaXhjbWQ5Zldhdmk3RGk4CnlLbC85YlJRM2U3a3hEbllGOG1Z
+            SHFrbGNkUzk2U29uanJPZllIUkx1bk0KLS0tIExDZndwb1BFWnFqeHdUVEl5aDAy
+            c1g2S0c2STNteGZQMG9UMWJKcUVYUkUKICBTGBmA2ND0oy86S/Zhy46+tlPzJCHR
+            n1Nj5NjfLSAuosw4u965wbifBxXY43fuDx1B0HbleM54cAqPdsWDWQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
+    lastmodified: "2026-08-07T23:30:12Z"
+    mac: ENC[AES256_GCM,data:73HNp1/K3rzTnlNujPwCLkzCz+dCJ90UGy0hVJNviHsKuUMkF0WljaCGs3eBn5+HbB/+NtShJSCKscQxQX8AyNcHGL3Jd8gQVPwUco6ogN0wmSnvldLN4UEV89IbD+oruJ4p3rCxRG/Dr4+kbzjNi3fcb1QR2iLBuf9CXbOo/k8=,iv:FT6ZfeDxBHJw6XjrhtavZhbOiea/wqjGCgMlzpHtyh8=,tag:CHz2P/YYZen5iyrwqRmjtA==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
bosun's credential lived at `/var/secrets/bosun-github-token`, put there by hand.
Nothing in the repo declared it, so a riptide rebuilt from scratch comes up with
a bosun that cannot mint a JIT config — and the fleet's pattern for exactly this
already existed on four other hosts.

riptide now imports `nix/system/sops.nix` and reads the token from
`nix/secrets/riptide.sops.yaml`, encrypted to the operator key and to riptide's
own `ssh-to-age` recipient. `restartUnits` bounces bosun on rotation, since it
reads the token once at startup.

## Validation

- `age1 5ylde96…` recipient derived from `/etc/ssh/ssh_host_ed25519_key.pub`
  read on riptide itself, not from `ssh-keyscan` — it matches the recipient in
  `.sops.yaml`, so the host can decrypt
- round-trip decrypt with the operator key returns the single key
  `bosun-github-token`
- sha256 of the encrypted value matches the live file on riptide byte for byte
- `nix eval …riptide.config.services.bosun.tokenFile` → `/run/secrets/bosun-github-token`
- `nix eval …riptide.config.sops.secrets.bosun-github-token` → owner/group `bosun`, mode `0400`, `restartUnits = ["bosun.service"]`

## What this does not fix

The stored value is byte-identical to the live one, so this moves the credential
without changing what it grants — and what it grants is wrong. It is a 40-hex
legacy classic PAT: no expiry, and `repo` scope on a classic PAT reaches every
repository the account can, not just this one. Narrowing it is the GitHub App
decision, tracked separately.

After the next rebuild, `/var/secrets/bosun-github-token` is dead and wants
deleting on the host.