### PR TITLE
Write a ValkeyCluster the restricted standard will admit

### DIFF
--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -250,6 +250,40 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
         shards: 1,
         replicas: 0,
         persistence: { size },
+        // Restricted Pod Security, stated here because nothing else states it.
+        // `spindrift-apps` enforces the `restricted` standard, and the Valkey
+        // operator sets no security context of its own — it copies
+        // `podSecurityContext` through and leaves the container's empty — so a
+        // ValkeyCluster written without this creates its StatefulSet, has every
+        // pod refused by admission, and sits in `WAITING` with the only useful
+        // sentence on an object the adapter never reads. CloudNativePG needs no
+        // equivalent: it sets a compliant context itself.
+        //
+        // `runAsUser` is not redundant beside `runAsNonRoot`. The valkey image
+        // has no `USER` and drops from root in its entrypoint, so the kubelet
+        // would refuse it as root-by-image with nothing but the flag. 999/1000
+        // is the `valkey` user that image creates, so the data directory it
+        // wants and the identity it runs as agree.
+        podSecurityContext: {
+          runAsNonRoot: true,
+          runAsUser: 999,
+          runAsGroup: 1000,
+          // The volume, group-owned so the same identity can write it.
+          fsGroup: 1000,
+          seccompProfile: { type: 'RuntimeDefault' },
+        },
+        // The two fields `restricted` demands that exist only on a container.
+        // A strategic merge patch onto the operator's own container, which it
+        // names `server` — everything else about it is left to the operator.
+        containers: [
+          {
+            name: 'server',
+            securityContext: {
+              allowPrivilegeEscalation: false,
+              capabilities: { drop: ['ALL'] },
+            },
+          },
+        ],
       },
     };
   }

--- a/apps/spindrift/test/adapters/datastore.test.ts
+++ b/apps/spindrift/test/adapters/datastore.test.ts
@@ -112,6 +112,47 @@ describe('provision', () => {
     });
   });
 
+  test('writes a ValkeyCluster the restricted standard will admit', async () => {
+    const { fake, adapter, target } = adapterOn();
+
+    await adapter.provision(target, {
+      name: 'sessions',
+      engine: 'valkey',
+      storageGiB: 1,
+    });
+
+    // Every field `restricted` demands, asserted as the standard states them
+    // rather than as one blob: the operator supplies none of these, so a
+    // regression here is not a wrong value but an object admission refuses —
+    // and the refusal lands on a StatefulSet the adapter never reads.
+    const spec = fake.get('valkeyclusters/spindrift-apps/sessions')
+      ?.spec as Record<string, any>;
+    expect(spec.podSecurityContext).toMatchObject({
+      runAsNonRoot: true,
+      seccompProfile: { type: 'RuntimeDefault' },
+    });
+    // Not redundant beside `runAsNonRoot`: the valkey image has no `USER` and
+    // drops from root itself, so without an explicit non-root uid the kubelet
+    // refuses it as root-by-image.
+    expect(spec.podSecurityContext.runAsUser).toBeGreaterThan(0);
+    // The volume has to be writable by whatever that uid is.
+    expect(spec.podSecurityContext.fsGroup).toBe(
+      spec.podSecurityContext.runAsGroup,
+    );
+    // Container-only fields, so they cannot be satisfied by the pod block
+    // above. The name is the operator's own container — a patch naming
+    // anything else is silently a second container.
+    expect(spec.containers).toEqual([
+      {
+        name: 'server',
+        securityContext: {
+          allowPrivilegeEscalation: false,
+          capabilities: { drop: ['ALL'] },
+        },
+      },
+    ]);
+  });
+
   test('a hyphenated name becomes a typeable SQL identifier', async () => {
     const { fake, adapter, target } = adapterOn();
 


### PR DESCRIPTION
Every `valkey` Datastore would have failed to provision. Found before spending a live cycle on it, by reading the operator rather than waiting for the symptom.

## What happens without this

`spindrift-apps` enforces the `restricted` Pod Security standard on both clusters. The Valkey operator sets no security context of its own — `internal/controller/valkeynode_resources.go` copies `spec.podSecurityContext` straight through and builds the container with none at all:

```go
SecurityContext: node.Spec.PodSecurityContext,
...
if podSpec.SecurityContext == nil { podSpec.SecurityContext = &corev1.PodSecurityContext{} }
```

So the CR applies cleanly, the operator creates its StatefulSet, and admission refuses every pod. The Datastore sits `WAITING` indefinitely with the only useful sentence on a StatefulSet the adapter never reads — a failure that looks like the platform hanging rather than a policy rejecting.

The CRD offers no defaults either: `podSecurityContext` has no `default` for any field, so nothing upstream fills this in.

## The fix

Pod level gets `runAsNonRoot`, `runAsUser`, `runAsGroup`, `fsGroup` and `seccompProfile`. `allowPrivilegeEscalation` and `capabilities` exist **only** on a container, so they cannot be satisfied by the pod block and go through the operator's documented strategic merge patch onto `server` — its own container's name. A patch naming anything else would quietly add a *second* container rather than harden the real one.

`runAsUser` is not redundant beside `runAsNonRoot`. The valkey image carries no `USER` and steps down from root in its entrypoint, so with only the flag the kubelet refuses it as root-by-image. `999`/`1000` is the `valkey` user that image creates (`adduser -S -G valkey -u 999`, `addgroup -S -g 1000`), and `fsGroup` matches so the volume it wants is writable by the identity it runs as.

CloudNativePG needs no equivalent — it sets a compliant context itself, which is why only one engine changes here.

## Validation

- New test asserts each field the standard demands, stated as the standard states them rather than as one blob.
- **Verified it bites**: reverting the adapter change alone turns it red (1 fail), reapplying turns it green (13 pass). A regression here is not a wrong value, it is an object admission refuses.
- `mise run ts:check` clean.

Still unproven live — no `ValkeyCluster` has ever run in either cluster. This makes the first provision likely to work rather than certain, and the remaining risk is now the operator's runtime behaviour, not admission.