### PR TITLE
feat(bosun): give a class a scratch disk so warm depth stops costing RAM

### DIFF
--- a/apps/bosun/README.md
+++ b/apps/bosun/README.md
@@ -40,9 +40,11 @@ Path given via `-config`. Example:
   "tokenFile": "/run/secrets/bosun-github-token",
   "runtimeDir": "/run/bosun",
   "logDir": "/var/log/bosun",
+  "workspaceDir": "/var/lib/bosun/workspace",
   "pollInterval": "30s",
   "classes": {
-    "skiff-nixos": {"hull": "/nix/store/...-hull-nixos", "vcpus": 4, "memory": "4096M", "warm": 1, "maxLifetime": "1h"}
+    "skiff-nixos": {"hull": "/nix/store/...-hull-nixos", "vcpus": 4, "memory": "4096M", "warm": 1, "maxLifetime": "1h"},
+    "skiff-ubuntu": {"hull": "/nix/store/...-hull-ubuntu", "vcpus": 4, "memory": "3072M", "workspace": "6G", "warm": 2, "maxLifetime": "1h"}
   }
 }
 ```
@@ -52,6 +54,14 @@ Path given via `-config`. Example:
 the label a workflow's `runs-on:` matches against; it must never be
 `self-hosted`, which the existing ARC runners use, and LoadConfig rejects a
 class named that.
+
+A class's `workspace` sizes a scratch disk, reserved under `workspaceDir` at
+boot and deleted with the skiff. Without one, both hull families put the guest
+root on a tmpfs overlay and `memory` is the class's disk budget too, so a
+checkout that outgrows it is an OOM rather than an ENOSPC. The disk is handed
+over raw and appended after every hull-declared device, with its guest device
+name on the kernel cmdline as `bosun.workspace=` — what filesystem it carries
+is the hull's business, and bosun never learns what was written to it.
 
 `bin.cloudHypervisor` / `bin.virtiofsd` / `bin.passt` override the binaries
 bosun execs; unset ones resolve from `PATH`.

--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -14,7 +15,8 @@ type Config struct {
 	TokenFile    string           `json:"tokenFile"`
 	RuntimeDir   string           `json:"runtimeDir"`
 	LogDir       string           `json:"logDir"`
-	MetricsFile  string           `json:"metricsFile"` // empty disables; a node-exporter textfile, not a listener
+	WorkspaceDir string           `json:"workspaceDir"` // real storage, not tmpfs: it holds whole filesystem images
+	MetricsFile  string           `json:"metricsFile"`  // empty disables; a node-exporter textfile, not a listener
 	PollInterval Duration         `json:"pollInterval"`
 	Classes      map[string]Class `json:"classes"`
 	Bin          BinPaths         `json:"bin"`
@@ -24,9 +26,13 @@ type Config struct {
 // skiffs to keep warm, and the busy-time budget before a running skiff is
 // scuttled and replaced.
 type Class struct {
-	Hull        string   `json:"hull"`
-	VCPUs       int      `json:"vcpus"`
-	Memory      string   `json:"memory"` // passed through verbatim as cloud-hypervisor's --memory size=
+	Hull   string `json:"hull"`
+	VCPUs  int    `json:"vcpus"`
+	Memory string `json:"memory"` // passed through verbatim as cloud-hypervisor's --memory size=
+	// Workspace sizes a scratch disk for this class; empty means none, and
+	// then the class's memory is its disk budget, since both hull families
+	// put the guest root on a tmpfs overlay.
+	Workspace   string   `json:"workspace,omitempty"`
 	Warm        int      `json:"warm"`
 	MaxLifetime Duration `json:"maxLifetime"`
 }
@@ -60,6 +66,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 const (
 	defaultRuntimeDir   = "/run/bosun"
 	defaultLogDir       = "/var/log/bosun"
+	defaultWorkspaceDir = "/var/lib/bosun/workspace"
 	defaultPollInterval = 30 * time.Second
 
 	// defaultMaxLifetime backstops a class that declares no budget. It is a
@@ -118,6 +125,11 @@ func LoadConfig(path string) (*Config, error) {
 		if c.Memory == "" {
 			return nil, fmt.Errorf("config: class %s: memory is required", name)
 		}
+		if c.Workspace != "" {
+			if _, err := parseSize(c.Workspace); err != nil {
+				return nil, fmt.Errorf("config: class %s: workspace: %w", name, err)
+			}
+		}
 		if c.Warm <= 0 {
 			return nil, fmt.Errorf("config: class %s: warm must be positive", name)
 		}
@@ -133,8 +145,37 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.LogDir == "" {
 		cfg.LogDir = defaultLogDir
 	}
+	if cfg.WorkspaceDir == "" {
+		cfg.WorkspaceDir = defaultWorkspaceDir
+	}
 	if cfg.PollInterval == 0 {
 		cfg.PollInterval = Duration(defaultPollInterval)
 	}
 	return &cfg, nil
+}
+
+// parseSize turns "6G", "512M" or a bare byte count into bytes, taking the
+// same suffixes cloud-hypervisor's --memory size= does so a class's two size
+// fields read alike.
+func parseSize(s string) (int64, error) {
+	mult := int64(1)
+	if s != "" {
+		switch s[len(s)-1] {
+		case 'K', 'k':
+			mult = 1 << 10
+		case 'M', 'm':
+			mult = 1 << 20
+		case 'G', 'g':
+			mult = 1 << 30
+		}
+	}
+	digits := s
+	if mult > 1 {
+		digits = s[:len(s)-1]
+	}
+	n, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid size %q", s)
+	}
+	return n * mult, nil
 }

--- a/apps/bosun/config_test.go
+++ b/apps/bosun/config_test.go
@@ -80,3 +80,35 @@ func TestDurationUnmarshal(t *testing.T) {
 		t.Fatal("expected error for invalid duration string")
 	}
 }
+
+func TestParseSize(t *testing.T) {
+	for in, want := range map[string]int64{
+		"6G":   6 << 30,
+		"512M": 512 << 20,
+		"64k":  64 << 10,
+		"4096": 4096,
+	} {
+		got, err := parseSize(in)
+		if err != nil {
+			t.Errorf("parseSize(%q): %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("parseSize(%q) = %d, want %d", in, got, want)
+		}
+	}
+	for _, in := range []string{"", "0", "-1G", "6GB", "big", "G"} {
+		if _, err := parseSize(in); err == nil {
+			t.Errorf("parseSize(%q): expected an error", in)
+		}
+	}
+}
+
+func TestLoadConfigRejectsUnparseableWorkspaceSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{"repo":"acme/widgets","tokenFile":"/x","classes":{"skiff-test":{"hull":"/h","vcpus":1,"memory":"512M","workspace":"lots","warm":1}}}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected an error for an unparseable workspace size")
+	}
+}

--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 )
 
 // hullManifest is hull.json: the declared shape of a microVM image. bosun
@@ -66,6 +67,7 @@ func loadHull(dir string) (*hull, error) {
 	}
 
 	shipped := []string{m.Kernel, m.Initrd}
+	disks := 0
 	for i, dev := range m.Devices {
 		switch {
 		case dev.Share != nil && dev.Disk == nil:
@@ -74,9 +76,16 @@ func loadHull(dir string) (*hull, error) {
 				return nil, fmt.Errorf("hull manifest %s: devices[%d].disk.path is required", dir, i)
 			}
 			shipped = append(shipped, dev.Disk.Path)
+			disks++
 		default:
 			return nil, fmt.Errorf("hull manifest %s: devices[%d] must declare exactly one of share or disk", dir, i)
 		}
+	}
+	// Guest disk names run /dev/vda..vdz, and bosun may append a workspace
+	// disk after whatever the hull declared. Past this the name it puts on the
+	// cmdline would be wrong rather than missing, so the manifest is rejected.
+	if disks > maxHullDisks {
+		return nil, fmt.Errorf("hull manifest %s: %d disks exceeds the %d guest device names available", dir, disks, maxHullDisks)
 	}
 
 	// ponytail: hashes every shipped file (a rootfs disk is GBs) on each
@@ -102,6 +111,18 @@ func hashFile(w io.Writer, path string) error {
 	return err
 }
 
+// maxHullDisks leaves one of the 26 /dev/vd? names for bosun's workspace
+// disk, which is always appended last.
+const maxHullDisks = 25
+
+// guestDiskName is the device cloud-hypervisor presents for the nth --disk,
+// in declaration order. bosun tells the guest this name rather than letting
+// it count, because an index shifts with whatever the hull declared while a
+// name handed over on the cmdline does not.
+func guestDiskName(n int) string {
+	return "/dev/vd" + string(rune('a'+n))
+}
+
 // maxSockPathLen is Linux's sockaddr_un.sun_path capacity minus its NUL
 // terminator (108 bytes total). A longer path truncates silently and the
 // VMM that tries to connect never starts.
@@ -121,6 +142,7 @@ func sockPath(dir, name string) (string, error) {
 // exactly one place.
 type skiffPaths struct {
 	dir         string   // runtimeDir/<id> — the credential share and bosun's entire state for this skiff
+	workspace   string   // workspaceDir/<id>.img — empty unless the class sizes a scratch disk
 	credSock    string   // runtimeDir/<id>.fs
 	diagDir     string   // logDir/<id>.diag — the guest's runner _diag, written through to the host
 	diagSock    string   // runtimeDir/<id>.diag.fs
@@ -183,6 +205,11 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 // (tag "bosun-diag", the only writable path a guest has). Both tags are fixed
 // by contract with the guest, and both are present even when the hull
 // declares no devices at all.
+//
+// A workspace disk, when the class sizes one, goes *after* every hull device,
+// so the hull's own disks keep the indices it built around. It carries no
+// filesystem: what a workspace holds is the hull's business, the same way its
+// rootfs is, and bosun never learns what was put there.
 func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 	args := []string{
 		"--kernel", filepath.Join(h.dir, h.manifest.Kernel),
@@ -192,6 +219,7 @@ func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 		"--fs", fmt.Sprintf("tag=bosun,socket=%s", p.credSock),
 		"--fs", fmt.Sprintf("tag=bosun-diag,socket=%s", p.diagSock),
 	}
+	disks := 0
 	for i, dev := range h.manifest.Devices {
 		switch {
 		case dev.Share != nil:
@@ -202,16 +230,43 @@ func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 				ro = "on"
 			}
 			args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=%s", filepath.Join(h.dir, dev.Disk.Path), ro))
+			disks++
 		}
+	}
+	cmdline := h.manifest.Cmdline
+	if p.workspace != "" {
+		args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=off", p.workspace))
+		cmdline += " bosun.workspace=" + guestDiskName(disks)
 	}
 	args = append(args,
 		"--net", fmt.Sprintf("vhost_user=on,socket=%s", p.netSock),
 		"--api-socket", p.apiSock,
 		"--console", "off",
 		"--serial", fmt.Sprintf("file=%s", p.logFile),
-		"--cmdline", fmt.Sprintf("%s bosun.skiff=%s bosun.hull=sha256:%s", h.manifest.Cmdline, id, h.digest),
+		"--cmdline", fmt.Sprintf("%s bosun.skiff=%s bosun.hull=sha256:%s", cmdline, id, h.digest),
 	)
 	return args
+}
+
+// createWorkspace reserves and creates one skiff's scratch disk. Reserved
+// rather than sparse on purpose: taking the workspace off the class's memory
+// is the whole point, and a sparse file would move the overcommit onto the
+// host filesystem instead of removing it. A pool that cannot fit fails a
+// spawn, which is visible, rather than a build mid-run, which is not.
+func createWorkspace(path, size string) error {
+	n, err := parseSize(size)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return syscall.Fallocate(int(f.Fd()), 0, 0, n)
 }
 
 // virtiofsdArgs builds one virtiofsd instance's argv, shared by the

--- a/apps/bosun/hull_test.go
+++ b/apps/bosun/hull_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"testing"
 )
 
@@ -295,5 +296,103 @@ func TestLoadHullRequiresFields(t *testing.T) {
 func TestLoadHullMissingFile(t *testing.T) {
 	if _, err := loadHull(t.TempDir()); err == nil {
 		t.Fatal("expected error for missing hull.json")
+	}
+}
+
+// The workspace disk goes after the hull's own disks so their indices are
+// untouched, and the guest is told the name rather than left to count.
+func TestChArgsWorkspaceDiskComesLastAndIsNamedOnTheCmdline(t *testing.T) {
+	h := &hull{
+		dir: "/hulls/ubuntu",
+		manifest: hullManifest{
+			Kernel: "vmlinux", Initrd: "initrd", Cmdline: "console=ttyS0",
+			Devices: []hullDevice{{Disk: &hullDisk{Path: "rootfs.img", RO: true}}},
+		},
+		digest: "deadbeef",
+	}
+	class := Class{VCPUs: 4, Memory: "3072M", Workspace: "6G"}
+	paths, err := resolvePaths("/run/bosun", "/var/log/bosun", "sk09", h.manifest.Devices)
+	if err != nil {
+		t.Fatalf("resolvePaths: %v", err)
+	}
+	paths.workspace = "/var/lib/bosun/workspace/sk09.img"
+
+	got := chArgs(h, class, "sk09", paths)
+	want := []string{
+		"--kernel", "/hulls/ubuntu/vmlinux",
+		"--initramfs", "/hulls/ubuntu/initrd",
+		"--cpus", "boot=4",
+		"--memory", "size=3072M,shared=on",
+		"--fs", "tag=bosun,socket=/run/bosun/sk09.fs",
+		"--fs", "tag=bosun-diag,socket=/run/bosun/sk09.diag.fs",
+		"--disk", "path=/hulls/ubuntu/rootfs.img,readonly=on",
+		"--disk", "path=/var/lib/bosun/workspace/sk09.img,readonly=off",
+		"--net", "vhost_user=on,socket=/run/bosun/sk09.net",
+		"--api-socket", "/run/bosun/sk09.api",
+		"--console", "off",
+		"--serial", "file=/var/log/bosun/sk09.log",
+		// vdb, not vda: the hull's rootfs holds vda.
+		"--cmdline", "console=ttyS0 bosun.workspace=/dev/vdb bosun.skiff=sk09 bosun.hull=sha256:deadbeef",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("argv mismatch:\n got:  %v\n want: %v", got, want)
+	}
+}
+
+// A class with no workspace must produce exactly the argv it produced before
+// the option existed: no disk, and nothing extra on the cmdline.
+func TestChArgsNoWorkspaceLeavesCmdlineAlone(t *testing.T) {
+	h := &hull{
+		dir:      "/hulls/nixos",
+		manifest: hullManifest{Kernel: "vmlinux", Initrd: "initrd", Cmdline: "console=ttyS0"},
+		digest:   "deadbeef",
+	}
+	paths, err := resolvePaths("/run/bosun", "/var/log/bosun", "sk10", nil)
+	if err != nil {
+		t.Fatalf("resolvePaths: %v", err)
+	}
+	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk10", paths)
+	if slices.Contains(got, "--disk") {
+		t.Fatalf("workspace-less class got a disk: %v", got)
+	}
+	if !slices.Contains(got, "console=ttyS0 bosun.skiff=sk10 bosun.hull=sha256:deadbeef") {
+		t.Fatalf("cmdline changed: %v", got)
+	}
+}
+
+// The reservation is the whole reason the disk exists: a sparse file would
+// move the overcommit onto the host filesystem rather than remove it.
+func TestCreateWorkspaceReservesTheWholeSize(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nested", "sk11.img")
+	if err := createWorkspace(path, "2M"); err != nil {
+		t.Fatalf("createWorkspace: %v", err)
+	}
+	var st syscall.Stat_t
+	if err := syscall.Stat(path, &st); err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if st.Size != 2<<20 {
+		t.Errorf("size = %d, want %d", st.Size, 2<<20)
+	}
+	// 512-byte blocks: a sparse file of this size reports far fewer.
+	if want := int64(2 << 20 / 512); st.Blocks < want {
+		t.Errorf("allocated %d blocks, want at least %d -- the file is sparse", st.Blocks, want)
+	}
+
+	if err := createWorkspace(path, "nonsense"); err == nil {
+		t.Fatal("expected an error for an unparseable size")
+	}
+}
+
+func TestLoadHullRejectsMoreDisksThanGuestDeviceNames(t *testing.T) {
+	dir := t.TempDir()
+	devices := make([]hullDevice, maxHullDisks+1)
+	for i := range devices {
+		devices[i] = hullDevice{Disk: &hullDisk{Path: "rootfs.img"}}
+	}
+	hullDir := writeTestHull(t, dir, "toomany", devices)
+	writeFile(t, filepath.Join(hullDir, "rootfs.img"), "rootfs-bytes")
+	if _, err := loadHull(hullDir); err == nil {
+		t.Fatal("expected an error for a hull declaring more disks than there are device names")
 	}
 }

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -26,6 +26,7 @@ let
       tokenFile
       runtimeDir
       logDir
+      workspaceDir
       metricsFile
       ;
     pollInterval = cfg.pollInterval;
@@ -34,6 +35,7 @@ let
         hull
         vcpus
         memory
+        workspace
         warm
         maxLifetime
         ;
@@ -100,6 +102,19 @@ in
       '';
     };
 
+    workspaceDir = mkOption {
+      type = types.str;
+      default = "/var/lib/bosun/workspace";
+      description = ''
+        Where per-skiff scratch disks are reserved, for classes that size one
+        with {option}`classes.<name>.workspace`. Must be real storage, not
+        tmpfs: the whole point is to stop charging a build's bytes against the
+        class's memory. Each image is fully allocated at boot and deleted when
+        its skiff is scuttled, so `warm × workspace` per class is the space
+        this host must keep free.
+      '';
+    };
+
     logRetention = mkOption {
       type = types.str;
       default = "7d";
@@ -159,13 +174,30 @@ in
               type = types.str;
               default = "4096M";
             };
+            workspace = mkOption {
+              type = types.str;
+              default = "";
+              example = "6G";
+              description = ''
+                Size of a scratch disk handed to each skiff of this class, or
+                empty for none. Both hull families put the guest root on a
+                tmpfs overlay, so without one a class's {option}`memory` is
+                also its disk budget and a checkout that outgrows it is an OOM
+                rather than an ENOSPC.
+
+                The disk is raw: what filesystem it carries is the hull's
+                business, and bosun never learns what was written to it.
+              '';
+            };
             warm = mkOption {
               type = types.ints.unsigned;
               default = 1;
               description = ''
                 How many skiffs of this class to keep booted and registered.
                 Each holds its memory for as long as it idles, so this is
-                bounded by RAM rather than by cores.
+                bounded by RAM rather than by cores — and by disk too, once
+                {option}`workspace` is set, since that space is reserved up
+                front rather than as a build uses it.
               '';
             };
             maxLifetime = mkOption {
@@ -208,7 +240,15 @@ in
     # Nothing in bosun deletes a retired skiff's logs, so this is the only
     # bound on logDir: one directory per skiff ever booted, plus whatever job
     # code chose to write into the diagnostic share.
-    systemd.tmpfiles.rules = [ "e ${cfg.logDir} - - - ${cfg.logRetention}" ];
+    #
+    # The workspace directory is tmpfiles' rather than a second
+    # StateDirectory=, because StateDirectoryMode is per-unit and the metrics
+    # directory below has to stay 0755 for node-exporter while a skiff's
+    # scratch disk should not be readable by anything else on the host.
+    systemd.tmpfiles.rules = [
+      "e ${cfg.logDir} - - - ${cfg.logRetention}"
+      "d ${cfg.workspaceDir} 0700 bosun bosun -"
+    ];
 
     systemd.services.bosun = {
       description = "warm pool of ephemeral microVM Actions runners";
@@ -252,6 +292,10 @@ in
         # an explicit ReadWritePaths instead.
         StateDirectory = "prometheus-node-exporter-text-files";
         StateDirectoryMode = "0755";
+
+        # ProtectSystem=strict makes everything outside the unit's own
+        # runtime/state/logs read-only, and the workspace directory is neither.
+        ReadWritePaths = [ cfg.workspaceDir ];
 
         # Every skiff is a child of this unit, so one filter covers the whole
         # pool: job code reaches the public internet and nothing on the LAN.

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -131,6 +131,12 @@ func (p *pool) sweep(ctx context.Context) error {
 			p.logger.Warn("sweep: remove stale state", "path", path, "error", err)
 		}
 	}
+	// Workspace images sit on real storage rather than tmpfs, so unlike
+	// everything above they survive a reboot as well as a restart, and nothing
+	// else ever deletes one whose skiff was killed with the cgroup.
+	if err := os.RemoveAll(p.cfg.WorkspaceDir); err != nil {
+		p.logger.Warn("sweep: remove stale workspaces", "path", p.cfg.WorkspaceDir, "error", err)
+	}
 	return nil
 }
 
@@ -171,6 +177,9 @@ func (p *pool) spawn(ctx context.Context, className string) {
 	if err != nil {
 		logger.Error("resolve paths", "error", err)
 		return
+	}
+	if class.Workspace != "" {
+		paths.workspace = filepath.Join(p.cfg.WorkspaceDir, id+".img")
 	}
 
 	// Mint immediately before boot, never stockpiled: the config expires
@@ -232,6 +241,14 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 		return fmt.Errorf("open helpers log: %w", err)
 	}
 	s.helpersLog = helpersLog
+
+	// Before any helper, so a host that cannot spare the space costs one
+	// failed spawn rather than four processes to unwind.
+	if s.paths.workspace != "" {
+		if err := createWorkspace(s.paths.workspace, class.Workspace); err != nil {
+			return fmt.Errorf("create workspace disk: %w", err)
+		}
+	}
 
 	virtiofsd := binPath(p.cfg.Bin.Virtiofsd, "virtiofsd")
 
@@ -342,8 +359,13 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 	}
 
 	// diagDir is deliberately not removed: it is the evidence, and this is
-	// the path a wedged skiff's own death takes.
+	// the path a wedged skiff's own death takes. The workspace is, and must
+	// be — it is the one thing bosun reserves that a reboot would not free,
+	// and it is where untrusted job code wrote.
 	os.RemoveAll(s.paths.dir)
+	if s.paths.workspace != "" {
+		os.Remove(s.paths.workspace)
+	}
 	// Each helper drops a sidecar file beside its socket -- virtiofsd a
 	// "<sock>.pid", passt a "<sock>.repair" -- and neither is cleaned up by
 	// the helper on the way out. Removing only the sockets leaked both for as

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 )
@@ -17,9 +18,10 @@ func testPool(t *testing.T) (*pool, *fakeGitHub, *fakeLaunch) {
 	dir := t.TempDir()
 	hullDir := writeTestHull(t, dir, "hull", nil)
 	cfg := &Config{
-		Repo:       "acme/widgets",
-		RuntimeDir: filepath.Join(dir, "run"),
-		LogDir:     filepath.Join(dir, "log"),
+		Repo:         "acme/widgets",
+		RuntimeDir:   filepath.Join(dir, "run"),
+		LogDir:       filepath.Join(dir, "log"),
+		WorkspaceDir: filepath.Join(dir, "workspace"),
 		Classes: map[string]Class{
 			"skiff-test": {Hull: hullDir, VCPUs: 1, Memory: "512M", Warm: 1, MaxLifetime: Duration(time.Hour)},
 		},
@@ -458,5 +460,52 @@ func TestTransientOfflineDoesNotKill(t *testing.T) {
 	p.mu.Unlock()
 	if !stillThere || n != 1 {
 		t.Fatalf("a skiff that never hit %d consecutive offline polls was killed anyway (present=%v, pool=%d)", wedgeThreshold, stillThere, n)
+	}
+}
+
+// A workspace image is reserved on real storage, so unlike everything else a
+// skiff leaves behind it does not evaporate with a tmpfs — retire has to
+// delete it, and sweep has to collect whatever a cgroup kill left.
+func TestWorkspaceDiskIsCreatedOnBootAndDeletedOnRetire(t *testing.T) {
+	p, _, fl := testPool(t)
+	class := p.cfg.Classes["skiff-test"]
+	class.Workspace = "1M"
+	p.cfg.Classes["skiff-test"] = class
+	ctx := context.Background()
+
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+
+	if s.paths.workspace == "" {
+		t.Fatal("class sizes a workspace but the skiff got no image path")
+	}
+	if _, err := os.Stat(s.paths.workspace); err != nil {
+		t.Fatalf("workspace image missing after boot: %v", err)
+	}
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	if !slices.Contains(chCall.args, "path="+s.paths.workspace+",readonly=off") {
+		t.Fatalf("workspace disk missing from argv: %v", chCall.args)
+	}
+
+	p.retire(ctx, s, testLogger())
+	if _, err := os.Stat(s.paths.workspace); !os.IsNotExist(err) {
+		t.Fatalf("workspace image survived retire: %v", err)
+	}
+}
+
+func TestSweepClearsOrphanedWorkspaceImages(t *testing.T) {
+	p, _, _ := testPool(t)
+	orphan := filepath.Join(p.cfg.WorkspaceDir, "deadbeef.img")
+	if err := createWorkspace(orphan, "1M"); err != nil {
+		t.Fatalf("createWorkspace: %v", err)
+	}
+	if err := p.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
+		t.Fatalf("orphaned workspace survived sweep: %v", err)
 	}
 }

--- a/docs/pages/Architecture___Bosun.md
+++ b/docs/pages/Architecture___Bosun.md
@@ -8,7 +8,7 @@ tags:: architecture
 	  | **skiff** | one microVM serving exactly one job, then halting |
 	  | **bosun** | the daemon that keeps skiffs alive, and the project |
 	  | **hull** | the immutable kernel + initrd + manifest a skiff boots from |
-	  | **class** | what a `runs-on:` label resolves to — which hull, how many vCPUs, how much memory |
+	  | **class** | what a `runs-on:` label resolves to — which hull, how many vCPUs, how much memory and scratch disk |
 	- GitHub owns `runner`, `job`, `workflow` and `label`; those words appear in YAML this project does not control, so they are never reused for anything here.
 - ## Warm pool, not dispatch
 	- A JIT-registered runner is ephemeral by construction: it runs one job, deregisters itself, and exits. So bosun keeps N skiffs booted and registered, and **GitHub hands one a matching job unprompted**.
@@ -44,4 +44,6 @@ tags:: architecture
 - ## Trying it
 	- `.github/workflows/skiff-smoke.yml` is a `workflow_dispatch` job on `runs-on: skiff-nixos`. It asserts what a skiff does differently: the warm shared store, the writable overlay, `nix-ld` resolving the FHS interpreter downloaded release binaries ask for, and socket-activated Docker.
 	- Inspect a host with `systemctl status bosun` and `journalctl -u bosun`. Under the module's `logDir`, each skiff leaves its serial console as `<id>.log`, and an Ubuntu-hull skiff also leaves the runner's own trace in `<id>.diag/` — a writable virtiofs share, so it lands on the host *while* the job runs and survives a skiff killed mid-job. bosun offers that share to every skiff; the NixOS hull does not mount it yet, so a `skiff-nixos` `<id>.diag/` is empty. Both outlive the skiff and are aged out by `logRetention`.
-	- A class's `memory` is also its **disk budget**: the whole guest root is a tmpfs overlay, so a checkout plus build that outgrows it is an OOM rather than an `ENOSPC`. A real virtio-blk workspace is the answer past that, not a bigger number.
+	- A class's `memory` is also its **disk budget** unless the class sizes a `workspace`: the whole guest root is a tmpfs overlay, so a checkout plus build that outgrows it is an OOM rather than an `ENOSPC`.
+	- A `workspace` is a virtio-blk scratch disk, reserved under the module's `workspaceDir` at boot and deleted with the skiff. bosun appends it after every hull-declared device and names it on the cmdline as `bosun.workspace=`, because a device index shifts with what the hull declared and a name does not. It is handed over raw — the Ubuntu hull formats it and puts the runner's workspace and docker's data root there, which is what lets a class hold more warm skiffs than its memory alone would allow. What the disk carries is the hull's business; bosun never learns what was written to it.
+	- The space is reserved up front, not as a build uses it, so `warm × workspace` per class is what the host must keep free — an overcommitted pool fails a spawn, which is visible, rather than a build mid-run, which is not.

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -63,31 +63,33 @@
       warm = 1;
     };
     # The FHS family: apt, dockerd, and the ARC image's toolchain, no Nix.
-    # More memory than skiff-nixos because jobs here apt-get and docker build
-    # inside the guest rather than leaning on a warm host store -- and because
-    # the whole guest root is a tmpfs overlay, so this number is the class's
-    # disk budget as much as its RAM. A checkout plus a docker build that
-    # exceeds it is an OOM, not an ENOSPC. 8192M against riptide's ~10 GiB
-    # free is the ceiling while kubelet shares the host; past that the answer
-    # is a real workspace disk, not a bigger number.
+    # A scratch disk carries the runner's workspace and docker's data root, so
+    # `memory` here is a RAM figure and nothing else -- without one the guest
+    # root is a tmpfs overlay and a checkout that outgrows the class is an OOM
+    # rather than an ENOSPC. 6G is generous for this repo's real workload
+    # (checkout, bun store, one build) and the two of them reserve 12 GiB of
+    # the ~20 GiB free on riptide's root filesystem.
+    #
+    # warm = 2 is the point of the disk: the bench measured a second
+    # skiff-ubuntu job waiting three minutes for the first to finish, which is
+    # what blocks migrating anything real onto skiffs.
     classes.skiff-ubuntu = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       vcpus = 4;
-      memory = "8192M";
-      warm = 1;
+      memory = "3072M";
+      workspace = "6G";
+      warm = 2;
     };
   };
 
-  # The pool's declared ceiling is 2048M + 8192M = 10 GiB, which riptide does
-  # not have to spare: 15.2 GiB total, ~5 GiB held by kubelet and the system,
-  # and no swap. Only a skiff-nixos job peaking at the same time as a
-  # skiff-ubuntu one gets there -- warm=1 serialises within a label but not
-  # across them -- and without a bound the *host* OOM killer picks the victim,
-  # which on a worker node may be a pod or kubelet rather than a skiff.
+  # The pool's declared ceiling is 2048M + 2x3072M = 8 GiB, inside the limit
+  # below with room to spare: riptide has 15.2 GiB total, ~5 GiB held by
+  # kubelet and the system, and no swap. Without a bound the *host* OOM killer
+  # picks the victim, which on a worker node may be a pod or kubelet rather
+  # than a skiff.
   #
-  # 9G clears the realistic worst case (one 8192M guest plus the other class
-  # idling, ~8.8 GiB) and stops the pathological one inside bosun's own
-  # cgroup. Every skiff is a child of this unit, so the limit covers the whole
-  # pool the same way IPAddressDeny does.
+  # Every skiff is a child of this unit, so the limit covers the whole pool
+  # the same way IPAddressDeny does. Raising warm further is now a disk
+  # question before it is a memory one -- see services.bosun.workspaceDir.
   systemd.services.bosun.serviceConfig.MemoryMax = "9G";
 }

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -4,7 +4,9 @@
 # boots. The rootfs is the repo's own ARC runner image — the exact filesystem
 # every `runs-on: offsite` job already passes on — flattened into a read-only
 # squashfs handed to the guest as a virtio-blk disk. Writes land in a tmpfs
-# overlay upper, so a skiff still leaves nothing behind.
+# overlay upper, so a skiff still leaves nothing behind. Where the class sizes
+# a scratch disk, the workspace and docker's data root move onto it instead, so
+# a build's bytes stop being charged against the class's memory.
 #
 # Nix builds all of it, but none of it reaches the guest: no /nix/store, no
 # store share, no Nix database. "No Nix in the cloud" is about the guest, not
@@ -137,10 +139,35 @@ let
     $bb ip link set eth0 up
     $bb udhcpc -i eth0 -q -n -s /opt/bosun/udhcpc-script
 
-    # A plain tmpfs: docker's overlayfs snapshotter cannot put upper/work
-    # dirs on the root overlay itself (EINVAL on mount).
-    $bb mkdir -p /var/lib/docker
-    $bb mount -t tmpfs -o mode=0710 tmpfs /var/lib/docker
+    # The scratch disk, when the class sized one. bosun appends it after
+    # every disk this hull declared and names it on the cmdline, because an
+    # index shifts with what the hull declared and a name does not.
+    #
+    # Formatting is this hull's business: bosun hands over a raw device and
+    # never learns what goes on it, the same seam that lets the rootfs above
+    # be a squashfs. Lazy init because the filesystem lives exactly as long as
+    # the skiff does -- nobody is left to benefit from an eager inode table.
+    #
+    # Both the runner's workspace and docker's data root land here, which is
+    # what takes them off the class's memory: without a disk they are tmpfs,
+    # and `memory` is the disk budget.
+    work=$($bb sed -n 's/.*bosun\.workspace=\([^ ]*\).*/\1/p' /proc/cmdline)
+    $bb mkdir -p /var/lib/docker /home/runner/_work
+    if [ -n "$work" ]; then
+      $bb modprobe ext4
+      /usr/sbin/mkfs.ext4 -Fq -m0 -E lazy_itable_init=1,lazy_journal_init=1 "$work"
+      $bb mkdir -p /mnt/skiff
+      $bb mount -t ext4 "$work" /mnt/skiff
+      $bb mkdir -p /mnt/skiff/work /mnt/skiff/docker
+      $bb chmod 0710 /mnt/skiff/docker
+      $bb mount -o bind /mnt/skiff/work /home/runner/_work
+      $bb mount -o bind /mnt/skiff/docker /var/lib/docker
+    else
+      # A plain tmpfs: docker's overlayfs snapshotter cannot put upper/work
+      # dirs on the root overlay itself (EINVAL on mount).
+      $bb mount -t tmpfs -o mode=0710 tmpfs /var/lib/docker
+    fi
+    echo "skiff-mark workspace-ready $($bb cut -d' ' -f1 /proc/uptime)"
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
       dockerd >/var/log/dockerd.log 2>&1 &
     echo "skiff-mark setup-done $($bb cut -d' ' -f1 /proc/uptime)"


### PR DESCRIPTION
## Why

The runner bench measured a second `skiff-ubuntu` job waiting three minutes for the first to finish. At `warm = 1` there is no second skiff, and concurrency — not speed — is what blocks moving real workflows onto skiffs. On compute a skiff already matches `ubuntu-latest`.

Raising `warm` was not available. Both hull families put the guest root on a tmpfs overlay, so `skiff-ubuntu`'s 8192M was a disk budget wearing a memory number, and two of them did not fit riptide alongside kubelet.

## What

A class can size a `workspace`. bosun reserves an image under `workspaceDir`, appends it as a `--disk` **after** every hull-declared device so the hull's own disks keep the indices it was built around, and puts the guest device name on the cmdline as `bosun.workspace=` — a device index shifts with what the hull declared, a name handed over does not.

The disk is handed over raw. The Ubuntu hull formats it and mounts the runner's workspace and docker's data root there; what filesystem a workspace carries is the hull's business, the same seam that lets one hull ship a squashfs rootfs and the other none at all. A class with no `workspace` produces byte-identical argv to before.

Reserved rather than sparse: a sparse file would move the overcommit onto the host filesystem instead of removing it. An overcommitted pool fails a spawn, which is visible, rather than a build mid-run, which is not — so `warm × workspace` per class is what a host must keep free.

riptide's `skiff-ubuntu` becomes 3072M of real RAM, a 6G disk, and `warm = 2`. The whole declared pool is 8 GiB, inside the existing 9G `MemoryMax` with room to spare; the two disks reserve 12 GiB of the ~20 GiB free on root.

## Validation

- `go build ./... && go vet ./... && go test ./...` in `apps/bosun` — green, including new coverage for the argv ordering, the cmdline device name, the reservation being non-sparse, deletion on retire, and sweep collecting an orphaned image.
- `nixos-rebuild build --flake .#riptide --build-host riptide.lolwtf.ca` — clean; generated `bosun.json` carries the new fields.
- `mise run docs:check` — green.
- **Not yet run live.** A deploy to riptide and a `skiff-ubuntu` job proving the guest mounts the disk is the remaining check.

## Risks

- The guest formats with `/usr/sbin/mkfs.ext4` from the pinned ARC runner image; verified present in the current rootfs. A base-image change that drops e2fsprogs would break boot for a class with a workspace.
- Disk, not memory, is now the bound on `warm` for `skiff-ubuntu` on riptide.