### PR TITLE
fix(bosun): make the workspace disk writable, then keep it warm between skiffs

### DIFF
--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -24,6 +24,13 @@ on:
           - skiff-ubuntu
           - ubuntu-latest
         default: all
+      caches:
+        description: 'best = each label uses the fastest cache it has; none = no dependency or build cache anywhere (isolates the runner from the network)'
+        type: choice
+        options:
+          - best
+          - none
+        default: best
 
 permissions:
   contents: read
@@ -70,6 +77,11 @@ jobs:
           printf 'cores      %s\n' "$(nproc)"
           printf 'memory     %s\n' "$(awk '/MemTotal/ {printf "%.1f GiB", $2/1048576}' /proc/meminfo)"
           printf 'uptime     %ss (how long this machine existed before the job)\n' "$(cut -d' ' -f1 /proc/uptime)"
+          printf 'warm disk  %s\n' "${SKIFF_CACHE:-none (this runner brings no cache of its own)}"
+          if [ -n "${SKIFF_CACHE:-}" ]; then
+            df -h "$SKIFF_CACHE" | tail -1
+            du -sh "$SKIFF_CACHE"/* "$RUNNER_TOOL_CACHE" 2>/dev/null || true
+          fi
 
   benchmark:
     needs: configure
@@ -110,6 +122,50 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      # Whether this runner brought a cache of its own, and where.
+      #
+      # A skiff whose class persists its workspace mounts the same disk the last
+      # job on that slot left behind, and its hull announces the one directory a
+      # job may keep things in as $SKIFF_CACHE. Nothing else sets it: a hosted
+      # runner, an ARC pod, and a skiff of a class that does not persist all
+      # arrive with nothing and fall through to the GitHub Actions cache below.
+      #
+      # This is what the bench compares under `caches: best`. The first clean run
+      # put a skiff at hosted-runner speed on compute (build 22 s against 25 s)
+      # and lost 70 s of a 99 s deficit inside one `actions/cache` step — the
+      # dependency store, over the internet. Both runners still do the same work
+      # here; each does it with the fastest cache it has, which is how either
+      # would be configured for real.
+      #
+      # `caches: none` is the other honest question, and the one that says what a
+      # runner *is*: no dependency cache and no build cache on any label, so what
+      # remains is cores, memory and disk. One caveat to state rather than hide —
+      # a skiff's git objects and runner tool cache live on the same disk and
+      # this wipes them too, but `actions/checkout` still fetches into the repo
+      # it finds, so a skiff's checkout is incremental where a hosted runner's is
+      # a clone. That difference is the runner, not a cache we configured.
+      - name: Where this runner's cache lives
+        run: |
+          if [ "${{ inputs.caches }}" = "none" ]; then
+            echo "caches: none — nothing is restored on any label."
+            if [ -n "${SKIFF_CACHE:-}" ]; then
+              rm -rf "$SKIFF_CACHE"/* "${RUNNER_TOOL_CACHE:?}"/* 2>/dev/null || true
+              echo "Warm disk emptied so this skiff measures cold too."
+            fi
+            exit 0
+          fi
+          if [ -z "${SKIFF_CACHE:-}" ]; then
+            echo "No warm disk. Restoring the dependency store over the network."
+            exit 0
+          fi
+          mkdir -p "$SKIFF_CACHE/bun" "$SKIFF_CACHE/turbo"
+          {
+            echo "SKIFF_CACHE_ROOT=$SKIFF_CACHE"
+            echo "BUN_INSTALL_CACHE_DIR=$SKIFF_CACHE/bun"
+            echo "TURBO_CACHE_DIR=$SKIFF_CACHE/turbo"
+          } >> "$GITHUB_ENV"
+          echo "Warm disk at $SKIFF_CACHE:"
+          du -sh "$SKIFF_CACHE"/* 2>/dev/null || echo "  (empty — this slot is cold)"
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Authenticate to Google Cloud
@@ -122,7 +178,11 @@ jobs:
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
+      # Skipped on a runner that mounted a warm disk: BUN_INSTALL_CACHE_DIR and
+      # TURBO_CACHE_DIR already point at one, and downloading a copy of what is
+      # on the local filesystem is the 70 s this whole exercise is about.
       - name: Cache Bun store
+        if: env.SKIFF_CACHE_ROOT == '' && inputs.caches != 'none'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.bun/install/cache
@@ -130,6 +190,7 @@ jobs:
           restore-keys: |
             bun-store-${{ runner.os }}-
       - name: Cache Turborepo
+        if: env.SKIFF_CACHE_ROOT == '' && inputs.caches != 'none'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: |

--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -32,7 +32,18 @@ type Class struct {
 	// Workspace sizes a scratch disk for this class; empty means none, and
 	// then the class's memory is its disk budget, since both hull families
 	// put the guest root on a tmpfs overlay.
-	Workspace   string   `json:"workspace,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+	// Persist hands the same workspace disks back to successive skiffs of this
+	// class instead of a freshly reserved one each boot. The disk is the only
+	// thing a skiff has that *could* outlive it, so this is the one place the
+	// "a skiff leaves nothing behind" stance is traded away, deliberately and
+	// per class: what survives is a warm cache, and what it buys is the entire
+	// measured gap to a hosted runner, which is network transfer and nothing
+	// else.
+	//
+	// Off by default. A class that sets it must also size a workspace, since
+	// there is otherwise no disk to persist.
+	Persist     bool     `json:"persist,omitempty"`
 	Warm        int      `json:"warm"`
 	MaxLifetime Duration `json:"maxLifetime"`
 }
@@ -129,6 +140,16 @@ func LoadConfig(path string) (*Config, error) {
 			if _, err := parseSize(c.Workspace); err != nil {
 				return nil, fmt.Errorf("config: class %s: workspace: %w", name, err)
 			}
+		} else if c.Persist {
+			return nil, fmt.Errorf("config: class %s: persist needs a workspace to persist", name)
+		}
+		if c.Persist && strings.ContainsAny(name, "/.") {
+			// Slot images are named <class>-<slot>.img under one flat
+			// directory, and sweep tells a slot image from an orphan by that
+			// shape. A class name carrying a separator or a dot would either
+			// escape the directory or produce a name sweep reads as somebody
+			// else's.
+			return nil, fmt.Errorf("config: class %s: a persisting class name may not contain '/' or '.'", name)
 		}
 		if c.Warm <= 0 {
 			return nil, fmt.Errorf("config: class %s: warm must be positive", name)

--- a/apps/bosun/config_test.go
+++ b/apps/bosun/config_test.go
@@ -112,3 +112,51 @@ func TestLoadConfigRejectsUnparseableWorkspaceSize(t *testing.T) {
 		t.Fatal("expected an error for an unparseable workspace size")
 	}
 }
+
+// persist is what a class trades the "leaves nothing behind" stance for, and
+// what it buys is a warm cache on a disk. A class that persists nothing is a
+// declaration whose only possible effect is to mislead whoever reads it.
+func TestLoadConfigRejectsPersistWithoutAWorkspace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff-ubuntu": {"hull": "/hulls/ubuntu", "vcpus": 4, "memory": "3072M", "warm": 2, "persist": true}}
+	}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for a persisting class with no workspace")
+	}
+}
+
+// Slot images live in one flat directory named <class>-<slot>.img, and sweep
+// tells a slot image from an orphan by that shape alone.
+func TestLoadConfigRejectsAPersistingClassNameThatWouldEscapeItsImageName(t *testing.T) {
+	for _, name := range []string{"skiff/ubuntu", "skiff.ubuntu"} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "config.json")
+		writeFile(t, path, `{
+			"repo": "acme/widgets",
+			"tokenFile": "/run/secrets/token",
+			"classes": {"`+name+`": {"hull": "/h", "vcpus": 1, "memory": "512M", "warm": 1, "workspace": "1G", "persist": true}}
+		}`)
+		if _, err := LoadConfig(path); err == nil {
+			t.Errorf("expected error for persisting class named %q", name)
+		}
+	}
+}
+
+// The same names are fine when nothing persists: only the slot image naming
+// constrains them.
+func TestLoadConfigAllowsADottedClassNameThatDoesNotPersist(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff.ubuntu": {"hull": "/h", "vcpus": 1, "memory": "512M", "warm": 1}}
+	}`)
+	if _, err := LoadConfig(path); err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+}

--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -210,6 +210,17 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 // so the hull's own disks keep the indices it built around. It carries no
 // filesystem: what a workspace holds is the hull's business, the same way its
 // rootfs is, and bosun never learns what was put there.
+//
+// image_type=raw is not optional and not cosmetic. cloud-hypervisor 52 refuses
+// sector-0 writes on a disk whose type it had to auto-detect -- it logs
+// "Autodetected raw image type. Disabling sector 0 writes", then answers the
+// guest's first write with ReadOnly. The guest sees an I/O error at sector 0,
+// mkfs dies, and the mount that follows fails on a device that looks broken
+// rather than protected. Measured on riptide 2026-08-08: every workspace disk
+// since it was introduced had been silently unusable for exactly this reason,
+// so a hull's disks are declared raw because the hull contract says a disk is a
+// raw file the hull ships. A hull wanting qcow2 wants a manifest field, and a
+// failing test to go with it.
 func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 	args := []string{
 		"--kernel", filepath.Join(h.dir, h.manifest.Kernel),
@@ -229,13 +240,13 @@ func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 			if dev.Disk.RO {
 				ro = "on"
 			}
-			args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=%s", filepath.Join(h.dir, dev.Disk.Path), ro))
+			args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=%s,image_type=raw", filepath.Join(h.dir, dev.Disk.Path), ro))
 			disks++
 		}
 	}
 	cmdline := h.manifest.Cmdline
 	if p.workspace != "" {
-		args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=off", p.workspace))
+		args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=off,image_type=raw", p.workspace))
 		cmdline += " bosun.workspace=" + guestDiskName(disks)
 	}
 	args = append(args,
@@ -248,18 +259,31 @@ func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 	return args
 }
 
-// createWorkspace reserves and creates one skiff's scratch disk. Reserved
-// rather than sparse on purpose: taking the workspace off the class's memory
-// is the whole point, and a sparse file would move the overcommit onto the
-// host filesystem instead of removing it. A pool that cannot fit fails a
-// spawn, which is visible, rather than a build mid-run, which is not.
-func createWorkspace(path, size string) error {
+// ensureWorkspace reserves one skiff's scratch disk. Reserved rather than
+// sparse on purpose: taking the workspace off the class's memory is the whole
+// point, and a sparse file would move the overcommit onto the host filesystem
+// instead of removing it. A pool that cannot fit fails a spawn, which is
+// visible, rather than a build mid-run, which is not.
+//
+// keep leaves an image the right size exactly as it is, which is how a
+// persisting class hands the last skiff's caches to the next one. bosun still
+// learns nothing about what is on it — the guest decides whether what it finds
+// is usable, the same seam that lets the rootfs be a squashfs. An image of the
+// wrong size is recreated regardless: a class whose `workspace` changed cannot
+// keep a filesystem sized for the old figure, and growing one in place would
+// hand the guest a disk its superblock disagrees with.
+func ensureWorkspace(path, size string, keep bool) error {
 	n, err := parseSize(size)
 	if err != nil {
 		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
+	}
+	if keep {
+		if info, err := os.Stat(path); err == nil && info.Size() == n {
+			return nil
+		}
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR|os.O_TRUNC, 0o600)
 	if err != nil {

--- a/apps/bosun/hull_test.go
+++ b/apps/bosun/hull_test.go
@@ -131,7 +131,7 @@ func TestChArgsWithDisk(t *testing.T) {
 		"--memory", "size=2048M,shared=on",
 		"--fs", "tag=bosun,socket=/run/bosun/sk03.fs",
 		"--fs", "tag=bosun-diag,socket=/run/bosun/sk03.diag.fs",
-		"--disk", "path=/hulls/ubuntu/rootfs.img,readonly=on",
+		"--disk", "path=/hulls/ubuntu/rootfs.img,readonly=on,image_type=raw",
 		"--net", "vhost_user=on,socket=/run/bosun/sk03.net",
 		"--api-socket", "/run/bosun/sk03.api",
 		"--console", "off",
@@ -325,8 +325,8 @@ func TestChArgsWorkspaceDiskComesLastAndIsNamedOnTheCmdline(t *testing.T) {
 		"--memory", "size=3072M,shared=on",
 		"--fs", "tag=bosun,socket=/run/bosun/sk09.fs",
 		"--fs", "tag=bosun-diag,socket=/run/bosun/sk09.diag.fs",
-		"--disk", "path=/hulls/ubuntu/rootfs.img,readonly=on",
-		"--disk", "path=/var/lib/bosun/workspace/sk09.img,readonly=off",
+		"--disk", "path=/hulls/ubuntu/rootfs.img,readonly=on,image_type=raw",
+		"--disk", "path=/var/lib/bosun/workspace/sk09.img,readonly=off,image_type=raw",
 		"--net", "vhost_user=on,socket=/run/bosun/sk09.net",
 		"--api-socket", "/run/bosun/sk09.api",
 		"--console", "off",
@@ -362,10 +362,10 @@ func TestChArgsNoWorkspaceLeavesCmdlineAlone(t *testing.T) {
 
 // The reservation is the whole reason the disk exists: a sparse file would
 // move the overcommit onto the host filesystem rather than remove it.
-func TestCreateWorkspaceReservesTheWholeSize(t *testing.T) {
+func TestEnsureWorkspaceReservesTheWholeSize(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "nested", "sk11.img")
-	if err := createWorkspace(path, "2M"); err != nil {
-		t.Fatalf("createWorkspace: %v", err)
+	if err := ensureWorkspace(path, "2M", false); err != nil {
+		t.Fatalf("ensureWorkspace: %v", err)
 	}
 	var st syscall.Stat_t
 	if err := syscall.Stat(path, &st); err != nil {
@@ -379,8 +379,65 @@ func TestCreateWorkspaceReservesTheWholeSize(t *testing.T) {
 		t.Errorf("allocated %d blocks, want at least %d -- the file is sparse", st.Blocks, want)
 	}
 
-	if err := createWorkspace(path, "nonsense"); err == nil {
+	if err := ensureWorkspace(path, "nonsense", false); err == nil {
 		t.Fatal("expected an error for an unparseable size")
+	}
+}
+
+// The whole value of a persisting class is that the next skiff finds what the
+// last one left, so an image the right size must survive being ensured again --
+// and the ephemeral path must still truncate, or a class that stopped
+// persisting would quietly keep handing out the old disk.
+func TestEnsureWorkspaceKeepsAPersistedImageAndTruncatesAnEphemeralOne(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "skiff-ubuntu-0.img")
+	if err := ensureWorkspace(path, "2M", true); err != nil {
+		t.Fatalf("ensureWorkspace: %v", err)
+	}
+	// Stands in for a filesystem and its caches: bosun never learns what is on
+	// the disk, only whether it left it alone.
+	if err := os.WriteFile(path, append([]byte("warm-cache"), make([]byte, 2<<20-10)...), 0o600); err != nil {
+		t.Fatalf("seed image: %v", err)
+	}
+
+	if err := ensureWorkspace(path, "2M", true); err != nil {
+		t.Fatalf("ensureWorkspace (keep): %v", err)
+	}
+	kept, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(kept[:10]) != "warm-cache" {
+		t.Errorf("persisted image was rewritten: got %q", kept[:10])
+	}
+
+	// A class whose workspace size changed cannot keep a filesystem sized for
+	// the old figure.
+	if err := ensureWorkspace(path, "3M", true); err != nil {
+		t.Fatalf("ensureWorkspace (resize): %v", err)
+	}
+	resized, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(resized) != 3<<20 {
+		t.Errorf("size = %d, want %d", len(resized), 3<<20)
+	}
+	if string(resized[:10]) == "warm-cache" {
+		t.Error("a resized image kept the old filesystem")
+	}
+
+	if err := ensureWorkspace(path, "3M", false); err != nil {
+		t.Fatalf("ensureWorkspace (ephemeral): %v", err)
+	}
+	fresh, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	for i, b := range fresh {
+		if b != 0 {
+			t.Fatalf("ephemeral image not truncated: byte %d = %#x", i, b)
+		}
 	}
 }
 

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -36,6 +36,7 @@ let
         vcpus
         memory
         workspace
+        persist
         warm
         maxLifetime
         ;
@@ -109,9 +110,13 @@ in
         Where per-skiff scratch disks are reserved, for classes that size one
         with {option}`classes.<name>.workspace`. Must be real storage, not
         tmpfs: the whole point is to stop charging a build's bytes against the
-        class's memory. Each image is fully allocated at boot and deleted when
-        its skiff is scuttled, so `warm × workspace` per class is the space
-        this host must keep free.
+        class's memory. Each image is fully allocated at boot, so
+        `warm × workspace` per class is the space this host must keep free.
+
+        An image is deleted when its skiff is scuttled unless the class sets
+        {option}`classes.<name>.persist`, which hands it to the replacement
+        instead. Either way the space is reserved up front, so the figure above
+        does not change.
       '';
     };
 
@@ -187,6 +192,40 @@ in
 
                 The disk is raw: what filesystem it carries is the hull's
                 business, and bosun never learns what was written to it.
+              '';
+            };
+            persist = mkOption {
+              type = types.bool;
+              default = false;
+              description = ''
+                Hand the same workspace disks back to successive skiffs of this
+                class instead of a freshly reserved one each boot. Needs
+                {option}`workspace`.
+
+                This is the one place a skiff is allowed to leave something
+                behind, and it is a deliberate trade rather than an oversight.
+                What it buys is the entire measured deficit to a GitHub-hosted
+                runner: on this repo's real suite that gap was 99 s, of which
+                70 s was `actions/cache` pulling a dependency store over the
+                internet — not compute, and not boot. A disk the next skiff
+                finds already warm removes the transfer instead of speeding it
+                up.
+
+                What it costs is that one job can affect the next one on the
+                same slot. The VM boundary still holds — a skiff cannot reach
+                the host, another skiff, or the LAN — so what is shared is a
+                filesystem, not a machine. That is the trade every
+                non-ephemeral self-hosted runner makes, and it is only sound
+                for a repository whose contributors are trusted. Leave it off
+                for anything that runs code from a fork.
+
+                Slot images are named `<class>-<slot>.img` under
+                {option}`workspaceDir` and survive a bosun restart, which
+                happens on every token rotation and every rebuild of this host.
+                Lowering {option}`warm` reclaims the images above the new count
+                on the next start. A guest that finds its disk nearly full
+                reformats it, so a cache that grows without bound costs one
+                cold job rather than an ENOSPC on every job after it.
               '';
             };
             warm = mkOption {

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -22,6 +22,7 @@ type skiff struct {
 	class    string
 	runnerID int64
 	paths    skiffPaths
+	slot     int       // workspace slot held from a persisting class, or -1
 	mintedAt time.Time // when the JIT config was minted; its ~1h expiry is measured from here
 
 	mu            sync.Mutex
@@ -65,10 +66,56 @@ type pool struct {
 
 	mu     sync.Mutex
 	skiffs map[string]*skiff
+	// slots is which workspace slot of a persisting class is currently held,
+	// per class. Tracked rather than derived from skiffs because a slot is
+	// claimed before there is a skiff to derive it from -- see claimSlot.
+	slots map[string]map[int]struct{}
 }
 
 func newPool(cfg *Config, gh githubClient, launch launcher, logger *slog.Logger) *pool {
-	return &pool{cfg: cfg, gh: gh, launch: launch, logger: logger, stats: newMetrics(), skiffs: map[string]*skiff{}}
+	return &pool{
+		cfg:    cfg,
+		gh:     gh,
+		launch: launch,
+		logger: logger,
+		stats:  newMetrics(),
+		skiffs: map[string]*skiff{},
+		slots:  map[string]map[int]struct{}{},
+	}
+}
+
+// workspaceSlotName is the image a persisting class's slot always reuses. Named
+// after the class and the slot rather than after a skiff, because the whole
+// point is that it outlives every skiff that mounts it.
+func workspaceSlotName(className string, slot int) string {
+	return fmt.Sprintf("%s-%d.img", className, slot)
+}
+
+// claimSlot reserves the lowest free workspace slot for a persisting class.
+//
+// Reserved rather than computed from the live skiff map, because two skiffs
+// finishing at once each spawn a replacement on their own goroutine: both would
+// read the same lowest-free index and hand two running guests the same disk.
+func (p *pool) claimSlot(className string) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	claimed, ok := p.slots[className]
+	if !ok {
+		claimed = map[int]struct{}{}
+		p.slots[className] = claimed
+	}
+	for slot := 0; ; slot++ {
+		if _, taken := claimed[slot]; !taken {
+			claimed[slot] = struct{}{}
+			return slot
+		}
+	}
+}
+
+func (p *pool) releaseSlot(className string, slot int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.slots[className], slot)
 }
 
 // publish writes the metrics textfile, if one is configured. Called after
@@ -131,13 +178,50 @@ func (p *pool) sweep(ctx context.Context) error {
 			p.logger.Warn("sweep: remove stale state", "path", path, "error", err)
 		}
 	}
-	// Workspace images sit on real storage rather than tmpfs, so unlike
-	// everything above they survive a reboot as well as a restart, and nothing
-	// else ever deletes one whose skiff was killed with the cgroup.
-	if err := os.RemoveAll(p.cfg.WorkspaceDir); err != nil {
-		p.logger.Warn("sweep: remove stale workspaces", "path", p.cfg.WorkspaceDir, "error", err)
-	}
+	p.sweepWorkspaces()
 	return nil
+}
+
+// sweepWorkspaces clears the workspace directory of everything a prior run left
+// behind — except the slot images of a class that persists.
+//
+// Workspace images sit on real storage rather than tmpfs, so unlike per-skiff
+// runtime state they survive a reboot as well as a restart, and nothing else
+// ever deletes one whose skiff was killed with the cgroup. A persisting class's
+// slot images are the exception and the point: they hold the caches the next
+// skiff is meant to find, and bosun restarts on every token rotation and every
+// rebuild of this host. Throwing them away there would make the warm cache a
+// thing that only ever works between two consecutive jobs.
+//
+// Slots at or above a class's current warm count are *not* kept, so lowering
+// warm reclaims the space on the next start rather than leaving images nothing
+// will ever mount again.
+func (p *pool) sweepWorkspaces() {
+	entries, err := os.ReadDir(p.cfg.WorkspaceDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			p.logger.Warn("sweep: reading workspaces", "path", p.cfg.WorkspaceDir, "error", err)
+		}
+		return
+	}
+	keep := map[string]struct{}{}
+	for name, class := range p.cfg.Classes {
+		if !class.Persist {
+			continue
+		}
+		for slot := 0; slot < class.Warm; slot++ {
+			keep[workspaceSlotName(name, slot)] = struct{}{}
+		}
+	}
+	for _, e := range entries {
+		if _, ok := keep[e.Name()]; ok {
+			continue
+		}
+		path := filepath.Join(p.cfg.WorkspaceDir, e.Name())
+		if err := os.RemoveAll(path); err != nil {
+			p.logger.Warn("sweep: remove stale workspace", "path", path, "error", err)
+		}
+	}
 }
 
 // fill boots every class up to its configured warm count.
@@ -178,10 +262,6 @@ func (p *pool) spawn(ctx context.Context, className string) {
 		logger.Error("resolve paths", "error", err)
 		return
 	}
-	if class.Workspace != "" {
-		paths.workspace = filepath.Join(p.cfg.WorkspaceDir, id+".img")
-	}
-
 	// Mint immediately before boot, never stockpiled: the config expires
 	// ~1h from this call, not from when a guest first connects.
 	runnerID, jitConfig, err := p.gh.GenerateJITConfig(ctx, p.cfg.Repo, "skiff-"+id, []string{className})
@@ -189,7 +269,21 @@ func (p *pool) spawn(ctx context.Context, className string) {
 		logger.Error("generate jitconfig", "error", err)
 		return
 	}
-	s := &skiff{id: id, class: className, runnerID: runnerID, paths: paths, mintedAt: time.Now()}
+
+	// Claimed after the mint, because every exit path past this point hands the
+	// skiff to retire, which is what releases it. A slot claimed before a
+	// failing mint would leak.
+	slot := -1
+	if class.Workspace != "" {
+		if class.Persist {
+			slot = p.claimSlot(className)
+			paths.workspace = filepath.Join(p.cfg.WorkspaceDir, workspaceSlotName(className, slot))
+			logger = logger.With("workspace_slot", slot)
+		} else {
+			paths.workspace = filepath.Join(p.cfg.WorkspaceDir, id+".img")
+		}
+	}
+	s := &skiff{id: id, class: className, runnerID: runnerID, paths: paths, slot: slot, mintedAt: time.Now()}
 
 	if err := p.writeState(paths.dir, runnerID, jitConfig, h.digest); err != nil {
 		logger.Error("write state", "error", err)
@@ -245,7 +339,7 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 	// Before any helper, so a host that cannot spare the space costs one
 	// failed spawn rather than four processes to unwind.
 	if s.paths.workspace != "" {
-		if err := createWorkspace(s.paths.workspace, class.Workspace); err != nil {
+		if err := ensureWorkspace(s.paths.workspace, class.Workspace, class.Persist); err != nil {
 			return fmt.Errorf("create workspace disk: %w", err)
 		}
 	}
@@ -359,12 +453,19 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 	}
 
 	// diagDir is deliberately not removed: it is the evidence, and this is
-	// the path a wedged skiff's own death takes. The workspace is, and must
-	// be — it is the one thing bosun reserves that a reboot would not free,
-	// and it is where untrusted job code wrote.
+	// the path a wedged skiff's own death takes.
 	os.RemoveAll(s.paths.dir)
+	// An ephemeral workspace is removed, and must be — it is the one thing
+	// bosun reserves that a reboot would not free, and it is where untrusted
+	// job code wrote. A slot from a persisting class is instead handed back for
+	// the replacement to mount: what the last job left on it is the cache the
+	// next one is here for.
 	if s.paths.workspace != "" {
-		os.Remove(s.paths.workspace)
+		if s.slot >= 0 {
+			p.releaseSlot(s.class, s.slot)
+		} else {
+			os.Remove(s.paths.workspace)
+		}
 	}
 	// Each helper drops a sidecar file beside its socket -- virtiofsd a
 	// "<sock>.pid", passt a "<sock>.repair" -- and neither is cleaned up by

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -10,12 +10,34 @@ import (
 	"time"
 )
 
+// poolTempDir is t.TempDir() without the cleanup assertion, and the difference
+// matters here for one reason: a skiff's lifetime goroutine outlives the test
+// that started it. Every test drives the pool with an uncancelled context, so
+// awaitExit boots a replacement each time a fake VMM's Wait() resolves — and a
+// replacement mid-boot writes into these directories while TempDir is deleting
+// them. t.TempDir() reports that as a failed cleanup on a test whose own
+// assertions all passed, which is a fault in the harness rather than in bosun.
+//
+// The goroutines are bounded by the test binary either way. What is deliberately
+// not built to close this is a graceful pool shutdown: bosun's real teardown is
+// systemd killing the cgroup and sweep-on-start deregistering what is left, so
+// a stop path existing only for tests would be machinery the daemon never runs.
+func poolTempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "bosun-pool-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
 // testPool wires a pool against a fake GitHub client and a fake launcher —
 // no KVM, no network, no real binaries — with one class, "skiff-test",
 // warm=1, pointed at a minimal on-disk hull.
 func testPool(t *testing.T) (*pool, *fakeGitHub, *fakeLaunch) {
 	t.Helper()
-	dir := t.TempDir()
+	dir := poolTempDir(t)
 	hullDir := writeTestHull(t, dir, "hull", nil)
 	cfg := &Config{
 		Repo:         "acme/widgets",
@@ -486,7 +508,7 @@ func TestWorkspaceDiskIsCreatedOnBootAndDeletedOnRetire(t *testing.T) {
 	if !ok {
 		t.Fatal("cloud-hypervisor was never launched")
 	}
-	if !slices.Contains(chCall.args, "path="+s.paths.workspace+",readonly=off") {
+	if !slices.Contains(chCall.args, "path="+s.paths.workspace+",readonly=off,image_type=raw") {
 		t.Fatalf("workspace disk missing from argv: %v", chCall.args)
 	}
 
@@ -499,13 +521,104 @@ func TestWorkspaceDiskIsCreatedOnBootAndDeletedOnRetire(t *testing.T) {
 func TestSweepClearsOrphanedWorkspaceImages(t *testing.T) {
 	p, _, _ := testPool(t)
 	orphan := filepath.Join(p.cfg.WorkspaceDir, "deadbeef.img")
-	if err := createWorkspace(orphan, "1M"); err != nil {
-		t.Fatalf("createWorkspace: %v", err)
+	if err := ensureWorkspace(orphan, "1M", false); err != nil {
+		t.Fatalf("ensureWorkspace: %v", err)
 	}
 	if err := p.sweep(context.Background()); err != nil {
 		t.Fatalf("sweep: %v", err)
 	}
 	if _, err := os.Stat(orphan); !os.IsNotExist(err) {
 		t.Fatalf("orphaned workspace survived sweep: %v", err)
+	}
+}
+
+// bosun restarts on every token rotation and every rebuild of its host. A sweep
+// that took the slot images with it would make a warm cache something that only
+// ever survives between two consecutive jobs.
+func TestSweepKeepsPersistedSlotImagesAndDropsSlotsAboveWarm(t *testing.T) {
+	p, _, _ := testPool(t)
+	class := p.cfg.Classes["skiff-test"]
+	class.Workspace = "1M"
+	class.Persist = true
+	class.Warm = 2
+	p.cfg.Classes["skiff-test"] = class
+
+	live := []string{
+		filepath.Join(p.cfg.WorkspaceDir, "skiff-test-0.img"),
+		filepath.Join(p.cfg.WorkspaceDir, "skiff-test-1.img"),
+	}
+	// Slot 2 belongs to a warm count this class no longer declares, so nothing
+	// will ever mount it again.
+	retired := filepath.Join(p.cfg.WorkspaceDir, "skiff-test-2.img")
+	// A skiff whose VMM was killed with the cgroup, from before the class
+	// persisted.
+	orphan := filepath.Join(p.cfg.WorkspaceDir, "deadbeef.img")
+	for _, path := range append(append([]string{}, live...), retired, orphan) {
+		if err := ensureWorkspace(path, "1M", false); err != nil {
+			t.Fatalf("ensureWorkspace %s: %v", path, err)
+		}
+	}
+
+	if err := p.sweep(context.Background()); err != nil {
+		t.Fatalf("sweep: %v", err)
+	}
+	for _, path := range live {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("persisted slot image did not survive sweep: %v", err)
+		}
+	}
+	for _, path := range []string{retired, orphan} {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("%s survived sweep: %v", filepath.Base(path), err)
+		}
+	}
+}
+
+// Two skiffs finishing at once spawn two replacements on two goroutines. Both
+// reading "the lowest free slot" off the live skiff map would hand two running
+// guests the same disk, so the claim has to be the reservation.
+func TestPersistingClassGivesEachLiveSkiffItsOwnSlotAndHandsItBack(t *testing.T) {
+	p, _, fl := testPool(t)
+	class := p.cfg.Classes["skiff-test"]
+	class.Workspace = "1M"
+	class.Persist = true
+	class.Warm = 2
+	p.cfg.Classes["skiff-test"] = class
+	ctx := context.Background()
+
+	p.fill(ctx)
+
+	p.mu.Lock()
+	held := map[string]int{}
+	for _, s := range p.skiffs {
+		held[filepath.Base(s.paths.workspace)] = s.slot
+	}
+	skiffs := make([]*skiff, 0, len(p.skiffs))
+	for _, s := range p.skiffs {
+		skiffs = append(skiffs, s)
+	}
+	p.mu.Unlock()
+
+	if len(held) != 2 {
+		t.Fatalf("two warm skiffs share a workspace image: %v", held)
+	}
+	for _, want := range []string{"skiff-test-0.img", "skiff-test-1.img"} {
+		if _, ok := held[want]; !ok {
+			t.Errorf("no skiff mounted %s: %v", want, want)
+		}
+	}
+	if _, ok := fl.last("cloud-hypervisor"); !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+
+	// Retire releases the slot rather than deleting the image: what the last
+	// job left on it is the cache the next one is here for.
+	victim := skiffs[0]
+	p.retire(ctx, victim, testLogger())
+	if _, err := os.Stat(victim.paths.workspace); err != nil {
+		t.Fatalf("persisted workspace was deleted on retire: %v", err)
+	}
+	if got := p.claimSlot("skiff-test"); got != victim.slot {
+		t.Errorf("released slot not reused: claimed %d, want %d", got, victim.slot)
 	}
 }

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -73,11 +73,21 @@
     # warm = 2 is the point of the disk: the bench measured a second
     # skiff-ubuntu job waiting three minutes for the first to finish, which is
     # what blocks migrating anything real onto skiffs.
+    #
+    # persist is what closes the remaining gap to a hosted runner. That gap was
+    # measured at 99 s on this repo's real suite and 70 s of it was
+    # `actions/cache` pulling the dependency store over the internet -- so the
+    # answer is not a faster transfer, it is no transfer. A slot the next skiff
+    # finds already carrying the checkout, the bun store and the tool cache
+    # removes it. `jonpulsifer/infra` runs no code from forks, which is the
+    # condition that makes the trade sound; the option's own documentation is
+    # where the reasoning lives.
     classes.skiff-ubuntu = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       vcpus = 4;
       memory = "3072M";
       workspace = "6G";
+      persist = true;
       warm = 2;
     };
   };

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -145,23 +145,63 @@ let
     #
     # Formatting is this hull's business: bosun hands over a raw device and
     # never learns what goes on it, the same seam that lets the rootfs above
-    # be a squashfs. Lazy init because the filesystem lives exactly as long as
-    # the skiff does -- nobody is left to benefit from an eager inode table.
+    # be a squashfs. That seam is also what makes a warm disk work without
+    # bosun growing an opinion: a class that persists hands the same image to
+    # successive skiffs, and the *guest* decides whether what it finds on it is
+    # a filesystem worth keeping.
     #
-    # Both the runner's workspace and docker's data root land here, which is
-    # what takes them off the class's memory: without a disk they are tmpfs,
-    # and `memory` is the disk budget.
+    # The runner's workspace, docker's data root and a cache directory land
+    # here, which is what takes them off the class's memory: without a disk
+    # they are tmpfs, and `memory` is the disk budget.
     work=$($bb sed -n 's/.*bosun\.workspace=\([^ ]*\).*/\1/p' /proc/cmdline)
     $bb mkdir -p /var/lib/docker /home/runner/_work
     if [ -n "$work" ]; then
       $bb modprobe ext4
