### PR TITLE
feat(spindrift): let a files artifact live in the registry, both ways

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -73,6 +73,10 @@ jobs:
             printf 'bundleDigest=%s\n' "$(read_key '.bundleDigest')"
             printf 'location=%s\n'     "$(read_key '.origin.location')"
             printf 'subpath=%s\n'      "$(read_key '.origin.subpath')"
+            # `// "image"` because this file and the controller ship on
+            # different clocks (see `destinations` below): a spec composed
+            # before the field existed built an image, and still does.
+            printf 'artifactType=%s\n' "$(read_key '.artifactType // "image"')"
             # `.destinations` with `.destination` behind it, because this file
             # and the controller ship on different clocks — the same reason
             # `tags` carries a default. A caller pins this workflow by a local
@@ -205,9 +209,35 @@ jobs:
           ROOT: ${{ steps.bundle.outputs.root }}
           SUBPATH: ${{ steps.request.outputs.subpath }}
           FRONTEND: ${{ steps.request.outputs.frontend }}
+          ARTIFACT_TYPE: ${{ steps.request.outputs.artifactType }}
         run: |
           set -euo pipefail
           scope="${ROOT}/${SUBPATH}"
+
+          # A `files` artifact is not built at all: the scope *is* the site,
+          # and what the registry holds is one layer that is the gzipped tar
+          # `bundle.ts` reads back at deploy time. `FROM scratch` + `COPY . /`
+          # makes buildx produce exactly that — a single tar+gzip layer of the
+          # scope's contents — while the push, the provenance, the signature,
+          # the attestation and the report all ride the ordinary pipeline
+          # unchanged, so a files artifact is admitted exactly like an image.
+          # This arm is checked before the Dockerfile one on purpose: the
+          # artifact type decides what the thing *is*, and a Dockerfile in the
+          # scope only ever decided how to build one.
+          # ponytail: a site whose files need a build step first (an
+          # outputDirectory) ships its sources today; grow that arm when a
+          # built site reaches a files Target.
+          if [ "$ARTIFACT_TYPE" = "files" ]; then
+            files="${RUNNER_TEMP}/files-artifact"
+            mkdir -p "$files"
+            printf 'FROM scratch\nCOPY . /\n' > "${files}/Dockerfile"
+            {
+              printf 'context=%s\n' "$scope"
+              printf 'file=%s\n' "${files}/Dockerfile"
+              printf 'buildArgs=\n'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           # The scope names the Dockerfile; the bundle root is what it builds.
           # A monorepo App is one subpath of a tree it shares a lockfile,

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -66,6 +66,7 @@ import type {
   StartedRun,
 } from '../contract.ts';
 import { BundleError, type BundleFile, readBundle } from './bundle.ts';
+import { googleRegistryRef, OciPullError, pullFilesLayer } from './oci.ts';
 
 export interface StaticAdapterOptions {
   /** Mints a bearer token per request. Never a stored credential (§13). */
@@ -174,12 +175,30 @@ export class StaticDeployAdapter implements DeployAdapter {
       );
     }
     // No registry filter: a static Target serves `files`, and the reachability
-    // §3 models over registries is about pulling an image. Its discovery says
-    // so itself — `reachableRegistries: []`.
-    const location = artifactAddress(desired.artifact);
+    // §3 models over registries is about a *runtime* pulling an image. This
+    // adapter is the one that pulls for itself, so the choice here is by what
+    // its own identity can read: a staged URL is fetched directly (a supplied
+    // upload's address), and among registry references only a Google-family
+    // one is readable with the federated token this adapter already holds —
+    // `ghcr.io` would take a credential the manifest deliberately does not
+    // model (§13).
+    const staged = artifactAddress(desired.artifact);
+    const location = /^https?:\/\//.test(staged ?? '')
+      ? staged
+      : googleRegistryRef(desired.artifact.refs);
     if (location === null) {
-      yield this.status('FAILED', { reason: 'INTERNAL' });
-      return this.internal('the artifact carries no address to fetch it from');
+      yield this.status('FAILED', { reason: 'ARTIFACT_UNAVAILABLE' });
+      const hosts = desired.artifact.refs
+        .map((ref) => ref.split('/')[0])
+        .join(', ');
+      return {
+        phase: 'FAILED',
+        reason: 'ARTIFACT_UNAVAILABLE',
+        detail:
+          desired.artifact.refs.length === 0
+            ? 'the artifact carries no address to fetch it from'
+            : `static hosting fetches the bytes itself, and none of the artifact's homes (${hosts}) is a registry its identity can read`,
+      };
     }
 
     const site = siteId(desired);
@@ -365,17 +384,40 @@ export class StaticDeployAdapter implements DeployAdapter {
     http: CloudHttp,
     location: string,
   ): Promise<readonly BundleFile[]> {
-    const fetched = await http.bytes(location);
-    if (!fetched.ok) {
-      // §6 blames the **platform** for an artifact that cannot be fetched, and
-      // this is exactly that case: the build is green and the bytes are not
-      // there. Raised as a typed error so `apply` maps it to the right reason
-      // rather than to whichever one this branch happened to be near.
+    // A staged URL is a supplied upload's address and is fetched as it always
+    // was. Anything else is a registry reference — the shape every built
+    // artifact's ref has — and the bytes are the artifact's one layer.
+    if (/^https?:\/\//.test(location)) {
+      const fetched = await http.bytes(location);
+      if (!fetched.ok) {
+        // §6 blames the **platform** for an artifact that cannot be fetched,
+        // and this is exactly that case: the build is green and the bytes are
+        // not there. Raised as a typed error so `apply` maps it to the right
+        // reason rather than to whichever one this branch happened to be near.
+        throw new ArtifactUnavailable(
+          `the artifact at ${location} could not be fetched: ${fetched.message}`,
+        );
+      }
+      return readBundle(fetched.value);
+    }
+    let layer: Uint8Array<ArrayBuffer>;
+    try {
+      layer = await pullFilesLayer({
+        ref: location,
+        token: this.options.token,
+        ...(this.options.fetch === undefined
+          ? {}
+          : { fetch: this.options.fetch }),
+      });
+    } catch (cause) {
+      if (!(cause instanceof OciPullError)) throw cause;
+      // Same blame as the URL arm: the build is green and the bytes are not
+      // fetchable in the form this Target serves.
       throw new ArtifactUnavailable(
-        `the artifact at ${location} could not be fetched: ${fetched.message}`,
+        `the artifact at ${location} could not be fetched: ${cause.message}`,
       );
     }
-    return readBundle(fetched.value);
+    return readBundle(layer);
   }
 
   /** The site, created if this is the first deploy to it. */

--- a/apps/spindrift/src/adapters/deploy/static/oci.ts
+++ b/apps/spindrift/src/adapters/deploy/static/oci.ts
@@ -1,0 +1,199 @@
+/**
+ * Pulling a `files` artifact out of an OCI registry.
+ *
+ * Static hosting is the one backend where the **controller** must hold the
+ * bytes: Cloud Run and Kubernetes hand a reference to a runtime that does its
+ * own pulling, but the hosting API is fed files, so whatever this adapter
+ * deploys it must first fetch. A `files` Build lands in the registry like
+ * every other artifact — as a single-layer image whose one layer *is* the
+ * gzipped tar `bundle.ts` reads (the build workflow's files arm produces
+ * exactly that with `FROM scratch` + `COPY . /`) — and this module is the read
+ * half of that agreement.
+ *
+ * It speaks just enough of the distribution API to resolve one digest to one
+ * layer: manifest, index-to-child, blob. It is not a registry client; there is
+ * deliberately no tag resolution, no listing, and no push.
+ *
+ * **Google-family registries only.** The adapter's identity is the federated
+ * token it already presents to the hosting API, and Artifact Registry accepts
+ * that same token as a Bearer credential on its Docker API. Nothing here can
+ * read `ghcr.io` — that would take a credential the manifest deliberately does
+ * not model (§13) — which is why the caller chooses the ref, not this module.
+ *
+ * The blob request may answer with a redirect to signed storage. The runtime's
+ * fetch follows it, and undici drops the `Authorization` header on the
+ * cross-origin hop — which is required, because a signed URL refuses a request
+ * that also carries credentials.
+ */
+import type { Fetcher, TokenProvider } from '../cloud/http.ts';
+
+/** Why a pull failed, as a sentence the deploy verdict can carry. */
+export class OciPullError extends Error {
+  override readonly name = 'OciPullError';
+}
+
+/** One reference, split into the three parts the v2 API addresses. */
+export interface OciRef {
+  readonly host: string;
+  readonly repository: string;
+  readonly digest: string;
+}
+
+/** `host/repository@sha256:…`, or null for anything else. */
+export function parseOciRef(ref: string): OciRef | null {
+  const match = /^([^/@\s]+)\/([^@\s]+)@(sha256:[0-9a-f]{64})$/.exec(ref);
+  if (match === null) return null;
+  return {
+    host: match[1] as string,
+    repository: match[2] as string,
+    digest: match[3] as string,
+  };
+}
+
+/**
+ * The first reference on a registry the adapter's own token reads.
+ *
+ * The predicate is the build workflow's `googleHosts` one, read from the other
+ * end: the hosts the runner logs into with the federated identity are exactly
+ * the hosts that identity can read back from.
+ */
+export function googleRegistryRef(refs: readonly string[]): string | null {
+  return (
+    refs.find((ref) => {
+      const host = ref.split('/')[0] ?? '';
+      return host.endsWith('-docker.pkg.dev') || host === 'gcr.io';
+    }) ?? null
+  );
+}
+
+/** Every manifest shape the one GET may answer with. */
+const MANIFEST_ACCEPT = [
+  'application/vnd.oci.image.index.v1+json',
+  'application/vnd.oci.image.manifest.v1+json',
+  'application/vnd.docker.distribution.manifest.list.v2+json',
+  'application/vnd.docker.distribution.manifest.v2+json',
+].join(', ');
+
+/** The two spellings of "a gzipped tar" the two manifest families use. */
+const GZIPPED_TAR_LAYERS = new Set([
+  'application/vnd.oci.image.layer.v1.tar+gzip',
+  'application/vnd.docker.image.rootfs.diff.tar.gzip',
+]);
+
+/** As much of a descriptor as choosing and fetching needs. */
+interface Descriptor {
+  readonly mediaType?: string;
+  readonly digest?: string;
+  readonly annotations?: Readonly<Record<string, string>>;
+  readonly platform?: { readonly os?: string; readonly architecture?: string };
+}
+
+/** An index and an image manifest, read through one shape. */
+interface Manifest {
+  readonly manifests?: readonly Descriptor[];
+  readonly layers?: readonly Descriptor[];
+}
+
+/** The files artifact's one layer, as the gzipped tar `readBundle` takes. */
+export async function pullFilesLayer(input: {
+  readonly ref: string;
+  readonly token: TokenProvider;
+  readonly fetch?: Fetcher;
+}): Promise<Uint8Array<ArrayBuffer>> {
+  const parsed = parseOciRef(input.ref);
+  if (parsed === null) {
+    throw new OciPullError(`not a registry reference: ${input.ref}`);
+  }
+  const send = input.fetch ?? ((request: Request) => fetch(request));
+  const authorization = `Bearer ${await input.token()}`;
+
+  const outer = await manifestOf(send, authorization, parsed, parsed.digest);
+  const image = await imageOf(send, authorization, parsed, outer, input.ref);
+
+  const layers = image.layers ?? [];
+  if (layers.length !== 1) {
+    // The one mismatch worth its own sentence: a multi-layer object at a
+    // files address is an *image* — a Build made by a route with no files arm
+    // — and "N layers" is what tells that story apart from a corrupt push.
+    throw new OciPullError(
+      `the artifact at ${input.ref} carries ${layers.length} layers — a files artifact is one gzipped tar, and this is an image`,
+    );
+  }
+  const layer = layers[0] as Descriptor;
+  if (!GZIPPED_TAR_LAYERS.has(layer.mediaType ?? '')) {
+    throw new OciPullError(
+      `the artifact's one layer is ${layer.mediaType ?? 'untyped'} rather than a gzipped tar`,
+    );
+  }
+  if (layer.digest === undefined) {
+    throw new OciPullError('the artifact names a layer with no digest');
+  }
+
+  const blob = await send(
+    new Request(
+      `https://${parsed.host}/v2/${parsed.repository}/blobs/${layer.digest}`,
+      { headers: { Authorization: authorization } },
+    ),
+  );
+  if (!blob.ok) {
+    throw new OciPullError(
+      `fetching the files layer ${layer.digest} answered ${blob.status}`,
+    );
+  }
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+/** One manifest GET, refused as a sentence rather than a status. */
+async function manifestOf(
+  send: Fetcher,
+  authorization: string,
+  ref: OciRef,
+  digest: string,
+): Promise<Manifest> {
+  const response = await send(
+    new Request(
+      `https://${ref.host}/v2/${ref.repository}/manifests/${digest}`,
+      {
+        headers: { Accept: MANIFEST_ACCEPT, Authorization: authorization },
+      },
+    ),
+  );
+  if (!response.ok) {
+    throw new OciPullError(
+      `the registry answered ${response.status} for the manifest at ${digest}`,
+    );
+  }
+  return (await response.json()) as Manifest;
+}
+
+/**
+ * The image manifest under an index, or the manifest itself.
+ *
+ * The selection is the build workflow's own (`Attest the artifact`): a child
+ * is something a runtime could run — not an attestation manifest, not an
+ * `unknown/unknown` platform. `provenance: mode=max` hangs both off every
+ * push, so this filter is the ordinary case rather than a defensive one.
+ */
+async function imageOf(
+  send: Fetcher,
+  authorization: string,
+  ref: OciRef,
+  manifest: Manifest,
+  named: string,
+): Promise<Manifest> {
+  if (manifest.manifests === undefined) return manifest;
+  const children = manifest.manifests.filter(
+    (child) =>
+      child.annotations?.['vnd.docker.reference.type'] !==
+        'attestation-manifest' &&
+      (child.platform?.os ?? '') !== 'unknown' &&
+      (child.platform?.architecture ?? '') !== 'unknown',
+  );
+  const digest = children[0]?.digest;
+  if (children.length !== 1 || digest === undefined) {
+    throw new OciPullError(
+      `the index at ${named} holds ${children.length} runnable manifests where a files artifact holds one`,
+    );
+  }
+  return manifestOf(send, authorization, ref, digest);
+}

--- a/apps/spindrift/test/adapters/files-artifact-arm.test.ts
+++ b/apps/spindrift/test/adapters/files-artifact-arm.test.ts
@@ -1,0 +1,115 @@
+/**
+ * The hosted route's files arm, run as the file actually ships it.
+ *
+ * The other half of this agreement is `static/oci.ts`: the adapter pulls one
+ * layer and reads it as a gzipped tar, which is only true of what this arm
+ * pushes — `FROM scratch` + `COPY . /`, one layer, no build. A fixture cannot
+ * prove the shipped script writes that Dockerfile; running the step's own
+ * `run:` script can (the same reasoning as `build-report-statement.test.ts`).
+ */
+import { describe, expect, test } from 'bun:test';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const WORKFLOW = join(
+  import.meta.dir,
+  '../../../../.github/workflows/spindrift-build.yml',
+);
+const FRONTEND_STEP = 'Choose the frontend';
+
+/** The `run:` script of the named step, straight out of the shipped file. */
+async function frontendScript(): Promise<string> {
+  const document = Bun.YAML.parse(await Bun.file(WORKFLOW).text()) as {
+    jobs: { build: { steps: { name?: string; run?: string }[] } };
+  };
+  const step = document.jobs.build.steps.find((s) => s.name === FRONTEND_STEP);
+  if (step?.run === undefined) {
+    throw new Error(`${WORKFLOW} has no “${FRONTEND_STEP}” step with a script`);
+  }
+  return step.run;
+}
+
+async function runArm(input: {
+  artifactType: string;
+  scopeFiles: Readonly<Record<string, string>>;
+}): Promise<{ outputs: Record<string, string>; workspace: string }> {
+  const workspace = await mkdtemp(join(tmpdir(), 'spindrift-files-arm-'));
+  const root = join(workspace, 'bundle');
+  const scope = join(root, 'site');
+  await mkdir(scope, { recursive: true });
+  for (const [name, contents] of Object.entries(input.scopeFiles)) {
+    await writeFile(join(scope, name), contents);
+  }
+  const outputPath = join(workspace, 'github-output');
+  await writeFile(outputPath, '');
+
+  const script = await frontendScript();
+  const proc = Bun.spawn(['bash', '-c', script], {
+    env: {
+      ...process.env,
+      ROOT: root,
+      SUBPATH: 'site',
+      FRONTEND: 'registry.example.test/zero-config:pinned',
+      ARTIFACT_TYPE: input.artifactType,
+      GITHUB_OUTPUT: outputPath,
+      RUNNER_TEMP: workspace,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`the step exited ${code}: ${stderr}`);
+  }
+
+  const outputs: Record<string, string> = {};
+  for (const line of (await readFile(outputPath, 'utf8')).split('\n')) {
+    const equals = line.indexOf('=');
+    if (equals > 0) {
+      outputs[line.slice(0, equals)] = line.slice(equals + 1);
+    }
+  }
+  return { outputs, workspace };
+}
+
+describe('the files arm of “Choose the frontend”', () => {
+  test('a files artifact is the scope as one scratch COPY, never a build', async () => {
+    const { outputs, workspace } = await runArm({
+      artifactType: 'files',
+      scopeFiles: {
+        'index.html': '<!doctype html>',
+        // A Dockerfile in the scope must not turn a files artifact into an
+        // image build: the artifact type decides what the thing *is*; a
+        // Dockerfile only ever decided how to build one.
+        Dockerfile: 'FROM nginx',
+      },
+    });
+    try {
+      expect(outputs.context).toBe(join(workspace, 'bundle', 'site'));
+      expect(outputs.file).toBe(
+        join(workspace, 'files-artifact', 'Dockerfile'),
+      );
+      const dockerfile = await readFile(outputs.file as string, 'utf8');
+      expect(dockerfile).toBe('FROM scratch\nCOPY . /\n');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('an image with a Dockerfile still builds from the bundle root', async () => {
+    const { outputs, workspace } = await runArm({
+      artifactType: 'image',
+      scopeFiles: { Dockerfile: 'FROM scratch' },
+    });
+    try {
+      expect(outputs.context).toBe(join(workspace, 'bundle'));
+      expect(outputs.file).toBe(
+        join(workspace, 'bundle', 'site', 'Dockerfile'),
+      );
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -39,6 +39,10 @@ import {
   FakeHosting,
   type FakeHostingOptions,
 } from '../harness/fakes/hosting-api.ts';
+import {
+  FakeOciRegistry,
+  type FakeOciRegistryOptions,
+} from '../harness/fakes/oci-registry.ts';
 import { CLOUD_ENDPOINTS } from '../harness/installation.ts';
 import { bytes, header, tar, tarball } from '../harness/tar.ts';
 
@@ -215,6 +219,104 @@ describe('the release is five steps, in the product’s order', () => {
     expect(
       api.pathsOf('POST').filter((path) => path.endsWith('/sites')),
     ).toEqual([]);
+  });
+});
+
+describe('a built files artifact is pulled out of the registry', () => {
+  const AR_HOST = 'region-docker.pkg.dev';
+  const AR_REPOSITORY = 'example-vessel/i/shop/site';
+  const DIGEST = `sha256:${'a'.repeat(64)}`;
+  const AR_REF = `${AR_HOST}/${AR_REPOSITORY}@${DIGEST}`;
+  const GHCR_REF = `ghcr.io/example/shop/site@${DIGEST}`;
+
+  function ociAdapter(options: Partial<FakeOciRegistryOptions> = {}): {
+    registry: FakeOciRegistry;
+    api: FakeHosting;
+    adapter: StaticDeployAdapter;
+  } {
+    const registry = new FakeOciRegistry({
+      host: AR_HOST,
+      repository: AR_REPOSITORY,
+      digest: DIGEST,
+      layer: SITE,
+      ...options,
+    });
+    const api = new FakeHosting({});
+    // One transport, split by host: the registry answers for itself and the
+    // hosting API answers for everything else — which is exactly the shape of
+    // the adapter's real traffic.
+    const adapter = new StaticDeployAdapter({
+      token: api.token,
+      fetch: async (request) =>
+        new URL(request.url).host === AR_HOST
+          ? registry.fetch(request)
+          : api.fetch(request),
+    });
+    return { registry, api, adapter };
+  }
+
+  function built(refs: readonly string[]): DesiredState {
+    return desired({ artifact: { type: 'files', digest: DIGEST, refs } });
+  }
+
+  test('the readable reference is chosen, pulled with the identity, and served', async () => {
+    const { registry, api, adapter } = ociAdapter();
+    const { verdict } = await drain(
+      adapter.apply(TARGET, built([GHCR_REF, AR_REF])),
+    );
+
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.servedPaths('shop-site')).toEqual([
+      '/assets/app.css',
+      '/index.html',
+    ]);
+    // Every registry call carried the same identity the hosting calls do —
+    // the read is federated, never anonymous and never a stored credential.
+    expect(registry.requests.length).toBeGreaterThan(0);
+    for (const request of registry.requests) {
+      expect(request.authorization).toStartWith('Bearer ');
+    }
+  });
+
+  test('an image at a files address is refused with the layer count in the sentence', async () => {
+    // The shape every Build made by a route with no files arm has: an
+    // ordinary image. The count is what tells that story apart from a
+    // corrupt push.
+    const { adapter } = ociAdapter({ layerCount: 4 });
+    const { verdict } = await drain(adapter.apply(TARGET, built([AR_REF])));
+
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(blameFor(verdict.reason)).toBe('platform');
+      expect(verdict.detail).toContain('4 layers');
+    }
+  });
+
+  test('an artifact homed only where the identity cannot read is refused by name', async () => {
+    const { registry, adapter } = ociAdapter();
+    const { verdict } = await drain(adapter.apply(TARGET, built([GHCR_REF])));
+
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(verdict.detail).toContain('ghcr.io');
+    }
+    // And nothing tried to pull anonymously on the way to refusing.
+    expect(registry.requests).toEqual([]);
+  });
+
+  test('a layer that is not a gzipped tar is refused as what it is', async () => {
+    const { adapter } = ociAdapter({
+      layerMediaType: 'application/vnd.oci.image.layer.v1.tar',
+    });
+    const { verdict } = await drain(adapter.apply(TARGET, built([AR_REF])));
+
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(verdict.detail).toContain('gzipped tar');
+    }
   });
 });
 

--- a/apps/spindrift/test/harness/fakes/oci-registry.ts
+++ b/apps/spindrift/test/harness/fakes/oci-registry.ts
@@ -1,0 +1,108 @@
+/**
+ * A fake of the OCI distribution read surface `static/oci.ts` speaks
+ * (§ Seam 2): manifest by digest, index to child, blob by digest.
+ *
+ * It serves exactly one artifact, shaped the way the build workflow's files
+ * arm pushes one — an index carrying one runnable child and one attestation
+ * manifest, the child carrying the layers — because that is the object the
+ * adapter meets in the world. Options bend it into the two wrong shapes the
+ * tests need: an image of many layers, and a layer that is not a gzipped tar.
+ */
+import type { Fetcher } from '../../../src/adapters/deploy/cloud/http.ts';
+
+export interface FakeOciRegistryOptions {
+  /** e.g. `region-docker.pkg.dev`. */
+  readonly host: string;
+  /** The repository path under the host, without the digest. */
+  readonly repository: string;
+  /** The index digest the artifact is addressed by. */
+  readonly digest: string;
+  /** The one layer's bytes — the gzipped tar of the site. */
+  readonly layer: Uint8Array;
+  /** More than 1 fabricates an image at a files address. */
+  readonly layerCount?: number;
+  readonly layerMediaType?: string;
+}
+
+const CHILD_DIGEST = `sha256:${'c'.repeat(64)}`;
+const ATTESTATION_DIGEST = `sha256:${'e'.repeat(64)}`;
+const LAYER_DIGEST = `sha256:${'d'.repeat(64)}`;
+
+export class FakeOciRegistry {
+  readonly requests: {
+    method: string;
+    path: string;
+    authorization: string | null;
+  }[] = [];
+
+  constructor(private readonly options: FakeOciRegistryOptions) {}
+
+  readonly fetch: Fetcher = async (request) => {
+    const url = new URL(request.url);
+    this.requests.push({
+      method: request.method,
+      path: url.pathname,
+      authorization: request.headers.get('authorization'),
+    });
+    if (url.host !== this.options.host) {
+      return json({ errors: [{ code: 'NAME_UNKNOWN' }] }, 404);
+    }
+    const base = `/v2/${this.options.repository}`;
+
+    if (url.pathname === `${base}/manifests/${this.options.digest}`) {
+      // The index every real push has: one runnable child, one attestation
+      // manifest — present so a reader that forgot to filter fails here
+      // rather than in the world.
+      return json({
+        schemaVersion: 2,
+        mediaType: 'application/vnd.oci.image.index.v1+json',
+        manifests: [
+          {
+            mediaType: 'application/vnd.oci.image.manifest.v1+json',
+            digest: CHILD_DIGEST,
+            platform: { os: 'linux', architecture: 'amd64' },
+          },
+          {
+            mediaType: 'application/vnd.oci.image.manifest.v1+json',
+            digest: ATTESTATION_DIGEST,
+            annotations: {
+              'vnd.docker.reference.type': 'attestation-manifest',
+            },
+            platform: { os: 'unknown', architecture: 'unknown' },
+          },
+        ],
+      });
+    }
+    if (url.pathname === `${base}/manifests/${CHILD_DIGEST}`) {
+      const count = this.options.layerCount ?? 1;
+      return json({
+        schemaVersion: 2,
+        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+        layers: Array.from({ length: count }, (_, at) => ({
+          mediaType:
+            this.options.layerMediaType ??
+            'application/vnd.oci.image.layer.v1.tar+gzip',
+          digest:
+            at === 0
+              ? LAYER_DIGEST
+              : `sha256:${`${at}`.repeat(64).slice(0, 64)}`,
+          size: this.options.layer.length,
+        })),
+      });
+    }
+    if (url.pathname === `${base}/blobs/${LAYER_DIGEST}`) {
+      return new Response(this.options.layer.slice() as unknown as BodyInit, {
+        status: 200,
+        headers: { 'Content-Type': 'application/octet-stream' },
+      });
+    }
+    return json({ errors: [{ code: 'MANIFEST_UNKNOWN' }] }, 404);
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
## Summary

The first static deploy ever attempted found that files artifacts existed only on paper: the build workflow pushed an ordinary railpack image for every `artifactType`, and the static adapter handed the bare OCI reference to an HTTP client (`Invalid URL`). Both halves, made to agree:

- **Workflow files arm** (`spindrift-build.yml`, "Choose the frontend"): `artifactType: files` writes a generated `FROM scratch` + `COPY . /` Dockerfile with the scope as context — buildx pushes exactly one `tar+gzip` layer holding the site, and the push, provenance, signing, attestation and report steps ride unchanged, so a files artifact is signed and admitted exactly like an image. Checked before the Dockerfile arm: the artifact type decides what the thing *is*; a Dockerfile in the scope only ever decided how to build one.
- **Adapter read half** (`static/oci.ts`): among the artifact's refs the adapter picks a staged URL first (supplied uploads, unchanged), else the Artifact Registry ref its federated token can read — `ghcr.io` would take a credential the manifest deliberately does not model. It resolves index → runnable child (the attestation-manifest filter is the workflow's own) → the one layer, and feeds the blob to the existing bundle reader. A multi-layer object at a files address is refused with the layer count in the sentence, which is how a pre-files-arm Build now fails instead of `Invalid URL`.
- An artifact homed only on unreadable registries is refused naming the hosts, as `ARTIFACT_UNAVAILABLE` instead of `INTERNAL`.

## Validation

- `bun test` — 2062 pass, 0 fail. New: four adapter tests against a fake OCI registry (readable-ref choice + Bearer on every registry call, multi-layer refusal, unreadable-home refusal, non-gzip layer refusal), and two tests that execute the shipped "Choose the frontend" script itself, proving the files arm writes the scratch Dockerfile and the image arm is unchanged.
- `tsc --noEmit` and `biome check` clean.

## Risk

The workflow ships on the default branch immediately (callers resolve it there), but the files arm only fires for `artifactType: files` specs — every image build takes the exact path it took yesterday, and the two shipped-script tests pin that. The adapter's URL arm (supplied uploads) is untouched. Registry blob redirects to signed storage rely on undici stripping `Authorization` on the cross-origin hop, which it does.