### PR TITLE
feat(spindrift): move the seed-pinned build workflow ref to @main

### DIFF
--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -56,8 +56,16 @@ export function upgradeManifestDocument(document: unknown): unknown {
 }
 
 /**
- * The one sha this repository's own seed declarations ever pinned, moved to
- * `@main`.
+ * The one commit a seed declaration ever pinned `buildWorkflow` at, and this
+ * project's own vocabulary rather than anyone's identity — which is why the
+ * step below may match on it where the extraction contract forbids naming the
+ * repository the workflow lives in. Exactly this sha, never a pattern: any
+ * other ref is an operator's pin, and it is theirs whatever it names.
+ */
+const SEED_PINNED_WORKFLOW_REF = '@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6';
+
+/**
+ * The sha a seed declaration pinned, moved to `@main`.
  *
  * The reusable workflow ref may move — see the `buildWorkflow` docblock in
  * `manifest.schema.ts`: a branch keeps every written caller current, and the
@@ -65,19 +73,24 @@ export function upgradeManifestDocument(document: unknown): unknown {
  * state `@main` now, but an installation seeded before that edit holds the pin
  * where no mounted correction can reach it — the stored row governs — and
  * every caller it writes into a connected repository copies a workflow frozen
- * at that commit.
+ * at that commit. The repository half of the value is kept, not restated:
+ * which repository publishes the workflow is the installation's fact, and the
+ * document already carries it.
  *
- * Exact-match on the one historical value, never a pattern: any other ref is
- * an operator's pin, and it is theirs whatever it names.
+ * **Must run after {@link scrubPlaceholderBuildWorkflow}**: the placeholder it
+ * nulls ends in this same sha, and moved instead of nulled it would be a live
+ * `@main` pointer at a repository this project does not own. The corpus's
+ * placeholder snapshot holds that ordering in place.
  */
 function movePinnedBuildWorkflowToMain(document: unknown): unknown {
   const manifest = asDocument(document);
   const github = asDocument(manifest?.github);
+  const workflow = github?.buildWorkflow;
   if (
     manifest === null ||
     github === null ||
-    github.buildWorkflow !==
-      'jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6'
+    typeof workflow !== 'string' ||
+    !workflow.endsWith(SEED_PINNED_WORKFLOW_REF)
   ) {
     return document;
   }
@@ -85,8 +98,7 @@ function movePinnedBuildWorkflowToMain(document: unknown): unknown {
     ...manifest,
     github: {
       ...github,
-      buildWorkflow:
-        'jonpulsifer/infra/.github/workflows/spindrift-build.yml@main',
+      buildWorkflow: `${workflow.slice(0, -SEED_PINNED_WORKFLOW_REF.length)}@main`,
     },
   };
 }

