### PR TITLE
fix(spindrift): give hosted-build run discovery the build's own budget

### DIFF
--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -52,6 +52,7 @@ import { parseBuildReport } from './report.ts';
 import {
   buildFailed,
   buildSucceeded,
+  DEFAULT_BUILD_TIMEOUT_MS,
   deadlineFrom,
   type PollingOptions,
 } from './route.ts';
@@ -169,9 +170,6 @@ export interface GitHubActionsRouteOptions extends PollingOptions {
   /** How long to keep looking for the run a dispatch started. */
   readonly discoveryMs?: number;
 }
-
-/** Long enough for a queued run to appear, short enough to fail visibly. */
-export const DEFAULT_RUN_DISCOVERY_MS = 120_000;
 
 /**
  * Where an archive builds: the repository half of the pinned reference.
@@ -451,7 +449,10 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
 
     const discovery = deadlineFrom({
       ...this.options,
-      timeoutMs: this.options.discoveryMs ?? DEFAULT_RUN_DISCOVERY_MS,
+      timeoutMs:
+        this.options.discoveryMs ??
+        this.options.timeoutMs ??
+        DEFAULT_BUILD_TIMEOUT_MS,
     });
     let run: ActionsRun | null = null;
     // A lookup the far side would not answer is retried until the discovery

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -356,6 +356,18 @@ describe('the hosted build route', () => {
     expect(text(events)).toContain('no run named');
   });
 
+  test('a run that queues past the old discovery default still succeeds', async () => {
+    // Observed live: the run sat queued past a 120s discovery deadline and the
+    // Build was FAILED for a run that went on to complete `success`. Discovery
+    // has no deadline of its own — it shares the build's own budget — so a slow
+    // queue is still inside it here, with no `discoveryMs` override to shrink
+    // that budget back down.
+    const { route } = hostedRoute({ actions: { discoveryDelay: 150 } });
+    const { result } = await run(route.build(archiveSource(), spec));
+
+    expect(result.status).toBe('SUCCEEDED');
+  });
+
   test('a lookup that flakes after a successful dispatch is retried, not failed', async () => {
     // Observed live: the dispatch worked, the call that goes looking for the
     // run it created answered `500`, and the build was recorded `FAILED` while


### PR DESCRIPTION
A hosted Build whose dispatched GitHub Actions run sat queued past 120s was recorded FAILED with "no run named ... appeared", even when the run went on to complete successfully — run discovery had its own fixed 120s deadline instead of sharing the build's own (much longer) timeout budget.

Discovery now falls back to the route's `timeoutMs` (and the shared `DEFAULT_BUILD_TIMEOUT_MS`) instead of the private `DEFAULT_RUN_DISCOVERY_MS` constant, which is deleted. `discoveryMs` remains available as an explicit override for callers or tests that want a tighter bound, and a run that truly never appears still fails with the same sentence.

## Validation

- `DATABASE_URL=... bun test test/adapters/build-routes.test.ts` from `apps/spindrift` — 63 pass, including a new test that fails against the pre-fix code (run visible only after the old 120s default, inside the build's own budget) and the two existing "never appears" tests (which pass explicit `discoveryMs`) still pass.
- `DATABASE_URL=... bun test` from `apps/spindrift` — 2066 pass.
- `mise run ts:check` from repo root — typecheck and lint clean.