### PR TITLE
docs(slides): lead with the product, not the estate it was built on

### DIFF
--- a/apps/slides/bosun/index.html
+++ b/apps/slides/bosun/index.html
@@ -553,7 +553,7 @@
     <span><b>4</b> nouns</span>
     <span><b>2,287</b> lines of Go</span>
     <span><b>0</b> dependencies</span>
-    <span>Peer of <b>Spindrift</b></span>
+    <span><b>0</b> inbound ports</span>
   </p>
 </section>
 
@@ -564,7 +564,7 @@
   <h2>“I pushed. Now everybody waits.”</h2>
   <div class="split">
     <div style="display:flex;flex-direction:column;gap:1rem">
-      <p class="dim">A CI job on somebody else's runner pays a fixed tax before it computes anything, and pays it again on every push. Two clusters and a metal fleet sitting idle downstairs do not reduce it by a second.</p>
+      <p class="dim">Before a job computes anything it re-acquires a machine, a toolchain and a cache it already had the last time it ran. That tax is fixed, it is paid again on every push, and a bigger runner does not remove it — a faster CPU runs the same six steps.</p>
       <p class="rule-kicker">None of this is your build. All of it is on the critical path between a push and an answer.</p>
     </div>
     <ol class="steps">
@@ -576,7 +576,8 @@
       <li>Share a kernel with whatever ran before you</li>
     </ol>
   </div>
-  <p class="verbatim">measured on this repo's own suite — cache restore over the internet <b>49–76 s</b> · waiting for a container runner <b>1–59 s</b> · the same cold suite on a hosted runner <b>271–375 s</b>, depending on the day</p>
+  <p class="verbatim">measured on one real repository's suite — restoring a dependency cache over the internet <b>49–76 s</b> · waiting for a container runner <b>1–59 s</b> · the same cold suite on a hosted runner <b>271–375 s</b>, same commit, different days</p>
+  <p class="small dim" style="max-width:68ch">The lever everyone knows about is to run it somewhere else. Almost nobody pulls it, because CI is welded to the place the code lives: the label, the cache, the queue, the identity and the logs all belong to one vendor, and moving the compute has meant giving up all five.</p>
 </section>
 
 <!-- ============================== 03 the idea ============================== -->
@@ -604,8 +605,8 @@
         <text class="d-t b" x="38" y="198">bosun</text>
         <text class="d-s" x="38" y="220">keeps N skiffs of each class</text>
         <text class="d-s" x="38" y="238">booted and registered —</text>
-        <text class="d-s" x="38" y="256">N is a number in the host's</text>
-        <text class="d-m" x="38" y="272">NixOS configuration</text>
+        <text class="d-s" x="38" y="256">N is declared, not derived —</text>
+        <text class="d-m" x="38" y="272">one number, one config file</text>
 
         <!-- skiff -->
         <rect class="d-acc" x="360" y="170" width="220" height="110" rx="8"/>
@@ -659,47 +660,44 @@
   </div>
 </section>
 
-<!-- ============================== 04 vocabulary ============================== -->
+<!-- ============================== 04 adoption ============================== -->
 <section class="slide">
   <span class="no"><b>04</b> / 11</span>
-  <p class="eyebrow">Four nouns, and no fifth</p>
-  <h2>Everything here is a <em>skiff</em>, a <em>hull</em>, a <em>class</em>, or bosun</h2>
-  <div class="nouns">
-    <span class="noun noun--authored">skiff</span>
-    <span class="noun noun--authored">hull</span>
-    <span class="noun noun--authored">class</span>
-    <span class="noun">bosun</span>
-  </div>
-  <div class="cols">
-    <div class="card card--flag">
-      <h4>skiff</h4>
-      <p>One ephemeral microVM serving exactly one job. The unit of isolation and the unit of accounting.</p>
+  <p class="eyebrow">What adoption costs</p>
+  <h2>One line moves, and it is the <em>label</em></h2>
+  <div class="split">
+    <div style="display:flex;flex-direction:column;gap:1.1rem">
+      <p class="verbatim" style="border-left-color:var(--good)"><span style="color:var(--caution)">- &nbsp;runs-on: ubuntu-latest</span><br /><span style="color:var(--good)">+ &nbsp;runs-on: skiff-ubuntu</span></p>
+      <p class="dim">The workflow is otherwise untouched. Same steps, same third-party actions, same <code>actions/cache</code> — the stock action, which the hull points at a cache service on the host's own disk instead of one across the internet.</p>
+      <p class="rule-kicker">Nothing about a skiff is visible to the job running inside it. A runner you have to write YAML for is a migration, not a runner.</p>
     </div>
