### PR TITLE
fix(tender): bring the cloud warm pool up — sops stage two, a real PAT, and a route GCE can use

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -19,12 +19,12 @@ creation_rules:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
           # riptide (ssh-to-age of its ed25519 host key)
           - age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
-  # tender is stage one: the operator key is the only recipient until the
-  # instance has booted once and its ed25519 host key exists to ssh-to-age.
   - path_regex: nix/secrets/tender\.sops\.ya?ml
     key_groups:
       - age:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          # tender (ssh-to-age of its ed25519 host key)
+          - age1j2288en0rzxqwsq8fu8m86ld0t4cd4mpyt8upwlw9yknu20s6dzqauyerw
   - path_regex: nix/secrets/optiplex\.sops\.ya?ml
     key_groups:
       - age:

--- a/nix/hosts/tender.nix
+++ b/nix/hosts/tender.nix
@@ -2,9 +2,9 @@
 # services the ship; this one keeps the warm pool that riptide keeps today,
 # without spending a folly worker's RAM to do it.
 #
-# The image module supplies the disk layout and takes the hostname from GCE
-# metadata, so the instance must be named `tender` for nixos-upgrade to resolve
-# its own configuration. Terraform is in terraform/gcp/projects/homelab-ng/bosun.tf.
+# The image module supplies the disk layout; the hostname is the registry
+# name, baked into the closure, which is what nixos-upgrade resolves.
+# Terraform is in terraform/gcp/projects/homelab-ng/bosun.tf.
 { config, inputs, ... }:
 {
   imports = [

--- a/nix/images/gce.nix
+++ b/nix/images/gce.nix
@@ -25,6 +25,11 @@
     };
   };
 
-  # get the hostname from gce
-  networking.hostName = lib.mkForce "";
+  # No hostname override: mkHost defaults it to the registry name. An empty
+  # hostname here was meant to let GCE metadata name the instance, but nothing
+  # in a NixOS guest consumes it -- the kernel's built-in "nixos" is what
+  # sticks, and nixos-upgrade then resolves nixosConfigurations."nixos", which
+  # does not exist, so every GCE host silently stopped self-upgrading. Each
+  # cloud host builds its own image from its own closure, so the baked name is
+  # correct from first boot.
 }

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -238,7 +238,14 @@ let
     case "$1" in
       bound|renew)
         $bb ifconfig "$interface" "$ip" netmask "''${subnet:-255.255.255.0}"
-        [ -n "$router" ] && $bb route add default gw "$router" dev "$interface"
+        # passt copies the host's addressing, and on GCE that is a /32 with an
+        # on-link gateway -- the router sits outside the interface's prefix, so
+        # a bare default route is refused. A host route to the gateway first
+        # makes it legal on both shapes of subnet.
+        [ -n "$router" ] && {
+          $bb ip route add "$router" dev "$interface" 2>/dev/null
+          $bb ip route add default via "$router" dev "$interface"
+        }
         $bb rm -f /etc/resolv.conf
         for d in $dns; do echo "nameserver $d" >> /etc/resolv.conf; done
         ;;

--- a/nix/lib/mkHost.nix
+++ b/nix/lib/mkHost.nix
@@ -32,10 +32,13 @@ in
 
       modules = [
         baselines.${baseline}
-        # mkDefault so an image config that takes its identity from elsewhere
-        # (nix/images/gce.nix reads it from GCE metadata, the installer images
-        # pin their own) can still override it.
-        { networking.hostName = lib.mkDefault name; }
+        # Above mkDefault (1000) so the registry name beats other modules'
+        # defaults -- nixpkgs' google-compute-config ships mkDefault "" and
+        # nothing in a GCE guest ever fills it in, which left cloud hosts
+        # named "nixos" and their nixos-upgrade resolving a configuration
+        # that does not exist. Below normal (100) so an image that pins its
+        # own identity (installer images, wsl) still wins.
+        { networking.hostName = lib.mkOverride 900 name; }
       ]
       ++ modules;
 

