### PR TITLE
fix(bosun): stop a warm skiff re-fetching what the warm disk could have held

### DIFF
--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -158,11 +158,16 @@ jobs:
             echo "No warm disk. Restoring the dependency store over the network."
             exit 0
           fi
-          mkdir -p "$SKIFF_CACHE/bun" "$SKIFF_CACHE/turbo"
+          mkdir -p "$SKIFF_CACHE/bun" "$SKIFF_CACHE/turbo" "$SKIFF_CACHE/mise"
+          # mise is the odd one out: setup-bun and the runner's own tool cache
+          # land in _work/_tool, which is already on this disk, but mise keeps
+          # its toolchains under its own data directory in $HOME and re-downloads
+          # helm every job without this line.
           {
             echo "SKIFF_CACHE_ROOT=$SKIFF_CACHE"
             echo "BUN_INSTALL_CACHE_DIR=$SKIFF_CACHE/bun"
             echo "TURBO_CACHE_DIR=$SKIFF_CACHE/turbo"
+            echo "MISE_DATA_DIR=$SKIFF_CACHE/mise"
           } >> "$GITHUB_ENV"
           echo "Warm disk at $SKIFF_CACHE:"
           du -sh "$SKIFF_CACHE"/* 2>/dev/null || echo "  (empty — this slot is cold)"

--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -149,7 +149,15 @@ jobs:
           if [ "${{ inputs.caches }}" = "none" ]; then
             echo "caches: none — nothing is restored on any label."
             if [ -n "${SKIFF_CACHE:-}" ]; then
-              rm -rf "$SKIFF_CACHE"/* "${RUNNER_TOOL_CACHE:?}"/* 2>/dev/null || true
+              rm -rf "$SKIFF_CACHE"/* "${RUNNER_TOOL_CACHE:-/nonexistent}"/* 2>/dev/null || true
+              mkdir -p "$SKIFF_CACHE/bun"
+              # Emptied, but still on the disk. Left to its default, bun's store
+              # lands in $HOME on the guest's tmpfs root and a cold install of
+              # this repo is ~1.5 GiB against a 2.9 GiB class — which is an
+              # ENOSPC mid-install, measured. "No cache" has to mean an empty
+              # cache, not a cache in RAM, or this input measures the wrong
+              # machine.
+              echo "BUN_INSTALL_CACHE_DIR=$SKIFF_CACHE/bun" >> "$GITHUB_ENV"
               echo "Warm disk emptied so this skiff measures cold too."
             fi
             exit 0

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -208,11 +208,19 @@ let
       # nothing and a workflow falls back to whatever it does on a hosted
       # runner. `run` below is what puts it in the runner's environment.
       #
-      # The runner's own tool cache needs no line here: with
-      # AGENT_TOOLSDIRECTORY unset it defaults to _work/_tool, which is already
-      # on this disk, so setup-bun and mise stop re-downloading a toolchain
-      # every job for free.
-      echo 'export SKIFF_CACHE=/mnt/skiff/cache' > /etc/skiff-env
+      # The runner's tool cache is named explicitly rather than left to default.
+      # Measured: `_work/_tool` stayed at 4 KiB across warm jobs while setup-bun
+      # kept paying to download, because with AGENT_TOOLSDIRECTORY unset the
+      # runner puts its tool cache somewhere on the root overlay -- which is
+      # tmpfs, so it costs the class's memory *and* is gone next boot. Naming it
+      # here rather than in a workflow makes it a property of the machine, which
+      # is what it is: the runner reads it before any job exists.
+      $bb mkdir -p /mnt/skiff/tools
+      {
+        echo 'export SKIFF_CACHE=/mnt/skiff/cache'
+        echo 'export RUNNER_TOOL_CACHE=/mnt/skiff/tools'
+        echo 'export AGENT_TOOLSDIRECTORY=/mnt/skiff/tools'
+      } > /etc/skiff-env
     else
       # A plain tmpfs: docker's overlayfs snapshotter cannot put upper/work
       # dirs on the root overlay itself (EINVAL on mount).

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -180,12 +180,23 @@ let
         /usr/sbin/mkfs.ext4 -Fq -m0 -E lazy_itable_init=1,lazy_journal_init=1,nodiscard "$work"
         $bb mount -t ext4 "$work" /mnt/skiff
       fi
-      # docker's data root is wiped every boot, persisted disk or not: a skiff
-      # killed mid-job leaves container metadata dockerd would try to restore
-      # into a machine that is not the one that wrote it, and what keeping the
-      # layer store would save is one image pull. The runner's workspace is
-      # where the value is.
-      $bb rm -rf /mnt/skiff/docker
+      # docker keeps its layer store across skiffs and loses everything mutable.
+      #
+      # The split matters in both directions. A skiff killed mid-job leaves
+      # container and network metadata that dockerd would try to restore into a
+      # machine that is not the one that wrote it, and a job's service container
+      # carries a name GitHub generated for a job that is over -- so `containers`
+      # and `network` go. `image` and `overlay2` are pulled bytes and nothing
+      # else: keeping them is what stopped this hull paying 25 s to pull
+      # `postgres:18-alpine` on every single job, measured against 20 s on a
+      # GitHub-hosted runner that has it seeded.
+      #
+      # ponytail: deleting `containers` orphans its entries under
+      # image/overlay2/layerdb/mounts, which docker tolerates and its own gc
+      # collects. The reset-when-nearly-full rule above is the backstop; a real
+      # `docker system prune` needs a dockerd that is already up, which races
+      # the job this guest booted to run.
+      $bb rm -rf /mnt/skiff/docker/containers /mnt/skiff/docker/network /mnt/skiff/docker/tmp
       $bb mkdir -p /mnt/skiff/work /mnt/skiff/docker /mnt/skiff/cache
       $bb chmod 0710 /mnt/skiff/docker
       $bb mount -o bind /mnt/skiff/work /home/runner/_work


### PR DESCRIPTION
Follow-on to #1912, which made the workspace disk actually writable. With a disk that works, the deficit to `ubuntu-latest` fell from 98 s to 21 s — and `Build` came in at 23 s against 24 s, so what remained was never compute. It was three things the disk was carrying nothing for.

**docker's layer store.** The data root was wiped whole every boot, so `postgres:18-alpine` was pulled on every job. It now keeps `image` and `overlay2` — pulled bytes and nothing else — and loses `containers`, `network` and `tmp`, which is the state a skiff killed mid-job would otherwise hand dockerd to restore into a machine that no longer exists. Measured: `Initialize containers` 25 s cold, **15 s warm, against 19–21 s on a GitHub-hosted runner**.

**mise's toolchains.** They live in mise's own data directory under `$HOME`, not the runner tool cache, so helm was re-downloaded every job. The bench points `MISE_DATA_DIR` at the warm disk.

**The runner's tool cache.** `_work/_tool` stayed at 4 KiB across warm jobs while `Set up Bun` kept paying: with `AGENT_TOOLSDIRECTORY` unset the runner puts its tool cache on the root overlay, which is tmpfs — so it cost the class's memory *and* vanished each boot. The hull names it explicitly now. That belongs in the hull rather than a workflow: the runner reads it before any job exists.

## Numbers

Job wall clock, `caches: best`, same commit, everything warm:

| label | before #1912 | now | cores | memory |
| --- | --- | --- | --- | --- |
| **skiff-ubuntu** | 172 s | **78 s** | 4 | 2.9 GiB |
| `ubuntu-latest` | 73 s | 87 s | 4 | 15.6 GiB |
| `infra-offsite` | 192 s | 119 s | 4 | 15.5 GiB |
| `infra-folly` | 230 s | 201 s | 8 | 15.5 GiB |

A skiff with **one fifth the memory** of a hosted runner is now the fastest label in the repo, and it is also the quickest to acquire: 2 s from job creation to start, against 4 s hosted and 18 s for an ARC pod. The concurrency wall #1912 named is gone with it — `overhead` and `benchmark` on `skiff-ubuntu` now start in the same second, where at `warm = 1` the second job waited three minutes.

`ubuntu-latest` moving 73 s → 87 s across runs is hosted-runner variance, not a regression here; the skiff's own 172 → 92 → 84 → 78 is the trend worth reading.

## `caches: none` produced an ENOSPC rather than a number, and that is fixed too

Emptying `$SKIFF_CACHE` without redirecting bun's store sends a cold install — ~1.5 GiB for this repo — into `$HOME` on a 2.9 GiB tmpfs root. "No cache" has to mean an empty cache on the disk, not a cache in RAM, or the input measures a machine nobody runs.

Worth recording from that failed run: **`infra-folly` hit ENOSPC on the same step**, on its own pod storage. That is an ARC problem this PR does not touch and it wants its own look.

## Validation

`go test ./apps/bosun` unchanged and green. Deployed to riptide from this branch and benchmarked live across all four labels; numbers above are from runs 31262454831, 31262612953 and 31262840803.