### PR TITLE
feat(bosun): export pool metrics, and alert on the failures nobody saw

### DIFF
--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	TokenFile    string           `json:"tokenFile"`
 	RuntimeDir   string           `json:"runtimeDir"`
 	LogDir       string           `json:"logDir"`
+	MetricsFile  string           `json:"metricsFile"` // empty disables; a node-exporter textfile, not a listener
 	PollInterval Duration         `json:"pollInterval"`
 	Classes      map[string]Class `json:"classes"`
 	Bin          BinPaths         `json:"bin"`

--- a/apps/bosun/metrics.go
+++ b/apps/bosun/metrics.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// metrics is bosun's counters. Gauges are not kept here -- they are read off
+// the live pool at write time, since the running skiffs are the state.
+type metrics struct {
+	mu       sync.Mutex
+	boots    map[string]int            // class -> skiffs booted
+	exits    map[string]map[string]int // class -> reason -> skiffs gone
+	ghErrors int
+}
+
+// Exit reasons. "completed" is the one that means a job ran: the guest reached
+// the end of its single job and powered itself off.
+const (
+	exitCompleted  = "completed"
+	exitWedged     = "wedged"
+	exitLifetime   = "lifetime"
+	exitJITExpired = "jit_expired"
+	exitBootFailed = "boot_failed"
+)
+
+func newMetrics() *metrics {
+	return &metrics{boots: map[string]int{}, exits: map[string]map[string]int{}}
+}
+
+func (m *metrics) boot(class string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.boots[class]++
+}
+
+func (m *metrics) exit(class, reason string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.exits[class] == nil {
+		m.exits[class] = map[string]int{}
+	}
+	m.exits[class][reason]++
+}
+
+func (m *metrics) githubError() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ghErrors++
+}
+
+// render writes the Prometheus text exposition format. It is a handful of
+// series, so it is built by hand rather than by pulling in a client library.
+//
+// live counts idle/busy skiffs per class; desired is each class's warm count.
+func (m *metrics) render(live map[string]poolState, desired map[string]int) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var b strings.Builder
+	b.WriteString("# HELP bosun_skiffs Skiffs currently booted, by class and state.\n")
+	b.WriteString("# TYPE bosun_skiffs gauge\n")
+	for _, class := range sortedKeys(desired) {
+		b.WriteString(fmt.Sprintf("bosun_skiffs{class=%q,state=\"idle\"} %d\n", class, live[class].idle))
+		b.WriteString(fmt.Sprintf("bosun_skiffs{class=%q,state=\"busy\"} %d\n", class, live[class].busy))
+	}
+
+	b.WriteString("# HELP bosun_skiffs_desired Warm skiffs the class is configured to keep.\n")
+	b.WriteString("# TYPE bosun_skiffs_desired gauge\n")
+	for _, class := range sortedKeys(desired) {
+		b.WriteString(fmt.Sprintf("bosun_skiffs_desired{class=%q} %d\n", class, desired[class]))
+	}
+
+	b.WriteString("# HELP bosun_skiff_boots_total Skiffs booted since bosun started.\n")
+	b.WriteString("# TYPE bosun_skiff_boots_total counter\n")
+	for _, class := range sortedKeys(desired) {
+		b.WriteString(fmt.Sprintf("bosun_skiff_boots_total{class=%q} %d\n", class, m.boots[class]))
+	}
+
+	b.WriteString("# HELP bosun_skiff_exits_total Skiffs gone since bosun started, by why.\n")
+	b.WriteString("# TYPE bosun_skiff_exits_total counter\n")
+	for _, class := range sortedKeys(desired) {
+		for _, reason := range []string{exitCompleted, exitWedged, exitLifetime, exitJITExpired, exitBootFailed} {
+			b.WriteString(fmt.Sprintf("bosun_skiff_exits_total{class=%q,reason=%q} %d\n", class, reason, m.exits[class][reason]))
+		}
+	}
+
+	b.WriteString("# HELP bosun_github_errors_total GitHub API calls that failed.\n")
+	b.WriteString("# TYPE bosun_github_errors_total counter\n")
+	b.WriteString(fmt.Sprintf("bosun_github_errors_total %d\n", m.ghErrors))
+	return b.String()
+}
+
+// poolState is one class's live skiff count split by whether GitHub has
+// reported the runner busy.
+type poolState struct{ idle, busy int }
+
+// writeTextfile publishes the metrics for node-exporter's textfile collector.
+// A file, not an HTTP listener: bosun's unit carries the IPAddressDeny that
+// every skiff inherits, so a socket that in-cluster Prometheus could reach
+// would mean opening the pod CIDR to untrusted job code as well.
+//
+// The write is atomic, and its mtime is the heartbeat -- node-exporter exports
+// it as node_textfile_mtime_seconds, so a stale file is how a dead or wedged
+// bosun is detected without bosun reporting anything about itself.
+func writeTextfile(path, body string) error {
+	tmp := path + ".tmp"
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	if err := os.WriteFile(tmp, []byte(body), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func sortedKeys(m map[string]int) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/apps/bosun/metrics_test.go
+++ b/apps/bosun/metrics_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRenderExposesPoolStateAndCounters(t *testing.T) {
+	m := newMetrics()
+	m.boot("skiff-test")
+	m.boot("skiff-test")
+	m.exit("skiff-test", exitCompleted)
+	m.exit("skiff-test", exitWedged)
+	m.githubError()
+
+	got := m.render(
+		map[string]poolState{"skiff-test": {idle: 1, busy: 2}},
+		map[string]int{"skiff-test": 3},
+	)
+
+	for _, want := range []string{
+		`bosun_skiffs{class="skiff-test",state="idle"} 1`,
+		`bosun_skiffs{class="skiff-test",state="busy"} 2`,
+		`bosun_skiffs_desired{class="skiff-test"} 3`,
+		`bosun_skiff_boots_total{class="skiff-test"} 2`,
+		`bosun_skiff_exits_total{class="skiff-test",reason="completed"} 1`,
+		`bosun_skiff_exits_total{class="skiff-test",reason="wedged"} 1`,
+		`bosun_skiff_exits_total{class="skiff-test",reason="lifetime"} 0`,
+		`bosun_github_errors_total 1`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing series %q in:\n%s", want, got)
+		}
+	}
+
+	// Every series needs its metadata, or the textfile collector rejects the
+	// whole file rather than the line.
+	for _, name := range []string{"bosun_skiffs", "bosun_skiffs_desired", "bosun_skiff_boots_total", "bosun_skiff_exits_total", "bosun_github_errors_total"} {
+		if !strings.Contains(got, "# TYPE "+name+" ") {
+			t.Errorf("missing TYPE line for %s", name)
+		}
+	}
+}
+
+// The mtime is the heartbeat, so the publish path has to actually land a file
+// even when nothing has happened yet.
+func TestPublishWritesTextfileAndCountsAGuestHalt(t *testing.T) {
+	p, _, fl := testPool(t)
+	p.cfg.MetricsFile = filepath.Join(t.TempDir(), "sub", "bosun.prom")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.fill(ctx)
+	body, err := os.ReadFile(p.cfg.MetricsFile)
+	if err != nil {
+		t.Fatalf("metrics file after fill: %v", err)
+	}
+	if !strings.Contains(string(body), `bosun_skiffs{class="skiff-test",state="idle"} 1`) {
+		t.Fatalf("warm skiff missing from metrics:\n%s", body)
+	}
+
+	// A guest that powers itself off is a completed job, not a kill.
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(nil)
+
+	waitFor(t, "completed exit is counted", func() bool {
+		body, err := os.ReadFile(p.cfg.MetricsFile)
+		return err == nil && strings.Contains(string(body), `bosun_skiff_exits_total{class="skiff-test",reason="completed"} 1`)
+	})
+}
+
+func TestWriteTextfileIsAtomicOverAnExistingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bosun.prom")
+	if err := writeTextfile(path, "first\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeTextfile(path, "second\n"); err != nil {
+		t.Fatal(err)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "second\n" {
+		t.Fatalf("got %q, want the second write", body)
+	}
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Fatal("the temporary file was left behind for the collector to read")
+	}
+}

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -26,6 +26,7 @@ let
       tokenFile
       runtimeDir
       logDir
