### PR TITLE
feat(spindrift): let the connect screen produce an Argo Target

### DIFF
--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -28,7 +28,11 @@ import type {
   PendingTargetConnection,
   TargetConnectionProposal,
 } from '../web/model.ts';
-import { type TargetConnection, targetLabel } from './target.ts';
+import {
+  type KubernetesDelivery,
+  type TargetConnection,
+  targetLabel,
+} from './target.ts';
 import { surfacesToProbe, type VesselKind } from './vessel.ts';
 
 /** The donor, spelled the way every other surface names a Target. */
@@ -199,10 +203,17 @@ export interface ClusterConnectChoices {
   readonly apiServer: string;
   /** Where App workloads land. Never created by Spindrift (§7). */
   readonly namespace: string;
-  /** Where the `HelmRelease` object itself is created. */
-  readonly deliveryNamespace: string;
-  /** The Flux source object the App chart is fetched from. */
-  readonly sourceRef: { readonly name: string; readonly namespace: string };
+  /**
+   * Which operator drives this Target, and what that operator needs (§6).
+   *
+   * Whole rather than field-by-field, because the two flavours share only the
+   * namespace their object is created in: everything else a `HelmRelease` needs
+   * is meaningless to an `Application` and the other way round. Carrying the
+   * union means the screen cannot assemble a half-Flux, half-Argo delivery, and
+   * the choice reaches `connectTarget` in the same shape the manifest declares
+   * it.
+   */
+  readonly delivery: KubernetesDelivery;
   /** The gateway routes attach to, and the address it answers on. */
   readonly gateway: {
     readonly name: string;
@@ -228,11 +239,7 @@ export interface ClusterConnectPlan {
   readonly vessel: string;
   readonly apiServer: string;
   readonly namespace: string;
-  readonly delivery: {
-    readonly flavour: 'flux-helmrelease';
-    readonly namespace: string;
-    readonly sourceRef: { readonly name: string; readonly namespace: string };
-  };
+  readonly delivery: KubernetesDelivery;
   readonly chartValues: Record<string, unknown>;
   readonly reaches: Reach[];
   readonly authReaches: Reach[];
@@ -299,11 +306,7 @@ export function clusterConnectPlan(
     vessel: choices.vessel,
     apiServer: choices.apiServer,
     namespace: choices.namespace,
-    delivery: {
-      flavour: 'flux-helmrelease',
-      namespace: choices.deliveryNamespace,
-      sourceRef: choices.sourceRef,
-    },
+    delivery: choices.delivery,
     // Only `platform`. §7 gives that key to the operator whole and Spindrift
     // renders `app` and `shared` per deploy, so writing either here would be
     // saving a value the next deploy overwrites.

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -47,6 +47,11 @@ import {
 } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
 import {
+  KUBERNETES_DELIVERY_FLAVOURS,
+  type KubernetesDelivery,
+  type KubernetesDeliveryFlavour,
+} from '../../../domain/target.ts';
+import {
   type ClusterConnectChoices,
   clusterConnectPlan,
   targetSeedOf,
@@ -335,6 +340,18 @@ function ClusterComponents({
   const [source, setSource] = useState(
     refKey(probe.chartSources, proposal.sourceRef),
   );
+  const [flavour, setFlavour] = useState<KubernetesDeliveryFlavour>(
+    pickFlavour(probe.deliveryFlavours, proposal.deliveryFlavour),
+  );
+  // Argo's half. None of it is readable: `repoURL` and `targetRevision` are
+  // where *this installation's* chart lives, which the cluster has no opinion
+  // about, and a project is a name Argo would answer for only if it were asked
+  // about one that already exists. So the two that have a conventional answer
+  // start at it and the two that do not start empty and gate the button.
+  const [project, setProject] = useState('default');
+  const [repoUrl, setRepoUrl] = useState('');
+  const [revision, setRevision] = useState('');
+  const [server, setServer] = useState('https://kubernetes.default.svc');
   const [gatewayName, setGatewayName] = useState(
     refKey(probe.gateways, undefined),
   );
@@ -374,12 +391,27 @@ function ClusterComponents({
     probe.gateways.find((entry) => refOf(entry) === gatewayName)?.address ??
     null;
 
+  const delivery: KubernetesDelivery =
+    flavour === 'argo-application'
+      ? {
+          flavour,
+          namespace: deliveryNamespace,
+          project: project.trim(),
+          repoUrl: repoUrl.trim(),
+          revision: revision.trim(),
+          server: server.trim(),
+        }
+      : {
+          flavour: 'flux-helmrelease',
+          namespace: deliveryNamespace,
+          sourceRef: chosenSource ?? { name: '', namespace: '' },
+        };
+
   const choices: ClusterConnectChoices = {
     vessel,
     apiServer,
     namespace,
-    deliveryNamespace,
-    sourceRef: chosenSource ?? { name: '', namespace: '' },
+    delivery,
     gateway:
       gatewayOn && chosenGateway !== null
         ? {
@@ -402,51 +434,108 @@ function ClusterComponents({
   };
   const plan = clusterConnectPlan(choices);
 
-  const servesFlux = probe.deliveryFlavours.includes('flux-helmrelease');
+  const serves = probe.deliveryFlavours.includes(delivery.flavour);
+  const kind =
+    delivery.flavour === 'argo-application' ? 'Application' : 'HelmRelease';
   const ready =
     vessel !== '' &&
     namespace !== '' &&
     deliveryNamespace !== '' &&
-    chosenSource !== null;
+    (delivery.flavour === 'argo-application'
+      ? delivery.project !== '' &&
+        delivery.repoUrl !== '' &&
+        delivery.revision !== '' &&
+        delivery.server !== ''
+      : chosenSource !== null);
 
   return (
     <div className="flex flex-col gap-3 border-t border-border-soft pt-4">
-      {!servesFlux ? (
+      {!serves ? (
         <Notice tone="warning">
-          This cluster serves no <span className="font-mono">HelmRelease</span>,
-          so a Target here has nothing to deliver through. Connecting still
-          records it — the checklist will say the same thing, and keep saying it
-          until Flux is installed.
+          This cluster serves no <span className="font-mono">{kind}</span>, so a
+          Target delivered that way has nothing to deliver through. Connecting
+          still records it — the checklist will say the same thing, and keep
+          saying it until the operator is installed.
         </Notice>
       ) : null}
 
       <Component
         icon={<Waypoints aria-hidden="true" className="size-4" />}
         title="Delivery"
-        because="Flux applies the App chart. Spindrift writes the HelmRelease through the API."
+        because="The GitOps operator applies the App chart. Spindrift writes its object through the API — never manifests to a repository (§6)."
         required
       >
         <div className="grid gap-4 md:grid-cols-2">
           <Choice
+            name="delivery-flavour"
+            label="Operator"
+            value={delivery.flavour}
+            onChange={(value) => setFlavour(value as KubernetesDeliveryFlavour)}
+            // Both, always, and never only what the probe found: a cluster
+            // whose Argo CRDs are applied but not yet established reads as
+            // serving neither, and a picker offering neither is a cluster that
+            // cannot be connected until somebody else's reconcile finishes.
+            // What was read shows up as the notice above instead.
+            options={[...KUBERNETES_DELIVERY_FLAVOURS]}
+            hint={
+              probe.deliveryFlavours.length === 0
+                ? 'Neither operator was readable here. Pick the one this cluster will run.'
+                : `Read off this cluster: ${probe.deliveryFlavours.join(', ')}.`
+            }
+          />
+          <Choice
             name="delivery-namespace"
-            label="HelmRelease namespace"
+            label={`${kind} namespace`}
             value={deliveryNamespace}
             onChange={setDeliveryNamespace}
             options={namespaces}
             hint="Read off this cluster."
           />
-          <Choice
-            name="chart-source"
-            label="Chart source"
-            value={source}
-            onChange={setSource}
-            options={probe.chartSources.map(refOf)}
-            hint={
-              probe.chartSources.length === 0
-                ? 'No source of the kind this installation’s chart needs was readable here — the App chart has nowhere to come from.'
-                : 'The Flux source the App chart is fetched from.'
-            }
-          />
+          {delivery.flavour === 'argo-application' ? (
+            <>
+              <Field
+                name="argo-project"
+                label="Project"
+                value={project}
+                onChange={(event) => setProject(event.target.value)}
+                hint="The Argo project the Application belongs to."
+              />
+              <Field
+                name="argo-server"
+                label="Destination cluster"
+                value={server}
+                onChange={(event) => setServer(event.target.value)}
+                hint="In Argo’s vocabulary. The in-cluster name, because the Application is created in the cluster it deploys to."
+              />
+              <Field
+                name="argo-repo-url"
+                label="Chart repository"
+                value={repoUrl}
+                onChange={(event) => setRepoUrl(event.target.value)}
+                hint="Where the App chart is fetched from. Argo resolves it with credentials Spindrift never sees, so nothing here was read."
+              />
+              <Field
+                name="argo-revision"
+                label="Revision"
+                value={revision}
+                onChange={(event) => setRevision(event.target.value)}
+                hint="The branch, tag, or version the chart is taken at."
+              />
+            </>
+          ) : (
+            <Choice
+              name="chart-source"
+              label="Chart source"
+              value={source}
+              onChange={setSource}
+              options={probe.chartSources.map(refOf)}
+              hint={
+                probe.chartSources.length === 0
+                  ? 'No source of the kind this installation’s chart needs was readable here — the App chart has nowhere to come from.'
+                  : 'The Flux source the App chart is fetched from.'
+              }
+            />
+          )}
         </div>
       </Component>
 
@@ -927,6 +1016,23 @@ function refKey(
         );
   const chosen = match ?? entries[0];
   return chosen === undefined ? '' : refOf(chosen);
+}
+
+/**
+ * Which operator to start on.
+ *
+ * What a working Target of this installation already uses, when this cluster
+ * serves it — that is the answer for the second cluster of a fleet, and the
+ * whole point of carrying a proposal. Otherwise whatever this cluster was found
+ * serving, and Flux when it was found serving neither: an unreadable cluster
+ * gets a pick that is editable rather than a blank one that gates the button.
+ */
+function pickFlavour(
+  served: readonly KubernetesDeliveryFlavour[],
+  proposed: KubernetesDeliveryFlavour | undefined,
+): KubernetesDeliveryFlavour {
+  if (proposed !== undefined && served.includes(proposed)) return proposed;
+  return served[0] ?? proposed ?? 'flux-helmrelease';
 }
 
 /** The preferred option when this cluster has it, otherwise the first one. */

--- a/apps/spindrift/test/domain/target-connect-plan.test.ts
+++ b/apps/spindrift/test/domain/target-connect-plan.test.ts
@@ -36,8 +36,11 @@ const BASE: ClusterConnectChoices = {
   vessel: 'metal',
   apiServer: 'https://cluster.invalid:6443',
   namespace: 'apps',
-  deliveryNamespace: 'apps',
-  sourceRef: { name: 'charts', namespace: 'delivery' },
+  delivery: {
+    flavour: 'flux-helmrelease',
+    namespace: 'apps',
+    sourceRef: { name: 'charts', namespace: 'delivery' },
+  },
   gateway: null,
   externalAuth: null,
   secretStore: null,
@@ -150,6 +153,36 @@ describe('a cluster connect plan', () => {
     expect(parsed.data.vessel).toBe('metal');
     expect(parsed.data.reaches).toEqual(plan.reaches);
     expect(parsed.data.connection?.chartValues).toEqual(plan.chartValues);
+  });
+
+  test('declares an Argo Target the manifest’s own way', () => {
+    // §6 puts the flavour on the Target, so the screen has to be able to
+    // produce either one — and the arm that is not the default is the one that
+    // can drift into a shape the manifest would refuse.
+    const plan = clusterConnectPlan({
+      ...BLENDED,
+      delivery: {
+        flavour: 'argo-application',
+        namespace: 'argocd',
+        project: 'default',
+        repoUrl: 'https://git.invalid/charts.git',
+        revision: 'main',
+        server: 'https://kubernetes.default.svc',
+      },
+    });
+    const parsed = targetSeedSchema.safeParse(targetSeedOf(plan));
+
+    if (!parsed.success) throw parsed.error;
+    if (parsed.data.adapter !== 'kubernetes') {
+      throw new Error(`declared a ${parsed.data.adapter} Target`);
+    }
+    expect(parsed.data.connection?.delivery).toEqual(plan.delivery);
+    // The rest of the plan is flavour-blind, which is what makes the operator a
+    // choice rather than a second screen.
+    expect(plan.reaches).toEqual(['none', 'private', 'public']);
+    expect(platformOf(plan).networkPolicy).toEqual({
+      allowedNamespaces: ['edge', 'auth'],
+    });
   });
 
   test('declares the boundary the same act connects', () => {

--- a/apps/spindrift/test/web/client-bundle.test.ts
+++ b/apps/spindrift/test/web/client-bundle.test.ts
@@ -158,18 +158,25 @@ describe('the client bundle', () => {
     // console line honest against each other.
     expect(built.stdout).toContain(`${files.length} files`);
 
-    // Measured today: ~6.0 MiB for this exact build — the creation screen's
-    // scope chooser and the checklist's remediation stanzas are ordinary UI
-    // growth on top of the ~5.4 MiB measured when the registry edge was cut.
-    // Before that cut, with the whole command layer pulled in through
-    // `client.ts` -> `dispatch.ts` -> `registry.ts`, the same build was
-    // ~8.7 MiB (the number `2026-08-01`'s ticket comment records). The
-    // ceiling below sits at 6.5 MiB: comfortably above today's measured
-    // size — headroom for ordinary UI growth — and comfortably below what
-    // reintroducing the registry edge would cost (+~3 MiB), so that
-    // regression trips this rather than shipping unnoticed the way it did
-    // the first time.
-    const CEILING_BYTES = 6.5 * 1024 * 1024;
+    // Measured today: ~6.5 MiB for this exact build — ordinary UI growth on
+    // top of the ~5.4 MiB measured when the registry edge was cut. Before that
+    // cut, with the whole command layer pulled in through `client.ts` ->
+    // `dispatch.ts` -> `registry.ts`, the same build was ~8.7 MiB (the number
+    // `2026-08-01`'s ticket comment records).
+    //
+    // **This sums every file in `dist/`, source maps included**, and the map is
+    // where the growth is: a screen gaining a hundred lines costs ~3 KiB of
+    // JavaScript and ~25 KiB of map, because the map embeds this codebase's
+    // source text and this codebase explains itself at length. So the headroom
+    // a ceiling here buys is about eight times smaller than the shipped bytes
+    // suggest, and a ceiling set close above a measurement is one screen from
+    // tripping on a change that added nothing a browser downloads.
+    //
+    // The ceiling below sits at 7.5 MiB: a MiB above today's measured size, and
+    // still two below what reintroducing the registry edge would cost (+~3 MiB
+    // of JavaScript, which the map doubles again), so that regression trips
+    // this rather than shipping unnoticed the way it did the first time.
+    const CEILING_BYTES = 7.5 * 1024 * 1024;
     expect(bytes).toBeLessThan(CEILING_BYTES);
   });
 });


### PR DESCRIPTION
§6 puts the delivery flavour on the Target, and every layer below the connect screen already had both arms — the union in `domain/target.ts`, the `connectTarget` schema, the manifest schema, and `KubernetesDeployAdapter.deliveryObject`'s branch on `flavour`. The screen was the one place that could not produce the Argo half: `clusterConnectPlan` wrote `flux-helmrelease` as a literal, so an Argo Target could only ever be declared in the manifest.

## What changed

- `ClusterConnectChoices` carries `KubernetesDelivery` whole instead of a namespace and a `sourceRef`. The two flavours share only the namespace their object is created in, so carrying the union is what stops the screen assembling a half-Flux, half-Argo delivery — and the choice reaches `connectTarget` in the shape the manifest declares it.
- The Delivery card gains an operator pick, and on the Argo arm the four fields Argo needs (project, destination cluster, chart repository, revision). `ready` and the "serves no *X*" notice follow the pick.
- Both flavours are always offered rather than only what the probe found: a cluster whose Argo CRDs are applied but not yet established serves neither, and a picker offering neither is a cluster nobody can connect until somebody else's reconcile finishes. What was read shows up in the notice instead.
- Argo defaults are the conventional answers where there is one — `default` project, `https://kubernetes.default.svc` destination. `repoUrl` and `revision` start empty and gate the button; neither is readable from a cluster.

Nothing else on the screen is flavour-aware. Reaches, the network policy, and the rendered declaration are unchanged, which the new test asserts alongside the Argo seed round-tripping through `targetSeedSchema`.

## Validation

- `mise run ts:check` — green (typecheck covers `test/`).
- `bun test test/domain/` — the connect-plan and onboarding suites pass, including the new Argo arm.
- The DB-backed suites did not run locally: no Postgres on `:15432` in this worktree, so every other failure is `DATABASE_URL is not set`. CI covers them.

## Risks

Argo's `path` is the installation's `charts.app`, so an installation whose chart reference is an `oci://` artifact would hand Argo a path it cannot resolve. That is an installation-manifest concern rather than a connect-screen one, and it surfaces as a sync error on the first deploy — not addressed here.