### PR TITLE
feat(spindrift): only atlantis crosses clusters now

### DIFF
--- a/nix/services/k8s/default.nix
+++ b/nix/services/k8s/default.nix
@@ -82,11 +82,10 @@ in
             {
               expression = ''
                 claims.sub in [
-                  "system:serviceaccount:atlantis:atlantis",
-                  "system:serviceaccount:spindrift:spindrift"
+                  "system:serviceaccount:atlantis:atlantis"
                 ]
               '';
-              message = "only the Atlantis and Spindrift service accounts may authenticate across clusters";
+              message = "only the Atlantis service account may authenticate across clusters";
             }
           ];
           claimMappings.username.expression = ''"federated:" + claims.sub'';


### PR DESCRIPTION
Removes the spindrift service account from the cross-cluster OIDC claim-validation rule in the API server's AuthenticationConfiguration. The namespace it named no longer exists on any cluster; Atlantis keeps its entry, and the refusal message now tells the truth.

Rolls out with each host's auto-upgrade from main (no manual deploy needed).