### PR TITLE
fix(spindrift): correct the default caConfigMap comment's claim

### DIFF
--- a/packages/charts/spindrift/tests/render.test.ts
+++ b/packages/charts/spindrift/tests/render.test.ts
@@ -661,8 +661,9 @@ describe('the trust store', () => {
   });
 
   test('it defaults to the cluster’s own published root', async () => {
-    // An installation whose Targets are all in-cluster needs nothing else, and
-    // must not be made to declare a bundle to keep working.
+    // Sufficient when that root is self-signed: an installation whose Targets
+    // are all in-cluster on such a cluster needs nothing else, and must not
+    // be made to declare a bundle to keep working.
     expect(
       trustSource(await render(federated()), 'spindrift-web'),
     ).toContainEqual({

--- a/packages/charts/spindrift/values.yaml
+++ b/packages/charts/spindrift/values.yaml
@@ -25,11 +25,19 @@ serviceAccount:
     expirationSeconds: 3600
     mountPath: /var/run/secrets/spindrift
     # The ConfigMap projected at `ca.crt` — the one file `NODE_EXTRA_CA_CERTS`
-    # names. The cluster's own published root by default, which is all an
-    # installation whose Targets are in-cluster ever needs. An installation
-    # holding a Target on another cluster names a ConfigMap carrying that
-    # cluster's chain as well, because the variable takes exactly one file and a
-    # projected volume cannot merge two sources onto one path.
+    # names. Defaults to the cluster's own published root, `kube-root-ca.crt`,
+    # because it is the only trust material every cluster publishes with zero
+    # operator input — a template cannot introspect certificate content to
+    # refuse a bad default at install time. That default is sufficient only
+    # when the published root is self-signed. A cluster whose CA is issued by
+    # an intermediate must name a ConfigMap carrying the full chain (the
+    # leaf-issuing CA, every intermediate, and the self-signed root); Node
+    # does no partial-chain verification through `NODE_EXTRA_CA_CERTS`, so a
+    # bare intermediate-issued root fails every verification with
+    # `unable to get issuer certificate`. An installation holding a Target on
+    # another cluster names a ConfigMap carrying that cluster's chain as well,
+    # because the variable takes exactly one file and a projected volume
+    # cannot merge two sources onto one path.
     caConfigMap: kube-root-ca.crt
 
 # Where the control plane's own UI is served. Empty renders no Gateway and no


### PR DESCRIPTION
The chart's default `caConfigMap` comment claimed `kube-root-ca.crt` is "all an installation whose Targets are in-cluster ever needs." That's false on a cluster whose CA is issued by an intermediate (both FML clusters): that ConfigMap alone can't anchor its own chain, and Node does no partial-chain verification via `NODE_EXTRA_CA_CERTS`, so verification fails with `unable to get issuer certificate`.

Rewrites the comment to state the default's actual scope (sufficient only when the published root is self-signed), what an intermediate-issued cluster must do instead (name a ConfigMap with the full chain), and why the default stays `kube-root-ca.crt` regardless (only trust material every cluster publishes with zero operator input; a template can't introspect certificate content to refuse at install time). Narrows the matching test comment to the same corrected scope without changing the assertion.

Documentation-only: no template or default change.

## Validation
- `bun test` (packages/charts/spindrift) — 29 pass
- `mise run ts:check` — typecheck + lint clean across all packages