### PR TITLE
fix(oldboy): the uptime was the hypervisor's

### DIFF
--- a/terraform/gcp/projects/homelab-ng/compute.tf
+++ b/terraform/gcp/projects/homelab-ng/compute.tf
@@ -63,8 +63,18 @@ resource "google_compute_instance" "oldboy" {
     scopes = ["cloud-platform"]
   }
 
+  # Secure Boot off. images/gce.nix builds an EFI image and nothing signs the
+  # NixOS bootloader with a key GCE's UEFI db trusts, so the firmware rejects
+  # the boot entry and loops on it:
+  #
+  #   BdsDxe: failed to load Boot0001 "UEFI Google PersistentDisk ":
+  #   Security Violation
+  #
+  # Which is to say the uptime this host exists to accumulate was the
+  # hypervisor's, not its own -- it has been RUNNING and unbooted since it was
+  # created. vTPM and integrity monitoring stay on.
   shielded_instance_config {
-    enable_secure_boot          = true
+    enable_secure_boot          = false
     enable_vtpm                 = true
     enable_integrity_monitoring = true
   }


### PR DESCRIPTION
Found while debugging tender, which hit the identical wall. oldboy has been
`RUNNING` since June 20 and has never reached NixOS:

```
$ gcloud compute instances describe oldboy --format='value(status,lastStartTimestamp)'
RUNNING   2026-06-20T18:10:58-07:00

$ gcloud compute instances get-serial-port-output oldboy | tail -1
BdsDxe: failed to load Boot0001 "UEFI Google PersistentDisk ": Security Violation
```

`nix/images/gce.nix` builds an EFI image and nothing signs the NixOS bootloader
with a key in GCE's UEFI db, so with Secure Boot on the firmware rejects the
boot entry and retries it forever.

Which makes the `maximum-uptime` tag a joke at its own expense: the uptime it
has been accumulating is the hypervisor's, not the guest's. This is the change
that lets it start actually racing.

vTPM and integrity monitoring stay on — they measure the boot either way. What
is given up is the firmware refusing an unsigned bootloader, which was never
protecting anything here, because this bootloader has never been signed.

## Validation

- `tofu validate` — homelab-ng root: **Success**
- `tofu fmt` clean
- `allow_stopping_for_update = true` is already set, so this is a stop, update,
  start rather than a replacement

## Risk

The boot disk is `auto_delete = true` and has been written to exactly never, so
there is nothing on it to lose. First real boot regenerates everything from the
image.
