### PR TITLE
fix(spindrift): retry the run lookup a successful dispatch is waiting on

### DIFF
--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -454,26 +454,42 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       timeoutMs: this.options.discoveryMs ?? DEFAULT_RUN_DISCOVERY_MS,
     });
     let run: ActionsRun | null = null;
+    // A lookup the far side would not answer is retried until the discovery
+    // deadline, not treated as the dispatch failing: the dispatch already
+    // succeeded and is already on the log, and a `5xx` is the one status class
+    // that says nothing about the request. The last refusal is kept so that a
+    // deadline that expires this way blames the lookup, not the dispatch.
+    let lookupFailure: string | null = null;
     while (run === null) {
       if (discovery.expired()) {
-        yield {
-          type: 'log',
-          at: now(),
-          line: `no run named “${runName}” appeared in ${repository}`,
-        };
+        const complaint =
+          lookupFailure === null
+            ? `no run named “${runName}” appeared in ${repository}`
+            : `the lookup for run “${runName}” in ${repository} kept failing: ${lookupFailure}`;
+        yield { type: 'log', at: now(), line: complaint };
         return buildFailed(
           logs,
           'TARGET_UNREACHABLE',
-          `the workflow was dispatched but no run appeared in ${repository}`,
+          `the workflow was dispatched but ${complaint}`,
           { repository, workflow, runName },
         );
       }
       await discovery.tick();
-      const runs = await host.workflowRuns(ref, repository, {
-        workflow,
-        branch,
-      });
-      run = runs.find((candidate) => candidate.name === runName) ?? null;
+      try {
+        const runs = await host.workflowRuns(ref, repository, {
+          workflow,
+          branch,
+        });
+        run = runs.find((candidate) => candidate.name === runName) ?? null;
+        lookupFailure = null;
+      } catch (error) {
+        lookupFailure = error instanceof Error ? error.message : String(error);
+        yield {
+          type: 'log',
+          at: now(),
+          line: `the dispatch succeeded and the lookup for its run did not; retrying: ${lookupFailure}`,
+        };
+      }
     }
 
     yield { type: 'log', at: now(), line: `run ${run.id} started` };