-      /usr/sbin/mkfs.ext4 -Fq -m0 -E lazy_itable_init=1,lazy_journal_init=1 "$work"
       $bb mkdir -p /mnt/skiff
-      $bb mount -t ext4 "$work" /mnt/skiff
-      $bb mkdir -p /mnt/skiff/work /mnt/skiff/docker
+      # Format only when the disk will not mount, which is the one test that
+      # answers both cases bosun can hand over: a freshly reserved image is
+      # zeroes and cannot mount, and a persisted slot image arrives with the
+      # last skiff's filesystem on it. Lazy init because a filesystem this
+      # guest creates is one nobody is left to benefit from an eager inode
+      # table on.
+      $bb mount -t ext4 "$work" /mnt/skiff 2>/dev/null || {
+        /usr/sbin/mkfs.ext4 -Fq -m0 -E lazy_itable_init=1,lazy_journal_init=1,nodiscard "$work"
+        $bb mount -t ext4 "$work" /mnt/skiff
+      }
+      # A cache is worth keeping right up to the point where it stops fitting.
+      # Past that every skiff after this one fails on ENOSPC, so the guest that
+      # finds the disk nearly full is the one that resets it -- there is nobody
+      # else who could, since bosun never mounts it. df's columns: 2 is 1K
+      # blocks, 4 is available.
+      set -- $($bb df -k /mnt/skiff | $bb tail -1)
+      if [ -n "$4" ] && [ "$4" -lt $(( $2 / 5 )) ]; then
+        echo "skiff-mark workspace-reset $4 of $2 KiB free"
+        $bb umount /mnt/skiff
+        /usr/sbin/mkfs.ext4 -Fq -m0 -E lazy_itable_init=1,lazy_journal_init=1,nodiscard "$work"
+        $bb mount -t ext4 "$work" /mnt/skiff
+      fi
+      # docker's data root is wiped every boot, persisted disk or not: a skiff
+      # killed mid-job leaves container metadata dockerd would try to restore
+      # into a machine that is not the one that wrote it, and what keeping the
+      # layer store would save is one image pull. The runner's workspace is
+      # where the value is.
+      $bb rm -rf /mnt/skiff/docker
+      $bb mkdir -p /mnt/skiff/work /mnt/skiff/docker /mnt/skiff/cache
       $bb chmod 0710 /mnt/skiff/docker
       $bb mount -o bind /mnt/skiff/work /home/runner/_work
       $bb mount -o bind /mnt/skiff/docker /var/lib/docker
