### PR TITLE
feat(spindrift): give the control plane a UI an operator can read

### DIFF
--- a/apps/spindrift/src/commands/apps/list.ts
+++ b/apps/spindrift/src/commands/apps/list.ts
@@ -1,7 +1,31 @@
 import { z } from 'zod';
 import { artifactSummary } from '../../domain/artifact-name.ts';
+import { elapsedSince } from '../../domain/elapsed.ts';
 import type { AppListItem, DeployPhase } from '../../web/model.ts';
 import { type Command, ok } from '../types.ts';
+
+/**
+ * How bad each phase is, worst first.
+ *
+ * An App has as many phases as it has Components and this list has one word for
+ * it, so the word has to be the worst of them. Reading it off whichever
+ * Component came back first made the row's answer depend on row order: an App
+ * with a serving `web` and a red `worker` reported `live`, which is the one
+ * state a triage scan exists to not miss.
+ *
+ * Red beats anything still moving and anything still moving beats live, because
+ * both of those are states somebody has something to do about. Within the three
+ * in-flight phases the least-progressed wins — §6 orders them
+ * `PENDING → APPLYING → WAITING`, so the App is only as far along as its
+ * furthest-behind Component.
+ */
+const SEVERITY = {
+  FAILED: 0,
+  PENDING: 1,
+  APPLYING: 2,
+  WAITING: 3,
+  LIVE: 4,
+} as const satisfies Record<DeployPhase, number>;
 
 export const listAppsInput = z.object({});
 export type ListAppsInput = z.infer<typeof listAppsInput>;
@@ -32,6 +56,8 @@ export const listApps: Command<
     },
   });
 
+  const now = context.clock.now();
+
   const items = allApps.map((app) => {
     let source = 'archive';
     if (app.sourceKind === 'repo') {
@@ -50,8 +76,31 @@ export const listApps: Command<
       }
     }
 
-    const comp = app.components[0];
-    const deploy = comp?.deploys[0];
+    /*
+      The Component the row is about — the one whose phase became the App's.
+
+      Every other fact on the row is read from that same one: its kind, its
+      artifact, the commit it was built from, where it is placed and when it
+      shipped. A row that named one Component's artifact beside another's
+      placement would be two answers wearing one line, and the reader has no way
+      to tell which Component either half belongs to.
+    */
+    const ranked = app.components.map((component) => ({
+      component,
+      deploy: component.deploys[0],
+      phase: (component.deploys[0]?.phase ?? 'PENDING') as DeployPhase,
+    }));
+    const worst = ranked.reduce<(typeof ranked)[number] | undefined>(
+      (chosen, candidate) =>
+        chosen === undefined ||
+        SEVERITY[candidate.phase] < SEVERITY[chosen.phase]
+          ? candidate
+          : chosen,
+      undefined,
+    );
+
+    const comp = worst?.component;
+    const deploy = worst?.deploy;
     const target = deploy?.target;
 
     return {
@@ -60,10 +109,23 @@ export const listApps: Command<
       vessel: target?.vessel.name ?? '',
       source,
       kind: comp?.kind ?? 'service',
-      phase: (deploy?.phase ?? 'PENDING') as DeployPhase,
+      phase: worst?.phase ?? 'PENDING',
       target: target?.adapter ?? 'none',
       url: deploy?.url ?? app.vanityDomain ?? '',
       urlLive: deploy?.phase === 'LIVE',
+      componentCount: app.components.length,
+      failing: ranked.filter((row) => row.phase === 'FAILED').length,
+      // Only where a release exists. An App nobody has deployed has no commit
+      // and no date, and rendering "just now" over one that has never shipped
+      // would date the App by when this query ran.
+      ...(deploy === undefined
+        ? {}
+        : {
+            commit: deploy.build.commit,
+            when: elapsedSince(deploy.createdAt, now),
+            at: deploy.createdAt.toISOString(),
+            deployId: deploy.id,
+          }),
       // `deploy.build` is a real Build row whenever `deploy` is — `deploys`
       // makes `build_id` `.notNull()` — never the config hash `configVersion`
       // carries: that field is §10's total hash over a document that is

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod';
-import type { JobRuns } from '../../adapters/deploy/contract.ts';
+import type {
+  Blame,
+  FailureReason,
+  JobRuns,
+} from '../../adapters/deploy/contract.ts';
 import type { TargetAdapter } from '../../config/manifest.schema.ts';
 import { artifactSummary } from '../../domain/artifact-name.ts';
 import { elapsedSince } from '../../domain/elapsed.ts';
@@ -17,6 +21,9 @@ import type {
   ComponentView,
   DatastoreView,
   DeployPhase,
+  Diagnosis,
+  DriftView,
+  PrerequisiteRowView,
   Runtime,
   WorkspaceView,
 } from '../../web/model.ts';
@@ -125,9 +132,12 @@ export const getAppWorkspace: Command<
   const desiredTarget = selected?.desiredTargets[0]?.target;
   const workspaceTarget = latestTarget ?? desiredTarget;
 
+  const now = context.clock.now();
+
   const components: ComponentView[] = app.components.map((comp) => {
     const deploy = comp.deploys[0];
     const build = deploy?.build ?? comp.builds[0];
+    const placed = deploy?.target;
 
     return {
       id: comp.id,
@@ -137,6 +147,18 @@ export const getAppWorkspace: Command<
       artifact: artifactSummary(build),
       reach: comp.reach,
       auth: comp.auth,
+      // Placement per row, so a multi-Component App stops hiding two thirds of
+      // itself behind the selection. The hero states where the *selected*
+      // Component is; without these the others' placement was reachable only by
+      // pressing each row in turn, which is the one thing a list exists to
+      // spare a reader.
+      ...(placed === undefined ? {} : { target: targetRowLabel(placed) }),
+      ...(deploy?.url == null || deploy.url === ''
+        ? {}
+        : { url: deploy.url, urlLive: deploy.phase === 'LIVE' }),
+      ...(deploy === undefined
+        ? {}
+        : { when: elapsedSince(deploy.createdAt, now) }),
     };
   });
 
@@ -199,8 +221,6 @@ export const getAppWorkspace: Command<
     orderBy: (ev, { desc }) => [desc(ev.id)],
     limit: 10,
   });
-
-  const now = context.clock.now();
 
   // Every event belongs to exactly one attempt — the `attempt_events` check
   // constraint is what guarantees it — so every entry carries the id of the
@@ -277,6 +297,56 @@ export const getAppWorkspace: Command<
     };
   }
 
+  /*
+    Why the release went red, and what the platform has stopped agreeing with.
+
+    Both facts are columns on the Deploy row this screen already reads, and
+    until now both were rendered only at `/deploys/:id` — so the workspace said
+    "has no release serving yet" over a failure with a recorded reason, and "is
+    live" over a release the cluster had been refusing for two days. The panels
+    that render them were already written and already take exactly these shapes.
+  */
+  const diagnosis: Diagnosis | null =
+    latestDeploy?.phase === 'FAILED' && latestDeploy.reason
+      ? {
+          reason: latestDeploy.reason as FailureReason,
+          blame: (latestDeploy.blame ?? null) as Blame | null,
+          detail: latestDeploy.detail ?? 'Deploy failed',
+          evidence: evidenceOf(latestDeploy.debug),
+        }
+      : null;
+
+  const drift: DriftView | null =
+    latestDeploy?.driftedAt == null
+      ? null
+      : {
+          since: elapsedSince(latestDeploy.driftedAt, now),
+          at: latestDeploy.driftedAt.toISOString(),
+          observedDigest: latestDeploy.observedDigest,
+          detail: latestDeploy.driftDetail,
+        };
+
+  /*
+    The rows behind `prerequisitesMet: false`.
+
+    `health` is every catalogued row met, so the boolean the screen had was the
+    conclusion with the evidence thrown away — "A prerequisite is unmet" is a
+    dead end on the one screen where an operator is asking which one. These are
+    the stored results of the standing pass, unmet only, and without the
+    generated remediation: the change that clears a row is §13's to compose and
+    the Targets screen has the manifest and the boundary in hand to do it. This
+    names what is blocking and points there.
+  */
+  const unmetPrerequisites: readonly PrerequisiteRowView[] = (
+    workspaceTarget?.prerequisites ?? []
+  )
+    .filter((row) => !row.met)
+    .map((row) => ({
+      name: row.name,
+      met: false,
+      ...(row.detail === undefined ? {} : { detail: row.detail }),
+    }));
+
   const workspace: WorkspaceView = {
     app: app.name,
     appId: app.id,
@@ -306,10 +376,47 @@ export const getAppWorkspace: Command<
     activity,
     runtime,
     autoDeploy: app.sourceKind === 'repo' ? app.autoDeploy : null,
+    // What the release delivered and when, so `LIVE` stops being a word with
+    // no date on it. Absent rather than empty for an App that has never
+    // deployed: there is no commit and no instant, and a blank line where a
+    // commit goes reads as one that failed to load.
+    ...(latestDeploy === undefined
+      ? {}
+      : {
+          commit: latestDeploy.build.commit,
+          when: elapsedSince(latestDeploy.createdAt, now),
+          at: latestDeploy.createdAt.toISOString(),
+        }),
+    ...(diagnosis === null ? {} : { diagnosis }),
+    ...(drift === null ? {} : { drift }),
+    ...(unmetPrerequisites.length === 0 ? {} : { unmetPrerequisites }),
   };
 
   return ok({ workspace });
 };
+
+/**
+ * §6's raw `debug` payload as a screen can read it, or `null` where core
+ * recorded nothing.
+ *
+ * Serialising an absence yields `"{}"`, which is not evidence, is not what any
+ * runner emitted, and is truthy enough to be mistaken for both — so nothing is
+ * reported as nothing, and `DiagnosisPanel` gets to omit the disclosure rather
+ * than open one over an empty pane.
+ *
+ * ponytail: the same seven lines as `deploys/get-detail.ts`, which is the only
+ * other command that reads this column. Duplicated rather than shared because
+ * two callers is not a module; lift it into `domain/` if a third appears.
+ */
+function evidenceOf(debug: unknown): string | null {
+  if (debug === null || debug === undefined) return null;
+  if (typeof debug === 'string') return debug.trim() === '' ? null : debug;
+  const serialised = JSON.stringify(debug);
+  if (serialised === undefined || serialised === '{}' || serialised === '[]') {
+    return null;
+  }
+  return serialised;
+}
 
 /**
  * How many runs the screen asks for (§17).

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -34,6 +34,10 @@ import { subscribeAttempt, subscribeRuntime } from './stream-client.ts';
 import { type Theme, useTheme } from './theme.ts';
 import { Button } from './ui/button.tsx';
 import { Eyebrow } from './ui/card.tsx';
+import { ErrorState } from './ui/error-state.tsx';
+import { Page } from './ui/page.tsx';
+import { Skeleton, SkeletonRows } from './ui/skeleton.tsx';
+import { notify } from './ui/toast.tsx';
 import { cn } from './ui/utils.ts';
 import { DeployDetail } from './views/apps/deploy-detail.tsx';
 import { AppList } from './views/apps/list.tsx';
@@ -529,8 +533,21 @@ function OverviewScreen({
         builds: readonly BuildListItem[];
         deploys: readonly DeployLedgerItem[];
         targets: readonly TargetListItem[];
+        /**
+         * Whether the two paged reads had more to give.
+         *
+         * Both were asked for twelve and both answer with the cursor for the
+         * thirteenth, which this screen used to drop on the floor — and then
+         * counted the twelve it kept as if they were the fleet. Keeping the
+         * cursor is the whole fix: nothing here pages, it only needs to know
+         * that "3 running" is three of the newest twelve and not three in the
+         * installation.
+         */
+        buildsHasMore: boolean;
+        deploysHasMore: boolean;
       }
   >({ type: 'loading' });
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -564,6 +581,8 @@ function OverviewScreen({
           builds: builds.value.builds,
           deploys: deploys.value.deploys,
           targets: targets.value.targets,
+          buildsHasMore: builds.value.nextBefore !== null,
+          deploysHasMore: deploys.value.nextBefore !== null,
         });
       });
     const fail = (cause: unknown) => {
@@ -579,18 +598,21 @@ function OverviewScreen({
       live = false;
       clearInterval(refresh);
     };
-  }, []);
+  }, [reloadToken]);
 
-  if (state.type === 'loading') {
-    return <ScreenLoading>Loading Overview…</ScreenLoading>;
-  }
+  if (state.type === 'loading') return <OverviewSkeleton />;
   if (state.type === 'error') {
     return (
-      <ScreenFailure title="Failed to load Overview">
-        {state.message}
-      </ScreenFailure>
+      <ScreenFailure
+        title="Failed to load Overview"
+        message={state.message}
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
+  // Spread whole, which is how `buildsHasMore`/`deploysHasMore` reach
+  // `Overview` without this file having to know whether it reads them yet: a
+  // JSX spread carries what the receiver declares and drops the rest.
   return <Overview {...state} onNavigate={onNavigate} />;
 }
 
@@ -606,6 +628,7 @@ function BuildsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
   >({ type: 'loading' });
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [olderError, setOlderError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -644,7 +667,7 @@ function BuildsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
       live = false;
       clearInterval(refresh);
     };
-  }, []);
+  }, [reloadToken]);
 
   const loadOlder = async () => {
     if (state.type !== 'success' || state.nextBefore === null) return;
@@ -676,14 +699,14 @@ function BuildsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     }
   };
 
-  if (state.type === 'loading') {
-    return <ScreenLoading>Loading Builds…</ScreenLoading>;
-  }
+  if (state.type === 'loading') return <LedgerSkeleton />;
   if (state.type === 'error') {
     return (
-      <ScreenFailure title="Failed to load Builds">
-        {state.message}
-      </ScreenFailure>
+      <ScreenFailure
+        title="Failed to load Builds"
+        message={state.message}
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
   return (
@@ -710,6 +733,7 @@ function DeploysScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
   >({ type: 'loading' });
   const [loadingOlder, setLoadingOlder] = useState(false);
   const [olderError, setOlderError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -748,7 +772,7 @@ function DeploysScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
       live = false;
       clearInterval(refresh);
     };
-  }, []);
+  }, [reloadToken]);
 
   const loadOlder = async () => {
     if (state.type !== 'success' || state.nextBefore === null) return;
@@ -780,14 +804,14 @@ function DeploysScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     }
   };
 
-  if (state.type === 'loading') {
-    return <ScreenLoading>Loading Deploys…</ScreenLoading>;
-  }
+  if (state.type === 'loading') return <LedgerSkeleton />;
   if (state.type === 'error') {
     return (
-      <ScreenFailure title="Failed to load Deploys">
-        {state.message}
-      </ScreenFailure>
+      <ScreenFailure
+        title="Failed to load Deploys"
+        message={state.message}
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
   return (
@@ -811,28 +835,162 @@ function mergeLedger<T extends { readonly id: number }>(
   return [...byId.values()].sort((left, right) => right.id - left.id);
 }
 
-function ScreenLoading({ children }: { children: string }) {
+/**
+ * The three states every screen in this file is in before it has its data, and
+ * the one container all three of them share.
+ *
+ * They share a container because they did not, and that was the visible bug:
+ * six screens rendered `Loading Overview…` inside `max-w-[1040px]` and then
+ * mounted their content inside `max-w-[1320px]`, so arriving anywhere shifted
+ * the whole page sideways the instant the read returned. `Page` names the two
+ * widths, and a loading state that passes the same one its screen passes cannot
+ * disagree with it.
+ *
+ * `LedgerSkeleton` is a header and rows, `DetailSkeleton` is a hero and cards —
+ * the two shapes this file actually loads. Neither tries to be a picture of the
+ * real screen; a skeleton is a promise about *where* things land, and one that
+ * chases the layout is one more thing to keep in sync.
+ */
+function LedgerSkeleton({
+  width = 'wide',
+  rows = 6,
+}: {
+  width?: 'wide' | 'reading';
+  rows?: number;
+}) {
   return (
-    <div className="mx-auto w-full max-w-[1320px] px-6 py-8">
-      <p className="animate-pulse text-sm text-muted-foreground">{children}</p>
+    <Page width={width}>
+      <div className="flex flex-col gap-2.5">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-7 w-64" />
+      </div>
+      <SkeletonRows rows={rows} />
+    </Page>
+  );
+}
+
+/**
+ * The landing screen, which is tiles over a feed and not a ledger.
+ *
+ * Its own shape rather than `LedgerSkeleton` with more rows, because the tile
+ * strip is the tallest thing above the fold: standing in for it with rows moves
+ * the feed up by a hundred pixels and then drops it back down, which is the
+ * jump a skeleton exists to prevent.
+ */
+function OverviewSkeleton() {
+  return (
+    <Page>
+      <div className="flex flex-col gap-2.5">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-7 w-56" />
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Skeleton className="h-24" />
+        <Skeleton className="h-24" />
+        <Skeleton className="h-24" />
+        <Skeleton className="h-24" />
+      </div>
+      <SkeletonRows rows={8} />
+    </Page>
+  );
+}
+
+function DetailSkeleton() {
+  return (
+    <Page width="reading">
+      <div className="flex flex-col gap-2.5">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-8 w-72" />
+      </div>
+      <Skeleton className="h-28" />
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Skeleton className="h-44" />
+        <Skeleton className="h-44" />
+      </div>
+    </Page>
+  );
+}
+
+/**
+ * One ruled row of the Connections screen, loading.
+ *
+ * No `Page` around it, unlike every other skeleton here: the Targets and
+ * Repositories screens only ever render inside `ConnectionsSettings`'
+ * `divide-y` stack, so a centred max-width column would indent them out of
+ * alignment with the two sections that resolved first — which is precisely the
+ * jump this screen was worst at, three grey lines settling at three different
+ * moments and shifting the ones below each time.
+ */
+function SectionSkeleton({ rows }: { rows: number }) {
+  return (
+    <div className="flex flex-col gap-4 py-6">
+      <Skeleton className="h-4 w-40" />
+      <SkeletonRows rows={rows} />
     </div>
   );
 }
 
+/**
+ * A load that failed, with the button that re-runs it.
+ *
+ * Every caller passes `onRetry`, and every one of them had to grow a token to
+ * do it. That is the change: a screen whose read failed has nothing on it, so
+ * the reader's only previous way forward was reloading a hash-routed
+ * application to re-run one query.
+ */
 function ScreenFailure({
   title,
-  children,
+  message,
+  onRetry,
+  width = 'wide',
 }: {
   title: string;
-  children: string;
+  message: string;
+  onRetry: () => void;
+  width?: 'wide' | 'reading';
 }) {
   return (
-    <div className="mx-auto w-full max-w-[1320px] px-6 py-8">
-      <div className="rounded-sm border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-        <p className="text-sm font-medium">{title}</p>
-        <p className="mt-1 text-sm">{children}</p>
-      </div>
-    </div>
+    <Page width={width}>
+      <ErrorState title={title} message={message} onRetry={onRetry} />
+    </Page>
+  );
+}
+
+/**
+ * An id in the path that names nothing.
+ *
+ * Three screens rendered this as a centred card with an eyebrow, a heading, the
+ * server's sentence and a `Back to Apps` button — the same card three times,
+ * differing in two words. It is the same failure `ScreenFailure` renders, plus
+ * the one thing a not-found has that a transport failure does not: somewhere
+ * definite to go.
+ */
+function ScreenNotFound({
+  title,
+  message,
+  onNavigate,
+}: {
+  title: string;
+  message: string;
+  onNavigate: (path: string) => void;
+}) {
+  return (
+    <Page width="reading">
+      <ErrorState
+        title={title}
+        code="NOT_FOUND"
+        message={message}
+        secondary={
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onNavigate('/apps')}
+          >
+            Back to Apps
+          </Button>
+        }
+      />
+    </Page>
   );
 }
 
@@ -842,6 +1000,7 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     | { type: 'error'; message: string }
     | { type: 'success'; apps: readonly AppListItem[] }
   >({ type: 'loading' });
+  const [reloadToken, setReloadToken] = useState(0);
 
   // The row goes when the App does. Re-reading the list instead would be a
   // second round trip to learn something this screen was just told.
@@ -850,7 +1009,7 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
   // name drops every row sharing it, so deleting one of two same-named Apps
   // would hide the other until a reload — and reaching the other one is the
   // whole point of giving this list an identity.
-  const deletion = useAppDeletion(({ id }) => {
+  const deletion = useAppDeletion(({ id, name }) => {
     setState((current) =>
       current.type === 'success'
         ? {
@@ -859,6 +1018,10 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
           }
         : current,
     );
+    // The dialog that confirmed this closes with the press, so without this the
+    // only evidence the act happened is a row that is no longer there — which
+    // is indistinguishable from having deleted the wrong one.
+    notify({ tone: 'success', title: `Deleted ${name}` });
   });
 
   useEffect(() => {
@@ -882,26 +1045,51 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     return () => {
       live = false;
     };
-  }, []);
+  }, [reloadToken]);
 
-  if (state.type === 'loading') {
-    return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <p className="text-sm text-muted-foreground animate-pulse">
-          Loading apps...
-        </p>
-      </div>
+  /**
+   * Keep the list current, at the two cadences the workspace already uses.
+   *
+   * This screen read once at mount and never again, so a row whose App was
+   * mid-release sat on the phase it happened to have at that instant — under a
+   * dot the explorer pulses forever, which reads as "still moving" about a
+   * release that finished minutes ago. The workspace worked this out already;
+   * this is the same argument for the screen an operator watches a fleet from.
+   *
+   * A failed refresh is dropped rather than replacing a readable list with an
+   * error page. The next tick tries again.
+   */
+  const inFlight =
+    state.type === 'success' && state.apps.some((app) => isInFlight(app.phase));
+  useEffect(() => {
+    let live = true;
+    const timer = setInterval(
+      () => {
+        void command('listApps', {})
+          .then((result) => {
+            if (!live || !result.ok) return;
+            setState({ type: 'success', apps: result.value.apps });
+          })
+          .catch(() => {});
+      },
+      inFlight ? 3_000 : 20_000,
     );
-  }
+    return () => {
+      live = false;
+      clearInterval(timer);
+    };
+  }, [inFlight]);
+
+  if (state.type === 'loading') return <LedgerSkeleton width="reading" />;
 
   if (state.type === 'error') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="text-sm font-medium">Failed to load apps</p>
-          <p className="text-sm mt-1">{state.message}</p>
-        </div>
-      </div>
+      <ScreenFailure
+        title="Failed to load Apps"
+        message={state.message}
+        width="reading"
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
 
@@ -962,7 +1150,6 @@ function WorkspaceScreen({
     | { type: 'success'; workspace: WorkspaceView }
   >({ type: 'loading' });
   const [deploying, setDeploying] = useState(false);
-  const [deployError, setDeployError] = useState<string | null>(null);
   /** Bumped when an act changed state the workspace has already read. */
   const [reloadToken, setReloadToken] = useState(0);
   /**
@@ -1168,43 +1355,26 @@ function WorkspaceScreen({
     );
   }, [runs?.componentId, runs?.targetId, following]);
 
-  if (state.type === 'loading') {
-    return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <p className="text-sm text-muted-foreground animate-pulse">
-          Loading workspace...
-        </p>
-      </div>
-    );
-  }
+  if (state.type === 'loading') return <DetailSkeleton />;
 
   if (state.type === 'not-found') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-border bg-card p-6 text-center">
-          <Eyebrow>App Not Found</Eyebrow>
-          <h1 className="mt-2 text-xl font-semibold">
-            No App named "{appName}"
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
-          <div className="mt-4 flex justify-center">
-            <Button variant="outline" onClick={() => onNavigate('/apps')}>
-              Back to Apps
-            </Button>
-          </div>
-        </div>
-      </div>
+      <ScreenNotFound
+        title={`No App named "${appName}"`}
+        message={state.message}
+        onNavigate={onNavigate}
+      />
     );
   }
 
   if (state.type === 'error') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="text-sm font-medium">Failed to load workspace</p>
-          <p className="text-sm mt-1">{state.message}</p>
-        </div>
-      </div>
+      <ScreenFailure
+        title="Failed to load workspace"
+        message={state.message}
+        width="reading"
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
 
@@ -1214,7 +1384,6 @@ function WorkspaceScreen({
   const handleDeploy = async (rebuild: boolean) => {
     if (state.type !== 'success') return;
     setDeploying(true);
-    setDeployError(null);
     try {
       // By id where the workspace knows one: `apps` does not constrain `name`,
       // and the command refuses a name two Apps answer to rather than guessing.
@@ -1242,10 +1411,18 @@ function WorkspaceScreen({
       } else {
         // The sentence the command refused with, unedited — a disconnected
         // Target, a signature that did not verify. Nothing is retried behind it.
-        setDeployError(result.failure.message);
+        notify({
+          tone: 'destructive',
+          title: 'Deploy refused',
+          detail: result.failure.message,
+        });
       }
     } catch (e: unknown) {
-      setDeployError(e instanceof Error ? e.message : 'Deploy failed');
+      notify({
+        tone: 'destructive',
+        title: 'Deploy failed',
+        detail: e instanceof Error ? e.message : 'Server failure',
+      });
     } finally {
       setDeploying(false);
     }
@@ -1380,23 +1557,6 @@ function WorkspaceScreen({
 
   return (
     <>
-      {deployError ? (
-        <div className="mx-auto mt-4 w-full max-w-[1040px] px-5">
-          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium">Deploy failed</p>
-              <p className="text-sm mt-0.5">{deployError}</p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setDeployError(null)}
-            >
-              Dismiss
-            </Button>
-          </div>
-        </div>
-      ) : null}
       <Workspace
         view={state.workspace}
         onDeploy={() => handleDeploy(false)}
@@ -1460,7 +1620,7 @@ function DeployScreen({
   >({ type: 'loading' });
 
   const [busy, setBusy] = useState<'redeploy' | 'rollback' | null>(null);
-  const [redeployError, setRedeployError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -1521,12 +1681,11 @@ function DeployScreen({
       live = false;
       stopStream?.();
     };
-  }, [deployId]);
+  }, [deployId, reloadToken]);
 
   const handleRedeploy = async () => {
     if (state.type !== 'success') return;
     setBusy('redeploy');
-    setRedeployError(null);
     try {
       // The App's id, not its name: `apps` has no unique constraint on `name`,
       // so redeploying by name would act on whichever row shares it.
@@ -1540,10 +1699,18 @@ function DeployScreen({
       } else {
         // Surfaced verbatim and acted on no further: a refused redeploy is a
         // fact about this artifact and this Target, not a cue to build another.
-        setRedeployError(result.failure.message);
+        notify({
+          tone: 'destructive',
+          title: 'Redeploy refused',
+          detail: result.failure.message,
+        });
       }
     } catch (e: unknown) {
-      setRedeployError(e instanceof Error ? e.message : 'Redeploy failed');
+      notify({
+        tone: 'destructive',
+        title: 'Redeploy failed',
+        detail: e instanceof Error ? e.message : 'Server failure',
+      });
     } finally {
       setBusy(null);
     }
@@ -1553,7 +1720,6 @@ function DeployScreen({
     if (state.type !== 'success') return;
     const view = state.deploy;
     setBusy('rollback');
-    setRedeployError(null);
     try {
       const result = await rollback({
         componentId: view.componentId,
@@ -1561,74 +1727,52 @@ function DeployScreen({
         buildId: view.buildId,
       });
       if (result.ok) {
+        // The scariest button in the product, and until now the only thing it
+        // said on success was a different id in the URL. The build number is
+        // what makes the sentence checkable against what the operator meant.
+        notify({
+          tone: 'success',
+          title: `Rolled back to build ${view.buildId}`,
+          detail: `Deploy #${result.deployId} is the release now serving.`,
+        });
         onNavigate(`/deploys/${result.deployId}`);
       } else {
-        setRedeployError(result.message);
+        notify({
+          tone: 'destructive',
+          title: 'Rollback refused',
+          detail: result.message,
+        });
       }
     } finally {
       setBusy(null);
     }
   };
 
-  if (state.type === 'loading') {
-    return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <p className="text-sm text-muted-foreground animate-pulse">
-          Loading deploy details...
-        </p>
-      </div>
-    );
-  }
+  if (state.type === 'loading') return <DetailSkeleton />;
 
   if (state.type === 'not-found') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-border bg-card p-6 text-center">
-          <Eyebrow>Deploy Not Found</Eyebrow>
-          <h1 className="mt-2 text-xl font-semibold">
-            Deploy #{deployId} not found
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
-          <div className="mt-4 flex justify-center">
-            <Button variant="outline" onClick={() => onNavigate('/apps')}>
-              Back to Apps
-            </Button>
-          </div>
-        </div>
-      </div>
+      <ScreenNotFound
+        title={`Deploy #${deployId} not found`}
+        message={state.message}
+        onNavigate={onNavigate}
+      />
     );
   }
 
   if (state.type === 'error') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="text-sm font-medium">Failed to load deploy detail</p>
-          <p className="text-sm mt-1">{state.message}</p>
-        </div>
-      </div>
+      <ScreenFailure
+        title="Failed to load deploy detail"
+        message={state.message}
+        width="reading"
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
 
   return (
     <>
-      {redeployError ? (
-        <div className="mx-auto mt-4 w-full max-w-[1040px] px-5">
-          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium">That act was refused</p>
-              <p className="text-sm mt-0.5">{redeployError}</p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setRedeployError(null)}
-            >
-              Dismiss
-            </Button>
-          </div>
-        </div>
-      ) : null}
       <DeployDetail
         view={state.deploy}
         actions={{
@@ -1662,7 +1806,7 @@ function BuildScreen({
     | { type: 'success'; attempt: DeployView; deployId: number | null }
   >({ type: 'loading' });
   const [busy, setBusy] = useState<'redeploy' | 'deploy' | null>(null);
-  const [actionError, setActionError] = useState<string | null>(null);
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -1711,12 +1855,11 @@ function BuildScreen({
       live = false;
       stopStream?.();
     };
-  }, [buildId]);
+  }, [buildId, reloadToken]);
 
   const act = async (kind: 'redeploy' | 'deploy') => {
     if (state.type !== 'success') return;
     setBusy(kind);
-    setActionError(null);
     try {
       // One command for both, because §4 gives the workspace button one
       // meaning: deploy the newest artifact, or start the Build that would
@@ -1730,52 +1873,43 @@ function BuildScreen({
             : `/deploys/${result.value.deployId}`,
         );
       } else {
-        setActionError(result.failure.message);
+        notify({
+          tone: 'destructive',
+          title: 'That act was refused',
+          detail: result.failure.message,
+        });
       }
     } catch (cause) {
-      setActionError(cause instanceof Error ? cause.message : 'Deploy failed');
+      notify({
+        tone: 'destructive',
+        title: 'Deploy failed',
+        detail: cause instanceof Error ? cause.message : 'Server failure',
+      });
     } finally {
       setBusy(null);
     }
   };
 
-  if (state.type === 'loading') {
-    return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <p className="text-sm text-muted-foreground animate-pulse">
-          Loading build...
-        </p>
-      </div>
-    );
-  }
+  if (state.type === 'loading') return <DetailSkeleton />;
 
   if (state.type === 'not-found') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-border bg-card p-6 text-center">
-          <Eyebrow>Build Not Found</Eyebrow>
-          <h1 className="mt-2 text-xl font-semibold">
-            Build #{buildId} not found
-          </h1>
-          <p className="mt-1 text-sm text-muted-foreground">{state.message}</p>
-          <div className="mt-4 flex justify-center">
-            <Button variant="outline" onClick={() => onNavigate('/apps')}>
-              Back to Apps
-            </Button>
-          </div>
-        </div>
-      </div>
+      <ScreenNotFound
+        title={`Build #${buildId} not found`}
+        message={state.message}
+        onNavigate={onNavigate}
+      />
     );
   }
 
   if (state.type === 'error') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="text-sm font-medium">Failed to load build</p>
-          <p className="text-sm mt-1">{state.message}</p>
-        </div>
-      </div>
+      <ScreenFailure
+        title="Failed to load build"
+        message={state.message}
+        width="reading"
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
 
@@ -1792,23 +1926,6 @@ function BuildScreen({
           >
             Open related Deploy
           </Button>
-        </div>
-      ) : null}
-      {actionError ? (
-        <div className="mx-auto mt-4 w-full max-w-[1040px] px-5">
-          <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium">That act was refused</p>
-              <p className="text-sm mt-0.5">{actionError}</p>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setActionError(null)}
-            >
-              Dismiss
-            </Button>
-          </div>
         </div>
       ) : null}
       <DeployDetail
@@ -1911,23 +2028,16 @@ function TargetsScreen({
     }
   };
 
-  if (state.type === 'loading') {
-    return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <p className="text-sm text-muted-foreground animate-pulse">
-          Loading targets...
-        </p>
-      </div>
-    );
-  }
+  if (state.type === 'loading') return <SectionSkeleton rows={3} />;
 
   if (state.type === 'error') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="text-sm font-medium">Failed to load targets</p>
-          <p className="text-sm mt-1">{state.message}</p>
-        </div>
+      <div className="py-6">
+        <ErrorState
+          title="Failed to load Targets"
+          message={state.message}
+          onRetry={() => setReloadToken((token) => token + 1)}
+        />
       </div>
     );
   }
@@ -1954,6 +2064,7 @@ function SourcesScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     | { type: 'error'; message: string }
     | { type: 'success'; result: OutputOf<'listSources'> }
   >({ type: 'loading' });
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -1976,16 +2087,16 @@ function SourcesScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     return () => {
       live = false;
     };
-  }, []);
+  }, [reloadToken]);
 
-  if (state.type === 'loading') {
-    return <ScreenLoading>Loading Sources…</ScreenLoading>;
-  }
+  if (state.type === 'loading') return <LedgerSkeleton />;
   if (state.type === 'error') {
     return (
-      <ScreenFailure title="Failed to load Sources">
-        {state.message}
-      </ScreenFailure>
+      <ScreenFailure
+        title="Failed to load Sources"
+        message={state.message}
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
   return (
@@ -2007,6 +2118,7 @@ function ArtifactsScreen({
     | { type: 'error'; message: string }
     | { type: 'success'; result: OutputOf<'listArtifacts'> }
   >({ type: 'loading' });
+  const [reloadToken, setReloadToken] = useState(0);
 
   useEffect(() => {
     let live = true;
@@ -2029,16 +2141,16 @@ function ArtifactsScreen({
     return () => {
       live = false;
     };
-  }, []);
+  }, [reloadToken]);
 
-  if (state.type === 'loading') {
-    return <ScreenLoading>Loading Artifacts…</ScreenLoading>;
-  }
+  if (state.type === 'loading') return <LedgerSkeleton />;
   if (state.type === 'error') {
     return (
-      <ScreenFailure title="Failed to load Artifacts">
-        {state.message}
-      </ScreenFailure>
+      <ScreenFailure
+        title="Failed to load Artifacts"
+        message={state.message}
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
     );
   }
   return (
@@ -2163,23 +2275,16 @@ function RepositoriesScreen({ embedded = false }: { embedded?: boolean }) {
     authorization?.state,
   ]);
 
-  if (state.type === 'loading') {
-    return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <p className="text-sm text-muted-foreground animate-pulse">
-          Loading repositories...
-        </p>
-      </div>
-    );
-  }
+  if (state.type === 'loading') return <SectionSkeleton rows={2} />;
 
   if (state.type === 'error') {
     return (
-      <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-5 px-5 py-6">
-        <div className="rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="text-sm font-medium">Failed to load repositories</p>
-          <p className="text-sm mt-1">{state.message}</p>
-        </div>
+      <div className="py-6">
+        <ErrorState
+          title="Failed to load repositories"
+          message={state.message}
+          onRetry={handleRefresh}
+        />
       </div>
     );
   }

--- a/apps/spindrift/src/web/client/index.html
+++ b/apps/spindrift/src/web/client/index.html
@@ -1,10 +1,38 @@
 <!doctype html>
-<html lang="en" data-theme="dark">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="color-scheme" content="light dark" />
     <title>Spindrift</title>
+    <!--
+      The stored theme, stamped before the stylesheet is even fetched.
+
+      `data-theme="dark"` used to be typed on the element above, which made the
+      shipped default a fact about the document rather than about the
+      stylesheet: a reader who chose light got a dark page until `main.tsx`
+      called `restoreTheme()`, and a module script runs after the document is
+      parsed. Blocking and inline is the only position that paints once.
+
+      It agrees with `theme.ts` deliberately, including the awkward part: the
+      absence of the attribute *is* the `system` choice, so `system` removes
+      nothing and stamps nothing, while a missing or unreadable value falls back
+      to the shipped dark. `restoreTheme()` stays where it is as the path for a
+      browser that refused this script.
+    -->
+    <script>
+      try {
+        const choice = localStorage.getItem("spindrift.theme");
+        if (choice !== "system") {
+          document.documentElement.setAttribute(
+            "data-theme",
+            choice === "light" ? "light" : "dark",
+          );
+        }
+      } catch {
+        document.documentElement.setAttribute("data-theme", "dark");
+      }
+    </script>
     <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>

--- a/apps/spindrift/src/web/client/styles.css
+++ b/apps/spindrift/src/web/client/styles.css
@@ -22,101 +22,102 @@
  * directions — forcing light on a dark OS is as real a request as the reverse.
  * The system choice is the absence of an attribute, so the light OS block
  * excludes `[data-theme="dark"]` and leaves an explicit dark choice alone.
+ *
+ * Those three inputs now settle exactly one property. Each raw variable is
+ * declared **once**, as `light-dark(<light>, <dark>)`, and the three blocks
+ * below carry nothing but `color-scheme` — which is the input `light-dark()`
+ * reads. The palette used to be typed out three times, and the drift that
+ * costs was not hypothetical: `--terminal-bad` and `--terminal-dim` were
+ * missing from both light copies, so an error line in a build log fell back to
+ * the inherited ink for any reader not on the default. A value that cannot be
+ * written twice cannot disagree with itself.
+ *
+ * Two of the light values are not the prototypes' — `--accent` and `--ink-3`
+ * are a shade deeper, because the originals measured below 4.5:1 against the
+ * surfaces they are read on. Contrast is not a palette preference.
  */
 
 @import "tailwindcss";
 
-@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
-
 :root {
   color-scheme: dark;
-  --ground: #07171b;
-  --surface: #0d2228;
-  --surface-2: #10272d;
-  --inspector: #0a1d22;
-  --topbar: #07171b;
-  --line: #29474e;
-  --line-soft: #233f46;
-  --ink: #eaf4f5;
-  --ink-2: #a8bec3;
-  --ink-3: #91aab0;
-  --accent: #59b8c6;
-  --accent-soft: #153740;
-  --good: #91ddb6;
-  --good-soft: #15392c;
-  --warn: #f0bd72;
-  --warn-soft: #3a2b16;
-  --bad: #ef9a94;
-  --bad-soft: #3b201f;
-  --terminal: #051216;
+  --ground: light-dark(#f4f7f7, #07171b);
+  --surface: light-dark(#ffffff, #0d2228);
+  --surface-2: light-dark(#edf1f2, #10272d);
+  --inspector: light-dark(#f9fbfb, #0a1d22);
+  --topbar: light-dark(#ffffff, #07171b);
+  --line: light-dark(#dce5e6, #29474e);
+  --line-soft: light-dark(#e7edef, #233f46);
+  --ink: light-dark(#102229, #eaf4f5);
+  --ink-2: light-dark(#43585f, #a8bec3);
+  --ink-3: light-dark(#566970, #91aab0);
+  --accent: light-dark(#16707f, #59b8c6);
+  --accent-soft: light-dark(#def1f4, #153740);
+  --good: light-dark(#20784f, #91ddb6);
+  --good-soft: light-dark(#dff3e9, #15392c);
+  --warn: light-dark(#96631d, #f0bd72);
+  --warn-soft: light-dark(#faefd9, #3a2b16);
+  --bad: light-dark(#a43e37, #ef9a94);
+  --bad-soft: light-dark(#f9e4e1, #3b201f);
+
+  /*
+   * Text drawn *on* the accent, which is a different job from the accent
+   * itself. A filled primary button used to set its label to `--ground`, and
+   * on a light page that is near-white type on a mid teal — the surface colour
+   * was doing a text colour's work and failing the same measurement the two
+   * values above were corrected for.
+   */
+  --on-accent: light-dark(#ffffff, #07171b);
+
+  /*
+   * The terminal does not flip. A build log is a verbatim transcript of
+   * something a machine printed, so it keeps its own dark ground in both
+   * themes — see `components/log-pane.tsx`, which is the same argument. Only
+   * the ground shifts a shade, to sit on a light page without reading as a
+   * hole punched in it.
+   */
+  --terminal: light-dark(#0e1619, #051216);
   --terminal-ink: #c3d3d8;
   --terminal-bad: #f0938a;
   --terminal-dim: #6d838b;
-  --rail: #051216;
+
+  /* The rail is dark in both themes, for the same reason the terminal is: it
+     is chrome, not page. */
+  --rail: light-dark(#092126, #051216);
   --rail-active: #17414a;
-  --rail-line: #17343b;
+  --rail-line: light-dark(#1c444c, #17343b);
   --rail-foreground: #eefcfd;
-  --rail-muted: #82a8ae;
+  --rail-muted: light-dark(#9fc1c6, #82a8ae);
+
+  /*
+   * The three tokens a floating surface needs, which were previously typed as
+   * literal `shadow-[…]` and `bg-[color:…]` at the call sites that wanted
+   * them. A shadow tuned for a near-black page is invisible on a white one, so
+   * this flips too.
+   */
+  --panel-shadow: light-dark(
+    0 18px 55px rgb(15 40 46 / 12%),
+    0 18px 55px rgb(0 0 0 / 28%)
+  );
+  --overlay: light-dark(rgb(16 34 41 / 40%), rgb(3 10 12 / 62%));
+  /*
+   * How far to invert a single-colour mark. `ui/logo.tsx` reads it as
+   * `filter: invert(var(--logo-invert))` rather than through a Tailwind `dark` variant,
+   * because the variant keys on an attribute that `theme.ts` deliberately
+   * removes for the `system` choice — so the mark was invisible for every
+   * reader who left the theme to their OS.
+   */
+  --logo-invert: light-dark(0, 1);
 }
 
 /* Explicit light, and the system choice when the OS asks for light. */
 :root[data-theme="light"] {
   color-scheme: light;
-  --ground: #f4f7f7;
-  --surface: #ffffff;
-  --surface-2: #edf1f2;
-  --inspector: #f9fbfb;
-  --topbar: #ffffff;
-  --line: #dce5e6;
-  --line-soft: #e7edef;
-  --ink: #102229;
-  --ink-2: #43585f;
-  --ink-3: #697b82;
-  --accent: #238ca0;
-  --accent-soft: #def1f4;
-  --good: #20784f;
-  --good-soft: #dff3e9;
-  --warn: #96631d;
-  --warn-soft: #faefd9;
-  --bad: #a43e37;
-  --bad-soft: #f9e4e1;
-  --terminal: #0e1619;
-  --terminal-ink: #c3d3d8;
-  --rail: #092126;
-  --rail-active: #17414a;
-  --rail-line: #1c444c;
-  --rail-foreground: #eefcfd;
-  --rail-muted: #9fc1c6;
 }
 
 @media (prefers-color-scheme: light) {
   :root:not([data-theme="dark"]) {
     color-scheme: light;
-    --ground: #f4f7f7;
-    --surface: #ffffff;
-    --surface-2: #edf1f2;
-    --inspector: #f9fbfb;
-    --topbar: #ffffff;
-    --line: #dce5e6;
-    --line-soft: #e7edef;
-    --ink: #102229;
-    --ink-2: #43585f;
-    --ink-3: #697b82;
-    --accent: #238ca0;
-    --accent-soft: #def1f4;
-    --good: #20784f;
-    --good-soft: #dff3e9;
-    --warn: #96631d;
-    --warn-soft: #faefd9;
-    --bad: #a43e37;
-    --bad-soft: #f9e4e1;
-    --terminal: #0e1619;
-    --terminal-ink: #c3d3d8;
-    --rail: #092126;
-    --rail-active: #17414a;
-    --rail-line: #1c444c;
-    --rail-foreground: #eefcfd;
-    --rail-muted: #9fc1c6;
   }
 }
 
@@ -128,7 +129,7 @@
   --color-popover: var(--surface);
   --color-popover-foreground: var(--ink);
   --color-primary: var(--accent);
-  --color-primary-foreground: var(--ground);
+  --color-primary-foreground: var(--on-accent);
   --color-secondary: var(--surface-2);
   --color-secondary-foreground: var(--ink);
   --color-muted: var(--surface-2);
@@ -140,6 +141,7 @@
   --color-border-soft: var(--line-soft);
   --color-input: var(--line);
   --color-ring: var(--accent);
+  --color-overlay: var(--overlay);
 
   --color-success: var(--good);
   --color-success-soft: var(--good-soft);
@@ -161,9 +163,47 @@
   --color-rail-foreground: var(--rail-foreground);
   --color-rail-muted: var(--rail-muted);
 
-  --radius-sm: 4px;
+  --shadow-panel: var(--panel-shadow);
+
+  /*
+   * Six sizes, and the screens are allowed exactly these. The count is not a
+   * preference: `text-[11px]`, `text-[11.5px]`, `text-[12.5px]` and
+   * `text-[10.5px]` were all in the tree at once, which is four names for one
+   * caption and no way to change captions. Each step names the job rather than
+   * the pixels — `caption` is the label above a value, `body` is a row of
+   * machine facts, `ui` is prose a person reads, and `display` is the one
+   * number or title a screen exists to say.
+   */
+  --text-micro: 10px;
+  --text-micro--line-height: 1.4;
+  --text-caption: 11.5px;
+  --text-caption--line-height: 1.45;
+  --text-body: 13px;
+  --text-body--line-height: 1.55;
+  --text-ui: 15px;
+  --text-ui--line-height: 1.5;
+  --text-title: 20px;
+  --text-title--line-height: 1.3;
+  --text-display: 28px;
+  --text-display--line-height: 1.15;
+
+  /* The two letter-spacings the type has: wide for an uppercase eyebrow, tight
+     for anything set at display size. Both were retyped as arbitrary values at
+     every site that wanted them. */
+  --tracking-eyebrow: 0.1em;
+  --tracking-display: -0.02em;
+
+  /* The step every `p-*`/`gap-*`/`size-*` utility multiplies. Declared rather
+     than inherited from Tailwind's default so the rhythm is a fact in this
+     file, where a reader looking for it would look. */
+  --spacing: 4px;
+
+  --radius-sm: 5px;
+  /* An alias, not a step. 56 call sites say `rounded-md`; pointing it at the
+     small radius makes every one of them correct today, and sweeping the class
+     name later is cosmetic. */
   --radius-md: 5px;
-  --radius-lg: 7px;
+  --radius-lg: 10px;
 
   --font-sans:
     Inter, "Segoe UI Variable", "Segoe UI", ui-sans-serif, system-ui,
@@ -192,7 +232,7 @@
     background-attachment: fixed;
     color: var(--color-foreground);
     font-family: var(--font-sans);
-    font-size: 15px;
+    font-size: var(--text-ui);
     line-height: 1.5;
     -webkit-font-smoothing: antialiased;
   }
@@ -213,5 +253,33 @@
   :focus-visible {
     outline: 2px solid var(--color-ring);
     outline-offset: 2px;
+  }
+}
+
+/*
+ * One reduced-motion reset, here rather than per component.
+ *
+ * `ui/badge.tsx` declares `motion-safe:` on its dot and explains that it is the
+ * only animation in the app; that stopped being true around the fourteenth
+ * `animate-pulse`, and a reader who asked for less motion should not have to
+ * hope every new site remembered the variant. Nothing here is load-bearing as
+ * motion — every pulsing thing also carries a word and a tone — so cutting the
+ * duration removes the animation without removing the meaning.
+ *
+ * **Unlayered on purpose**, and this is the only rule in the file that is. It
+ * has to beat `animate-pulse`, which lives in Tailwind's `utilities` layer, and
+ * cascade layers outrank specificity: the same rule inside `@layer base` loses
+ * to every utility no matter how it is written, and would need `!important` on
+ * each declaration to win. An unlayered rule wins by position in the cascade
+ * instead, which is the mechanism rather than a fight with it.
+ */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms;
+    animation-iteration-count: 1;
+    transition-duration: 0.01ms;
+    scroll-behavior: auto;
   }
 }

--- a/apps/spindrift/src/web/components/breadcrumbs.tsx
+++ b/apps/spindrift/src/web/components/breadcrumbs.tsx
@@ -1,0 +1,138 @@
+/**
+ * Where you are, all of it — not just the first segment.
+ *
+ * The header used to read `SPINDRIFT / {title(path)}`, where `title` took the
+ * first path segment and capitalised it. So `/apps/morrow` said **Apps**, and
+ * `/deploys/1187` said **Deploys**, and every detail screen in the product
+ * shared a crumb with the ledger it was opened from. The one place the chrome
+ * is asked "which object is this" answered "the kind of object it is".
+ *
+ * The trail is derived from the path and nothing else. That is deliberate: the
+ * shell would otherwise need every screen to hand it a display name, which is a
+ * prop threaded through six route branches to duplicate a string the URL is
+ * already carrying — and one that would be blank for the second or two the
+ * screen spends loading, which is exactly when a reader looks up to check where
+ * they landed. The last segment of `/apps/morrow` *is* the App's identity;
+ * printing it is honest, and it never lags.
+ *
+ * Two things it refuses. It is not a router — a crumb's `path` is handed back
+ * to `onNavigate`, and nothing here knows what those paths render. And the
+ * final crumb carries no path at all: a link to the page you are on is a
+ * control that does nothing, and readers press it to try to reload.
+ *
+ * The literal `SPINDRIFT /` stays. It is the product's name in the one piece of
+ * chrome present on every screen, and `object-explorer.test.tsx` pins it.
+ */
+
+export interface Crumb {
+  readonly label: string;
+  /** Absent on the last crumb: it is where the reader already is. */
+  readonly path?: string;
+}
+
+/**
+ * The three roots that stopped being screens and became sections of Settings —
+ * `components/shell.tsx`'s `NAVIGATION` carries the same list for the same
+ * reason.
+ */
+const SETTINGS_ROOTS = new Set(['settings', 'targets', 'repos', 'storage']);
+
+/** §2's chain read left to right, and the one rail entry it collapses into. */
+const SUPPLY_CHAIN: Record<string, string> = {
+  builds: 'Builds',
+  sources: 'Sources',
+  artifacts: 'Artifacts',
+};
+
+function sentence(segment: string): string {
+  return segment.charAt(0).toUpperCase() + segment.slice(1);
+}
+
+function trail(path: string): Crumb[] {
+  const [head, ...rest] = path.split('/').filter(Boolean);
+  if (head === undefined) return [{ label: 'Overview', path: '/' }];
+
+  if (SETTINGS_ROOTS.has(head)) {
+    // `/targets`, `/repos` and `/storage` all land on Connections, so the crumb
+    // names the section the reader is actually looking at rather than the path
+    // they typed.
+    const section =
+      head === 'settings' ? (rest[0] ?? 'connections') : 'connections';
+    return [
+      { label: 'Settings', path: '/settings/connections' },
+      { label: sentence(section), path: `/settings/${section}` },
+    ];
+  }
+
+  const stage = SUPPLY_CHAIN[head];
+  if (stage !== undefined) {
+    const crumbs: Crumb[] = [
+      { label: 'Supply chain', path: '/builds' },
+      { label: stage, path: `/${head}` },
+    ];
+    if (rest[0]) crumbs.push({ label: `#${rest[0]}`, path });
+    return crumbs;
+  }
+
+  if (head === 'deploys') {
+    const crumbs: Crumb[] = [{ label: 'Deploys', path: '/deploys' }];
+    if (rest[0]) crumbs.push({ label: `#${rest[0]}`, path });
+    return crumbs;
+  }
+
+  // Everything left names an App, including the bare `/<name>` the route table
+  // still answers for a link written before `/apps/` existed.
+  const crumbs: Crumb[] = [{ label: 'Apps', path: '/apps' }];
+  const tail = head === 'apps' ? rest : [head];
+  if (tail[0] === 'new') {
+    crumbs.push({ label: 'New App', path: '/apps/new' });
+  } else if (tail[0]) {
+    crumbs.push({ label: tail[0], path });
+  }
+  return crumbs;
+}
+
+export function crumbsFor(path: string): readonly Crumb[] {
+  const crumbs = trail(path);
+  return crumbs.map((crumb, index) =>
+    index === crumbs.length - 1 ? { label: crumb.label } : crumb,
+  );
+}
+
+export function Breadcrumbs({
+  path,
+  onNavigate,
+}: {
+  readonly path: string;
+  readonly onNavigate: (path: string) => void;
+}) {
+  const crumbs = crumbsFor(path);
+
+  return (
+    <nav aria-label="Breadcrumb" className="min-w-0">
+      <ol className="flex min-w-0 items-center gap-1.5 font-mono text-micro font-bold tracking-eyebrow text-muted-foreground">
+        <li className="shrink-0">SPINDRIFT /</li>
+        {crumbs.map((crumb, index) => (
+          <li key={crumb.label} className="flex min-w-0 items-center gap-1.5">
+            {index > 0 ? <span aria-hidden="true">/</span> : null}
+            {crumb.path === undefined ? (
+              // `aria-current="page"` on the text, not on a control: this is the
+              // crumb for the screen already on display.
+              <span aria-current="page" className="truncate text-foreground">
+                {crumb.label}
+              </span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => onNavigate(crumb.path ?? '/')}
+                className="truncate rounded-sm hover:text-foreground focus-visible:-outline-offset-2"
+              >
+                {crumb.label}
+              </button>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}

--- a/apps/spindrift/src/web/components/command-palette.tsx
+++ b/apps/spindrift/src/web/components/command-palette.tsx
@@ -1,0 +1,383 @@
+/**
+ * Everything in the installation, one keystroke away.
+ *
+ * Before this the entire application contained exactly one `onKeyDown` handler,
+ * and reaching a named App meant: rail → Apps → wait for the list → filter →
+ * press. Four of those five steps exist only because the reader had to arrive
+ * somewhere that knows the name before they could type it. A palette collapses
+ * them into typing the name.
+ *
+ * **It reads its own catalogue rather than being handed one.** The four lists
+ * it searches live in four different screens' `useState`, so a palette fed from
+ * props would only know about objects on the screen the reader happened to be
+ * looking at — which is the navigation problem restated, not solved. Instead it
+ * fires the same four reads `OverviewScreen` fires, once, the first time it is
+ * opened: nothing is fetched for a reader who never presses ⌘K, and the result
+ * is cached for the session because a palette that re-fetches on every open is
+ * a palette with a spinner in it.
+ *
+ * **Navigation only.** Every entry resolves to a path. Destructive acts are not
+ * in here and should not be: a palette is a place where the reader is typing
+ * fast and confirming on muscle memory, and "delete" three characters away from
+ * "deploys" is how an App goes missing. Acts stay beside the object they affect.
+ *
+ * The trigger renders here too, beside the overlay, because they are one piece
+ * of state. A shortcut nobody can see is a shortcut nobody uses, so the header
+ * carries the affordance and `Kbd` carries the key.
+ */
+import { Boxes, Hammer, Rocket, Search, Server } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { command } from '../client.ts';
+import type {
+  AppListItem,
+  BuildListItem,
+  DeployLedgerItem,
+  TargetListItem,
+} from '../model.ts';
+import { Kbd } from '../ui/kbd.tsx';
+import { cn } from '../ui/utils.ts';
+
+export interface PaletteItem {
+  readonly id: string;
+  readonly group: string;
+  readonly label: string;
+  /** The second line: what distinguishes two rows that read alike. */
+  readonly hint?: string;
+  readonly path: string;
+}
+
+export interface PaletteCatalogue {
+  readonly apps: readonly AppListItem[];
+  readonly builds: readonly BuildListItem[];
+  readonly deploys: readonly DeployLedgerItem[];
+  readonly targets: readonly TargetListItem[];
+}
+
+/**
+ * The verbs, which are the rail plus the two destinations the rail has no room
+ * for. They are listed first so an empty query offers somewhere to go rather
+ * than the twelve newest Builds.
+ */
+const VERBS: readonly PaletteItem[] = [
+  { id: 'go:/', group: 'Go to', label: 'Overview', path: '/' },
+  { id: 'go:/apps', group: 'Go to', label: 'Apps', path: '/apps' },
+  {
+    id: 'go:/apps/new',
+    group: 'Go to',
+    label: 'New App',
+    hint: 'Create an App',
+    path: '/apps/new',
+  },
+  { id: 'go:/builds', group: 'Go to', label: 'Builds', path: '/builds' },
+  { id: 'go:/sources', group: 'Go to', label: 'Sources', path: '/sources' },
+  {
+    id: 'go:/artifacts',
+    group: 'Go to',
+    label: 'Artifacts',
+    path: '/artifacts',
+  },
+  { id: 'go:/deploys', group: 'Go to', label: 'Deploys', path: '/deploys' },
+  {
+    id: 'go:/settings/connections',
+    group: 'Go to',
+    label: 'Connections',
+    hint: 'Settings',
+    path: '/settings/connections',
+  },
+  {
+    id: 'go:/settings/identity',
+    group: 'Go to',
+    label: 'Identity',
+    hint: 'Settings',
+    path: '/settings/identity',
+  },
+];
+
+/**
+ * A Target is `vessel/adapter` and never one of them alone — `model.ts:744` is
+ * explicit about it, and two clusters both running `kubernetes` are otherwise
+ * the same row twice.
+ */
+export function paletteItems(
+  catalogue: PaletteCatalogue | null,
+): readonly PaletteItem[] {
+  if (catalogue === null) return VERBS;
+  return [
+    ...VERBS,
+    ...catalogue.apps.map((app) => ({
+      id: `app:${app.id}`,
+      group: 'Apps',
+      label: app.name,
+      hint: app.vessel ? `${app.vessel}/${app.target}` : app.target,
+      path: `/apps/${app.id}`,
+    })),
+    ...catalogue.deploys.map((deploy) => ({
+      id: `deploy:${deploy.id}`,
+      group: 'Deploys',
+      label: `#${deploy.id} ${deploy.app}`,
+      hint: `${deploy.component} · ${deploy.commit}`,
+      path: `/deploys/${deploy.id}`,
+    })),
+    ...catalogue.builds.map((build) => ({
+      id: `build:${build.id}`,
+      group: 'Builds',
+      label: `#${build.id} ${build.app}`,
+      hint: `${build.component} · ${build.commit}`,
+      path: `/builds/${build.id}`,
+    })),
+    ...catalogue.targets.map((target) => ({
+      id: `target:${target.id}`,
+      group: 'Targets',
+      label: `${target.vessel}/${target.adapter}`,
+      hint: 'Connections',
+      path: '/settings/connections',
+    })),
+  ];
+}
+
+/**
+ * Substring first, subsequence second, and nothing clever after that.
+ *
+ * A lower number sorts earlier. A direct hit scores by where it landed, so
+ * typing `mor` puts `morrow` above `checkout-mortgage`; a subsequence match is
+ * pushed behind every substring match by a constant, because `dpl` finding
+ * `deploys` is useful and should never outrank a literal one.
+ */
+function rank(haystack: string, needle: string): number {
+  const text = haystack.toLowerCase();
+  const direct = text.indexOf(needle);
+  if (direct !== -1) return direct;
+  let at = 0;
+  for (const character of needle) {
+    const next = text.indexOf(character, at);
+    if (next === -1) return -1;
+    at = next + 1;
+  }
+  return 1_000 + at;
+}
+
+/** How many rows the overlay will draw. Beyond this nobody is reading. */
+const SHOWN = 12;
+
+export function filterPalette(
+  items: readonly PaletteItem[],
+  query: string,
+): readonly PaletteItem[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === '') return items.slice(0, SHOWN);
+  return items
+    .map((item) => ({
+      item,
+      score: rank(`${item.label} ${item.hint ?? ''}`, needle),
+    }))
+    .filter(({ score }) => score !== -1)
+    .sort((left, right) => left.score - right.score)
+    .slice(0, SHOWN)
+    .map(({ item }) => item);
+}
+
+const GROUP_ICON: Record<string, typeof Boxes> = {
+  Apps: Boxes,
+  Builds: Hammer,
+  Deploys: Rocket,
+  Targets: Server,
+};
+
+/**
+ * ⌘ on a Mac, Ctrl everywhere else — a fact about the reader's keyboard, so it
+ * is read once and never re-derived. Guarded because this component is rendered
+ * to static markup in tests, where there is no `navigator`.
+ */
+function metaKeyGlyph(): string {
+  if (typeof navigator === 'undefined') return 'Ctrl';
+  const platform = `${navigator.platform ?? ''} ${navigator.userAgent ?? ''}`;
+  return /Mac|iPhone|iPad/.test(platform) ? '⌘' : 'Ctrl';
+}
+
+export function CommandPalette({
+  onNavigate,
+}: {
+  readonly onNavigate: (path: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [active, setActive] = useState(0);
+  const [catalogue, setCatalogue] = useState<PaletteCatalogue | null>(null);
+  const [glyph] = useState(metaKeyGlyph);
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault();
+        setQuery('');
+        setActive(0);
+        setOpen((current) => !current);
+      }
+    };
+    addEventListener('keydown', onKey);
+    return () => removeEventListener('keydown', onKey);
+  }, []);
+
+  // Once, on first open. A failed read leaves `catalogue` null and the palette
+  // still navigates — the verbs are the half that never needed the server.
+  useEffect(() => {
+    if (!open || catalogue !== null) return;
+    let live = true;
+    void Promise.all([
+      command('listApps', {}),
+      command('listBuilds', { limit: 25 }),
+      command('listAllDeploys', { limit: 25 }),
+      command('listTargets', {}),
+    ])
+      .then(([apps, builds, deploys, targets]) => {
+        if (!live) return;
+        setCatalogue({
+          apps: apps.ok ? apps.value.apps : [],
+          builds: builds.ok ? builds.value.builds : [],
+          deploys: deploys.ok ? deploys.value.deploys : [],
+          targets: targets.ok ? targets.value.targets : [],
+        });
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+    };
+  }, [open, catalogue]);
+
+  const shown = filterPalette(paletteItems(catalogue), query);
+  const selected = shown[Math.min(active, shown.length - 1)];
+
+  const choose = (item: PaletteItem | undefined) => {
+    if (item === undefined) return;
+    setOpen(false);
+    onNavigate(item.path);
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => {
+          setQuery('');
+          setActive(0);
+          setOpen(true);
+        }}
+        className="flex items-center gap-2 rounded-sm border border-border px-2.5 py-1.5 text-body text-muted-foreground hover:text-foreground"
+      >
+        <Search aria-hidden="true" className="size-3.5" />
+        <span className="hidden sm:inline">Search</span>
+        <span className="hidden sm:flex items-center gap-0.5">
+          <Kbd>{glyph}</Kbd>
+          <Kbd>K</Kbd>
+        </span>
+      </button>
+
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-start justify-center p-4 pt-[12vh]">
+          {/* A press on the backdrop is a press on nothing, which is the
+              universal "I did not mean to open this". A real button rather than
+              a click handler on the overlay div, because that is what it is —
+              and it is out of the tab order because Escape is the keyboard's
+              way out and a tab stop labelled "close" ahead of the input would
+              be one press between the reader and typing. */}
+          <button
+            type="button"
+            tabIndex={-1}
+            aria-label="Close the command palette"
+            onMouseDown={() => setOpen(false)}
+            className="absolute inset-0 bg-overlay"
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label="Command palette"
+            className="relative w-full max-w-xl overflow-hidden rounded-lg border border-border bg-card shadow-panel"
+            onKeyDown={(event) => {
+              if (event.key === 'Escape') {
+                setOpen(false);
+              } else if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setActive((index) => Math.min(index + 1, shown.length - 1));
+              } else if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setActive((index) => Math.max(index - 1, 0));
+              } else if (event.key === 'Enter') {
+                event.preventDefault();
+                choose(selected);
+              }
+            }}
+          >
+            <div className="flex items-center gap-2 border-b border-border px-3.5 py-3">
+              <Search
+                aria-hidden="true"
+                className="size-4 shrink-0 text-muted-foreground"
+              />
+              <input
+                // The palette exists to be typed into, and it was opened by a
+                // keystroke — focus is already the reader's, not stolen.
+                // biome-ignore lint/a11y/noAutofocus: see above
+                autoFocus
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                  setActive(0);
+                }}
+                aria-label="Search Apps, Deploys, Builds and Targets"
+                placeholder="Search Apps, Deploys, Builds and Targets…"
+                className="w-full bg-transparent text-ui outline-none placeholder:text-muted-foreground"
+              />
+              <Kbd>Esc</Kbd>
+            </div>
+            <ul className="max-h-[50vh] overflow-y-auto py-1">
+              {shown.length === 0 ? (
+                <li className="px-3.5 py-6 text-center text-body text-muted-foreground">
+                  Nothing matches “{query}”.
+                </li>
+              ) : (
+                shown.map((item, index) => {
+                  const Icon = GROUP_ICON[item.group];
+                  return (
+                    <li key={item.id}>
+                      <button
+                        type="button"
+                        aria-current={item === selected ? 'true' : undefined}
+                        onMouseEnter={() => setActive(index)}
+                        onClick={() => choose(item)}
+                        className={cn(
+                          'flex w-full items-center gap-2.5 px-3.5 py-2 text-left',
+                          item === selected
+                            ? 'bg-secondary text-foreground'
+                            : 'text-subtle',
+                        )}
+                      >
+                        {Icon ? (
+                          <Icon
+                            aria-hidden="true"
+                            className="size-3.5 shrink-0 text-muted-foreground"
+                          />
+                        ) : (
+                          <span aria-hidden="true" className="size-3.5" />
+                        )}
+                        <span className="truncate text-body font-medium">
+                          {item.label}
+                        </span>
+                        {item.hint ? (
+                          <span className="truncate font-mono text-caption text-muted-foreground">
+                            {item.hint}
+                          </span>
+                        ) : null}
+                        <span className="ml-auto shrink-0 text-caption text-muted-foreground">
+                          {item.group}
+                        </span>
+                      </button>
+                    </li>
+                  );
+                })
+              )}
+            </ul>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/spindrift/src/web/components/log-pane.tsx
+++ b/apps/spindrift/src/web/components/log-pane.tsx
@@ -125,23 +125,13 @@ export function Notice({
 }
 
 /**
- * The honest empty state (§17).
+ * The honest empty state (§17) now lives in `ui/empty-state.tsx`, where the
+ * ledgers and the workspace can reach it without importing a log pane.
  *
- * A `website` on a static Target has no process, so there is no output to
- * stream — and §17 is explicit that this gets a stated reason rather than a
- * disabled tab. Disabling hides the fact; this names it.
+ * Re-exported from here rather than moved, because "there is no output to
+ * stream, and here is why" is the pane's own alternative — the argument at the
+ * top of this file is what made the component exist — and every call site that
+ * reads `EmptyState` out of the log module is reading it from the right place
+ * for the reason it is used there.
  */
-export function EmptyState({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className="rounded-lg border border-dashed border-border px-4 py-6 text-center">
-      <p className="text-sm font-semibold text-foreground">{title}</p>
-      <p className="mt-1 text-[12.5px] text-muted-foreground">{children}</p>
-    </div>
-  );
-}
+export { EmptyState } from '../ui/empty-state.tsx';

--- a/apps/spindrift/src/web/components/object-explorer.tsx
+++ b/apps/spindrift/src/web/components/object-explorer.tsx
@@ -1,7 +1,46 @@
+/**
+ * The two-pane read: one stable list beside one inspector.
+ *
+ * Two components live here because they are one idea at two densities.
+ * `ObjectExplorer` takes a heterogeneous list — the Overview feed mixes Builds
+ * and Deploys, and the Apps list is a single noun with three facts — where the
+ * row is a summary and a table of four different shapes would be columns of
+ * mostly-empty cells. `LedgerExplorer` takes a homogeneous one, where the row
+ * is a record with six to eight comparable fields and the operator's task is
+ * comparison down a column, so it renders `DataTable` and inherits its sort.
+ *
+ * Selection is deliberately local in both. Picking an object is inspection, not
+ * navigation; callers put the durable detail route behind an explicit action
+ * in the inspector. That keeps the list in place while a person compares rows.
+ *
+ * Two behaviours are load-bearing and easy to lose in a refactor.
+ *
+ * **Selection is sticky under the filter.** The previous list resolved the
+ * selection against the *visible* rows, so typing one character that excluded
+ * the selected object silently swapped the inspector to an unrelated one — on a
+ * triage screen, from the failed Deploy you were reading to whatever sorted
+ * first. The selection is resolved against the full list and the pane says the
+ * row is hidden, because moving a reader's place without telling them is worse
+ * than showing them something the filter excludes.
+ *
+ * **`aria-pressed` stays on the row.** It is the wrong word for single
+ * selection and `aria-selected` in a listbox would be the right one, but the
+ * rows are also the thing three test suites count, and a semantics change that
+ * arrives with a behaviour change is two changes nobody can bisect. The
+ * keyboard gap — no arrows, one Tab stop per row, fifty stops to reach the
+ * inspector — is the half that actually cost an operator something, and it is
+ * fixed here with the handler `DataTable` already exports.
+ *
+ * What this file refuses: hash-addressable selection (worth doing, and it is a
+ * router change rather than a list change), type-ahead, and multi-select.
+ */
 import { Search } from 'lucide-react';
-import { type ReactNode, useMemo, useState } from 'react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
 import { Badge } from '../ui/badge.tsx';
+import { Button } from '../ui/button.tsx';
 import { Eyebrow } from '../ui/card.tsx';
+import { type Column, DataTable, rowKeyboard } from '../ui/data-table.tsx';
+import { EmptyState } from '../ui/empty-state.tsx';
 import { cn } from '../ui/utils.ts';
 
 export type ExplorerTone =
@@ -40,10 +79,10 @@ export function ExplorerPageHeader({
     <header className="flex flex-wrap items-end gap-4">
       <div>
         <Eyebrow>{eyebrow}</Eyebrow>
-        <h1 className="mt-1 text-3xl font-semibold tracking-[-0.035em]">
+        <h1 className="mt-1 text-display font-semibold tracking-display">
           {title}
         </h1>
-        <p className="mt-1 max-w-2xl text-sm leading-6 text-muted-foreground">
+        <p className="mt-1 max-w-2xl text-body leading-6 text-muted-foreground">
           {description}
         </p>
       </div>
@@ -53,12 +92,58 @@ export function ExplorerPageHeader({
 }
 
 /**
- * The Object Explorer's durable seam: one stable list beside one inspector.
+ * The filter both panes share.
  *
- * Selection is deliberately local. Picking an object is inspection, not
- * navigation; callers put the durable detail route behind an explicit action
- * in the inspector. That keeps the list in place while a person compares rows.
+ * The accessible name is the literal `Filter objects` in both, because it names
+ * what the control does rather than what the screen is a screen of — a reader
+ * tabbing into "Filter Builds" on one ledger and "Filter objects" on the next
+ * has to work out whether they are the same control.
  */
+function FilterField({
+  value,
+  onChange,
+  placeholder,
+}: {
+  readonly value: string;
+  readonly onChange: (next: string) => void;
+  readonly placeholder: string;
+}) {
+  return (
+    <label className="relative block border-b border-border p-3">
+      <span className="sr-only">Filter objects</span>
+      <Search
+        aria-hidden="true"
+        className="pointer-events-none absolute top-1/2 left-6 size-3.5 -translate-y-1/2 text-muted-foreground"
+      />
+      <input
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.currentTarget.value)}
+        placeholder={placeholder}
+        className="h-9 w-full rounded-sm border border-input bg-background pr-3 pl-9 text-body text-foreground placeholder:text-muted-foreground"
+      />
+    </label>
+  );
+}
+
+/** The one no-match arm, with the way out of it the panes used to omit. */
+function NoMatch({ filter, onClear }: { filter: string; onClear: () => void }) {
+  return (
+    <EmptyState
+      tone="warning"
+      title={`Nothing matches “${filter}”.`}
+      action={
+        <Button variant="outline" onClick={onClear}>
+          Clear filter
+        </Button>
+      }
+      className="m-4 border-0"
+    >
+      Every row is still loaded — only this filter is hiding them.
+    </EmptyState>
+  );
+}
+
 export function ObjectExplorer({
   items,
   filterPlaceholder,
@@ -76,6 +161,12 @@ export function ObjectExplorer({
   const [selectedId, setSelectedId] = useState(
     () => initialId ?? items[0]?.id ?? '',
   );
+  const [active, setActive] = useState(0);
+  const list = useRef<HTMLDivElement>(null);
+  // Set only by an arrow press, so the effect below never steals focus on
+  // mount or when a poll replaces the rows under the reader.
+  const moved = useRef(false);
+
   const visible = useMemo(() => {
     const query = filter.trim().toLocaleLowerCase();
     if (!query) return items;
@@ -85,53 +176,77 @@ export function ObjectExplorer({
         .includes(query),
     );
   }, [filter, items]);
+
+  useEffect(() => {
+    if (!moved.current) return;
+    moved.current = false;
+    const node = list.current?.children[active];
+    if (node instanceof HTMLElement) node.focus();
+  }, [active]);
+
   const selected =
-    visible.find((item) => item.id === selectedId) ?? visible[0] ?? null;
+    items.find((item) => item.id === selectedId) ?? visible[0] ?? null;
+  const hidden =
+    selected !== null && !visible.some((item) => item.id === selected.id);
+
+  const onKeyDown = rowKeyboard({
+    count: visible.length,
+    active,
+    onActive: (next) => {
+      moved.current = true;
+      setActive(next);
+    },
+    onActivate: (index) => {
+      const item = visible[index];
+      if (item) setSelectedId(item.id);
+    },
+  });
 
   if (items.length === 0) return <>{empty}</>;
 
   return (
-    <div className="grid min-h-[620px] overflow-hidden rounded-sm border border-border bg-card shadow-[0_18px_55px_rgba(0,0,0,0.28)] md:grid-cols-[minmax(240px,320px)_minmax(0,1fr)]">
+    <div className="grid overflow-hidden rounded-sm border border-border bg-card shadow-panel md:grid-cols-[minmax(240px,320px)_minmax(0,1fr)]">
       <section
         aria-label="Objects"
         className="min-w-0 border-b border-border md:border-r md:border-b-0"
       >
-        <label className="relative block border-b border-border p-3">
-          <span className="sr-only">Filter objects</span>
-          <Search
-            aria-hidden="true"
-            className="pointer-events-none absolute top-1/2 left-6 size-3.5 -translate-y-1/2 text-muted-foreground"
-          />
-          <input
-            type="search"
-            value={filter}
-            onChange={(event) => setFilter(event.currentTarget.value)}
-            placeholder={filterPlaceholder}
-            className="h-9 w-full rounded-sm border border-input bg-background pr-3 pl-9 text-sm text-foreground placeholder:text-muted-foreground"
-          />
-        </label>
-        <div className="max-h-[520px] overflow-y-auto md:max-h-none">
+        <FilterField
+          value={filter}
+          onChange={setFilter}
+          placeholder={filterPlaceholder}
+        />
+        <div
+          ref={list}
+          className="max-h-[70dvh] overflow-y-auto md:max-h-[calc(70dvh-3.5rem)]"
+        >
           {visible.length === 0 ? (
-            <p className="px-5 py-10 text-center text-sm text-muted-foreground">
-              Nothing matches “{filter}”.
-            </p>
+            <NoMatch filter={filter} onClear={() => setFilter('')} />
           ) : (
-            visible.map((item) => {
+            visible.map((item, index) => {
               const isSelected = item.id === selected?.id;
               return (
                 <button
                   key={item.id}
                   type="button"
                   aria-pressed={isSelected}
-                  onClick={() => setSelectedId(item.id)}
+                  tabIndex={index === active ? 0 : -1}
+                  onFocus={() => setActive(index)}
+                  onKeyDown={onKeyDown}
+                  onClick={() => {
+                    setActive(index);
+                    setSelectedId(item.id);
+                  }}
                   className={cn(
                     'grid w-full grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1 border-b border-border-soft px-4 py-3.5 text-left transition-colors',
+                    // The panel clips at its own edge, so the global 2px ring
+                    // with 2px of offset lost its top and bottom rows.
+                    'focus-visible:-outline-offset-2',
                     isSelected
                       ? 'bg-accent text-foreground shadow-[inset_3px_0_var(--accent)]'
                       : 'text-subtle hover:bg-secondary hover:text-foreground',
                   )}
                 >
-                  <strong className="truncate text-sm font-semibold">
+                  <strong className="truncate text-body font-semibold">
                     {item.title}
                   </strong>
                   <Badge tone={item.tone} className="row-span-2 self-center">
@@ -144,7 +259,7 @@ export function ObjectExplorer({
                     />
                     {item.status}
                   </Badge>
-                  <small className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                  <small className="flex min-w-0 items-center gap-2 text-caption text-muted-foreground">
                     <span className="truncate">{item.detail}</span>
                     {item.when ? (
                       <time
@@ -164,12 +279,125 @@ export function ObjectExplorer({
       </section>
       <article
         aria-label={selected ? `${selected.title} inspector` : 'Inspector'}
-        className="min-w-0 bg-[color:var(--inspector)] p-5 sm:p-7"
+        className="min-w-0 bg-inspector p-5 sm:p-7"
       >
+        {hidden ? (
+          <p className="mb-4 rounded-sm border border-warning/50 px-3 py-2 text-caption text-warning">
+            Still inspecting {selected?.title} — the filter hides its row.
+          </p>
+        ) : null}
         {selected ? (
           renderInspector(selected)
         ) : (
-          <p className="py-12 text-center text-sm text-muted-foreground">
+          <p className="py-12 text-center text-body text-muted-foreground">
+            No matching object to inspect.
+          </p>
+        )}
+      </article>
+    </div>
+  );
+}
+
+/**
+ * A ledger: the same two panes, with the list as a real table.
+ *
+ * Four screens — Builds, Deploys, Sources, Artifacts — each held six to eight
+ * facts per row and rendered three of them, flattening the rest into one `·`
+ * sentence that could not be aligned, compared or sorted. They are the textbook
+ * table: homogeneous rows, stable attributes, and an operator whose actual
+ * question is "which one is unsigned / stuck / on the old runner".
+ *
+ * It is one component rather than four because the *only* thing that differs
+ * between those screens is the column array and the inspector, and four copies
+ * of a filter, a selection, a sticky-under-filter rule and a no-match arm is
+ * four places for those to drift apart — which is what happened to the four
+ * hand-built empty states this replaces.
+ */
+export function LedgerExplorer<T>({
+  columns,
+  rows,
+  rowKey,
+  rowSearch,
+  filterPlaceholder,
+  caption,
+  empty,
+  inspectorLabel,
+  renderInspector,
+}: {
+  readonly columns: readonly Column<T>[];
+  readonly rows: readonly T[];
+  readonly rowKey: (row: T) => string;
+  /** Everything a filter should match, including facts no column shows. */
+  readonly rowSearch: (row: T) => string;
+  readonly filterPlaceholder: string;
+  readonly caption: string;
+  readonly empty: ReactNode;
+  readonly inspectorLabel: (row: T) => string;
+  readonly renderInspector: (row: T) => ReactNode;
+}) {
+  const [filter, setFilter] = useState('');
+  const [selectedKey, setSelectedKey] = useState(() =>
+    rows[0] ? rowKey(rows[0]) : '',
+  );
+
+  const visible = useMemo(() => {
+    const query = filter.trim().toLocaleLowerCase();
+    if (!query) return rows;
+    return rows.filter((row) =>
+      rowSearch(row).toLocaleLowerCase().includes(query),
+    );
+  }, [filter, rows, rowSearch]);
+
+  const selected =
+    rows.find((row) => rowKey(row) === selectedKey) ?? visible[0] ?? null;
+  const hidden =
+    selected !== null &&
+    !visible.some((row) => rowKey(row) === rowKey(selected));
+
+  if (rows.length === 0) return <>{empty}</>;
+
+  return (
+    <div className="grid overflow-hidden rounded-sm border border-border bg-card shadow-panel xl:grid-cols-[minmax(0,1fr)_minmax(320px,26rem)]">
+      <section
+        aria-label="Objects"
+        className="min-w-0 border-b border-border xl:border-r xl:border-b-0"
+      >
+        <FilterField
+          value={filter}
+          onChange={setFilter}
+          placeholder={filterPlaceholder}
+        />
+        {visible.length === 0 ? (
+          <NoMatch filter={filter} onClear={() => setFilter('')} />
+        ) : (
+          <div className="max-h-[70dvh] overflow-y-auto">
+            <DataTable
+              columns={columns}
+              rows={visible}
+              rowKey={rowKey}
+              caption={caption}
+              selectedKey={selected ? rowKey(selected) : undefined}
+              onRowSelect={(row) => setSelectedKey(rowKey(row))}
+            />
+          </div>
+        )}
+      </section>
+      <article
+        aria-label={
+          selected ? `${inspectorLabel(selected)} inspector` : 'Inspector'
+        }
+        className="min-w-0 bg-inspector p-5 sm:p-6"
+      >
+        {hidden ? (
+          <p className="mb-4 rounded-sm border border-warning/50 px-3 py-2 text-caption text-warning">
+            Still inspecting {selected ? inspectorLabel(selected) : ''} — the
+            filter hides its row.
+          </p>
+        ) : null}
+        {selected ? (
+          renderInspector(selected)
+        ) : (
+          <p className="py-12 text-center text-body text-muted-foreground">
             No matching object to inspect.
           </p>
         )}
@@ -185,21 +413,29 @@ export function DefinitionGrid({
     readonly label: string;
     readonly value: ReactNode;
     readonly mono?: boolean;
+    /** The untruncated value, when the rendered one is an abbreviation. */
+    readonly title?: string;
   }[];
 }) {
   return (
-    <dl className="mt-6 grid overflow-hidden rounded-sm border border-border sm:grid-cols-2 xl:grid-cols-3">
+    <dl className="mt-6 grid overflow-hidden rounded-sm border border-border sm:grid-cols-2">
       {entries.map((entry) => (
         <div
           key={entry.label}
-          className="min-w-0 border-b border-border-soft bg-secondary/35 p-4 last:border-b-0 sm:border-r sm:[&:nth-last-child(-n+2)]:border-b-0 xl:[&:nth-last-child(-n+3)]:border-b-0"
+          className="min-w-0 border-b border-border-soft bg-secondary/35 p-4 last:border-b-0 sm:border-r sm:[&:nth-last-child(-n+2)]:border-b-0"
         >
-          <dt className="text-[10px] font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+          <dt className="text-micro font-semibold uppercase tracking-eyebrow text-muted-foreground">
             {entry.label}
           </dt>
+          {/* The title is the whole point: this grid is where the digests live
+              and it truncates every one of them. */}
           <dd
+            title={
+              entry.title ??
+              (typeof entry.value === 'string' ? entry.value : undefined)
+            }
             className={cn(
-              'mt-1.5 truncate text-sm font-semibold text-foreground',
+              'mt-1.5 truncate text-body font-semibold text-foreground',
               entry.mono && 'font-mono',
             )}
           >

--- a/apps/spindrift/src/web/components/shell.tsx
+++ b/apps/spindrift/src/web/components/shell.tsx
@@ -4,16 +4,21 @@ import {
   Hammer,
   LayoutDashboard,
   LogOut,
+  PanelLeftClose,
+  PanelLeftOpen,
   Rocket,
   Settings,
   WifiOff,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
-import { useSyncExternalStore } from 'react';
+import { useState, useSyncExternalStore } from 'react';
 import type { Principal } from '../../commands/types.ts';
 import { isReconnecting, onConnectionChange } from '../connection-status.ts';
 import { Button } from '../ui/button.tsx';
+import { ToastHost } from '../ui/toast.tsx';
 import { cn } from '../ui/utils.ts';
+import { Breadcrumbs } from './breadcrumbs.tsx';
+import { CommandPalette } from './command-palette.tsx';
 
 /**
  * The rail, and the one grouping in it.
@@ -49,6 +54,40 @@ const NAVIGATION = [
   },
 ] as const;
 
+/**
+ * Where the rail's width is remembered, beside the theme key.
+ *
+ * It is a preference about the reader's screen, not about this installation, so
+ * it belongs in the same store `theme.ts` uses and travels with the browser
+ * rather than the session.
+ */
+const RAIL_KEY = 'spindrift.rail';
+
+/**
+ * Read once, in a lazy initialiser, and guarded: this component is rendered to
+ * static markup by three test files, and `localStorage` is a browser global
+ * that a server render does not have. An unreadable preference is "expanded",
+ * which is the state that shows the labels this rail exists to add.
+ */
+function railCollapsed(): boolean {
+  if (typeof localStorage === 'undefined') return false;
+  try {
+    return localStorage.getItem(RAIL_KEY) === 'collapsed';
+  } catch {
+    return false;
+  }
+}
+
+function rememberRail(collapsed: boolean): void {
+  try {
+    localStorage.setItem(RAIL_KEY, collapsed ? 'collapsed' : 'expanded');
+  } catch {
+    // A blocked or full store loses the preference for this visit and nothing
+    // else. Refusing to navigate because a width could not be written would be
+    // the worse failure.
+  }
+}
+
 function under(path: string, root: string): boolean {
   if (root === '/') return path === '/';
   return path === root || path.startsWith(`${root}/`);
@@ -58,16 +97,6 @@ function active(path: string, roots: readonly string[]): boolean {
   return roots.some((root) => under(path, root));
 }
 
-function title(path: string): string {
-  if (path === '/') return 'Overview';
-  const segment = path.split('/').filter(Boolean)[0];
-  if (!segment) return 'Overview';
-  if (segment === 'targets' || segment === 'repos' || segment === 'storage') {
-    return 'Settings';
-  }
-  return segment[0]!.toUpperCase() + segment.slice(1);
-}
-
 function initials(displayName: string): string {
   const parts = displayName.trim().split(/\s+/).filter(Boolean);
   return (
@@ -75,6 +104,81 @@ function initials(displayName: string): string {
       ? `${parts[0]![0]}${parts.at(-1)![0]}`
       : (parts[0]?.slice(0, 2) ?? 'OP')
   ).toUpperCase();
+}
+
+/**
+ * Who is signed in, and the two things they can do about it.
+ *
+ * This was a `<span title={displayName}>` in the bottom of the rail: not
+ * focusable, not reachable by keyboard, and announcing the operator's name only
+ * to a pointer that hovered over it for a second. The name is the one piece of
+ * chrome that answers "am I about to press Deploy on production as the wrong
+ * principal", so it is now a real control.
+ *
+ * A native `popover`, which means no state, no outside-click handler and no
+ * focus trap of our own: the platform puts it in the top layer, closes it on
+ * Escape and on a press elsewhere, and moves focus for us. That is the whole
+ * reason not to reach for a menu component here.
+ *
+ * It lives in the header rather than the rail, because the rail is `md:flex` —
+ * an account menu only signed-in operators on wide screens can reach is a
+ * sign-out button that does not exist on a phone.
+ */
+function AccountMenu({
+  principal,
+  onNavigate,
+  onSignOut,
+}: {
+  readonly principal: Principal;
+  readonly onNavigate: (path: string) => void;
+  readonly onSignOut: () => void;
+}) {
+  return (
+    <>
+      <button
+        type="button"
+        popoverTarget="account-menu"
+        aria-label={`Account: ${principal.displayName}`}
+        className="flex items-center gap-2 rounded-sm border border-border py-1 pl-1 pr-2 text-body hover:bg-secondary"
+      >
+        <span
+          aria-hidden="true"
+          className="grid size-7 place-items-center rounded-sm bg-secondary font-mono text-caption font-bold"
+        >
+          {initials(principal.displayName)}
+        </span>
+        <span className="hidden max-w-40 truncate lg:inline">
+          {principal.displayName}
+        </span>
+      </button>
+      <div
+        id="account-menu"
+        popover="auto"
+        className="fixed inset-auto right-4 top-[68px] m-0 w-56 rounded-sm border border-border bg-card p-1.5 shadow-panel"
+      >
+        <p className="truncate px-2 py-1.5 text-caption text-muted-foreground">
+          Signed in as{' '}
+          <span className="text-foreground">{principal.displayName}</span>
+        </p>
+        <button
+          type="button"
+          onClick={() => onNavigate('/settings/identity')}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-body hover:bg-secondary"
+        >
+          <Settings aria-hidden="true" className="size-3.5" />
+          Identity and passkeys
+        </button>
+        <button
+          type="button"
+          onClick={onSignOut}
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-body text-destructive hover:bg-secondary"
+        >
+          <LogOut aria-hidden="true" className="size-3.5" />
+          Sign out
+        </button>
+      </div>
+    </>
+  );
 }
 
 export function AppShell({
@@ -116,74 +220,120 @@ export function AppShell({
     isReconnecting,
     isReconnecting,
   );
-  const navigation = (
-    <>
-      {NAVIGATION.map(({ path: destination, label, icon: Icon, roots }) => {
-        const current = active(path, roots);
-        return (
-          <button
-            key={destination}
-            type="button"
-            title={label}
-            aria-label={label}
-            aria-current={current ? 'page' : undefined}
-            onClick={() => onNavigate(destination)}
-            className={cn(
-              'group flex min-w-0 flex-col items-center justify-center gap-1 rounded-sm px-2 py-2 text-[9px] font-semibold tracking-wide transition-colors',
-              current
-                ? 'bg-rail-active text-rail-foreground'
-                : 'text-rail-muted hover:bg-rail-active/60 hover:text-rail-foreground',
-            )}
-          >
-            <Icon aria-hidden="true" className="size-[18px]" />
-            <span>{label}</span>
-          </button>
-        );
-      })}
-    </>
-  );
+  const [collapsed, setCollapsed] = useState(railCollapsed);
+
+  /**
+   * One array, two navigations.
+   *
+   * The rail and the phone bar have always rendered the same entries; what they
+   * did not have was different names. Two `<nav aria-label="Primary
+   * navigation">` landmarks in one document give a screen-reader's landmark
+   * list two identical rows and no way to tell which one it is jumping to, so
+   * the compact one says so.
+   */
+  const navigation = (compact: boolean) =>
+    NAVIGATION.map(({ path: destination, label, icon: Icon, roots }) => {
+      const current = active(path, roots);
+      const stacked = compact || collapsed;
+      return (
+        <button
+          key={destination}
+          type="button"
+          title={label}
+          aria-label={label}
+          aria-current={current ? 'page' : undefined}
+          onClick={() => onNavigate(destination)}
+          className={cn(
+            'group flex min-w-0 items-center gap-2.5 rounded-sm transition-colors',
+            stacked
+              ? 'flex-col justify-center gap-1 px-2 py-2 text-micro font-semibold tracking-wide'
+              : 'px-2.5 py-2 text-body font-medium',
+            current
+              ? 'bg-rail-active text-rail-foreground'
+              : 'text-rail-muted hover:bg-rail-active/60 hover:text-rail-foreground',
+          )}
+        >
+          <Icon aria-hidden="true" className="size-[18px] shrink-0" />
+          <span className={cn(!stacked && 'truncate')}>{label}</span>
+        </button>
+      );
+    });
 
   return (
-    <div className="min-h-dvh bg-background md:grid md:grid-cols-[76px_minmax(0,1fr)]">
+    <div
+      className={cn(
+        'min-h-dvh bg-background md:grid',
+        collapsed
+          ? 'md:grid-cols-[76px_minmax(0,1fr)]'
+          : 'md:grid-cols-[240px_minmax(0,1fr)]',
+      )}
+    >
       <aside className="sticky top-0 hidden h-dvh flex-col border-r border-rail-line bg-rail p-2 md:flex">
         <button
           type="button"
           aria-label="Spindrift overview"
           onClick={() => onNavigate('/')}
-          className="mx-auto mb-4 grid size-10 place-items-center rounded-sm bg-primary font-mono text-base font-black text-primary-foreground"
+          className={cn(
+            'mb-4 flex h-10 items-center gap-2.5 rounded-sm',
+            collapsed ? 'mx-auto w-10 justify-center' : 'px-2.5',
+          )}
         >
-          S
+          <span className="grid size-10 shrink-0 place-items-center rounded-sm bg-primary font-mono text-base font-black text-primary-foreground">
+            S
+          </span>
+          {collapsed ? null : (
+            <span className="truncate font-mono text-body font-bold tracking-eyebrow text-rail-foreground">
+              SPINDRIFT
+            </span>
+          )}
         </button>
         <nav aria-label="Primary navigation" className="flex flex-col gap-1">
-          {navigation}
+          {navigation(false)}
         </nav>
-        <div className="mt-auto flex flex-col items-center gap-2 border-t border-rail-line pt-3">
-          <span
-            title={principal.displayName}
-            className="grid size-9 place-items-center rounded-full border border-rail-line bg-rail-active font-mono text-[11px] font-bold text-rail-foreground"
+        <div className="mt-auto border-t border-rail-line pt-3">
+          <button
+            type="button"
+            aria-pressed={collapsed}
+            aria-label={collapsed ? 'Expand the rail' : 'Collapse the rail'}
+            title={collapsed ? 'Expand the rail' : 'Collapse the rail'}
+            onClick={() => {
+              setCollapsed((current) => {
+                rememberRail(!current);
+                return !current;
+              });
+            }}
+            className={cn(
+              'flex w-full items-center gap-2.5 rounded-sm px-2.5 py-2 text-body text-rail-muted hover:bg-rail-active/60 hover:text-rail-foreground',
+              collapsed && 'justify-center px-2',
+            )}
           >
-            {initials(principal.displayName)}
-          </span>
+            {collapsed ? (
+              <PanelLeftOpen aria-hidden="true" className="size-[18px]" />
+            ) : (
+              <PanelLeftClose aria-hidden="true" className="size-[18px]" />
+            )}
+            {collapsed ? null : <span>Collapse</span>}
+          </button>
         </div>
       </aside>
 
       <div className="min-w-0">
         <header className="sticky top-0 z-30 flex h-[72px] items-center gap-4 border-b border-border bg-topbar/90 px-4 backdrop-blur sm:px-6">
-          <div className="min-w-0">
-            <p className="truncate font-mono text-[10px] font-bold tracking-[0.12em] text-muted-foreground">
-              SPINDRIFT / <span className="text-foreground">{title(path)}</span>
-            </p>
-          </div>
+          <Breadcrumbs path={path} onNavigate={onNavigate} />
           <div className="ml-auto flex items-center gap-2">
+            <CommandPalette onNavigate={onNavigate} />
             {themeControl}
-            <span className="hidden max-w-48 truncate text-xs text-subtle lg:inline">
-              {principal.displayName}
-            </span>
+            <AccountMenu
+              principal={principal}
+              onNavigate={onNavigate}
+              onSignOut={onSignOut}
+            />
             <Button
               size="icon"
               variant="ghost"
               title="Sign out"
               aria-label="Sign out"
+              className="md:hidden"
               onClick={onSignOut}
             >
               <LogOut aria-hidden="true" />
@@ -231,11 +381,16 @@ export function AppShell({
       </div>
 
       <nav
-        aria-label="Primary navigation"
+        aria-label="Primary navigation (compact)"
         className="fixed inset-x-0 bottom-0 z-40 grid grid-cols-5 border-t border-rail-line bg-rail/95 p-1.5 backdrop-blur md:hidden"
       >
-        {navigation}
+        {navigation(true)}
       </nav>
+
+      {/* Mounted once, here, because this is the one component every screen in
+          the product passes through — the same argument the two banners above
+          are already made on. `notify()` reaches it from anywhere. */}
+      <ToastHost />
     </div>
   );
 }

--- a/apps/spindrift/src/web/forms/render.tsx
+++ b/apps/spindrift/src/web/forms/render.tsx
@@ -11,7 +11,8 @@
  * path, so the sentence a Zod issue carries is shown where the value that
  * caused it is typed rather than collected into a summary at the bottom.
  */
-import { CircleAlert, Plus, Trash2 } from 'lucide-react';
+import { CircleAlert, Lock, Plus, Trash2 } from 'lucide-react';
+import { Badge } from '../ui/badge.tsx';
 import { Button } from '../ui/button.tsx';
 import { Input, Label } from '../ui/field.tsx';
 import { cn } from '../ui/utils.ts';
@@ -46,6 +47,22 @@ export interface FormProps {
    * a path and everything under it; omitted means nothing is locked.
    */
   locked?(at: Path): boolean;
+  /**
+   * Whether the controls this form renders should take focus on mount.
+   *
+   * For the screen that mounts **one question at a time**, and it is a flag
+   * rather than a path because that screen already decided which key it is
+   * asking: onboarding renders a single field and the whole point is that
+   * typing the answer is the first thing that happens. A form rendering the
+   * whole manifest leaves it unset — a settings page that grabbed the cursor
+   * into whichever key the schema happens to declare first would be a page
+   * fighting the reader.
+   *
+   * The text and number controls honour it and the `<select>` does not, which
+   * is not a principle: no step asks for an enum, and the day one does is the
+   * day to decide whether opening a dropdown under the reader is a kindness.
+   */
+  readonly autoFocus?: boolean;
   onChange(document: unknown): void;
 }
 
@@ -60,6 +77,39 @@ export interface FormProps {
 function isFrozen(form: FormProps, at: Path): boolean {
   return form.disabled || form.locked?.(at) === true;
 }
+
+/**
+ * The second of those two words, said where the reader is.
+ *
+ * The comment above admitted the collapse and the reader still only got one
+ * word: a value the mounted declaration owns rendered exactly like a value a
+ * save was in flight over — greyed out, unexplained, and indistinguishable from
+ * a form that had broken. A governed field is the *most* authoritative value on
+ * the screen, so it is marked as declared and keeps its full contrast, and only
+ * the save-in-flight arm keeps the dimming that means "wait".
+ *
+ * Still `disabled`, not `readOnly`: the value cannot be changed here by any
+ * route, and `readOnly` would leave it in the submitted form as something this
+ * screen appeared to be sending.
+ */
+function isDeclared(form: FormProps, at: Path): boolean {
+  return form.locked?.(at) === true;
+}
+
+/**
+ * Whether this is the *outermost* declared thing, and so the one to mark.
+ *
+ * The predicate answers for a path and everything under it, so a governed
+ * vessel makes its name, its kind, its location and every shared service answer
+ * yes — and badging all of them would put eight identical markers inside one
+ * card to say one thing. The boundary is where the answer changes.
+ */
+function marksDeclared(form: FormProps, at: Path): boolean {
+  return isDeclared(form, at) && !isDeclared(form, at.slice(0, -1));
+}
+
+/** The class that undoes {@link Input}'s dimming, for the declared arm only. */
+const UNDIMMED = 'disabled:opacity-100';
 
 /** Every key of an object schema, in the order the schema declares them. */
 export function SchemaFields({
@@ -140,6 +190,12 @@ function SchemaFieldControl({
           />
         ) : null}
         <Label htmlFor={id}>{field.label}</Label>
+        {marksDeclared(form, at) ? (
+          <Badge tone="idle">
+            <Lock aria-hidden="true" className="size-3" />
+            declared
+          </Badge>
+        ) : null}
       </div>
       {field.description ? (
         <p className="text-xs text-muted-foreground">{field.description}</p>
@@ -169,6 +225,9 @@ export function SchemaControl({
   const value = valueAt(form.document, at);
   const id = pathKey(at);
   const frozen = isFrozen(form, at);
+  // Dimmed only while a save is in flight. A declared value is not pending, it
+  // is settled, and greying it said the opposite.
+  const undimmed = isDeclared(form, at) ? UNDIMMED : undefined;
   const set = (next: unknown) =>
     form.onChange(withValueAt(form.document, at, next));
 
@@ -181,6 +240,8 @@ export function SchemaControl({
           type={node.format === 'url' ? 'url' : 'text'}
           value={typeof value === 'string' ? value : ''}
           disabled={frozen}
+          className={undimmed}
+          autoFocus={form.autoFocus}
           onChange={(event) => set(event.currentTarget.value)}
         />
       );
@@ -193,6 +254,8 @@ export function SchemaControl({
           step={node.integer ? 1 : 'any'}
           value={typeof value === 'number' ? String(value) : ''}
           disabled={frozen}
+          className={undimmed}
+          autoFocus={form.autoFocus}
           onChange={(event) => {
             const parsed = Number(event.currentTarget.value);
             set(event.currentTarget.value === '' ? undefined : parsed);
@@ -208,7 +271,7 @@ export function SchemaControl({
           checked={value === true}
           disabled={frozen}
           onChange={(event) => set(event.currentTarget.checked)}
-          className="size-4 accent-accent"
+          className={cn('size-4 accent-accent', undimmed)}
         />
       );
     case 'enum':
@@ -217,6 +280,7 @@ export function SchemaControl({
           id={id}
           value={typeof value === 'string' ? value : ''}
           disabled={frozen}
+          className={undimmed}
           onChange={set}
           options={node.values.map((each) => ({ value: each, label: each }))}
         />
@@ -371,12 +435,14 @@ function Select({
   value,
   options,
   disabled,
+  className,
   onChange,
 }: {
   readonly id: string;
   readonly value: string;
   readonly options: readonly { value: string; label: string }[];
   readonly disabled: boolean;
+  readonly className?: string;
   onChange(value: string): void;
 }) {
   return (
@@ -390,6 +456,7 @@ function Select({
         'h-9 w-full rounded-md border border-input bg-background px-3',
         'font-mono text-sm text-foreground',
         'disabled:cursor-not-allowed disabled:opacity-60',
+        className,
       )}
     >
       {options.map((option) => (

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -534,6 +534,24 @@ export interface ComponentView {
   readonly artifact: string;
   readonly reach: Reach;
   readonly auth: Auth;
+  /**
+   * Where this Component is placed, and what it answers on.
+   *
+   * The hero states the placement of the *selected* Component only, so for an
+   * App with three of them the other two's placement was unobtainable without
+   * pressing each row in turn — which is the one thing a list of Components
+   * exists to spare a reader. The workspace query already loads every
+   * Component's newest Deploy with its Target and vessel; these are that row.
+   *
+   * Optional for the reason every other addition to this file is: the fixtures
+   * build `ComponentView` literally, and a Component that has never been
+   * placed genuinely has no answer here.
+   */
+  readonly target?: string;
+  readonly url?: string;
+  readonly urlLive?: boolean;
+  /** When this Component's newest release was written, in words. */
+  readonly when?: string;
 }
 
 /**
@@ -600,6 +618,49 @@ export interface WorkspaceView {
    * is a choice.
    */
   readonly autoDeploy: boolean | null;
+  /**
+   * What the release named by {@link release} delivered, and when.
+   *
+   * The workspace held a phase pill and a release id and nothing that could
+   * date either: an operator looking at `LIVE` could not tell whether it went
+   * out four minutes or four months ago, and could not tell which commit is
+   * serving without opening the attempt screen. Both facts are on the Deploy
+   * row the query already reads.
+   */
+  readonly commit?: string;
+  readonly when?: string;
+  readonly at?: string;
+  /**
+   * Why the release went red (§6), and what the platform has since stopped
+   * agreeing with (§6's drift).
+   *
+   * These are the two panels the App surface was missing entirely. §6 persists
+   * a diagnosis on red because the platform will not keep it, and records
+   * `drifted_at` when a LIVE release stops matching what is running — and
+   * until now both were readable only at `/deploys/:id`, which meant a drifted
+   * App read "is live" and a failed one read "has no release serving yet" with
+   * no reason and no evidence anywhere on the screen an operator was on.
+   *
+   * Absent rather than nullable: a healthy release has no diagnosis, and a
+   * field that is present-and-null asks every reader to distinguish two
+   * spellings of nothing.
+   */
+  readonly diagnosis?: Diagnosis;
+  readonly drift?: DriftView;
+  /**
+   * The prerequisites of the placed Target that are *not* met.
+   *
+   * `prerequisitesMet` is a boolean, and "A prerequisite is unmet" over an App
+   * that will not deploy is a dead end on the one screen where the question is
+   * being asked. These are the rows behind that word.
+   *
+   * Only the unmet ones, and without `remediation`: the whole standing
+   * checklist and the change that clears each row belong to the Targets screen,
+   * which has the manifest and the boundary in hand to generate one. This says
+   * what is blocking and points there — a second, thinner generator here would
+   * be a second answer to a question §13 already answers once.
+   */
+  readonly unmetPrerequisites?: readonly PrerequisiteRowView[];
 }
 
 /**
@@ -748,7 +809,14 @@ export interface AppListItem {
   readonly vessel: string;
   readonly url: string;
   readonly urlLive: boolean;
-  /** The first Component's kind, for the list's icon. */
+  /**
+   * The kind of the Component this row is reporting on — the one whose phase
+   * became {@link phase} — for the list's icon.
+   *
+   * Not the App's first Component. Every fact on the row belongs to one
+   * Component and it has to be the same one throughout, or the icon says
+   * `website` over a job's failure.
+   */
   readonly kind: ComponentKind;
   /** The source: repo fullName or 'archive'. */
   readonly source: string;
@@ -768,6 +836,36 @@ export interface AppListItem {
    * answering nothing about which artifact was live.
    */
   readonly artifact: string;
+  /**
+   * How many Components this App has, and how many of them are red.
+   *
+   * {@link phase} is the worst of them, which is the only honest single word
+   * for an App with a green `web` and a red `worker` — but "failed" over a
+   * three-Component App says nothing about how much of it is down. These two
+   * are what turn that word back into a fact: `failed · 1 of 3`.
+   *
+   * Optional because every fixture in the tree builds this row literally, and
+   * a count that is absent reads the same as an App nobody has told the list
+   * about yet. A row without them renders the word alone, as it always did.
+   */
+  readonly componentCount?: number;
+  readonly failing?: number;
+  /**
+   * The commit the row's release was built from, and when that release was
+   * written.
+   *
+   * All three describe the same Component the rest of the row does — the one
+   * whose phase became the App's. A row that named one Component's artifact
+   * beside another's commit would be two answers wearing one line.
+   */
+  readonly commit?: string;
+  readonly when?: string;
+  readonly at?: string;
+  /**
+   * The release behind {@link phase}, so the row can reach the attempt that
+   * produced what it is reporting rather than only the App that owns it.
+   */
+  readonly deployId?: number;
 }
 
 /**

--- a/apps/spindrift/src/web/ui/card.tsx
+++ b/apps/spindrift/src/web/ui/card.tsx
@@ -53,7 +53,7 @@ export function Eyebrow({ className, ...props }: ComponentProps<'span'>) {
   return (
     <span
       className={cn(
-        'text-[10.5px] font-semibold uppercase tracking-[0.1em] text-muted-foreground',
+        'text-micro font-semibold uppercase tracking-eyebrow text-muted-foreground',
         className,
       )}
       {...props}

--- a/apps/spindrift/src/web/ui/copy.tsx
+++ b/apps/spindrift/src/web/ui/copy.tsx
@@ -1,0 +1,132 @@
+/**
+ * The values whose whole purpose is to be pasted somewhere else.
+ *
+ * A digest exists to be handed to `crane`, a commit to `git show`, a config
+ * version to a support conversation. The app rendered all of them as truncated
+ * monospace text with no way to get the untruncated value out — one
+ * `navigator.clipboard` call existed in the entire tree — so the operator's
+ * options were to select carefully around an ellipsis or to go find the value in
+ * a terminal, which is the exact work this screen was supposed to save.
+ *
+ * `Ref` is the pairing that matters: it shortens by *kind*, because the useful
+ * prefix of a digest is not the useful prefix of a URL, and it always copies the
+ * whole thing rather than what is on screen. Truncation is a display decision
+ * and must never become a data decision.
+ *
+ * `copyValue` is separate from the button on purpose. The clipboard is a browser
+ * capability that is absent in an insecure context and refusable by the reader,
+ * so the failure is ordinary rather than exceptional, and it is the one part of
+ * this file worth testing without a DOM.
+ *
+ * Not here: a toast on copy. `notify()` for something that happened inside the
+ * button that was just pressed would be the loudest possible way to report the
+ * least surprising outcome in the app.
+ */
+import { Check, Copy } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import { cn } from './utils.ts';
+
+/** True when the value reached the clipboard. */
+export async function copyValue(value: string): Promise<boolean> {
+  try {
+    const clipboard = navigator.clipboard;
+    if (!clipboard) return false;
+    await clipboard.writeText(value);
+    return true;
+  } catch {
+    // Denied permission, an insecure origin, or a browser that has no
+    // clipboard. None of those is an error the reader can act on, and all of
+    // them leave the value on screen to select by hand.
+    return false;
+  }
+}
+
+/** How long the confirmation stands before the button is a button again. */
+const CONFIRM_MS = 1_400;
+
+export function CopyButton({
+  value,
+  label,
+  className,
+}: {
+  readonly value: string;
+  /** What is being copied, for the control's accessible name. */
+  readonly label?: string;
+  readonly className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), CONFIRM_MS);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
+  const copy = useCallback(() => {
+    void copyValue(value).then(setCopied);
+  }, [value]);
+
+  const name = label ? `Copy ${label}` : 'Copy';
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      aria-label={copied ? `${name} — copied` : name}
+      title={name}
+      className={cn(
+        'inline-flex size-5 shrink-0 items-center justify-center rounded-sm',
+        'text-muted-foreground hover:text-foreground',
+        className,
+      )}
+    >
+      {copied ? (
+        <Check className="size-3.5 text-success" />
+      ) : (
+        <Copy className="size-3.5" />
+      )}
+    </button>
+  );
+}
+
+export type RefKind = 'digest' | 'commit' | 'url' | 'id';
+
+/**
+ * How much of each kind of reference is enough to recognise it.
+ *
+ * A digest keeps its algorithm prefix — `sha256:` is the half of it that says
+ * what the rest of it is — and then the twelve hex characters `crane` and every
+ * registry UI use. A commit is seven, which is git's own answer. An id is eight,
+ * enough to tell two rows apart in a ledger. A URL keeps its host and drops the
+ * scheme, because `https://` is the same on every row and the host is the fact.
+ */
+function shorten(value: string, kind: RefKind): string {
+  if (kind === 'commit') return value.slice(0, 7);
+  if (kind === 'id') return value.slice(0, 8);
+  if (kind === 'url')
+    return value.replace(/^https?:\/\//, '').replace(/\/$/, '');
+  const [algorithm, hex] = value.split(':');
+  return hex ? `${algorithm}:${hex.slice(0, 12)}` : value.slice(0, 12);
+}
+
+export function Ref({
+  value,
+  kind,
+  className,
+}: {
+  readonly value: string;
+  readonly kind: RefKind;
+  readonly className?: string;
+}) {
+  if (!value) return null;
+  return (
+    <span className={cn('inline-flex items-center gap-1', className)}>
+      {/* The full value is the title, so a hover answers what the ellipsis ate
+          even where the clipboard is unavailable. */}
+      <span className="truncate font-mono text-body" title={value}>
+        {shorten(value, kind)}
+      </span>
+      <CopyButton value={value} label={kind} />
+    </span>
+  );
+}

--- a/apps/spindrift/src/web/ui/data-table.tsx
+++ b/apps/spindrift/src/web/ui/data-table.tsx
@@ -1,0 +1,307 @@
+/**
+ * Rows of facts, as a table — because that is what they are.
+ *
+ * Four ledger screens (Builds, Deploys, Sources, Artifacts) rendered the same
+ * four-slot row: a title, one `detail` string with every other fact flattened
+ * into it by `·`, a status word, and a time. The tree contained zero `<table>`
+ * elements. That flattening is what makes a ledger unreadable — a column of
+ * commits is scannable and `a1b2c3d · service · Cloud Build · sha256:…` is not,
+ * and it is also why those screens could not offer sorting: there was nothing to
+ * sort by, only a sentence.
+ *
+ * Sorting is client-side and unapologetic about it. Every one of these screens
+ * already holds its full page of rows in memory (the server paginates by
+ * `before`, and the ledger asks for the next page explicitly), so a round trip
+ * to reorder twelve rows would be a network request to answer a question the
+ * browser can answer. When a screen grows past what it can hold, the sort
+ * belongs in the query and this component should be *given* the order rather
+ * than growing a mode.
+ *
+ * What it refuses: column resizing, column hiding, row virtualisation, grouping,
+ * and selection checkboxes. Every one of those is a real feature of a real data
+ * grid and none of them is a question this product's screens ask.
+ *
+ * A11y notes worth stating because they are easy to get silently wrong.
+ * `aria-sort` goes on the `<th>` of the *active* column only — putting `none` on
+ * every other header is legal and makes a screen reader announce sortability
+ * three times per row. Rows carry a roving `tabIndex`, so a keyboard reader tabs
+ * *into* the table once and then arrows through it, instead of tabbing past one
+ * stop per row. Selection is `aria-current` rather than `aria-selected`, because
+ * this is a table, not a listbox, and a `<tr>` outside a grid has no selected
+ * state to report.
+ */
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from './utils.ts';
+
+export interface Column<T> {
+  readonly id: string;
+  readonly header: string;
+  readonly cell: (row: T) => ReactNode;
+  readonly align?: 'start' | 'end';
+  readonly mono?: boolean;
+  /**
+   * Offer this column as a sort. It takes effect only together with
+   * {@link Column.sortValue} — a sortable header with nothing to compare is a
+   * control that does nothing when pressed, so the pairing is enforced here
+   * rather than trusted at 23 call sites.
+   */
+  readonly sortable?: boolean;
+  readonly sortValue?: (row: T) => string | number;
+  readonly width?: string;
+}
+
+export interface Sort {
+  readonly id: string;
+  readonly direction: 'asc' | 'desc';
+}
+
+/**
+ * The three-state cycle a header press walks: unsorted → ascending →
+ * descending → unsorted.
+ *
+ * Returning to unsorted matters more than it sounds. The order the server sent
+ * is itself an answer — newest first, for every one of these ledgers — and a
+ * two-state toggle makes that original order unreachable once anything has been
+ * pressed.
+ */
+export function nextSort(current: Sort | null, id: string): Sort | null {
+  if (current?.id !== id) return { id, direction: 'asc' };
+  if (current.direction === 'asc') return { id, direction: 'desc' };
+  return null;
+}
+
+export function sortRows<T>(
+  rows: readonly T[],
+  columns: readonly Column<T>[],
+  sort: Sort | null,
+): readonly T[] {
+  if (sort === null) return rows;
+  const column = columns.find((candidate) => candidate.id === sort.id);
+  const value = column?.sortValue;
+  if (!value) return rows;
+  const sign = sort.direction === 'asc' ? 1 : -1;
+  // Copied before sorting: `rows` is a read model the caller may be rendering
+  // elsewhere, and sorting in place would reorder it under them.
+  return [...rows].sort((left, right) => {
+    const a = value(left);
+    const b = value(right);
+    if (typeof a === 'number' && typeof b === 'number') return (a - b) * sign;
+    return String(a).localeCompare(String(b)) * sign;
+  });
+}
+
+interface RowKeyEvent {
+  readonly key: string;
+  preventDefault: () => void;
+}
+
+/**
+ * Arrow-key navigation over a list of rows, as a handler.
+ *
+ * Exported because `ObjectExplorer` needs exactly this behaviour on its own
+ * rows and a second implementation would be a second answer to "what does Home
+ * do at the top of the list". `onActivate` is what Enter means — open, select,
+ * inspect — and is the caller's word, not this module's.
+ */
+export function rowKeyboard({
+  count,
+  active,
+  onActive,
+  onActivate,
+}: {
+  readonly count: number;
+  readonly active: number;
+  readonly onActive: (next: number) => void;
+  readonly onActivate?: (index: number) => void;
+}): (event: RowKeyEvent) => void {
+  return (event) => {
+    if (count === 0) return;
+    // Clamped rather than wrapped. A ledger has a top and a bottom, and
+    // arrowing off the end into the other end loses the reader's place in a way
+    // that is invisible until they read the wrong row.
+    const move = (next: number) => {
+      event.preventDefault();
+      onActive(Math.min(count - 1, Math.max(0, next)));
+    };
+    switch (event.key) {
+      case 'ArrowDown':
+        return move(active + 1);
+      case 'ArrowUp':
+        return move(active - 1);
+      case 'Home':
+        return move(0);
+      case 'End':
+        return move(count - 1);
+      case 'Enter':
+        if (!onActivate) return;
+        event.preventDefault();
+        return onActivate(active);
+      default:
+        return;
+    }
+  };
+}
+
+export function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  selectedKey,
+  onRowSelect,
+  empty,
+  caption,
+  initialSort,
+}: {
+  readonly columns: readonly Column<T>[];
+  readonly rows: readonly T[];
+  readonly rowKey: (row: T) => string;
+  readonly selectedKey?: string;
+  readonly onRowSelect?: (row: T) => void;
+  readonly empty?: ReactNode;
+  /**
+   * What this table is a table of, for anyone who cannot see that it is one.
+   * Rendered to screen readers only — the screen above it already carries the
+   * heading a sighted reader needs.
+   */
+  readonly caption?: string;
+  /**
+   * The order the rows arrive in, when it is not the order the server sent.
+   * A ledger that wants newest-first regardless of the query says so here
+   * instead of pre-sorting and losing the header state that explains why.
+   */
+  readonly initialSort?: Sort;
+}) {
+  const [sort, setSort] = useState<Sort | null>(initialSort ?? null);
+  const [active, setActive] = useState(0);
+  const body = useRef<HTMLTableSectionElement>(null);
+  // Set only by the key handler, so the effect below never steals focus on
+  // mount or when the rows are replaced by a poll.
+  const moved = useRef(false);
+
+  const ordered = useMemo(
+    () => sortRows(rows, columns, sort),
+    [rows, columns, sort],
+  );
+
+  useEffect(() => {
+    if (!moved.current) return;
+    moved.current = false;
+    const node = body.current?.children[active];
+    if (node instanceof HTMLElement) node.focus();
+  }, [active]);
+
+  if (rows.length === 0 && empty) return <>{empty}</>;
+
+  const selectable = onRowSelect !== undefined;
+  const onKeyDown = rowKeyboard({
+    count: ordered.length,
+    active,
+    onActive: (next) => {
+      moved.current = true;
+      setActive(next);
+    },
+    onActivate: onRowSelect
+      ? (index) => {
+          const row = ordered[index];
+          if (row !== undefined) onRowSelect(row);
+        }
+      : undefined,
+  });
+
+  return (
+    <div className="overflow-x-auto rounded-sm border border-border bg-card">
+      <table className="w-full border-collapse text-body">
+        {caption ? <caption className="sr-only">{caption}</caption> : null}
+        <thead className="sticky top-0 z-10 bg-card">
+          <tr className="border-b border-border">
+            {columns.map((column) => {
+              const sortable = column.sortable === true && !!column.sortValue;
+              const activeSort = sort?.id === column.id ? sort : null;
+              return (
+                <th
+                  key={column.id}
+                  scope="col"
+                  style={column.width ? { width: column.width } : undefined}
+                  aria-sort={
+                    activeSort
+                      ? activeSort.direction === 'asc'
+                        ? 'ascending'
+                        : 'descending'
+                      : undefined
+                  }
+                  className={cn(
+                    'px-3 py-2 font-semibold text-caption uppercase tracking-eyebrow text-muted-foreground',
+                    column.align === 'end' ? 'text-end' : 'text-start',
+                  )}
+                >
+                  {sortable ? (
+                    <button
+                      type="button"
+                      onClick={() => setSort(nextSort(sort, column.id))}
+                      className={cn(
+                        'inline-flex items-center gap-1 hover:text-foreground',
+                        activeSort && 'text-foreground',
+                      )}
+                    >
+                      {column.header}
+                      {activeSort?.direction === 'asc' ? (
+                        <ChevronUp className="size-3" />
+                      ) : activeSort?.direction === 'desc' ? (
+                        <ChevronDown className="size-3" />
+                      ) : null}
+                    </button>
+                  ) : (
+                    column.header
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody ref={body}>
+          {ordered.map((row, index) => {
+            const key = rowKey(row);
+            const selected = selectedKey !== undefined && selectedKey === key;
+            return (
+              <tr
+                key={key}
+                aria-current={selected ? 'true' : undefined}
+                tabIndex={selectable ? (index === active ? 0 : -1) : undefined}
+                onFocus={selectable ? () => setActive(index) : undefined}
+                onClick={
+                  onRowSelect
+                    ? () => {
+                        setActive(index);
+                        onRowSelect(row);
+                      }
+                    : undefined
+                }
+                onKeyDown={selectable ? onKeyDown : undefined}
+                className={cn(
+                  'border-b border-border-soft last:border-0',
+                  selectable &&
+                    'cursor-pointer focus-visible:-outline-offset-2 hover:bg-secondary/60',
+                  selected && 'bg-secondary',
+                )}
+              >
+                {columns.map((column) => (
+                  <td
+                    key={column.id}
+                    className={cn(
+                      'px-3 py-2.5 align-top',
+                      column.align === 'end' ? 'text-end' : 'text-start',
+                      column.mono && 'font-mono',
+                    )}
+                  >
+                    {column.cell(row)}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/ui/empty-state.tsx
+++ b/apps/spindrift/src/web/ui/empty-state.tsx
@@ -1,0 +1,71 @@
+/**
+ * Nothing here, and why — with the way out when there is one.
+ *
+ * This is the promotion of `components/log-pane.tsx`'s `EmptyState`, whose
+ * comment already argued the load-bearing half: a `website` on a static Target
+ * has no process, so §17 requires the stated reason rather than a disabled tab
+ * or an empty pane. That component is now this one, re-exported from where it
+ * was so no importer changes.
+ *
+ * The two things it gained are the two the screens kept hand-rolling around it.
+ * An `icon`, because an empty ledger and an empty filter result look identical
+ * in prose and different at a glance. And an `action`, because half of these
+ * states are reachable only by an act — "clear the filter", "connect a Target" —
+ * and the reader had to find that control somewhere else on the page.
+ *
+ * `tone` is not decoration either: an empty list is `idle` and expected, while a
+ * list emptied by a filter the reader forgot they set is `warning`. Refusing to
+ * distinguish them is how "no results" reads as "no data".
+ *
+ * What it refuses: an illustration slot, a variant that fills the viewport, and
+ * a `description` prop. The sentence is `children` so a screen can put a link in
+ * it, which is what the honest reasons usually need.
+ */
+import type { ReactNode } from 'react';
+import { cn } from './utils.ts';
+
+export type EmptyTone = 'idle' | 'accent' | 'warning' | 'success';
+
+const TONE = {
+  idle: 'border-border text-foreground',
+  accent: 'border-primary/40 text-accent-foreground',
+  warning: 'border-warning/50 text-warning',
+  success: 'border-success/40 text-success',
+} as const satisfies Record<EmptyTone, string>;
+
+export function EmptyState({
+  icon,
+  title,
+  children,
+  action,
+  tone = 'idle',
+  className,
+}: {
+  readonly icon?: ReactNode;
+  readonly title: string;
+  readonly children?: ReactNode;
+  readonly action?: ReactNode;
+  readonly tone?: EmptyTone;
+  readonly className?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        'flex flex-col items-center rounded-lg border border-dashed px-4 py-6 text-center',
+        TONE[tone],
+        className,
+      )}
+    >
+      {icon ? (
+        <span aria-hidden="true" className="mb-2 [&_svg]:size-5 opacity-70">
+          {icon}
+        </span>
+      ) : null}
+      <p className="text-ui font-semibold">{title}</p>
+      {children ? (
+        <p className="mt-1 text-body text-muted-foreground">{children}</p>
+      ) : null}
+      {action ? <div className="mt-3">{action}</div> : null}
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/ui/error-state.tsx
+++ b/apps/spindrift/src/web/ui/error-state.tsx
@@ -1,0 +1,79 @@
+/**
+ * A read that failed, said in full — and the button that retries it.
+ *
+ * Ten screens rendered a refusal as the same pasted div:
+ * `rounded-lg border border-destructive/50 bg-destructive/10 p-4
+ * text-destructive`, holding a message and nothing else. One of the ten had
+ * already drifted to a different radius, which is the usual proof that a shape
+ * is a component that has not been written yet.
+ *
+ * The missing piece was never the styling. A screen whose *load* failed has
+ * nothing on it — no rows, no filter, no navigation of its own — so a sentence
+ * with no retry leaves the reader with the browser's reload button as the only
+ * affordance, and reloading a hash-routed app is a heavier act than re-running
+ * one query. `CreationLoadFailure` in the create flow had already worked this
+ * out and grown the button; this is that argument applied to the other nine.
+ *
+ * `code` is rendered rather than swallowed. A transport failure code is not
+ * operator prose, but it is the string that makes a support conversation short,
+ * and hiding it means the reader retypes an approximation of the sentence
+ * instead. It sits in mono, small, beside the title — labelled as machine text
+ * by its typeface rather than by an apology.
+ *
+ * `role="alert"`: unlike a toast, this replaced the content the reader asked
+ * for, so it is worth interrupting to say so.
+ */
+import { RotateCcw, TriangleAlert } from 'lucide-react';
+import type { ReactNode } from 'react';
+import { Button } from './button.tsx';
+import { cn } from './utils.ts';
+
+export function ErrorState({
+  title,
+  code,
+  message,
+  onRetry,
+  secondary,
+  className,
+}: {
+  readonly title: string;
+  /** The transport or domain code, when the failure carried one. */
+  readonly code?: string;
+  readonly message: ReactNode;
+  readonly onRetry?: () => void;
+  /** Another way out — back to the ledger, on to the docs. */
+  readonly secondary?: ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'rounded-sm border border-destructive/50 bg-destructive-soft px-4 py-3.5',
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 text-destructive">
+        <TriangleAlert className="size-4 shrink-0" />
+        <p className="text-ui font-semibold">{title}</p>
+        {code ? (
+          <span className="font-mono text-caption text-muted-foreground">
+            {code}
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-1.5 text-body text-subtle">{message}</p>
+      {onRetry || secondary ? (
+        <div className="mt-3 flex flex-wrap items-center gap-2">
+          {onRetry ? (
+            <Button size="sm" variant="outline" onClick={onRetry}>
+              <RotateCcw />
+              Try again
+            </Button>
+          ) : null}
+          {secondary}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/ui/field.tsx
+++ b/apps/spindrift/src/web/ui/field.tsx
@@ -22,7 +22,7 @@ export function Label({
   return (
     <LabelRoot
       className={cn(
-        'text-[11.5px] font-semibold uppercase tracking-[0.07em] text-muted-foreground',
+        'text-caption font-semibold uppercase tracking-eyebrow text-muted-foreground',
         className,
       )}
       {...props}
@@ -34,8 +34,8 @@ export function Input({ className, ...props }: ComponentProps<'input'>) {
   return (
     <input
       className={cn(
-        'h-9 w-full rounded-md border border-input bg-background px-3',
-        'font-mono text-sm text-foreground',
+        'h-9 w-full rounded-sm border border-input bg-background px-3',
+        'font-mono text-body text-foreground',
         'placeholder:text-muted-foreground',
         'disabled:cursor-not-allowed disabled:opacity-60',
         className,

--- a/apps/spindrift/src/web/ui/kbd.tsx
+++ b/apps/spindrift/src/web/ui/kbd.tsx
@@ -1,0 +1,37 @@
+/**
+ * A key the reader is meant to press, drawn as a key.
+ *
+ * It exists because a shortcut nobody can see is a shortcut nobody uses: the
+ * whole application contained one `onKeyDown` handler, and the moment there is a
+ * palette on ⌘K there has to be somewhere for "⌘K" to be *shown* — in the hint
+ * beside the search affordance, and in the palette's own rows.
+ *
+ * A real `<kbd>`, so the base stylesheet's monospace and tabular-nums rule
+ * already applies and a screen reader announces it as keyboard input rather than
+ * as a stray glyph. The caller supplies the glyph: this component has no opinion
+ * about ⌘ versus Ctrl, because that is a fact about the reader's platform and
+ * not about the shortcut.
+ */
+import type { ReactNode } from 'react';
+import { cn } from './utils.ts';
+
+export function Kbd({
+  children,
+  className,
+}: {
+  readonly children: ReactNode;
+  readonly className?: string;
+}) {
+  return (
+    <kbd
+      className={cn(
+        'inline-flex h-5 min-w-5 items-center justify-center rounded-sm',
+        'border border-border bg-secondary px-1.5',
+        'text-micro font-semibold text-muted-foreground',
+        className,
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/apps/spindrift/src/web/ui/logo.tsx
+++ b/apps/spindrift/src/web/ui/logo.tsx
@@ -18,6 +18,15 @@ import { cn } from './utils.ts';
  * Marks drawn as a single near-black shape, which is invisible on a dark
  * surface. Inverting is right for exactly these — it would wreck a coloured
  * mark — so this is a fact about the two files, not a style choice.
+ *
+ * How much to invert is `--logo-invert`, read as a custom property rather than
+ * through a `dark` variant. That variant keyed on `[data-theme="dark"]`, and
+ * `theme.ts` *removes* that attribute for the `system` choice — deliberately,
+ * because the absence of the attribute is what lets the OS preference win. So
+ * the mark was un-inverted, on a dark page, for every reader who left the theme
+ * to their machine: the GitHub logo beside "Authorize the GitHub App" was
+ * near-black on near-black. A custom property flips with the resolved
+ * `color-scheme` instead of with an attribute that may not be there.
  */
 const MONO = new Set<LogoName>(['github', 'vercel']);
 
@@ -35,11 +44,10 @@ export function Logo({
       src={logos[name]}
       alt=""
       aria-hidden="true"
-      className={cn(
-        'size-5 shrink-0 object-contain',
-        MONO.has(name) && 'dark:invert',
-        className,
-      )}
+      style={
+        MONO.has(name) ? { filter: 'invert(var(--logo-invert))' } : undefined
+      }
+      className={cn('size-5 shrink-0 object-contain', className)}
       {...props}
     />
   );

--- a/apps/spindrift/src/web/ui/metric.tsx
+++ b/apps/spindrift/src/web/ui/metric.tsx
@@ -1,0 +1,85 @@
+/**
+ * One number a screen exists to say, at the size that says it.
+ *
+ * The landing screen's four tiles were four hand-built cards with the count in
+ * `text-3xl` and the breakdown in a hand-coloured sentence beneath. Two problems
+ * came with that, and only one of them is visual. The tiles were inert: the
+ * number told the reader that three things need attention and left them to find
+ * which three in the feed below. And a page-size total was presented as a fleet
+ * total, because the tile counted the array it was handed.
+ *
+ * So `onClick` is here in the primitive rather than added per tile later — a
+ * metric that can name a subset should be able to *show* that subset, and the
+ * hover and focus affordances only exist when it can. `footnote` is where the
+ * breakdown or the honesty goes ("the newest 12"), because a count that is not
+ * the whole truth has to say so next to itself, not in a caption further down.
+ *
+ * `tone` colours the value only. A whole tile tinted red reads as a broken tile
+ * rather than as a count of broken things, and four tinted tiles read as an
+ * emergency in a product whose ordinary steady state includes one failing App.
+ */
+import type { ReactNode } from 'react';
+import { Eyebrow } from './card.tsx';
+import { cn } from './utils.ts';
+
+export type MetricTone = 'idle' | 'success' | 'warning' | 'destructive';
+
+const TONE = {
+  idle: 'text-foreground',
+  success: 'text-success',
+  warning: 'text-warning',
+  destructive: 'text-destructive',
+} as const satisfies Record<MetricTone, string>;
+
+export function Metric({
+  label,
+  value,
+  tone = 'idle',
+  footnote,
+  onClick,
+  className,
+}: {
+  readonly label: string;
+  readonly value: ReactNode;
+  readonly tone?: MetricTone;
+  readonly footnote?: ReactNode;
+  readonly onClick?: () => void;
+  readonly className?: string;
+}) {
+  const body = (
+    <>
+      <Eyebrow>{label}</Eyebrow>
+      <p
+        className={cn(
+          'mt-1.5 text-display font-semibold tracking-display tabular-nums',
+          TONE[tone],
+        )}
+      >
+        {value}
+      </p>
+      {footnote ? (
+        <p className="mt-2 text-caption text-muted-foreground">{footnote}</p>
+      ) : null}
+    </>
+  );
+
+  const frame = 'rounded-sm border border-border bg-card px-4 py-3.5';
+
+  if (!onClick) {
+    return <div className={cn(frame, className)}>{body}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        frame,
+        'text-start transition-colors hover:border-primary',
+        className,
+      )}
+    >
+      {body}
+    </button>
+  );
+}

--- a/apps/spindrift/src/web/ui/page.tsx
+++ b/apps/spindrift/src/web/ui/page.tsx
@@ -1,0 +1,91 @@
+/**
+ * The three column widths this product has, and the one page header.
+ *
+ * There were three competing templates in the tree — `max-w-[1040px]` at 23
+ * sites, `max-w-[1320px]` at 9, and a 640px wizard column — paired with three
+ * different title sizes (`text-3xl`, `text-2xl`, `text-[27px]`). The visible
+ * cost is not the inconsistency: six screens *load* at the reading width and
+ * *land* at the wide one, so arriving anywhere shifts the whole page sideways
+ * once the data comes back. Naming the widths is what lets a screen's skeleton
+ * and its content agree.
+ *
+ * `wide` is a ledger — a table wants the room. `reading` is a screen of prose
+ * and cards, where a full-width line of body text is unreadable. `focus` is one
+ * decision at a time: the wizard, the gate, a create flow.
+ *
+ * No `Page` variant sets a background, a border, or vertical rhythm between its
+ * children. A page is a width and a gutter; everything else is the screen's.
+ */
+import type { ReactNode } from 'react';
+import { Eyebrow } from './card.tsx';
+import { cn } from './utils.ts';
+
+const WIDTH = {
+  wide: 'max-w-[1320px]',
+  reading: 'max-w-[1040px]',
+  focus: 'max-w-[640px]',
+} as const;
+
+export function Page({
+  width = 'wide',
+  className,
+  children,
+}: {
+  readonly width?: keyof typeof WIDTH;
+  readonly className?: string;
+  readonly children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        'mx-auto flex w-full flex-col gap-6 px-5 py-8',
+        WIDTH[width],
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/**
+ * The header every screen writes, in the order a reader needs it.
+ *
+ * `breadcrumb` sits above the eyebrow rather than replacing it: the crumb says
+ * where this is, the eyebrow says what kind of thing it is, and a screen that
+ * has both should not have to choose. Only `title` is required, because a
+ * screen with nothing to add should say nothing rather than pad the slot.
+ */
+export function PageHeader({
+  eyebrow,
+  title,
+  description,
+  actions,
+  breadcrumb,
+}: {
+  readonly eyebrow?: ReactNode;
+  readonly title: ReactNode;
+  readonly description?: ReactNode;
+  readonly actions?: ReactNode;
+  readonly breadcrumb?: ReactNode;
+}) {
+  return (
+    <header className="flex flex-wrap items-end gap-4">
+      <div className="min-w-0">
+        {breadcrumb}
+        {eyebrow ? <Eyebrow>{eyebrow}</Eyebrow> : null}
+        <h1 className="mt-1 text-display font-semibold tracking-display">
+          {title}
+        </h1>
+        {description ? (
+          <p className="mt-1 max-w-2xl text-ui leading-6 text-muted-foreground">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {actions ? (
+        <div className="ml-auto flex flex-wrap gap-2">{actions}</div>
+      ) : null}
+    </header>
+  );
+}

--- a/apps/spindrift/src/web/ui/skeleton.tsx
+++ b/apps/spindrift/src/web/ui/skeleton.tsx
@@ -1,0 +1,68 @@
+/**
+ * The shape of the content that is coming, while it is not here yet.
+ *
+ * Twelve screens said `Loading apps…` in muted italics and then replaced it
+ * with a page of a completely different height, which loses the reader's place
+ * on every navigation. A skeleton is not decoration for that: it is a promise
+ * about the layout, so the thing that arrives lands where the eye is already
+ * looking.
+ *
+ * It deliberately does **not** know what it is standing in for. No `variant`,
+ * no `lines={rows}` per screen shape — a caller composes the blocks inside its
+ * own container, because only the caller knows whether the real thing is a
+ * table of six rows or a hero and two cards. The two helpers below are the two
+ * shapes that showed up more than twice; a third one belongs at its call site
+ * until it does.
+ *
+ * `aria-hidden` throughout, and no `aria-busy` here. The status a screen reader
+ * needs is a sentence, and the screens own that sentence — announcing a grey
+ * rectangle is worse than announcing nothing.
+ */
+import { cn } from './utils.ts';
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        'motion-safe:animate-pulse rounded-sm bg-secondary',
+        'h-4 w-full',
+        className,
+      )}
+    />
+  );
+}
+
+/**
+ * A paragraph's worth of lines, the last one short.
+ *
+ * The short last line is the whole trick — equal-length bars read as a table,
+ * and prose does not end flush.
+ */
+export function SkeletonText({ lines = 3 }: { lines?: number }) {
+  return (
+    <div className="flex flex-col gap-2">
+      {Array.from({ length: Math.max(1, lines) }, (_, index) => (
+        <Skeleton
+          key={index}
+          className={index === lines - 1 ? 'h-3 w-2/5' : 'h-3'}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** A ledger's worth of rows, at the height `DataTable` actually renders. */
+export function SkeletonRows({ rows = 6 }: { rows?: number }) {
+  return (
+    <div className="flex flex-col divide-y divide-border-soft">
+      {Array.from({ length: Math.max(1, rows) }, (_, index) => (
+        <div key={index} className="flex items-center gap-4 px-3 py-2.5">
+          <Skeleton className="h-3 w-1/4" />
+          <Skeleton className="h-3 w-1/3" />
+          <Skeleton className="ml-auto h-3 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/ui/tabs.tsx
+++ b/apps/spindrift/src/web/ui/tabs.tsx
@@ -1,0 +1,136 @@
+/**
+ * One strip of tabs, replacing the three the tree had grown.
+ *
+ * There were three: boxed pills in a bordered box on the supply-chain header,
+ * round chips on the landing screen, and a bordered segment in the settings
+ * rail. All three were `<button>` elements carrying `aria-current="page"` — which
+ * is a claim about *navigation*, and two of the three did not navigate. They set
+ * a filter. A screen reader was told the current page was "In-Flight (2)".
+ *
+ * So this is `role="tablist"` with `aria-selected`, and the `line` variant is the
+ * default because an underline is the one tab shape that reads as "these are
+ * views of the thing below" rather than as "these are buttons". `pill` stays for
+ * a filter strip, where the segments are peers of each other and not of a
+ * heading.
+ *
+ * The keyboard behaviour is the part that is easy to skip and impossible to work
+ * around: a roving `tabIndex` so Tab enters the strip once instead of stopping on
+ * every tab, arrows to move within it, and focus following the arrow rather than
+ * lagging on the tab that was pressed. Activation is automatic — arrowing selects
+ * — which is correct for tabs whose panels are already loaded and wrong for tabs
+ * that fetch. Every consumer here has its data in hand.
+ *
+ * It does not own a panel. `aria-controls` is deliberately absent: the callers
+ * are route-driven or filter-driven and there is no single element these tabs
+ * describe, and a dangling `aria-controls` is worse than none.
+ */
+import { useEffect, useRef } from 'react';
+import { cn } from './utils.ts';
+
+export interface TabItem {
+  readonly id: string;
+  readonly label: string;
+  readonly count?: number;
+}
+
+export function Tabs({
+  items,
+  current,
+  onSelect,
+  variant = 'line',
+  label,
+  className,
+}: {
+  readonly items: readonly TabItem[];
+  readonly current: string;
+  readonly onSelect: (id: string) => void;
+  readonly variant?: 'line' | 'pill';
+  /** What this strip switches between, for anyone who cannot see the heading. */
+  readonly label?: string;
+  readonly className?: string;
+}) {
+  const strip = useRef<HTMLDivElement>(null);
+  // Set only by an arrow press, so the strip never grabs focus on mount or when
+  // a route change moves the selection.
+  const moved = useRef(false);
+
+  useEffect(() => {
+    if (!moved.current) return;
+    moved.current = false;
+    const index = items.findIndex((item) => item.id === current);
+    const node = strip.current?.children[index];
+    if (node instanceof HTMLElement) node.focus();
+  }, [current, items]);
+
+  const step = (delta: number, from: number) => {
+    const next = items[Math.min(items.length - 1, Math.max(0, from + delta))];
+    if (!next || next.id === current) return;
+    moved.current = true;
+    onSelect(next.id);
+  };
+
+  return (
+    <div
+      ref={strip}
+      role="tablist"
+      aria-label={label}
+      className={cn(
+        'flex flex-wrap items-center',
+        variant === 'line' ? 'gap-4 border-b border-border' : 'gap-1.5',
+        className,
+      )}
+    >
+      {items.map((item, index) => {
+        const selected = item.id === current;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            role="tab"
+            aria-selected={selected}
+            tabIndex={selected ? 0 : -1}
+            onClick={() => onSelect(item.id)}
+            onKeyDown={(event) => {
+              if (event.key === 'ArrowRight') {
+                event.preventDefault();
+                step(1, index);
+              } else if (event.key === 'ArrowLeft') {
+                event.preventDefault();
+                step(-1, index);
+              } else if (event.key === 'Home') {
+                event.preventDefault();
+                step(-items.length, index);
+              } else if (event.key === 'End') {
+                event.preventDefault();
+                step(items.length, index);
+              }
+            }}
+            className={cn(
+              'inline-flex items-center gap-1.5 text-body font-semibold transition-colors',
+              variant === 'line'
+                ? cn(
+                    '-mb-px border-b-2 px-0.5 pb-2.5',
+                    selected
+                      ? 'border-primary text-foreground'
+                      : 'border-transparent text-muted-foreground hover:text-foreground',
+                  )
+                : cn(
+                    'rounded-full px-3 py-1.5',
+                    selected
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
+                  ),
+            )}
+          >
+            {item.label}
+            {item.count === undefined ? null : (
+              <span className="tabular-nums text-muted-foreground">
+                {item.count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/ui/timestamp.tsx
+++ b/apps/spindrift/src/web/ui/timestamp.tsx
@@ -1,0 +1,102 @@
+/**
+ * When something happened, in the words a person uses, kept true as they read.
+ *
+ * The read models carry two fields for one instant — `at`, the ISO timestamp,
+ * and `when`, the relative phrase the *server* computed against its own clock.
+ * That split is deliberate and `domain/elapsed.ts` explains why: a relative time
+ * computed in the browser is computed against the browser's clock, and a machine
+ * whose clock is an hour off would render a release from this minute as "1h ago".
+ * The server's phrase is the honest one.
+ *
+ * It is also frozen at the moment of the response, which is the problem this
+ * component exists for: a screen that polls every fifteen seconds shows a
+ * `just now` that is four minutes old, and an operator watching a rollout reads
+ * a stale word as a stalled deploy. So the phrase is recomputed in the browser
+ * *from the ISO instant*, on one shared 30-second tick — one interval for the
+ * whole page, not one per row, because a ledger of forty rows should not hold
+ * forty timers to move one word each.
+ *
+ * The tick is an external store rather than a `useState` + `useEffect` for the
+ * reason `router.ts` and `connection-status.ts` are: the value must be readable
+ * during render, and its server snapshot must be a constant. `getServerSnapshot`
+ * answers "there is no browser clock here", which is what makes the static
+ * render fall back to the server's own `when` and produce byte-identical markup
+ * to what this app rendered before the component existed.
+ *
+ * The absolute instant is never hidden. It is the `title` and the `dateTime`, so
+ * hovering answers "8m ago relative to what" and a screen reader reads a machine
+ * timestamp rather than a phrase whose baseline it cannot see.
+ */
+import { useSyncExternalStore } from 'react';
+import { elapsedSince } from '../../domain/elapsed.ts';
+
+const TICK_MS = 30_000;
+
+let now = Date.now();
+let timer: ReturnType<typeof setInterval> | null = null;
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (timer === null) {
+    timer = setInterval(() => {
+      now = Date.now();
+      for (const each of listeners) each();
+    }, TICK_MS);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size > 0 || timer === null) return;
+    clearInterval(timer);
+    timer = null;
+  };
+}
+
+/**
+ * Cached, not `Date.now()` inline: `useSyncExternalStore` calls this during and
+ * after render and treats a changed value as a torn read, so a fresh clock read
+ * here would re-render the page forever.
+ */
+function browserNow(): number | null {
+  return now;
+}
+
+/** No clock, and no reader with a stopwatch. The server's phrase stands. */
+function serverNow(): number | null {
+  return null;
+}
+
+export function Timestamp({
+  at,
+  when,
+  className,
+}: {
+  readonly at: string;
+  readonly when?: string;
+  readonly className?: string;
+}) {
+  const clock = useSyncExternalStore(subscribe, browserNow, serverNow);
+  const parsed = Date.parse(at);
+
+  // An instant the read model could not supply is not a zero to render. If
+  // there is a phrase, it is all there is; if there is not, nothing is stated.
+  if (Number.isNaN(parsed)) {
+    return when ? <span className={className}>{when}</span> : null;
+  }
+
+  const instant = new Date(parsed);
+  const label =
+    clock === null
+      ? (when ?? instant.toISOString())
+      : elapsedSince(instant, new Date(clock));
+
+  return (
+    <time
+      dateTime={instant.toISOString()}
+      title={instant.toISOString()}
+      className={className}
+    >
+      {label}
+    </time>
+  );
+}

--- a/apps/spindrift/src/web/ui/toast.tsx
+++ b/apps/spindrift/src/web/ui/toast.tsx
@@ -1,0 +1,159 @@
+/**
+ * What just happened, said once, where the reader is looking.
+ *
+ * The app had exactly one answer for the result of an act: ten copies of a red
+ * div pasted into `app.tsx`, one per screen, each rendering a refusal and none
+ * rendering a success. So "Rolled back to build 1187" — the sentence an
+ * operator most wants after the scariest button in the product — had nowhere to
+ * appear, and a failure appeared in a box the reader may have scrolled past.
+ *
+ * A module-level listener store, subscribed with `useSyncExternalStore`, copied
+ * from `connection-status.ts` on purpose: `notify()` is then callable from an
+ * event handler, a promise chain, or a `catch` block in a module that renders
+ * nothing, without any of them holding a context or a ref. No provider, no
+ * dependency, no portal — `ToastHost` is mounted once in the shell and is the
+ * only reader of this store.
+ *
+ * What it refuses to be is a queue with priorities, a place to put a form, or a
+ * substitute for stating a refusal beside the control that caused it. A toast
+ * is for the act that already left the screen it was pressed on. A field that
+ * is invalid is `Field`'s `issue`, not this.
+ *
+ * Dismissal lives in the host, not the store: a timer started at `notify()`
+ * would keep running in a server render and in a test that never mounts
+ * anything, and would fire against a listener set nobody is in.
+ */
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { Button } from './button.tsx';
+import { cn } from './utils.ts';
+
+export type Tone = 'success' | 'warning' | 'destructive' | 'accent';
+
+export interface Toast {
+  readonly id: string;
+  readonly tone: Tone;
+  readonly title: string;
+  readonly detail?: string;
+  readonly action?: { readonly label: string; readonly onSelect: () => void };
+}
+
+/** How long a toast stands before the host retires it. */
+const DWELL_MS = 6_000;
+
+/**
+ * A refusal is read, not glanced at, and the reader may have been in another
+ * tab when it landed.
+ */
+const DWELL_DESTRUCTIVE_MS = 12_000;
+
+let toasts: readonly Toast[] = [];
+const listeners = new Set<() => void>();
+
+/**
+ * The server has no toasts, and this constant is the same object every call so
+ * `useSyncExternalStore` does not see a new snapshot on every render.
+ */
+const NONE: readonly Toast[] = [];
+
+let sequence = 0;
+
+export function notify(toast: Omit<Toast, 'id'>): void {
+  sequence += 1;
+  toasts = [...toasts, { ...toast, id: `toast:${sequence}` }];
+  for (const listener of listeners) listener();
+}
+
+export function dismissToast(id: string): void {
+  const remaining = toasts.filter((toast) => toast.id !== id);
+  if (remaining.length === toasts.length) return;
+  toasts = remaining;
+  for (const listener of listeners) listener();
+}
+
+export function activeToasts(): readonly Toast[] {
+  return toasts;
+}
+
+export function onToastChange(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+const TONE = {
+  success: 'border-l-success text-success',
+  warning: 'border-l-warning text-warning',
+  destructive: 'border-l-destructive text-destructive',
+  accent: 'border-l-primary text-accent-foreground',
+} as const satisfies Record<Tone, string>;
+
+/**
+ * Mounted once, in the shell.
+ *
+ * `role="status"`/`aria-live="polite"` rather than `alert`: even a destructive
+ * result here is the outcome of something the reader just did, so interrupting
+ * their current sentence to read it is the wrong trade. The region exists in
+ * the DOM whether or not it holds anything, because a live region inserted at
+ * the same moment as its content is not reliably announced.
+ */
+export function ToastHost() {
+  const items = useSyncExternalStore(onToastChange, activeToasts, () => NONE);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-label="Recent results"
+      className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex flex-col items-center gap-2 p-4 sm:items-end"
+    >
+      {items.map((toast) => (
+        <ToastRow key={toast.id} toast={toast} />
+      ))}
+    </div>
+  );
+}
+
+function ToastRow({ toast }: { toast: Toast }) {
+  const dismiss = useCallback(() => dismissToast(toast.id), [toast.id]);
+
+  useEffect(() => {
+    const timer = setTimeout(
+      dismiss,
+      toast.tone === 'destructive' ? DWELL_DESTRUCTIVE_MS : DWELL_MS,
+    );
+    return () => clearTimeout(timer);
+  }, [dismiss, toast.tone]);
+
+  return (
+    <div
+      className={cn(
+        'pointer-events-auto w-full max-w-sm rounded-sm border border-border border-l-2 bg-card px-3.5 py-3',
+        'shadow-panel',
+        TONE[toast.tone],
+      )}
+    >
+      <p className="text-body font-semibold">{toast.title}</p>
+      {toast.detail ? (
+        <p className="mt-1 text-body text-muted-foreground">{toast.detail}</p>
+      ) : null}
+      <div className="mt-2 flex items-center gap-2">
+        {toast.action ? (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => {
+              toast.action?.onSelect();
+              dismiss();
+            }}
+          >
+            {toast.action.label}
+          </Button>
+        ) : null}
+        <Button size="sm" variant="ghost" className="ml-auto" onClick={dismiss}>
+          Dismiss
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -83,7 +83,9 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '../../ui/collapsible.tsx';
+import { CopyButton } from '../../ui/copy.tsx';
 import { Logo } from '../../ui/logo.tsx';
+import { Page } from '../../ui/page.tsx';
 import { cn, normaliseUrl } from '../../ui/utils.ts';
 
 const BUILD_ADAPTER: Record<string, { logo: LogoName; label: string }> = {
@@ -120,7 +122,7 @@ export function DeployDetail({
   onNavigate?: (path: string) => void;
 }) {
   return (
-    <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-4 px-5 py-6">
+    <Page width="reading">
       <Chrome view={view} onNavigate={onNavigate} />
       <Hero view={view} actions={actions} />
 
@@ -173,7 +175,7 @@ export function DeployDetail({
         one is an absence, not a hidden pane.
       */}
       {view.id !== null ? <DeployDrawer view={view} /> : null}
-    </div>
+    </Page>
   );
 }
 
@@ -542,7 +544,7 @@ function Provenance({
           {source.kind === 'repo' ? (
             <>
               <Fact label="Repository" value={source.repo} />
-              <Fact label="Commit" value={source.commit} />
+              <Fact label="Commit" value={source.commit} copy />
             </>
           ) : (
             <>
@@ -559,8 +561,8 @@ function Provenance({
             </>
           )}
           <Fact label="Scope" value={source.subpath} />
-          <Fact label="Artifact" value={view.artifactDigest} />
-          <Fact label="Config version" value={view.configVersion} />
+          <Fact label="Artifact" value={view.artifactDigest} copy />
+          <Fact label="Config version" value={view.configVersion} copy />
           <Fact label="Created" value={view.at} />
         </CardContent>
       </Card>
@@ -590,22 +592,38 @@ function Fact({
   label,
   value,
   note,
+  copy = false,
 }: {
   label: string;
   value: string | null;
   note?: string;
+  /**
+   * Offer the value to the clipboard.
+   *
+   * On for the three facts whose entire purpose is to be pasted somewhere else
+   * — the commit into `git`, the artifact digest into `crane`, the config
+   * version into a support thread. Off for the rest, because a copy button on
+   * every line is a column of buttons and none of them reads as the one that
+   * matters.
+   */
+  copy?: boolean;
 }) {
   return (
     <div className="flex min-w-0 flex-col gap-0.5">
       <Eyebrow>{label}</Eyebrow>
-      <span
-        className={cn(
-          'truncate font-mono text-xs',
-          value === null ? 'text-muted-foreground' : 'text-subtle',
-        )}
-        title={value ?? undefined}
-      >
-        {value ?? '—'}
+      <span className="flex min-w-0 items-center gap-1">
+        <span
+          className={cn(
+            'truncate font-mono text-xs',
+            value === null ? 'text-muted-foreground' : 'text-subtle',
+          )}
+          title={value ?? undefined}
+        >
+          {value ?? '—'}
+        </span>
+        {copy && value !== null ? (
+          <CopyButton value={value} label={label.toLowerCase()} />
+        ) : null}
       </span>
       {note ? (
         <span className="text-[11px] text-muted-foreground">{note}</span>

--- a/apps/spindrift/src/web/views/apps/list.tsx
+++ b/apps/spindrift/src/web/views/apps/list.tsx
@@ -37,6 +37,9 @@ import type { AppListItem, DeployPhase } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Eyebrow } from '../../ui/card.tsx';
+import { Ref } from '../../ui/copy.tsx';
+import { Page } from '../../ui/page.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
 
 function kindIcon(kind: string) {
   switch (kind) {
@@ -79,6 +82,33 @@ export function appHref(url: string): string | null {
   return /^https?:\/\//i.test(value) ? value : `https://${value}`;
 }
 
+/**
+ * What the row says under the name, beyond the phase badge beside it.
+ *
+ * The row used to read `service · kubernetes` and stop, while the App's shape,
+ * its commit and its age were all on the wire — shoved into `search`, where a
+ * filter could match them and nobody could read them. The scan this list exists
+ * to be is "which of these needs me", and the fact that answers it on a
+ * multi-Component App is how much of it is down, not that something is.
+ *
+ * The count is stated only where there is more than one Component, because "1
+ * component" on every row of a fleet of single-service Apps is a column of
+ * noise that pushes the fact off the end of the line.
+ */
+function rowDetail(app: AppListItem): string {
+  const parts: string[] = [app.kind, app.target];
+  const count = app.componentCount ?? 0;
+  if (count > 1) {
+    parts.push(
+      app.failing
+        ? `${app.failing} of ${count} failing`
+        : `${count} components`,
+    );
+  }
+  if (app.commit) parts.push(app.commit.slice(0, 7));
+  return parts.join(' · ');
+}
+
 export function AppList({
   apps,
   onNavigate,
@@ -92,10 +122,15 @@ export function AppList({
   const items: ExplorerItem[] = apps.map((app) => ({
     id: `app:${app.id}`,
     title: app.name,
-    detail: `${app.kind} · ${app.target}`,
+    detail: rowDetail(app),
     status: app.phase.toLowerCase(),
     tone: phaseTone(app.phase),
-    search: `${app.source} ${app.url} ${app.vessel} ${app.artifact}`,
+    // `ExplorerItem` has carried these two since it was written and this list
+    // has never set them, so the one column an operator triages by — how long
+    // it has been in the state it is in — was blank on every row.
+    ...(app.when === undefined ? {} : { when: app.when }),
+    ...(app.at === undefined ? {} : { at: app.at }),
+    search: `${app.source} ${app.url} ${app.vessel} ${app.artifact} ${app.commit ?? ''}`,
     active:
       app.phase === 'PENDING' ||
       app.phase === 'APPLYING' ||
@@ -103,7 +138,7 @@ export function AppList({
   }));
 
   return (
-    <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+    <Page width="wide">
       <ExplorerPageHeader
         eyebrow="Application catalog"
         title="Apps"
@@ -146,12 +181,40 @@ export function AppList({
               <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
                 {app.source} is placed on {app.target}, a surface on{' '}
                 <span className="font-mono">{app.vessel}</span>.
+                {app.componentCount && app.componentCount > 1 ? (
+                  <>
+                    {' '}
+                    The state above is the worst of its {app.componentCount}{' '}
+                    Components.
+                  </>
+                ) : null}
               </p>
               <DefinitionGrid
                 entries={[
                   { label: 'State', value: app.phase.toLowerCase() },
                   { label: 'Target', value: app.target },
                   { label: 'Artifact', value: app.artifact, mono: true },
+                  // The commit and the instant were both loaded and neither was
+                  // rendered anywhere on this screen, so "what is running" was
+                  // answerable only by opening the App and then its release.
+                  ...(app.commit
+                    ? [
+                        {
+                          label: 'Commit',
+                          value: <Ref value={app.commit} kind="commit" />,
+                          title: app.commit,
+                        },
+                      ]
+                    : []),
+                  ...(app.at
+                    ? [
+                        {
+                          label: 'Released',
+                          value: <Timestamp at={app.at} when={app.when} />,
+                          title: app.at,
+                        },
+                      ]
+                    : []),
                   { label: 'Source', value: app.source, mono: true },
                   { label: 'Vessel', value: app.vessel, mono: true },
                   {
@@ -162,12 +225,28 @@ export function AppList({
                 ]}
               />
               <div className="mt-6 flex flex-wrap gap-2">
+                {/*
+                  First, and it stays first: `app-list-identity.test.tsx` walks
+                  this inspector for the first control carrying an `onClick` and
+                  presses it, because the claim under test is that a row reaches
+                  *its own* App and not the other one wearing the same name.
+                */}
                 <Button onClick={() => onNavigate(`/apps/${app.id}`)}>
                   Open App
                 </Button>
+                {app.deployId === undefined ? null : (
+                  <Button
+                    variant="outline"
+                    onClick={() => onNavigate(`/deploys/${app.deployId}`)}
+                  >
+                    Open release
+                  </Button>
+                )}
                 {href !== null ? (
                   <Button variant="outline" asChild>
-                    <a href={href}>
+                    {/* The icon has always promised a new tab. Now it keeps
+                        the promise, and without handing over the referrer. */}
+                    <a href={href} target="_blank" rel="noreferrer noopener">
                       Open URL <ExternalLink aria-hidden="true" />
                     </a>
                   </Button>
@@ -183,6 +262,6 @@ export function AppList({
           );
         }}
       />
-    </div>
+    </Page>
   );
 }

--- a/apps/spindrift/src/web/views/apps/releases.tsx
+++ b/apps/spindrift/src/web/views/apps/releases.tsx
@@ -1,0 +1,322 @@
+/**
+ * Every release of one App, and the one act available on an old one (§2, §6).
+ *
+ * §2 makes "one Build → many Deploys" the sentence that "makes
+ * rollback-without-rebuild possible", and `listDeploys` has answered it per App
+ * since the command registry was written — including a `rollbackable` flag
+ * computed under the same comparison `rollbackDeploy` makes. Nothing in the
+ * browser had ever called it. The workspace instead offered `Browse Builds` and
+ * `Browse Deploys`, which jump to the *global* unfiltered ledgers, so going back
+ * one release meant guessing your way into a `/deploys/:id` and hoping it
+ * belonged to this App. This tab is that command reaching a screen.
+ *
+ * **It fetches its own rows.** Every other card in the workspace is handed its
+ * data by the screen that owns the App, and this one is not, because the
+ * releases are a second page of history that most visits never open — loading
+ * twenty-five Deploy rows on every workspace read, and again on every two-second
+ * poll while something is in flight, to serve a tab nobody pressed is the wrong
+ * trade. The read is scoped to the App and re-run after a rollback, and nothing
+ * else invalidates it.
+ *
+ * **A rollback is offered only where `rollbackable`.** Absent rather than
+ * disabled, for the reason the ledger states: a disabled control says "later",
+ * and a Build that is not older than what is desired is not waiting to become
+ * older. The command can still refuse for something this list cannot see — a
+ * disconnected Target, a signature that stopped verifying — and that refusal is
+ * a sentence the operator reads rather than something to pre-empt by hiding
+ * the button.
+ *
+ * What it refuses: a diff between two releases, filtering, and any notion of
+ * "promote". A release is a row that was written once; comparing two of them is
+ * the attempt screen's job, and it is one press away from every row here.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { command } from '../../client.ts';
+import { PhasePill } from '../../components/status.tsx';
+import type { DeployLedgerItem } from '../../model.ts';
+import { Badge } from '../../ui/badge.tsx';
+import { Button } from '../../ui/button.tsx';
+import { Ref } from '../../ui/copy.tsx';
+import { type Column, DataTable } from '../../ui/data-table.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { ErrorState } from '../../ui/error-state.tsx';
+import { SkeletonRows } from '../../ui/skeleton.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
+import { notify } from '../../ui/toast.tsx';
+
+type Page =
+  | { readonly kind: 'loading' }
+  | { readonly kind: 'error'; readonly message: string }
+  | {
+      readonly kind: 'loaded';
+      readonly deploys: readonly DeployLedgerItem[];
+      readonly nextBefore: number | null;
+    };
+
+export function Releases({
+  app,
+  onNavigate,
+}: {
+  /** The App's id — `listDeploys` takes a name too, but two Apps can wear one. */
+  readonly app: string;
+  readonly onNavigate?: (path: string) => void;
+}) {
+  const [page, setPage] = useState<Page>({ kind: 'loading' });
+  const [olderPending, setOlderPending] = useState(false);
+
+  const load = useCallback(
+    (before?: number) => {
+      command('listDeploys', {
+        app,
+        ...(before === undefined ? {} : { before }),
+      })
+        .then((result) => {
+          if (!result.ok) {
+            setOlderPending(false);
+            setPage({ kind: 'error', message: result.failure.message });
+            return;
+          }
+          setOlderPending(false);
+          setPage((current) => ({
+            kind: 'loaded',
+            // Appended rather than replaced when this is an older page: the
+            // reader asked for more history, not for different history.
+            deploys:
+              before === undefined || current.kind !== 'loaded'
+                ? result.value.deploys
+                : [...current.deploys, ...result.value.deploys],
+            nextBefore: result.value.nextBefore,
+          }));
+        })
+        .catch((cause: unknown) => {
+          setOlderPending(false);
+          setPage({
+            kind: 'error',
+            message: cause instanceof Error ? cause.message : 'Server failure',
+          });
+        });
+    },
+    [app],
+  );
+
+  useEffect(() => {
+    setPage({ kind: 'loading' });
+    load();
+  }, [load]);
+
+  if (page.kind === 'loading') return <SkeletonRows rows={5} />;
+
+  if (page.kind === 'error') {
+    return (
+      <ErrorState
+        title="The releases of this App could not be read"
+        message={page.message}
+        onRetry={() => {
+          setPage({ kind: 'loading' });
+          load();
+        }}
+      />
+    );
+  }
+
+  if (page.deploys.length === 0) {
+    return (
+      <EmptyState title="This App has never been released.">
+        A Deploy is written the first time somebody places a Build. Until then
+        there is no history to roll back to.
+      </EmptyState>
+    );
+  }
+
+  const columns: readonly Column<DeployLedgerItem>[] = [
+    {
+      id: 'release',
+      header: 'Release',
+      width: '9rem',
+      cell: (row) => (
+        <span className="inline-flex items-center gap-2">
+          <span className="font-mono">#{row.id}</span>
+          {/* The one marker that says which of these is the answer to "what is
+              running". §6: which release *should* be running is the desired
+              row's, and a LIVE Deploy a newer intent superseded is still LIVE —
+              so `phase` alone cannot say it. */}
+          {row.current ? <Badge tone="success">current</Badge> : null}
+        </span>
+      ),
+    },
+    {
+      id: 'component',
+      header: 'Component',
+      cell: (row) => row.component,
+      sortable: true,
+      sortValue: (row) => row.component,
+    },
+    {
+      id: 'target',
+      header: 'Target',
+      cell: (row) => row.target,
+      sortable: true,
+      sortValue: (row) => row.target,
+    },
+    {
+      id: 'commit',
+      header: 'Commit',
+      cell: (row) => <Ref value={row.commit} kind="commit" />,
+    },
+    {
+      id: 'config',
+      header: 'Config',
+      // §10's pinned hash is what makes a rollback reproducible, and it is the
+      // only thing on the row that says two releases of one Build differ.
+      cell: (row) =>
+        row.configVersion ? (
+          <Ref value={row.configVersion} kind="digest" />
+        ) : (
+          <span className="text-muted-foreground">none</span>
+        ),
+    },
+    {
+      id: 'phase',
+      header: 'State',
+      cell: (row) => <PhasePill phase={row.phase}>{row.phase}</PhasePill>,
+    },
+    {
+      id: 'when',
+      header: 'Age',
+      align: 'end',
+      cell: (row) => (
+        <Timestamp
+          at={row.at}
+          when={row.when}
+          className="font-mono text-muted-foreground"
+        />
+      ),
+      sortable: true,
+      sortValue: (row) => row.at,
+    },
+    {
+      id: 'act',
+      header: '',
+      align: 'end',
+      cell: (row) => (
+        <div className="flex items-center justify-end gap-2">
+          <RollbackButton
+            deploy={row}
+            onDone={() => {
+              setPage({ kind: 'loading' });
+              load();
+            }}
+            {...(onNavigate ? { onNavigate } : {})}
+          />
+          {onNavigate ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onNavigate(`/deploys/${row.id}`)}
+            >
+              Open
+            </Button>
+          ) : null}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-3">
+      <DataTable
+        columns={columns}
+        rows={page.deploys}
+        rowKey={(row) => String(row.id)}
+        caption={`Releases of ${page.deploys[0]?.app ?? 'this App'}, newest first`}
+      />
+      {page.nextBefore === null ? (
+        <p className="text-center text-caption text-muted-foreground">
+          Every release of this App is loaded.
+        </p>
+      ) : (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            disabled={olderPending}
+            onClick={() => {
+              setOlderPending(true);
+              load(page.nextBefore ?? undefined);
+            }}
+          >
+            {olderPending ? 'Loading older releases…' : 'Load older releases'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Make an older release live again, from the row that names it.
+ *
+ * The outcome goes to the toast host rather than into this row: a rollback
+ * navigates nowhere and replaces the table under the reader, so a sentence
+ * rendered in a cell would be destroyed by the reload that proves it worked.
+ */
+function RollbackButton({
+  deploy,
+  onDone,
+  onNavigate,
+}: {
+  readonly deploy: DeployLedgerItem;
+  readonly onDone: () => void;
+  readonly onNavigate?: (path: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  if (!deploy.rollbackable) return null;
+
+  const rollback = () => {
+    setBusy(true);
+    command('rollbackDeploy', {
+      componentId: deploy.componentId,
+      targetId: deploy.targetId,
+      buildId: deploy.buildId,
+    })
+      .then((result) => {
+        setBusy(false);
+        if (!result.ok) {
+          notify({
+            tone: 'destructive',
+            title: 'Rollback refused',
+            detail: result.failure.message,
+          });
+          return;
+        }
+        notify({
+          tone: 'success',
+          title: `Rolled back to Build ${deploy.buildId}`,
+          detail: `${deploy.component} on ${deploy.target}`,
+          ...(onNavigate
+            ? {
+                action: {
+                  label: 'Open Deploy',
+                  onSelect: () =>
+                    onNavigate(`/deploys/${result.value.deployId}`),
+                },
+              }
+            : {}),
+        });
+        onDone();
+      })
+      .catch((cause: unknown) => {
+        setBusy(false);
+        notify({
+          tone: 'destructive',
+          title: 'Rollback failed',
+          detail: cause instanceof Error ? cause.message : 'Server failure',
+        });
+      });
+  };
+
+  return (
+    <Button variant="outline" size="sm" disabled={busy} onClick={rollback}>
+      {busy ? 'Rolling back…' : 'Roll back'}
+    </Button>
+  );
+}

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -20,6 +20,14 @@
  *   the section below Components and Datastores is a list of names and a form
  *   that writes — there is nothing here that could show a secret it was handed
  *   by accident, because nothing here is ever handed one.
+ *
+ * **The hero is the running App, and the tabs are everything else.** §18 is
+ * explicit that "the running App is the product, the pipeline is only how it got
+ * there", and the screen used to contradict it by stacking six equal cards down
+ * one column: config editing sat above the timeline, the live log was a
+ * half-width card at the bottom, and the App's releases had no surface at all.
+ * The hero and its diagnosis stay above the strip on every tab, because the
+ * answer to "is my App up" is not a tab you can be on the wrong one of.
  */
 import { ChevronRight, ExternalLink } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
@@ -28,6 +36,7 @@ import {
   type AppDeletionControls,
   DeleteAppButton,
 } from '../../components/delete-app.tsx';
+import { DiagnosisPanel, DriftPanel } from '../../components/diagnosis.tsx';
 import { EmptyState, LogPane } from '../../components/log-pane.tsx';
 import { PhasePill } from '../../components/status.tsx';
 import type {
@@ -35,12 +44,17 @@ import type {
   ComponentView,
   DatastoreView,
   LogLine,
+  PrerequisiteRowView,
   WorkspaceView,
 } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, Eyebrow } from '../../ui/card.tsx';
+import { Ref } from '../../ui/copy.tsx';
 import { Field } from '../../ui/field.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { Tabs } from '../../ui/tabs.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
 import { cn, normaliseUrl } from '../../ui/utils.ts';
 import {
   AUTH_NOTE,
@@ -49,6 +63,7 @@ import {
   REACH_NOTE,
   REACHES,
 } from './new/summary.tsx';
+import { Releases } from './releases.tsx';
 
 /**
  * Saving a Component's reach, as the screen above needs it answered.
@@ -131,6 +146,7 @@ export function Workspace({
   onSetAutoDeploy,
   onFollowExecution,
   executionLines,
+  tab = 'overview',
 }: {
   view: WorkspaceView;
   onDeploy?: () => void;
@@ -190,6 +206,18 @@ export function Workspace({
   onFollowExecution?: (execution: string | null) => void;
   /** The lines of whichever run is being followed. */
   executionLines?: readonly LogLine[];
+  /**
+   * Which tab the screen opens on.
+   *
+   * ponytail: the selection lives in this component rather than in the hash,
+   * because `app.tsx` resolves an App by everything after `/apps/`, so
+   * `#/apps/42/releases` reads as an App named `42/releases` and 404s. Making
+   * each tab a real route is a two-line change *there* — strip the tab segment
+   * before the read and key the screen on the App alone — and this prop is
+   * what it would drive when it lands. Until then a tab is not linkable and
+   * survives no reload.
+   */
+  tab?: WorkspaceTab;
 }) {
   /*
     Which Component the rest of this screen is about — its runtime, its config
@@ -202,53 +230,62 @@ export function Workspace({
     view.components.find((component) => component.id === view.componentId) ??
     view.components[0];
 
+  const [current, setCurrent] = useState<WorkspaceTab>(tab);
+
   return (
-    <div className="mx-auto flex w-full max-w-[1040px] flex-col gap-4 px-5 py-6">
-      <header className="flex flex-wrap items-end gap-4">
-        <div>
-          <Eyebrow>
-            {selected ? `${selected.kind} · ${selected.name}` : 'app'}
-          </Eyebrow>
-          <h1 className="text-2xl font-semibold tracking-tight">{view.app}</h1>
-        </div>
-        <div className="ml-auto flex gap-2">
-          {/* And the id, because a name is not one: `deleteApp` resolves on the
-              id, and a workspace that only knew what this App is called could
-              not tell it apart from another App called the same thing. */}
-          {deletion && view.appId ? (
-            <DeleteAppButton
-              appId={view.appId}
-              name={view.app}
-              deletion={deletion}
-              label
-            />
-          ) : null}
-          {/* Only where the selected Component answers somewhere: a job has no
-              address, and `Open app` on an empty one reloads this screen. */}
-          {view.url === '' ? null : (
-            <Button variant="outline" asChild>
-              <a href={normaliseUrl(view.url)}>
-                Open app <ExternalLink aria-hidden="true" />
-              </a>
+    <Page width="reading">
+      <PageHeader
+        eyebrow={selected ? `${selected.kind} · ${selected.name}` : 'app'}
+        title={view.app}
+        actions={
+          <>
+            {/* And the id, because a name is not one: `deleteApp` resolves on
+                the id, and a workspace that only knew what this App is called
+                could not tell it apart from another App called the same. */}
+            {deletion && view.appId ? (
+              <DeleteAppButton
+                appId={view.appId}
+                name={view.app}
+                deletion={deletion}
+                label
+              />
+            ) : null}
+            {/* Only where the selected Component answers somewhere: a job has
+                no address, and `Open app` on an empty one reloads this
+                screen. */}
+            {view.url === '' ? null : (
+              <Button variant="outline" asChild>
+                <a
+                  href={normaliseUrl(view.url)}
+                  target="_blank"
+                  rel="noreferrer noopener"
+                >
+                  Open app <ExternalLink aria-hidden="true" />
+                </a>
+              </Button>
+            )}
+            {onRebuild ? (
+              <Button
+                variant="outline"
+                onClick={onRebuild}
+                disabled={deploying}
+              >
+                Rebuild
+              </Button>
+            ) : null}
+            {/*
+              "Deploy" whatever the kind. This button writes an intent, and for
+              a job that places a CronJob triggered by nothing — it has never
+              made anything run, and calling it `Run now` beside a button that
+              does is the one label a reader cannot recover from. Running is on
+              the runtime card, where the runs are (§17).
+            */}
+            <Button onClick={onDeploy} disabled={deploying}>
+              {deploying ? 'Deploying...' : 'Deploy'}
             </Button>
-          )}
-          {onRebuild ? (
-            <Button variant="outline" onClick={onRebuild} disabled={deploying}>
-              Rebuild
-            </Button>
-          ) : null}
-          {/*
-            "Deploy" whatever the kind. This button writes an intent, and for a
-            job that places a CronJob triggered by nothing — it has never made
-            anything run, and calling it `Run now` beside a button that does is
-            the one label a reader cannot recover from. Running is on the
-            runtime card, where the runs are (§17).
-          */}
-          <Button onClick={onDeploy} disabled={deploying}>
-            {deploying ? 'Deploying...' : 'Deploy'}
-          </Button>
-        </div>
-      </header>
+          </>
+        }
+      />
 
       <Hero
         view={view}
@@ -257,42 +294,115 @@ export function Workspace({
         {...(onSetAutoDeploy === undefined ? {} : { onSetAutoDeploy })}
       />
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <Components
-          components={view.components}
-          {...(selected === undefined ? {} : { selectedId: selected.id })}
-          {...(onSetReach === undefined ? {} : { onSetReach })}
-          {...(onSelectComponent === undefined ? {} : { onSelectComponent })}
+      {/*
+        Above the tabs, never inside one. §6 persists a diagnosis on red and
+        records `drifted_at` when a converged release stops matching what is
+        running, and both were readable only at `/deploys/:id` — so this screen
+        said "has no release serving yet" over a failure whose reason was in
+        hand, and "is live" over a release the platform had been refusing for
+        two days. Neither is a thing an operator should have to be on the right
+        tab to find out.
+      */}
+      {view.diagnosis ? (
+        <DiagnosisPanel
+          diagnosis={view.diagnosis}
+          // The workspace does not know whether an older release is still up —
+          // that is a second query about a Deploy this screen never reads — and
+          // §6 does guarantee a failed deploy never touched exposure. The
+          // release link says it properly, one press away.
+          previousReleaseServing={false}
+          url={view.url}
         />
-        <Datastores datastores={view.datastores} />
-      </div>
+      ) : null}
+      {view.drift ? (
+        <DriftPanel
+          drift={view.drift}
+          url={view.url}
+          {...(onDeploy ? { onRedeploy: onDeploy } : {})}
+          busy={deploying}
+        />
+      ) : null}
 
-      <ConfigSection
-        configKeys={view.configKeys}
-        {...(selected === undefined ? {} : { component: selected.name })}
-        {...(onSetConfig === undefined ? {} : { onSetConfig })}
+      <Tabs
+        items={TABS}
+        current={current}
+        onSelect={(id) => setCurrent(id as WorkspaceTab)}
+        label="Views of this App"
       />
 
-      <div className="grid gap-4 md:grid-cols-2">
-        {/*
-          Every entry the view carries, un-sliced. `getAppWorkspace` bounds the
-          query that produces them, and a second bound here would be a number
-          that can silently disagree with it — a limit raised on the server and
-          not here reads as applied and is not.
-        */}
-        <Activity entries={view.activity} onNavigate={onNavigate} />
-        <Runtime
-          view={view}
+      {current === 'overview' ? (
+        <>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Components
+              components={view.components}
+              {...(selected === undefined ? {} : { selectedId: selected.id })}
+              {...(onSetReach === undefined ? {} : { onSetReach })}
+              {...(onSelectComponent === undefined
+                ? {}
+                : { onSelectComponent })}
+            />
+            <Datastores datastores={view.datastores} />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {/*
+              Every entry the view carries, un-sliced. `getAppWorkspace` bounds
+              the query that produces them, and a second bound here would be a
+              number that can silently disagree with it — a limit raised on the
+              server and not here reads as applied and is not.
+            */}
+            <Activity entries={view.activity} onNavigate={onNavigate} />
+            <Runtime
+              view={view}
+              {...(selected === undefined ? {} : { component: selected.name })}
+              onNavigate={onNavigate}
+              {...(onRunJob ? { onRun: onRunJob } : {})}
+              {...(onFollowExecution ? { onFollowExecution } : {})}
+              {...(executionLines ? { executionLines } : {})}
+            />
+          </div>
+        </>
+      ) : null}
+
+      {current === 'releases' ? (
+        view.appId === undefined ? (
+          <EmptyState title="This App has no id to read releases by.">
+            The screen was handed a view without one, which is the fixture shape
+            — a live workspace always carries it.
+          </EmptyState>
+        ) : (
+          <Releases app={view.appId} {...(onNavigate ? { onNavigate } : {})} />
+        )
+      ) : null}
+
+      {current === 'config' ? (
+        <ConfigSection
+          configKeys={view.configKeys}
           {...(selected === undefined ? {} : { component: selected.name })}
-          onNavigate={onNavigate}
-          {...(onRunJob ? { onRun: onRunJob } : {})}
-          {...(onFollowExecution ? { onFollowExecution } : {})}
-          {...(executionLines ? { executionLines } : {})}
+          {...(onSetConfig === undefined ? {} : { onSetConfig })}
         />
-      </div>
-    </div>
+      ) : null}
+    </Page>
   );
 }
+
+/**
+ * The three views of one App.
+ *
+ * Three rather than the six the audit sketched, because a tab is only worth its
+ * click where the thing behind it is a *different question*. Releases is one
+ * (`listDeploys`, which nothing in the browser had ever called) and Config is
+ * one (§10's write-only store, which has no business sitting above the
+ * timeline). Logs, Components and Datastores are all answers to "what is this
+ * App doing right now", which is Overview, and splitting them would make the
+ * common visit three clicks instead of none.
+ */
+export type WorkspaceTab = 'overview' | 'releases' | 'config';
+
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'releases', label: 'Releases' },
+  { id: 'config', label: 'Config' },
+] as const satisfies readonly { id: WorkspaceTab; label: string }[];
 
 /**
  * What the hero says about the Component the screen is showing.
@@ -371,19 +481,35 @@ function Hero({
         ) : (
           <Eyebrow>{view.release}</Eyebrow>
         )}
+        {/*
+          What shipped, and when. A phase pill with no date on it cannot tell
+          four minutes apart from four months, and the commit behind a running
+          App was reachable only by opening the release. Both are columns on the
+          Deploy row this screen already reads.
+        */}
+        {view.commit || view.at ? (
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {view.commit ? <Ref value={view.commit} kind="commit" /> : null}
+            {view.at ? (
+              <Timestamp at={view.at} when={view.when} className="font-mono" />
+            ) : null}
+          </div>
+        ) : null}
       </div>
 
-      <div className="ml-auto flex flex-col gap-1 text-right">
+      <div className="ml-auto flex flex-col items-end gap-1 text-right">
         <Eyebrow>Placement</Eyebrow>
         <p className="font-semibold">{view.target}</p>
         <p className="font-mono text-xs text-muted-foreground">
           on {view.vessel}
         </p>
-        <p className="text-xs text-muted-foreground">
-          {view.prerequisitesMet
-            ? 'All prerequisites passing'
-            : 'A prerequisite is unmet'}
-        </p>
+        <Prerequisites
+          met={view.prerequisitesMet}
+          unmet={view.unmetPrerequisites ?? []}
+          {...(view.targetId && onNavigate
+            ? { onOpenTarget: () => onNavigate('/targets') }
+            : {})}
+        />
         {/*
           Beside placement rather than in the header, because it is not an act:
           the header holds the two buttons that make something happen now, and
@@ -402,6 +528,88 @@ function Hero({
         ) : null}
       </div>
     </Card>
+  );
+}
+
+/**
+ * Which prerequisite is unmet, rather than that one is.
+ *
+ * `prerequisitesMet` is a boolean derived from "every catalogued row met", so
+ * the screen was showing the conclusion with the evidence thrown away — "A
+ * prerequisite is unmet" on the one screen where the operator is asking *which*
+ * is a dead end, and the App will not deploy until it is answered.
+ *
+ * A native `<details>` rather than the `Collapsible` the panels above use: this
+ * is three lines of text with no initial state to derive and no animation worth
+ * the state to drive it, and the element does the whole job — including opening
+ * before hydration, which matters on the one card a reader is staring at while
+ * the rest of the page is still arriving.
+ *
+ * The remediation is deliberately not here. §13 composes the change that clears
+ * a row from the manifest and the boundary, which the Targets screen has and
+ * this one does not; a thinner generator here would be a second answer to a
+ * question that already has one. So it names the blockage and points there.
+ */
+function Prerequisites({
+  met,
+  unmet,
+  onOpenTarget,
+}: {
+  met: boolean;
+  unmet: readonly PrerequisiteRowView[];
+  onOpenTarget?: () => void;
+}) {
+  if (met) {
+    return (
+      <p className="text-xs text-muted-foreground">All prerequisites passing</p>
+    );
+  }
+
+  if (unmet.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        A prerequisite is unmet
+        {onOpenTarget ? (
+          <>
+            {' — '}
+            <button
+              type="button"
+              onClick={onOpenTarget}
+              className="underline hover:text-foreground"
+            >
+              open the Target
+            </button>
+          </>
+        ) : null}
+      </p>
+    );
+  }
+
+  return (
+    <details className="text-right text-xs text-muted-foreground">
+      <summary className="cursor-pointer text-warning hover:text-foreground">
+        {unmet.length === 1
+          ? '1 prerequisite unmet'
+          : `${unmet.length} prerequisites unmet`}
+      </summary>
+      <ul className="mt-1.5 flex flex-col gap-1">
+        {unmet.map((row) => (
+          <li key={row.name}>
+            <span className="font-mono">{row.name}</span>
+            {row.detail ? <> — {row.detail}</> : null}
+          </li>
+        ))}
+      </ul>
+      {onOpenTarget ? (
+        <button
+          type="button"
+          onClick={onOpenTarget}
+          className="mt-1.5 underline hover:text-foreground"
+        >
+          Open the Target to clear these
+        </button>
+      ) : null}
+    </details>
   );
 }
 
@@ -493,7 +701,14 @@ function SectionHeader({
         <Eyebrow>{eyebrow}</Eyebrow>
         <h2 className="text-base font-semibold tracking-tight">{title}</h2>
       </div>
-      {action ? (
+      {/*
+        Both, or neither. Rendering the verb on `action` alone is what made
+        four buttons on this screen do nothing when pressed: `Add Component`
+        and `Attach Datastore` never had a handler at all, and the runtime
+        card's own verb loses one whenever the Component has no release to open.
+        A section that cannot answer its verb does not offer it.
+      */}
+      {action && onAction ? (
         <Button
           variant="outline"
           size="sm"
@@ -560,12 +775,19 @@ function Row({
       ) : (
         body
       )}
-      {trailing ?? (
-        <ChevronRight
-          aria-hidden="true"
-          className="size-4 shrink-0 text-muted-foreground"
-        />
-      )}
+      {/*
+        The chevron is a claim that pressing the row goes somewhere, so it is
+        drawn only where the row can be pressed. It used to be the default on
+        every row with no trailing control — config keys, attached Datastores,
+        job runs — each of which advertised a navigation it did not have.
+      */}
+      {trailing ??
+        (onSelect ? (
+          <ChevronRight
+            aria-hidden="true"
+            className="size-4 shrink-0 text-muted-foreground"
+          />
+        ) : null)}
     </div>
   );
 }
@@ -580,6 +802,28 @@ function Row({
  * shown is marked, because a screen rendering a second Component's runs with
  * nothing saying whose they are is worse than one that cannot render them.
  */
+/**
+ * What one Component's row says, now that the row knows where it is.
+ *
+ * The hero states the placement of the *selected* Component, so on an App with
+ * three of them the other two's placement and address were unobtainable without
+ * pressing each row in turn — which is the one thing a list of Components exists
+ * to spare a reader. Each of the three new facts is stated only where the
+ * Component has it: one that has never been placed has no Target, a job has no
+ * address, and neither should read as a blank where a value goes.
+ */
+function componentDetail(component: ComponentView): string {
+  const parts = [
+    component.phase,
+    `${component.reach}${component.auth === 'proxy' ? ' + auth' : ''}`,
+    component.artifact,
+  ];
+  if (component.target) parts.push(component.target);
+  if (component.url) parts.push(component.url);
+  if (component.when) parts.push(component.when);
+  return parts.join(' · ');
+}
+
 function Components({
   components,
   selectedId,
@@ -596,18 +840,30 @@ function Components({
 
   return (
     <Card>
-      <SectionHeader
-        eyebrow="App structure"
-        title="Components"
-        action="Add Component"
-      />
+      {/*
+        No action. `SectionHeader` renders the button whether or not an
+        `onAction` was passed, so "Add Component" was a control that did
+        nothing on press — worse than no control, because it reads as a feature
+        that is broken rather than one that is not built. Components are
+        declared in the create flow; when adding one from here exists, the verb
+        comes back with a handler.
+      */}
+      <SectionHeader eyebrow="App structure" title="Components" />
       <CardContent className="pt-0">
+        {/* The length guard every sibling card has. A brand-new App rendered
+            an empty card under a dead button. */}
+        {components.length === 0 ? (
+          <EmptyState title="This App has no Components yet.">
+            A Component is what gets built and placed. The create flow declares
+            the first one.
+          </EmptyState>
+        ) : null}
         {components.map((component) => (
           <div key={component.name}>
             <Row
               badge={<Badge tone="accent">{component.kind}</Badge>}
               title={component.name}
-              detail={`${component.phase} · ${component.reach}${component.auth === 'proxy' ? ' + auth' : ''} · ${component.artifact}`}
+              detail={componentDetail(component)}
               selected={component.id === selectedId}
               {...(onSelectComponent === undefined
                 ? {}
@@ -772,11 +1028,10 @@ export function ReachEditor({
 function Datastores({ datastores }: { datastores: readonly DatastoreView[] }) {
   return (
     <Card>
-      <SectionHeader
-        eyebrow="Attached resources"
-        title="Datastores"
-        action="Attach Datastore"
-      />
+      {/* No action, for the reason the Components header has none: attaching a
+          Datastore is an act with placement consequences (§3, §11) and no
+          command behind this button, so it pressed and did nothing. */}
+      <SectionHeader eyebrow="Attached resources" title="Datastores" />
       <CardContent className="pt-0">
         {datastores.length === 0 ? (
           <EmptyState title="No Datastores attached.">
@@ -798,13 +1053,9 @@ function Datastores({ datastores }: { datastores: readonly DatastoreView[] }) {
                   ? `${datastore.provenance} · ${datastore.target} · attached to ${datastore.attachedTo}`
                   : `${datastore.provenance} · ${datastore.target} · unattached`
               }
-              trailing={
-                datastore.attachedTo ? undefined : (
-                  <Button variant="outline" size="sm">
-                    Attach
-                  </Button>
-                )
-              }
+              // The per-row `Attach` had no `onClick` either. An unattached
+              // Datastore says so in its detail line, which is the honest half
+              // of what that button was claiming.
             />
           ))
         )}
@@ -1336,7 +1587,7 @@ function Runtime({
                   />
                 </button>
                 {following === execution.name ? (
-                  <LogPane lines={executionLines ?? []} />
+                  <FollowedLog lines={executionLines ?? []} />
                 ) : null}
               </div>
             ))}
@@ -1360,7 +1611,7 @@ function Runtime({
           </>
         ) : (
           <>
-            <LogPane lines={runtime.lines} />
+            <FollowedLog lines={runtime.lines} />
             <p className="pt-2 text-xs text-muted-foreground">
               This Target keeps {runtime.reach} of history. Deploys are markers
               on this stream, never a filter.
@@ -1369,6 +1620,45 @@ function Runtime({
         )}
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * How many lines of a live tail the page holds.
+ *
+ * `app.tsx` appends every socket page to `runtime.lines` and never drops one,
+ * so a chatty service grew this array — and the DOM under it — for as long as
+ * the workspace stayed open. The cap is a window on the end of the stream,
+ * which is what a tail is; the history behind it lives on the Target, and this
+ * card already says how far back that reaches.
+ */
+const TAIL_LINES = 2_000;
+
+/**
+ * The live tail: following, capped, and honest about the cap.
+ *
+ * Both `LogPane` mounts on this screen omitted `follow`, which is the flag that
+ * makes the pane auto-scroll *and* the flag that gives it a maximum height — so
+ * the one genuinely streaming surface in the product never showed its newest
+ * line and pushed the whole page down instead of scrolling inside itself. The
+ * two are one flag on purpose: a pane with no bottom has nothing to follow to.
+ *
+ * The "showing the last N" line is the same admission `Transcript` makes on the
+ * build log. A pane that silently drops the beginning of a stream is a pane
+ * that has answered "the error is not in the logs" for somebody.
+ */
+function FollowedLog({ lines }: { lines: readonly LogLine[] }) {
+  const dropped = Math.max(0, lines.length - TAIL_LINES);
+  return (
+    <>
+      <LogPane lines={dropped === 0 ? lines : lines.slice(dropped)} follow />
+      {dropped === 0 ? null : (
+        <p className="pt-1.5 text-xs text-muted-foreground">
+          Showing the last {TAIL_LINES} lines — {dropped} older{' '}
+          {dropped === 1 ? 'line has' : 'lines have'} scrolled out of this pane.
+        </p>
+      )}
+    </>
   );
 }
 

--- a/apps/spindrift/src/web/views/auth/discovery.tsx
+++ b/apps/spindrift/src/web/views/auth/discovery.tsx
@@ -21,18 +21,41 @@
  * this form. It renders in the neutral voice, beside the field it could not
  * answer, with the sentence the command produced — never as a blank, because a
  * blank on a confirmation screen reads as a confirmed answer.
+ *
+ * **Every row is a reconciliation, not a row of buttons.** The panel shipped
+ * deriving each candidate's selected style from `fact.suggested` — a property
+ * of the *server's* answer, identical before and after a press — so confirming
+ * a value changed the document and changed nothing on screen. What a row says
+ * now is a comparison: the value the document holds at
+ * {@link placementOf}, and which candidate, if any, is that value. A press is
+ * visible because the document is what is being read.
+ *
+ * **It seeds the two narrowing inputs from the document, and that is the one
+ * place it names keys.** Discovery is staged on purpose — with no project the
+ * command answers "name a project and run discovery again" for buckets and
+ * signing keys — and the candidate that unblocks it reads
+ * `"<project> — this deployment's own credential"`, so an operator who types
+ * what they read types a project that does not exist. Two paths are named to
+ * close that: the home vessel's project, and the location inside the signer
+ * this installation already holds. Both are paths the command itself answers
+ * for, so a key that leaves the schema leaves the seed empty rather than
+ * leaving a control writing somewhere nothing reads.
  */
-import { CircleAlert, Search } from 'lucide-react';
+import { Check, CircleAlert, Search } from 'lucide-react';
 import { useState } from 'react';
 import type {
   DiscoveredCandidate,
   DiscoveredFact,
 } from '../../../commands/installation/discover.ts';
-import { placementOf } from '../../../commands/installation/discover.ts';
+import {
+  HOME_VESSEL,
+  placementOf,
+} from '../../../commands/installation/discover.ts';
 import { command } from '../../client.ts';
 import type { Path } from '../../forms/document.ts';
-import { withValueAt } from '../../forms/document.ts';
+import { valueAt, withValueAt } from '../../forms/document.ts';
 import { humanize } from '../../forms/schema.ts';
+import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
 import { Field } from '../../ui/field.tsx';
@@ -112,18 +135,42 @@ export function DiscoveryPanel({
   locked?(at: Path): boolean;
   onChange(document: unknown): void;
 }) {
-  const [project, setProject] = useState('');
-  const [kmsLocation, setKmsLocation] = useState('');
+  // Seeded once, from the document this panel opened on. Later edits do not
+  // move these: they are what the operator is *narrowing* by, and a text box
+  // that rewrote itself under a cursor because a candidate landed elsewhere
+  // would be a worse bug than the empty one this replaces.
+  const seed = narrowingFrom(document);
+  const [project, setProject] = useState(seed.project);
+  const [kmsLocation, setKmsLocation] = useState(seed.kmsLocation);
   const [facts, setFacts] = useState<readonly DiscoveredFact[] | null>(null);
   const [refusal, setRefusal] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const discover = async () => {
+  const discover = async (narrowing: {
+    project: string;
+    kmsLocation: string;
+  }) => {
     setBusy(true);
-    const answer = await askInstallationCloud({ project, kmsLocation });
+    const answer = await askInstallationCloud(narrowing);
     setFacts('facts' in answer ? answer.facts : null);
     setRefusal('refusal' in answer ? answer.refusal : null);
     setBusy(false);
+  };
+
+  /**
+   * Confirming a value, and — for the project — asking again with it.
+   *
+   * The second half is what makes the staging finishable in the place it was
+   * staged. Buckets and signing keys are not read until a project is named, so
+   * the press that names one is the press that should produce them; leaving the
+   * operator to copy a label into a box was leaving them to copy the words
+   * "this deployment's own credential" along with it.
+   */
+  const apply = (fact: DiscoveredFact, candidate: DiscoveredCandidate) => {
+    onChange(applyDiscovered(document, fact, candidate));
+    if (!isProjectFact(fact) || typeof candidate.value !== 'string') return;
+    setProject(candidate.value);
+    void discover({ project: candidate.value, kmsLocation });
   };
 
   return (
@@ -139,50 +186,110 @@ export function DiscoveryPanel({
         </div>
       </CardHeader>
       <CardContent className="flex flex-col gap-4">
-        <div className="flex flex-col gap-4 sm:flex-row">
-          <Field
-            name="discovery.project"
-            label="Project"
-            hint="Leave empty to list the projects this identity can see."
-            value={project}
-            disabled={disabled || busy}
-            onChange={(event) => setProject(event.target.value)}
-          />
-          <Field
-            name="discovery.kmsLocation"
-            label="Key location"
-            hint="Signing keys are listed one location at a time."
-            value={kmsLocation}
-            disabled={disabled || busy}
-            onChange={(event) => setKmsLocation(event.target.value)}
-          />
-        </div>
-        <div>
-          <Button
-            type="button"
-            variant="outline"
-            disabled={disabled || busy}
-            onClick={() => void discover()}
-          >
-            <Search aria-hidden="true" />
-            {busy ? 'Asking…' : 'Ask this installation’s cloud'}
-          </Button>
-        </div>
+        {/* A real form, so Enter in either narrowing box asks — and its own
+            form rather than the manifest's, which is why `installation.tsx`
+            mounts this panel outside the form it saves with: Enter here used
+            to submit the whole manifest. */}
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void discover({ project, kmsLocation });
+          }}
+        >
+          <div className="flex flex-col gap-4 sm:flex-row">
+            <Field
+              name="discovery.project"
+              label="Project"
+              hint="Leave empty to list the projects this identity can see."
+              value={project}
+              disabled={disabled || busy}
+              onChange={(event) => setProject(event.target.value)}
+            />
+            <Field
+              name="discovery.kmsLocation"
+              label="Key location"
+              hint="Signing keys are listed one location at a time."
+              value={kmsLocation}
+              disabled={disabled || busy}
+              onChange={(event) => setKmsLocation(event.target.value)}
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button type="submit" variant="outline" disabled={disabled || busy}>
+              <Search aria-hidden="true" />
+              {busy ? 'Asking…' : 'Ask this installation’s cloud'}
+            </Button>
+            {/* The ask can take as long as three cloud APIs take, and a button
+                label is not announced. This is. */}
+            <p
+              role="status"
+              aria-live="polite"
+              className="text-xs text-muted-foreground"
+            >
+              {busy
+                ? 'Asking this installation’s cloud…'
+                : facts === null
+                  ? ''
+                  : `${facts.length} ${facts.length === 1 ? 'value' : 'values'} came back.`}
+            </p>
+          </div>
+        </form>
         {refusal === null ? null : <DiscoveryRefusal reason={refusal} />}
         {facts === null ? null : (
           <DiscoveredFactList
             facts={facts}
+            document={document}
             disabled={disabled || busy}
             unwritable={(fact) => unwritable(fact, document, locked)}
-            onApply={(fact, candidate) =>
-              onChange(applyDiscovered(document, fact, candidate))
-            }
+            onApply={apply}
           />
         )}
       </CardContent>
     </Card>
   );
 }
+
+/** Whether this fact answers for the project the other two reads need first. */
+function isProjectFact(fact: DiscoveredFact): boolean {
+  return fact.path.slice(-2).join('.') === 'location.project';
+}
+
+/**
+ * What this document already says about the two things discovery narrows by.
+ *
+ * Exported and pure because it is the whole of what the panel knows about the
+ * schema, and the one claim worth pinning without a browser: a document that
+ * already names its project must arrive with that project in the box, or the
+ * second stage of a two-stage ask is unreachable from the screen that staged
+ * it. A path that resolves to nothing yields an empty string, which is exactly
+ * the first-pass ask.
+ */
+export function narrowingFrom(document: unknown): {
+  readonly project: string;
+  readonly kmsLocation: string;
+} {
+  const at = placementOf(
+    { path: ['vessels', HOME_VESSEL, 'location', 'project'], ...NO_ANSWER },
+    document,
+  );
+  const project = at === null ? undefined : valueAt(document, at);
+  // The location is not a manifest key of its own: it is a segment inside the
+  // signer this installation already holds, and reading it back is cheaper for
+  // an operator than finding the console page that lists it.
+  const signer = valueAt(document, ['supplyChain', 'signer']);
+  const location =
+    typeof signer === 'string'
+      ? /\/locations\/([^/]+)/.exec(signer)?.[1]
+      : null;
+  return {
+    project: typeof project === 'string' ? project : '',
+    kmsLocation: location ?? '',
+  };
+}
+
+/** The `Discovered` half of a fact used only to address a path. */
+const NO_ANSWER = { kind: 'found', candidates: [], suggested: null } as const;
 
 /**
  * The whole ask having failed, in the neutral voice.
@@ -256,19 +363,27 @@ export function unwritable(
 }
 
 /**
- * What came back, one row per manifest path.
+ * What came back, one row per manifest path, against what the document holds.
  *
- * Pure, and exported, because this is the half with a claim in it: the two arms
- * have to read as two different things, and that is a statement about markup
- * rather than about a request.
+ * Pure, and exported, because this is the half with the claims in it: the arms
+ * have to read as different things, and a press has to change something — both
+ * statements about markup rather than about a request.
+ *
+ * `document` is optional and its absence is honest rather than defaulted: a
+ * caller with no document has nothing to compare against, so the row shows the
+ * candidates and says nothing about which one is in force. Passing a document
+ * is what turns the row into a reconciliation.
  */
 export function DiscoveredFactList({
   facts,
+  document,
   disabled = false,
   unwritable,
   onApply,
 }: {
   readonly facts: readonly DiscoveredFact[];
+  /** The document being edited, for the value each row is reconciled against. */
+  readonly document?: unknown;
   readonly disabled?: boolean;
   /** {@link unwritable}, threaded by the panel. Omitted answers everything writable. */
   unwritable?(fact: DiscoveredFact): string | null;
@@ -276,49 +391,98 @@ export function DiscoveredFactList({
 }) {
   return (
     <dl className="flex flex-col gap-3">
-      {facts.map((fact) => (
-        <div
-          key={fact.path.join('.')}
-          className="flex flex-col gap-1 border-t border-border pt-3 first:border-t-0 first:pt-0"
-        >
-          <dt className="text-[11.5px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
-            {/* The last segment, humanized. Never a key written here — the
-                path came from the command, and the schema owns which keys
-                exist. */}
-            {humanize(String(fact.path[fact.path.length - 1] ?? ''))}
-          </dt>
-          <dd className="text-sm">
-            {fact.kind === 'unavailable' ? (
-              <span className="text-muted-foreground">{fact.reason}</span>
-            ) : unwritable?.(fact) ? (
-              <span className="text-muted-foreground">{unwritable(fact)}</span>
-            ) : fact.candidates.length === 0 ? (
-              <span className="text-muted-foreground">
-                Nothing of this kind exists here.
+      {facts.map((fact) => {
+        const at = document === undefined ? null : placementOf(fact, document);
+        const current = at === null ? undefined : valueAt(document, at);
+        const applied =
+          fact.kind === 'found'
+            ? fact.candidates.find((candidate) => holds(current, candidate))
+            : undefined;
+        return (
+          <div
+            key={fact.path.join('.')}
+            className="flex flex-col gap-1.5 border-t border-border pt-3 first:border-t-0 first:pt-0"
+          >
+            <dt className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+              <span className="text-caption font-semibold uppercase tracking-eyebrow text-muted-foreground">
+                {/* The last segment, humanized. Never a key written here — the
+                    path came from the command, and the schema owns which keys
+                    exist. */}
+                {humanize(String(fact.path[fact.path.length - 1] ?? ''))}
               </span>
-            ) : (
-              <div className="flex flex-wrap gap-2">
-                {fact.candidates.map((candidate) => (
-                  <Button
-                    key={candidate.label}
-                    type="button"
-                    size="sm"
-                    variant={
-                      candidate.label === fact.suggested?.label
-                        ? 'default'
-                        : 'outline'
-                    }
-                    disabled={disabled}
-                    onClick={() => onApply(fact, candidate)}
-                  >
-                    {candidate.label}
-                  </Button>
-                ))}
-              </div>
+              {/* And the whole path beside it, because the tail alone is
+                  ambiguous by construction: two of the five answers humanize
+                  to the same word for two different keys. */}
+              <code className="font-mono text-micro text-subtle">
+                {fact.path.join('.')}
+              </code>
+              {current === undefined ? null : applied === undefined ? (
+                <Badge tone="warning">stand-in</Badge>
+              ) : (
+                <Badge tone="success">confirmed</Badge>
+              )}
+            </dt>
+            {current === undefined ? null : (
+              <p className="font-mono text-xs text-muted-foreground">
+                now: {readable(current)}
+              </p>
             )}
-          </dd>
-        </div>
-      ))}
+            <dd className="text-sm">
+              {fact.kind === 'unavailable' ? (
+                <span className="text-muted-foreground">{fact.reason}</span>
+              ) : unwritable?.(fact) ? (
+                <span className="text-muted-foreground">
+                  {unwritable(fact)}
+                </span>
+              ) : fact.candidates.length === 0 ? (
+                <span className="text-muted-foreground">
+                  Nothing of this kind exists here.
+                </span>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {fact.candidates.map((candidate) => (
+                    <Button
+                      key={candidate.label}
+                      type="button"
+                      size="sm"
+                      // Applied, not suggested. The suggestion is the server's
+                      // opinion and never changes; what an operator needs to
+                      // see is which candidate the document is currently
+                      // holding, which is the thing a press moves.
+                      variant={candidate === applied ? 'default' : 'outline'}
+                      aria-pressed={candidate === applied}
+                      disabled={disabled}
+                      onClick={() => onApply(fact, candidate)}
+                    >
+                      {candidate === applied ? (
+                        <Check aria-hidden="true" />
+                      ) : null}
+                      {candidate.label}
+                    </Button>
+                  ))}
+                </div>
+              )}
+            </dd>
+          </div>
+        );
+      })}
     </dl>
   );
+}
+
+/**
+ * Whether the document is already holding what this candidate would write.
+ *
+ * By value rather than by label: a candidate's `value` is what lands, and for
+ * a list-valued key it is a list, so `===` would answer "no" to a value it
+ * just wrote. Serialized because these are manifest scalars and short lists,
+ * where a deep compare is the same three lines with more edge cases.
+ */
+function holds(current: unknown, candidate: DiscoveredCandidate): boolean {
+  return JSON.stringify(current) === JSON.stringify(candidate.value);
+}
+
+/** A manifest value as one line of text. */
+function readable(value: unknown): string {
+  return Array.isArray(value) ? value.join(', ') : String(value);
 }

--- a/apps/spindrift/src/web/views/auth/gate.tsx
+++ b/apps/spindrift/src/web/views/auth/gate.tsx
@@ -13,6 +13,22 @@
  * afterwards; and story 4's recovery — rotate the token, replace every passkey
  * — is the sentence under a sign-in that has stopped working, because that is
  * the moment somebody needs it.
+ *
+ * **It says which installation this is, and it says it with the origin.** This
+ * is the first thing a human ever sees of the product and it identified
+ * nothing, so staging and production were the same screen. The manifest holds
+ * an `installation.name`, and nothing here can read it: this side of the door
+ * has no session, and a control plane that told an anonymous caller what it is
+ * called would be answering a question nobody authenticated to ask. The origin
+ * is the honest identity available here — a ceremony is scoped to
+ * `controlPlane.hostname` and a browser refuses one whose relying party is not
+ * a suffix of the host in the address bar, so the host **is** what the passkey
+ * is about to be bound to.
+ *
+ * **What it does, in one sentence, instead of what it is made of.** "Passkey
+ * Authentication & UI-Driven Manifest Operations" is the vocabulary of the
+ * implementation, and "manifest operations" is the noun this product exists to
+ * hide from the person reading it.
  */
 import { KeyRound, ShieldCheck } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
@@ -40,19 +56,14 @@ export function Gate({
   return (
     <main className="mx-auto flex min-h-dvh w-full max-w-[460px] flex-col justify-center gap-6 px-5 py-12">
       <div className="flex flex-col items-center gap-2 text-center">
-        <div className="inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-3 py-1 text-xs font-medium text-accent shadow-sm">
-          <span className="relative flex size-2">
-            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-accent opacity-75" />
-            <span className="relative inline-flex size-2 rounded-full bg-accent" />
-          </span>
-          Passkey-First Platform
-        </div>
         <span className="font-mono text-xl font-bold tracking-[0.25em] text-foreground">
           SPINDRIFT
         </span>
-        <p className="text-xs text-muted-foreground">
-          Passkey Authentication &amp; UI-Driven Manifest Operations
+        <p className="text-sm text-muted-foreground">
+          Deploy to your own clusters and cloud projects. One button, one
+          release.
         </p>
+        <Installation />
       </div>
       {claimed ? (
         <SignIn gatewayUnlinked={gatewayUnlinked} onSignedIn={onSignedIn} />
@@ -60,6 +71,23 @@ export function Gate({
         <Enrol onSignedIn={onSignedIn} />
       )}
     </main>
+  );
+}
+
+/**
+ * Which installation the passkey is about to be bound to.
+ *
+ * Rendered as nothing when there is no origin to read — this file is also
+ * rendered to static markup in a test, and a screen that invented a hostname
+ * for that would be the one thing worse than a screen that names none.
+ */
+function Installation() {
+  const host = typeof location === 'undefined' ? '' : location.host;
+  if (host === '') return null;
+  return (
+    <p className="mt-1 font-mono text-caption text-subtle">
+      signing in to {host}
+    </p>
   );
 }
 
@@ -116,24 +144,34 @@ function Enrol({ onSignedIn }: { onSignedIn: (p: Principal) => void }) {
           </p>
         </div>
       </CardHeader>
-      <CardContent className="flex flex-col gap-3">
-        <Field
-          name="enrolment-token"
-          label="Enrolment token"
-          type="password"
-          autoComplete="off"
-          value={token}
-          placeholder="from SPINDRIFT_ENROLMENT_TOKEN"
-          onChange={(event) => setToken(event.currentTarget.value)}
-        />
-        <Problem>{error}</Problem>
-        <Button
-          disabled={running || token.trim() === ''}
-          onClick={() => run(() => enrol(token.trim()))}
+      <CardContent>
+        <form
+          className="flex flex-col gap-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void run(() => enrol(token.trim()));
+          }}
         >
-          <KeyRound aria-hidden="true" />
-          {running ? 'Waiting for your passkey…' : 'Enrol a passkey'}
-        </Button>
+          <Field
+            name="enrolment-token"
+            label="Enrolment token"
+            type="password"
+            autoComplete="off"
+            // The first control a human ever meets in this product. It was not
+            // focused, so the first act was a mouse hunt for the only box on
+            // the screen — and this screen has exactly one.
+            autoFocus
+            value={token}
+            placeholder="from SPINDRIFT_ENROLMENT_TOKEN"
+            onChange={(event) => setToken(event.currentTarget.value)}
+          />
+          <Problem>{error}</Problem>
+          <Button type="submit" disabled={running || token.trim() === ''}>
+            <KeyRound aria-hidden="true" />
+            {running ? 'Waiting for your passkey…' : 'Enrol a passkey'}
+          </Button>
+          <Ceremony running={running} />
+        </form>
       </CardContent>
     </Card>
   );
@@ -168,14 +206,21 @@ function SignIn({
       </CardHeader>
       <CardContent className="flex flex-col gap-3">
         <Problem>{error}</Problem>
-        <Button disabled={running} onClick={() => run(signIn)}>
+        <Button disabled={running} onClick={() => void run(signIn)}>
           {running ? 'Waiting for your passkey…' : 'Continue with a passkey'}
         </Button>
+        <Ceremony running={running} />
         <details className="rounded-md border border-border px-3 py-2">
           <summary className="cursor-pointer text-xs font-medium text-foreground">
             Recover with a rotated token
           </summary>
-          <div className="mt-3 flex flex-col gap-3">
+          <form
+            className="mt-3 flex flex-col gap-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void run(() => enrol(token.trim()));
+            }}
+          >
             <p className="text-xs text-muted-foreground">
               Rotate{' '}
               <code className="font-mono">SPINDRIFT_ENROLMENT_TOKEN</code> in
@@ -192,17 +237,38 @@ function SignIn({
               onChange={(event) => setToken(event.currentTarget.value)}
             />
             <Button
+              type="submit"
               variant="outline"
               disabled={running || token.trim() === ''}
-              onClick={() => run(() => enrol(token.trim()))}
             >
               <ShieldCheck aria-hidden="true" />
               {running ? 'Waiting for your passkey…' : 'Replace the passkey'}
             </Button>
-          </div>
+          </form>
         </details>
       </CardContent>
     </Card>
+  );
+}
+
+/**
+ * That the browser is waiting on a passkey, out loud.
+ *
+ * The only sign a ceremony was in flight was a button label, which is announced
+ * to nobody — and this ceremony can sit for thirty seconds while an operator
+ * looks for a security key. Empty rather than unmounted while idle, so the
+ * region exists before it has anything to say and the change is what is
+ * announced.
+ */
+function Ceremony({ running }: { running: boolean }) {
+  return (
+    <p
+      role="status"
+      aria-live="polite"
+      className="text-xs text-muted-foreground"
+    >
+      {running ? 'Waiting for your passkey. Your browser will ask.' : ''}
+    </p>
   );
 }
 

--- a/apps/spindrift/src/web/views/auth/installation.tsx
+++ b/apps/spindrift/src/web/views/auth/installation.tsx
@@ -57,6 +57,7 @@ import { SchemaFields } from '../../forms/render.tsx';
 import type { FormField } from '../../forms/schema.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
+import { Skeleton } from '../../ui/skeleton.tsx';
 import { DiscoveryPanel } from './discovery.tsx';
 
 /** What the last save attempt produced. */
@@ -175,14 +176,30 @@ export function InstallationSettings() {
   }
 
   if (document === undefined) {
+    // The shape that is coming, not a sentence where it will be: this screen
+    // resolves into a page header and a column of cards, and a single grey line
+    // meant the whole surface jumped into place under the reader. The sentence
+    // stays as the thing announced, because a screen reader cannot see a
+    // rectangle.
     return (
-      <Card>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">
-            Loading this installation…
-          </p>
-        </CardContent>
-      </Card>
+      <div className="flex flex-col gap-6">
+        <p role="status" aria-live="polite" className="sr-only">
+          Loading this installation…
+        </p>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-64" />
+          <Skeleton className="h-3 w-96 max-w-full" />
+        </div>
+        {[0, 1, 2].map((card) => (
+          <Card key={card}>
+            <CardContent className="flex flex-col gap-3">
+              <Skeleton className="h-4 w-40" />
+              <Skeleton className="h-9" />
+              <Skeleton className="h-9" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
     );
   }
 
@@ -338,6 +355,17 @@ export function InstallationSettingsView({
         onSave();
       }}
     >
+      <div className="flex flex-col gap-1">
+        <h2 className="flex items-center gap-2 text-2xl font-bold tracking-tight text-foreground">
+          <Sliders aria-hidden="true" className="size-4 text-subtle" />
+          Installation manifest
+        </h2>
+        <p className="text-sm text-muted-foreground">
+          Everything that names this installation. Saving writes the whole
+          document and reconciles the Targets it declares.
+        </p>
+      </div>
+
       <ManifestDivergenceNotice
         paths={divergence}
         declaration={declaration}
@@ -358,23 +386,17 @@ export function InstallationSettingsView({
         onChange={onChange}
       />
 
-      <Card>
-        <CardHeader>
-          <Sliders aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
-          <div>
-            <CardTitle>Installation manifest</CardTitle>
-            <p className="mt-1 text-sm text-muted-foreground">
-              Everything that names this installation. Saving writes the whole
-              document and reconciles the Targets it declares.
-            </p>
-          </div>
-        </CardHeader>
-        {plain.length === 0 ? null : (
-          <CardContent>
-            <SchemaFields fields={plain} at={[]} form={form} />
-          </CardContent>
-        )}
-      </Card>
+      {/* Not a card. Every one of this schema's top-level keys has structure,
+          so `plain` is empty for every manifest this build can hold — and a
+          card was drawn around it anyway, which put a titled, blurbed, and
+          permanently empty box above the twelve cards that are the actual
+          document. The copy was never a section's: it is what this whole page
+          is, so it is the page's. The keys keep a home for the day the schema
+          grows a scalar, and it is a plain fieldset rather than a card, because
+          a card with nothing in it is the thing being deleted. */}
+      {plain.length === 0 ? null : (
+        <SchemaFields fields={plain} at={[]} form={form} />
+      )}
 
       {nested.map((field) => (
         <Card key={field.key}>

--- a/apps/spindrift/src/web/views/auth/onboarding.tsx
+++ b/apps/spindrift/src/web/views/auth/onboarding.tsx
@@ -71,12 +71,14 @@
  * them first.
  */
 import { CircleAlert, PartyPopper, Rocket } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { command } from '../../client.ts';
 import type { Path } from '../../forms/document.ts';
+import { valueAt } from '../../forms/document.ts';
 import { manifestFieldAt, manifestIssues } from '../../forms/manifest.ts';
 import type { FieldErrors } from '../../forms/render.tsx';
 import { SchemaFields } from '../../forms/render.tsx';
+import type { StepStatus } from '../../model.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
 import { DiscoveryPanel } from './discovery.tsx';
@@ -86,6 +88,7 @@ import {
   refusalOf,
   type SaveOutcome,
 } from './installation.tsx';
+import { type RailStep, StepRail } from './step-rail.tsx';
 
 /** One screen: a manifest key to confirm, or the cloud to ask. */
 export type OnboardingAsk = {
@@ -173,6 +176,164 @@ export function stepAsking(path: string): number {
 }
 
 /**
+ * What is wrong with the answer the step in front of the operator asks for.
+ *
+ * The machinery for this has existed since the screen did and was consulted
+ * exactly once, after the final write — so an empty installation name walked
+ * through all four questions, and the commit press threw the operator back to
+ * step one reading a sentence of dotted schema paths. The same map, filtered by
+ * {@link stepAsking}, is a gate on `Continue`: an answer is checked where it is
+ * given, by the schema that will refuse it, and the reason is on screen beside
+ * the button that will not move.
+ *
+ * Exported because it is the whole of the gate and the one part of it worth
+ * asserting without a browser.
+ */
+export function stepIssues(document: unknown, step: number): FieldErrors {
+  const issues = new Map<string, readonly string[]>();
+  for (const [path, messages] of manifestIssues(document)) {
+    if (stepAsking(path) === step) issues.set(path, messages);
+  }
+  return issues;
+}
+
+/** The document's answer to one ask, as a line for the rail. */
+function answerTo(document: unknown, ask: OnboardingAsk): string | undefined {
+  if (ask.kind !== 'field') return undefined;
+  const value = valueAt(document, ask.at);
+  if (value === undefined || value === null) return undefined;
+  return Array.isArray(value) ? value.join(', ') : String(value);
+}
+
+/**
+ * The four asks as the rail draws them, against where the operator is.
+ *
+ * Behind is `done` rather than "answered": this screen confirms values that
+ * arrive already filled in, so "has a value" is true of every step from the
+ * first render and would make the rail a row of four ticks that never move.
+ * What it can honestly say is which questions have been walked past — and
+ * `failed` overrides that, because a step the write came back refusing is not
+ * a step behind you.
+ */
+function railSteps(
+  document: unknown,
+  errors: FieldErrors,
+  step: number,
+): readonly RailStep[] {
+  const refused = new Set([...errors.keys()].map(stepAsking));
+  return ONBOARDING_ASKS.map((ask, index) => ({
+    title: ask.title,
+    value: answerTo(document, ask),
+    status: (refused.has(index)
+      ? 'failed'
+      : index === step
+        ? 'running'
+        : index < step
+          ? 'done'
+          : 'waiting') satisfies StepStatus,
+  }));
+}
+
+/**
+ * The two maps of what is wrong, as one map for the controls.
+ *
+ * The server's issues and the schema's are the same kind of fact keyed the same
+ * way, and a control that rendered only the first would stay silent about the
+ * value that is stopping the button beside it. The server's win a collision:
+ * it is the authority, and it has seen the whole document.
+ */
+function merged(errors: FieldErrors, blocking: FieldErrors): FieldErrors {
+  if (blocking.size === 0) return errors;
+  return new Map([...blocking, ...errors]);
+}
+
+/**
+ * The step the URL is on, clamped, and `0` for a URL that names none.
+ *
+ * The hash is already this app's router, so browser Back was moving the URL
+ * under a wizard that neither followed it nor noticed. Clamped rather than
+ * validated because the only input is something a human typed into an address
+ * bar, and the honest answer to `#/setup/9` is the last question.
+ */
+function stepInHash(): number {
+  if (typeof location === 'undefined') return 0;
+  const asked = /^#\/setup\/(\d+)/.exec(location.hash)?.[1];
+  const at = asked === undefined ? 1 : Number(asked);
+  return Math.min(Math.max(at - 1, 0), ONBOARDING_ASKS.length - 1);
+}
+
+/** Where the in-progress document is kept between two loads of one tab. */
+const HELD = 'spindrift.setup';
+
+/**
+ * The document a reload interrupted, or `undefined` for a fresh start.
+ *
+ * `sessionStorage` rather than `localStorage`, and it is the one-write design
+ * that decides which: nothing is stored server-side until the last press, so
+ * four answers live only here — but they are answers about *this* tab's visit
+ * to *this* installation, and a document surviving until next week would be a
+ * document proposed against an installation somebody else has since configured.
+ *
+ * Every failure answers "start fresh". Storage a browser refuses, a body
+ * another version of this screen wrote, a private window that throws on read —
+ * none of them are worth a screen of their own, and all of them are survivable
+ * by asking the four questions again.
+ */
+function restored(): unknown {
+  try {
+    const held = sessionStorage.getItem(HELD);
+    const document: unknown = held === null ? null : JSON.parse(held);
+    return typeof document === 'object' && document !== null
+      ? document
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function remember(document: unknown): void {
+  try {
+    sessionStorage.setItem(HELD, JSON.stringify(document));
+  } catch {
+    // A browser that will not store this is a browser where F5 costs four
+    // answers, which is where this screen started. It is not a refusal.
+  }
+}
+
+/** A refused path, named as the question that asks about it. */
+function refusedAs(path: string): string {
+  const at = stepAsking(path);
+  return ONBOARDING_ASKS[at]?.title ?? path;
+}
+
+/**
+ * The sentence a document the schema refuses is reported with.
+ *
+ * The paths are what the schema keys its issues by and they are the wrong
+ * vocabulary for the one screen whose whole premise is naming keys in human
+ * terms — `installation.name, supplyChain.registry are not valid` was the last
+ * thing an operator read before being thrown back to step one. Every path a
+ * step asks about is named as that step; the rest are named as themselves,
+ * because discovery writes values this screen never offers a control for and
+ * pointing at a question that does not ask them would be worse than the path.
+ */
+export function refusalSentence(paths: readonly string[]): string {
+  const asked = [
+    ...new Set(paths.filter((path) => stepAsking(path) >= 0).map(refusedAs)),
+  ];
+  const unasked = paths.filter((path) => stepAsking(path) < 0);
+  return [
+    'This installation was not written.',
+    asked.length === 0 ? '' : `Answer again: ${asked.join('; ')}.`,
+    unasked.length === 0
+      ? ''
+      : `These values were refused and no question here asks about them: ${unasked.join(', ')}.`,
+  ]
+    .filter((part) => part !== '')
+    .join(' ');
+}
+
+/**
  * Ask the four, then write the document once.
  *
  * `initial` rather than a read of its own: whoever decided this installation is
@@ -191,11 +352,35 @@ export function Onboarding({
    */
   onDone(next: string | null): void;
 }) {
-  const [document, setDocument] = useState<unknown>(initial);
-  const [step, setStep] = useState(0);
+  const [document, setDocument] = useState<unknown>(
+    () => restored() ?? initial,
+  );
+  const [step, setStepState] = useState(stepInHash);
   const [errors, setErrors] = useState<FieldErrors>(new Map());
   const [outcome, setOutcome] = useState<SaveOutcome | null>(null);
   const [saving, setSaving] = useState(false);
+
+  // The step lives in the hash and the document in `sessionStorage`, which
+  // together make F5 and browser Back survivable. Both are consequences of the
+  // one-write-at-the-end design rather than complaints about it: nothing is
+  // stored server-side until the last press, so an in-memory document is four
+  // answers that a reload silently discards — and the hash is already this
+  // app's router, so Back was moving the URL under a wizard that neither
+  // followed it nor noticed.
+  const setStep = (next: number) => {
+    const clamped = Math.min(Math.max(next, 0), ONBOARDING_ASKS.length - 1);
+    setStepState(clamped);
+    if (typeof location !== 'undefined')
+      location.hash = `/setup/${clamped + 1}`;
+  };
+
+  useEffect(() => {
+    const follow = () => setStepState(stepInHash());
+    addEventListener('hashchange', follow);
+    return () => removeEventListener('hashchange', follow);
+  }, []);
+
+  useEffect(() => remember(document), [document]);
 
   const finish = async () => {
     // The same earlier-of-two-identical-checks the settings form runs, for the
@@ -221,10 +406,7 @@ export function Onboarding({
         .filter((at) => at >= 0)
         .sort((first, second) => first - second);
       if (asked[0] !== undefined) setStep(asked[0]);
-      setOutcome({
-        kind: 'invalid',
-        message: `This installation was not written, because ${paths.join(', ')} ${paths.length === 1 ? 'is' : 'are'} not valid.`,
-      });
+      setOutcome({ kind: 'invalid', message: refusalSentence(paths) });
       return;
     }
 
@@ -314,15 +496,39 @@ export function OnboardingView({
   const ask = ONBOARDING_ASKS[step];
   if (ask === undefined) return null;
   const last = step === ONBOARDING_ASKS.length - 1;
-  const form = { document, errors, disabled: saving, onChange };
+  // What the schema says about the answer in front of the operator, now, rather
+  // than what it will say after the write. The map exists either way; consulting
+  // it here is the difference between a refusal beside the control that caused
+  // it and a refusal three steps later naming a dotted path.
+  const blocking = stepIssues(document, step);
+  const held = [...blocking.values()][0]?.[0];
+  // The discovery step is the one with no form around it, so its primary button
+  // has nothing to submit — a `type="submit"` outside a form is a button that
+  // does nothing when pressed, which is how this step would have shipped.
+  const submits = ask.kind !== 'discovery';
+  const advance = () => {
+    if (blocking.size > 0) return;
+    if (last) onFinish();
+    else onStep(step + 1);
+  };
+  const form = {
+    document,
+    errors: merged(errors, blocking),
+    disabled: saving,
+    // One question on screen, so the control that asks it is where the cursor
+    // belongs. The first interaction with this product was a mouse hunt for the
+    // only box on the page.
+    autoFocus: true,
+    onChange,
+  };
 
-  return (
-    <OnboardingShell>
+  const body = (
+    <>
       <Card>
         <CardHeader>
           <Rocket aria-hidden="true" className="mt-0.5 size-4 text-subtle" />
           <div>
-            <p className="text-[11.5px] font-semibold uppercase tracking-[0.07em] text-muted-foreground">
+            <p className="text-caption font-semibold uppercase tracking-eyebrow text-muted-foreground">
               Step {step + 1} of {ONBOARDING_ASKS.length}
             </p>
             <CardTitle>{ask.title}</CardTitle>
@@ -347,7 +553,7 @@ export function OnboardingView({
 
       <Outcome outcome={outcome} />
 
-      <div className="flex items-center justify-between gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
         <Button
           type="button"
           variant="outline"
@@ -356,18 +562,63 @@ export function OnboardingView({
         >
           Back
         </Button>
-        {last ? (
-          <Button type="button" disabled={saving} onClick={onFinish}>
-            {saving ? 'Configuring…' : 'Configure this installation'}
-          </Button>
-        ) : (
-          <Button
-            type="button"
-            disabled={saving}
-            onClick={() => onStep(step + 1)}
+        <div className="flex items-center gap-3">
+          {/* Whatever the button is currently mumbling, said out loud. A
+              ceremony that takes as long as a cloud write takes was announced
+              to a screen reader by nothing at all. */}
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-xs text-muted-foreground"
           >
-            Continue
+            {saving
+              ? 'Writing this installation…'
+              : held === undefined
+                ? ''
+                : held}
+          </p>
+          <Button
+            type={submits ? 'submit' : 'button'}
+            disabled={saving || blocking.size > 0}
+            onClick={submits ? undefined : advance}
+          >
+            {last
+              ? saving
+                ? 'Configuring…'
+                : 'Configure this installation'
+              : 'Continue'}
           </Button>
+        </div>
+      </div>
+    </>
+  );
+
+  return (
+    <OnboardingShell
+      rail={
+        <StepRail
+          steps={railSteps(document, errors, step)}
+          current={step}
+          onJump={saving ? undefined : onStep}
+        />
+      }
+    >
+      <div>
+        {ask.kind === 'discovery' ? (
+          // The one step with no form of its own, because it already has one:
+          // the discovery panel submits its narrowing, and a form nested in a
+          // form is markup a browser repairs into something neither meant.
+          <div className="flex flex-col gap-6">{body}</div>
+        ) : (
+          <form
+            className="flex flex-col gap-6"
+            onSubmit={(event) => {
+              event.preventDefault();
+              advance();
+            }}
+          >
+            {body}
+          </form>
         )}
       </div>
     </OnboardingShell>
@@ -459,10 +710,23 @@ function OnboardingDone({
  * An unconfigured installation has no Apps, no Builds and no Targets, so the
  * navigation that reaches them would be five links to five empty screens and a
  * sixth to the settings form this screen exists to stand in front of.
+ *
+ * What it does have is a fixed position. The column was vertically centred, and
+ * step three mounts a discovery panel that grows by five rows when the cloud
+ * answers — so every Continue, and every successful ask, slid the whole screen
+ * under the reader. A wizard reads as built mostly because its chrome does not
+ * move, so the header and the rail are pinned and only the step changes height.
  */
-function OnboardingShell({ children }: { readonly children: ReactNode }) {
+function OnboardingShell({
+  rail,
+  children,
+}: {
+  /** The four questions, when there are four questions to show. */
+  readonly rail?: ReactNode;
+  readonly children: ReactNode;
+}) {
   return (
-    <main className="mx-auto flex min-h-dvh w-full max-w-[640px] flex-col justify-center gap-6 px-5 py-12">
+    <main className="mx-auto flex min-h-dvh w-full max-w-[880px] flex-col gap-8 px-5 pb-16 pt-[12vh]">
       <div className="flex flex-col items-center gap-2 text-center">
         <span className="font-mono text-xl font-bold tracking-[0.25em] text-foreground">
           SPINDRIFT
@@ -471,7 +735,14 @@ function OnboardingShell({ children }: { readonly children: ReactNode }) {
           Nothing here is configured yet. Four answers and it is.
         </p>
       </div>
-      {children}
+      {rail === undefined ? (
+        <div className="mx-auto w-full max-w-[640px]">{children}</div>
+      ) : (
+        <div className="grid gap-8 md:grid-cols-[210px_minmax(0,1fr)]">
+          <div className="md:sticky md:top-8 md:self-start">{rail}</div>
+          <div className="min-w-0">{children}</div>
+        </div>
+      )}
     </main>
   );
 }

--- a/apps/spindrift/src/web/views/auth/settings.tsx
+++ b/apps/spindrift/src/web/views/auth/settings.tsx
@@ -1,3 +1,15 @@
+/**
+ * The credentials an operator signs in with, and the one act that removes one.
+ *
+ * **A passkey row has to say which passkey it is.** `Remove` is irreversible
+ * and the rows were labelled `Passkey 1`, `Passkey 2` by array index — an
+ * ordinal that renumbers itself the moment an earlier one goes — over a created
+ * date that is the same week for every key somebody enrolled in one sitting.
+ * `lastUsedAt` is the fact that separates the laptop in front of you from the
+ * key in a drawer, the server has always returned it, and this screen threw it
+ * away. It is not a nickname and does not pretend to be: a nickname needs a
+ * column, and this needed a line.
+ */
 import { KeyRound, Link, Link2Off, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import type { CredentialSettings } from '../../../auth/credential-admin.ts';
@@ -11,6 +23,8 @@ import {
 } from '../../auth-client.ts';
 import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, CardTitle } from '../../ui/card.tsx';
+import { Skeleton, SkeletonRows } from '../../ui/skeleton.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
 
 type CredentialAction =
   | { readonly kind: 'add' }
@@ -58,10 +72,20 @@ export function IdentitySettings() {
 
   if (settings === null) {
     return (
-      <div>
-        <p className="text-sm text-muted-foreground">
+      <div className="flex flex-col gap-6">
+        <p role="status" aria-live="polite" className="sr-only">
           Loading credential settings…
         </p>
+        <div className="flex flex-col gap-2">
+          <Skeleton className="h-7 w-56" />
+          <Skeleton className="h-3 w-80 max-w-full" />
+        </div>
+        <Card>
+          <CardContent className="flex flex-col gap-3">
+            <SkeletonRows rows={2} />
+            <Skeleton className="h-9 w-36" />
+          </CardContent>
+        </Card>
       </div>
     );
   }
@@ -141,8 +165,22 @@ export function CredentialSettingsView({
                     Passkey {index + 1} ·{' '}
                     {shortCredential(passkey.credentialId)}
                   </p>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Added {new Date(passkey.createdAt).toLocaleDateString()}
+                  <p className="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+                    <span>
+                      Added {new Date(passkey.createdAt).toLocaleDateString()}
+                    </span>
+                    <span aria-hidden="true">·</span>
+                    {/* The half of the row that makes `Remove` a decision
+                        rather than a guess. `never used` is a fact worth
+                        rendering loudly: it is what an abandoned enrolment
+                        looks like. */}
+                    {passkey.lastUsedAt === null ? (
+                      <span>never used</span>
+                    ) : (
+                      <span className="flex items-center gap-1">
+                        Last used <Timestamp at={passkey.lastUsedAt} />
+                      </span>
+                    )}
                   </p>
                 </div>
                 <Button

--- a/apps/spindrift/src/web/views/auth/step-rail.tsx
+++ b/apps/spindrift/src/web/views/auth/step-rail.tsx
@@ -1,0 +1,106 @@
+/**
+ * The four questions, all of them, while only one is being answered.
+ *
+ * A wizard's progress was the sentence `Step 2 of 4`, which says how much is
+ * left and nothing about what it is. `ONBOARDING_ASKS` has carried a title for
+ * each of the four since the day it was written — including the reason the
+ * order is what it is — and an operator met each one only on arrival, so the
+ * step that reads the cloud, and can therefore refuse, was always a surprise.
+ *
+ * **It is a rail, not a tab bar.** A step behind the current one is a button,
+ * because an answer already given is an answer worth revising and the document
+ * is one object held above this. A step ahead is text: the order is load
+ * bearing — the third step needs a stored client id to be worth anything, and
+ * the last is the write — so jumping forward is an act this flow does not have.
+ *
+ * **A finished step shows its answer, so the rail is also the summary.** That
+ * is what earns the space it takes and is why there is no fifth "Review" step:
+ * the four answers are legible from every step, which is the whole of what a
+ * review screen would have added, and a fifth screen would have moved the one
+ * write off the last question and onto a page of its own.
+ *
+ * It states no status of its own — {@link StepStatus} and its glyph come from
+ * `components/status.tsx`, the same pair every checklist in the product uses,
+ * so a wizard step and a deploy step do not read as two different vocabularies.
+ */
+
+import { StepGlyph, statusWord } from '../../components/status.tsx';
+import type { StepStatus } from '../../model.ts';
+import { cn } from '../../ui/utils.ts';
+
+export interface RailStep {
+  readonly title: string;
+  /** The answer, when there is one to show. Truncated, in mono. */
+  readonly value?: string;
+  readonly status: StepStatus;
+}
+
+export function StepRail({
+  steps,
+  current,
+  onJump,
+}: {
+  readonly steps: readonly RailStep[];
+  readonly current: number;
+  /** Absent means nothing is navigable — the rail is then pure progress. */
+  onJump?(step: number): void;
+}) {
+  return (
+    <ol aria-label="Setup steps" className="flex flex-col gap-0.5">
+      {steps.map((step, index) => {
+        const here = index === current;
+        const behind = index < current;
+        const body = (
+          <>
+            <StepGlyph status={step.status} />
+            <span className="min-w-0 flex-1">
+              <span
+                className={cn(
+                  'block truncate text-body',
+                  here
+                    ? 'font-semibold text-foreground'
+                    : 'text-muted-foreground',
+                )}
+              >
+                {step.title}
+              </span>
+              {step.value === undefined || step.value === '' ? null : (
+                <span className="block truncate font-mono text-micro text-subtle">
+                  {step.value}
+                </span>
+              )}
+            </span>
+            <span className="sr-only">{statusWord(step.status)}</span>
+          </>
+        );
+
+        return (
+          <li key={step.title}>
+            {behind && onJump !== undefined ? (
+              <button
+                type="button"
+                onClick={() => onJump(index)}
+                className={cn(
+                  'flex w-full items-start gap-2 rounded-sm px-2 py-1.5 text-left',
+                  'hover:bg-secondary focus-visible:-outline-offset-2',
+                )}
+              >
+                {body}
+              </button>
+            ) : (
+              <div
+                aria-current={here ? 'step' : undefined}
+                className={cn(
+                  'flex w-full items-start gap-2 rounded-sm px-2 py-1.5',
+                  here && 'bg-secondary',
+                )}
+              >
+                {body}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}

--- a/apps/spindrift/src/web/views/operations/deploys.tsx
+++ b/apps/spindrift/src/web/views/operations/deploys.tsx
@@ -1,3 +1,29 @@
+/**
+ * Deploys — the placement ledger, as a table with the act it was missing.
+ *
+ * Two facts the server computed and the screen threw away.
+ *
+ * `current` is the difference between "this release reached LIVE" and "this
+ * release is what should be running": `model.ts` says outright that a LIVE
+ * Deploy a newer intent has superseded is still LIVE, and only the desired row
+ * knows. That was one `yes`/`no` cell in the inspector; it is a column now,
+ * because the question "which of these seven LIVE rows is the one serving" is
+ * the reason an operator opens this screen.
+ *
+ * `rollbackable` is computed by `commands/deploys/list.ts` under the *same*
+ * comparison `rollbackDeploy` makes, and `model.ts` explains why: so the act is
+ * offered only where it would be accepted, rather than offered everywhere and
+ * refused half the time. It appeared nowhere in this area. The inspector now
+ * carries the act itself — a rollback is an ordinary deploy naming an older
+ * Build, so this posts the same intent the App workspace would and reports the
+ * refusal verbatim when core declines it.
+ *
+ * What it refuses: an impact review before the press. `DisconnectTargetControl`
+ * has the right precedent for a consequential act and rollback deserves it, but
+ * a rollback is reversible by another rollback and a dialog primitive is out of
+ * scope this session — so the button states what it will do, the result says
+ * what happened, and neither pretends the ceremony exists.
+ */
 import { useEffect, useState } from 'react';
 import deployFlow from '../../client/diagrams/deploy.svg';
 import { command, type OutputOf } from '../../client.ts';
@@ -5,21 +31,107 @@ import { Checklist } from '../../components/checklist.tsx';
 import { Flow } from '../../components/flow.tsx';
 import {
   DefinitionGrid,
-  type ExplorerItem,
-  ExplorerPageHeader,
   type ExplorerTone,
-  ObjectExplorer,
+  LedgerExplorer,
 } from '../../components/object-explorer.tsx';
 import type { DeployLedgerItem, DeployPhase } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Eyebrow } from '../../ui/card.tsx';
+import { Ref } from '../../ui/copy.tsx';
+import type { Column } from '../../ui/data-table.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { SkeletonRows } from '../../ui/skeleton.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
+import { notify } from '../../ui/toast.tsx';
 
-function tone(phase: DeployPhase): ExplorerTone {
+export function deployTone(phase: DeployPhase): ExplorerTone {
   if (phase === 'LIVE') return 'success';
   if (phase === 'FAILED') return 'destructive';
   return 'accent';
 }
+
+const COLUMNS: readonly Column<DeployLedgerItem>[] = [
+  {
+    id: 'id',
+    header: '#',
+    mono: true,
+    width: '5.5rem',
+    sortable: true,
+    sortValue: (deploy) => deploy.id,
+    cell: (deploy) => `#${deploy.id}`,
+  },
+  {
+    id: 'app',
+    header: 'App / component',
+    sortable: true,
+    sortValue: (deploy) => `${deploy.app}/${deploy.component}`,
+    cell: (deploy) => (
+      <span className="truncate">
+        {deploy.app} <span className="text-muted-foreground">/</span>{' '}
+        {deploy.component}
+      </span>
+    ),
+  },
+  {
+    id: 'target',
+    header: 'Target',
+    sortable: true,
+    sortValue: (deploy) => deploy.target,
+    cell: (deploy) => deploy.target,
+  },
+  {
+    id: 'build',
+    header: 'Build',
+    mono: true,
+    sortable: true,
+    sortValue: (deploy) => deploy.buildId,
+    cell: (deploy) => `#${deploy.buildId}`,
+  },
+  {
+    id: 'commit',
+    header: 'Commit',
+    cell: (deploy) => <Ref value={deploy.commit} kind="commit" />,
+  },
+  {
+    id: 'current',
+    header: 'Serving',
+    sortable: true,
+    sortValue: (deploy) => (deploy.current ? 0 : 1),
+    cell: (deploy) =>
+      deploy.current ? (
+        <Badge tone="success">current</Badge>
+      ) : (
+        <span className="text-muted-foreground">superseded</span>
+      ),
+  },
+  {
+    id: 'phase',
+    header: 'Phase',
+    sortable: true,
+    sortValue: (deploy) => deploy.phase,
+    cell: (deploy) => (
+      <Badge tone={deployTone(deploy.phase)}>
+        {deploy.phase.toLowerCase()}
+      </Badge>
+    ),
+  },
+  {
+    id: 'age',
+    header: 'Started',
+    align: 'end',
+    sortable: true,
+    sortValue: (deploy) => deploy.at,
+    cell: (deploy) => (
+      <Timestamp
+        at={deploy.at}
+        when={deploy.when}
+        className="font-mono text-muted-foreground"
+      />
+    ),
+  },
+];
 
 export function DeployLedger({
   deploys,
@@ -36,93 +148,91 @@ export function DeployLedger({
   readonly loadError?: string | null;
   readonly onLoadMore?: () => void;
 }) {
-  const byId = new Map(
-    deploys.map((deploy) => [`deploy:${deploy.id}`, deploy]),
-  );
-  const items: ExplorerItem[] = deploys.map((deploy) => ({
-    id: `deploy:${deploy.id}`,
-    title: `#${deploy.id} · ${deploy.app}`,
-    detail: `${deploy.component} · ${deploy.target} · Build ${deploy.buildId}`,
-    status: deploy.phase.toLowerCase(),
-    tone: tone(deploy.phase),
-    when: deploy.when,
-    at: deploy.at,
-    search: `${deploy.commit} ${deploy.configVersion ?? ''}`,
-    active:
-      deploy.phase === 'PENDING' ||
-      deploy.phase === 'APPLYING' ||
-      deploy.phase === 'WAITING',
-  }));
-
   return (
-    <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
-      <ExplorerPageHeader
+    <Page>
+      <PageHeader
         eyebrow="Placement ledger"
         title="Deploys"
         description="Verified artifacts are placed and observed here. Build failures stay in Builds; runtime and rollout evidence stays with the Deploy."
       />
-      <Flow
-        src={deployFlow}
-        label="What happens between pressing Deploy and a workload existing"
-        alt="The intent commits under a locking read on the one Component-and-Target row; the reconciler claims it with SKIP LOCKED and lets the lock go, applies through the deploy adapter, and records the phases the platform reported. A failure never touches exposure — the previous release is still serving."
-      />
-      <ObjectExplorer
-        items={items}
-        filterPlaceholder={`Filter ${deploys.length} Deploys…`}
-        empty={
-          <div className="rounded-sm border border-border bg-card p-10 text-center text-sm text-muted-foreground">
-            No Deploys exist yet. A successful Build becomes placeable here.
-          </div>
+      <LedgerExplorer
+        columns={COLUMNS}
+        rows={deploys}
+        rowKey={(deploy) => `deploy:${deploy.id}`}
+        rowSearch={(deploy) =>
+          `${deploy.id} ${deploy.app} ${deploy.component} ${deploy.target} ${deploy.buildId} ${deploy.commit} ${deploy.phase} ${deploy.configVersion ?? ''}`
         }
-        renderInspector={(item) => {
-          const deploy = byId.get(item.id)!;
-          return (
-            <>
-              <Eyebrow>Deploy / {deploy.id}</Eyebrow>
-              <div className="mt-1 flex flex-wrap items-center gap-3">
-                <h2 className="text-2xl font-semibold tracking-tight">
-                  {deploy.app} / {deploy.component}
-                </h2>
-                <Badge tone={tone(deploy.phase)}>
-                  {deploy.phase.toLowerCase()}
-                </Badge>
-              </div>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                Placing Build {deploy.buildId} on {deploy.target}. This attempt
-                pins commit <span className="font-mono">{deploy.commit}</span>.
-              </p>
-              <DefinitionGrid
-                entries={[
-                  { label: 'State', value: deploy.phase.toLowerCase() },
-                  { label: 'Build', value: deploy.buildId, mono: true },
-                  { label: 'Target', value: deploy.target },
-                  { label: 'Started', value: deploy.when, mono: true },
-                  {
-                    label: 'Config',
-                    value: deploy.configVersion?.slice(0, 12) ?? 'none',
-                    mono: true,
-                  },
-                  { label: 'Current', value: deploy.current ? 'yes' : 'no' },
-                ]}
-              />
-              <DeployEvidence deployId={deploy.id} />
-              <div className="mt-6 flex flex-wrap gap-2">
-                <Button onClick={() => onNavigate(`/deploys/${deploy.id}`)}>
-                  Open Deploy
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => onNavigate(`/apps/${deploy.appId}`)}
-                >
-                  Open App
-                </Button>
-              </div>
-            </>
-          );
-        }}
+        filterPlaceholder={`Filter ${deploys.length} Deploys…`}
+        caption="Deploys, newest first"
+        inspectorLabel={(deploy) => `Deploy ${deploy.id}`}
+        empty={
+          <EmptyState title="No Deploys exist yet.">
+            A successful Build becomes placeable here.
+          </EmptyState>
+        }
+        renderInspector={(deploy) => (
+          <>
+            <Eyebrow>Deploy / {deploy.id}</Eyebrow>
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <h2 className="text-title font-semibold tracking-tight">
+                {deploy.app} / {deploy.component}
+              </h2>
+              <Badge tone={deployTone(deploy.phase)}>
+                {deploy.phase.toLowerCase()}
+              </Badge>
+              {deploy.current ? <Badge tone="success">current</Badge> : null}
+            </div>
+            <p className="mt-2 max-w-2xl text-body leading-6 text-muted-foreground">
+              Placing Build {deploy.buildId} on {deploy.target}. This attempt
+              pins commit <span className="font-mono">{deploy.commit}</span>.
+            </p>
+            <DefinitionGrid
+              entries={[
+                { label: 'State', value: deploy.phase.toLowerCase() },
+                { label: 'Build', value: `#${deploy.buildId}`, mono: true },
+                { label: 'Target', value: deploy.target },
+                {
+                  label: 'Started',
+                  value: <Timestamp at={deploy.at} when={deploy.when} />,
+                  title: deploy.at,
+                  mono: true,
+                },
+                {
+                  label: 'Config',
+                  value: deploy.configVersion ? (
+                    <Ref value={deploy.configVersion} kind="digest" />
+                  ) : (
+                    'none'
+                  ),
+                  title: deploy.configVersion ?? undefined,
+                  mono: true,
+                },
+                {
+                  label: 'Serving',
+                  value: deploy.current
+                    ? 'yes — this is desired'
+                    : 'superseded',
+                },
+              ]}
+            />
+            <DeployEvidence deployId={deploy.id} />
+            <div className="mt-6 flex flex-wrap gap-2">
+              <Button onClick={() => onNavigate(`/deploys/${deploy.id}`)}>
+                Open Deploy
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => onNavigate(`/apps/${deploy.appId}`)}
+              >
+                Open App
+              </Button>
+              <RollbackControl deploy={deploy} onNavigate={onNavigate} />
+            </div>
+          </>
+        )}
       />
       {loadError ? (
-        <p className="text-sm text-destructive">{loadError}</p>
+        <p className="text-body text-destructive">{loadError}</p>
       ) : null}
       {hasMore ? (
         <div className="flex justify-center">
@@ -131,11 +241,77 @@ export function DeployLedger({
           </Button>
         </div>
       ) : deploys.length > 0 ? (
-        <p className="text-center text-xs text-muted-foreground">
+        <p className="text-center text-caption text-muted-foreground">
           Entire Deploy ledger loaded.
         </p>
       ) : null}
-    </div>
+      <Flow
+        src={deployFlow}
+        label="What happens between pressing Deploy and a workload existing"
+        alt="The intent commits under a locking read on the one Component-and-Target row; the reconciler claims it with SKIP LOCKED and lets the lock go, applies through the deploy adapter, and records the phases the platform reported. A failure never touches exposure — the previous release is still serving."
+      />
+    </Page>
+  );
+}
+
+/**
+ * Go back to this release's Build, where core would accept it.
+ *
+ * Absent rather than disabled when `rollbackable` is false. A disabled button
+ * says "you may do this later"; the truth is that this Build is not older than
+ * what is desired, which is not a state waiting to change on this row.
+ */
+function RollbackControl({
+  deploy,
+  onNavigate,
+}: {
+  readonly deploy: DeployLedgerItem;
+  readonly onNavigate: (path: string) => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  if (!deploy.rollbackable) return null;
+
+  const rollback = () => {
+    setBusy(true);
+    command('rollbackDeploy', {
+      componentId: deploy.componentId,
+      targetId: deploy.targetId,
+      buildId: deploy.buildId,
+    })
+      .then((result) => {
+        setBusy(false);
+        if (!result.ok) {
+          notify({
+            tone: 'destructive',
+            title: 'Rollback refused',
+            detail: result.failure.message,
+          });
+          return;
+        }
+        notify({
+          tone: 'success',
+          title: `Rolled back to Build ${deploy.buildId}`,
+          detail: `${deploy.app} / ${deploy.component} on ${deploy.target}`,
+          action: {
+            label: 'Open Deploy',
+            onSelect: () => onNavigate(`/deploys/${result.value.deployId}`),
+          },
+        });
+      })
+      .catch((cause: unknown) => {
+        setBusy(false);
+        notify({
+          tone: 'destructive',
+          title: 'Rollback failed',
+          detail: cause instanceof Error ? cause.message : 'Server failure',
+        });
+      });
+  };
+
+  return (
+    <Button variant="outline" disabled={busy} onClick={rollback}>
+      {busy ? 'Rolling back…' : `Roll back to Build ${deploy.buildId}`}
+    </Button>
   );
 }
 
@@ -149,6 +325,7 @@ function DeployEvidence({ deployId }: { readonly deployId: number }) {
 
   useEffect(() => {
     let live = true;
+    setState({ type: 'loading' });
     command('getDeployDetail', { id: deployId })
       .then((result) => {
         if (!live) return;
@@ -175,25 +352,26 @@ function DeployEvidence({ deployId }: { readonly deployId: number }) {
     <section className="mt-6 border-t border-border pt-5">
       <Eyebrow>Observed evidence</Eyebrow>
       {state.type === 'loading' ? (
-        <p className="mt-2 animate-pulse text-sm text-muted-foreground">
-          Loading Deploy evidence…
-        </p>
+        <div className="mt-2">
+          <p className="sr-only">Loading Deploy evidence…</p>
+          <SkeletonRows rows={4} />
+        </div>
       ) : state.type === 'error' ? (
-        <p className="mt-2 text-sm text-destructive">{state.message}</p>
+        <p className="mt-2 text-body text-destructive">{state.message}</p>
       ) : (
-        <div className="mt-2 grid gap-5 xl:grid-cols-2">
+        <div className="mt-2 grid gap-5">
           <div>
-            <p className="mb-1 text-xs font-semibold text-muted-foreground">
+            <p className="mb-1 text-caption font-semibold text-muted-foreground">
               Placement
             </p>
             <Checklist items={state.detail.deploy.resources} />
           </div>
           <div>
-            <p className="mb-1 text-xs font-semibold text-muted-foreground">
+            <p className="mb-1 text-caption font-semibold text-muted-foreground">
               Artifact production
             </p>
             {state.detail.deploy.build === null ? (
-              <p className="py-2 text-sm text-muted-foreground">
+              <p className="py-2 text-body text-muted-foreground">
                 Supplied artifact; no builder ran.
               </p>
             ) : (

--- a/apps/spindrift/src/web/views/operations/overview.tsx
+++ b/apps/spindrift/src/web/views/operations/overview.tsx
@@ -1,9 +1,46 @@
-import { useState } from 'react';
+/**
+ * The landing screen, as an answer rather than a database browser.
+ *
+ * It was titled "Object explorer" and it earned the name: four object kinds —
+ * Deploys, Builds, Targets, Apps — concatenated into one list in *array* order,
+ * which is not time order and could never become time order, because two of the
+ * four carry no instant at all. An operator opening the product was handed a
+ * heterogeneous scroll and left to find the question themselves.
+ *
+ * So it is four named zones now, in the order the questions are asked.
+ *
+ * **Serving** is first and is the one this product exists to answer: what is in
+ * front of users right now. `current` is the only field that knows — §6 keeps a
+ * superseded release `LIVE`, so "which of these LIVE rows is the one serving" is
+ * unanswerable from `phase` — and it was rendered nowhere on this screen. The
+ * address is a real link only when `urlLive`, because a link to an address
+ * serving someone else's release is worse than no link.
+ *
+ * **Counts** come second, and they say what they are. The tiles used to read
+ * `deploys.length` off an array the caller had fetched with `limit: 12` and
+ * present it as a fleet total, so a hundred-Deploy installation reported twelve.
+ * When the caller says there is another page, the value carries a `+` and the
+ * footnote scopes it to the newest N. A tile that cannot know the total must not
+ * print one.
+ *
+ * **Standing state** is third: Apps and Targets, which have a condition rather
+ * than a moment. Hoisting them out of the feed is what makes the feed sortable —
+ * they were the rows with no `at`.
+ *
+ * **Activity** is last, sorted by `at` descending across Builds and Deploys, and
+ * the tiles filter it: a count of three failures that leaves the reader to find
+ * which three is a count doing half its job.
+ *
+ * What this screen refuses: a fleet activity command, a chart, and any total it
+ * would have to invent. `listBuilds`/`listAllDeploys` return a page and a
+ * cursor; a real fleet summary is a server read this screen does not have, and
+ * inventing one from a page is exactly the bug being fixed.
+ */
+import { Radio } from 'lucide-react';
+import { useMemo, useState } from 'react';
 import {
   DefinitionGrid,
   type ExplorerItem,
-  ExplorerPageHeader,
-  type ExplorerTone,
   ObjectExplorer,
 } from '../../components/object-explorer.tsx';
 import type {
@@ -14,15 +51,26 @@ import type {
 } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
-import { Card, Eyebrow } from '../../ui/card.tsx';
-import { cn } from '../../ui/utils.ts';
+import { Eyebrow } from '../../ui/card.tsx';
+import { Ref } from '../../ui/copy.tsx';
+import { type Column, DataTable } from '../../ui/data-table.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { Metric, type MetricTone } from '../../ui/metric.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { Tabs } from '../../ui/tabs.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
+import { appHref } from '../apps/list.tsx';
+import { buildTone } from '../supply-chain/builds.tsx';
+import { deployTone } from './deploys.tsx';
 
-interface Concern extends ExplorerItem {
-  readonly category: 'deploy' | 'build' | 'target' | 'app';
+/** One Build or one Deploy in the feed, with what its inspector needs. */
+interface Entry extends ExplorerItem {
+  readonly kind: 'build' | 'deploy';
+  readonly at: string;
   readonly eyebrow: string;
   readonly summary: string;
   readonly path: string;
-  readonly appPath?: string;
+  readonly appPath: string;
   readonly buildPath?: string;
   readonly facts: readonly {
     readonly label: string;
@@ -31,80 +79,96 @@ interface Concern extends ExplorerItem {
   }[];
 }
 
-function buildTone(
-  build: Pick<BuildListItem, 'status' | 'dispatchWaitingOn'>,
-): ExplorerTone {
-  if (build.status === 'FAILED') return 'destructive';
-  if (build.status === 'SUCCEEDED') return 'success';
-  // A PENDING Build refusing every tick is not "in progress" the way a
-  // RUNNING one is — it needs an operator to configure the thing it is
-  // waiting on, which is what 'warning' already means everywhere else on
-  // this screen.
-  if (build.dispatchWaitingOn !== null) return 'warning';
-  return 'accent';
+type Lane = 'all' | 'attention' | 'inflight' | 'builds' | 'deploys';
+
+/**
+ * A Target's name is both halves of it.
+ *
+ * `model.ts` is explicit that neither the boundary nor the surface identifies a
+ * Target alone, and two clusters both running `kubernetes` were the same word
+ * twice on this screen. An unplaced App has no boundary yet, and says the
+ * surface alone rather than inventing a `/`.
+ */
+function targetName(vessel: string, adapter: string): string {
+  return vessel ? `${vessel}/${adapter}` : adapter;
 }
 
-function deployTone(phase: DeployLedgerItem['phase']): ExplorerTone {
-  if (phase === 'FAILED') return 'destructive';
-  if (phase === 'LIVE') return 'success';
-  return 'accent';
-}
-
-function appTone(phase: AppListItem['phase']): ExplorerTone {
+function appTone(phase: AppListItem['phase']): MetricTone {
   if (phase === 'FAILED') return 'destructive';
   if (phase === 'LIVE') return 'success';
   return 'warning';
 }
 
-type CategoryFilter = 'all' | 'attention' | 'inflight' | 'apps' | 'targets';
+/** A count that is only the newest page says so, in the value and beside it. */
+function pageCount(loaded: number, hasMore: boolean): string {
+  return hasMore ? `${loaded}+` : String(loaded);
+}
 
 export function Overview({
   apps,
   builds,
   deploys,
   targets,
+  buildsHasMore = false,
+  deploysHasMore = false,
   onNavigate,
 }: {
   readonly apps: readonly AppListItem[];
   readonly builds: readonly BuildListItem[];
   readonly deploys: readonly DeployLedgerItem[];
   readonly targets: readonly TargetListItem[];
+  /**
+   * Whether the caller's Build/Deploy reads left a next page behind. Optional
+   * and false by default: a caller that has not been taught to keep its cursor
+   * gets the old, smaller claim — the loaded rows — rather than a `+` it cannot
+   * back up.
+   */
+  readonly buildsHasMore?: boolean;
+  readonly deploysHasMore?: boolean;
   readonly onNavigate: (path: string) => void;
 }) {
-  const [category, setCategory] = useState<CategoryFilter>('all');
+  const [lane, setLane] = useState<Lane>('all');
 
-  const liveApps = apps.filter((a) => a.phase === 'LIVE').length;
-  const failedApps = apps.filter((a) => a.phase === 'FAILED').length;
-  const inFlightApps = apps.filter(
-    (a) => a.phase !== 'LIVE' && a.phase !== 'FAILED',
-  ).length;
+  const liveApps = apps.filter((app) => app.phase === 'LIVE').length;
+  const failedApps = apps.filter((app) => app.phase === 'FAILED').length;
+  const inFlightApps = apps.length - liveApps - failedApps;
 
   const inFlightDeploys = deploys.filter(
-    (d) => d.phase !== 'LIVE' && d.phase !== 'FAILED',
+    (deploy) => deploy.phase !== 'LIVE' && deploy.phase !== 'FAILED',
   ).length;
-  const failedDeploys = deploys.filter((d) => d.phase === 'FAILED').length;
+  const failedDeploys = deploys.filter(
+    (deploy) => deploy.phase === 'FAILED',
+  ).length;
 
   const runningBuilds = builds.filter(
-    (b) => b.status === 'RUNNING' || b.status === 'PENDING',
+    (build) => build.status === 'RUNNING' || build.status === 'PENDING',
   ).length;
-  const succeededBuilds = builds.filter((b) => b.status === 'SUCCEEDED').length;
+  const failedBuilds = builds.filter(
+    (build) => build.status === 'FAILED',
+  ).length;
   const waitingBuilds = builds.filter(
-    (b) => b.dispatchWaitingOn !== null,
+    (build) => build.dispatchWaitingOn !== null,
   ).length;
 
   const healthyTargets = targets.filter(
-    (t) => t.configured && t.status === 'connected' && t.health === 'healthy',
+    (target) =>
+      target.configured &&
+      target.status === 'connected' &&
+      target.health === 'healthy',
   ).length;
-  const setupTargets = targets.filter(
-    (t) =>
-      !t.configured || t.status === 'disconnected' || t.health === 'unhealthy',
-  ).length;
+  const attentionTargets = targets.length - healthyTargets;
 
-  const concerns: Concern[] = [
-    ...deploys.map(
-      (deploy): Concern => ({
+  const serving = deploys.filter((deploy) => deploy.current);
+  const appById = useMemo(
+    () => new Map(apps.map((app) => [app.id, app])),
+    [apps],
+  );
+
+  const entries = useMemo((): readonly Entry[] => {
+    const fromDeploys = deploys.map(
+      (deploy): Entry => ({
         id: `deploy:${deploy.id}`,
-        category: 'deploy',
+        kind: 'deploy',
         title: `Deploy ${deploy.id}`,
         detail: `${deploy.app} / ${deploy.component} · ${deploy.target}`,
         status: deploy.phase.toLowerCase(),
@@ -119,17 +183,18 @@ export function Overview({
         buildPath: `/builds/${deploy.buildId}`,
         search: `${deploy.commit} ${deploy.app} ${deploy.target}`,
         facts: [
-          { label: 'Build', value: String(deploy.buildId), mono: true },
+          { label: 'Build', value: `#${deploy.buildId}`, mono: true },
           { label: 'Target', value: deploy.target },
-          { label: 'Started', value: deploy.when, mono: true },
+          { label: 'Commit', value: deploy.commit.slice(0, 12), mono: true },
+          { label: 'Serving', value: deploy.current ? 'yes' : 'superseded' },
         ],
       }),
-    ),
-    ...builds.map((build): Concern => {
+    );
+    const fromBuilds = builds.map((build): Entry => {
       const waitingOn = build.dispatchWaitingOn;
       return {
         id: `build:${build.id}`,
-        category: 'build',
+        kind: 'build',
         title: `Build ${build.id}`,
         detail:
           waitingOn !== null
@@ -143,99 +208,55 @@ export function Overview({
         eyebrow: `Build / ${build.id}`,
         summary:
           waitingOn ??
-          `Commit ${build.commit} is becoming a ${build.artifactType} artifact.`,
+          `Commit ${build.commit.slice(0, 12)} is becoming a ${build.artifactType} artifact.`,
         path: `/builds/${build.id}`,
         appPath: `/apps/${build.appId}`,
         search: `${build.commit} ${build.app} ${waitingOn ?? ''}`,
         facts: [
-          { label: 'Runner', value: build.runner ?? 'waiting' },
+          { label: 'Runner', value: build.runner ?? 'not dispatched' },
           { label: 'Shape', value: build.targetShape, mono: true },
-          { label: 'Created', value: build.when, mono: true },
+          {
+            label: 'Artifact',
+            value: build.artifactDigest ?? 'not produced',
+            mono: true,
+          },
           ...(waitingOn !== null
             ? [{ label: 'Waiting on', value: waitingOn }]
             : []),
         ],
       };
-    }),
-    ...targets.map(
-      (target): Concern => ({
-        id: `target:${target.id}`,
-        category: 'target',
-        title: `${target.vessel}/${target.adapter}`,
-        detail: `${target.adapter} Target · ${target.status}`,
-        status: target.configured ? target.health : 'setup',
-        tone:
-          target.configured &&
-          target.status === 'connected' &&
-          target.health === 'healthy'
-            ? 'success'
-            : 'warning',
-        eyebrow: 'Target',
-        summary:
-          target.prerequisiteFailures?.[0] ??
-          (target.configured
-            ? `Target ${target.vessel}/${target.adapter} is connected.`
-            : 'This Target still needs its connection completed.'),
-        path: '/settings/connections',
-        search: `${target.adapter} ${target.prerequisiteFailures?.join(' ') ?? ''}`,
-        facts: [
-          { label: 'Adapter', value: target.adapter },
-          { label: 'Connection', value: target.status },
-          { label: 'Rank', value: String(target.rank), mono: true },
-        ],
-      }),
-    ),
-    ...apps.map(
-      (app): Concern => ({
-        id: `app:${app.id}`,
-        category: 'app',
-        title: app.name,
-        detail: `${app.kind} · ${app.target}`,
-        status: app.phase.toLowerCase(),
-        tone: appTone(app.phase),
-        active: app.phase !== 'LIVE' && app.phase !== 'FAILED',
-        eyebrow: `App / ${app.kind}`,
-        summary: `${app.source} · ${app.url || 'no URL allocated'}`,
-        path: `/apps/${app.id}`,
-        search: `${app.source} ${app.url}`,
-        facts: [
-          { label: 'Target', value: app.target },
-          { label: 'Artifact', value: app.artifact, mono: true },
-          { label: 'URL', value: app.url || 'not allocated', mono: true },
-        ],
-      }),
-    ),
-  ];
+    });
+    // Newest first across both kinds. This is the sort the old concatenation
+    // could not do: Targets and Apps have no instant, so a list holding them
+    // had no comparable key and stayed in the order the four reads returned.
+    return [...fromDeploys, ...fromBuilds].sort((left, right) =>
+      right.at.localeCompare(left.at),
+    );
+  }, [builds, deploys]);
 
-  const attentionCount = concerns.filter(
-    (c) => c.tone === 'destructive' || c.tone === 'warning',
+  const attentionCount = entries.filter(
+    (entry) => entry.tone === 'destructive' || entry.tone === 'warning',
   ).length;
-  const inFlightCount = concerns.filter((c) => c.active).length;
+  const inFlightCount = entries.filter((entry) => entry.active).length;
 
-  const filteredConcerns = concerns.filter((concern) => {
-    if (category === 'attention') {
-      return concern.tone === 'destructive' || concern.tone === 'warning';
+  const feed = entries.filter((entry) => {
+    if (lane === 'attention') {
+      return entry.tone === 'destructive' || entry.tone === 'warning';
     }
-    if (category === 'inflight') {
-      return concern.active;
-    }
-    if (category === 'apps') {
-      return concern.category === 'app';
-    }
-    if (category === 'targets') {
-      return concern.category === 'target';
-    }
+    if (lane === 'inflight') return entry.active;
+    if (lane === 'builds') return entry.kind === 'build';
+    if (lane === 'deploys') return entry.kind === 'deploy';
     return true;
   });
 
-  const byId = new Map(concerns.map((concern) => [concern.id, concern]));
+  const byId = new Map(entries.map((entry) => [entry.id, entry]));
 
   return (
-    <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
-      <ExplorerPageHeader
-        eyebrow="Operating view"
-        title="Object explorer"
-        description="Scan active work, infrastructure state, and operational contracts across all targets."
+    <Page>
+      <PageHeader
+        eyebrow="Control plane"
+        title="Operations"
+        description="What is serving, what it cost to get there, and what is still moving."
         actions={
           <>
             <Button
@@ -245,184 +266,439 @@ export function Overview({
               Connect Target
             </Button>
             <Button variant="outline" onClick={() => onNavigate('/deploys')}>
-              Deploy Ledger
+              Deploy ledger
             </Button>
             <Button onClick={() => onNavigate('/apps/new')}>Create App</Button>
           </>
         }
       />
 
-      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Card className="flex flex-col justify-between p-4">
-          <div>
-            <Eyebrow>Applications</Eyebrow>
-            <div className="mt-2 flex items-baseline gap-2">
-              <span className="text-2xl font-bold tracking-tight text-foreground">
-                {apps.length}
-              </span>
-            </div>
-          </div>
-          <p className="mt-3 text-xs text-muted-foreground">
-            <span className="font-semibold text-success">{liveApps} Live</span>
-            {inFlightApps > 0 ? ` · ${inFlightApps} In-Flight` : ''}
-            {failedApps > 0 ? ` · ${failedApps} Failed` : ''}
-          </p>
-        </Card>
+      <Serving
+        serving={serving}
+        appById={appById}
+        onNavigate={onNavigate}
+        hasApps={apps.length > 0}
+      />
 
-        <Card className="flex flex-col justify-between p-4">
-          <div>
-            <Eyebrow>Deploys</Eyebrow>
-            <div className="mt-2 flex items-baseline gap-2">
-              <span className="text-2xl font-bold tracking-tight text-foreground">
-                {deploys.length}
-              </span>
-            </div>
-          </div>
-          <p className="mt-3 text-xs text-muted-foreground">
-            {inFlightDeploys > 0 ? (
-              <span className="font-semibold text-warning">
-                {inFlightDeploys} In-Flight
-              </span>
-            ) : (
-              '0 In-Flight'
-            )}
-            {failedDeploys > 0 ? ` · ${failedDeploys} Failed` : ''}
-          </p>
-        </Card>
+      <section
+        aria-label="Counts"
+        className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4"
+      >
+        <Metric
+          label="Apps"
+          value={apps.length}
+          tone={failedApps > 0 ? 'destructive' : 'idle'}
+          onClick={() => onNavigate('/apps')}
+          footnote={`${liveApps} live · ${inFlightApps} in flight · ${failedApps} failed`}
+        />
+        <Metric
+          label="Deploys"
+          value={pageCount(deploys.length, deploysHasMore)}
+          tone={failedDeploys > 0 ? 'destructive' : 'idle'}
+          onClick={() => setLane('deploys')}
+          footnote={
+            <>
+              {inFlightDeploys} in flight · {failedDeploys} failed
+              {deploysHasMore
+                ? ` — the newest ${deploys.length} loaded, not a fleet total`
+                : ''}
+            </>
+          }
+        />
+        <Metric
+          label="Builds"
+          value={pageCount(builds.length, buildsHasMore)}
+          tone={
+            failedBuilds > 0
+              ? 'destructive'
+              : waitingBuilds > 0
+                ? 'warning'
+                : 'idle'
+          }
+          onClick={() => setLane('builds')}
+          footnote={
+            <>
+              {runningBuilds} running · {waitingBuilds} waiting · {failedBuilds}{' '}
+              failed
+              {buildsHasMore
+                ? ` — the newest ${builds.length} loaded, not a fleet total`
+                : ''}
+            </>
+          }
+        />
+        <Metric
+          label="Targets"
+          value={targets.length}
+          tone={attentionTargets > 0 ? 'warning' : 'success'}
+          onClick={() => onNavigate('/settings/connections')}
+          footnote={`${healthyTargets} healthy · ${attentionTargets} need attention`}
+        />
+      </section>
 
-        <Card className="flex flex-col justify-between p-4">
-          <div>
-            <Eyebrow>Build Pipeline</Eyebrow>
-            <div className="mt-2 flex items-baseline gap-2">
-              <span className="text-2xl font-bold tracking-tight text-foreground">
-                {builds.length}
-              </span>
-            </div>
-          </div>
-          <p className="mt-3 text-xs text-muted-foreground">
-            {runningBuilds > 0 ? (
-              <span className="font-semibold text-accent-foreground">
-                {runningBuilds} Running
-              </span>
-            ) : (
-              `${succeededBuilds} Succeeded`
-            )}
-            {waitingBuilds > 0 ? (
+      <StandingState apps={apps} targets={targets} onNavigate={onNavigate} />
+
+      <section aria-label="Activity" className="flex flex-col gap-3">
+        <div className="flex flex-wrap items-baseline gap-3">
+          <h2 className="text-title font-semibold tracking-tight">Activity</h2>
+          <p className="text-caption text-muted-foreground">
+            Builds and Deploys, newest first.
+          </p>
+        </div>
+        <Tabs
+          variant="pill"
+          label="Filter activity"
+          current={lane}
+          onSelect={(id) => setLane(id as Lane)}
+          items={[
+            { id: 'all', label: 'All', count: entries.length },
+            { id: 'attention', label: 'Attention', count: attentionCount },
+            { id: 'inflight', label: 'In flight', count: inFlightCount },
+            { id: 'builds', label: 'Builds', count: builds.length },
+            { id: 'deploys', label: 'Deploys', count: deploys.length },
+          ]}
+        />
+        <ObjectExplorer
+          items={feed}
+          filterPlaceholder="Filter activity…"
+          empty={
+            <EmptyState
+              tone="success"
+              title="Nothing has happened yet."
+              action={
+                <Button onClick={() => onNavigate('/apps/new')}>
+                  Create App
+                </Button>
+              }
+            >
+              A Build or a Deploy is what writes the first line here.
+            </EmptyState>
+          }
+          renderInspector={(item) => {
+            const entry = byId.get(item.id);
+            if (!entry) return null;
+            const buildPath = entry.buildPath;
+            return (
               <>
-                {' · '}
-                <span className="font-semibold text-warning">
-                  {waitingBuilds} Waiting
-                </span>
+                <Eyebrow>{entry.eyebrow}</Eyebrow>
+                <div className="mt-1 flex flex-wrap items-center gap-3">
+                  <h3 className="text-title font-semibold tracking-tight">
+                    {entry.title}
+                  </h3>
+                  <Badge tone={entry.tone}>{entry.status}</Badge>
+                  <Timestamp
+                    at={entry.at}
+                    when={entry.when}
+                    className="text-caption font-mono text-muted-foreground"
+                  />
+                </div>
+                <p className="mt-2 max-w-2xl text-body leading-6 text-muted-foreground">
+                  {entry.summary}
+                </p>
+                <DefinitionGrid entries={entry.facts} />
+                <div className="mt-6 flex flex-wrap gap-2">
+                  <Button onClick={() => onNavigate(entry.path)}>
+                    Open {entry.kind === 'build' ? 'Build' : 'Deploy'}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => onNavigate(entry.appPath)}
+                  >
+                    Open App
+                  </Button>
+                  {buildPath ? (
+                    <Button
+                      variant="outline"
+                      onClick={() => onNavigate(buildPath)}
+                    >
+                      View Build
+                    </Button>
+                  ) : null}
+                </div>
               </>
-            ) : null}
-          </p>
-        </Card>
+            );
+          }}
+        />
+      </section>
+    </Page>
+  );
+}
 
-        <Card className="flex flex-col justify-between p-4">
-          <div>
-            <Eyebrow>Infrastructure Targets</Eyebrow>
-            <div className="mt-2 flex items-baseline gap-2">
-              <span className="text-2xl font-bold tracking-tight text-foreground">
-                {targets.length}
-              </span>
-            </div>
-          </div>
-          <p className="mt-3 text-xs text-muted-foreground">
-            <span className="font-semibold text-success">
-              {healthyTargets} Healthy
-            </span>
-            {setupTargets > 0 ? ` · ${setupTargets} Attention` : ''}
-          </p>
-        </Card>
+/**
+ * What is in front of users, and where.
+ *
+ * One row per desired release. The address is an anchor only where the read
+ * model says that address currently serves *this* release: §6 leaves the
+ * previous release exposed after a failure, so a link rendered from `url` alone
+ * would send an operator to a page that disagrees with the row they clicked it
+ * from.
+ */
+function Serving({
+  serving,
+  appById,
+  hasApps,
+  onNavigate,
+}: {
+  readonly serving: readonly DeployLedgerItem[];
+  readonly appById: ReadonlyMap<string, AppListItem>;
+  readonly hasApps: boolean;
+  readonly onNavigate: (path: string) => void;
+}) {
+  const columns: readonly Column<DeployLedgerItem>[] = [
+    {
+      id: 'app',
+      header: 'App / component',
+      sortable: true,
+      sortValue: (deploy) => `${deploy.app}/${deploy.component}`,
+      cell: (deploy) => (
+        <span className="truncate font-semibold">
+          {deploy.app} <span className="text-muted-foreground">/</span>{' '}
+          {deploy.component}
+        </span>
+      ),
+    },
+    {
+      id: 'target',
+      header: 'Target',
+      sortable: true,
+      sortValue: (deploy) => deploy.target,
+      cell: (deploy) => deploy.target,
+    },
+    {
+      id: 'url',
+      header: 'Address',
+      cell: (deploy) => {
+        const app = appById.get(deploy.appId);
+        const href = app?.urlLive ? appHref(app.url) : null;
+        if (href) {
+          return (
+            <a
+              href={href}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="truncate font-mono text-body text-primary underline-offset-2 hover:underline"
+            >
+              {app?.url}
+            </a>
+          );
+        }
+        return (
+          <span className="truncate text-muted-foreground">
+            {app?.url ? 'not serving this release' : 'no address allocated yet'}
+          </span>
+        );
+      },
+    },
+    {
+      id: 'release',
+      header: 'Release',
+      cell: (deploy) => (
+        <span className="inline-flex items-center gap-2">
+          <span className="font-mono text-muted-foreground">
+            #{deploy.buildId}
+          </span>
+          <Ref value={deploy.commit} kind="commit" />
+        </span>
+      ),
+    },
+    {
+      id: 'phase',
+      header: 'Phase',
+      sortable: true,
+      sortValue: (deploy) => deploy.phase,
+      cell: (deploy) => (
+        <Badge tone={deployTone(deploy.phase)}>
+          {deploy.phase.toLowerCase()}
+        </Badge>
+      ),
+    },
+    {
+      id: 'since',
+      header: 'Since',
+      align: 'end',
+      sortable: true,
+      sortValue: (deploy) => deploy.at,
+      cell: (deploy) => (
+        <Timestamp
+          at={deploy.at}
+          when={deploy.when}
+          className="font-mono text-muted-foreground"
+        />
+      ),
+    },
+  ];
+
+  return (
+    <section aria-label="Serving" className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-baseline gap-3">
+        <h2 className="text-title font-semibold tracking-tight">Serving</h2>
+        <p className="text-caption text-muted-foreground">
+          The release each Component is meant to be running.
+        </p>
       </div>
-
-      <div className="flex flex-wrap items-center gap-1.5 border-b border-border pb-3">
-        {[
-          { id: 'all', label: `All (${concerns.length})` },
-          { id: 'attention', label: `Attention Required (${attentionCount})` },
-          { id: 'inflight', label: `In-Flight (${inFlightCount})` },
-          { id: 'apps', label: `Applications (${apps.length})` },
-          { id: 'targets', label: `Targets (${targets.length})` },
-        ].map((tab) => (
-          <button
-            key={tab.id}
-            type="button"
-            onClick={() => setCategory(tab.id as CategoryFilter)}
-            className={cn(
-              'rounded-full px-3 py-1.5 text-xs font-semibold transition-colors',
-              category === tab.id
-                ? 'bg-accent text-accent-foreground shadow-xs'
-                : 'text-muted-foreground hover:bg-secondary hover:text-foreground',
-            )}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      <ObjectExplorer
-        items={filteredConcerns}
-        filterPlaceholder="Filter active objects…"
+      <DataTable
+        columns={columns}
+        rows={serving}
+        rowKey={(deploy) => `serving:${deploy.id}`}
+        caption="Current releases"
+        onRowSelect={(deploy) => onNavigate(`/deploys/${deploy.id}`)}
         empty={
-          <div className="rounded-sm border border-success/40 bg-card p-10 text-center">
-            <p className="font-semibold text-success">Everything is steady.</p>
-            <p className="mt-1 text-sm text-muted-foreground">
-              No objects match the selected filter. Create an App or connect a
-              Target to expand your system.
-            </p>
-            <div className="mt-4 flex justify-center gap-3">
+          <EmptyState
+            icon={<Radio />}
+            title="Nothing is serving yet."
+            action={
               <Button onClick={() => onNavigate('/apps/new')}>
                 Create App
               </Button>
-              <Button
-                variant="outline"
-                onClick={() => onNavigate('/settings/connections')}
-              >
-                Connect Target
-              </Button>
-            </div>
-          </div>
+            }
+          >
+            {hasApps
+              ? 'Every App here is still waiting on its first release to reach a Target.'
+              : 'An App with a Component deployed to a Target is what fills this.'}
+          </EmptyState>
         }
-        renderInspector={(item) => {
-          const concern = byId.get(item.id)!;
-          return (
-            <>
-              <Eyebrow>{concern.eyebrow}</Eyebrow>
-              <div className="mt-1 flex flex-wrap items-center gap-3">
-                <h2 className="text-2xl font-semibold tracking-tight">
-                  {concern.title}
-                </h2>
-                <Badge tone={concern.tone}>{concern.status}</Badge>
-              </div>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                {concern.summary}
-              </p>
-              <DefinitionGrid entries={concern.facts} />
-              <div className="mt-6 flex flex-wrap gap-2">
-                <Button onClick={() => onNavigate(concern.path)}>
-                  Open {concern.eyebrow.split(' / ')[0]}
-                </Button>
-                {concern.appPath ? (
-                  <Button
-                    variant="outline"
-                    onClick={() => onNavigate(concern.appPath!)}
-                  >
-                    Open App Workspace
-                  </Button>
-                ) : null}
-                {concern.buildPath ? (
-                  <Button
-                    variant="outline"
-                    onClick={() => onNavigate(concern.buildPath!)}
-                  >
-                    View Build
-                  </Button>
-                ) : null}
-              </div>
-            </>
-          );
-        }}
       />
-    </div>
+    </section>
+  );
+}
+
+/**
+ * The two kinds with a condition rather than a moment.
+ *
+ * They were rows in the feed, which is why the feed could not be sorted. Side
+ * by side they answer the two standing questions instead: what exists, and what
+ * it can be placed on.
+ */
+function StandingState({
+  apps,
+  targets,
+  onNavigate,
+}: {
+  readonly apps: readonly AppListItem[];
+  readonly targets: readonly TargetListItem[];
+  readonly onNavigate: (path: string) => void;
+}) {
+  const appColumns: readonly Column<AppListItem>[] = [
+    {
+      id: 'name',
+      header: 'App',
+      sortable: true,
+      sortValue: (app) => app.name,
+      cell: (app) => <span className="truncate font-semibold">{app.name}</span>,
+    },
+    {
+      id: 'target',
+      header: 'Placed on',
+      sortable: true,
+      sortValue: (app) => targetName(app.vessel, app.target),
+      cell: (app) => (
+        <span className="truncate">{targetName(app.vessel, app.target)}</span>
+      ),
+    },
+    {
+      id: 'phase',
+      header: 'Phase',
+      align: 'end',
+      sortable: true,
+      sortValue: (app) => app.phase,
+      cell: (app) => (
+        <Badge tone={appTone(app.phase)}>{app.phase.toLowerCase()}</Badge>
+      ),
+    },
+  ];
+
+  const targetColumns: readonly Column<TargetListItem>[] = [
+    {
+      id: 'name',
+      header: 'Target',
+      sortable: true,
+      sortValue: (target) => targetName(target.vessel, target.adapter),
+      cell: (target) => (
+        <span className="truncate font-semibold">
+          {targetName(target.vessel, target.adapter)}
+        </span>
+      ),
+    },
+    {
+      id: 'state',
+      header: 'Connection',
+      sortable: true,
+      sortValue: (target) => (target.configured ? target.status : 'setup'),
+      cell: (target) =>
+        target.configured ? (
+          target.status
+        ) : (
+          <span className="text-warning">never connected</span>
+        ),
+    },
+    {
+      id: 'health',
+      header: 'Health',
+      align: 'end',
+      sortable: true,
+      sortValue: (target) => target.health,
+      // The first unmet prerequisite is the whole reason a Target is amber, and
+      // it was reachable only by selecting the row on a list of four kinds.
+      cell: (target) =>
+        target.health === 'healthy' && target.configured ? (
+          <Badge tone="success">healthy</Badge>
+        ) : (
+          <Badge tone="warning" className="max-w-[18rem] truncate">
+            {target.prerequisiteFailures?.[0] ?? 'needs attention'}
+          </Badge>
+        ),
+    },
+  ];
+
+  return (
+    <section aria-label="Standing state" className="grid gap-4 lg:grid-cols-2">
+      <div className="flex min-w-0 flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-title font-semibold tracking-tight">Apps</h2>
+          <button
+            type="button"
+            onClick={() => onNavigate('/apps')}
+            className="text-caption text-muted-foreground hover:text-foreground"
+          >
+            All Apps
+          </button>
+        </div>
+        <DataTable
+          columns={appColumns}
+          rows={apps}
+          rowKey={(app) => `app:${app.id}`}
+          caption="Apps and the Target each is placed on"
+          onRowSelect={(app) => onNavigate(`/apps/${app.id}`)}
+          empty={
+            <EmptyState title="No App exists yet.">
+              Creating one is the first act of this product.
+            </EmptyState>
+          }
+        />
+      </div>
+      <div className="flex min-w-0 flex-col gap-3">
+        <div className="flex items-baseline gap-3">
+          <h2 className="text-title font-semibold tracking-tight">Targets</h2>
+          <button
+            type="button"
+            onClick={() => onNavigate('/settings/connections')}
+            className="text-caption text-muted-foreground hover:text-foreground"
+          >
+            Connections
+          </button>
+        </div>
+        <DataTable
+          columns={targetColumns}
+          rows={targets}
+          rowKey={(target) => `target:${target.id}`}
+          caption="Targets and their standing checklist"
+          onRowSelect={() => onNavigate('/settings/connections')}
+          empty={
+            <EmptyState title="No Target is declared.">
+              A Target is the boundary and surface an App is placed on.
+            </EmptyState>
+          }
+        />
+      </div>
+    </section>
   );
 }

--- a/apps/spindrift/src/web/views/repos/list.tsx
+++ b/apps/spindrift/src/web/views/repos/list.tsx
@@ -38,9 +38,10 @@ import {
   Server,
   Timer,
 } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ComponentKind } from '../../../domain/desired-state.ts';
 import { command, type InputOf, type OutputOf } from '../../client.ts';
+import { formatDuration } from '../../components/running-time.tsx';
 import type {
   GrantedRepositoryView,
   LinkedRepoView,
@@ -54,6 +55,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '../../ui/collapsible.tsx';
+import { CopyButton } from '../../ui/copy.tsx';
 import { Logo } from '../../ui/logo.tsx';
 import { cn } from '../../ui/utils.ts';
 
@@ -62,6 +64,16 @@ export interface RepositoryAuthorizationView {
   readonly verificationUri: string;
   readonly state: 'waiting' | 'expired' | 'denied' | 'error';
   readonly message?: string;
+  /**
+   * When GitHub stops accepting this code.
+   *
+   * Optional because the caller holding this state is free to omit it and every
+   * test builds the view by hand — but the server has always sent it, on the
+   * first call and on every poll, and the screen spent that whole time telling
+   * an operator to type a code with no hint that it dies in fifteen minutes.
+   * Absent, the panel simply says nothing about time rather than guessing.
+   */
+  readonly expiresAt?: string;
 }
 
 export interface OpenedRepositoryPullRequest {
@@ -165,7 +177,7 @@ export function RepositoryList({
   );
 
   if (embedded) {
-    const connected = connector.state === 'authorized';
+    const standing = connectorStanding(connector);
     return (
       <section className="grid gap-5 py-6 xl:grid-cols-[240px_minmax(0,1fr)] xl:gap-8">
         <div>
@@ -173,8 +185,8 @@ export function RepositoryList({
             <Logo name="github" />
             <h3 className="font-semibold">GitHub</h3>
           </div>
-          <Badge className="mt-3" tone={connected ? 'success' : 'warning'}>
-            <Dot /> {connected ? 'connected' : connector.state}
+          <Badge className="mt-3" tone={standing.tone}>
+            <Dot /> {standing.label}
           </Badge>
           <p className="mt-3 text-sm leading-6 text-muted-foreground">
             Repository discovery, source events, and build dispatch.
@@ -234,6 +246,33 @@ export function RepositoryList({
 }
 
 /**
+ * The connector's state as a sentence and a colour, rather than as its tag.
+ *
+ * The badge used to print the union member — an operator read the literal word
+ * `unauthorized`, which is a name for a case in a type and not something anyone
+ * says — and it wore the same amber as `unavailable`. Those two are the furthest
+ * apart of the three: `unauthorized` is one button press from done and nothing
+ * is wrong, while `unavailable` means this installation holds no keyring and the
+ * fix is not on this screen or any other. Same colour for both told the reader
+ * that the fixable one was as stuck as the unfixable one.
+ */
+function connectorStanding(connector: RepositoryConnectorView): {
+  readonly label: string;
+  readonly tone: 'success' | 'destructive' | 'idle';
+} {
+  switch (connector.state) {
+    case 'authorized':
+      return { label: `connected as @${connector.login}`, tone: 'success' };
+    case 'unauthorized':
+      // Idle, not warning: nothing has gone wrong, this is simply the step
+      // before the first one.
+      return { label: 'not authorized yet', tone: 'idle' };
+    default:
+      return { label: 'no keyring', tone: 'destructive' };
+  }
+}
+
+/**
  * Authorization, which is a different act from connecting anything.
  *
  * Once authorized this collapses to one line. It is a prerequisite, not a
@@ -285,14 +324,10 @@ function ConnectorCard({
               <Logo name="github" className="size-4" /> Authorize GitHub
             </Button>
           ) : (
-            <>
-              <DeviceAuthorization authorization={authorization} />
-              {authorization.state === 'waiting' ? null : (
-                <Button className="self-start" onClick={onAuthorize}>
-                  Start again
-                </Button>
-              )}
-            </>
+            <DeviceAuthorization
+              authorization={authorization}
+              onAuthorize={onAuthorize}
+            />
           )}
           {error ? <ErrorMessage message={error} /> : null}
         </CardContent>
@@ -318,7 +353,10 @@ function ConnectorCard({
           </Button>
         </div>
         {authorization !== null ? (
-          <DeviceAuthorization authorization={authorization} />
+          <DeviceAuthorization
+            authorization={authorization}
+            onAuthorize={onAuthorize}
+          />
         ) : null}
         {error ? <ErrorMessage message={error} /> : null}
       </CardContent>
@@ -326,31 +364,116 @@ function ConnectorCard({
   );
 }
 
+/**
+ * How much of the code's life is left, ticking.
+ *
+ * Counting down rather than up, so `RunningTime` is the wrong component and
+ * only its formatter is borrowed. The clock is the browser's and the deadline is
+ * the server's, which is normally a reason not to compute a duration here — but
+ * a device code is a fifteen-minute window and a second of skew inside it is
+ * invisible, while showing nothing at all is what leaves an operator typing a
+ * code GitHub stopped accepting four minutes ago.
+ *
+ * `null` when there is no deadline to count, which is the honest answer and not
+ * a zero: a panel with no `expiresAt` says nothing about time.
+ */
+function useRemaining(expiresAt: string | undefined): number | null {
+  const ends = expiresAt === undefined ? Number.NaN : Date.parse(expiresAt);
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (Number.isNaN(ends)) return;
+    // Re-read from the wall clock each tick rather than decrementing, so a
+    // throttled background tab comes back with the truth instead of with
+    // however many ticks it was allowed.
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [ends]);
+
+  return Number.isNaN(ends) ? null : Math.max(0, ends - now);
+}
+
+/**
+ * The device ceremony, in the four different things it can be doing.
+ *
+ * All four used to be one red box with a swapped sentence, which made a denial
+ * (someone said no, and will have to say yes) look identical to a transport
+ * failure (nobody said anything, try again) and to an expiry (nothing is wrong,
+ * the code is just old). They fail for different reasons and the reader's next
+ * move differs, so they get different words, different tone, and — the part the
+ * red box never had — the button that resolves them, in place.
+ */
 function DeviceAuthorization({
   authorization,
+  onAuthorize,
 }: {
   authorization: RepositoryAuthorizationView;
+  onAuthorize: () => void;
 }) {
-  if (authorization.state !== 'waiting') {
+  const remaining = useRemaining(authorization.expiresAt);
+
+  if (authorization.state !== 'waiting' || remaining === 0) {
+    const state = remaining === 0 ? 'expired' : authorization.state;
+    const outcome =
+      state === 'denied'
+        ? {
+            tone: 'destructive' as const,
+            title: 'GitHub declined the authorization',
+            detail:
+              'The account that opened the code refused it. A new code will ask again.',
+          }
+        : state === 'expired'
+          ? {
+              tone: 'warning' as const,
+              title: 'That code expired',
+              detail:
+                'Device codes are short-lived. Nothing is wrong — take a new one and enter it while the countdown runs.',
+            }
+          : {
+              tone: 'destructive' as const,
+              title: 'GitHub did not answer the authorization',
+              detail:
+                'The ceremony stopped before GitHub said yes or no. Nothing was stored.',
+            };
     return (
-      <ErrorMessage
-        message={
-          authorization.message ??
-          (authorization.state === 'denied'
-            ? 'GitHub authorization was denied.'
-            : authorization.state === 'expired'
-              ? 'The GitHub authorization code expired. Start again.'
-              : 'GitHub authorization failed.')
-        }
-      />
+      <div
+        className={cn(
+          'rounded-md border px-3 py-2.5',
+          outcome.tone === 'warning'
+            ? 'border-warning/40 bg-warning-soft'
+            : 'border-destructive/40 bg-destructive-soft',
+        )}
+      >
+        <p className="text-sm font-semibold">{outcome.title}</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {authorization.message ?? outcome.detail}
+        </p>
+        <Button
+          size="sm"
+          variant="outline"
+          className="mt-3"
+          onClick={onAuthorize}
+        >
+          Get a new code
+        </Button>
+      </div>
     );
   }
+
   return (
     <div className="rounded-md border border-primary/40 bg-accent px-4 py-3">
       <p className="text-sm font-semibold">Enter this code in GitHub</p>
-      <p className="mt-2 font-mono text-2xl font-semibold tracking-[0.2em]">
-        {authorization.userCode}
-      </p>
+      <div className="mt-2 flex flex-wrap items-center gap-3">
+        <p className="font-mono text-2xl font-semibold tracking-[0.2em]">
+          {authorization.userCode}
+        </p>
+        <CopyButton value={authorization.userCode} label="device code" />
+        {remaining === null ? null : (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            expires in {formatDuration(remaining)}
+          </span>
+        )}
+      </div>
       <Button asChild className="mt-3">
         <a
           href={authorization.verificationUri}
@@ -360,8 +483,18 @@ function DeviceAuthorization({
           Continue in GitHub <ExternalLink aria-hidden="true" />
         </a>
       </Button>
-      <p className="mt-2 text-xs text-muted-foreground">
-        This page checks automatically after GitHub approves the App.
+      {/* The poll is real and silent; a reader watching a static panel has no
+          way to tell it apart from a page that gave up. */}
+      <p
+        role="status"
+        className="mt-2 flex items-center gap-1.5 text-xs text-muted-foreground"
+      >
+        <Loader2
+          aria-hidden="true"
+          className="size-3 motion-safe:animate-spin"
+        />
+        checking with GitHub… this page continues on its own once the App is
+        approved.
       </p>
     </div>
   );
@@ -653,6 +786,19 @@ function DetectedScope({ scope }: { scope: InspectedScope }) {
   );
 }
 
+/**
+ * Where a fact about a connected repository lives on the host.
+ *
+ * The same assumption the opened-pull-request link above already makes, named
+ * once so it is visible: this templates the public host. `LinkedRepoView`
+ * carries no clone URL, so an installation pointed at its own GitHub is the
+ * case this gets wrong — and a commit that is one click away is worth more than
+ * a hash that is zero clicks away and useless.
+ */
+function githubUrl(fullName: string, ...path: readonly string[]): string {
+  return `https://github.com/${fullName}/${path.join('/')}`;
+}
+
 function ConnectedRepositories({
   repos,
 }: {
@@ -662,7 +808,10 @@ function ConnectedRepositories({
 
   return (
     <section className="flex flex-col gap-2">
-      <Eyebrow>Connected</Eyebrow>
+      <Eyebrow>
+        Connected · {repos.length}{' '}
+        {repos.length === 1 ? 'repository' : 'repositories'}
+      </Eyebrow>
       <div className="flex flex-col gap-3">
         {repos.map((repo) => (
           <Card
@@ -687,12 +836,26 @@ function ConnectedRepositories({
                     : 'connection lost'}
                 </Badge>
                 {repo.lastReconciledSha ? (
-                  <span className="ml-auto font-mono text-xs text-muted-foreground">
-                    {repo.lastReconciledSha.slice(0, 7)}
+                  <span className="ml-auto flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <span>reconciled at</span>
+                    <a
+                      className="font-mono underline underline-offset-2 hover:text-foreground"
+                      href={githubUrl(
+                        repo.fullName,
+                        'commit',
+                        repo.lastReconciledSha,
+                      )}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      title={repo.lastReconciledSha}
+                    >
+                      {repo.lastReconciledSha.slice(0, 7)}
+                    </a>
+                    <CopyButton value={repo.lastReconciledSha} label="commit" />
                   </span>
                 ) : null}
               </div>
-              {repo.health === 'connection_lost' && repo.error ? (
+              {repo.error ? (
                 <div className="flex items-start gap-2 rounded-md border border-destructive bg-destructive-soft px-3 py-2">
                   <AlertTriangle
                     aria-hidden="true"
@@ -716,14 +879,30 @@ function ConnectedRepositories({
                 </div>
               ) : null}
               {repo.appSubpaths.length > 0 ? (
-                <div className="flex flex-wrap gap-1.5">
+                <div className="flex flex-wrap items-center gap-1.5">
+                  <span className="text-xs text-muted-foreground">
+                    Deploying from
+                  </span>
+                  {/* Each subpath is a directory an App is built out of, and the
+                      chip went nowhere. It links at the directory rather than at
+                      the App because the read model carries the path and not the
+                      App's id — see the note in the batch summary. */}
                   {repo.appSubpaths.map((subpath) => (
-                    <span
+                    <a
                       key={subpath}
-                      className="rounded-md border bg-secondary px-2 py-1 font-mono text-xs"
+                      href={githubUrl(
+                        repo.fullName,
+                        'tree',
+                        repo.defaultBranch,
+                        subpath === '.' ? '' : subpath,
+                      )}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 rounded-md border bg-secondary px-2 py-1 font-mono text-xs hover:border-primary/50"
                     >
-                      {subpath}
-                    </span>
+                      {subpath === '.' ? 'repository root' : subpath}
+                      <ExternalLink aria-hidden="true" className="size-3" />
+                    </a>
                   ))}
                 </div>
               ) : (

--- a/apps/spindrift/src/web/views/settings/connections.tsx
+++ b/apps/spindrift/src/web/views/settings/connections.tsx
@@ -61,6 +61,7 @@ import { Button } from '../../ui/button.tsx';
 import { Card, CardContent } from '../../ui/card.tsx';
 import { Field } from '../../ui/field.tsx';
 import { Logo } from '../../ui/logo.tsx';
+import { Skeleton, SkeletonRows, SkeletonText } from '../../ui/skeleton.tsx';
 import { cn } from '../../ui/utils.ts';
 
 type Verification = OutputOf<'testBucketPermissions'>;
@@ -133,15 +134,7 @@ export function SourceBuckets() {
   );
   const onChanged = () => setReloadToken((token) => token + 1);
 
-  if (loaded.state === 'loading') {
-    return (
-      <SectionShell>
-        <p className="animate-pulse text-sm text-muted-foreground">
-          Loading source storage…
-        </p>
-      </SectionShell>
-    );
-  }
+  if (loaded.state === 'loading') return <LoadingSection rows={3} />;
   if (loaded.state === 'error' || loaded.value === undefined) {
     return (
       <SectionShell>
@@ -265,33 +258,46 @@ function SourceBucketList({
 
       {adding ? (
         <Card>
-          <CardContent className="flex flex-col gap-3">
-            <Field
-              name="bucket"
-              label="Bucket name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder="spindrift-sources"
-              hint="Checked before it is added — a bucket the controller cannot write to is a build that dies at staging."
-            />
-            <div className="flex flex-wrap gap-2">
-              <Button
-                disabled={busy || name.trim() === ''}
-                onClick={() => use(name.trim(), false)}
-              >
-                {busy ? 'Checking…' : 'Verify and add'}
-              </Button>
-              <Button
-                variant="outline"
-                disabled={busy || name.trim() === ''}
-                onClick={() => use(name.trim(), true)}
-              >
-                Add as default
-              </Button>
-              <Button variant="ghost" onClick={() => setAdding(false)}>
-                Cancel
-              </Button>
-            </div>
+          <CardContent>
+            {/* A real form, so Enter in the one field does what the reader
+                expects. The second verb stays a button: adding as the default
+                is a different act, not the same act confirmed harder. */}
+            <form
+              className="flex flex-col gap-3"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void use(name.trim(), false);
+              }}
+            >
+              <Field
+                name="bucket"
+                label="Bucket name"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                placeholder="spindrift-sources"
+                hint="Checked before it is added — a bucket the controller cannot write to is a build that dies at staging."
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button type="submit" disabled={busy || name.trim() === ''}>
+                  {busy ? 'Checking…' : 'Verify and add'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={busy || name.trim() === ''}
+                  onClick={() => use(name.trim(), true)}
+                >
+                  Add as default
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setAdding(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </form>
           </CardContent>
         </Card>
       ) : null}
@@ -370,13 +376,23 @@ function BucketRow({
         </div>
       </div>
 
+      {/* Both halves were unlabelled monospace, so a region name and the two
+          IAM permissions the check actually exercised read as one undifferentiated
+          string — and the second one is the entire evidence behind the `writable`
+          badge above it, which is the fact worth naming. */}
       {check.state === 'reachable' ? (
-        <div className="flex flex-wrap gap-x-4 gap-y-0.5 pl-6 text-[11px] text-subtle">
-          <span className="font-mono">{check.result.location}</span>
-          <span className="font-mono">
-            {check.result.permissions.join(' · ')}
-          </span>
-        </div>
+        <dl className="flex flex-wrap gap-x-4 gap-y-0.5 pl-6 text-[11px] text-subtle">
+          <div className="flex gap-1.5">
+            <dt>Region</dt>
+            <dd className="font-mono">{check.result.location}</dd>
+          </div>
+          <div className="flex gap-1.5">
+            <dt>Granted</dt>
+            <dd className="font-mono">
+              {check.result.permissions.join(' · ')}
+            </dd>
+          </div>
+        </dl>
       ) : null}
       {check.state === 'unreachable' ? (
         <p className="pl-6 text-xs text-destructive">{check.message}</p>
@@ -409,15 +425,7 @@ export function ArtifactRegistries() {
   );
   const onChanged = () => setReloadToken((token) => token + 1);
 
-  if (loaded.state === 'loading') {
-    return (
-      <SectionShell>
-        <p className="animate-pulse text-sm text-muted-foreground">
-          Loading artifact registries…
-        </p>
-      </SectionShell>
-    );
-  }
+  if (loaded.state === 'loading') return <LoadingSection rows={2} />;
   if (loaded.state === 'error' || loaded.value === undefined) {
     return (
       <SectionShell>
@@ -526,33 +534,46 @@ function ArtifactRegistryList({
 
       {adding ? (
         <Card>
-          <CardContent className="flex flex-col gap-3">
-            <Field
-              name="registry"
-              label="Registry namespace"
-              value={namespace}
-              onChange={(event) => setNamespace(event.target.value)}
-              placeholder="ghcr.io/an-owner"
-              hint="A host and a namespace — the repository path is appended per Component. Checked before it is declared; the check proves the registry answers, never that a push will be authorized."
-            />
-            <div className="flex flex-wrap gap-2">
-              <Button
-                disabled={busy || namespace.trim() === ''}
-                onClick={() => use(namespace.trim(), false)}
-              >
-                {busy ? 'Checking…' : 'Verify and connect'}
-              </Button>
-              <Button
-                variant="outline"
-                disabled={busy || namespace.trim() === ''}
-                onClick={() => use(namespace.trim(), true)}
-              >
-                Connect as first
-              </Button>
-              <Button variant="ghost" onClick={() => setAdding(false)}>
-                Cancel
-              </Button>
-            </div>
+          <CardContent>
+            <form
+              className="flex flex-col gap-3"
+              onSubmit={(event) => {
+                event.preventDefault();
+                void use(namespace.trim(), false);
+              }}
+            >
+              <Field
+                name="registry"
+                label="Registry namespace"
+                value={namespace}
+                onChange={(event) => setNamespace(event.target.value)}
+                placeholder="ghcr.io/an-owner"
+                hint="A host and a namespace — the repository path is appended per Component. Checked before it is declared; the check proves the registry answers, never that a push will be authorized."
+              />
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="submit"
+                  disabled={busy || namespace.trim() === ''}
+                >
+                  {busy ? 'Checking…' : 'Verify and connect'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={busy || namespace.trim() === ''}
+                  onClick={() => use(namespace.trim(), true)}
+                >
+                  Connect as first
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setAdding(false)}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </form>
           </CardContent>
         </Card>
       ) : null}
@@ -723,7 +744,22 @@ function RegistryCredentialForm({
   };
 
   return (
-    <div className="ml-6 mt-1 flex flex-col gap-3 rounded-md border border-border bg-secondary/40 px-3 py-3">
+    <form
+      className="ml-6 mt-1 flex flex-col gap-3 rounded-md border border-border bg-secondary/40 px-3 py-3"
+      onSubmit={(event) => {
+        event.preventDefault();
+        void act(async () => {
+          const result = await command('setRegistryCredential', {
+            registry: registry.namespace,
+            username: username.trim(),
+            secret,
+          });
+          return result.ok
+            ? { ok: true }
+            : { ok: false, message: result.failure.message };
+        });
+      }}
+    >
       <Field
         name={`registry-username-${registry.host}`}
         label="Username"
@@ -743,24 +779,14 @@ function RegistryCredentialForm({
       />
       <div className="flex flex-wrap gap-2">
         <Button
+          type="submit"
           disabled={busy || username.trim() === '' || secret === ''}
-          onClick={() =>
-            void act(async () => {
-              const result = await command('setRegistryCredential', {
-                registry: registry.namespace,
-                username: username.trim(),
-                secret,
-              });
-              return result.ok
-                ? { ok: true }
-                : { ok: false, message: result.failure.message };
-            })
-          }
         >
           {busy ? 'Checking…' : 'Verify and save'}
         </Button>
         {registry.credentialUsername !== null ? (
           <Button
+            type="button"
             variant="outline"
             disabled={busy}
             onClick={() =>
@@ -777,7 +803,7 @@ function RegistryCredentialForm({
             Forget it
           </Button>
         ) : null}
-        <Button variant="ghost" onClick={onCancel}>
+        <Button type="button" variant="ghost" onClick={onCancel}>
           Cancel
         </Button>
       </div>
@@ -787,7 +813,7 @@ function RegistryCredentialForm({
           Forgetting it here does not revoke it at the registry.
         </p>
       ) : null}
-    </div>
+    </form>
   );
 }
 
@@ -796,6 +822,35 @@ function RegistryCredentialForm({
 /** The frame a section keeps while it is loading or refusing. */
 function SectionShell({ children }: { children: ReactNode }) {
   return <section className="flex flex-col gap-4 py-6">{children}</section>;
+}
+
+/**
+ * A section that has not answered yet, in the shape of the section that will.
+ *
+ * Each section reads its own far side, which is the right call and had one
+ * visible cost: three grey sentences of one line each, resolving at three
+ * different times, each replaced by a two-column block several hundred pixels
+ * tall. The screen jumped three times and the reader lost their place twice.
+ *
+ * So this is not a spinner in a box — it is `ConnectionSection`'s own grid, with
+ * the provider column and the ruled card the real section will put there. It
+ * deliberately does not guess the row count: the caller knows how many rows this
+ * particular connection usually has, and a skeleton that promised six where two
+ * arrive is a jump in the other direction.
+ */
+function LoadingSection({ rows }: { rows: number }) {
+  return (
+    <section className="grid gap-5 py-6 xl:grid-cols-[240px_minmax(0,1fr)] xl:gap-8">
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-5 w-24 rounded-full" />
+        <SkeletonText lines={3} />
+      </div>
+      <div className="min-w-0 rounded-md border border-border">
+        <SkeletonRows rows={rows} />
+      </div>
+    </section>
+  );
 }
 
 /**

--- a/apps/spindrift/src/web/views/settings/layout.tsx
+++ b/apps/spindrift/src/web/views/settings/layout.tsx
@@ -1,6 +1,24 @@
+/**
+ * The administrative rail, and the one tab strip left in this corner of the app.
+ *
+ * The rail was the third hand-rolled tab treatment in the tree: a column of
+ * bare `<button>` elements each claiming to be the current *page*, with no
+ * tablist around them and no way into the strip except Tab, Tab, Tab. These
+ * entries do navigate, which is more than the other two strips could say — but a
+ * tab navigating is still a tab, and `Tabs` is what the other two became, so
+ * there is no reason left for this one to be its own thing. It keeps the
+ * vertical column on wide screens purely through a class: the primitive owns
+ * roving focus and the selected state, this file owns where the strip sits.
+ *
+ * `Danger zone` stays in the list. Its content is a paragraph explaining that the
+ * category does not exist, which is a poor use of a fifth of the rail — but
+ * `object-explorer.test.tsx` asserts all five labels and that file belongs to
+ * another change in flight. Removing the entry and the assertion is one commit,
+ * and it is not this one.
+ */
 import type { ReactNode } from 'react';
 import { Eyebrow } from '../../ui/card.tsx';
-import { cn } from '../../ui/utils.ts';
+import { Tabs } from '../../ui/tabs.tsx';
 
 export type SettingsSection =
   | 'connections'
@@ -41,27 +59,14 @@ export function SettingsLayout({
       <div className="grid overflow-hidden rounded-sm border border-border bg-card lg:grid-cols-[230px_minmax(0,1fr)]">
         <aside className="border-b border-border p-3 lg:border-r lg:border-b-0 lg:p-5">
           <Eyebrow className="hidden lg:inline">Sections</Eyebrow>
-          <nav
-            aria-label="Settings sections"
-            className="flex gap-1 overflow-x-auto lg:mt-3 lg:flex-col"
-          >
-            {SECTIONS.map((item) => (
-              <button
-                key={item.id}
-                type="button"
-                aria-current={section === item.id ? 'page' : undefined}
-                onClick={() => onNavigate(`/settings/${item.id}`)}
-                className={cn(
-                  'shrink-0 rounded-sm px-3 py-2 text-left text-sm transition-colors',
-                  section === item.id
-                    ? 'bg-secondary font-semibold text-foreground'
-                    : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground',
-                )}
-              >
-                {item.label}
-              </button>
-            ))}
-          </nav>
+          <Tabs
+            variant="pill"
+            label="Settings sections"
+            items={SECTIONS}
+            current={section}
+            onSelect={(id) => onNavigate(`/settings/${id}`)}
+            className="overflow-x-auto lg:mt-3 lg:flex-col lg:flex-nowrap lg:items-stretch"
+          />
         </aside>
         <article className="min-w-0 p-4 sm:p-6 lg:p-8">{children}</article>
       </div>

--- a/apps/spindrift/src/web/views/supply-chain/artifacts.tsx
+++ b/apps/spindrift/src/web/views/supply-chain/artifacts.tsx
@@ -12,31 +12,118 @@
  * placed is a build that was never released, and that is not visible anywhere
  * a Build's status is the only thing on the row.
  *
- * Provenance shows the level core actually verified and whether core signed it
- * (§16). The full envelope stays on the Build, beside the evidence that
+ * Signature and provenance are columns rather than a colour. The row used to
+ * encode `signed` as the difference between an `accent` dot and an `idle` one,
+ * with no legend anywhere — so "which of these is unsigned" was a question
+ * about a shade of grey, on the one screen whose subject is supply-chain
+ * evidence. §16's verified level and core's own signature are two separate
+ * claims and they get two separate cells; an unsigned row is `warning` because
+ * that is the one an operator has to decide about.
+ *
+ * The full provenance envelope stays on the Build, beside the evidence that
  * produced it — a level here that was not derived from a document there would
  * be a claim about a claim.
  */
+import { Boxes } from 'lucide-react';
 import type { OutputOf } from '../../client.ts';
 import {
   DefinitionGrid,
-  type ExplorerItem,
-  ExplorerPageHeader,
-  type ExplorerTone,
-  ObjectExplorer,
+  LedgerExplorer,
 } from '../../components/object-explorer.tsx';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Eyebrow } from '../../ui/card.tsx';
+import { Ref } from '../../ui/copy.tsx';
+import type { Column } from '../../ui/data-table.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
 import { shortDigest } from './sources.tsx';
 import { SupplyChainTabs } from './tabs.tsx';
 
 export type ArtifactListItem = OutputOf<'listArtifacts'>['artifacts'][number];
 
-function tone(artifact: ArtifactListItem): ExplorerTone {
-  if (artifact.deploys > 0) return 'success';
-  return artifact.signed ? 'accent' : 'idle';
-}
+const COLUMNS: readonly Column<ArtifactListItem>[] = [
+  {
+    id: 'digest',
+    header: 'Digest',
+    sortable: true,
+    sortValue: (artifact) => artifact.digest,
+    cell: (artifact) => <Ref value={artifact.digest} kind="digest" />,
+  },
+  {
+    id: 'app',
+    header: 'App / component',
+    sortable: true,
+    sortValue: (artifact) => `${artifact.app}/${artifact.component}`,
+    cell: (artifact) => (
+      <span className="truncate">
+        {artifact.app} <span className="text-muted-foreground">/</span>{' '}
+        {artifact.component}
+      </span>
+    ),
+  },
+  {
+    id: 'type',
+    header: 'Type',
+    sortable: true,
+    sortValue: (artifact) => artifact.type,
+    cell: (artifact) => (
+      <span className="truncate">
+        {artifact.type}
+        {artifact.supplied ? (
+          <span className="text-muted-foreground"> · supplied</span>
+        ) : null}
+      </span>
+    ),
+  },
+  {
+    id: 'provenance',
+    header: 'Provenance',
+    sortable: true,
+    sortValue: (artifact) => artifact.provenanceLevel ?? -1,
+    cell: (artifact) =>
+      artifact.provenanceLevel === null ? (
+        <span className="text-muted-foreground">not verified</span>
+      ) : (
+        `SLSA L${artifact.provenanceLevel}`
+      ),
+  },
+  {
+    id: 'signed',
+    header: 'Signature',
+    sortable: true,
+    sortValue: (artifact) => (artifact.signed ? 0 : 1),
+    cell: (artifact) =>
+      artifact.signed ? (
+        <Badge tone="success">signed</Badge>
+      ) : (
+        <Badge tone="warning">unsigned</Badge>
+      ),
+  },
+  {
+    id: 'deploys',
+    header: 'Placed',
+    sortable: true,
+    sortValue: (artifact) => artifact.deploys,
+    cell: (artifact) =>
+      artifact.deploys > 0 ? (
+        `${artifact.deploys} deploy${artifact.deploys === 1 ? '' : 's'}`
+      ) : (
+        <span className="text-muted-foreground">never placed</span>
+      ),
+  },
+  {
+    id: 'age',
+    header: 'Produced',
+    align: 'end',
+    sortable: true,
+    sortValue: (artifact) => artifact.at,
+    cell: (artifact) => (
+      <Timestamp at={artifact.at} className="font-mono text-muted-foreground" />
+    ),
+  },
+];
 
 export function ArtifactLedger({
   artifacts,
@@ -47,125 +134,126 @@ export function ArtifactLedger({
   readonly limit: number;
   readonly onNavigate: (path: string) => void;
 }) {
-  const byId = new Map(
-    artifacts.map((artifact) => [`artifact:${artifact.buildId}`, artifact]),
-  );
-  const items: ExplorerItem[] = artifacts.map((artifact) => ({
-    id: `artifact:${artifact.buildId}`,
-    title: shortDigest(artifact.digest),
-    detail: `${artifact.app} / ${artifact.component}`,
-    status:
-      artifact.deploys > 0
-        ? `${artifact.deploys} deploy${artifact.deploys === 1 ? '' : 's'}`
-        : 'never placed',
-    tone: tone(artifact),
-    at: artifact.at,
-    search: `${artifact.type} ${artifact.commit} ${artifact.refs.join(' ')}`,
-  }));
-
   return (
-    <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+    <Page>
       <SupplyChainTabs current="artifacts" onNavigate={onNavigate} />
-      <ExplorerPageHeader
+      <PageHeader
         eyebrow="Artifact ledger"
         title="Artifacts"
         description="What a Build produced, newest first. An Artifact is immutable and outlives the attempt that made it — the same digest is what every Deploy of it places."
       />
-      <ObjectExplorer
-        items={items}
-        filterPlaceholder={`Filter ${artifacts.length} Artifacts…`}
-        empty={
-          <div className="rounded-sm border border-border bg-card p-10 text-center text-sm text-muted-foreground">
-            No Artifact exists yet. A Build that succeeds produces the first
-            one.
-          </div>
+      <LedgerExplorer
+        columns={COLUMNS}
+        rows={artifacts}
+        rowKey={(artifact) => `artifact:${artifact.buildId}`}
+        rowSearch={(artifact) =>
+          `${artifact.digest} ${artifact.app} ${artifact.component} ${artifact.type} ${artifact.commit} ${artifact.refs.join(' ')} ${artifact.signed ? 'signed' : 'unsigned'} ${artifact.deploys === 0 ? 'never placed' : 'placed'}`
         }
-        renderInspector={(item) => {
-          const artifact = byId.get(item.id)!;
-          return (
-            <>
-              <Eyebrow>Artifact / {shortDigest(artifact.digest)}</Eyebrow>
-              <div className="mt-1 flex flex-wrap items-center gap-3">
-                <h2 className="text-2xl font-semibold tracking-tight">
-                  {artifact.app} / {artifact.component}
-                </h2>
-                <Badge tone="idle">{artifact.type}</Badge>
-                {artifact.signed ? <Badge tone="success">signed</Badge> : null}
-                {artifact.supplied ? (
-                  <Badge tone="accent">supplied</Badge>
-                ) : null}
-                {artifact.deploys === 0 ? (
-                  <Badge tone="idle">never placed</Badge>
-                ) : null}
-              </div>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                {artifact.supplied
-                  ? 'Uploaded finished output: no builder ran, and the staged digest is the artifact.'
-                  : `Built from commit ${artifact.commit.slice(0, 12)} by Build #${artifact.buildId}.`}{' '}
-                {artifact.deploys > 0
-                  ? `Placed by ${artifact.deploys} Deploy${artifact.deploys === 1 ? '' : 's'}.`
-                  : 'Nothing has placed it.'}
-              </p>
-              <DefinitionGrid
-                entries={[
-                  { label: 'Digest', value: artifact.digest, mono: true },
-                  { label: 'Type', value: artifact.type },
-                  {
-                    label: 'Source',
-                    value: artifact.sourceDigest
-                      ? shortDigest(artifact.sourceDigest)
-                      : 'none recorded',
-                    mono: true,
-                  },
-                  {
-                    label: 'Provenance',
-                    value:
-                      artifact.provenanceLevel === null
-                        ? 'not verified'
-                        : `SLSA L${artifact.provenanceLevel}`,
-                  },
-                  {
-                    label: 'Signature',
-                    value: artifact.signed ? 'signed by core' : 'none',
-                  },
-                  { label: 'Deploys', value: String(artifact.deploys) },
-                ]}
-              />
-              {artifact.refs.length > 0 ? (
-                <section className="mt-6 border-t border-border pt-5">
-                  <Eyebrow>Pushed to</Eyebrow>
-                  <ul className="mt-2 flex flex-col gap-1">
-                    {artifact.refs.map((ref) => (
-                      <li key={ref} className="font-mono text-xs text-subtle">
-                        {ref}
-                      </li>
-                    ))}
-                  </ul>
-                </section>
+        filterPlaceholder={`Filter ${artifacts.length} Artifacts…`}
+        caption="Artifacts, newest first"
+        inspectorLabel={(artifact) =>
+          `Artifact ${shortDigest(artifact.digest)}`
+        }
+        empty={
+          <EmptyState icon={<Boxes />} title="No Artifact exists yet.">
+            A Build that succeeds produces the first one.
+          </EmptyState>
+        }
+        renderInspector={(artifact) => (
+          <>
+            <Eyebrow>Artifact / {shortDigest(artifact.digest)}</Eyebrow>
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <h2 className="text-title font-semibold tracking-tight">
+                {artifact.app} / {artifact.component}
+              </h2>
+              <Badge tone="idle">{artifact.type}</Badge>
+              {artifact.signed ? <Badge tone="success">signed</Badge> : null}
+              {artifact.supplied ? <Badge tone="accent">supplied</Badge> : null}
+              {artifact.deploys === 0 ? (
+                <Badge tone="idle">never placed</Badge>
               ) : null}
-              <div className="mt-6 flex flex-wrap gap-2">
-                <Button
-                  onClick={() => onNavigate(`/builds/${artifact.buildId}`)}
-                >
-                  Open Build
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => onNavigate(`/apps/${artifact.app}`)}
-                >
-                  Open App
-                </Button>
-              </div>
-            </>
-          );
-        }}
+            </div>
+            <p className="mt-2 max-w-2xl text-body leading-6 text-muted-foreground">
+              {artifact.supplied
+                ? 'Uploaded finished output: no builder ran, and the staged digest is the artifact.'
+                : `Built from commit ${artifact.commit.slice(0, 12)} by Build #${artifact.buildId}.`}{' '}
+              {artifact.deploys > 0
+                ? `Placed by ${artifact.deploys} Deploy${artifact.deploys === 1 ? '' : 's'}.`
+                : 'Nothing has placed it.'}
+            </p>
+            <DefinitionGrid
+              entries={[
+                {
+                  label: 'Digest',
+                  value: <Ref value={artifact.digest} kind="digest" />,
+                  title: artifact.digest,
+                  mono: true,
+                },
+                { label: 'Type', value: artifact.type },
+                {
+                  label: 'Source',
+                  value: artifact.sourceDigest ? (
+                    <Ref value={artifact.sourceDigest} kind="digest" />
+                  ) : (
+                    'none recorded'
+                  ),
+                  title: artifact.sourceDigest ?? undefined,
+                  mono: true,
+                },
+                {
+                  label: 'Provenance',
+                  value:
+                    artifact.provenanceLevel === null
+                      ? 'not verified'
+                      : `SLSA L${artifact.provenanceLevel}`,
+                },
+                {
+                  label: 'Signature',
+                  value: artifact.signed ? 'signed by core' : 'none',
+                },
+                {
+                  label: 'Produced',
+                  value: <Timestamp at={artifact.at} />,
+                  title: artifact.at,
+                  mono: true,
+                },
+              ]}
+            />
+            {artifact.refs.length > 0 ? (
+              <section className="mt-6 border-t border-border pt-5">
+                <Eyebrow>Pushed to</Eyebrow>
+                <ul className="mt-2 flex flex-col gap-1">
+                  {artifact.refs.map((ref) => (
+                    <li
+                      key={ref}
+                      className="font-mono text-caption text-subtle"
+                    >
+                      {ref}
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            ) : null}
+            <div className="mt-6 flex flex-wrap gap-2">
+              <Button onClick={() => onNavigate(`/builds/${artifact.buildId}`)}>
+                Open Build
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => onNavigate(`/apps/${artifact.app}`)}
+              >
+                Open App
+              </Button>
+            </div>
+          </>
+        )}
       />
       {artifacts.length === limit ? (
-        <p className="text-center text-xs text-muted-foreground">
+        <p className="text-center text-caption text-muted-foreground">
           Showing the newest {limit} Artifacts. Older ones are reachable from
           the App they belong to.
         </p>
       ) : null}
-    </div>
+    </Page>
   );
 }

--- a/apps/spindrift/src/web/views/supply-chain/builds.tsx
+++ b/apps/spindrift/src/web/views/supply-chain/builds.tsx
@@ -1,24 +1,149 @@
+/**
+ * Builds — the act between the two nouns, as a table of comparable attempts.
+ *
+ * The row used to carry three of the eight facts `BuildListItem` ships:
+ * `#id · app`, `component · commit`, a status word and a time. `runner`,
+ * `targetShape` and `artifactType` were stuffed into the Explorer's invisible
+ * `search` string, so an operator could *filter* by runner and never *see* one
+ * — and `artifactDigest`, the thing the whole act exists to produce, reached
+ * only the inspector.
+ *
+ * `dispatchWaitingOn` is the one that mattered. `model.ts` calls it "what a
+ * PENDING Build is stuck on, in the operator's own words", the Overview
+ * rendered it, and the screen named after Builds did not — so a Build
+ * permanently refused because no configured route meets its Target's threshold
+ * looked exactly like one that started two seconds ago. It is a column here,
+ * in the artifact slot, because a Build that is waiting has no artifact and the
+ * reason it has none is the honest thing to put where one would go.
+ *
+ * The evidence panel is still a per-selection fetch and still does not follow a
+ * running attempt: `getBuildDetail` is called once per selected Build, so the
+ * step list beside a RUNNING row stays at whatever it was when the row was
+ * clicked while the status badge updates from the list poll. That is a real gap
+ * and it wants the attempt stream, not an interval.
+ */
 import { useEffect, useState } from 'react';
 import { command, type OutputOf } from '../../client.ts';
 import { Checklist } from '../../components/checklist.tsx';
 import {
   DefinitionGrid,
-  type ExplorerItem,
-  ExplorerPageHeader,
   type ExplorerTone,
-  ObjectExplorer,
+  LedgerExplorer,
 } from '../../components/object-explorer.tsx';
-import type { BuildListItem, BuildStatus } from '../../model.ts';
+import type { BuildListItem } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Eyebrow } from '../../ui/card.tsx';
-import { SupplyChainTabs } from './tabs.tsx';
+import { Ref } from '../../ui/copy.tsx';
+import type { Column } from '../../ui/data-table.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { SkeletonRows } from '../../ui/skeleton.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
+import { SupplyChainFlow, SupplyChainTabs } from './tabs.tsx';
 
-function tone(status: BuildStatus): ExplorerTone {
-  if (status === 'SUCCEEDED') return 'success';
-  if (status === 'FAILED') return 'destructive';
+/**
+ * The tone a Build's state deserves, including the state that is not one.
+ *
+ * A PENDING Build refusing every tick is not "in progress" the way a RUNNING
+ * one is — it needs an operator to configure the thing it is waiting on, which
+ * is what `warning` already means everywhere else. Shared with the Overview so
+ * the same Build is never two colours on two screens.
+ */
+export function buildTone(
+  build: Pick<BuildListItem, 'status' | 'dispatchWaitingOn'>,
+): ExplorerTone {
+  if (build.status === 'FAILED') return 'destructive';
+  if (build.status === 'SUCCEEDED') return 'success';
+  if (build.dispatchWaitingOn !== null) return 'warning';
   return 'accent';
 }
+
+const COLUMNS: readonly Column<BuildListItem>[] = [
+  {
+    id: 'id',
+    header: '#',
+    mono: true,
+    width: '5.5rem',
+    sortable: true,
+    sortValue: (build) => build.id,
+    cell: (build) => `#${build.id}`,
+  },
+  {
+    id: 'app',
+    header: 'App / component',
+    sortable: true,
+    sortValue: (build) => `${build.app}/${build.component}`,
+    cell: (build) => (
+      <span className="truncate">
+        {build.app} <span className="text-muted-foreground">/</span>{' '}
+        {build.component}
+      </span>
+    ),
+  },
+  {
+    id: 'commit',
+    header: 'Commit',
+    sortable: true,
+    sortValue: (build) => build.commit,
+    cell: (build) => <Ref value={build.commit} kind="commit" />,
+  },
+  {
+    id: 'runner',
+    header: 'Runner',
+    sortable: true,
+    sortValue: (build) => build.runner ?? '',
+    cell: (build) =>
+      build.runner ?? (
+        <span className="text-muted-foreground">supplied artifact</span>
+      ),
+  },
+  {
+    id: 'shape',
+    header: 'Shape',
+    mono: true,
+    cell: (build) => build.targetShape,
+  },
+  {
+    id: 'artifact',
+    header: 'Artifact',
+    cell: (build) =>
+      build.dispatchWaitingOn !== null ? (
+        <span className="text-warning">{build.dispatchWaitingOn}</span>
+      ) : build.artifactDigest ? (
+        <Ref value={build.artifactDigest} kind="digest" />
+      ) : (
+        <span className="text-muted-foreground">not produced</span>
+      ),
+  },
+  {
+    id: 'status',
+    header: 'State',
+    sortable: true,
+    sortValue: (build) => build.status,
+    cell: (build) => (
+      <Badge tone={buildTone(build)}>
+        {build.dispatchWaitingOn !== null
+          ? 'waiting'
+          : build.status.toLowerCase()}
+      </Badge>
+    ),
+  },
+  {
+    id: 'age',
+    header: 'Created',
+    align: 'end',
+    sortable: true,
+    sortValue: (build) => build.at,
+    cell: (build) => (
+      <Timestamp
+        at={build.at}
+        when={build.when}
+        className="font-mono text-muted-foreground"
+      />
+    ),
+  },
+];
 
 export function BuildLedger({
   builds,
@@ -35,100 +160,106 @@ export function BuildLedger({
   readonly loadError?: string | null;
   readonly onLoadMore?: () => void;
 }) {
-  const byId = new Map(builds.map((build) => [`build:${build.id}`, build]));
-  const items: ExplorerItem[] = builds.map((build) => ({
-    id: `build:${build.id}`,
-    title: `#${build.id} · ${build.app}`,
-    detail: `${build.component} · ${build.commit.slice(0, 12)}`,
-    status: build.status.toLowerCase(),
-    tone: tone(build.status),
-    when: build.when,
-    at: build.at,
-    search: `${build.runner ?? ''} ${build.targetShape} ${build.artifactType}`,
-    active: build.status === 'PENDING' || build.status === 'RUNNING',
-  }));
-
   return (
-    <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+    <Page>
       <SupplyChainTabs current="builds" onNavigate={onNavigate} />
-      <ExplorerPageHeader
+      <PageHeader
         eyebrow="Build ledger"
         title="Builds"
         description="The act between the two nouns: a Source becomes an Artifact here. Placement remains a separate Deploy, with its own state and evidence."
       />
-      <ObjectExplorer
-        items={items}
-        filterPlaceholder={`Filter ${builds.length} Builds…`}
-        empty={
-          <div className="rounded-sm border border-border bg-card p-10 text-center text-sm text-muted-foreground">
-            No Builds exist yet. Creating and deploying an App starts the first
-            one.
-          </div>
+      <LedgerExplorer
+        columns={COLUMNS}
+        rows={builds}
+        rowKey={(build) => `build:${build.id}`}
+        rowSearch={(build) =>
+          `${build.id} ${build.app} ${build.component} ${build.commit} ${build.status} ${build.runner ?? ''} ${build.targetShape} ${build.artifactType} ${build.artifactDigest ?? ''} ${build.dispatchWaitingOn ?? ''}`
         }
-        renderInspector={(item) => {
-          const build = byId.get(item.id)!;
-          return (
-            <>
-              <Eyebrow>Build / {build.id}</Eyebrow>
-              <div className="mt-1 flex flex-wrap items-center gap-3">
-                <h2 className="text-2xl font-semibold tracking-tight">
-                  {build.app} / {build.component}
-                </h2>
-                <Badge tone={tone(build.status)}>
-                  {build.status.toLowerCase()}
-                </Badge>
-              </div>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                Turning commit <span className="font-mono">{build.commit}</span>{' '}
-                into a {build.artifactType} artifact for {build.targetShape}.
+        filterPlaceholder={`Filter ${builds.length} Builds…`}
+        caption="Builds, newest first"
+        inspectorLabel={(build) => `Build ${build.id}`}
+        empty={
+          <EmptyState title="No Builds exist yet.">
+            Creating and deploying an App starts the first one.
+          </EmptyState>
+        }
+        renderInspector={(build) => (
+          <>
+            <Eyebrow>Build / {build.id}</Eyebrow>
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <h2 className="text-title font-semibold tracking-tight">
+                {build.app} / {build.component}
+              </h2>
+              <Badge tone={buildTone(build)}>
+                {build.status.toLowerCase()}
+              </Badge>
+            </div>
+            {build.dispatchWaitingOn !== null ? (
+              <p className="mt-3 rounded-sm border border-warning/50 px-3 py-2 text-body text-warning">
+                Waiting: {build.dispatchWaitingOn}
               </p>
-              <DefinitionGrid
-                entries={[
-                  { label: 'State', value: build.status.toLowerCase() },
-                  { label: 'Created', value: build.when, mono: true },
-                  {
-                    label: 'Runner',
-                    value: build.runner ?? 'supplied artifact',
-                  },
-                  {
-                    label: 'Artifact',
-                    value: build.artifactDigest?.slice(0, 20) ?? 'not produced',
-                    mono: true,
-                  },
-                  { label: 'Shape', value: build.targetShape, mono: true },
-                  {
-                    label: 'Commit',
-                    value: build.commit.slice(0, 12),
-                    mono: true,
-                  },
-                ]}
-              />
-              <BuildEvidence buildId={build.id} />
-              <div className="mt-6 flex flex-wrap gap-2">
-                <Button onClick={() => onNavigate(`/builds/${build.id}`)}>
-                  Open Build
-                </Button>
-                {build.deployId !== null ? (
-                  <Button
-                    variant="outline"
-                    onClick={() => onNavigate(`/deploys/${build.deployId}`)}
-                  >
-                    Related Deploy
-                  </Button>
-                ) : null}
+            ) : null}
+            <p className="mt-2 max-w-2xl text-body leading-6 text-muted-foreground">
+              Turning commit <span className="font-mono">{build.commit}</span>{' '}
+              into a {build.artifactType} artifact for {build.targetShape}.
+            </p>
+            <DefinitionGrid
+              entries={[
+                { label: 'State', value: build.status.toLowerCase() },
+                {
+                  label: 'Created',
+                  value: <Timestamp at={build.at} when={build.when} />,
+                  title: build.at,
+                  mono: true,
+                },
+                {
+                  label: 'Runner',
+                  value: build.runner ?? 'supplied artifact',
+                },
+                {
+                  label: 'Artifact',
+                  value: build.artifactDigest ? (
+                    <Ref value={build.artifactDigest} kind="digest" />
+                  ) : (
+                    'not produced'
+                  ),
+                  title: build.artifactDigest ?? undefined,
+                  mono: true,
+                },
+                { label: 'Shape', value: build.targetShape, mono: true },
+                {
+                  label: 'Commit',
+                  value: <Ref value={build.commit} kind="commit" />,
+                  title: build.commit,
+                  mono: true,
+                },
+              ]}
+            />
+            <BuildEvidence buildId={build.id} />
+            <div className="mt-6 flex flex-wrap gap-2">
+              <Button onClick={() => onNavigate(`/builds/${build.id}`)}>
+                Open Build
+              </Button>
+              {build.deployId !== null ? (
                 <Button
                   variant="outline"
-                  onClick={() => onNavigate(`/apps/${build.appId}`)}
+                  onClick={() => onNavigate(`/deploys/${build.deployId}`)}
                 >
-                  Open App
+                  Related Deploy
                 </Button>
-              </div>
-            </>
-          );
-        }}
+              ) : null}
+              <Button
+                variant="outline"
+                onClick={() => onNavigate(`/apps/${build.appId}`)}
+              >
+                Open App
+              </Button>
+            </div>
+          </>
+        )}
       />
       {loadError ? (
-        <p className="text-sm text-destructive">{loadError}</p>
+        <p className="text-body text-destructive">{loadError}</p>
       ) : null}
       {hasMore ? (
         <div className="flex justify-center">
@@ -137,11 +268,12 @@ export function BuildLedger({
           </Button>
         </div>
       ) : builds.length > 0 ? (
-        <p className="text-center text-xs text-muted-foreground">
+        <p className="text-center text-caption text-muted-foreground">
           Entire Build ledger loaded.
         </p>
       ) : null}
-    </div>
+      <SupplyChainFlow />
+    </Page>
   );
 }
 
@@ -155,6 +287,7 @@ function BuildEvidence({ buildId }: { readonly buildId: number }) {
 
   useEffect(() => {
     let live = true;
+    setState({ type: 'loading' });
     command('getBuildDetail', { id: buildId })
       .then((result) => {
         if (!live) return;
@@ -181,13 +314,14 @@ function BuildEvidence({ buildId }: { readonly buildId: number }) {
     <section className="mt-6 border-t border-border pt-5">
       <Eyebrow>Observed steps</Eyebrow>
       {state.type === 'loading' ? (
-        <p className="mt-2 animate-pulse text-sm text-muted-foreground">
-          Loading Build evidence…
-        </p>
+        <div className="mt-2">
+          <p className="sr-only">Loading Build evidence…</p>
+          <SkeletonRows rows={3} />
+        </div>
       ) : state.type === 'error' ? (
-        <p className="mt-2 text-sm text-destructive">{state.message}</p>
+        <p className="mt-2 text-body text-destructive">{state.message}</p>
       ) : state.detail.attempt.build === null ? (
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className="mt-2 text-body text-muted-foreground">
           This was a supplied artifact; no builder ran.
         </p>
       ) : (

--- a/apps/spindrift/src/web/views/supply-chain/sources.tsx
+++ b/apps/spindrift/src/web/views/supply-chain/sources.tsx
@@ -16,28 +16,137 @@
  * durable, a repository fetch ephemeral. Fetchable is whether a build route
  * could be handed this location at all: `upload://` is deliberately not a URL,
  * and a listing that did not say so would show a Source that cannot be built
- * as indistinguishable from one that can.
+ * as indistinguishable from one that can. Both were one word in a single status
+ * slot before, which meant a `durable` Source no builder can fetch could only
+ * report one of the two things wrong with it.
+ *
+ * `origin` and `commit` were in the Explorer's invisible `search` string: an
+ * operator could filter for a repository and never see which rows came from
+ * one. And every row carried an `at` that never reached the screen, because the
+ * old row only drew a time when the server had also computed a relative phrase
+ * — which `listSources` does not. {@link Timestamp} needs only the instant.
  */
+import { PackageOpen } from 'lucide-react';
 import type { OutputOf } from '../../client.ts';
 import {
   DefinitionGrid,
-  type ExplorerItem,
-  ExplorerPageHeader,
-  ObjectExplorer,
+  LedgerExplorer,
 } from '../../components/object-explorer.tsx';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Eyebrow } from '../../ui/card.tsx';
+import { Ref } from '../../ui/copy.tsx';
+import type { Column } from '../../ui/data-table.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
 import { SupplyChainTabs } from './tabs.tsx';
 
 export type SourceListItem = OutputOf<'listSources'>['sources'][number];
 
-/** `sha256:abc…` — enough to recognise, short enough to sit in a row. */
+/**
+ * `sha256:abc…` — enough to recognise, short enough to sit in a heading.
+ *
+ * Kept beside {@link Ref}, which shortens the same way but renders a control.
+ * A heading and an accessible name are text, and a copy button inside either is
+ * a control nobody can reach by reading.
+ */
 export function shortDigest(digest: string): string {
   const [algorithm, hex] = digest.split(':');
   if (hex === undefined) return digest;
   return `${algorithm}:${hex.slice(0, 12)}`;
 }
+
+const COLUMNS: readonly Column<SourceListItem>[] = [
+  {
+    id: 'digest',
+    header: 'Digest',
+    sortable: true,
+    sortValue: (source) => source.digest,
+    cell: (source) => <Ref value={source.digest} kind="digest" />,
+  },
+  {
+    id: 'app',
+    header: 'App / component',
+    sortable: true,
+    sortValue: (source) => `${source.app}/${source.component}`,
+    cell: (source) => (
+      <span className="truncate">
+        {source.app} <span className="text-muted-foreground">/</span>{' '}
+        {source.component}
+      </span>
+    ),
+  },
+  {
+    id: 'origin',
+    header: 'Origin',
+    sortable: true,
+    sortValue: (source) => `${source.origin} ${source.repository ?? ''}`,
+    cell: (source) =>
+      source.origin === 'repo' ? (
+        <span className="truncate">{source.repository ?? 'repository'}</span>
+      ) : (
+        <span className="text-muted-foreground">upload</span>
+      ),
+  },
+  {
+    id: 'commit',
+    header: 'Commit',
+    sortable: true,
+    sortValue: (source) => source.commit ?? '',
+    cell: (source) =>
+      source.commit ? (
+        <Ref value={source.commit} kind="commit" />
+      ) : (
+        <span className="text-muted-foreground">none</span>
+      ),
+  },
+  {
+    id: 'builds',
+    header: 'Builds',
+    align: 'end',
+    mono: true,
+    sortable: true,
+    sortValue: (source) => source.builds,
+    cell: (source) => source.builds,
+  },
+  {
+    id: 'retention',
+    header: 'Retention',
+    sortable: true,
+    sortValue: (source) => source.retention,
+    cell: (source) => (
+      <Badge tone={source.retention === 'durable' ? 'success' : 'idle'}>
+        {source.retention}
+      </Badge>
+    ),
+  },
+  {
+    id: 'fetchable',
+    header: 'Fetchable',
+    sortable: true,
+    sortValue: (source) => (source.fetchable ? 1 : 0),
+    // The warning is the whole reason this column exists: a Source no build
+    // route can be handed is a dead end, and it used to look like every other
+    // row until somebody clicked it.
+    cell: (source) =>
+      source.fetchable ? (
+        <span className="text-muted-foreground">yes</span>
+      ) : (
+        <Badge tone="warning">unfetchable</Badge>
+      ),
+  },
+  {
+    id: 'age',
+    header: 'Staged',
+    align: 'end',
+    sortable: true,
+    sortValue: (source) => source.at,
+    cell: (source) => (
+      <Timestamp at={source.at} className="font-mono text-muted-foreground" />
+    ),
+  },
+];
 
 export function SourceLedger({
   sources,
@@ -48,108 +157,110 @@ export function SourceLedger({
   readonly limit: number;
   readonly onNavigate: (path: string) => void;
 }) {
-  const byId = new Map(sources.map((source) => [source.digest, source]));
-  const items: ExplorerItem[] = sources.map((source) => ({
-    id: source.digest,
-    title: shortDigest(source.digest),
-    detail: `${source.app} / ${source.component}`,
-    status: source.fetchable ? source.retention : 'unfetchable',
-    tone: !source.fetchable
-      ? 'warning'
-      : source.retention === 'durable'
-        ? 'success'
-        : 'idle',
-    at: source.at,
-    search: `${source.origin} ${source.repository ?? ''} ${source.commit ?? ''} ${source.location ?? ''}`,
-  }));
-
   return (
-    <div className="mx-auto flex w-full max-w-[1320px] flex-col gap-5 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+    <Page>
       <SupplyChainTabs current="sources" onNavigate={onNavigate} />
-      <ExplorerPageHeader
+      <PageHeader
         eyebrow="Source ledger"
         title="Sources"
         description="Every immutable bundle staged before a builder could fetch it, newest first. A Source plus a Build is an Artifact; the one Source that deploys as-is is an uploaded archive of finished output."
       />
-      <ObjectExplorer
-        items={items}
-        filterPlaceholder={`Filter ${sources.length} Sources…`}
-        empty={
-          <div className="rounded-sm border border-border bg-card p-10 text-center text-sm text-muted-foreground">
-            Nothing has been staged yet. Uploading an archive or connecting a
-            repository is what stages the first Source.
-          </div>
+      <LedgerExplorer
+        columns={COLUMNS}
+        rows={sources}
+        rowKey={(source) => source.digest}
+        rowSearch={(source) =>
+          `${source.digest} ${source.app} ${source.component} ${source.origin} ${source.repository ?? ''} ${source.commit ?? ''} ${source.location ?? ''} ${source.retention} ${source.fetchable ? 'fetchable' : 'unfetchable'}`
         }
-        renderInspector={(item) => {
-          const source = byId.get(item.id)!;
-          return (
-            <>
-              <Eyebrow>Source / {shortDigest(source.digest)}</Eyebrow>
-              <div className="mt-1 flex flex-wrap items-center gap-3">
-                <h2 className="text-2xl font-semibold tracking-tight">
-                  {source.app} / {source.component}
-                </h2>
-                <Badge
-                  tone={source.retention === 'durable' ? 'success' : 'idle'}
-                >
-                  {source.retention}
-                </Badge>
-                {source.supplied ? (
-                  <Badge tone="accent">supplied artifact</Badge>
-                ) : null}
-                {!source.fetchable ? (
-                  <Badge tone="warning">no builder can fetch this</Badge>
-                ) : null}
-              </div>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
-                {source.origin === 'repo'
-                  ? `Fetched once from ${source.repository ?? 'its repository'} and staged whole.`
-                  : 'Uploaded and staged whole.'}{' '}
-                {source.supplied
-                  ? 'It is finished output: no builder ran over it, and it deploys as it stands.'
-                  : 'Every Build dispatched from it was handed these exact bytes.'}
-              </p>
-              <DefinitionGrid
-                entries={[
-                  { label: 'Digest', value: source.digest, mono: true },
-                  { label: 'Origin', value: source.origin },
-                  {
-                    label: 'Commit',
-                    value: source.commit?.slice(0, 12) ?? 'no commit',
-                    mono: true,
-                  },
-                  { label: 'Retention', value: source.retention },
-                  {
-                    label: 'Location',
-                    value: source.location ?? 'none recorded',
-                    mono: true,
-                  },
-                  { label: 'Builds', value: String(source.builds) },
-                ]}
-              />
-              <div className="mt-6 flex flex-wrap gap-2">
-                <Button
-                  onClick={() => onNavigate(`/builds/${source.latestBuildId}`)}
-                >
-                  Latest Build
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => onNavigate(`/apps/${source.app}`)}
-                >
-                  Open App
-                </Button>
-              </div>
-            </>
-          );
-        }}
+        filterPlaceholder={`Filter ${sources.length} Sources…`}
+        caption="Sources, newest first"
+        inspectorLabel={(source) => `Source ${shortDigest(source.digest)}`}
+        empty={
+          <EmptyState icon={<PackageOpen />} title="Nothing has been staged.">
+            Uploading an archive or connecting a repository is what stages the
+            first Source.
+          </EmptyState>
+        }
+        renderInspector={(source) => (
+          <>
+            <Eyebrow>Source / {shortDigest(source.digest)}</Eyebrow>
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <h2 className="text-title font-semibold tracking-tight">
+                {source.app} / {source.component}
+              </h2>
+              <Badge tone={source.retention === 'durable' ? 'success' : 'idle'}>
+                {source.retention}
+              </Badge>
+              {source.supplied ? (
+                <Badge tone="accent">supplied artifact</Badge>
+              ) : null}
+              {!source.fetchable ? (
+                <Badge tone="warning">no builder can fetch this</Badge>
+              ) : null}
+            </div>
+            <p className="mt-2 max-w-2xl text-body leading-6 text-muted-foreground">
+              {source.origin === 'repo'
+                ? `Fetched once from ${source.repository ?? 'its repository'} and staged whole.`
+                : 'Uploaded and staged whole.'}{' '}
+              {source.supplied
+                ? 'It is finished output: no builder ran over it, and it deploys as it stands.'
+                : 'Every Build dispatched from it was handed these exact bytes.'}
+            </p>
+            <DefinitionGrid
+              entries={[
+                {
+                  label: 'Digest',
+                  value: <Ref value={source.digest} kind="digest" />,
+                  title: source.digest,
+                  mono: true,
+                },
+                { label: 'Origin', value: source.origin },
+                {
+                  label: 'Commit',
+                  value: source.commit ? (
+                    <Ref value={source.commit} kind="commit" />
+                  ) : (
+                    'no commit'
+                  ),
+                  title: source.commit ?? undefined,
+                  mono: true,
+                },
+                {
+                  label: 'Staged',
+                  value: <Timestamp at={source.at} />,
+                  title: source.at,
+                  mono: true,
+                },
+                {
+                  label: 'Location',
+                  value: source.location ?? 'none recorded',
+                  mono: true,
+                },
+                { label: 'Builds', value: String(source.builds) },
+              ]}
+            />
+            <div className="mt-6 flex flex-wrap gap-2">
+              <Button
+                onClick={() => onNavigate(`/builds/${source.latestBuildId}`)}
+              >
+                Latest Build
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => onNavigate(`/apps/${source.app}`)}
+              >
+                Open App
+              </Button>
+            </div>
+          </>
+        )}
       />
       {sources.length === limit ? (
-        <p className="text-center text-xs text-muted-foreground">
+        <p className="text-center text-caption text-muted-foreground">
           Showing the newest {limit} Sources. Older ones are reachable from the
           App they belong to.
         </p>
       ) : null}
-    </div>
+    </Page>
   );
 }

--- a/apps/spindrift/src/web/views/supply-chain/tabs.tsx
+++ b/apps/spindrift/src/web/views/supply-chain/tabs.tsx
@@ -16,11 +16,20 @@
  *
  * The tabs are plain links into the existing routes, so `/builds` and
  * `/builds/<id>` keep meaning exactly what they meant.
+ *
+ * Two things moved out of this component and the reason is the same for both:
+ * everything above the first row of data is a toll the operator pays on every
+ * visit. The `Supply chain` eyebrow is gone because the strip beneath it said
+ * the same word twice — it is now the strip's own accessible name, which is
+ * where a label belongs when the thing it labels is already legible. And
+ * {@link SupplyChainFlow} is exported separately so each screen can render the
+ * diagram *below* its ledger; `components/flow.tsx` already concedes that "the
+ * operator came for the rows", and documentation stacked on top of the rows is
+ * the one place it helps nobody.
  */
 import supplyChainFlow from '../../client/diagrams/supply-chain.svg';
 import { Flow } from '../../components/flow.tsx';
-import { Eyebrow } from '../../ui/card.tsx';
-import { cn } from '../../ui/utils.ts';
+import { Tabs } from '../../ui/tabs.tsx';
 
 export type SupplyChainTab = 'sources' | 'builds' | 'artifacts';
 
@@ -42,36 +51,25 @@ export function SupplyChainTabs({
   readonly onNavigate: (path: string) => void;
 }) {
   return (
-    <div className="flex flex-col gap-3">
-      <div className="flex flex-wrap items-center gap-3">
-        <Eyebrow>Supply chain</Eyebrow>
-        <nav
-          aria-label="Supply chain"
-          className="flex gap-1 rounded-sm border border-border bg-card p-1"
-        >
-          {TABS.map((tab) => (
-            <button
-              key={tab.id}
-              type="button"
-              aria-current={current === tab.id ? 'page' : undefined}
-              onClick={() => onNavigate(tab.path)}
-              className={cn(
-                'rounded-sm px-3 py-1.5 text-sm transition-colors',
-                current === tab.id
-                  ? 'bg-secondary font-semibold text-foreground'
-                  : 'text-muted-foreground hover:bg-secondary/60 hover:text-foreground',
-              )}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </nav>
-      </div>
-      <Flow
-        src={supplyChainFlow}
-        label="How a Source becomes something that is serving"
-        alt="Source and Build produce an Artifact through one BuildKit program on any of three routes; the gate verifies, caps the level and signs; the Artifact plus pinned config references becomes a Deploy, admitted by a signature check."
-      />
-    </div>
+    <Tabs
+      label="Supply chain"
+      items={TABS}
+      current={current}
+      onSelect={(id) => {
+        const tab = TABS.find((candidate) => candidate.id === id);
+        if (tab) onNavigate(tab.path);
+      }}
+    />
+  );
+}
+
+/** The chain as a picture, for the reader who has not built the model yet. */
+export function SupplyChainFlow() {
+  return (
+    <Flow
+      src={supplyChainFlow}
+      label="How a Source becomes something that is serving"
+      alt="Source and Build produce an Artifact through one BuildKit program on any of three routes; the gate verifies, caps the level and signs; the Artifact plus pinned config references becomes a Deploy, admitted by a signature check."
+    />
   );
 }

--- a/apps/spindrift/test/harness/dom.ts
+++ b/apps/spindrift/test/harness/dom.ts
@@ -125,6 +125,14 @@ export class FakeNode {
   addEventListener(): void {}
   removeEventListener(): void {}
 
+  /**
+   * `commitMount` calls this directly on a mounted `input`/`select`/`button`
+   * carrying `autoFocus`, so a tree with an autofocused control does not mount
+   * without it. There is no focus in this shim — `activeElement` stays `null` —
+   * and that is the honest state: nothing here has a viewport to focus into.
+   */
+  focus(): void {}
+
   getBoundingClientRect() {
     return {
       x: 0,

--- a/apps/spindrift/test/web/app-list-identity.test.tsx
+++ b/apps/spindrift/test/web/app-list-identity.test.tsx
@@ -34,6 +34,12 @@ import type {
   CommandContext,
 } from '../../src/commands/types.ts';
 import {
+  builds,
+  componentTargetDesired,
+  deploys,
+  targets,
+} from '../../src/db/schema.ts';
+import {
   type AppDeletion,
   type AppDeletionControls,
   DeleteAppButton,
@@ -42,10 +48,15 @@ import {
   type ExplorerItem,
   ObjectExplorer,
 } from '../../src/web/components/object-explorer.tsx';
-import type { AppListItem } from '../../src/web/model.ts';
+import type { AppListItem, DeployPhase } from '../../src/web/model.ts';
 import { AppList, appHref } from '../../src/web/views/apps/list.tsx';
 import { withIsolatedDatabase } from '../harness/db.ts';
-import { fixtureManifest } from '../harness/installation.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+import { aDesiredDocument } from '../harness/release.ts';
 
 const manifest = await fixtureManifest();
 const database = withIsolatedDatabase();
@@ -118,6 +129,126 @@ async function seedTwins(ctx: CommandContext, name: string) {
   }
   return made;
 }
+
+/**
+ * One App with two Components, released to two different verdicts.
+ *
+ * The `web` Component is serving and the `worker` behind it is red — the shape
+ * the list used to report as `live`, because it read the phase off
+ * `components[0]` and stopped. Each Component gets its own Target so the two
+ * releases are genuinely independent rather than two rows on one placement.
+ */
+async function seedSplitApp(ctx: CommandContext) {
+  const name = `split-${crypto.randomUUID().slice(0, 8)}`;
+  const app = await createApp(
+    { name, sourceKind: 'repo', repoUrl: 'https://vcs.example/acme/split.git' },
+    ctx,
+  );
+  if (!app.ok) throw new Error(app.failure.message);
+
+  const released: { name: string; phase: DeployPhase; commit: string }[] = [];
+  let redDeployId = 0;
+
+  for (const [componentName, phase] of [
+    ['web', 'LIVE'],
+    ['worker', 'FAILED'],
+  ] as const) {
+    const component = await createComponent(
+      {
+        appId: app.value.appId,
+        name: componentName,
+        kind: 'service',
+        expose: componentName === 'web',
+        reach: componentName === 'web' ? 'private' : 'none',
+        auth: componentName === 'web' ? 'proxy' : 'none',
+      },
+      ctx,
+    );
+    if (!component.ok) throw new Error(component.failure.message);
+
+    const vessel = await insertVessel(ctx.db, 'kubernetes', {
+      name: `cluster-${crypto.randomUUID()}`,
+    });
+    const [target] = await ctx.db
+      .insert(targets)
+      .values(targetValues({ adapter: 'kubernetes', vesselId: vessel.id }))
+      .returning();
+    await ctx.db.insert(componentTargetDesired).values({
+      componentId: component.value.componentId,
+      targetId: target!.id,
+    });
+
+    const commit = crypto.randomUUID().slice(0, 7);
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId: component.value.componentId,
+        commit,
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'c'.repeat(64)}`,
+        status: 'SUCCEEDED',
+        runner: 'hosted runner',
+      })
+      .returning();
+
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId: component.value.componentId,
+        desired: aDesiredDocument(),
+        targetId: target!.id,
+        buildId: build!.id,
+        phase,
+      })
+      .returning();
+
+    if (phase === 'FAILED') redDeployId = deploy!.id;
+    released.push({ name: componentName, phase, commit });
+  }
+
+  return { appId: app.value.appId, name, released, redDeployId };
+}
+
+describe('an App is as healthy as its worst Component', () => {
+  test('a green service in front of a red worker does not read as live', async () => {
+    const ctx = context();
+    const seeded = await seedSplitApp(ctx);
+
+    const listed = await listApps({}, ctx);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+
+    const row = listed.value.apps.find((app) => app.id === seeded.appId);
+    expect(row).toBeDefined();
+    if (!row) return;
+
+    // The whole defect: `components[0]` is the `web` that is serving.
+    expect(row.phase).toBe('FAILED');
+    expect(row.componentCount).toBe(2);
+    expect(row.failing).toBe(1);
+  });
+
+  test('and every other fact on the row belongs to that same Component', async () => {
+    // A row that named one Component's commit beside another's placement is
+    // two answers wearing one line, and no reader can tell which is which.
+    const ctx = context();
+    const seeded = await seedSplitApp(ctx);
+    const red = seeded.released.find((entry) => entry.phase === 'FAILED');
+
+    const listed = await listApps({}, ctx);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+
+    const row = listed.value.apps.find((app) => app.id === seeded.appId);
+    expect(row?.commit).toBe(red?.commit ?? '');
+    expect(row?.deployId).toBe(seeded.redDeployId);
+    // The instant the release was written, so the scan can be ordered by how
+    // long each App has been in the state it is in.
+    expect(row?.at).toBeDefined();
+    expect(row?.when).toBeDefined();
+  });
+});
 
 describe('two Apps answer to one name', () => {
   test('the list carries an id for each, and the ids differ', async () => {

--- a/apps/spindrift/test/web/installation-discovery.test.tsx
+++ b/apps/spindrift/test/web/installation-discovery.test.tsx
@@ -34,6 +34,7 @@ import {
   askInstallationCloud,
   DiscoveredFactList,
   DiscoveryRefusal,
+  narrowingFrom,
   unwritable,
 } from '../../src/web/views/auth/discovery.tsx';
 import { InstallationSettingsView } from '../../src/web/views/auth/installation.tsx';
@@ -176,6 +177,100 @@ describe('confirming a value edits the document at the path it came with', () =>
     expect(applyDiscovered(document, fact, bucket)).toMatchObject({
       sources: { buckets: ['a-bucket'] },
     });
+  });
+});
+
+describe('a row is a reconciliation, not a row of buttons', () => {
+  const fact = FACTS[0]!;
+  if (fact.kind !== 'found') throw new Error('the fixture lost its arm');
+
+  function withProject(project: string): unknown {
+    return {
+      installation: { homeVessel: 'home' },
+      vessels: [{ name: 'home', location: { project } }],
+    };
+  }
+
+  function row(document: unknown): string {
+    return renderToStaticMarkup(
+      <DiscoveredFactList
+        facts={[fact]}
+        document={document}
+        onApply={() => undefined}
+      />,
+    );
+  }
+
+  test('confirming a value is visible, because the row reads the document', () => {
+    // The defect this replaces: the selected style came from `fact.suggested`,
+    // a property of the *server's* answer that is identical before and after a
+    // press. An operator confirmed a discovered project and every pixel on the
+    // screen stayed where it was.
+    const before = row(withProject('typed-by-hand'));
+    const after = row(withProject('example-home'));
+    expect(before).not.toEqual(after);
+    expect(before).toContain('aria-pressed="false"');
+    expect(after).toContain('aria-pressed="true"');
+  });
+
+  test('a row says what the document holds and whether it is settled', () => {
+    expect(row(withProject('typed-by-hand'))).toContain('typed-by-hand');
+    expect(row(withProject('typed-by-hand'))).toContain('stand-in');
+    expect(row(withProject('example-home'))).toContain('confirmed');
+  });
+
+  test('the whole path is on the row, because the tail is ambiguous', () => {
+    // Two of the five answers humanize to the same word: `Project` is the home
+    // vessel's own and `Artifacts project` is its shared one, and a panel
+    // showing only the last segment showed the same heading twice.
+    expect(row(withProject('example-home'))).toContain(
+      'vessels.homeVessel.location.project',
+    );
+  });
+
+  test('a caller with no document states nothing about which value is in force', () => {
+    // The honest absence: the settings screen passes a document and the row is
+    // a comparison; a caller that has none gets candidates and no verdict,
+    // rather than a verdict computed against nothing.
+    const markup = renderToStaticMarkup(
+      <DiscoveredFactList facts={[fact]} onApply={() => undefined} />,
+    );
+    expect(markup).not.toContain('confirmed');
+    expect(markup).not.toContain('stand-in');
+  });
+});
+
+describe('the narrowing inputs are seeded from the document', () => {
+  test('a project the document already names arrives in the box', () => {
+    // Discovery is staged deliberately: with no project, buckets and signing
+    // keys answer "name a project and run discovery again" — and the candidate
+    // that would unblock it is labelled `<project> — this deployment's own
+    // credential`, so an operator who typed what they read typed a project
+    // that does not exist.
+    expect(
+      narrowingFrom({
+        installation: { homeVessel: 'home' },
+        vessels: [{ name: 'home', location: { project: 'example-home' } }],
+      }),
+    ).toMatchObject({ project: 'example-home' });
+  });
+
+  test('the key location is read out of the signer this installation holds', () => {
+    // Not a manifest key of its own — it is a segment inside the signer, and
+    // reading it back is cheaper for an operator than finding the console page
+    // that lists it.
+    expect(
+      narrowingFrom({
+        supplyChain: {
+          signer:
+            'gcpkms://projects/example-home/locations/us-central1/keyRings/r/cryptoKeys/k',
+        },
+      }),
+    ).toMatchObject({ kmsLocation: 'us-central1' });
+  });
+
+  test('a document that names neither asks for everything', () => {
+    expect(narrowingFrom({})).toEqual({ project: '', kmsLocation: '' });
   });
 });
 

--- a/apps/spindrift/test/web/installation-settings.test.tsx
+++ b/apps/spindrift/test/web/installation-settings.test.tsx
@@ -85,6 +85,22 @@ describe('every manifest value is reachable', () => {
     expect(markup).toContain(manifest.build.zeroConfigFrontend);
   });
 
+  test('the page states what saving does, and it is not a card', () => {
+    // Every top-level key this schema declares has structure, so the "plain"
+    // half of the split is empty for every manifest this build can hold — and
+    // a card was drawn around it regardless: a title, a blurb, and a
+    // permanently empty body sitting above the twelve cards that are the
+    // document. The claim it made was never a section's, it was the page's.
+    expect(
+      manifestFields().every(
+        (field) => field.node.kind === 'object' || field.node.kind === 'array',
+      ),
+    ).toBe(true);
+    expect(markup).toContain('<h2');
+    expect(markup).toContain('reconciles the Targets it declares');
+    expect(markup.split('Installation manifest').length - 1).toBe(1);
+  });
+
   test('a value the schema calls a url is entered as one', () => {
     expect(markup).toContain('type="url"');
   });
@@ -218,6 +234,30 @@ describe('the vessels this installation is built on are read-only', () => {
         declarationGoverns: true,
       }),
     ).toContain('are declared, not configured here');
+  });
+
+  test('a governed field is marked declared where it is, not only at the top', () => {
+    // The sentence above is one sentence at the top of a page that runs to
+    // twelve cards, and the fields it explains were rendered as `disabled`,
+    // which is the same attribute a save in flight sets. A declared value is
+    // the most authoritative thing on the screen and it read as the most
+    // broken.
+    const markup = screen({
+      document: withAppVessel,
+      declaration: manifest,
+      declarationGoverns: true,
+    });
+
+    expect(markup).toContain('declared</span>');
+    // At the boundary the answer changes, not on every descendant of it: a
+    // governed vessel would otherwise carry eight identical badges inside one
+    // card to say one thing.
+    expect(markup.split('declared</span>').length - 1).toBeLessThan(
+      manifestFields().length,
+    );
+    expect(screen({ document: withAppVessel })).not.toContain(
+      'declared</span>',
+    );
   });
 
   test('with no declaration mounted the whole document is this screen’s', () => {

--- a/apps/spindrift/test/web/object-explorer.test.tsx
+++ b/apps/spindrift/test/web/object-explorer.test.tsx
@@ -4,6 +4,7 @@ import { ObjectExplorer } from '../../src/web/components/object-explorer.tsx';
 import { AppShell } from '../../src/web/components/shell.tsx';
 import type { BuildListItem, DeployLedgerItem } from '../../src/web/model.ts';
 import { DeployLedger } from '../../src/web/views/operations/deploys.tsx';
+import { Overview } from '../../src/web/views/operations/overview.tsx';
 import { SettingsLayout } from '../../src/web/views/settings/layout.tsx';
 import { ArtifactLedger } from '../../src/web/views/supply-chain/artifacts.tsx';
 import { BuildLedger } from '../../src/web/views/supply-chain/builds.tsx';
@@ -210,6 +211,60 @@ describe('the global operation ledgers', () => {
     expect(markup).toContain('never placed');
     expect(markup).toContain('SLSA L3');
     expect(markup).toContain('ghcr.io/an-owner/morrow');
+  });
+
+  /**
+   * The ledgers are tables now, and the point of a table is the columns: the
+   * facts these rows carried and did not show were flattened into one `·`
+   * sentence nobody could sort, align or compare down.
+   */
+  test('a ledger row is a table row with the facts it used to hide', () => {
+    const markup = renderToStaticMarkup(
+      <BuildLedger builds={[build]} onNavigate={() => undefined} />,
+    );
+    expect(markup).toContain('<table');
+    expect(markup).toContain('scope="col"');
+    for (const header of ['Runner', 'Shape', 'Artifact', 'Commit']) {
+      expect(markup).toContain(header);
+    }
+  });
+
+  /**
+   * A count off an array the caller fetched with `limit: 12` is not a fleet
+   * total. The tile may only claim what it can back up.
+   */
+  test('the landing screen scopes a page count instead of presenting it as a total', () => {
+    const markup = renderToStaticMarkup(
+      <Overview
+        apps={[]}
+        builds={[build]}
+        deploys={[deploy]}
+        targets={[]}
+        buildsHasMore
+        deploysHasMore
+        onNavigate={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain('Object explorer');
+    expect(markup).toContain('aria-label="Serving"');
+    expect(markup).toContain('aria-label="Standing state"');
+    expect(markup).toContain('aria-label="Activity"');
+    expect(markup).toContain('1+');
+    expect(markup).toContain('not a fleet total');
+  });
+
+  test('a landing screen with a whole ledger loaded claims the whole ledger', () => {
+    const markup = renderToStaticMarkup(
+      <Overview
+        apps={[]}
+        builds={[build]}
+        deploys={[deploy]}
+        targets={[]}
+        onNavigate={() => undefined}
+      />,
+    );
+    expect(markup).not.toContain('1+');
+    expect(markup).not.toContain('not a fleet total');
   });
 
   test('offers the next cursor page instead of truncating history', () => {

--- a/apps/spindrift/test/web/onboarding.test.tsx
+++ b/apps/spindrift/test/web/onboarding.test.tsx
@@ -45,7 +45,9 @@ import type { SaveOutcome } from '../../src/web/views/auth/installation.tsx';
 import {
   ONBOARDING_ASKS,
   OnboardingView,
+  refusalSentence,
   stepAsking,
+  stepIssues,
 } from '../../src/web/views/auth/onboarding.tsx';
 
 /** The document an unconfigured installation actually holds. */
@@ -211,6 +213,98 @@ describe('a refusal is the same three things it is on the settings screen', () =
     // And a value no step asks about is not forced onto one. Discovery writes
     // cloud facts this screen never offers a control for.
     expect(stepAsking('secretStore.endpoint')).toBe(-1);
+  });
+});
+
+describe('the four questions are all visible while one is being answered', () => {
+  test('the rail names every step from the first step', () => {
+    // The titles have existed since the day `ONBOARDING_ASKS` did and an
+    // operator met each one only on arrival — so the step that reads the cloud,
+    // and can therefore refuse, was always a surprise three screens in.
+    const markup = screen({ step: 0 });
+    for (const ask of ONBOARDING_ASKS) expect(markup).toContain(ask.title);
+    expect(markup).toContain('aria-label="Setup steps"');
+  });
+
+  test('the progress sentence is still there, and there is no fifth screen', () => {
+    // `Step 1 of 4` is what the shell asserts against. The rail is beside it,
+    // not instead of it, and it adds no question: four asks, one write, and the
+    // write is still on the last of them.
+    expect(screen({ step: 0 })).toContain('Step 1 of 4');
+    expect(ONBOARDING_ASKS).toHaveLength(4);
+  });
+});
+
+describe('an answer is refused where it is given', () => {
+  const nameless = {
+    ...DEFAULT_PLACEHOLDER_MANIFEST,
+    installation: { ...DEFAULT_PLACEHOLDER_MANIFEST.installation, name: '' },
+  } as unknown;
+
+  /** The `<button>` whose whole content is this label. */
+  function control(markup: string, label: string): string {
+    const end = markup.indexOf(`>${label}</button>`);
+    if (end < 0) throw new Error(`no button labelled ${label}`);
+    return markup.slice(markup.lastIndexOf('<button', end), end + 1);
+  }
+
+  test('only the issues the step in front of you can fix', () => {
+    // The map is the whole of the gate, and it is worth pinning without a
+    // browser: an issue is actionable on the step that mounts the control it
+    // belongs to and nowhere else.
+    expect([...stepIssues(nameless, 0).keys()]).toEqual(['installation.name']);
+    expect(stepIssues(nameless, 1).size).toBe(0);
+    expect(stepIssues(DEFAULT_PLACEHOLDER_MANIFEST as unknown, 0).size).toBe(0);
+  });
+
+  test('the step that asks refuses to advance, and says why', () => {
+    // Before this, an empty name walked through all four questions and the
+    // commit press threw the operator back here reading a sentence of dotted
+    // schema paths.
+    const markup = screen({ step: 0, document: nameless });
+    expect(control(markup, 'Continue')).toContain('disabled=""');
+    expect(markup).toContain('Too small: expected string');
+  });
+
+  test('a valid answer advances', () => {
+    expect(control(screen({ step: 0 }), 'Continue')).not.toContain(
+      'disabled=""',
+    );
+  });
+
+  test('the step with no form of its own still advances when pressed', () => {
+    // The discovery step is the one the wizard does not wrap in a form, because
+    // the panel it mounts already is one. A `type="submit"` there is a button
+    // outside any form, which is a button that does nothing.
+    const markup = screen({ step: 2 });
+    expect(control(markup, 'Continue')).toContain('type="button"');
+    expect(control(screen({ step: 0 }), 'Continue')).toContain('type="submit"');
+  });
+
+  test('Enter is a way to answer a question', () => {
+    // The wizard had no `<form>` anywhere, so typing an answer and pressing
+    // Enter did nothing at all. The discovery step is the exception and has its
+    // own reason: its panel already submits, and a form inside a form is not a
+    // thing a browser keeps.
+    expect(screen({ step: 0 })).toContain('<form');
+    expect(screen({ step: 3 })).toContain('<form');
+  });
+
+  test('the backstop names the questions, not the schema paths', () => {
+    // The end-of-flow check stays — the command is the authority and reports
+    // every offending key at once — but this is the one screen whose premise is
+    // that keys are named in human terms, and it was reporting them in Zod's.
+    const said = refusalSentence(['installation.name', 'supplyChain.registry']);
+    expect(said).toContain('Name this installation');
+    expect(said).toContain('Where artifacts are published');
+    expect(said).not.toContain('supplyChain.registry');
+
+    // A value no step asks about has no question to be named as. Discovery
+    // applies cloud facts this screen never offers a control for, so the key
+    // itself is the most honest thing left to say.
+    expect(refusalSentence(['secretStore.endpoint'])).toContain(
+      'secretStore.endpoint',
+    );
   });
 });
 

--- a/apps/spindrift/test/web/shell-chrome.test.tsx
+++ b/apps/spindrift/test/web/shell-chrome.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * The chrome every screen in the product is rendered inside.
+ *
+ * These are claims about the frame rather than about any one screen: that the
+ * rail names its destinations instead of only drawing them, that the two
+ * navigations a document carries are distinguishable to anything reading
+ * landmarks, that the crumb answers "which object is this" and not "what kind
+ * of object is this", and that the palette's catalogue is built from the rows
+ * the installation actually has.
+ *
+ * `renderToStaticMarkup` throughout, and the two pure functions called
+ * directly. The shell holds a `localStorage` preference, a `navigator` sniff
+ * and a keydown listener, none of which exist in a server render — which is the
+ * point: this file is also the proof that none of that runs at module scope or
+ * during the first paint.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { crumbsFor } from '../../src/web/components/breadcrumbs.tsx';
+import {
+  filterPalette,
+  type PaletteCatalogue,
+  paletteItems,
+} from '../../src/web/components/command-palette.tsx';
+import { AppShell } from '../../src/web/components/shell.tsx';
+import { APP_LIST, TARGET_LIST } from '../fixtures/scenarios.ts';
+
+const OPERATOR = { id: 'operator', displayName: 'Ada Operator' };
+
+function shell(path: string): string {
+  return renderToStaticMarkup(
+    <AppShell
+      path={path}
+      principal={OPERATOR}
+      onNavigate={() => undefined}
+      onSignOut={() => undefined}
+      themeControl={<span>theme</span>}
+    >
+      <p>screen</p>
+    </AppShell>,
+  );
+}
+
+function occurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe('the shell names where it goes', () => {
+  test('every rail destination is a word, not only a glyph', () => {
+    const markup = shell('/builds');
+
+    for (const label of ['Overview', 'Apps', 'Supply chain', 'Deploys']) {
+      expect(markup).toContain(`>${label}</span>`);
+    }
+  });
+
+  test('the two navigations are two landmarks with two names', () => {
+    const markup = shell('/');
+
+    expect(occurrences(markup, 'aria-label="Primary navigation"')).toBe(1);
+    expect(
+      occurrences(markup, 'aria-label="Primary navigation (compact)"'),
+    ).toBe(1);
+  });
+
+  test('the operator is a control, not a title attribute', () => {
+    const markup = shell('/');
+
+    expect(markup).toContain('aria-label="Account: Ada Operator"');
+    // Both things the menu exists to reach.
+    expect(markup).toContain('Identity and passkeys');
+    expect(markup).toContain('Sign out');
+  });
+
+  test('results have somewhere to land on every screen', () => {
+    expect(shell('/')).toContain('aria-label="Recent results"');
+  });
+});
+
+describe('the crumb carries the object', () => {
+  test('a detail route says which one, under the product name', () => {
+    const markup = shell('/deploys/1187');
+
+    expect(markup).toContain('SPINDRIFT /');
+    expect(markup).toContain('#1187');
+  });
+
+  test('an App is named, where the header used to say only "Apps"', () => {
+    expect(crumbsFor('/apps/morrow')).toEqual([
+      { label: 'Apps', path: '/apps' },
+      { label: 'morrow' },
+    ]);
+  });
+
+  test('the last crumb is never a link to the page already open', () => {
+    for (const path of ['/', '/builds', '/builds/42', '/settings/identity']) {
+      expect(crumbsFor(path).at(-1)?.path).toBeUndefined();
+    }
+  });
+
+  test('the three roots that became Settings sections say so', () => {
+    expect(crumbsFor('/repos')).toEqual([
+      { label: 'Settings', path: '/settings/connections' },
+      { label: 'Connections' },
+    ]);
+  });
+});
+
+describe('the palette searches what the installation has', () => {
+  const catalogue: PaletteCatalogue = {
+    apps: APP_LIST,
+    builds: [],
+    deploys: [],
+    targets: TARGET_LIST,
+  };
+
+  test('with nothing read yet it still navigates', () => {
+    const items = paletteItems(null);
+
+    expect(items.length).toBeGreaterThan(0);
+    expect(items.every((item) => item.group === 'Go to')).toBe(true);
+  });
+
+  test('loaded rows become entries', () => {
+    const labels = paletteItems(catalogue).map((item) => item.label);
+
+    for (const app of APP_LIST) expect(labels).toContain(app.name);
+  });
+
+  test('a Target is vessel/adapter, because neither names it alone', () => {
+    const targets = paletteItems(catalogue).filter(
+      (item) => item.group === 'Targets',
+    );
+
+    expect(targets.length).toBe(TARGET_LIST.length);
+    for (const target of TARGET_LIST) {
+      expect(targets.map((item) => item.label)).toContain(
+        `${target.vessel}/${target.adapter}`,
+      );
+    }
+  });
+
+  test('a literal hit outranks a subsequence one', () => {
+    const items = paletteItems(catalogue);
+    const [first] = filterPalette(items, 'wiki');
+
+    expect(first?.label).toBe('wiki');
+  });
+
+  test('the list is capped, because nobody reads the thirteenth row', () => {
+    expect(filterPalette(paletteItems(catalogue), '').length).toBeLessThan(13);
+  });
+
+  test('a query that matches nothing matches nothing', () => {
+    expect(filterPalette(paletteItems(catalogue), 'zzzzzz')).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/web/ui-primitives.test.tsx
+++ b/apps/spindrift/test/web/ui-primitives.test.tsx
@@ -1,0 +1,407 @@
+/**
+ * The primitives whose behaviour is invisible when it breaks.
+ *
+ * Six screens are being rewritten on top of `ui/`, so a defect in here is a
+ * defect in all six — and every defect this file is aimed at is silent. A sort
+ * that compares `12` against `9` as strings still renders a table. A `<time>`
+ * without a `dateTime` still shows "8m ago". A tab strip where every tab is a
+ * tab stop still looks right in a screenshot. A toast store that notifies
+ * nobody renders exactly the same markup as one that works.
+ *
+ * The shape of the assertions is set by what the suite can do rather than by
+ * preference. There is no jsdom in this package (see `test/harness/dom.ts` for
+ * why), and the shim it does have has no event system — so nothing here can
+ * click. That splits each primitive in two: what it *renders* is asserted
+ * through `renderToStaticMarkup`, exactly as `views.test.tsx` and
+ * `progress.test.tsx` do, and what it *decides* is asserted against the pure
+ * function the component delegates the decision to. Those functions are
+ * exported for this reason, which is also why they are the ones the other
+ * batches reuse.
+ */
+import { describe, expect, test } from 'bun:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { copyValue, Ref } from '../../src/web/ui/copy.tsx';
+import {
+  type Column,
+  DataTable,
+  nextSort,
+  rowKeyboard,
+  sortRows,
+} from '../../src/web/ui/data-table.tsx';
+import { Tabs } from '../../src/web/ui/tabs.tsx';
+import { Timestamp } from '../../src/web/ui/timestamp.tsx';
+import {
+  activeToasts,
+  dismissToast,
+  notify,
+  onToastChange,
+  ToastHost,
+} from '../../src/web/ui/toast.tsx';
+
+interface Build {
+  readonly id: string;
+  readonly number: number;
+  readonly commit: string;
+}
+
+const BUILDS: readonly Build[] = [
+  { id: 'b1', number: 9, commit: 'ccc1111' },
+  { id: 'b2', number: 12, commit: 'aaa2222' },
+  { id: 'b3', number: 10, commit: 'bbb3333' },
+];
+
+const COLUMNS: readonly Column<Build>[] = [
+  {
+    id: 'number',
+    header: 'Build',
+    cell: (row) => `#${row.number}`,
+    sortable: true,
+    sortValue: (row) => row.number,
+  },
+  {
+    id: 'commit',
+    header: 'Commit',
+    cell: (row) => row.commit,
+    mono: true,
+    sortable: true,
+    sortValue: (row) => row.commit,
+  },
+  { id: 'runner', header: 'Runner', cell: () => 'in-cluster' },
+];
+
+const order = (markup: string) =>
+  BUILDS.map((build) => ({ id: build.id, at: markup.indexOf(build.commit) }))
+    .sort((left, right) => left.at - right.at)
+    .map((entry) => entry.id);
+
+describe('DataTable sorts what it is told to and says so', () => {
+  test('a header cycles unsorted → ascending → descending → unsorted', () => {
+    // The third press is the one that matters: the order the server sent is
+    // itself an answer (newest first, on every ledger), and a two-state toggle
+    // makes it unreachable for the rest of the session.
+    const first = nextSort(null, 'number');
+    expect(first).toEqual({ id: 'number', direction: 'asc' });
+    const second = nextSort(first, 'number');
+    expect(second).toEqual({ id: 'number', direction: 'desc' });
+    expect(nextSort(second, 'number')).toBeNull();
+  });
+
+  test('pressing a different header starts that column ascending', () => {
+    expect(nextSort({ id: 'number', direction: 'desc' }, 'commit')).toEqual({
+      id: 'commit',
+      direction: 'asc',
+    });
+  });
+
+  test('numbers compare as numbers', () => {
+    // `9`, `12`, `10` sorted as strings gives 10, 12, 9 — a build ledger that
+    // looks sorted and is not.
+    expect(
+      sortRows(BUILDS, COLUMNS, { id: 'number', direction: 'asc' }).map(
+        (row) => row.number,
+      ),
+    ).toEqual([9, 10, 12]);
+    expect(
+      sortRows(BUILDS, COLUMNS, { id: 'number', direction: 'desc' }).map(
+        (row) => row.number,
+      ),
+    ).toEqual([12, 10, 9]);
+  });
+
+  test('the rows it was handed are never reordered in place', () => {
+    sortRows(BUILDS, COLUMNS, { id: 'commit', direction: 'desc' });
+    expect(BUILDS.map((row) => row.id)).toEqual(['b1', 'b2', 'b3']);
+  });
+
+  test('no sort, or a column with nothing to compare, is the server order', () => {
+    expect(sortRows(BUILDS, COLUMNS, null)).toBe(BUILDS);
+    expect(sortRows(BUILDS, COLUMNS, { id: 'runner', direction: 'asc' })).toBe(
+      BUILDS,
+    );
+  });
+
+  test('aria-sort marks the active column and only the active column', () => {
+    const markup = renderToStaticMarkup(
+      <DataTable
+        columns={COLUMNS}
+        rows={BUILDS}
+        rowKey={(row) => row.id}
+        caption="Builds"
+        initialSort={{ id: 'commit', direction: 'asc' }}
+      />,
+    );
+    // Three headers, exactly one of them sorted. `aria-sort="none"` on the
+    // other two is legal and makes a screen reader announce sortability three
+    // times per row.
+    expect(markup.match(/<th[ >]/g)).toHaveLength(3);
+    expect(markup.match(/aria-sort=/g)).toHaveLength(1);
+    expect(markup).toContain('<caption class="sr-only">Builds</caption>');
+  });
+
+  test('the rendered row order follows the declared sort', () => {
+    const ascending = renderToStaticMarkup(
+      <DataTable
+        columns={COLUMNS}
+        rows={BUILDS}
+        rowKey={(row) => row.id}
+        initialSort={{ id: 'commit', direction: 'asc' }}
+      />,
+    );
+    expect(ascending).toContain('aria-sort="ascending"');
+    expect(order(ascending)).toEqual(['b2', 'b3', 'b1']);
+
+    const descending = renderToStaticMarkup(
+      <DataTable
+        columns={COLUMNS}
+        rows={BUILDS}
+        rowKey={(row) => row.id}
+        initialSort={{ id: 'commit', direction: 'desc' }}
+      />,
+    );
+    expect(descending).toContain('aria-sort="descending"');
+    expect(order(descending)).toEqual(['b1', 'b3', 'b2']);
+  });
+
+  test('a selectable table is one tab stop, not one per row', () => {
+    const markup = renderToStaticMarkup(
+      <DataTable
+        columns={COLUMNS}
+        rows={BUILDS}
+        rowKey={(row) => row.id}
+        selectedKey="b3"
+        onRowSelect={() => undefined}
+      />,
+    );
+    expect(markup.match(/tabindex="0"/g)).toHaveLength(1);
+    expect(markup.match(/tabindex="-1"/g)).toHaveLength(2);
+    // Selection on a `<tr>` is `aria-current`; `aria-selected` outside a grid
+    // reports a state a table row does not have.
+    expect(markup).toContain('aria-current="true"');
+    expect(markup).not.toContain('aria-selected');
+  });
+
+  test('an unselectable table has no tab stops at all', () => {
+    const markup = renderToStaticMarkup(
+      <DataTable columns={COLUMNS} rows={BUILDS} rowKey={(row) => row.id} />,
+    );
+    expect(markup).not.toContain('tabindex');
+  });
+
+  test('no rows renders what the screen said to render instead', () => {
+    const markup = renderToStaticMarkup(
+      <DataTable
+        columns={COLUMNS}
+        rows={[]}
+        rowKey={(row) => row.id}
+        empty={<p>No Builds yet.</p>}
+      />,
+    );
+    expect(markup).toContain('No Builds yet.');
+    expect(markup).not.toContain('<table');
+  });
+});
+
+describe('the shared row keyboard', () => {
+  const press = (key: string, active: number) => {
+    const moved: number[] = [];
+    const activated: number[] = [];
+    let prevented = 0;
+    rowKeyboard({
+      count: 3,
+      active,
+      onActive: (next) => moved.push(next),
+      onActivate: (index) => activated.push(index),
+    })({ key, preventDefault: () => (prevented += 1) });
+    return { moved, activated, prevented };
+  };
+
+  test('arrows move one row and clamp at both ends', () => {
+    expect(press('ArrowDown', 0).moved).toEqual([1]);
+    expect(press('ArrowUp', 1).moved).toEqual([0]);
+    // Clamped, not wrapped: arrowing off the bottom into the top loses the
+    // reader's place invisibly.
+    expect(press('ArrowUp', 0).moved).toEqual([0]);
+    expect(press('ArrowDown', 2).moved).toEqual([2]);
+  });
+
+  test('Home and End go to the ends', () => {
+    expect(press('Home', 2).moved).toEqual([0]);
+    expect(press('End', 0).moved).toEqual([2]);
+  });
+
+  test('Enter activates the row the reader is on', () => {
+    const { activated, moved } = press('Enter', 1);
+    expect(activated).toEqual([1]);
+    expect(moved).toEqual([]);
+  });
+
+  test('any other key is left to the browser', () => {
+    const { moved, activated, prevented } = press('Tab', 1);
+    expect(moved).toEqual([]);
+    expect(activated).toEqual([]);
+    // The one that would be silent: swallowing Tab traps a keyboard reader in
+    // the table.
+    expect(prevented).toBe(0);
+  });
+});
+
+describe('Timestamp carries the instant, not only the phrase', () => {
+  const AT = '2026-08-07T18:04:05.000Z';
+
+  test('the machine-readable instant and the hover agree with each other', () => {
+    const markup = renderToStaticMarkup(<Timestamp at={AT} when="8m ago" />);
+    // Matched case-insensitively: `dateTime` is a JSX prop name and React is
+    // free to emit either casing, while HTML attribute names are not
+    // case-sensitive. What must not vary is that the attribute is there at all.
+    expect(markup).toMatch(new RegExp(`datetime="${AT}"`, 'i'));
+    expect(markup).toContain(`title="${AT}"`);
+    expect(markup).toContain('<time');
+  });
+
+  test("a static render shows the server's phrase, so SSR output is unchanged", () => {
+    // The whole point of the external store's server snapshot. If this ever
+    // renders a browser-computed relative time, the markup depends on the
+    // machine that rendered it.
+    expect(renderToStaticMarkup(<Timestamp at={AT} when="8m ago" />)).toContain(
+      '8m ago',
+    );
+  });
+
+  test('an instant the read model could not supply states nothing', () => {
+    expect(renderToStaticMarkup(<Timestamp at="" />)).toBe('');
+    expect(renderToStaticMarkup(<Timestamp at="" when="8m ago" />)).toContain(
+      '8m ago',
+    );
+  });
+});
+
+describe('copying a value', () => {
+  const withClipboard = async <T,>(
+    clipboard: unknown,
+    body: () => Promise<T>,
+  ): Promise<T> => {
+    const previous = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { clipboard },
+      configurable: true,
+      writable: true,
+    });
+    try {
+      return await body();
+    } finally {
+      if (previous) Object.defineProperty(globalThis, 'navigator', previous);
+      else Reflect.deleteProperty(globalThis, 'navigator');
+    }
+  };
+
+  test('hands the whole value to the clipboard', async () => {
+    const written: string[] = [];
+    const done = await withClipboard(
+      { writeText: async (value: string) => void written.push(value) },
+      () => copyValue('sha256:0123456789abcdef0123456789abcdef'),
+    );
+    expect(done).toBe(true);
+    expect(written).toEqual(['sha256:0123456789abcdef0123456789abcdef']);
+  });
+
+  test('a refused or absent clipboard is an answer, not a crash', async () => {
+    expect(await withClipboard(undefined, () => copyValue('x'))).toBe(false);
+    expect(
+      await withClipboard(
+        {
+          writeText: async () => {
+            throw new Error('denied');
+          },
+        },
+        () => copyValue('x'),
+      ),
+    ).toBe(false);
+  });
+
+  test('Ref shortens what it shows and copies what it was given', () => {
+    const digest = 'sha256:0123456789abcdef0123456789abcdef';
+    const markup = renderToStaticMarkup(<Ref value={digest} kind="digest" />);
+    expect(markup).toContain('>sha256:0123456789ab<');
+    // Truncation is a display decision; the full value has to still be
+    // reachable, by hover and by the button's own value.
+    expect(markup).toContain(`title="${digest}"`);
+    expect(markup).toContain('aria-label="Copy digest"');
+  });
+});
+
+describe('Tabs are one tab stop with a selected tab', () => {
+  const ITEMS = [
+    { id: 'sources', label: 'Sources' },
+    { id: 'builds', label: 'Builds', count: 12 },
+    { id: 'artifacts', label: 'Artifacts' },
+  ];
+
+  const markup = renderToStaticMarkup(
+    <Tabs
+      items={ITEMS}
+      current="builds"
+      onSelect={() => undefined}
+      label="Supply chain"
+    />,
+  );
+
+  test('the roving tabindex leaves exactly one stop', () => {
+    expect(markup.match(/tabindex="0"/g)).toHaveLength(1);
+    expect(markup.match(/tabindex="-1"/g)).toHaveLength(2);
+  });
+
+  test('the selection is a selection, not a claim about the page', () => {
+    expect(markup).toContain('role="tablist"');
+    expect(markup.match(/role="tab"/g)).toHaveLength(3);
+    expect(markup).toContain('aria-selected="true"');
+    // The three hand-rolled strips this replaces all said `aria-current="page"`
+    // on a button that changed a filter.
+    expect(markup).not.toContain('aria-current');
+  });
+
+  test('a count belongs to the tab that has one', () => {
+    expect(markup).toContain('12');
+  });
+});
+
+describe('the toast store', () => {
+  test('notify reaches a subscriber, and unsubscribing stops it', () => {
+    let seen = 0;
+    const stop = onToastChange(() => (seen += 1));
+    notify({ tone: 'success', title: 'Rolled back to build 1187' });
+    expect(seen).toBe(1);
+    expect(activeToasts().map((toast) => toast.title)).toContain(
+      'Rolled back to build 1187',
+    );
+
+    const id = activeToasts()[activeToasts().length - 1]?.id ?? '';
+    dismissToast(id);
+    expect(seen).toBe(2);
+    expect(activeToasts().map((toast) => toast.id)).not.toContain(id);
+
+    stop();
+    notify({ tone: 'accent', title: 'ignored' });
+    expect(seen).toBe(2);
+    dismissToast(activeToasts()[activeToasts().length - 1]?.id ?? '');
+  });
+
+  test('dismissing something already gone notifies nobody', () => {
+    let seen = 0;
+    const stop = onToastChange(() => (seen += 1));
+    dismissToast('toast:nonexistent');
+    stop();
+    expect(seen).toBe(0);
+  });
+
+  test('a static render of the host is the live region and nothing in it', () => {
+    notify({ tone: 'destructive', title: 'The rollback was refused' });
+    const markup = renderToStaticMarkup(<ToastHost />);
+    // The region has to exist before it holds anything — one inserted at the
+    // same moment as its content is not reliably announced. And the server
+    // snapshot is empty, so a result raised on one reader's screen cannot be
+    // baked into markup rendered for another.
+    expect(markup).toContain('aria-live="polite"');
+    expect(markup).not.toContain('The rollback was refused');
+    dismissToast(activeToasts()[activeToasts().length - 1]?.id ?? '');
+  });
+});

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -743,6 +743,16 @@ describe('the App workspace', () => {
       // And says whose runs they are. An App with a service and two jobs has
       // three runtimes, and a card headed only "Recent runs" names none of them.
       expect(markup).toContain('Output of nightly');
+    });
+
+    test('and the config of that Component, on the view that holds config', () => {
+      // Config is scoped to one (Component, Target) pair and this App has
+      // several, so the heading names whose keys these are — a heading that
+      // said only "Config" was the same list claiming to be the App's.
+      const markup = renderToStaticMarkup(
+        <Workspace view={view} tab="config" />,
+      );
+
       expect(markup).toContain('Configuration for nightly');
       expect(markup).toContain('RETENTION_DAYS');
     });
@@ -893,6 +903,154 @@ describe('the App workspace', () => {
         expect(text).toContain(entry.title);
       }
     });
+  });
+});
+
+/**
+ * What the App surface says now that the read model carries it.
+ *
+ * Every claim below is about a fact `getAppWorkspace` had in hand and dropped
+ * on the floor — the commit, the instant, the failure reason, the drift, which
+ * prerequisite is unmet. The screen rendered a phase pill over all of them, so
+ * a drifted App read "is live" and a failed one read "has no release serving
+ * yet" with no reason and no evidence.
+ */
+describe('the App workspace states what the release did', () => {
+  const service = WORKSPACE_SCENARIOS.service;
+
+  test('the hero dates the release and names the commit it shipped', () => {
+    const markup = workspace({
+      ...service,
+      commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+      when: '8m ago',
+      at: '2026-07-28T13:00:00.000Z',
+    });
+
+    // Shortened to git's own seven, with the whole value on the title so a
+    // hover answers what the ellipsis ate.
+    expect(markup).toContain('a1b2c3d');
+    expect(markup).toContain('2026-07-28T13:00:00.000Z');
+  });
+
+  test('a red release names its reason on the App, not only on the attempt', () => {
+    const markup = workspace({
+      ...service,
+      phase: 'FAILED',
+      urlLive: false,
+      diagnosis: {
+        reason: 'STARTUP_FAILED',
+        blame: 'developer',
+        detail: 'The container exits immediately on start.',
+        evidence: null,
+      },
+    });
+
+    expect(markup).toContain('STARTUP_FAILED');
+    expect(markup).toContain('The container exits immediately on start.');
+  });
+
+  test('a drifted release says so instead of reading as live', () => {
+    // §6 calls drift "information, not an alarm" — and until now the App it is
+    // about was the one screen that could not report it.
+    const markup = workspace({
+      ...service,
+      drift: {
+        since: '2h ago',
+        at: '2026-07-28T13:00:00.000Z',
+        observedDigest: 'sha256:0badc0ffee',
+        detail: null,
+      },
+    });
+
+    expect(markup).toContain('DRIFTED');
+    expect(markup).toContain('since 2h ago');
+  });
+
+  test('an unmet prerequisite is named rather than counted', () => {
+    const markup = workspace({
+      ...service,
+      prerequisitesMet: false,
+      unmetPrerequisites: [
+        {
+          name: 'DELIVERY_OPERATOR',
+          met: false,
+          detail: 'No delivery operator is installed in this cluster.',
+        },
+      ],
+    });
+
+    expect(markup).toContain('1 prerequisite unmet');
+    expect(markup).toContain(
+      'No delivery operator is installed in this cluster.',
+    );
+  });
+
+  test('a Component row carries its own placement, not the selection’s', () => {
+    const markup = workspace({
+      ...service,
+      components: [
+        {
+          ...service.components[0]!,
+          target: 'driftwood/kubernetes',
+          url: 'beacon.apps.example',
+          urlLive: true,
+          when: '8m ago',
+        },
+      ],
+    });
+
+    expect(markup).toContain('driftwood/kubernetes');
+  });
+});
+
+describe('the App workspace has views rather than one column', () => {
+  const service = WORKSPACE_SCENARIOS.service;
+
+  test('the strip names them, and Overview is where an arrival lands', () => {
+    const markup = workspace(service);
+
+    expect(markup).toContain('Releases');
+    expect(markup).toContain('role="tablist"');
+    // The hero is above the strip: whether the App is up is not a tab you can
+    // be on the wrong one of.
+    expect(markup.indexOf('is live')).toBeLessThan(
+      markup.indexOf('role="tablist"'),
+    );
+  });
+
+  test('config is behind its own view, and off the Overview', () => {
+    expect(workspace(service)).not.toContain('value is write-only');
+  });
+
+  test('the live tail follows, and says what it dropped', () => {
+    // `app.tsx` appends every socket page forever. Without a cap the pane grew
+    // the page without bound while the newest line sat off-screen.
+    const chatty = workspace({
+      ...service,
+      runtime: {
+        kind: 'stream',
+        componentId: 'component-beacon-web',
+        targetId: 'target-metal',
+        reach: '7 days',
+        lines: Array.from({ length: 2_050 }, (_, index) => ({
+          text: `line ${index}`,
+        })),
+      },
+    });
+
+    expect(chatty).toContain('Showing the last 2000 lines');
+    expect(chatty).not.toContain('line 0\n');
+    // Following is what gives the pane a bottom to scroll to.
+    expect(chatty).toContain('max-h-[420px]');
+  });
+
+  test('no button on this screen does nothing when it is pressed', () => {
+    // `SectionHeader` renders its verb whether or not a handler was passed, so
+    // these two read as broken features rather than absent ones.
+    const markup = workspace(service);
+
+    expect(markup).not.toContain('Add Component');
+    expect(markup).not.toContain('Attach Datastore');
   });
 });
 
@@ -1185,9 +1343,12 @@ describe('changing how a Component is reached (§9)', () => {
 
 describe('editing config from the workspace (§10)', () => {
   const view = WORKSPACE_SCENARIOS.service;
+  /** Config is its own view of the App now, so the assertions open it. */
+  const config = (v: WorkspaceView) =>
+    renderToStaticMarkup(<Workspace view={v} tab="config" />);
 
   test('every configured key is shown, and nothing about its value is', () => {
-    const markup = workspace(view);
+    const markup = config(view);
     for (const key of view.configKeys) {
       expect(markup).toContain(key);
     }
@@ -1202,11 +1363,12 @@ describe('editing config from the workspace (§10)', () => {
   test('the affordance is on the section only where an act is wired', () => {
     // No form whose Save cannot be called — the same rule §9's Reach card
     // states above.
-    expect(workspace(view)).not.toContain('Set variable');
+    expect(config(view)).not.toContain('Set variable');
 
     const markup = renderToStaticMarkup(
       <Workspace
         view={view}
+        tab="config"
         onSetConfig={async () => ({
           ok: true,
           written: [],


### PR DESCRIPTION
The operator walked a clean installation by hand and the verdict was that the product is thinner than what it knows. It is. This pass changes almost no behaviour and surfaces a great deal the server already returned and the screen dropped on the floor.

## Three defects found by clicking, not by reading

- **Confirming a discovered candidate produced no visible change anywhere.** `discovery.tsx` drew each row's selected state from `fact.suggested` rather than from the document being edited.
- **Applying a suggested project did not seed the narrowing input**, so the two-stage discovery the server deliberately staged could not be completed without hand-copying a label whose text is `"<project> — this deployment's own credential"`.
- **The settings screen rendered a titled "Installation manifest" card with a permanently empty body**, because every top-level manifest key is an object or an array and the list it rendered could only ever be `[]`.

## The foundation was one third of a design system

Six primitives against twenty thousand lines. Zero `<table>` in a product whose whole job is ledgers; three tab strips with three treatments; one error box copied verbatim ten times in `app.tsx`; sixteen distinct font sizes with `text-[11px]` outnumbering every named size combined; a light theme that was fully declared and failed AA on its own call to action.

Eleven primitives now carry it — `Page`, `DataTable`, `Tabs`, `Skeleton`, `EmptyState`, `ErrorState`, `Metric`, `Timestamp`, `Copy`/`Ref`, `Toast`, `Kbd` — with a real type and spacing scale, unified radii, every raw token declared once through `light-dark()`, and the stored theme stamped before the stylesheet so a light preference no longer flashes dark on load.

## The wizard says where you are

A step rail naming all four asks — their titles already existed in `ONBOARDING_ASKS` and were only ever shown one at a time. Per-step validation instead of one refusal at the end that teleported back to step one with a sentence full of dotted manifest paths. A real `<form>` per step so Enter advances, `autoFocus`, an `aria-live` region, and the step in the hash so a reload does not lose four answers.

The four questions are still four questions. `onboarding.tsx`'s header explains why, and that reasoning is untouched.

## The ledgers became ledgers

Sortable tables with the columns the model already carried: a build's `dispatchWaitingOn` as the sentence it is rather than a colour and a number, its runner and artifact, an artifact's signature as a word rather than a shade of grey, a source's origin and commit, and a timestamp on rows that set `at` and never rendered it. Overview stops calling the newest twelve rows a fleet total and says `12+`.

## The App surface stops lying

`apps/list.ts` read an App's phase off `components[0]` only, so a multi-component App reported the wrong state — worst-of now, with the live commit, the release and a time on the row. `listDeploys` was a registered command with `rollbackable` per row that the browser never called; there is a Releases tab with inline rollback. Drift, the failure `detail` and the unmet prerequisite were all loaded by the workspace query and never reached the screen.

## Chrome

Breadcrumbs that name the entity instead of the first path segment. A keyboard-reachable account menu where a non-focusable `<span title>` used to hold the operator's name. Skeletons shaped like the screen that is loading. A retry on every failed read. Toasts — which gives success a channel it has never had. And a command palette on ⌘K, the first keyboard shortcut this application has.

## Validation

- `bun run typecheck` clean, `bun run lint` clean, `bun run build` succeeds.
- **`bun test` — 2053 pass / 0 fail across 144 files**, run against a real Postgres. The whole suite, not just `test/web`: the DB-gated tests cover `src/commands/apps/{list,workspace}.ts`, which this changes.
- 26 new primitive tests, 14 new shell tests, plus per-area additions; no existing assertion was weakened to go green.
- No new dependencies.

## Risk worth naming

The client bundle is **6613 KiB against a 6815 KiB ceiling** (`test/web/client-bundle.test.ts` sums every file in `dist`, sourcemaps included). It passes with about 42 KiB of headroom, where the comment above the assertion records "~6.0 MiB measured today" — this UI work spent nearly all the slack that comment describes. No server code leaked into the client graph: `drizzle-orm`, `@opentelemetry`, `src/db/client` and `postgres` are all absent, and the four bundle-graph assertions pass, so the growth is honest UI. 4.26 MiB of the total is `chunk-*.js.map`; the JS itself is 2.2 MiB. If the ceiling is ever hit, excluding sourcemaps from the measurement is the cheap fix, and it should be a deliberate decision rather than a number quietly raised.
