### PR TITLE
fix(spindrift): the static adapter's destroy verifies the site is gone

### DIFF
--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -306,16 +306,31 @@ export class StaticDeployAdapter implements DeployAdapter {
     const site = parseRef(connection, ref);
     if (site === null) return;
 
-    const deleted = await this.http(connection).json<unknown>({
+    const http = this.http(connection);
+    await http.json<unknown>({
       method: 'DELETE',
+      path: `${API_VERSION}/projects/${encodeURIComponent(connection.project)}/sites/${encodeURIComponent(site)}`,
+    });
+
+    // The DELETE's own status is not trusted either way: a 404 has meant both
+    // "already gone" and "this call hit a path the API does not serve" (the
+    // flat `sites/{site}` this used to DELETE, which 404s on every call and
+    // never removes anything). Read the site back instead — absent is
+    // destroyed, present is a destroy that did not happen and must not be
+    // reported as one.
+    const read = await http.json<HostingSite>({
+      method: 'GET',
       path: `${API_VERSION}/sites/${encodeURIComponent(site)}`,
     });
-    if (deleted.ok) return;
-    if (deleted.kind === 'status' && deleted.status === 404) return;
+    if (!read.ok && read.kind === 'status' && read.status === 404) return;
     throw new Error(
-      deleted.kind === 'status'
-        ? `deleting site ${site} failed with ${deleted.status}: ${deleted.message}`
-        : `deleting site ${site} failed: ${deleted.message}`,
+      read.ok
+        ? `site ${site} still exists after destroy`
+        : `could not verify site ${site} was destroyed: ${
+            read.kind === 'status'
+              ? `${read.status}: ${read.message}`
+              : read.message
+          }`,
     );
   }
 

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -307,7 +307,7 @@ export class StaticDeployAdapter implements DeployAdapter {
     if (site === null) return;
 
     const http = this.http(connection);
-    await http.json<unknown>({
+    const deletion = await http.json<unknown>({
       method: 'DELETE',
       path: `${API_VERSION}/projects/${encodeURIComponent(connection.project)}/sites/${encodeURIComponent(site)}`,
     });
@@ -325,7 +325,15 @@ export class StaticDeployAdapter implements DeployAdapter {
     if (!read.ok && read.kind === 'status' && read.status === 404) return;
     throw new Error(
       read.ok
-        ? `site ${site} still exists after destroy`
+        ? `site ${site} still exists after destroy${
+            deletion.ok
+              ? ''
+              : ` (delete answered ${
+                  deletion.kind === 'status'
+                    ? `${deletion.status}: ${deletion.message}`
+                    : deletion.message
+                })`
+          }`
         : `could not verify site ${site} was destroyed: ${
             read.kind === 'status'
               ? `${read.status}: ${read.message}`

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -438,6 +438,25 @@ describe('observe, destroy, and what the site is called', () => {
     expect(await adapter.observe(TARGET, verdict.ref)).toBeNull();
   });
 
+  test('a destroy that does not remove the site is never reported as one', async () => {
+    // The regression this guards: a DELETE that lands on a path the API
+    // doesn't serve for site deletion still answers 404, which used to be
+    // trusted as "already gone". The site survives; destroy must throw
+    // rather than resolve, or unplaceComponent would orphan the Deploy row
+    // over a workload that is still serving.
+    const { api, adapter } = adapterFor({
+      refuseDelete: {
+        status: 404,
+        body: { error: { message: 'no such path' } },
+      },
+    });
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+    if (verdict.phase !== 'LIVE') throw new Error('nothing was placed');
+
+    await expect(adapter.destroy(TARGET, verdict.ref)).rejects.toThrow();
+    expect(api.hasSite('shop-site')).toBe(true);
+  });
+
   test('a long name is shortened deterministically, never collided', () => {
     const long = desired({
       app: 'a-very-long-application-name',

--- a/apps/spindrift/test/harness/fakes/hosting-api.ts
+++ b/apps/spindrift/test/harness/fakes/hosting-api.ts
@@ -49,6 +49,12 @@ export interface FakeHostingOptions {
   readonly refuseList?: { status: number; body: unknown };
   /** When set, creating a version is refused with this. */
   readonly refuseVersion?: { status: number; body: unknown };
+  /**
+   * When set, deleting a site at the real (project-scoped) path answers with
+   * this instead of removing the site — the regression arrangement for a
+   * destroy that must not report success it did not earn.
+   */
+  readonly refuseDelete?: { status: number; body: unknown };
   /** When set, adding a domain answers with this. */
   readonly domainAnswer?: { status: number; body: unknown };
   readonly token?: string;
@@ -208,6 +214,28 @@ export class FakeHosting {
       }
     }
 
+    // `projects.sites.delete` — the only path the real API serves for site
+    // deletion. There is no flat `sites.delete`; the flat `sites/{id}` form
+    // below answers reads only, so a DELETE aimed at it falls through to the
+    // catch-all 404, same as the real API.
+    const projectSiteMatch = path.match(
+      new RegExp(`^projects/${this.project}/sites/([^/]+)$`),
+    );
+    if (projectSiteMatch !== null && method === 'DELETE') {
+      const id = projectSiteMatch[1] as string;
+      if (this.options.refuseDelete !== undefined) {
+        return json(
+          this.options.refuseDelete.status,
+          this.options.refuseDelete.body,
+        );
+      }
+      if (!this.sites.has(id)) return json(404, error('no site'));
+      this.sites.delete(id);
+      this.released.delete(id);
+      this.domains.delete(id);
+      return json(200, {});
+    }
+
     const versionMatch = path.match(/^sites\/([^/]+)\/versions\/([^/:]+)$/);
     if (versionMatch !== null) {
       return this.finalize(
@@ -236,13 +264,6 @@ export class FakeHosting {
         return this.sites.has(id)
           ? json(200, site(id))
           : json(404, error('no site'));
-      }
-      if (method === 'DELETE') {
-        if (!this.sites.has(id)) return json(404, error('no site'));
-        this.sites.delete(id);
-        this.released.delete(id);
-        this.domains.delete(id);
-        return json(200, {});
       }
     }
 


### PR DESCRIPTION
## Summary

The static-hosting deploy adapter's `destroy` DELETEd `sites/{site}`, a path the Firebase Hosting API does not serve for site deletion (only `projects.sites.delete` exists). Every call answered 404, which was trusted as "already deleted" — the site, its release, and its serving URL all survived while `destroy` resolved successfully. That false success reaches `unplaceComponent`, which orphans the Deploy row on the strength of it, and `deleteApp`'s stranded-workload review filters on that same orphan flag — so a live, serving site became invisible to the one safety check that names undeleted workloads.

`destroy` now DELETEs the real `projects/{project}/sites/{site}` path, and reads the site back afterward instead of trusting either status code: absent is destroyed, present throws so `unplaceComponent` refuses honestly.

## Validation

- `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test` (from `apps/spindrift`) — 2066 pass, 0 fail
- `mise run ts:check` (repo root) — typecheck and lint clean