### PR TITLE
fix(nix): refresh mise fetchurl hashes for 2026.8.2

### DIFF
--- a/nix/overlays/mise.nix
+++ b/nix/overlays/mise.nix
@@ -40,9 +40,9 @@ in
       url = "https://github.com/jdx/mise/releases/download/v${version}/mise-v${version}-linux-${arch}.tar.gz";
       hash =
         if final.stdenv.hostPlatform.isAarch64 then
-          "sha256-uy236Cq68Pm+EykFYpW6bch0Wt0wgcNLKRPiO5aum9s="
+          "sha256-vC+DjUhBmeGvEy9MvtCpqaiyph6LUgO8PrwnXQ7mmHU="
         else
-          "sha256-w2HJLUsGt//BgFklEsfA4qmbbveVJxDu+evE/xoawsA=";
+          "sha256-/r2ldKxOA2v5Hh750z7F4k2/rWg56w3vpqvBISUYa3Q=";
     };
 
     # The tarball unpacks into ./mise/{bin,man,...}; set sourceRoot so the


### PR DESCRIPTION
**Main is red for every Nix build.** `#1891` bumped mise 2026.8.1 → 2026.8.2 as a one-line change to `version`, leaving the 2026.8.1 hashes in place:

```
error: hash mismatch in fixed-output derivation
  '…-mise-v2026.8.2-linux-x64.tar.gz.drv'
```

This is the failure mode the comment directly above those hashes describes — Renovate bumps `version` only, the `fetchurl` hashes are not covered by it, and they have to be refreshed by hand before the bump PR merges. That did not happen and the PR was merged with the checks red.

Everything that builds mise fails, which is every host closure and every image. It also means **riptide's next auto-upgrade fails**, so nothing merged since is reaching the fleet.

Regenerated with the repo's own `.github/scripts/update-mise-hashes.sh`.

## Validation

`nix build .#nixosConfigurations.optiplex.config.system.build.toplevel` — the exact job that was failing — now builds to completion locally.