### PR TITLE
fix(spindrift): let a move rebuild into the new target's shape

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -53,6 +53,7 @@ import {
   targets,
   vessels,
 } from '../../db/schema.ts';
+import { artifactTypeFor, placementTargetOf } from '../../domain/placement.ts';
 import { repositoryRefOf } from '../../domain/repository.ts';
 import { isFetchableBundleLocation } from '../../storage/archives.ts';
 import { createDeploy } from '../deploys/create.ts';
@@ -89,11 +90,11 @@ export const deployAppInput = z
      * The Target for a Component deploying for the first time — its id, or the
      * two facts that identify it spelled `<vessel>/<adapter>`.
      *
-     * Only a first deploy needs it: placement is a fact a deploy writes, so a
-     * Component that has never deployed has none to read back — `placeComponent`
-     * migrates configuration, it does not place. Absent, the Component's own
-     * history answers as it always has, and a value that disagrees with that
-     * history is refused rather than silently moving the Component.
+     * Only a first deploy needs it: placement is a fact `placeComponent` or a
+     * first deploy writes, so a Component that has done neither has none to
+     * read back. Absent, the Component's own placement answers as it always
+     * has, and a value that disagrees with it is refused rather than silently
+     * moving the Component — moves go through `placeComponent`.
      */
     target: z.string().trim().min(1).optional(),
   })
