### PR TITLE
fix(spindrift): deploy a static site as a revision, not a first creation

### DIFF
--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -312,15 +312,18 @@ export class StaticDeployAdapter implements DeployAdapter {
       path: `${API_VERSION}/projects/${encodeURIComponent(connection.project)}/sites/${encodeURIComponent(site)}`,
     });
 
-    // The DELETE's own status is not trusted either way: a 404 has meant both
-    // "already gone" and "this call hit a path the API does not serve" (the
-    // flat `sites/{site}` this used to DELETE, which 404s on every call and
-    // never removes anything). Read the site back instead — absent is
-    // destroyed, present is a destroy that did not happen and must not be
-    // reported as one.
+    // The DELETE's own status is not trusted either way: a 404 means both
+    // "already gone" and "this call hit a path the API does not serve". Read
+    // the site back instead — absent is destroyed, present is a destroy that
+    // did not happen and must not be reported as one.
+    //
+    // The read is project-scoped for the same reason the DELETE above is. A
+    // read of the flat `sites/{site}` answers 404 unconditionally, which
+    // makes this check pass unconditionally — the exact blindness it exists
+    // to end, reintroduced one line below the comment describing it.
     const read = await http.json<HostingSite>({
       method: 'GET',
-      path: `${API_VERSION}/sites/${encodeURIComponent(site)}`,
+      path: this.sitePath(connection, site),
     });
     if (!read.ok && read.kind === 'status' && read.status === 404) return;
     throw new Error(
@@ -443,7 +446,20 @@ export class StaticDeployAdapter implements DeployAdapter {
     return readBundle(layer);
   }
 
-  /** The site, created if this is the first deploy to it. */
+  /**
+   * The site, ensured rather than created.
+   *
+   * A site is a durable place and a deploy is a revision of what it serves —
+   * the five steps below are the revision. So the only question here is
+   * whether the place exists, and "it already does" is this function
+   * succeeding, not failing.
+   *
+   * The read is `projects/{project}/sites/{id}`, which is the only form of it
+   * the API serves. The flat `sites/{id}` this used to GET is not a route:
+   * it 404s whether or not the site exists, so every deploy concluded the
+   * site was missing, tried to create it, and collided with the one the
+   * previous deploy made. A static App could be deployed exactly once.
+   */
   private async ensureSite(
     http: CloudHttp,
     connection: StaticAdapterConnection,
@@ -451,7 +467,7 @@ export class StaticDeployAdapter implements DeployAdapter {
   ): Promise<Outcome<HostingSite>> {
     const read = await http.json<HostingSite>({
       method: 'GET',
-      path: `${API_VERSION}/sites/${encodeURIComponent(site)}`,
+      path: this.sitePath(connection, site),
     });
     if (read.ok && read.value !== undefined) {
       return { ok: true, value: read.value };
@@ -466,8 +482,26 @@ export class StaticDeployAdapter implements DeployAdapter {
       query: { siteId: site },
       body: {},
     });
+    // Losing a create race is the desired state arriving from somewhere else.
+    // Read it back rather than trusting the 409's body, so what returns is a
+    // site this function actually saw.
+    if (!created.ok && created.kind === 'status' && created.status === 409) {
+      const after = await http.json<HostingSite>({
+        method: 'GET',
+        path: this.sitePath(connection, site),
+      });
+      if (after.ok && after.value !== undefined) {
+        return { ok: true, value: after.value };
+      }
+      return { ok: false, failure: created };
+    }
     if (!created.ok) return { ok: false, failure: created };
     return { ok: true, value: created.value ?? {} };
+  }
+
+  /** The one form of a site's own resource name the API serves. */
+  private sitePath(connection: StaticAdapterConnection, site: string): string {
+    return `${API_VERSION}/projects/${encodeURIComponent(connection.project)}/sites/${encodeURIComponent(site)}`;
   }
 
   /**

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -220,6 +220,47 @@ describe('the release is five steps, in the product’s order', () => {
       api.pathsOf('POST').filter((path) => path.endsWith('/sites')),
     ).toEqual([]);
   });
+
+  // The one above starts from a site somebody else made, so it never exercises
+  // the case an App actually lives: *this* deploy created the site, and the
+  // next one has to land on it. That is the ordinary act — pushing a new
+  // revision of a site you already published — and it was impossible.
+  test('a site this adapter created takes the next deploy as a revision', async () => {
+    const { api, adapter } = adapterFor();
+
+    const first = await drain(adapter.apply(TARGET, desired()));
+    expect(first.verdict.phase).toBe('LIVE');
+
+    const second = await drain(
+      adapter.apply(TARGET, desired({ deploy: 'deploy-2' })),
+    );
+    expect(second.verdict.phase).toBe('LIVE');
+
+    // One site, made once, serving the newer release.
+    expect(
+      api.pathsOf('POST').filter((path) => path.endsWith('/sites')),
+    ).toHaveLength(1);
+    expect(api.serving('shop-site')?.labels['spindrift-deploy']).toBe(
+      'deploy-2',
+    );
+  });
+
+  test('losing the create race is the desired state, not a failure', async () => {
+    const { api, adapter } = adapterFor({ appearsBeforeCreate: 'shop-site' });
+
+    const { verdict } = await drain(adapter.apply(TARGET, desired()));
+
+    // The create was attempted and refused; the deploy carried on onto the
+    // site that turned up, because a site that exists is what was wanted.
+    expect(
+      api.pathsOf('POST').filter((path) => path.endsWith('/sites')),
+    ).toHaveLength(1);
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.servedPaths('shop-site')).toEqual([
+      '/assets/app.css',
+      '/index.html',
+    ]);
+  });
 });
 
 describe('a built files artifact is pulled out of the registry', () => {

--- a/apps/spindrift/test/harness/fakes/hosting-api.ts
+++ b/apps/spindrift/test/harness/fakes/hosting-api.ts
@@ -31,6 +31,15 @@ export interface FakeHostingOptions {
   readonly project?: string;
   /** Sites that already exist, by id. */
   readonly sites?: readonly string[];
+  /**
+   * A site that appears between the adapter's read and its create.
+   *
+   * The create race: two deploys of a new App, or a retry after a timeout
+   * that did land. The read says missing, the create says `ALREADY_EXISTS`,
+   * and the desired state is true either way — so this exists to prove the
+   * adapter treats it that way rather than failing on a site it wanted.
+   */
+  readonly appearsBeforeCreate?: string;
   /** Hashes the product already holds, so it will not ask for them again. */
   readonly held?: readonly string[];
   /**
@@ -209,6 +218,24 @@ export class FakeHosting {
       if (method === 'POST') {
         const id = url.searchParams.get('siteId') ?? '';
         if (id === '') return json(400, error('no siteId'));
+        // Somebody else got there between the read and this call.
+        if (this.options.appearsBeforeCreate === id && !this.sites.has(id)) {
+          this.sites.add(id);
+        }
+        // Creating a site that exists is a 409, not a second create. A fake
+        // that quietly succeeded here let a deploy-once adapter look
+        // idempotent: nothing in the suite could tell "the site was already
+        // there" from "the site was made", which is the whole difference
+        // between a revision and a first deploy.
+        if (this.sites.has(id)) {
+          return json(409, {
+            error: {
+              code: 409,
+              status: 'ALREADY_EXISTS',
+              message: `Site \`projects/${this.project}/sites/${id}\` already exists.`,
+            },
+          });
+        }
         this.sites.add(id);
         return json(200, site(id));
       }
@@ -221,6 +248,14 @@ export class FakeHosting {
     const projectSiteMatch = path.match(
       new RegExp(`^projects/${this.project}/sites/([^/]+)$`),
     );
+    // `projects.sites.get` — and the only form of it. Reading a site is
+    // project-scoped for the same reason deleting one is.
+    if (projectSiteMatch !== null && method === 'GET') {
+      const id = projectSiteMatch[1] as string;
+      return this.sites.has(id)
+        ? json(200, site(id))
+        : json(404, error('no site'));
+    }
     if (projectSiteMatch !== null && method === 'DELETE') {
       const id = projectSiteMatch[1] as string;
       if (this.options.refuseDelete !== undefined) {
@@ -257,15 +292,13 @@ export class FakeHosting {
       );
     }
 
-    const siteMatch = path.match(/^sites\/([^/]+)$/);
-    if (siteMatch !== null) {
-      const id = siteMatch[1] as string;
-      if (method === 'GET') {
-        return this.sites.has(id)
-          ? json(200, site(id))
-          : json(404, error('no site'));
-      }
-    }
+    // No flat `sites/{id}` resource: the real API routes the sub-collections
+    // below (`/versions`, `/releases`, `/domains`) under a bare site id, but
+    // the site *itself* is only ever `projects/{project}/sites/{id}`. A GET
+    // here falls through to the catch-all, which is what production does —
+    // and a 404 from a path that was never a path reads exactly like a 404
+    // from a site that is not there, which is how a deploy-once adapter
+    // survived this suite.
 
     const versionsMatch = path.match(/^sites\/([^/]+)\/versions$/);
     if (versionsMatch !== null && method === 'POST') {


### PR DESCRIPTION
A site is a durable place; a deploy is a revision of what it serves. The adapter already implements the revision — `version → populate → upload → finalize → release` — but the existence check in front of it made that path unreachable after the first deploy.

## What was wrong

`ensureSite` read the flat `sites/{id}`. **That is not a route the API serves.** Measured directly:

| Path | Response |
| --- | --- |
| `GET /v1beta1/sites/<id>` | HTML 404 from the Google frontend — not a route |
| `GET /v1beta1/projects/<project>/sites/<id>` | JSON — a route that exists |

It answers 404 whether or not the site is there, so every deploy concluded the site was missing, tried to create it, and collided with the one the previous deploy made:

```
409 ALREADY_EXISTS — Site `projects/<n>/sites/<id>` already exists.
```

So a static App could be deployed **exactly once**, and the second attempt was recorded `REJECTED` and blamed on the developer — who supplied nothing wrong.

Found by deploying a real App twice on the live installation.

## What this changes

- The site read is project-scoped, via one `sitePath` both callers share.
- Losing a create race is reconciled: a 409 means the desired state arrived from somewhere else, so the site is read back and the deploy carries on.
- **The destroy's read-back had the same flat path.** The check added to stop a destroy being reported blind was itself blind — one line below the comment explaining why it must not be. Fixed by the same seam.

## The suite could not have caught this

The fake answered flat `sites/{id}` reads and let a create of an existing site succeed, so it modelled an API more forgiving than the real one. Two tests were green on fake behaviour, including the one guarding the destroy verification.

The fake now routes a site's own resource project-scoped only, and answers 409 on a repeat create. Against the **old** adapter that turns both of those tests red — which is the check that this fix is real rather than fake-shaped. I verified that by reverting the fix and watching them fail, then restoring it.

Two cases the fake had made unreachable are now covered:
- a site this adapter created taking the next deploy as a revision
- a create race resolving to the site that turned up

## Validation

`bun test test/adapters/` — 357 pass, 0 fail. `tsc --noEmit` and `biome check` clean. The wider suite needs a database this machine does not have; CI runs it.

## Still open

Deleting an App strands its site (correct per §13), and Hosting reserves a deleted site id, so the name cannot be reused. That pairing is recorded in the tracker rather than changed here — it is a product decision about what delete should say, not a path bug.