### PR TITLE
feat(ci): the typescript and container builds run on the warm pool

### DIFF
--- a/.github/scripts/detect-containers.sh
+++ b/.github/scripts/detect-containers.sh
@@ -34,6 +34,12 @@ set -euo pipefail
 manifest=".github/containers.json"
 
 mapfile -t changed_files <<<"${CHANGED_FILES:-}"
+# tj-actions' safe_output escapes the newline separator, so every element but
+# the last arrives with a trailing backslash. The per-path prefix globs below
+# tolerated that; the exact-match rebuild-all grep did not, which silently
+# killed rebuild-on-workflow-change. Strip it regardless of the action's
+# current escaping mood.
+changed_files=("${changed_files[@]%\\}")
 
 # A change to the workflow, this script, or the allowlist rebuilds every image.
 rebuild_all=false

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -41,11 +41,13 @@ jobs:
   build:
     needs: detect
     if: needs.detect.outputs.has_changes == 'true'
-    # The warm pool. dockerd runs inside every skiff, buildx brings its own
-    # buildkitd container, and `type=gha` cache traffic lands on the bosun
-    # host's local cache service via ACTIONS_RESULTS_URL — layer caches stop
-    # crossing the internet.
-    runs-on: skiff-ubuntu
+    # The warm pool's image-build class: same hull, 20G workspace, because a
+    # docker build lives in the guest's docker data root and the whole matrix
+    # ENOSPCed on the suite-sized 6G disk. dockerd runs inside every skiff,
+    # buildx brings its own buildkitd container, and `type=gha` cache traffic
+    # lands on the bosun host's local cache service via ACTIONS_RESULTS_URL —
+    # layer caches stop crossing the internet.
+    runs-on: skiff-ubuntu-xl
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -41,7 +41,11 @@ jobs:
   build:
     needs: detect
     if: needs.detect.outputs.has_changes == 'true'
