### PR TITLE
fix(bosun): give skiff-ubuntu room, spare busy skiffs, keep the evidence

### DIFF
--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -62,15 +62,22 @@ const (
 	defaultLogDir       = "/var/log/bosun"
 	defaultPollInterval = 30 * time.Second
 
+	// defaultMaxLifetime backstops a class that declares no budget. It is a
+	// default rather than "unlimited" because the busy-time budget is the
+	// only thing that reaps a skiff whose guest wedged mid-job -- the wedge
+	// detector deliberately will not touch one.
+	defaultMaxLifetime = time.Hour
+
 	// selfHosted is the label the existing ARC runners hold. A skiff class
 	// must never claim it.
 	selfHosted = "self-hosted"
 
 	// wedgeThreshold is how many consecutive offline observations it takes to
-	// call a guest wedged. A runner drops its connection whenever the network
-	// hiccups -- observed live, one minute after a transient
-	// "connection reset by peer" on the poll itself -- and killing on the
-	// first observation kills whatever job the skiff was running.
+	// call an idle guest wedged. A runner drops its connection whenever the
+	// network hiccups -- observed live, one minute after a transient
+	// "connection reset by peer" on the poll itself. Debouncing it is why the
+	// rule is safe to apply at all; not applying it to a busy skiff is why a
+	// job is never the thing it kills.
 	wedgeThreshold = 3
 
 	// jitExpiry is how long a generated JIT config is valid if never
@@ -113,6 +120,10 @@ func LoadConfig(path string) (*Config, error) {
 		}
 		if c.Warm <= 0 {
 			return nil, fmt.Errorf("config: class %s: warm must be positive", name)
+		}
+		if c.MaxLifetime <= 0 {
+			c.MaxLifetime = Duration(defaultMaxLifetime)
+			cfg.Classes[name] = c
 		}
 	}
 