+      metricsFile
       ;
     pollInterval = cfg.pollInterval;
     classes = lib.mapAttrs (_: c: {
@@ -92,6 +93,22 @@ in
       type = types.str;
       default = "/var/log/bosun";
       description = "Where each skiff's serial console is written.";
+    };
+
+    metricsFile = mkOption {
+      type = types.str;
+      default = "/var/lib/node-exporter-textfiles/bosun.prom";
+      description = ''
+        Prometheus textfile for node-exporter's textfile collector to serve.
+        Empty disables it.
+
+        A file rather than an HTTP listener on purpose: the IPAddressDeny
+        below is inherited by every skiff, so a socket in-cluster Prometheus
+        could reach would mean opening the pod CIDR to untrusted job code
+        too. The file's mtime is bosun's heartbeat -- node-exporter exports it
+        as `node_textfile_mtime_seconds`, so a stale file is what a dead or
+        wedged bosun looks like.
+      '';
     };
 
     pollInterval = mkOption {
@@ -204,6 +221,10 @@ in
         # restart leaks a ghost registration.
         RuntimeDirectoryPreserve = "yes";
         LogsDirectory = "bosun";
+        # Holds metricsFile. 0755 so node-exporter -- which reads it from
+        # outside this unit, as a DaemonSet mounting the host path -- can.
+        StateDirectory = "node-exporter-textfiles";
+        StateDirectoryMode = "0755";
 
         # Every skiff is a child of this unit, so one filter covers the whole
         # pool: job code reaches the public internet and nothing on the LAN.

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -28,10 +28,25 @@ type skiff struct {
 	everOnline    bool      // true once the runner has reported online at least once
 	offlineStreak int       // consecutive offline observations; reset by any other status
 	busySince     time.Time // zero until the runner first reports busy; maxLifetime is measured from here
+	exitReason    string    // why bosun killed this skiff; empty means the guest halted itself
 
 	helpersLog *os.File
 	helpers    []proc // virtiofsd(s) + passt
 	ch         proc   // cloud-hypervisor; Wait() on this is "did the job finish"
+}
+
+// setExitReason records why bosun is about to kill this skiff. The poll loop
+// sets it; awaitExit's retire reads it on another goroutine.
+func (s *skiff) setExitReason(reason string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.exitReason = reason
+}
+
+func (s *skiff) reason() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.exitReason
 }
 
 // pool keeps every class's warm count full. On start it sweeps stale state
@@ -46,13 +61,46 @@ type pool struct {
 	gh     githubClient
 	launch launcher
 	logger *slog.Logger
+	stats  *metrics
 
 	mu     sync.Mutex
 	skiffs map[string]*skiff
 }
 
 func newPool(cfg *Config, gh githubClient, launch launcher, logger *slog.Logger) *pool {
-	return &pool{cfg: cfg, gh: gh, launch: launch, logger: logger, skiffs: map[string]*skiff{}}
+	return &pool{cfg: cfg, gh: gh, launch: launch, logger: logger, stats: newMetrics(), skiffs: map[string]*skiff{}}
+}
+
+// publish writes the metrics textfile, if one is configured. Called after
+// every pool change and on every poll tick, so its mtime doubles as bosun's
+// heartbeat.
+func (p *pool) publish() {
+	if p.cfg.MetricsFile == "" {
+		return
+	}
+	live := map[string]poolState{}
+	desired := map[string]int{}
+	for name, class := range p.cfg.Classes {
+		desired[name] = class.Warm
+	}
+	p.mu.Lock()
+	for _, s := range p.skiffs {
+		state := live[s.class]
+		s.mu.Lock()
+		busy := !s.busySince.IsZero()
+		s.mu.Unlock()
+		if busy {
+			state.busy++
+		} else {
+			state.idle++
+		}
+		live[s.class] = state
+	}
+	p.mu.Unlock()
+
+	if err := writeTextfile(p.cfg.MetricsFile, p.stats.render(live, desired)); err != nil {
+		p.logger.Warn("write metrics", "path", p.cfg.MetricsFile, "error", err)
+	}
 }
 
 // sweep clears every entry under runtimeDir and deletes the GitHub
@@ -136,12 +184,14 @@ func (p *pool) spawn(ctx context.Context, className string) {
 
 	if err := p.writeState(paths.dir, runnerID, jitConfig, h.digest); err != nil {
 		logger.Error("write state", "error", err)
+		s.setExitReason(exitBootFailed)
 		p.retire(ctx, s, logger)
 		return
 	}
 
 	if err := p.boot(s, h, class, logger); err != nil {
 		logger.Error("boot", "error", err)
+		s.setExitReason(exitBootFailed)
 		p.retire(ctx, s, logger)
 		return
 	}
@@ -150,7 +200,9 @@ func (p *pool) spawn(ctx context.Context, className string) {
 	p.skiffs[id] = s
 	p.mu.Unlock()
 
+	p.stats.boot(className)
 	logger.Info("skiff booted", "runner_id", runnerID)
+	p.publish()
 	go p.awaitExit(ctx, s, logger)
 }
 
@@ -249,6 +301,12 @@ func (p *pool) awaitExit(ctx context.Context, s *skiff, logger *slog.Logger) {
 // and socket files. Best effort throughout — /run is tmpfs, so anything left
 // behind here does not survive a reboot either way.
 func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
+	reason := s.reason()
+	if reason == "" {
+		reason = exitCompleted // the guest powered itself off at the end of its job
+	}
+	p.stats.exit(s.class, reason)
+
 	for _, h := range s.helpers {
 		killBestEffort(h, logger, "helper")
 	}
@@ -310,6 +368,9 @@ func (p *pool) pollOnce(ctx context.Context) {
 	for _, s := range snapshot {
 		p.pollSkiff(ctx, s)
 	}
+	// Every tick, whether anything changed or not: the file's mtime is the
+	// only signal that says bosun is still alive.
+	p.publish()
 }
 
 // pollSkiff reconciles one skiff against GitHub's view of its runner.
@@ -332,6 +393,7 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	logger := p.logger.With("skiff", s.id, "class", s.class)
 	status, busy, err := p.gh.GetRunner(ctx, p.cfg.Repo, s.runnerID)
 	if err != nil {
+		p.stats.githubError()
 		logger.Warn("poll runner status", "error", err)
 		return
 	}
@@ -365,12 +427,15 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	switch {
 	case status == "offline" && everOnline && offlineStreak >= wedgeThreshold:
 		logger.Warn("wedged guest: went offline with the VMM still alive", "consecutive_polls", offlineStreak)
+		s.setExitReason(exitWedged)
 		killBestEffort(s.ch, logger, "wedged cloud-hypervisor")
 	case !busySince.IsZero() && p.exceededLifetime(s.class, busySince):
 		logger.Info("max lifetime exceeded, recycling", "busy_for", time.Since(busySince))
+		s.setExitReason(exitLifetime)
 		killBestEffort(s.ch, logger, "expired cloud-hypervisor")
 	case busySince.IsZero() && time.Since(s.mintedAt) > jitExpiry:
 		logger.Info("idle past JIT expiry, recycling")
+		s.setExitReason(exitJITExpired)
 		killBestEffort(s.ch, logger, "idle-expired cloud-hypervisor")
 	}
 }

--- a/clusters/folly/monitoring/bosun.yaml
+++ b/clusters/folly/monitoring/bosun.yaml
@@ -1,0 +1,90 @@
+---
+# bosun runs on riptide as a host service, outside the cluster. Its metrics
+# arrive through node-exporter's textfile collector (see the extraArgs in
+# kube-prometheus.yaml), so there is no target to declare here — only what to
+# alert on.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: bosun
+  namespace: monitoring
+  labels:
+    lolwtf.ca/service: bosun
+    release: prom-stack
+spec:
+  groups:
+    - name: bosun
+      rules:
+        # bosun rewrites its textfile every poll interval, so the mtime is a
+        # heartbeat. A stale file means bosun is dead, wedged, or unable to
+        # write — the case that went unnoticed for nine hours on 2026-08-07,
+        # when a SIGTERM plus Restart=on-failure left the pool empty.
+        - alert: BosunNotReporting
+          expr: time() - node_textfile_mtime_seconds{file="bosun.prom"} > 300
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            message: bosun on {{ $labels.instance }} has not written metrics in {{ $value | humanizeDuration }}
+            description: "The warm pool is unmanaged: no skiff is being replaced and no runner label it serves is being fed."
+
+        # A class below its warm count for this long is not refill latency —
+        # a skiff boots in about a second. It is minting failing, a hull
+        # failing to boot, or the credential being refused.
+        - alert: BosunPoolStarved
+          expr: sum by (class) (bosun_skiffs) < max by (class) (bosun_skiffs_desired)
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            message: bosun class {{ $labels.class }} has {{ $value }} skiffs, fewer than it wants
+            description: "Jobs written runs-on {{ $labels.class }} will queue until this recovers."
+
+        # Every skiff GitHub reports offline while its VMM is still alive is a
+        # job that died mid-run. One is a network hiccup; a rate this high is
+        # a hull problem.
+        - alert: BosunSkiffsWedging
+          expr: sum(rate(bosun_skiff_exits_total{reason="wedged"}[1h])) * 3600 > 3
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: bosun killed {{ $value | printf "%.0f" }} wedged skiffs in the last hour
+            description: "A wedged guest takes its job down with it. Check the skiff serial logs in /var/log/bosun on the host."
+---
+# Not bosun-specific, and the reason bosun's leak ran for nine hours without
+# anyone noticing: this cluster deploys 161 alert rules and not one of them
+# looks at whether a node is saturated.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-saturation
+  namespace: monitoring
+  labels:
+    lolwtf.ca/service: node-exporter
+    release: prom-stack
+spec:
+  groups:
+    - name: node-saturation
+      rules:
+        # Runnable work per core. Load rather than utilisation on purpose: a CI
+        # host pegged at 100% with load ~= cores is working, not drowning.
+        #
+        # The shape is dictated by two quirks of this cluster, both verified
+        # against live Prometheus: node_load5 and node_cpu_seconds_total carry
+        # different label sets, so an unqualified division silently matched
+        # only 4 of 12 hosts; and four lab hosts are scraped twice, so counting
+        # cpu series without collapsing (instance, cpu) first doubled their
+        # core count. This resolves to exactly one series per host.
+        - alert: NodeLoadHigh
+          expr: |
+            max by (instance) (node_load5)
+              / on (instance)
+            count by (instance) (count by (instance, cpu) (node_cpu_seconds_total{mode="idle"}))
+              > 2
+          for: 30m
+          labels:
+            severity: warning
+          annotations:
+            message: "{{ $labels.instance }} has {{ $value | printf \"%.1f\" }}x more runnable work than cores, sustained"
+            description: "Something is oversubscribing this host. On 2026-08-07 this was 19 orphaned passt processes spinning on a 6-core node."

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -215,6 +215,19 @@ spec:
               - *am
         pathType: Prefix
     prometheus-node-exporter:
+      # A host service that wants metrics scraped drops a .prom file in
+      # /var/lib/node-exporter-textfiles and this picks it up, labelled with the
+      # node it came from. That is how bosun on riptide is scraped: its unit
+      # carries an IPAddressDeny every skiff inherits, so a listener in-cluster
+      # Prometheus could reach would open the pod CIDR to job code as well.
+      #
+      # Reached through the host-root mount the chart already makes, so this
+      # needs no extra volume. extraArgs REPLACES the chart's defaults, so the
+      # two filesystem excludes below are the chart's own and must stay.
+      extraArgs:
+        - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/containerd/.+|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+        - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|erofs)$
+        - --collector.textfile.directory=/host/root/var/lib/node-exporter-textfiles
       prometheus:
         monitor:
           relabelings:

--- a/clusters/folly/monitoring/kustomization.yaml
+++ b/clusters/folly/monitoring/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - kube-prometheus.yaml
   - grafana-dashboards
   - local-node-exporters.yaml
+  - bosun.yaml
   - capsule.yaml
   - spore.yaml
   - git-repository-loki.yaml


### PR DESCRIPTION
riptide burned ~3.4 of its 6 cores for nine hours and then sat with an empty warm
pool. Neither was noticed. This cluster deploys **161 alert rules and not one of
them asks whether a host is saturated**, so the gap was total, not partial.

## What bosun exports

Pool depth by class and state, boots, exits by reason (`completed`, `wedged`,
`lifetime`, `jit_expired`, `boot_failed`), and a GitHub error counter. Six series
in Prometheus text format built with `fmt` — a client library is a dependency for
something twenty lines of Builder does.

**A textfile, not an HTTP listener.** bosun's unit carries the `IPAddressDeny`
that every skiff inherits, so a socket in-cluster Prometheus could reach would
mean opening the pod CIDR to untrusted job code too. The node-exporter DaemonSet
already mounts the host root at `/host/root`, so pointing its textfile collector
at `/var/lib/node-exporter-textfiles` needs **no new volume, port, firewall rule,
or scrape target** — and any other host service can use the same drop box.

The file's mtime is the heartbeat (`node_textfile_mtime_seconds`), so a dead or
wedged bosun is detectable without bosun reporting on itself.

## Alerts

| Alert | Catches |
| --- | --- |
| `BosunNotReporting` | the 2026-08-07 case: SIGTERM + `Restart=on-failure` left the pool empty |
| `BosunPoolStarved` | minting failing, a hull failing to boot, a refused credential |
| `BosunSkiffsWedging` | guests dying mid-job faster than a network hiccup explains |
| `NodeLoadHigh` | not bosun-specific; the rule whose absence let the leak run |

## Validation

- `go build ./... && go vet ./... && go test ./...` green; new tests cover the
  exposition format, the atomic write, and that a self-powered-off guest counts
  as `completed` rather than a kill
- `kustomize build clusters/folly/monitoring` renders all four alerts
- `nix eval …riptide.config.services.bosun.metricsFile` → the textfile path
- `NodeLoadHigh` was **developed against live Prometheus**, and the first two
  attempts were wrong in ways only querying revealed: `node_load5` and
  `node_cpu_seconds_total` carry different label sets, so an unqualified division
  silently matched 4 of 12 hosts, and four lab hosts are scraped twice, so
  counting cpu series without collapsing `(instance, cpu)` first doubled their
  core count. It now returns exactly 8 series, one per host, with correct core
  counts (riptide 6, optiplex 8, radiopi0 1). riptide's 19.3 would have read
  3.2x against a threshold of 2.

## Risk

`extraArgs` **replaces** the node-exporter chart's defaults, so the two
filesystem excludes are restated verbatim from the live DaemonSet. Dropping them
would have Prometheus scrape every container mount on every node.

Alertmanager has no receivers configured, so these fire into a dashboard rather
than at anyone. Routing is a separate decision.