-    runs-on: ubuntu-latest
+    # The warm pool. dockerd runs inside every skiff, buildx brings its own
+    # buildkitd container, and `type=gha` cache traffic lands on the bosun
+    # host's local cache service via ACTIONS_RESULTS_URL — layer caches stop
+    # crossing the internet.
+    runs-on: skiff-ubuntu
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -119,7 +119,10 @@ jobs:
       - name: Cache Bun store
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: ~/.bun/install/cache
+          # A skiff's hull points bun's store at the workspace disk; the
+          # cache step must follow it or it caches an empty directory. On a
+          # hosted runner the env is unset and this is the usual path.
+          path: ${{ env.BUN_INSTALL_CACHE_DIR || '~/.bun/install/cache' }}
           key: bun-store-${{ runner.os }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-store-${{ runner.os }}-

--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -8,13 +8,14 @@ on:
   workflow_dispatch:
     inputs:
       runner:
-        description: 'Runner target (infra-offsite, infra-folly, ubuntu-latest)'
+        description: 'Runner target (skiff-ubuntu, infra-offsite, infra-folly, ubuntu-latest)'
         type: choice
         options:
+          - skiff-ubuntu
           - infra-offsite
           - infra-folly
           - ubuntu-latest
-        default: ubuntu-latest
+        default: skiff-ubuntu
 
 permissions:
   contents: read
@@ -60,7 +61,11 @@ jobs:
   validate:
     needs: detect
     if: needs.detect.outputs.has_changes == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: ${{ inputs.runner || 'ubuntu-latest' }}
+    # The warm pool: acquisition is ~1 s, the suite runs level with a hosted
+    # runner (bench, ticketed), and actions/cache restores from the bosun
+    # host's local cache service instead of over the internet. The dispatch
+    # input still reaches any other label for comparison runs.
+    runs-on: ${{ inputs.runner || 'skiff-ubuntu' }}
     permissions:
       contents: read
       id-token: write

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -63,6 +63,9 @@ type pool struct {
 	launch launcher
 	logger *slog.Logger
 	stats  *metrics
+	// host is baked into every runner's name (skiff-<host>-<id>) so a job's
+	// own "Set up job" log says which bosun host to look at.
+	host string
 
 	mu     sync.Mutex
 	skiffs map[string]*skiff
@@ -73,15 +76,27 @@ type pool struct {
 }
 
 func newPool(cfg *Config, gh githubClient, launch launcher, logger *slog.Logger) *pool {
+	host, _ := os.Hostname()
 	return &pool{
 		cfg:    cfg,
 		gh:     gh,
 		launch: launch,
 		logger: logger,
 		stats:  newMetrics(),
+		host:   host,
 		skiffs: map[string]*skiff{},
 		slots:  map[string]map[int]struct{}{},
 	}
+}
+
+// runnerName is what GitHub shows in a job's "Set up job" header. It carries
+// the bosun host because that is the first thing anyone debugging a job needs
+// and nothing else in the job log says it.
+func (p *pool) runnerName(id string) string {
+	if p.host == "" {
+		return "skiff-" + id
+	}
+	return "skiff-" + p.host + "-" + id
 }
 
 // workspaceSlotName is the image a persisting class's slot always reuses. Named
@@ -264,7 +279,7 @@ func (p *pool) spawn(ctx context.Context, className string) {
 	}
 	// Mint immediately before boot, never stockpiled: the config expires
 	// ~1h from this call, not from when a guest first connects.
-	runnerID, jitConfig, err := p.gh.GenerateJITConfig(ctx, p.cfg.Repo, "skiff-"+id, []string{className})
+	runnerID, jitConfig, err := p.gh.GenerateJITConfig(ctx, p.cfg.Repo, p.runnerName(id), []string{className})
 	if err != nil {
 		logger.Error("generate jitconfig", "error", err)
 		return

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -47,6 +47,13 @@
       persist = true;
       warm = 1;
     };
+
+    # 30 GB of the 200 GB root for the actions/cache service — this is the
+    # site with the fast internet, so a cold miss refills it cheapest here.
+    cache = {
+      enable = true;
+      maxSizeBytes = 32212254720;
+    };
   };
 
   # Class ceiling is one 3072M skiff; the bound exists so a runaway pool can

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -48,6 +48,17 @@
       warm = 1;
     };
 
+    # Image builds: the 20G disk is the point — see tender.nix. The 200G
+    # root carries it easily.
+    classes.skiff-ubuntu-xl = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 4;
+      memory = "3072M";
+      workspace = "20G";
+      persist = true;
+      warm = 1;
+    };
+
     # 30 GB of the 200 GB root for the actions/cache service — this is the
     # site with the fast internet, so a cold miss refills it cheapest here.
     cache = {
@@ -56,7 +67,7 @@
     };
   };
 
-  # Class ceiling is one 3072M skiff; the bound exists so a runaway pool can
+  # Class ceiling is two 3072M skiffs; the bound exists so a runaway pool can
   # never make the host OOM killer choose between a skiff and kubelet.
-  systemd.services.bosun.serviceConfig.MemoryMax = "4G";
+  systemd.services.bosun.serviceConfig.MemoryMax = "7G";
 }

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -48,16 +48,9 @@
       warm = 1;
     };
 
-    # Image builds: the 20G disk is the point — see tender.nix. The 200G
-    # root carries it easily.
-    classes.skiff-ubuntu-xl = {
-      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
-      vcpus = 4;
-      memory = "3072M";
-      workspace = "20G";
-      persist = true;
-      warm = 1;
-    };
+    # No xl class here on purpose: image builds want cores and disk this box
+    # is already spending on kubelet, yarr and harmonia. The suite slot and
+    # the cache service are what the fast-internet site contributes.
 
     # 30 GB of the 200 GB root for the actions/cache service — this is the
     # site with the fast internet, so a cold miss refills it cheapest here.
@@ -67,7 +60,7 @@
     };
   };
 
