### PR TITLE
Let the job demo an attached Datastore

### DIFF
--- a/apps/spindrift-demo/job/job.js
+++ b/apps/spindrift-demo/job/job.js
@@ -16,7 +16,19 @@
  *   EXIT_CODE          what to exit with (default 0) — set it non-zero to see
  *                      how a failed run surfaces
  *   STEPS              how many progress lines to emit (default 5)
+ *
+ * `REDIS_URL` is the fourth, and it is not set by an operator: it is what a
+ * `valkey` Datastore attached to this App fills, and the name is fixed by the
+ * engine rather than chosen here. A run counts itself in it, because a counter
+ * that survives the run is the shortest thing that proves the connection was
+ * real — a job that merely started is a job that proves the variable parsed.
+ *
+ * Optional like the rest, and deliberately so: the same image runs on Cloud
+ * Run, where there is no Datastore to attach, and a demo that failed there
+ * would be demonstrating the wrong thing.
  */
+import { connect } from 'node:net';
+
 const duration = Number(process.env.DURATION_SECONDS ?? 15);
 const exitCode = Number(process.env.EXIT_CODE ?? 0);
 const steps = Math.max(1, Number(process.env.STEPS ?? 5));
@@ -40,12 +52,64 @@ function whoAmI() {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * `INCR <key>`, spoken straight down a socket.
+ *
+ * No client library, for the same reason nothing else here has a dependency:
+ * the demo is read as much as it is run, and one command whose reply is a
+ * single line is smaller than the install that would save writing it.
+ *
+ * ponytail: understands exactly one reply — `:<n>`, which is all `INCR` can
+ * answer with on success. Anything else is handed back verbatim as an error
+ * rather than parsed, so a wrong assumption reads as a wrong assumption. Reach
+ * for a real client the moment a second command is wanted.
+ */
+function incr(url, key) {
+  const { hostname, port } = new URL(url);
+  return new Promise((resolve, reject) => {
+    const socket = connect({ host: hostname, port: Number(port) || 6379 }, () =>
+      socket.write(
+        `*2\r\n$4\r\nINCR\r\n$${Buffer.byteLength(key)}\r\n${key}\r\n`,
+      ),
+    );
+    socket.setTimeout(5000);
+    socket.once('data', (chunk) => {
+      socket.end();
+      const reply = chunk.toString().trim();
+      if (reply.startsWith(':')) resolve(Number(reply.slice(1)));
+      else reject(new Error(`unexpected reply: ${reply}`));
+    });
+    socket.once('timeout', () => {
+      socket.destroy();
+      reject(new Error('timed out after 5s'));
+    });
+    socket.once('error', reject);
+  });
+}
+
 const log = (message) =>
   console.log(`[${new Date().toISOString()}] ${message}`);
 
 log(`spindrift-demo-job starting — ${whoAmI()}`);
 log(`build: ${process.env.SPINDRIFT_BUILD ?? 'unknown'}`);
 log(`plan: ${steps} stepz over ${duration}s, exiting ${exitCode}`);
+
+// Before the work rather than after it: a run that fails on purpose still
+// counted, and reading the tally at the top is how the log answers "is this the
+// first run since the Datastore was attached" without anyone counting runs.
+if (process.env.REDIS_URL) {
+  try {
+    const runs = await incr(process.env.REDIS_URL, 'spindrift-demo-job:runs');
+    log(`valkey: run #${runs}`);
+  } catch (error) {
+    // Reported and survived. The datastore is what this run *uses*, not what
+    // it is for, and a job that died because a cache was unreachable would
+    // make every other thing it demonstrates unobservable.
+    log(`valkey: unreachable — ${error.message}`);
+  }
+} else {
+  log('valkey: no REDIS_URL, so no Datastore is attached');
+}
 
 // Emitted one at a time rather than all at once: the log pane is supposed to
 // show a run in progress, and a job that printed everything in the first

--- a/apps/spindrift-demo/job/spindrift.yaml
+++ b/apps/spindrift-demo/job/spindrift.yaml
@@ -11,6 +11,13 @@
 # Component, not to a directory: the same code is a job you press Run on and a
 # job that fires every five minutes, and which one it is is the operator's
 # choice at Place, not the repository's.
+#
+# There is no datastore key either, and that one is not an omission this file
+# could correct: a Datastore is top-level and attached, never a field of the
+# thing attached to it, because it outlives every App and can be reattached to
+# another. So the job reads `REDIS_URL` and says what it found, and whether
+# anything fills it is decided by attaching a `valkey` Datastore — the same
+# code demoing both states without this file knowing which it is in.
 version: 1
 component:
   kind: job


### PR DESCRIPTION
The jobs demo proved a run happened and nothing about what a run can reach. It now counts itself in `REDIS_URL` and logs which run it was — a counter that outlives the run is the shortest thing that proves the connection was real, where a job that merely started proves only that the variable parsed.

`REDIS_URL` is filled by attaching a `valkey` Datastore, not by an operator typing it, and the name is fixed by the engine. There is deliberately no key in `spindrift.yaml` to ask for one: a Datastore is top-level and attached, because it outlives the App and can be reattached to another. So the same file demos both states without knowing which it is in.

`INCR` is spoken straight down a socket with `node:net`. The demo has no dependencies and is read as much as it is run; one command whose reply is a single line is smaller than the install that would save writing it. It understands exactly one reply shape and hands anything else back verbatim, marked with a `ponytail:` comment naming the ceiling.

## Validation

- Wire format and reply parse checked against a fake RESP server: the bytes sent are `*2\r\n$4\r\nINCR\r\n$23\r\nspindrift-demo-job:runs\r\n` and a `:7\r\n` reply parses to `7`.
- Both fallback paths run and still exit 0 — no `REDIS_URL` logs that no Datastore is attached; an unreachable one is reported and survived.
- `mise run ts:check` clean; biome clean.

No permanent test was added. This package has no test setup and is a zero-dependency demo; adding a harness for one parser would be more scaffolding than the thing it guards. The standing check is the job's own log line, which is what the demo exists to show.