@@ -496,13 +512,25 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     let jobs: readonly ActionsJob[] = [];
 
     for (;;) {
-      jobs = await host.runJobs(ref, repository, run.id);
-      for (const event of stepEvents(jobs, seen, now())) yield event;
+      try {
+        jobs = await host.runJobs(ref, repository, run.id);
+        for (const event of stepEvents(jobs, seen, now())) yield event;
 
-      const current = await host.workflowRun(ref, repository, run.id);
-      if (current !== null && current.status === 'completed') {
-        conclusion = current.conclusion;
-        break;
+        const current = await host.workflowRun(ref, repository, run.id);
+        if (current !== null && current.status === 'completed') {
+          conclusion = current.conclusion;
+          break;
+        }
+      } catch (error) {
+        // Same posture as the discovery lookup: the run demonstrably exists,
+        // so a status read the far side would not answer is retried within
+        // the budget rather than ending a build that is still going.
+        const detail = error instanceof Error ? error.message : String(error);
+        yield {
+          type: 'log',
+          at: now(),
+          line: `the status of run ${run.id} could not be read; retrying: ${detail}`,
+        };
       }
       if (budget.expired()) {
         return buildFailed(

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -348,9 +348,47 @@ describe('the hosted build route', () => {
     expect(result.status).toBe('FAILED');
     if (result.status === 'FAILED') {
       expect(result.reason).toBe('TARGET_UNREACHABLE');
-      expect(result.detail).toContain('no run appeared');
+      expect(result.detail).toContain('no run named');
     }
     expect(text(events)).toContain('no run named');
+  });
+
+  test('a lookup that flakes after a successful dispatch is retried, not failed', async () => {
+    // Observed live: the dispatch worked, the call that goes looking for the
+    // run it created answered `500`, and the build was recorded `FAILED` while
+    // the run it dispatched ran to green. A `5xx` is the far side's fault by
+    // definition — it says nothing about the dispatch, which already succeeded
+    // and is already on the log.
+    const { route } = hostedRoute({ actions: { listFailures: 2 } });
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('SUCCEEDED');
+    expect(text(events)).toContain('the dispatch succeeded');
+    expect(text(events)).toContain('retrying');
+  });
+
+  test('a lookup that never recovers blames the lookup, not the dispatch', async () => {
+    const { route } = hostedRoute(
+      { actions: { listFailures: 1000 } },
+      { discoveryMs: 5_000 },
+    );
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('TARGET_UNREACHABLE');
+      expect(result.detail).toContain('the workflow was dispatched but');
+      expect(result.detail).toContain('kept failing');
+    }
+    expect(text(events)).not.toContain('dispatch failed');
+  });
+
+  test('a status read that flakes mid-run is retried within the budget', async () => {
+    const { route } = hostedRoute({ actions: { statusFailures: 2 } });
+    const { events, result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('SUCCEEDED');
+    expect(text(events)).toContain('could not be read; retrying');
   });
 
   test('a red run is a build failure carrying the runner’s own log', async () => {

--- a/apps/spindrift/test/harness/fakes/github-api.ts
+++ b/apps/spindrift/test/harness/fakes/github-api.ts
@@ -90,6 +90,13 @@ export interface FakeActionsOptions {
    * its text — the one failure a green run can still die of.
    */
   logStatus?: number;
+  /**
+   * List calls that answer `500` before the endpoint serves. Models the far
+   * side flaking on the lookup for a run whose dispatch already worked.
+   */
+  listFailures?: number;
+  /** Status reads that answer `500` before the endpoint serves. */
+  statusFailures?: number;
 }
 
 interface FakeRun {
@@ -169,6 +176,7 @@ export class FakeGitHub {
   private pullNumber = 0;
   private runNumber = 0;
   private listCalls = 0;
+  private statusCalls = 0;
   private readonly runs: FakeRun[] = [];
   private readonly actions: Required<FakeActionsOptions>;
 
@@ -182,6 +190,8 @@ export class FakeGitHub {
       conclusion: options.actions?.conclusion ?? 'success',
       log: options.actions?.log ?? defaultBuildLog,
       logStatus: options.actions?.logStatus ?? 200,
+      listFailures: options.actions?.listFailures ?? 0,
+      statusFailures: options.actions?.statusFailures ?? 0,
     };
   }
 
@@ -362,6 +372,9 @@ export class FakeGitHub {
     const list = rest.match(/^\/actions\/workflows\/([^/]+)\/runs$/);
     if (list && method === 'GET') {
       this.listCalls += 1;
+      if (this.listCalls <= this.actions.listFailures) {
+        return this.json({ message: 'Server Error' }, 500);
+      }
       const visible =
         this.listCalls > this.actions.discoveryDelay ? this.runs : [];
       return this.json({
@@ -378,6 +391,10 @@ export class FakeGitHub {
     if (read && method === 'GET') {
       const run = this.runs.find((each) => each.id === Number(read[1]));
       if (run === undefined) return this.notFound();
+      this.statusCalls += 1;
+      if (this.statusCalls <= this.actions.statusFailures) {
+        return this.json({ message: 'Server Error' }, 500);
+      }
       run.reads += 1;
       const done = run.reads > this.actions.duration;
       return this.json({


### PR DESCRIPTION
## Summary

Observed live on the acceptance installation's first build: the dispatch worked, the run-discovery call answered `500`, and the build row went `FAILED` while the run it dispatched ran to green on GitHub.

- The discovery loop in the hosted route now retries a lookup the far side would not answer, bounded by the existing discovery deadline, and logs what it is waiting on ("the dispatch succeeded and the lookup for its run did not; retrying: …").
- A deadline that expires with the lookup still failing blames the lookup, not the dispatch: "the workflow was dispatched but the lookup for run … kept failing: …".
- The mid-run status poll (`runJobs`/`workflowRun`) gets the same posture — a transient `5xx` there previously escaped the generator and was stamped "build dispatch failed" by the command's catch-all, exactly like the discovery case, with more exposure (one poll per second for the length of a build).

## Validation

- `bun test` — 2056 pass, 0 fail (full suite against local Postgres)
- Three new tests: a flaking lookup recovers to `SUCCEEDED`, a never-recovering lookup fails as `TARGET_UNREACHABLE` blaming the lookup, a flaking mid-run status read recovers
- `tsc --noEmit` and `biome check` clean

## Risk

The retry is bounded by deadlines that already existed (discovery: 120s default; run watch: the build budget), so a far side that never recovers fails in exactly the same amount of time as before — only the sentence changes.