### PR TITLE
feat: direct spindrift→bosun build route (outbox, poller, build-hull)

### DIFF
--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -11,14 +11,14 @@ import (
 
 // Config is bosun's on-disk JSON configuration. A NixOS module generates it.
 type Config struct {
-	Repo         string           `json:"repo"`
-	TokenFile    string           `json:"tokenFile"`
-	RuntimeDir   string           `json:"runtimeDir"`
-	LogDir       string           `json:"logDir"`
-	WorkspaceDir string           `json:"workspaceDir"` // real storage, not tmpfs: it holds whole filesystem images
-	MetricsFile  string           `json:"metricsFile"`  // empty disables; a node-exporter textfile, not a listener
-	CacheURL     string           `json:"cacheUrl"`     // empty disables; announced to every skiff as bosun.cache on the cmdline
-	PollInterval Duration         `json:"pollInterval"`
+	Repo         string   `json:"repo"`
+	TokenFile    string   `json:"tokenFile"`
+	RuntimeDir   string   `json:"runtimeDir"`
+	LogDir       string   `json:"logDir"`
+	WorkspaceDir string   `json:"workspaceDir"` // real storage, not tmpfs: it holds whole filesystem images
+	MetricsFile  string   `json:"metricsFile"`  // empty disables; a node-exporter textfile, not a listener
+	CacheURL     string   `json:"cacheUrl"`     // empty disables; announced to every skiff as bosun.cache on the cmdline
+	PollInterval Duration `json:"pollInterval"`
 	// DrainTimeout bounds how long a stop waits for busy skiffs to finish
 	// their jobs. Idle skiffs are scuttled immediately; what this buys is a
 	// deploy that no longer fails every in-flight job, and what it costs is
@@ -26,6 +26,22 @@ type Config struct {
 	DrainTimeout Duration         `json:"drainTimeout"`
 	Classes      map[string]Class `json:"classes"`
 	Bin          BinPaths         `json:"bin"`
+	// Spindrift turns this host into a build source alongside its GitHub warm
+	// pool. nil (the default) means bosun never talks to Spindrift.
+	Spindrift *SpindriftConfig `json:"spindrift,omitempty"`
+}
+
+// SpindriftConfig is how a bosun host long-polls a Spindrift outbox for
+// build requests and runs each on a skiff of one of Classes, instead of only
+// ever registering GitHub runners.
+type SpindriftConfig struct {
+	URL       string   `json:"url"`
+	TokenFile string   `json:"tokenFile"`
+	Classes   []string `json:"classes"`
+	// PollInterval is the retry wait after a failed claim, not the poll
+	// cadence itself -- the claim call long-polls server-side, so a
+	// successful round trip is the wait.
+	PollInterval Duration `json:"pollInterval"`
 }
 
 // Class is one warm-pool class: a hull to boot, its resources, how many
@@ -184,6 +200,28 @@ func LoadConfig(path string) (*Config, error) {
 	if cfg.DrainTimeout <= 0 {
 		cfg.DrainTimeout = Duration(defaultDrainTimeout)
 	}
+
+	if cfg.Spindrift != nil {
+		sd := cfg.Spindrift
+		if sd.URL == "" {
+			return nil, fmt.Errorf("config: spindrift.url is required")
+		}
+		if sd.TokenFile == "" {
+			return nil, fmt.Errorf("config: spindrift.tokenFile is required")
+		}
+		if len(sd.Classes) == 0 {
+			return nil, fmt.Errorf("config: spindrift.classes is required")
+		}
+		for _, name := range sd.Classes {
+			if _, ok := cfg.Classes[name]; !ok {
+				return nil, fmt.Errorf("config: spindrift.classes: class %q is not declared in classes", name)
+			}
+		}
+		if sd.PollInterval <= 0 {
+			sd.PollInterval = Duration(defaultPollInterval)
+		}
+	}
+
 	return &cfg, nil
 }
 

--- a/apps/bosun/config_test.go
+++ b/apps/bosun/config_test.go
@@ -155,6 +155,105 @@ func TestLoadConfigRejectsAPersistingClassNameThatWouldEscapeItsImageName(t *tes
 	}
 }
 
+func TestLoadConfigDefaultsSpindriftPollInterval(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff-build": {"hull": "/hulls/nixos", "vcpus": 4, "memory": "4096M", "warm": 0}},
+		"spindrift": {"url": "https://spindrift.example", "tokenFile": "/run/secrets/spindrift", "classes": ["skiff-build"]}
+	}`)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Spindrift == nil {
+		t.Fatal("spindrift config should be set")
+	}
+	if time.Duration(cfg.Spindrift.PollInterval) != defaultPollInterval {
+		t.Errorf("spindrift pollInterval default: got %s", cfg.Spindrift.PollInterval)
+	}
+}
+
+func TestLoadConfigOmittedSpindriftIsNil(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff-nixos": {"hull": "/hulls/nixos", "vcpus": 4, "memory": "4096M", "warm": 1}}
+	}`)
+
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Spindrift != nil {
+		t.Fatalf("spindrift should be nil when omitted, got %+v", cfg.Spindrift)
+	}
+}
+
+func TestLoadConfigRejectsSpindriftMissingURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff-build": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 0}},
+		"spindrift": {"tokenFile": "/x", "classes": ["skiff-build"]}
+	}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for spindrift with no url")
+	}
+}
+
+func TestLoadConfigRejectsSpindriftMissingTokenFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff-build": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 0}},
+		"spindrift": {"url": "https://spindrift.example", "classes": ["skiff-build"]}
+	}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for spindrift with no tokenFile")
+	}
+}
+
+func TestLoadConfigRejectsSpindriftWithNoClasses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff-build": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 0}},
+		"spindrift": {"url": "https://spindrift.example", "tokenFile": "/x", "classes": []}
+	}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for spindrift with no classes")
+	}
+}
+
+// A build class Spindrift is told to claim for must also be a class bosun
+// actually knows how to boot -- otherwise a claim would arrive for a class
+// spawnBuild can never resolve.
+func TestLoadConfigRejectsSpindriftClassNotDeclaredInClasses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{
+		"repo": "acme/widgets",
+		"tokenFile": "/run/secrets/token",
+		"classes": {"skiff-nixos": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 1}},
+		"spindrift": {"url": "https://spindrift.example", "tokenFile": "/x", "classes": ["skiff-build"]}
+	}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for a spindrift class not declared in classes")
+	}
+}
+
 // The same names are fine when nothing persists: only the slot image naming
 // constrains them.
 func TestLoadConfigAllowsADottedClassNameThatDoesNotPersist(t *testing.T) {

--- a/apps/bosun/hull.go
+++ b/apps/bosun/hull.go
@@ -211,6 +211,11 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 // filesystem: what a workspace holds is the hull's business, the same way its
 // rootfs is, and bosun never learns what was put there.
 //
+// build marks a skiff spawned for a Spindrift build request rather than a
+// GitHub runner: the guest finds request.json instead of a jitconfig in the
+// same "bosun" share, and bosun.mode=build on the cmdline is what tells it
+// which one to expect.
+//
 // image_type=raw is not optional and not cosmetic. cloud-hypervisor 52 refuses
 // sector-0 writes on a disk whose type it had to auto-detect -- it logs
 // "Autodetected raw image type. Disabling sector 0 writes", then answers the
@@ -221,7 +226,7 @@ func resolvePaths(runtimeDir, logDir, id string, devices []hullDevice) (skiffPat
 // so a hull's disks are declared raw because the hull contract says a disk is a
 // raw file the hull ships. A hull wanting qcow2 wants a manifest field, and a
 // failing test to go with it.
-func chArgs(h *hull, class Class, id string, p skiffPaths, cacheURL string) []string {
+func chArgs(h *hull, class Class, id string, p skiffPaths, cacheURL string, build bool) []string {
 	args := []string{
 		"--kernel", filepath.Join(h.dir, h.manifest.Kernel),
 		"--initramfs", filepath.Join(h.dir, h.manifest.Initrd),
@@ -253,6 +258,9 @@ func chArgs(h *hull, class Class, id string, p skiffPaths, cacheURL string) []st
 	// decides whether and how to consume it, like every other cmdline fact.
 	if cacheURL != "" {
 		cmdline += " bosun.cache=" + cacheURL
+	}
+	if build {
+		cmdline += " bosun.mode=build"
 	}
 	args = append(args,
 		"--net", fmt.Sprintf("vhost_user=on,socket=%s", p.netSock),

--- a/apps/bosun/hull_test.go
+++ b/apps/bosun/hull_test.go
@@ -54,7 +54,7 @@ func TestChArgsNoDevices(t *testing.T) {
 		t.Fatalf("resolvePaths: %v", err)
 	}
 
-	got := chArgs(h, class, "sk01", paths, "")
+	got := chArgs(h, class, "sk01", paths, "", false)
 	want := []string{
 		"--kernel", "/hulls/nixos/vmlinux",
 		"--initramfs", "/hulls/nixos/initrd",
@@ -73,6 +73,25 @@ func TestChArgsNoDevices(t *testing.T) {
 	}
 }
 
+func TestChArgsAppendsBuildModeForABuildSkiff(t *testing.T) {
+	h := &hull{
+		dir:      "/hulls/nixos",
+		manifest: hullManifest{Kernel: "vmlinux", Initrd: "initrd", Cmdline: "console=ttyS0"},
+		digest:   "deadbeef",
+	}
+	class := Class{VCPUs: 4, Memory: "4096M"}
+	paths, err := resolvePaths("/run/bosun", "/var/log/bosun", "sk01", h.manifest.Devices)
+	if err != nil {
+		t.Fatalf("resolvePaths: %v", err)
+	}
+
+	got := chArgs(h, class, "sk01", paths, "", true)
+	want := "console=ttyS0 bosun.mode=build bosun.skiff=sk01 bosun.hull=sha256:deadbeef"
+	if !slices.Contains(got, want) {
+		t.Fatalf("cmdline missing bosun.mode=build:\n got:  %v\n want cmdline: %q", got, want)
+	}
+}
+
 func TestChArgsWithDevices(t *testing.T) {
 	h := &hull{
 		dir: "/hulls/nixos",
@@ -88,7 +107,7 @@ func TestChArgsWithDevices(t *testing.T) {
 		t.Fatalf("resolvePaths: %v", err)
 	}
 
-	got := chArgs(h, class, "sk02", paths, "")
+	got := chArgs(h, class, "sk02", paths, "", false)
 	want := []string{
 		"--kernel", "/hulls/nixos/vmlinux",
 		"--initramfs", "/hulls/nixos/initrd",
@@ -123,7 +142,7 @@ func TestChArgsWithDisk(t *testing.T) {
 		t.Fatalf("resolvePaths: %v", err)
 	}
 
-	got := chArgs(h, class, "sk03", paths, "")
+	got := chArgs(h, class, "sk03", paths, "", false)
 	want := []string{
 		"--kernel", "/hulls/ubuntu/vmlinux",
 		"--initramfs", "/hulls/ubuntu/initrd",
@@ -317,7 +336,7 @@ func TestChArgsWorkspaceDiskComesLastAndIsNamedOnTheCmdline(t *testing.T) {
 	}
 	paths.workspace = "/var/lib/bosun/workspace/sk09.img"
 
-	got := chArgs(h, class, "sk09", paths, "")
+	got := chArgs(h, class, "sk09", paths, "", false)
 	want := []string{
 		"--kernel", "/hulls/ubuntu/vmlinux",
 		"--initramfs", "/hulls/ubuntu/initrd",
@@ -351,7 +370,7 @@ func TestChArgsNoWorkspaceLeavesCmdlineAlone(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolvePaths: %v", err)
 	}
-	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk10", paths, "")
+	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk10", paths, "", false)
 	if slices.Contains(got, "--disk") {
 		t.Fatalf("workspace-less class got a disk: %v", got)
 	}
@@ -370,7 +389,7 @@ func TestChArgsAnnouncesCacheURLOnCmdline(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolvePaths: %v", err)
 	}
-	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk12", paths, "http://10.113.113.1:3000/")
+	got := chArgs(h, Class{VCPUs: 1, Memory: "512M"}, "sk12", paths, "http://10.113.113.1:3000/", false)
 	if !slices.Contains(got, "console=ttyS0 bosun.cache=http://10.113.113.1:3000/ bosun.skiff=sk12 bosun.hull=sha256:deadbeef") {
 		t.Fatalf("cache URL missing from cmdline: %v", got)
 	}

--- a/apps/bosun/main.go
+++ b/apps/bosun/main.go
@@ -68,6 +68,26 @@ func main() {
 	p.fill(ctx)
 	logger.Info("warm pool filled", "classes", len(cfg.Classes))
 
+	// buildDone closes once buildLoop has returned, so shutdown can wait for
+	// it: buildLoop keeps running (heartbeating, then posting a result) past
+	// ctx's cancellation for a build already in flight, and letting main
+	// return while that is still happening would abandon the result mid-post.
+	var buildDone chan struct{}
+	if cfg.Spindrift != nil {
+		sdTokenRaw, err := os.ReadFile(cfg.Spindrift.TokenFile)
+		if err != nil {
+			logger.Error("read spindrift token file", "path", cfg.Spindrift.TokenFile, "error", err)
+			os.Exit(1)
+		}
+		sd := newSDClient(cfg.Spindrift.URL, strings.TrimSpace(string(sdTokenRaw)))
+		buildDone = make(chan struct{})
+		go func() {
+			defer close(buildDone)
+			p.buildLoop(ctx, sd, cfg.Spindrift.Classes, time.Duration(cfg.Spindrift.PollInterval))
+		}()
+		logger.Info("spindrift build source enabled", "classes", cfg.Spindrift.Classes)
+	}
+
 	p.pollLoop(ctx)
 
 	// SIGTERM landed: drain rather than die. Refills are already stopped by
@@ -81,5 +101,8 @@ func main() {
 	drainCtx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.DrainTimeout))
 	defer cancel()
 	p.drain(drainCtx)
+	if buildDone != nil {
+		<-buildDone
+	}
 	logger.Info("shutting down")
 }

--- a/apps/bosun/metrics.go
+++ b/apps/bosun/metrics.go
@@ -12,12 +12,15 @@ import (
 // metrics is bosun's counters. Gauges are not kept here -- they are read off
 // the live pool at write time, since the running skiffs are the state.
 type metrics struct {
-	mu          sync.Mutex
-	boots       map[string]int            // class -> skiffs booted
-	exits       map[string]map[string]int // class -> reason -> skiffs gone
-	onlineSum   map[string]float64        // class -> total mint-to-online seconds
-	onlineCount map[string]int            // class -> skiffs that came online
-	ghErrors    int
+	mu           sync.Mutex
+	boots        map[string]int            // class -> skiffs booted
+	exits        map[string]map[string]int // class -> reason -> skiffs gone
+	onlineSum    map[string]float64        // class -> total mint-to-online seconds
+	onlineCount  map[string]int            // class -> skiffs that came online
+	ghErrors     int
+	buildClaims  int
+	buildResults map[string]int // "succeeded"|"failed" -> builds finished
+	sdErrors     int
 }
 
 // Exit reasons. "completed" is the one that means a job ran: the guest reached
@@ -44,10 +47,11 @@ const (
 
 func newMetrics() *metrics {
 	return &metrics{
-		boots:       map[string]int{},
-		exits:       map[string]map[string]int{},
-		onlineSum:   map[string]float64{},
-		onlineCount: map[string]int{},
+		boots:        map[string]int{},
+		exits:        map[string]map[string]int{},
+		onlineSum:    map[string]float64{},
+		onlineCount:  map[string]int{},
+		buildResults: map[string]int{},
 	}
 }
 
@@ -81,6 +85,27 @@ func (m *metrics) githubError() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.ghErrors++
+}
+
+func (m *metrics) buildClaimed() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.buildClaims++
+}
+
+// buildResult records one finished build by outcome. status is always
+// buildSucceeded or buildFailed, so lower-casing it is the whole mapping to
+// the metric's label.
+func (m *metrics) buildResult(status string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.buildResults[strings.ToLower(status)]++
+}
+
+func (m *metrics) spindriftError() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sdErrors++
 }
 
 // render writes the Prometheus text exposition format. It is a handful of
@@ -129,6 +154,20 @@ func (m *metrics) render(live map[string]poolState, desired map[string]int) stri
 	b.WriteString("# HELP bosun_github_errors_total GitHub API calls that failed.\n")
 	b.WriteString("# TYPE bosun_github_errors_total counter\n")
 	b.WriteString(fmt.Sprintf("bosun_github_errors_total %d\n", m.ghErrors))
+
+	b.WriteString("# HELP bosun_build_claims_total Spindrift build requests claimed.\n")
+	b.WriteString("# TYPE bosun_build_claims_total counter\n")
+	b.WriteString(fmt.Sprintf("bosun_build_claims_total %d\n", m.buildClaims))
+
+	b.WriteString("# HELP bosun_build_results_total Spindrift builds finished, by outcome.\n")
+	b.WriteString("# TYPE bosun_build_results_total counter\n")
+	for _, status := range []string{"succeeded", "failed"} {
+		b.WriteString(fmt.Sprintf("bosun_build_results_total{status=%q} %d\n", status, m.buildResults[status]))
+	}
+
+	b.WriteString("# HELP bosun_spindrift_errors_total Spindrift API calls that failed.\n")
+	b.WriteString("# TYPE bosun_spindrift_errors_total counter\n")
+	b.WriteString(fmt.Sprintf("bosun_spindrift_errors_total %d\n", m.sdErrors))
 	return b.String()
 }
 

--- a/apps/bosun/metrics_test.go
+++ b/apps/bosun/metrics_test.go
@@ -17,6 +17,12 @@ func TestRenderExposesPoolStateAndCounters(t *testing.T) {
 	m.online("skiff-test", 17.5)
 	m.online("skiff-test", 2.5)
 	m.githubError()
+	m.buildClaimed()
+	m.buildClaimed()
+	m.buildResult(buildSucceeded)
+	m.buildResult(buildFailed)
+	m.buildResult(buildFailed)
+	m.spindriftError()
 
 	got := m.render(
 		map[string]poolState{"skiff-test": {idle: 1, busy: 2}},
@@ -34,6 +40,10 @@ func TestRenderExposesPoolStateAndCounters(t *testing.T) {
 		`bosun_skiff_time_to_online_seconds_sum{class="skiff-test"} 20`,
 		`bosun_skiff_time_to_online_seconds_count{class="skiff-test"} 2`,
 		`bosun_github_errors_total 1`,
+		`bosun_build_claims_total 2`,
+		`bosun_build_results_total{status="succeeded"} 1`,
+		`bosun_build_results_total{status="failed"} 2`,
+		`bosun_spindrift_errors_total 1`,
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("missing series %q in:\n%s", want, got)
@@ -42,7 +52,7 @@ func TestRenderExposesPoolStateAndCounters(t *testing.T) {
 
 	// Every series needs its metadata, or the textfile collector rejects the
 	// whole file rather than the line.
-	for _, name := range []string{"bosun_skiffs", "bosun_skiffs_desired", "bosun_skiff_boots_total", "bosun_skiff_exits_total", "bosun_skiff_time_to_online_seconds", "bosun_github_errors_total"} {
+	for _, name := range []string{"bosun_skiffs", "bosun_skiffs_desired", "bosun_skiff_boots_total", "bosun_skiff_exits_total", "bosun_skiff_time_to_online_seconds", "bosun_github_errors_total", "bosun_build_claims_total", "bosun_build_results_total", "bosun_spindrift_errors_total"} {
 		if !strings.Contains(got, "# TYPE "+name+" ") {
 			t.Errorf("missing TYPE line for %s", name)
 		}

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -48,6 +48,14 @@ let
       virtiofsd = "${pkgs.virtiofsd}/bin/virtiofsd";
       passt = lib.getExe' pkgs.passt "passt";
     };
+    spindrift =
+      if cfg.spindrift == null then
+        null
+      else
+        {
+          inherit (cfg.spindrift) url tokenFile classes;
+          pollInterval = cfg.spindrift.pollInterval;
+        };
   };
 in
 {
@@ -273,6 +281,52 @@ in
                 Budget for a skiff once its runner goes busy. Measured from
                 the busy transition, not from boot -- otherwise time spent
                 waiting in the warm pool eats the job's budget.
+              '';
+            };
+          };
+        }
+      );
+    };
+
+    spindrift = mkOption {
+      default = null;
+      description = ''
+        Turns this host into a Spindrift build source alongside its GitHub
+        warm pool: bosun long-polls {option}`spindrift.url` for a build
+        request in one of {option}`spindrift.classes`, boots a skiff of that
+        class with the request written into its share instead of a JIT
+        config, and posts the result back once the skiff halts. null (the
+        default) means this host never talks to Spindrift.
+
+        A class serving builds should set its own `warm = 0`: a build skiff
+        boots on claim rather than ahead of time the way a GitHub-registered
+        skiff does, so keeping one warm buys nothing.
+      '';
+      type = types.nullOr (
+        types.submodule {
+          options = {
+            url = mkOption {
+              type = types.str;
+              description = "Base URL of the Spindrift instance whose outbox this host claims builds from.";
+            };
+            tokenFile = mkOption {
+              type = types.path;
+              description = "File holding the bearer token bosun authenticates to Spindrift with.";
+            };
+            classes = mkOption {
+              type = types.listOf types.str;
+              description = ''
+                Which of {option}`classes` this host claims builds for. Every
+                entry must also be declared there.
+              '';
+            };
+            pollInterval = mkOption {
+              type = types.str;
+              default = "30s";
+              description = ''
+                Wait before retrying after a failed claim. Not the poll
+                cadence itself -- the claim call long-polls Spindrift
+                server-side, so a successful round trip is the wait.
               '';
             };
           };

--- a/apps/bosun/pool.go
+++ b/apps/bosun/pool.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -35,6 +36,16 @@ type skiff struct {
 	helpersLog *os.File
 	helpers    []proc // virtiofsd(s) + passt
 	ch         proc   // cloud-hypervisor; Wait() on this is "did the job finish"
+
+	// build marks a skiff spawned for a Spindrift build request rather than a
+	// GitHub runner. It carries no registration to poll or deregister, and
+	// awaitExit never spawns a replacement for one -- buildLoop's own claim
+	// loop is what decides whether another skiff boots.
+	build   bool
+	buildID string
+	// done closes once retire has finished tearing this build skiff down, so
+	// runBuild knows it is safe to read the diag share for a result.
+	done chan struct{}
 }
 
 // setExitReason records why bosun is about to kill this skiff. The poll loop
@@ -357,6 +368,111 @@ func (p *pool) spawn(ctx context.Context, className string) {
 	go p.awaitExit(ctx, s, logger)
 }
 
+// spawnBuild boots one skiff to run a claimed Spindrift build instead of
+// registering it as a GitHub runner. It shares spawn's low-level machinery --
+// claimSlot, writeState's build sibling writeBuildState, boot, and
+// awaitExit -- but duplicates spawn's setup (draining guard, id, hull,
+// paths) rather than threading a build/non-build fork through spawn itself:
+// the two diverge immediately after that prefix on the one thing that
+// matters (a GitHub JIT mint vs a request write), and forking spawn's own
+// early-return chain would cost more clarity than the small duplication
+// here does.
+//
+// Returns (nil, errDraining) when a stop is in progress: bosun never ran the
+// build, so runBuild must NOT post a result -- staying silent lets the claim's
+// lease expire and another host pick the request up, where a FAILED post
+// would close the Spindrift build permanently for work nobody attempted. Any
+// other nil return is a real setup failure, already logged; runBuild reports
+// that one, and Spindrift's lease expiry is not waited on for it.
+func (p *pool) spawnBuild(ctx context.Context, claim *buildClaim) (*skiff, error) {
+	p.mu.Lock()
+	if p.draining {
+		p.mu.Unlock()
+		return nil, errDraining
+	}
+	p.spawning++
+	p.mu.Unlock()
+	defer func() {
+		p.mu.Lock()
+		p.spawning--
+		p.mu.Unlock()
+	}()
+
+	class, ok := p.cfg.Classes[claim.Class]
+	if !ok {
+		p.logger.Error("spawnBuild: unknown class", "class", claim.Class)
+		return nil, fmt.Errorf("unknown class %q", claim.Class)
+	}
+	logger := p.logger.With("class", claim.Class, "build_id", claim.ID)
+
+	id, err := newSkiffID()
+	if err != nil {
+		logger.Error("generate skiff id", "error", err)
+		return nil, err
+	}
+	logger = logger.With("skiff", id)
+
+	h, err := loadHull(class.Hull)
+	if err != nil {
+		logger.Error("load hull", "error", err)
+		return nil, err
+	}
+
+	paths, err := resolvePaths(p.cfg.RuntimeDir, p.cfg.LogDir, id, h.manifest.Devices)
+	if err != nil {
+		logger.Error("resolve paths", "error", err)
+		return nil, err
+	}
+
+	slot := -1
+	if class.Workspace != "" {
+		if class.Persist {
+			slot = p.claimSlot(claim.Class)
+			paths.workspace = filepath.Join(p.cfg.WorkspaceDir, workspaceSlotName(claim.Class, slot))
+			logger = logger.With("workspace_slot", slot)
+		} else {
+			paths.workspace = filepath.Join(p.cfg.WorkspaceDir, id+".img")
+		}
+	}
+	now := time.Now()
+	s := &skiff{
+		id: id, class: claim.Class, paths: paths, slot: slot, mintedAt: now,
+		busySince: now, // busy by construction; see pollBuildSkiff
+		build:     true, buildID: claim.ID, done: make(chan struct{}),
+	}
+
+	if err := p.writeBuildState(paths.dir, claim.Request, h.digest); err != nil {
+		logger.Error("write build state", "error", err)
+		s.setExitReason(exitBootFailed)
+		p.retire(ctx, s, logger)
+		return nil, err
+	}
+
+	if err := p.boot(s, h, class, logger); err != nil {
+		logger.Error("boot", "error", err)
+		s.setExitReason(exitBootFailed)
+		p.retire(ctx, s, logger)
+		return nil, err
+	}
+
+	p.mu.Lock()
+	if p.draining {
+		p.mu.Unlock()
+		logger.Info("drain: scuttling build skiff spawned mid-stop")
+		s.setExitReason(exitDrained)
+		p.retire(ctx, s, logger)
+		return nil, errDraining
+	}
+	p.skiffs[id] = s
+	p.mu.Unlock()
+
+	p.stats.boot(claim.Class)
+	logger.Info("build skiff booted")
+	p.publish()
+	go p.awaitExit(ctx, s, logger)
+	return s, nil
+}
+
 // writeState makes runtimeDir/<id> — bosun's entire state for this skiff.
 // /run is tmpfs, so a reboot clears it; there is no database.
 func (p *pool) writeState(dir string, runnerID int64, jitConfig, hullDigest string) error {
@@ -367,6 +483,20 @@ func (p *pool) writeState(dir string, runnerID int64, jitConfig, hullDigest stri
 		return err
 	}
 	if err := os.WriteFile(filepath.Join(dir, "runner-id"), []byte(strconv.FormatInt(runnerID, 10)), 0o600); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, "hull"), []byte(hullDigest), 0o600)
+}
+
+// writeBuildState is writeState's build-skiff sibling: request.json where a
+// GitHub skiff has jitconfig, plus the same hull digest. No runner-id file --
+// a build skiff never registers with GitHub, so retire and sweep have
+// nothing to deregister for it.
+func (p *pool) writeBuildState(dir string, request json.RawMessage, hullDigest string) error {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(dir, "request.json"), request, 0o400); err != nil {
 		return err
 	}
 	return os.WriteFile(filepath.Join(dir, "hull"), []byte(hullDigest), 0o600)
@@ -426,7 +556,7 @@ func (p *pool) boot(s *skiff, h *hull, class Class, logger *slog.Logger) error {
 		return fmt.Errorf("start passt: %w", err)
 	}
 
-	chProc, err := p.launch.Start(binPath(p.cfg.Bin.CloudHypervisor, "cloud-hypervisor"), chArgs(h, class, s.id, s.paths, p.cfg.CacheURL), helpersLog, helpersLog)
+	chProc, err := p.launch.Start(binPath(p.cfg.Bin.CloudHypervisor, "cloud-hypervisor"), chArgs(h, class, s.id, s.paths, p.cfg.CacheURL, s.build), helpersLog, helpersLog)
 	if err != nil {
 		return fmt.Errorf("start cloud-hypervisor: %w", err)
 	}
@@ -471,6 +601,10 @@ func (p *pool) awaitExit(ctx context.Context, s *skiff, logger *slog.Logger) {
 	}
 	logger.Info("skiff halted", "error", err)
 	p.retire(ctx, s, logger)
+	if s.build {
+		close(s.done) // runBuild is waiting to read the diag share for a result
+		return        // buildLoop's own claim loop decides whether another skiff boots
+	}
 	if ctx.Err() != nil {
 		return // shutting down; do not refill
 	}
@@ -501,10 +635,11 @@ func (p *pool) retire(ctx context.Context, s *skiff, logger *slog.Logger) {
 	// else deregisters here, on a context that survives shutdown: by the time
 	// a drain-era retire runs, the run context is cancelled, and a DELETE that
 	// never happens is a ghost registration until the next sweep.
+	// A build skiff never registered with GitHub in the first place.
 	s.mu.Lock()
 	deregistered := s.deregistered
 	s.mu.Unlock()
-	if !deregistered {
+	if !s.build && !deregistered {
 		dctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
 		defer cancel()
 		if err := p.gh.DeleteRunner(dctx, p.cfg.Repo, s.runnerID); err != nil {
@@ -603,6 +738,10 @@ func (p *pool) pollOnce(ctx context.Context) {
 //   - Idle past jitExpiry: the credential this skiff registered with is now
 //     dead and it never connected; recycle it for a fresh one.
 func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
+	if s.build {
+		p.pollBuildSkiff(s)
+		return
+	}
 	logger := p.logger.With("skiff", s.id, "class", s.class)
 	status, busy, err := p.gh.GetRunner(ctx, p.cfg.Repo, s.runnerID)
 	if err != nil {
@@ -654,6 +793,22 @@ func (p *pool) pollSkiff(ctx context.Context, s *skiff) {
 		s.setExitReason(exitJITExpired)
 		killBestEffort(s.ch, logger, "idle-expired cloud-hypervisor")
 	}
+}
+
+// pollBuildSkiff is a build skiff's entire reconciliation: it never
+// registers with GitHub, so the wedge and JIT-expiry checks above do not
+// apply, and the only thing left to reap is the class's lifetime budget. A
+// build skiff is busy by construction, so busySince is set at spawn rather
+// than on a status transition, and the same exceededLifetime check every
+// busy GitHub skiff gets applies here unchanged.
+func (p *pool) pollBuildSkiff(s *skiff) {
+	if !p.exceededLifetime(s.class, s.busySince) {
+		return
+	}
+	logger := p.logger.With("skiff", s.id, "class", s.class, "build_id", s.buildID)
+	logger.Info("build max lifetime exceeded, killing", "running_for", time.Since(s.busySince))
+	s.setExitReason(exitLifetime)
+	killBestEffort(s.ch, logger, "expired cloud-hypervisor")
 }
 
 // drain is the stop path: the run context is already cancelled, so awaitExit
@@ -725,6 +880,12 @@ func (p *pool) empty() bool {
 // DELETE would be refused anyway.
 func (p *pool) scuttleIdle(ctx context.Context) {
 	for _, s := range p.snapshot() {
+		if s.build {
+			// No GitHub registration to prove idle against, and busy by
+			// construction anyway; killRemaining condemns it at the drain
+			// deadline like any other busy skiff.
+			continue
+		}
 		s.mu.Lock()
 		busy := !s.busySince.IsZero()
 		condemned := s.exitReason != ""

--- a/apps/bosun/pool_test.go
+++ b/apps/bosun/pool_test.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -778,5 +780,231 @@ func TestPersistingClassGivesEachLiveSkiffItsOwnSlotAndHandsItBack(t *testing.T)
 	}
 	if got := p.claimSlot("skiff-test"); got != victim.slot {
 		t.Errorf("released slot not reused: claimed %d, want %d", got, victim.slot)
+	}
+}
+
+// A build claim boots a skiff the same way a GitHub label does, except the
+// share carries request.json instead of a jitconfig and the cmdline tells
+// the guest which one to expect.
+func TestSpawnBuildBootsSkiffWithRequestJSONAndNoJITConfig(t *testing.T) {
+	p, _, fl := testPool(t)
+	ctx := context.Background()
+	claim := &buildClaim{ID: "build-1", Class: "skiff-test", Request: json.RawMessage(`{"repo":"acme/widgets"}`)}
+
+	s, err := p.spawnBuild(ctx, claim)
+	if err != nil || s == nil {
+		t.Fatalf("spawnBuild: %v", err)
+	}
+	if !s.build || s.buildID != "build-1" {
+		t.Fatalf("skiff not marked as a build skiff: %+v", s)
+	}
+
+	got, err := os.ReadFile(filepath.Join(s.paths.dir, "request.json"))
+	if err != nil {
+		t.Fatalf("request.json missing: %v", err)
+	}
+	if string(got) != `{"repo":"acme/widgets"}` {
+		t.Fatalf("unexpected request.json contents: %s", got)
+	}
+	if _, err := os.Stat(filepath.Join(s.paths.dir, "jitconfig")); !os.IsNotExist(err) {
+		t.Fatalf("build skiff should not have a jitconfig, err=%v", err)
+	}
+
+	chCall, ok := fl.last("cloud-hypervisor")
+	if !ok {
+		t.Fatal("cloud-hypervisor was never launched")
+	}
+	found := false
+	for i, a := range chCall.args {
+		if a == "--cmdline" && i+1 < len(chCall.args) && strings.Contains(chCall.args[i+1], "bosun.mode=build") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("cmdline missing bosun.mode=build: %v", chCall.args)
+	}
+}
+
+// The end-to-end path: runBuild boots the skiff, and once it halts the
+// result posted to Spindrift is composed from whatever the guest left in the
+// diag share -- the same share retire deliberately keeps around.
+func TestBuildSkiffExitPostsResultFromDiagFiles(t *testing.T) {
+	p, _, fl := testPool(t)
+	ctx := context.Background()
+	claim := &buildClaim{ID: "build-1", Class: "skiff-test", Request: json.RawMessage(`{}`)}
+	sd := &fakeSpindrift{}
+
+	done := make(chan struct{})
+	go func() {
+		p.runBuild(ctx, sd, claim)
+		close(done)
+	}()
+
+	waitFor(t, "cloud-hypervisor launched for the build skiff", func() bool {
+		_, ok := fl.last("cloud-hypervisor")
+		return ok
+	})
+	s := onlySkiff(t, p)
+
+	// Fake the guest: it drops its result into the diag share before halting.
+	resultDir := filepath.Join(s.paths.diagDir, "result")
+	if err := os.MkdirAll(resultDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(resultDir, "status"), "SUCCEEDED")
+	writeFile(t, filepath.Join(resultDir, "build.log"), "build ok\n")
+
+	chCall, _ := fl.last("cloud-hypervisor")
+	chCall.proc.exit(nil)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runBuild did not return after the build skiff halted")
+	}
+
+	results := sd.postedResults()
+	if len(results) != 1 {
+		t.Fatalf("want 1 posted result, got %d", len(results))
+	}
+	if results[0].id != "build-1" || results[0].res.Status != buildSucceeded || results[0].res.Log != "build ok\n" {
+		t.Fatalf("unexpected posted result: %+v", results[0])
+	}
+}
+
+// A guest that halts without ever writing a result -- crashed before it
+// could, or the hull does not understand bosun.mode=build at all -- must not
+// leave Spindrift's build row hanging until its lease expires.
+func TestBuildSkiffExitWithNoResultFilesPostsFailed(t *testing.T) {
+	p, _, fl := testPool(t)
+	ctx := context.Background()
+	claim := &buildClaim{ID: "build-2", Class: "skiff-test", Request: json.RawMessage(`{}`)}
+	sd := &fakeSpindrift{}
+
+	done := make(chan struct{})
+	go func() {
+		p.runBuild(ctx, sd, claim)
+		close(done)
+	}()
+
+	waitFor(t, "cloud-hypervisor launched for the build skiff", func() bool {
+		_, ok := fl.last("cloud-hypervisor")
+		return ok
+	})
+	chCall, _ := fl.last("cloud-hypervisor")
+	chCall.proc.exit(nil)
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runBuild did not return after the build skiff halted")
+	}
+
+	results := sd.postedResults()
+	if len(results) != 1 || results[0].res.Status != buildFailed {
+		t.Fatalf("want a single FAILED result, got %+v", results)
+	}
+}
+
+// awaitExit's replacement logic is scoped to GitHub skiffs: a build skiff's
+// next boot is buildLoop's own claim loop, not an automatic refill.
+func TestBuildSkiffExitDoesNotRefillTheClass(t *testing.T) {
+	p, _, fl := testPool(t)
+	ctx := context.Background()
+	claim := &buildClaim{ID: "build-3", Class: "skiff-test", Request: json.RawMessage(`{}`)}
+	sd := &fakeSpindrift{}
+
+	go p.runBuild(ctx, sd, claim)
+	waitFor(t, "cloud-hypervisor launched for the build skiff", func() bool {
+		_, ok := fl.last("cloud-hypervisor")
+		return ok
+	})
+	chCall, _ := fl.last("cloud-hypervisor")
+	chCall.proc.exit(nil)
+
+	waitFor(t, "build skiff retired", func() bool {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		return len(p.skiffs) == 0
+	})
+
+	time.Sleep(20 * time.Millisecond) // give a wrongly-spawned replacement a chance to appear
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.skiffs) != 0 {
+		t.Fatalf("build skiff exit refilled the class: %d skiffs", len(p.skiffs))
+	}
+}
+
+// A build skiff has no GitHub registration to prove idle against, and is
+// busy by construction, so drain's registration-first scuttle must leave it
+// alone entirely -- not even attempt a DeleteRunner call.
+func TestDrainDoesNotScuttleAnInFlightBuildSkiffViaScuttleIdle(t *testing.T) {
+	p, gh, _ := testPool(t)
+	ctx := context.Background()
+	claim := &buildClaim{ID: "build-4", Class: "skiff-test", Request: json.RawMessage(`{}`)}
+
+	s, err := p.spawnBuild(ctx, claim)
+	if err != nil || s == nil {
+		t.Fatalf("spawnBuild: %v", err)
+	}
+
+	p.scuttleIdle(context.Background())
+
+	p.mu.Lock()
+	_, stillThere := p.skiffs[s.id]
+	p.mu.Unlock()
+	if !stillThere {
+		t.Fatal("scuttleIdle killed a build skiff, which has no registration to prove idle against")
+	}
+	if len(gh.deletedIDs()) != 0 {
+		t.Fatalf("scuttleIdle called DeleteRunner for a build skiff: %v", gh.deletedIDs())
+	}
+}
+
+// The wedge and JIT-expiry checks do not apply to a build skiff, but the
+// class's lifetime budget still does -- measured from spawn, since a build
+// skiff is busy from the moment it boots.
+func TestBuildSkiffIsReapedByMaxLifetime(t *testing.T) {
+	p, _, _ := testPool(t)
+	p.cfg.Classes["skiff-test"] = Class{
+		Hull:  p.cfg.Classes["skiff-test"].Hull,
+		VCPUs: 1, Memory: "512M", Warm: 0,
+		MaxLifetime: Duration(time.Millisecond),
+	}
+	ctx := context.Background()
+	claim := &buildClaim{ID: "build-5", Class: "skiff-test", Request: json.RawMessage(`{}`)}
+
+	s, err := p.spawnBuild(ctx, claim)
+	if err != nil || s == nil {
+		t.Fatalf("spawnBuild: %v", err)
+	}
+	time.Sleep(5 * time.Millisecond)
+
+	p.pollOnce(ctx)
+
+	if r := s.reason(); r != exitLifetime {
+		t.Fatalf("want exitLifetime, got %q", r)
+	}
+}
+
+// A claim that lands just as a stop begins is refused by spawnBuild -- and
+// runBuild must post nothing for it: the build was never attempted, so
+// staying silent lets Spindrift's lease expire and another host claim the
+// request, where a FAILED post would close the build permanently.
+func TestDrainRefusedClaimPostsNoResult(t *testing.T) {
+	p, _, _ := testPool(t)
+	ctx := context.Background()
+	claim := &buildClaim{ID: "build-6", Class: "skiff-test", Request: json.RawMessage(`{}`)}
+	sd := &fakeSpindrift{}
+
+	p.mu.Lock()
+	p.draining = true
+	p.mu.Unlock()
+
+	p.runBuild(ctx, sd, claim)
+
+	if results := sd.postedResults(); len(results) != 0 {
+		t.Fatalf("drain-refused claim posted a result: %+v", results)
 	}
 }

--- a/apps/bosun/spindrift.go
+++ b/apps/bosun/spindrift.go
@@ -1,0 +1,279 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// errDraining marks a claim spawnBuild refused because a stop is in
+// progress; runBuild posts nothing for it so the lease can recover the work.
+var errDraining = errors.New("draining")
+
+// spindriftClient is the port bosun talks to a Spindrift outbox through.
+// Spindrift never dials in -- bosun is always the poller, the same shape as
+// githubClient -- so there is one claim call and two calls scoped to the
+// build it returned. sdClient is the real adapter; tests substitute a fake.
+type spindriftClient interface {
+	// ClaimBuild long-polls Spindrift for a build request in one of classes.
+	// nil, nil means none arrived within the poll window; that is not an
+	// error.
+	ClaimBuild(ctx context.Context, classes []string) (*buildClaim, error)
+	Heartbeat(ctx context.Context, id string) error
+	PostResult(ctx context.Context, id string, res buildResult) error
+}
+
+// buildClaim is one build request handed to this bosun host. Request is
+// opaque -- bosun never parses it, only writes it into the claimed skiff's
+// share for the guest to read.
+type buildClaim struct {
+	ID      string          `json:"id"`
+	Class   string          `json:"class"`
+	Request json.RawMessage `json:"request"`
+}
+
+// buildResult is what bosun posts back once a build skiff halts.
+type buildResult struct {
+	Status string `json:"status"`
+	Log    string `json:"log"`
+	Detail string `json:"detail,omitempty"`
+}
+
+const (
+	buildSucceeded = "SUCCEEDED"
+	buildFailed    = "FAILED"
+
+	// claimTimeout allows for Spindrift holding the request open server-side
+	// for up to ~55s of long-polling, plus round-trip slack.
+	claimTimeout = 70 * time.Second
+	callTimeout  = 30 * time.Second
+
+	buildHeartbeatInterval = 60 * time.Second
+
+	// buildResultMaxLog caps the log bosun posts back. The tail is kept, not
+	// the head, because a build's report marker line is written last.
+	buildResultMaxLog = 1 << 20 // 1 MiB
+)
+
+// sdClient is the real spindriftClient, talking to a Spindrift instance's
+// internal bosun API. base is overridable so tests can point it at an
+// httptest server.
+type sdClient struct {
+	httpClient *http.Client
+	token      string
+	base       string
+}
+
+func newSDClient(url, token string) *sdClient {
+	return &sdClient{
+		httpClient: &http.Client{},
+		token:      token,
+		base:       strings.TrimSuffix(url, "/"),
+	}
+}
+
+func (c *sdClient) ClaimBuild(ctx context.Context, classes []string) (*buildClaim, error) {
+	ctx, cancel := context.WithTimeout(ctx, claimTimeout)
+	defer cancel()
+	var claim buildClaim
+	status, err := c.do(ctx, http.MethodPost, c.base+"/internal/bosun/claim", map[string]any{"classes": classes}, &claim)
+	if err != nil {
+		return nil, err
+	}
+	if status == http.StatusNoContent {
+		return nil, nil
+	}
+	return &claim, nil
+}
+
+func (c *sdClient) Heartbeat(ctx context.Context, id string) error {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+	_, err := c.do(ctx, http.MethodPost, c.base+"/internal/bosun/requests/"+id+"/heartbeat", nil, nil)
+	return err
+}
+
+func (c *sdClient) PostResult(ctx context.Context, id string, res buildResult) error {
+	ctx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+	_, err := c.do(ctx, http.MethodPost, c.base+"/internal/bosun/requests/"+id+"/result", res, nil)
+	return err
+}
+
+// do sends one request and, for a body-bearing response, decodes it into
+// out. The status code is always returned so ClaimBuild can tell a 204
+// "nothing to claim" apart from a 200 without out ever being touched.
+func (c *sdClient) do(ctx context.Context, method, url string, body, out any) (status int, err error) {
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return 0, err
+		}
+		reqBody = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+		return resp.StatusCode, fmt.Errorf("spindrift %s %s: %s: %s", method, url, resp.Status, bytes.TrimSpace(data))
+	}
+	if out != nil && resp.StatusCode != http.StatusNoContent {
+		return resp.StatusCode, json.NewDecoder(resp.Body).Decode(out)
+	}
+	return resp.StatusCode, nil
+}
+
+// buildLoop claims and runs one Spindrift build at a time until ctx is
+// cancelled.
+//
+// ponytail: one build in flight per bosun host, not one per available warm
+// slot. Pool capacity -- the same warm/persist machinery every other class
+// already has -- is the real limiter on how many builds a host could serve
+// at once, so this leaves spare capacity on the table on a host with more
+// than one build class. It also keeps a bosun restart from ever stranding
+// more than one build mid-heartbeat. A second lane is another goroutine
+// calling this loop, if the capacity ever matters more than that.
+func (p *pool) buildLoop(ctx context.Context, sd spindriftClient, classes []string, pollInterval time.Duration) {
+	for ctx.Err() == nil {
+		claim, err := sd.ClaimBuild(ctx, classes)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			p.stats.spindriftError()
+			p.logger.Warn("claim build", "error", err)
+			time.Sleep(pollInterval)
+			continue
+		}
+		if claim == nil {
+			time.Sleep(time.Second) // guard a tight 204 loop; the long-poll IS the wait
+			continue
+		}
+		p.stats.buildClaimed()
+		p.runBuild(ctx, sd, claim)
+	}
+}
+
+// runBuild boots a skiff for claim, waits for it to halt while heartbeating
+// Spindrift so the claim's lease does not expire mid-build, and posts the
+// result composed from whatever the guest left in the skiff's diag share.
+// It blocks until the skiff is gone regardless of ctx, so a build in
+// progress at shutdown gets the same drain-then-kill treatment as a busy
+// GitHub runner rather than being abandoned mid-heartbeat.
+func (p *pool) runBuild(ctx context.Context, sd spindriftClient, claim *buildClaim) {
+	logger := p.logger.With("build_id", claim.ID, "class", claim.Class)
+
+	s, err := p.spawnBuild(ctx, claim)
+	if err != nil {
+		if errors.Is(err, errDraining) {
+			// Never attempted: stay silent so the claim's lease expires and
+			// another host picks the request up. A FAILED post here would
+			// close the Spindrift build permanently for work nobody ran.
+			logger.Info("claim refused mid-drain; leaving it for lease expiry")
+			return
+		}
+		res := buildResult{Status: buildFailed, Detail: fmt.Sprintf("failed to spawn a build skiff: %v", err)}
+		p.stats.buildResult(res.Status)
+		p.postBuildResult(ctx, sd, claim.ID, res, logger)
+		return
+	}
+
+	heartbeat := time.NewTicker(buildHeartbeatInterval)
+	defer heartbeat.Stop()
+	for {
+		select {
+		case <-s.done:
+			res := p.collectBuildResult(s, logger)
+			p.stats.buildResult(res.Status)
+			p.postBuildResult(ctx, sd, claim.ID, res, logger)
+			return
+		case <-heartbeat.C:
+			if err := sd.Heartbeat(ctx, claim.ID); err != nil {
+				logger.Warn("heartbeat", "error", err)
+			}
+		}
+	}
+}
+
+// collectBuildResult reads whatever the guest left in s's diag share --
+// retire keeps that directory on purpose, the same evidence a wedged GitHub
+// skiff leaves behind -- and composes the result Spindrift gets. A missing
+// status file means the guest never finished the handshake, which is
+// reported as FAILED rather than left for Spindrift's lease to time out on.
+func (p *pool) collectBuildResult(s *skiff, logger *slog.Logger) buildResult {
+	logBytes, _ := os.ReadFile(filepath.Join(s.paths.diagDir, "result", "build.log"))
+	logText := tailString(logBytes, buildResultMaxLog)
+
+	statusRaw, err := os.ReadFile(filepath.Join(s.paths.diagDir, "result", "status"))
+	if err != nil {
+		reason := s.reason()
+		detail := "skiff exited without writing a result"
+		if reason != "" && reason != exitCompleted {
+			detail = fmt.Sprintf("skiff exited without writing a result (%s)", reason)
+		}
+		logger.Warn("build result missing", "error", err, "exit_reason", reason)
+		return buildResult{Status: buildFailed, Log: logText, Detail: detail}
+	}
+
+	status := strings.TrimSpace(string(statusRaw))
+	if status != buildSucceeded && status != buildFailed {
+		logger.Warn("build result status unrecognized", "status", status)
+		return buildResult{Status: buildFailed, Log: logText, Detail: fmt.Sprintf("unrecognized result status %q", status)}
+	}
+	return buildResult{Status: status, Log: logText}
+}
+
+// tailString caps b at max bytes, keeping the end: a build's report marker
+// line is written last, so a truncation must drop the head instead.
+func tailString(b []byte, max int) string {
+	if len(b) <= max {
+		return string(b)
+	}
+	return string(b[len(b)-max:])
+}
+
+// postBuildResult posts a build's outcome with a few retries on a context
+// that outlives ctx -- the same posture retire's own DeleteRunner takes, and
+// for the same reason: a lost result strands a Spindrift build row until its
+// lease expires, which is worth a little extra time after bosun has
+// otherwise decided to move on.
+func (p *pool) postBuildResult(ctx context.Context, sd spindriftClient, id string, res buildResult, logger *slog.Logger) {
+	pctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 2*time.Minute)
+	defer cancel()
+	const attempts = 3
+	var err error
+	for i := 0; i < attempts; i++ {
+		if i > 0 {
+			time.Sleep(5 * time.Second)
+		}
+		if err = sd.PostResult(pctx, id, res); err == nil {
+			logger.Info("build result posted", "status", res.Status)
+			return
+		}
+		logger.Warn("post build result", "attempt", i+1, "error", err)
+	}
+	logger.Error("build result not posted, giving up", "error", err)
+}

--- a/apps/bosun/spindrift_test.go
+++ b/apps/bosun/spindrift_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// fakeSpindrift is an in-memory stand-in for the three bosun-facing
+// endpoints Spindrift exposes.
+type fakeSpindrift struct {
+	mu sync.Mutex
+
+	claims       []*buildClaim // popped front-to-back by ClaimBuild
+	claimErr     error
+	heartbeats   []string
+	heartbeatErr error
+	results      []postedResult
+	resultErr    error
+}
+
+type postedResult struct {
+	id  string
+	res buildResult
+}
+
+func (f *fakeSpindrift) ClaimBuild(ctx context.Context, classes []string) (*buildClaim, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.claimErr != nil {
+		return nil, f.claimErr
+	}
+	if len(f.claims) == 0 {
+		return nil, nil
+	}
+	c := f.claims[0]
+	f.claims = f.claims[1:]
+	return c, nil
+}
+
+func (f *fakeSpindrift) Heartbeat(ctx context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.heartbeats = append(f.heartbeats, id)
+	return f.heartbeatErr
+}
+
+func (f *fakeSpindrift) PostResult(ctx context.Context, id string, res buildResult) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.resultErr != nil {
+		return f.resultErr
+	}
+	f.results = append(f.results, postedResult{id: id, res: res})
+	return nil
+}
+
+func (f *fakeSpindrift) postedResults() []postedResult {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]postedResult(nil), f.results...)
+}
+
+func TestSDClientClaimBuildDecodes200(t *testing.T) {
+	var gotBody map[string]any
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /internal/bosun/claim", func(w http.ResponseWriter, r *http.Request) {
+		if auth := r.Header.Get("Authorization"); auth != "Bearer test-token" {
+			t.Errorf("unexpected auth header: %s", auth)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"id":      "build-1",
+			"class":   "skiff-build",
+			"request": map[string]any{"repo": "acme/widgets"},
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &sdClient{httpClient: server.Client(), token: "test-token", base: server.URL}
+	claim, err := c.ClaimBuild(context.Background(), []string{"skiff-build"})
+	if err != nil {
+		t.Fatalf("ClaimBuild: %v", err)
+	}
+	if claim == nil || claim.ID != "build-1" || claim.Class != "skiff-build" {
+		t.Fatalf("unexpected claim: %+v", claim)
+	}
+	classes, _ := gotBody["classes"].([]any)
+	if len(classes) != 1 || classes[0] != "skiff-build" {
+		t.Fatalf("unexpected request body: %v", gotBody)
+	}
+}
+
+func TestSDClientClaimBuildReturnsNilOn204(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /internal/bosun/claim", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &sdClient{httpClient: server.Client(), token: "t", base: server.URL}
+	claim, err := c.ClaimBuild(context.Background(), []string{"skiff-build"})
+	if err != nil {
+		t.Fatalf("ClaimBuild: %v", err)
+	}
+	if claim != nil {
+		t.Fatalf("want nil claim on 204, got %+v", claim)
+	}
+}
+
+func TestSDClientClaimBuildErrorsOn500(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /internal/bosun/claim", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &sdClient{httpClient: server.Client(), token: "t", base: server.URL}
+	if _, err := c.ClaimBuild(context.Background(), []string{"skiff-build"}); err == nil {
+		t.Fatal("expected error on 500")
+	}
+}
+
+func TestSDClientPostResultSendsBodyAndAuth(t *testing.T) {
+	var gotBody map[string]any
+	var gotAuth string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /internal/bosun/requests/build-1/result", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &sdClient{httpClient: server.Client(), token: "test-token", base: server.URL}
+	err := c.PostResult(context.Background(), "build-1", buildResult{Status: buildSucceeded, Log: "ok"})
+	if err != nil {
+		t.Fatalf("PostResult: %v", err)
+	}
+	if gotAuth != "Bearer test-token" {
+		t.Fatalf("unexpected auth header: %s", gotAuth)
+	}
+	if gotBody["status"] != buildSucceeded || gotBody["log"] != "ok" {
+		t.Fatalf("unexpected posted result: %v", gotBody)
+	}
+}
+
+func TestSDClientHeartbeatPostsToTheRequestID(t *testing.T) {
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /internal/bosun/requests/build-1/heartbeat", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	c := &sdClient{httpClient: server.Client(), token: "t", base: server.URL}
+	if err := c.Heartbeat(context.Background(), "build-1"); err != nil {
+		t.Fatalf("Heartbeat: %v", err)
+	}
+	if !called {
+		t.Fatal("heartbeat endpoint was never called")
+	}
+}
+
+func TestTailStringKeepsTheEndNotTheStart(t *testing.T) {
+	body := []byte("0123456789")
+	got := tailString(body, 4)
+	if got != "6789" {
+		t.Fatalf("got %q, want the last 4 bytes", got)
+	}
+	if got := tailString(body, 100); got != string(body) {
+		t.Fatalf("short input should be returned unchanged, got %q", got)
+	}
+}

--- a/apps/spindrift/src/adapters/build/bosun.ts
+++ b/apps/spindrift/src/adapters/build/bosun.ts
@@ -1,0 +1,252 @@
+/**
+ * The bosun build route.
+ *
+ * Bosun is a warm-pool microVM runner daemon — a peer system, not something
+ * this process dials. Every other route here reaches out: a workflow
+ * dispatch, a cloud API, a Job on a cluster this process already holds a
+ * token for. Bosun is the mirror image — an operator-controlled host this
+ * process cannot reach, which **long-polls in** over the three
+ * shared-secret-authed endpoints `src/web/bosun-route.ts` serves. This route
+ * is the far side of that: it writes an intent to the outbox
+ * (`src/storage/build-outbox.ts`) and polls the same row for a verdict,
+ * exactly the way every other route here polls a status endpoint — the
+ * endpoint just happens to be this installation's own database instead of a
+ * far side's API.
+ *
+ * `ON_COMPLETION`, and it has to be: a bosun host reports nothing until it
+ * posts a result, so there is nothing to watch live (§4's fidelity is a
+ * property of the runner, and this runner has none of the other two modes'
+ * shape).
+ */
+
+import type { RegistryFlavour } from '../../domain/artifact-name.ts';
+import type {
+  BuildAdapter,
+  BuildEvent,
+  BuildLevel,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+  LogFidelity,
+} from './contract.ts';
+import type { BuildRouteDescriptor } from './descriptor.ts';
+import { parseBuildReport } from './report.ts';
+import {
+  buildFailed,
+  buildSucceeded,
+  deadlineFrom,
+  type PollingOptions,
+} from './route.ts';
+
+/** What a finished attempt reports back, exactly as `bosun-route.ts` stores it. */
+export interface BosunOutboxResult {
+  readonly status: 'SUCCEEDED' | 'FAILED';
+  readonly log: string;
+  readonly detail?: string;
+}
+
+/** One outbox row, as much of it as this route reads. */
+export interface BosunOutboxState {
+  readonly state: 'PENDING' | 'CLAIMED' | 'DONE';
+  /**
+   * Opaque here rather than typed as {@link BosunOutboxResult}: the outbox
+   * table's column is `jsonb`, and the shape was already checked once, by
+   * `bosun-route.ts`'s zod schema, on the way in. This route trusts its own
+   * database the way every other route trusts the process it just dispatched.
+   */
+  readonly result: unknown;
+}
+
+/**
+ * The far side this route drives — the outbox, narrowed to the three verbs a
+ * build actually needs. Declared here rather than importing `BuildOutbox`
+ * itself, the same reason `ActionsHost` is its own interface in
+ * `github-actions.ts`: naming exactly what is needed is what lets a test
+ * stand a fake behind this route without building the whole store.
+ *
+ * `src/storage/build-outbox.ts`'s `buildOutbox()` satisfies this directly —
+ * its `enqueue`, `get`, and `cancel` already have this shape.
+ */
+export interface BosunOutbox {
+  enqueue(input: {
+    readonly class: string;
+    readonly request: unknown;
+  }): Promise<{ readonly id: string }>;
+  get(id: string): Promise<BosunOutboxState | null>;
+  cancel(id: string): Promise<void>;
+}
+
+export interface BosunRouteOptions extends PollingOptions {
+  readonly name: string;
+  /** The skiff pool this route enqueues onto. */
+  readonly class: string;
+  readonly outbox: BosunOutbox;
+  /** The zero-config BuildKit frontend the installation pinned (§4). */
+  readonly zeroConfigFrontend: string;
+  /**
+   * The trusted builder identity the build-hull stamps in its statement, as
+   * this installation's manifest names it (§20) — see
+   * `bosunConfigSchema.provenanceBuilderId` for why it travels as
+   * configuration rather than as a constant here.
+   */
+  readonly provenanceBuilderId: string;
+}
+
+export class BosunBuildRoute implements BuildAdapter {
+  readonly name: string;
+  readonly logFidelity: LogFidelity = 'ON_COMPLETION';
+  /**
+   * A skiff is an operator-controlled microVM under a daemon this repository
+   * cannot reach — the same isolation gap ARC's runner pool carries in this
+   * repo's own SLSA charting, and the same rating for the same reason: the
+   * operator who controls the host also controls what a build running on it
+   * can see.
+   */
+  readonly buildLevel: BuildLevel = 2;
+  readonly provenanceBuilderId: string;
+  /**
+   * The credential travels inside the claim response body, over the same
+   * authed channel every field of the request does, into a skiff's private
+   * directory that nothing outside that microVM reads. That is a materially
+   * different exposure than `github-actions.ts`'s: there, the danger is
+   * GitHub rendering `workflow_dispatch` inputs in a run header anyone with
+   * read access to the repository can open, which is why that route seals the
+   * credential before it ever reaches the request. Nothing here renders the
+   * outbox row anywhere public, so it travels as the other fields do.
+   */
+  readonly carriesRegistryCredential = true;
+  /** A skiff has no ambient registry identity — nothing it pushes to is unaided. */
+  readonly selfAuthorizedRegistries: readonly RegistryFlavour[] = [];
+
+  constructor(private readonly options: BosunRouteOptions) {
+    this.name = options.name;
+    this.provenanceBuilderId = options.provenanceBuilderId;
+  }
+
+  async *build(
+    source: BuildSource,
+    spec: BuildSpec,
+  ): AsyncGenerator<BuildEvent, BuildResult, void> {
+    const now = this.options.now ?? (() => new Date());
+    const logs = { backend: this.name, fidelity: this.logFidelity } as const;
+    const { outbox } = this.options;
+
+    const request = {
+      source,
+      spec: {
+        artifactType: spec.artifactType,
+        kind: spec.kind,
+        platform: spec.platform,
+        destinations: spec.destinations,
+        tags: spec.tags,
+        buildArgs: spec.buildArgs,
+        zeroConfigFrontend: this.options.zeroConfigFrontend,
+        registryAuth: spec.registryAuth,
+      },
+    };
+
+    const { id } = await outbox.enqueue({ class: this.options.class, request });
+    yield {
+      type: 'log',
+      at: now(),
+      line: `enqueued on bosun class “${this.options.class}” as ${id}`,
+    };
+
+    const budget = deadlineFrom(this.options);
+    let claimed = false;
+    let row: BosunOutboxState | null = null;
+
+    for (;;) {
+      row = await outbox.get(id);
+      if (row === null) {
+        return buildFailed(
+          logs,
+          'INTERNAL',
+          `the outbox lost track of build request ${id}`,
+          { id },
+        );
+      }
+      if (row.state === 'DONE') break;
+      if (row.state === 'CLAIMED' && !claimed) {
+        claimed = true;
+        yield { type: 'log', at: now(), line: 'claimed by the pool' };
+      }
+
+      if (budget.expired()) {
+        // Best-effort: a failed cancel leaves a row a reclaim will eventually
+        // return to PENDING, which is stale but not wrong — the Build this
+        // route is answering for is already failing either way.
+        await outbox.cancel(id).catch(() => {});
+        return buildFailed(
+          logs,
+          claimed ? 'TIMEOUT' : 'TARGET_UNREACHABLE',
+          claimed
+            ? `request ${id} was claimed but did not finish within the build budget`
+            : `no bosun host claimed request ${id} within the build budget`,
+          { id },
+        );
+      }
+      await budget.tick();
+    }
+
+    const result = row.result as BosunOutboxResult | null;
+    if (result === null) {
+      // A DONE row with no result is one this route (or an earlier attempt)
+      // gave up on — `cancel`'s own contract. Nothing else writes DONE with a
+      // null result.
+      return buildFailed(
+        logs,
+        'INTERNAL',
+        `build request ${id} was cancelled before a bosun host reported a result`,
+        { id },
+      );
+    }
+
+    for (const line of result.log.split('\n')) {
+      if (line.trim() === '') continue;
+      yield { type: 'log', at: now(), line };
+    }
+
+    if (result.status === 'FAILED') {
+      return buildFailed(logs, 'BUILD_FAILED', result.detail, { id });
+    }
+
+    const report = parseBuildReport(result.log);
+    if (report === null) {
+      return buildFailed(
+        logs,
+        'INTERNAL',
+        `build request ${id} succeeded but reported no artifact`,
+        { id },
+      );
+    }
+
+    return buildSucceeded({
+      source,
+      spec,
+      logs,
+      level: this.buildLevel,
+      report,
+    });
+  }
+}
+
+import { bosunConfigSchema } from '../../config/build-route-schemas.ts';
+
+export const bosunDescriptor = {
+  kind: 'bosun',
+  displayName: 'bosun',
+  logo: 'nixos',
+  buildLevel: 2,
+  configSchema: bosunConfigSchema,
+  create(config, context) {
+    if (!context.outbox) return null;
+    return new BosunBuildRoute({
+      name: config.name,
+      class: config.class,
+      outbox: context.outbox,
+      zeroConfigFrontend: context.manifest.build.zeroConfigFrontend,
+      provenanceBuilderId: config.provenanceBuilderId,
+    });
+  },
+} satisfies BuildRouteDescriptor;

--- a/apps/spindrift/src/adapters/build/descriptor.ts
+++ b/apps/spindrift/src/adapters/build/descriptor.ts
@@ -1,6 +1,7 @@
 import type { z } from 'zod';
 import type { GitHubApp } from '../../integrations/github/app.ts';
 import type { TokenProvider } from '../deploy/kubernetes/api.ts';
+import type { BosunOutbox } from './bosun.ts';
 import type { BuildAdapter, BuildLevel } from './contract.ts';
 
 export interface BuildRouteContext {
@@ -17,6 +18,14 @@ export interface BuildRouteContext {
   readonly token: TokenProvider;
   readonly fetch?: (request: Request) => Promise<Response>;
   readonly env?: Record<string, string | undefined>;
+  /**
+   * The bosun build route's outbox, or `null` where this process has no
+   * database — the same "both halves or nothing" posture
+   * `registryCredentials()` takes in `adapters/registry.ts`. `bosunDescriptor`
+   * answers `null` from `create` whenever this is absent, exactly as
+   * `inClusterDescriptor` does for a missing `token`.
+   */
+  readonly outbox?: BosunOutbox | null;
 }
 
 export interface BuildRouteDescriptor<

--- a/apps/spindrift/src/adapters/build/descriptors.ts
+++ b/apps/spindrift/src/adapters/build/descriptors.ts
@@ -1,14 +1,21 @@
+import { bosunDescriptor } from './bosun.ts';
 import { cloudBuildDescriptor } from './cloud-build.ts';
 import type { BuildRouteDescriptor } from './descriptor.ts';
 import { githubActionsDescriptor } from './github-actions.ts';
 import { inClusterDescriptor } from './in-cluster.ts';
 
-export { cloudBuildDescriptor, githubActionsDescriptor, inClusterDescriptor };
+export {
+  bosunDescriptor,
+  cloudBuildDescriptor,
+  githubActionsDescriptor,
+  inClusterDescriptor,
+};
 
 export const BUILD_ROUTE_DESCRIPTORS = [
   githubActionsDescriptor,
   cloudBuildDescriptor,
   inClusterDescriptor,
+  bosunDescriptor,
 ] as const;
 
 export function findBuildRouteDescriptor(

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -48,11 +48,13 @@ import { GitHubApp } from '../integrations/github/app.ts';
 import type { Fetcher } from '../integrations/github/http.ts';
 import { GitHubDeviceOAuth } from '../integrations/github/oauth.ts';
 import { sourceDepotFor, stageArchiveBytes } from '../storage/archives.ts';
+import { buildOutbox } from '../storage/build-outbox.ts';
 import { withGitHubRegistryCredential } from '../storage/github-registry-credential.ts';
 import { registryCredentialStore } from '../storage/registry-credentials.ts';
 import { CoreSupplyChain, CosignSigner } from '../supply-chain/sign.ts';
 import { SpindriftSignatureVerifier } from '../supply-chain/signature.ts';
 import { SlsaVerifier } from '../supply-chain/verify.ts';
+import type { BosunOutbox } from './build/bosun.ts';
 import type { BuildAdapter } from './build/contract.ts';
 import { findBuildRouteDescriptor } from './build/descriptors.ts';
 import { GcpDiscovery } from './cloud-discovery.ts';
@@ -228,11 +230,21 @@ export function createAdapterRegistry(
     ...(options.fetch ? { fetch: options.fetch } : {}),
   });
 
+  // The bosun route's outbox: built once, over the same `db` the registry
+  // credential store is, and `null` under the identical condition —
+  // "no database, no durable state this route can claim against".
+  const outbox =
+    options.db === undefined
+      ? null
+      : buildOutbox(options.db, () =>
+          (options.clock ?? { now: () => new Date() }).now(),
+        );
+
   // §16's ordered list: the manifest's order *is* the admin rank, so the map is
   // built from it in order and `buildRouteProfiles` reads it back the same way.
   const buildRoutes = new Map<string, BuildAdapter>();
   for (const route of options.manifest.build.routes) {
-    const built = createBuildRoute(route, options, app, cloud);
+    const built = createBuildRoute(route, options, app, cloud, outbox);
     if (built !== null) buildRoutes.set(route.name, built);
   }
 
@@ -469,6 +481,7 @@ function createBuildRoute(
   options: RegistryOptions,
   app: GitHubApp | null,
   cloud: TokenProvider,
+  outbox: BosunOutbox | null,
 ): BuildAdapter | null {
   const descriptor = findBuildRouteDescriptor(route.adapter);
   if (!descriptor) return null;
@@ -479,6 +492,7 @@ function createBuildRoute(
     app,
     cloud,
     token,
+    outbox,
     ...(options.fetch ? { fetch: options.fetch } : {}),
     ...(options.env ? { env: options.env } : {}),
   });

--- a/apps/spindrift/src/config/build-route-schemas.ts
+++ b/apps/spindrift/src/config/build-route-schemas.ts
@@ -33,14 +33,37 @@ export const inClusterConfigSchema = z
   })
   .strict();
 
+/**
+ * The bosun build route (Task: bosun build route). `class` names the skiff
+ * pool a request is routed to — a bosun installation's own vocabulary, not
+ * this contract's, so it is an opaque string rather than an enum.
+ *
+ * `provenanceBuilderId` is configured rather than a code-defined constant the
+ * way the other three routes' builder ids are: theirs name a vendor's own
+ * domain (`github.com`, `spindrift.dev`), identical in every installation,
+ * while a bosun fleet's builder id names *this* installation's own bosun
+ * host — exactly the kind of value §20 puts in the manifest rather than in
+ * source.
+ */
+export const bosunConfigSchema = z
+  .object({
+    name: nonEmptyString,
+    adapter: z.literal('bosun'),
+    class: nonEmptyString,
+    provenanceBuilderId: nonEmptyString,
+  })
+  .strict();
+
 export const buildRouteAdapterSchema = z.enum([
   'github-actions',
   'cloud-build',
   'in-cluster',
+  'bosun',
 ]);
 
 export const buildRouteSchema = z.discriminatedUnion('adapter', [
   githubActionsConfigSchema,
   cloudBuildConfigSchema,
   inClusterConfigSchema,
+  bosunConfigSchema,
 ]);

--- a/apps/spindrift/src/db/migrations/0031_bosun_build_outbox.sql
+++ b/apps/spindrift/src/db/migrations/0031_bosun_build_outbox.sql
@@ -1,0 +1,26 @@
+-- The bosun build route's outbox.
+--
+-- Bosun is a warm-pool microVM runner daemon this process cannot dial — it
+-- long-polls in over three shared-secret-authed endpoints instead. A row here
+-- is the queue entry that makes that direction of contact possible: enqueued
+-- PENDING, claimed CLAIMED for the life of a lease, and DONE once a result
+-- has landed, win or lose. `src/storage/build-outbox.ts` is the only reader
+-- and writer.
+--
+-- The index matches exactly what `claim` scans: the oldest PENDING row of a
+-- given class. `lease_expires` is nullable because a PENDING row (never
+-- claimed) and a DONE row (lease no longer relevant) both have no lease to
+-- expire — only a CLAIMED row does.
+CREATE TYPE "public"."build_request_state" AS ENUM('PENDING', 'CLAIMED', 'DONE');--> statement-breakpoint
+CREATE TABLE "build_requests" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"class" text NOT NULL,
+	"request" jsonb NOT NULL,
+	"state" "public"."build_request_state" DEFAULT 'PENDING' NOT NULL,
+	"lease_expires" timestamp with time zone,
+	"result" jsonb,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "build_requests_state_class_created_at_idx" ON "build_requests" USING btree ("state","class","created_at");

--- a/apps/spindrift/src/db/migrations/meta/_journal.json
+++ b/apps/spindrift/src/db/migrations/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1785374380774,
       "tag": "0030_component_placement_of_record",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1786363272470,
+      "tag": "0031_bosun_build_outbox",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/spindrift/src/db/schema.ts
+++ b/apps/spindrift/src/db/schema.ts
@@ -29,6 +29,7 @@ import {
   boolean,
   check,
   customType,
+  index,
   integer,
   pgEnum,
   pgTable,
@@ -158,6 +159,24 @@ export const buildStatus = pgEnum('build_status', ['PENDING', ...BUILD_STATES]);
 
 /** §4: "a declared `logFidelity` of `LIVE_TEXT | LIVE_STATUS | ON_COMPLETION`." */
 export const logFidelity = pgEnum('log_fidelity', LOG_FIDELITIES);
+
+/**
+ * The bosun build outbox's own lifecycle — not {@link buildStatus}, and not
+ * built from a shared contract tuple the way that one is from
+ * {@link BUILD_STATES}. A `build_requests` row is core's *outbox entry*, one
+ * layer below a Build: `PENDING` until a bosun host claims it, `CLAIMED` for
+ * the life of its lease, `DONE` once a result has landed (win or lose). The
+ * one place this vocabulary is read outside this file is
+ * `src/storage/build-outbox.ts`, and it reads it off `BuildRequest['state']`
+ * rather than restating the tuple — kept here, beside the table, because
+ * nothing outside the outbox needs to name these three states.
+ */
+export const BUILD_REQUEST_STATES = ['PENDING', 'CLAIMED', 'DONE'] as const;
+
+export const buildRequestState = pgEnum(
+  'build_request_state',
+  BUILD_REQUEST_STATES,
+);
 
 /** §6: "PENDING -> APPLYING -> WAITING -> LIVE | FAILED". */
 export const deployPhase = pgEnum('deploy_phase', DEPLOY_PHASES);
@@ -1408,6 +1427,57 @@ export const registryCredentials = pgTable('registry_credentials', {
     .defaultNow(),
 });
 
+/**
+ * The bosun build route's outbox (Task: bosun build route).
+ *
+ * Bosun is a warm-pool microVM runner daemon this process cannot reach — it
+ * long-polls in, rather than being dialed the way the in-cluster Job or the
+ * hosted dispatch are. An outbox row is the queue entry that makes that
+ * direction of contact possible: `enqueue` writes one, a bosun host claims it
+ * over `POST /internal/bosun/claim`, and `complete` is the same row's last
+ * write. `src/storage/build-outbox.ts` is the seam; this table is only ever
+ * read or written through it.
+ *
+ * `lease_expires` is what makes a claim revocable without a second actor —
+ * `builds.leased_at` is the precedent (a claimed dispatch that stops
+ * heartbeating is eventually reclaimed), except here reclamation is a plain
+ * `UPDATE ... WHERE state = 'CLAIMED' AND lease_expires < now()` rather than a
+ * comparison against a fixed timeout, because the poller extends it itself on
+ * every heartbeat.
+ *
+ * `result` lands only once, `iff state != 'DONE'` — a late result from a
+ * lease-expired claimant that got superseded still lands if nothing else
+ * claimed the row in between, because a real result beats a rerun.
+ */
+export const buildRequests = pgTable(
+  'build_requests',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** The bosun class this request is routed to, e.g. a skiff pool name. */
+    class: text('class').notNull(),
+    /** The composed request document, handed back to the claimant verbatim. */
+    request: jsonbDocument('request').notNull(),
+    state: buildRequestState('state').notNull().default('PENDING'),
+    leaseExpires: timestamp('lease_expires', { withTimezone: true }),
+    /** `null` until `complete` writes it; also `null` for a cancelled request. */
+    result: jsonbDocument('result'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (table) => [
+    // What `claim` scans: the oldest PENDING row of a given class.
+    index('build_requests_state_class_created_at_idx').on(
+      table.state,
+      table.class,
+      table.createdAt,
+    ),
+  ],
+);
+
 // --- Relations (query-builder convenience; no schema effect) ---------------
 
 export const appsRelations = relations(apps, ({ one, many }) => ({
@@ -1589,3 +1659,5 @@ export type ConfigAuditEvent = typeof configAuditEvents.$inferSelect;
 export type NewConfigAuditEvent = typeof configAuditEvents.$inferInsert;
 export type AttemptEvent = typeof attemptEvents.$inferSelect;
 export type NewAttemptEvent = typeof attemptEvents.$inferInsert;
+export type BuildRequest = typeof buildRequests.$inferSelect;
+export type NewBuildRequest = typeof buildRequests.$inferInsert;

--- a/apps/spindrift/src/storage/build-outbox.ts
+++ b/apps/spindrift/src/storage/build-outbox.ts
@@ -1,0 +1,219 @@
+/**
+ * The bosun build route's outbox.
+ *
+ * Every other build route is dialed: core reaches a Job's API, a workflow
+ * dispatch, a cloud build submission. Bosun is the opposite shape — a warm-pool
+ * microVM daemon on a host this process cannot reach, which **long-polls in**
+ * over three shared-secret-authed endpoints (`src/web/bosun-route.ts`) instead
+ * of being called. An outbox row is what makes that direction workable: the
+ * `bosun.ts` adapter writes an intent with {@link BuildOutbox.enqueue}, a
+ * bosun host claims it, and the same row carries the result back.
+ *
+ * **The claim is the one place this module has to be exactly right.** Two
+ * bosun hosts polling the same class must never claim the same row — that is
+ * a build run twice for one Build — so `claim` is `SELECT ... FOR UPDATE SKIP
+ * LOCKED` inside a transaction, the identical mechanism
+ * `src/reconciler/deploy-loop.ts`'s `claimNextDeploy` already proves against
+ * real Postgres. § Testing: "the concurrency design is a claim about
+ * transactions and a fake store cannot falsify it" — this module has no fake,
+ * on purpose; `test/storage/build-outbox.test.ts` runs it against real
+ * Postgres or not at all.
+ *
+ * **A lease, not a session.** A claimed row expires after
+ * {@link BUILD_REQUEST_LEASE_MS} unless the claimant heartbeats it, mirroring
+ * `builds.leased_at`'s precedent for a dispatch that stops reporting.
+ * `reclaimExpired` is the reclamation half; nothing calls it but the claim
+ * route, right before it looks for something new to hand out.
+ *
+ * **A result lands once it is state-consistent to land, not once it is
+ * first.** `complete` writes only where the row is not already `DONE` — a
+ * result from a claimant whose lease already expired still lands if nothing
+ * else claimed the row in between, because a real result beats a rerun. The
+ * guard is one `UPDATE ... WHERE state != 'DONE'`, which is what makes two
+ * concurrent completions of the same id resolve to exactly one `'done'` and
+ * one `'conflict'` rather than both believing they won.
+ */
+import { and, asc, eq, inArray, lt, ne } from 'drizzle-orm';
+import type { Database } from '../db/client.ts';
+import { type BuildRequest, buildRequests } from '../db/schema.ts';
+
+/** How long a claim holds before it is eligible for reclamation. */
+export const BUILD_REQUEST_LEASE_MS = 5 * 60_000;
+
+/** What a claim hands the poller: enough to run the build, nothing more. */
+export interface ClaimedBuildRequest {
+  readonly id: string;
+  readonly class: string;
+  /** The request document exactly as `enqueue` stored it. */
+  readonly request: unknown;
+}
+
+/** What a finished attempt reports back. */
+export interface BuildRequestResult {
+  readonly status: 'SUCCEEDED' | 'FAILED';
+  readonly log: string;
+  readonly detail?: string;
+}
+
+/**
+ * The far side of the outbox table.
+ *
+ * Shaped like `RegistryCredentialStore`: a factory over `Database` and a
+ * clock, closures for verbs, nothing above this seam touches `buildRequests`
+ * directly.
+ */
+export interface BuildOutbox {
+  /** Write one intent, `PENDING` until a bosun host claims it. */
+  enqueue(input: {
+    readonly class: string;
+    readonly request: unknown;
+  }): Promise<{ readonly id: string }>;
+  /**
+   * The oldest `PENDING` row whose class is in the list, claimed and leased —
+   * one attempt, race-safe under concurrent callers. `null` when nothing is
+   * claimable right now; the long-poll loop that retries lives in the route,
+   * not here.
+   */
+  claim(classes: readonly string[]): Promise<ClaimedBuildRequest | null>;
+  /** Return every lease-expired `CLAIMED` row to `PENDING`. */
+  reclaimExpired(): Promise<void>;
+  /** Extend a claim's lease. `false` when the row is not currently claimed. */
+  heartbeat(id: string): Promise<boolean>;
+  /** Record a result, unless one already landed. */
+  complete(
+    id: string,
+    result: BuildRequestResult,
+  ): Promise<'done' | 'conflict' | 'missing'>;
+  /** The row as it stands, or `null` when no such request exists. */
+  get(id: string): Promise<BuildRequest | null>;
+  /**
+   * Mark a row `DONE` with no result — the adapter's move when it gives up on
+   * a request, so a dead request can never be claimed later. A no-op against
+   * a row that already carries a real result: that result beats the give-up.
+   */
+  cancel(id: string): Promise<void>;
+}
+
+/** The outbox an installation with a database has. */
+export function buildOutbox(
+  db: Database,
+  now: () => Date = () => new Date(),
+): BuildOutbox {
+  return {
+    async enqueue({ class: requestClass, request }) {
+      const [row] = await db
+        .insert(buildRequests)
+        .values({ class: requestClass, request })
+        .returning({ id: buildRequests.id });
+      return { id: row!.id };
+    },
+
+    async claim(classes) {
+      if (classes.length === 0) return null;
+      const claimedAt = now();
+
+      return db.transaction(async (tx) => {
+        const [row] = await tx
+          .select({
+            id: buildRequests.id,
+            class: buildRequests.class,
+            request: buildRequests.request,
+          })
+          .from(buildRequests)
+          .where(
+            and(
+              eq(buildRequests.state, 'PENDING'),
+              inArray(buildRequests.class, [...classes]),
+            ),
+          )
+          .orderBy(asc(buildRequests.createdAt))
+          .limit(1)
+          .for('update', { skipLocked: true });
+        if (row === undefined) return null;
+
+        await tx
+          .update(buildRequests)
+          .set({
+            state: 'CLAIMED',
+            leaseExpires: new Date(
+              claimedAt.getTime() + BUILD_REQUEST_LEASE_MS,
+            ),
+            updatedAt: claimedAt,
+          })
+          .where(eq(buildRequests.id, row.id));
+
+        return row;
+      });
+    },
+
+    async reclaimExpired() {
+      await db
+        .update(buildRequests)
+        .set({ state: 'PENDING', leaseExpires: null, updatedAt: now() })
+        .where(
+          and(
+            eq(buildRequests.state, 'CLAIMED'),
+            lt(buildRequests.leaseExpires, now()),
+          ),
+        );
+    },
+
+    async heartbeat(id) {
+      const heartbeatAt = now();
+      const rows = await db
+        .update(buildRequests)
+        .set({
+          leaseExpires: new Date(
+            heartbeatAt.getTime() + BUILD_REQUEST_LEASE_MS,
+          ),
+          updatedAt: heartbeatAt,
+        })
+        .where(
+          and(eq(buildRequests.id, id), eq(buildRequests.state, 'CLAIMED')),
+        )
+        .returning({ id: buildRequests.id });
+      return rows.length > 0;
+    },
+
+    async complete(id, result) {
+      const completedAt = now();
+      const done = await db
+        .update(buildRequests)
+        .set({
+          state: 'DONE',
+          result,
+          leaseExpires: null,
+          updatedAt: completedAt,
+        })
+        .where(and(eq(buildRequests.id, id), ne(buildRequests.state, 'DONE')))
+        .returning({ id: buildRequests.id });
+      if (done.length > 0) return 'done';
+
+      const [existing] = await db
+        .select({ id: buildRequests.id })
+        .from(buildRequests)
+        .where(eq(buildRequests.id, id));
+      return existing === undefined ? 'missing' : 'conflict';
+    },
+
+    async get(id) {
+      const [row] = await db
+        .select()
+        .from(buildRequests)
+        .where(eq(buildRequests.id, id));
+      return row ?? null;
+    },
+
+    async cancel(id) {
+      await db
+        .update(buildRequests)
+        .set({
+          state: 'DONE',
+          result: null,
+          leaseExpires: null,
+          updatedAt: now(),
+        })
+        .where(and(eq(buildRequests.id, id), ne(buildRequests.state, 'DONE')));
+    },
+  };
+}

--- a/apps/spindrift/src/web/bosun-route.ts
+++ b/apps/spindrift/src/web/bosun-route.ts
@@ -1,0 +1,240 @@
+/**
+ * The bosun poll surface, mounted (Task: bosun build route).
+ *
+ * `src/adapters/build/bosun.ts` writes an intent into the outbox and never
+ * calls out again — bosun's warm-pool daemon is on a host this process
+ * cannot dial, so the only way to hand it work is to let it come and ask.
+ * These three routes are what it asks: claim something to build, keep a
+ * claim alive, and report what happened. `src/storage/build-outbox.ts` is
+ * the store underneath all three; nothing here holds outbox state of its
+ * own.
+ *
+ * **A deliberate exception to `dispatch.ts`'s "session-authenticated only,
+ * never a token."** That rule exists because a token is what turns an
+ * internal protocol into an API somebody scripts against — but a bosun host
+ * cannot present a browser session, the same reason `webhook-route.ts` is
+ * the other named exception. It follows that route's posture exactly: the
+ * shared secret arrives as an installation Secret key
+ * ({@link BOSUN_SECRET_VAR}), read once at boot, and its absence refuses
+ * every request before anything below runs — an installation nobody has
+ * configured a secret for has nothing here for a poller to prove.
+ *
+ * **The claim endpoint long-polls.** A bosun host would otherwise have to
+ * busy-loop `POST`ing every second to notice new work; instead this route
+ * holds the connection, re-checking on a short interval, and answers `204`
+ * once its own budget runs out so the host can immediately ask again. The
+ * pacing is injectable for the same reason every build route's own polling
+ * is (`adapters/build/route.ts`'s `Deadline`, reused here rather than
+ * reimplemented): a test that actually waited out a 25-second window would
+ * be a test nobody could run twice in a row.
+ */
+import { z } from 'zod';
+import { deadlineFrom, type Sleeper } from '../adapters/build/route.ts';
+import type { Clock } from '../commands/types.ts';
+import type { Database } from '../db/client.ts';
+import { buildOutbox } from '../storage/build-outbox.ts';
+
+export const BOSUN_CLAIM_PATH = '/internal/bosun/claim';
+export const BOSUN_HEARTBEAT_PATH = '/internal/bosun/requests/:id/heartbeat';
+export const BOSUN_RESULT_PATH = '/internal/bosun/requests/:id/result';
+
+/** Every route this file mounts, for `routes.ts`'s table. */
+export const BOSUN_PATHS = [
+  BOSUN_CLAIM_PATH,
+  BOSUN_HEARTBEAT_PATH,
+  BOSUN_RESULT_PATH,
+] as const;
+
+/**
+ * Where the shared secret arrives — mirrors `webhook-route.ts`'s
+ * `WEBHOOK_SECRET_VAR`: an installation Secret key, read once at boot, never
+ * from the manifest an operator authors and hands around.
+ */
+export const BOSUN_SECRET_VAR = 'SPINDRIFT_BOSUN_SECRET';
+
+/** How long the claim endpoint holds a connection open with nothing to hand out. */
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const DEFAULT_POLL_TIMEOUT_MS = 25_000;
+
+/** A result's log, capped so one runaway build cannot fill the outbox table. */
+const MAX_LOG_BYTES = 2 * 1024 * 1024;
+
+const claimBodySchema = z
+  .object({
+    classes: z.array(z.string().trim().min(1)).min(1),
+  })
+  .strict();
+
+const resultBodySchema = z
+  .object({
+    status: z.enum(['SUCCEEDED', 'FAILED']),
+    log: z
+      .string()
+      .refine((log) => Buffer.byteLength(log, 'utf8') <= MAX_LOG_BYTES, {
+        message: `log exceeds ${MAX_LOG_BYTES} bytes`,
+      }),
+    detail: z.string().optional(),
+  })
+  .strict();
+
+export interface BosunRouteDeps {
+  readonly db: Database;
+  readonly clock: Clock;
+  /** `null` when this installation has no bosun secret configured. */
+  readonly secret: string | null;
+  /** Injected so a test's claim long-poll takes no wall-clock time. */
+  readonly pollIntervalMs?: number;
+  readonly pollTimeoutMs?: number;
+  readonly sleep?: Sleeper;
+}
+
+export function bosunRoutes(
+  deps: BosunRouteDeps,
+): Record<string, (request: Request) => Promise<Response>> {
+  return {
+    [BOSUN_CLAIM_PATH]: (request) => handleClaim(request, deps),
+    [BOSUN_HEARTBEAT_PATH]: (request) => handleHeartbeat(request, deps),
+    [BOSUN_RESULT_PATH]: (request) => handleResult(request, deps),
+  };
+}
+
+function refuse(status: number, code: string, message: string): Response {
+  return Response.json({ ok: false, failure: { code, message } }, { status });
+}
+
+/**
+ * The `:id` segment, read from the URL rather than from Bun's `.params`.
+ *
+ * Bun's router only populates `.params` on a request it matched itself, which
+ * a direct call to a handler — every test in `test/web/bosun-route.test.ts`
+ * — never goes through. Parsing the path here instead makes a handler
+ * callable identically in production (mounted by `Bun.serve`) and in a unit
+ * test (called directly against a manufactured `Request`); the pattern in
+ * {@link BOSUN_HEARTBEAT_PATH} and {@link BOSUN_RESULT_PATH} still tells
+ * `Bun.serve` which requests reach these handlers at all.
+ */
+function idFromPath(pathname: string): string | null {
+  const match =
+    /^\/internal\/bosun\/requests\/([^/]+)\/(?:heartbeat|result)$/.exec(
+      pathname,
+    );
+  return match?.[1] ?? null;
+}
+
+/** `null` when the request may proceed; the refusal to answer with otherwise. */
+function checkAuth(request: Request, deps: BosunRouteDeps): Response | null {
+  if (deps.secret === null) {
+    return refuse(
+      503,
+      'NOT_CONFIGURED',
+      `this installation has no ${BOSUN_SECRET_VAR} configured`,
+    );
+  }
+  const header = request.headers.get('authorization') ?? '';
+  const [scheme, token] = header.split(' ');
+  if (scheme !== 'Bearer' || token !== deps.secret) {
+    return refuse(401, 'UNAUTHORIZED', 'missing or wrong bearer token');
+  }
+  return null;
+}
+
+async function readJsonBody(request: Request): Promise<unknown> {
+  try {
+    return await request.json();
+  } catch {
+    return undefined;
+  }
+}
+
+async function handleClaim(
+  request: Request,
+  deps: BosunRouteDeps,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return refuse(405, 'METHOD_NOT_ALLOWED', 'a claim is a POST');
+  }
+  const denied = checkAuth(request, deps);
+  if (denied) return denied;
+
+  const parsed = claimBodySchema.safeParse(await readJsonBody(request));
+  if (!parsed.success) {
+    return refuse(400, 'BODY_MALFORMED', parsed.error.message);
+  }
+
+  const outbox = buildOutbox(deps.db, deps.clock.now);
+  const budget = deadlineFrom({
+    intervalMs: deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
+    timeoutMs: deps.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
+    now: deps.clock.now,
+    ...(deps.sleep ? { sleep: deps.sleep } : {}),
+  });
+
+  for (;;) {
+    // Reclamation runs on every pass, not on a separate timer: a lease that
+    // expired between two long-polls is reclaimed the moment anything next
+    // asks for work, which is the only time reclaiming it matters.
+    await outbox.reclaimExpired();
+    const claimed = await outbox.claim(parsed.data.classes);
+    if (claimed !== null) {
+      return Response.json({
+        id: claimed.id,
+        class: claimed.class,
+        request: claimed.request,
+      });
+    }
+    if (budget.expired()) return new Response(null, { status: 204 });
+    await budget.tick();
+  }
+}
+
+async function handleHeartbeat(
+  request: Request,
+  deps: BosunRouteDeps,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return refuse(405, 'METHOD_NOT_ALLOWED', 'a heartbeat is a POST');
+  }
+  const denied = checkAuth(request, deps);
+  if (denied) return denied;
+
+  const id = idFromPath(new URL(request.url).pathname);
+  if (id === null) return refuse(400, 'BODY_MALFORMED', 'missing request id');
+  const outbox = buildOutbox(deps.db, deps.clock.now);
+  const extended = await outbox.heartbeat(id);
+  return extended
+    ? new Response(null, { status: 204 })
+    : refuse(404, 'NOT_FOUND', `no claimed build request ${id}`);
+}
+
+async function handleResult(
+  request: Request,
+  deps: BosunRouteDeps,
+): Promise<Response> {
+  if (request.method !== 'POST') {
+    return refuse(405, 'METHOD_NOT_ALLOWED', 'a result is a POST');
+  }
+  const denied = checkAuth(request, deps);
+  if (denied) return denied;
+
+  const parsed = resultBodySchema.safeParse(await readJsonBody(request));
+  if (!parsed.success) {
+    return refuse(400, 'BODY_MALFORMED', parsed.error.message);
+  }
+
+  const id = idFromPath(new URL(request.url).pathname);
+  if (id === null) return refuse(400, 'BODY_MALFORMED', 'missing request id');
+  const outbox = buildOutbox(deps.db, deps.clock.now);
+  const outcome = await outbox.complete(id, parsed.data);
+  switch (outcome) {
+    case 'done':
+      return new Response(null, { status: 204 });
+    case 'missing':
+      return refuse(404, 'NOT_FOUND', `no build request ${id}`);
+    case 'conflict':
+      return refuse(
+        409,
+        'CONFLICT',
+        `build request ${id} already has a result`,
+      );
+  }
+}

--- a/apps/spindrift/src/web/routes.ts
+++ b/apps/spindrift/src/web/routes.ts
@@ -8,7 +8,7 @@
  * to be inline in `server.ts` next to a top-level `Bun.serve` no test can
  * import. So the table moved here and the entries call it.
  *
- * Eight kinds of route exist, and three of the eight are generated:
+ * Nine kinds of route exist, and three of the nine are generated:
  *
  * 1. **Commands**, from the registry (`dispatch.ts`).
  * 2. **The client**, from whatever built it — `bundle.ts` reading a directory in
@@ -24,8 +24,11 @@
  * 6. **The webhook** (`webhook-route.ts`), the one route with no session at
  *    all — its authentication is the GitHub HMAC over the raw body, not a
  *    cookie, so it cannot go through `DispatchDeps.authenticate` either.
- * 7. **{@link HEALTH_PATH}**, a liveness probe that consults nothing.
- * 8. **{@link READY_PATH}**, a readiness probe that does — see below.
+ * 7. **Bosun** (`bosun-route.ts`), the other route with no session — a
+ *    warm-pool poller cannot hold one either, so it carries an installation
+ *    Secret bearer token the same way the webhook carries a signature.
+ * 8. **{@link HEALTH_PATH}**, a liveness probe that consults nothing.
+ * 9. **{@link READY_PATH}**, a readiness probe that does — see below.
  *
  * A further hand-authored route is a decision somebody has to make on purpose,
  * in this file, against a test that names it.
@@ -36,6 +39,7 @@ import type { EnrolmentDeps } from '../auth/enrol.ts';
 import type { GatewayDeps } from '../auth/gateway.ts';
 import { authRoutes } from '../auth/routes.ts';
 import type { Database } from '../db/client.ts';
+import { type BosunRouteDeps, bosunRoutes } from './bosun-route.ts';
 import { commandRoutes, type DispatchDeps } from './dispatch.ts';
 import { streamRoutes } from './streams.ts';
 import { uploadRoutes } from './upload.ts';
@@ -99,6 +103,7 @@ export function webRoutes<Client extends Record<string, ClientRoute>>(
   deps: DispatchDeps,
   auth: EnrolmentDeps & GatewayDeps,
   webhook: WebhookRouteDeps,
+  bosun: BosunRouteDeps,
 ) {
   return {
     ...client,
@@ -109,5 +114,6 @@ export function webRoutes<Client extends Record<string, ClientRoute>>(
     ...streamRoutes(deps),
     ...uploadRoutes(deps),
     ...webhookRoutes(webhook),
+    ...bosunRoutes(bosun),
   };
 }

--- a/apps/spindrift/src/web/serve.ts
+++ b/apps/spindrift/src/web/serve.ts
@@ -33,6 +33,7 @@ import {
   loadStoredManifest,
 } from '../config/manifest-store.ts';
 import { createDb } from '../db/client.ts';
+import { BOSUN_SECRET_VAR } from './bosun-route.ts';
 import { type ClientRoute, webRoutes } from './routes.ts';
 import { type StreamSocketData, streamWebSocket } from './streams.ts';
 import { WEBHOOK_SECRET_VAR } from './webhook-route.ts';
@@ -247,6 +248,11 @@ export async function start(
       // request, rebuilt only when `configureInstallation` actually changed
       // something.
       current: installationNow,
+    },
+    {
+      db,
+      clock: systemClock,
+      secret: Bun.env[BOSUN_SECRET_VAR]?.trim() || null,
     },
   );
 

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -92,6 +92,7 @@ const BUILD_ADAPTER: Record<string, { logo: LogoName; label: string }> = {
   'github-actions': { logo: 'github', label: 'GitHub Actions' },
   'cloud-build': { logo: 'google-cloud', label: 'Cloud Build' },
   'in-cluster': { logo: 'kubernetes', label: 'in-cluster' },
+  bosun: { logo: 'nixos', label: 'bosun' },
 };
 
 /**

--- a/apps/spindrift/test/adapters/bosun-build-route.test.ts
+++ b/apps/spindrift/test/adapters/bosun-build-route.test.ts
@@ -1,0 +1,270 @@
+/**
+ * The bosun build route (Task: bosun build route).
+ *
+ * Unlike the other three routes, bosun's far side is not dialed — it is
+ * polled through `src/storage/build-outbox.ts`, which is why this file's
+ * fake (`FakeBosunOutbox`) scripts what `get` reports on each poll rather
+ * than standing behind an HTTP client the way `FakeGitHub` or `FakeKubernetes`
+ * do for the other three. The pacing pattern is identical to theirs:
+ * `fakeClock()` only advances when the route sleeps, so a deadline test
+ * spends no wall-clock time.
+ */
+import { describe, expect, test } from 'bun:test';
+import { BosunBuildRoute } from '../../src/adapters/build/bosun.ts';
+import type {
+  BuildEvent,
+  BuildResult,
+  BuildSource,
+  BuildSpec,
+} from '../../src/adapters/build/contract.ts';
+import { encodeBuildReport } from '../../src/adapters/build/report.ts';
+import type { PollingOptions } from '../../src/adapters/build/route.ts';
+import {
+  FakeBosunOutbox,
+  type FakeBosunOutboxOptions,
+} from '../harness/fakes/bosun-outbox.ts';
+
+const FRONTEND = 'registry.example.test/zero-config:pinned';
+const BUILDER_ID = 'https://bosun.example.test/skiff';
+const REQUEST_ID = 'fake-build-request';
+
+function archiveSource(): BuildSource {
+  return {
+    bundleDigest: 'sha256:bundle',
+    origin: { type: 'archive', location: 'staged://bundle', subpath: '.' },
+  };
+}
+
+const spec: BuildSpec = {
+  artifactType: 'image',
+  kind: 'service',
+  platform: { os: 'linux', arch: 'amd64' },
+  destinations: ['registry.example.test/app'],
+  tags: ['sha256-bundle', 'latest'],
+  buildArgs: { EXAMPLE: 'value' },
+  registryAuth: [],
+};
+
+/** A clock that only moves when the route waits — see `build-routes.test.ts`. */
+function fakeClock(): {
+  now: () => Date;
+  sleep: (ms: number) => Promise<void>;
+} {
+  let elapsed = 0;
+  return {
+    now: () => new Date(elapsed),
+    sleep: async (ms: number) => {
+      elapsed += ms;
+    },
+  };
+}
+
+const PACING = { intervalMs: 1_000, timeoutMs: 60_000 } as const;
+
+/** Drive a route to its verdict, collecting the timeline it yielded. */
+async function run(
+  stream: AsyncGenerator<BuildEvent, BuildResult, void>,
+): Promise<{ events: BuildEvent[]; result: BuildResult }> {
+  const events: BuildEvent[] = [];
+  let step = await stream.next();
+  while (!step.done) {
+    events.push(step.value);
+    step = await stream.next();
+  }
+  return { events, result: step.value };
+}
+
+/** Every log line the route yielded, joined — what a person would read. */
+function text(events: readonly BuildEvent[]): string {
+  return events
+    .filter((event) => event.type === 'log')
+    .map((event) => (event as { line: string }).line)
+    .join('\n');
+}
+
+function route(
+  outbox: FakeBosunOutbox,
+  options: Partial<PollingOptions> = {},
+): BosunBuildRoute {
+  const clock = fakeClock();
+  return new BosunBuildRoute({
+    name: 'bosun',
+    class: 'skiff-a',
+    outbox,
+    zeroConfigFrontend: FRONTEND,
+    provenanceBuilderId: BUILDER_ID,
+    ...PACING,
+    now: clock.now,
+    sleep: clock.sleep,
+    ...options,
+  });
+}
+
+function fakeOutbox(options: FakeBosunOutboxOptions = {}): FakeBosunOutbox {
+  return new FakeBosunOutbox(options);
+}
+
+const digest = `sha256:${'a'.repeat(64)}`;
+const report = {
+  bundleDigest: 'sha256:bundle',
+  digest,
+  refs: [`registry.example.test/app@${digest}`],
+  baseDigest: null,
+};
+
+describe('enqueueing', () => {
+  test('enqueues under the configured class and names it in the log', async () => {
+    const outbox = fakeOutbox({
+      states: [
+        {
+          state: 'DONE',
+          result: { status: 'SUCCEEDED', log: encodeBuildReport(report) },
+        },
+      ],
+    });
+    const { events } = await run(route(outbox).build(archiveSource(), spec));
+
+    expect(outbox.enqueued).toHaveLength(1);
+    expect(outbox.enqueued[0]?.class).toBe('skiff-a');
+    expect(text(events)).toContain('skiff-a');
+    expect(text(events)).toContain(REQUEST_ID);
+  });
+
+  test('the request carries the source verbatim and the pinned frontend', async () => {
+    const outbox = fakeOutbox({
+      states: [
+        {
+          state: 'DONE',
+          result: { status: 'SUCCEEDED', log: encodeBuildReport(report) },
+        },
+      ],
+    });
+    await run(route(outbox).build(archiveSource(), spec));
+
+    const request = outbox.enqueued[0]?.request as {
+      source: BuildSource;
+      spec: {
+        destinations: readonly string[];
+        zeroConfigFrontend: string;
+        registryAuth: unknown;
+      };
+    };
+    expect(request.source).toEqual(archiveSource());
+    expect(request.spec.destinations).toEqual(spec.destinations);
+    expect(request.spec.zeroConfigFrontend).toBe(FRONTEND);
+    expect(request.spec.registryAuth).toEqual(spec.registryAuth);
+  });
+});
+
+describe('a successful build', () => {
+  test('the claim is announced, the log is read, and the digest is echoed', async () => {
+    const outbox = fakeOutbox({
+      states: [
+        { state: 'CLAIMED', result: null },
+        {
+          state: 'DONE',
+          result: {
+            status: 'SUCCEEDED',
+            log: `line one\n${encodeBuildReport(report)}`,
+          },
+        },
+      ],
+    });
+    const { events, result } = await run(
+      route(outbox).build(archiveSource(), spec),
+    );
+
+    expect(text(events)).toContain('claimed by the pool');
+    expect(text(events)).toContain('line one');
+    expect(result.status).toBe('SUCCEEDED');
+    if (result.status === 'SUCCEEDED') {
+      // §16's join: the route echoes the digest it was given.
+      expect(result.provenance.bundleDigest).toBe('sha256:bundle');
+      expect(result.artifact.digest).toBe(digest);
+      expect(result.provenance.claimedLevel).toBe(2);
+    }
+  });
+
+  test('a green result with no report is INTERNAL', async () => {
+    const outbox = fakeOutbox({
+      states: [
+        {
+          state: 'DONE',
+          result: { status: 'SUCCEEDED', log: 'no marker here' },
+        },
+      ],
+    });
+    const { result } = await run(route(outbox).build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') expect(result.reason).toBe('INTERNAL');
+  });
+});
+
+describe('a failed build', () => {
+  test('a FAILED status becomes BUILD_FAILED, carrying the detail', async () => {
+    const outbox = fakeOutbox({
+      states: [
+        {
+          state: 'DONE',
+          result: { status: 'FAILED', log: 'boom', detail: 'exit code 1' },
+        },
+      ],
+    });
+    const { events, result } = await run(
+      route(outbox).build(archiveSource(), spec),
+    );
+
+    expect(text(events)).toContain('boom');
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('BUILD_FAILED');
+      expect(result.detail).toBe('exit code 1');
+    }
+  });
+
+  test('a cancelled row — DONE with no result — is INTERNAL', async () => {
+    const outbox = fakeOutbox({ states: [{ state: 'DONE', result: null }] });
+    const { result } = await run(route(outbox).build(archiveSource(), spec));
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') expect(result.reason).toBe('INTERNAL');
+  });
+});
+
+describe('the deadline', () => {
+  test('never claimed: cancels and reports TARGET_UNREACHABLE', async () => {
+    const outbox = fakeOutbox(); // defaults to PENDING forever
+    const { result } = await run(
+      route(outbox, { timeoutMs: 3_000 }).build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') {
+      expect(result.reason).toBe('TARGET_UNREACHABLE');
+    }
+    expect(outbox.cancelled).toEqual([REQUEST_ID]);
+  });
+
+  test('claimed but never finished: cancels and reports TIMEOUT', async () => {
+    const outbox = fakeOutbox({ states: [{ state: 'CLAIMED', result: null }] });
+    const { result } = await run(
+      route(outbox, { timeoutMs: 3_000 }).build(archiveSource(), spec),
+    );
+
+    expect(result.status).toBe('FAILED');
+    if (result.status === 'FAILED') expect(result.reason).toBe('TIMEOUT');
+    expect(outbox.cancelled).toEqual([REQUEST_ID]);
+  });
+});
+
+describe('the route’s declared profile', () => {
+  test('carries the configured builder id, the class properties, and an empty self-authorized set', () => {
+    const built = route(fakeOutbox());
+    expect(built.logFidelity).toBe('ON_COMPLETION');
+    expect(built.buildLevel).toBe(2);
+    expect(built.provenanceBuilderId).toBe(BUILDER_ID);
+    expect(built.carriesRegistryCredential).toBe(true);
+    expect(built.selfAuthorizedRegistries).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -374,7 +374,7 @@ export function storeAdapterSuite(
  */
 export const ADAPTERS = {
   deploy: ['fake', 'kubernetes', 'cloudrun', 'static'],
-  build: ['fake', 'github-actions', 'cloud-build', 'in-cluster'],
+  build: ['fake', 'github-actions', 'cloud-build', 'in-cluster', 'bosun'],
   // The two fakes name the real store whose reference shape each one produces,
   // because a suite comparing two shapes no store can hold would prove §10's
   // "nothing above the seam can tell which strategy produced it" of nothing.

--- a/apps/spindrift/test/conformance/adapters.test.ts
+++ b/apps/spindrift/test/conformance/adapters.test.ts
@@ -13,6 +13,7 @@
  * tell `NATIVE` from `IMMUTABLE_ITEM_PER_VERSION` — a tested claim rather than a
  * stated one.
  */
+import { BosunBuildRoute } from '../../src/adapters/build/bosun.ts';
 import { CloudBuildRoute } from '../../src/adapters/build/cloud-build.ts';
 import { GitHubActionsBuildRoute } from '../../src/adapters/build/github-actions.ts';
 import {
@@ -27,6 +28,7 @@ import { StaticDeployAdapter } from '../../src/adapters/deploy/static/index.ts';
 import { SecretManagerStore } from '../../src/adapters/store/gcp-secret-manager.ts';
 import { OnePasswordStore } from '../../src/adapters/store/onepassword.ts';
 import { GitHubApp } from '../../src/integrations/github/app.ts';
+import { FakeBosunOutbox } from '../harness/fakes/bosun-outbox.ts';
 import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
 import { FakeCloudBuild } from '../harness/fakes/cloud-build-api.ts';
 import { FakeCloudRun } from '../harness/fakes/cloudrun-api.ts';
@@ -231,6 +233,37 @@ buildAdapterSuite('in-cluster', () => {
     id: () => 'conformance',
     intervalMs: 1,
     sleep: async () => {},
+  });
+});
+
+// Bosun's far side is polled, not dialed, so its fake scripts the outbox row
+// rather than an HTTP API — see `FakeBosunOutbox`. A single `DONE` state is
+// enough for the suite: none of its assertions poll, so nothing here needs
+// the pacing overrides the dialed routes give their fakes.
+buildAdapterSuite('bosun', () => {
+  const conformanceDigest = `sha256:${'d'.repeat(64)}`;
+  const outbox = new FakeBosunOutbox({
+    states: [
+      {
+        state: 'DONE',
+        result: {
+          status: 'SUCCEEDED',
+          log: encodeBuildReport({
+            bundleDigest: 'sha256:bundle',
+            digest: conformanceDigest,
+            refs: [`registry.example.test/app@${conformanceDigest}`],
+            baseDigest: null,
+          }),
+        },
+      },
+    ],
+  });
+  return new BosunBuildRoute({
+    name: 'bosun',
+    class: 'skiff-conformance',
+    outbox,
+    zeroConfigFrontend: 'registry.example.test/zero-config:pinned',
+    provenanceBuilderId: 'https://bosun.example.test/skiff',
   });
 });
 

--- a/apps/spindrift/test/harness/fakes/bosun-outbox.ts
+++ b/apps/spindrift/test/harness/fakes/bosun-outbox.ts
@@ -1,0 +1,59 @@
+/**
+ * A fake bosun outbox (Task: bosun build route).
+ *
+ * § Testing: "Fake the far side, not our side." `BosunOutbox` is the seam
+ * `src/adapters/build/bosun.ts` polls through; this is the pool that never
+ * answers on its own — a test scripts exactly what `get` reports on each
+ * poll, the same way `FakeBuildAdapter` scripts a route's result.
+ */
+import type {
+  BosunOutbox,
+  BosunOutboxState,
+} from '../../../src/adapters/build/bosun.ts';
+
+export interface FakeBosunOutboxOptions {
+  /**
+   * What `get` reports, in poll order, for the one request this fake ever
+   * hands out. The last entry repeats once the script is exhausted — a poll
+   * loop that ran one iteration longer than expected should not fall off the
+   * end of the script into `undefined`.
+   */
+  readonly states?: readonly BosunOutboxState[];
+}
+
+const NEVER_CLAIMED: BosunOutboxState = { state: 'PENDING', result: null };
+
+export class FakeBosunOutbox implements BosunOutbox {
+  /** Every `enqueue`, in call order. */
+  readonly enqueued: { class: string; request: unknown }[] = [];
+  /** Every id `cancel` was called with, in call order. */
+  readonly cancelled: string[] = [];
+
+  private readonly states: readonly BosunOutboxState[];
+  private reads = 0;
+  private readonly id: string;
+
+  constructor(options: FakeBosunOutboxOptions = {}) {
+    this.states = options.states?.length ? options.states : [NEVER_CLAIMED];
+    this.id = 'fake-build-request';
+  }
+
+  async enqueue(input: {
+    readonly class: string;
+    readonly request: unknown;
+  }): Promise<{ readonly id: string }> {
+    this.enqueued.push(input);
+    return { id: this.id };
+  }
+
+  async get(id: string): Promise<BosunOutboxState | null> {
+    if (id !== this.id) return null;
+    const index = Math.min(this.reads, this.states.length - 1);
+    this.reads += 1;
+    return this.states[index] ?? null;
+  }
+
+  async cancel(id: string): Promise<void> {
+    this.cancelled.push(id);
+  }
+}

--- a/apps/spindrift/test/storage/build-outbox.test.ts
+++ b/apps/spindrift/test/storage/build-outbox.test.ts
@@ -1,0 +1,204 @@
+/**
+ * The bosun outbox's claim race, over real Postgres (Task: bosun build
+ * route).
+ *
+ * § Testing: "the concurrency design is a claim about transactions and a
+ * fake store cannot falsify it." `claim` is `SELECT ... FOR UPDATE SKIP
+ * LOCKED`, the identical mechanism `test/reconciler/deploy-loop.test.ts`
+ * proves for `claimNextDeploy` — this file is that proof for the outbox.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createDb } from '../../src/db/client.ts';
+import {
+  BUILD_REQUEST_LEASE_MS,
+  buildOutbox,
+} from '../../src/storage/build-outbox.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+
+describe('enqueue and claim', () => {
+  test('a claim returns the request document verbatim', async () => {
+    const store = buildOutbox(database().db);
+    const request = { source: { bundleDigest: 'sha256:bundle' }, spec: {} };
+    const { id } = await store.enqueue({ class: 'skiff-a', request });
+
+    const claimed = await store.claim(['skiff-a']);
+    expect(claimed).toEqual({ id, class: 'skiff-a', request });
+  });
+
+  test('claim filters by class', async () => {
+    const store = buildOutbox(database().db);
+    await store.enqueue({ class: 'skiff-a', request: { n: 1 } });
+    const { id: wanted } = await store.enqueue({
+      class: 'skiff-b',
+      request: { n: 2 },
+    });
+
+    const claimed = await store.claim(['skiff-b']);
+    expect(claimed?.id).toBe(wanted);
+    // Nothing left to claim under either class this call could take: the
+    // `skiff-a` row is untouched (wrong class) and `skiff-b`'s is taken.
+    expect(await store.claim(['skiff-b'])).toBeNull();
+  });
+
+  test('claim is oldest-first within a class', async () => {
+    const store = buildOutbox(database().db);
+    const { id: older } = await store.enqueue({
+      class: 'skiff-a',
+      request: { n: 1 },
+    });
+    await store.enqueue({ class: 'skiff-a', request: { n: 2 } });
+
+    expect((await store.claim(['skiff-a']))?.id).toBe(older);
+  });
+
+  test('nothing to claim answers null', async () => {
+    const store = buildOutbox(database().db);
+    expect(await store.claim(['skiff-a'])).toBeNull();
+  });
+
+  test('an empty class list claims nothing', async () => {
+    const store = buildOutbox(database().db);
+    await store.enqueue({ class: 'skiff-a', request: {} });
+    expect(await store.claim([])).toBeNull();
+  });
+
+  test('a claimed row is not claimed twice', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    expect((await store.claim(['skiff-a']))?.id).toBe(id);
+    expect(await store.claim(['skiff-a'])).toBeNull();
+  });
+});
+
+describe('claiming is race-safe under concurrency (SKIP LOCKED)', () => {
+  test('two concurrent claims never return the same row', async () => {
+    const store = buildOutbox(database().db);
+    const other = buildOutbox(createDb(database().connect()));
+    const { id: first } = await store.enqueue({
+      class: 'skiff-a',
+      request: { n: 1 },
+    });
+    const { id: second } = await store.enqueue({
+      class: 'skiff-a',
+      request: { n: 2 },
+    });
+
+    const [a, b] = await Promise.all([
+      store.claim(['skiff-a']),
+      other.claim(['skiff-a']),
+    ]);
+
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a?.id).not.toBe(b?.id);
+    expect([a?.id, b?.id].sort()).toEqual([first, second].sort());
+  });
+});
+
+describe('lease expiry and reclamation', () => {
+  test('a claimed row is reclaimed once its lease expires, and stays claimed until then', async () => {
+    let clock = new Date('2026-01-01T00:00:00.000Z');
+    const store = buildOutbox(database().db, () => clock);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    expect((await store.claim(['skiff-a']))?.id).toBe(id);
+
+    // Well within the lease: reclamation finds nothing, and the row stays
+    // unavailable to a second claimant.
+    clock = new Date(clock.getTime() + BUILD_REQUEST_LEASE_MS - 1000);
+    await store.reclaimExpired();
+    expect(await store.claim(['skiff-a'])).toBeNull();
+
+    // Past the lease: reclamation returns it to PENDING, claimable again.
+    clock = new Date(clock.getTime() + 2000);
+    await store.reclaimExpired();
+    expect((await store.claim(['skiff-a']))?.id).toBe(id);
+  });
+
+  test('heartbeat extends the lease', async () => {
+    let clock = new Date('2026-01-01T00:00:00.000Z');
+    const store = buildOutbox(database().db, () => clock);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    clock = new Date(clock.getTime() + BUILD_REQUEST_LEASE_MS - 1000);
+    expect(await store.heartbeat(id)).toBe(true);
+
+    // Had the heartbeat not landed, this moment would already be past the
+    // original lease and reclaimable.
+    clock = new Date(clock.getTime() + BUILD_REQUEST_LEASE_MS - 1000);
+    await store.reclaimExpired();
+    expect(await store.claim(['skiff-a'])).toBeNull();
+  });
+
+  test('heartbeat on an unclaimed or unknown id answers false', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    // PENDING, never claimed.
+    expect(await store.heartbeat(id)).toBe(false);
+    expect(await store.heartbeat(crypto.randomUUID())).toBe(false);
+  });
+});
+
+describe('complete', () => {
+  test('the first result lands, done', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    const result = { status: 'SUCCEEDED' as const, log: 'ok' };
+    expect(await store.complete(id, result)).toBe('done');
+    expect((await store.get(id))?.state).toBe('DONE');
+    expect((await store.get(id))?.result).toEqual(result);
+  });
+
+  test('a second result conflicts and the first is kept', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    const first = { status: 'SUCCEEDED' as const, log: 'ok' };
+    expect(await store.complete(id, first)).toBe('done');
+    const second = { status: 'FAILED' as const, log: 'late', detail: 'x' };
+    expect(await store.complete(id, second)).toBe('conflict');
+    expect((await store.get(id))?.result).toEqual(first);
+  });
+
+  test('an unknown id is missing', async () => {
+    const store = buildOutbox(database().db);
+    const result = { status: 'SUCCEEDED' as const, log: 'ok' };
+    expect(await store.complete(crypto.randomUUID(), result)).toBe('missing');
+  });
+});
+
+describe('get and cancel', () => {
+  test('get answers null for an unknown id', async () => {
+    const store = buildOutbox(database().db);
+    expect(await store.get(crypto.randomUUID())).toBeNull();
+  });
+
+  test('cancel marks a live row DONE with no result', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.cancel(id);
+
+    const row = await store.get(id);
+    expect(row?.state).toBe('DONE');
+    expect(row?.result).toBeNull();
+    // A cancelled row can never be claimed later.
+    expect(await store.claim(['skiff-a'])).toBeNull();
+  });
+
+  test('cancel never clobbers a result that already landed', async () => {
+    const store = buildOutbox(database().db);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+    const result = { status: 'SUCCEEDED' as const, log: 'ok' };
+    await store.complete(id, result);
+
+    await store.cancel(id);
+
+    expect((await store.get(id))?.result).toEqual(result);
+  });
+});

--- a/apps/spindrift/test/web/auth-routes.test.ts
+++ b/apps/spindrift/test/web/auth-routes.test.ts
@@ -90,6 +90,12 @@ function serve() {
         throw new Error('an auth-route test reached installation state');
       },
     },
+    {
+      db: auth.db,
+      clock: auth.clock,
+      // Likewise: this file is about the auth surface, not bosun.
+      secret: null,
+    },
   );
 
   return { auth, routes };

--- a/apps/spindrift/test/web/bosun-route.test.ts
+++ b/apps/spindrift/test/web/bosun-route.test.ts
@@ -1,0 +1,238 @@
+/**
+ * The mounted bosun poll surface (Task: bosun build route).
+ *
+ * Mirrors `webhook-route.test.ts`'s shape for the other machine-authed
+ * route: real `Request`s against the handlers `webRoutes` mounts, over a real
+ * outbox row. The claim endpoint's long-poll window is injected short so
+ * these tests take milliseconds, not the ~25s production waits.
+ */
+import { describe, expect, test } from 'bun:test';
+import { buildOutbox } from '../../src/storage/build-outbox.ts';
+import {
+  BOSUN_CLAIM_PATH,
+  BOSUN_HEARTBEAT_PATH,
+  BOSUN_RESULT_PATH,
+  type BosunRouteDeps,
+  bosunRoutes,
+} from '../../src/web/bosun-route.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+
+const database = withIsolatedDatabase();
+const SECRET = 'the-pools-shared-secret';
+const NOW = new Date('2026-08-10T00:00:00.000Z');
+
+function deps(overrides: Partial<BosunRouteDeps> = {}): BosunRouteDeps {
+  return {
+    db: database().db,
+    // A real, advancing clock — not `NOW` — because the claim route's
+    // long-poll budget measures real elapsed time against it. `pollTimeoutMs`
+    // below is what keeps that real wait down to single-digit milliseconds
+    // rather than the production ~25s.
+    clock: { now: () => new Date() },
+    secret: SECRET,
+    pollIntervalMs: 1,
+    pollTimeoutMs: 5,
+    ...overrides,
+  };
+}
+
+function request(
+  path: string,
+  body?: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request(`https://spindrift.example.test${path}`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: `Bearer ${SECRET}`,
+      ...headers,
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+function post(
+  routePath: string,
+  d: BosunRouteDeps,
+  req: Request,
+): Promise<Response> {
+  return bosunRoutes(d)[routePath]!(req);
+}
+
+describe('authentication, identical across all three routes', () => {
+  test('refuses every request when no secret is configured', async () => {
+    const response = await post(
+      BOSUN_CLAIM_PATH,
+      deps({ secret: null }),
+      request(BOSUN_CLAIM_PATH, { classes: ['skiff-a'] }),
+    );
+    expect(response.status).toBe(503);
+    expect((await response.json()).failure.code).toBe('NOT_CONFIGURED');
+  });
+
+  test('refuses a wrong bearer token', async () => {
+    const response = await post(
+      BOSUN_CLAIM_PATH,
+      deps(),
+      request(
+        BOSUN_CLAIM_PATH,
+        { classes: ['skiff-a'] },
+        {
+          authorization: 'Bearer not-the-secret',
+        },
+      ),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test('refuses a missing bearer token', async () => {
+    const response = await post(
+      BOSUN_CLAIM_PATH,
+      deps(),
+      request(
+        BOSUN_CLAIM_PATH,
+        { classes: ['skiff-a'] },
+        { authorization: '' },
+      ),
+    );
+    expect(response.status).toBe(401);
+  });
+
+  test('refuses a non-POST', async () => {
+    const response = await post(
+      BOSUN_CLAIM_PATH,
+      deps(),
+      new Request(`https://spindrift.example.test${BOSUN_CLAIM_PATH}`, {
+        headers: { authorization: `Bearer ${SECRET}` },
+      }),
+    );
+    expect(response.status).toBe(405);
+  });
+});
+
+describe('claim', () => {
+  test('nothing claimable answers 204 after the poll window', async () => {
+    const response = await post(
+      BOSUN_CLAIM_PATH,
+      deps(),
+      request(BOSUN_CLAIM_PATH, { classes: ['skiff-a'] }),
+    );
+    expect(response.status).toBe(204);
+  });
+
+  test('claims the enqueued request and returns it verbatim', async () => {
+    const store = buildOutbox(database().db, () => NOW);
+    const body = { source: { bundleDigest: 'sha256:bundle' }, spec: {} };
+    const { id } = await store.enqueue({ class: 'skiff-a', request: body });
+
+    const response = await post(
+      BOSUN_CLAIM_PATH,
+      deps(),
+      request(BOSUN_CLAIM_PATH, { classes: ['skiff-a'] }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      id,
+      class: 'skiff-a',
+      request: body,
+    });
+  });
+
+  test('a malformed body is refused', async () => {
+    const response = await post(
+      BOSUN_CLAIM_PATH,
+      deps(),
+      request(BOSUN_CLAIM_PATH, { classes: [] }),
+    );
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('heartbeat', () => {
+  test('extends a claimed request’s lease', async () => {
+    const store = buildOutbox(database().db, () => NOW);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    const response = await post(
+      BOSUN_HEARTBEAT_PATH,
+      deps(),
+      request(`/internal/bosun/requests/${id}/heartbeat`),
+    );
+    expect(response.status).toBe(204);
+  });
+
+  test('an unknown or unclaimed id is 404', async () => {
+    const response = await post(
+      BOSUN_HEARTBEAT_PATH,
+      deps(),
+      request(`/internal/bosun/requests/${crypto.randomUUID()}/heartbeat`),
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('result', () => {
+  test('records a result for a claimed request', async () => {
+    const store = buildOutbox(database().db, () => NOW);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    const response = await post(
+      BOSUN_RESULT_PATH,
+      deps(),
+      request(`/internal/bosun/requests/${id}/result`, {
+        status: 'SUCCEEDED',
+        log: 'the build finished',
+      }),
+    );
+    expect(response.status).toBe(204);
+    expect((await store.get(id))?.state).toBe('DONE');
+  });
+
+  test('an unknown id is 404', async () => {
+    const response = await post(
+      BOSUN_RESULT_PATH,
+      deps(),
+      request(`/internal/bosun/requests/${crypto.randomUUID()}/result`, {
+        status: 'FAILED',
+        log: '',
+      }),
+    );
+    expect(response.status).toBe(404);
+  });
+
+  test('a second result is 409', async () => {
+    const store = buildOutbox(database().db, () => NOW);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+    await store.complete(id, { status: 'SUCCEEDED', log: 'first' });
+
+    const response = await post(
+      BOSUN_RESULT_PATH,
+      deps(),
+      request(`/internal/bosun/requests/${id}/result`, {
+        status: 'FAILED',
+        log: 'second, too late',
+      }),
+    );
+    expect(response.status).toBe(409);
+  });
+
+  test('a log over 2 MiB is refused', async () => {
+    const store = buildOutbox(database().db, () => NOW);
+    const { id } = await store.enqueue({ class: 'skiff-a', request: {} });
+    await store.claim(['skiff-a']);
+
+    const response = await post(
+      BOSUN_RESULT_PATH,
+      deps(),
+      request(`/internal/bosun/requests/${id}/result`, {
+        status: 'SUCCEEDED',
+        log: 'x'.repeat(2 * 1024 * 1024 + 1),
+      }),
+    );
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/spindrift/test/web/readyz.test.ts
+++ b/apps/spindrift/test/web/readyz.test.ts
@@ -56,8 +56,23 @@ function noWebhook(db: Database): WebhookRouteDeps {
   };
 }
 
+/** Inert: `/readyz` never routes a claim, so reaching these is the bug. */
+function noBosun(db: Database) {
+  return {
+    db,
+    clock: { now: () => new Date('2026-01-01T00:00:00Z') },
+    secret: null,
+  };
+}
+
 async function readyz(db: Database): Promise<Response> {
-  const routes = webRoutes(CLIENT, noSession, authDeps(db), noWebhook(db));
+  const routes = webRoutes(
+    CLIENT,
+    noSession,
+    authDeps(db),
+    noWebhook(db),
+    noBosun(db),
+  );
   const handler = routes[READY_PATH] as () => Promise<Response>;
   return handler();
 }

--- a/apps/spindrift/test/web/routes.test.ts
+++ b/apps/spindrift/test/web/routes.test.ts
@@ -18,6 +18,7 @@ import type { GatewayDeps } from '../../src/auth/gateway.ts';
 import { AUTH_ACTS, authPathFor } from '../../src/auth/routes.ts';
 import { commandNames } from '../../src/commands/registry.ts';
 import type { Database } from '../../src/db/client.ts';
+import { BOSUN_PATHS, type BosunRouteDeps } from '../../src/web/bosun-route.ts';
 import { BundleMissingError, bundleRoutes } from '../../src/web/bundle.ts';
 import { pathFor } from '../../src/web/dispatch.ts';
 import { HEALTH_PATH, READY_PATH, webRoutes } from '../../src/web/routes.ts';
@@ -90,10 +91,32 @@ const noWebhook: WebhookRouteDeps = {
   },
 };
 
+/**
+ * Bosun deps that would throw if reached, and a secret that is never
+ * configured — this file asserts over the *shape* of the table, so a claim
+ * actually reaching the outbox here would mean the assertion had gone wrong.
+ */
+const noBosun: BosunRouteDeps = {
+  db: new Proxy(
+    {},
+    {
+      get: () => {
+        throw new Error('a route-table test reached the database');
+      },
+    },
+  ) as Database,
+  clock: {
+    now: () => {
+      throw new Error('a route-table test read the clock');
+    },
+  },
+  secret: null,
+};
+
 /** A stand-in for the client, so this file never depends on a build having run. */
 const CLIENT = { '/': new Response('the client document') };
 
-const served = webRoutes(CLIENT, noSession, noAuth, noWebhook);
+const served = webRoutes(CLIENT, noSession, noAuth, noWebhook, noBosun);
 
 const AUTH_PATHS = AUTH_ACTS.map(authPathFor);
 
@@ -109,6 +132,7 @@ describe('what the web process serves', () => {
         ...STREAM_PATHS,
         UPLOAD_PATH,
         WEBHOOK_PATH,
+        ...BOSUN_PATHS,
       ].sort(),
     );
   });
@@ -131,6 +155,7 @@ describe('what the web process serves', () => {
         ...STREAM_PATHS,
         UPLOAD_PATH,
         WEBHOOK_PATH,
+        ...BOSUN_PATHS,
       ].sort(),
     );
   });

--- a/nix/hosts/default.nix
+++ b/nix/hosts/default.nix
@@ -138,4 +138,11 @@
     kind = "package";
     module = ../images/hull-ubuntu.nix;
   };
+
+  # The Ubuntu hull's build variant: same rootfs and boot plumbing, a
+  # Spindrift build script in place of the ARC runner.
+  hull-build-ubuntu = {
+    kind = "package";
+    module = ../images/hull-build-ubuntu.nix;
+  };
 }

--- a/nix/images/hull-build-ubuntu.nix
+++ b/nix/images/hull-build-ubuntu.nix
@@ -1,0 +1,5 @@
+# The build variant of the Ubuntu hull: same boot plumbing as hull-ubuntu,
+# a build script in place of the ARC runner. See hull-ubuntu.nix's `variant`
+# parameter for what actually differs.
+{ callPackage }:
+callPackage ./hull-ubuntu.nix { variant = "build"; }

--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -19,8 +19,16 @@
 {
   lib,
   pkgs,
+  # "runner" boots the ARC runner (`Runner.Listener run`, the default and the
+  # only thing this file built before this parameter existed). "build" swaps
+  # in a script that runs a Spindrift build instead — same kernel, same
+  # initrd, same setup, same squashfs assembly; only the run script and one
+  # extra rootfs binary (buildx) differ, so that plumbing stays one source of
+  # truth for both.
+  variant ? "runner",
 }:
 let
+  isBuild = variant == "build";
   # Same kernel derivation the NixOS hull boots, so riptide's store already
   # has it: the `dev` output's vmlinux carries the PVH entry note
   # cloud-hypervisor needs, and /lib/modules below comes from the same build.
@@ -54,6 +62,16 @@ let
   busybox = pkgs.pkgsStatic.busybox;
   # dockerd shells out to iptables; the container-image rootfs has none.
   iptables = pkgs.pkgsStatic.iptables;
+
+  # The build variant's one extra binary: a static buildx plugin, since the
+  # runner image carries the docker CLI but not buildx. Upstream's release
+  # binary, not pkgs.docker-buildx — that one is glibc-dynamic against
+  # nixpkgs' glibc, which does not exist in this Ubuntu guest (see the
+  # dockerStatic comment above).
+  buildxPlugin = pkgs.fetchurl {
+    url = "https://github.com/docker/buildx/releases/download/v0.30.1/buildx-v0.30.1.linux-amd64";
+    hash = "sha256-w3EU/NA0Al7GjiJGV8ilqFDfRy3tPdy8p1rTp+u5cQ0=";
+  };
 
   # Everything stage-1 needs before there is a rootfs to load modules from.
   # The full module tree rides inside the rootfs for everything later (docker
@@ -273,7 +291,7 @@ let
   # Stage 2, line 2: the one job this skiff was booted for. The runner
   # deregisters itself after one job and exits; this script then powers off,
   # which exits the VMM with 0 — the launcher's completion signal.
-  run = pkgs.writeScript "skiff-run" ''
+  runnerRun = pkgs.writeScript "skiff-run" ''
     #!/opt/bosun/busybox sh
     export HOME=/home/runner
     export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -295,6 +313,258 @@ let
     echo "skiff-mark runner-exit $(/opt/bosun/busybox cut -d' ' -f1 /proc/uptime)"
     /opt/bosun/busybox poweroff -f
   '';
+
+  # The build variant's stage 2, line 2: a Spindrift build instead of a job.
+  # Real bash, not busybox sh — this needs curl/tar/jq/docker from the
+  # Ubuntu rootfs, none of which busybox's ash can call into meaningfully
+  # more than by exec'ing them anyway. Every line printed is captured to
+  # $diag/result/build.log (see the setup script's bosun-diag mount), and
+  # the EXIT trap is what keeps the two invariants this hull's wait entry
+  # depends on: /home/runner/_diag/result/status always gets written, and
+  # the VM always powers off, on every exit path — not just the ones this
+  # script anticipated (same reasoning as the runner variant's poweroff
+  # placement above).
+  buildRun = pkgs.writeScript "skiff-build" ''
+    #!/bin/bash
+    # Stage 2, line 2 for the build variant: fetch the bundle §5 staged, run it
+    # through the same frontend ladder spindrift-build.yml runs on GitHub's own
+    # runners, and push. Everything printed here — including the marker line
+    # core reads — is captured to $diag/result/build.log as well as the serial
+    # console, and $diag/result/status is the one file that always lands: this
+    # trap is what makes "always write a status, always power off" true on every
+    # exit path, not just the ones this script anticipated.
+    set -euo pipefail
+    export HOME=/home/runner
+    export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    [ -f /etc/skiff-env ] && . /etc/skiff-env
+
+    diag=/home/runner/_diag
+    result="$diag/result"
+    mkdir -p "$result"
+
+    status_written=0
+    write_status() {
+      printf '%s' "$1" > "$result/status"
+      status_written=1
+    }
+    finish() {
+      rc=$?
+      if [ "$status_written" -eq 0 ]; then
+        if [ "$rc" -eq 0 ]; then write_status SUCCEEDED; else write_status FAILED; fi
+      fi
+      # Flush the log through virtiofs before the VMM dies: poweroff -f gives
+      # the page cache no chance on its own, and the report marker is the last
+      # line of exactly this file.
+      sync
+      /opt/bosun/busybox poweroff -f
+    }
+    trap finish EXIT
+
+    # Straight into the log file, not through a tee to the console: a tee is a
+    # background process poweroff -f races, and losing its unflushed tail
+    # loses the marker line. The log reaches the operator through the diag
+    # share and the posted result; the serial console keeps the setup script's
+    # boot marks.
+    exec > "$result/build.log" 2>&1
+    echo "skiff-mark build-start $(cut -d' ' -f1 /proc/uptime)"
+
+    req=/run/bosun/request.json
+    if [ ! -f "$req" ]; then
+      echo "skiff-build: missing $req" >&2
+      exit 1
+    fi
+
+    bundle_digest=$(jq -r '.source.bundleDigest' "$req")
+    location=$(jq -r '.source.origin.location' "$req")
+    subpath=$(jq -r '.source.origin.subpath // ""' "$req")
+    artifact_type=$(jq -r '.spec.artifactType // "image"' "$req")
+    frontend=$(jq -r '.spec.zeroConfigFrontend // ""' "$req")
+    destination=$(jq -r '.spec.destinations[0]' "$req")
+    # spec.platform arrives as either an OCI-shaped object or a plain
+    # "os/arch" string; buildx wants the string either way.
+    platform=$(jq -r '
+      .spec.platform as $p
+      | if ($p == null) then ""
+        elif ($p | type) == "string" then $p
+        elif ($p | type) == "object" then (($p.os // "linux") + "/" + ($p.architecture // $p.arch // "amd64"))
+        else "" end
+    ' "$req")
+
+    # The workspace mount setup carved out of the scratch disk when the class
+    # sized one (see skiff-setup); a class with no disk still made the mount
+    # point, so /tmp is only ever a fallback for a boot that skipped setup.
+    workdir=/home/runner/_work
+    [ -d "$workdir" ] || workdir=/tmp
+    build_root="$workdir/build"
+    mkdir -p "$build_root"
+
+    echo "skiff-mark bundle-fetch $(cut -d' ' -f1 /proc/uptime)"
+    bundle_file="$build_root/bundle.tar.gz"
+    curl --fail --silent --show-error --location -o "$bundle_file" "$location"
+
+    want="''${bundle_digest#sha256:}"
+    got="$(sha256sum "$bundle_file" | cut -d' ' -f1)"
+    if [ "$want" != "$got" ]; then
+      echo "skiff-build: bundle digest mismatch: want $want got $got" >&2
+      exit 1
+    fi
+
+    bundle_root="$build_root/bundle"
+    mkdir -p "$bundle_root"
+    tar -xzf "$bundle_file" -C "$bundle_root"
+
+    # §5's unwrap: a bundle whose root is exactly one directory has that
+    # directory as its real root — the same rule spindrift-build.yml applies.
+    root="$bundle_root"
+    shopt -s dotglob nullglob
+    entries=("$root"/*)
+    if [ "''${#entries[@]}" -eq 1 ] && [ -d "''${entries[0]}" ]; then
+      root="''${entries[0]}"
+    fi
+    shopt -u dotglob nullglob
+    scope="$root/$subpath"
+
+    # setup backgrounds dockerd; wait for the socket rather than racing it.
+    # The runner variant never needed this because Runner.Listener's own
+    # startup and job assignment mask the daemon's.
+    for _ in $(seq 1 100); do
+      docker version >/dev/null 2>&1 && break
+      /opt/bosun/busybox sleep 0.2
+    done
+    if ! docker version >/dev/null 2>&1; then
+      echo "skiff-build: dockerd never came up" >&2
+      exit 1
+    fi
+
+    echo "skiff-mark registry-login $(cut -d' ' -f1 /proc/uptime)"
+    auth_count=$(jq -r '(.spec.registryAuth // []) | length' "$req")
+    for ((i = 0; i < auth_count; i++)); do
+      host=$(jq -r ".spec.registryAuth[$i].host" "$req")
+      username=$(jq -r ".spec.registryAuth[$i].username" "$req")
+      jq -r ".spec.registryAuth[$i].secret" "$req" | docker login "$host" --username "$username" --password-stdin
+    done
+
+    echo "skiff-mark frontend-select $(cut -d' ' -f1 /proc/uptime)"
+    frontend_build_arg=""
+    if [ "$artifact_type" = "files" ]; then
+      # A `files` artifact is not built at all — see spindrift-build.yml's
+      # "Choose the frontend" step for why `FROM scratch` + `COPY . /` is
+      # what makes the scope itself the pushed layer.
+      dockerfile="$build_root/Dockerfile.files"
+      printf 'FROM scratch\nCOPY . /\n' > "$dockerfile"
+      context="$scope"
+      file="$dockerfile"
+    elif [ -f "$scope/Dockerfile" ]; then
+      # ponytail: skips the workflow's COPY/ADD context-sniffing probe and
+      # always builds from the bundle root; upgrade to the probe in
+      # spindrift-build.yml's "Choose the frontend" step if a scoped
+      # Dockerfile that expects its own directory as context shows up here.
+      context="$root"
+      file="$scope/Dockerfile"
+    else
+      plan_dir="$build_root/railpack-plan"
+      mkdir -p "$plan_dir"
+      docker run --rm \
+        -v "$scope:/scope:ro" -v "$plan_dir:/out" \
+        --entrypoint /railpack "$frontend" \
+        prepare /scope --plan-out /out/railpack-plan.json
+      context="$scope"
+      file="$plan_dir/railpack-plan.json"
+      frontend_build_arg="BUILDKIT_SYNTAX=$frontend"
+    fi
+
+    build_arg_flags=()
+    while IFS= read -r kv; do
+      [ -n "$kv" ] && build_arg_flags+=(--build-arg "$kv")
+    done < <(jq -r '(.spec.buildArgs // {}) | to_entries[] | "\(.key)=\(.value)"' "$req")
+    [ -n "$frontend_build_arg" ] && build_arg_flags+=(--build-arg "$frontend_build_arg")
+
+    tag_flags=()
+    while IFS= read -r t; do
+      [ -n "$t" ] && tag_flags+=(-t "$t")
+    done < <(jq -r '.spec.destinations[] as $d | (.spec.tags // ["latest"])[] | $d + ":" + .' "$req")
+
+    platform_flags=()
+    [ -n "$platform" ] && platform_flags=(--platform "$platform")
+
+    echo "skiff-mark build-push $(cut -d' ' -f1 /proc/uptime)"
+    metadata_file="$build_root/metadata.json"
+    docker buildx build \
+      --push \
+      "''${tag_flags[@]}" \
+      "''${build_arg_flags[@]}" \
+      "''${platform_flags[@]}" \
+      --provenance=mode=max --sbom=true \
+      --metadata-file "$metadata_file" \
+      -f "$file" \
+      "$context"
+
+    digest=$(jq -r '."containerimage.digest"' "$metadata_file")
+
+    # Best effort, and null when it is not there — mirrors spindrift-build.yml's
+    # "Report what was built" base-digest extraction exactly.
+    base="$(docker buildx imagetools inspect "''${destination}@''${digest}" --format '{{ json .Provenance }}' 2>/dev/null \
+      | jq -r '[.. | .uri? // empty | select(startswith("pkg:docker"))][0] // empty' \
+      | grep -oE 'sha256(:|%3A)[0-9a-f]{64}' \
+      | sed 's/%3A/:/' || true)"
+
+    refs=$(jq -c --arg digest "$digest" '[.spec.destinations[] | . + "@" + $digest]' "$req")
+
+    skiff_id=""
+    hull_digest=""
+    for tok in $(cat /proc/cmdline); do
+      case "$tok" in
+        bosun.skiff=*) skiff_id="''${tok#bosun.skiff=}" ;;
+        bosun.hull=*) hull_digest="''${tok#bosun.hull=}" ;;
+      esac
+    done
+
+    report="$(jq -nc \
+      --arg bundleDigest "$bundle_digest" \
+      --arg digest "$digest" \
+      --arg destination "$destination" \
+      --arg ref "''${destination}@''${digest}" \
+      --argjson refs "$refs" \
+      --arg base "$base" \
+      --arg invocationId "$skiff_id" \
+      --arg hullDigest "$hull_digest" \
+      '{bundleDigest: $bundleDigest,
+        digest: $digest,
+        refs: $refs,
+        baseDigest: (if $base == "" then null else $base end),
+        buildkitProvenanceRef: $ref,
+        sbomRef: $ref,
+        statement: {
+          _type: "https://in-toto.io/Statement/v1",
+          subject: [{
+            name: $destination,
+            digest: {sha256: ($digest | ltrimstr("sha256:"))}
+          }],
+          predicateType: "https://slsa.dev/provenance/v1",
+          predicate: {
+            buildDefinition: {
+              buildType: "https://bosun.lolwtf.ca/buildtypes/skiff/v1",
+              externalParameters: {
+                bundleDigest: $bundleDigest
+              },
+              internalParameters: {
+                hullDigest: $hullDigest
+              }
+            },
+            runDetails: {
+              builder: {id: "https://bosun.lolwtf.ca/skiff"},
+              metadata: {invocationId: $invocationId}
+            }
+          }
+        }}')"
+
+    echo "skiff-mark build-done $(cut -d' ' -f1 /proc/uptime)"
+    write_status SUCCEEDED
+    echo "spindrift-result $(printf '%s' "$report" | base64 | tr -d '\n')"
+  '';
+
+  # The one job this skiff was booted for, whichever job that is.
+  run = if isBuild then buildRun else runnerRun;
 
   inittab = pkgs.writeText "inittab" ''
     ::sysinit:/opt/bosun/setup
@@ -332,6 +602,13 @@ let
         # dockerd, containerd, runc and friends.
         tar -xzf ${dockerStatic}
         install -m755 docker/* root/usr/local/bin/
+
+        ${lib.optionalString isBuild ''
+          # The build variant's one rootfs addition: buildx as a CLI plugin,
+          # in the path the docker CLI's plugin discovery looks in.
+          mkdir -p root/usr/local/lib/docker/cli-plugins
+          install -m755 ${buildxPlugin} root/usr/local/lib/docker/cli-plugins/docker-buildx
+        ''}
 
         # Static iptables where dockerd's PATH will find it.
         mkdir -p root/usr/local/sbin


### PR DESCRIPTION
## Summary

A build path from Spindrift to bosun that does not transit the GitHub Actions plane, for the outage mode where Actions is down but the API stays up. Buildkite-shaped: Spindrift is the control plane and owns the queue; bosun hosts are agents that long-poll, claim, and report back. Nothing pushes to an agent, and bosun still has no listener.

- **Spindrift**: a `build_requests` outbox table; three endpoints under `/internal/bosun/` (claim with a 5-minute `SKIP LOCKED` lease and ~25 s long-poll, heartbeat, result) authed by `SPINDRIFT_BOSUN_SECRET` with the webhook route's refuse-all-when-unset posture; a `bosun` build route adapter (`ON_COMPLETION`, level 2) that enqueues `{source, spec}` and parses the standard `spindrift-result` marker out of the posted log.
- **bosun**: an optional `spindrift` config block. When present, the daemon long-polls the outbox, boots a skiff of the named class with `request.json` in its share instead of a jitconfig, heartbeats while it runs, and posts the result read from the diag share after halt. Build skiffs never touch GitHub, are busy by construction (lifetime reaped from boot, drained like busy runners, never refilled), and a claim refused mid-drain posts nothing so the lease recovers the work elsewhere.
- **hull**: `hull-ubuntu.nix` gains a `variant` parameter; `hull-build-ubuntu` swaps the run script for a build script mirroring `spindrift-build.yml`'s ladder (bundle fetch + digest verify, files/Dockerfile/railpack, buildx `--push --provenance=mode=max --sbom=true`, report marker) and adds a pinned static buildx. Runner-variant output is unchanged (setup/inittab verified byte-identical).

Everything is inert until wired: the route needs a manifest entry, the endpoints need the secret, bosun needs the config block, and no host declares a build class yet.

## Validation

- `apps/spindrift`: typecheck, lint, `bun test` — 2116 pass (42 new; storage/route/adapter suites against real Postgres), migration + conformance suites cover the new table and adapter.
- `apps/bosun`: `gofmt`, `go build`, `go vet`, `go test` — 78 tests pass, stdlib only, `vendorHash` unchanged.
- `nix build .#hull-build-ubuntu` and `.#hull-ubuntu` both succeed; build script passes `bash -n`; `nixosConfigurations.riptide` evaluates with the new module option.

## Risks

- The hull hardcodes the builder id (`https://bosun.lolwtf.ca/skiff`) in its provenance statement while the adapter reads it from manifest config (the no-literals contract keeps it out of adapter code) — a mismatch fails verification closed, but wiring must keep the two in agreement.
- The build script skips the workflow's Dockerfile context-sniffing probe (always builds from the bundle root) and the GHA cache flags; both marked in-script with their upgrade paths.
- A result posted after a lease expired is accepted unless the row is already DONE — a deliberate choice (a real artifact beats a rerun), noted in the store.