### PR TITLE
feat(oldschool): a one-slot bosun pool at the site with the fast internet

### DIFF
--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -1,6 +1,6 @@
 # oldschool: offsite worker node that also carries the site's odd jobs —
-# yarr and the offsite harmonia binary cache.
-{ ... }:
+# yarr, the offsite harmonia binary cache, and a one-slot bosun pool.
+{ config, inputs, ... }:
 {
   imports = [
     ../profiles/k8s-node.nix
@@ -8,6 +8,7 @@
     ../system/quiker.nix
     ../system/sops.nix
     ../system/tailscale-disable.nix
+    ../../apps/bosun/module.nix
   ];
 
   services.k8s.clusterCa.enable = true;
@@ -22,4 +23,33 @@
   # nix/secrets/oldschool-harmonia-cache.pub); wired into
   # services.harmonia in the deploy-harmonia ticket.
   sops.secrets."harmonia-cache-key" = { };
+
+  sops.secrets."bosun-github-token" = {
+    owner = "bosun";
+    group = "bosun";
+    mode = "0400";
+    restartUnits = [ "bosun.service" ];
+  };
+
+  # One warm FHS slot at the site with the fast internet. The class shape
+  # matches tender's so the label stays homogeneous; what differs here is the
+  # neighbourhood -- kubelet, yarr and harmonia share the same 4 cores and
+  # 16 GiB, and that contention is part of any number measured on this slot.
+  services.bosun = {
+    enable = true;
+    repo = "jonpulsifer/infra";
+    tokenFile = config.sops.secrets."bosun-github-token".path;
+    classes.skiff-ubuntu = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 4;
+      memory = "3072M";
+      workspace = "6G";
+      persist = true;
+      warm = 1;
+    };
+  };
+
+  # Class ceiling is one 3072M skiff; the bound exists so a runaway pool can
+  # never make the host OOM killer choose between a skiff and kubelet.
+  systemd.services.bosun.serviceConfig.MemoryMax = "4G";
 }

--- a/nix/secrets/oldschool.sops.yaml
+++ b/nix/secrets/oldschool.sops.yaml
@@ -1,25 +1,26 @@
-harmonia-cache-key: ENC[AES256_GCM,data:+tSoPRtR+7V3tdDuP4xYX2xppWDPxT/+hL9l+YtG8owBY6T+lhJxV2jitGA1P9RR9jYZ6hsitm0HHWm1XhImjLD3j9AGfZubWlFc+3GUvSsCbCVwkqHaSHZAX4lp6gW9GvSjBGyNVFcYH1chBKRb,iv:ZK7E/4iGwC+OSC01b5VvUctV1uwX4WUtQAasaU6NR1k=,tag:+jb6ho37HAPRs5SxVNLfDA==,type:str]
+harmonia-cache-key: ENC[AES256_GCM,data:ESNhTjkJKYGAgCtluET3SDDZcPVM4qHqOw1Re3r1D2o0S+zLL3u4i4AiJudMcqZ6cTlXv8Zeop8MEnxtubr/TdQGpannMJmsOKc/fS49FCgf47X6GLHbscw8CCSJFTGAEy9F5vlZZxVGuyRLIZW0,iv:A6WiSyYKXebItw7dRBMaEJkuurLn7lcSzkOXJaZvwOo=,tag:YEKTTIIIzoEzheORfOfAVA==,type:str]
+bosun-github-token: ENC[AES256_GCM,data:HEAVzbV+uGIAxSA1ptcirLEaCLjUxoHAOC9dC2lmKZP7aMbAAhK+Xg==,iv:MqGmNAx7faWzNDwopI9qZveBoTgoeRFbosPRoK3KSOY=,tag:ShB27uZKFHAu25xrLlj9ug==,type:str]
 sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBBa0RyeGYyUU11YUJFQzR4
