### PR TITLE
Harden the sidecar too, and name the Service the operator made

### DIFF
--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -284,7 +284,7 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
         // The two fields `restricted` demands that exist only on a container,
         // so the pod block above cannot supply them. Every container in the pod
         // needs them, and this operator builds **two**: `server`, patched here,
-        // and a `metrics-exporter` sidecar it adds unasked — which has its own
+        // and the metrics exporter sidecar it adds unasked — which has its own
         // spec field rather than living in `containers`, and so is set below.
         // Admission fails the whole pod on the one that is missing them, which
         // is why hardening only the obvious container hardens nothing.

--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -86,6 +86,15 @@ export const ENGINE_KINDS = {
  */
 const NAME_LIMIT = 50;
 
+/**
+ * What the Valkey operator prefixes everything it creates with.
+ *
+ * `resourcePrefix` in the operator's own `internal/controller/utils.go`. Named
+ * here because two places need it and neither is allowed to guess: the address
+ * a Datastore hands out, and the Service that address is confirmed against.
+ */
+const VALKEY_RESOURCE_PREFIX = 'valkey-';
+
 export interface KubernetesDatastoreOptions {
   /** Minted per request. Never a stored credential (§13). */
   readonly token: TokenProvider;
@@ -272,9 +281,13 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
           fsGroup: 1000,
           seccompProfile: { type: 'RuntimeDefault' },
         },
-        // The two fields `restricted` demands that exist only on a container.
-        // A strategic merge patch onto the operator's own container, which it
-        // names `server` — everything else about it is left to the operator.
+        // The two fields `restricted` demands that exist only on a container,
+        // so the pod block above cannot supply them. Every container in the pod
+        // needs them, and this operator builds **two**: `server`, patched here,
+        // and a `metrics-exporter` sidecar it adds unasked — which has its own
+        // spec field rather than living in `containers`, and so is set below.
+        // Admission fails the whole pod on the one that is missing them, which
+        // is why hardening only the obvious container hardens nothing.
         containers: [
           {
             name: 'server',
@@ -284,6 +297,17 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
             },
           },
         ],
+        // The sidecar, hardened through the field the operator gives it rather
+        // than through `containers` — it is not in that list, and a patch
+        // naming it there would add a third container instead of amending the
+        // second. Left enabled: the fleet scrapes what it runs, and switching
+        // metrics off to satisfy a policy would be answering the wrong question.
+        exporter: {
+          securityContext: {
+            allowPrivilegeEscalation: false,
+            capabilities: { drop: ['ALL'] },
+          },
+        },
       },
     };
   }
@@ -314,23 +338,31 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
       // reading `<cluster>-app` means reading every Secret in the namespace.
       return `secret://${parsed.namespace}/${parsed.name}-app`;
     }
-    // The Valkey operator fronts a cluster with a Service of the same name.
+    // The Valkey operator fronts a cluster with a Service named for it, under
+    // the prefix it gives everything it creates (`resourcePrefix = "valkey-"`
+    // in the operator's `internal/controller/utils.go`, and its own e2e suite
+    // reads back `service valkey-<cluster>`).
+    //
     // Confirmed against the cluster rather than asserted, because this is the
     // one fact here that is a naming convention rather than a documented API
     // field — and `services: get` is a grant that names an ordinary object.
-    const service = await api.get({
+    // The confirmation is what makes a wrong guess here a Datastore that never
+    // reports a connection rather than one that hands out an address nothing
+    // answers on.
+    const service = `${VALKEY_RESOURCE_PREFIX}${parsed.name}`;
+    const found = await api.get({
       apiVersion: 'v1',
       plural: 'services',
       namespace: parsed.namespace,
-      name: parsed.name,
+      name: service,
     });
     // `redis://`, not `valkey://`. This fills `REDIS_URL` (the variable is fixed
     // by engine), and every client that reads it — node-redis, ioredis,
     // redis-py — parses `redis://` and rejects a scheme it does not know. A
     // scheme naming the server would be honest and unusable.
-    return service === null
+    return found === null
       ? null
-      : `redis://${parsed.name}.${parsed.namespace}.svc:6379`;
+      : `redis://${service}.${parsed.namespace}.svc:6379`;
   }
 }
 

