### PR TITLE
feat(spindrift): seed the build workflow ref at @main

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -205,7 +205,11 @@ spec:
         clientId: Iv1.918d699f36ee7afc
         apiBaseUrl: https://api.github.com
         oauthBaseUrl: https://github.com
-        buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
+        # `@main` on purpose: every caller written into a configuration PR
+        # copies this ref, and a branch keeps them all current — this
+        # repository's merge gate is the version gate. Pinning a sha here
+        # freezes every repo's builds at that commit with no re-pin path.
+        buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@main
         # Where every boundary below is declared. An unmet prerequisite
         # renders the Terraform that clears it, and this is the repository the
         # pull request adding that stanza is opened against.


### PR DESCRIPTION
## Summary
Flip the offsite installation's seeded `github.buildWorkflow` from the stale sha pin (`@0a7d0ea0`, ~600 lines behind the workflow on `main`) to `@main`, which the manifest schema accepts since #1979. Every caller written into a configuration PR copies this ref, so a branch keeps all connected repos building the current workflow — this repo's merge gate is the version gate.

## Changes
- `clusters/offsite/apps/spindrift/helm-release.yaml`: `buildWorkflow: ...@main`, with a comment naming the trade.

## Notes
- A declaration seeds; it does not govern. If the rebuilt installation has already stored its manifest row, this surfaces as `manifestDivergence` until the row is re-seeded or configured — if the row doesn't exist yet, the seed lands as-is on first boot.
- Repos connected before this keep their old sha-pinned callers until each reconnects and merges a fresh configuration PR.

## Test Plan
- [x] `mise run k8s:render-apps` renders clean; `kustomize build clusters/offsite/apps/spindrift` passes.
- [x] Branch refs are accepted by the manifest schema (covered by `apps/spindrift/test/config/manifest.test.ts`).