-    <div class="card card--flag">
-      <h4>hull</h4>
-      <p>The immutable artifact a skiff boots from — a kernel, an initrd, and whatever else its manifest names. One hull serves many skiffs.</p>
-    </div>
-    <div class="card card--flag">
-      <h4>class</h4>
-      <p>What a <code>runs-on:</code> label resolves to: which hull, how many vCPUs, how much memory, how much disk, how many kept warm.</p>
-    </div>
-    <div class="card">
-      <h4>bosun</h4>
-      <p>The daemon, and the project. The ship's officer historically responsible for the boats.</p>
+    <div style="display:flex;flex-direction:column;gap:1.1rem">
+      <div class="stats">
+        <div class="stat stat--ink"><b>1</b><span>line changed in the workflow</span></div>
+        <div class="stat stat--ink"><b>0</b><span>firewall changes — a pool only ever dials out</span></div>
+        <div class="stat"><b>14 s</b><span>cache restore on-host, against 49–76 s over the internet</span></div>
+        <div class="stat"><b>1 s</b><span>queue to start, on every run</span></div>
+      </div>
+      <p class="small dim" style="max-width:62ch">Two shapes already exist for this. One keeps your workflow and swaps the hardware behind the label. The other keeps a hosted orchestrator and moves the agents onto machines you own. This keeps the label, moves the machines, and then deletes the orchestrator — because a warm pool never needed one.</p>
     </div>
   </div>
-  <p class="small dim" style="max-width:64ch">The vocabulary was constrained before it was chosen: GitHub already owns <span class="m">runner</span>, <span class="m">job</span> and <span class="m">label</span>; Spindrift owns <span class="m">Vessel</span>, <span class="m">Target</span>, <span class="m">Build</span> and <span class="m">Deploy</span>; the repo owns <span class="m">Fleet</span>. <span class="m">image</span> already meant three other things here, which is why a hull is not called one.</p>
 </section>
 
 <!-- ============================== 05 the hull contract ============================== -->
 <section class="slide">
   <span class="no"><b>05</b> / 11</span>
-  <p class="eyebrow">Where the daemon stops</p>
+  <p class="eyebrow">Four nouns, and the seam between them</p>
   <h2>The hull describes itself. bosun never learns <em>why</em>.</h2>
+  <div class="lineage">
+    <div><b>skiff</b><span>one microVM · one job · then scuttled</span></div>
+    <div><b>hull</b><span>the kernel + initrd it boots from</span></div>
+    <div><b>class</b><span>what a runs-on: label resolves to</span></div>
+    <div><b>bosun</b><span>the daemon, and the project</span></div>
+  </div>
   <div class="split">
     <div style="display:flex;flex-direction:column;gap:1rem">
       <p class="dim">A hull is a directory holding a <code>hull.json</code> beside the files it names — a kernel, an initrd, a command line, and a list of devices. bosun translates that manifest into hypervisor arguments and provisions what it asks for.</p>
-      <p class="rule-kicker">There is no per-family branching anywhere in the daemon. Two very different operating systems boot through one code path.</p>
+      <p class="rule-kicker">There is no per-family branching anywhere in the daemon. Two unrelated operating systems boot through one code path.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:1.1rem">
       <div class="cols">
@@ -723,7 +721,7 @@
         </div>
       </div>
       <p class="verbatim">the contract names no runner, no version, no operating system and no package manager</p>
-      <p class="small dim" style="max-width:64ch">Which is what makes “no Nix in the cloud” an ordinary sentence instead of a special case. Two families exist today: a NixOS hull with the host's own <code>/nix/store</code> shared in, and an Ubuntu hull that is this repo's existing Actions-runner image flattened into a read-only squashfs. The shared store is therefore a property of <em>one hull</em>, not of the platform.</p>
+      <p class="small dim" style="max-width:66ch">Two hull families exist today: a NixOS hull that mounts the host's own <code>/nix/store</code> read-only, and an Ubuntu hull that is an ordinary container image flattened into a read-only squashfs. The daemon cannot tell them apart — which is why the shared store is a property of <em>one hull</em> and never of the platform. One implementation would have made this seam hypothetical; two is what makes it real.</p>
     </div>
   </div>
 </section>
@@ -741,14 +739,14 @@
         <div class="stat"><b>0</b><span>inbound ports on the daemon</span></div>
         <div class="stat"><b>0</b><span>databases</span></div>
       </div>
-      <p class="small dim">State lives in <code>/run/bosun/&lt;id&gt;/</code>, which is tmpfs — so a reboot clears it and that is correct. Desired state is the host's NixOS configuration, which is why the daemon has no runtime configuration surface at all.</p>
+      <p class="small dim">State lives in <code>/run/bosun/&lt;id&gt;/</code>, which is tmpfs — so a reboot clears it, and that is correct. Desired state is one config file on the host, which is why the daemon has no runtime configuration surface at all: no API that can resize the pool, and so no drift between what is running and what was declared.</p>
     </div>
     <ul class="reasons">
       <li><b>The webhook receiver</b> — a warm pool is never told a job was queued, so there is nothing to receive.</li>
       <li><b>The queue listener and the control plane</b> — both existed to answer a question the inversion deleted.</li>
       <li><b>Credential transport over vsock</b> — a kernel module, a CID allocator and a guest listener, for one string delivered once at boot. It is a file in a per-skiff directory instead.</li>
       <li><b>Snapshot and restore</b> — measured, not assumed: restore is flat at ~1.8 s, and the Ubuntu hull reaches the runner in 0.68–0.97 s. A snapshot cannot pay for itself against a guest that cheap.</li>
