### PR TITLE
feat(tender): return the cloud bosun host, wired as a spindrift build source

### DIFF
--- a/.github/workflows/nix-image-builder.yaml
+++ b/.github/workflows/nix-image-builder.yaml
@@ -11,6 +11,7 @@ on:
           - gce
           - iso
           - oldboy
+          - tender
           - cloudpi4
           - homepi4
           - weatherpi4
@@ -29,6 +30,14 @@ jobs:
       contents: read
       id-token: write
     steps:
+      # tender's closure carries the Ubuntu hull: an OCI runner image pulled,
+      # flattened to squashfs, and then written into a raw GCE disk alongside
+      # the system closure. That does not fit in the ~14 GB a hosted runner
+      # leaves free on /, and /nix is on /.
+      - name: Reclaim runner disk
+        if: ${{ inputs.image == 'tender' }}
+        run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: NixOS/nix-installer-action@62c1943b776c509394b550f3f983adc14e9212d6 # main
         with:
@@ -56,20 +65,20 @@ jobs:
         run: sudo ./result/bin/nixos-wsl-tarball-builder ./nixos.wsl
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' || inputs.image == 'wsl' }}
+        if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' || inputs.image == 'tender' || inputs.image == 'wsl' }}
         with:
           workload_identity_provider: 'projects/629296473058/locations/global/workloadIdentityPools/homelab/providers/github'
           project_id: homelab-ng
 
       - uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
-        if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' }}
+        if: ${{ inputs.image == 'gce' || inputs.image == 'oldboy' || inputs.image == 'tender' }}
         with:
           path: result
           glob: "*.raw.tar.gz"
           # nixpkgs names every googleComputeImage tarball the same thing, so
-          # anything sharing a prefix clobbers its siblings; gce and oldboy
-          # share this root on purpose.
-          destination: homelab-ng-free
+          # anything sharing a prefix clobbers its siblings. tender gets its
+          # own; gce and oldboy keep the root they already share.
+          destination: ${{ inputs.image == 'tender' && 'homelab-ng-free/tender' || 'homelab-ng-free' }}
           parent: false
           gzip: false
           process_gcloudignore: false

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -23,9 +23,8 @@ creation_rules:
     key_groups:
       - age:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
-          # stage one: operator only. The previous host recipient died with
-          # the instance's disk; the new ssh-to-age recipient lands here after
-          # first boot, per the SOPS runbook's two-stage flow.
+          # tender (ssh-to-age of its ed25519 host key, 2026-08-10 boot)
+          - age1r3g45ssdtcvjuz07n7cp4d2jrngpx03ekkggq0hk4pgx5ky70sgsqnvx3l
   - path_regex: nix/secrets/optiplex\.sops\.ya?ml
     key_groups:
       - age:

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -19,6 +19,13 @@ creation_rules:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
           # riptide (ssh-to-age of its ed25519 host key)
           - age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
+  - path_regex: nix/secrets/tender\.sops\.ya?ml
+    key_groups:
+      - age:
+          - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          # stage one: operator only. The previous host recipient died with
+          # the instance's disk; the new ssh-to-age recipient lands here after
+          # first boot, per the SOPS runbook's two-stage flow.
   - path_regex: nix/secrets/optiplex\.sops\.ya?ml
     key_groups:
       - age:

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -169,6 +169,19 @@ spec:
             # engine every build on this route runs, and a moving tag is an
             # engine that changes underneath a reproducible build.
             image: moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
+          # The outage fallback: a bosun host long-polls the outbox over the
+          # same tunnel and /internal/* posture the GitHub webhook rides,
+          # claims the request, and builds it on a microVM skiff. Ranked
+          # last — hosted and managed win whenever they are reachable; this
+          # is the route that still works when the Actions plane is down.
+          # The builder id must match the constant the build-hull stamps
+          # into its provenance statement (nix/images/hull-ubuntu.nix,
+          # buildRun) — a mismatch fails closed at verification. The class
+          # names tender's skiff-build-xl pool (nix/hosts/tender.nix).
+          - name: pool
+            adapter: bosun
+            class: skiff-build-xl
+            provenanceBuilderId: https://bosun.lolwtf.ca/skiff
         # Railpack publishes the frontend as its own repository. Pinned to a
         # version rather than a moving tag: it is the only input to a
         # zero-config build that no digest covers.

