### PR TITLE
fix(spindrift): give the acceptance installation real boundaries and a trust store that reaches a root

### DIFF
--- a/.github/containers.json
+++ b/.github/containers.json
@@ -34,7 +34,8 @@
       "clusters/folly/apps/tronbyt/07-rackstat-deployment.yaml"
     ],
     "spindrift": [
-      "clusters/offsite/apps/spindrift/helm-release.yaml"
+      "clusters/offsite/apps/spindrift/helm-release.yaml",
+      "clusters/offsite/apps/spindrift-acceptance/helm-release.yaml"
     ]
   },
   "ignore": [

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -68,14 +68,35 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           has_changes="$ANY_CHANGED"
-          release=clusters/offsite/apps/spindrift/helm-release.yaml
 
-          # Continuous delivery only rewrites this image digest. The rest of
-          # the release is a conformance-test input and remains significant.
-          if [[ "$ALL_CHANGED_FILES" == "$release" ]] &&
-            git diff --quiet \
+          # Every release continuous delivery stamps this image's digest into,
+          # from `.github/containers.json`. Plural since the clean-installation
+          # acceptance environment consumes the same image: one bump rewrites
+          # both files, so a check that only knew the first would run the whole
+          # suite on every digest bump forever.
+          releases=(
+            clusters/offsite/apps/spindrift/helm-release.yaml
+            clusters/offsite/apps/spindrift-acceptance/helm-release.yaml
+          )
+
+          # Continuous delivery only rewrites the image digest. The rest of each
+          # release is a conformance-test input and remains significant, so this
+          # skips only when every changed file is one of those releases and
+          # every one of them differs at nothing but that line.
+          only_digests=true
+          for changed in $ALL_CHANGED_FILES; do
+            known=false
+            for release in "${releases[@]}"; do
+              [[ "$changed" == "$release" ]] && known=true && break
+            done
+            if ! "$known" || ! git diff --quiet \
               --ignore-matching-lines='^[[:space:]]*image: ghcr\.io/jonpulsifer/spindrift:latest@sha256:[[:xdigit:]]{64}$' \
-              "$BASE_SHA" "$HEAD_SHA" -- "$release"; then
+              "$BASE_SHA" "$HEAD_SHA" -- "$changed"; then
+              only_digests=false
+              break
+            fi
+          done
+          if [[ -n "$ALL_CHANGED_FILES" ]] && "$only_digests"; then
             has_changes=false
           fi
 

--- a/apps/spindrift/src/commands/installation/get.ts
+++ b/apps/spindrift/src/commands/installation/get.ts
@@ -60,7 +60,10 @@ import {
   type AuthoredManifest,
   toAuthoredManifest,
 } from '../../config/manifest.schema.ts';
-import { isUnconfiguredInstallation } from '../../config/manifest.ts';
+import {
+  governingDeclaration,
+  isUnconfiguredInstallation,
+} from '../../config/manifest.ts';
 import { type Command, ok } from '../types.ts';
 
 export const getInstallationManifestInput = z.object({}).strict();
@@ -84,6 +87,23 @@ export interface GetInstallationManifestResult {
    * for a round trip to disagree about.
    */
   readonly declaration: AuthoredManifest | null;
+  /**
+   * Whether that declaration takes the governed slice back on every boot.
+   *
+   * `false` for no declaration, and — the case this field exists for — `false`
+   * for a declaration that is the chart's stand-in, which governs nothing
+   * (`governingDeclaration`). The editing surface reads it to decide whether to
+   * lock the two vessels' fields, and it must reach the same answer
+   * `configureInstallation` will: a field locked against a write that would
+   * have been accepted is a screen refusing on the server's behalf and getting
+   * it wrong, which on a chart-only installation is the wizard refusing the
+   * only two values it exists to collect.
+   *
+   * A boolean rather than the predicate itself, because answering it needs
+   * `DEFAULT_PLACEHOLDER_MANIFEST` and the module that holds it is not one the
+   * client bundle may import.
+   */
+  readonly declarationGoverns: boolean;
   /**
    * Dotted paths where {@link declaration} disagrees with the manifest above,
    * or `[]` when nothing is mounted or the two agree. Paths only — see
@@ -125,6 +145,7 @@ export const getInstallationManifest: Command<
   return ok({
     manifest,
     declaration: context.declaration ?? null,
+    declarationGoverns: governingDeclaration(context.declaration) !== null,
     declarationDivergence: context.declarationDivergence ?? [],
     // The authored document, not the resolved one: the deployment's federation
     // is joined onto `context.manifest` per read, and the predicate reads keys

--- a/apps/spindrift/src/config/manifest-store.ts
+++ b/apps/spindrift/src/config/manifest-store.ts
@@ -19,6 +19,7 @@ import {
 } from './manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
+  governingDeclaration,
   loadManifestIfPresent,
   ManifestError,
   resolveManifest,
@@ -75,12 +76,17 @@ export async function loadStoredManifest(
       `installation manifest: the stored manifest is not valid for this build, so this installation is being re-seeded from the mounted declaration — anything configured through the UI that the declaration does not carry is lost: ${unreadable.message}`,
     );
   }
+  // Seeding takes the declaration whatever it is — a stand-in carrying this
+  // release's own hostname is the whole of what makes a chart-only install
+  // reachable (ticket 77). Governing is the other half of the same document and
+  // does not follow: see {@link governingDeclaration}.
+  const governing = governingDeclaration(declaration);
   const declared =
     stored === null
       ? (declaration ?? DEFAULT_PLACEHOLDER_MANIFEST)
-      : declaration === null
+      : governing === null
         ? stored
-        : governedByDeclaration(stored, declaration);
+        : governedByDeclaration(stored, governing);
   if (unreadable === null && stored !== null && declaration !== null) {
     // The generic half of this warning has existed since the rule did — "a
     // declaration is mounted and ignored" — and it is not enough. Proven live:
@@ -232,7 +238,8 @@ export function governedSliceRefusal(
   manifest: AuthoredManifest,
   declaration: AuthoredManifest | null | undefined,
 ): string | null {
-  if (declaration == null) return null;
+  const governing = governingDeclaration(declaration);
+  if (governing === null) return null;
   // Both sides through the same parse. The schema normalizes as it validates —
   // `supplyChain.registry` is authored as a string or a list and comes out a
   // list — and {@link governedByDeclaration} validates what it merges, so
@@ -240,7 +247,7 @@ export function governedSliceRefusal(
   // normalization as a path a boot reverts and refuse a document nobody edited.
   const normalized = validateManifest(manifest, 'the submitted manifest');
   const reverted = diffManifestPaths(
-    governedByDeclaration(normalized, declaration),
+    governedByDeclaration(normalized, governing),
     normalized,
   );
   if (reverted.length === 0) return null;

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -269,6 +269,37 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
  * honest — they chose nothing — but it does mean "configured" is a record of a
  * document, not of a ceremony.
  */
+/**
+ * The mounted declaration where it governs, and `null` where it does not.
+ *
+ * **A stand-in governs nothing.** The governed slice
+ * (`manifest-store.ts:governedByDeclaration`) exists so a rollout cannot revert
+ * the two vessels an installation is built on: a control plane pointed at a
+ * boundary that is not there, or a home vessel whose bucket and signer nobody
+ * can reach, is an installation that cannot come back, and that is worth taking
+ * out of the operator's hands. **None of that reasoning survives the document
+ * being the placeholder.** There is no operator assertion to protect, and what
+ * the rule protects instead is `spindrift-vessel` and `spindrift-artifacts` —
+ * names of nothing — against the real ones, forever, because the wizard that
+ * would set them is refused for editing a governed path.
+ *
+ * That is not a hypothetical: the chart mounts exactly this document on a
+ * release with no `manifest:` value, which is the chart-only install path, and
+ * the two collided the first time anybody ran one. The relying party is why the
+ * chart mounts it at all — see `files/default-manifest.yaml` — so the document
+ * has to stay mounted and stop governing, rather than not be mounted.
+ *
+ * The same four keys as {@link isUnconfiguredInstallation}, and deliberately
+ * the same function: "this document is the stand-in" is one fact, and a second
+ * spelling of it is a second thing to keep in step with the chart's copy.
+ */
+export function governingDeclaration(
+  declaration: AuthoredManifest | null | undefined,
+): AuthoredManifest | null {
+  if (declaration == null) return null;
+  return isUnconfiguredInstallation(declaration) ? null : declaration;
+}
+
 export function isUnconfiguredInstallation(
   manifest: AuthoredManifest,
 ): boolean {

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -83,6 +83,17 @@ export function InstallationSettings() {
    * not offer the act without it.
    */
   const [declaration, setDeclaration] = useState<unknown>(null);
+  /**
+   * Whether that declaration takes the governed slice back on every boot.
+   *
+   * Separate from `declaration` because a mounted document and a governing one
+   * are different facts, and the chart-only install is where they part: the
+   * chart mounts its stand-in to bind the relying party, and a stand-in governs
+   * nothing. Answered by the server (`getInstallationManifest`) rather than
+   * decided here, so this screen locks exactly what `configureInstallation`
+   * would refuse — never a field it would have accepted.
+   */
+  const [declarationGoverns, setDeclarationGoverns] = useState(false);
 
   const load = useCallback(async () => {
     const result = await command('getInstallationManifest', {});
@@ -90,6 +101,7 @@ export function InstallationSettings() {
       setDocument(result.value.manifest);
       setDivergence(result.value.declarationDivergence);
       setDeclaration(result.value.declaration);
+      setDeclarationGoverns(result.value.declarationGoverns);
       setLoadError(null);
     } else {
       setLoadError(result.failure.message);
@@ -183,6 +195,7 @@ export function InstallationSettings() {
       saving={saving}
       divergence={divergence}
       declaration={declaration}
+      declarationGoverns={declarationGoverns}
       onChange={(next) => {
         setDocument(next);
         setOutcome(null);
@@ -250,6 +263,7 @@ export function InstallationSettingsView({
   saving,
   divergence = [],
   declaration = null,
+  declarationGoverns = false,
   onChange,
   onSave,
   onReload,
@@ -277,6 +291,12 @@ export function InstallationSettingsView({
    * entitled to leave unset.
    */
   readonly declaration?: unknown;
+  /**
+   * Whether {@link declaration} governs. Defaults to `false` so a caller that
+   * passes neither locks nothing, which is the honest answer for a screen with
+   * no declaration behind it.
+   */
+  readonly declarationGoverns?: boolean;
   onChange(document: unknown): void;
   onSave(): void;
   onReload(): void;
@@ -294,7 +314,10 @@ export function InstallationSettingsView({
   // is a field that teaches them the wrong thing about who owns it. Still no
   // key named in this file — the paths come from the schema module that owns
   // them, resolved against the document being edited.
-  const governed = governedManifestPaths(declaration, document).map(pathKey);
+  const governed = governedManifestPaths(
+    declarationGoverns ? declaration : null,
+    document,
+  ).map(pathKey);
   const locked = (at: Path) => {
     const here = pathKey(at);
     return governed.some((key) => here === key || here.startsWith(`${key}.`));

--- a/apps/spindrift/test/conformance/chart-only-enrolment.test.ts
+++ b/apps/spindrift/test/conformance/chart-only-enrolment.test.ts
@@ -25,11 +25,14 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
+import type { AuthoredManifest } from '../../src/config/manifest.schema.ts';
 import {
   DEFAULT_PLACEHOLDER_MANIFEST,
+  governingDeclaration,
   isUnconfiguredInstallation,
   validateManifest,
 } from '../../src/config/manifest.ts';
+import { governedSliceRefusal } from '../../src/config/manifest-store.ts';
 
 /** The repository root, for reading the chart's copy of the placeholder. */
 const REPO_ROOT = join(import.meta.dir, '../../../..');
@@ -101,5 +104,90 @@ describe('the chart-only default manifest matches the code copy', () => {
     );
     expect(seeded.controlPlane.hostname).toBe('spindrift.lolwtf.ca');
     expect(isUnconfiguredInstallation(seeded)).toBe(true);
+  });
+});
+
+/**
+ * The wizard the chart-only install exists to reach must be able to finish.
+ *
+ * 77 got the first operator to the door and 81 governs the two vessels an
+ * installation is built on, so a rollout cannot point a control plane at a
+ * boundary that is not there. On a chart-only install those two meet: the
+ * declaration the chart mounts to bind the relying party is the *stand-in*, and
+ * governing it locks `spindrift-vessel` and `spindrift-artifacts` — names of
+ * nothing — over the real values, forever, because the only surface that could
+ * set them is refused for editing a governed path.
+ *
+ * Observed live 2026-08-08 on the acceptance installation, at the wizard's
+ * artifacts-project step:
+ *
+ *   the vessels this installation is built on … would be taken back at:
+ *   vessels.1.shared.artifactsProject, vessels.1.location.project.
+ *   Change the declaration instead.
+ *
+ * There is no declaration to change: the operator installed a chart.
+ */
+describe('a stand-in declaration governs nothing', () => {
+  /** The document the chart mounts on a real release. */
+  async function seeded(): Promise<AuthoredManifest> {
+    const raw = await Bun.file(DEFAULT_MANIFEST_FILE).text();
+    return validateManifest(
+      Bun.YAML.parse(
+        raw.replace(
+          '{{ .Values.hostname | quote }}',
+          JSON.stringify('spindrift-acceptance.lolwtf.ca'),
+        ),
+      ),
+      'chart default manifest',
+    );
+  }
+
+  /** The same document with the two values the wizard exists to collect. */
+  function configured(base: AuthoredManifest): AuthoredManifest {
+    return validateManifest(
+      {
+        ...base,
+        vessels: base.vessels.map((vessel) =>
+          vessel.name === base.installation.homeVessel
+            ? {
+                ...vessel,
+                location: { project: 'bluenose' },
+                shared: {
+                  ...(vessel as { shared?: Record<string, unknown> }).shared,
+                  artifactsProject: 'trusted-builds',
+                },
+              }
+            : vessel,
+        ),
+      },
+      'the operator’s document',
+    );
+  }
+
+  test('the wizard’s own two fields are accepted, not refused', async () => {
+    const stand = await seeded();
+    expect(governedSliceRefusal(configured(stand), stand)).toBeNull();
+  });
+
+  test('and an operator’s declaration still governs them', async () => {
+    // The other direction, so this does not become "nothing governs anything".
+    // One key away from the stand-in is a document somebody wrote, and 81's
+    // rule applies to it in full.
+    const stand = await seeded();
+    const authored = validateManifest(
+      { ...stand, installation: { ...stand.installation, name: 'offsite' } },
+      'an operator’s declaration',
+    );
+    const refusal = governedSliceRefusal(configured(authored), authored);
+    expect(refusal).toContain('vessels.1.location.project');
+    expect(refusal).toContain('Change the declaration instead');
+  });
+
+  test('a boot leaves the configured values standing', async () => {
+    // The refusal is the symptom; this is the thing it was protecting against.
+    // `governedByDeclaration` runs on every boot, so a stand-in that governed
+    // would put the placeholder projects back under a running installation.
+    const stand = await seeded();
+    expect(governingDeclaration(stand)).toBeNull();
   });
 });

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -37,6 +37,7 @@ function screen({
   saving = false,
   divergence = [] as readonly string[],
   declaration = null as unknown,
+  declarationGoverns = false,
 } = {}): string {
   return renderToStaticMarkup(
     <InstallationSettingsView
@@ -47,6 +48,7 @@ function screen({
       saving={saving}
       divergence={divergence}
       declaration={declaration}
+      declarationGoverns={declarationGoverns}
       onChange={() => undefined}
       onSave={() => undefined}
       onReload={() => undefined}
@@ -188,7 +190,11 @@ describe('the vessels this installation is built on are read-only', () => {
   }
 
   test('a declaration locks the pointers and the entries they name', () => {
-    const markup = screen({ document: withAppVessel, declaration: manifest });
+    const markup = screen({
+      document: withAppVessel,
+      declaration: manifest,
+      declarationGoverns: true,
+    });
 
     expect(locked(markup, 'installation.controlPlaneVessel')).toBe(true);
     expect(locked(markup, 'installation.homeVessel')).toBe(true);
@@ -206,7 +212,11 @@ describe('the vessels this installation is built on are read-only', () => {
   test('the lock carries the sentence saying why', () => {
     // A disabled input with nothing beside it reads as a bug in the form.
     expect(
-      screen({ document: withAppVessel, declaration: manifest }),
+      screen({
+        document: withAppVessel,
+        declaration: manifest,
+        declarationGoverns: true,
+      }),
     ).toContain('are declared, not configured here');
   });
 
@@ -218,6 +228,26 @@ describe('the vessels this installation is built on are read-only', () => {
 
     expect(locked(markup, 'installation.homeVessel')).toBe(false);
     expect(locked(markup, 'vessels.1.shared.sourceBucket')).toBe(false);
+    expect(markup).not.toContain('are declared, not configured here');
+  });
+
+  test('a mounted declaration that governs nothing locks nothing', () => {
+    // The chart-only install. The chart mounts its stand-in so the passkey
+    // relying party is the hostname the release actually serves, and a stand-in
+    // asserts nothing about anybody's boundaries — so this screen has to be the
+    // one place those two values can be set, not the one place they cannot.
+    //
+    // The server answers whether the declaration governs; this screen must not
+    // lock on `declaration` being present, which is the shape that shipped the
+    // wizard nobody could finish.
+    const markup = screen({
+      document: withAppVessel,
+      declaration: manifest,
+      declarationGoverns: false,
+    });
+
+    expect(locked(markup, 'installation.homeVessel')).toBe(false);
+    expect(locked(markup, 'vessels.1.shared.artifactsProject')).toBe(false);
     expect(markup).not.toContain('are declared, not configured here');
   });
 });

--- a/clusters/offsite/apps/spindrift-acceptance/ca-bundle.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/ca-bundle.yaml
@@ -1,0 +1,68 @@
+---
+# The one file `NODE_EXTRA_CA_CERTS` names, for this installation.
+#
+# **Three certificates, and all three are load-bearing.** offsite's API server
+# serves a leaf issued by the FML K8s offsite CA, which is itself issued by the
+# FML intermediate — so the chain does not terminate until the self-signed root.
+# The runtime does no partial-chain verification: an issuing CA in the store is
+# not a trust anchor unless the path reaches a root, and a store holding only
+# the issuing CA answers `unable to get issuer certificate` on every call.
+#
+# That is not a prediction. This installation was first declared with the
+# chart's default `kube-root-ca.crt`, which carries the offsite CA and an
+# unrelated retired NixOS anchor and neither of the two above it, and every one
+# of the control-plane vessel's six checklist rows failed with exactly that
+# sentence.
+#
+# No folly chain here, unlike the running installation's bundle: this one holds
+# no Target on folly. Every certificate is read from `terraform/pki/certs/`.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spindrift-acceptance-ca-bundle
+  namespace: spindrift-acceptance
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDlTCCA0egAwIBAgIRAOnaEOtL2R5JxKS455AmmR4wBQYDK2VwMDYxNDAyBgNV
+    BAMTK0ZvbGx5IE1vdW50YWluIExhYm9yYXRvcmllcyBJbnRlcm1lZGlhdGUgQ0Ew
+    HhcNMjYwNzE4MjEyMDAxWhcNMjgwNzE4MDkyMDAxWjBDMSQwIgYDVQQKExtGb2xs
+    eSBNb3VudGFpbiBMYWJvcmF0b3JpZXMxGzAZBgNVBAMTEkZNTCBLOHMgb2Zmc2l0
+    ZSBDQTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAN92dwMiLLGpTzW8
+    cysU6uK8z3yIe2plVsDZyRCRP1tMbPDQznldElE6ammP5LZVKCdeveU/giqEvLEz
+    E8nipgXka3k+FGGpELEH2Lw2bLMsOWbNRmGOmKNKGYXdh748eloiOFOihG4UzxoG
+    KWsSVUxuTr4HzQIYqxPxeI/YvYrlpld3k4eYT6D8UTKhoBhfxUtUcaUiDDAQuge5
+    l9ihvhibLjRb1Qt+ZcKtitgb859JjZXej1YW70I6CVs9u9Vsnbto5JlXy6h1Iemy
+    oqEZEVSLKg6EAT60syaqt/KYyqZrJK0XcOisNvtvlnTnGs+H2XcmcYYg6zP5OR0B
+    SXUo7D9VI2m98ReXKt3aDzDh6dwx9Y9DGP8MwP4IxKR9us99fKIMZkRR6KqlPsM6
+    NYdaBWRN4jI1qp7d2Sz9TEjS//vurO+GEFH0jGRC3TT8yWfI6WNFt9YHVTutBCul
+    0REVWiqS+fsgM/18vZYNPE17uOjV4rV5bk7/gPJdjK7wQKjDyg6ZB5QzKIZRNr6r
+    IghXdQsPehM3faFYNtUF/WJqVWuWRs+NMFZdgDPUQ3UnWbr78miOqFy3+ijjpic5
+    Nt3rXeip1+C+HsIoaFqhs4hWIe3syMdzboEUIAToYacsYZxTCIibl1Dt2cBYXI+W
+    XUxtvjArHpFRykjQEwhGIRBbxQRlAgMBAAGjYzBhMA4GA1UdDwEB/wQEAwIBhjAP
+    BgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRdgBy2YXrhX/b3AaGNtEEDav840zAf
+    BgNVHSMEGDAWgBQE4eZ0TSBnmQEKvk26Id8ATiZ+xDAFBgMrZXADQQCf5euKB1l9
+    c332iif7gRqnALxClaOwveNNbcRWIiY5GvKLM2d53A/12v6lH8pPg7KVHCdKhSW3
+    5q4gZV+fDo4K
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIBiDCCATqgAwIBAgIQK5wHYh6HX8zQO7sHttvrTjAFBgMrZXAwLjEsMCoGA1UE
+    AxMjRm9sbHkgTW91bnRhaW4gTGFib3JhdG9yaWVzIFJvb3QgQ0EwHhcNMjYwNzE4
+    MTg1NTU0WhcNMjgwNzE3MTg1NTU0WjA2MTQwMgYDVQQDEytGb2xseSBNb3VudGFp
+    biBMYWJvcmF0b3JpZXMgSW50ZXJtZWRpYXRlIENBMCowBQYDK2VwAyEAclzwIx98
+    DSJ636NKmoc2KCw6t+CdMAvSd9jrRmBgZVyjZjBkMA4GA1UdDwEB/wQEAwIBBjAS
+    BgNVHRMBAf8ECDAGAQH/AgEAMB0GA1UdDgQWBBQE4eZ0TSBnmQEKvk26Id8ATiZ+
+    xDAfBgNVHSMEGDAWgBSbBOje8ZeYfD1aixEVw2QQ+jERQzAFBgMrZXADQQCFbA5y
+    Ibqi4DUxCcWsOmlQSTgEYnEl6t2R67c0+ECiSE67OsWT6WXTPgDyBpwd9XSkUbf7
+    UZ+9hrIYRu4FFOcO
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    MIIBYDCCARKgAwIBAgIRAK3yD7NcGXGorLa+hQf7QlYwBQYDK2VwMC4xLDAqBgNV
+    BAMTI0ZvbGx5IE1vdW50YWluIExhYm9yYXRvcmllcyBSb290IENBMB4XDTI2MDcx
+    ODE4NTU1M1oXDTQxMDcxNDE4NTU1M1owLjEsMCoGA1UEAxMjRm9sbHkgTW91bnRh
+    aW4gTGFib3JhdG9yaWVzIFJvb3QgQ0EwKjAFBgMrZXADIQAWtUf+j7uRyb2XWbZj
+    sN29BK5mRKfQCQdURx584PniOKNFMEMwDgYDVR0PAQH/BAQDAgEGMBIGA1UdEwEB
+    /wQIMAYBAf8CAQEwHQYDVR0OBBYEFJsE6N7xl5h8PVqLERXDZBD6MRFDMAUGAytl
+    cANBALK2I8ljioXmfP3TOxjvkGopFnxMQJlg02kA3LooJ8MRe6nizV7cS9XHy1RM
+    u/ctyGaHaBwU6tSvez0rc+IQiQ4=
+    -----END CERTIFICATE-----

--- a/clusters/offsite/apps/spindrift-acceptance/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/helm-release.yaml
@@ -56,11 +56,13 @@ spec:
       token:
         gcpAudience: //iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/fml-pool/providers/offsite
         gcpImpersonationUrl: https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/spindrift-controller@bluenose.iam.gserviceaccount.com:generateAccessToken
-        # The cluster's own root and nothing else. The running installation
-        # extends its bundle because it holds a Target on folly; this one
-        # places on cloud surfaces, which are reached over public TLS the
-        # image's own trust store already covers.
-        caConfigMap: kube-root-ca.crt
+        # **Not `kube-root-ca.crt`**, which is the chart's default and cannot
+        # verify the cluster it runs in: it carries the FML K8s offsite CA and
+        # nothing above it, and the runtime does no partial-chain verification.
+        # Declared with the default first, and every one of the control-plane
+        # vessel's six checklist rows answered `unable to get issuer
+        # certificate`. See ca-bundle.yaml beside this file.
+        caConfigMap: spindrift-acceptance-ca-bundle
     ingress:
       enabled: true
     # Its own database, and `keepOnDelete` off — an acceptance installation
@@ -73,3 +75,113 @@ spec:
         enabled: true
     reconciler:
       enabled: true
+    # **Every value here is real.** The chart-only path — no `manifest:` at all,
+    # the placeholder seeding itself — is what this installation was declared
+    # for and it has already been spent: the first operator enrolled a passkey
+    # against this origin (ticket 77), and the wizard defect that path exposed
+    # is fixed (ticket 97). What the placeholder cannot do is be *configured
+    # into* something real, because half of it names boundaries that do not
+    # exist: `spindrift-vessel` in `spindrift-region` is not a project this or
+    # any identity can be granted anything on, so every probe against it is
+    # refused for the one reason no grant fixes.
+    #
+    # So this document states what is true. The remaining acceptance clauses —
+    # Target connection, archive-to-URL, repository-to-signed-artifact,
+    # second-Target admission — are about the deploy chain, and a clean
+    # installation with a correct declaration is still a clean installation.
+    #
+    # **It shares the running installation's boundary, not its state.** Same
+    # project, same source bucket, same store of record, same registries —
+    # because they are the same infrastructure and inventing a second of each
+    # would be testing this repository's Terraform rather than Spindrift. What
+    # is not shared is the database, the identity's *subject*, the enrolment,
+    # and every row. Its Apps take names nothing else uses.
+    manifest:
+      installation:
+        name: acceptance
+        controlPlaneVessel: offsite
+        homeVessel: bluenose
+      controlPlane:
+        hostname: spindrift-acceptance.${SECRET_DOMAIN}
+      dns:
+        zones:
+          private: ${SPINDRIFT_DOMAIN}
+          public: ${SPINDRIFT_DOMAIN}
+      auth:
+        gateway: null
+      github:
+        clientId: Iv1.918d699f36ee7afc
+        apiBaseUrl: https://api.github.com
+        oauthBaseUrl: https://github.com
+        buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
+        infrastructureRepository: jonpulsifer/infra
+      sources:
+        buckets:
+          - bluenose-spindrift-source
+      charts:
+        app: oci://ghcr.io/jonpulsifer/charts/spindrift-app
+      build:
+        routes:
+          - name: hosted
+            adapter: github-actions
+            sealPublicKey: |
+              -----BEGIN PUBLIC KEY-----
+              MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAqJhA+am3NJ4pDPNi/EDi
+              TD3UjZoP736+Nn3/RluZhdazx+UoUftS0FCXDBBI9WIG0ZzSGPYwpYXgoiZ45x+T
+              IwOrqvl+MXpU436eLPZH8vGuC9I1lRhLpepkoDkXaXixf5+CBAGHKTe/7WjlcMuS
+              +5Wkqhr20qYm8Xt2Znq9hNZHV+3x32rZGG4SEG9QdRJXt39+SI2gARpTwSdRdcpd
+              H7ScPha8cmxUiEM4S2GtVByIrwGXfxWHxb80OZrU4Kvea/GFSlWk9nKQUrmFqnj0
+              Lx4nh617h7SClmYeagkGyiQ8SL6C3hM3sGpnkaXXA4DQ/+W6QADLSAuLJKaI0xv9
+              tsDFqkNz60VQf9+SNkF446ekKqFztdsOM879nyAOIv4SfpQI3ZdvK3daFep/z4K9
+              2BUBzdb5F/f9TgTpW+PSQA2fX4vzt73WeeikVRxKx6zpnZKgFzjVMIhmu3Y47btD
+              xrPbOokNfv3N7OIhNuC7oz0tX1Lq0andlplZlcTm8pv/3bkT2QmmxtEPDRJ+Xn8h
+              fi04rbJRFt4x8GqPwCJSswH+eKOLw7c5Jtjl1vRoIKsxs5hICcFTZEIXnyycHxtA
+              Ve9Xp3LMmVgqq70mHzGCVMfJXfZgm8HBqJ5U9K5Xzjp0EHNdsE/tFjlBA/x+4KSh
+              ey2JEg4EriDjMik2MaTQqHcCAwEAAQ==
+              -----END PUBLIC KEY-----
+        zeroConfigFrontend: ghcr.io/railwayapp/railpack-frontend:v0.35.0
+      secretStore:
+        adapter: gcp-secret-manager
+        endpoint: https://secretmanager.googleapis.com
+      supplyChain:
+        signer: gcpkms://projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer
+        registry:
+          - ghcr.io/jonpulsifer
+          - northamerica-northeast1-docker.pkg.dev/trusted-builds/i
+        verifier: ghcr.io/jonpulsifer/spindrift-verifier
+        attestor: projects/trusted-builds/attestors/provenance
+      vessels:
+        # Where this control plane runs. It carries no Target here: a Kubernetes
+        # Target would want an Apps namespace, its own gateway with a pinned
+        # address, and a wildcard certificate — none of which the acceptance
+        # clauses need, because a Cloud Run service mints its own URL. The
+        # vessel is still declared because `controlPlaneVessel` names it.
+        - name: offsite
+          kind: cluster
+          location:
+            apiServer: https://kubernetes.default.svc
+          reachableRegistries:
+            - ghcr.io
+        - name: bluenose
+          kind: gcp-project
+          location:
+            project: bluenose
+          terraformRoot: terraform/gcp/projects/bluenose
+          shared:
+            sourceBucket: bluenose-spindrift-source
+            artifactsProject: trusted-builds
+            secretStoreContainer: bluenose
+          reachableRegistries:
+            - northamerica-northeast1-docker.pkg.dev
+      targets:
+        - vessel: bluenose
+          adapter: cloudrun
+          connection:
+            region: northamerica-northeast1
+            endpoint: https://run.googleapis.com
+            policyEndpoint: https://binaryauthorization.googleapis.com
+            serviceAccount: spindrift-runtime@bluenose.iam.gserviceaccount.com
+        - vessel: bluenose
+          adapter: static
+          connection:
+            endpoint: https://firebasehosting.googleapis.com

--- a/clusters/offsite/apps/spindrift-acceptance/kustomization.yaml
+++ b/clusters/offsite/apps/spindrift-acceptance/kustomization.yaml
@@ -3,6 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - ca-bundle.yaml
   - secret.sops.yaml
   - oci-repository.yaml
   - helm-release.yaml


### PR DESCRIPTION
Both faults were found by driving the live acceptance installation.

## The trust store could not verify the cluster it runs in

Every one of the control-plane vessel's six checklist rows answered `unable to get issuer certificate`.

I declared it with the chart's default `caConfigMap: kube-root-ca.crt`. On offsite that ConfigMap carries two certificates — the FML K8s offsite CA, and an unrelated retired NixOS anchor — and neither the FML intermediate that issued the first nor the root above that:

```text
acceptance (kube-root-ca.crt)          live (spindrift-ca-bundle)
FML K8s offsite CA  ← intermediate     FML K8s offsite CA  ← intermediate
NixOS (retired, self-signed)           FML K8s folly CA    ← intermediate
                                       FML Intermediate CA ← root
                                       FML Root CA         ← self
```

The runtime does no partial-chain verification — an issuing CA in the store is not a trust anchor unless the path reaches a self-signed root. The running installation's own `ca-bundle.yaml` already records this being measured: *"the issuing CA alone answers `unable to get issuer certificate`, and so does the intermediate beside it; only all three reach HTTP 200."* I picked the default anyway.

Its own bundle now, three certificates, all read from `terraform/pki/certs/`. No folly chain — this installation holds no Target there.

**This is also a chart-default problem worth naming**: `kube-root-ca.crt` is documented in `values.yaml` as "all an installation whose Targets are in-cluster ever needs", and on this cluster it cannot verify the cluster itself. Left alone here rather than changed under a release that depends on it.

## The placeholder cannot be configured into something real

The wizard defect is fixed and the fields are editable, but the document underneath still names boundaries that do not exist. `spindrift-vessel` in `spindrift-region` is not a project any identity can hold a grant on, so the `OIDC_FEDERATION` probe is refused for the one reason no grant fixes — and the remediation it generates is a correct stanza for a project nobody can apply it to.

The chart-only path this installation was declared for is **already spent**: the first operator enrolled a passkey against this origin (ticket 77, closed), and the wizard defect that path exposed is fixed (ticket 97). What remains of the acceptance is the deploy chain — Target connection, archive-to-URL, repository-to-signed-artifact, second-Target admission — and a clean installation with a correct declaration is still a clean installation.

So every value is real.

**It shares the running installation's boundary and none of its state.** Same project, source bucket, store of record and registries, because they are the same infrastructure and inventing a second of each would exercise this repository's Terraform rather than Spindrift. Separate database, separate federation subject, separate enrolment, separate rows. Its Apps take names nothing else uses.

**No Kubernetes Target.** That wants an Apps namespace, a gateway with its own pinned address, and a wildcard certificate. Two cloud surfaces are still two Targets, and bluenose carries Binary Authorization — so second-Target admission is assessed against a real policy boundary rather than a softer one.

**No new Terraform.** The acceptance installation federates as `spindrift-controller@bluenose`, which already holds every role on bluenose and trusted-builds; the only Terraform it ever needed was the subject binding that merged with the environment.

## Validation

- The declaration parsed through the real loader: `VALID — acceptance | home: bluenose | targets: bluenose/cloudrun, bluenose/static`.
- `helm template` against the chart renders all ten objects, so none of the chart's render-time manifest refusals fire.
- `bash .github/scripts/render-cluster-apps.sh` clean.
- `bun test` — 1981 pass, 0 fail across 142 files.

## After merge

The stored row was seeded from the placeholder and a declaration seeds only when there is no row, so this document does not reach the installation on its own. The governed slice moves the two vessels; everything else needs the row discarded so it re-seeds. The enrolled passkey lives in a different table and survives.