### PR TITLE
fix(spindrift): enable the API on the project the refusal named

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
+++ b/apps/spindrift/src/adapters/deploy/cloud/checklist.ts
@@ -87,11 +87,19 @@ export function cloudChecklist(
   const disabled =
     probe.reason === SERVICE_DISABLED || probe.body.includes(SERVICE_DISABLED);
   if (disabled) {
+    const consumer =
+      probe.consumer !== null && probe.consumer !== subject.project
+        ? probe.consumer
+        : undefined;
     return checklist({
       PLATFORM_API: {
         met: false,
         assessed: true,
         detail: `the ${subject.service} API is not enabled on ${disabledProject(probe.consumer, subject)}`,
+        // The same fact the sentence carries, in a field: `remediation.ts`
+        // decides which project a stanza enables the service on, and reading it
+        // back out of the sentence would be parsing prose written for a person.
+        ...(consumer === undefined ? {} : { consumer }),
       },
       OIDC_FEDERATION: notAssessed(subject.service),
       VESSEL: notAssessed(subject.service),
@@ -231,6 +239,8 @@ type Unmet = {
   readonly met: false;
   readonly assessed: boolean;
   readonly detail: string;
+  /** See {@link PrerequisiteResult.consumer}. Only the disabled-service arm. */
+  readonly consumer?: string;
 };
 
 /** Assemble the three in their declared order, so the UI never reorders them. */

--- a/apps/spindrift/src/commands/targets/remediate.ts
+++ b/apps/spindrift/src/commands/targets/remediate.ts
@@ -130,9 +130,12 @@ export const openPrerequisiteRemediation: Command<
     );
   }
   if (remediation.destination.kind !== 'root') {
+    // The destination's own vessel, not the one asked about: a refusal names
+    // the project it billed, so the boundary with no root can be a different
+    // one from the surface this row is on.
     return failed(
       'NOT_DEPLOYABLE',
-      `${input.vessel} declares no Terraform root, so there is nowhere to open this change — the stanza names what a root would contain, and creating one is not something Spindrift does`,
+      `${remediation.destination.vessel} declares no Terraform root, so there is nowhere to open this change — the stanza names what a root would contain, and creating one is not something Spindrift does`,
     );
   }
 

--- a/apps/spindrift/src/commands/targets/remediation.ts
+++ b/apps/spindrift/src/commands/targets/remediation.ts
@@ -24,6 +24,7 @@ import {
 } from '../../config/manifest.schema.ts';
 import type {
   AnyPrerequisite,
+  DeclaredVessel,
   Remediation,
   RemediationSubject,
 } from '../../domain/remediation.ts';
@@ -108,7 +109,36 @@ export function remediationSubject(
     // about a source bucket, so naming one here would be a stanza declaring
     // this installation's bucket in somebody else's project.
     sourceBucket: isHome ? sharedServicesOf(manifest).sourceBucket : null,
+    declared: declaredProjects(manifest),
   };
+}
+
+/**
+ * Every declared boundary that says which project it is.
+ *
+ * From the document rather than from the vessel rows, for the reason
+ * `terraformRootOf` reads the document: a root is a fact about where the
+ * declaration lives, and the row it would otherwise be joined to is one this
+ * caller does not hold — the refusal names a project, not a boundary.
+ *
+ * A vessel that declares no location is left out rather than listed with a
+ * null: it cannot match a project, and a reader that had to skip it would be
+ * the second place this rule is written.
+ */
+function declaredProjects(
+  manifest: InstallationManifest,
+): readonly DeclaredVessel[] {
+  return manifest.vessels.flatMap((vessel) =>
+    vessel.kind === 'gcp-project' && vessel.location !== undefined
+      ? [
+          {
+            name: vessel.name,
+            project: vessel.location.project,
+            terraformRoot: vessel.terraformRoot ?? null,
+          },
+        ]
+      : [],
+  );
 }
 
 /**
@@ -124,6 +154,8 @@ interface ChecklistRow {
   readonly name: AnyPrerequisite;
   readonly met: boolean;
   readonly assessed?: boolean;
+  /** Travels for the same reason `assessed` does — see `AnyPrerequisiteRow`. */
+  readonly consumer?: string;
 }
 
 /**

--- a/apps/spindrift/src/domain/capabilities.ts
+++ b/apps/spindrift/src/domain/capabilities.ts
@@ -161,6 +161,21 @@ export interface PrerequisiteResult {
    */
   readonly assessed?: boolean;
   /**
+   * The project whose switch a `SERVICE_DISABLED` refusal was actually about,
+   * where that is not the project the call was aimed at.
+   *
+   * GCP refuses a call whose *consumer* — the project the federated token bills
+   * — has the service off, whatever project the URL names. Ticket 90 made the
+   * sentence say so; this is the same fact in a field, because the sentence is
+   * written for an operator and `remediation.ts` must not parse it: a stanza
+   * generated off `subject.project` enables the API on a project that was never
+   * the problem, and files it in that project's root.
+   *
+   * Absent means the refusal named no consumer or named the probed project,
+   * which is every other row.
+   */
+  readonly consumer?: string;
+  /**
    * What would clear it, as Terraform, and where that belongs.
    *
    * Absent on a stored row and present on a read one: the loops store what was

--- a/apps/spindrift/src/domain/remediation.ts
+++ b/apps/spindrift/src/domain/remediation.ts
@@ -89,6 +89,17 @@ export interface AnyPrerequisiteRow {
   readonly name: AnyPrerequisite;
   /** `false` where the probe never got far enough to reach a verdict. */
   readonly assessed?: boolean;