--- a/clusters/offsite/apps/spindrift/secret.sops.yaml
+++ b/clusters/offsite/apps/spindrift/secret.sops.yaml
@@ -7,6 +7,7 @@ type: Opaque
 stringData:
     SPINDRIFT_ENROLMENT_TOKEN: ENC[AES256_GCM,data:7waL0a1UjOWO3FZ4ETkdbY2op0fUcrwBlnlI/Ryfhbk0erI9HkebAUrHpw==,iv:PrdKSR6nyYZqz3tUEguVEXzZwoRtzalfOu/BJlxhg5A=,tag:BegMo+jgS2BsVuDos553Mw==,type:str]
     SPINDRIFT_CREDENTIAL_KEYRING: ENC[AES256_GCM,data:C5QT+VjbKLlK17+VrTa57k+CNlTwPd5iAkCclbDuRhSU0YzIYtHB/fYEl7T9Z6JyJn6amgA39W1uDhrlSLFkjZZ2pZwzpTOMCzL8,iv:h1ondPCwwmJULLMABwC2iRuFi961bs6GQjDuPbMc6/s=,tag:pJsROp/JSDdwjDWhWpJRvA==,type:str]
+    SPINDRIFT_BOSUN_SECRET: ENC[AES256_GCM,data:RvxZmU8LsiaWkeBpeO8Ta0cjoUUiLm5g5TgU0UDFRecTyfBVhzK5yG738l6KUphkBS7V3fapwwilUEGgcAZfvQ==,iv:5P8MvD3SPkZToeiUSZqLeJ78BAmp7evwVNazVjdGXBI=,tag:sgeoGj3thwMc5XsaojjHOg==,type:str]
 sops:
     age:
         - enc: |
@@ -19,6 +20,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-10T11:08:59Z"
-    mac: ENC[AES256_GCM,data:Ou5/1lvVo4ZBVAZXIzrirSJMrlD8Wi5KKXDRZfDy3mc3JZPNaPnr0/kYrJYvly4qtialuXdCABOCoknYNp6U+VtCXbIO8eaDZ29lc/EImKnK8tvKLkVP38+o+zZed0LmWtq9kU2Ix8Va+RGnKzlDRz9rVWHeJVlhQJb7nyvoYPI=,iv:kp5vckmWYE8fhT5iz6945kxG5EXLkhmkq/RGeBRugI4=,tag:POh2V3J3d/CTaQ3p/aqOpA==,type:str]
+    lastmodified: "2026-08-10T13:12:02Z"
+    mac: ENC[AES256_GCM,data:5Hv1x4em7A/qhjp8lv8XmjfJ6yygG2WDplfj/2Ev7MDLTjEGBR+BQ3SbHTTejgy7Vpv8d2MMabMj8+1K08U7UFExpyNMQXx4GvAgvEO8CCD+FxHPIoT40jP7AoqglTGer0CTQ0EbP6xlzTfUZMCrq2DC0rECxa3iMEytTw7Yftc=,iv:R73cvEGTE/P6Hbbny8YC1SWp4LFgiMlDVNCk8qrxV5c=,tag:e5nqwMEK5YWEZwMJ2IgUnQ==,type:str]
     version: 3.13.3

--- a/nix/hosts/default.nix
+++ b/nix/hosts/default.nix
@@ -86,6 +86,11 @@
     artifact = "googleComputeImage";
   };
 
+  tender = {
+    tags = [ "gcp" ];
+    artifact = "googleComputeImage";
+  };
+
   # ── images ─────────────────────────────────────────────────────────────────
   # rackpi5 is the image-only source for spore's native-boot publisher. Forge's
   # EEPROM keeps this signed HTTP/RAM artifact as its fallback path, so the full