--- a/apps/spindrift/test/adapters/datastore.test.ts
+++ b/apps/spindrift/test/adapters/datastore.test.ts
@@ -142,15 +142,18 @@ describe('provision', () => {
     // Container-only fields, so they cannot be satisfied by the pod block
     // above. The name is the operator's own container — a patch naming
     // anything else is silently a second container.
+    const hardened = {
+      allowPrivilegeEscalation: false,
+      capabilities: { drop: ['ALL'] },
+    };
     expect(spec.containers).toEqual([
-      {
-        name: 'server',
-        securityContext: {
-          allowPrivilegeEscalation: false,
-          capabilities: { drop: ['ALL'] },
-        },
-      },
+      { name: 'server', securityContext: hardened },
     ]);
+    // The sidecar the operator adds unasked, hardened through its own field.
+    // Admission fails the whole pod on whichever container lacks these, so
+    // asserting only `server` would assert a pod that still cannot be created —
+    // which is exactly what shipped before a live provision found it.
+    expect(spec.exporter).toEqual({ securityContext: hardened });
   });
 
   test('a hyphenated name becomes a typeable SQL identifier', async () => {
@@ -262,10 +265,12 @@ describe('observe', () => {
       engine: 'valkey',
       storageGiB: 1,
     });
-    fake.place('services/spindrift-apps/sessions', {
+    // `valkey-`, the prefix the operator gives everything it creates. A
+    // Service placed under the bare name is the cluster as it is *not*.
+    fake.place('services/spindrift-apps/valkey-sessions', {
       apiVersion: 'v1',
       kind: 'Service',
-      metadata: { name: 'sessions', namespace: 'spindrift-apps' },
+      metadata: { name: 'valkey-sessions', namespace: 'spindrift-apps' },
     });
 
     const state = await adapter.observe(
@@ -276,7 +281,9 @@ describe('observe', () => {
     // ACL user is declared, so the address is the whole of it. `redis://`
     // because this lands in `REDIS_URL` and no mainstream client parses a
     // `valkey://` scheme.
-    expect(state?.connection).toBe('redis://sessions.spindrift-apps.svc:6379');
+    expect(state?.connection).toBe(
+      'redis://valkey-sessions.spindrift-apps.svc:6379',
+    );
   });
 
   test('a degraded Valkey is FAILED with §6s reason for readiness that never passed', async () => {


### PR DESCRIPTION
Two defects found by actually provisioning one. Both leave a `valkey` Datastore **stuck rather than wrong**, which is the harder kind to notice.

## 1. The operator builds two containers

#2001 hardened `server` and stopped. The operator also adds a `metrics-exporter` sidecar, unasked, with no security context of its own — and admission fails the **whole pod** on whichever container is missing the fields. Live result:

```
Warning FailedCreate 9s (x14 over 50s) statefulset-controller
  Create Pod valkey-demo-cache-0-0-0 ... is forbidden: violates PodSecurity "restricted:latest":
  allowPrivilegeEscalation != false (container "metrics-exporter" must set ...)
  unrestricted capabilities (container "metrics-exporter" must set capabilities.drop=["ALL"])
```

The sidecar is not in `spec.containers` and cannot be patched through it — a patch naming it there adds a *third* container. The operator gives it `spec.exporter.securityContext`, which is where this goes.

Left enabled rather than switched off. The fleet scrapes what it runs; disabling metrics to satisfy a policy answers a different question than the one asked.

## 2. The Service is `valkey-<name>`, not `<name>`

`resourcePrefix = "valkey-"` in the operator's `internal/controller/utils.go`, and its own e2e suite reads back `service valkey-<cluster>`. The comment asserting *"a Service of the same name"* was wrong.

This one would have been much worse than a crash. The read-back would find nothing for a cluster that was working perfectly, so the Datastore would reach `LIVE` and simply never report a connection — no error anywhere. The decision to *confirm* the Service rather than assert it is what downgraded a wrong guess into "no connection" instead of an address nothing answers on.

## Validation

- 13 pass. The restricted test now asserts the sidecar too — asserting only `server` asserted a pod that still could not be created, which is precisely what shipped.
- Naming came from the operator's source and e2e suite, not from a second guess.
- `mise run ts:check` clean.

## Worth a follow-up, not fixed here

Throughout the failure the loop reported the operator's own `Updating ValkeyNodes` — accurate, and never the admission refusal, which lands on a StatefulSet nothing in the adapter reads. The Datastore looked like it was progressing while it could not possibly succeed. Closing that gap means reading a level deeper than the CR on a stall, and is its own change.