-  # Class ceiling is two 3072M skiffs; the bound exists so a runaway pool can
+  # Class ceiling is one 3072M skiff; the bound exists so a runaway pool can
   # never make the host OOM killer choose between a skiff and kubelet.
-  systemd.services.bosun.serviceConfig.MemoryMax = "7G";
+  systemd.services.bosun.serviceConfig.MemoryMax = "4G";
 }

--- a/nix/hosts/tender.nix
+++ b/nix/hosts/tender.nix
@@ -44,11 +44,26 @@
       memory = "3072M";
       workspace = "6G";
       persist = true;
-      warm = 4;
+      warm = 3;
     };
 
-    # 30 GB of the 100 GB boot disk for the actions/cache service; the four
-    # workspace disks reserve another 24 GB and the closure needs the rest.
+    # Image builds. A docker build lives in the guest's docker data root on
+    # the workspace disk, and a fat image plus persisted layers of earlier
+    # builds does not fit in 6G — the whole container matrix ENOSPCed there
+    # (dpkg padding, buildkit "failed to reserve cache"). Same hull, same
+    # RAM; only the disk differs, which is exactly what a class is for.
+    classes.skiff-ubuntu-xl = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 4;
+      memory = "3072M";
+      workspace = "20G";
+      persist = true;
+      warm = 1;
+    };
+
+    # 30 GB of the 100 GB boot disk for the actions/cache service; the
+    # workspace disks (3x6G + 20G) reserve another 38 GB and the closure
+    # needs the rest.
     cache = {
       enable = true;
       maxSizeBytes = 32212254720;

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -215,11 +215,19 @@ let
       # tmpfs, so it costs the class's memory *and* is gone next boot. Naming it
       # here rather than in a workflow makes it a property of the machine, which
       # is what it is: the runner reads it before any job exists.
-      $bb mkdir -p /mnt/skiff/tools
+      $bb mkdir -p /mnt/skiff/tools /mnt/skiff/cache/bun /mnt/skiff/cache/xdg
       {
         echo 'export SKIFF_CACHE=/mnt/skiff/cache'
         echo 'export RUNNER_TOOL_CACHE=/mnt/skiff/tools'
         echo 'export AGENT_TOOLSDIRECTORY=/mnt/skiff/tools'
+        # $HOME is the tmpfs root, so a tool cache written there is charged
+        # against the class's memory -- bun's store alone is ~1.5G, which
+        # ENOSPCed the first unmodified workflow this pool served (measured:
+        # typescript.yml, bun extracting its own platform packages). A hosted
+        # runner's $HOME is a 90G SSD; fidelity here means big caches land on
+        # the disk without the workflow having to know.
+        echo 'export BUN_INSTALL_CACHE_DIR=/mnt/skiff/cache/bun'
+        echo 'export XDG_CACHE_HOME=/mnt/skiff/cache/xdg'
       } > /etc/skiff-env
     else
       # A plain tmpfs: docker's overlayfs snapshotter cannot put upper/work


### PR DESCRIPTION
Moves the two heaviest CI surfaces onto `skiff-ubuntu` (5 warm slots: tender 4, oldschool 1):

- **`typescript.yml`**: `validate` defaults to the pool; the dispatch input still reaches `infra-*` and `ubuntu-latest` for comparison runs. Bench-proven: ~1 s acquisition, suite level with hosted, `actions/cache` restore 14 s from the local cache service vs 49–76 s over the internet.
- **`containers.yml`**: `build` runs on the pool — dockerd lives in every skiff, buildx brings its own buildkitd, and `type=gha` layer cache lands on the bosun host's local cache service via `ACTIONS_RESULTS_URL`. A workflow change rebuilds the **whole image matrix**, so this PR validates every image build on the pool it migrates to.
- **oldschool** gains the cache service (30 GB) — fast-internet site, cheapest cold refill. Deployed from this branch.

This PR's own checks are the validation: `TypeScript` and `containers` below ran on skiffs.