### PR TITLE
fix(bosun): give the guest /dev/fd for bash process substitution

### DIFF
--- a/nix/images/hull-ubuntu.nix
+++ b/nix/images/hull-ubuntu.nix
@@ -142,6 +142,13 @@ let
     $bb mount -t devpts devpts /dev/pts
     $bb mount -t tmpfs shm /dev/shm
     $bb mount -t cgroup2 cgroup2 /sys/fs/cgroup
+    # devtmpfs carries no fd symlinks; full distros get them from their init.
+    # bash process substitution (<(...)) opens /dev/fd/N, so without these the
+    # build script dies at its first jq-fed while loop.
+    $bb ln -sf /proc/self/fd /dev/fd
+    $bb ln -sf /proc/self/fd/0 /dev/stdin
+    $bb ln -sf /proc/self/fd/1 /dev/stdout
+    $bb ln -sf /proc/self/fd/2 /dev/stderr
 
     $bb hostname skiff
     echo "127.0.0.1 localhost skiff" > /etc/hosts


### PR DESCRIPTION
## Summary

The first live pool build (`spindrift-slides`, build 9) failed 3 s in at `/opt/bosun/run: line 152: /dev/fd/63: No such file or directory` — bash process substitution opens `/dev/fd/N`, devtmpfs ships no fd symlinks, and busybox init doesn't create the `/dev/fd → /proc/self/fd` link full distros get from theirs. Everything upstream of that line worked: claim, skiff boot, bundle fetch + digest verify (~1 s), dockerd readiness, registry login.

One symlink in the shared setup script (plus stdin/stdout/stderr), both hull variants.

## Validation

`nix build .#hull-ubuntu` and `.#hull-build-ubuntu` both succeed. Live re-verification follows on tender: redeploy, re-dispatch the build, expect the marker line back.