### PR TITLE
Actually deliver the Discord alerts

### DIFF
--- a/clusters/base/monitoring/alertmanager-discord.yaml
+++ b/clusters/base/monitoring/alertmanager-discord.yaml
@@ -22,5 +22,7 @@ spec:
   data:
     - secretKey: webhook-url
       remoteRef:
-        key: discord alertmanager webhook
+        # Item id rather than title, so renaming the item in 1Password cannot
+        # quietly stop alert delivery.
+        key: aujvxijpz3oi25ccfdynev5sb4
         property: password

--- a/clusters/base/monitoring/alertmanager-discord.yaml
+++ b/clusters/base/monitoring/alertmanager-discord.yaml
@@ -3,9 +3,12 @@
 # every alert is what tells the messages apart, so there is nothing per-site
 # here and this lives in base rather than beside each HelmRelease.
 #
-# Alertmanager reads the URL through `webhook_url_file` from the secret this
-# creates, mounted by `alertmanagerSpec.secrets` in each cluster's
-# kube-prometheus HelmRelease.
+# The receiver lives in an AlertmanagerConfig rather than the HelmRelease's
+# inline `alertmanager.config`, because the operator parses that inline config
+# with its own Go types before generating the running one, and its discordConfig
+# has no `webhook_url_file` — it rejects the whole document and silently keeps
+# serving the last config it accepted. `apiURL` below is the operator's own
+# secret reference, so the URL still never appears in git.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -26,3 +29,30 @@ spec:
         # quietly stop alert delivery.
         key: aujvxijpz3oi25ccfdynev5sb4
         property: password
+---
+# Appended by the operator as a sub-route of the HelmRelease's top-level route,
+# after that route's own Watchdog entry — so Watchdog is still swallowed first
+# and everything surviving it lands here. Carries no matchers of its own, which
+# only catches everything because alertmanagerConfigMatcherStrategy is None; the
+# default would pin it to alerts labelled namespace=monitoring.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: discord
+  namespace: monitoring
+  labels:
+    alertmanagerConfig: discord
+spec:
+  route:
+    receiver: discord
+    groupBy: [cluster, namespace, alertname]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 12h
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: alertmanager-discord
+            key: webhook-url
+          sendResolved: true

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -206,7 +206,8 @@ spec:
           group_wait: 30s
           group_interval: 5m
           repeat_interval: 12h
-          receiver: discord
+          # Anything the AlertmanagerConfig sub-route does not take lands here.
+          receiver: "null"
           routes:
             # Watchdog fires forever by design — it means the pipeline is alive.
             # Delivering it twice a day trains the channel to ignore itself, and
@@ -216,12 +217,6 @@ spec:
                 - alertname = "Watchdog"
         receivers:
           - name: "null"
-          - name: discord
-            discord_configs:
-              # Read from the mounted file so the URL never lands in this
-              # HelmRelease, the rendered manifest, or the wiki.
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/webhook-url
-                send_resolved: true
         inhibit_rules:
           - source_matchers: [severity = "critical"]
             target_matchers: [severity =~ "warning|info"]
@@ -234,10 +229,16 @@ spec:
             equal: [namespace]
           - target_matchers: [alertname = "InfoInhibitor"]
       alertmanagerSpec:
-        # Mounts at /etc/alertmanager/secrets/<name>/, which is what
-        # webhook_url_file above reads.
-        secrets:
-          - alertmanager-discord
+        # The Discord receiver is an AlertmanagerConfig in base/monitoring. The
+        # operator merges only the ones it can select, and the chart's default
+        # selector is empty, which selects nothing.
+        alertmanagerConfigSelector:
+          matchLabels:
+            alertmanagerConfig: discord
+        # Otherwise the operator pins that config's route to alerts labelled
+        # namespace=monitoring, and nothing else ever reaches Discord.
+        alertmanagerConfigMatcherStrategy:
+          type: None
       ingress:
         enabled: true
         annotations:

--- a/clusters/offsite/monitoring/kube-prometheus.yaml
+++ b/clusters/offsite/monitoring/kube-prometheus.yaml
@@ -85,7 +85,8 @@ spec:
           group_wait: 30s
           group_interval: 5m
           repeat_interval: 12h
-          receiver: discord
+          # Anything the AlertmanagerConfig sub-route does not take lands here.
+          receiver: "null"
           routes:
             # Watchdog fires forever by design — it means the pipeline is alive.
             # Delivering it twice a day trains the channel to ignore itself, and
@@ -95,12 +96,6 @@ spec:
                 - alertname = "Watchdog"
         receivers:
           - name: "null"
-          - name: discord
-            discord_configs:
-              # Read from the mounted file so the URL never lands in this
-              # HelmRelease, the rendered manifest, or the wiki.
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/webhook-url
-                send_resolved: true
         inhibit_rules:
           - source_matchers: [severity = "critical"]
             target_matchers: [severity =~ "warning|info"]
@@ -113,10 +108,16 @@ spec:
             equal: [namespace]
           - target_matchers: [alertname = "InfoInhibitor"]
       alertmanagerSpec:
-        # Mounts at /etc/alertmanager/secrets/<name>/, which is what
-        # webhook_url_file above reads.
-        secrets:
-          - alertmanager-discord
+        # The Discord receiver is an AlertmanagerConfig in base/monitoring. The
+        # operator merges only the ones it can select, and the chart's default
+        # selector is empty, which selects nothing.
+        alertmanagerConfigSelector:
+          matchLabels:
+            alertmanagerConfig: discord
+        # Otherwise the operator pins that config's route to alerts labelled
+        # namespace=monitoring, and nothing else ever reaches Discord.
+        alertmanagerConfigMatcherStrategy:
+          type: None
       ingress:
         enabled: false
     grafana:


### PR DESCRIPTION
Follow-up to #1882. The Discord wiring merged and looked healthy at every layer except the one that matters — no alert was ever going to be delivered.

## What was wrong

The Prometheus Operator parses the HelmRelease's inline `alertmanager.config` with its own Go types before generating the config the pod actually mounts. At v0.93.0 its `discordConfig` has no `webhook_url_file`:

```
provision alertmanager configuration: failed to initialize from secret:
field webhook_url_file not found in type alertmanager.discordConfig
```

It rejected the whole document and kept serving the last config it accepted — the stock route to `"null"`. Every surface said fine: Helm reported `upgrade succeeded`, the ExternalSecret synced on both clusters, the base config secret held the correct Discord config, and the Alertmanager CR listed the mounted secret. Only the generated secret the pod reads was stale, and the sole evidence was in the operator log.

Worth noting `amtool check-config` accepts `webhook_url_file` — Alertmanager 0.33 supports it. The operator's types are the narrower constraint, so validating against amtool alone is not sufficient here.

## Fix

Move the receiver into an `AlertmanagerConfig`, whose `discordConfigs.apiURL` is the operator's own `SecretKeySelector`, so the webhook URL still never enters git and the ExternalSecret from #1882 is reused unchanged.

- The operator appends it as a sub-route after the top-level route's own Watchdog entry, so Watchdog is still swallowed first and everything surviving it lands in Discord.
- `alertmanagerConfigMatcherStrategy: None` — the default pins the route to alerts labelled `namespace=monitoring`, which would silently deliver almost nothing.
- Explicit `alertmanagerConfigSelector`, since the chart's default selector matches nothing.

Also pins the 1Password item by id rather than title, so renaming it cannot quietly stop delivery.

## Validation

`mise run k8s:render-apps` clean; both configs pass `amtool check-config`; the AlertmanagerConfig passes `kubectl apply --dry-run=server` against the live CRD.

Verification that it genuinely delivers has to happen after merge — that is the failure mode this PR exists to fix, and it is only observable once the operator regenerates.