### PR TITLE
fix(monitoring): make the bosun alerts able to fire, and stop inventing a second textfile directory

### DIFF
--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -97,7 +97,7 @@ in
 
     metricsFile = mkOption {
       type = types.str;
-      default = "/var/lib/node-exporter-textfiles/bosun.prom";
+      default = "/var/lib/prometheus-node-exporter-text-files/bosun.prom";
       description = ''
         Prometheus textfile for node-exporter's textfile collector to serve.
         Empty disables it.
@@ -223,7 +223,13 @@ in
         LogsDirectory = "bosun";
         # Holds metricsFile. 0755 so node-exporter -- which reads it from
         # outside this unit, as a DaemonSet mounting the host path -- can.
-        StateDirectory = "node-exporter-textfiles";
+        #
+        # The directory name is the fleet's, not bosun's:
+        # nix/services/spore-native-boot.nix already drops a .prom file here.
+        # ponytail: StateDirectory chowns it to bosun, so one writer per host.
+        # A second host service wanting the same directory wants tmpfiles and
+        # an explicit ReadWritePaths instead.
+        StateDirectory = "prometheus-node-exporter-text-files";
         StateDirectoryMode = "0755";
 
         # Every skiff is a child of this unit, so one filter covers the whole

--- a/clusters/folly/monitoring/bosun.yaml
+++ b/clusters/folly/monitoring/bosun.yaml
@@ -15,18 +15,38 @@ spec:
   groups:
     - name: bosun
       rules:
+        # node-exporter labels a textfile series with its full path, not its
+        # basename — verified against the one that already exists on spore. A
+        # file="bosun.prom" selector matches nothing, which is how the first
+        # version of these two alerts stayed silent through 22 hours of bosun
+        # being down.
+        #
         # bosun rewrites its textfile every poll interval, so the mtime is a
         # heartbeat. A stale file means bosun is dead, wedged, or unable to
         # write — the case that went unnoticed for nine hours on 2026-08-07,
         # when a SIGTERM plus Restart=on-failure left the pool empty.
         - alert: BosunNotReporting
-          expr: time() - node_textfile_mtime_seconds{file="bosun.prom"} > 300
+          expr: time() - node_textfile_mtime_seconds{file=~".*/bosun\\.prom"} > 300
           for: 5m
           labels:
             severity: warning
           annotations:
             message: bosun on {{ $labels.instance }} has not written metrics in {{ $value | humanizeDuration }}
             description: "The warm pool is unmanaged: no skiff is being replaced and no runner label it serves is being fed."
+
+        # A staleness alert cannot fire on a series that never appears, so it
+        # covers "bosun stopped" and not "bosun never came up" — a host
+        # rebuilt without it, a unit that failed to start, a metricsFile the
+        # collector is not looking at. That is the same silence, and this is
+        # the rule that breaks it.
+        - alert: BosunAbsent
+          expr: absent(node_textfile_mtime_seconds{file=~".*/bosun\\.prom"})
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            message: no bosun is reporting metrics anywhere on this cluster
+            description: "Either no bosun host is running, or its metricsFile is not in the directory node-exporter's textfile collector reads."
 
         # A class below its warm count for this long is not refill latency —
         # a skiff boots in about a second. It is minting failing, a hull

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -254,8 +254,10 @@ spec:
         pathType: Prefix
     prometheus-node-exporter:
       # A host service that wants metrics scraped drops a .prom file in
-      # /var/lib/node-exporter-textfiles and this picks it up, labelled with the
-      # node it came from. That is how bosun on riptide is scraped: its unit
+      # /var/lib/prometheus-node-exporter-text-files -- the same directory
+      # nix/services/spore-native-boot.nix already uses, so the fleet has one
+      # drop box and not one per exporter -- and this picks it up, labelled
+      # with the node it came from. That is how bosun on riptide is scraped: its unit
       # carries an IPAddressDeny every skiff inherits, so a listener in-cluster
       # Prometheus could reach would open the pod CIDR to job code as well.
       #
@@ -265,7 +267,7 @@ spec:
       extraArgs:
         - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/containerd/.+|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
         - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|erofs)$
-        - --collector.textfile.directory=/host/root/var/lib/node-exporter-textfiles
+        - --collector.textfile.directory=/host/root/var/lib/prometheus-node-exporter-text-files
       prometheus:
         monitor:
           relabelings:


### PR DESCRIPTION
Follow-up on #1883, from asking whether it actually works rather than whether it
deployed. It deployed. It does not work.

**Both bosun alerts keyed on `file="bosun.prom"`.** node-exporter labels a
textfile series with its **full path**, not its basename — the series that has
existed on spore all along reads
`file="/var/lib/prometheus-node-exporter-text-files/spore-native-boot.prom"`. So
the selector matched nothing, and the two rules stayed silent through 22 hours of
bosun being down — precisely the incident they were written for. Now
`.*/bosun\.prom`, which also survives the path change below.

**`BosunAbsent` added.** A staleness alert cannot fire on a series that never
appears, so the pair covered "bosun stopped" but not "bosun never came up": a
host rebuilt without it, a unit that failed to start, a `metricsFile` the
collector is not reading. Same silence, different cause.

**One textfile directory, not two.** `nix/services/spore-native-boot.nix` has
been using `/var/lib/prometheus-node-exporter-text-files` since long before this;
yesterday's `/var/lib/node-exporter-textfiles` was a second convention for the
same job, invented by not looking. bosun uses the fleet's.

## Validation

Both new selectors run against live Prometheus:

- `absent(node_textfile_mtime_seconds{file=~".*/bosun\\.prom"})` → `1`, so
  `BosunAbsent` correctly fires in today's state
- the same regex against spore's file returns its mtime, proving the label really
  is a full path
- `kustomize build clusters/folly/monitoring` clean

## Sequencing

The rename lands cluster-side on merge and host-side on the next riptide rebuild,
so bosun's metrics have a gap between the two. `BosunAbsent` waits 15m — deploy
riptide promptly after merge and it stays quiet.