### PR TITLE
feat(spindrift): rebuild the supply chain as a module call

### DIFF
--- a/terraform/gcp/projects/trusted-builds/README.md
+++ b/terraform/gcp/projects/trusted-builds/README.md
@@ -1,3 +1,21 @@
+# trusted-builds
+
+`trusted-builds` is the artifacts project every Spindrift vessel's supply
+chain runs through: a KMS key signs, a Binary Authorization attestor checks
+admission against the signature, and an Artifact Registry repository
+(`artifact-registry.tf`) stages what Cloud Run pulls. The chain itself is
+`terraform/modules/spindrift-supply-chain`, called from `supply-chain.tf`;
+the principal lists it takes — who signs, who verifies, who reads and writes
+the repository — are declared as locals in `locals.tf` so an operator reading
+the root sees who may sign without chasing the module. `outputs.tf` hands the
+attestor id to the bluenose vessel root and the signer/registry pair to the
+installation manifest's `supplyChain` block.
+
+The KMS ring and key exist in the project outside any state file, so
+`supply-chain.tf` adopts them with `import` blocks rather than creating them.
+GCP never deletes a ring or a key: creating fresh ones under the same names
+collides, and every other name leaves a signing key nothing uses.
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -14,7 +32,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_supply_chain"></a> [supply\_chain](#module\_supply\_chain) | ../../../modules/spindrift-supply-chain | n/a |
 
 ## Resources
 