-      <li><b>The orphan scan and the re-adoption path</b> — systemd's default <code>KillMode=control-group</code> kills <code>setsid</code> grandchildren, so an orphaned hypervisor cannot exist to be reclaimed.</li>
+      <li><b>Re-adopting an orphaned hypervisor</b> — systemd SIGKILLs the whole cgroup at the stop timeout, so a VMM cannot outlive the daemon and be found again later. Sweeping stale registrations on start is the entire recovery path.</li>
     </ul>
   </div>
 </section>
@@ -760,8 +758,8 @@
   <h2>Deny the LAN. Allow the internet.</h2>
   <div class="split">
     <div style="display:flex;flex-direction:column;gap:1rem">
-      <p class="dim">The obvious policy — “reach GitHub and nothing else” — breaks every job in this repository, which already fetches seven public hosts plus three Nix substituters. Every one of them is public, and that is what makes the inverted policy both possible and cheap.</p>
-      <p class="rule-kicker">One <code>IPAddressDeny</code> directive on bosun's own unit. Every skiff inherits it down the cgroup subtree.</p>
+      <p class="dim">The obvious policy — “reach the CI provider and nothing else” — breaks every real job, which pulls package registries, base images and release binaries from a dozen public hosts. So invert it. One <code>IPAddressDeny</code> on bosun's own unit denies RFC1918 and <code>169.254.0.0/16</code>, and systemd's IP filtering inherits down the cgroup subtree to every skiff underneath it. There is no per-skiff rule anywhere.</p>
+      <p class="rule-kicker">A job reaches the internet and cannot reach anything of yours — including the cloud metadata service, which sits on the wrong side of that same line.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:1.1rem">
       <div class="cols">
@@ -775,8 +773,13 @@
           <h4>Removed the moment it is spent</h4>
           <p>bosun deletes it host-side as soon as GitHub reports the runner online. virtiofs passes through to the host filesystem, so it vanishes inside the guest with no cooperation from the guest — untrusted job code never sees a live credential.</p>
         </div>
+        <div class="card card--flag">
+          <span class="tag t-acc">The tenancy</span>
+          <h4>One job, one kernel</h4>
+          <p>Not a scrubbed workspace, and not a fresh container on a kernel the last job also used. A skiff is its own kernel, and it stops existing when the job ends — so there is no residue for the next job to inherit and nothing to scrub correctly.</p>
+        </div>
       </div>
-      <p class="small dim" style="max-width:64ch">RFC1918 and <code>169.254.0.0/16</code>, so a cloud metadata service is on the wrong side of the line too. Denying RFC1918 also breaks DNS on every host the fleet has, so a public resolver is pinned and the deny stays absolute rather than growing an exception.</p>
+      <p class="small dim" style="max-width:66ch">Denying RFC1918 also breaks DNS, so a public resolver is pinned and the deny stays absolute rather than growing its first exception. An allowlist with one hole in it is an allowlist nobody can reason about a year later.</p>
     </div>
   </div>
 </section>
@@ -825,14 +828,15 @@
     <li><b>GitHub silently removes an expired registration while the agent keeps running.</b> A skiff aged past its credential was offered a job at its own label and never claimed it; by 89 minutes the runner was a 404 while the VMM was alive and idle. Without recycling, that is a permanent RAM leak wearing the costume of a healthy skiff.</li>
     <li><b>The suite outgrew its class</b> — restored tests that each stand up a database segfaulted at 3 GiB and passed on hosted from the same commit. Long test durations plus a moving crash site is starvation, not a logic bug.</li>
   </ul>
-  <p class="small dim" style="max-width:66ch">Every one of these was live behaviour on a real host. The generalisable lesson is written into the map: a comment that says “if this becomes a problem in practice” is a prediction with no alarm attached. That one came true in nine hours.</p>
+  <p class="small dim" style="max-width:66ch">Every one of these was live behaviour on a real host, and none of them is exotic. The generalisable lesson: a code comment reading “if this becomes a problem in practice” is a prediction with no alarm attached to it. That one came true in nine hours.</p>
 </section>
 
 <!-- ============================== 10 the sibling ============================== -->
 <section class="slide">
   <span class="no"><b>10</b> / 11</span>
