### PR TITLE
fix(spindrift): post-move rebuild binding and the COPY ./ context edge

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -83,6 +83,10 @@ export const getAppWorkspace: Command<
             limit: 1,
           },
           desiredTargets: {
+            // Newest first — the placement of record, exactly as `deployApp`
+            // reads it. A moved Component keeps the old pair's row until it is
+            // retired, and an unordered pick could name either.
+            orderBy: (desiredTable, { desc }) => [desc(desiredTable.updatedAt)],
             limit: 1,
             with: {
               // With its vessel, for the reason the deploy's Target carries

--- a/apps/spindrift/src/commands/builds/get-detail.ts
+++ b/apps/spindrift/src/commands/builds/get-detail.ts
@@ -54,6 +54,10 @@ export const getBuildDetail: Command<
         with: {
           app: true,
           desiredTargets: {
+            // Newest first — the placement of record, exactly as `deployApp`
+            // reads it. A moved Component keeps the old pair's row until it is
+            // retired, and an unordered pick could name either.
+            orderBy: (desiredTable, { desc }) => [desc(desiredTable.updatedAt)],
             limit: 1,
             with: { target: { with: { vessel: true } } },
           },

--- a/apps/spindrift/src/domain/detection/dockerfile-context.ts
+++ b/apps/spindrift/src/domain/detection/dockerfile-context.ts
@@ -56,7 +56,13 @@ export function contextSources(dockerfile: string): readonly string[] {
       ) {
         continue;
       }
-      sources.push(token.startsWith('./') ? token.slice(2) : token);
+      const source = token.startsWith('./') ? token.slice(2) : token;
+      // `COPY ./ <dest>` names the whole context, like `.` — an empty source
+      // resolves to a directory both roots have, which the shell probes read
+      // as no evidence. Passing it on would say the scope copies ""
+      // from beside itself.
+      if (source === '') continue;
+      sources.push(source);
     }
   }
   return sources;

--- a/apps/spindrift/src/domain/placement.ts
+++ b/apps/spindrift/src/domain/placement.ts
@@ -266,10 +266,14 @@ function routesAttachTo(target: RankedTargetRow): boolean {
  * land on either, rendered to files on a `static` Target and to a server image
  * anywhere else. That is the whole reason exposure "filters Targets and selects
  * artifact shape" rather than being a chart setting (§28).
+ *
+ * Narrowed to the one capability it reads, the way {@link sentence} is: the
+ * build loop asks it of bare `targets` rows, which have an adapter's artifact
+ * types to offer but no full placement resolution behind them.
  */
 export function artifactTypeFor(
   kind: ComponentKind,
-  target: PlacementTarget,
+  target: { readonly capabilities: Pick<TargetCapabilities, 'artifactTypes'> },
 ): ArtifactType {
   if (
     kind === 'website' &&

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -17,7 +17,10 @@ import {
   components,
   componentTargetDesired,
   targets,
+  vessels,
 } from '../db/schema.ts';
+import { artifactTypeFor } from '../domain/placement.ts';
+import { targetLabel } from '../domain/target.ts';
 import {
   reconcilerAttemptDuration,
   reconcilerLoopDuration,
@@ -63,6 +66,15 @@ export async function runBuildPass(
       // the `where` clause, so this is the age of a Build still waiting to be
       // claimed.
       createdAt: builds.createdAt,
+      // For binding the Build to a placement that admits its shape: what this
+      // Build produces, what the Component is, and enough of the Target to
+      // derive the shape it takes — plus the row's `updatedAt`, which is what
+      // says which placement is the one of record.
+      targetShape: builds.targetShape,
+      kind: components.kind,
+      adapter: targets.adapter,
+      vessel: vessels.name,
+      desiredUpdatedAt: componentTargetDesired.updatedAt,
     })
     .from(builds)
     .innerJoin(components, eq(builds.componentId, components.id))
@@ -71,14 +83,69 @@ export async function runBuildPass(
       eq(componentTargetDesired.componentId, components.id),
     )
     .innerJoin(targets, eq(targets.id, componentTargetDesired.targetId))
+    .innerJoin(vessels, eq(vessels.id, targets.vesselId))
     .where(eq(builds.status, 'PENDING'))
     .orderBy(asc(builds.id), asc(targets.rank));
 
-  let dispatched = 0;
-  const visited = new Set<number>();
+  // A moved Component deliberately keeps the old pair's desired row until what
+  // still serves there is retired, so a PENDING Build can join two placements —
+  // and only one of them takes the shape this Build produces. Each Build is
+  // bound to the newest desired row whose Target admits its shape: the same
+  // newest-row-is-the-placement-of-record reading `deployApp` uses. Rank is
+  // only the tie-break the ordering above already applied.
+  const perBuild = new Map<number, typeof rows>();
   for (const row of rows) {
-    if (visited.has(row.buildId)) continue;
-    visited.add(row.buildId);
+    const group = perBuild.get(row.buildId);
+    if (group === undefined) perBuild.set(row.buildId, [row]);
+    else group.push(row);
+  }
+  const shapeTaken = (candidate: (typeof rows)[number]) =>
+    artifactTypeFor(candidate.kind, {
+      capabilities: {
+        artifactTypes:
+          context.adapters.deploy(candidate.adapter)?.artifactTypes ?? [],
+      },
+    });
+
+  let dispatched = 0;
+  for (const group of perBuild.values()) {
+    let row: (typeof rows)[number] | undefined;
+    for (const candidate of group) {
+      if (shapeTaken(candidate) !== candidate.targetShape) continue;
+      if (
+        row === undefined ||
+        candidate.desiredUpdatedAt > row.desiredUpdatedAt
+      ) {
+        row = candidate;
+      }
+    }
+    if (row === undefined) {
+      // No placement takes what this Build produces. Binding it anywhere would
+      // evaluate route and policy against a Target the artifact can never land
+      // on, so the Build stays PENDING and says so: placing the Component
+      // somewhere that admits the shape is an operator act that makes the next
+      // tick work.
+      const pending = group[0]!;
+      const refused = group
+        .map(
+          (candidate) =>
+            `${targetLabel(candidate)} takes ${shapeTaken(candidate)}`,
+        )
+        .join('; ');
+      await recordDispatchWait(
+        context,
+        {
+          attempt: {
+            appId: pending.appId,
+            componentId: pending.componentId,
+            buildId: pending.buildId,
+          },
+          waitingOn: pending.waitingOn,
+        },
+        `this Build produces a ${pending.targetShape} artifact and no Target this Component is placed on takes one (${refused}), so nothing can run it`,
+      );
+      continue;
+    }
     const selection = await buildRouteFor(row.targetId, context, row.appId);
     if (selection.route === null) {
       // A Target whose policy no available route satisfies. Configuring a
@@ -135,10 +202,10 @@ export async function runBuildPass(
       );
     }
   }
-  // `visited` is every distinct Build this pass looked at, all of them
+  // `perBuild` holds every distinct Build this pass looked at, all of them
   // PENDING by the `where` clause — the backlog this pass found, whether or
   // not it managed to dispatch all of it.
-  reconcilerQueueDepth.record(visited.size, { kind: 'build' });
+  reconcilerQueueDepth.record(perBuild.size, { kind: 'build' });
   return dispatched;
 }
 

--- a/apps/spindrift/test/adapters/dockerfile-context-arm.test.ts
+++ b/apps/spindrift/test/adapters/dockerfile-context-arm.test.ts
@@ -134,6 +134,19 @@ describe('the Dockerfile arm of “Choose the frontend”', () => {
     ).toBe('root');
   });
 
+  test('`COPY ./` names the whole context and decides nothing', async () => {
+    // `./` normalizes to an empty source, which resolves to a directory both
+    // roots have — never evidence. The shell probes always read it that way;
+    // the mirror once turned it into `{context: 'scope', copies: ''}` and a
+    // sentence claiming a context the build does not use.
+    expect(
+      await contextChosen({
+        [`${SUBPATH}/Dockerfile`]: 'FROM golang:1.24\nCOPY ./ /app\n',
+        [`${SUBPATH}/go.mod`]: 'module example.test/ddns\n',
+      }),
+    ).toBe('root');
+  });
+
   test('stage copies, globs and absolute paths decide nothing', async () => {
     expect(
       await contextChosen({

--- a/apps/spindrift/test/reconciler/build-loop.test.ts
+++ b/apps/spindrift/test/reconciler/build-loop.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Which placement `runBuildPass` binds a Build's dispatch to.
+ *
+ * A moved Component deliberately keeps the old pair's desired row until what
+ * still serves there is retired, so a PENDING Build can join two placements.
+ * The loop used to bind each Build to whichever Target ranked lowest — which,
+ * after a move across shapes, is the *old* Target: the files Build the move's
+ * own refusal prescribed was then routed and policy-checked against the image
+ * Target it can never land on. These tests hold the loop to the Build's own
+ * shape: bind to the newest desired row whose Target admits it, and where none
+ * does, say so instead of dispatching anywhere.
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  componentTargetDesired,
+  configItems,
+  targets,
+} from '../../src/db/schema.ts';
+import { runBuildPass } from '../../src/reconciler/build-loop.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { FakeDeployAdapter } from '../harness/fakes/deploy-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+const BUNDLE_DIGEST = `sha256:${'c'.repeat(64)}`;
+
+/** The build side registered under the fixture's `hosted` route name. */
+function registryOf(route: FakeBuildAdapter): AdapterRegistry {
+  return {
+    deploy: (adapter) =>
+      adapter === 'static'
+        ? new FakeDeployAdapter({ adapter: 'static', artifactTypes: ['files'] })
+        : adapter === 'kubernetes'
+          ? new FakeDeployAdapter({ adapter: 'kubernetes' })
+          : null,
+    build: (name) => (name === 'hosted' ? route : null),
+    store: () => new FakeSecretStore(),
+    repository: () => null,
+    supplyChain: () => new SupplyChainHarness(),
+  };
+}
+
+function context(adapters: AdapterRegistry): CommandContext {
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** A website with image-shaped history on a runtime Target, moved to static. */
+async function movedWebsite() {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'shop', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({
+      appId: app!.id,
+      name: 'web',
+      kind: 'website',
+      expose: true,
+      reach: 'public',
+      auth: 'none',
+    })
+    .returning();
+
+  const runtimeVessel = await insertVessel(db, 'kubernetes', {
+    name: `cluster-${crypto.randomUUID()}`,
+  });
+  const [runtimeTarget] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        adapter: 'kubernetes',
+        vesselId: runtimeVessel.id,
+        rank: 1,
+        discovery: null,
+      }),
+    )
+    .returning();
+
+  const staticVessel = await insertVessel(db, 'static', {
+    name: `static-${crypto.randomUUID()}`,
+  });
+  const [staticTarget] = await db
+    .insert(targets)
+    .values(
+      targetValues({
+        adapter: 'static',
+        vesselId: staticVessel.id,
+        rank: 2,
+        discovery: null,
+      }),
+    )
+    .returning();
+
+  // The move's residue: the old pair's row survives so unplacement can retire
+  // what still serves there, and the new pair's row is the newest — the
+  // placement of record.
+  await db.insert(componentTargetDesired).values({
+    componentId: component!.id,
+    targetId: runtimeTarget!.id,
+    updatedAt: new Date(FROZEN.getTime() - 60_000),
+  });
+  await db.insert(componentTargetDesired).values({
+    componentId: component!.id,
+    targetId: staticTarget!.id,
+    updatedAt: FROZEN,
+  });
+
+  // The rebuild the move remediation staged: a files Build, PENDING.
+  const [build] = await db
+    .insert(builds)
+    .values({
+      componentId: component!.id,
+      commit: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+      targetShape: 'files',
+      artifactType: 'files',
+      bundleDigest: BUNDLE_DIGEST,
+      bundleLocation: 'https://depot.lolwtf.ca/bundles/site.zip',
+      status: 'PENDING',
+    })
+    .returning();
+
+  return {
+    component: component!,
+    runtimeTarget: runtimeTarget!,
+    runtimeVessel,
+    staticTarget: staticTarget!,
+    build: build!,
+  };
+}
+
+async function buildRow(buildId: number) {
+  const [row] = await database()
+    .db.select()
+    .from(builds)
+    .where(eq(builds.id, buildId));
+  return row!;
+}
+
+describe('a rebuild staged by a move dispatches against the new placement', () => {
+  test('the files Build binds to the static Target, not the lower-ranked image one', async () => {
+    const { component, runtimeTarget, staticTarget, build } =
+      await movedWebsite();
+    const db = database().db;
+
+    // The old Target's policy admits no configured route. Bound there, this
+    // Build would sit PENDING behind that Target's threshold — so a dispatch
+    // that succeeds is a dispatch whose route and policy were evaluated
+    // against the new Target.
+    await db
+      .update(targets)
+      .set({ minBuildLevel: 3 })
+      .where(eq(targets.id, runtimeTarget.id));
+
+    // A website's build arguments are read for the placement the dispatch
+    // names, so a per-Target value pins which Target that was.
+    await db.insert(configItems).values([
+      {
+        componentId: component.id,
+        targetId: runtimeTarget.id,
+        key: 'SITE_URL',
+        kind: 'plain',
+        plainValue: 'https://old.example.test',
+      },
+      {
+        componentId: component.id,
+        targetId: staticTarget.id,
+        key: 'SITE_URL',
+        kind: 'plain',
+        plainValue: 'https://new.example.test',
+      },
+    ]);
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(context(registryOf(route)))).toBe(1);
+
+    expect((await buildRow(build.id)).status).toBe('SUCCEEDED');
+    expect(route.built).toHaveLength(1);
+    expect(route.built[0]?.spec.artifactType).toBe('files');
+    expect(route.built[0]?.spec.buildArgs).toEqual({
+      SITE_URL: 'https://new.example.test',
+    });
+  });
+
+  test('a Build whose shape no placement takes waits and says so', async () => {
+    const { runtimeTarget, runtimeVessel, staticTarget, build } =
+      await movedWebsite();
+    const db = database().db;
+
+    // Retire the placement that admitted the shape, leaving only the image
+    // Target. Binding the files Build there anyway would evaluate policy
+    // against a Target the artifact can never land on.
+    await db
+      .delete(componentTargetDesired)
+      .where(eq(componentTargetDesired.targetId, staticTarget.id));
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(context(registryOf(route)))).toBe(0);
+
+    const row = await buildRow(build.id);
+    expect(row.status).toBe('PENDING');
+    expect(route.built).toHaveLength(0);
+    expect(row.dispatchWaitingOn).toContain('files');
+    expect(row.dispatchWaitingOn).toContain(
+      `${runtimeVessel.name}/${runtimeTarget.adapter} takes image`,
+    );
+  });
+});


### PR DESCRIPTION
Two defects in apps/spindrift, both found by review of the move-rebuild and Dockerfile-context-probe changes.

## Rebuild dispatch bound to the wrong Target after a move

A moved Component deliberately keeps the old pair's `componentTargetDesired` row until what still serves there is retired, so a PENDING Build can join two placements. `runBuildPass` deduplicated per Build by `asc(targets.rank)` — after a move across shapes that binds the files rebuild the move itself prescribed to the old image Target, so route selection and build policy were evaluated against a Target the artifact can never land on (worst case: stuck PENDING behind the old Target's policy).

The loop now binds each Build to the newest desired row whose Target admits the Build's own `targetShape` (shape derived through `artifactTypeFor`, the same mapping every other caller uses; newest-`updatedAt` is the same placement-of-record reading `deployApp` uses). Where no placement admits the shape, the Build records a dispatch wait naming the shape and each refusing Target instead of dispatching anywhere (`src/reconciler/build-loop.ts`).

Other desired-row readers checked: the deploy loop joins on the Deploy's own `targetId`, so it cannot mis-bind; `dispatchBuild` refuses multi-placement dispatches that name no Target. Two display-path reads picked a desired row with `limit: 1` and no ordering (`commands/builds/get-detail.ts`, `commands/apps/workspace.ts`) — post-move those could show either Target; both now order by `updatedAt desc`, matching `deployApp`.

## `COPY ./` garbled the context sentence

In the inspect-time TS mirror of the Dockerfile context probe, the source token `./` normalized to an empty string, producing `{context: 'scope', copies: ''}` — a connect sentence reading "which copies  from beside itself" and claiming a context the build does not use. Both shell probes already answer root here (an empty source resolves to a directory both roots have). The mirror now skips sources that normalize to empty (`src/domain/detection/dockerfile-context.ts`); the shell probe needs no change, and the parity suite now pins the case for all three readers.

## Validation

- `bun test` — 2073 pass, 0 fail (full suite against local Postgres)
- both new tests verified to fail against the pre-fix code
- `bun run typecheck`, `bun run lint` — clean
