### PR TITLE
feat(ci): eval on the PR, build on the merge

### DIFF
--- a/.github/workflows/nix-ci.yaml
+++ b/.github/workflows/nix-ci.yaml
@@ -48,8 +48,13 @@ jobs:
       - run: nix flake check
   nixos:
     runs-on: ubuntu-latest
-    needs: [changed-paths, check]
-    if: needs.changed-paths.outputs.nix_changed == 'true'
+    needs: changed-paths
+    # Push-to-main only: a PR proves the whole fleet still evaluates (`check`),
+    # and the merge proves it builds — with the artifacts pushed to cachix
+    # instead of discarded, which is all the PR builds ever did. An
+    # unbuildable merge surfaces here within minutes, and hosts upgrading
+    # from main fail safe by keeping their running generation.
+    if: github.event_name == 'push' && needs.changed-paths.outputs.nix_changed == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: NixOS/nix-installer-action@62c1943b776c509394b550f3f983adc14e9212d6 # main
@@ -66,8 +71,13 @@ jobs:
   spore:
     name: Build native Spore package and host
     runs-on: ubuntu-24.04-arm
-    needs: [changed-paths, check]
-    if: needs.changed-paths.outputs.nix_changed == 'true'
+    needs: changed-paths
+    # Push-to-main only: a PR proves the whole fleet still evaluates (`check`),
+    # and the merge proves it builds — with the artifacts pushed to cachix
+    # instead of discarded, which is all the PR builds ever did. An
+    # unbuildable merge surfaces here within minutes, and hosts upgrading
+    # from main fail safe by keeping their running generation.
+    if: github.event_name == 'push' && needs.changed-paths.outputs.nix_changed == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: NixOS/nix-installer-action@62c1943b776c509394b550f3f983adc14e9212d6 # main
@@ -84,8 +94,13 @@ jobs:
           nix build
           .#nixosConfigurations.spore.config.system.build.toplevel
   images:
-    needs: [changed-paths, check]
-    if: needs.changed-paths.outputs.nix_changed == 'true'
+    needs: changed-paths
+    # Push-to-main only: a PR proves the whole fleet still evaluates (`check`),
+    # and the merge proves it builds — with the artifacts pushed to cachix
+    # instead of discarded, which is all the PR builds ever did. An
+    # unbuildable merge surfaces here within minutes, and hosts upgrading
+    # from main fail safe by keeping their running generation.
+    if: github.event_name == 'push' && needs.changed-paths.outputs.nix_changed == 'true'
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Nix PR wall time drops ~9 min → ~4 min by making the PR run exactly the thing that inspires confidence and nothing that doesn't:

- **PR**: `nix flake check` — the whole fleet (every host, every package) must still evaluate. This catches the dominant failure class: options, types, syntax, cross-host fallout.
- **Push to main**: the build set (optiplex canary, spore, container/wsl/forge images) — unchanged in content, no longer serialized behind `check`, and its cachix push finally isn't duplicated: the PR-side builds ran with `skipPush` and discarded everything, so main was already rebuilding the same closures.

An unbuildable merge now surfaces on main's run within minutes instead of blocking the PR; hosts that auto-upgrade from main fail safe by keeping their running generation when a build is red. Today's actual hull bug (`/dev/fd`) is worth naming here: it was a runtime defect neither eval *nor* a CI build would have caught — the build jobs were not buying the confidence they cost.

## Validation

Required status checks verified via the rulesets API: `check` (still on every PR) is required; none of the build jobs are, so nothing waits on a skipped check. Workflow YAML parses.

## Risks

Main can go red post-merge where a PR previously would have. That's the trade, deliberately: visible-in-minutes, non-blocking, fail-safe on the hosts.