### PR TITLE
fix(spindrift): let a stand-in declaration govern nothing

### DIFF
--- a/.github/containers.json
+++ b/.github/containers.json
@@ -34,7 +34,8 @@
       "clusters/folly/apps/tronbyt/07-rackstat-deployment.yaml"
     ],
     "spindrift": [
-      "clusters/offsite/apps/spindrift/helm-release.yaml"
+      "clusters/offsite/apps/spindrift/helm-release.yaml",
+      "clusters/offsite/apps/spindrift-acceptance/helm-release.yaml"
     ]
   },
   "ignore": [

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -68,14 +68,35 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           has_changes="$ANY_CHANGED"
-          release=clusters/offsite/apps/spindrift/helm-release.yaml
 
-          # Continuous delivery only rewrites this image digest. The rest of
-          # the release is a conformance-test input and remains significant.
-          if [[ "$ALL_CHANGED_FILES" == "$release" ]] &&
-            git diff --quiet \
+          # Every release continuous delivery stamps this image's digest into,
+          # from `.github/containers.json`. Plural since the clean-installation
+          # acceptance environment consumes the same image: one bump rewrites
+          # both files, so a check that only knew the first would run the whole
+          # suite on every digest bump forever.
+          releases=(
+            clusters/offsite/apps/spindrift/helm-release.yaml
+            clusters/offsite/apps/spindrift-acceptance/helm-release.yaml
+          )
+
+          # Continuous delivery only rewrites the image digest. The rest of each
+          # release is a conformance-test input and remains significant, so this
+          # skips only when every changed file is one of those releases and
+          # every one of them differs at nothing but that line.
+          only_digests=true
+          for changed in $ALL_CHANGED_FILES; do
+            known=false
+            for release in "${releases[@]}"; do
+              [[ "$changed" == "$release" ]] && known=true && break
+            done
+            if ! "$known" || ! git diff --quiet \
               --ignore-matching-lines='^[[:space:]]*image: ghcr\.io/jonpulsifer/spindrift:latest@sha256:[[:xdigit:]]{64}$' \
-              "$BASE_SHA" "$HEAD_SHA" -- "$release"; then
+              "$BASE_SHA" "$HEAD_SHA" -- "$changed"; then
+              only_digests=false
+              break
+            fi
+          done
+          if [[ -n "$ALL_CHANGED_FILES" ]] && "$only_digests"; then
             has_changes=false
           fi
 

--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -60,7 +60,10 @@ import {
   type AuthoredManifest,
   toAuthoredManifest,
 } from '../../config/manifest.schema.ts';
-import { isUnconfiguredInstallation } from '../../config/manifest.ts';
+import {
+  governingDeclaration,
+  isUnconfiguredInstallation,
+} from '../../config/manifest.ts';
 import { type Command, ok } from '../types.ts';
 
 export const getInstallationManifestInput = z.object({}).strict();
@@ -84,6 +87,23 @@ export interface GetInstallationManifestResult {
    * for a round trip to disagree about.
    */
   readonly declaration: AuthoredManifest | null;
+  /**
+   * Whether that declaration takes the governed slice back on every boot.
+   *
+   * `false` for no declaration, and — the case this field exists for — `false`
+   * for a declaration that is the chart's stand-in, which governs nothing
+   * (`governingDeclaration`). The editing surface reads it to decide whether to
+   * lock the two vessels' fields, and it must reach the same answer
+   * `configureInstallation` will: a field locked against a write that would
+   * have been accepted is a screen refusing on the server's behalf and getting
+   * it wrong, which on a chart-only installation is the wizard refusing the
+   * only two values it exists to collect.
+   *
+   * A boolean rather than the predicate itself, because answering it needs
+   * `DEFAULT_PLACEHOLDER_MANIFEST` and the module that holds it is not one the
+   * client bundle may import.
+   */
+  readonly declarationGoverns: boolean;
   /**
    * Dotted paths where {@link declaration} disagrees with the manifest above,
    * or `[]` when nothing is mounted or the two agree. Paths only — see
@@ -125,6 +145,7 @@ export const getInstallationManifest: Command<
   return ok({
     manifest,
     declaration: context.declaration ?? null,
+    declarationGoverns: governingDeclaration(context.declaration) !== null,
     declarationDivergence: context.declarationDivergence ?? [],
     // The authored document, not the resolved one: the deployment's federation
     // is joined onto `context.manifest` per read, and the predicate reads keys

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -19,6 +19,7 @@ import {
 } from './manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
+  governingDeclaration,
   loadManifestIfPresent,
   ManifestError,
   resolveManifest,
@@ -75,12 +76,17 @@ export async function loadStoredManifest(
       `installation manifest: the stored manifest is not valid for this build, so this installation is being re-seeded from the mounted declaration — anything configured through the UI that the declaration does not carry is lost: ${unreadable.message}`,
     );
   }
+  // Seeding takes the declaration whatever it is — a stand-in carrying this
+  // release's own hostname is the whole of what makes a chart-only install
+  // reachable (ticket 77). Governing is the other half of the same document and
+  // does not follow: see {@link governingDeclaration}.
+  const governing = governingDeclaration(declaration);
   const declared =
     stored === null
       ? (declaration ?? DEFAULT_PLACEHOLDER_MANIFEST)
-      : declaration === null
+      : governing === null
         ? stored
-        : governedByDeclaration(stored, declaration);
+        : governedByDeclaration(stored, governing);
   if (unreadable === null && stored !== null && declaration !== null) {
     // The generic half of this warning has existed since the rule did — "a
     // declaration is mounted and ignored" — and it is not enough. Proven live:
@@ -232,7 +238,8 @@ export function governedSliceRefusal(
   manifest: AuthoredManifest,
   declaration: AuthoredManifest | null | undefined,
 ): string | null {
-  if (declaration == null) return null;
+  const governing = governingDeclaration(declaration);
+  if (governing === null) return null;
   // Both sides through the same parse. The schema normalizes as it validates —
   // `supplyChain.registry` is authored as a string or a list and comes out a
   // list — and {@link governedByDeclaration} validates what it merges, so
@@ -240,7 +247,7 @@ export function governedSliceRefusal(
   // normalization as a path a boot reverts and refuse a document nobody edited.
   const normalized = validateManifest(manifest, 'the submitted manifest');
   const reverted = diffManifestPaths(
-    governedByDeclaration(normalized, declaration),
+    governedByDeclaration(normalized, governing),
     normalized,
   );
   if (reverted.length === 0) return null;

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -269,6 +269,37 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * honest — they chose nothing — but it does mean "configured" is a record of a
  * document, not of a ceremony.
  */
+/**
+ * The mounted declaration where it governs, and `null` where it does not.
+ *
+ * **A stand-in governs nothing.** The governed slice
+ * (`manifest-store.ts:governedByDeclaration`) exists so a rollout cannot revert
+ * the two vessels an installation is built on: a control plane pointed at a
+ * boundary that is not there, or a home vessel whose bucket and signer nobody
+ * can reach, is an installation that cannot come back, and that is worth taking
+ * out of the operator's hands. **None of that reasoning survives the document
+ * being the placeholder.** There is no operator assertion to protect, and what
+ * the rule protects instead is `spindrift-vessel` and `spindrift-artifacts` —
+ * names of nothing — against the real ones, forever, because the wizard that
+ * would set them is refused for editing a governed path.
+ *
+ * That is not a hypothetical: the chart mounts exactly this document on a
+ * release with no `manifest:` value, which is the chart-only install path, and
+ * the two collided the first time anybody ran one. The relying party is why the
+ * chart mounts it at all — see `files/default-manifest.yaml` — so the document
+ * has to stay mounted and stop governing, rather than not be mounted.
+ *
+ * The same four keys as {@link isUnconfiguredInstallation}, and deliberately
+ * the same function: "this document is the stand-in" is one fact, and a second
+ * spelling of it is a second thing to keep in step with the chart's copy.
+ */
+export function governingDeclaration(
+  declaration: AuthoredManifest | null | undefined,
+): AuthoredManifest | null {
+  if (declaration == null) return null;
+  return isUnconfiguredInstallation(declaration) ? null : declaration;
+}
+
 export function isUnconfiguredInstallation(
   manifest: AuthoredManifest,
 ): boolean {

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -83,6 +83,17 @@ export function InstallationSettings() {
    * not offer the act without it.
    */
   const [declaration, setDeclaration] = useState<unknown>(null);
+  /**
+   * Whether that declaration takes the governed slice back on every boot.
+   *
+   * Separate from `declaration` because a mounted document and a governing one
+   * are different facts, and the chart-only install is where they part: the
+   * chart mounts its stand-in to bind the relying party, and a stand-in governs
+   * nothing. Answered by the server (`getInstallationManifest`) rather than
+   * decided here, so this screen locks exactly what `configureInstallation`
+   * would refuse — never a field it would have accepted.
+   */
+  const [declarationGoverns, setDeclarationGoverns] = useState(false);
 
   const load = useCallback(async () => {
     const result = await command('getInstallationManifest', {});
@@ -90,6 +101,7 @@ export function InstallationSettings() {
       setDocument(result.value.manifest);
       setDivergence(result.value.declarationDivergence);
       setDeclaration(result.value.declaration);
+      setDeclarationGoverns(result.value.declarationGoverns);
       setLoadError(null);
     } else {
       setLoadError(result.failure.message);
@@ -183,6 +195,7 @@ export function InstallationSettings() {
       saving={saving}
       divergence={divergence}
       declaration={declaration}
+      declarationGoverns={declarationGoverns}
       onChange={(next) => {
         setDocument(next);
         setOutcome(null);
@@ -250,6 +263,7 @@ export function InstallationSettingsView({
   saving,
   divergence = [],
   declaration = null,
+  declarationGoverns = false,
   onChange,
   onSave,
   onReload,
@@ -277,6 +291,12 @@ export function InstallationSettingsView({
    * entitled to leave unset.
    */
   readonly declaration?: unknown;
+  /**
+   * Whether {@link declaration} governs. Defaults to `false` so a caller that
+   * passes neither locks nothing, which is the honest answer for a screen with
+   * no declaration behind it.
+   */
+  readonly declarationGoverns?: boolean;
   onChange(document: unknown): void;
   onSave(): void;
   onReload(): void;
@@ -294,7 +314,10 @@ export function InstallationSettingsView({
   // is a field that teaches them the wrong thing about who owns it. Still no
   // key named in this file — the paths come from the schema module that owns
   // them, resolved against the document being edited.
-  const governed = governedManifestPaths(declaration, document).map(pathKey);
+  const governed = governedManifestPaths(
+    declarationGoverns ? declaration : null,
+    document,
+  ).map(pathKey);
   const locked = (at: Path) => {
     const here = pathKey(at);
     return governed.some((key) => here === key || here.startsWith(`${key}.`));

--- a/apps/spindrift/test/conformance/chart-only-enrolment.test.ts
+++ b/apps/spindrift/test/conformance/chart-only-enrolment.test.ts
@@ -25,11 +25,14 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
+import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
+  governingDeclaration,
   isUnconfiguredInstallation,
   validateManifest,
 } from '../../src/config/manifest.ts';
+import { governedSliceRefusal } from '../../src/config/manifest-store.ts';
 
 /** The repository root, for reading the chart's copy of the placeholder. */
 const REPO_ROOT = join(import.meta.dir, '../../../..');
@@ -101,5 +104,90 @@ describe('the chart-only default manifest matches the code copy', () => {
     );
     expect(seeded.controlPlane.hostname).toBe('spindrift.lolwtf.ca');
     expect(isUnconfiguredInstallation(seeded)).toBe(true);
+  });
+});
+
+/**
+ * The wizard the chart-only install exists to reach must be able to finish.
+ *
+ * 77 got the first operator to the door and 81 governs the two vessels an
+ * installation is built on, so a rollout cannot point a control plane at a
+ * boundary that is not there. On a chart-only install those two meet: the
+ * declaration the chart mounts to bind the relying party is the *stand-in*, and
+ * governing it locks `spindrift-vessel` and `spindrift-artifacts` — names of
+ * nothing — over the real values, forever, because the only surface that could
+ * set them is refused for editing a governed path.
+ *
+ * Observed live 2026-08-08 on the acceptance installation, at the wizard's
+ * artifacts-project step:
+ *
+ *   the vessels this installation is built on … would be taken back at:
+ *   vessels.1.shared.artifactsProject, vessels.1.location.project.
+ *   Change the declaration instead.
+ *
+ * There is no declaration to change: the operator installed a chart.
+ */
+describe('a stand-in declaration governs nothing', () => {
+  /** The document the chart mounts on a real release. */
+  async function seeded(): Promise<AuthoredManifest> {
+    const raw = await Bun.file(DEFAULT_MANIFEST_FILE).text();
+    return validateManifest(
+      Bun.YAML.parse(
+        raw.replace(
+          '{{ .Values.hostname | quote }}',
+          JSON.stringify('spindrift-acceptance.lolwtf.ca'),
+        ),
+      ),
+      'chart default manifest',
+    );
+  }
+
+  /** The same document with the two values the wizard exists to collect. */
+  function configured(base: AuthoredManifest): AuthoredManifest {
+    return validateManifest(
+      {
+        ...base,
+        vessels: base.vessels.map((vessel) =>
+          vessel.name === base.installation.homeVessel
+            ? {
+                ...vessel,
+                location: { project: 'bluenose' },
+                shared: {
+                  ...(vessel as { shared?: Record<string, unknown> }).shared,
+                  artifactsProject: 'trusted-builds',
+                },
+              }
+            : vessel,
+        ),
+      },
+      'the operator’s document',
+    );
+  }
+
+  test('the wizard’s own two fields are accepted, not refused', async () => {
+    const stand = await seeded();
+    expect(governedSliceRefusal(configured(stand), stand)).toBeNull();
+  });
+
+  test('and an operator’s declaration still governs them', async () => {
+    // The other direction, so this does not become "nothing governs anything".
+    // One key away from the stand-in is a document somebody wrote, and 81's
+    // rule applies to it in full.
+    const stand = await seeded();
+    const authored = validateManifest(
+      { ...stand, installation: { ...stand.installation, name: 'offsite' } },
+      'an operator’s declaration',
+    );
+    const refusal = governedSliceRefusal(configured(authored), authored);
+    expect(refusal).toContain('vessels.1.location.project');
+    expect(refusal).toContain('Change the declaration instead');
+  });
+
+  test('a boot leaves the configured values standing', async () => {
+    // The refusal is the symptom; this is the thing it was protecting against.
+    // `governedByDeclaration` runs on every boot, so a stand-in that governed
+    // would put the placeholder projects back under a running installation.
+    const stand = await seeded();
+    expect(governingDeclaration(stand)).toBeNull();
   });
 });

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -37,6 +37,7 @@ function screen({
   saving = false,
   divergence = [] as readonly string[],
   declaration = null as unknown,
+  declarationGoverns = false,
 } = {}): string {
   return renderToStaticMarkup(
     <InstallationSettingsView
@@ -47,6 +48,7 @@ function screen({
       saving={saving}
       divergence={divergence}
       declaration={declaration}
+      declarationGoverns={declarationGoverns}
       onChange={() => undefined}
       onSave={() => undefined}
       onReload={() => undefined}
@@ -188,7 +190,11 @@ describe('the vessels this installation is built on are read-only', () => {
   }
 
   test('a declaration locks the pointers and the entries they name', () => {
-    const markup = screen({ document: withAppVessel, declaration: manifest });
+    const markup = screen({
+      document: withAppVessel,
+      declaration: manifest,
+      declarationGoverns: true,
+    });
 
     expect(locked(markup, 'installation.controlPlaneVessel')).toBe(true);
     expect(locked(markup, 'installation.homeVessel')).toBe(true);
@@ -206,7 +212,11 @@ describe('the vessels this installation is built on are read-only', () => {
   test('the lock carries the sentence saying why', () => {
     // A disabled input with nothing beside it reads as a bug in the form.
     expect(
-      screen({ document: withAppVessel, declaration: manifest }),
+      screen({
+        document: withAppVessel,
+        declaration: manifest,
+        declarationGoverns: true,
+      }),
     ).toContain('are declared, not configured here');
   });
 
@@ -218,6 +228,26 @@ describe('the vessels this installation is built on are read-only', () => {
 
     expect(locked(markup, 'installation.homeVessel')).toBe(false);
     expect(locked(markup, 'vessels.1.shared.sourceBucket')).toBe(false);
+    expect(markup).not.toContain('are declared, not configured here');
+  });
+
+  test('a mounted declaration that governs nothing locks nothing', () => {
+    // The chart-only install. The chart mounts its stand-in so the passkey
+    // relying party is the hostname the release actually serves, and a stand-in
+    // asserts nothing about anybody's boundaries — so this screen has to be the
+    // one place those two values can be set, not the one place they cannot.
+    //
+    // The server answers whether the declaration governs; this screen must not
+    // lock on `declaration` being present, which is the shape that shipped the
+    // wizard nobody could finish.
+    const markup = screen({
+      document: withAppVessel,
+      declaration: manifest,
+      declarationGoverns: false,
+    });
+
+    expect(locked(markup, 'installation.homeVessel')).toBe(false);
+    expect(locked(markup, 'vessels.1.shared.artifactsProject')).toBe(false);
     expect(markup).not.toContain('are declared, not configured here');
   });
 });


### PR DESCRIPTION
The onboarding wizard on a chart-only installation refuses the only two values it exists to collect. Observed live on the acceptance installation, at the artifacts-project step:

```text
the vessels this installation is built on, and the repository they are declared in, are
reconciled from the mounted declaration on every boot — so this document would be taken
back at: vessels.1.shared.artifactsProject, vessels.1.location.project.
Change the declaration instead.
```

There is no declaration to change. The operator installed a chart.

## Two correct rules, one dead end

The chart mounts its copy of the placeholder whenever a release sets no `manifest:` value, because the passkey relying party has to be the hostname the release actually serves — that is the whole reason `files/default-manifest.yaml` exists.

The governed slice then reconciles the two vessels an installation is built on from whatever is mounted. So it takes `spindrift-vessel` and `spindrift-artifacts` — names of nothing — and holds them over the real values on every boot, and the one surface that could set them refuses, correctly, because it would be reverted.

The reasoning behind governing does not survive the document being the stand-in. It exists so a rollout cannot point a control plane at a boundary that is not there or a home vessel at a bucket nobody can reach; a placeholder asserts nothing about anybody's boundaries, and what the rule protects there is a wizard nobody can finish.

**So a stand-in governs nothing** — decided by the predicate that already answers "this document is the stand-in", not a second spelling of it that would have to be kept in step with the chart's copy. Seeding is untouched: the declaration is still taken whole, for the hostname it carries.

The screen has to reach the same answer the server will. A field locked against a write that would have been accepted is the form refusing on the server's behalf and getting it wrong, so `getInstallationManifest` now answers `declarationGoverns` and the lock reads that rather than the declaration merely being present.

## Validation

Three new conformance tests on the chart-only path, run against the code with the predicate neutralised:

```text
(fail) a stand-in declaration governs nothing > the wizard's own two fields are accepted, not refused
(fail) a stand-in declaration governs nothing > a boot leaves the configured values standing
 5 pass
 2 fail
```

The third holds either way on purpose — it asserts the *other* direction, that a document one key away from the stand-in still governs in full, so this does not quietly become "nothing governs anything".

Restored: **1981 pass, 0 fail** across 142 files against a real Postgres. `typecheck` and `lint` exit 0. The two existing view tests that assert the lock now state which case they are in rather than relying on a declaration being present.

## Risk

The running installation is unaffected: its declaration is named `offsite`, so it is not a stand-in by any of the four keys and governs exactly as before. The behaviour changes only where the mounted document *is* the placeholder — which until today had never been installed anywhere.