### PR TITLE
feat(bosun): drain on stop, and a lite class for science

### DIFF
--- a/apps/bosun/README.md
+++ b/apps/bosun/README.md
@@ -18,6 +18,13 @@ names. bosun carries no branching per hull family; it only translates the
 manifest into cloud-hypervisor argv, and computes the hull's digest itself
 from hull.json plus the files it names.
 
+On SIGTERM bosun drains rather than dies: idle skiffs are scuttled
+registration-first (GitHub refuses to delete a busy runner, so a successful
+delete proves no job can land on one mid-drain), busy skiffs get
+`drainTimeout` (default 15m) to finish their job, and whatever remains at the
+deadline is killed and counted under the `drained` exit reason. A stop — and
+so a deploy — blocks for up to that long.
+
 ## Build and test
 
 ```
@@ -42,6 +49,7 @@ Path given via `-config`. Example:
   "logDir": "/var/log/bosun",
   "workspaceDir": "/var/lib/bosun/workspace",
   "pollInterval": "30s",
+  "drainTimeout": "15m",
   "classes": {
     "skiff-nixos": {"hull": "/nix/store/...-hull-nixos", "vcpus": 4, "memory": "4096M", "warm": 1, "maxLifetime": "1h"},
     "skiff-ubuntu": {"hull": "/nix/store/...-hull-ubuntu", "vcpus": 4, "memory": "3072M", "workspace": "6G", "warm": 2, "maxLifetime": "1h"}

--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	MetricsFile  string           `json:"metricsFile"`  // empty disables; a node-exporter textfile, not a listener
 	CacheURL     string           `json:"cacheUrl"`     // empty disables; announced to every skiff as bosun.cache on the cmdline
 	PollInterval Duration         `json:"pollInterval"`
+	// DrainTimeout bounds how long a stop waits for busy skiffs to finish
+	// their jobs. Idle skiffs are scuttled immediately; what this buys is a
+	// deploy that no longer fails every in-flight job, and what it costs is
+	// a stop (and so a deploy) that blocks for up to this long.
+	DrainTimeout Duration         `json:"drainTimeout"`
 	Classes      map[string]Class `json:"classes"`
 	Bin          BinPaths         `json:"bin"`
 }
@@ -80,6 +85,7 @@ const (
 	defaultLogDir       = "/var/log/bosun"
 	defaultWorkspaceDir = "/var/lib/bosun/workspace"
 	defaultPollInterval = 30 * time.Second
+	defaultDrainTimeout = 15 * time.Minute
 
 	// defaultMaxLifetime backstops a class that declares no budget. It is a
 	// default rather than "unlimited" because the busy-time budget is the
@@ -174,6 +180,9 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	if cfg.PollInterval == 0 {
 		cfg.PollInterval = Duration(defaultPollInterval)
+	}
+	if cfg.DrainTimeout <= 0 {
+		cfg.DrainTimeout = Duration(defaultDrainTimeout)
 	}
 	return &cfg, nil
 }

--- a/apps/bosun/github_test.go
+++ b/apps/bosun/github_test.go
@@ -19,6 +19,7 @@ type fakeGitHub struct {
 	statuses  map[int64]fakeRunnerStatus
 	deleted   []int64
 	generated []fakeGenerated
+	onDelete  func(runnerID int64) // observation hook for a successful delete; drain tests pin ordering with it
 }
 
 type fakeRunnerStatus struct {
@@ -58,9 +59,23 @@ func (f *fakeGitHub) GetRunner(ctx context.Context, repo string, runnerID int64)
 func (f *fakeGitHub) DeleteRunner(ctx context.Context, repo string, runnerID int64) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	// The real API refuses to delete a runner that is running a job (422),
+	// and drain's whole safety argument rests on that refusal.
+	if s, ok := f.statuses[runnerID]; ok && s.busy {
+		return fmt.Errorf("fake: runner %d is busy", runnerID)
+	}
 	f.deleted = append(f.deleted, runnerID)
 	delete(f.statuses, runnerID)
+	if f.onDelete != nil {
+		f.onDelete(runnerID)
+	}
 	return nil
+}
+
+func (f *fakeGitHub) deletedIDs() []int64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]int64(nil), f.deleted...)
 }
 
 func (f *fakeGitHub) setStatus(runnerID int64, status string, busy bool) {

--- a/apps/bosun/launcher_test.go
+++ b/apps/bosun/launcher_test.go
@@ -18,6 +18,7 @@ type fakeProc struct {
 	exitCh chan error
 	once   sync.Once
 	waited atomic.Bool // someone is Wait()ing, so this process gets reaped
+	killed atomic.Bool // Kill was called; drain tests assert ordering against it
 }
 
 func newFakeProc() *fakeProc {
@@ -30,6 +31,7 @@ func (p *fakeProc) Wait() error {
 }
 
 func (p *fakeProc) Kill() error {
+	p.killed.Store(true)
 	p.once.Do(func() { p.exitCh <- errFakeKilled })
 	return nil
 }

--- a/apps/bosun/main.go
+++ b/apps/bosun/main.go
@@ -19,6 +19,7 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+	"time"
 )
 
 func main() {
@@ -68,5 +69,17 @@ func main() {
 	logger.Info("warm pool filled", "classes", len(cfg.Classes))
 
 	p.pollLoop(ctx)
+
+	// SIGTERM landed: drain rather than die. Refills are already stopped by
+	// the cancelled run context; what remains is giving busy skiffs their
+	// window to finish, on a fresh context because the drain's own GitHub
+	// calls must outlive the one that just ended. Restoring the default
+	// signal disposition first keeps a second signal as the escape hatch:
+	// it kills the process outright, and sweep-on-start owns the mess.
+	stop()
+	logger.Info("draining", "timeout", cfg.DrainTimeout.String())
+	drainCtx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.DrainTimeout))
+	defer cancel()
+	p.drain(drainCtx)
 	logger.Info("shutting down")
 }

--- a/apps/bosun/metrics.go
+++ b/apps/bosun/metrics.go
@@ -33,6 +33,11 @@ const (
 	// OOM-killed job as a finished one hides exactly the thing worth alerting
 	// on.
 	exitKilled = "killed"
+	// exitDrained is a skiff scuttled by the stop path: idle ones after their
+	// registration was deleted (so no job was lost), busy ones only at the
+	// drain deadline (so a job was — which is why the reason is visible in
+	// the exit counter rather than folded into "killed").
+	exitDrained = "drained"
 )
 
 func newMetrics() *metrics {
@@ -91,7 +96,7 @@ func (m *metrics) render(live map[string]poolState, desired map[string]int) stri
 	b.WriteString("# HELP bosun_skiff_exits_total Skiffs gone since bosun started, by why.\n")
 	b.WriteString("# TYPE bosun_skiff_exits_total counter\n")
 	for _, class := range sortedKeys(desired) {
-		for _, reason := range []string{exitCompleted, exitWedged, exitLifetime, exitJITExpired, exitBootFailed, exitKilled} {
+		for _, reason := range []string{exitCompleted, exitWedged, exitLifetime, exitJITExpired, exitBootFailed, exitKilled, exitDrained} {
 			b.WriteString(fmt.Sprintf("bosun_skiff_exits_total{class=%q,reason=%q} %d\n", class, reason, m.exits[class][reason]))
 		}
 	}

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -30,6 +30,7 @@ let
       metricsFile
       ;
     pollInterval = cfg.pollInterval;
+    drainTimeout = "${toString cfg.drainTimeout}s";
     cacheUrl = if cfg.cache.enable then "http://${cfg.cache.address}:${toString cfg.cache.port}/" else "";
     classes = lib.mapAttrs (_: c: {
       inherit (c)
@@ -155,6 +156,31 @@ in
         How often to ask GitHub whether a skiff's runner is online and busy.
         One request per skiff, by id -- never the runner list, which carries
         ghosts from registrations no skiff ever consumed.
+      '';
+    };
+
+    drainTimeout = mkOption {
+      # positive, not unsigned: 0 would read as "stop immediately" but the
+      # daemon treats a non-positive value as unset and drains for the 15 min
+      # default anyway, while TimeoutStopSec would drop to 60 -- a stop that
+      # ends in a cgroup SIGKILL mid-drain. The immediate-stop spelling is
+      # `systemctl kill bosun`, not a zero here.
+      type = types.ints.positive;
+      default = 900;
+      description = ''
+        Seconds a stop waits for busy skiffs to finish their jobs. Idle
+        skiffs are scuttled immediately, registration first, so no job can
+        land on one mid-drain; at the deadline whatever is still busy is
+        killed. A stop is what every deploy and token rotation does to this
+        unit, so this is also how long `nixos-rebuild switch` may block on
+        this host -- the price of a deploy no longer failing every in-flight
+        job. Must exceed the longest job this host's classes are expected to
+        run; a wedged busy guest is reaped earlier by its class's
+        `maxLifetime` where that is shorter.
+
+        The unit's TimeoutStopSec is derived from this with a minute of
+        slack, so systemd's cgroup SIGKILL stays the backstop rather than
+        the mechanism.
       '';
     };
 
@@ -405,6 +431,21 @@ in
         # stops it.
         Restart = "always";
         RestartSec = "5s";
+
+        # Drain needs the stop signal to reach the daemon alone: the default
+        # KillMode=control-group SIGTERMs every process in the cgroup at
+        # stop, killing the very VMMs drain exists to let finish. mixed still
+        # SIGKILLs the whole cgroup at the timeout, so the no-orphans
+        # guarantee stands -- the backstop moved, the mechanism changed.
+        #
+        # The trade lives on the crash path: when the daemon dies uncleanly
+        # with skiffs booted, nothing SIGTERMs the surviving VMMs, so the
+        # restart waits out the full stop timeout while the orphaned runners
+        # keep serving jobs on their own -- a crash costs minutes of stale
+        # pool where control-group killed everything in seconds. A startup
+        # crash loop boots no VMMs and still cycles at RestartSec.
+        KillMode = "mixed";
+        TimeoutStopSec = cfg.drainTimeout + 60;
 
         RuntimeDirectory = "bosun";
         RuntimeDirectoryMode = "0700";

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -30,6 +30,7 @@ type skiff struct {
 	offlineStreak int       // consecutive offline observations; reset by any other status
 	busySince     time.Time // zero until the runner first reports busy; maxLifetime is measured from here
 	exitReason    string    // why bosun killed this skiff; empty means the guest halted itself
+	deregistered  bool      // drain already deleted the GitHub registration; retire must not again
 
 	helpersLog *os.File
 	helpers    []proc // virtiofsd(s) + passt
@@ -73,6 +74,12 @@ type pool struct {
 	// per class. Tracked rather than derived from skiffs because a slot is
 	// claimed before there is a skiff to derive it from -- see claimSlot.
 	slots map[string]map[int]struct{}
+	// draining refuses new spawns and, with spawning, lets drain wait out a
+	// refill that raced the stop signal: a skiff between mint and map-add is
+	// in neither the map nor the process table, and without the counter
+	// drain could declare the pool empty while one was mid-boot.
+	draining bool
+	spawning int
 }
 
 func newPool(cfg *Config, gh githubClient, launch launcher, logger *slog.Logger) *pool {
@@ -252,6 +259,21 @@ func (p *pool) fill(ctx context.Context) {
 // its lifetime off to awaitExit. Errors are logged and swallowed: a single
 // failed spawn should not take down the rest of the pool.
 func (p *pool) spawn(ctx context.Context, className string) {
+	// Checked under the same mutex drain sets it under, so every spawn either
+	// happens-before drain's first scuttle pass or is refused outright.
+	p.mu.Lock()
+	if p.draining {
+		p.mu.Unlock()
+		return
+	}
+	p.spawning++
+	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.spawning--
+		p.mu.Unlock()
+	}()
+
 	class, ok := p.cfg.Classes[className]
 	if !ok {
 		p.logger.Error("spawn: unknown class", "class", className)
@@ -315,6 +337,17 @@ func (p *pool) spawn(ctx context.Context, className string) {
 	}
 
 	p.mu.Lock()
+	if p.draining {
+		// Drain began mid-boot. The registration minted above may postdate
+		// drain's scuttle pass, so this skiff must not join the pool: retire
+		// deregisters it and kills what boot started, and the spawning
+		// counter keeps drain from returning before that finishes.
+		p.mu.Unlock()
+		logger.Info("drain: scuttling skiff spawned mid-stop")
+		s.setExitReason(exitDrained)
+		p.retire(ctx, s, logger)
+		return
+	}
 	p.skiffs[id] = s
 	p.mu.Unlock()
 
@@ -463,8 +496,20 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 		s.helpersLog.Close()
 	}
 
-	if err := p.gh.DeleteRunner(ctx, p.cfg.Repo, s.runnerID); err != nil {
-		logger.Warn("delete runner on retire", "runner_id", s.runnerID, "error", err)
+	// An idle-scuttled skiff's registration was already deleted — first, on
+	// purpose, because that is what proved no job could land on it. Everything
+	// else deregisters here, on a context that survives shutdown: by the time
+	// a drain-era retire runs, the run context is cancelled, and a DELETE that
+	// never happens is a ghost registration until the next sweep.
+	s.mu.Lock()
+	deregistered := s.deregistered
+	s.mu.Unlock()
+	if !deregistered {
+		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		if err := p.gh.DeleteRunner(dctx, p.cfg.Repo, s.runnerID); err != nil {
+			logger.Warn("delete runner on retire", "runner_id", s.runnerID, "error", err)
+		}
 	}
 
 	// diagDir is deliberately not removed: it is the evidence, and this is
@@ -524,14 +569,7 @@ func (p *pool) pollLoop(ctx context.Context) {
 }
 
 func (p *pool) pollOnce(ctx context.Context) {
-	p.mu.Lock()
-	snapshot := make([]*skiff, 0, len(p.skiffs))
-	for _, s := range p.skiffs {
-		snapshot = append(snapshot, s)
-	}
-	p.mu.Unlock()
-
-	for _, s := range snapshot {
+	for _, s := range p.snapshot() {
 		p.pollSkiff(ctx, s)
 	}
 	// Every tick, whether anything changed or not: the file's mtime is the
@@ -612,6 +650,119 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 		logger.Info("idle past JIT expiry, recycling")
 		s.setExitReason(exitJITExpired)
 		killBestEffort(s.ch, logger, "idle-expired cloud-hypervisor")
+	}
+}
+
+// drain is the stop path: the run context is already cancelled, so awaitExit
+// no longer refills, and what remains is emptying the pool without failing a
+// running job — the thing a plain stop did twice during the CI migration.
+//
+// Idle skiffs are scuttled registration-first: GitHub refuses to delete a
+// busy runner, so a successful DELETE proves no job can ever land on that
+// skiff and its VMM is safe to kill — bosun's own busy flag, up to a poll
+// interval stale, never gets a vote. A failed DELETE means the runner is
+// busy (the guest finishes its job and halts on its own) or GitHub is
+// unreachable (retried next tick).
+//
+// ctx is the drain budget, not the run context. When it expires, whatever
+// remains is killed here rather than left to systemd's cgroup SIGKILL, so
+// each skiff still gets a retire and a best-effort deregistration.
+func (p *pool) drain(ctx context.Context) {
+	p.mu.Lock()
+	p.draining = true
+	p.mu.Unlock()
+	// The last write before the process exits, so the drained exit counter
+	// reaches the textfile at all. The next start rewrites the file with
+	// fresh counters, so this is best-effort visibility for the scrape that
+	// lands in between, not durable accounting.
+	defer p.publish()
+	p.scuttleIdle(ctx)
+	check := time.NewTicker(100 * time.Millisecond)
+	defer check.Stop()
+	poll := time.NewTicker(time.Duration(p.cfg.PollInterval))
+	defer poll.Stop()
+	for {
+		if p.empty() {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			p.logger.Warn("drain budget exhausted, killing remaining skiffs")
+			p.killRemaining()
+			p.awaitEmpty(30 * time.Second)
+			return
+		case <-poll.C:
+			// Busy skiffs still need the lifetime reaper, and the metrics
+			// file's mtime is still the heartbeat.
+			p.pollOnce(ctx)
+			p.scuttleIdle(ctx)
+		case <-check.C:
+		}
+	}
+}
+
+func (p *pool) snapshot() []*skiff {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	skiffs := make([]*skiff, 0, len(p.skiffs))
+	for _, s := range p.skiffs {
+		skiffs = append(skiffs, s)
+	}
+	return skiffs
+}
+
+func (p *pool) empty() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.skiffs) == 0 && p.spawning == 0
+}
+
+// scuttleIdle deregisters and kills every skiff not known to be busy and not
+// already condemned. Known-busy ones are skipped without an API call — the
+// DELETE would be refused anyway.
+func (p *pool) scuttleIdle(ctx context.Context) {
+	for _, s := range p.snapshot() {
+		s.mu.Lock()
+		busy := !s.busySince.IsZero()
+		condemned := s.exitReason != ""
+		s.mu.Unlock()
+		if busy || condemned {
+			continue
+		}
+		logger := p.logger.With("skiff", s.id, "class", s.class)
+		if err := p.gh.DeleteRunner(ctx, p.cfg.Repo, s.runnerID); err != nil {
+			logger.Info("drain: leaving skiff to finish", "error", err)
+			continue
+		}
+		s.mu.Lock()
+		s.deregistered = true
+		s.exitReason = exitDrained
+		s.mu.Unlock()
+		logger.Info("drain: idle skiff scuttled")
+		killBestEffort(s.ch, logger, "drained cloud-hypervisor")
+	}
+}
+
+// killRemaining condemns whatever the drain budget ran out on. Every one of
+// these is a lost job or a wedged guest; the exit counter says which host and
+// class it cost.
+func (p *pool) killRemaining() {
+	for _, s := range p.snapshot() {
+		if s.reason() != "" {
+			continue
+		}
+		s.setExitReason(exitDrained)
+		killBestEffort(s.ch, p.logger.With("skiff", s.id, "class", s.class), "cloud-hypervisor at drain deadline")
+	}
+}
+
+// awaitEmpty gives the awaitExit goroutines a bounded window to finish their
+// retires — deregistration included — before main returns and systemd
+// SIGKILLs the cgroup.
+func (p *pool) awaitEmpty(limit time.Duration) {
+	deadline := time.Now().Add(limit)
+	for !p.empty() && time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
 	}
 }
 

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -18,10 +18,9 @@ import (
 // them. t.TempDir() reports that as a failed cleanup on a test whose own
 // assertions all passed, which is a fault in the harness rather than in bosun.
 //
-// The goroutines are bounded by the test binary either way. What is deliberately
-// not built to close this is a graceful pool shutdown: bosun's real teardown is
-// systemd killing the cgroup and sweep-on-start deregistering what is left, so
-// a stop path existing only for tests would be machinery the daemon never runs.
+// The goroutines are bounded by the test binary either way. drain is the
+// daemon's real stop path, but it is not the answer here: it empties the pool,
+// and most of these tests assert on a pool that is deliberately still running.
 func poolTempDir(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("", "bosun-pool-")
@@ -44,6 +43,9 @@ func testPool(t *testing.T) (*pool, *fakeGitHub, *fakeLaunch) {
 		RuntimeDir:   filepath.Join(dir, "run"),
 		LogDir:       filepath.Join(dir, "log"),
 		WorkspaceDir: filepath.Join(dir, "workspace"),
+		// Real config always has one (LoadConfig defaults it); drain's poll
+		// ticker would panic on zero. Short, so drain-path tests retry fast.
+		PollInterval: Duration(25 * time.Millisecond),
 		Classes: map[string]Class{
 			"skiff-test": {Hull: hullDir, VCPUs: 1, Memory: "512M", Warm: 1, MaxLifetime: Duration(time.Hour)},
 		},
@@ -272,6 +274,162 @@ func TestPoolDoesNotRefillDuringShutdown(t *testing.T) {
 	defer p.mu.Unlock()
 	if len(p.skiffs) != 0 {
 		t.Fatalf("pool refilled during shutdown: %d skiffs", len(p.skiffs))
+	}
+}
+
+// Drain's safety argument, end to end: the registration is deleted before the
+// VMM is killed, so GitHub can never hand this skiff a job mid-scuttle — and
+// the fake refuses the DELETE for a busy runner exactly as GitHub does, which
+// is what makes bosun's own (poll-interval-stale) busy flag irrelevant.
+func TestDrainScuttlesIdleSkiffRegistrationFirst(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	cancel() // SIGTERM: refills are off
+
+	// The ordering is the safety property, so it is asserted at the moment
+	// of the DELETE rather than inferred from the end state: a kill-first
+	// scuttle would leave a live registration GitHub could hand a job to.
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	gh.onDelete = func(int64) {
+		if chCall.proc.killed.Load() {
+			t.Error("VMM was killed before its registration was deleted")
+		}
+	}
+
+	done := make(chan struct{})
+	go func() { p.drain(context.Background()); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return for an all-idle pool")
+	}
+
+	if got := gh.deletedIDs(); len(got) != 1 || got[0] != s.runnerID {
+		t.Fatalf("want the idle skiff's registration deleted, got %v", got)
+	}
+	if !p.empty() {
+		t.Fatal("pool not empty after drain")
+	}
+	p.stats.mu.Lock()
+	drained := p.stats.exits["skiff-test"][exitDrained]
+	p.stats.mu.Unlock()
+	if drained != 1 {
+		t.Fatalf("idle scuttle not counted as drained: %d", drained)
+	}
+}
+
+// A busy skiff is left to finish its job: the DELETE is refused, drain waits,
+// and the pool empties only when the guest halts itself — counted as
+// completed, because the job was.
+func TestDrainWaitsForBusySkiffToFinish(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	gh.setStatus(s.runnerID, "online", true)
+	p.pollOnce(ctx) // bosun observes the job start
+	cancel()
+
+	done := make(chan struct{})
+	go func() { p.drain(context.Background()); close(done) }()
+
+	time.Sleep(100 * time.Millisecond) // several drain ticks
+	select {
+	case <-done:
+		t.Fatal("drain returned while a job was still running")
+	default:
+	}
+
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(nil) // the job finished; the guest powered off
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return after the busy guest halted")
+	}
+
+	p.stats.mu.Lock()
+	completed := p.stats.exits["skiff-test"][exitCompleted]
+	drained := p.stats.exits["skiff-test"][exitDrained]
+	p.stats.mu.Unlock()
+	if completed != 1 || drained != 0 {
+		t.Fatalf("a job that finished during drain must count as completed, got completed=%d drained=%d", completed, drained)
+	}
+}
+
+// A refill can race the stop signal: awaitExit's ctx check may pass an
+// instant before cancellation, so spawn itself must refuse once drain has
+// begun — otherwise a freshly minted skiff joins a pool drain already swept,
+// and GitHub can hand it a brand-new job mid-stop.
+func TestSpawnRefusesDuringDrain(t *testing.T) {
+	p, gh, fl := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	gh.setStatus(s.runnerID, "online", true)
+	p.pollOnce(ctx) // busy, so drain stays in its wait loop
+	cancel()
+
+	done := make(chan struct{})
+	go func() { p.drain(context.Background()); close(done) }()
+	waitFor(t, "drain marks the pool draining", func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return p.draining
+	})
+
+	p.spawn(ctx, "skiff-test") // the racing refill
+	gh.mu.Lock()
+	mints := len(gh.generated)
+	gh.mu.Unlock()
+	if mints != 1 {
+		t.Fatalf("a spawn during drain minted a registration: %d mints", mints)
+	}
+
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	chCall.proc.exit(nil)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("drain did not return after the busy guest halted")
+	}
+}
+
+// The drain budget is what bounds how long a stop can block a deploy: at the
+// deadline whatever remains is killed and retired, and the loss is visible in
+// the exit counter rather than folded into a clean shutdown.
+func TestDrainDeadlineKillsRemainingBusySkiff(t *testing.T) {
+	p, gh, _ := testPool(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.fill(ctx)
+	s := onlySkiff(t, p)
+	gh.setStatus(s.runnerID, "online", true)
+	p.pollOnce(ctx)
+	cancel()
+
+	drainCtx, dcancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer dcancel()
+	p.drain(drainCtx)
+
+	if !p.empty() {
+		t.Fatal("pool not empty after the drain deadline")
+	}
+	p.stats.mu.Lock()
+	drained := p.stats.exits["skiff-test"][exitDrained]
+	p.stats.mu.Unlock()
+	if drained != 1 {
+		t.Fatalf("deadline kill not counted as drained: %d", drained)
 	}
 }
 

--- a/docs/pages/Architecture___Bosun.md
+++ b/docs/pages/Architecture___Bosun.md
@@ -35,7 +35,8 @@ tags:: architecture
 	- Denying RFC1918 breaks DNS, so a public resolver is pinned and the deny stays absolute.
 - ## State
 	- One directory per skiff under `/run`, holding the runner id and the hull digest. `/run` is tmpfs, so a reboot clears it, which is correct — there is no database.
-	- Orphaned VMMs cannot exist: systemd's default `KillMode=control-group` takes the whole cgroup down with the unit. That also means **a bosun restart fails every in-flight job**, so a `nixos-rebuild switch` kills running CI on that host.
+	- A stop **drains** instead of failing every in-flight job. Idle skiffs are scuttled registration-first: GitHub refuses to delete a busy runner's registration, so a successful delete proves no job can land on that skiff and its VMM is safe to kill. Busy skiffs get the module's `drainTimeout` (default 15 min) to finish — which is also how long a `nixos-rebuild switch` may block on that host.
+	- Orphaned VMMs still cannot exist: the unit runs `KillMode=mixed`, so the stop signal reaches the daemon alone but systemd SIGKILLs the whole cgroup at the stop timeout.
 	- Because a cgroup kill leaves no chance to run teardown, bosun sweeps on start and deregisters what it finds.
 - ## Where it runs
 	- [[Fleet/riptide]] enables `services.bosun`. It shares the box with kubelet.

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -41,7 +41,12 @@
     tokenFile = config.sops.secrets."bosun-github-token".path;
     classes.skiff-ubuntu = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
-      vcpus = 4;
+      # 2, not 4: this box has 4 cores shared with kubelet, yarr and
+      # harmonia, and a skiff that can contend for all of them is how the
+      # suite's DB-timing tests flake -- the same signature the ARC runner
+      # here showed twice in the bench. Half the cores caps the contention;
+      # the bench put the Build delta at seconds, not minutes.
+      vcpus = 2;
       memory = "3072M";
       workspace = "6G";
       persist = true;

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -62,6 +62,21 @@
       memory = "2048M";
       warm = 1;
     };
+
+    # A little one, for science: platform experiments that want a real skiff
+    # without claiming real capacity. This site rides the satellite link, so
+    # production CI labels are served from oldschool -- one small slot is the
+    # agreed exception, not the start of a pool. 4G workspace, not 6G,
+    # because the ~20 GiB free on this root also backs the 10G cache cap
+    # below and skiff-ubuntu's parked slots: the standing reservation stays
+    # small so the un-park arithmetic stays possible at all.
+    classes.skiff-ubuntu-lite = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 1;
+      memory = "2048M";
+      workspace = "4G";
+      warm = 1;
+    };
     # The FHS family: apt, dockerd, and the ARC image's toolchain, no Nix.
     # A scratch disk carries the runner's workspace and docker's data root, so
     # `memory` here is a RAM figure and nothing else -- without one the guest
@@ -88,10 +103,14 @@
       memory = "3072M";
       workspace = "6G";
       persist = true;
-      # Parked: this host keeps its single skiff-nixos slot and oldschool
-      # serves skiff-ubuntu. Restore warm = 2 to serve the label from here
-      # again; the slot disks are reclaimed at 0 and rebuilt cold on the way
-      # back up.
+      # Parked, and not as spare capacity: a CI job's traffic -- checkout,
+      # caches, docker pulls -- does not belong on this site's satellite
+      # link, so oldschool serves skiff-ubuntu from the fast-internet site.
+      # Un-parking is a last resort, not a rebalancing lever, and re-does
+      # the disk arithmetic first as well as the memory's: two 6G slots
+      # plus the lite slot's 4G plus a full 10G cache oversubscribe the
+      # ~20 GiB free here. The slot disks are reclaimed at 0 and rebuilt
+      # cold on the way back up.
       warm = 0;
     };
 
@@ -104,12 +123,13 @@
     };
   };
 
-  # The pool's declared ceiling is 2048M + warm x 3072M -- 8 GiB at warm = 2,
-  # inside the limit
-  # below with room to spare: riptide has 15.2 GiB total, ~5 GiB held by
-  # kubelet and the system, and no swap. Without a bound the *host* OOM killer
-  # picks the victim, which on a worker node may be a pod or kubelet rather
-  # than a skiff.
+  # The pool's declared ceiling is 2048M + 2048M with skiff-ubuntu parked,
+  # well inside the limit below. Un-parking skiff-ubuntu at warm = 2 would
+  # take the declared total to 10 GiB -- over this limit and over what the
+  # host can spare (15.2 GiB total, ~5 GiB held by kubelet and the system,
+  # no swap), so that last resort re-does this arithmetic first. Without a
+  # bound the *host* OOM killer picks the victim, which on a worker node may
+  # be a pod or kubelet rather than a skiff.
   #
   # Every skiff is a child of this unit, so the limit covers the whole pool
   # the same way IPAddressDeny does. Raising warm further is now a disk


### PR DESCRIPTION
## Summary

- **Drain-on-stop**: SIGTERM now drains the pool instead of failing every in-flight job (two died to deploys during the CI migration). Idle skiffs are scuttled *registration-first* — GitHub refuses to `DELETE` a busy runner, so a successful delete proves no job can land on that skiff before its VMM is killed. Busy skiffs get `drainTimeout` (default 15 m) to finish, the lifetime reaper keeps running mid-drain, and deadline kills are counted under a new `drained` exit reason and published before exit. Refills that race the stop signal are refused; retire now deregisters on a context that survives shutdown, closing the ghost-registration-per-restart leak.
- **Unit semantics**: `KillMode=mixed` + `TimeoutStopSec = drainTimeout + 60`, so the cgroup SIGKILL is the backstop, not the mechanism. A stop — and so a deploy — can block up to the drain budget. The crash-path trade (an unclean daemon death with skiffs booted waits out the stop timeout) is documented on the unit.
- **riptide**: new `skiff-ubuntu-lite` class (1 vCPU / 2 GiB / 4G workspace) for platform experiments, beside the untouched `skiff-nixos` slot. Comments now record that `skiff-ubuntu` stays parked because CI traffic doesn't belong on the satellite link, and that un-parking re-does memory *and* disk arithmetic.
- **oldschool**: `skiff-ubuntu` drops to 2 vCPUs so a skiff can't contend for all four cores kubelet, yarr and harmonia share — the signature behind the suite's DB-timing flakes.

## Validation

- `go build`, `go vet`, `go test -race -count=2` — clean; new tests pin the registration-before-kill ordering, the busy-wait, the deadline kill, and spawn refusal mid-drain.
- `nix eval` of both riptide and oldschool system closures.
- `mise run docs:check` for the wiki edit.
- Adversarially reviewed (concurrency, systemd semantics, API fidelity); all real findings fixed or documented.

## Risks

- A deploy touching bosun's unit now blocks until running jobs finish (≤ 16 min worst case). Escape hatch: `systemctl kill bosun`.
- An unclean daemon crash with skiffs booted recovers in ~16 min instead of ~5 s (documented trade; orphaned runners keep serving during the window).
- oldschool's suite wall-clock may lengthen slightly; the bench put the Build delta at seconds.