### PR TITLE
fix(bosun): tender cannot boot with Secure Boot on

### DIFF
--- a/terraform/gcp/projects/homelab-ng/bosun.tf
+++ b/terraform/gcp/projects/homelab-ng/bosun.tf
@@ -142,8 +142,18 @@ resource "google_compute_instance" "tender" {
     scopes = ["https://www.googleapis.com/auth/logging.write"]
   }
 
+  # Secure Boot off, and it is not a shortcut. nix/images/gce.nix builds an EFI
+  # image, and nothing signs the NixOS bootloader with a key GCE's UEFI db
+  # trusts, so the firmware rejects it and loops on the boot entry forever:
+  #
+  #   BdsDxe: failed to load Boot0001 ... Status: Security Violation
+  #
+  # oldboy has been in that loop, "RUNNING" and unbooted, since it was created.
+  # vTPM and integrity monitoring stay on; they measure the boot either way.
+  # Turning this back on means signing the bootloader (lanzaboote) and putting
+  # the certificate in the image, which is a project, not a flag.
   shielded_instance_config {
-    enable_secure_boot          = true
+    enable_secure_boot          = false
     enable_vtpm                 = true
     enable_integrity_monitoring = true
   }


### PR DESCRIPTION
tender applied cleanly and came up `RUNNING`, but it has never booted. The
serial console is a loop:

```
BdsDxe: loading Boot0001 "UEFI nvme_card-pd 0nvme_card-pd0 1" ...
UEFI: Failed to load image.
Status: Security Violation.
BdsDxe: failed to load Boot0001 ...: Security Violation
```

`nix/images/gce.nix` builds an EFI image, and nothing signs the NixOS
bootloader with a key in GCE's UEFI db. With Secure Boot on, the firmware
rejects the boot entry and retries it forever. The instance bills, answers no
SSH, and has no `/etc/ssh/ssh_host_ed25519_key` — which is also what blocks
the second stage of its sops setup.

## oldboy is in the same loop

Same image module, same `enable_secure_boot = true`:

```
$ gcloud compute instances describe oldboy --format='value(status,lastStartTimestamp)'
RUNNING   2026-06-20T18:10:58-07:00

$ gcloud compute instances get-serial-port-output oldboy | tail -1
BdsDxe: failed to load Boot0001 "UEFI Google PersistentDisk ": Security Violation
```

It has been up and unbooted since June. This PR does not touch it — the same
one-line change would fix it, and that is worth doing deliberately rather than
as a side effect of unblocking tender.

## What this does not give up

vTPM and integrity monitoring stay on; they measure the boot either way. What
is lost is the firmware refusing to run an unsigned bootloader — which, given
the bootloader here has never been signed, was never actually protecting
anything on this image.

Turning it back on means signing the bootloader (lanzaboote) and shipping the
certificate in the image. That is a project, not a flag, and it belongs with
the repo's other signing trust roots rather than bolted onto this PR.

## Validation

- `tofu validate` — homelab-ng root: **Success**
- `tofu fmt` clean
- `allow_stopping_for_update = true` is already set, so this is a stop, update,
  start rather than a replacement. The boot disk survives — and it holds
  nothing yet, since the host has never booted to generate a host key.

## After this applies

1. Confirm the serial console reaches a NixOS stage-1
2. `gcloud compute ssh tender --tunnel-through-iap`, `ssh-to-age` its
   `/etc/ssh/ssh_host_ed25519_key.pub`, add the recipient to `.sops.yaml`
3. Real PAT into `nix/secrets/tender.sops.yaml`, push, rebuild the host