+      # What a job may keep between skiffs. Announced as one environment
+      # variable rather than as a path a workflow has to know, because the
+      # honest reading of "is there a warm cache here" is "did the hull set
+      # this" -- a class with no disk, or one that does not persist, sets
+      # nothing and a workflow falls back to whatever it does on a hosted
+      # runner. `run` below is what puts it in the runner's environment.
+      #
+      # The runner's own tool cache needs no line here: with
+      # AGENT_TOOLSDIRECTORY unset it defaults to _work/_tool, which is already
+      # on this disk, so setup-bun and mise stop re-downloading a toolchain
+      # every job for free.
+      echo 'export SKIFF_CACHE=/mnt/skiff/cache' > /etc/skiff-env
     else
       # A plain tmpfs: docker's overlayfs snapshotter cannot put upper/work
       # dirs on the root overlay itself (EINVAL on mount).
@@ -194,6 +234,10 @@ let
     export HOME=/home/runner
     export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
     export RUNNER_ALLOW_RUNASROOT=1
+    # Whatever setup decided this skiff may keep between jobs, or nothing. The
+    # runner hands its own environment down to every step, so a variable
+    # exported here is a variable a workflow can read.
+    [ -f /etc/skiff-env ] && . /etc/skiff-env
     # Read rather than passed as an argument: --jitconfig would put the
     # credential in every process listing inside the guest.
     export ACTIONS_RUNNER_INPUT_JITCONFIG="$(/opt/bosun/busybox cat /run/bosun/jitconfig)"


