### PR TITLE
fix(jellyfin): unwedge the folly Kustomization the Recreate strategy stalled

### DIFF
--- a/clusters/folly/apps/jellyfin/deployment.yaml
+++ b/clusters/folly/apps/jellyfin/deployment.yaml
@@ -9,11 +9,22 @@ metadata:
 spec:
   replicas: 1
   # riptide advertises exactly one gpu.intel.com/i915, and the container below
-  # claims it. A rolling update surges the replacement before releasing the
-  # old pod's claim, so the new one can never be scheduled and the rollout
-  # deadlocks — the old pod keeps the device it is no longer able to use.
+  # claims it. A surging replacement is scheduled before the old pod releases
+  # its claim, so the new one can never be placed and the rollout deadlocks —
+  # the old pod keeps the device it is no longer able to use.
+  #
+  # `maxSurge: 0` rather than `type: Recreate`, which says the same thing about
+  # one replica and cannot be applied here: the live object carries the
+  # `rollingUpdate` block the API server defaulted, owned by a field manager
+  # this apply is not, so a `Recreate` patch merges into an object holding both
+  # and the API refuses it — `rollingUpdate: Forbidden ... when strategy type is
+  # 'Recreate'`. That is a dry-run failure, so Flux stops applying the whole
+  # Kustomization rather than only this file.
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels: *labels
   template:


### PR DESCRIPTION
`Kustomization/jellyfin` on folly has been stuck on `dea32905` and has not applied since. Its last attempted revision is current; every pass fails the same way:

```text
Deployment/jellyfin/jellyfin dry-run failed (Invalid): Deployment.apps "jellyfin" is invalid:
spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

The live Deployment carries the `rollingUpdate` block the API server defaulted when the strategy was `RollingUpdate`, owned by a field manager this apply is not. So a `Recreate` patch merges into an object holding both, and the API refuses it — at **dry-run**, which is before anything is written, so the controller abandons the whole Kustomization rather than just this file.

The GPU container fix merged behind it and never reached the cluster.

`maxSurge: 0` says exactly what `Recreate` was there to say for a single replica — the old pod is gone before its replacement is scheduled, which is the point for a container claiming the node's only `gpu.intel.com/i915` — and it patches cleanly because the strategy type never changes.

## Validation

Both directions, against the live cluster, with the field manager the controller uses:

```text
$ kubectl apply --server-side --field-manager=kustomize-controller --dry-run=server \
    -f clusters/folly/apps/jellyfin/deployment.yaml
deployment.apps/jellyfin serverside-applied (server dry run)

$ git show origin/main:clusters/folly/apps/jellyfin/deployment.yaml | kubectl apply --server-side … -f -
The Deployment "jellyfin" is invalid: spec.strategy.rollingUpdate: Forbidden: …
```

## Risk

On merge the Kustomization resumes and applies everything queued behind it — the GPU fix included — so jellyfin's pod will be replaced once. `maxSurge: 0` means it goes down before it comes back up, which is what a single-GPU workload has to do either way.