### PR TITLE
fix(spindrift): refuse to connect without a pinned build workflow

### DIFF
--- a/apps/spindrift/src/commands/repositories/connect.ts
+++ b/apps/spindrift/src/commands/repositories/connect.ts
@@ -118,6 +118,13 @@ export interface ConnectRepositoryResult {
   readonly defaultBranch: string;
   /** The configuration pull request an operator now has to merge, or null if PR creation failed. */
   readonly pullRequest: number | null;
+  /**
+   * Why `pullRequest` is null, when it is. The repository stays connected
+   * either way — the repo loop reads the default branch, not the PR — but a
+   * connection whose PR silently never opened reads exactly like one whose PR
+   * opened fine, and the operator deserves the difference.
+   */
+  readonly pullRequestError: string | null;
   /** Always null: nothing is authoritative before that merge (§15). */
   readonly authoritativeCommit: null;
 }
@@ -218,8 +225,17 @@ export const connectRepository: Command<
   // pinned reusable workflow. An installation that has not published one has no
   // configuration PR to open — refused here rather than opened without the
   // caller, because a repository connected without a build route is connected
-  // to nothing.
+  // to nothing. The manifest schema says this refusal out loud ("null means
+  // repositories cannot be connected"), and `inspectRepository` answers
+  // `canConnect: false` for the same reason, so the button that reaches this
+  // path is already disabled.
   const buildWorkflow = context.manifest.github?.buildWorkflow ?? null;
+  if (buildWorkflow === null) {
+    return failed(
+      'NOT_DEPLOYABLE',
+      'this installation has pinned no reusable build workflow (github.buildWorkflow), so there is no CI caller to write into the configuration pull request; pin one, then connect again',
+    );
+  }
 
   // Every read below refuses through the one taxonomy (`access.ts`): §15's
   // lost-access rule reaches back to here — a repository the App cannot see is
@@ -289,27 +305,29 @@ export const connectRepository: Command<
     .returning();
 
   let pullRequest: number | null = null;
-  if (buildWorkflow !== null) {
-    const transaction = configurationTransaction({
-      scopes,
-      buildWorkflow,
-    });
+  let pullRequestError: string | null = null;
+  const transaction = configurationTransaction({
+    scopes,
+    buildWorkflow,
+  });
 
-    try {
-      const opened = await openConfigurationPullRequest(host, ref, {
-        fullName: input.fullName,
-        defaultBranch,
-        transaction,
-      });
-      pullRequest = opened.number;
-      await context.db
-        .update(repositories)
-        .set({ configPullRequest: opened.number, updatedAt: now })
-        .where(eq(repositories.id, row!.id));
-    } catch {
-      // Fail open: opening the configuration PR failed (e.g. GitHub permission or API error),
-      // but the repository remains connected.
-    }
+  try {
+    const opened = await openConfigurationPullRequest(host, ref, {
+      fullName: input.fullName,
+      defaultBranch,
+      transaction,
+    });
+    pullRequest = opened.number;
+    await context.db
+      .update(repositories)
+      .set({ configPullRequest: opened.number, updatedAt: now })
+      .where(eq(repositories.id, row!.id));
+  } catch (cause) {
+    // Fail open: the repository stays connected and the repo loop still adopts
+    // its default branch; only the PR is lost, and the result says which and
+    // why rather than leaving `pullRequest: null` to mean three different
+    // things.
+    pullRequestError = cause instanceof Error ? cause.message : String(cause);
   }
 
   return ok({
@@ -317,6 +335,7 @@ export const connectRepository: Command<
     fullName: row!.fullName,
     defaultBranch,
     pullRequest,
+    pullRequestError,
     authoritativeCommit: null,
   });
 };

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -48,7 +48,38 @@ function asDocument(value: unknown): Document | null {
  * what is wrong with it rather than reporting what this function made of it.
  */
 export function upgradeManifestDocument(document: unknown): unknown {
-  return nameInstallationVessels(dropTargetNames(addDeclaredVessels(document)));
+  return scrubPlaceholderBuildWorkflow(
+    nameInstallationVessels(dropTargetNames(addDeclaredVessels(document))),
+  );
+}
+
+/**
+ * The one placeholder workflow ref a seed document ever carried, nulled.
+ *
+ * The chart's seed document stated this exact value where it now states null,
+ * and the stored row keeps whatever seeded it — so an installation seeded from
+ * that document holds the value where no mounted correction can reach it. It
+ * is not inert the way `spindrift.example.com` is: `connectRepository` writes
+ * it into a caller workflow inside connected repositories, and it names a
+ * repository this project does not own. Null is the schema's own word for "no
+ * workflow pinned", and connect refuses on it until an operator states a real
+ * one.
+ *
+ * Exact-match on the one historical string, never a pattern: any other value
+ * is an operator's pin, and it is theirs whatever it names.
+ */
+function scrubPlaceholderBuildWorkflow(document: unknown): unknown {
+  const manifest = asDocument(document);
+  const github = asDocument(manifest?.github);
+  if (
+    manifest === null ||
+    github === null ||
+    github.buildWorkflow !==
+      'spindrift/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6'
+  ) {
+    return document;
+  }
+  return { ...manifest, github: { ...github, buildWorkflow: null } };
 }
 
 /**

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -133,8 +133,15 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
     clientId: 'Iv1.918d699f36ee7afc',
     oauthBaseUrl: 'https://github.com',
     apiBaseUrl: 'https://api.github.com',
-    buildWorkflow:
-      'spindrift/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6',
+    /**
+     * Null, never a placeholder ref. `connectRepository` writes this value
+     * into a caller workflow inside somebody's repository, so a stand-in
+     * `owner/repo@sha` here is not inert scaffolding the way
+     * `spindrift.example.com` is — it is a foreign repository handed the
+     * build of every repo an unseeded installation connects. Null makes the
+     * gap loud: connect refuses until an operator pins a real workflow.
+     */
+    buildWorkflow: null,
   },
   build: {
     routes: [{ name: 'hosted', adapter: 'github-actions' }],

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -2323,6 +2323,10 @@ function RepositoriesScreen({ embedded = false }: { embedded?: boolean }) {
           fullName: result.value.fullName,
           number: result.value.pullRequest,
         });
