### PR TITLE
fix(spindrift): open the configuration PR, and say so

### DIFF
--- a/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
+++ b/apps/spindrift/src/commands/creation-drafts/lifecycle.ts
@@ -77,6 +77,19 @@ export interface CompletedCreation extends CreateAppResult {
   readonly targetId: string;
   readonly buildId: number;
   readonly buildStatus: 'PENDING' | 'RUNNING' | 'SUCCEEDED' | 'FAILED';
+  /**
+   * The configuration pull request creating this App opened, if it opened one.
+   *
+   * Read back off the repository row rather than only forwarded from the
+   * connect, so a reload of a completed draft still names the pull request
+   * somebody has to merge — the number is the whole of what makes §15's
+   * "merging it is what connects this repository" actionable.
+   */
+  readonly configPullRequest: number | null;
+  /** Why no pull request was opened. Null whenever one was, or none was due. */
+  readonly configPullRequestError: string | null;
+  /** `owner/name`, so the number can be made into a link. */
+  readonly configRepository: string | null;
 }
 
 const preparations = new Map<
@@ -334,6 +347,10 @@ export const completeCreationDraft: Command<
           targetId: row.draft.targetId,
           buildId: build!.id,
           buildStatus: build!.status,
+          configPullRequest: prepared.value.configPullRequest,
+          configPullRequestError: prepared.value.configPullRequestError,
+          configRepository:
+            row.draft.source.kind === 'repo' ? row.draft.source.repo : null,
         },
       });
     },
@@ -349,6 +366,18 @@ interface PreparedCreation {
   readonly bundleLocation: string;
   readonly subpath: string;
   readonly supplied: boolean;
+  /**
+   * The configuration pull request this creation opened, if it opened one.
+   *
+   * Carried rather than discarded because Deploy is the *only* place a
+   * grant-only repository gets connected, and §15 makes merging that pull
+   * request the act that connects it. An App created without its number on
+   * screen is an App whose repository has a branch on it nobody was told about
+   * and a `spindrift.yaml` that will never reach the default branch.
+   */
+  readonly configPullRequest: number | null;
+  /** Why there is no number, when there is none. Null on every other path. */
+  readonly configPullRequestError: string | null;
 }
 
 async function prepareOnce(
@@ -423,10 +452,16 @@ async function prepareCreation(
       bundleLocation: location,
       subpath: draft.source.subpath ?? '.',
       supplied,
+      // An archive has no repository, so there is nothing to connect and no
+      // pull request to merge.
+      configPullRequest: null,
+      configPullRequestError: null,
     });
   }
 
   let repository = await repositoryRow(context, draft.source.repo);
+  let configPullRequest: number | null = null;
+  let configPullRequestError: string | null = null;
   if (
     draft.source.connect === true &&
     (repository?.access !== 'active' || repository.authoritativeCommit === null)
@@ -437,7 +472,9 @@ async function prepareCreation(
       context,
     );
     if (!connected.ok) return connected;
-    repository = connected.value;
+    repository = connected.value.repository;
+    configPullRequest = connected.value.pullRequest;
+    configPullRequestError = connected.value.pullRequestError;
   }
   if (
     repository?.access !== 'active' ||
@@ -480,6 +517,8 @@ async function prepareCreation(
     bundleLocation: staged.location,
     subpath: draft.source.subpath,
     supplied: false,
+    configPullRequest,
+    configPullRequestError,
   });
 }
 
@@ -519,24 +558,38 @@ async function connectAndAdopt(
   fullName: string,
   subpath: string,
   context: CommandContext,
-): Promise<CommandResult<Repository>> {
+): Promise<
+  CommandResult<{
+    readonly repository: Repository;
+    /** The pull request the connect opened, forwarded rather than dropped. */
+    readonly pullRequest: number | null;
+    readonly pullRequestError: string | null;
+  }>
+> {
   const connected = await connectRepository(
     { fullName, scopes: [subpath] },
     context,
   );
   if (!connected.ok) return connected;
+  const { pullRequest, pullRequestError } = connected.value;
 
   const row = await repositoryRow(context, fullName);
   if (row === undefined) {
     throw new Error(`connecting ${fullName} wrote no repository row`);
   }
   const host = context.adapters.repository?.() ?? null;
-  if (host === null) return ok(row);
+  if (host === null) {
+    return ok({ repository: row, pullRequest, pullRequestError });
+  }
   await reconcileRepository(
     { db: context.db, clock: context.clock, host },
     row,
   );
-  return ok((await repositoryRow(context, fullName)) ?? row);
+  return ok({
+    repository: (await repositoryRow(context, fullName)) ?? row,
+    pullRequest,
+    pullRequestError,
+  });
 }
 
 async function completedCreation(
@@ -579,6 +632,16 @@ async function completedCreation(
   if (!completed || !component || !build || !placement) {
     throw new Error('creation draft points at an incomplete App intent');
   }
+  // The receipt has to survive a reload, and the connect that opened the pull
+  // request happened once, on a response nobody kept. The row is where the
+  // number lives, which is the only reason the column is written at all.
+  const repository =
+    completed.repositoryId === null
+      ? undefined
+      : await context.db.query.repositories.findFirst({
+          where: (repositories, { eq }) =>
+            eq(repositories.id, completed.repositoryId!),
+        });
   return ok({
     draft: {
       id: row.id,
@@ -596,6 +659,9 @@ async function completedCreation(
       targetId: placement.targetId,
       buildId: build.id,
       buildStatus: build.status,
+      configPullRequest: repository?.configPullRequest ?? null,
+      configPullRequestError: null,
+      configRepository: repository?.fullName ?? null,
     },
   });
 }
@@ -751,8 +817,12 @@ async function revalidate(
     blockers.push({
       code: 'BUILD_ROUTE_UNAVAILABLE',
       title: `No eligible build route can build for ${targetRowLabel(selectedTarget)}.`,
+      // Names where, because build routes are not on this screen and the
+      // banner carrying this sentence has nothing to press. The draft is a
+      // durable row reachable by URL, which is the other half of the
+      // instruction: leaving to fix it loses nothing.
       remediation:
-        'Configure a route that clears this Target’s minimum Build Level, then review the draft again.',
+        'Configure a route that clears this Target’s minimum Build Level under Settings → Build routes, then come back to this draft — it is kept.',
     });
   }
 

--- a/apps/spindrift/src/commands/repositories/connect.ts
+++ b/apps/spindrift/src/commands/repositories/connect.ts
@@ -299,6 +299,16 @@ export const connectRepository: Command<
       set: {
         installationId: ref.installationId,
         defaultBranch,
+        // Everything above this line has already read the repository — the
+        // installation, its facts, and a whole tree scan — so a freeze standing
+        // on the row is a statement about the world that this command has just
+        // disproved. Left in place it outlives the connect by a whole repo-loop
+        // interval, with the Repositories screen reading "connection lost" over
+        // a connection that plainly works and the creation wizard refusing on
+        // the same stale fact.
+        access: 'active',
+        frozenReason: null,
+        frozenAt: null,
         updatedAt: now,
       },
     })