+  /**
+   * The project the refusal named as the consumer, where that is not the one
+   * probed — see `PrerequisiteResult.consumer`.
+   *
+   * On the row rather than on the subject because it is an observation about
+   * one refusal, and the subject is the boundary the probe was aimed at. The
+   * two differ exactly when this field is present, which is the whole reason it
+   * exists: a stanza generated off the subject would enable a service on a
+   * project whose switch was never off.
+   */
+  readonly consumer?: string;
 }
 
 /**
@@ -175,6 +186,27 @@ export interface RemediationSubject {
   readonly region: string | null;
   /** The bucket this installation stages sources into, when it holds one. */
   readonly sourceBucket: string | null;
+  /**
+   * Every boundary this installation's declaration puts at a project, so a
+   * refusal about a *different* project than the one probed still lands where
+   * that project is declared.
+   *
+   * Needed because {@link RemediationSubject} is one boundary and a
+   * `SERVICE_DISABLED` is routinely about another: the consumer the federated
+   * token bills, which for this installation's own calls is the home vessel.
+   * Resolving it here rather than by convention keeps rule 2 — a project no
+   * declaration names has no honest root to put a change in, and inventing one
+   * is what this module will not do.
+   */
+  readonly declared: readonly DeclaredVessel[];
+}
+
+/** A boundary the declaration names, as a destination lookup reads one. */
+export interface DeclaredVessel {
+  readonly name: string;
+  /** The project it is; only boundaries that declare one are listed. */
+  readonly project: string;
+  readonly terraformRoot: string | null;
 }
 
 /**
@@ -263,7 +295,7 @@ export function remediationFor(
 
   switch (name) {
     case 'PLATFORM_API':
-      return enablePlatformApi(subject);
+      return enablePlatformApi(row, subject);
     case 'OIDC_FEDERATION':
       return grantFederatedAccess(subject);
     case 'SOURCE_BUCKET':
@@ -276,8 +308,21 @@ export function remediationFor(
   }
 }
 
-/** The one service the probe found switched off — never the full set. */
-function enablePlatformApi(subject: RemediationSubject): Remediation {
+/**
+ * The one service the probe found switched off — never the full set, and never
+ * on a project whose switch was not the one refused.
+ *
+ * A `SERVICE_DISABLED` names its *consumer*: the project the federated token
+ * bills, which for this installation's own calls is the home vessel and not the
+ * vessel being probed. Where the two differ, both halves of the change follow
+ * the consumer — the stanza's `project` and the root it is filed in — because a
+ * change enabling an API on the probed project would clear nothing and would be
+ * reviewed by whoever owns a boundary that was never at fault.
+ */
+function enablePlatformApi(
+  row: AnyPrerequisiteRow,
+  subject: RemediationSubject,
+): Remediation {
   const service = serviceOf(subject.adapter);
   if (service === null || subject.project === null) {
     return {
@@ -286,18 +331,44 @@ function enablePlatformApi(subject: RemediationSubject): Remediation {
         'nothing observed which project this row is about, or which service was switched off in it',
     };
   }
+  const consumer =
+    row.consumer === undefined || row.consumer === subject.project
+      ? null
+      : row.consumer;
+  const owner =
+    consumer === null
+      ? null
+      : (subject.declared.find((vessel) => vessel.project === consumer) ??
+        null);
+  if (consumer !== null && owner === null) {
+    // Rule 2, in the one place the destination is not this subject's: a project
+    // that appears only in somebody else's refusal is a boundary this
+    // declaration has never named, so there is no root to file a change in and
+    // no vessel to say one is missing from.
+    return {
+      kind: 'none',
+      reason: `the ${service} switch this refusal is about is ${consumer}’s — the project this installation’s calls bill to, not ${subject.project} — and nothing in this declaration names ${consumer} as a vessel, so there is no root to put the change in`,
+    };
+  }
+  const project = consumer ?? subject.project;
   const label = identifier(`spindrift_${service.split('.')[0]}`);
   return {
     kind: 'generated',
-    summary: `Enable ${service} on ${subject.project}. Only the service this probe found switched off; the rest of the project’s services are untouched.`,
-    destination: destinationOf(subject, DESTINATION_FILE.PLATFORM_API),
+    summary:
+      owner === null
+        ? `Enable ${service} on ${project}. Only the service this probe found switched off; the rest of the project’s services are untouched.`
+        : `Enable ${service} on ${project} — the project this installation’s calls bill to, not ${subject.project}, which the refusal establishes nothing about. Only the service this probe found switched off; the rest of the project’s services are untouched.`,
+    destination:
+      owner === null
+        ? destinationOf(subject, DESTINATION_FILE.PLATFORM_API)
+        : rootOf(owner, DESTINATION_FILE.PLATFORM_API),
     // The service string and not only the address: a root that enables its
     // APIs through one `for_each` resource owns this service under a label
     // nothing here can predict, and appending beside it is two resources
     // managing one enablement.
     declares: [address('google_project_service', label), quote(service)],
     terraform: `resource "google_project_service" "${label}" {
-  project            = ${quote(subject.project)}
+  project            = ${quote(project)}
   service            = ${quote(service)}
   disable_on_destroy = false
 }
@@ -399,9 +470,20 @@ function destinationOf(
   subject: RemediationSubject,
   file: string,
 ): RemediationDestination {
-  return subject.terraformRoot === null
-    ? { kind: 'absent', vessel: subject.vessel, file }
-    : { kind: 'root', path: `${subject.terraformRoot}/${file}` };
+  return rootOf(
+    { name: subject.vessel, terraformRoot: subject.terraformRoot },
+    file,
+  );
+}
+
+/** The same answer for a boundary that is not the one the row is on. */
+function rootOf(
+  vessel: Pick<DeclaredVessel, 'name' | 'terraformRoot'>,
+  file: string,
+): RemediationDestination {
+  return vessel.terraformRoot === null
+    ? { kind: 'absent', vessel: vessel.name, file }
+    : { kind: 'root', path: `${vessel.terraformRoot}/${file}` };
 }
 
 /** A Terraform resource name: the label characters HCL admits, and no others. */

--- a/apps/spindrift/test/domain/remediation.test.ts
+++ b/apps/spindrift/test/domain/remediation.test.ts
@@ -20,12 +20,29 @@
  * rather than an empty box.
  */
 import { describe, expect, test } from 'bun:test';
+import { cloudChecklist } from '../../src/adapters/deploy/cloud/checklist.ts';
+import type { CloudResponse } from '../../src/adapters/deploy/cloud/http.ts';
+import {
+  remediationSubject,
+  withRemediations,
+} from '../../src/commands/targets/remediation.ts';
+import type { InstallationManifest } from '../../src/config/manifest.ts';
 import { PREREQUISITES } from '../../src/domain/capabilities.ts';
 import {
   type RemediationSubject,
   remediationFor,
 } from '../../src/domain/remediation.ts';
 import { VESSEL_PREREQUISITES } from '../../src/domain/vessel.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+/** The boundaries the declaration names, as the destination lookup reads them. */
+const DECLARED = [
+  {
+    name: 'cloud',
+    project: 'example-vessel',
+    terraformRoot: 'terraform/projects/cloud',
+  },
+] as const;
 
 const HOME: RemediationSubject = {
   vessel: 'cloud',
@@ -35,7 +52,40 @@ const HOME: RemediationSubject = {
   principal: 'serviceAccount:spindrift@example.test',
   region: 'example-region',
   sourceBucket: 'example-source-bucket',
+  declared: DECLARED,
 };
+
+/**
+ * A boundary that is not this installation's own, connected through the UI.
+ *
+ * The shape the consumer distinction is about: the probe is aimed here, and the
+ * switch that is off is the home vessel's, because that is the project the
+ * federated token bills.
+ */
+const ELSEWHERE: RemediationSubject = {
+  ...HOME,
+  vessel: 'elsewhere',
+  project: 'other-vessel',
+  terraformRoot: null,
+  sourceBucket: null,
+};
+
+/**
+ * The fixture, with its home boundary saying which project it is.
+ *
+ * The fixture leaves `location` off on purpose — it seeds identity and leaves
+ * reach to the connect act — and the consumer distinction only exists for an
+ * installation whose home vessel declares a project, as the live one does.
+ */
+const declaring: InstallationManifest = ((manifest: InstallationManifest) => ({
+  ...manifest,
+  vessels: manifest.vessels.map((vessel) =>
+    vessel.name === manifest.installation.homeVessel &&
+    vessel.kind === 'gcp-project'
+      ? { ...vessel, location: { project: 'example-vessel' } }
+      : vessel,
+  ),
+}))(await fixtureManifest());
 
 /** The `kind: 'generated'` arm, or a failure naming what came back instead. */
 function generated(remediation: ReturnType<typeof remediationFor>) {
@@ -88,6 +138,64 @@ describe('a service the probe found switched off', () => {
     // The stanza still stands: "here is what a root would contain" is an answer
     // an operator can act on. What is withheld is the location.
     expect(change.terraform).toContain('google_project_service');
+  });
+
+  test('the switch that is off is the consumer’s, so the stanza is too', () => {
+    // GCP refuses the call whose *consumer* has the service off, whatever
+    // project the URL named. Enabling the API on `other-vessel` would clear
+    // nothing and would be reviewed by whoever owns a boundary that was never
+    // at fault.
+    const change = generated(
+      remediationFor(
+        { name: 'PLATFORM_API', consumer: 'example-vessel' },
+        ELSEWHERE,
+      ),
+    );
+    expect(change.terraform).toContain('"example-vessel"');
+    expect(change.terraform).not.toContain('other-vessel');
+    expect(change.summary).toContain('not other-vessel');
+  });
+
+  test('and it goes to the root the consumer’s boundary declares', () => {
+    // Not the probed boundary's — which here has no root at all, so a
+    // destination taken from the subject would have withheld the location of a
+    // change that has a perfectly good place to go.
+    const change = generated(
+      remediationFor(
+        { name: 'PLATFORM_API', consumer: 'example-vessel' },
+        ELSEWHERE,
+      ),
+    );
+    expect(change.destination).toEqual({
+      kind: 'root',
+      path: 'terraform/projects/cloud/services.tf',
+    });
+  });
+
+  test('a consumer no declaration names gets the reason, never a guess', () => {
+    const change = remediationFor(
+      { name: 'PLATFORM_API', consumer: 'somebody-elses-project' },
+      ELSEWHERE,
+    );
+    expect(change.kind).toBe('none');
+    if (change.kind !== 'none') return;
+    expect(change.reason).toContain('somebody-elses-project');
+    expect(change.reason).toContain('no root');
+  });
+
+  test('a consumer that is the probed project changes nothing', () => {
+    const change = generated(
+      remediationFor(
+        { name: 'PLATFORM_API', consumer: 'example-vessel' },
+        HOME,
+      ),
+    );
+    expect(change.terraform).toContain('"example-vessel"');
+    expect(change.destination).toEqual({
+      kind: 'root',
+      path: 'terraform/projects/cloud/services.tf',
+    });
+    expect(change.summary).not.toContain('bill');
   });
 
   test('a surface with no service of its own generates nothing', () => {
@@ -271,5 +379,80 @@ describe('the rows Terraform does not clear', () => {
       expect(change.reason).toContain('Terraform');
       expect(change.reason).toContain('cluster');
     }
+  });
+});
+
+/**
+ * The consumer, from the refusal that named it to the stanza that acts on it.
+ *
+ * Deliberately across the seam rather than at either side of it: the fact is
+ * observed in `cloud/checklist.ts`, stored on a jsonb row, and read by a
+ * generator two modules away, and every previous defect of this shape was a
+ * fact that survived one of those hops and not the next. Ticket 90 fixed the
+ * sentence; a test that only asserted the sentence would have passed while the
+ * generated change still enabled the API on the wrong project.
+ */
+describe('a refusal about the project the calls bill to', () => {
+  /** What Cloud Run answers when the *caller's* project has it switched off. */
+  const REFUSED: CloudResponse<unknown> = {
+    ok: false,
+    kind: 'status',
+    status: 403,
+    body: JSON.stringify({ error: { status: 'PERMISSION_DENIED' } }),
+    reason: 'SERVICE_DISABLED',
+    consumer: 'example-vessel',
+    message:
+      'Cloud Run Admin API has not been used in project example-vessel before or it is disabled',
+  };
+
+  test('the stanza names that project, and lands in its root', () => {
+    const rows = cloudChecklist(REFUSED, {
+      project: 'other-vessel',
+      service: 'Cloud Run',
+      scope: 'services in other-vessel',
+    });
+    const answered = withRemediations(
+      rows,
+      remediationSubject(
+        declaring,
+        {
+          name: 'elsewhere',
+          location: { kind: 'gcp-project', project: 'other-vessel' },
+          surfaces: [
+            { connection: { adapter: 'cloudrun', region: 'example-region' } },
+          ],
+        },
+        'cloudrun',
+      ),
+    );
+
+    const change = generated(
+      answered.find((row) => row.name === 'PLATFORM_API')?.remediation ?? {
+        kind: 'none',
+        reason: 'PLATFORM_API is not on the checklist this refusal produced',
+      },
+    );
+    expect(change.terraform).toContain('"example-vessel"');
+    expect(change.terraform).toContain('"run.googleapis.com"');
+    expect(change.terraform).not.toContain('other-vessel');
+    expect(change.destination).toEqual({
+      kind: 'root',
+      path: 'terraform/projects/cloud/services.tf',
+    });
+  });
+
+  test('a refusal naming no consumer still answers about the probed project', () => {
+    const rows = cloudChecklist(
+      { ...REFUSED, consumer: null },
+      {
+        project: 'example-vessel',
+        service: 'Cloud Run',
+        scope: 'services in example-vessel',
+      },
+    );
+    const platform = rows.find((row) => row.name === 'PLATFORM_API');
+    expect(platform?.consumer).toBeUndefined();
+    expect(platform?.detail).toContain('example-vessel');
+    expect(platform?.detail).not.toContain('bill');
   });
 });


### PR DESCRIPTION
A `SERVICE_DISABLED` refusal is about its **consumer** — the project the federated token bills — which is routinely not the project the call was aimed at. The sentence has named the consumer since the last change here; the *generated Terraform* still enabled the service on the probed project, and filed it in that boundary's root. Merging one would have enabled an API that was never off, in a repository directory owned by whoever runs a boundary that was never at fault.

The consumer now travels the whole way:

- `cloud/checklist.ts` puts it on the `PLATFORM_API` row, and only when it differs from the probed project. No migration — the column is a document.
- `enablePlatformApi` takes the row as well as the subject, and follows the consumer for the project the stanza names, the summary it writes, and the root it is filed in.
- `RemediationSubject.declared` resolves a project to the boundary that declares it, read from `manifest.vessels` — the same place `terraformRootOf` reads, for the same reason.

A consumer project no vessel declares gets the reason there is no change, rather than a directory nothing in the repository has agreed to. A declared boundary carrying no root gets the existing "here is what a root would contain" arm, exactly as the probed boundary would.

Rode along: `openPrerequisiteRemediation`'s "declares no Terraform root" refusal named the vessel it was asked about, which is the wrong boundary once a destination can follow a consumer. It names the destination's own.

## Validation

The four new tests were run against the code with the consumer guard neutralised, and fail:

```text
(fail) the switch that is off is the consumer's, so the stanza is too
(fail) and it goes to the root the consumer's boundary declares
(fail) a consumer no declaration names gets the reason, never a guess
(fail) the stanza names that project, and lands in its root
 19 pass
 4 fail
```

Restored, the whole suite against a real Postgres: **1977 pass, 0 fail** across 142 files. `bun run typecheck` and `bun run lint` exit 0.

The end-to-end test crosses the checklist/generator seam deliberately: the previous fix corrected the sentence, and a test asserting only the sentence would have passed while the generated change still named the wrong project.

## Risk

Additive on a document column, so no rollout ordering. The behaviour only changes for a refusal whose ErrorInfo names a different consumer than the project probed; every other row generates exactly what it did before. Nothing is applied by this — the stanza is still reviewed and applied by Atlantis, and the row goes green because the loop probed again.