### PR TITLE
fix(bosun): contain the pool, and stop miscounting kills as completions

### DIFF
--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -130,6 +130,19 @@ type skiffPaths struct {
 	deviceSocks []string // parallel to the hull manifest's Devices
 }
 
+// sockets is every vhost-user/virtiofs socket bosun creates for one skiff.
+// Cleanup iterates this rather than naming each field, so a socket added to
+// skiffPaths cannot be forgotten on the teardown path.
+func (p skiffPaths) sockets() []string {
+	socks := []string{p.credSock, p.diagSock, p.netSock, p.apiSock}
+	for _, sock := range p.deviceSocks {
+		if sock != "" {
+			socks = append(socks, sock)
+		}
+	}
+	return socks
+}
+
 func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPaths, error) {
 	var p skiffPaths
 	var err error

--- a/apps/bosun/metrics.go
+++ b/apps/bosun/metrics.go
@@ -26,6 +26,13 @@ const (
 	exitLifetime   = "lifetime"
 	exitJITExpired = "jit_expired"
 	exitBootFailed = "boot_failed"
+	// exitKilled is a VMM that died without bosun asking. The cgroup OOM
+	// killer is the one that happens: every skiff is a child of bosun's unit,
+	// so a MemoryMax there reaps the biggest guest rather than letting the
+	// host pick a victim. Distinct from "completed" because counting an
+	// OOM-killed job as a finished one hides exactly the thing worth alerting
+	// on.
+	exitKilled = "killed"
 )
 
 func newMetrics() *metrics {
@@ -84,7 +91,7 @@ func (m *metrics) render(live map[string]poolState, desired map[string]int) stri
 	b.WriteString("# HELP bosun_skiff_exits_total Skiffs gone since bosun started, by why.\n")
 	b.WriteString("# TYPE bosun_skiff_exits_total counter\n")
 	for _, class := range sortedKeys(desired) {
-		for _, reason := range []string{exitCompleted, exitWedged, exitLifetime, exitJITExpired, exitBootFailed} {
+		for _, reason := range []string{exitCompleted, exitWedged, exitLifetime, exitJITExpired, exitBootFailed, exitKilled} {
 			b.WriteString(fmt.Sprintf("bosun_skiff_exits_total{class=%q,reason=%q} %d\n", class, reason, m.exits[class][reason]))
 		}
 	}

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -303,6 +303,13 @@ func binPath(override, fallback string) string {
 // finished on its own or bosun killed it for being wedged or over budget.
 func (p *pool) awaitExit(ctx context.Context, s *skiff, logger *slog.Logger) {
 	err := s.ch.Wait()
+	// A clean guest poweroff exits 0. A non-zero exit with no reason already
+	// set means the VMM died without bosun asking -- the cgroup OOM killer is
+	// the one that happens -- and calling that "completed" would hide it in
+	// the one metric that says whether jobs are finishing.
+	if err != nil && s.reason() == "" {
+		s.setExitReason(exitKilled)
+	}
 	logger.Info("skiff halted", "error", err)
 	p.retire(ctx, s, logger)
 	if ctx.Err() != nil {
@@ -337,12 +344,15 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 	// diagDir is deliberately not removed: it is the evidence, and this is
 	// the path a wedged skiff's own death takes.
 	os.RemoveAll(s.paths.dir)
-	os.Remove(s.paths.credSock)
-	os.Remove(s.paths.diagSock)
-	os.Remove(s.paths.netSock)
-	os.Remove(s.paths.apiSock)
-	for _, sock := range s.paths.deviceSocks {
+	// Each helper drops a sidecar file beside its socket -- virtiofsd a
+	// "<sock>.pid", passt a "<sock>.repair" -- and neither is cleaned up by
+	// the helper on the way out. Removing only the sockets leaked both for as
+	// long as bosun ran, since sweep-on-start is what eventually collected
+	// them. os.Remove on a name that was never created is a no-op here.
+	for _, sock := range s.paths.sockets() {
 		os.Remove(sock)
+		os.Remove(sock + ".pid")
+		os.Remove(sock + ".repair")
 	}
 
 	p.mu.Lock()

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -153,6 +154,76 @@ func TestPoolReplacesSkiffAfterExit(t *testing.T) {
 	// under logDir rather than in the state dir retire wipes.
 	if _, err := os.Stat(first.paths.diagDir); err != nil {
 		t.Fatalf("retired skiff's diag dir should survive, err=%v", err)
+	}
+}
+
+// Helpers drop sidecar files beside their sockets and do not clean them up:
+// virtiofsd a "<sock>.pid", passt a "<sock>.repair". Removing only the socket
+// leaked both for as long as bosun ran.
+func TestRetireRemovesHelperSidecarFiles(t *testing.T) {
+	p, _, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.fill(ctx)
+	first := onlySkiff(t, p)
+
+	var litter []string
+	for _, sock := range first.paths.sockets() {
+		for _, path := range []string{sock, sock + ".pid", sock + ".repair"} {
+			writeFile(t, path, "")
+			litter = append(litter, path)
+		}
+	}
+	if len(litter) == 0 {
+		t.Fatal("no sockets to litter: skiffPaths.sockets() returned nothing")
+	}
+
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(nil)
+
+	waitFor(t, "retire clears every socket and its sidecars", func() bool {
+		for _, path := range litter {
+			if _, err := os.Stat(path); !os.IsNotExist(err) {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// A VMM that exits non-zero without bosun having asked was killed by
+// something outside -- the cgroup OOM killer is the one that happens. Calling
+// that "completed" would hide an OOM-killed job in the metric that says
+// whether jobs are finishing.
+func TestExternallyKilledSkiffIsNotCountedAsCompleted(t *testing.T) {
+	p, _, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	p.fill(ctx)
+	first := onlySkiff(t, p)
+
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(errors.New("signal: killed"))
+
+	waitFor(t, "exit is recorded as killed", func() bool {
+		p.stats.mu.Lock()
+		defer p.stats.mu.Unlock()
+		return p.stats.exits[first.class][exitKilled] == 1
+	})
+
+	p.stats.mu.Lock()
+	completed := p.stats.exits[first.class][exitCompleted]
+	p.stats.mu.Unlock()
+	if completed != 0 {
+		t.Fatalf("an externally killed skiff was counted as completed (%d)", completed)
 	}
 }
 

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -77,4 +77,17 @@
       warm = 1;
     };
   };
+
+  # The pool's declared ceiling is 2048M + 8192M = 10 GiB, which riptide does
+  # not have to spare: 15.2 GiB total, ~5 GiB held by kubelet and the system,
+  # and no swap. Only a skiff-nixos job peaking at the same time as a
+  # skiff-ubuntu one gets there -- warm=1 serialises within a label but not
+  # across them -- and without a bound the *host* OOM killer picks the victim,
+  # which on a worker node may be a pod or kubelet rather than a skiff.
+  #
+  # 9G clears the realistic worst case (one 8192M guest plus the other class
+  # idling, ~8.8 GiB) and stops the pathological one inside bosun's own
+  # cgroup. Every skiff is a child of this unit, so the limit covers the whole
+  # pool the same way IPAddressDeny does.
+  systemd.services.bosun.serviceConfig.MemoryMax = "9G";
 }


### PR DESCRIPTION
Three things the first clean bench run surfaced. None changes what a skiff does; all three change what happens when one misbehaves.

## Bound the pool's memory

riptide gets `MemoryMax=9G` on `bosun.service`.

The pool's declared ceiling is `2048M + 8192M = 10 GiB`. riptide has 15.2 GiB total, ~5 GiB held by kubelet and the system, and **no swap** — measured, not assumed. `warm = 1` serialises jobs *within* a label but not *across* them, so a `skiff-nixos` job peaking alongside a `skiff-ubuntu` one reaches that ceiling. Nothing bounded the cgroup, so the host OOM killer would pick the victim — and on a worker node that may be a pod or kubelet rather than a skiff.

9G clears the realistic worst case (one 8192M guest plus the other class idling, ~8.8 GiB) and confines the pathological one to bosun's own cgroup. Every skiff is a child of the unit, so one limit covers the whole pool the same way `IPAddressDeny` already does.

Measured for context — guest memory is lazily allocated, so the ceiling is a ceiling and not a reservation:

| | |
|---|---|
| Whole pool cgroup, 2 idle skiffs | ~2043 MB |
| Idle `skiff-ubuntu` RSS | ~662 MB of its 8192M declaration |
| Idle `skiff-nixos` RSS | ~441 MB |

## Stop leaking helper sidecar files

`retire` removed each socket but not the files the helpers drop beside them — virtiofsd's `<sock>.pid`, passt's `<sock>.repair`. They leaked for as long as bosun ran; only `sweep` on the next start collected them. Observed live in `/run/bosun`: orphans from three already-dead skiffs.

Cleanup now iterates a new `skiffPaths.sockets()` rather than naming each field, so a socket added to `skiffPaths` later cannot be forgotten on the teardown path — which is how the `bosun-diag` socket would have been missed.

## Stop counting kills as completions

A VMM that exits non-zero without bosun having asked was reported as `completed`. That is precisely the kill `MemoryMax` above introduces, and burying an OOM-killed job in the one metric that says whether jobs are finishing would make the new limit invisible. It now gets its own exit reason, `killed`, distinct from the guest powering itself off at the end of its work.

## Validation

- `go test`, `go vet`, `gofmt` clean
- Both new tests verified to **fail** without their fix, not merely pass with it
- `MemoryMax` confirmed as `9G` on riptide via `nix eval`

Not deployed. riptide picks this up on its next auto-upgrade, or on a manual switch.

## Deliberately not fixed here

`home-manager-jawn.service` fails on every riptide activation — `~/.config/zsh/.zshrc`, `~/.config/nvim/init.lua` and `~/.zshenv` exist as real read-only files placed by the mise dotfiles deploy, while `nix/home/jawn.nix` declares `programs.zsh` (`dotDir = ".config/zsh"`) and `programs.neovim`, which generate the same three paths. That is an ownership collision between two dotfile systems mid-migration, and the two fixes are opposites — `backupFileExtension` has home-manager clobber the mise-deployed files fleet-wide, or the migration drops those declarations. Not a call to make inside a bosun PR.