+      } else if (result.value.pullRequestError !== null) {
+        setActionError(
+          `Connected, but the configuration pull request could not be opened: ${result.value.pullRequestError}`,
+        );
       }
       setRefresh((value) => value + 1);
     } catch (cause) {

--- a/apps/spindrift/src/web/views/repos/list.tsx
+++ b/apps/spindrift/src/web/views/repos/list.tsx
@@ -717,15 +717,17 @@ function ScanPanel({
             className="mt-0.5 size-4 shrink-0 text-warning"
           />
           <p className="text-xs">
-            This installation has published no build workflow, so connecting
-            writes a repository row but opens no configuration pull request.
+            This installation has pinned no reusable build workflow, so
+            repositories cannot be connected until an operator publishes one.
           </p>
         </div>
       ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
         <Button
-          disabled={connecting || deployable.length === 0}
+          disabled={
+            connecting || deployable.length === 0 || !inspection.canConnect
+          }
           onClick={() => onConnect({ fullName })}
         >
           {connecting ? 'Opening pull request…' : 'Connect repository'}

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -214,7 +214,7 @@ describe('connecting a repository', () => {
     expect(await database().db.select().from(repositories)).toEqual([]);
   });
 
-  test('connects without configuration PR when this installation has published no build workflow', async () => {
+  test('refuses when this installation has published no build workflow', async () => {
     const fake = new FakeGitHub();
     fake.commitFiles('main', { 'README.md': 'unconnected' });
     const base = await context(fake);
@@ -227,19 +227,14 @@ describe('connecting a repository', () => {
       },
     });
 
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.value.pullRequest).toBeNull();
-
-    const [row] = await database()
-      .db.select()
-      .from(repositories)
-      .where(eq(repositories.id, result.value.repositoryId));
-    expect(row).toMatchObject({
-      fullName: fake.fullName,
-      access: 'active',
-      configPullRequest: null,
-    });
+    // The schema's word ("null means repositories cannot be connected") is the
+    // command's word too: a repository connected without a build route is
+    // connected to nothing, so nothing is written at all.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(result.failure.message).toContain('build workflow');
+    expect(await database().db.select().from(repositories)).toEqual([]);
     expect(fake.pulls).toEqual([]);
   });
 
@@ -261,6 +256,9 @@ describe('connecting a repository', () => {
     expect(result.ok).toBe(true);
     if (!result.ok) return;
     expect(result.value.pullRequest).toBeNull();
+    // Fail open, but never silently: the result names the failure, so a null
+    // pull request is distinguishable from one that was never needed.
+    expect(result.value.pullRequestError).toContain('pull request error');
 
     const [row] = await database()
       .db.select()

--- a/apps/spindrift/test/fixtures/stored-manifests/05-chart-placeholder-build-workflow.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/05-chart-placeholder-build-workflow.yaml
@@ -1,21 +1,18 @@
-# A stored manifest as this build writes one: the two vessels this installation
-# is built on are named by the installation itself, and the four keys that
-# described the second one without saying so are its properties.
+# The `04` shape as a chart-seeded installation's stored row holds it: every
+# key current, and `github.buildWorkflow` carrying the seed document's
+# placeholder ref instead of an operator's pin.
 #
-# `03` stated `cloud.homeVesselProject`, `cloud.artifactsProject`,
-# `sources.defaultBucket` and `secretStore.container` as four unrelated
-# top-level values. Nothing said they described one boundary, so nothing noticed
-# when they stopped describing the same one. `manifest-upgrade.ts` recovers the
-# home vessel by matching `cloud.homeVesselProject` against a declared vessel's
-# project — and, where the old document named a project no vessel declared,
-# takes the first cloud vessel rather than minting a boundary out of a string.
-# The control plane is the vessel of the rank-0 Target, which is where every
-# document written so far put it.
+# That value is not inert the way `spindrift.example.com` is. `connectRepository`
+# writes it into a caller workflow inside connected repositories, and it names a
+# repository this project does not own — so `manifest-upgrade.ts` nulls exactly
+# this string, and only this string, on the way through validation. This file is
+# what proves that scrub is load-bearing: it boots, the row is rewritten with
+# `buildWorkflow: null`, and nothing else about the document moves.
 #
 # `installation.name` differs from every declaration this suite mounts, for the
 # reason `01` gives.
 installation:
-  name: stored-with-installation-vessels
+  name: stored-with-chart-placeholder-workflow
   controlPlaneVessel: cluster
   homeVessel: cloud
 
@@ -46,7 +43,7 @@ github:
   clientId: Iv1.example
   oauthBaseUrl: https://git.example.test
   apiBaseUrl: https://api.git.example.test
-  buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
+  buildWorkflow: spindrift/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
 
 build:
   routes:

--- a/apps/spindrift/test/fixtures/stored-manifests/06-null-build-workflow.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/06-null-build-workflow.yaml
@@ -1,21 +1,20 @@
-# A stored manifest as this build writes one: the two vessels this installation
-# is built on are named by the installation itself, and the four keys that
-# described the second one without saying so are its properties.
+# A stored manifest as this build writes one: `05` after the scrub, which is
+# also what a fresh chart seed states — `github.buildWorkflow: null`, the
+# schema's own word for "no workflow pinned". `connectRepository` refuses on it
+# until an operator states a real pin; nothing else in the document changes.
 #
-# `03` stated `cloud.homeVesselProject`, `cloud.artifactsProject`,
-# `sources.defaultBucket` and `secretStore.container` as four unrelated
-# top-level values. Nothing said they described one boundary, so nothing noticed
-# when they stopped describing the same one. `manifest-upgrade.ts` recovers the
-# home vessel by matching `cloud.homeVesselProject` against a declared vessel's
-# project — and, where the old document named a project no vessel declared,
-# takes the first cloud vessel rather than minting a boundary out of a string.
-# The control plane is the vessel of the rank-0 Target, which is where every
-# document written so far put it.
+# **The newest file in this corpus, and the test asserts this build needs no
+# upgrade to read it.** That is the forcing function: change the manifest schema
+# in any way that stops accepting this document, and the assertion fails. The
+# fix is never to edit this file — it is to copy it to the next number, edit
+# *that* to the new shape, and teach `manifest-upgrade.ts` how to get from here
+# to there. Doing it the other way round is exactly how a schema change reaches
+# production able to discard a configured installation.
 #
 # `installation.name` differs from every declaration this suite mounts, for the
 # reason `01` gives.
 installation:
-  name: stored-with-installation-vessels
+  name: stored-with-null-build-workflow
   controlPlaneVessel: cluster
   homeVessel: cloud
 
@@ -46,7 +45,7 @@ github:
   clientId: Iv1.example
   oauthBaseUrl: https://git.example.test
   apiBaseUrl: https://api.git.example.test
-  buildWorkflow: example/platform/.github/workflows/spindrift-build.yml@4bf1f21a7c1e2d3b5a6f708192a3b4c5d6e7f809
+  buildWorkflow: null
 
 build:
   routes:

--- a/packages/charts/spindrift/files/default-manifest.yaml
+++ b/packages/charts/spindrift/files/default-manifest.yaml
@@ -40,7 +40,12 @@ github:
   clientId: Iv1.918d699f36ee7afc
   oauthBaseUrl: https://github.com
   apiBaseUrl: https://api.github.com
-  buildWorkflow: spindrift/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
+  # Null, never a placeholder ref: this value is written into a caller
+  # workflow inside connected repositories, so a stand-in owner/repo@sha would
+  # hand a foreign repository the build of every repo an unseeded installation
+  # connects. Null makes connect refuse until an operator pins a real workflow
+  # — see the doc comment on `DEFAULT_PLACEHOLDER_MANIFEST.github.buildWorkflow`.
+  buildWorkflow: null
 build:
   routes:
     - name: hosted


### PR DESCRIPTION
## Summary

The spindrift chart's seed manifest pinned `github.buildWorkflow` to `spindrift/infra/...@0a7d0ea0` — a placeholder owner this project does not control, grafted onto a real commit sha of this repository. Because `connectRepository` gates PR-opening on `buildWorkflow !== null`, a placeholder passes the gate: an installation seeded from the chart default would write caller workflows referencing that foreign repository into every repo it connects, and route archive-build dispatches there too. On top of that, connect silently accepted a null workflow (connecting a repository it could open no configuration PR for, despite its own docblock and the schema contract saying it refuses) and swallowed every PR-creation failure in a bare `catch {}`, so all three states read back as the same success.

## Changes

- `connectRepository` refuses (`NOT_DEPLOYABLE`) when `github.buildWorkflow` is null — the behavior the manifest schema documents and `inspectRepository.canConnect` already answers; the creation wizard passes the refusal through as designed
- PR-creation failure stays fail-open (the repository remains connected; the repo loop still adopts the default branch) but the result now carries `pullRequestError`, and the web connect handler surfaces it instead of dropping it
- both seed documents (`DEFAULT_PLACEHOLDER_MANIFEST` and the chart's `files/default-manifest.yaml`) state `buildWorkflow: null`
- a manifest upgrade step nulls the exact historical placeholder string in stored rows, where a corrected mounted declaration cannot reach (stored beats mounted); corpus fixtures `05`/`06` prove the scrub and pin the new current shape
- the repositories screen disables Connect and states the refusal when the installation has no pinned workflow, replacing text that described the old fail-open

## Validation

- `bun test` (spindrift, against local Postgres): 2251 pass, 0 fail, on the branch rebased onto current `main`
- `tsc --noEmit`, `biome check` on changed files: clean
- `helm lint` + `helm template` on `packages/charts/spindrift`: renders the seeded ConfigMap with `buildWorkflow: null`

## Notes

- The null-workflow refusal also blocks connecting on an installation configured with only bundle-based build routes (cloud-build / in-cluster), which never read `buildWorkflow`. No such installation exists today — the seed carries only the hosted route — and loosening the gate per-route is a deliberate non-goal here.
- The stale-pin problem (callers pin `@0a7d0ea0` while `spindrift-build.yml` has moved ~600 lines since, with no fleet re-pin path) is real but untouched by this change.
