### PR TITLE
feat(spindrift): let the build workflow ref move

### DIFF
--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -2,10 +2,11 @@
  * The hosted-CI build route (§4).
  *
  * §4 puts the default build "somewhere with a fast pipe rather than at home
- * behind Starlink", and §15 puts the run in the connected repository: "the
- * connected repo owns its Actions minutes; a **SHA-pinned reusable workflow**
- * plus a workflow-ref-scoped cloud identity hold the machinery." Everything
- * awkward about this file follows from that one arrangement.
+ * behind Starlink", and §15 puts the run in the connected repository: the
+ * connected repo owns its Actions minutes, while a **reusable workflow the
+ * manifest names** plus a workflow-ref-scoped cloud identity hold the
+ * machinery. Everything awkward about this file follows from that one
+ * arrangement.
  *
  * **Three consequences worth knowing before reading the code.**
  *
@@ -141,15 +142,17 @@ export interface GitHubActionsRouteOptions extends PollingOptions {
   readonly name: string;
   readonly host: ActionsHost;
   /**
-   * The reusable workflow, `owner/repo/.github/workflows/<file>@<sha>`, exactly
-   * as the manifest pins it.
+   * The reusable workflow, `owner/repo/.github/workflows/<file>@<ref>`, exactly
+   * as the manifest names it.
    *
-   * Only the repository half is read here, and the reason is the pin: a
-   * dispatch names a *branch*, so dispatching the reusable workflow directly
-   * would run whatever is on the default branch and discard the commit §15
-   * requires. This route therefore always dispatches a **caller** — the one the
-   * configuration PR wrote in a connected repository, or the one committed
-   * beside the reusable workflow here — and the caller is what holds the pin.
+   * Only the repository half is read here: a dispatch addresses a workflow
+   * file in one repository, and §15 puts the run in the repository that owns
+   * its minutes — so dispatching the reusable workflow directly would run on
+   * the platform's own minutes and ignore the ref the manifest states. This
+   * route therefore always dispatches a **caller** — the one the configuration
+   * PR wrote in a connected repository, or the one committed beside the
+   * reusable workflow here — and the caller's `uses:` carries the manifest's
+   * ref.
    */
   readonly buildWorkflow: string;
   /** The zero-config BuildKit frontend the installation pinned (§4). */
@@ -172,7 +175,7 @@ export interface GitHubActionsRouteOptions extends PollingOptions {
 }
 
 /**
- * Where an archive builds: the repository half of the pinned reference.
+ * Where an archive builds: the repository half of the manifest's reference.
  *
  * The manifest schema already refuses anything that does not match this shape,
  * so a failure here is a programming error rather than a configuration one —
@@ -184,9 +187,7 @@ export function reusableWorkflowRepository(reference: string): string {
     reference,
   );
   if (match === null) {
-    throw new TypeError(
-      `not a pinned reusable workflow reference: ${reference}`,
-    );
+    throw new TypeError(`not a reusable workflow reference: ${reference}`);
   }
   return match[1] as string;
 }
@@ -294,8 +295,8 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
    */
   readonly carriesRegistryCredential: boolean;
   /**
-   * Both, because the run holds two identities at once and the pinned workflow
-   * uses each: `docker/login-action` against `ghcr.io` with the run's own
+   * Both, because the run holds two identities at once and the reusable
+   * workflow uses each: `docker/login-action` against `ghcr.io` with the run's own
    * token, and `google-github-actions/auth` federating into the artifact
    * registry. So the hosted route is the one that publishes everywhere this
    * installation pushes, and it is why nothing here has ever needed a stored
@@ -306,7 +307,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
     'artifactRegistry',
   ];
   /**
-   * §16's profile level. A reusable workflow pinned by commit, running on a
+   * §16's profile level. A platform-controlled reusable workflow, running on a
    * runner the repository does not control, producing signed provenance — that
    * is L2. It is not L3: the workflow runs with the connected repository's own
    * permissions, so its own maintainers can reach the build environment.
@@ -354,9 +355,9 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       source.origin.repository !== this.platformRepository
         ? [source.origin.repository, this.platformRepository]
         : [this.platformRepository];
-    // Always a caller, never the reusable workflow itself — a dispatch names a
-    // branch, so dispatching the reusable workflow directly would discard the
-    // commit §15 pins. The connected repository runs the caller the
+    // Always a caller, never the reusable workflow itself — a dispatch runs in
+    // the repository it addresses, and §15 puts the run on the connected
+    // repository's own minutes. The connected repository runs the caller the
     // configuration PR wrote there; the platform repository runs the one
     // committed beside the reusable workflow. Same file name, same inputs.
     const workflow = CALLER_WORKFLOW_FILE;
@@ -707,9 +708,11 @@ function spkiPemToDer(pem: string): Uint8Array<ArrayBuffer> {
  * is what lets this route tell "your build failed" apart from "our scaffolding
  * failed" — a distinction §6 spends its whole blame column on.
  *
- * Coupled to the workflow by name, which is sound only because the manifest
- * pins that workflow by SHA (`github.buildWorkflow`): the file this route
- * dispatches cannot change under it without the pin rolling too.
+ * Coupled to the workflow by name. The manifest may name a moving ref
+ * (`github.buildWorkflow`), so the file this route dispatches can be newer
+ * than this constant — a step rename there reads as scaffolding blame until
+ * this catches up, the same skew window the platform repository's own
+ * local-reference caller already has.
  */
 export const DEVELOPER_BUILD_STEP = 'Build and push';
 

--- a/apps/spindrift/src/commands/repositories/connect.ts
+++ b/apps/spindrift/src/commands/repositories/connect.ts
@@ -221,8 +221,8 @@ export const connectRepository: Command<
     );
   }
 