--- a/nix/secrets/tender.sops.yaml
+++ b/nix/secrets/tender.sops.yaml
@@ -3,13 +3,22 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOMlhzVnFhT3Z0OVlMVzlo
-            TGVITFlzMmp2SkVaSEFEcGk2ckRhVDJBdEh3Clp5aWFYa0h4WlJIeEtPUld0cElt
-            US9VczJHbXk5MlJpdWVVZ0lJYnVuSDAKLS0tIHZ0RWVFU3dYb1QxM2oyWUV0TTNq
-            eHRSdC92eFFjNkFrMXVTMnFqcXdNNU0K2Y+kO8k6k8fo0WuVJ5Y6j085a32wDsVB
-            3Ii4czGGcpUtLiZ3aGGE+ZfTc9EzYcVsKHq/rm14pip/Ak7G59AF4Q==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqM21rTG5sSmtRRUN2K0NW
+            Z2RVWHl0N2phWjVPQXRmSU9ZK2MxMEZyTGtZCmV2dnBXUlJ5dDdNVUdzU2MzY0ZP
+            SEtaOGpLQ2FDZ2tQNFdsRHNTaWRZT28KLS0tIFNJcnNSUFd1em03MDNpcWY1dU5P
+            Z3E2YzVLRll5WWhTL0Vpb0Nja1hPRGcKJx+Rsv/YhB+E7NF1QZG+8cwwgREyon7j
+            D2m+BDqehX8W/3rQWZ5+7dhgZ4OLf5AH6GlbKgIEYH1qg91cLwIRyA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOc0hIYTJURTJtUGZRUTZG
+            YXp1dVpOeExiSUEza2tmNUlaMGxzSmlrSms0CjFMcTFWZkl5VE1pL2p4MEdSZTJn
+            L1dUblgwQk1wSUFzZlpJbjg3eHpMU1EKLS0tIGlvaHBoVk53QUQwdHJEMmRiNVNT
+            NEM3V3ByWVd1RVp2WitLK3VyMHJlU00KOLqSBJH7gmDfsnOOH8TOYHQZ5u4KE51F
+            eEc8v7GMnoLK2Serw43NrJ84KT/cLoO1XfYD9zvSqVaVzzGNWg2aeg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1j2288en0rzxqwsq8fu8m86ld0t4cd4mpyt8upwlw9yknu20s6dzqauyerw
     lastmodified: "2026-08-08T15:03:26Z"
     mac: ENC[AES256_GCM,data:i99eXV0lHIGiOEou3IcazQ2QPriXOqVHLmtHRI3ea3wtDuuCazre8ifwIR6fAq+cwHJb1/SUV1ZFJWfaoviwB5ynSpaPXKROclt/SgrkkrawWxgIBUfNLZWlgfYTaa116QfDY2XdOCPwa1ZyHMQ0Ea2EmdcOMLWQjTTIS92v7Kw=,iv:NZF9dQ3kUuMzQQyzHDrfwxt9P9AJ5sgbwkb1CY+izZg=,tag:/2zIH115pKDrh7dum+Ua8Q==,type:str]
     unencrypted_suffix: _unencrypted

