### PR TITLE
docs(slides): the upload boundary normalizes the container now

### DIFF
--- a/apps/slides/README.md
+++ b/apps/slides/README.md
@@ -20,12 +20,16 @@ the deck directory to `/internal/upload`, and the returned digest and location
 become an `uploadArchive` Build that the ordinary build route turns into a
 `files` artifact for the `bluenose/static` Target.
 
-**It has to be a gzipped tarball.** The upload boundary takes any bytes and the
-field is called an archive, but the build route fetches it with
-`curl … | tar -xz`, so a ZIP reaches the builder intact and dies at
-`tar: This does not look like a tar archive` — reported four steps later as
-`ARTIFACT_UNAVAILABLE`, which reads as a platform fault rather than a wrong
-container format.
+The upload boundary normalizes the container before anything durable happens: a
+gzipped tar stages as-is, a ZIP is transcoded into one, and anything else is
+refused with a `400` naming what arrived. Every build route opens a staged
+bundle with `tar -xz`, so gzip is the wire format rather than a preference, and
+the one conversion sits in front of the depot instead of in three fetchers —
+`apps/spindrift/src/storage/archive-format.ts` carries the reasoning.
+
+The digest describes the **converted** bytes, so a ZIP upload's `bundleDigest`
+names the tarball the builders actually fetch, not the file that left this
+machine.
 
 A deck is therefore its own acceptance evidence — the deployed page is the
 product describing itself — which is why the copy carries live digests, build


### PR DESCRIPTION
`apps/slides/README.md` warned that a deck archive "has to be a gzipped tarball", and spent a paragraph on a ZIP reaching the builder intact, dying at `tar: This does not look like a tar archive`, and surfacing four steps later as `ARTIFACT_UNAVAILABLE`.

That defect is fixed. `apps/spindrift/src/storage/archive-format.ts` sniffs by magic number at the upload boundary: a gzipped tar stages as-is, a ZIP is transcoded into one, and anything else is refused with a `400` naming what arrived. The README was describing behaviour the tree no longer has — the archaeology the writing rule prohibits.

Replaced with what is true today, plus the one thing a caller can still get wrong: the digest is over the **converted** bytes, so a ZIP upload's `bundleDigest` names the tarball the builders fetch rather than the file that was posted.

Found while redeploying both decks — the uploads went through as gzip, so this cost nothing this time, but the next person reading the README would have been told to work around a fix that already landed.

## Validation

- `mise run docs:check` — wikilinks, repo paths, archaeology all ok.
- Claims verified against `archive-format.ts` (`sniffArchiveFormat`, `normalizeArchive`) and the `400` path in `web/upload.ts`.