-  // §15's transaction carries one CI caller, and the caller has to name a
-  // pinned reusable workflow. An installation that has not published one has no
+  // §15's transaction carries one CI caller, and the caller has to name the
+  // manifest's reusable workflow. An installation that has not published one has no
   // configuration PR to open — refused here rather than opened without the
   // caller, because a repository connected without a build route is connected
   // to nothing. The manifest schema says this refusal out loud ("null means
@@ -233,7 +233,7 @@ export const connectRepository: Command<
   if (buildWorkflow === null) {
     return failed(
       'NOT_DEPLOYABLE',
-      'this installation has pinned no reusable build workflow (github.buildWorkflow), so there is no CI caller to write into the configuration pull request; pin one, then connect again',
+      'this installation has published no reusable build workflow (github.buildWorkflow), so there is no CI caller to write into the configuration pull request; publish one, then connect again',
     );
   }
 

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -62,8 +62,8 @@ export function upgradeManifestDocument(document: unknown): unknown {
  * is not inert the way `spindrift.example.com` is: `connectRepository` writes
  * it into a caller workflow inside connected repositories, and it names a
  * repository this project does not own. Null is the schema's own word for "no
- * workflow pinned", and connect refuses on it until an operator states a real
- * one.
+ * workflow published", and connect refuses on it until an operator states a
+ * real one.
  *
  * Exact-match on the one historical string, never a pattern: any other value
  * is an operator's pin, and it is theirs whatever it names.

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -593,25 +593,30 @@ export const installationManifestSchema = z
           .refine((value) => !value.endsWith('/'), 'must not end with a slash'),
         /**
          * The reusable build workflow the configuration PR's one caller calls
-         * (§15).
+         * (§15), as `owner/repo/.github/workflows/<file>@<ref>`.
          *
-         * **Pinned to a commit, and the schema is what enforces it.** §15 gives
-         * the connected repository the Actions minutes and the billing, which
-         * means the workflow runs with that repository's own permissions —
-         * so a mutable ref here would let whoever can move it run arbitrary
-         * steps in every connected repository at once. A branch or tag is
-         * refused rather than warned about.
+         * **The ref may move, and that is a named trade.** §15 gives the
+         * connected repository the Actions minutes and the billing, which
+         * means the workflow runs with that repository's own permissions — so
+         * whoever can move the ref runs arbitrary steps in every connected
+         * repository at once. A branch ref hands that power to the platform
+         * repository's own merge gate, and buys the fleet its currency: the
+         * caller written into each connected repository tracks the platform's
+         * present workflow instead of freezing at whatever commit was current
+         * when that repository connected — a freeze nothing walks back,
+         * because no fleet re-pin exists. An installation that wants the
+         * freeze anyway states a commit sha; the schema takes either.
          *
          * Nullable, stated the way `auth.gateway` is: an installation that has
          * not published a reusable workflow yet has no honest value to put here,
-         * and a placeholder commit would be a configuration that looks complete
+         * and a placeholder would be a configuration that looks complete
          * and fails at the first build. Null means repositories cannot be
          * connected — `connectRepository` says so — and nothing else changes.
          */
         buildWorkflow: nonEmptyString
           .regex(
-            /^[^/@\s]+\/[^/@\s]+\/\.github\/workflows\/[^@\s]+@[0-9a-f]{40}$/,
-            'must be owner/repo/.github/workflows/<file>@<40-character commit sha>',
+            /^[^/@\s]+\/[^/@\s]+\/\.github\/workflows\/[^@\s]+@\S+$/,
+            'must be owner/repo/.github/workflows/<file>@<ref>',
           )
           .nullable(),
         /**

--- a/apps/spindrift/src/config/manifest.ts
+++ b/apps/spindrift/src/config/manifest.ts
@@ -139,7 +139,7 @@ export const DEFAULT_PLACEHOLDER_MANIFEST: AuthoredManifest = {
      * `owner/repo@sha` here is not inert scaffolding the way
      * `spindrift.example.com` is — it is a foreign repository handed the
      * build of every repo an unseeded installation connects. Null makes the
-     * gap loud: connect refuses until an operator pins a real workflow.
+     * gap loud: connect refuses until an operator states a real workflow.
      */
     buildWorkflow: null,
   },

