### PR TITLE
fix(bosun): reach the outbox through a path-scoped tunnel hostname

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -169,8 +169,9 @@ spec:
             # engine every build on this route runs, and a moving tag is an
             # engine that changes underneath a reproducible build.
             image: moby/buildkit:v0.32.2@sha256:28a898719c18a33f4e8000685287fa36fd0dd9560c6440227d3a732d79bb41d8
-          # The outage fallback: a bosun host long-polls the outbox over the
-          # same tunnel and /internal/* posture the GitHub webhook rides,
+          # The outage fallback: a bosun host long-polls the outbox over a
+          # path-scoped tunnel hostname that exposes /internal/bosun/ and
+          # nothing else (terraform/network/cloudflare/spindrift.tf),
           # claims the request, and builds it on a microVM skiff. Ranked
           # last — hosted and managed win whenever they are reachable; this
           # is the route that still works when the Actions plane is down.

--- a/nix/hosts/tender.nix
+++ b/nix/hosts/tender.nix
@@ -84,11 +84,14 @@
     };
 
     # The outage fallback this host exists to serve: long-poll Spindrift's
-    # outbox and run claimed builds on skiff-build-xl. The hostname is the
-    # control plane's public tunnel — reachable from GCE, and outside the
-    # RFC1918 deny bosun's unit already carries.
+    # outbox and run claimed builds on skiff-build-xl. The hostname is a
+    # path-scoped rule on the spindrift tunnel exposing /internal/bosun/
+    # and nothing else (terraform/network/cloudflare/spindrift.tf) — the
+    # control plane's own hostname is a LAN record a cloud host cannot
+    # reach, and the tunnel address is public, outside the RFC1918 deny
+    # bosun's unit carries.
     spindrift = {
-      url = "https://spindrift.lolwtf.ca";
+      url = "https://spindrift-control.lolwtf.dev";
       tokenFile = config.sops.secrets."spindrift-pool-token".path;
       classes = [ "skiff-build-xl" ];
     };

--- a/terraform/network/cloudflare/modules/tunnel/variables.tf
+++ b/terraform/network/cloudflare/modules/tunnel/variables.tf
@@ -18,7 +18,11 @@ variable "config" {
   type = object({
     ingress = list(object({
       hostname = optional(string)
-      service  = string
+      # Regex over the request path. A rule with one matches only that slice
+      # of its hostname, which is what lets a single path prefix go public
+      # without the rest of the origin coming with it.
+      path    = optional(string)
+      service = string
     }))
   })
   default = {

--- a/terraform/network/cloudflare/spindrift.tf
+++ b/terraform/network/cloudflare/spindrift.tf
@@ -10,6 +10,17 @@ module "tunnel_spindrift" {
   config = {
     ingress = [
       {
+        # The bosun outbox, and only it. tender long-polls this path from
+        # GCE — the control plane's own hostname is a LAN record a cloud
+        # host cannot reach — bearer-authed by SPINDRIFT_BOSUN_SECRET.
+        # Path-scoped so the session-authed rest of the control plane stays
+        # off the internet; everything else on this hostname falls through
+        # to the wildcard and 404s at the Apps gateway.
+        hostname = "spindrift-control.${cloudflare_zone.lolwtf_dev.name}"
+        path     = "^/internal/bosun/"
+        service  = "http://spindrift.spindrift.svc.cluster.local:3000"
+      },
+      {
         hostname = "*.${cloudflare_zone.lolwtf_dev.name}"
         service  = "http://cilium-gateway-spindrift-apps.spindrift-apps.svc.cluster.local"
       },


### PR DESCRIPTION
## Summary

Tender's first claim attempt exposed the gap: `spindrift.lolwtf.ca` is a LAN A record (10.89.0.68), unreachable from GCE — the spindrift tunnel only serves the `*.lolwtf.dev` Apps wildcard. This adds one ordered ingress rule ahead of that wildcard: `spindrift-control.lolwtf.dev`, path-scoped to `^/internal/bosun/`, pointed at the control-plane Service — the bearer-authed outbox goes public, the session-authed rest of the control plane stays LAN-only, and every other path on the hostname falls through to the wildcard's 404. The tunnel module's ingress type gains an optional `path`, the module publishes the proxied CNAME automatically, and tender polls the new hostname.

## Validation

`tofu validate` clean on the cloudflare root; `nixosConfigurations.tender` toplevel evaluates. Live verification after apply: bosun's claim loop on tender goes from `dial tcp 10.89.0.68 i/o timeout` to 404s (until the spindrift digest CD rolls the post-adapter image) and then 204s.

## Risks

An App named `spindrift-control` would collide with the ingress rule's CNAME; the specific rule shadows the wildcard for that one name.