### PR TITLE
docs(bootstrap): say how a flux-bootstrap change actually ships

### DIFF
--- a/terraform/modules/flux-bootstrap/main.tf
+++ b/terraform/modules/flux-bootstrap/main.tf
@@ -12,6 +12,12 @@ resource "github_repository_deploy_key" "this" {
 
 # CoreDNS is part of the bootstrap boundary: Flux requires cluster DNS before it
 # can fetch and reconcile its own desired state.
+#
+# The boundary has a shipping quirk: both clusters' bootstrap roots consume
+# this module and never automerge, so a change here is applied only when
+# someone comments `atlantis apply` on the PR *before* merging it. A change
+# merged without that sits in git unapplied — invisibly, because every other
+# root in this repository applies on merge.
 
 resource "kubernetes_service_account_v1" "coredns" {
   metadata {


### PR DESCRIPTION
## Summary

A comment in the module recording the shipping quirk of the bootstrap boundary: its roots never automerge, and a direct `clusters/*/bootstrap` change does not autoplan, so a change there ships only when someone drives Atlantis on the PR. Module changes do autoplan both roots — this PR's own plans are the demonstration (they came back "no changes", confirming the CoreDNS replica change from #1920 is applied).

Comment-only; merging changes no infrastructure.