--- a/apps/spindrift/src/commands/repositories/list.ts
+++ b/apps/spindrift/src/commands/repositories/list.ts
@@ -112,6 +112,7 @@ export const listRepositories: Command<
       lastReconciledSha: repo.authoritativeCommit ?? null,
       staleReason: staleReasons.get(repo.id) ?? null,
       appSubpaths,
+      configPullRequest: repo.configPullRequest ?? null,
     });
   }
 

--- a/apps/spindrift/src/domain/creation-draft.ts
+++ b/apps/spindrift/src/domain/creation-draft.ts
@@ -19,12 +19,7 @@ export const ENTRIES = [
   {
     id: 'repo',
     label: 'Link repo',
-    note: 'Detect the kind from one directory',
-  },
-  {
-    id: 'discover',
-    label: 'Discover',
-    note: 'List every directory a repo can deploy',
+    note: 'Detect what a repository holds and pick a directory',
   },
 ] as const;
 
@@ -34,6 +29,15 @@ export const ENTRIES = [
 export const componentKind = z.enum(['service', 'website', 'job']);
 export const reach = z.enum(['none', 'private', 'public']);
 export const auth = z.enum(['none', 'proxy']);
+/**
+ * `discover` is accepted and never offered.
+ *
+ * It pressed the same reducer arm as `repo` and produced the same screen —
+ * choosing a repository lists every directory read from it either way — so the
+ * two tiles were one tile drawn twice, and the pair read as a choice with
+ * consequences. It stays in the vocabulary because drafts are durable rows: a
+ * value dropped from the enum is a stored draft that no longer parses.
+ */
 const entry = z.enum(['service', 'website', 'upload', 'repo', 'discover']);
 
 /**
@@ -215,7 +219,15 @@ export type DraftAction =
   | { type: 'reach'; reach: Reach }
   | { type: 'auth'; auth: Auth }
   | { type: 'repo'; fullName: string; url: string; connect?: boolean }
-  | { type: 'subpath'; subpath: string }
+  /**
+   * A directory being typed, and — once — the operator having finished typing.
+   *
+   * `settled` is what counts as the answer. Taking every keystroke as one meant
+   * the first character of `apps/web` marked the draft answered: the "nothing
+   * is chosen to deploy from here" prerequisite cleared and, once the debounced
+   * save landed, Deploy went green for a path nothing had read.
+   */
+  | { type: 'subpath'; subpath: string; settled?: boolean }
   /**
    * What the detector found, applied.
    *
@@ -325,11 +337,23 @@ export function initialCreationDraft(input: {
       note: 'the installation home vessel',
     },
     targetId: input.targetId ?? '',
-    reach: 'private',
-    auth: 'proxy',
+    reach: OPENING_REACH,
+    auth: OPENING_AUTH,
     config: [],
   };
 }
+
+/**
+ * What a draft opens on, named so a screen can tell a default from a decision.
+ *
+ * These two rows state a definition of their value and the same sentence
+ * renders whichever way it got there, so "still the value it was born with" is
+ * the only signal available that nobody has looked at it. Exported rather than
+ * inlined twice, because a default that drifts from what the screen calls a
+ * default is a screen that lies quietly.
+ */
+export const OPENING_REACH: Reach = 'private';
+export const OPENING_AUTH: Auth = 'proxy';
 
 /** An archive nobody has staged yet — what the `Upload` tile opens on. */
 function emptyArchive(): DraftSource {
@@ -368,10 +392,22 @@ export function draftReducer(draft: Draft, action: DraftAction): Draft {
     // switches away from is kept, so that pressing the other tile and coming
     // back is a look rather than a loss.
     case 'entry': {
-      const kind =
+      // A tile that names a kind names it, and one that names a source says
+      // nothing about the kind at all. Falling back to `detection.kind` made
+      // `Upload` and `Link repo` silently revert a kind the operator had
+      // corrected two rows down, taking the "corrected" badge with it and
+      // reporting nothing. A named kind detection has ruled out is ignored for
+      // the same reason the Component row disables it: a tile that is selected
+      // and greyed at once, wearing the reason it cannot be chosen, is not an
+      // answer anybody gave.
+      const named =
         action.entry === 'service' || action.entry === 'website'
           ? action.entry
-          : draft.detection.kind;
+          : null;
+      const kind =
+        named !== null && draft.detection.unavailable[named] === undefined
+          ? named
+          : draft.kind;
       const wanted = sourceKindFor(action.entry);
       if (wanted === null || wanted === draft.source.kind) {
         return { ...draft, entry: action.entry, kind };
@@ -464,15 +500,16 @@ export function draftReducer(draft: Draft, action: DraftAction): Draft {
         detection: openingDetection(),
       };
     }
-    // Typing a directory is the operator answering where the App is, so it
+    // Naming a directory is the operator answering where the App is, so it
     // stands however detection reads it (story 32) and it survives the draft
-    // being closed and reopened.
+    // being closed and reopened. Half a path on the way to one is not that
+    // answer, so the flag waits for the edit to settle.
     case 'subpath':
       return draft.source.kind === 'repo'
         ? {
             ...draft,
             source: { ...draft.source, subpath: action.subpath },
-            scopeByOperator: true,
+            ...(action.settled === true ? { scopeByOperator: true } : {}),
           }
         : draft;
     case 'archive':
@@ -536,7 +573,11 @@ export function blockersFor(
     blockers.push({
       code: 'CONFIG_INCOMPLETE',
       title: `${missing.length} configuration key${missing.length === 1 ? '' : 's'} still needs a value.`,
-      remediation: `Supply ${missing.map((key) => key.name).join(', ')} under Config. Values are write-only once stored, so they cannot be filled in later from here.`,
+      // Not "under Config": that disclosure lists keys and holds no input, and
+      // no action on this screen can supply one. The App's own Config screen is
+      // where a value goes, and saying so beats naming a control that cannot do
+      // it.
+      remediation: `Supply ${missing.map((key) => key.name).join(', ')} from the App's Config screen once it exists. Values are write-only once stored, so they cannot be filled in later from here.`,
     });
   }
 

--- a/apps/spindrift/src/integrations/github/app.ts
+++ b/apps/spindrift/src/integrations/github/app.ts
@@ -319,6 +319,14 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
    * for is Spindrift's own configuration branch: re-running a connection should
    * replace what it wrote last time rather than fail on a non-fast-forward, and
    * the branch holds nothing a human authored.
+   *
+   * **`422` is what a branch that is not there answers.** GitHub's ref-update
+   * endpoint documents `200`, `409` and `422` and no `404` at all — a `404` is
+   * what *reading* a missing ref answers, which is why `branchHead` is right to
+   * expect one and this is not. Tolerating only `404` here made the create
+   * below unreachable, so the first connection of every repository threw on the
+   * branch it was about to cut, and `connectRepository`'s fail-open turned that
+   * into a repository connected with no configuration pull request.
    */
   async setBranch(
     ref: InstallationRef,
@@ -330,7 +338,7 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
       method: 'PATCH',
       path: `/repos/${fullName}/git/refs/heads/${branch}`,
       body: { sha: commit, force: true },
-      tolerate: [404],
+      tolerate: [404, 422],
     });
     if (updated !== null) return;
 
@@ -341,7 +349,18 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
     });
   }
 