--- a/apps/bosun/config_test.go
+++ b/apps/bosun/config_test.go
@@ -29,6 +29,11 @@ func TestLoadConfigDefaults(t *testing.T) {
 	if time.Duration(cfg.PollInterval) != defaultPollInterval {
 		t.Errorf("pollInterval default: got %s", cfg.PollInterval)
 	}
+	// Not optional: the busy-time budget is the only thing that reaps a skiff
+	// whose guest wedged mid-job, so a class that declares none still gets one.
+	if time.Duration(cfg.Classes["skiff-nixos"].MaxLifetime) != defaultMaxLifetime {
+		t.Errorf("maxLifetime default: got %s", cfg.Classes["skiff-nixos"].MaxLifetime)
+	}
 }
 
 func TestLoadConfigRejectsSelfHostedClassName(t *testing.T) {

--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -122,6 +122,8 @@ func sockPath(dir, name string) (string, error) {
 type skiffPaths struct {
 	dir         string   // runtimeDir/<id> — the credential share and bosun's entire state for this skiff
 	credSock    string   // runtimeDir/<id>.fs
+	diagDir     string   // logDir/<id>.diag — the guest's runner _diag, written through to the host
+	diagSock    string   // runtimeDir/<id>.diag.fs
 	netSock     string   // runtimeDir/<id>.net
 	apiSock     string   // runtimeDir/<id>.api
 	logFile     string   // logDir/<id>.log — the guest's serial console, via cloud-hypervisor's --serial
@@ -133,7 +135,13 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 	var err error
 	p.dir = filepath.Join(runtimeDir, id)
 	p.logFile = filepath.Join(logDir, id+".log")
+	// Under logDir, not runtimeDir: this is the one thing about a skiff that
+	// must outlive it, and runtimeDir is tmpfs that retire empties anyway.
+	p.diagDir = filepath.Join(logDir, id+".diag")
 	if p.credSock, err = sockPath(runtimeDir, id+".fs"); err != nil {
+		return skiffPaths{}, err
+	}
+	if p.diagSock, err = sockPath(runtimeDir, id+".diag.fs"); err != nil {
 		return skiffPaths{}, err
 	}
 	if p.netSock, err = sockPath(runtimeDir, id+".net"); err != nil {
@@ -156,10 +164,12 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 	return p, nil
 }
 
-// chArgs builds cloud-hypervisor's argv for one skiff. The credential share
-// (tag "bosun") is injected unconditionally ahead of any hull-declared
-// devices; its tag is fixed by contract with the guest-side agent, and it is
-// present even when the hull declares no devices at all.
+// chArgs builds cloud-hypervisor's argv for one skiff. Two shares are
+// injected unconditionally ahead of any hull-declared devices — the
+// credential (tag "bosun", read-only in-guest) and the diagnostic drop box
+// (tag "bosun-diag", the only writable path a guest has). Both tags are fixed
+// by contract with the guest, and both are present even when the hull
+// declares no devices at all.
 func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 	args := []string{
 		"--kernel", filepath.Join(h.dir, h.manifest.Kernel),
@@ -167,6 +177,7 @@ func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 		"--cpus", fmt.Sprintf("boot=%d", class.VCPUs),
 		"--memory", fmt.Sprintf("size=%s,shared=on", class.Memory),
 		"--fs", fmt.Sprintf("tag=bosun,socket=%s", p.credSock),
+		"--fs", fmt.Sprintf("tag=bosun-diag,socket=%s", p.diagSock),
 	}
 	for i, dev := range h.manifest.Devices {
 		switch {

--- a/apps/bosun/hull_test.go
+++ b/apps/bosun/hull_test.go
@@ -60,6 +60,7 @@ func TestChArgsNoDevices(t *testing.T) {
 		"--cpus", "boot=4",
 		"--memory", "size=4096M,shared=on",
 		"--fs", "tag=bosun,socket=/run/bosun/sk01.fs",
+		"--fs", "tag=bosun-diag,socket=/run/bosun/sk01.diag.fs",
 		"--net", "vhost_user=on,socket=/run/bosun/sk01.net",
 		"--api-socket", "/run/bosun/sk01.api",
 		"--console", "off",
@@ -93,6 +94,7 @@ func TestChArgsWithDevices(t *testing.T) {
 		"--cpus", "boot=2",
 		"--memory", "size=2048M,shared=on",
 		"--fs", "tag=bosun,socket=/run/bosun/sk02.fs",
+		"--fs", "tag=bosun-diag,socket=/run/bosun/sk02.diag.fs",
 		"--fs", "tag=ro-store,socket=/run/bosun/sk02.ro-store.fs",
 		"--net", "vhost_user=on,socket=/run/bosun/sk02.net",
 		"--api-socket", "/run/bosun/sk02.api",
@@ -127,6 +129,7 @@ func TestChArgsWithDisk(t *testing.T) {
 		"--cpus", "boot=2",
 		"--memory", "size=2048M,shared=on",
 		"--fs", "tag=bosun,socket=/run/bosun/sk03.fs",
+		"--fs", "tag=bosun-diag,socket=/run/bosun/sk03.diag.fs",
 		"--disk", "path=/hulls/ubuntu/rootfs.img,readonly=on",
 		"--net", "vhost_user=on,socket=/run/bosun/sk03.net",
 		"--api-socket", "/run/bosun/sk03.api",
@@ -168,6 +171,19 @@ func TestSockPathTooLong(t *testing.T) {
 	}
 	if _, err := sockPath("/run/bosun", "sk01.fs"); err != nil {
 		t.Fatalf("unexpected error for short path: %v", err)
+	}
+}
+
+func TestResolvePathsPutsDiagUnderLogDir(t *testing.T) {
+	p, err := resolvePaths("/run/bosun", "/var/log/bosun", "sk01", nil)
+	if err != nil {
+		t.Fatalf("resolvePaths: %v", err)
+	}
+	if p.diagDir != "/var/log/bosun/sk01.diag" {
+		t.Errorf("diagDir: got %s", p.diagDir)
+	}
+	if p.diagSock != "/run/bosun/sk01.diag.fs" {
+		t.Errorf("diagSock: got %s", p.diagSock)
 	}
 }
 

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -92,7 +92,23 @@ in
     logDir = mkOption {
       type = types.str;
       default = "/var/log/bosun";
-      description = "Where each skiff's serial console is written.";
+      description = ''
+        Where each skiff's serial console is written, and where its
+        `<id>.diag/` — the guest's own runner trace, shared in writable — is
+        left behind after the skiff is gone. Both survive retire on purpose;
+        {option}`logRetention` is what bounds them.
+      '';
+    };
+
+    logRetention = mkOption {
+      type = types.str;
+      default = "7d";
+      description = ''
+        How long a scuttled skiff's serial console and diagnostic directory
+        stay readable. Nothing else deletes them: retire keeps them so a
+        skiff that died mid-job can still be read afterwards, and the
+        diagnostic share is writable by untrusted job code.
+      '';
     };
 
     metricsFile = mkOption {
@@ -188,6 +204,11 @@ in
       extraGroups = [ "kvm" ];
     };
     users.groups.bosun = { };
+
+    # Nothing in bosun deletes a retired skiff's logs, so this is the only
+    # bound on logDir: one directory per skiff ever booted, plus whatever job
+    # code chose to write into the diagnostic share.
+    systemd.tmpfiles.rules = [ "e ${cfg.logDir} - - - ${cfg.logRetention}" ];
 
     systemd.services.bosun = {
       description = "warm pool of ephemeral microVM Actions runners";

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -239,6 +239,21 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 		return fmt.Errorf("start credential virtiofsd: %w", err)
 	}
 
+	// The guest's only writable path onto the host, and the whole reason it
+	// exists: a skiff's root is a tmpfs overlay, so a guest that dies mid-job
+	// takes the runner's own diagnostic log with it and leaves the serial
+	// console — which carries no _diag — as the only evidence.
+	//
+	// ponytail: no quota. Untrusted job code can fill logDir; the tmpfiles
+	// rule in module.nix only ages files out. A loopback filesystem or an
+	// XFS project quota is the answer if a job ever does it.
+	if err := os.MkdirAll(s.paths.diagDir, 0o755); err != nil {
+		return fmt.Errorf("create diag dir: %w", err)
+	}
+	if err := p.startHelper(s, virtiofsd, virtiofsdArgs(s.paths.diagSock, s.paths.diagDir, false)); err != nil {
+		return fmt.Errorf("start diag virtiofsd: %w", err)
+	}
+
 	for i, dev := range h.manifest.Devices {
 		if dev.Share == nil {
 			continue // a disk rides cloud-hypervisor's own --disk; no helper
@@ -319,8 +334,11 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 		logger.Warn("delete runner on retire", "runner_id", s.runnerID, "error", err)
 	}
 
+	// diagDir is deliberately not removed: it is the evidence, and this is
+	// the path a wedged skiff's own death takes.
 	os.RemoveAll(s.paths.dir)
 	os.Remove(s.paths.credSock)
+	os.Remove(s.paths.diagSock)
 	os.Remove(s.paths.netSock)
 	os.Remove(s.paths.apiSock)
 	for _, sock := range s.paths.deviceSocks {
@@ -378,15 +396,24 @@ func (p *pool) pollOnce(ctx context.Context) {
 //   - First online observation: revoke the JIT credential host-side. virtiofs
 //     passes the delete through, so it vanishes in-guest with no guest
 //     cooperation, and untrusted job code never sees a live credential again.
-//   - Offline after having been online: the guest may be wedged. ch-remote ping
-//     cannot tell a hung guest from a healthy one — both answer with a live
-//     VMM — so GitHub's own view of the runner is the only signal. It takes
+//
+//   - Offline after having been online, and never busy: the guest is wedged
+//     holding a credential it will never spend. ch-remote ping cannot tell a
+//     hung guest from a healthy one — both answer with a live VMM — so
+//     GitHub's own view of the runner is the only signal. It takes
 //     wedgeThreshold consecutive offline observations, because a runner
-//     briefly loses its connection whenever the network hiccups and one
-//     observation is not worth killing a job over.
+//     briefly loses its connection whenever the network hiccups.
+//
+//     A skiff that has gone busy is exempt. The same signal on a running job
+//     is indistinguishable from a job whose runner is merely quiet, and
+//     killing on it destroys the job *and* the evidence of why. maxLifetime
+//     is the reaper there: it bounds a wedged busy skiff to the budget its
+//     class already declares, which is why that budget may not be zero.
+//
 //   - Busy transition: recorded once, so maxLifetime is measured from when
 //     the job started, not from boot (which would let warm idle time eat a
 //     job's budget).
+//
 //   - Idle past jitExpiry: the credential this skiff registered with is now
 //     dead and it never connected; recycle it for a fresh one.
 func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
@@ -425,7 +452,7 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	}
 
 	switch {
-	case status == "offline" && everOnline && offlineStreak >= wedgeThreshold:
+	case status == "offline" && everOnline && busySince.IsZero() && offlineStreak >= wedgeThreshold:
 		logger.Warn("wedged guest: went offline with the VMM still alive", "consecutive_polls", offlineStreak)
 		s.setExitReason(exitWedged)
 		killBestEffort(s.ch, logger, "wedged cloud-hypervisor")
@@ -440,12 +467,11 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	}
 }
 
+// exceededLifetime is the only thing that reaps a busy skiff, wedged or
+// working, so LoadConfig guarantees every class carries a non-zero budget.
 func (p *pool) exceededLifetime(className string, busySince time.Time) bool {
 	class, ok := p.cfg.Classes[className]
-	if !ok || class.MaxLifetime == 0 {
-		return false
-	}
-	return time.Since(busySince) > time.Duration(class.MaxLifetime)
+	return ok && time.Since(busySince) > time.Duration(class.MaxLifetime)
 }
 
 func newSkiffID() (string, error) {

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -74,22 +74,34 @@ func TestFillBootsWarmCountAndCredentialShareAlwaysPresent(t *testing.T) {
 		t.Fatalf("unexpected jitconfig generation: %v", gh.generated)
 	}
 
-	// virtiofsd (credential) + passt + cloud-hypervisor, no hull devices.
-	if fl.count() != 3 {
-		t.Fatalf("want 3 launches for a device-less hull, got %d", fl.count())
+	// virtiofsd (credential) + virtiofsd (diag) + passt + cloud-hypervisor,
+	// no hull devices.
+	if fl.count() != 4 {
+		t.Fatalf("want 4 launches for a device-less hull, got %d", fl.count())
 	}
 	chCall, ok := fl.last("cloud-hypervisor")
 	if !ok {
 		t.Fatal("cloud-hypervisor was never launched")
 	}
-	found := false
-	for i, a := range chCall.args {
-		if a == "--fs" && i+1 < len(chCall.args) && chCall.args[i+1] == "tag=bosun,socket="+s.paths.credSock {
-			found = true
+	for _, want := range []string{
+		"tag=bosun,socket=" + s.paths.credSock,
+		"tag=bosun-diag,socket=" + s.paths.diagSock,
+	} {
+		found := false
+		for i, a := range chCall.args {
+			if a == "--fs" && i+1 < len(chCall.args) && chCall.args[i+1] == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("share %q missing from cloud-hypervisor argv: %v", want, chCall.args)
 		}
 	}
-	if !found {
-		t.Fatalf("credential share missing from cloud-hypervisor argv: %v", chCall.args)
+
+	// The diag share is a real host directory, made before the VMM starts:
+	// virtiofsd has nothing to serve otherwise.
+	if fi, err := os.Stat(s.paths.diagDir); err != nil || !fi.IsDir() {
+		t.Fatalf("diag dir not created: err=%v", err)
 	}
 }
 
@@ -136,6 +148,11 @@ func TestPoolReplacesSkiffAfterExit(t *testing.T) {
 
 	if _, err := os.Stat(first.paths.dir); !os.IsNotExist(err) {
 		t.Fatalf("retired skiff's state dir should be gone, err=%v", err)
+	}
+	// The evidence outlives the skiff; that is the entire point of putting it
+	// under logDir rather than in the state dir retire wipes.
+	if _, err := os.Stat(first.paths.diagDir); err != nil {
+		t.Fatalf("retired skiff's diag dir should survive, err=%v", err)
 	}
 }
 
@@ -191,27 +208,94 @@ func TestJITConfigDeletedOnFirstOnline(t *testing.T) {
 	}
 }
 
-// TestWedgedGuestIsKilled drives the wedge path (online, then offline while
-// the VMM is still alive) and observes its effect the same way
-// TestPoolReplacesSkiffAfterExit does: the skiff gets replaced. It
-// deliberately does not read chCall.proc.exitCh directly — awaitExit's own
-// goroutine is already receiving from that channel via Wait(), and a second
-// receiver would race it for the single buffered value.
-func TestWedgedGuestIsKilled(t *testing.T) {
+// TestWedgedIdleGuestIsKilled drives the wedge path (online, then offline
+// while the VMM is still alive, having never gone busy) and observes its
+// effect the same way TestPoolReplacesSkiffAfterExit does: the skiff gets
+// replaced. It deliberately does not read chCall.proc.exitCh directly —
+// awaitExit's own goroutine is already receiving from that channel via
+// Wait(), and a second receiver would race it for the single buffered value.
+func TestWedgedIdleGuestIsKilled(t *testing.T) {
+	p, gh, _ := testPool(t)
+	ctx := context.Background()
+	p.fill(ctx)
+	first := onlySkiff(t, p)
+
+	gh.setStatus(first.runnerID, "online", false)
+	p.pollOnce(ctx) // connects, idle
+
+	gh.setStatus(first.runnerID, "offline", false)
+	for i := 0; i < wedgeThreshold; i++ {
+		p.pollOnce(ctx) // wedge: offline after having been online, repeatedly
+	}
+
+	waitFor(t, "wedged idle skiff is killed and replaced", func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if len(p.skiffs) != 1 {
+			return false
+		}
+		for id := range p.skiffs {
+			return id != first.id
+		}
+		return false
+	})
+}
+
+// TestWedgeRuleSpareABusySkiff is the reason the rule is scoped to idle
+// skiffs at all: the offline-with-a-live-VMM signal cannot distinguish a hung
+// guest from a running job whose runner went quiet, and killing on it takes
+// the job and the evidence of why. A busy skiff is maxLifetime's problem.
+func TestWedgeRuleSparesABusySkiff(t *testing.T) {
 	p, gh, _ := testPool(t)
 	ctx := context.Background()
 	p.fill(ctx)
 	first := onlySkiff(t, p)
 
 	gh.setStatus(first.runnerID, "online", true)
-	p.pollOnce(ctx) // connects, goes busy
+	p.pollOnce(ctx) // connects and goes busy: a job is running
 
 	gh.setStatus(first.runnerID, "offline", true)
-	for i := 0; i < wedgeThreshold; i++ {
-		p.pollOnce(ctx) // wedge: offline after having been online, repeatedly
+	for i := 0; i < wedgeThreshold*3; i++ {
+		p.pollOnce(ctx)
 	}
 
-	waitFor(t, "wedged skiff is killed and replaced", func() bool {
+	// The decision, not its effect: pollSkiff sets the exit reason on this
+	// goroutine before killing, while retire runs on awaitExit's and would
+	// race an assertion about the pool's contents.
+	if r := first.reason(); r != "" {
+		t.Fatalf("a busy skiff was condemned after %d offline polls, reason=%q", wedgeThreshold*3, r)
+	}
+	time.Sleep(20 * time.Millisecond) // give a wrongly-scheduled retire a chance to land
+	p.mu.Lock()
+	_, stillThere := p.skiffs[first.id]
+	p.mu.Unlock()
+	if !stillThere {
+		t.Fatal("a busy skiff was killed by the wedge rule")
+	}
+}
+
+// The other half of that trade: with the wedge rule declining to act, the
+// class's busy-time budget must still reap it, or a wedged job holds its
+// label forever.
+func TestBusySkiffIsReapedByMaxLifetime(t *testing.T) {
+	p, gh, _ := testPool(t)
+	ctx := context.Background()
+	p.cfg.Classes["skiff-test"] = Class{
+		Hull:  p.cfg.Classes["skiff-test"].Hull,
+		VCPUs: 1, Memory: "512M", Warm: 1,
+		MaxLifetime: Duration(time.Millisecond),
+	}
+	p.fill(ctx)
+	first := onlySkiff(t, p)
+
+	gh.setStatus(first.runnerID, "online", true)
+	p.pollOnce(ctx) // goes busy; the budget starts here
+	time.Sleep(5 * time.Millisecond)
+
+	gh.setStatus(first.runnerID, "offline", true) // wedged, and over budget
+	p.pollOnce(ctx)
+
+	waitFor(t, "over-budget busy skiff is killed and replaced", func() bool {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		if len(p.skiffs) != 1 {
@@ -269,29 +353,31 @@ func TestSweepOnEmptyRuntimeDirIsANoop(t *testing.T) {
 	}
 }
 
-// TestTransientOfflineDoesNotKill covers the incident this debounce exists for:
-// a runner briefly lost its connection to GitHub, and killing on the first
-// offline observation destroyed a healthy skiff a minute later. Anything short
-// of wedgeThreshold consecutive observations, or a streak broken by a single
-// online, must leave the skiff alone -- it may be running a job.
+// TestTransientOfflineDoesNotKill covers the incident this debounce exists
+// for: a runner briefly lost its connection to GitHub, and killing on the
+// first offline observation destroyed a healthy skiff a minute later. Driven
+// idle, where the wedge rule does apply, so the debounce is what is under
+// test rather than the busy exemption. Anything short of wedgeThreshold
+// consecutive observations, or a streak broken by a single online, must leave
+// the skiff alone.
 func TestTransientOfflineDoesNotKill(t *testing.T) {
 	p, gh, _ := testPool(t)
 	ctx := context.Background()
 	p.fill(ctx)
 	first := onlySkiff(t, p)
 
-	gh.setStatus(first.runnerID, "online", true)
+	gh.setStatus(first.runnerID, "online", false)
 	p.pollOnce(ctx)
 
 	for i := 0; i < wedgeThreshold-1; i++ {
-		gh.setStatus(first.runnerID, "offline", true)
+		gh.setStatus(first.runnerID, "offline", false)
 		p.pollOnce(ctx)
 	}
 	// one good observation resets the streak, exactly as a reconnect would
-	gh.setStatus(first.runnerID, "online", true)
+	gh.setStatus(first.runnerID, "online", false)
 	p.pollOnce(ctx)
 	for i := 0; i < wedgeThreshold-1; i++ {
-		gh.setStatus(first.runnerID, "offline", true)
+		gh.setStatus(first.runnerID, "offline", false)
 		p.pollOnce(ctx)
 	}
 

--- a/docs/pages/Architecture___Bosun.md
+++ b/docs/pages/Architecture___Bosun.md
@@ -16,7 +16,7 @@ tags:: architecture
 	- Named cost: idle skiffs hold RAM, and there is no scale-to-zero.
 - ## The hull contract is the seam
 	- A hull is a directory holding a `hull.json` beside its artifacts, declaring `kernel`, `initrd`, `cmdline`, and an optional `devices[]` list. bosun reads the manifest and translates it to cloud-hypervisor arguments; it carries **no per-hull-family branching** and never learns what any device means.
-	- bosun promises every skiff the same three things regardless of hull — a credential at a contract-fixed location, a writable workspace, and outbound network — plus its own identity appended to the cmdline as `bosun.skiff` and `bosun.hull`. Those are correlation facts, never claims: a guest reporting its own hull digest proves nothing to anyone.
+	- bosun promises every skiff the same four things regardless of hull — a credential at a contract-fixed location, a writable workspace, outbound network, and a writable diagnostic share on the host — plus its own identity appended to the cmdline as `bosun.skiff` and `bosun.hull`. Those are correlation facts, never claims: a guest reporting its own hull digest proves nothing to anyone.
 	- A hull promises to boot from what it declared, find its credential, run one job, and halt. The last clause is enforced by GitHub rather than by anyone here.
 	- Hull identity is a **content digest** over the manifest and the files it names — not a Nix store path, so a hull built without Nix can have one too.
 - ## The NixOS hull
@@ -28,6 +28,7 @@ tags:: architecture
 	- bosun mints a JIT config **immediately before boot** and never stockpiles: an unused one expires about an hour after it is minted.
 	- It arrives on a per-skiff virtiofs share rather than the kernel cmdline, which is world-readable inside the guest. bosun **deletes it host-side** the moment GitHub reports the runner online — virtiofs passes through to the host filesystem, so it vanishes in-guest with no cooperation from the guest, and untrusted job code never sees a live credential.
 	- bosun polls **one runner id at a time and never the runner list**. A registration that no skiff ever consumes leaves a ghost behind, so the list is never the source of truth for pool size; local bookkeeping is. That one call also distinguishes a booted-*idle* skiff from a booted-*busy* one, which is invisible from the host, and catches a wedged guest — which `ch-remote ping` cannot, because a hung guest with a live VMM answers ping.
+	- The wedge rule applies to **idle skiffs only**. Offline-with-a-live-VMM does not distinguish a hung guest from a running job whose runner went quiet, so on a busy skiff it would destroy the job and the evidence of why. A busy skiff is bounded by its class's `maxLifetime` instead, which is why that budget may not be zero.
 - ## Egress
 	- The policy is inverted from the obvious one: **deny the LAN, allow the internet.** Every job in this repo already fetches many public hosts, and none needs a LAN destination.
 	- It is a single `IPAddressDeny` on bosun's own systemd unit. systemd's IP filtering inherits down the whole cgroup subtree, so one directive covers every skiff with no per-skiff rule anywhere.
@@ -42,4 +43,5 @@ tags:: architecture
 	- ARC keeps serving `folly`, `offsite` and `self-hosted` throughout. A skiff never claims those labels — its class name is its only label.
 - ## Trying it
 	- `.github/workflows/skiff-smoke.yml` is a `workflow_dispatch` job on `runs-on: skiff-nixos`. It asserts what a skiff does differently: the warm shared store, the writable overlay, `nix-ld` resolving the FHS interpreter downloaded release binaries ask for, and socket-activated Docker.
-	- Inspect a host with `systemctl status bosun` and `journalctl -u bosun`; each skiff's serial console is written under the module's `logDir`.
+	- Inspect a host with `systemctl status bosun` and `journalctl -u bosun`. Under the module's `logDir`, each skiff leaves its serial console as `<id>.log`, and an Ubuntu-hull skiff also leaves the runner's own trace in `<id>.diag/` — a writable virtiofs share, so it lands on the host *while* the job runs and survives a skiff killed mid-job. bosun offers that share to every skiff; the NixOS hull does not mount it yet, so a `skiff-nixos` `<id>.diag/` is empty. Both outlive the skiff and are aged out by `logRetention`.
+	- A class's `memory` is also its **disk budget**: the whole guest root is a tmpfs overlay, so a checkout plus build that outgrows it is an OOM rather than an `ENOSPC`. A real virtio-blk workspace is the answer past that, not a bigger number.

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -38,11 +38,16 @@
     };
     # The FHS family: apt, dockerd, and the ARC image's toolchain, no Nix.
     # More memory than skiff-nixos because jobs here apt-get and docker build
-    # inside the guest rather than leaning on a warm host store.
+    # inside the guest rather than leaning on a warm host store -- and because
+    # the whole guest root is a tmpfs overlay, so this number is the class's
+    # disk budget as much as its RAM. A checkout plus a docker build that
+    # exceeds it is an OOM, not an ENOSPC. 8192M against riptide's ~10 GiB
+    # free is the ceiling while kubelet shares the host; past that the answer
+    # is a real workspace disk, not a bigger number.
     classes.skiff-ubuntu = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       vcpus = 4;
-      memory = "4096M";
+      memory = "8192M";
       warm = 1;
     };
   };

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -126,6 +126,13 @@ let
     $bb hostname skiff
     echo "127.0.0.1 localhost skiff" > /etc/hosts
 
+    # The runner writes its trace to <runner root>/_diag. Everything else in
+    # this guest is a tmpfs overlay that dies with the VM, so this one
+    # directory is bound through to the host: a skiff killed mid-job leaves
+    # the _diag behind on riptide instead of nothing at all.
+    $bb mkdir -p /home/runner/_diag
+    $bb mount -t virtiofs bosun-diag /home/runner/_diag
+
     $bb ip link set lo up
     $bb ip link set eth0 up
     $bb udhcpc -i eth0 -q -n -s /opt/bosun/udhcpc-script


### PR DESCRIPTION
Three fixes that have to land together, because they all need the same riptide rebuild before the runner bench is worth re-running.

## Room

`skiff-ubuntu` 4096M → 8192M. The whole guest root is a tmpfs overlay, so a class's `memory` is its disk budget as much as its RAM: a checkout plus a docker build that outgrows it OOMs rather than returning `ENOSPC`, and the guest dies in a way the runner cannot report. 8192M is the ceiling while kubelet shares riptide's ~10 GiB free. A real virtio-blk workspace is the answer past that, not a bigger number.

## Spare busy skiffs

The wedge detector now applies to **idle** skiffs only. Offline-with-a-live-VMM cannot distinguish a hung guest from a running job whose runner went quiet, so three consecutive offline polls on a busy skiff guaranteed the job died — and took the evidence with it. The debounce is right for an idle skiff holding a credential it will never spend; it is wrong for a job.

A busy skiff is bounded by its class's `maxLifetime` instead. That budget is now defaulted (1h) rather than optional, because with the wedge rule declining to act it is the only thing that reaps a skiff which wedges mid-job.

## Keep the evidence

Every skiff gets a second unconditional virtiofs share, tag `bosun-diag`, backed by `logDir/<id>.diag` and writable — the only writable host path a guest has. The Ubuntu hull mounts it at `/home/runner/_diag`, so the runner's own trace is on the host *while* the job runs and survives a skiff killed at any point. `retire` deliberately keeps the directory.

The serial console was the alternative and was rejected: `--serial file=` costs a VM exit per byte (loglevel=4 alone is ~0.3 s of a ~1 s boot), and taxing every job to read its logs would taint the bench this exists to serve.

Two consequences worth naming:

- **The NixOS hull does not mount it yet.** bosun offers the share to every skiff, so a `skiff-nixos` `<id>.diag/` is simply empty. That family is already excluded from the bench, and wiring it needs no bosun change.
- **No quota.** Untrusted job code can write into `logDir`. A new `logRetention` option (default `7d`) drives a tmpfiles rule that ages `logDir` out — which nothing had bounded before, so this also fixes the pre-existing unbounded growth of `<id>.log` and `<id>.helpers.log`. A loopback filesystem or an XFS project quota is the answer if a job ever abuses it; marked `ponytail:` in the source.

## Validation

- `go test ./...`, `go vet`, `gofmt` clean in `apps/bosun`
- The new busy-skiff test was verified to **fail** against the old rule (`reason="wedged"`), not just pass against the new one. It asserts the exit reason synchronously — `retire` runs on `awaitExit`'s goroutine and races an assertion about pool contents.
- `TestTransientOfflineDoesNotKill` was re-driven idle, so it still tests the debounce rather than the new busy exemption
- riptide's `system.build.toplevel` and `hull-ubuntu` both evaluate; tmpfiles rule and `8192M` confirmed via `nix eval`
- `mise run docs:check`

Not built or deployed from here — riptide builds for itself. Nothing is measured until it rebuilds and the bench is dispatched.