### PR TITLE
Take a ZIP upload, and refuse a non-archive at the door

### DIFF
--- a/apps/spindrift/src/storage/archive-format.ts
+++ b/apps/spindrift/src/storage/archive-format.ts
@@ -1,0 +1,450 @@
+/**
+ * Normalizing an uploaded archive to the one container every route can open.
+ *
+ * §4 calls the upload "real bytes", and the creation flow's own tile offers a
+ * "ZIP, artifact, or source archive" — but a staged bundle is fetched by three
+ * different programs in three different runtimes, and every one of them opens
+ * it the same way: `curl … | tar -xz` in the reusable workflow,
+ * `wget -qO- … | tar -xz` in `adapters/build/buildkit.ts`, and `tar -xzf` in
+ * the bosun build hull. A gzipped tar is therefore not a preference, it is the
+ * wire format of a staged bundle, and `adapters/deploy/static/bundle.ts` reads
+ * a `files` artifact back on the same assumption.
+ *
+ * Nothing enforced it. A ZIP was accepted, staged, signed for and dispatched,
+ * and died in the builder at `tar: This does not look like a tar archive` —
+ * surfacing four steps later as `ARTIFACT_UNAVAILABLE`, which names the
+ * platform for what is a container-format mistake, and after a workflow run has
+ * already been spent. So this module makes the invariant true at the one place
+ * that sees the bytes: a ZIP is **transcoded** here, and anything that is
+ * neither is **refused** here, with a sentence that says what arrived.
+ *
+ * **Why transcode rather than teach the fetchers.** Three programs would each
+ * need a sniff and an unzip binary that two of their images do not carry, and
+ * their silent divergence is what produced this defect in the first place. One
+ * conversion at the boundary leaves all three unchanged and correct.
+ *
+ * **Why the digest is over the converted bytes.** §16 joins the source receipt
+ * to the provenance document by a digest over exactly what was staged, and the
+ * build hull re-checks it (`sha256sum` against `bundleDigest`, before it
+ * extracts). A digest of the uploaded ZIP would name bytes no builder ever
+ * holds. So conversion happens before staging, and the digest describes the
+ * object in the depot — which is what every reader of it already assumes.
+ *
+ * The conversion is **deterministic**: entry order is the ZIP's own central
+ * directory, and every field a tar header carries that is not in the ZIP is a
+ * constant. The same upload therefore always yields the same digest, which is
+ * what lets `uploadArchive`'s `onConflictDoNothing` mean "byte-identical input
+ * lands on the Build row that already describes it".
+ *
+ * It is hand-written rather than a dependency for the reason `bundle.ts` gives
+ * for its tar reader: §20's extraction contract wants a package that prunes to
+ * something self-contained, and these are two fixed formats that have not moved
+ * in thirty years.
+ */
+import { deflateRawSync, inflateRawSync } from 'node:zlib';
+
+/** The containers an upload may arrive in. */
+export type ArchiveFormat = 'gzip' | 'zip';
+
+/** Why an upload could not be normalized. A closed set, so a caller can say which. */
+export type ArchiveFormatErrorCode =
+  | 'UNKNOWN_FORMAT'
+  | 'UNSUPPORTED_ZIP'
+  | 'MALFORMED_ZIP'
+  | 'PATH_ESCAPES_ARCHIVE';
+
+export class ArchiveFormatError extends Error {
+  constructor(
+    readonly code: ArchiveFormatErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ArchiveFormatError';
+  }
+}
+
+/**
+ * What these bytes are, by their magic number rather than by their name.
+ *
+ * A filename is a caller's assertion and an upload may carry none at all — the
+ * route defaults it to `upload.zip`, which is exactly the claim that must not
+ * be trusted here.
+ */
+export function sniffArchiveFormat(bytes: Uint8Array): ArchiveFormat | null {
+  if (bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b)
+    return 'gzip';
+  // Local file header, end of central directory (an empty archive), or a
+  // spanned-archive marker. All three begin a file a ZIP reader will open.
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x50 &&
+    bytes[1] === 0x4b &&
+    (bytes[2] === 0x03 || bytes[2] === 0x05 || bytes[2] === 0x07)
+  ) {
+    return 'zip';
+  }
+  return null;
+}
+
+export interface NormalizedArchive {
+  readonly bytes: Uint8Array;
+  /** Named for what it now is, so the depot object is not called `.zip`. */
+  readonly filename: string;
+  readonly from: ArchiveFormat;
+}
+
+/**
+ * The gzipped tar these bytes are, or the one they convert to.
+ *
+ * Throws {@link ArchiveFormatError} for anything else, which is the whole point
+ * of the function: the refusal belongs here, in front of the depot, rather than
+ * inside a runner log nobody is watching.
+ */
+export function normalizeArchive(
+  filename: string,
+  bytes: Uint8Array,
+): NormalizedArchive {
+  const format = sniffArchiveFormat(bytes);
+  if (format === null) {
+    throw new ArchiveFormatError(
+      'UNKNOWN_FORMAT',
+      `${filename} is neither a gzipped tar nor a ZIP — a staged bundle has to be one of those, because every build route opens it with \`tar -xz\`. What arrived starts ${describe(bytes)}.`,
+    );
+  }
+  if (format === 'gzip') return { bytes, filename, from: 'gzip' };
+  return {
+    bytes: tarGzOf(readZipEntries(bytes, filename)),
+    filename: `${filename.replace(/\.zip$/i, '')}.tar.gz`,
+    from: 'zip',
+  };
+}
+
+/** The first bytes, for a refusal that says what it saw rather than only what it wanted. */
+function describe(bytes: Uint8Array): string {
+  if (bytes.length === 0) return 'empty';
+  const head = [...bytes.subarray(0, 4)]
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join(' ');
+  return `with ${head}`;
+}
+
+// ---------------------------------------------------------------------------
+// ZIP, read far enough to get the files out of it
+// ---------------------------------------------------------------------------
+
+interface ZipEntry {
+  readonly path: string;
+  readonly bytes: Uint8Array;
+  readonly mode: number;
+  readonly directory: boolean;
+}
+
+const EOCD_SIGNATURE = 0x06054b50;
+const CENTRAL_SIGNATURE = 0x02014b50;
+/** The largest an end-of-central-directory record can be: 22 bytes + a 64 KiB comment. */
+const EOCD_MAX = 22 + 0xffff;
+const STORED = 0;
+const DEFLATED = 8;
+
+function readZipEntries(zip: Uint8Array, filename: string): ZipEntry[] {
+  const view = new DataView(zip.buffer, zip.byteOffset, zip.byteLength);
+  const eocd = findEndOfCentralDirectory(view, zip.length, filename);
+
+  const count = view.getUint16(eocd + 10, true);
+  const start = view.getUint32(eocd + 16, true);
+  // Zip64 spends these fields as sentinels and puts the real values in a record
+  // this reader does not parse. Refused by name rather than half-read: a
+  // truncated bundle that builds is worse than one that never staged.
+  if (count === 0xffff || start === 0xffffffff) {
+    throw new ArchiveFormatError(
+      'UNSUPPORTED_ZIP',
+      `${filename} is a Zip64 archive, which this boundary does not read — upload it as a gzipped tar instead.`,
+    );
+  }
+
+  const entries: ZipEntry[] = [];
+  let at = start;
+  for (let index = 0; index < count; index += 1) {
+    if (
+      at + 46 > zip.length ||
+      view.getUint32(at, true) !== CENTRAL_SIGNATURE
+    ) {
+      throw new ArchiveFormatError(
+        'MALFORMED_ZIP',
+        `${filename} has a central directory this reader cannot follow at entry ${index + 1} of ${count}.`,
+      );
+    }
+    const madeBy = view.getUint16(at + 4, true);
+    const method = view.getUint16(at + 10, true);
+    const compressedSize = view.getUint32(at + 20, true);
+    const uncompressedSize = view.getUint32(at + 24, true);
+    const nameLength = view.getUint16(at + 28, true);
+    const extraLength = view.getUint16(at + 30, true);
+    const commentLength = view.getUint16(at + 32, true);
+    const externalAttributes = view.getUint32(at + 38, true);
+    const localHeader = view.getUint32(at + 42, true);
+    const path = new TextDecoder().decode(
+      zip.subarray(at + 46, at + 46 + nameLength),
+    );
+
+    const directory = path.endsWith('/');
+    entries.push({
+      path: safePath(directory ? path.slice(0, -1) : path, filename),
+      bytes: directory
+        ? new Uint8Array(0)
+        : inflateEntry(
+            zip,
+            view,
+            localHeader,
+            method,
+            compressedSize,
+            uncompressedSize,
+            path,
+            filename,
+          ),
+      mode: modeOf(madeBy, externalAttributes, directory),
+      directory,
+    });
+
+    at += 46 + nameLength + extraLength + commentLength;
+  }
+  return entries;
+}
+
+/**
+ * Scan back for the end-of-central-directory record.
+ *
+ * Backwards, because the record sits at the end and a ZIP comment of arbitrary
+ * length sits after it — there is no other way to find it, which is also why a
+ * ZIP cannot be read from a pipe and why the fetchers were never going to open
+ * one by accident.
+ */
+function findEndOfCentralDirectory(
+  view: DataView,
+  length: number,
+  filename: string,
+): number {
+  const floor = Math.max(0, length - EOCD_MAX);
+  for (let at = length - 22; at >= floor; at -= 1) {
+    if (view.getUint32(at, true) === EOCD_SIGNATURE) return at;
+  }
+  throw new ArchiveFormatError(
+    'MALFORMED_ZIP',
+    `${filename} starts like a ZIP but carries no end-of-central-directory record — it is truncated or only part of a multi-part archive.`,
+  );
+}
+
+function inflateEntry(
+  zip: Uint8Array,
+  view: DataView,
+  localHeader: number,
+  method: number,
+  compressedSize: number,
+  uncompressedSize: number,
+  path: string,
+  filename: string,
+): Uint8Array {
+  if (method !== STORED && method !== DEFLATED) {
+    throw new ArchiveFormatError(
+      'UNSUPPORTED_ZIP',
+      `${filename} compresses ${path} with method ${method}; this boundary reads stored and deflated entries only.`,
+    );
+  }
+  // The local header's extra field may be a different length than the central
+  // directory's copy, so the data offset is only knowable from the local one.
+  const nameLength = view.getUint16(localHeader + 26, true);
+  const extraLength = view.getUint16(localHeader + 28, true);
+  const from = localHeader + 30 + nameLength + extraLength;
+  const raw = zip.subarray(from, from + compressedSize);
+
+  const bytes =
+    method === STORED
+      ? new Uint8Array(raw)
+      : new Uint8Array(inflateRawSync(raw));
+  if (bytes.length !== uncompressedSize) {
+    throw new ArchiveFormatError(
+      'MALFORMED_ZIP',
+      `${path} in ${filename} unpacked to ${bytes.length} bytes where its directory entry declares ${uncompressedSize}.`,
+    );
+  }
+  return bytes;
+}
+
+/**
+ * The unix mode a ZIP recorded, or a sane constant.
+ *
+ * The executable bit is the reason this is read at all: a source bundle whose
+ * `build.sh` arrives without `+x` builds differently than the tree it came
+ * from. The high byte of `version made by` is the host system, and 3 is unix.
+ */
+function modeOf(
+  madeBy: number,
+  externalAttributes: number,
+  directory: boolean,
+): number {
+  const unix = madeBy >> 8 === 3;
+  const recorded = (externalAttributes >>> 16) & 0o7777;
+  if (unix && recorded !== 0) return recorded;
+  return directory ? 0o755 : 0o644;
+}
+
+/**
+ * Refuse a path that would write outside the extracted root.
+ *
+ * The same rule and the same reason as `bundle.ts`'s: this is untrusted input
+ * from whoever uploaded it, and every consumer of the tar we are about to write
+ * extracts it with `tar -x`, which will happily follow `../` out of the
+ * workspace. Rejecting here means no route has to remember to.
+ */
+function safePath(path: string, filename: string): string {
+  const normalized = path.replaceAll('\\', '/').replace(/^\/+/, '');
+  const escapes =
+    normalized === '..' ||
+    normalized.startsWith('../') ||
+    normalized.includes('/../') ||
+    normalized.endsWith('/..');
+  if (escapes || normalized === '') {
+    throw new ArchiveFormatError(
+      'PATH_ESCAPES_ARCHIVE',
+      `${filename} contains an entry named ${path}, which would write outside the bundle.`,
+    );
+  }
+  return normalized;
+}
+
+// ---------------------------------------------------------------------------
+// tar, written the one way every extractor reads
+// ---------------------------------------------------------------------------
+
+const BLOCK = 512;
+const REGULAR = '0';
+const DIRECTORY = '5';
+const GNU_LONG_NAME = 'L';
+/** Long enough that the 100-byte name field cannot hold it. */
+const NAME_LIMIT = 100;
+
+function tarGzOf(entries: readonly ZipEntry[]): Uint8Array {
+  const blocks: Uint8Array[] = [];
+  for (const entry of entries) {
+    const name = entry.directory ? `${entry.path}/` : entry.path;
+    const bytes = new TextEncoder().encode(name);
+    if (bytes.length > NAME_LIMIT) {
+      // GNU's long-name entry: a pseudo-file whose *contents* are the real
+      // name. `bundle.ts` reads this form, and so does every tar in the wild;
+      // the ustar prefix field cannot express a long name with no `/` in the
+      // right place, which is why this is the form written.
+      blocks.push(
+        header(`${'././@LongLink'}`, bytes.length + 1, 0o644, GNU_LONG_NAME),
+      );
+      blocks.push(padded(new TextEncoder().encode(`${name}\0`)));
+    }
+    blocks.push(
+      header(
+        truncate(name),
+        entry.directory ? 0 : entry.bytes.length,
+        entry.mode,
+        entry.directory ? DIRECTORY : REGULAR,
+      ),
+    );
+    if (!entry.directory && entry.bytes.length > 0) {
+      blocks.push(padded(entry.bytes));
+    }
+  }
+  // Two zero blocks end an archive, and tar warns about a short one.
+  blocks.push(new Uint8Array(BLOCK * 2));
+
+  return gzip(concat(blocks));
+}
+
+/** gzip framing around raw deflate, with no timestamp and no filename. */
+function gzip(tar: Uint8Array): Uint8Array {
+  const body = new Uint8Array(deflateRawSync(tar, { level: 9 }));
+  const out = new Uint8Array(10 + body.length + 8);
+  out.set([0x1f, 0x8b, 8, 0, 0, 0, 0, 0, 2, 0xff], 0);
+  out.set(body, 10);
+  const trailer = new DataView(out.buffer, 10 + body.length, 8);
+  trailer.setUint32(0, crc32(tar), true);
+  trailer.setUint32(4, tar.length >>> 0, true);
+  return out;
+}
+
+let crcTable: Uint32Array | null = null;
+function crc32(bytes: Uint8Array): number {
+  if (crcTable === null) {
+    crcTable = new Uint32Array(256);
+    for (let index = 0; index < 256; index += 1) {
+      let value = index;
+      for (let bit = 0; bit < 8; bit += 1) {
+        value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+      }
+      crcTable[index] = value >>> 0;
+    }
+  }
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc = (crcTable[(crc ^ byte) & 0xff] as number) ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** A name the 100-byte field can hold; the long-name entry before it carries the rest. */
+function truncate(name: string): string {
+  const bytes = new TextEncoder().encode(name);
+  if (bytes.length <= NAME_LIMIT) return name;
+  return new TextDecoder().decode(bytes.subarray(0, NAME_LIMIT));
+}
+
+function header(
+  name: string,
+  size: number,
+  mode: number,
+  typeFlag: string,
+): Uint8Array {
+  const block = new Uint8Array(BLOCK);
+  const write = (text: string, at: number, length: number) => {
+    const bytes = new TextEncoder().encode(text);
+    block.set(bytes.subarray(0, length), at);
+  };
+  const octal = (value: number, at: number, length: number) => {
+    write(value.toString(8).padStart(length - 1, '0'), at, length);
+  };
+
+  write(name, 0, 100);
+  octal(mode & 0o7777, 100, 8);
+  octal(0, 108, 8); // uid
+  octal(0, 116, 8); // gid
+  octal(size, 124, 12);
+  octal(0, 136, 12); // mtime — a constant, so the digest is a function of content
+  write(typeFlag, 156, 1);
+  write('ustar', 257, 6);
+  write('00', 263, 2);
+
+  // The checksum is computed with its own field read as spaces, then written
+  // back into it. Every tar does this, and getting it wrong is the one mistake
+  // that produces an archive `tar` calls corrupt rather than merely odd.
+  block.fill(0x20, 148, 156);
+  let sum = 0;
+  for (const byte of block) sum += byte;
+  octal(sum, 148, 7);
+  block[155] = 0x20;
+  return block;
+}
+
+/** Entry data, rounded up to the block size tar counts in. */
+function padded(bytes: Uint8Array): Uint8Array {
+  const size = Math.ceil(bytes.length / BLOCK) * BLOCK;
+  const block = new Uint8Array(size);
+  block.set(bytes, 0);
+  return block;
+}
+
+function concat(blocks: readonly Uint8Array[]): Uint8Array {
+  const total = blocks.reduce((sum, block) => sum + block.length, 0);
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const block of blocks) {
+    out.set(block, at);
+    at += block.length;
+  }
+  return out;
+}