-  /** Open the pull request and return its number. If a PR already exists for the head branch, find and return it. */
+  /**
+   * Open the pull request and return its number.
+   *
+   * A second connection force-updates the branch and then finds GitHub refusing
+   * to open a second pull request for the same head. The existing one *is* the
+   * answer — it now carries the commit just pushed — so it is found rather than
+   * reported as a failure, and its title and body are rewritten to the
+   * transaction that just landed on it. Leaving the prose alone would leave an
+   * operator reviewing a description of the previous connection over the diff
+   * of this one, which is the thing `connectRepository`'s own header promises
+   * does not happen.
+   */
   async openPullRequest(
     ref: InstallationRef,
     fullName: string,
@@ -368,25 +387,37 @@ export class GitHubApp implements ExactCommitFetcher<InstallationRef> {
         fullName,
         input.head,
       );
-      if (existing !== null) {
-        return existing;
-      }
-      throw cause;
+      if (existing === null) throw cause;
+      await this.http(ref).send({
+        method: 'PATCH',
+        path: `/repos/${fullName}/pulls/${existing}`,
+        body: { title: input.title, body: input.body },
+      });
+      return existing;
     }
   }
 
-  /** Find an open pull request for a given head branch. */
+  /**
+   * Find an open pull request for a given head branch.
+   *
+   * Asked of GitHub rather than filtered here: the unfiltered listing is thirty
+   * newest-first, so a repository with a page of open dependency bumps answered
+   * "no such pull request" about one that was sitting right there — and the
+   * branch had already been force-updated by then, so the operator was told the
+   * opposite of what had happened.
+   */
   async findOpenPullRequest(
     ref: InstallationRef,
     fullName: string,
     headBranch: string,
   ): Promise<number | null> {
+    const owner = fullName.slice(0, fullName.indexOf('/'));
     try {
       const pulls = await this.http(ref).json<
         Array<{ number: number; head: { ref?: string } }>
       >({
         method: 'GET',
-        path: `/repos/${fullName}/pulls?state=open`,
+        path: `/repos/${fullName}/pulls?state=open&per_page=${PAGE_SIZE}&head=${encodeURIComponent(`${owner}:${headBranch}`)}`,
       });
       if (Array.isArray(pulls)) {
         const match = pulls.find((p) => p.head?.ref === headBranch);

--- a/apps/spindrift/src/integrations/github/config-pr.ts
+++ b/apps/spindrift/src/integrations/github/config-pr.ts
@@ -85,9 +85,27 @@ export interface ConfigurationTransaction {
   readonly files: readonly ConfigurationFile[];
 }
 
+/** Anything outside this needs quoting for YAML to read it as written. */
+const PLAIN = /^[A-Za-z0-9][\w./-]*$/;
+
+/**
+ * What YAML resolves to a boolean, a null or a number rather than to a string.
+ *
+ * Plain by the shape test above and still not a string once parsed, which is
+ * the whole failure: a `buildCommand` of `true` is emitted bare, comes back
+ * from `parseSpindriftFile` as a boolean, and `buildSchema` refuses the
+ * document. One refused scope makes the repo loop reject the entire commit, so
+ * the repository stops advancing for every App on it until a human edits a file
+ * Spindrift wrote.
+ */
+const TYPED =
+  /^(?:true|false|null|~|[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?)$/i;
+
 /** Quote a scalar only where YAML would otherwise read it as something else. */
 function scalar(value: string): string {
-  return /^[A-Za-z0-9][\w./-]*$/.test(value) ? value : JSON.stringify(value);
+  return PLAIN.test(value) && !TYPED.test(value)
+    ? value
+    : JSON.stringify(value);
 }
 
 /**

--- a/apps/spindrift/src/reconciler/repo-loop.ts
+++ b/apps/spindrift/src/reconciler/repo-loop.ts
@@ -350,6 +350,13 @@ export async function reconcileRepository(
     };
   }
 
+  // Adopting a Spindrift file from the default branch is what the merge of the
+  // configuration pull request looks like from in here — no `pull_request`
+  // delivery is subscribed to, and none is needed, because the merge is only
+  // interesting for having put the file where this loop reads it. Clearing the
+  // number is what stops "merge your configuration PR" standing on a screen
+  // over a pull request that landed weeks ago.
+  const adopted = outcomes.some((outcome) => outcome.outcome === 'adopted');
   await context.db
     .update(repositories)
     .set({
@@ -357,6 +364,7 @@ export async function reconcileRepository(
       authoritativeCommit: head,
       reconciledAt: now,
       updatedAt: now,
+      ...(adopted ? { configPullRequest: null } : {}),
     })
     .where(eq(repositories.id, repository.id));
 

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -805,6 +805,16 @@ export interface LinkedRepoView {
   readonly staleReason: string | null;
   /** App subpaths connected to this repository. */
   readonly appSubpaths: readonly string[];
+  /**
+   * The configuration pull request this connection opened, while it is still
+   * the thing standing between the repository and its own builds.
+   *
+   * Null once the repo loop has adopted a Spindrift file from the default
+   * branch, which is what merging it looks like from here: nothing subscribes
+   * to `pull_request` deliveries, so a merge is observed as configuration
+   * arriving on the default branch rather than as a pull request closing.
+   */
+  readonly configPullRequest: number | null;
 }
 
 /**

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -34,6 +34,8 @@ import type {
 import {
   appNameSchema,
   componentNameSchema,
+  OPENING_AUTH,
+  OPENING_REACH,
 } from '../../../../domain/creation-draft.ts';
 import {
   type ClientResult,
@@ -55,6 +57,8 @@ import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
 import { Card, Eyebrow } from '../../../ui/card.tsx';
 import { Field } from '../../../ui/field.tsx';
+import { notify } from '../../../ui/toast.tsx';
+import { cn } from '../../../ui/utils.ts';
 import { deployDraft } from './deploy.ts';
 import {
   type InspectedScope,
@@ -162,7 +166,9 @@ function unreadRepository(
     {
       code: 'REPOSITORY_UNAVAILABLE',
       title: `Spindrift could not read ${draft.source.repo}.`,
-      remediation: `${trouble.message} Until it can be read, everything below Source is the draft's opening claim rather than anything found in the repository.`,
+      // The message itself is already on screen, as the Source row's reason.
+      // Repeating it here read as two separate problems with one repository.
+      remediation: `Until it can be read, everything below Source is the draft's opening claim rather than anything found in the repository.`,
     },
   ];
 }
@@ -176,6 +182,48 @@ function answeredScope(draft: Draft): boolean {
 function issueWith(schema: ZodType<string>, value: string): string | null {
   const parsed = schema.safeParse(value);
   return parsed.success ? null : (parsed.error.issues[0]?.message ?? null);
+}
+
+/**
+ * What creating the App did to the repository, said once, on the way out.
+ *
+ * Deploy is the only place a repository GitHub merely grants gets connected,
+ * and connecting opens the one configuration pull request §15 makes
+ * authoritative on merge. `connectRepository` fails open on that pull request —
+ * the repository stays connected either way — so a silence here is the
+ * difference between "merge this" and "your builds will never run on your own
+ * repository", and neither was ever said on this screen.
+ */
+function reportConfigPullRequest(app: {
+  readonly configPullRequest: number | null;
+  readonly configPullRequestError: string | null;
+  readonly configRepository: string | null;
+}): void {
+  const { configPullRequest, configPullRequestError, configRepository } = app;
+  if (configRepository === null) return;
+  if (configPullRequest !== null) {
+    const url = `https://github.com/${configRepository}/pull/${configPullRequest}`;
+    notify({
+      tone: 'success',
+      title: `Configuration PR opened: ${configRepository}#${configPullRequest}`,
+      detail:
+        'Merging it puts the Spindrift file and the build workflow on the default branch. Until then nothing in this repository is authoritative, and its builds run on the platform repository.',
+      action: {
+        label: 'Review it',
+        onSelect: () => {
+          window.open(url, '_blank', 'noopener,noreferrer');
+        },
+      },
+    });
+    return;
+  }
+  if (configPullRequestError !== null) {
+    notify({
+      tone: 'destructive',
+      title: `${configRepository} is connected, but its configuration PR did not open`,
+      detail: `${configPullRequestError} Open it again from Repositories, or add the Spindrift file and the build workflow by hand.`,
+    });
+  }
 }
 
 /** A refusal, and what the operator was doing when it arrived. */
@@ -329,8 +377,17 @@ export function NewApp({
   ];
   const blockers = [
     ...localBlockers,
+    // Deduped on what the blocker *says*, not on its code. Both sides mint
+    // `SOURCE_UNAVAILABLE` about different facts — "nothing is chosen to deploy
+    // from this repository" here, "no authoritative commit ready to stage"
+    // there — and matching on the code alone hid the server's sentence behind
+    // the local one, so clearing the first revealed a second, unrelated
+    // problem that had been there all along.
     ...serverBlockers.filter(
-      (server) => !localBlockers.some((local) => local.code === server.code),
+      (server) =>
+        !localBlockers.some(
+          (local) => local.code === server.code && local.title === server.title,
+        ),
     ),
   ];
   const target = targets.find((option) => option.targetId === draft.targetId);
@@ -545,10 +602,17 @@ export function NewApp({
     });
   };
 
-  /** A settled subpath edit asks about the directory it now names. */
+  /**
+   * A settled subpath edit asks about the directory it now names.
+   *
+   * And is the point the typing counts as an answer — the flag rides on this
+   * dispatch rather than on every keystroke, so a half-typed path no longer
+   * clears the prerequisite that says nothing has been chosen yet.
+   */
   const settleSubpath = () => {
     const source = draftRef.current.source;
     if (source.kind !== 'repo' || source.repo === '' || !source.subpath) return;
+    dispatch({ type: 'subpath', subpath: source.subpath, settled: true });
     void inspect(source.repo, source.subpath);
   };
 
@@ -612,6 +676,12 @@ export function NewApp({
       setRefusal(null);
       setServerBlockers(outcome.result.draft.blockers);
       if (outcome.result.app === null) return;
+      // Said before the navigation, because after it this screen is gone and
+      // the pull request is the one thing creation did that is not on the App
+      // it navigates to. §15 makes merging it the act that connects the
+      // repository, so an App created with an unmentioned pull request is an
+      // App whose next Build runs on the wrong repository's minutes.
+      reportConfigPullRequest(outcome.result.app);
       onCreated?.({
         id: outcome.result.app.appId,
         name: outcome.result.app.name,
@@ -669,7 +739,13 @@ export function NewApp({
           why={
             readElsewhere && draft.source.kind === 'repo'
               ? `${draft.detection.reason} — read in ${draft.detection.scope}, and the root directory now names ${draft.source.subpath}.`
-              : draft.detection.reason
+              : draft.kind !== draft.detection.kind
+                ? // The badge says a correction happened; the reason underneath
+                  // was still detection's, so the row read `web · website` over
+                  // "the default is a long-running service" and flatly
+                  // contradicted the value beside it.
+                  `You chose ${draft.kind}. Detection read ${draft.detection.kind} — ${draft.detection.reason}`
+                : draft.detection.reason
           }
           tone={
             draft.kind === draft.detection.kind ? null : (
@@ -809,7 +885,17 @@ export function NewApp({
           }
         />
 
-        <Row label="Reach" value={draft.reach} why={REACH_NOTE[draft.reach]}>
+        {/*
+          `Row`'s whole claim is that a stated reason is what separates a
+          default from something somebody typed — and these two notes are
+          dictionary definitions of the value, identical whether the operator
+          chose it or the draft was born with it. Saying which is the reason.
+        */}
+        <Row
+          label="Reach"
+          value={draft.reach}
+          why={`${draft.reach === OPENING_REACH ? 'Default — ' : ''}${REACH_NOTE[draft.reach]}`}
+        >
           <div className="grid gap-2 sm:grid-cols-3">
             {REACHES.map((reach) => (
               <Choice
@@ -829,7 +915,11 @@ export function NewApp({
           refusal validation makes, stated by not asking.
         */}
         {draft.reach !== 'none' && (
-          <Row label="Auth" value={draft.auth} why={AUTH_NOTE[draft.auth]}>
+          <Row
+            label="Auth"
+            value={draft.auth}
+            why={`${draft.auth === OPENING_AUTH ? 'Default — ' : ''}${AUTH_NOTE[draft.auth]}`}
+          >
             <div className="grid gap-2 sm:grid-cols-2">
               {AUTHS.map((auth) => (
                 <Choice
@@ -919,7 +1009,17 @@ export function NewApp({
           onClick={start}
         >
           <Rocket aria-hidden="true" />
-          {submitting ? 'Creating…' : saving ? 'Saving…' : 'Deploy'}
+          {/* Every arm of the disable expression says which one it is. Reading
+              the repository was the one that did not, so the button went dead
+              on open — before anybody had touched it — under a label promising
+              it would create something. */}
+          {submitting
+            ? 'Creating…'
+            : saving
+              ? 'Saving…'
+              : detecting
+                ? 'Reading the repository…'
+                : 'Deploy'}
         </Button>
         <p className="text-xs text-muted-foreground">
           {blockers.length > 0
@@ -1174,15 +1274,20 @@ function SourceRow({
 }
 
 /**
- * Every directory the repository was read for, as a list to choose from.
+ * Every directory the repository was read for, as one control to choose from.
  *
  * §5 says discovery "proposes a list of candidate directories for a human to
  * choose from", and this is that list rather than a summary of it. A directory
  * detection knows how to build is selectable and wears the kind and the
  * sentence behind it; one it does not is here too, disabled, wearing what it
- * found instead — §3's grammar, which only works if the alternatives are
- * visible. An empty list means nothing has been read yet, which is a different
- * thing from a repository with nothing in it.
+ * found instead — §3's grammar, which only works if the alternatives stay
+ * readable. A `<select>` keeps them readable and keeps a monorepo's twenty
+ * directories from burying the rows below Source, which a grid of tiles did.
+ * The reason rides in each option's own label for the same reason: a dropdown
+ * has nowhere else to put a per-option sentence.
+ *
+ * An empty list means nothing has been read yet, which is a different thing
+ * from a repository with nothing in it.
  */
 function ScopeChooser({
   subpath,
@@ -1195,25 +1300,46 @@ function ScopeChooser({
 }) {
   if (scopes === null || scopes.length === 0) return null;
 
+  // The directory the draft names is what it is deploying, whatever detection
+  // made of it — story 32 keeps that escape hatch open, and Deploy is not
+  // blocked on it. So the control points at it rather than drawing it as the
+  // one row that cannot be chosen while it is the row in force. Only a subpath
+  // nothing has read at all leaves the placeholder standing.
+  const chosen = scopes.find((scope) => scope.scope === subpath);
+
   return (
     <div className="flex flex-col gap-2">
       <Eyebrow>Directories Spindrift read</Eyebrow>
-      <div className="grid gap-2 sm:grid-cols-2">
+      <select
+        aria-label="Directories Spindrift read"
+        value={chosen?.scope ?? ''}
+        onChange={(event) => {
+          const picked = scopes.find(
+            (scope) => scope.scope === event.currentTarget.value,
+          );
+          if (picked !== undefined) onChoose(picked);
+        }}
+        className={cn(
+          'h-9 w-full rounded-md border border-border bg-card px-3',
+          'font-mono text-sm text-foreground',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
+        )}
+      >
+        <option value="" disabled>
+          {`Choose one of ${scopes.length} directories…`}
+        </option>
         {scopes.map((scope) => (
-          <Choice
+          <option
             key={scope.scope}
-            selected={scope.outcome === 'detected' && scope.scope === subpath}
-            disabled={scope.outcome !== 'detected'}
-            title={scope.scope}
-            note={
-              scope.outcome === 'detected'
-                ? `${scope.kind} — ${scope.reason}`
-                : scope.detail
-            }
-            onClick={() => onChoose(scope)}
-          />
+            value={scope.scope}
+            disabled={scope.outcome !== 'detected' && scope.scope !== subpath}
+          >
+            {scope.outcome === 'detected'
+              ? `${scope.scope} — ${scope.kind} — ${scope.reason}`
+              : `${scope.scope} — cannot build: ${scope.detail}`}
+          </option>
         ))}
-      </div>
+      </select>
       <p className="text-xs text-muted-foreground">
         Choosing one detects that directory and names the Component after it.
         Nothing is picked for you when there is more than one.

--- a/apps/spindrift/src/web/views/apps/new/summary.tsx
+++ b/apps/spindrift/src/web/views/apps/new/summary.tsx
@@ -12,7 +12,7 @@
  * decides, which is exactly what a five-step rail cost.
  */
 import { ChevronRight, Lock, Pencil } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useRef, useState } from 'react';
 import type {
   Auth,
   ComponentKind,
@@ -52,14 +52,33 @@ export function Row({
    * places that do not fit is behind a disclosure. Same rule §18 gives the
    * build log: collapsed on green, open on anything else.
    *
-   * Toggling takes over from it, so a reader who closed a row keeps it closed.
+   * **It opens by itself and never closes by itself.** Every input to
+   * `unsettled` is asynchronous — a repository read landing, a `listTargets`
+   * refetch answering — so a row that tracked it in both directions collapsed
+   * several hundred pixels of controls under the reader's cursor in reply to
+   * something nobody pressed, and everything below jumped up to meet them.
+   * Closing is the operator's, through Done.
    */
   unsettled?: boolean;
   /** The correction, if this row has one. Absent makes the row a fact. */
   children?: ReactNode;
 }) {
   const [toggled, setToggled] = useState<boolean | null>(null);
-  const open = toggled ?? unsettled;
+  // Sticky: having been unsettled once is what holds the row open, so an answer
+  // arriving from a read nobody pressed reveals nothing and hides nothing.
+  const opened = useRef(unsettled);
+  // A row that goes unsettled *again* is asking a question the operator's
+  // earlier Done was not an answer to — the blocker under the card says "pick
+  // one under Source", and one press a minute ago must not be what makes that
+  // sentence point at a row that will never reopen.
+  const previously = useRef(unsettled);
+  if (unsettled) {
+    opened.current = true;
+    if (!previously.current) setToggled(null);
+  }
+  previously.current = unsettled;
+
+  const open = toggled ?? opened.current;
   const setOpen = (next: (current: boolean) => boolean) =>
     setToggled(next(open));
 

--- a/apps/spindrift/src/web/views/repos/list.tsx
+++ b/apps/spindrift/src/web/views/repos/list.tsx
@@ -866,6 +866,37 @@ function ConnectedRepositories({
                   <p className="text-sm">{repo.error}</p>
                 </div>
               ) : null}
+              {/* Connected, and still waiting on the one merge that makes any
+                  of it authoritative. The row is the durable place to say so:
+                  the banner above answers the press that opened it and is gone
+                  on the next load, and creating an App from the wizard opens
+                  this pull request without ever visiting this screen. */}
+              {repo.configPullRequest !== null ? (
+                <div className="flex items-start gap-2 rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-sm">
+                  <AlertTriangle
+                    aria-hidden="true"
+                    className="mt-0.5 size-4 shrink-0 text-warning"
+                  />
+                  <p>
+                    Configuration pull request{' '}
+                    <a
+                      className="font-semibold underline underline-offset-2"
+                      href={githubUrl(
+                        repo.fullName,
+                        'pull',
+                        String(repo.configPullRequest),
+                      )}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      #{repo.configPullRequest}
+                    </a>{' '}
+                    is open. Nothing in this repository is authoritative until
+                    it merges, and its builds run on the platform repository
+                    until then.
+                  </p>
+                </div>
+              ) : null}
               {/* Still connected, and the commit beside it is older than it
                   looks: listing refreshes every row, and one the host would
                   not answer about says so rather than passing for current. */}

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -937,6 +937,7 @@ export const LINKED_REPOS: readonly LinkedRepoView[] = [
     lastReconciledSha: 'a1b2c3d',
     staleReason: null,
     appSubpaths: ['apps/hub', 'apps/api', 'apps/wiki'],
+    configPullRequest: null,
   },
   {
     repositoryId: 100002,
@@ -947,6 +948,8 @@ export const LINKED_REPOS: readonly LinkedRepoView[] = [
     lastReconciledSha: 'e4f5g6h',
     staleReason: null,
     appSubpaths: ['.'],
+    // Connected, and still one merge short of governing itself.
+    configPullRequest: 42,
   },
   {
     repositoryId: 100004,
@@ -958,6 +961,7 @@ export const LINKED_REPOS: readonly LinkedRepoView[] = [
     lastReconciledSha: 'i7j8k9l',
     staleReason: null,
     appSubpaths: ['.'],
+    configPullRequest: null,
   },
 ];
 

--- a/apps/spindrift/test/harness/dom.ts
+++ b/apps/spindrift/test/harness/dom.ts
@@ -126,6 +126,23 @@ export class FakeNode {
   removeEventListener(): void {}
 
   /**
+   * Just enough of `HTMLSelectElement.options` to mount a `<select>`.
+   *
+   * React's `updateOptions` runs on every select as it is created — it reads
+   * `node.options` and walks it looking for the one whose `value` matches, so a
+   * select without that collection throws before the tree is ever on screen.
+   * Derived from `childNodes` rather than maintained beside them, so an option
+   * React inserts later is in the list without a second write path.
+   *
+   * Which option ends up marked `selected` is not modelled: nothing here
+   * renders a selection, and `textContent` — what these tests read — carries
+   * every option's label either way.
+   */
+  get options(): FakeNode[] {
+    return this.childNodes.filter((child) => child.tagName === 'OPTION');
+  }
+
+  /**
    * `commitMount` calls this directly on a mounted `input`/`select`/`button`
    * carrying `autoFocus`, so a tree with an autofocused control does not mount
    * without it. There is no focus in this shim — `activeElement` stays `null` —

--- a/apps/spindrift/test/harness/fakes/github-api.ts
+++ b/apps/spindrift/test/harness/fakes/github-api.ts
@@ -583,7 +583,14 @@ export class FakeGitHub {
     const update = rest.match(/^\/git\/refs\/heads\/(.+)$/);
     if (update && method === 'PATCH') {
       const name = decodeURIComponent(update[1] ?? '');
-      if (!this.branches.has(name)) return this.notFound();
+      // The host's own answer, and not the one it is easy to assume: updating a
+      // ref that is not there is a `422`, message and all. This fake said `404`
+      // for years and the production client was written to match the fake, so
+      // the create-the-branch path it falls through to was never once taken
+      // against GitHub.
+      if (!this.branches.has(name)) {
+        return this.json({ message: 'Reference does not exist' }, 422);
+      }
       this.branches.set(name, String(body.sha ?? ''));
       return this.json({ ref: `refs/heads/${name}` });
     }
@@ -605,6 +612,18 @@ export class FakeGitHub {
       };
       this.pulls.push(pull);
       return this.json(pull, 201);
+    }
+
+    // Rewriting an open pull request's prose, which is what a second connect
+    // does to the one it finds already standing on its branch.
+    const editPull = rest.match(/^\/pulls\/(\d+)$/);
+    if (editPull && method === 'PATCH') {
+      const number = Number(editPull[1]);
+      const pull = this.pulls.find((candidate) => candidate.number === number);
+      if (pull === undefined) return this.notFound();
+      if (body.title !== undefined) pull.title = String(body.title);
+      if (body.body !== undefined) pull.body = String(body.body);
+      return this.json(pull);
     }
 
     return null;

--- a/apps/spindrift/test/integrations/github/config-pr.test.ts
+++ b/apps/spindrift/test/integrations/github/config-pr.test.ts
@@ -90,6 +90,27 @@ describe('the Spindrift file Spindrift writes', () => {
     );
   });
 
+  test.each(['true', 'false', 'null', '~', '3', '1.5'])(
+    'round-trips a build command YAML would otherwise retype: %s',
+    (command) => {
+      // Plain by shape and not a string once parsed, which is a file Spindrift
+      // wrote and can never read back. One refused scope makes the repo loop
+      // reject the whole commit, so the repository stops advancing for every
+      // App on it until a human edits it by hand.
+      const typed: DetectionProposal = {
+        ...railpack,
+        build: {
+          frontend: 'railpack',
+          buildCommand: command,
+          outputDirectory: null,
+        },
+      };
+      expect(parseSpindriftFile(serializeSpindriftFile(typed)).build).toEqual(
+        typed.build,
+      );
+    },
+  );
+
   test('is block-style YAML a person can edit', () => {
     const written = serializeSpindriftFile(railpack);
     expect(written).toContain('component:\n  kind: website');
@@ -225,6 +246,67 @@ describe('opening it against the repository API', () => {
     });
     expect(fake.pulls[0]?.body).toContain('apps/site');
     expect(fake.pulls[0]?.body).toContain('services/api');
+  });
+
+  test('cuts the configuration branch when there is not one yet', async () => {
+    // The bug this pins cost every repository its configuration pull request on
+    // the first connect, and reported nothing: GitHub answers a ref *update*
+    // for a ref that does not exist with `422`, not `404` — 404 is what reading
+    // one answers — so a client tolerating only 404 threw on the branch it was
+    // about to create, and `connectRepository` fails open on that throw.
+    const fake = new FakeGitHub();
+    const { opened } = await open(fake);
+
+    expect(fake.head(CONFIG_BRANCH)).toBe(opened.commit);
+    const created = fake.requests.filter(
+      (request) =>
+        request.method === 'POST' && request.path.endsWith('/git/refs'),
+    );
+    expect(created).toHaveLength(1);
+  });
+
+  test('a second connection rewrites the pull request it finds standing', async () => {
+    const fake = new FakeGitHub();
+    const first = await open(fake);
+
+    // The far side from the second connect onwards: the branch takes the new
+    // commit, and the pull request for it already exists.
+    const existing = (async (request: any) => {
+      const url = new URL(typeof request === 'string' ? request : request.url);
+      if (request.method === 'POST' && url.pathname.endsWith('/pulls')) {
+        return new Response(
+          JSON.stringify({
+            message: 'Validation Failed',
+            errors: [
+              { message: `A pull request already exists for ${CONFIG_BRANCH}` },
+            ],
+          }),
+          { status: 422, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+      return fake.fetch(request);
+    }) as any;
+
+    const transaction = configurationTransaction({
+      scopes: [{ scope: 'services/api', proposal: dockerfile }],
+      buildWorkflow: BUILD_WORKFLOW,
+    });
+    const second = await openConfigurationPullRequest(
+      app(fake, existing),
+      { installationId: fake.installationId },
+      { fullName: fake.fullName, defaultBranch: 'main', transaction },
+    );
+
+    expect(second.number).toBe(first.opened.number);
+    // Reviewing a description of the first connection over the diff of the
+    // second is the thing `connectRepository`'s own header promises does not
+    // happen — the branch was corrected and the prose was not.
+    const pull = fake.pulls.find(
+      (candidate) => candidate.number === second.number,
+    );
+    expect(pull?.title).toBe(transaction.title);
+    expect(pull?.body).toContain('services/api');
+    expect(pull?.body).not.toContain('apps/site');
   });
 
   test('re-running the connection replaces the branch rather than failing', async () => {

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -263,7 +263,18 @@ describe('non-candidate Targets are listed rather than hidden', () => {
 
 describe('the draft reducer', () => {
   test('a tile that names a kind preselects it', () => {
-    const next = draftReducer(INITIAL_DRAFT, {
+    // `website` is ruled out on the shared fixture, which is a different case
+    // — see below — so this is asked about a kind detection allows.
+    const openToWebsite: Draft = {
+      ...INITIAL_DRAFT,
+      kind: 'job',
+      detection: {
+        ...INITIAL_DRAFT.detection,
+        available: ['service', 'website', 'job'],
+        unavailable: {},
+      },
+    };
+    const next = draftReducer(openToWebsite, {
       type: 'entry',
       entry: 'website',
     });
@@ -273,12 +284,25 @@ describe('the draft reducer', () => {
     expect(next.source).toEqual(INITIAL_DRAFT.source);
   });
 
-  test("a tile that names no kind leaves detection's proposal standing", () => {
+  test('a tile naming a kind detection ruled out does not select it', () => {
+    // The Component row draws that kind disabled, wearing the reason it cannot
+    // be chosen (§3). A tile that wrote it anyway produced the one state the
+    // grammar has no reading for: selected and greyed at once.
+    expect(INITIAL_DRAFT.detection.unavailable.website).toBeDefined();
     const next = draftReducer(INITIAL_DRAFT, {
       type: 'entry',
-      entry: 'upload',
+      entry: 'website',
     });
-    expect(next.kind).toBe(INITIAL_DRAFT.detection.kind);
+    expect(next.kind).toBe(INITIAL_DRAFT.kind);
+  });
+
+  test('a tile that names no kind leaves the draft’s kind standing', () => {
+    // Not detection's kind — the operator's, if they corrected it. Reverting to
+    // the proposal on a press about where the *source* comes from undid a
+    // correction made two rows down and took its "corrected" badge with it.
+    const corrected: Draft = { ...INITIAL_DRAFT, kind: 'job' };
+    const next = draftReducer(corrected, { type: 'entry', entry: 'upload' });
+    expect(next.kind).toBe('job');
   });
 
   test('the Upload tile switches the source to an archive', () => {
@@ -474,13 +498,26 @@ describe('the draft reducer', () => {
     expect(next.detection.reason).not.toContain('spindrift.yaml');
   });
 
-  test('a directory the operator typed is recorded as theirs', () => {
+  test('a directory the operator settled on is recorded as theirs', () => {
     // Durable rather than session state, because the guard it feeds is about
     // the read that runs when a saved draft is reopened.
     const next = draftReducer(INITIAL_DRAFT, {
       type: 'subpath',
       subpath: 'apps/ddnsd',
+      settled: true,
     });
     expect(next.scopeByOperator).toBe(true);
+  });
+
+  test('a directory still being typed is not yet an answer', () => {
+    // The keystroke that took `a` for an answer cleared the prerequisite that
+    // says nothing has been chosen to deploy, and once the debounced save
+    // landed Deploy went green for a path nothing had read.
+    const next = draftReducer(INITIAL_DRAFT, {
+      type: 'subpath',
+      subpath: 'a',
+    });
+    expect(next.source).toMatchObject({ subpath: 'a' });
+    expect(next.scopeByOperator).toBe(INITIAL_DRAFT.scopeByOperator);
   });
 });


### PR DESCRIPTION
## The PR path

The first connection of any repository never opened its configuration pull request. `setBranch` cut the branch by PATCHing the ref and falling through to a create only on a tolerated `404` — but [GitHub's ref-update endpoint](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28) documents `200`, `409` and `422` and no `404`: a ref that is not there answers `422`, and `404` is what *reading* one answers. The create was unreachable, so the PATCH threw on the branch it was about to make, and `connectRepository`'s fail-open turned that into a repository connected with no pull request and no complaint. The fake modelled the missing ref as `404` — the one status the client was written against — so no test could see it.

Creating an App is the only place a granted-but-unconnected repository gets connected, and that path discarded the result outright: neither the number to merge nor the reason none opened reached the operator. It is now carried through completion, raised as a toast on the way to the new App, and read back off the repository row on reload — which is what `config_pull_request` was always for and what nothing read. The repo loop clears it when it adopts a Spindrift file from the default branch, which is what the merge looks like from in here.

Also on this path: a second connection rewrites the title and body of the pull request it finds standing on its branch; the existing-PR lookup asks GitHub for the head branch instead of scanning the 30 newest open PRs; a build command YAML retypes (`true`, `null`, `3`) is quoted, which previously made the repo loop reject the whole commit and stall every App on the repository; and connecting a frozen repository thaws the row it has just proved it can read.

## The wizard flow

Too much of it moved on its own. Rows now open themselves and never close themselves — every input to `unsettled` is an async read landing, so an answer arriving collapsed several hundred pixels of controls under the reader's cursor. A row that goes unsettled again reopens, so a blocker cannot point at a section one earlier Done closed forever.

The directories detection read are one dropdown rather than a grid of tiles, each option carrying its own kind and reason, and the directory the draft actually names is selectable there even when detection made nothing of it. Deploy says "Reading the repository…" while it is disabled for that — the one arm of the disable expression that announced nothing. "Discover" is gone; it pressed the same reducer arm as "Link repo" and produced the same screen.

Corrections stick: a tile naming a source no longer reverts a corrected kind, and a tile naming a kind detection ruled out no longer selects it (which produced a Component tile both selected and greyed, wearing the reason it could not be chosen). Typing in "Root directory" counts as an answer when the edit settles, not on every keystroke — the first character used to clear the "nothing is chosen to deploy" prerequisite and turn Deploy green for a path nothing had read.

Smaller: blockers dedupe on what they say rather than on their code alone (both sides mint `SOURCE_UNAVAILABLE` about different facts); the Component row's reason no longer contradicts the value beside it after a correction; the unreadable-repository sentence is not printed twice; Reach and Auth mark an untouched value as the default it is; and two remediations that named controls incapable of what they asked now name the screens that can.

## Validation

`bun test` 2198 pass / 0 fail, `tsc --noEmit` clean, `biome check` clean.

New coverage for the two silent ones: the branch being cut when there is not one yet, the second connection rewriting the pull request it finds, and a build command YAML would otherwise retype round-tripping through the parser. The test DOM shim gained `select.options`, without which React cannot mount a `<select>` at all.

## Risk

`repositories.config_pull_request` was write-only and is now read in two places; rows written before this change hold a number whose pull request may already be merged, and the row clears on the next reconciliation that adopts a file. The `discover` entry value stays in the schema and is only removed from the tiles, so stored drafts carrying it still parse.