### PR TITLE
fix(dotfiles): let home-manager own zsh and neovim on NixOS

### DIFF
--- a/dotfiles/scripts/deploy-dotfiles.sh
+++ b/dotfiles/scripts/deploy-dotfiles.sh
@@ -28,17 +28,22 @@ link_file "${DOTFILES_DIR}" "${HOME}/.dotfiles"
 # 2. Individual config files and directories
 link_file "${DOTFILES_DIR}/.tmux.conf" "${HOME}/.tmux.conf"
 link_file "${DOTFILES_DIR}/.vimrc" "${HOME}/.vimrc"
-link_file "${DOTFILES_DIR}/.zshenv" "${HOME}/.zshenv"
 link_file "${DOTFILES_DIR}/.config/.bunfig.toml" "${HOME}/.config/.bunfig.toml"
 link_file "${DOTFILES_DIR}/.config/git" "${HOME}/.config/git"
 link_file "${DOTFILES_DIR}/.config/ghostty/config" "${HOME}/.config/ghostty/config"
-link_file "${DOTFILES_DIR}/.config/nvim" "${HOME}/.config/nvim"
-# On NixOS hosts where home-manager owns zsh (HM_ACTIVATED=1), skip deploying
-# the .config/zsh dir: home-manager writes ~/.config/zsh/.zshrc itself, and a
-# symlink here would shadow its generated file. Everything else (.zshenv,
-# git, ssh, ...) still deploys.
+# Everything home-manager's programs.zsh and programs.neovim generate. On a
+# NixOS host home-manager owns these outright (HM_ACTIVATED=1) and refuses to
+# overwrite a file it did not create, so deploying them here does not merely
+# shadow the generated versions -- it fails the whole home-manager activation,
+# taking every other programs.<x> with it.
+#
+# Everywhere else -- macOS, where Homebrew and these dotfiles are the whole
+# story and there is no home-manager -- the guard is false and all three
+# deploy exactly as before.
 if [[ "${HM_ACTIVATED:-0}" != "1" ]]; then
+  link_file "${DOTFILES_DIR}/.zshenv" "${HOME}/.zshenv"
   link_file "${DOTFILES_DIR}/.config/zsh" "${HOME}/.config/zsh"
+  link_file "${DOTFILES_DIR}/.config/nvim" "${HOME}/.config/nvim"
 fi
 link_file "${DOTFILES_DIR}/.local/bin" "${HOME}/.local/bin"
 link_file "${DOTFILES_DIR}/.ssh/config" "${HOME}/.ssh/config"

--- a/nix/system/mise-dotfiles.nix
+++ b/nix/system/mise-dotfiles.nix
@@ -33,13 +33,17 @@ lib.mkIf (config.homelab.fleet.miseDotfiles && (user.isNormalUser or false)) {
       "users"
       "groups"
     ];
+    # `|| true` on purpose: a dotfiles problem must not fail an activation and
+    # strand the host. stderr is deliberately *not* discarded, though -- it was,
+    # and a bootstrap that failed every run left no trace anywhere, which is
+    # how the home-manager collision above went unnoticed.
     text = ''
       HOME="${user.home}" MISE_YES=1 ${wslEnv}\
       ${pkgs.sudo}/bin/sudo --preserve-env=${preserveEnv} -u ${user.name} \
-        ${mise}/bin/mise trust -y ${dotfilesSource} 2>/dev/null || true
+        ${mise}/bin/mise trust -y ${dotfilesSource} || true
       HOME="${user.home}" MISE_YES=1 ${wslEnv}HM_ACTIVATED=1 \
       ${pkgs.sudo}/bin/sudo --preserve-env=${preserveEnv},HM_ACTIVATED -u ${user.name} \
-        ${mise}/bin/mise run bootstrap -y --cd ${dotfilesSource} 2>/dev/null || true
+        ${mise}/bin/mise run bootstrap -y --cd ${dotfilesSource} || true
     '';
   };
 }


### PR DESCRIPTION
`home-manager-jawn.service` fails on **every activation of every fleet host**, not just riptide.

`homelab.fleet.homeManager` and `homelab.fleet.miseDotfiles` both default to `true` in `nix/profiles/base.nix`, so every closure carries two writers for the same three paths:

| Path | home-manager | mise bootstrap |
|---|---|---|
| `~/.zshenv` | `programs.zsh` | deployed unconditionally |
| `~/.config/zsh` | `programs.zsh` (`dotDir`) | guarded ✓ |
| `~/.config/nvim` | `programs.neovim` | deployed unconditionally |

home-manager refuses to overwrite a file it did not create, so it aborts — and it takes **every other `programs.<x>` with it** (bat, btop, fzf, gh, eza, git-delta). Losing the shell integrations and plugin ecosystems is the actual cost here, not a noisy unit.

## The fix

The `HM_ACTIVATED` guard for precisely this already existed and covered only `.config/zsh`. All three now sit inside it.

**macOS is untouched.** There is no home-manager there, so `HM_ACTIVATED` is unset, the guard is false, and Homebrew plus these dotfiles remain the whole story — all three deploy exactly as before.

## Also: stop hiding the evidence

`nix/system/mise-dotfiles.nix` ran the bootstrap under `2>/dev/null || true`. The `|| true` stays — a dotfiles problem must not strand a host — but discarding stderr meant a bootstrap failing every single run left no trace in the activation log, which is why this went unnoticed for months of activations.

## Validation

- `shellcheck` and `shfmt -d -i 2 -ci -bn` clean on the changed script
- Ran the script both ways against a throwaway `$HOME`:
  - `HM_ACTIVATED=1` — none of the three deploy
  - unset (the macOS path) — all three deploy
- riptide's closure still evaluates

## One-time host cleanup, not in this PR

The guard stops the files being *recreated*; it does not remove what is already on disk. Hosts currently carrying real files at those paths need them removed once before home-manager can take ownership — on riptide that is `~/.zshenv`, `~/.config/zsh/.zshrc` and `~/.config/nvim`. Worth eyeballing rather than scripting blind: `~/.config/zsh` also holds live `.zsh_history` and `.zcompdump` that should stay.