--- a/nix/hosts/tender.nix
+++ b/nix/hosts/tender.nix
@@ -1,0 +1,109 @@
+# tender: a Google Compute Engine bosun host. A tender is the boat that
+# services the ship; this one keeps the warm pool that riptide keeps today,
+# without spending a folly worker's RAM to do it.
+#
+# The image module supplies the disk layout; the hostname is the registry
+# name, baked into the closure, which is what nixos-upgrade resolves.
+# Terraform is in terraform/gcp/projects/homelab-ng/bosun.tf.
+{ config, inputs, ... }:
+{
+  imports = [
+    ../images/gce.nix
+    ../system/sops.nix
+    ../../apps/bosun/module.nix
+  ];
+
+  sops.defaultSopsFile = ../secrets/tender.sops.yaml;
+  # bosun reads this once at startup, so a rotated token needs the unit
+  # bounced -- which is what restartUnits does on the activation that
+  # rewrites the secret.
+  sops.secrets."bosun-github-token" = {
+    owner = "bosun";
+    group = "bosun";
+    mode = "0400";
+    restartUnits = [ "bosun.service" ];
+  };
+
+  sops.secrets."spindrift-pool-token" = {
+    owner = "bosun";
+    group = "bosun";
+    mode = "0400";
+    restartUnits = [ "bosun.service" ];
+  };
+
+  # The FHS family only. skiff-nixos would work here -- it shares whatever
+  # host's /nix/store it boots on -- but "no Nix in the cloud" is about what a
+  # job sees, and carrying the NixOS hull's closure would roughly double the
+  # image this host is imported from for a family nothing in CI targets.
+  #
+  # Sized against c4-standard-8's 8 vCPU / 30 GB, with no kubelet to share
+  # with: 4x3072M is 12 GiB of the pool's declared ceiling, and 4x6G of
+  # workspace is reserved up front out of the 100 GB boot disk. warm = 4 is
+  # double what riptide can hold, which is the point -- concurrency, not
+  # speed, is what the bench found blocking migration.
+  services.bosun = {
+    enable = true;
+    repo = "jonpulsifer/infra";
+    tokenFile = config.sops.secrets."bosun-github-token".path;
+    classes.skiff-ubuntu = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 4;
+      memory = "3072M";
+      workspace = "6G";
+      persist = true;
+      warm = 3;
+    };
+
+    # Image builds. A docker build lives in the guest's docker data root on
+    # the workspace disk, and a fat image plus persisted layers of earlier
+    # builds does not fit in 6G — the whole container matrix ENOSPCed there
+    # (dpkg padding, buildkit "failed to reserve cache"). Same hull, same
+    # RAM; only the disk differs, which is exactly what a class is for.
+    classes.skiff-ubuntu-xl = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 4;
+      memory = "3072M";
+      workspace = "20G";
+      persist = true;
+      warm = 1;
+    };
+
+    # Spindrift builds. The xl sizing (an image build needs the 20G disk),
+    # the build hull, and warm = 0 — a build skiff boots on claim, never
+    # ahead of time. persist = false, deliberately: sweepWorkspaces keeps
+    # persisted images only for slots < warm, so persist with warm = 0 is a
+    # cache the next restart deletes. The cost is a cold docker layer cache
+    # per build; the upgrade is a persist slot count independent of warm.
+    classes.skiff-build-xl = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-build-ubuntu}";
+      vcpus = 4;
+      memory = "3072M";
+      workspace = "20G";
+      persist = false;
+      warm = 0;
+    };
+
+    # The outage fallback this host exists to serve: long-poll Spindrift's
+    # outbox and run claimed builds on skiff-build-xl. The hostname is the
+    # control plane's public tunnel — reachable from GCE, and outside the
+    # RFC1918 deny bosun's unit already carries.
+    spindrift = {
+      url = "https://spindrift.lolwtf.ca";
+      tokenFile = config.sops.secrets."spindrift-pool-token".path;
+      classes = [ "skiff-build-xl" ];
+    };
+
+    # 30 GB of the 100 GB boot disk for the actions/cache service; the
+    # workspace disks (3x6G + 20G) reserve another 38 GB and the closure
+    # needs the rest.
+    cache = {
+      enable = true;
+      maxSizeBytes = 32212254720;
+    };
+  };
+
+  # 30 GiB total and nothing else on the box, so the bound is generous rather
+  # than tight -- but it still exists, because without one the *host* OOM
+  # killer picks the victim and on a spot instance that is a job either way.
+  systemd.services.bosun.serviceConfig.MemoryMax = "24G";
+}