--- a/apps/spindrift/src/integrations/github/config-pr.ts
+++ b/apps/spindrift/src/integrations/github/config-pr.ts
@@ -140,14 +140,15 @@ export function serializeSpindriftFile(proposal: DetectionProposal): string {
  *
  * Thin is the requirement, and it has two halves. **The run happens in the
  * connected repository** — §15 gives that repository the Actions minutes and
- * the billing — while **the machinery lives in the pinned reusable workflow**,
+ * the billing — while **the machinery lives in the manifest's reusable
+ * workflow**,
  * so what lands in somebody's repo is a dispatch trigger and a `uses:`.
  *
  * The single opaque `spec` input is what keeps it thin over time. A caller with
  * one input per build parameter would have to be regenerated — and re-reviewed,
  * in every connected repository — each time a build gained a parameter. The
- * reusable workflow is pinned by commit and versioned by the platform, so it is
- * the right place for that shape to live.
+ * reusable workflow is named by the manifest and versioned by the platform, so
+ * it is the right place for that shape to live.
  *
  * **`correlation` is the one exception, and it is not a build parameter.** The
  * dispatch API answers `204` and names no run, so a dispatched build has to be
@@ -165,7 +166,7 @@ export function buildWorkflowCaller(buildWorkflow: string): string {
 #
 # Spindrift dispatches this workflow when it needs a build. The run happens
 # here, on this repository’s own Actions minutes; everything it does lives in
-# the reusable workflow below, which is pinned by commit.
+# the reusable workflow below, which the platform versions.
 name: ${RUN_NAME_PREFIX}
 run-name: ${RUN_NAME_PREFIX} \${{ inputs.correlation }}
 on:
@@ -207,7 +208,7 @@ ${rows}
 
 Each \`${SPINDRIFT_FILE}\` is yours to edit, here or later. Once it is on the default branch it wins over detection.
 
-\`${WORKFLOW_PATH}\` runs builds for this repository on its own Actions minutes. It calls a reusable workflow pinned by commit.
+\`${WORKFLOW_PATH}\` runs builds for this repository on its own Actions minutes. It calls a reusable workflow the platform versions.
 `;
 }
 

--- a/apps/spindrift/src/storage/signed-url.ts
+++ b/apps/spindrift/src/storage/signed-url.ts
@@ -6,8 +6,8 @@
  * standing relationship to this installation's cloud project. It cannot read
  * `gs://` and it holds nothing that would let it authenticate to GCS. So the
  * durable object address has to be turned into something `curl` resolves, and
- * the reusable workflow — SHA-pinned by the manifest, therefore not ours to
- * change — already does exactly one thing with what it is handed:
+ * the reusable workflow — named by the manifest, not composed at dispatch —
+ * already does exactly one thing with what it is handed:
  * `curl --fail --location "$LOCATION"`.
  *
  * A **V4 signed URL** is what fits that sentence. It is a bearer capability and

--- a/apps/spindrift/src/web/views/repos/list.tsx
+++ b/apps/spindrift/src/web/views/repos/list.tsx
@@ -717,8 +717,8 @@ function ScanPanel({
             className="mt-0.5 size-4 shrink-0 text-warning"
           />
           <p className="text-xs">
-            This installation has pinned no reusable build workflow, so
-            repositories cannot be connected until an operator publishes one.
+            This installation has published no reusable build workflow, so
+            repositories cannot be connected until an operator states one.
           </p>
         </div>
       ) : null}

--- a/apps/spindrift/test/config/manifest.test.ts
+++ b/apps/spindrift/test/config/manifest.test.ts
@@ -207,9 +207,10 @@ describe('a vessel’s kind is not a list of the runtimes on it', () => {
 /**
  * §15 gives the connected repository the Actions minutes and the billing, so
  * the caller Spindrift writes into somebody's repository runs with that
- * repository's own permissions. A ref that can be moved is therefore a way to
- * run arbitrary steps in every connected repository at once, and the schema is
- * where that is refused rather than warned about.
+ * repository's own permissions. The ref names who holds that power: a commit
+ * sha freezes it, a branch hands it to the platform repository's merge gate
+ * and keeps every caller current. The schema takes either and still refuses a
+ * value that does not address a workflow file at some ref at all.
  */
 describe('the reusable build workflow ref', () => {
   const line = (value: string) => `  buildWorkflow: ${value}`;
@@ -221,9 +222,18 @@ describe('the reusable build workflow ref', () => {
     ['a branch', 'example/platform/.github/workflows/build.yml@main'],
     ['a tag', 'example/platform/.github/workflows/build.yml@v1.2.3'],
     [
-      'an abbreviated sha',
-      'example/platform/.github/workflows/build.yml@4bf1f21',
+      'a full sha',
+      `example/platform/.github/workflows/build.yml@${'0'.repeat(40)}`,
     ],
+  ] as const)('accepts %s', (_name, ref) => {
+    const manifest = parseManifest(
+      fixtureText.replace(current ?? '', line(ref)),
+      'test',
+    );
+    expect(manifest.github.buildWorkflow).toBe(ref);
+  });
+
+  test.each([
     ['no ref at all', 'example/platform/.github/workflows/build.yml'],
     [
       'a path that is not a workflow',

--- a/apps/spindrift/test/fixtures/stored-manifests/06-null-build-workflow.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/06-null-build-workflow.yaml
@@ -1,7 +1,7 @@
 # A stored manifest as this build writes one: `05` after the scrub, which is
 # also what a fresh chart seed states — `github.buildWorkflow: null`, the
-# schema's own word for "no workflow pinned". `connectRepository` refuses on it
-# until an operator states a real pin; nothing else in the document changes.
+# schema's own word for "no workflow published". `connectRepository` refuses on
+# it until an operator states a real one; nothing else in the document changes.
 #
 # **The newest file in this corpus, and the test asserts this build needs no
 # upgrade to read it.** That is the forcing function: change the manifest schema

--- a/apps/spindrift/test/integrations/github/config-pr.test.ts
+++ b/apps/spindrift/test/integrations/github/config-pr.test.ts
@@ -99,7 +99,7 @@ describe('the Spindrift file Spindrift writes', () => {
 });
 
 describe('the CI caller', () => {
-  test('calls the pinned reusable workflow and nothing else', () => {
+  test("calls the manifest's reusable workflow and nothing else", () => {
     const caller = buildWorkflowCaller(BUILD_WORKFLOW);
     expect(caller).toContain(`uses: ${BUILD_WORKFLOW}`);
     // §15: the run happens in the connected repository, so the trigger is a

--- a/packages/charts/spindrift/files/default-manifest.yaml
+++ b/packages/charts/spindrift/files/default-manifest.yaml
@@ -43,7 +43,7 @@ github:
   # Null, never a placeholder ref: this value is written into a caller
   # workflow inside connected repositories, so a stand-in owner/repo@sha would
   # hand a foreign repository the build of every repo an unseeded installation
-  # connects. Null makes connect refuse until an operator pins a real workflow
+  # connects. Null makes connect refuse until an operator states a real workflow
   # — see the doc comment on `DEFAULT_PLACEHOLDER_MANIFEST.github.buildWorkflow`.
   buildWorkflow: null
 build:


### PR DESCRIPTION
## Summary

`github.buildWorkflow` accepted only a 40-character commit sha, and the freeze had no thaw: the sha travels in every configuration PR's caller, nothing re-pins connected repositories when the platform workflow moves (`spindrift-build.yml` is ~600 lines past the last pin), and the platform repository's own caller sidesteps the rule with a local reference — so repo builds and archive builds ran different machinery. The schema now takes any ref (`owner/repo/.github/workflows/<file>@<ref>`): a branch such as `@main` hands the power to move the workflow to the platform repository's own merge gate and keeps every caller current, while a sha still freezes it for an installation that wants that. Null still refuses connect (#1975's behavior is unchanged).

## Changes

- manifest schema accepts any ref for `buildWorkflow`, with the mutable-ref trade stated in the docblock; schema tests now assert branch/tag/sha accepted, no-ref and non-workflow paths refused
- comments and operator-facing text (config-PR caller, PR body, connect refusal, repos screen, seed manifests) stop claiming a sha is enforced
- `DEVELOPER_BUILD_STEP`'s coupling note states the real skew window instead of a soundness claim the local-reference caller already broke

## Validation

- `bun test` (spindrift, local Postgres): 2128 pass, 0 fail on the branch rebased onto current `main` (includes #1977)
- `tsc --noEmit`, `biome check`: clean

## Notes

- No behavior changes at runtime today: both seed manifests still carry `buildWorkflow: null`, and no live installation exists. The rebuild's HelmRelease can state `jonpulsifer/infra/.github/workflows/spindrift-build.yml@main`.
- Already-written callers in connected repositories keep their old sha pins until each repo reconnects and merges a fresh configuration PR — this change stops the freeze from spreading, it does not walk existing pins back.