### PR DESCRIPTION
## The workspace disk has never worked

Measured on riptide today. Every `skiff-ubuntu` since the disk was introduced logged this and carried on, because nothing checked:

```
I/O error, dev vdb, sector 0 op 0x3:(DISCARD)
I/O error, dev vdb, sector 0 op 0x1:(WRITE)
mkfs.ext4: Input/output error while writing out and closing file system
mount: mounting /dev/vdb on /mnt/skiff failed: Invalid argument
```

cloud-hypervisor 52 explains it in its own log: `Autodetected raw image type. Disabling sector 0 writes`, then `Request check failed: … ReadOnly`. A disk whose type it had to guess refuses sector-0 writes, so `mkfs` dies and the mount that follows fails on a device that looks broken rather than protected.

The consequence is not cosmetic: the runner's workspace and docker's data root have been on the guest's tmpfs overlay the whole time — the exact condition the disk exists to end — at a `memory` figure that was lowered to 3072M on the strength of the disk working. `image_type=raw` on every `--disk` is the fix; the hull also stops asking `mkfs` for a discard the backend cannot do.

## Then keep it warm

The last bench put a skiff at hosted-runner speed on compute (build 22 s against `ubuntu-latest`'s 25 s) and lost 70 s of a 99 s deficit inside one `actions/cache` step — a dependency store, over the internet. The answer is not a faster transfer.

`persist` on a class hands the same disk to successive skiffs, so the next one finds the checkout, the bun store, the runner's tool cache and the downloaded actions already there. Slot images are per class and per slot, claimed before boot so two replacements spawning at once cannot share one, and kept across a bosun restart — which happens on every token rotation and every rebuild of the host. A guest that finds its disk under 20% free reformats it, so an unbounded cache costs one cold job instead of ENOSPC on every job after it.

This is the one place a skiff is allowed to leave something behind. It is off by default. What is shared is a filesystem, not a machine — the VM boundary and the unit's egress filter are untouched. riptide turns it on because this repo runs no code from forks; the option's documentation carries the reasoning and the condition.

## The bench gains a `caches` input

- `best` — each label uses the fastest cache it has, which is how either would be configured for real.
- `none` — nothing is restored on any label, and a skiff's warm disk is emptied first. That is the honest question about what a runner *is* with the network out of the picture.

## Validation

- `go test ./apps/bosun` green, `-count=3`, including new coverage for slot claiming/handback, sweep keeping slot images while dropping slots above `warm`, and `ensureWorkspace` keeping a persisted image but truncating an ephemeral one.
- `nix eval .#nixosConfigurations.riptide.config.system.build.toplevel.drvPath` clean.
- Deployed to riptide from this branch and verified live: `workspace_slot` 0 and 1 claimed, `skiff-ubuntu-{0,1}.img` on disk, and the guest reaches `workspace-ready` at 0.85 s with no mkfs or mount error for the first time.

Also fixes a pre-existing test flake: every pool test drives an uncancelled context, so a skiff's lifetime goroutine outlives the test and boots a replacement into the directory `t.TempDir()` is deleting. Two tests failed their cleanup on `main` without their own assertions ever failing.

## Risk

A branch deploy reverts on riptide's next auto-upgrade from `main`, so this wants merging rather than sitting.