--- a/apps/spindrift/src/config/manifest-upgrade.ts
+++ b/apps/spindrift/src/config/manifest-upgrade.ts
@@ -48,9 +48,47 @@ function asDocument(value: unknown): Document | null {
  * what is wrong with it rather than reporting what this function made of it.
  */
 export function upgradeManifestDocument(document: unknown): unknown {
-  return scrubPlaceholderBuildWorkflow(
-    nameInstallationVessels(dropTargetNames(addDeclaredVessels(document))),
+  return movePinnedBuildWorkflowToMain(
+    scrubPlaceholderBuildWorkflow(
+      nameInstallationVessels(dropTargetNames(addDeclaredVessels(document))),
+    ),
   );
+}
+
+/**
+ * The one sha this repository's own seed declarations ever pinned, moved to
+ * `@main`.
+ *
+ * The reusable workflow ref may move — see the `buildWorkflow` docblock in
+ * `manifest.schema.ts`: a branch keeps every written caller current, and the
+ * platform repository's merge gate is the version gate. The seed declarations
+ * state `@main` now, but an installation seeded before that edit holds the pin
+ * where no mounted correction can reach it — the stored row governs — and
+ * every caller it writes into a connected repository copies a workflow frozen
+ * at that commit.
+ *
+ * Exact-match on the one historical value, never a pattern: any other ref is
+ * an operator's pin, and it is theirs whatever it names.
+ */
+function movePinnedBuildWorkflowToMain(document: unknown): unknown {
+  const manifest = asDocument(document);
+  const github = asDocument(manifest?.github);
+  if (
+    manifest === null ||
+    github === null ||
+    github.buildWorkflow !==
+      'jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6'
+  ) {
+    return document;
+  }
+  return {
+    ...manifest,
+    github: {
+      ...github,
+      buildWorkflow:
+        'jonpulsifer/infra/.github/workflows/spindrift-build.yml@main',
+    },
+  };
 }
 
 /**

--- a/apps/spindrift/test/fixtures/stored-manifests/07-sha-pinned-build-workflow.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/07-sha-pinned-build-workflow.yaml
@@ -1,12 +1,15 @@
-# A stored manifest holding `05` after the scrub, which is also what a fresh
-# chart seed states — `github.buildWorkflow: null`, the schema's own word for
-# "no workflow published". `connectRepository` refuses on it until an operator
-# states a real one; nothing else in the document changes.
+# A stored manifest holding the one sha this repository's own seed
+# declarations ever pinned: `github.buildWorkflow` at `@0a7d0ea0…`. The
+# offsite rebuild seeded from a declaration that stated exactly this, so its
+# row holds the value where no mounted correction can reach it — and every
+# caller `connectRepository` writes copies a workflow frozen at that commit.
+# `movePinnedBuildWorkflowToMain` moves it to `@main`; nothing else in the
+# document changes.
 #
 # `installation.name` differs from every declaration this suite mounts, for the
 # reason `01` gives.
 installation:
-  name: stored-with-null-build-workflow
+  name: stored-with-sha-pinned-build-workflow
   controlPlaneVessel: cluster
   homeVessel: cloud
 
@@ -37,7 +40,7 @@ github:
   clientId: Iv1.example
   oauthBaseUrl: https://git.example.test
   apiBaseUrl: https://api.git.example.test
-  buildWorkflow: null
+  buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@0a7d0ea0ca5c9963eea1104c5802a8af2901d4b6
 
 build:
   routes:

--- a/apps/spindrift/test/fixtures/stored-manifests/08-main-build-workflow.yaml
+++ b/apps/spindrift/test/fixtures/stored-manifests/08-main-build-workflow.yaml
@@ -1,12 +1,20 @@
-# A stored manifest holding `05` after the scrub, which is also what a fresh
-# chart seed states — `github.buildWorkflow: null`, the schema's own word for
-# "no workflow published". `connectRepository` refuses on it until an operator
-# states a real one; nothing else in the document changes.
+# A stored manifest as this build writes one: `07` after
+# `movePinnedBuildWorkflowToMain`, which is also what the seed declarations
+# state — `github.buildWorkflow` at `@main`, so every caller written into a
+# connected repository stays current with the platform repository's merge gate.
+#
+# **The newest file in this corpus, and the test asserts this build needs no
+# upgrade to read it.** That is the forcing function: change the manifest schema
+# in any way that stops accepting this document, and the assertion fails. The
+# fix is never to edit this file — it is to copy it to the next number, edit
+# *that* to the new shape, and teach `manifest-upgrade.ts` how to get from here
+# to there. Doing it the other way round is exactly how a schema change reaches
+# production able to discard a configured installation.
 #
 # `installation.name` differs from every declaration this suite mounts, for the
 # reason `01` gives.
 installation:
-  name: stored-with-null-build-workflow
+  name: stored-with-main-build-workflow
   controlPlaneVessel: cluster
   homeVessel: cloud
 
@@ -37,7 +45,7 @@ github:
   clientId: Iv1.example
   oauthBaseUrl: https://git.example.test
   apiBaseUrl: https://api.git.example.test
-  buildWorkflow: null
+  buildWorkflow: jonpulsifer/infra/.github/workflows/spindrift-build.yml@main
 
 build:
   routes:


### PR DESCRIPTION
## Summary
A manifest-upgrade step that moves a stored `github.buildWorkflow` holding the one sha this repo's seed declarations ever pinned (`@0a7d0ea0`) to `@main`. The offsite rebuild seeded its row before the seed moved to `@main` (#1987), and the stored row governs — no mounted correction can reach it. An upgrade step is the one mechanism a git change legitimately reaches stored rows through, so the pin moves on the next boot after this image rolls out, hands-free.

Exact-match on the one historical value, never a pattern: any other ref is an operator's pin.

## Changes
- `manifest-upgrade.ts`: `movePinnedBuildWorkflowToMain`, chained outermost.
- Fixture corpus: `07-sha-pinned-build-workflow.yaml` (the live row's shape, proves the step) and `08-main-build-workflow.yaml` (new newest, needs no upgrade, carries the forcing-function header from 06).

## Test Plan
- [x] `bun test test/config/manifest-upgrade.test.ts` — 20 pass (every fixture boots without re-seeding; newest needs no upgrade; oldest genuinely needs one).
- [x] `tsc --noEmit`, `biome check` clean.