-  <p class="eyebrow">Where it meets Spindrift</p>
-  <h2>A peer, not a subsystem — and the only route that <em>dials in</em></h2>
+  <p class="eyebrow">Beyond CI</p>
+  <h2>A producer that cannot reach the pool can still <em>feed</em> it</h2>
+  <p class="dim" style="max-width:72ch">No inbound port is the point of the design, and also the obvious objection: how does anything other than GitHub hand a pool work? By not pushing. A producer writes an intent to a row in its own database, and the pool long-polls in to claim it. Spindrift — a deploy control plane, and a peer project, not an owner — routes container builds this way.</p>
   <figure>
     <div class="figwrap">
       <svg viewBox="0 0 920 400" role="img" aria-label="Spindrift's build routes: the hosted GitHub Actions route, the managed Cloud Build route, and the in-cluster Job route are all dialled outward by the Spindrift process. The bosun route is the mirror image: Spindrift writes an intent to a build outbox row in its own Postgres, and an operator-controlled bosun host that Spindrift cannot reach long-polls in to claim it, heartbeat, and post the result.">
@@ -900,7 +904,7 @@
     </div>
     <div class="card card--cau">
       <h4>Declared, and honestly unserved</h4>
-      <p>The cloud host that served this class is at rest again — the size-matched benchmark was what it was resurrected to answer. The route stays declared and ranked last, so a resurrection serves it with no configuration at all.</p>
+      <p>The host that served this class is powered down again; answering the benchmark two slides back is what it was woken for. The route stays declared and ranked last, so bringing a host back serves it with no configuration change at all — which is the same claim, tested by its absence.</p>
     </div>
   </div>
 </section>
@@ -909,24 +913,24 @@
 <section class="slide">
   <span class="no"><b>11</b> / 11</span>
   <p class="eyebrow">Where it stands</p>
-  <h2>Two lab hosts, three warm slots, and an honest open list</h2>
+  <h2>Two hosts, three warm slots, and an honest open list</h2>
   <div class="split">
     <div style="display:flex;flex-direction:column;gap:1rem">
       <div class="lineage">
-        <div><b>riptide</b><span>folly · nixos + ubuntu-lite</span></div>
-        <div><b>oldschool</b><span>offsite · ubuntu, 2 vCPU</span></div>
+        <div><b>Two hosts</b><span>one on-site, one remote — nothing in common</span></div>
+        <div><b>Three warm slots</b><span>same daemon · same hulls · nothing between them</span></div>
       </div>
-      <p class="small dim">Both hosts run a local <code>actions/cache</code> service on their own disk, which the stock action talks to transparently: 14 s to restore where GitHub's service took 49–76 s. A workflow gets that by changing one label and nothing else.</p>
+      <p class="small dim">A host joins by importing the module and naming its classes. Nothing coordinates the two, because there is no fleet controller to coordinate with — a pool is per-host by construction, and the only shared fact is a label GitHub already knows how to route on.</p>
       <p class="small dim" style="border-left:3px solid var(--good);padding-left:0.9rem">Bosun drains on stop rather than dying: idle skiffs are scuttled registration-first — GitHub refuses to delete a busy runner, so a successful delete <b>proves</b> no job can land there — and busy ones get fifteen minutes to finish.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:1rem">
       <div class="card card--cau">
         <h4>Open</h4>
         <ul class="ticks">
-          <li>The production suite is back on hosted while a class grows — that is a memory bound guarding kubelet on a shared box, which is an operator's arithmetic and not a workflow's to make.</li>
+          <li>The production suite is back on hosted while a class grows — the pool's host shares its box with other workloads, so the class's memory bound is an operator's arithmetic and not a workflow's to make.</li>
           <li>Every decision that reads GitHub — busy or idle, lifetime, pool count — has the same single-source dependency, and none of them has been thought about under a GitHub outage.</li>
           <li>What a guest breakout would actually cost, given the data path is three unprivileged processes rather than root.</li>
-          <li>arm64. The fleet has native arm64 and nobody has asked the question.</li>
+          <li>arm64. Native arm64 hosts are sitting right there and nobody has asked the question.</li>
         </ul>
       </div>
     </div>

--- a/apps/slides/spindrift/index.html
+++ b/apps/slides/spindrift/index.html
@@ -533,7 +533,7 @@
     </svg>
   </div>
 
-  <p class="eyebrow">Deploy control plane · <span class="m" style="text-transform:none;letter-spacing:0">apps/spindrift</span></p>
+  <p class="eyebrow">Adapter-based deploy control plane · <span class="m" style="text-transform:none;letter-spacing:0">apps/spindrift</span></p>
 
   <div style="display:flex;flex-direction:column;gap:clamp(1rem,3vh,2rem)">
     <h1>Spindrift</h1>
@@ -544,6 +544,7 @@
   <p class="colophon">
     <span>One contract</span>
     <span><b>3</b> parts</span>
+    <span><b>5</b> adapter seams</span>
     <span>Auth <b>in the contract</b></span>
   </p>
 </section>
@@ -555,8 +556,8 @@
   <h2>“I wrote a thing. Put it somewhere with a URL.”</h2>
   <div class="split">
     <div style="display:flex;flex-direction:column;gap:1rem">
