### PR TITLE
feat(riptide): park the skiff-ubuntu slots while tender carries the label

### DIFF
--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -151,8 +151,10 @@ func LoadConfig(path string) (*Config, error) {
 			// else's.
 			return nil, fmt.Errorf("config: class %s: a persisting class name may not contain '/' or '.'", name)
 		}
-		if c.Warm <= 0 {
-			return nil, fmt.Errorf("config: class %s: warm must be positive", name)
+		// warm = 0 is a parked class: declared, serving nothing. The pool
+		// reclaims its slot images on start, so parking also frees the disk.
+		if c.Warm < 0 {
+			return nil, fmt.Errorf("config: class %s: warm must not be negative", name)
 		}
 		if c.MaxLifetime <= 0 {
 			c.MaxLifetime = Duration(defaultMaxLifetime)

--- a/apps/bosun/config_test.go
+++ b/apps/bosun/config_test.go
@@ -67,6 +67,15 @@ func TestLoadConfigRequiresAtLeastOneClass(t *testing.T) {
 	}
 }
 
+func TestLoadConfigAllowsParkedClass(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{"repo": "acme/widgets", "tokenFile": "/x", "classes": {"c": {"hull":"/h","vcpus":1,"memory":"1G","warm":0}}}`)
+	if _, err := LoadConfig(path); err != nil {
+		t.Fatalf("warm = 0 is a parked class, not an error: %v", err)
+	}
+}
+
 func TestDurationUnmarshal(t *testing.T) {
 	var d Duration
 	if err := json.Unmarshal([]byte(`"30s"`), &d); err != nil {

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -88,11 +88,17 @@
       memory = "3072M";
       workspace = "6G";
       persist = true;
-      warm = 2;
+      # warm = 0 while tender carries this label: the lab keeps a single warm
+      # slot (skiff-nixos above) and every skiff-ubuntu job lands on the cloud
+      # pool, which is also what makes the cloud bench numbers unambiguous.
+      # Restore warm = 2 to serve the label from this host again; the slot
+      # disks are reclaimed at 0 and rebuilt cold on the way back up.
+      warm = 0;
     };
   };
 
-  # The pool's declared ceiling is 2048M + 2x3072M = 8 GiB, inside the limit
+  # The pool's declared ceiling is 2048M + warm x 3072M -- 8 GiB at warm = 2,
+  # inside the limit
   # below with room to spare: riptide has 15.2 GiB total, ~5 GiB held by
   # kubelet and the system, and no swap. Without a bound the *host* OOM killer
   # picks the victim, which on a worker node may be a pod or kubelet rather


### PR DESCRIPTION
The lab keeps a single warm slot (`skiff-nixos`, warm 1); `skiff-ubuntu` is served by tender's cloud pool alone, which also makes the cloud bench numbers unambiguous — no slot lottery between sites.

`warm = 0` keeps the class and its documentation; pool.go reclaims the slot disks on the next start. Restore `warm = 2` to serve the label from riptide again.

Validation: `nix eval` confirms the class renders `warm = 0`; deployed to riptide from this branch and verified the label moved cloud-only.