@@ -307,6 +308,11 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
             limit: 1,
           },
           desiredTargets: {
+            // Newest first, because the newest desired row is the Component's
+            // current address: every deploy touches its pair's row, and
+            // `placeComponent` touches the pair a move commits — so a moved
+            // Component's newest row is the Target it was moved to.
+            orderBy: (desiredTable, { desc }) => [desc(desiredTable.updatedAt)],
             limit: 1,
             with: {
               target: true,
@@ -356,9 +362,13 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     component = named;
   }
 
+  // The desired row is the placement of record — `placeComponent` moves it,
+  // and every deploy touches it — so it answers first. Deploy history only
+  // answers for a Component whose rows are gone, which is what an unplaced
+  // pair being deployed again looks like.
   const latestDeploy = component.deploys[0];
   const placedTargetId =
-    latestDeploy?.targetId ?? component.desiredTargets[0]?.targetId;
+    component.desiredTargets[0]?.targetId ?? latestDeploy?.targetId;
 
   let targetId = placedTargetId;
   if (input.target !== undefined) {
@@ -383,9 +393,9 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     if (named === undefined) {
       return failed('NOT_FOUND', `there is no Target '${input.target}'`);
     }
-    // History wins where it exists: a deploy that named a different Target
+    // Placement wins where it exists: a deploy that named a different Target
     // than the one this Component lives on is a move, and moves go through
-    // placement — not through a deploy that quietly lands somewhere new.
+    // `placeComponent` — not through a deploy that quietly lands somewhere new.
     if (placedTargetId !== undefined && placedTargetId !== named.id) {
       return failed(
         'INVALID_INPUT',
@@ -442,6 +452,30 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     buildToRun.status === 'FAILED' ||
     buildToRun.status === 'SUCCEEDED'
   ) {
+    // §3: shape follows the Target, not the predecessor. A rebuild is the
+    // remediation the cross-shape refusal prescribes — "this placement needs
+    // a rebuild" — so the new Build derives its shape from the Target this
+    // Component is placed on, the same derivation `createDeploy` admits with
+    // and `completeCreationDraft` creates with. Inheriting the predecessor's
+    // shape instead reruns it forever, and the Build that refusal asks for
+    // never becomes reachable.
+    const placedOn = targetId;
+    const target = await context.db.query.targets.findFirst({
+      where: (targetsTable, { eq: eqOp }) => eqOp(targetsTable.id, placedOn),
+      with: { vessel: true },
+    });
+    if (target === undefined) {
+      return failed('NOT_FOUND', `there is no Target with id ${targetId}`);
+    }
+    const shape = artifactTypeFor(
+      component.kind,
+      placementTargetOf(target, {
+        artifactTypes:
+          context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+        manifest: context.manifest,
+      }),
+    );
+
     // The bundle is staged before the row exists, so what the row records is
     // this Build's own source rather than the last one's. A refusal here is
     // returned unchanged, the same way `createDeploy`'s is: it names the App and
@@ -460,8 +494,8 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
       .values({
         componentId: component.id,
         commit: commitRef,
-        targetShape: buildToRun?.targetShape ?? 'image',
-        artifactType: buildToRun?.artifactType ?? 'image',
+        targetShape: shape,
+        artifactType: shape,
         bundleDigest: rerun.value.bundleDigest,
         bundleLocation: rerun.value.bundleLocation,
         // A repo Build's subpath is the App's declared subpath, never an

--- a/apps/spindrift/src/commands/components/place.ts
+++ b/apps/spindrift/src/commands/components/place.ts
@@ -15,6 +15,13 @@
  * 3. **Refuse, naming the keys**, when something cannot be carried and was not
  *    supplied. Not a warning: §10 wants "a re-placement never comes up green and
  *    unconfigured", and a warning is a thing that gets clicked through.
+ * 4. **Write the placement.** The desired row for (Component, Target) is what
+ *    `deployApp` reads as where this Component now lives, so a move that wrote
+ *    no row was a move nothing could see: the next deploy still resolved the
+ *    old Target, refused the new one as "placed elsewhere — move it first",
+ *    and pointed back at the command that had already run. The old pair's row
+ *    stays — what is live there keeps serving until `unplaceComponent`
+ *    retires it.
  *
  * `createDeploy` refuses on the same condition, because a developer who skipped
  * Place and deployed straight at the new Target would otherwise get exactly the
@@ -23,7 +30,7 @@
 
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { targets, vessels } from '../../db/schema.ts';
+import { componentTargetDesired, targets, vessels } from '../../db/schema.ts';
 import { VARIABLE_NAME } from '../../domain/config.ts';
 import { targetLabel } from '../../domain/target.ts';
 import { carryReferences } from '../config/carry.ts';
@@ -109,6 +116,25 @@ export const placeComponent: Command<
   // a value to reach the store.
   const applied = await applyConfigChange(context, subject, input.supply, []);
   if (!applied.ok) return applied;
+
+  // The move itself, committed last so a refusal above leaves the placement
+  // where it was. Touching `updatedAt` on conflict is what makes a re-placement
+  // onto an already-placed pair the Component's newest row again.
+  const now = context.clock.now();
+  await context.db
+    .insert(componentTargetDesired)
+    .values({
+      componentId: input.componentId,
+      targetId: input.targetId,
+      updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [
+        componentTargetDesired.componentId,
+        componentTargetDesired.targetId,
+      ],
+      set: { updatedAt: now },
+    });
 
   return ok({
     ...applied.value,

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -25,6 +25,7 @@ import { placeIntent } from '../../src/commands/deploys/create.ts';
 import {
   createDeploy,
   dispatchBuild,
+  placeComponent,
   rollbackDeploy,
   uploadArchive,
 } from '../../src/commands/index.ts';
@@ -736,9 +737,9 @@ describe('deployApp selects which Component it acts on', () => {
   });
 
   /**
-   * Placement is a fact a deploy writes, so a Component that has never
-   * deployed has none to read back — `placeComponent` migrates configuration,
-   * it does not place. The first deploy is where a Target gets named.
+   * Placement is a fact `placeComponent` or a first deploy writes, so a
+   * Component that has done neither has none to read back. Naming a Target is
+   * how the first deploy writes it.
    */
   test('a first deploy names the Target that placement will remember', async () => {
     const { app, target } = await fixture();
@@ -838,6 +839,104 @@ describe('deployApp selects which Component it acts on', () => {
       .from(deploys)
       .where(eq(deploys.id, result.value.deployId!));
     expect(deploy?.componentId).toBe(component.id);
+  });
+});
+
+describe('a move across shapes reaches the Build the refusal asks for (§3)', () => {
+  /**
+   * The remediation loop, end to end: a website with an image-shaped history
+   * moves to static hosting, the deploy at the new placement refuses with
+   * "this placement needs a rebuild", the rebuild stages a *files* Build —
+   * the moved-to Target's shape, not the predecessor's — and deploying it is
+   * admitted. Before the rerun arm derived shape from the placed Target it
+   * inherited the predecessor's, so the Build this refusal prescribes was
+   * unreachable from the Component it refused.
+   */
+  test('move, rebuild into files, deploy admitted', async () => {
+    const { app, component, target } = await fixture({
+      kind: 'website',
+      reach: 'public',
+      auth: 'none',
+    });
+    // Image-shaped history on a runtime Target, placed and built long enough
+    // ago that the move below is unambiguously the newest placement.
+    const before = new Date(FROZEN.getTime() - 60_000);
+    await database().db.insert(componentTargetDesired).values({
+      componentId: component.id,
+      targetId: target.id,
+      updatedAt: before,
+    });
+    const imageBuild = await succeededBuild(component.id, 70, 'image');
+    await database()
+      .db.update(builds)
+      .set({ createdAt: before })
+      .where(eq(builds.id, imageBuild.id));
+
+    const staticVessel = await insertVessel(database().db, 'static', {
+      name: `static-${crypto.randomUUID()}`,
+    });
+    const [staticTarget] = await database()
+      .db.insert(targets)
+      .values(
+        targetValues({
+          adapter: 'static',
+          vesselId: staticVessel.id,
+          discovery: null,
+        }),
+      )
+      .returning();
+    const ctx = context(
+      registryOf(
+        new FakeDeployAdapter({ adapter: 'static', artifactTypes: ['files'] }),
+      ),
+    );
+
+    // The move commits, and commits the row `deployApp` reads as placement.
+    const moved = await placeComponent(
+      { componentId: component.id, targetId: staticTarget!.id, supply: [] },
+      ctx,
+    );
+    expect(moved.ok).toBe(true);
+    expect(await desiredRow(component.id, staticTarget!.id)).toBeDefined();
+
+    // The button now acts on the new placement, and refuses with the exact
+    // remediation the rest of this test follows.
+    const refused = await deployApp({ name: app.name }, ctx);
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(refused.failure.message).toContain('needs a rebuild');
+
+    // Following it: the rebuild stages a Build of the *new* Target's shape.
+    const rebuilt = await deployApp({ name: app.name, rebuild: true }, ctx);
+    expect(rebuilt.ok).toBe(true);
+    if (!rebuilt.ok) return;
+    expect(rebuilt.value.phase).toBe('BUILDING');
+    const [staged] = await database()
+      .db.select()
+      .from(builds)
+      .where(eq(builds.id, rebuilt.value.buildId));
+    expect(staged?.targetShape).toBe('files');
+    expect(staged?.artifactType).toBe('files');
+
+    // The build loop finishing is not under test; a finished files artifact is.
+    await database()
+      .db.update(builds)
+      .set({
+        status: 'SUCCEEDED',
+        artifactDigest: digest(71),
+        artifactRefs: ['https://shop.static.test/site'],
+      })
+      .where(eq(builds.id, rebuilt.value.buildId));
+
+    const admitted = await deployApp({ name: app.name }, ctx);
+    expect(admitted.ok).toBe(true);
+    if (!admitted.ok) return;
+    expect(admitted.value.phase).toBe('PENDING');
+    expect(admitted.value.buildId).toBe(rebuilt.value.buildId);
+
+    const desired = await desiredRow(component.id, staticTarget!.id);
+    expect(desired?.desiredBuildId).toBe(rebuilt.value.buildId);
   });
 });
 


### PR DESCRIPTION
## What was wrong

A Component moved to a Target that takes a different artifact shape could never produce the Build that Target admits. `createDeploy` refused correctly — *"Build N produced image, and \<target\> takes files — this placement needs a rebuild"* — but the remediation it prescribed was unreachable:

- The rebuild arm in `apps/spindrift/src/commands/apps/deploy.ts` wrote `targetShape: buildToRun?.targetShape ?? 'image'` — the **predecessor's** shape — so an image-shaped history rerun image forever.
- `placeComponent` migrated configuration but wrote no desired placement row, while `deployApp` refused a deploy naming a new Target with *"placed elsewhere — move it first"*. The two refusals pointed at each other: the move that was demanded moved nothing the deploy could see.

## What changed

- `placeComponent` now commits the move by writing the (Component, Target) desired row (`onConflictDoUpdate` touching `updatedAt`), after the config migration's demands are satisfied. The old pair's row stays — what is live there keeps serving until `unplaceComponent` retires it.
- `deployApp` resolves placement from the newest desired row before falling back to deploy history, so a committed move is what the one button acts on.
- `deployApp`'s rerun arm derives `targetShape`/`artifactType` from the placed Target via `artifactTypeFor` — the derivation `createDeploy` already admits with and `completeCreationDraft` already creates with — instead of inheriting the predecessor's shape.

The new test in `test/commands/deploys.test.ts` walks the remediation loop end to end: image-shaped history, move to a files-shaped static Target, the shape refusal, a rebuild that stages a files Build, and the deploy admitted.

## Validation

- `bun test` — 2063 pass, 0 fail (145 files, real Postgres)
- `bun run typecheck` — clean
- `bun run lint` — clean