-      <p class="dim">Two Kubernetes clusters. A set of GCP projects. A network fabric. A working GitOps pipeline. None of it reduces that sentence to a few minutes.</p>
-      <p class="rule-kicker">Every step is solved infrastructure. Assembling them is the work — and it is the work every single time.</p>
+      <p class="dim">Nothing on that list is unsolved. Clusters exist, registries exist, GitOps engines exist, certificates are free. What nobody hands you is the assembly — and the assembly is the work, in full, every single time, no matter how much infrastructure you already own.</p>
+      <p class="rule-kicker">Seven decisions, made by hand, by whoever is holding it. Each one is a place to be quietly wrong for a month.</p>
     </div>
     <ol class="steps">
       <li>Write a Dockerfile</li>
@@ -608,9 +609,42 @@
   </div>
 </section>
 
-<!-- ============================== 05 what it buys ============================== -->
+<!-- ============================== 05 the seams ============================== -->
 <section class="slide">
   <span class="no"><b>05</b> / 12</span>
+  <p class="eyebrow">Where the far sides plug in</p>
+  <h2>Every outside thing sits behind a contract, and <em>none of them</em> is the architecture</h2>
+  <p class="dim" style="max-width:74ch">A seam is a place behaviour can be swapped without editing at that place. One implementation would leave a seam hypothetical; every one of these has at least two.</p>
+  <div class="tablewrap">
+    <table class="bench">
+      <thead>
+        <tr><th scope="col">Seam</th><th scope="col">What varies across it</th><th scope="col">Adapters today</th></tr>
+      </thead>
+      <tbody>
+        <tr><th scope="row">Build</th><td>where the artifact is produced</td><td>GitHub Actions · Cloud Build · microVM pool · in-cluster Job</td></tr>
+        <tr><th scope="row">Deploy</th><td>what runtime receives it</td><td>Kubernetes · Cloud Run · static hosting</td></tr>
+        <tr><th scope="row">Delivery</th><td>which operator drives it</td><td>Flux HelmRelease · Argo Application</td></tr>
+        <tr><th scope="row">Config store</th><td>where the value of record lives</td><td>Secret Manager · 1Password · HTTP</td></tr>
+        <tr><th scope="row">Datastore</th><td>where a Target's state lives</td><td>cloud project · cluster</td></tr>
+      </tbody>
+    </table>
+  </div>
+  <div class="cols">
+    <div class="card card--flag">
+      <h4>Flux is an adapter, not the architecture</h4>
+      <p>A Target declares which operator drives it, and Spindrift writes that operator's own object. Both flavours end at the same status type and nothing above them branches — so the GitOps engine is a choice a Target makes, never a thing the platform is built out of.</p>
+    </div>
+    <div class="card card--flag">
+      <h4>What a seam is worth, measured once</h4>
+      <p>A whole fourth way of building — a microVM pool on a machine this process cannot reach, calling in the opposite direction — arrived as one row in a list. Everything above the seam was already written.</p>
+    </div>
+  </div>
+  <p class="verbatim">apply · observe · destroy · run · executions · tail · inspect   →   seven verbs, and “deploy anything, anywhere” is behind them</p>
+</section>
+
+<!-- ============================== 06 what it buys ============================== -->
+<section class="slide">
+  <span class="no"><b>06</b> / 12</span>
   <p class="eyebrow">Consequences, not features</p>
   <h2>Four things nobody had to build</h2>
   <div class="cols">
@@ -637,54 +671,41 @@
   </div>
 </section>
 
-<!-- ============================== 06 auth is desired state ============================== -->
+<!-- ============================== 07 auth ============================== -->
 <section class="slide">
-  <span class="no"><b>06</b> / 12</span>
+  <span class="no"><b>07</b> / 12</span>
   <p class="eyebrow">Auth, first-class</p>
   <h2>Who may reach it is <em>part of the contract</em></h2>
   <div class="split">
     <div style="display:flex;flex-direction:column;gap:1rem">
-      <p class="dim"><code>reach</code> and <code>auth</code> are fields on the Component, sitting in desired state beside the image and the config — not a policy bolted on afterwards, and not a wiki page about which ingress to copy.</p>
-      <p class="rule-kicker">So they are pinned into the deploy like everything else. A deployment records who could reach it, as a fact, at that version.</p>
-    </div>
-    <div style="display:flex;flex-direction:column;gap:0.9rem">
+      <p class="dim"><code>reach</code> and <code>auth</code> are fields on the Component, sitting in desired state beside the image and the config — not a policy bolted on afterwards, and not a wiki page about which ingress to copy. So they are pinned into the deploy like everything else, and a deployment records who could reach it, as a fact, at that version.</p>
       <div class="lineage">
         <div><b>Internal</b><span>cluster only</span></div>
         <div><b>Private</b><span>an RFC1918 address — the record type <em>is</em> the boundary</span></div>
         <div><b>Public</b><span>through the tunnel</span></div>
       </div>
       <p class="small dim">Private is the default. Nothing becomes reachable because somebody forgot a field.</p>
+      <p class="rule-kicker">A Target declares which reaches it can <em>authenticate</em>, not merely which it can serve. So auth decides where you are allowed to deploy.</p>
     </div>