--- a/apps/spindrift/src/web/upload.ts
+++ b/apps/spindrift/src/web/upload.ts
@@ -9,6 +9,10 @@
  * returns the digest and location.
  */
 import {
+  ArchiveFormatError,
+  normalizeArchive,
+} from '../storage/archive-format.ts';
+import {
   type StagedArchive,
   sourceDepotFor,
   stageArchiveBytes,
@@ -106,6 +110,27 @@ export async function handleUpload(
       bytes = new Uint8Array(buffer);
     }
 
+    // The one container every build route can open, before anything durable
+    // happens. A ZIP is transcoded and anything else is refused here — see
+    // `storage/archive-format.ts` for why the boundary is the right place and
+    // why the digest is therefore over the converted bytes.
+    //
+    // Refused as a `400`, because it is: the request carried bytes this
+    // installation cannot stage, and saying so now is the whole difference
+    // between a wrong upload and a spent build that blames the platform.
+    let archive: ReturnType<typeof normalizeArchive>;
+    try {
+      archive = normalizeArchive(filename, bytes);
+    } catch (error: unknown) {
+      if (error instanceof ArchiveFormatError) {
+        return Response.json(
+          { ok: false, failure: { code: error.code, message: error.message } },
+          { status: 400 },
+        );
+      }
+      throw error;
+    }
+
     // One staging call, to one place, so the returned location describes where
     // the bytes actually are. A depot failure is a `500` that says so, because
     // a staged bundle nobody can retrieve is not a staged bundle.
@@ -119,7 +144,7 @@ export async function handleUpload(
 
     let staged: StagedArchive;
     try {
-      staged = await stageArchiveBytes(filename, bytes, depot);
+      staged = await stageArchiveBytes(archive.filename, archive.bytes, depot);
     } catch (error: unknown) {
       const message =
         error instanceof Error

--- a/apps/spindrift/test/conformance/archive-to-live.test.ts
+++ b/apps/spindrift/test/conformance/archive-to-live.test.ts
@@ -38,7 +38,9 @@
  * §4 makes the two arms "one pipeline" and a pipeline claimed to be one is a
  * claim only a test that runs both can make.
  */
+
 import { describe, expect, test } from 'bun:test';
+import { gzipSync } from 'node:zlib';
 import { asc, eq } from 'drizzle-orm';
 import {
   completeCreationDraft,
@@ -88,9 +90,19 @@ const baseManifest = await fixtureManifest();
 
 const FROZEN = new Date('2026-08-03T12:00:00.000Z');
 
-/** The archive a developer picks in the browser. Real bytes, real digest. */
-const ARCHIVE = new TextEncoder().encode(
-  'PK not a real zip, but real bytes with a real digest\n',
+/**
+ * The archive a developer picks in the browser. Real bytes, real digest.
+ *
+ * A real gzipped tar, because the upload boundary now checks. It used to be a
+ * string carrying a ZIP's magic number and nothing else behind it — exactly the
+ * shape of upload that staged happily, spent a build, and died inside the
+ * builder at `tar: This does not look like a tar archive`. A ZIP is accepted
+ * too and converted on the way in; that path is covered in
+ * `test/web/upload.test.ts`, and this fixture stays the format the depot ends
+ * up holding, so every digest assertion below still means what it says.
+ */
+const ARCHIVE = new Uint8Array(
+  gzipSync(new TextEncoder().encode('a tarball, as far as the boundary reads')),
 );
 
 /**

--- a/apps/spindrift/test/fixtures/zip.ts
+++ b/apps/spindrift/test/fixtures/zip.ts
@@ -1,0 +1,100 @@
+/**
+ * A real ZIP, written by hand rather than checked in as a blob.
+ *
+ * Shared because two suites need one: the normalizer's own tests, and the
+ * upload boundary's — which used to stage the string `dummy zip file contents`
+ * under the name `test-app.zip` and pass. A fixture that is actually the format
+ * is what makes that test able to fail.
+ */
+/** One entry, as a ZIP stores it: stored (method 0), so the fixture needs no deflate. */
+export interface Entry {
+  readonly path: string;
+  readonly text: string;
+  readonly mode?: number;
+}
+
+/**
+ * A real ZIP, written here rather than checked in as a blob.
+ *
+ * Built by hand for the same reason the reader is: it is the format's own
+ * layout, and a fixture nobody can read is a fixture nobody can correct.
+ */
+export function zipOf(entries: readonly Entry[]): Uint8Array<ArrayBuffer> {
+  const encoder = new TextEncoder();
+  const locals: Uint8Array[] = [];
+  const centrals: Uint8Array[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const name = encoder.encode(entry.path);
+    const data = encoder.encode(entry.text);
+
+    const local = new Uint8Array(30 + name.length + data.length);
+    const localView = new DataView(local.buffer);
+    localView.setUint32(0, 0x04034b50, true);
+    localView.setUint16(4, 20, true); // version needed
+    localView.setUint16(8, 0, true); // stored
+    localView.setUint32(14, crc32(data), true);
+    localView.setUint32(18, data.length, true);
+    localView.setUint32(22, data.length, true);
+    localView.setUint16(26, name.length, true);
+    local.set(name, 30);
+    local.set(data, 30 + name.length);
+    locals.push(local);
+
+    const central = new Uint8Array(46 + name.length);
+    const centralView = new DataView(central.buffer);
+    centralView.setUint32(0, 0x02014b50, true);
+    // High byte 3 is unix, which is what makes the mode below readable.
+    centralView.setUint16(4, (3 << 8) | 20, true);
+    centralView.setUint16(10, 0, true); // stored
+    centralView.setUint32(16, crc32(data), true);
+    centralView.setUint32(20, data.length, true);
+    centralView.setUint32(24, data.length, true);
+    centralView.setUint16(28, name.length, true);
+    centralView.setUint32(
+      38,
+      (entry.mode ?? (entry.path.endsWith('/') ? 0o755 : 0o644)) << 16,
+      true,
+    );
+    centralView.setUint32(42, offset, true);
+    central.set(name, 46);
+    centrals.push(central);
+
+    offset += local.length;
+  }
+
+  const centralSize = centrals.reduce((sum, block) => sum + block.length, 0);
+  const eocd = new Uint8Array(22);
+  const eocdView = new DataView(eocd.buffer);
+  eocdView.setUint32(0, 0x06054b50, true);
+  eocdView.setUint16(8, entries.length, true);
+  eocdView.setUint16(10, entries.length, true);
+  eocdView.setUint32(12, centralSize, true);
+  eocdView.setUint32(16, offset, true);
+
+  return concat([...locals, ...centrals, eocd]);
+}
+
+function concat(blocks: readonly Uint8Array[]): Uint8Array<ArrayBuffer> {
+  const out = new Uint8Array(
+    blocks.reduce((sum, block) => sum + block.length, 0),
+  );
+  let at = 0;
+  for (const block of blocks) {
+    out.set(block, at);
+    at += block.length;
+  }
+  return out;
+}
+
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = crc & 1 ? 0xedb88320 ^ (crc >>> 1) : crc >>> 1;
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}

--- a/apps/spindrift/test/storage/archive-format.test.ts
+++ b/apps/spindrift/test/storage/archive-format.test.ts
@@ -1,0 +1,212 @@
+/**
+ * The upload boundary's one container.
+ *
+ * The defect these cover is not a wrong value, it is a *late* refusal: a ZIP
+ * was accepted, staged, signed for, dispatched, and died inside the builder at
+ * `tar: This does not look like a tar archive`, reported back four steps later
+ * as `ARTIFACT_UNAVAILABLE` — a platform fault for a container-format mistake,
+ * after a workflow run had already been spent.
+ *
+ * So the assertions worth making are about what a *builder* would find. A test
+ * that only checked "the function returned some bytes" is the test that was
+ * already passing while a static App could not be uploaded as a ZIP at all.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { gunzipSync } from 'node:zlib';
+import {
+  ArchiveFormatError,
+  normalizeArchive,
+  sniffArchiveFormat,
+} from '../../src/storage/archive-format.ts';
+import { zipOf } from '../fixtures/zip.ts';
+
+/**
+ * Read the produced tar the way an extractor does, so the assertions are about
+ * an archive rather than about this module's own idea of one.
+ */
+function tarEntries(
+  gzipped: Uint8Array,
+): { path: string; text: string; mode: number; type: string }[] {
+  const tar = new Uint8Array(gunzipSync(gzipped));
+  const decoder = new TextDecoder();
+  const out: { path: string; text: string; mode: number; type: string }[] = [];
+  let pendingName: string | null = null;
+
+  for (let at = 0; at + 512 <= tar.length; ) {
+    const header = tar.subarray(at, at + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    // The checksum, verified rather than assumed: it is the one field that
+    // makes `tar` call an archive corrupt, and the one a writer gets wrong.
+    const declared = Number.parseInt(
+      decoder.decode(header.subarray(148, 156)).replace(/\0.*$/, '').trim(),
+      8,
+    );
+    const check = header.slice();
+    check.fill(0x20, 148, 156);
+    let sum = 0;
+    for (const byte of check) sum += byte;
+    expect(sum).toBe(declared);
+
+    const name = decoder.decode(header.subarray(0, 100)).replace(/\0.*$/, '');
+    const size = Number.parseInt(
+      decoder.decode(header.subarray(124, 136)).replace(/\0.*$/, '').trim(),
+      8,
+    );
+    const mode = Number.parseInt(
+      decoder.decode(header.subarray(100, 108)).replace(/\0.*$/, '').trim(),
+      8,
+    );
+    const type = String.fromCharCode(header[156] ?? 0);
+    const data = tar.subarray(at + 512, at + 512 + size);
+
+    if (type === 'L') {
+      pendingName = decoder.decode(data).replace(/\0.*$/, '');
+    } else {
+      out.push({
+        path: pendingName ?? name,
+        text: decoder.decode(data),
+        mode,
+        type,
+      });
+      pendingName = null;
+    }
+    at += 512 + Math.ceil(size / 512) * 512;
+  }
+  return out;
+}
+
+describe('sniffArchiveFormat', () => {
+  test('reads the magic number, not the filename', () => {
+    expect(sniffArchiveFormat(new Uint8Array([0x1f, 0x8b, 8, 0]))).toBe('gzip');
+    expect(sniffArchiveFormat(zipOf([{ path: 'a', text: 'b' }]))).toBe('zip');
+    expect(
+      sniffArchiveFormat(new TextEncoder().encode('<!doctype html>')),
+    ).toBe(null);
+    expect(sniffArchiveFormat(new Uint8Array(0))).toBe(null);
+  });
+});
+
+describe('normalizeArchive', () => {
+  test('passes a gzipped tar through untouched', () => {
+    const already = new Uint8Array([0x1f, 0x8b, 8, 0, 1, 2, 3]);
+    const normalized = normalizeArchive('bundle.tar.gz', already);
+    expect(normalized.from).toBe('gzip');
+    expect(normalized.bytes).toBe(already);
+    expect(normalized.filename).toBe('bundle.tar.gz');
+  });
+
+  test('converts a ZIP into a tar an extractor can read', () => {
+    const normalized = normalizeArchive(
+      'deck.zip',
+      zipOf([
+        { path: 'index.html', text: '<h1>hi</h1>' },
+        { path: 'assets/app.css', text: 'body{}' },
+      ]),
+    );
+
+    expect(normalized.from).toBe('zip');
+    // Named for what it now is: the depot object is content-addressed with this
+    // extension, and calling a tarball `.zip` is how the next reader is misled.
+    expect(normalized.filename).toBe('deck.tar.gz');
+    expect(sniffArchiveFormat(normalized.bytes)).toBe('gzip');
+
+    const entries = tarEntries(normalized.bytes);
+    expect(entries.map((entry) => entry.path)).toEqual([
+      'index.html',
+      'assets/app.css',
+    ]);
+    expect(entries[0]?.text).toBe('<h1>hi</h1>');
+    expect(entries[1]?.text).toBe('body{}');
+  });
+
+  test('carries the executable bit across, because a build context depends on it', () => {
+    const entries = tarEntries(
+      normalizeArchive(
+        'src.zip',
+        zipOf([
+          { path: 'build.sh', text: '#!/bin/sh\n', mode: 0o755 },
+          { path: 'README', text: 'no\n', mode: 0o644 },
+        ]),
+      ).bytes,
+    );
+    expect(entries[0]?.mode).toBe(0o755);
+    expect(entries[1]?.mode).toBe(0o644);
+  });
+
+  test('writes a long path through the long-name entry', () => {
+    const long = `${'nested/'.repeat(20)}file.txt`;
+    expect(long.length).toBeGreaterThan(100);
+    const entries = tarEntries(
+      normalizeArchive('deep.zip', zipOf([{ path: long, text: 'deep' }])).bytes,
+    );
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.path).toBe(long);
+    expect(entries[0]?.text).toBe('deep');
+  });
+
+  test('keeps a directory entry as a directory', () => {
+    const entries = tarEntries(
+      normalizeArchive(
+        'dirs.zip',
+        zipOf([
+          { path: 'static/', text: '' },
+          { path: 'static/a.txt', text: 'a' },
+        ]),
+      ).bytes,
+    );
+    expect(entries.map((entry) => entry.type)).toEqual(['5', '0']);
+    expect(entries[0]?.path).toBe('static/');
+  });
+
+  test('is deterministic, so the same upload keeps its digest', () => {
+    const zip = zipOf([{ path: 'index.html', text: 'same' }]);
+    const first = normalizeArchive('deck.zip', zip).bytes;
+    const second = normalizeArchive('deck.zip', zip).bytes;
+    expect(Buffer.from(second).equals(Buffer.from(first))).toBe(true);
+  });
+
+  test('refuses bytes that are neither, and says what arrived', () => {
+    const html = new TextEncoder().encode('<!doctype html><title>oops</title>');
+    let thrown: unknown;
+    try {
+      normalizeArchive('site.zip', html);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ArchiveFormatError);
+    const error = thrown as ArchiveFormatError;
+    expect(error.code).toBe('UNKNOWN_FORMAT');
+    // The refusal has to name the real cause. `ARTIFACT_UNAVAILABLE` four steps
+    // later is the failure this whole module exists to stop.
+    expect(error.message).toContain('gzipped tar');
+    expect(error.message).toContain('3c 21 64 6f');
+  });
+
+  test('refuses an entry that would write outside the bundle', () => {
+    let thrown: unknown;
+    try {
+      normalizeArchive(
+        'evil.zip',
+        zipOf([{ path: '../../etc/cron.d/x', text: 'pwn' }]),
+      );
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ArchiveFormatError);
+    expect((thrown as ArchiveFormatError).code).toBe('PATH_ESCAPES_ARCHIVE');
+  });
+
+  test('refuses a truncated ZIP rather than staging half of one', () => {
+    const zip = zipOf([{ path: 'index.html', text: 'hello' }]);
+    let thrown: unknown;
+    try {
+      normalizeArchive('cut.zip', zip.subarray(0, zip.length - 10));
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeInstanceOf(ArchiveFormatError);
+    expect((thrown as ArchiveFormatError).code).toBe('MALFORMED_ZIP');
+  });
+});

--- a/apps/spindrift/test/web/upload.test.ts
+++ b/apps/spindrift/test/web/upload.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, test } from 'bun:test';
+import { gunzipSync, gzipSync } from 'node:zlib';
 import type { Principal } from '../../src/commands/types.ts';
+import { sniffArchiveFormat } from '../../src/storage/archive-format.ts';
 import { readStagedArchive } from '../../src/storage/archives.ts';
 import type { DispatchDeps } from '../../src/web/dispatch.ts';
 import { handleUpload } from '../../src/web/upload.ts';
+import { zipOf } from '../fixtures/zip.ts';
 
 const mockPrincipal: Principal = {
   id: '00000000-0000-4000-8000-000000000001',
@@ -35,12 +38,12 @@ describe('archive upload endpoint', () => {
     expect(body.failure.code).toBe('UNAUTHENTICATED');
   });
 
-  test('stages raw binary upload bytes durably and returns digest and location', async () => {
-    const payload = new TextEncoder().encode('dummy zip file contents');
+  test('stages a gzipped tar exactly as it arrived', async () => {
+    const payload = new Uint8Array(gzipSync(new TextEncoder().encode('tar')));
     const request = new Request('http://localhost/internal/upload', {
       method: 'POST',
       headers: {
-        'x-filename': 'test-app.zip',
+        'x-filename': 'test-app.tar.gz',
       },
       body: payload,
     });
@@ -49,22 +52,25 @@ describe('archive upload endpoint', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.ok).toBe(true);
-    expect(body.value.filename).toBe('test-app.zip');
+    expect(body.value.filename).toBe('test-app.tar.gz');
     expect(body.value.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
     expect(body.value.location).toMatch(/^upload:\/\/[0-9a-f]{64}$/);
     expect(body.value.size).toBe(payload.byteLength);
 
+    // Byte-for-byte, because the format was already the one every route opens
+    // and a needless re-pack would change the digest of an unchanged upload.
     const staged = await readStagedArchive(body.value.digest);
     expect(staged).not.toBeNull();
-    expect(new TextDecoder().decode(staged!)).toBe('dummy zip file contents');
+    expect(Buffer.from(staged!).equals(Buffer.from(payload))).toBe(true);
   });
 
-  test('stages multipart/form-data upload file durably', async () => {
-    const fileContent = 'multipart archive content';
+  test('stages a ZIP as the gzipped tar every build route can open', async () => {
     const formData = new FormData();
     formData.append(
       'file',
-      new File([fileContent], 'sample.tar.gz', { type: 'application/gzip' }),
+      new File([zipOf([{ path: 'index.html', text: 'hi' }])], 'sample.zip', {
+        type: 'application/zip',
+      }),
     );
 
     const request = new Request('http://localhost/internal/upload', {
@@ -76,11 +82,36 @@ describe('archive upload endpoint', () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.ok).toBe(true);
+    // Renamed, because the staged object is no longer a ZIP and the depot names
+    // it by this extension.
     expect(body.value.filename).toBe('sample.tar.gz');
-    expect(body.value.digest).toMatch(/^sha256:[0-9a-f]{64}$/);
 
     const staged = await readStagedArchive(body.value.digest);
     expect(staged).not.toBeNull();
-    expect(new TextDecoder().decode(staged!)).toBe('multipart archive content');
+    expect(sniffArchiveFormat(staged!)).toBe('gzip');
+    // The digest names what is in the depot, not what was uploaded — the build
+    // hull re-checks it with `sha256sum` before it extracts.
+    expect(body.value.size).toBe(staged!.byteLength);
+    expect(new TextDecoder().decode(gunzipSync(staged!))).toContain(
+      'index.html',
+    );
+  });
+
+  test('refuses bytes no build route could open, at the boundary', async () => {
+    // The whole defect in one request: a file named `.zip` that is not one.
+    // This used to stage, sign, dispatch, and fail inside a runner as
+    // ARTIFACT_UNAVAILABLE.
+    const request = new Request('http://localhost/internal/upload', {
+      method: 'POST',
+      headers: { 'x-filename': 'site.zip' },
+      body: new TextEncoder().encode('<!doctype html>not an archive'),
+    });
+
+    const response = await handleUpload(request, deps(true));
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.ok).toBe(false);
+    expect(body.failure.code).toBe('UNKNOWN_FORMAT');
+    expect(body.failure.message).toContain('gzipped tar');
   });
 });


### PR DESCRIPTION
The creation flow's own tile offers "ZIP, artifact, or source archive", and
`/internal/upload` accepted one. But a staged bundle is opened by three programs
in three runtimes, and every one of them runs `tar -xz`:

| Route | Fetch |
| --- | --- |
| hosted | `.github/workflows/spindrift-build.yml` — `curl … \| tar -xz` |
| managed / in-cluster | `adapters/build/buildkit.ts` — `wget -qO- … \| tar -xz` |
| pool | `nix/images/hull-ubuntu.nix` — `sha256sum`, then `tar -xzf` |

So a ZIP staged, was signed for, spent a build, and died in the builder at `tar:
This does not look like a tar archive` — reported back as `ARTIFACT_UNAVAILABLE`
four steps later, which names the platform for what is a container-format
mistake. Found by uploading one.

## The fix

Normalize at the one place that sees the bytes. `storage/archive-format.ts`
sniffs the magic number, transcodes a ZIP to a gzipped tar, and refuses anything
else with a `400` naming what arrived. **All three fetchers are unchanged** —
teaching each of them to sniff is what let them drift apart in the first place,
and two of those images carry no unzip.

Two consequences worth stating rather than discovering:

- **The digest is over the converted bytes**, because that is what §16's join has
  to name — the build hull re-checks it with `sha256sum` before extracting. A
  digest of the uploaded ZIP would name bytes no builder ever holds.
- **The conversion is deterministic** — the ZIP's own entry order, and a constant
  for every tar field a ZIP does not carry — so re-uploading identical input
  still lands on the Build row that already describes it rather than minting a
  second one.

Reader and writer are hand-written for the reason `bundle.ts` gives for its tar
reader: §20's extraction contract wants a package that prunes to something
self-contained, and these are two fixed formats. Executable bits are carried
across, long paths go through a GNU long-name entry, and an entry that would
write outside the bundle is refused.

## Validation

`2186 pass, 0 fail` on the full suite; `ts:check` clean.

The output is verified against **GNU tar** and against `bundle.ts`'s own reader,
not only against this module's idea of an archive — a python-made ZIP round-trips
to a tree with its executable bit, its empty directory, a 148-character path and
a UTF-8 filename intact. The new boundary tests were confirmed to fail with the
normalizer disabled.

Two fixtures had to become real archives to stay honest. `test/web/upload.test.ts`
staged the string `dummy zip file contents` under the name `test-app.zip` and
asserted it round-tripped; the conformance fixture was a ZIP magic number with
nothing behind it. Both were green while a static App could not be uploaded as a
ZIP at all.