### PR TITLE
fix: clear the firing folly alerts (spore disk, textfile drop box)

### DIFF
--- a/nix/hosts/spore.nix
+++ b/nix/hosts/spore.nix
@@ -30,6 +30,14 @@
 
   homelab.nfsServer.dataDevice = "/dev/disk/by-label/nfs-data";
 
+  # Root is capped at 32G and every daily auto-upgrade generation drags a
+  # fresh rackpi5 native-boot image along (~1G delta), so the fleet's
+  # weekly/30d GC keeps a month of images and fills the disk.
+  nix.gc = {
+    dates = "daily";
+    options = "--delete-older-than 7d";
+  };
+
   # Signed native-boot publishing for rackpi5. The cross-host target is wired
   # in nix/lib/registry.nix, where rackpi5's piBootImg derivation is in scope.
   services.spore.enable = true;

--- a/nix/profiles/k8s-node.nix
+++ b/nix/profiles/k8s-node.nix
@@ -44,4 +44,12 @@ in
     enable = true;
     inherit network;
   };
+
+  # The in-cluster node-exporter DaemonSet scrapes this drop box on every
+  # node (clusters/folly/monitoring/kube-prometheus.yaml); a node without
+  # the directory trips NodeTextFileCollectorScrapeError. Ownership is left
+  # unmanaged ("-") so bosun's StateDirectory keeps the dir on riptide.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/prometheus-node-exporter-text-files 0755 - - -"
+  ];
 }

--- a/nix/system/nixos.nix
+++ b/nix/system/nixos.nix
@@ -14,8 +14,8 @@
     package = pkgs.nixVersions.latest;
     gc = {
       automatic = true;
-      dates = "weekly";
-      options = "--delete-older-than 30d";
+      dates = lib.mkDefault "weekly";
+      options = lib.mkDefault "--delete-older-than 30d";
     };
     # Free up to 5GiB whenever there is less than 2GiB left.
     extraOptions = ''


### PR DESCRIPTION
## Summary

Folly's Alertmanager has six firing alerts, two root causes:

- **NodeFilesystemAlmostOutOfSpace / SpaceFillingUp on spore** — root is capped at 32G by design, and every daily auto-upgrade generation pins a fresh rackpi5 native-boot image (~1G delta). The fleet's weekly/30d GC keeps ~25 rooted generations, so the store sits at 26G live and the disk at 100%. Spore now collects daily and keeps a week; the fleet default becomes `mkDefault` so hosts can override.
- **NodeTextFileCollectorScrapeError on optiplex + shale** — the in-cluster node-exporter DaemonSet points its textfile collector at `/var/lib/prometheus-node-exporter-text-files` on every node, but only riptide has the directory (bosun's `StateDirectory` creates it). The shared k8s-node profile now declares the drop box with unmanaged ownership so bosun keeps owning it on riptide.

Offsite is clean (Watchdog only). Other Pis have 86–95% root free, so the GC tightening is spore-scoped.

## Validation

- `nix eval` of spore, optiplex, and riptide toplevels on this branch: clean.
- Evaluated config spot-checks: spore gc `daily`/`--delete-older-than 7d`, forge still `weekly` (default intact), tmpfiles rule renders on optiplex and riptide.

## Notes

- spore has 193M free **now**; tonight's auto-upgrade may fail on ENOSPC before this merges. One-time relief: `ssh spore.lolwtf.ca sudo nix-collect-garbage --delete-older-than 7d`.
- `/home/jawn/result` on spore (Aug 3, 3.9G closure) is also a GC root; mostly shared with the current system, left alone.