### PR TITLE
feat(spindrift): stand up a clean installation, and fix what stopped it

### DIFF
--- a/apps/spindrift/test/conformance/second-target-admission.test.ts
+++ b/apps/spindrift/test/conformance/second-target-admission.test.ts
@@ -464,6 +464,15 @@ describe('Ticket 12 — Admit the artifact on a second Target', () => {
     // annotation) that this test does not touch and does not subsume.
     const consumers: [string, string][] = [
       ['spindrift', 'clusters/offsite/apps/spindrift/oci-repository.yaml'],
+      // The clean-installation acceptance environment consumes the same
+      // artifact independently, and is listed for the reason the pair above is:
+      // a consumer nothing checks is a tag that stops resolving the first time
+      // the chart version moves, and this one exists precisely to prove the
+      // published chart installs.
+      [
+        'spindrift',
+        'clusters/offsite/apps/spindrift-acceptance/oci-repository.yaml',
+      ],
       [
         'spindrift-app',
         'clusters/base/platform/spindrift-target/oci-repository.yaml',

--- a/clusters/folly/apps/jellyfin/deployment.yaml
+++ b/clusters/folly/apps/jellyfin/deployment.yaml
@@ -9,11 +9,22 @@ metadata:
 spec:
   replicas: 1
   # riptide advertises exactly one gpu.intel.com/i915, and the container below
-  # claims it. A rolling update surges the replacement before releasing the
-  # old pod's claim, so the new one can never be scheduled and the rollout
-  # deadlocks — the old pod keeps the device it is no longer able to use.
+  # claims it. A surging replacement is scheduled before the old pod releases
+  # its claim, so the new one can never be placed and the rollout deadlocks —
+  # the old pod keeps the device it is no longer able to use.
+  #
+  # `maxSurge: 0` rather than `type: Recreate`, which says the same thing about
+  # one replica and cannot be applied here: the live object carries the
+  # `rollingUpdate` block the API server defaulted, owned by a field manager
+  # this apply is not, so a `Recreate` patch merges into an object holding both
+  # and the API refuses it — `rollingUpdate: Forbidden ... when strategy type is
+  # 'Recreate'`. That is a dry-run failure, so Flux stops applying the whole
+  # Kustomization rather than only this file.
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   selector:
     matchLabels: *labels
   template:

--- a/clusters/offsite/apps/kustomization.yaml
+++ b/clusters/offsite/apps/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - descheduler
   - hub
   - spindrift
+  - spindrift-acceptance
   - ../../base/platform/spindrift-target
   - dave.yaml
   - ../../base/apps/reloader

--- a/clusters/offsite/apps/spindrift-acceptance/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/helm-release.yaml
@@ -1,0 +1,75 @@
+---
+# The bare install: the chart, an image, a hostname, and nothing else.
+#
+# **There is deliberately no `manifest:` here, and that is the whole point.**
+# The installation next door seeds a fully authored declaration, so everything
+# it proves is about a document somebody already wrote. This one comes up with
+# no declaration at all — the state a first-time operator installs into — which
+# means the placeholder is what seeds the row, the relying party has to be the
+# hostname this is actually served at, and every genuine choice is made in the
+# product by the wizard.
+#
+# What that leaves untested here is intentional: a re-seedable declaration is
+# the other installation's job, and it holds it.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spindrift
+  namespace: spindrift-acceptance
+  labels:
+    # See the comment on the running installation's release: this patch target
+    # only applies to charts sourced through `chart.spec`, and a `chartRef`
+    # release has none.
+    source.toolkit.fluxcd.io/kind: OCIRepository
+spec:
+  interval: 5m
+  chartRef:
+    kind: OCIRepository
+    name: spindrift
+  values:
+    # The same digest the running installation is on. A fresh install of a
+    # different image would answer a question about that image instead.
+    image: ghcr.io/jonpulsifer/spindrift:latest@sha256:eeab79ec9c3be369949c8645d800c6eb2ca9a55680a9038386d52cb5ccbf0484
+    # A real origin, because a passkey ceremony is scoped to one and a
+    # relying party that is not a suffix of the origin is refused by the
+    # browser rather than by anything here. cert-manager issues the
+    # certificate from the chart's Gateway and external-dns publishes the
+    # record from its HTTPRoute, so this line is the whole of it.
+    hostname: spindrift-acceptance.${SECRET_DOMAIN}
+    envFromSecret: spindrift-acceptance-env
+    # **The one thing this shares with the running installation.** The pool
+    # provider mints a token whose subject is this namespace's service account,
+    # and `terraform/gcp/projects/bluenose/iam.tf` binds that subject to the
+    # same `spindrift-controller` account the other installation impersonates.
+    #
+    # A second identity would be the more faithful shape and is not worth it:
+    # §14 puts identity provisioning in the operator's Terraform rather than in
+    # the product, so what a second account would exercise is this repository's
+    # own IAM, not anything Spindrift does. What it would cost is every project
+    # role, the bucket grants and the signer duplicated for an environment
+    # meant to be deleted.
+    #
+    # The consequence, stated rather than discovered: this installation can
+    # reach everything the other one can, in the same projects. Give its Apps
+    # names nothing else uses.
+    serviceAccount:
+      token:
+        gcpAudience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
+        gcpImpersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
+        # The cluster's own root and nothing else. The running installation
+        # extends its bundle because it holds a Target on folly; this one
+        # places on cloud surfaces, which are reached over public TLS the
+        # image's own trust store already covers.
+        caConfigMap: kube-root-ca.crt
+    ingress:
+      enabled: true
+    # Its own database, and `keepOnDelete` off — an acceptance installation
+    # that leaves a volume behind is one whose next run is not clean.
+    database:
+      enabled: true
+      size: 2Gi
+      keepOnDelete: false
+      migration:
+        enabled: true
+    reconciler:
+      enabled: true

--- a/clusters/offsite/apps/spindrift-acceptance/kustomization.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - secret.sops.yaml
+  - oci-repository.yaml
+  - helm-release.yaml

--- a/clusters/offsite/apps/spindrift-acceptance/namespace.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/namespace.yaml
@@ -1,0 +1,26 @@
+---
+# A second Spindrift installation, sharing nothing with the first but the
+# cluster it runs on and the identity it federates as.
+#
+# It exists to answer a question the running installation cannot: does the
+# published chart, installed by somebody who has never seen this repository,
+# come up far enough for a first operator to enrol and configure it in the
+# product? The installation next door was seeded from a declaration and has
+# been reconfigured by hand for months, so every answer it gives is about
+# itself.
+#
+# Its own namespace rather than a release beside the other one: the chart's
+# names are release-scoped, the database is a Cluster inside the namespace, and
+# a teardown has to be a namespace delete or it is not a teardown.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spindrift-acceptance
+  labels:
+    kustomize.toolkit.fluxcd.io/prune: enabled
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest

--- a/clusters/offsite/apps/spindrift-acceptance/oci-repository.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/oci-repository.yaml
@@ -1,0 +1,20 @@
+---
+# The same published artifact the running installation consumes, resolved
+# independently in this namespace.
+#
+# Pinned to the same tag on purpose. The claim being tested is that the chart
+# an outsider would `helm install` produces a working installation, so pointing
+# this at anything the other one is not on would test a different chart.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: spindrift
+  namespace: spindrift-acceptance
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.1.4
+  url: oci://ghcr.io/jonpulsifer/charts/spindrift

--- a/clusters/offsite/apps/spindrift-acceptance/secret.sops.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/secret.sops.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: spindrift-acceptance-env
+    namespace: spindrift-acceptance
+type: Opaque
+stringData:
+    SPINDRIFT_ENROLMENT_TOKEN: ENC[AES256_GCM,data:opb9e5US7quwObOmva2v7ulnFCACs+k+MjLw62O261kt3LOpZ2ZmYtndZg==,iv:yoUJ3htPqHfh07b5DXbl/FmwzlR2vbyJOfYkVeUCbqw=,tag:BSgHhVswkCszZBDLl0MXxQ==,type:str]
+    SPINDRIFT_CREDENTIAL_KEYRING: ENC[AES256_GCM,data:VIgCO53vQwgMyBbrVUmm6ZJdvjZS/hAAhwJOpGuTA4+lsjtROUu6nDqP80Mp64Sm8ziGNhwPrCrckehluVwuBF0BDkpb/dIGsLmz,iv:CiLuGRHAR+PskXq1BOTr3NMaOUP16PWX+YDJ1q5yvx8=,tag:0lLQfuK5knuhBBYQIcj0kw==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB1YmlhQXNWZ0F2Smt1Wndm
+            Y3I5bzlVTGYxT1N1ZEpZcHRHMzNuQ0tVT2lrCmtaNmpqQXlnK0d2K2FBUENZRXlB
+            dG9QaXl0Y2ZhNG8yRCt3RzNMY0RZOHcKLS0tIENraDZQV0pPWkFZNGtZbE0xeHZz
+            R3NxQTJsNUlJSnZlbWFscFFjOERjZE0KUn0bG5ZjDm4OUhzR43ufWfW+oHc2LGm3
+            kZNgEjO9b3fxWyey3T8qF8/J8PZwbrBAwiJ8q/+p5DHqMlU8HhIcxA==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+    encrypted_regex: ^(data|stringData)$
+    lastmodified: "2026-08-08T03:47:00Z"
+    mac: ENC[AES256_GCM,data:rdLnPD4GFwQ3P7uNgqg6XwSPbcje+HDa/fm03klgcS+dZQvQTbY2K69H1Nq8aFl8jcvP+WgJdbHun4rhajKNAat7+J7n5PoHpHtYCQX1URumqkR0HuSKaa8YQ/70eX3pzDJBgpqEWwEphadx6ZZllNJCnmxFs5nL5wfXBzJKrYs=,iv:DdnLFHmJAXI5UXrpZvVPkynwqoFFRznyX2IPh86C+qE=,tag:UZlXue5v2vWPjNPgo++8Og==,type:str]
+    version: 3.13.3

--- a/clusters/offsite/apps/spindrift/oci-repository.yaml
+++ b/clusters/offsite/apps/spindrift/oci-repository.yaml
@@ -17,5 +17,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 0.1.3
+    tag: 0.1.4
   url: oci://ghcr.io/jonpulsifer/charts/spindrift

--- a/packages/charts/spindrift/Chart.yaml
+++ b/packages/charts/spindrift/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spindrift
 description: The Spindrift installer chart — the web and reconciler Deployments, their database, and the route the UI is served on
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "latest"

--- a/packages/charts/spindrift/templates/_helpers.tpl
+++ b/packages/charts/spindrift/templates/_helpers.tpl
@@ -1,13 +1,29 @@
 {{/*
-The release's base name. Every object is derived from it, and the namespace is
-assumed to match — Flux creates the Namespace alongside this release.
+The release's base name. Every object is derived from it.
 */}}
 {{- define "spindrift.fullname" -}}
 {{- default .Release.Name .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{/*
+Where this release installs.
+
+`.Release.Namespace` — the namespace Helm was told to install into — rather
+than the release's own name, which is what this used to assume. The two agree
+for the installation this chart was written beside and disagree for every
+other: `helm install spindrift oci://… -n anything-else` wrote its Deployments,
+its database and its Gateway into a namespace called `spindrift`, which is
+either a namespace that does not exist or, worse, somebody else's installation.
+
+That is a property of an extractable artifact rather than a detail: a chart
+that only installs where its author put it has not been extracted, whatever
+registry it is published to.
+
+`namespaceOverride` stays for a release that genuinely wants to write outside
+the namespace it was installed into.
+*/}}
 {{- define "spindrift.namespace" -}}
-{{- default (include "spindrift.fullname" .) .Values.namespaceOverride }}
+{{- default .Release.Namespace .Values.namespaceOverride }}
 {{- end }}
 
 {{- define "spindrift.serviceAccountName" -}}

--- a/terraform/gcp/projects/bluenose/iam.tf
+++ b/terraform/gcp/projects/bluenose/iam.tf
@@ -31,6 +31,34 @@ resource "google_service_account_iam_member" "spindrift_controller_token_creator
   member             = local.spindrift_principal
 }
 
+# The clean-installation acceptance environment federates as this same account.
+#
+# The pool's subject is the cluster, the namespace and the service account, so a
+# second installation is a second subject however identical its deployment is —
+# it gets no access at all without these two, which is the shape working
+# correctly rather than an obstacle.
+#
+# Bound to the existing account rather than given its own. §14 puts identity
+# provisioning in this repository's Terraform and not in the product, so a
+# second account would exercise these files rather than anything Spindrift
+# does, at the price of duplicating every project role, both bucket grants and
+# the signer for an environment whose purpose is to be deleted. What it costs
+# is stated where the installation is declared: the acceptance installation can
+# reach everything the running one can.
+#
+# Deleting `clusters/offsite/apps/spindrift-acceptance` is what retires these.
+resource "google_service_account_iam_member" "spindrift_acceptance_workload_identity" {
+  service_account_id = google_service_account.spindrift_controller.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = local.spindrift_acceptance_principal
+}
+
+resource "google_service_account_iam_member" "spindrift_acceptance_token_creator" {
+  service_account_id = google_service_account.spindrift_controller.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = local.spindrift_acceptance_principal
+}
+
 # The roles the controller holds on this vessel. Declared in this file rather
 # than beside the module call for the reason services.tf gives: Spindrift's
 # generated remediation stanzas append `google_project_iam_member` resources

--- a/terraform/gcp/projects/bluenose/versions.tf
+++ b/terraform/gcp/projects/bluenose/versions.tf
@@ -9,6 +9,11 @@ locals {
   fml_pool = "iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool"
 
   spindrift_principal = "principal://${local.fml_pool}/subject/offsite:system:serviceaccount:spindrift:spindrift"
+
+  # The clean-installation acceptance environment, declared in
+  # clusters/offsite/apps/spindrift-acceptance. Same cluster, same service
+  # account name, different namespace — which is a different subject entirely.
+  spindrift_acceptance_principal = "principal://${local.fml_pool}/subject/offsite:system:serviceaccount:spindrift-acceptance:spindrift"
 }
 
 data "google_project" "current" {

--- a/turbo.json
+++ b/turbo.json
@@ -61,7 +61,8 @@
         "$TURBO_ROOT$/packages/charts/spindrift/Chart.yaml",
         "$TURBO_ROOT$/packages/charts/spindrift-app/Chart.yaml",
         "$TURBO_ROOT$/clusters/base/platform/spindrift-target/oci-repository.yaml",
-        "$TURBO_ROOT$/clusters/offsite/apps/spindrift/oci-repository.yaml"
+        "$TURBO_ROOT$/clusters/offsite/apps/spindrift/oci-repository.yaml",
+        "$TURBO_ROOT$/clusters/offsite/apps/spindrift-acceptance/oci-repository.yaml"
       ],
       "env": ["DATABASE_URL"],
       "outputs": []


### PR DESCRIPTION
The remaining acceptance criterion asks for enrolment, Target connection, archive-to-URL, repository-to-signed-artifact and second-Target admission **on a clean installation**. The running installation cannot answer it: it was seeded from a fully authored declaration and has been reconfigured in-product for months, so everything it demonstrates is about itself.

This adds a second installation — its own namespace, its own database, the published chart, and **no `manifest:` at all**. That is the state a first-time operator installs into, and the state the onboarding wizard exists for.

## It found the defect before it ran

`spindrift.namespace` defaulted to the release's own name rather than `.Release.Namespace`. So the published chart, installed anywhere but a namespace spelled the same as the release, wrote its Deployments, its CNPG Cluster and its Gateway into a namespace called `spindrift` — one that does not exist, or somebody else's installation.

That is not cosmetic for a chart whose whole claim is that it is extractable. It is fixed here, `namespaceOverride` kept as the escape hatch, and the chart version bumped to `0.1.4`.

**The running installation is provably unaffected** — its release name and its namespace are the same word, so the render does not move:

```text
$ diff <(helm template spindrift oci://…/spindrift --version 0.1.3 -n spindrift -f live-values.yaml) \
       <(helm template spindrift packages/charts/spindrift          -n spindrift -f live-values.yaml)
IDENTICAL — the running installation renders byte-for-byte the same
```

And the acceptance render now lands where it was installed:

```text
$ helm template spindrift packages/charts/spindrift -n spindrift-acceptance -f acc-values.yaml | grep '^  namespace:'
     10   namespace: spindrift-acceptance     ← was 10 × `namespace: spindrift`
```

## What it shares, and why

One thing: the GCP identity. The pool's subject is cluster + namespace + service account, so a second installation is a second subject and gets no access at all without a binding — the shape working correctly. The Terraform here binds that subject to the existing `spindrift-controller` rather than minting a second account: §14 puts identity provisioning in this repository rather than in the product, so a second account would exercise these files and not Spindrift, at the cost of duplicating every project role, both bucket grants and the signer for an environment whose purpose is to be deleted.

The consequence is stated where the installation is declared: it can reach everything the running one can, in the same projects. Its Apps get names nothing else uses.

Deliberately **not** included: a Kubernetes Target for it. That would want an Apps gateway with its own pinned address, a wildcard certificate and a zone. Its Targets are bluenose's cloud surfaces, which mint their own URLs.

## Validation

- `bun test` — 1977 pass, 0 fail across 142 files, against a real Postgres. `typecheck` and `lint` exit 0.
- `bash .github/scripts/render-cluster-apps.sh` — renders clean and picks up the new installation.
- `tofu validate` on the bluenose root — valid; `tofu fmt -check` clean.
- The chart-pin conformance test gains the new consumer, and `turbo.json`'s fast lane gains its file.

## Merge order

The `0.1.4` tag is published by `spindrift-charts.yml` on merge of this PR, so both `OCIRepository` objects fail to resolve for the few minutes between merge and publish. Neither release changes in that window — Flux keeps the last successful one — and this is the same window every chart version bump in this repository has.

## What happens next

The installation comes up unenrolled and unconfigured, which is the point. Closing the criterion needs a passkey enrolled against its real origin by a human, and then the chain driven through the product's own surfaces.