-            dnZaZ3k1d1l3cDluZmxXNmhzS08wUUlWWVJnCnR1L1l4NEYyYmdTa1psNTNWSVl6
-            ZDV6WFREM21GRlduekdQaVBwMGd1M2sKLS0tIEZOb0lnU3lyYUNhTXovRFN6Zzg5
-            bmRSYStxUzN6VHA1T0VvQnZYSmMyZkEKLK0Jg9xn7tImHeQsakpihQRHUdZZqvFU
-            mSXPCn7HWcpyhlKh5hXoDIGoO9TjHOJEiB17FmPFSFjH5WDFkOnZ1g==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBGZ3BNS3hvU2hFREgrWVg5
+            Sjd6MkZmSHo2cjM3MGtiOVBGejRTemQrdVFZCng0OWJ4bzR3c25uUDZFcHhTRmZR
+            TllwUzkwdnhYQ2JrZm1XTUR2UlVVa0UKLS0tIDg4ZTZac1FPSGhBTDl3UkRYMGxN
+            YkNFOThPV3JhU2F6enBmOHQ3UU9JbkUKLuKIRmcppqEt5HTR6vpCPwbn0dwX2lJe
+            Eq5lIC61mYrxHNcIneSXpYmSvmPgL403Jcwd9n3Wm1s3u/22eYM3Mg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLblkvMkY1T25DMG9zVzZj
-            U2g3cjF5Y0IyZ1hjeGlKUHV3RkJGVGxPa1dVCnBzTktpWVduSGlLY1RKSmJTanE3
-            ZjNHSTBVNjgwNlpRd3c2VUFGcDIzVG8KLS0tIDdJdmNpNjBkNy84K2FHbkJiSHZz
-            UmUxZk5sKythWXRFTFJ2bzdocnh0aW8Ko6hKpkhnsMz9blw2aSpH0JrWLXgXY9Y3
-            R9aic1eFiEHPRodNFxrD7z5C0gI3NhoNbKlkG3rVYDFcqUrkMAU49A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA4NUpSRUs4SlpoYjhjUC9Z
+            T0NObHI2K0lXdTlhbklaVEt1TE5UZlUyMDMwCllTbHU2Vk1MeXAxeUh6d3hmUllL
+            SGdZaFlRRW5SYi8weUR1d3hxZndMRW8KLS0tIERsVUFGc25vdWJBUTlhZTZrcVVZ
+            N3JzRjBNc1FjNXBNeVVWaWdnOStWM1kKQ/oFfDeh7OfPsdsUu7xTTXw48Cdn//0S
+            342lL87ttVLwXjIUyl4//X3uuPejCpeHb77AZR6xUS7qM7N/W7GJ6Q==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c
-    lastmodified: "2026-07-12T01:05:48Z"
-    mac: ENC[AES256_GCM,data:U69fm8DhVHGbTzLChm/XiMVbSjw2zi/Go4qaH7V+uFjlIKeaxv3DV8iXzIvipRWyFBuTix/L1U0+nyyVabnoUMhJnXmHqktC4iFfRnYCrju4or/MMDQnLVsfnYtQYfYZZuM51lPfLU668vFg4E5Lofo9SbAYacF5dQscYnx7epo=,iv:+A8Lom3jKN0vaHoR/AbNCgISL9kcxcPXGeHyZE0dTBc=,tag:SlBi77ffjMDo91/QSWu9ow==,type:str]
+    lastmodified: "2026-08-09T23:08:28Z"
+    mac: ENC[AES256_GCM,data:uokCeHF1eO7fxC6xkUpbeedEGDHa4uG1E1vrr5PD1tOJifpj8MFcK7ThhsEzz2DKURutbn9B7ryv4NKoeq9/2g2/dhc0uLqWuDFPCj23PzyuyBr2F64YApjPhcG35RmX+1R7uu0mhS+2hY2HV9BQm/Aqam+Luim0IeP+xHjrlH8=,iv:XnXsnHqNCkMbkgYRxhfXOqPyxlJureDsvxuvc9Kn9fs=,tag:gcYSca5hhv5i1U2UrDvRMQ==,type:str]
     unencrypted_suffix: _unencrypted
-    version: 3.13.2
+    version: 3.13.3


### PR DESCRIPTION
One warm `skiff-ubuntu` slot on oldschool, same class shape as tender so the label stays homogeneous — the differing neighbourhood (kubelet, yarr, harmonia on 4 cores / 16 GiB) is part of any number measured on this slot, and `MemoryMax = 4G` keeps a runaway pool from making the host OOM killer choose between a skiff and kubelet.

The token rides the existing `oldschool.sops.yaml` (both keys verified decryptable, both recipients intact).

Validation: `nix eval` renders the class; deployed to oldschool from this branch and verified the runner registers online.