### PR TITLE
feat(monitoring): bosun observability on both clusters, and a latency series

### DIFF
--- a/apps/bosun/metrics.go
+++ b/apps/bosun/metrics.go
@@ -12,10 +12,12 @@ import (
 // metrics is bosun's counters. Gauges are not kept here -- they are read off
 // the live pool at write time, since the running skiffs are the state.
 type metrics struct {
-	mu       sync.Mutex
-	boots    map[string]int            // class -> skiffs booted
-	exits    map[string]map[string]int // class -> reason -> skiffs gone
-	ghErrors int
+	mu          sync.Mutex
+	boots       map[string]int            // class -> skiffs booted
+	exits       map[string]map[string]int // class -> reason -> skiffs gone
+	onlineSum   map[string]float64        // class -> total mint-to-online seconds
+	onlineCount map[string]int            // class -> skiffs that came online
+	ghErrors    int
 }
 
 // Exit reasons. "completed" is the one that means a job ran: the guest reached
@@ -41,7 +43,12 @@ const (
 )
 
 func newMetrics() *metrics {
-	return &metrics{boots: map[string]int{}, exits: map[string]map[string]int{}}
+	return &metrics{
+		boots:       map[string]int{},
+		exits:       map[string]map[string]int{},
+		onlineSum:   map[string]float64{},
+		onlineCount: map[string]int{},
+	}
 }
 
 func (m *metrics) boot(class string) {
@@ -57,6 +64,17 @@ func (m *metrics) exit(class, reason string) {
 		m.exits[class] = map[string]int{}
 	}
 	m.exits[class][reason]++
+}
+
+// online records how long a skiff took from JIT mint to GitHub first reporting
+// its runner online -- boot, registration and connect together. The five
+// hand-run benches all measured this edge by stopwatch; recording it makes a
+// hull or network regression visible without one.
+func (m *metrics) online(class string, seconds float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onlineSum[class] += seconds
+	m.onlineCount[class]++
 }
 
 func (m *metrics) githubError() {
@@ -99,6 +117,13 @@ func (m *metrics) render(live map[string]poolState, desired map[string]int) stri
 		for _, reason := range []string{exitCompleted, exitWedged, exitLifetime, exitJITExpired, exitBootFailed, exitKilled, exitDrained} {
 			b.WriteString(fmt.Sprintf("bosun_skiff_exits_total{class=%q,reason=%q} %d\n", class, reason, m.exits[class][reason]))
 		}
+	}
+
+	b.WriteString("# HELP bosun_skiff_time_to_online_seconds Mint-to-online latency; avg = rate(sum)/rate(count).\n")
+	b.WriteString("# TYPE bosun_skiff_time_to_online_seconds summary\n")
+	for _, class := range sortedKeys(desired) {
+		b.WriteString(fmt.Sprintf("bosun_skiff_time_to_online_seconds_sum{class=%q} %g\n", class, m.onlineSum[class]))
+		b.WriteString(fmt.Sprintf("bosun_skiff_time_to_online_seconds_count{class=%q} %d\n", class, m.onlineCount[class]))
 	}
 
 	b.WriteString("# HELP bosun_github_errors_total GitHub API calls that failed.\n")

--- a/apps/bosun/metrics_test.go
+++ b/apps/bosun/metrics_test.go
@@ -14,6 +14,8 @@ func TestRenderExposesPoolStateAndCounters(t *testing.T) {
 	m.boot("skiff-test")
 	m.exit("skiff-test", exitCompleted)
 	m.exit("skiff-test", exitWedged)
+	m.online("skiff-test", 17.5)
+	m.online("skiff-test", 2.5)
 	m.githubError()
 
 	got := m.render(
@@ -29,6 +31,8 @@ func TestRenderExposesPoolStateAndCounters(t *testing.T) {
 		`bosun_skiff_exits_total{class="skiff-test",reason="completed"} 1`,
 		`bosun_skiff_exits_total{class="skiff-test",reason="wedged"} 1`,
 		`bosun_skiff_exits_total{class="skiff-test",reason="lifetime"} 0`,
+		`bosun_skiff_time_to_online_seconds_sum{class="skiff-test"} 20`,
+		`bosun_skiff_time_to_online_seconds_count{class="skiff-test"} 2`,
 		`bosun_github_errors_total 1`,
 	} {
 		if !strings.Contains(got, want) {
@@ -38,7 +42,7 @@ func TestRenderExposesPoolStateAndCounters(t *testing.T) {
 
 	// Every series needs its metadata, or the textfile collector rejects the
 	// whole file rather than the line.
-	for _, name := range []string{"bosun_skiffs", "bosun_skiffs_desired", "bosun_skiff_boots_total", "bosun_skiff_exits_total", "bosun_github_errors_total"} {
+	for _, name := range []string{"bosun_skiffs", "bosun_skiffs_desired", "bosun_skiff_boots_total", "bosun_skiff_exits_total", "bosun_skiff_time_to_online_seconds", "bosun_github_errors_total"} {
 		if !strings.Contains(got, "# TYPE "+name+" ") {
 			t.Errorf("missing TYPE line for %s", name)
 		}

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -630,6 +630,9 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 	s.mu.Unlock()
 
 	if justConnected {
+		// The poll interval quantizes this, but a hull regression moves it by
+		// tens of seconds, which survives the rounding.
+		p.stats.online(s.class, time.Since(s.mintedAt).Seconds())
 		if err := os.Remove(filepath.Join(s.paths.dir, "jitconfig")); err != nil && !os.IsNotExist(err) {
 			logger.Warn("delete jitconfig", "error", err)
 		} else {

--- a/clusters/base/monitoring/bosun-rules.yaml
+++ b/clusters/base/monitoring/bosun-rules.yaml
@@ -1,8 +1,9 @@
 ---
-# bosun runs on riptide as a host service, outside the cluster. Its metrics
-# arrive through node-exporter's textfile collector (see the extraArgs in
+# bosun runs as a host service on a node of each cluster (riptide on folly,
+# oldschool on offsite), outside the cluster itself. Its metrics arrive through
+# node-exporter's textfile collector (see the extraArgs in each cluster's
 # kube-prometheus.yaml), so there is no target to declare here — only what to
-# alert on.
+# alert on, the same on both sites.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -73,8 +74,8 @@ spec:
             description: "A wedged guest takes its job down with it. Check the skiff serial logs in /var/log/bosun on the host."
 ---
 # Not bosun-specific, and the reason bosun's leak ran for nine hours without
-# anyone noticing: this cluster deploys 161 alert rules and not one of them
-# looks at whether a node is saturated.
+# anyone noticing: each cluster deploys over 160 alert rules and not one of
+# them looks at whether a node is saturated.
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:

--- a/clusters/base/monitoring/grafana-dashboards/bosun.json
+++ b/clusters/base/monitoring/grafana-dashboards/bosun.json
@@ -1,0 +1,473 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "id": 1,
+      "type": "row",
+      "title": "Pool",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
+      "panels": []
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Heartbeat age",
+      "description": "Seconds since bosun last rewrote its textfile. Stale means bosun is dead, wedged, or writing somewhere node-exporter is not reading.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 120 },
+              { "color": "red", "value": 300 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "time() - node_textfile_mtime_seconds{file=~\".*/bosun\\\\.prom\"}",
+          "refId": "A",
+          "legendFormat": "{{instance}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Skiffs booted now",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(bosun_skiffs)",
+          "refId": "A",
+          "legendFormat": "skiffs"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Jobs completed (24h)",
+      "description": "Guests that reached the end of their single job and powered themselves off.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "none",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(increase(bosun_skiff_exits_total{reason=\"completed\"}[24h]))",
+          "refId": "A",
+          "legendFormat": "completed"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "stat",
+      "title": "GitHub API errors (1h)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 1 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 5 },
+              { "color": "red", "value": 20 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(increase(bosun_github_errors_total[1h]))",
+          "refId": "A",
+          "legendFormat": "errors"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Pool depth vs desired, by class",
+      "description": "Solid is booted skiffs; dashed is the class's configured warm count. A class below its dashed line for more than a few minutes is BosunPoolStarved.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".* desired" },
+            "properties": [
+              { "id": "custom.lineStyle", "value": { "dash": [4, 4], "fill": "dash" } },
+              { "id": "custom.fillOpacity", "value": 0 }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (class) (bosun_skiffs)",
+          "refId": "A",
+          "legendFormat": "{{class}}"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "max by (class) (bosun_skiffs_desired)",
+          "refId": "B",
+          "legendFormat": "{{class}} desired"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Busy skiffs, by class",
+      "description": "Skiffs GitHub reports as running a job. The gap to pool depth is warm capacity.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (class) (bosun_skiffs{state=\"busy\"})",
+          "refId": "A",
+          "legendFormat": "{{class}}"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "row",
+      "title": "Lifecycle",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 13 },
+      "panels": []
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Exits per hour, by reason",
+      "description": "completed is the healthy exit. wedged and killed each took a job down with them; drained is the stop path's deadline; jit_expired is idle recycling doing its job.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "completed" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "green" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "wedged" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "killed" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "dark-red" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "drained" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "jit_expired" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "yellow" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "lifetime" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "blue" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "boot_failed" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "purple" } }]
+          }
+        ]
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (reason) (rate(bosun_skiff_exits_total[1h])) * 3600 > 0",
+          "refId": "A",
+          "legendFormat": "{{reason}}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Time to online, by class",
+      "description": "Average seconds from JIT mint to GitHub first reporting the runner online: boot, registration and connect together. Quantized by the poll interval; a hull regression moves it by tens of seconds.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "rate(bosun_skiff_time_to_online_seconds_sum[1h]) / rate(bosun_skiff_time_to_online_seconds_count[1h])",
+          "refId": "A",
+          "legendFormat": "{{class}}"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Boots per hour, by class",
+      "description": "Refill rate. Tracks job throughput plus recycling; a boot storm with no matching completed exits is a crash loop.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (class) (rate(bosun_skiff_boots_total[1h])) * 3600",
+          "refId": "A",
+          "legendFormat": "{{class}}"
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "GitHub API error rate",
+      "description": "Transient spikes here explain wedge kills and pool churn — one failed poll is a hiccup, a sustained rate is an outage.",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": { "group": "A", "mode": "none" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(bosun_github_errors_total[5m]))",
+          "refId": "A",
+          "legendFormat": "errors/s"
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 37,
+  "style": "dark",
+  "tags": ["bosun"],
+  "templating": { "list": [] },
+  "time": { "from": "now-24h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Bosun (skiff warm pool)",
+  "uid": "bosun",
+  "version": 1,
+  "weekStart": ""
+}

--- a/clusters/base/monitoring/grafana-dashboards/dashboards.yaml
+++ b/clusters/base/monitoring/grafana-dashboards/dashboards.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dashboards-base
+  namespace: monitoring
+  labels:
+    grafana_dashboard: "1"

--- a/clusters/base/monitoring/grafana-dashboards/kustomization.yaml
+++ b/clusters/base/monitoring/grafana-dashboards/kustomization.yaml
@@ -1,0 +1,22 @@
+# Dashboards for services that run on both clusters. Each cluster's Grafana
+# sidecar picks up any ConfigMap labelled grafana_dashboard, so this ships to
+# folly and offsite alike; folly's own dashboards ConfigMap keeps its
+# folly-only ones. The name differs from folly's "dashboards" so the two
+# generators cannot collide in the monitoring namespace.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+configMapGenerator:
+  - name: dashboards-base
+    files:
+      - bosun.json
+generatorOptions:
+  disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
+patches:
+  - path: dashboards.yaml
+    target:
+      kind: ConfigMap
+      name: dashboards-base
+      version: v1

--- a/clusters/base/monitoring/kustomization.yaml
+++ b/clusters/base/monitoring/kustomization.yaml
@@ -10,6 +10,8 @@ resources:
   - opentelemetry-collector.yaml
   - opentelemetry-collector-servicemonitor.yaml
   - alertmanager-discord.yaml
+  - bosun-rules.yaml
   - coredns-rules.yaml
+  - grafana-dashboards
   - helm-repository-grafana.yaml
   - helm-repository-prometheus.yaml

--- a/clusters/folly/monitoring/kustomization.yaml
+++ b/clusters/folly/monitoring/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - kube-prometheus.yaml
   - grafana-dashboards
   - local-node-exporters.yaml
-  - bosun.yaml
   - capsule.yaml
   - spore.yaml
   - git-repository-loki.yaml

--- a/clusters/offsite/monitoring/kube-prometheus.yaml
+++ b/clusters/offsite/monitoring/kube-prometheus.yaml
@@ -179,6 +179,20 @@ spec:
         storageClassName: local-path
         size: 1Gi
     prometheus-node-exporter:
+      # A host service that wants metrics scraped drops a .prom file in
+      # /var/lib/prometheus-node-exporter-text-files, and this picks it up
+      # labelled with the node it came from -- the same drop box folly uses.
+      # That is how bosun on oldschool is scraped: its unit carries an
+      # IPAddressDeny every skiff inherits, so a listener in-cluster Prometheus
+      # could reach would open the pod CIDR to job code as well.
+      #
+      # Reached through the host-root mount the chart already makes, so this
+      # needs no extra volume. extraArgs REPLACES the chart's defaults, so the
+      # two filesystem excludes below are the chart's own and must stay.
+      extraArgs:
+        - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|run/containerd/.+|var/lib/docker/.+|var/lib/kubelet/.+)($|/)
+        - --collector.filesystem.fs-types-exclude=^(autofs|binfmt_misc|bpf|cgroup2?|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|iso9660|mqueue|nsfs|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|selinuxfs|squashfs|sysfs|tracefs|erofs)$
+        - --collector.textfile.directory=/host/root/var/lib/prometheus-node-exporter-text-files
       prometheus:
         monitor:
           relabelings:


### PR DESCRIPTION
## Summary
Bosun's observability becomes two-cluster and self-measuring: offsite gains the node-exporter textfile scrape (oldschool's bosun.prom currently lands nowhere), the bosun and node-saturation alert rules move to base so both sites carry them, a shared Grafana dashboard ships from base via the sidecar label, and bosun records mint-to-online latency per class so the next hull regression shows up without a stopwatch.

## Changes
- feat(bosun): record mint-to-online latency in the textfile
- feat(monitoring): serve bosun alerts, scrape and dashboard on both clusters

## Test Plan
- [x] `go test ./...` in apps/bosun (green, includes new summary-series assertions)
- [x] `kubectl kustomize` renders clean for base, folly and offsite monitoring; offsite output now carries the bosun PrometheusRule and dashboards-base ConfigMap; folly renders both dashboards ConfigMaps without collision
- [ ] After merge: offsite Prometheus shows `bosun_skiffs{instance="oldschool"}`, and the Bosun dashboard appears in both Grafanas
