### PR TITLE
feat(spindrift): make the placement of record a stored fact

### DIFF
--- a/apps/spindrift/src/commands/apps/deploy.ts
+++ b/apps/spindrift/src/commands/apps/deploy.ts
@@ -42,12 +42,13 @@
  * one here would name an artifact that does not exist (§4: "a build records an
  * artifact rather than deploying one").
  */
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import { targetAdapterSchema } from '../../config/manifest.schema.ts';
 import {
   type apps,
   builds,
+  components,
   componentTargetDesired,
   repositories,
   targets,
@@ -295,28 +296,9 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
         // two the same sentence about different Components.
         orderBy: (componentsTable, { asc }) => [asc(componentsTable.createdAt)],
         with: {
-          deploys: {
-            orderBy: (deploysTable, { desc }) => [desc(deploysTable.createdAt)],
-            limit: 1,
-            with: {
-              target: true,
-              build: true,
-            },
-          },
           builds: {
             orderBy: (buildsTable, { desc }) => [desc(buildsTable.createdAt)],
             limit: 1,
-          },
-          desiredTargets: {
-            // Newest first, because the newest desired row is the Component's
-            // current address: every deploy touches its pair's row, and
-            // `placeComponent` touches the pair a move commits — so a moved
-            // Component's newest row is the Target it was moved to.
-            orderBy: (desiredTable, { desc }) => [desc(desiredTable.updatedAt)],
-            limit: 1,
-            with: {
-              target: true,
-            },
           },
         },
       },
@@ -362,13 +344,11 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
     component = named;
   }
 
-  // The desired row is the placement of record — `placeComponent` moves it,
-  // and every deploy touches it — so it answers first. Deploy history only
-  // answers for a Component whose rows are gone, which is what an unplaced
-  // pair being deployed again looks like.
-  const latestDeploy = component.deploys[0];
-  const placedTargetId =
-    component.desiredTargets[0]?.targetId ?? latestDeploy?.targetId;
+  // The placement of record, read off the Component itself: the one fact
+  // `placeComponent` moves, a first placement establishes, and
+  // `unplaceComponent` clears. Nothing here infers it from desired rows or
+  // deploy history — an unplaced Component is unplaced, whatever once served.
+  const placedTargetId = component.placedTargetId ?? undefined;
 
   let targetId = placedTargetId;
   if (input.target !== undefined) {
@@ -527,11 +507,12 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
       .where(eq(builds.id, buildToRun.id));
   }
 
-  // The desired row, and nothing on it. `runBuildPass` joins Build → Component →
-  // this row → Target to find the route to dispatch on, so a Build with no such
-  // row is one no loop can see. `desiredBuildId` and `desiredDeployId` stay
-  // untouched: those say what should be *live* here, and only an intent written
-  // under §6's lock gets to answer that.
+  // The desired row, and nothing on it. `runBuildPass` dispatches a Build
+  // against the Target its Component is placed on, and `dispatchBuild` checks
+  // that placement names a desired row — so a Build with no such row is one no
+  // loop can run. `desiredBuildId` and `desiredDeployId` stay untouched: those
+  // say what should be *live* here, and only an intent written under §6's lock
+  // gets to answer that.
   await context.db
     .insert(componentTargetDesired)
     .values({
@@ -540,6 +521,17 @@ export const deployApp: Command<DeployAppInput, DeployAppResult> = async (
       updatedAt: now,
     })
     .onConflictDoNothing();
+
+  // A first deploy of an unplaced Component establishes its placement of
+  // record, exactly as `placeIntent` does on the deployable branch.
+  // Conditional on NULL, so a Build staged for an already-placed Component
+  // never moves it.
+  await context.db
+    .update(components)
+    .set({ placedTargetId: targetId })
+    .where(
+      and(eq(components.id, component.id), isNull(components.placedTargetId)),
+    );
 
   return ok({
     deployId: null,

--- a/apps/spindrift/src/commands/apps/list.ts
+++ b/apps/spindrift/src/commands/apps/list.ts
@@ -51,6 +51,11 @@ export const listApps: Command<
               build: true,
             },
           },
+          // The placement of record, for a Component that holds one and has
+          // never deployed — without it the row read `none`, indistinguishable
+          // from unplaced, and the difference decides whether an unplace is
+          // needed before delete.
+          placedTarget: { with: { vessel: true } },
         },
       },
     },
@@ -102,15 +107,22 @@ export const listApps: Command<
     const comp = worst?.component;
     const deploy = worst?.deploy;
     const target = deploy?.target;
+    // Placed but never deployed: the placement of record answers where the
+    // deploy history cannot, marked so the row is distinguishable from a
+    // placement something has shipped to — and from `none`, which now means
+    // exactly "not placed anywhere".
+    const placed = deploy === undefined ? comp?.placedTarget : undefined;
 
     return {
       id: app.id,
       name: app.name,
-      vessel: target?.vessel.name ?? '',
+      vessel: target?.vessel.name ?? placed?.vessel.name ?? '',
       source,
       kind: comp?.kind ?? 'service',
       phase: worst?.phase ?? 'PENDING',
-      target: target?.adapter ?? 'none',
+      target:
+        target?.adapter ??
+        (placed == null ? 'none' : `${placed.adapter} (awaiting first deploy)`),
       url: deploy?.url ?? app.vanityDomain ?? '',
       urlLive: deploy?.phase === 'LIVE',
       componentCount: app.components.length,

--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -82,19 +82,9 @@ export const getAppWorkspace: Command<
             orderBy: (builds, { desc }) => [desc(builds.createdAt)],
             limit: 1,
           },
