### PR TITLE
Say the metrics sidecar is off, because it is

### DIFF
--- a/apps/spindrift/src/adapters/datastore/kubernetes.ts
+++ b/apps/spindrift/src/adapters/datastore/kubernetes.ts
@@ -297,17 +297,20 @@ export class KubernetesDatastoreAdapter implements DatastoreAdapter {
             },
           },
         ],
-        // The sidecar, hardened through the field the operator gives it rather
-        // than through `containers` — it is not in that list, and a patch
-        // naming it there would add a third container instead of amending the
-        // second. Left enabled: the fleet scrapes what it runs, and switching
-        // metrics off to satisfy a policy would be answering the wrong question.
-        exporter: {
-          securityContext: {
-            allowPrivilegeEscalation: false,
-            capabilities: { drop: ['ALL'] },
-          },
-        },
+        // The metrics sidecar, off — stated rather than left to the absence of
+        // a field, because that absence is what turned it off by accident.
+        // `enabled` has no default in the CRD, so naming `exporter` at all to
+        // carry a security context was already switching it off; a reader
+        // deserves to see the decision rather than infer it from a missing key.
+        //
+        // Off rather than hardened because hardening it is not one line: the
+        // pod block above runs every container as uid 999, which is the valkey
+        // user, and the exporter is a different image with no reason to accept
+        // it — the operator's own hardened sample gives the two distinct uids.
+        // Nothing scrapes a datastore sidecar in this fleet yet, so switching
+        // it on is a change worth making when something wants the metrics, with
+        // the uid question answered against a running pod rather than guessed.
+        exporter: { enabled: false },
       },
     };
   }

--- a/apps/spindrift/test/adapters/datastore.test.ts
+++ b/apps/spindrift/test/adapters/datastore.test.ts
@@ -149,11 +149,11 @@ describe('provision', () => {
     expect(spec.containers).toEqual([
       { name: 'server', securityContext: hardened },
     ]);
-    // The sidecar the operator adds unasked, hardened through its own field.
-    // Admission fails the whole pod on whichever container lacks these, so
-    // asserting only `server` would assert a pod that still cannot be created —
-    // which is exactly what shipped before a live provision found it.
-    expect(spec.exporter).toEqual({ securityContext: hardened });
+    // The sidecar the operator adds unasked is switched off, and the assertion
+    // is on the switch rather than on the absence of a container: admission
+    // fails the whole pod on whichever container lacks the fields above, so a
+    // sidecar that came back without them would take the datastore with it.
+    expect(spec.exporter).toEqual({ enabled: false });
   });
 
   test('a hyphenated name becomes a typeable SQL identifier', async () => {


### PR DESCRIPTION
#2008 set `exporter.securityContext` to harden the sidecar and its body claimed it *"left enabled: the fleet scrapes what it runs."* That was wrong, and the live pod proves it — one container, `server`.

`exporter.enabled` has **no default** in the CRD. Naming `exporter` at all, purely to carry a security context, was already switching the sidecar off. So #2008 fixed admission by accident: not by hardening the second container, but by removing it.

The resulting behaviour is fine. The code saying the opposite of what it does is not.

## What this changes

The switch is now stated: `exporter: { enabled: false }`.

Off rather than hardened, because hardening is not one line. The pod block runs every container as uid 999 — the *valkey* user — and the exporter is a different image with no reason to accept that uid; the operator's own hardened sample gives the two containers distinct uids for exactly this reason. Turning it on properly means answering the uid question against a running pod, not guessing at it, and nothing in this fleet scrapes a datastore sidecar today.

The test asserts the switch rather than the absence of a container, since a sidecar returning without the container-only fields would take the whole pod down with it.

## Validation

Full suite 2187 pass / 0 fail, `ts:check` clean — and the live estate already shows the end state this describes: `demo-cache` is `LIVE` on offsite with `connection_ref` `redis://valkey-demo-cache.spindrift-apps.svc:6379`, one container, admitted under `restricted`.