### PR TITLE
Fix jellyfin's GPU container creation at the source

### DIFF
--- a/clusters/base/monitoring/alertmanager-discord.yaml
+++ b/clusters/base/monitoring/alertmanager-discord.yaml
@@ -22,5 +22,7 @@ spec:
   data:
     - secretKey: webhook-url
       remoteRef:
-        key: discord alertmanager webhook
+        # Item id rather than title, so renaming the item in 1Password cannot
+        # quietly stop alert delivery.
+        key: aujvxijpz3oi25ccfdynev5sb4
         property: password

--- a/clusters/base/monitoring/alertmanager-discord.yaml
+++ b/clusters/base/monitoring/alertmanager-discord.yaml
@@ -3,9 +3,12 @@
 # every alert is what tells the messages apart, so there is nothing per-site
 # here and this lives in base rather than beside each HelmRelease.
 #
-# Alertmanager reads the URL through `webhook_url_file` from the secret this
-# creates, mounted by `alertmanagerSpec.secrets` in each cluster's
-# kube-prometheus HelmRelease.
+# The receiver lives in an AlertmanagerConfig rather than the HelmRelease's
+# inline `alertmanager.config`, because the operator parses that inline config
+# with its own Go types before generating the running one, and its discordConfig
+# has no `webhook_url_file` — it rejects the whole document and silently keeps
+# serving the last config it accepted. `apiURL` below is the operator's own
+# secret reference, so the URL still never appears in git.
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
@@ -26,3 +29,30 @@ spec:
         # quietly stop alert delivery.
         key: aujvxijpz3oi25ccfdynev5sb4
         property: password
+---
+# Appended by the operator as a sub-route of the HelmRelease's top-level route,
+# after that route's own Watchdog entry — so Watchdog is still swallowed first
+# and everything surviving it lands here. Carries no matchers of its own, which
+# only catches everything because alertmanagerConfigMatcherStrategy is None; the
+# default would pin it to alerts labelled namespace=monitoring.
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: discord
+  namespace: monitoring
+  labels:
+    alertmanagerConfig: discord
+spec:
+  route:
+    receiver: discord
+    groupBy: [cluster, namespace, alertname]
+    groupWait: 30s
+    groupInterval: 5m
+    repeatInterval: 12h
+  receivers:
+    - name: discord
+      discordConfigs:
+        - apiURL:
+            name: alertmanager-discord
+            key: webhook-url
+          sendResolved: true

--- a/clusters/base/monitoring/alertmanager-discord.yaml
+++ b/clusters/base/monitoring/alertmanager-discord.yaml
@@ -30,11 +30,14 @@ spec:
         key: aujvxijpz3oi25ccfdynev5sb4
         property: password
 ---
-# Appended by the operator as a sub-route of the HelmRelease's top-level route,
-# after that route's own Watchdog entry — so Watchdog is still swallowed first
-# and everything surviving it lands here. Carries no matchers of its own, which
-# only catches everything because alertmanagerConfigMatcherStrategy is None; the
-# default would pin it to alerts labelled namespace=monitoring.
+# The operator merges this as the FIRST sub-route of the HelmRelease's
+# top-level route and forces `continue: true` on it, so it is evaluated before
+# that route's own entries and does not stop them matching. Watchdog therefore
+# has to be excluded here: relying on a later `alertname = "Watchdog"` route to
+# swallow it first does not work, it just lands in both receivers.
+#
+# Matching everything else only works because alertmanagerConfigMatcherStrategy
+# is None; the default would pin this to alerts labelled namespace=monitoring.
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
@@ -45,6 +48,10 @@ metadata:
 spec:
   route:
     receiver: discord
+    matchers:
+      - name: alertname
+        value: Watchdog
+        matchType: "!="
     groupBy: [cluster, namespace, alertname]
     groupWait: 30s
     groupInterval: 5m

--- a/clusters/folly/apps/jellyfin/deployment.yaml
+++ b/clusters/folly/apps/jellyfin/deployment.yaml
@@ -8,6 +8,12 @@ metadata:
     app.kubernetes.io/part-of: jellyfin
 spec:
   replicas: 1
+  # riptide advertises exactly one gpu.intel.com/i915, and the container below
+  # claims it. A rolling update surges the replacement before releasing the
+  # old pod's claim, so the new one can never be scheduled and the rollout
+  # deadlocks — the old pod keeps the device it is no longer able to use.
+  strategy:
+    type: Recreate
   selector:
     matchLabels: *labels
   template:

--- a/clusters/folly/monitoring/kube-prometheus.yaml
+++ b/clusters/folly/monitoring/kube-prometheus.yaml
@@ -206,7 +206,8 @@ spec:
           group_wait: 30s
           group_interval: 5m
           repeat_interval: 12h
-          receiver: discord
+          # Anything the AlertmanagerConfig sub-route does not take lands here.
+          receiver: "null"
           routes:
             # Watchdog fires forever by design — it means the pipeline is alive.
             # Delivering it twice a day trains the channel to ignore itself, and
@@ -216,12 +217,6 @@ spec:
                 - alertname = "Watchdog"
         receivers:
           - name: "null"
-          - name: discord
-            discord_configs:
-              # Read from the mounted file so the URL never lands in this
-              # HelmRelease, the rendered manifest, or the wiki.
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/webhook-url
-                send_resolved: true
         inhibit_rules:
           - source_matchers: [severity = "critical"]
             target_matchers: [severity =~ "warning|info"]
@@ -234,10 +229,16 @@ spec:
             equal: [namespace]
           - target_matchers: [alertname = "InfoInhibitor"]
       alertmanagerSpec:
-        # Mounts at /etc/alertmanager/secrets/<name>/, which is what
-        # webhook_url_file above reads.
-        secrets:
-          - alertmanager-discord
+        # The Discord receiver is an AlertmanagerConfig in base/monitoring. The
+        # operator merges only the ones it can select, and the chart's default
+        # selector is empty, which selects nothing.
+        alertmanagerConfigSelector:
+          matchLabels:
+            alertmanagerConfig: discord
+        # Otherwise the operator pins that config's route to alerts labelled
+        # namespace=monitoring, and nothing else ever reaches Discord.
+        alertmanagerConfigMatcherStrategy:
+          type: None
       ingress:
         enabled: true
         annotations:

--- a/clusters/offsite/monitoring/kube-prometheus.yaml
+++ b/clusters/offsite/monitoring/kube-prometheus.yaml
@@ -85,7 +85,8 @@ spec:
           group_wait: 30s
           group_interval: 5m
           repeat_interval: 12h
-          receiver: discord
+          # Anything the AlertmanagerConfig sub-route does not take lands here.
+          receiver: "null"
           routes:
             # Watchdog fires forever by design — it means the pipeline is alive.
             # Delivering it twice a day trains the channel to ignore itself, and
@@ -95,12 +96,6 @@ spec:
                 - alertname = "Watchdog"
         receivers:
           - name: "null"
-          - name: discord
-            discord_configs:
-              # Read from the mounted file so the URL never lands in this
-              # HelmRelease, the rendered manifest, or the wiki.
-              - webhook_url_file: /etc/alertmanager/secrets/alertmanager-discord/webhook-url
-                send_resolved: true
         inhibit_rules:
           - source_matchers: [severity = "critical"]
             target_matchers: [severity =~ "warning|info"]
@@ -113,10 +108,16 @@ spec:
             equal: [namespace]
           - target_matchers: [alertname = "InfoInhibitor"]
       alertmanagerSpec:
-        # Mounts at /etc/alertmanager/secrets/<name>/, which is what
-        # webhook_url_file above reads.
-        secrets:
-          - alertmanager-discord
+        # The Discord receiver is an AlertmanagerConfig in base/monitoring. The
+        # operator merges only the ones it can select, and the chart's default
+        # selector is empty, which selects nothing.
+        alertmanagerConfigSelector:
+          matchLabels:
+            alertmanagerConfig: discord
+        # Otherwise the operator pins that config's route to alerts labelled
+        # namespace=monitoring, and nothing else ever reaches Discord.
+        alertmanagerConfigMatcherStrategy:
+          type: None
       ingress:
         enabled: false
     grafana:

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -10,6 +10,32 @@
 
   services.k8s.clusterCa.enable = true;
 
+  # simpledrm claims card0 early in boot and i915 replaces it with card1 a
+  # second later, but udev leaves
+  # /dev/dri/by-path/pci-...-platform-simple-framebuffer.0-card pointing at the
+  # card0 that no longer exists. runc cannot recreate a symlink whose target is
+  # missing, so every container handed the DRI directory — which is what the
+  # Intel device plugin does for a gpu.intel.com/i915 claim — dies in
+  # CreateContainerError. Prune the danglers before kubelet can start a pod.
+  systemd.services.prune-dri-by-path = {
+    description = "Remove dangling /dev/dri/by-path symlinks left by the simpledrm handover";
+    wantedBy = [ "multi-user.target" ];
+    before = [ "kubelet.service" ];
+    unitConfig.ConditionPathIsDirectory = "/dev/dri/by-path";
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      for link in /dev/dri/by-path/*; do
+        [ -L "$link" ] || continue
+        [ -e "$link" ] && continue
+        echo "pruning dangling $link -> $(readlink "$link")"
+        rm -f "$link"
+      done
+    '';
+  };
+
   homelab.disko.device = "/dev/nvme0n1";
 
   sops.defaultSopsFile = ../secrets/riptide.sops.yaml;


### PR DESCRIPTION
Follow-up to the jellyfin change in #1882, which did not fix it. Jellyfin is running now; this is what makes that survive a reboot.

## What #1882 got wrong

I removed the `/dev/dri` hostPath on the theory that it was dragging in `by-path`. The mechanism was right, the source was not: the **Intel device plugin** hands the DRI directory to any container claiming `gpu.intel.com/i915`, so the new pod failed with the identical error.

```
failed to mkdir "/dev/dri/by-path/pci-0000:00:02.0-platform-simple-framebuffer.0-card": file exists
```

The symlink is **dangling**, which is the actual defect:

```
pci-0000:00:02.0-platform-simple-framebuffer.0-card -> ../card0   # card0 does not exist
pci-0000:00:02.0-card                               -> ../card1
pci-0000:00:02.0-render                             -> ../renderD128
```

simpledrm claims `card0` at 02:18, i915 replaces it with `card1` at 02:19, and udev leaves the stale by-path entry behind. runc cannot recreate a symlink whose target is missing.

Clearing it by hand on riptide brought jellyfin to `1/1 Running` immediately, confirming the cause. It comes back on every boot, hence the unit.

## Also: the rollout deadlocked

riptide advertises exactly one `gpu.intel.com/i915`. With the default `RollingUpdate`, the deployment surges a replacement before releasing the outgoing pod's claim, so the new pod sits `Pending` on `Insufficient gpu.intel.com/i915` while the old pod holds a device it can no longer use. It sat that way for two hours. Pinned to `Recreate`.

## Validation

`nix-instantiate --parse` clean; the unit evaluates via `nix eval` against riptide's real config; the prune loop is exercised against a mock tree that keeps a good symlink and a regular file while removing only the dangler. Jellyfin verified `1/1 Running` after the manual clear.

Needs a `nixos-rebuild` on riptide to take effect — the unit only matters at next boot.