@@ -30,6 +50,7 @@ No modules.
 | [google_storage_bucket.trusted_artifacts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
 | [google_storage_bucket_iam_policy.trusted_artifacts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_policy) | resource |
 | [google_iam_policy.trusted_artifacts](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
+| [google_project.bluenose](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 | [google_project.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
 
 ## Inputs
@@ -38,5 +59,8 @@ No inputs.
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_attestor"></a> [attestor](#output\_attestor) | Binary Authorization attestor id (projects/*/attestors/*) the bluenose vessel root's attestor variable takes. |
+| <a name="output_supply_chain_manifest_block"></a> [supply\_chain\_manifest\_block](#output\_supply\_chain\_manifest\_block) | The installation manifest's supplyChain block: signer key uri and registry namespace. |
 <!-- END_TF_DOCS -->

--- a/terraform/gcp/projects/trusted-builds/README.md
+++ b/terraform/gcp/projects/trusted-builds/README.md
@@ -11,13 +11,11 @@ the root sees who may sign without chasing the module. `outputs.tf` hands the
 attestor id to the bluenose vessel root and the signer/registry pair to the
 installation manifest's `supplyChain` block.
 
-A ring named `keys` holding a key named `signer` is live in this project and
-in no state file, its only version `DESTROY_SCHEDULED`. GCP never deletes a
-ring or a key, so both names are spent — `supply-chain.tf` names the ring
-`spindrift` instead and lets the module create it, the key, and the first
-version. Reading the public half of a version that was generated moments ago
-can fail once with `PENDING_GENERATION`; the second apply converges, and the
-module README says so.
+The KMS ring and key are live in this project and in no state file, so
+`supply-chain.tf` adopts them with `import` blocks rather than creating them.
+GCP never deletes a ring or a key: creating fresh ones under these names
+collides, and any other name is a new signing key, which means a new public
+half for the cluster admission policy to pin.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/gcp/projects/trusted-builds/README.md
+++ b/terraform/gcp/projects/trusted-builds/README.md
@@ -11,10 +11,13 @@ the root sees who may sign without chasing the module. `outputs.tf` hands the
 attestor id to the bluenose vessel root and the signer/registry pair to the
 installation manifest's `supplyChain` block.
 
-The KMS ring and key exist in the project outside any state file, so
-`supply-chain.tf` adopts them with `import` blocks rather than creating them.
-GCP never deletes a ring or a key: creating fresh ones under the same names
-collides, and every other name leaves a signing key nothing uses.
+A ring named `keys` holding a key named `signer` is live in this project and
+in no state file, its only version `DESTROY_SCHEDULED`. GCP never deletes a
+ring or a key, so both names are spent — `supply-chain.tf` names the ring
+`spindrift` instead and lets the module create it, the key, and the first
+version. Reading the public half of a version that was generated moments ago
+can fail once with `PENDING_GENERATION`; the second apply converges, and the
+module README says so.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/terraform/gcp/projects/trusted-builds/locals.tf
+++ b/terraform/gcp/projects/trusted-builds/locals.tf
@@ -1,0 +1,31 @@
+data "google_project" "bluenose" {
+  project_id = "bluenose"
+}
+
+locals {
+  spindrift_vessel_project                    = "bluenose"
+  spindrift_controller_member                 = "serviceAccount:spindrift-controller@${local.spindrift_vessel_project}.iam.gserviceaccount.com"
+  bluenose_binary_authorization_service_agent = "serviceAccount:service-${data.google_project.bluenose.number}@gcp-sa-binaryauthorization.iam.gserviceaccount.com"
+
+  cloud_build_worker_member = "serviceAccount:${data.google_project.current.number}@cloudbuild.gserviceaccount.com"
+
+  # Everything that signs with the attestor's key. Each gets four grants —
+  # `signerVerifier` and `viewer` on the key, `occurrences.editor` on the
+  # project, `notes.attacher` on the note — because attesting is two
+  # permissions in two places and holding one of them is holding neither.
+  #
+  # The workflow run, the controller, and the cloud build worker: one per build
+  # route that can reach a Target enforcing a Binary Authorization policy. The
+  # worker is here because the attestation runs as a step of the build it
+  # attests (`adapters/build/cloud-build.ts`), which is the only thing in that
+  # route holding the digest at the moment it is pushed.
+  attester_principals = [
+    "principalSet://iam.googleapis.com/projects/629296473058/locations/global/workloadIdentityPools/homelab/attribute.repository_owner/jonpulsifer",
+    local.spindrift_controller_member,
+    local.cloud_build_worker_member,
+  ]
+
+  attestor_viewers = concat(local.attester_principals, [
+    "serviceAccount:terraform@homelab-ng.iam.gserviceaccount.com",
+  ])
+}

--- a/terraform/gcp/projects/trusted-builds/outputs.tf
+++ b/terraform/gcp/projects/trusted-builds/outputs.tf
@@ -1,0 +1,12 @@
+output "attestor" {
+  description = "Binary Authorization attestor id (projects/*/attestors/*) the bluenose vessel root's attestor variable takes."
+  value       = module.supply_chain.attestor
+}
+
+output "supply_chain_manifest_block" {
+  description = "The installation manifest's supplyChain block: signer key uri and registry namespace."
+  value = {
+    signer   = module.supply_chain.signer_uri
+    registry = module.supply_chain.registry_namespace
+  }
+}

--- a/terraform/gcp/projects/trusted-builds/supply-chain.tf
+++ b/terraform/gcp/projects/trusted-builds/supply-chain.tf
@@ -1,0 +1,41 @@
+# GCP never deletes a KMS ring or key. The hand-rolled predecessor's
+# `google_kms_key_ring.keys` and `google_kms_crypto_key.signer` were dropped
+# from state by commit 396bc1c16 (PR #1947), but the ring and the key are
+# still live in this project, orphaned. This rebuild adopts them into the
+# module's addresses instead of the apply colliding with an "already exists"
+# error — and because the key is the one from its previous life, its version
+# is already generated, so the module README's PENDING_GENERATION
+# first-apply retry does not apply here.
+import {
+  to = module.supply_chain.google_kms_key_ring.keys[0]
+  id = "projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys"
+}
+
+import {
+  to = module.supply_chain.google_kms_crypto_key.signer[0]
+  id = "projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer"
+}
+
+module "supply_chain" {
+  source = "../../../modules/spindrift-supply-chain"
+
+  project    = local.project
+  location   = local.region
+  repository = google_artifact_registry_repository.images.repository_id
+
+  controller_member = local.spindrift_controller_member
+
+  attester_principals = local.attester_principals
+  attestor_viewers    = local.attestor_viewers
+
+  # Vessel agents only. This project's own Binary Authorization agent reads
+  # occurrences on the note because the module composes that grant from the
+  # project number; it verifies nothing, so it does not belong here.
+  verifier_agents = [local.bluenose_binary_authorization_service_agent]
+
+  registry_readers = [
+    local.spindrift_controller_member,
+    local.bluenose_binary_authorization_service_agent,
+    "serviceAccount:service-${data.google_project.bluenose.number}@serverless-robot-prod.iam.gserviceaccount.com",
+  ]
+}

--- a/terraform/gcp/projects/trusted-builds/supply-chain.tf
+++ b/terraform/gcp/projects/trusted-builds/supply-chain.tf
@@ -1,27 +1,19 @@
-# GCP never deletes a KMS ring or key. The hand-rolled predecessor's
-# `google_kms_key_ring.keys` and `google_kms_crypto_key.signer` were dropped
-# from state by commit 396bc1c16 (PR #1947), but the ring and the key are
-# still live in this project, orphaned. This rebuild adopts them into the
-# module's addresses instead of the apply colliding with an "already exists"
-# error — and because the key is the one from its previous life, its version
-# is already generated, so the module README's PENDING_GENERATION
-# first-apply retry does not apply here.
-import {
-  to = module.supply_chain.google_kms_key_ring.keys[0]
-  id = "projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys"
-}
-
-import {
-  to = module.supply_chain.google_kms_crypto_key.signer[0]
-  id = "projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer"
-}
-
 module "supply_chain" {
   source = "../../../modules/spindrift-supply-chain"
 
   project    = local.project
   location   = local.region
   repository = google_artifact_registry_repository.images.repository_id
+
+  # A ring named `keys` holding a key named `signer` is live in this project
+  # and in no state file, its only version DESTROY_SCHEDULED. GCP never
+  # deletes a ring or a key, so those two names are spent: creating them
+  # collides, and adopting them yields a key whose only version cannot be
+  # read. The module's other branch is these names — it creates the ring, the
+  # key, and a first version, and the chain signs with material that belongs
+  # to this installation.
+  key_ring_name   = "spindrift"
+  signer_key_name = "signer"
 
   controller_member = local.spindrift_controller_member
 

--- a/terraform/gcp/projects/trusted-builds/supply-chain.tf
+++ b/terraform/gcp/projects/trusted-builds/supply-chain.tf
@@ -1,19 +1,25 @@
+# GCP never deletes a KMS ring or a key, so the ring and key this chain signs
+# with are live in the project and in no state file. The module adopts them at
+# its own addresses rather than colliding with them on create. Their single
+# version is enabled, so the public half reads on the first apply and the
+# module README's PENDING_GENERATION retry does not arise — and the public key
+# the cluster admission policy pins is the one it already pins.
+import {
+  to = module.supply_chain.google_kms_key_ring.keys[0]
+  id = "projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys"
+}
+
+import {
+  to = module.supply_chain.google_kms_crypto_key.signer[0]
+  id = "projects/trusted-builds/locations/northamerica-northeast1/keyRings/keys/cryptoKeys/signer"
+}
+
 module "supply_chain" {
   source = "../../../modules/spindrift-supply-chain"
 
   project    = local.project
   location   = local.region
   repository = google_artifact_registry_repository.images.repository_id
-
-  # A ring named `keys` holding a key named `signer` is live in this project
-  # and in no state file, its only version DESTROY_SCHEDULED. GCP never
-  # deletes a ring or a key, so those two names are spent: creating them
-  # collides, and adopting them yields a key whose only version cannot be
-  # read. The module's other branch is these names — it creates the ring, the
-  # key, and a first version, and the chain signs with material that belongs
-  # to this installation.
-  key_ring_name   = "spindrift"
-  signer_key_name = "signer"
 
   controller_member = local.spindrift_controller_member
 


### PR DESCRIPTION
First of the Spindrift rebuild PRs. `trusted-builds` becomes a caller of `terraform/modules/spindrift-supply-chain` rather than a hand-rolled chain: the module provisions the attestor, the note, and every grant, and the root keeps the principal lists as locals so the answer to "who may sign" is in the root an operator opens.

## The KMS import

The ring and the key are live in the project and in no state file — GCP never deletes either. This root adopts them with config-driven `import` blocks rather than creating new ones.

Keeping the original key is what keeps the pinned public key out of the rebuild's dependency chain: the cluster image-admission `ClusterPolicy` pins the signer's public half, and adopting this key means the value it already pins is still correct. Any other key name would make that policy a downstream edit gated on this apply.

The key's single version was left `DESTROY_SCHEDULED` by the teardown, which is what failed the first plan here (`KEY_DESTROY_SCHEDULED` on the attestor's public-key read). It has been restored and enabled, so the public half reads on the first apply and the module README's `PENDING_GENERATION` retry does not arise.

Both orphans match the module's shape exactly — `ASYMMETRIC_SIGN`, `RSA_SIGN_PKCS1_4096_SHA512`, the module's default `keys`/`signer` names — so the plan should show two imports and no replacement. **A plan proposing to destroy or replace either is wrong and should not be applied.**

## verifier_agents

The vessel's Binary Authorization agent alone. This project's own agent gets its note read composed by the module from the project number, and it verifies nothing, so it is not in the roster.

## Validation

`tofu init -backend=false && tofu validate` clean, `tofu fmt` clean. Plan is Atlantis's to produce.

Sequencing: the vessel root's Binary Authorization policy names this attestor, so this applies before it.