-  </div>
-  <p class="verbatim">reach: private · auth: proxy   →   AUTH_UNSUPPORTED excludes every Target that cannot authenticate at that reach</p>
-  <p class="small dim" style="max-width:64ch">That is what first-class buys. A Target declares which reaches it can <em>authenticate</em>, not just which it can serve, and one that cannot is removed from placement before a build is ever dispatched. Auth decides <b>where you are allowed to deploy</b>.</p>
-</section>
-
-<!-- ============================== 07 auth, both sides ============================== -->
-<section class="slide">
-  <span class="no"><b>07</b> / 12</span>
-  <p class="eyebrow">Two boundaries, same discipline</p>
-  <h2>Enforced somewhere Spindrift does not own</h2>
-  <div class="cols cols--2">
-    <div class="card card--flag">
-      <span class="tag t-acc">The App edge</span>
-      <h4>A filter on the route, not a library in the app</h4>
-      <p>An <code>auth: proxy</code> Component gets an ExternalAuth filter on its HTTPRoute, enforced in-cluster by an authentication proxy that <b>Flux owns and Spindrift never installs</b>. Nothing is linked into the application; an App cannot opt itself out.</p>
-    </div>
-    <div class="card card--flag">
-      <span class="tag t-acc">The control plane</span>
-      <h4>A passkey against a real origin</h4>
-      <p>First run is one screen: an installation nobody has claimed shows enrolment, a claimed one shows sign-in, and there is no toggle. The token is consumed on use, so the window in which anyone else could claim it closes the moment enrolment completes. No password exists to phish.</p>
-    </div>
-  </div>
-  <div class="cols">
-    <div class="card card--cau">
-      <h4>And it is allowed to disqualify a backend</h4>
-      <p>Static hosting refuses <code>auth: proxy</code> outright — there is no non-bypassable origin to put a boundary in front of, so the placement is rejected rather than shipped with a caveat. A guarantee that quietly degrades is not a guarantee.</p>
-    </div>
-    <div class="card">
-      <h4>The hostname is the ceremony</h4>
-      <p>A passkey is scoped to the origin in the address bar, so the control plane's hostname is picked before anything is installed. An installation with a placeholder hostname cannot enrol anybody — which is why that is step one of the runbook, not a detail.</p>
+    <div style="display:flex;flex-direction:column;gap:1.1rem">
+      <div class="cols">
+        <div class="card card--flag">
+          <span class="tag t-acc">The App edge</span>
+          <h4>A filter on the route, not a library in the app</h4>
+          <p>An <code>auth: proxy</code> Component gets an ExternalAuth filter on its HTTPRoute, enforced by an authentication proxy the platform owns and <b>Spindrift never installs</b>. Nothing is linked into the application, so an App cannot opt itself out of its own edge.</p>
+        </div>
+        <div class="card card--flag">
+          <span class="tag t-acc">The control plane</span>
+          <h4>A passkey against a real origin</h4>
+          <p>First run is one screen: an unclaimed installation shows enrolment, a claimed one shows sign-in, and there is no toggle. The token is consumed on use. A passkey is scoped to the origin in the address bar, which is why the hostname is chosen before anything is installed — and why no password exists to phish.</p>
+        </div>
+        <div class="card card--cau">
+          <span class="tag t-cau">The refusal</span>
+          <h4>It is allowed to disqualify a backend</h4>
+          <p>Static hosting refuses <code>auth: proxy</code> outright — there is no non-bypassable origin to put a boundary in front of, so the placement is rejected rather than shipped with a caveat. A guarantee that quietly degrades is not a guarantee.</p>
+        </div>
+      </div>
+      <p class="verbatim">reach: private · auth: proxy   →   AUTH_UNSUPPORTED excludes every Target that cannot authenticate at that reach, before a build is ever dispatched</p>
     </div>
   </div>
 </section>
@@ -693,7 +714,8 @@
 <section class="slide">
   <span class="no"><b>08</b> / 12</span>
   <p class="eyebrow">Where the contract stops</p>
-  <h2>Terraform owns the vessel. Spindrift owns the <em>contents</em>.</h2>
+  <h2>It cannot create what it deploys into — so it opens a <em>pull request</em></h2>
+  <p class="dim" style="max-width:76ch">Spindrift holds delegated write access to contents: a release object in one namespace, an App inside one pre-provisioned project. It holds nothing that can create a cluster, a project, a VPC, a tunnel, a signing key or a policy engine. When a prerequisite is missing it writes the infrastructure code that would clear it and opens that as a pull request — a human merges, the apply bot applies, and a standing check turns the row green.</p>
     <figure>
     <div class="figwrap">
       <svg viewBox="0 0 920 560" role="img" aria-label="Ownership boundary: Flux and Terraform provision vessel prerequisites; Spindrift writes only into the contents through delegated APIs, and clears missing prerequisites by opening a pull request that Atlantis applies.">
