### PR TITLE
fix(spindrift): let the installation authenticate to folly again

### DIFF
--- a/nix/services/k8s/default.nix
+++ b/nix/services/k8s/default.nix
@@ -82,10 +82,11 @@ in
             {
               expression = ''
                 claims.sub in [
-                  "system:serviceaccount:atlantis:atlantis"
+                  "system:serviceaccount:atlantis:atlantis",
+                  "system:serviceaccount:spindrift:spindrift"
                 ]
               '';
-              message = "only the Atlantis service account may authenticate across clusters";
+              message = "only the Atlantis and Spindrift service accounts may authenticate across clusters";
             }
           ];
           claimMappings.username.expression = ''"federated:" + claims.sub'';


### PR DESCRIPTION
Found by the from-scratch rebuild: folly's Kubernetes Target connects but reports **unhealthy**, with all six prerequisite rows — `VESSEL`, `OIDC_FEDERATION`, `DELIVERY_OPERATOR`, `CHART_SOURCE`, `CHART_CONTRACT`, `WRITABLE_STORE` — carrying the same detail:

```
GET https://folly.lolwtf.ca:6443/apis/helm.toolkit.fluxcd.io/v2 failed with 401: Unauthorized
```

Six rows, one cause. The teardown narrowed folly's API server claim validation rule to Atlantis alone, so the installation's service account no longer authenticates across clusters. This puts it back.

Reading the row set is what makes this cheap: six unrelated-looking prerequisites failing with a byte-identical detail string is one auth problem wearing six hats, not six things to chase.

## Where this sits in the rebuild

The estate is otherwise up and claimed: the supply chain, home vessel and tunnel are applied, the installation is live at `https://spindrift.lolwtf.ca`, and the first operator has enrolled. `bluenose/cloudrun`, `bluenose/static` and `offsite/kubernetes` all came back healthy on first probe. folly is the only Target that did not, and this is why.

offsite is unaffected — the installation runs on it and talks to it in-cluster, so it never crosses the federated path this rule guards.

## Applying

This is host config, so it lands on folly's control plane at its next auto-upgrade from `main`, or sooner with an explicit rebuild. It changes kube-apiserver's authentication configuration, so the API server restarts when it applies.

## Validation

`nix flake check --no-build` — all checks passed.