-          desiredTargets: {
-            // Newest first — the placement of record, exactly as `deployApp`
-            // reads it. A moved Component keeps the old pair's row until it is
-            // retired, and an unordered pick could name either.
-            orderBy: (desiredTable, { desc }) => [desc(desiredTable.updatedAt)],
-            limit: 1,
-            with: {
-              // With its vessel, for the reason the deploy's Target carries
-              // one: `workspaceTarget` is either of these two rows and the
-              // screen states the boundary from whichever it got.
-              target: { with: { vessel: true } },
-            },
-          },
+          // The placement of record — the stored fact `deployApp` acts on,
+          // with its vessel because the screen states the boundary from it.
+          placedTarget: { with: { vessel: true } },
         },
       },
       datastores: {
@@ -133,8 +123,10 @@ export const getAppWorkspace: Command<
 
   const latestDeploy = selected?.deploys[0];
   const latestTarget = latestDeploy?.target;
-  const desiredTarget = selected?.desiredTargets[0]?.target;
-  const workspaceTarget = latestTarget ?? desiredTarget;
+  // The placement of record, never deploy history: the screen names the Target
+  // the deploy button would act on, including for a moved-but-never-deployed
+  // Component — where history would name the Target it moved away from.
+  const workspaceTarget = selected?.placedTarget ?? undefined;
 
   const now = context.clock.now();
 

--- a/apps/spindrift/src/commands/builds/get-detail.ts
+++ b/apps/spindrift/src/commands/builds/get-detail.ts
@@ -53,14 +53,9 @@ export const getBuildDetail: Command<
       component: {
         with: {
           app: true,
-          desiredTargets: {
-            // Newest first — the placement of record, exactly as `deployApp`
-            // reads it. A moved Component keeps the old pair's row until it is
-            // retired, and an unordered pick could name either.
-            orderBy: (desiredTable, { desc }) => [desc(desiredTable.updatedAt)],
-            limit: 1,
-            with: { target: { with: { vessel: true } } },
-          },
+          // The placement of record — the stored fact, exactly what
+          // `deployApp` acts on.
+          placedTarget: { with: { vessel: true } },
         },
       },
       deploys: {
@@ -75,11 +70,11 @@ export const getBuildDetail: Command<
   }
 
   const { view: buildView } = await buildViewOf(context, build);
-  const target = build.component.desiredTargets[0]?.target ?? null;
+  const target = build.component.placedTarget;
 
   // Where this Build is headed, resolved the same way `deployApp` resolves it:
-  // the desired row is what says which Target a Component belongs on before any
-  // intent has named one.
+  // the placement of record is what says which Target a Component belongs on
+  // before any intent has named one.
   const previousLive = target
     ? await context.db.query.deploys.findFirst({
         where: (deploys, { eq, and }) =>
@@ -100,14 +95,14 @@ export const getBuildDetail: Command<
     appId: build.component.app.id,
     app: build.component.app.name,
     component: build.component.name,
-    target: target === undefined ? 'not placed' : targetRowLabel(target),
+    target: targetRowLabel(target),
     commit: build.commit,
     phase: PHASE[build.status],
     phaseWord: buildView === null ? 'Extracted' : PHASE_WORD[build.status],
     headline: headlineFor(
       build.status,
       buildView?.runner ?? null,
-      target === undefined ? null : targetRowLabel(target),
+      target === null ? null : targetRowLabel(target),
     ),
     url: build.component.app.vanityDomain ?? '',
     // A Build never serves anything: §6's exposure is only ever changed by an

--- a/apps/spindrift/src/commands/components/place.ts
+++ b/apps/spindrift/src/commands/components/place.ts
@@ -30,7 +30,12 @@
 
 import { eq } from 'drizzle-orm';
 import { z } from 'zod';
-import { componentTargetDesired, targets, vessels } from '../../db/schema.ts';
+import {
+  components,
+  componentTargetDesired,
+  targets,
+  vessels,
+} from '../../db/schema.ts';
 import { VARIABLE_NAME } from '../../domain/config.ts';
 import { targetLabel } from '../../domain/target.ts';
 import { carryReferences } from '../config/carry.ts';
@@ -118,23 +123,32 @@ export const placeComponent: Command<
   if (!applied.ok) return applied;
 
   // The move itself, committed last so a refusal above leaves the placement
-  // where it was. Touching `updatedAt` on conflict is what makes a re-placement
-  // onto an already-placed pair the Component's newest row again.
+  // where it was. Two writes in one transaction: the pair's desired row, which
+  // is what the loops act on, and `placedTargetId`, the placement of record —
+  // this command is the only one that *moves* it. The old pair's desired row
+  // stays: what is live there keeps serving until `unplaceComponent` retires
+  // it.
   const now = context.clock.now();
-  await context.db
-    .insert(componentTargetDesired)
-    .values({
-      componentId: input.componentId,
-      targetId: input.targetId,
-      updatedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: [
-        componentTargetDesired.componentId,
-        componentTargetDesired.targetId,
-      ],
-      set: { updatedAt: now },
-    });
+  await context.db.transaction(async (tx) => {
+    await tx
+      .insert(componentTargetDesired)
+      .values({
+        componentId: input.componentId,
+        targetId: input.targetId,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: [
+          componentTargetDesired.componentId,
+          componentTargetDesired.targetId,
+        ],
+        set: { updatedAt: now },
+      });
+    await tx
+      .update(components)
+      .set({ placedTargetId: input.targetId, updatedAt: now })
+      .where(eq(components.id, input.componentId));
+  });
 
   return ok({
     ...applied.value,

--- a/apps/spindrift/src/commands/components/unplace.ts
+++ b/apps/spindrift/src/commands/components/unplace.ts
@@ -179,6 +179,19 @@ export const unplaceComponent: Command<
     await tx
       .delete(componentTargetDesired)
       .where(eq(componentTargetDesired.id, desired.id));
+    // The placement of record clears only when the pair being retired *is* it.
+    // Unplacing the old pair after a move is retirement of what still served
+    // there, and the Component's home — wherever `placeComponent` put it —
+    // is not this command's to touch.
+    await tx
+      .update(components)
+      .set({ placedTargetId: null, updatedAt: now })
+      .where(
+        and(
+          eq(components.id, input.componentId),
+          eq(components.placedTargetId, input.targetId),
+        ),
+      );
     await tx
       .update(deploys)
       .set({ orphanedAt: now, updatedAt: now })

--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -286,6 +286,9 @@ export const completeCreationDraft: Command<
           expose: row.draft.kind === 'job' ? null : true,
           reach: row.draft.reach,
           auth: row.draft.auth,
+          // The draft's chosen Target is this Component's first placement of
+          // record, written at birth rather than inferred later.
+          placedTargetId: row.draft.targetId,
           createdAt: now,
           updatedAt: now,
         })

--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -33,7 +33,7 @@
  * already succeeded, so there is nothing here to run and — structurally — no
  * `adapters.build` lookup to run it with.
  */
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { z } from 'zod';
 import {
   apps,
@@ -241,6 +241,20 @@ export async function placeIntent(
     if (vetoed !== null) {
       return { vetoed, deployId: null, supersededBuildId: null };
     }
+
+    // A first intent for a Component with no placement of record establishes
+    // one — that is what "a first deploy writes it" means. Conditional on NULL
+    // so an intent addressed at a retired pair (rollback, config-set) never
+    // moves a placed Component: only `placeComponent` does that.
+    await tx
+      .update(components)
+      .set({ placedTargetId: checked.targetId })
+      .where(
+        and(
+          eq(components.id, checked.componentId),
+          isNull(components.placedTargetId),
+        ),
+      );
 
     const [deploy] = await tx
       .insert(deploys)

--- a/apps/spindrift/src/db/migrations/0030_component_placement_of_record.sql
+++ b/apps/spindrift/src/db/migrations/0030_component_placement_of_record.sql
@@ -1,0 +1,30 @@
+-- The placement of record becomes a stored fact on the Component.
+--
+-- "Where is this Component placed" was inferred: every reader took the
+-- Component's newest `component_target_desired` row, because `placeComponent`
+-- touches the pair a move commits. But every intent touches its pair's
+-- `updated_at` too, so a rollback or config-set addressed at the *old* pair
+-- after a move made the old row newest again, and the next deploy resolved the
+-- retired Target with no `placeComponent` involved. "Newest" cannot
+-- distinguish moved-here from touched-here; a column can.
+--
+-- `set null` on the foreign key, because a Target row that is gone leaves the
+-- Component honestly unplaced rather than undeletable — the desired rows,
+-- which carry the live state, already cascade.
+--
+-- The backfill is the inference, frozen once: the newest desired row per
+-- Component is what every reader answered until this migration, so it is the
+-- only honest value to promote. A Component with no desired rows stays NULL,
+-- which is what unplaced has always looked like.
+ALTER TABLE "components" ADD COLUMN "placed_target_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "components" ADD CONSTRAINT "components_placed_target_id_targets_id_fk"
+	FOREIGN KEY ("placed_target_id") REFERENCES "public"."targets"("id")
+	ON DELETE set null ON UPDATE no action;
+--> statement-breakpoint
+UPDATE "components" SET "placed_target_id" = (
+	SELECT "target_id" FROM "component_target_desired" d
+	WHERE d."component_id" = "components"."id"
+	ORDER BY d."updated_at" DESC
+	LIMIT 1
+);

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1785374380773,
       "tag": "0029_vessel_checklist",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1785374380774,
+      "tag": "0030_component_placement_of_record",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -534,6 +534,22 @@ export const components = pgTable(
      */
     reach: reachState('reach').notNull().default('private'),
     auth: authMode('auth').notNull().default('proxy'),
+    /**
+     * The placement of record: the Target this Component lives on, as a stored
+     * fact rather than an inference over `componentTargetDesired`.
+     *
+     * The newest desired row could not answer this — every intent bumps its
+     * pair's `updatedAt`, so a rollback or config-set addressed at a retired
+     * pair made the old row newest and every reader followed it back. Only
+     * `placeComponent` moves this; the first act that places a Component with
+     * none (a creation draft, a first deploy) establishes it; and
+     * `unplaceComponent` clears it when the pair it retires is this one.
+     * Desired rows for other Targets are what still serves there, not where
+     * the Component is.
+     */
+    placedTargetId: uuid('placed_target_id').references(() => targets.id, {
+      onDelete: 'set null',
+    }),
     createdAt: timestamp('created_at', { withTimezone: true })
       .notNull()
       .defaultNow(),
@@ -1413,6 +1429,10 @@ export const componentsRelations = relations(components, ({ one, many }) => ({
   deploys: many(deploys),
   configItems: many(configItems),
   desiredTargets: many(componentTargetDesired),
+  placedTarget: one(targets, {
+    fields: [components.placedTargetId],
+    references: [targets.id],
+  }),
 }));
 
 export const buildsRelations = relations(builds, ({ one, many }) => ({

--- a/apps/spindrift/src/reconciler/build-loop.ts
+++ b/apps/spindrift/src/reconciler/build-loop.ts
@@ -12,13 +12,7 @@ import {
   recordDispatchWait,
 } from '../commands/builds/dispatch.ts';
 import { buildRouteFor } from '../commands/builds/route.ts';
-import {
-  builds,
-  components,
-  componentTargetDesired,
-  targets,
-  vessels,
-} from '../db/schema.ts';
+import { builds, components, targets, vessels } from '../db/schema.ts';
 import { artifactTypeFor } from '../domain/placement.ts';
 import { targetLabel } from '../domain/target.ts';
 import {
@@ -53,10 +47,15 @@ export interface BuildLoopOptions {
 export async function runBuildPass(
   context: BuildDispatchContext,
 ): Promise<number> {
+  // One row per PENDING Build: the placement of record is a stored fact on the
+  // Component (`placedTargetId`), so there is nothing to rank or dedupe — the
+  // old pair's desired row a move leaves behind is what still serves there,
+  // never a second candidate. Left joins, because an unplaced Component's
+  // Build is a refusal this loop owes a sentence, not a row to drop.
   const rows = await context.db
     .select({
       buildId: builds.id,
-      targetId: componentTargetDesired.targetId,
+      targetId: targets.id,
       // Carried for the refusal below, which needs an attempt reference and
       // cannot get one from `dispatchBuild` — it never reaches it.
       appId: components.appId,
@@ -66,83 +65,65 @@ export async function runBuildPass(
       // the `where` clause, so this is the age of a Build still waiting to be
       // claimed.
       createdAt: builds.createdAt,
-      // For binding the Build to a placement that admits its shape: what this
-      // Build produces, what the Component is, and enough of the Target to
-      // derive the shape it takes — plus the row's `updatedAt`, which is what
-      // says which placement is the one of record.
+      // For holding the Build to the placement's shape: what this Build
+      // produces, what the Component is, and enough of the Target to derive
+      // the shape it takes.
       targetShape: builds.targetShape,
       kind: components.kind,
       adapter: targets.adapter,
       vessel: vessels.name,
-      desiredUpdatedAt: componentTargetDesired.updatedAt,
     })
     .from(builds)
     .innerJoin(components, eq(builds.componentId, components.id))
-    .innerJoin(
-      componentTargetDesired,
-      eq(componentTargetDesired.componentId, components.id),
-    )
-    .innerJoin(targets, eq(targets.id, componentTargetDesired.targetId))
-    .innerJoin(vessels, eq(vessels.id, targets.vesselId))
+    .leftJoin(targets, eq(targets.id, components.placedTargetId))
+    .leftJoin(vessels, eq(vessels.id, targets.vesselId))
     .where(eq(builds.status, 'PENDING'))
-    .orderBy(asc(builds.id), asc(targets.rank));
-
-  // A moved Component deliberately keeps the old pair's desired row until what
-  // still serves there is retired, so a PENDING Build can join two placements —
-  // and only one of them takes the shape this Build produces. Each Build is
-  // bound to the newest desired row whose Target admits its shape: the same
-  // newest-row-is-the-placement-of-record reading `deployApp` uses. Rank is
-  // only the tie-break the ordering above already applied.
-  const perBuild = new Map<number, typeof rows>();
-  for (const row of rows) {
-    const group = perBuild.get(row.buildId);
-    if (group === undefined) perBuild.set(row.buildId, [row]);
-    else group.push(row);
-  }
-  const shapeTaken = (candidate: (typeof rows)[number]) =>
-    artifactTypeFor(candidate.kind, {
-      capabilities: {
-        artifactTypes:
-          context.adapters.deploy(candidate.adapter)?.artifactTypes ?? [],
-      },
-    });
+    .orderBy(asc(builds.id));
 
   let dispatched = 0;
-  for (const group of perBuild.values()) {
-    let row: (typeof rows)[number] | undefined;
-    for (const candidate of group) {
-      if (shapeTaken(candidate) !== candidate.targetShape) continue;
-      if (
-        row === undefined ||
-        candidate.desiredUpdatedAt > row.desiredUpdatedAt
-      ) {
-        row = candidate;
-      }
-    }
-    if (row === undefined) {
-      // No placement takes what this Build produces. Binding it anywhere would
-      // evaluate route and policy against a Target the artifact can never land
-      // on, so the Build stays PENDING and says so: placing the Component
-      // somewhere that admits the shape is an operator act that makes the next
-      // tick work.
-      const pending = group[0]!;
-      const refused = group
-        .map(
-          (candidate) =>
-            `${targetLabel(candidate)} takes ${shapeTaken(candidate)}`,
-        )
-        .join('; ');
+  for (const row of rows) {
+    if (row.targetId === null || row.adapter === null || row.vessel === null) {
+      // Nowhere to bind: the Component is placed on no Target, so there is no
+      // route or policy to evaluate this Build against. It stays PENDING and
+      // says so — placing the Component is the operator act that makes the
+      // next tick work.
       await recordDispatchWait(
         context,
         {
           attempt: {
-            appId: pending.appId,
-            componentId: pending.componentId,
-            buildId: pending.buildId,
+            appId: row.appId,
+            componentId: row.componentId,
+            buildId: row.buildId,
           },
-          waitingOn: pending.waitingOn,
+          waitingOn: row.waitingOn,
         },
-        `this Build produces a ${pending.targetShape} artifact and no Target this Component is placed on takes one (${refused}), so nothing can run it`,
+        'this Component is placed on no Target, so nothing can run this Build',
+      );
+      continue;
+    }
+    const shapeTaken = artifactTypeFor(row.kind, {
+      capabilities: {
+        artifactTypes:
+          context.adapters.deploy(row.adapter)?.artifactTypes ?? [],
+      },
+    });
+    if (shapeTaken !== row.targetShape) {
+      // The placement of record does not take what this Build produces —
+      // it was staged for a placement the Component has since moved off.
+      // Binding it anywhere else would evaluate route and policy against a
+      // Target the artifact can never land on, so the Build stays PENDING and
+      // says so.
+      await recordDispatchWait(
+        context,
+        {
+          attempt: {
+            appId: row.appId,
+            componentId: row.componentId,
+            buildId: row.buildId,
+          },
+          waitingOn: row.waitingOn,
+        },
+        `this Build produces a ${row.targetShape} artifact and the Target this Component is placed on takes another (${targetLabel({ vessel: row.vessel, adapter: row.adapter })} takes ${shapeTaken}), so nothing can run it`,
       );
       continue;
     }
@@ -202,10 +183,10 @@ export async function runBuildPass(
       );
     }
   }
-  // `perBuild` holds every distinct Build this pass looked at, all of them
-  // PENDING by the `where` clause — the backlog this pass found, whether or
-  // not it managed to dispatch all of it.
-  reconcilerQueueDepth.record(perBuild.size, { kind: 'build' });
+  // Every Build this pass looked at — one row each, all of them PENDING by
+  // the `where` clause — the backlog this pass found, whether or not it
+  // managed to dispatch all of it.
+  reconcilerQueueDepth.record(rows.length, { kind: 'build' });
   return dispatched;
 }
 

--- a/apps/spindrift/test/commands/build-dispatch-refusal.test.ts
+++ b/apps/spindrift/test/commands/build-dispatch-refusal.test.ts
@@ -105,6 +105,7 @@ describe('a dispatch refusal the operator can see', () => {
         appId: app!.id,
         name: overrides.componentName ?? 'web',
         kind: 'service',
+        placedTargetId: targetId,
       })
       .returning();
     await ctx.db

--- a/apps/spindrift/test/commands/deploys.test.ts
+++ b/apps/spindrift/test/commands/deploys.test.ts
@@ -647,6 +647,7 @@ describe('deployApp selects which Component it acts on', () => {
         kind: 'job',
         reach: 'none',
         auth: 'none',
+        placedTargetId: targetId,
       })
       .returning();
     await db
@@ -776,6 +777,10 @@ describe('deployApp selects which Component it acts on', () => {
       targetId: target.id,
       updatedAt: FROZEN,
     });
+    await database()
+      .db.update(components)
+      .set({ placedTargetId: target.id })
+      .where(eq(components.id, component.id));
     const elsewhereVessel = await insertVessel(database().db, 'kubernetes', {
       name: `cluster-${crypto.randomUUID()}`,
     });
@@ -823,6 +828,10 @@ describe('deployApp selects which Component it acts on', () => {
       targetId: target.id,
       updatedAt: FROZEN,
     });
+    await database()
+      .db.update(components)
+      .set({ placedTargetId: target.id })
+      .where(eq(components.id, component.id));
 
     const result = await deployApp(
       { name: app.name },

--- a/apps/spindrift/test/commands/placement-of-record.test.ts
+++ b/apps/spindrift/test/commands/placement-of-record.test.ts
@@ -21,6 +21,7 @@ import {
   placeComponent,
   rollbackDeploy,
   setConfig,
+  unplaceComponent,
 } from '../../src/commands/index.ts';
 import type {
   AdapterRegistry,
@@ -265,6 +266,52 @@ describe('an intent addressed at the old pair does not move the placement', () =
     expect(workspace.ok).toBe(true);
     if (!workspace.ok) return;
     expect(workspace.value.workspace.targetId).toBe(to.target.id);
+  });
+});
+
+describe('unplacing clears the fact only for the pair that is it', () => {
+  test('unplacing the placement itself sets the Component home to nowhere', async () => {
+    const { component, from } = await fixture();
+    const ctx = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    const placed = await placeComponent(
+      { componentId: component.id, targetId: from.target.id, supply: [] },
+      ctx,
+    );
+    expect(placed.ok).toBe(true);
+    expect(await placedTargetOf(component.id)).toBe(from.target.id);
+
+    const retracted = await unplaceComponent(
+      { componentId: component.id, targetId: from.target.id },
+      ctx,
+    );
+    expect(retracted.ok).toBe(true);
+    expect(await placedTargetOf(component.id)).toBeNull();
+  });
+
+  test('unplacing the retired pair after a move leaves the home where the move put it', async () => {
+    const { component, from, to } = await fixture();
+    const ctx = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    for (const targetId of [from.target.id, to.target.id]) {
+      const placed = await placeComponent(
+        { componentId: component.id, targetId, supply: [] },
+        ctx,
+      );
+      expect(placed.ok).toBe(true);
+    }
+    expect(await placedTargetOf(component.id)).toBe(to.target.id);
+
+    const retracted = await unplaceComponent(
+      { componentId: component.id, targetId: from.target.id },
+      ctx,
+    );
+    expect(retracted.ok).toBe(true);
+    expect(await placedTargetOf(component.id)).toBe(to.target.id);
   });
 });
 

--- a/apps/spindrift/test/commands/placement-of-record.test.ts
+++ b/apps/spindrift/test/commands/placement-of-record.test.ts
@@ -1,0 +1,337 @@
+/**
+ * The placement of record is a stored fact, not an inference.
+ *
+ * Every surface used to answer "where is this Component placed" from the
+ * newest `component_target_desired` row — and every intent bumps its pair's
+ * `updatedAt`, so a rollback or config-set addressed at the *old* pair after a
+ * move made the old row newest and flipped every reader back to the retired
+ * Target. These tests hold the fact to its writers: only `placeComponent`
+ * moves `components.placedTargetId`, an intent at the old pair leaves it
+ * alone, and the workspace, `deployApp`, and the app list all read the same
+ * column — including for a Component that has moved and never deployed.
+ */
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import type { DeployAdapter } from '../../src/adapters/deploy/contract.ts';
+import { deployApp } from '../../src/commands/apps/deploy.ts';
+import { listApps } from '../../src/commands/apps/list.ts';
+import { getAppWorkspace } from '../../src/commands/apps/workspace.ts';
+import {
+  createDeploy,
+  placeComponent,
+  rollbackDeploy,
+  setConfig,
+} from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  apps,
+  builds,
+  components,
+  deploys,
+  targets,
+  users,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import {
+  CAPABLE_DISCOVERY,
+  FakeDeployAdapter,
+} from '../harness/fakes/deploy-adapter.ts';
+import { FakeSecretStore } from '../harness/fakes/store-adapter.ts';
+import {
+  SupplyChainHarness,
+  testSignature,
+} from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const database = withIsolatedDatabase();
+const manifest = await fixtureManifest();
+
+const FROZEN = new Date('2024-06-01T00:00:00.000Z');
+const clock: Clock = { now: () => FROZEN };
+
+/** A digest of the right shape, distinct per call. */
+function digest(seed: number): string {
+  return `sha256:${seed.toString(16).padStart(64, '0')}`;
+}
+
+let store: FakeSecretStore;
+
+beforeEach(() => {
+  store = new FakeSecretStore({ adapter: manifest.secretStore.adapter });
+});
+
+function registryOf(deployAdapter: DeployAdapter): AdapterRegistry {
+  return {
+    deploy: (adapter) =>
+      adapter === deployAdapter.adapter ? deployAdapter : null,
+    build: () => null,
+    store: (adapter) =>
+      adapter === manifest.secretStore.adapter ? store : null,
+    repository: () => null,
+    supplyChain: () => new SupplyChainHarness(),
+  };
+}
+
+/**
+ * A context whose principal is a real `users` row, because `setConfig`'s audit
+ * trail is a foreign key into it.
+ */
+async function context(adapters: AdapterRegistry): Promise<CommandContext> {
+  const [user] = await database()
+    .db.insert(users)
+    .values({ displayName: 'Operator' })
+    .returning();
+  return {
+    principal: { id: user!.id, displayName: user!.displayName },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** A kubernetes Target that can reach this installation's store. */
+async function connectedTarget() {
+  const vesselName = `cluster-${crypto.randomUUID()}`;
+  const vessel = await insertVessel(database().db, 'kubernetes', {
+    name: vesselName,
+  });
+  const [target] = await database()
+    .db.insert(targets)
+    .values(
+      targetValues({
+        adapter: 'kubernetes',
+        vesselId: vessel.id,
+        discovery: CAPABLE_DISCOVERY,
+      }),
+    )
+    .returning();
+  return { target: target!, vesselName };
+}
+
+/** An App, a Component, and two Targets a move can cross between. */
+async function fixture() {
+  const db = database().db;
+  const [app] = await db
+    .insert(apps)
+    .values({ name: 'shop', sourceKind: 'archive' })
+    .returning();
+  const [component] = await db
+    .insert(components)
+    .values({ appId: app!.id, name: 'web', kind: 'service', expose: true })
+    .returning();
+  const from = await connectedTarget();
+  const to = await connectedTarget();
+  return { app: app!, component: component!, from, to };
+}
+
+async function succeededBuild(componentId: string, seed: number) {
+  const [build] = await database()
+    .db.insert(builds)
+    .values({
+      componentId,
+      commit: digest(seed),
+      targetShape: 'image',
+      artifactType: 'image',
+      artifactDigest: digest(seed),
+      bundleDigest: digest(seed),
+      bundleLocation: `https://depot.lolwtf.ca/bundles/${seed}.zip`,
+      status: 'SUCCEEDED',
+      verifiedBuildLevel: 2,
+      signature: testSignature(digest(seed), FROZEN.toISOString()),
+    })
+    .returning();
+  return build!;
+}
+
+async function placedTargetOf(componentId: string): Promise<string | null> {
+  const [row] = await database()
+    .db.select({ placedTargetId: components.placedTargetId })
+    .from(components)
+    .where(eq(components.id, componentId));
+  return row!.placedTargetId;
+}
+
+describe('an intent addressed at the old pair does not move the placement', () => {
+  test('a rollback at the retired pair leaves it alone, and deployApp still acts on the move', async () => {
+    const { app, component, from, to } = await fixture();
+    const ctx = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    const first = await succeededBuild(component.id, 1);
+    const second = await succeededBuild(component.id, 2);
+
+    // Two releases at the original Target, so a rollback there has an older
+    // Build to name.
+    for (const build of [first, second]) {
+      const deployed = await createDeploy(
+        {
+          componentId: component.id,
+          targetId: from.target.id,
+          buildId: build.id,
+        },
+        ctx,
+      );
+      expect(deployed.ok).toBe(true);
+    }
+    expect(await placedTargetOf(component.id)).toBe(from.target.id);
+
+    const moved = await placeComponent(
+      { componentId: component.id, targetId: to.target.id, supply: [] },
+      ctx,
+    );
+    expect(moved.ok).toBe(true);
+    expect(await placedTargetOf(component.id)).toBe(to.target.id);
+
+    // The regression: an ordinary deploy addressed at the old pair. It
+    // succeeds — what still serves there can be rolled back — and it must not
+    // move the Component home.
+    const rolled = await rollbackDeploy(
+      {
+        componentId: component.id,
+        targetId: from.target.id,
+        buildId: first.id,
+      },
+      ctx,
+    );
+    expect(rolled.ok).toBe(true);
+    expect(await placedTargetOf(component.id)).toBe(to.target.id);
+
+    // Every reader agrees: the screen names the moved-to Target, and the
+    // button writes its intent there.
+    const workspace = await getAppWorkspace({ name: app.name }, ctx);
+    expect(workspace.ok).toBe(true);
+    if (!workspace.ok) return;
+    expect(workspace.value.workspace.targetId).toBe(to.target.id);
+
+    const pressed = await deployApp({ name: app.name }, ctx);
+    expect(pressed.ok).toBe(true);
+    if (!pressed.ok) return;
+    const [intent] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, pressed.value.deployId!));
+    expect(intent?.targetId).toBe(to.target.id);
+  });
+
+  test('a config write at the retired pair redeploys there and leaves it alone', async () => {
+    const { app, component, from, to } = await fixture();
+    const ctx = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    const build = await succeededBuild(component.id, 3);
+
+    const deployed = await createDeploy(
+      {
+        componentId: component.id,
+        targetId: from.target.id,
+        buildId: build.id,
+      },
+      ctx,
+    );
+    expect(deployed.ok).toBe(true);
+
+    const moved = await placeComponent(
+      { componentId: component.id, targetId: to.target.id, supply: [] },
+      ctx,
+    );
+    expect(moved.ok).toBe(true);
+
+    // `setConfig` at the old pair delivers the change to what still serves
+    // there — an intent that bumps that pair's desired row.
+    const configured = await setConfig(
+      {
+        componentId: component.id,
+        targetId: from.target.id,
+        entries: [{ key: 'TOKEN', value: 'one' }],
+      },
+      ctx,
+    );
+    expect(configured.ok).toBe(true);
+    if (!configured.ok) return;
+    expect(configured.value.deployId).not.toBeNull();
+
+    expect(await placedTargetOf(component.id)).toBe(to.target.id);
+
+    const workspace = await getAppWorkspace({ name: app.name }, ctx);
+    expect(workspace.ok).toBe(true);
+    if (!workspace.ok) return;
+    expect(workspace.value.workspace.targetId).toBe(to.target.id);
+  });
+});
+
+describe('a moved-but-never-deployed Component reads the same everywhere', () => {
+  test('the workspace names the Target the deploy button would act on', async () => {
+    const { app, component, from, to } = await fixture();
+    const ctx = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+
+    for (const targetId of [from.target.id, to.target.id]) {
+      const placed = await placeComponent(
+        { componentId: component.id, targetId, supply: [] },
+        ctx,
+      );
+      expect(placed.ok).toBe(true);
+    }
+
+    // Nothing has ever deployed, so history has no answer — the fact does.
+    const workspace = await getAppWorkspace({ name: app.name }, ctx);
+    expect(workspace.ok).toBe(true);
+    if (!workspace.ok) return;
+    expect(workspace.value.workspace.targetId).toBe(to.target.id);
+    expect(workspace.value.workspace.vessel).toBe(to.vesselName);
+
+    // The button acts on the same Target the screen named: with nothing built
+    // yet, it stages a Build for the moved-to placement.
+    const pressed = await deployApp({ name: app.name }, ctx);
+    expect(pressed.ok).toBe(true);
+    if (!pressed.ok) return;
+    expect(pressed.value.phase).toBe('BUILDING');
+    expect(await placedTargetOf(component.id)).toBe(to.target.id);
+  });
+});
+
+describe('the app list shows a placement no deploy has reached (§18)', () => {
+  test('placed-but-never-deployed names the Target; unplaced stays none', async () => {
+    const { app, component, from } = await fixture();
+    const ctx = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    const placed = await placeComponent(
+      { componentId: component.id, targetId: from.target.id, supply: [] },
+      ctx,
+    );
+    expect(placed.ok).toBe(true);
+
+    // A second App nobody has placed, to hold the two rows apart.
+    const [bare] = await database()
+      .db.insert(apps)
+      .values({ name: 'bare', sourceKind: 'archive' })
+      .returning();
+    await database()
+      .db.insert(components)
+      .values({ appId: bare!.id, name: 'web', kind: 'service', expose: true });
+
+    const listed = await listApps({}, ctx);
+    expect(listed.ok).toBe(true);
+    if (!listed.ok) return;
+    const byId = new Map(listed.value.apps.map((row) => [row.id, row]));
+
+    // The placed row names its Target and boundary, marked as awaiting its
+    // first deploy — distinguishable from both a live placement and `none`.
+    expect(byId.get(app.id)?.target).toBe('kubernetes (awaiting first deploy)');
+    expect(byId.get(app.id)?.vessel).toBe(from.vesselName);
+
+    expect(byId.get(bare!.id)?.target).toBe('none');
+    expect(byId.get(bare!.id)?.vessel).toBe('');
+  });
+});

--- a/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
+++ b/apps/spindrift/test/commands/rerun-bundle-staging.test.ts
@@ -130,6 +130,10 @@ describe('the bundle a rerun stages', () => {
     await ctx.db
       .insert(componentTargetDesired)
       .values({ componentId: component!.id, targetId: target!.id });
+    await ctx.db
+      .update(components)
+      .set({ placedTargetId: target!.id })
+      .where(eq(components.id, component!.id));
     if (options.previousBuild === false) {
       return { app: app!, component: component!, build: null };
     }

--- a/apps/spindrift/test/commands/workspace-component-selection.test.ts
+++ b/apps/spindrift/test/commands/workspace-component-selection.test.ts
@@ -28,6 +28,7 @@ import type {
 } from '../../src/commands/types.ts';
 import {
   builds,
+  components,
   componentTargetDesired,
   configItems,
   deploys,
@@ -90,6 +91,10 @@ async function placed(
   const targetId = target?.id as string;
 
   await ctx.db.insert(componentTargetDesired).values({ componentId, targetId });
+  await ctx.db
+    .update(components)
+    .set({ placedTargetId: targetId })
+    .where(eq(components.id, componentId));
 
   const artifactDigest = `sha256:${'a'.repeat(64)}`;
   const [build] = await ctx.db

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -18,6 +18,7 @@ import type {
 import {
   attemptEvents,
   builds,
+  components,
   componentTargetDesired,
   deploys,
   targets,
@@ -134,6 +135,10 @@ async function scaffold(
     componentId: component.value.componentId,
     targetId: target!.id,
   });
+  await ctx.db
+    .update(components)
+    .set({ placedTargetId: target!.id })
+    .where(eq(components.id, component.value.componentId));
 
   return {
     appName: name,
@@ -465,6 +470,12 @@ describe('getAppWorkspace command', () => {
       buildId: build!.id,
       phase: 'LIVE',
     });
+    // The intent path that placed this deploy would have established the
+    // placement of record; seeding the row directly has to write the fact too.
+    await database()
+      .db.update(components)
+      .set({ placedTargetId: target!.id })
+      .where(eq(components.id, createdComp.value.componentId));
 
     const result = await getAppWorkspace({ name: appName }, ctx);
     expect(result.ok).toBe(true);
@@ -528,6 +539,12 @@ describe('getAppWorkspace command', () => {
       buildId: build!.id,
       phase: 'LIVE',
     });
+    // The intent path that placed this deploy would have established the
+    // placement of record; seeding the row directly has to write the fact too.
+    await database()
+      .db.update(components)
+      .set({ placedTargetId: target!.id })
+      .where(eq(components.id, createdComp.value.componentId));
 
     const result = await getAppWorkspace({ name: appName }, ctx);
     expect(result.ok).toBe(true);
@@ -570,6 +587,10 @@ describe('getAppWorkspace command', () => {
       componentId: createdComp.value.componentId,
       targetId: target!.id,
     });
+    await database()
+      .db.update(components)
+      .set({ placedTargetId: target!.id })
+      .where(eq(components.id, createdComp.value.componentId));
     await database()
       .db.insert(builds)
       .values({
@@ -1567,6 +1588,10 @@ describe('deployApp command', () => {
       componentId: createdComp.value.componentId,
       targetId: targetRow!.id,
     });
+    await ctx.db
+      .update(components)
+      .set({ placedTargetId: targetRow!.id })
+      .where(eq(components.id, createdComp.value.componentId));
 
     const [buildRow] = await ctx.db
       .insert(builds)
@@ -1641,6 +1666,10 @@ describe('deployApp command', () => {
       componentId: createdComp.value.componentId,
       targetId: targetRow!.id,
     });
+    await ctx.db
+      .update(components)
+      .set({ placedTargetId: targetRow!.id })
+      .where(eq(components.id, createdComp.value.componentId));
 
     const [buildRow] = await ctx.db
       .insert(builds)
@@ -1766,6 +1795,10 @@ describe('deployApp command', () => {
       componentId: createdComp.value.componentId,
       targetId: targetRow!.id,
     });
+    await ctx.db
+      .update(components)
+      .set({ placedTargetId: targetRow!.id })
+      .where(eq(components.id, createdComp.value.componentId));
 
     await ctx.db.insert(builds).values({
       componentId: createdComp.value.componentId,

--- a/apps/spindrift/test/reconciler/auto-deploy.test.ts
+++ b/apps/spindrift/test/reconciler/auto-deploy.test.ts
@@ -69,6 +69,10 @@ async function deployableApp(autoDeploy: boolean) {
     targetId: target!.id,
     updatedAt: NOW,
   });
+  await db
+    .update(components)
+    .set({ placedTargetId: target!.id })
+    .where(eq(components.id, component!.id));
   const digest = `sha256:${crypto.randomUUID().replaceAll('-', '').padEnd(64, '0')}`;
   const [build] = await db
     .insert(builds)

--- a/apps/spindrift/test/reconciler/build-loop.test.ts
+++ b/apps/spindrift/test/reconciler/build-loop.test.ts
@@ -2,13 +2,11 @@
  * Which placement `runBuildPass` binds a Build's dispatch to.
  *
  * A moved Component deliberately keeps the old pair's desired row until what
- * still serves there is retired, so a PENDING Build can join two placements.
- * The loop used to bind each Build to whichever Target ranked lowest — which,
- * after a move across shapes, is the *old* Target: the files Build the move's
- * own refusal prescribed was then routed and policy-checked against the image
- * Target it can never land on. These tests hold the loop to the Build's own
- * shape: bind to the newest desired row whose Target admits it, and where none
- * does, say so instead of dispatching anywhere.
+ * still serves there is retired, so the rows alone cannot say where a Build
+ * belongs. The loop binds every Build to the placement of record —
+ * `components.placedTargetId`, the stored fact `placeComponent` moves — and
+ * where that placement does not take the Build's shape, says so instead of
+ * dispatching anywhere.
  */
 import { describe, expect, test } from 'bun:test';
 import { eq } from 'drizzle-orm';
@@ -121,8 +119,8 @@ async function movedWebsite() {
     .returning();
 
   // The move's residue: the old pair's row survives so unplacement can retire
-  // what still serves there, and the new pair's row is the newest — the
-  // placement of record.
+  // what still serves there, the new pair has its own row, and the placement
+  // of record — the fact the move wrote — names the static Target.
   await db.insert(componentTargetDesired).values({
     componentId: component!.id,
     targetId: runtimeTarget!.id,
@@ -133,6 +131,10 @@ async function movedWebsite() {
     targetId: staticTarget!.id,
     updatedAt: FROZEN,
   });
+  await db
+    .update(components)
+    .set({ placedTargetId: staticTarget!.id })
+    .where(eq(components.id, component!.id));
 
   // The rebuild the move remediation staged: a files Build, PENDING.
   const [build] = await db
@@ -210,17 +212,22 @@ describe('a rebuild staged by a move dispatches against the new placement', () =
     });
   });
 
-  test('a Build whose shape no placement takes waits and says so', async () => {
-    const { runtimeTarget, runtimeVessel, staticTarget, build } =
+  test('a Build whose shape the placement of record does not take waits and says so', async () => {
+    const { component, runtimeTarget, runtimeVessel, staticTarget, build } =
       await movedWebsite();
     const db = database().db;
 
-    // Retire the placement that admitted the shape, leaving only the image
-    // Target. Binding the files Build there anyway would evaluate policy
-    // against a Target the artifact can never land on.
+    // Move the Component back onto the image Target: the files Build now
+    // belongs to a placement the Component no longer holds. Binding it to the
+    // image Target anyway would evaluate policy against a Target the artifact
+    // can never land on.
     await db
       .delete(componentTargetDesired)
       .where(eq(componentTargetDesired.targetId, staticTarget.id));
+    await db
+      .update(components)
+      .set({ placedTargetId: runtimeTarget.id })
+      .where(eq(components.id, component.id));
 
     const route = new FakeBuildAdapter();
     expect(await runBuildPass(context(registryOf(route)))).toBe(0);
@@ -232,5 +239,25 @@ describe('a rebuild staged by a move dispatches against the new placement', () =
     expect(row.dispatchWaitingOn).toContain(
       `${runtimeVessel.name}/${runtimeTarget.adapter} takes image`,
     );
+  });
+
+  test('an unplaced Component’s Build waits and says so', async () => {
+    const { component, build } = await movedWebsite();
+    const db = database().db;
+
+    // Unplacement clears the fact. The desired rows that remain are what
+    // still serves, never a place to bind a Build to.
+    await db
+      .update(components)
+      .set({ placedTargetId: null })
+      .where(eq(components.id, component.id));
+
+    const route = new FakeBuildAdapter();
+    expect(await runBuildPass(context(registryOf(route)))).toBe(0);
+
+    const row = await buildRow(build.id);
+    expect(row.status).toBe('PENDING');
+    expect(route.built).toHaveLength(0);
+    expect(row.dispatchWaitingOn).toContain('placed on no Target');
   });
 });

--- a/apps/spindrift/test/reconciler/process.test.ts
+++ b/apps/spindrift/test/reconciler/process.test.ts
@@ -413,6 +413,10 @@ async function pendingBuildNoRouteSatisfies() {
   await db
     .insert(componentTargetDesired)
     .values({ componentId: component!.id, targetId: target!.id });
+  await db
+    .update(components)
+    .set({ placedTargetId: target!.id })
+    .where(eq(components.id, component!.id));
   await db.insert(builds).values({
     componentId: component!.id,
     commit: 'abcdef0',

--- a/apps/spindrift/test/web/webhook-route.test.ts
+++ b/apps/spindrift/test/web/webhook-route.test.ts
@@ -208,6 +208,10 @@ describe('a push that reaches an opted-in App', () => {
       targetId: target!.id,
       updatedAt: NOW,
     });
+    await db
+      .update(components)
+      .set({ placedTargetId: target!.id })
+      .where(eq(components.id, component!.id));
     const digest = `sha256:${'a'.repeat(64)}`;
     const [build] = await db
       .insert(builds)


### PR DESCRIPTION
## What

"Where is this Component placed" was inferred from the newest `component_target_desired` row, and every intent bumps its pair's `updatedAt` — so a rollback or config-set addressed at the retired pair after a move made the old row newest, and `deployApp`, the workspace, `getBuildDetail`, and the build loop's dedupe all followed it back to the Target the Component had moved off. The placement is now a stored fact, `components.placed_target_id`: only `placeComponent` moves it, the first placing act (creation draft, first deploy) establishes it, and `unplaceComponent` clears it only when the pair it retires is the placement of record — retiring the old pair after a move leaves the Component's home alone. Every reader reads the column; the workspace drops history-first resolution, so a moved-but-never-deployed Component names the Target the deploy button acts on, and `runBuildPass` binds each PENDING Build to the placement of record directly (one row per Build, no rank-ordered dedupe).

On top of that, `listApps` now falls back to the placed Target for a Component with no deploy, rendered as `<adapter> (awaiting first deploy)` beside its vessel — previously placed-but-never-deployed showed `target: none`, indistinguishable from unplaced, and the difference decides whether an unplace is needed before delete.

## Validation

- `bun test` (full suite, real Postgres): 2070 pass, 0 fail — includes new `test/commands/placement-of-record.test.ts` covering the core regression (rollback and config-set at the old pair leave the placement alone), workspace/deployApp agreement after a move with no deploy, and the app-list placed-vs-unplaced distinction
- `mise run ts:check` (workspace typecheck + biome): clean
- Migration `0030_component_placement_of_record.sql` backfills the column from each Component's newest desired row — a one-time freeze of the inference every reader used until now, which is the only honest backfill; Components with no desired rows stay NULL (unplaced)

## Risk

The build loop's binding rule changes for one edge: a PENDING Build whose shape the placement of record does not take now waits with a sentence naming the mismatch, instead of dispatching against a still-serving old pair that happens to admit the shape. That Build was staged for a placement the operator has since moved off; the rebuild arm stages the right-shaped Build for the new placement.