### PR TITLE
fix(spindrift): file Docker Hub under the key BuildKit reads it from

### DIFF
--- a/apps/spindrift/src/adapters/build/buildkit.ts
+++ b/apps/spindrift/src/adapters/build/buildkit.ts
@@ -60,11 +60,39 @@ export function dockerConfigFor(auth: readonly RegistryAuth[]): string | null {
   return JSON.stringify({
     auths: Object.fromEntries(
       auth.map((one) => [
-        one.host,
+        configKeyFor(one.host),
         { auth: btoa(`${one.username}:${one.secret}`) },
       ]),
     ),
   });
+}
+
+/** The Docker Hub entry every registry client has agreed to disagree about. */
+const DOCKER_HUB_CONFIG_KEY = 'https://index.docker.io/v1/';
+
+/**
+ * The key BuildKit looks a host up under, which is the host for all but one.
+ *
+ * Docker Hub is the exception, and it is not cosmetic: BuildKit resolves
+ * `docker.io` to the registry host `registry-1.docker.io` and then substitutes
+ * the legacy index URL before reading the config —
+ *
+ * ```go
+ * hostKey := host
+ * if host == DockerHubRegistryHost { hostKey = DockerHubConfigfileKey }
+ * ac, err := ap.config.GetAuthConfig(hostKey)
+ * ```
+ *
+ * — so an entry filed under either spelling of the hostname is an entry it
+ * never reads, and the push fails as `push access denied, repository does not
+ * exist or may require authorization`, which names authorization last and a
+ * missing repository first. The hosted route never met this: its workflow runs
+ * `docker login`, which writes this key itself.
+ */
+function configKeyFor(host: string): string {
+  return host === 'docker.io' || host === 'registry-1.docker.io'
+    ? DOCKER_HUB_CONFIG_KEY
+    : host;
 }
 
 /** Everything the program needs to know, all of it already decided by core. */

--- a/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
+++ b/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
@@ -29,15 +29,38 @@ const AUTH: readonly RegistryAuth[] = [
 ];
 
 describe('the Docker config a builder is handed', () => {
-  test('is the format every registry client reads', () => {
+  /**
+   * Docker Hub under the legacy index URL and nothing else, because that is
+   * the only key BuildKit reads for it: it resolves the host to
+   * `registry-1.docker.io` and substitutes `DockerHubConfigfileKey` before
+   * looking anything up. Filed under either hostname the entry is invisible,
+   * and the push fails as `push access denied` — observed live on the managed
+   * route, where this config is the only credential the builder gets.
+   */
+  test('files Docker Hub under the key BuildKit reads it from', () => {
     const config = dockerConfigFor(AUTH);
     expect(config).not.toBeNull();
     expect(JSON.parse(config ?? '{}')).toEqual({
       auths: {
-        'registry-1.docker.io': {
+        'https://index.docker.io/v1/': {
           auth: btoa(`an-owner:${TOKEN}`),
         },
       },
+    });
+    // The spelling an operator actually stores reaches the same entry.
+    expect(
+      JSON.parse(
+        dockerConfigFor([{ ...AUTH[0]!, host: 'docker.io' }]) ?? '{}',
+      ),
+    ).toEqual(JSON.parse(config ?? '{}'));
+  });
+
+  test('leaves every other registry under its own hostname', () => {
+    const config = dockerConfigFor([
+      { host: 'ghcr.io', username: 'an-owner', secret: TOKEN },
+    ]);
+    expect(JSON.parse(config ?? '{}')).toEqual({
+      auths: { 'ghcr.io': { auth: btoa(`an-owner:${TOKEN}`) } },
     });
   });
 

--- a/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
+++ b/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
@@ -49,9 +49,7 @@ describe('the Docker config a builder is handed', () => {
     });
     // The spelling an operator actually stores reaches the same entry.
     expect(
-      JSON.parse(
-        dockerConfigFor([{ ...AUTH[0]!, host: 'docker.io' }]) ?? '{}',
-      ),
+      JSON.parse(dockerConfigFor([{ ...AUTH[0]!, host: 'docker.io' }]) ?? '{}'),
     ).toEqual(JSON.parse(config ?? '{}'));
   });
 


### PR DESCRIPTION
## What

`dockerConfigFor` keyed every credential by hostname. BuildKit reads Docker Hub
from the legacy index URL instead — `session/auth/authprovider/authconfigprovider.go`
substitutes it before the lookup:

```go
hostKey := host
if host == DockerHubRegistryHost { hostKey = DockerHubConfigfileKey }
ac, err := ap.config.GetAuthConfig(hostKey)
```

So `auths["docker.io"]` was an entry it never read.

## Evidence

Observed live. With a working GHCR credential in place, build 70 pushed the GHCR
manifest and then died:

```
#21 pushing manifest for ghcr.io/jonpulsifer/plainboi/web:latest@sha256:7cb146d6… 0.3s done
#21 ERROR: failed to push docker.io/jonpulsifer/plainboi-web:…:
    push access denied, repository does not exist or may require authorization
```

The stored credential is keyed `docker.io`. The hosted route is unaffected — its
workflow runs `docker login`, which writes the index key itself — which is why
Docker Hub pushes have always worked there and have never worked on a route that
hands the builder a config.

## Validation

`bun test test/adapters` — 329 pass. Typecheck clean. The old test pinned
`registry-1.docker.io`, a key neither stored nor read; it now pins the index URL
and asserts both stored spellings reach the same entry.