@@ -727,12 +749,12 @@
 
         <!-- left actors -->
         <rect class="d-box" x="30" y="80" width="250" height="46" rx="6"/>
-        <text class="d-t b" x="46" y="102">Flux</text>
-        <text class="d-s" x="46" y="118">renders it on a Kubernetes Target</text>
+        <text class="d-t b" x="46" y="102">Platform GitOps</text>
+        <text class="d-s" x="46" y="118">Flux, on a Kubernetes Target</text>
 
         <rect class="d-box" x="30" y="138" width="250" height="46" rx="6"/>
-        <text class="d-t b" x="46" y="160">Terraform</text>
-        <text class="d-s" x="46" y="176">renders it in GCP</text>
+        <text class="d-t b" x="46" y="160">Infrastructure as code</text>
+        <text class="d-s" x="46" y="176">Terraform, in the cloud project</text>
 
         <path class="d-line" d="M280 103 L352 116" marker-end="url(#ahg)"/>
         <path class="d-line" d="M280 161 L352 148" marker-end="url(#ahg)"/>
@@ -759,8 +781,8 @@
         <text class="d-s" x="46" y="474">the Terraform stanza + the root it belongs in</text>
 
         <rect class="d-box" x="330" y="432" width="190" height="58" rx="6"/>
-        <text class="d-t b" x="346" y="456">Atlantis</text>
-        <text class="d-s" x="346" y="474">applies it</text>
+        <text class="d-t b" x="346" y="456">The apply bot</text>
+        <text class="d-s" x="346" y="474">Atlantis, on the pull request</text>
 
         <rect class="d-box" x="570" y="432" width="310" height="58" rx="6"/>
         <text class="d-t b" x="586" y="456">The standing check turns the row green</text>
@@ -847,8 +869,8 @@
         <rect class="d-box" x="660" y="128" width="200" height="84" rx="6"/>
         <text class="d-t b" x="676" y="152">Artifact</text>
         <text class="d-s" x="676" y="172">one digest, type image or files</text>
-        <text class="d-s" x="676" y="190">staged in trusted-builds/i,</text>
-        <text class="d-s" x="676" y="206">swept at 24h — ghcr holds it</text>
+        <text class="d-s" x="676" y="190">staged in a build project,</text>
+        <text class="d-s" x="676" y="206">swept at 24 h by design</text>
         <path class="d-flow" d="M614 60 L652 150" marker-end="url(#ah2)"/>
         <path class="d-flow" d="M614 130 L652 162" marker-end="url(#ah2)"/>
         <path class="d-flow" d="M614 200 L652 182" marker-end="url(#ah2)"/>
@@ -904,20 +926,20 @@
 <!-- ============================== 10 the sibling ============================== -->
 <section class="slide">
   <span class="no"><b>10</b> / 12</span>
-  <p class="eyebrow">A sibling, not a subsystem</p>
-  <h2>The fourth route arrived without a <em>new concept</em></h2>
+  <p class="eyebrow">The seam that runs backwards</p>
+  <h2>One adapter dials <em>in</em>, and the interface never noticed</h2>
   <div class="split">
     <div style="display:flex;flex-direction:column;gap:1rem">
-      <p class="dim"><b>Bosun</b> is a peer project: a warm pool of ephemeral microVMs, each serving exactly one CI job before it is scuttled. It is not part of Spindrift and Spindrift does not run it — a Build is routed to it by label, and nothing else about it is known here.</p>
-      <p class="rule-kicker">The same shape this map has ruled four times. A registry, a base image, a log store, a Target — all of them <em>a place an admin connects</em>, never machinery the control plane owns.</p>
-      <p class="small dim">So a runner pool is not an exception being made. It is that ruling applied a fifth time, and the proof it was the right ruling is that the fourth build backend cost one row in a list.</p>
+      <p class="dim">Three build adapters reach outward — a workflow dispatch, a cloud API, a Job on a cluster this process already holds a token for. The fourth is a pool of microVMs on a machine Spindrift cannot open a connection to at all. Every instinct says that needs a new concept.</p>
+      <p class="rule-kicker">It needed a row in a list. The route writes an intent to an outbox row and polls that row for a verdict — exactly the way the other three poll a status endpoint. The endpoint just happens to be its own database.</p>
+      <p class="small dim">That is the test a contract passes or fails, and it is not a test you can run on paper. An interface that only admits far sides you are able to dial was never a seam; it was the shape of the three things that happened to exist when it was written.</p>
     </div>
     <div style="display:flex;flex-direction:column;gap:1.1rem">
       <div class="cols">
         <div class="card card--flag">
