### PR TITLE
fix(clusters): notice a wedged CoreDNS, and run two of them

### DIFF
--- a/clusters/base/monitoring/coredns-rules.yaml
+++ b/clusters/base/monitoring/coredns-rules.yaml
@@ -1,0 +1,30 @@
+# Cluster CoreDNS losing its API-server watches is invisible from the outside:
+# it keeps serving whatever snapshot it holds, stays Ready (the kubernetes
+# plugin reports ready once and never again), and Postgres-shaped symptoms show
+# up in workloads days later. Observed live: offsite's CoreDNS lost its watches
+# on a CA rotation and answered from a six-day-old snapshot until restarted.
+#
+# The signal is client-go's own request metric, which the kubernetes plugin
+# exports: a transport-level failure — TLS refusal included — is recorded with
+# `code="<error>"`. A healthy CoreDNS logs a handful of these over weeks; a
+# wedged one fails its watch reconnects continuously for as long as it is
+# wedged, which is what the `for:` filters on.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: coredns
+  namespace: monitoring
+  labels:
+    release: prom-stack
+spec:
+  groups:
+    - name: coredns
+      rules:
+        - alert: CoreDNSWatchesFailing
+          expr: sum by (cluster, instance) (rate(coredns_kubernetes_rest_client_requests_total{job="coredns", code="<error>"}[10m])) > 0
+          for: 30m
+          labels:
+            severity: critical
+          annotations:
+            message: CoreDNS on {{ $labels.cluster }} cannot reach the API server
+            description: "CoreDNS ({{ $labels.instance }}) has been failing its API-server requests for 30 minutes. It is still serving DNS — from a snapshot that is no longer being refreshed, so records created or moved since the wedge do not resolve. Restart the coredns Deployment in kube-system and find what broke the connection (certificate rotation is the known cause)."

--- a/clusters/base/monitoring/kustomization.yaml
+++ b/clusters/base/monitoring/kustomization.yaml
@@ -11,5 +11,6 @@ resources:
   - opentelemetry-collector-servicemonitor.yaml
   - grafana-dashboards
   - alertmanager-discord.yaml
+  - coredns-rules.yaml
   - helm-repository-grafana.yaml
   - helm-repository-prometheus.yaml

--- a/terraform/modules/flux-bootstrap/main.tf
+++ b/terraform/modules/flux-bootstrap/main.tf
@@ -171,7 +171,13 @@ resource "kubernetes_deployment_v1" "coredns" {
     }
   }
   spec {
-    replicas = 1
+    # Two, spread across nodes where there are two to spread across: a CoreDNS
+    # that loses its API-server watches keeps serving its last snapshot and
+    # still answers /ready, so a single replica is a single copy of a cache
+    # nothing refreshes. A second replica does not prevent the wedge — a CA
+    # rotation breaks both — but it is the floor for cluster DNS surviving one
+    # pod or one node.
+    replicas = 2
     strategy {
       type = "RollingUpdate"
       rolling_update {
@@ -190,7 +196,24 @@ resource "kubernetes_deployment_v1" "coredns" {
         }
       }
       spec {
-        priority_class_name             = "system-cluster-critical"
+        priority_class_name = "system-cluster-critical"
+        affinity {
+          pod_anti_affinity {
+            # Preferred, not required: a site down to one schedulable node
+            # still gets both replicas rather than one Pending forever.
+            preferred_during_scheduling_ignored_during_execution {
+              weight = 100
+              pod_affinity_term {
+                topology_key = "kubernetes.io/hostname"
+                label_selector {
+                  match_labels = {
+                    "k8s-app" = "kube-dns"
+                  }
+                }
+              }
+            }
+          }
+        }
         service_account_name            = kubernetes_service_account_v1.coredns.metadata[0].name
         dns_policy                      = "Default"
         automount_service_account_token = true


### PR DESCRIPTION
## Summary

Offsite's cluster CoreDNS lost its API-server watches on a CA rotation (`x509: certificate signed by unknown authority`) and answered DNS from the snapshot it held for six days — Ready the whole time, nothing alerting. Two changes, one per unbuilt half:

- **`clusters/base/monitoring/coredns-rules.yaml`** — `CoreDNSWatchesFailing`, critical after 30m of nonzero `coredns_kubernetes_rest_client_requests_total{code="<error>"}` rate. Verified live on folly that the metric and its `<error>` code exist under the `coredns` job (a healthy cluster shows 12 such errors against ~3.4k successes, so the 30m `for:` clears transient blips while a wedge — which retries its watches continuously — keeps firing). Both clusters scrape CoreDNS via the chart's default and both route alerts through the Discord AlertmanagerConfig in `base/monitoring`.
- **`terraform/modules/flux-bootstrap/main.tf`** — CoreDNS runs 2 replicas with preferred hostname anti-affinity. Preferred, not required, so a site down to one schedulable node still gets both replicas. This is availability hygiene, not wedge protection — a CA rotation breaks both replicas' watches, which is what the alert is for.

## Validation

- `mise run k8s:render-apps` — both clusters' overlays render
- `mise run tf:validate` — all roots valid
- `tofu fmt` clean

## Applying

The alert ships with Flux on merge. The module change autoplanned both bootstrap roots on this PR (in-place update of the CoreDNS Deployment only, plus recomputed metadata on `helm_release.flux`); comment `atlantis apply` to roll it (bootstrap declares `automerge: false`, so merge after).

## Risk

The deployment update rolls CoreDNS with `max_unavailable: 1`, so one replica serves throughout the roll. The alert can page at most once per cluster per wedge; its remediation text names the restart and the known cause.

