### PR TITLE
feat(bosun): a host-local actions/cache service every skiff can actually use

### DIFF
--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -150,13 +150,15 @@ jobs:
           if [ "${{ inputs.caches }}" = "gha" ]; then
             echo "caches: gha — actions/cache on every label, no warm-disk shortcuts."
             if [ -n "${SKIFF_CACHE:-}" ]; then
-              # The one honest divergence: bun's store must not land on the
-              # guest's tmpfs root (a cold install ENOSPCs a 2.9 GiB class),
-              # so it goes on the disk — emptied, so the cache step still
-              # transfers every byte. The cache steps' paths follow the env.
-              rm -rf "$SKIFF_CACHE/gha-bun"
-              mkdir -p "$SKIFF_CACHE/gha-bun"
-              echo "BUN_INSTALL_CACHE_DIR=$SKIFF_CACHE/gha-bun" >> "$GITHUB_ENV"
+              # The warm-disk content is emptied so the cache step transfers
+              # every byte, and bun's store is redirected onto the disk — a
+              # second copy beside the old one overflows a 6G slot (measured:
+              # ENOSPC), and landing it on the tmpfs root OOMs the class.
+              # The tool cache survives: this input measures actions/cache,
+              # not mise.
+              rm -rf "$SKIFF_CACHE"/*
+              mkdir -p "$SKIFF_CACHE/bun"
+              echo "BUN_INSTALL_CACHE_DIR=$SKIFF_CACHE/bun" >> "$GITHUB_ENV"
               echo "ACTIONS_RESULTS_URL=${ACTIONS_RESULTS_URL:-unset (talking to GitHub)}"
             fi
             exit 0

--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -25,11 +25,12 @@ on:
           - ubuntu-latest
         default: all
       caches:
-        description: 'best = each label uses the fastest cache it has; none = no dependency or build cache anywhere (isolates the runner from the network)'
+        description: 'best = each label uses the fastest cache it has; none = no dependency or build cache anywhere (isolates the runner from the network); gha = actions/cache on every label, exactly as a hosted runner uses it — on a skiff whose host runs the local cache service, this measures that service'
         type: choice
         options:
           - best
           - none
+          - gha
         default: best
 
 permissions:
@@ -146,6 +147,20 @@ jobs:
       # a clone. That difference is the runner, not a cache we configured.
       - name: Where this runner's cache lives
         run: |
+          if [ "${{ inputs.caches }}" = "gha" ]; then
+            echo "caches: gha — actions/cache on every label, no warm-disk shortcuts."
+            if [ -n "${SKIFF_CACHE:-}" ]; then
+              # The one honest divergence: bun's store must not land on the
+              # guest's tmpfs root (a cold install ENOSPCs a 2.9 GiB class),
+              # so it goes on the disk — emptied, so the cache step still
+              # transfers every byte. The cache steps' paths follow the env.
+              rm -rf "$SKIFF_CACHE/gha-bun"
+              mkdir -p "$SKIFF_CACHE/gha-bun"
+              echo "BUN_INSTALL_CACHE_DIR=$SKIFF_CACHE/gha-bun" >> "$GITHUB_ENV"
+              echo "ACTIONS_RESULTS_URL=${ACTIONS_RESULTS_URL:-unset (talking to GitHub)}"
+            fi
+            exit 0
+          fi
           if [ "${{ inputs.caches }}" = "none" ]; then
             echo "caches: none — nothing is restored on any label."
             if [ -n "${SKIFF_CACHE:-}" ]; then
@@ -198,7 +213,9 @@ jobs:
         if: env.SKIFF_CACHE_ROOT == '' && inputs.caches != 'none'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.bun/install/cache
+          # Follows the gha-mode redirect on a skiff; the hosted default
+          # otherwise.
+          path: ${{ env.BUN_INSTALL_CACHE_DIR || '~/.bun/install/cache' }}
           key: bun-store-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-store-${{ runner.os }}-

--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	LogDir       string           `json:"logDir"`
 	WorkspaceDir string           `json:"workspaceDir"` // real storage, not tmpfs: it holds whole filesystem images
 	MetricsFile  string           `json:"metricsFile"`  // empty disables; a node-exporter textfile, not a listener
+	CacheURL     string           `json:"cacheUrl"`     // empty disables; announced to every skiff as bosun.cache on the cmdline
 	PollInterval Duration         `json:"pollInterval"`
 	Classes      map[string]Class `json:"classes"`
 	Bin          BinPaths         `json:"bin"`

--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -221,7 +221,7 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 // so a hull's disks are declared raw because the hull contract says a disk is a
 // raw file the hull ships. A hull wanting qcow2 wants a manifest field, and a
 // failing test to go with it.
-func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
+func chArgs(h *hull, class Class, id string, p skiffPaths, cacheURL string) []string {
 	args := []string{
 		"--kernel", filepath.Join(h.dir, h.manifest.Kernel),
 		"--initramfs", filepath.Join(h.dir, h.manifest.Initrd),
@@ -248,6 +248,11 @@ func chArgs(h *hull, class Class, id string, p skiffPaths) []string {
 	if p.workspace != "" {
 		args = append(args, "--disk", fmt.Sprintf("path=%s,readonly=off,image_type=raw", p.workspace))
 		cmdline += " bosun.workspace=" + guestDiskName(disks)
+	}
+	// A location an admin connected, not machinery bosun owns: the hull
+	// decides whether and how to consume it, like every other cmdline fact.
+	if cacheURL != "" {
+		cmdline += " bosun.cache=" + cacheURL
 	}
 	args = append(args,
 		"--net", fmt.Sprintf("vhost_user=on,socket=%s", p.netSock),

--- a/apps/bosun/hull_test.go
+++ b/apps/bosun/hull_test.go
@@ -54,7 +54,7 @@ func TestChArgsNoDevices(t *testing.T) {
 		t.Fatalf("resolvePaths: %v", err)
 	}
 
-	got := chArgs(h, class, "sk01", paths)
+	got := chArgs(h, class, "sk01", paths, "")
 	want := []string{
 		"--kernel", "/hulls/nixos/vmlinux",
 		"--initramfs", "/hulls/nixos/initrd",
@@ -88,7 +88,7 @@ func TestChArgsWithDevices(t *testing.T) {
 		t.Fatalf("resolvePaths: %v", err)
 	}
 
-	got := chArgs(h, class, "sk02", paths)
+	got := chArgs(h, class, "sk02", paths, "")
 	want := []string{
 		"--kernel", "/hulls/nixos/vmlinux",
 		"--initramfs", "/hulls/nixos/initrd",
@@ -123,7 +123,7 @@ func TestChArgsWithDisk(t *testing.T) {
 		t.Fatalf("resolvePaths: %v", err)
 	}
 
-	got := chArgs(h, class, "sk03", paths)
+	got := chArgs(h, class, "sk03", paths, "")
 	want := []string{
 		"--kernel", "/hulls/ubuntu/vmlinux",
 		"--initramfs", "/hulls/ubuntu/initrd",
@@ -317,7 +317,7 @@ func TestChArgsWorkspaceDiskComesLastAndIsNamedOnTheCmdline(t *testing.T) {
 	}
 	paths.workspace = "/var/lib/bosun/workspace/sk09.img"
 
-	got := chArgs(h, class, "sk09", paths)
+	got := chArgs(h, class, "sk09", paths, "")
 	want := []string{
 		"--kernel", "/hulls/ubuntu/vmlinux",
 		"--initramfs", "/hulls/ubuntu/initrd",
@@ -351,12 +351,28 @@ func TestChArgsNoWorkspaceLeavesCmdlineAlone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolvePaths: %v", err)
 	}
-	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk10", paths)
+	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk10", paths, "")
 	if slices.Contains(got, "--disk") {
 		t.Fatalf("workspace-less class got a disk: %v", got)
 	}
 	if !slices.Contains(got, "console=ttyS0 bosun.skiff=sk10 bosun.hull=sha256:deadbeef") {
 		t.Fatalf("cmdline changed: %v", got)
+	}
+}
+
+func TestChArgsAnnouncesCacheURLOnCmdline(t *testing.T) {
+	h := &hull{
+		dir:      "/hulls/nixos",
+		manifest: hullManifest{Kernel: "vmlinux", Initrd: "initrd", Cmdline: "console=ttyS0"},
+		digest:   "deadbeef",
+	}
+	paths, err := resolvePaths("/run/bosun", "/var/log/bosun", "sk12", nil)
+	if err != nil {
+		t.Fatalf("resolvePaths: %v", err)
+	}
+	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk12", paths, "http://10.113.113.1:3000/")
+	if !slices.Contains(got, "console=ttyS0 bosun.cache=http://10.113.113.1:3000/ bosun.skiff=sk12 bosun.hull=sha256:deadbeef") {
+		t.Fatalf("cache URL missing from cmdline: %v", got)
 	}
 }
 

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -303,7 +303,7 @@ in
 
       image = mkOption {
         type = types.str;
-        default = "ghcr.io/falcondev-oss/github-actions-cache-server:v9.7.0";
+        default = "ghcr.io/falcondev-oss/github-actions-cache-server:9.7.0";
         description = ''
           Pinned server image. v9+ speaks only the v2 twirp protocol, which
           is what actions/cache >= 4.2 uses against github.com.

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -30,6 +30,7 @@ let
       metricsFile
       ;
     pollInterval = cfg.pollInterval;
+    cacheUrl = if cfg.cache.enable then "http://${cfg.cache.address}:${toString cfg.cache.port}/" else "";
     classes = lib.mapAttrs (_: c: {
       inherit (c)
         hull
@@ -252,6 +253,63 @@ in
         }
       );
     };
+
+    # A GitHub-Actions cache service on this host's own disk, announced to
+    # every skiff as `bosun.cache=<url>` on the cmdline. The Ubuntu hull
+    # patches its runner so the stock actions/cache action talks to it
+    # instead of GitHub's cache service -- the bench measured 49-76 s of
+    # `actions/cache` restore over the internet against 0 s from local disk,
+    # and this is that number for workflows that were never taught about
+    # SKIFF_CACHE.
+    #
+    # The server binds a dummy interface that exists only for this purpose,
+    # and the skiffs' egress filter gains exactly that /32: systemd's most-
+    # specific-match rule lets it through the RFC1918 deny without opening
+    # the host's real address, its loopback, or anything else on the LAN.
+    # The server itself validates each runner's GitHub-signed JWT against
+    # GitHub's JWKS, so an address is all a caller gets, not a cache.
+    cache = {
+      enable = mkEnableOption "a host-local GitHub Actions cache service for the skiffs";
+
+      address = mkOption {
+        type = types.str;
+        default = "10.113.113.1";
+        description = ''
+          Host-local dummy address the cache service binds. Deliberately
+          inside RFC1918 so it stays unroutable beyond this host; chosen
+          away from every declared fabric range.
+        '';
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 3000;
+      };
+
+      storageDir = mkOption {
+        type = types.path;
+        default = "/var/lib/bosun-cache";
+        description = "Cache payloads and the sqlite metadata DB live here.";
+      };
+
+      maxSizeBytes = mkOption {
+        type = types.nullOr types.int;
+        default = null;
+        description = ''
+          LRU-eviction cap on stored cache payloads. null leaves only the
+          server's own 90% volume-usage guard.
+        '';
+      };
+
+      image = mkOption {
+        type = types.str;
+        default = "ghcr.io/falcondev-oss/github-actions-cache-server:v9.7.0";
+        description = ''
+          Pinned server image. v9+ speaks only the v2 twirp protocol, which
+          is what actions/cache >= 4.2 uses against github.com.
+        '';
+      };
+    };
   };
 
   config = mkIf cfg.enable {
@@ -287,7 +345,43 @@ in
     systemd.tmpfiles.rules = [
       "e ${cfg.logDir} - - - ${cfg.logRetention}"
       "d ${cfg.workspaceDir} 0700 bosun bosun -"
-    ];
+    ]
+    ++ lib.optional cfg.cache.enable "d ${cfg.cache.storageDir} 0700 root root -";
+
+    # The dummy interface the cache service binds. A netdev with no carrier
+    # and no routes beyond the host: the address exists so the skiffs' egress
+    # exception can name exactly one /32 that serves nothing but cache.
+    systemd.network.netdevs."20-bosun-cache" = mkIf cfg.cache.enable {
+      netdevConfig = {
+        Name = "bosun-cache0";
+        Kind = "dummy";
+      };
+    };
+    systemd.network.networks."20-bosun-cache" = mkIf cfg.cache.enable {
+      matchConfig.Name = "bosun-cache0";
+      address = [ "${cfg.cache.address}/32" ];
+      linkConfig.ActivationPolicy = "always-up";
+    };
+
+    virtualisation.oci-containers = mkIf cfg.cache.enable {
+      backend = "podman";
+      containers.bosun-cache = {
+        image = cfg.cache.image;
+        # Published on the dummy address only: the host's real interfaces
+        # never listen, so nothing off-host can reach the server even before
+        # any firewall has an opinion.
+        ports = [ "${cfg.cache.address}:${toString cfg.cache.port}:3000" ];
+        volumes = [ "${cfg.cache.storageDir}:/data" ];
+        environment = {
+          API_BASE_URL = "http://${cfg.cache.address}:${toString cfg.cache.port}";
+          STORAGE_FILESYSTEM_PATH = "/data/storage";
+          DB_SQLITE_PATH = "/data/cache-server.db";
+        }
+        // lib.optionalAttrs (cfg.cache.maxSizeBytes != null) {
+          CACHE_MAX_SIZE_BYTES = toString cfg.cache.maxSizeBytes;
+        };
+      };
+    };
 
     systemd.services.bosun = {
       description = "warm pool of ephemeral microVM Actions runners";
@@ -340,7 +434,10 @@ in
         # pool: job code reaches the public internet and nothing on the LAN.
         # systemd's IP filtering is hierarchical and inherits down the entire
         # cgroup subtree, which is why there is no per-skiff rule anywhere.
-        IPAddressAllow = "any";
+        # "any" is /0 and systemd's most-specific-match rule means the deny
+        # prefixes below still bite; the cache /32, when enabled, is more
+        # specific than 10.0.0.0/8 and punches exactly one host-local hole.
+        IPAddressAllow = [ "any" ] ++ lib.optional cfg.cache.enable "${cfg.cache.address}/32";
         IPAddressDeny = [
           "10.0.0.0/8"
           "172.16.0.0/12"

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -378,7 +378,7 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 		return fmt.Errorf("start passt: %w", err)
 	}
 
-	chProc, err := p.launch.Start(binPath(p.cfg.Bin.CloudHypervisor, "cloud-hypervisor"), chArgs(h, class, s.id, s.paths), helpersLog, helpersLog)
+	chProc, err := p.launch.Start(binPath(p.cfg.Bin.CloudHypervisor, "cloud-hypervisor"), chArgs(h, class, s.id, s.paths, p.cfg.CacheURL), helpersLog, helpersLog)
 	if err != nil {
 		return fmt.Errorf("start cloud-hypervisor: %w", err)
 	}

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -95,6 +95,14 @@
       # disks are reclaimed at 0 and rebuilt cold on the way back up.
       warm = 0;
     };
+
+    # 10 GB on the NVMe root for the actions/cache service. Announced to
+    # every skiff on this host; the parked class picks it up whenever it
+    # un-parks, and skiff-nixos ignores it until that hull learns the trick.
+    cache = {
+      enable = true;
+      maxSizeBytes = 10737418240;
+    };
   };
 
   # The pool's declared ceiling is 2048M + warm x 3072M -- 8 GiB at warm = 2,

--- a/nix/hosts/tender.nix
+++ b/nix/hosts/tender.nix
@@ -46,6 +46,13 @@
       persist = true;
       warm = 4;
     };
+
+    # 30 GB of the 100 GB boot disk for the actions/cache service; the four
+    # workspace disks reserve another 24 GB and the closure needs the rest.
+    cache = {
+      enable = true;
+      maxSizeBytes = 32212254720;
+    };
   };
 
   # 30 GiB total and nothing else on the box, so the bound is generous rather

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -226,6 +226,16 @@ let
       # dirs on the root overlay itself (EINVAL on mount).
       $bb mount -t tmpfs -o mode=0710 tmpfs /var/lib/docker
     fi
+    # The host-local actions/cache service, when this host runs one. The
+    # runner's Worker is patched at build time (see the squashfs staging) so
+    # this env-provided URL survives into jobs and the stock actions/cache
+    # talks to the local server instead of GitHub's. No announcement, no
+    # override: the skiff behaves exactly as the hosted runner does.
+    for tok in $($bb cat /proc/cmdline); do
+      case "$tok" in
+        bosun.cache=*) echo "export ACTIONS_RESULTS_URL=''${tok#bosun.cache=}" >> /etc/skiff-env ;;
+      esac
+    done
     echo "skiff-mark workspace-ready $($bb cut -d' ' -f1 /proc/uptime)"
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
       dockerd >/var/log/dockerd.log 2>&1 &
@@ -333,6 +343,20 @@ let
         chmod u+w root/etc/sudoers
         echo 'root ALL=(ALL:ALL) NOPASSWD:ALL' >> root/etc/sudoers
         chmod 440 root/etc/sudoers
+
+        # Stock Runner.Worker overwrites ACTIONS_RESULTS_URL with the value
+        # from GitHub's job message, which would clobber the host-provided
+        # cache endpoint. The documented fix (gha-cache-server.falcondev.io):
+        # rewrite the UTF-16LE string to a dead name, so the worker's
+        # overwrite lands on ACTIONS_RESULTS_ORL and the environment's URL
+        # survives. Same length, so no .NET metadata shifts. Skiffs never
+        # self-update -- the runner lives in this immutable squashfs -- so
+        # the patch cannot be reverted at runtime.
+        sed -i 's/\x41\x00\x43\x00\x54\x00\x49\x00\x4F\x00\x4E\x00\x53\x00\x5F\x00\x52\x00\x45\x00\x53\x00\x55\x00\x4C\x00\x54\x00\x53\x00\x5F\x00\x55\x00\x52\x00\x4C\x00/\x41\x00\x43\x00\x54\x00\x49\x00\x4F\x00\x4E\x00\x53\x00\x5F\x00\x52\x00\x45\x00\x53\x00\x55\x00\x4C\x00\x54\x00\x53\x00\x5F\x00\x4F\x00\x52\x00\x4C\x00/g' \
+          root/home/runner/bin/Runner.Worker.dll
+        # A silent no-op patch would mean cache traffic quietly going to
+        # GitHub; fail the build instead. (`.` matches the UTF-16 NULs.)
+        LC_ALL=C grep -qa 'A.C.T.I.O.N.S._.R.E.S.U.L.T.S._.O.R.L' root/home/runner/bin/Runner.Worker.dll
 
         mkdir -p root/opt/bosun root/run/bosun
         install -m755 ${busybox}/bin/busybox root/opt/bosun/busybox


### PR DESCRIPTION
The five-wave bench put 49–76 s of every self-hosted job inside `actions/cache` pulling the dependency store over the internet, and the warm-disk answer only covers workflows taught about `SKIFF_CACHE`. This serves the **stock** action instead.

- **`services.bosun.cache`** runs falcondev-oss/github-actions-cache-server (v2 twirp — the only protocol `actions/cache` ≥ 4.2 speaks since GitHub retired the legacy service in April 2025) as a podman container on the host's own disk, bound to a dummy `10.113.113.1/32` that exists for nothing else. Skiffs gain exactly that /32 via `IPAddressAllow` — systemd's most-specific-match lets it through the RFC1918 deny without opening the host's real address, its loopback, or the LAN. The server validates each runner's GitHub-signed JWT against GitHub's JWKS, so an address is all a caller gets, and non-cache results traffic is proxied through to GitHub so artifacts keep working.
- **bosun** announces the URL as `bosun.cache=` on the cmdline (a location an admin connected, per the hull contract); covered by a chArgs test.
- **The Ubuntu hull** turns that into `ACTIONS_RESULTS_URL` and patches `Runner.Worker.dll` at build time (the documented UTF-16LE rename to `ACTIONS_RESULTS_ORL`) so the job message cannot clobber it; the build fails if the patch does not take. Skiffs never self-update — the runner lives in an immutable squashfs.
- **The bench** gains `caches: gha` — `actions/cache` on every label exactly as a hosted runner uses it, which on a cache-serving host measures the local service against the 49–76 s internet number.

Enabled on tender (30 GB cap) and riptide (10 GB, ready for whenever its class un-parks).

Validation: bosun test suite green (incl. new chArgs and parked-class cases); hull dry-run evals; deployed to tender from this branch — cache container healthy, and back-to-back `caches: gha` bench runs measured save-then-restore against the local service (numbers in PR comment / ticket).