### PR TITLE
fix(gcp): select the newest image tarball, not the first one listed

### DIFF
--- a/terraform/gcp/projects/homelab-ng/bosun.tf
+++ b/terraform/gcp/projects/homelab-ng/bosun.tf
@@ -20,6 +20,14 @@ locals {
   # re-checking the nested-virt column, not just the price.
   tender_machine_type = "c4-standard-8" # 8 vCPU / 30 GB
   tender_disk_size    = 100             # closure + hull + warm x workspace
+
+  # GCS lists objects lexicographically, so element zero is the *oldest* name
+  # the moment the prefix holds more than one build -- not a race, just
+  # reliably the wrong one. The nixpkgs filename carries version and commit
+  # date in sort order, so the newest image is the last element.
+  tender_image_object = reverse(sort([
+    for o in data.google_storage_bucket_objects.tender.bucket_objects : o.name
+  ]))[0]
 }
 
 # No IAM role bindings anywhere: this host needs nothing from GCP beyond
@@ -51,7 +59,7 @@ resource "google_compute_image" "tender" {
   family            = "tender"
   storage_locations = ["us-east1"]
   raw_disk {
-    source = "https://storage.googleapis.com/homelab-ng-free/${data.google_storage_bucket_objects.tender.bucket_objects[0].name}"
+    source = "https://storage.googleapis.com/homelab-ng-free/${local.tender_image_object}"
   }
   guest_os_features {
     type = "UEFI_COMPATIBLE"

--- a/terraform/gcp/projects/homelab-ng/compute.tf
+++ b/terraform/gcp/projects/homelab-ng/compute.tf
@@ -21,13 +21,20 @@ data "google_storage_bucket_objects" "files" {
   prefix = "nixos-image-google-compute"
 }
 
+locals {
+  # Same lexicographic trap as tender's image; see bosun.tf.
+  nixos_image_object = reverse(sort([
+    for o in data.google_storage_bucket_objects.files.bucket_objects : o.name
+  ]))[0]
+}
+
 resource "google_compute_image" "nixos" {
   provider          = google.free-tier
   name              = "nixos"
   family            = "nixos"
   storage_locations = ["us-east1"]
   raw_disk {
-    source = "https://storage.googleapis.com/homelab-ng-free/${data.google_storage_bucket_objects.files.bucket_objects[0].name}"
+    source = "https://storage.googleapis.com/homelab-ng-free/${local.nixos_image_object}"
   }
   guest_os_features {
     type = "UEFI_COMPATIBLE"


### PR DESCRIPTION
`bucket_objects[0]` picks whichever object name sorts first, because GCS lists
lexicographically. That is not a race — it is reliably the **oldest** build as
soon as a prefix holds more than one. The nixpkgs filename carries version and
commit date in sort order, so the newest image is the last element, not the
first.

Both prefixes hold exactly one object right now:

```
gs://homelab-ng-free/nixos-image-google-compute-26.05.20260611.a037402-…tar.gz
gs://homelab-ng-free/tender/nixos-image-google-compute-26.05.20260801.6d65bfc-…tar.gz
```

so this moves nothing today. It stops being true the next time either image is
rebuilt, at which point `nixos` and `tender` would each quietly pin themselves
to the older tarball.

## This apply also reconciles tender's Secure Boot

Worth knowing before applying, because it is not in this diff.

`enable_secure_boot = false` for tender is on `main`, but the live instance
still reads `true`. #1926 was branched before #1925 merged, so its plan was
computed against code where tender still had Secure Boot on; applying it
reverted what #1925 had just turned off. tender restarted at `02:02:33Z` and is
back in the firmware loop.

`main` is correct and this root has drifted from it, so a fresh plan picks the
change up on its own:

```
# google_compute_instance.tender will be updated in-place
!   enable_secure_boot = true -> false
```

Apply this from a freshly generated plan. A plan made before this PR's merge
carries the same staleness that caused the problem in the first place.

## Validation

- `tofu validate` — homelab-ng root: **Success**
- `tofu fmt` clean
- Expected plan: the tender Secure Boot flip and nothing else. If either image
  shows as replaced, the selection expression picked a different object than
  `[0]` did and that is worth reading before applying.