--- a/nix/secrets/tender.sops.yaml
+++ b/nix/secrets/tender.sops.yaml
@@ -1,0 +1,17 @@
+bosun-github-token: ENC[AES256_GCM,data:tPWZoi2I8ksTWaWhWVtNLOyt5jQmJqOaXYKVPycVbG4hVWWzbVvLcw==,iv:N4MjLvp9FWlOObdCfD8NAkXkAiMH5iYM8Pz0EFJOvRk=,tag:Xb02EOtUQceJkZyAwtkA+g==,type:str]
+spindrift-pool-token: ENC[AES256_GCM,data:XoBX9cSsd/nYW2IDtyn4PrMotNT2Rp3HjxuukEHl0IFjzy5cWSNH2sXHzQIgBc+pYA2+cLJl1QuuyGgqOdITGQ==,iv:Rsuyl8HG4XZgZXizjDOETyI3wmQ0Z+WHWtLlG8UpvtU=,tag:SbFQG2sPjAtO1BZKB1jrmA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMckhwTFpZaGhHNlhYMjNS
+            aEhXZGtrK2dIeE1RdDJUdHRwOVZCMS95aXpjCmhGUmczZzl4QmVwc0tUWjk3Z1h1
+            UXgxNHJYSmFEOGVtRFNvR3VPalYyZlkKLS0tIFBJcUJ6Um10d0poZTZCR1Z3ZlNj
+            Uyt1bnVlcmxJRGVmdldFaFh5Vi9Qc2MKHfEHbLCJdwkt1Q6c5NExnPLN0z35vKYK
+            Uz89vKdmeR/ZFp3lqTWQE/8D2yAUEi52oqVoWaEX3hleGHxFAx1ZXQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+    lastmodified: "2026-08-10T13:10:30Z"
+    mac: ENC[AES256_GCM,data:rkCLLPeKTmmSwW8Ee5JfSSc0SIYM45ykiKQH66c0BU7WAkcUI3ENCFjk+2xnkRoNMsU4b476USrVKiG70kfELmSPOpCpzHT6gSbgM2ocElUJeau6Yo8pgaoCpTxMWT1xsTy9X/VegKqO9Pvciwcz7Z8S+aduR41LxbesJi1J150=,iv:uKAmA/j3nIWmHSkIwvCnmLak/Mfe8ajeMkvDwx73FzU=,tag:s1vHO5kmk6B5CWfi3aNHAw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3

--- a/nix/secrets/tender.sops.yaml
+++ b/nix/secrets/tender.sops.yaml
@@ -4,13 +4,22 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBMckhwTFpZaGhHNlhYMjNS
-            aEhXZGtrK2dIeE1RdDJUdHRwOVZCMS95aXpjCmhGUmczZzl4QmVwc0tUWjk3Z1h1
-            UXgxNHJYSmFEOGVtRFNvR3VPalYyZlkKLS0tIFBJcUJ6Um10d0poZTZCR1Z3ZlNj
-            Uyt1bnVlcmxJRGVmdldFaFh5Vi9Qc2MKHfEHbLCJdwkt1Q6c5NExnPLN0z35vKYK
-            Uz89vKdmeR/ZFp3lqTWQE/8D2yAUEi52oqVoWaEX3hleGHxFAx1ZXQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAyeXNCMVhaaTFFYTRRcUJS
+            WVpLNHE1aXVndDhWUUhPZG9pKzQvQ0NNMlZ3Ck9aWjdoc0svenBadkI3eUJ3L1lv
+            eWZGTnkxM3YybEVZRk5ibHArd1M3WTAKLS0tIFoxUmhmTDJZRDBBblFvNDdJZWdR
+            ajlONnJtUXZrNkZUWVdLVTJRa0RNeXcKXUjwzO6o5W4f6FJJHiQ8PixHl7sxBfpS
+            UG0ZKYxm3oHlJhG7IZwOp+jtLqrhKsmB8uF165qOu8/bXfbY7J5dLw==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBwTFUwMTk3YzM3S3A0MUdM
+            VVVuU2lpVU15UElMK3Y3NFU5MEN1QVVuSUg0CmZsYWpOb2NieG1NckFkS1YwSTQ2
+            cklBY3JRZUlmQURGRGFzK0UrWVptK00KLS0tIEE0SXpFRzN6R2VIRUVIeXVNS3gz
+            RDVxTjgxRTh2RVlWTWdOMm5idEFKRjQKOd/3Z2BwtiXXVZTR+QU6UesL8VjvHJvp
+            cPdlMu6i5yTTIDbjWrAQsVizRZEmjbOjN7hwRJMJyfb4uWp+nWM3oQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1r3g45ssdtcvjuz07n7cp4d2jrngpx03ekkggq0hk4pgx5ky70sgsqnvx3l
     lastmodified: "2026-08-10T13:10:30Z"
     mac: ENC[AES256_GCM,data:rkCLLPeKTmmSwW8Ee5JfSSc0SIYM45ykiKQH66c0BU7WAkcUI3ENCFjk+2xnkRoNMsU4b476USrVKiG70kfELmSPOpCpzHT6gSbgM2ocElUJeau6Yo8pgaoCpTxMWT1xsTy9X/VegKqO9Pvciwcz7Z8S+aduR41LxbesJi1J150=,iv:uKAmA/j3nIWmHSkIwvCnmLak/Mfe8ajeMkvDwx73FzU=,tag:s1vHO5kmk6B5CWfi3aNHAw==,type:str]
     unencrypted_suffix: _unencrypted

--- a/terraform/gcp/projects/homelab-ng/bosun.tf
+++ b/terraform/gcp/projects/homelab-ng/bosun.tf
@@ -1,0 +1,177 @@
+# tender: the cloud bosun host, running the same warm pool riptide does but
+# off the folly cluster entirely.
+#
+# C4 is the machine family because nested virtualization on Compute Engine is
+# Intel-only -- every AMD (`D`) and Arm (`A`/Axion) family is excluded outright
+# -- and among the Intel families C4 is the highest clocked: Granite Rapids at
+# a 3.9 GHz sustained all-core turbo, 4.2 GHz max. That is the whole reason to
+# run CI here rather than on a cheaper N2.
+#
+# Nested virt itself is a plain boolean on the instance. It needs no custom
+# image and no `enable-vmx` license, so nix/images/gce.nix is unchanged from
+# what oldboy boots.
+#
+# Bare metal was weighed and rejected: the smallest x86 metal SKU GCE sells is
+# 192 vCPU at ~$8.67/hr, it forces an IDPF-only NIC and a TERMINATE maintenance
+# policy, and it buys back only the ~10% nested-virt tax.
+
+locals {
+  # The one knob worth turning while measuring. Changing family means
+  # re-checking the nested-virt column, not just the price.
+  tender_machine_type = "c4-standard-8" # 8 vCPU / 30 GB
+  tender_disk_size    = 100             # closure + hull + warm x workspace
+
+  # GCS lists objects lexicographically, so element zero is the *oldest* name
+  # the moment the prefix holds more than one build -- not a race, just
+  # reliably the wrong one. The nixpkgs filename carries version and commit
+  # date in sort order, so the newest image is the last element.
+  tender_image_object = reverse(sort([
+    for o in data.google_storage_bucket_objects.tender.bucket_objects : o.name
+  ]))[0]
+}
+
+# No IAM role bindings anywhere: this host needs nothing from GCP beyond
+# writing its own logs. Skiffs cannot reach the metadata server at all --
+# bosun's unit denies 169.254.0.0/16 and every skiff inherits the filter --
+# but the host can, so the scope is kept to the one thing it uses.
+resource "google_service_account" "tender" {
+  account_id   = "tender"
+  display_name = "tender (cloud bosun host) VM Service Account"
+}
+
+# Published by .github/workflows/nix-image-builder.yaml under its own prefix.
+# `gce` and `oldboy` both write the same nixpkgs-generated filename to the
+# bucket root and clobber each other; tender stays out of that.
+data "google_storage_bucket_objects" "tender" {
+  bucket = "homelab-ng-free"
+  prefix = "tender/nixos-image-google-compute"
+}
+
+# Everything below rides the `free-tier` alias -- us-east1-b -- with the rest of
+# this root, and so lands on the module's existing subnet. Montreal sells C4 and
+# would otherwise have been the closer region, but this project's C4 quota there
+# is 0 while us-east1 already carries 24: `CPUS-PER-VM-FAMILY-per-project-region`
+# is dimensioned by region, and a zero is a support request, not a terraform
+# change.
+resource "google_compute_image" "tender" {
+  provider          = google.free-tier
+  name              = "tender"
+  family            = "tender"
+  storage_locations = ["us-east1"]
+  raw_disk {
+    source = "https://storage.googleapis.com/homelab-ng-free/${local.tender_image_object}"
+  }
+  guest_os_features {
+    type = "UEFI_COMPATIBLE"
+  }
+  # C4 is gVNIC-only -- Granite Rapids does not offer virtio-net -- so GCE sets
+  # the interface's NicType to GVNIC on its own and then rejects the instance
+  # if the image has not declared it can drive one. The kernel can: CONFIG_GVE
+  # is a module, udev autoloads it by PCI id, and google-compute-config.nix
+  # turns off predictable interface names, so it still arrives as eth0.
+  guest_os_features {
+    type = "GVNIC"
+  }
+}
+
+# C4 is Hyperdisk-only; Persistent Disk is not offered on the newest families.
+#
+# ignore_changes on `image` is load-bearing, not caution. sops-nix decrypts
+# with this host's own SSH host key, which lives on this disk -- so replacing
+# the disk on every image rebuild would invalidate nix/secrets/tender.sops.yaml
+# every time. The host carries itself forward with nixos-upgrade from main the
+# same way every other fleet host does; the image is a birth certificate, not a
+# deploy channel.
+#
+# The cost of that: a disk copies the image's guest_os_features when it is
+# created and never revisits them, and the image's self_link does not change
+# when the image is replaced under the same name -- so a change to the features
+# above produces no diff here at all. Replacing an existing disk to pick them up
+# is a deliberate `-replace`, and only ever safe before first boot, while there
+# is no host key on it yet.
+resource "google_compute_disk" "tender" {
+  provider = google.free-tier
+  name     = "tender"
+  image    = google_compute_image.tender.self_link
+  size     = local.tender_disk_size
+  type     = "hyperdisk-balanced"
+
+  lifecycle {
+    ignore_changes = [image]
+  }
+}
+
+resource "google_compute_instance" "tender" {
+  provider                  = google.free-tier
+  name                      = "tender"
+  description               = "Cloud bosun host: a warm pool of microVM Actions runners"
+  machine_type              = local.tender_machine_type
+  allow_stopping_for_update = true
+
+  # The point of the whole exercise: a skiff is a KVM guest inside this guest.
+  advanced_machine_features {
+    enable_nested_virtualization = true
+  }
+
+  # Spot, because a measurement box that idles overnight should not be billed
+  # like a server. instance_termination_action = STOP keeps the boot disk on a
+  # preemption, so the host key -- and every sops secret encrypted to it --
+  # survives; the instance comes back with `gcloud compute instances start`.
+  #
+  # ponytail: nothing restarts it automatically. A preemption empties the pool
+  # until someone notices. A size-1 MIG with autohealing is the upgrade if this
+  # stops being a science box.
+  scheduling {
+    provisioning_model          = "SPOT"
+    preemptible                 = true
+    automatic_restart           = false
+    on_host_maintenance         = "TERMINATE"
+    instance_termination_action = "STOP"
+  }
+
+  boot_disk {
+    auto_delete = false
+    source      = google_compute_disk.tender.self_link
+  }
+
+  # An ephemeral external IP rather than Cloud NAT: CI reaches github.com,
+  # ghcr.io, cache.nixos.org and half a dozen other public hosts, and a NAT
+  # gateway costs ~10x an IPv4 address for one instance. Ingress is still
+  # default-deny -- the VPC is custom-mode and the only rule in it is the
+  # module's IAP-range SSH allow.
+  network_interface {
+    network    = module.network.network.self_link
+    subnetwork = module.network.subnet.self_link
+    access_config {}
+  }
+
+  service_account {
+    email  = google_service_account.tender.email
+    scopes = ["https://www.googleapis.com/auth/logging.write"]
+  }
+
+  # Secure Boot off, and it is not a shortcut. nix/images/gce.nix builds an EFI
+  # image, and nothing signs the NixOS bootloader with a key GCE's UEFI db
+  # trusts, so the firmware rejects it and loops on the boot entry forever:
+  #
+  #   BdsDxe: failed to load Boot0001 ... Status: Security Violation
+  #
+  # oldboy has been in that loop, "RUNNING" and unbooted, since it was created.
+  # vTPM and integrity monitoring stay on; they measure the boot either way.
+  # Turning this back on means signing the bootloader (lanzaboote) and putting
+  # the certificate in the image, which is a project, not a flag.
+  shielded_instance_config {
+    enable_secure_boot          = false
+    enable_vtpm                 = true
+    enable_integrity_monitoring = true
+  }
+
+  metadata = {
+    enable-oslogin-2fa = "FALSE"
+  }
+}
+
+output "tender_external_ip" {
+  description = "tender's ephemeral external address, for the first-boot SSH that seeds its sops recipient."
+  value       = google_compute_instance.tender.network_interface[0].access_config[0].nat_ip
+}

--- a/terraform/gcp/projects/homelab-ng/compute.tf
+++ b/terraform/gcp/projects/homelab-ng/compute.tf
@@ -22,8 +22,7 @@ data "google_storage_bucket_objects" "files" {
 }
 
 locals {
-  # GCS lists objects lexicographically, so element zero is the oldest name
-  # the moment the prefix holds more than one build; the newest is last.
+  # Same lexicographic trap as tender's image; see bosun.tf.
   nixos_image_object = reverse(sort([
     for o in data.google_storage_bucket_objects.files.bucket_objects : o.name
   ]))[0]


### PR DESCRIPTION
## Summary

The tender resurrection plus the build-route wiring, in one PR because the second is why the first is happening now.

**Restore (selective, not a revert)** — `bosun.tf`, `nix/hosts/tender.nix`, the registry entry, the tender image-builder path, and the sops creation rule return from the retirement commit's parent. Deliberately *not* restored: the README benchmarks stay, riptide/oldschool keep today's class balance, and `containers.yml` stays on hosted. The sops file is rebuilt as **stage one** (operator recipient only) — the old host recipient died with the disk; stage two follows first boot per the runbook. The GitHub token carries forward; a new `spindrift-pool-token` rides beside it (also in 1Password, homelab vault).

**Wiring** — tender gains `skiff-build-xl` (build hull, 20 G workspace, `warm = 0`, `persist = false` — persist with warm 0 is a cache every restart deletes) and the `spindrift` block long-polling the control plane's public tunnel. The offsite installation gains `SPINDRIFT_BOSUN_SECRET` in `spindrift-env` and the `pool` route ranked last, `provenanceBuilderId` matching the constant the build-hull stamps.

## Ordering notes

- The declaration **seeds**; adopting it into the stored manifest row is a deploy-time step after Flux applies.
- The pinned spindrift digest predates the bosun adapter; until the digest CD bump rolls out, tender's claims 404 and retry — a log line, not a stuck build. Everything converges without coordination.
- After the Atlantis apply boots the instance: ssh-to-age the new host key, stage-two re-encrypt, deploy.

## Validation

`nixosConfigurations.tender` toplevel evaluates; `tofu validate` clean on the homelab-ng root; `kustomize build` renders the offsite spindrift kustomization; both sops files decrypt with the operator key and carry the expected keys.