### PR TITLE
fix(spindrift): restart coredns when the cluster CA rotates under it

### DIFF
--- a/clusters/folly/bootstrap/bootstrap.tftest.hcl
+++ b/clusters/folly/bootstrap/bootstrap.tftest.hcl
@@ -14,6 +14,7 @@ run "exposes_folly_bootstrap_resources" {
         cluster_role_binding = "system:coredns"
         config_map           = "kube-system/coredns"
         deployment           = "kube-system/coredns"
+        reload_annotation    = "kube-root-ca.crt"
         service              = "kube-system/kube-dns"
         service_account      = "kube-system/coredns"
       }

--- a/clusters/offsite/bootstrap/bootstrap.tftest.hcl
+++ b/clusters/offsite/bootstrap/bootstrap.tftest.hcl
@@ -14,6 +14,7 @@ run "exposes_offsite_bootstrap_resources" {
         cluster_role_binding = "system:coredns"
         config_map           = "kube-system/coredns"
         deployment           = "kube-system/coredns"
+        reload_annotation    = "kube-root-ca.crt"
         service              = "kube-system/kube-dns"
         service_account      = "kube-system/coredns"
       }

--- a/terraform/modules/flux-bootstrap/main.tf
+++ b/terraform/modules/flux-bootstrap/main.tf
@@ -175,6 +175,13 @@ resource "kubernetes_deployment_v1" "coredns" {
       "k8s-app"            = "kube-dns"
       "kubernetes.io/name" = "CoreDNS"
     }
+    # CoreDNS builds its API-server root pool once, at process start. A CA
+    # rotation rewrites kube-root-ca.crt in place and nothing else restarts
+    # CoreDNS, so it keeps trusting the old CA and silently wedges. Reloader
+    # turns that ConfigMap change into the restart that makes the rotation take.
+    annotations = {
+      "configmap.reloader.stakater.com/reload" = "kube-root-ca.crt"
+    }
   }
   spec {
     # Two, spread across nodes where there are two to spread across: a CoreDNS

--- a/terraform/modules/flux-bootstrap/outputs.tf
+++ b/terraform/modules/flux-bootstrap/outputs.tf
@@ -7,6 +7,7 @@ output "bootstrap_resources" {
       cluster_role_binding = kubernetes_cluster_role_binding_v1.coredns.metadata[0].name
       config_map           = "${kubernetes_config_map_v1.coredns.metadata[0].namespace}/${kubernetes_config_map_v1.coredns.metadata[0].name}"
       deployment           = "${kubernetes_deployment_v1.coredns.metadata[0].namespace}/${kubernetes_deployment_v1.coredns.metadata[0].name}"
+      reload_annotation    = kubernetes_deployment_v1.coredns.metadata[0].annotations["configmap.reloader.stakater.com/reload"]
       service              = "${kubernetes_service_v1.kube_dns.metadata[0].namespace}/${kubernetes_service_v1.kube_dns.metadata[0].name}"
       service_account      = "${kubernetes_service_account_v1.coredns.metadata[0].namespace}/${kubernetes_service_account_v1.coredns.metadata[0].name}"
     }


### PR DESCRIPTION
CoreDNS builds its API-server root pool once, at process start. A cluster CA
rotation rewrites kube-root-ca.crt in place and nothing restarts CoreDNS, so
it keeps trusting the old CA and its watches silently wedge — it then serves
whatever it had cached, with no error visible to a caller. This happened on
offsite: after a CA rotation, CoreDNS answered from its frozen cache for six
days — every Service created in that window was unresolvable — until a manual
rollout restart cleared it.

Adds the same Reloader annotation pattern already proven on the Spindrift
chart (packages/charts/spindrift/templates/deployment.yaml): the Deployment
watches kube-root-ca.crt and Reloader restarts it on change. Exposes the
annotation value in bootstrap_resources.coredns and pins it in both
bootstrap roots' tests.

## Validation
- `tofu init -backend=false && tofu validate` in terraform/modules/flux-bootstrap
- `tofu init -backend=false && tofu validate` in clusters/folly/bootstrap and clusters/offsite/bootstrap
- `tofu test` in clusters/folly/bootstrap and clusters/offsite/bootstrap (both pass)
- `tofu fmt -check -diff` on the changed .tf files (no diff)

## Notes for the operator
- Atlantis will autoplan the roots that consume this module, but the two
  bootstrap roots never automerge — apply requires `atlantis apply` from an
  operator.
- After Reloader first fires a restart on a real CA rotation, a later plan
  will show Reloader's restart-marker annotation as drift on this Deployment.
  That's cosmetic and expected, not a sign the module needs another change.