--- a/nix/secrets/tender.sops.yaml
+++ b/nix/secrets/tender.sops.yaml
@@ -1,25 +1,25 @@
-bosun-github-token: ENC[AES256_GCM,data:dfKSJJWJ01p73usGq8+rZ+DcT4mitf4MWFVHnw==,iv:UUQDqVizOsG98ttBzhYo4R/wBg6XCefyogU5qSC9NBA=,tag:dfmJkG0wfhvHviNzhtXmEA==,type:str]
+bosun-github-token: ENC[AES256_GCM,data:fN1lJe0ZfeX9kuSlxrBRwYM7tP7F13fLgnNNgOFyO3CEUD3Gbz/MuA==,iv:W+UhKeqnOCIUeb3fxNPQx0tppVL5glFOg5/BRKIIdzk=,tag:w1HkFqpjDIl6tmrEJYr50g==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBqM21rTG5sSmtRRUN2K0NW
-            Z2RVWHl0N2phWjVPQXRmSU9ZK2MxMEZyTGtZCmV2dnBXUlJ5dDdNVUdzU2MzY0ZP
-            SEtaOGpLQ2FDZ2tQNFdsRHNTaWRZT28KLS0tIFNJcnNSUFd1em03MDNpcWY1dU5P
-            Z3E2YzVLRll5WWhTL0Vpb0Nja1hPRGcKJx+Rsv/YhB+E7NF1QZG+8cwwgREyon7j
-            D2m+BDqehX8W/3rQWZ5+7dhgZ4OLf5AH6GlbKgIEYH1qg91cLwIRyA==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBZWWhKdWJ4TWpobkNHek5i
+            OWNtL09IdCs4VU1NZ1lQejg5MlIzY1YxVFhJCkQxQjNHV3VkUFliV2VGRi9NMTVK
+            WXpnRy9nUWpBVmZVNGo1Q0MzMjdCTlkKLS0tIDhEbnZYVnJtbWt5L3NKV2huZHBQ
+            S0xldWUrNm5LOG8yWkEzMERxUUFFNXMK8iWdBkZ7sdgcCwXSbzp269FAN/kvpWHz
+            IlDZJ0ntTzCJrGeo+e77OgqMuscM4bfr1X8ciFuOg/WAvR9NrZrriQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBOc0hIYTJURTJtUGZRUTZG
-            YXp1dVpOeExiSUEza2tmNUlaMGxzSmlrSms0CjFMcTFWZkl5VE1pL2p4MEdSZTJn
-            L1dUblgwQk1wSUFzZlpJbjg3eHpMU1EKLS0tIGlvaHBoVk53QUQwdHJEMmRiNVNT
-            NEM3V3ByWVd1RVp2WitLK3VyMHJlU00KOLqSBJH7gmDfsnOOH8TOYHQZ5u4KE51F
-            eEc8v7GMnoLK2Serw43NrJ84KT/cLoO1XfYD9zvSqVaVzzGNWg2aeg==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5VEs1VkJDYjZQT2dMRTd5
+            Y2tXdFJDYlBhKzl6eXNiVGU0bVY4cnhndjBrCjBvUXF4bDRlc2dBaHBVMUJUajBV
+            U1dWajBQMzQxSEU5eFlXMXJhaTJPMGMKLS0tIFVLYVdiVG9kazhsNWJOWFRNODFG
+            RkIrWWtDS2paRzJ4MndEWXFxVDVFcGsKW+cxmfceImPcaX2a/mnb6ZF/y2pgbWxL
+            TyB+qVn2E8GiDFdJAnbba1DCAS8NB0GEjMijvxMpg0rHW3tfllOdYw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1j2288en0rzxqwsq8fu8m86ld0t4cd4mpyt8upwlw9yknu20s6dzqauyerw
-    lastmodified: "2026-08-08T15:03:26Z"
-    mac: ENC[AES256_GCM,data:i99eXV0lHIGiOEou3IcazQ2QPriXOqVHLmtHRI3ea3wtDuuCazre8ifwIR6fAq+cwHJb1/SUV1ZFJWfaoviwB5ynSpaPXKROclt/SgrkkrawWxgIBUfNLZWlgfYTaa116QfDY2XdOCPwa1ZyHMQ0Ea2EmdcOMLWQjTTIS92v7Kw=,iv:NZF9dQ3kUuMzQQyzHDrfwxt9P9AJ5sgbwkb1CY+izZg=,tag:/2zIH115pKDrh7dum+Ua8Q==,type:str]
+    lastmodified: "2026-08-09T19:17:14Z"
+    mac: ENC[AES256_GCM,data:vRlZr2on8tu2diYI0g1o+4+1YYVLm+vnG6SgxXzr3UR2EpqZLLedixiWTI30cxfjjIxFHgf+mnA9k7f5DWZ8TG2gtHsT4XfuiaiEeHyedvoqjLOtGKb6EdCyF+rwBV6/jJ821UOrlsbbuRYnUIPPiSI5NrZX3PZpWx/mNJvqsyY=,iv:tSwc41+5+lAu6EWKsAf0a/g0IdTQ1aBZDjOJYir4lTE=,tag:BbbQxq2/3H6n0KnXuXeRFA==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.13.3


### PR DESCRIPTION
tender was RUNNING with bosun crash-looping (~11k restarts). Four fixes, one commit each:

1. **sops stage two was never done.** `tender.sops.yaml` was operator-key-only, so sops-nix could not produce `/run/secrets/bosun-github-token`. The booted instance's ed25519 host key is now a recipient (`sops updatekeys`).
2. **The stored token was a stub** — 28 characters GitHub never issued, 401 on every `generate-jitconfig`. Now carries the same PAT riptide's pool uses.
3. **The Ubuntu hull could not route on GCE.** passt copies the host's addressing; GCE hands out a /32 with an on-link gateway, so `route add default gw` failed and runners registered but never connected, wedge-churning the pool. Host route to the gateway first; riptide's /24 unchanged.
4. **Every GCE host had hostname `nixos`.** nixpkgs' google-compute-config defaults hostName empty and nothing in the guest fills it from metadata, so `nixos-upgrade` resolved `nixosConfigurations."nixos"` — cloud hosts have silently never self-upgraded. mkHost bakes the registry name at `mkOverride 900` (below explicit image identities like wsl's). Eval-checked: tender/oldboy/gce/riptide all resolve correctly.

Validation: deployed to tender from this branch, then reset the instance — it booted as `tender`, refilled the pool, and all four skiffs came online. `skiff-ubuntu` now serves six warm slots across riptide and tender; bench run 31331732241 started both skiff legs in the same second, one per site, and the `caches: none` pair (31332175945/31332177009) ran green: Test 270 s on the 2.9 GiB skiff vs 244 s hosted.

Merge promptly — tender reverts to the broken pool on its nightly rebuild from main otherwise (which, after commit 4, actually runs).