-          <span class="tag t-acc">The seam</span>
-          <h4>The only far side that dials in</h4>
-          <p>Every other route reaches out — a workflow dispatch, a cloud API, a Job on a cluster this process already holds a token for. A bosun host is an operator's machine Spindrift <b>cannot reach</b>. So the route writes an intent to an outbox row in its own Postgres and polls that row for a verdict, while the host long-polls in over three shared-secret endpoints.</p>
+          <span class="tag t-acc">The far side</span>
+          <h4>A peer project, not a subsystem</h4>
+          <p><b>Bosun</b> keeps a warm pool of ephemeral microVMs, each serving exactly one CI job before it is destroyed. Spindrift does not run it, install it, or know anything about it beyond a label — the host long-polls in over three shared-secret endpoints and claims what it finds.</p>
         </div>
         <div class="card card--flag">
           <span class="tag t-acc">Why it earns its place</span>
@@ -973,11 +995,12 @@
     </div>
     <div class="card card--cau">
       <h4>Open</h4>
-      <p>The v1 gate waits on the remaining ticket set. The defects still outstanding are mostly wrong <em>sentences</em> shown to an operator — the failure mode a green suite is worst at catching.</p>
+      <p>The work left before a v1 is known and unglamorous. What is still outstanding is mostly wrong <em>sentences</em> shown to an operator — the failure mode a green suite is worst at catching, and the one the previous slide is entirely about.</p>
     </div>
   </div>
   <p class="colophon">
     <span>Artifact <b>+</b> Target <b>+</b> configVersion</span>
+    <span><b>5</b> seams, every one of them real</span>
     <span>Everything else is bookkeeping</span>
   </p>
 </section>


### PR DESCRIPTION
Both decks were written inside-out: they described what got built and assumed the reader cared about the estate it got built on. Every problem slide opened on the author's hardware — *"two clusters and a metal fleet sitting idle downstairs"*, *"two Kubernetes clusters, a set of GCP projects"* — which is a homelab owner's lament, not a problem a reader has. The productized idea existed in both decks, in `.small .dim` footnotes underneath the homelab.

Slide counts and the shared CSS are unchanged. No new slides net, no styling touched — the decks stay one series printed with two plates.

## bosun (11 slides)

- **Slide 2** — the tax is structural now: a job re-acquires a machine, a toolchain and a cache it already had, and a faster CPU runs the same six steps. Adds the coupling thesis the deck never stated: the label, the cache, the queue, the identity and the logs all belong to one vendor, so moving compute has meant giving up all five.
- **New slide 4, adoption cost** — the `runs-on:` one-line diff, four cost stats, and where this sits against the two shapes that already exist (one keeps your workflow and swaps the hardware; one keeps a hosted orchestrator and moves the agents onto your machines). Describes those shapes rather than naming vendors, so the page asserts nothing about someone else's product.
- **Slides 4+5 merged** to hold 11: the four nouns become a `.lineage` strip on the hull-contract slide, since the nouns and the seam they sit around are one idea. The naming-provenance paragraph is cut.
- **Slide 7** — claim in the kicker, mechanism in the prose (it was backwards). The cloud metadata service moves from a footnote into body copy, and a third card states the tenancy claim: one job, one kernel.
- **Slide 11** — host names replaced by the architectural point they were evidence for: a host joins by importing the module and naming its classes, and nothing coordinates them because there is no fleet controller.

## spindrift (12 slides)

- **New slide 5, the adapter thesis** — a table of the five seams read off `apps/spindrift/src/adapters/`, with the test applied: one implementation leaves a seam hypothetical, and every one of these has at least two. Closes on the seven verbs of `DeployAdapter`.
- **Flux is presented as one adapter** at the delivery seam, beside the Argo flavour it shares a status type with. That is both the accurate description and the one that stops the deck reading as a tour of this repo.
- **Slide 10 repurposed** from "how Spindrift uses bosun" to the interface point that earns the slide: one adapter dials in, and the contract did not change to admit it.
- **Slide 8 headline** is now the claim rather than the org chart — it cannot create what it deploys into, so it opens a pull request. Diagram actors are labelled role-first, with the tools named underneath.
- **The two auth slides merge into one** to hold 12; the dropped card's substance survives as a clause in the passkey card.
- Removed a leak on the close slide that pointed at the private planning surface from a public page.

## Correctness fix

The bosun deck credited systemd's default `KillMode=control-group` for making an orphaned hypervisor impossible. `apps/bosun/module.nix:501` sets `mixed`, deliberately — per the comment at `:490`, `control-group` would kill the very VMMs drain exists to let finish. The real backstop is the cgroup SIGKILL at the stop timeout. The same bullet also implied the start-up sweep was deleted; it is the whole recovery path.

## Validation

- Both files parse with balanced tags (`html.parser`, SVG void elements accounted for).
- Slide counts and numbering consistent: 11/11 and 12/12, no gaps or duplicates.
- Swept for the leaked-context class: host names, `this repo`, staging-registry paths, private-tracker vocabulary — none remain.
- No `mise` task covers `apps/slides`, so there is no lint or build step to run. Every number kept on a slide still traces to `apps/bosun/README.md`; the seam table traces to `apps/spindrift/src/adapters/`.

## Risk

Copy-only, on two standalone pages with no importers. The decks ship through Spindrift as uploaded archives, so nothing here reaches a cluster on merge.
