### PR TITLE
feat(tender): c4-highmem-8 and a hosted-shaped bench class

### DIFF
--- a/.github/workflows/container-benchmark.yml
+++ b/.github/workflows/container-benchmark.yml
@@ -27,6 +27,7 @@ on:
           - both
           - ubuntu-latest
           - skiff-ubuntu-xl
+          - skiff-ubuntu-bench
         default: both
 
 permissions:

--- a/.github/workflows/typescript-benchmark.yml
+++ b/.github/workflows/typescript-benchmark.yml
@@ -23,6 +23,7 @@ on:
           - infra-folly
           - skiff-ubuntu
           - skiff-ubuntu-xl
+          - skiff-ubuntu-bench
           - ubuntu-latest
         default: all
       caches:

--- a/nix/hosts/tender.nix
+++ b/nix/hosts/tender.nix
@@ -36,7 +36,7 @@
   # job sees, and carrying the NixOS hull's closure would roughly double the
   # image this host is imported from for a family nothing in CI targets.
   #
-  # Sized against c4-standard-8's 8 vCPU / 30 GB, with no kubelet to share
+  # Sized against c4-highmem-8's 8 vCPU / 62 GB, with no kubelet to share
   # with: 4x3072M is 12 GiB of the pool's declared ceiling, and 4x6G of
   # workspace is reserved up front out of the 100 GB boot disk. warm = 4 is
   # double what riptide can hold, which is the point -- concurrency, not
@@ -63,6 +63,19 @@
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       vcpus = 4;
       memory = "3072M";
+      workspace = "20G";
+      persist = true;
+      warm = 1;
+    };
+
+    # The hosted-shaped bench class: 4 vCPU / 16 GiB, the exact spec of a
+    # public-repo ubuntu-latest runner, so the benchmark's memory column
+    # reads zero instead of 3-vs-16. Exists for measurement; park it
+    # (warm = 0) when nothing is being measured.
+    classes.skiff-ubuntu-bench = {
+      hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
+      vcpus = 4;
+      memory = "16384M";
       workspace = "20G";
       persist = true;
       warm = 1;
@@ -96,9 +109,9 @@
       classes = [ "skiff-build-xl" ];
     };
 
-    # 30 GB of the 100 GB boot disk for the actions/cache service; the
-    # workspace disks (3x6G + 20G) reserve another 38 GB and the closure
-    # needs the rest.
+    # 30 GB of the 130 GB boot disk for the actions/cache service; the
+    # workspace disks (3x6G + 20G + 20G + 20G) reserve another 78 GB and the
+    # closure needs the rest.
     cache = {
       enable = true;
       maxSizeBytes = 32212254720;
@@ -108,5 +121,5 @@
   # 30 GiB total and nothing else on the box, so the bound is generous rather
   # than tight -- but it still exists, because without one the *host* OOM
   # killer picks the victim and on a spot instance that is a job either way.
-  systemd.services.bosun.serviceConfig.MemoryMax = "24G";
+  systemd.services.bosun.serviceConfig.MemoryMax = "48G";
 }

--- a/terraform/gcp/projects/homelab-ng/bosun.tf
+++ b/terraform/gcp/projects/homelab-ng/bosun.tf
@@ -18,8 +18,11 @@
 locals {
   # The one knob worth turning while measuring. Changing family means
   # re-checking the nested-virt column, not just the price.
-  tender_machine_type = "c4-standard-8" # 8 vCPU / 30 GB
-  tender_disk_size    = 100             # closure + hull + warm x workspace
+  # highmem rather than standard-16: memory, not cores, bounds warm-pool
+  # depth, a 16 GiB hosted-shaped bench class needs the headroom, and staying
+  # at 8 vCPUs keeps the C4 CPU quota question unasked.
+  tender_machine_type = "c4-highmem-8" # 8 vCPU / 62 GB
+  tender_disk_size    = 130             # closure + hull + cache + warm x workspace (the bench class adds a fifth 20G slot)
 
   # GCS lists objects lexicographically, so element zero is the *oldest* name
   # the moment the prefix holds more than one build -- not a race, just


### PR DESCRIPTION
## Summary

A true size-matched bench point: `skiff-ubuntu-bench` at 4 vCPU / 16 GiB / 20 G — a public-repo `ubuntu-latest` runner's exact spec. The host grows `c4-standard-8 → c4-highmem-8` (62 GiB; memory bounds warm-pool depth, cores were never the constraint, and 8 vCPUs stays inside the known quota), the boot disk `100 → 130 G` for the fifth persisted workspace slot, `MemoryMax 24 → 48 G`. Both benchmark workflows gain the label.

The machine-type change stop/starts the instance in place (`allow_stopping_for_update`); the boot disk — and the host key and sops recipients on it — survives. GCB's bigger machines are a dead end for now: `e2-highcpu-32` is quota-refused in both org-policy regions, so `e2-highcpu-8` stands as its ceiling.

## Validation

`tofu validate` clean; `nixosConfigurations.tender` evaluates; both workflow YAMLs parse.