### PR TITLE
fix(slides): correct four claims the spindrift deck cannot support

### DIFF
--- a/apps/slides/spindrift/index.html
+++ b/apps/slides/spindrift/index.html
@@ -417,6 +417,32 @@
   .stat--cau b { color: var(--caution); }
   .stat--ink b { color: var(--ink); }
 
+  /* measurement table */
+  .tablewrap { overflow-x: auto; border: 1px solid var(--rule); background: var(--surface); }
+  table.bench {
+    border-collapse: collapse;
+    width: 100%;
+    min-width: 34rem;
+    font-size: clamp(0.85rem, 0.8rem + 0.3vw, 1rem);
+  }
+  table.bench th, table.bench td {
+    text-align: left;
+    padding: 0.6rem 1rem;
+    border-bottom: 1px solid var(--rule-soft);
+  }
+  table.bench thead th {
+    font-family: var(--mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-weight: 500;
+  }
+  table.bench tbody tr:last-child th,
+  table.bench tbody tr:last-child td { border-bottom: 0; }
+  table.bench tbody th { font-weight: 500; color: var(--ink-2); }
+  table.bench td { font-variant-numeric: tabular-nums; }
+
   /* timeline */
   .log {
     display: grid;
@@ -845,7 +871,7 @@
         <rect class="d-box" x="404" y="100" width="210" height="58" rx="6"/>
         <text class="d-t b" x="420" y="122">Cloud builder</text>
         <text class="d-s" x="420" y="142">Cloud Build</text>
-        <text class="d-lab" x="598" y="122" text-anchor="end">SLSA L2</text>
+        <text class="d-lab" x="598" y="122" text-anchor="end">SLSA L3</text>
 
         <rect class="d-box" x="404" y="170" width="210" height="58" rx="6"/>
         <text class="d-t b" x="420" y="192">Pool — a bosun skiff</text>
@@ -943,8 +969,8 @@
         </div>
         <div class="card card--flag">
           <span class="tag t-acc">Why it earns its place</span>
-          <h4>A hosted outage stops being fatal</h4>
-          <p>Two of the three original routes are somebody else's service. The pool is the one that keeps building when they are down — and it clears the same <span class="m">SLSA L2</span> bar, verified against the build hull's own builder identity before core signs the digest.</p>
+          <h4>Proven, and honestly unserved</h4>
+          <p>Two of the three original routes are somebody else's service; this one owes them nothing, and it clears the same <span class="m">SLSA L2</span> bar — verified against the build hull's own builder identity before core signs the digest. No host serves the class today: the route stays declared and ranked last, so bringing a host back serves it with no configuration change, and a build that falls through to it times out at the build budget rather than hanging.</p>
         </div>
       </div>
       <p class="verbatim">claim · heartbeat · result   →   the endpoint just happens to be this installation's own database</p>
@@ -965,7 +991,7 @@
     </div>
     <div style="display:flex;flex-direction:column;gap:1.1rem">
       <div class="stats">
-        <div class="stat"><b>2,065</b><span>tests green</span></div>
+        <div class="stat"><b>2,188</b><span>tests green</span></div>
         <div class="stat"><b>5</b><span>clauses proven live</span></div>
         <div class="stat"><b>3/4</b><span>Targets healthy on first probe</span></div>
         <div class="stat stat--cau"><b>4</b><span>defects only a live install found</span></div>
@@ -973,7 +999,7 @@
       <ul class="ticks">
         <li>Two Terraform roots that each need the other applied first — the runbook stated one direction.</li>
         <li>A derived string carries no dependency edge, so grants ran before the account they named existed.</li>
-        <li>Six prerequisite rows failing with one byte-identical 401.</li>
+        <li>Six prerequisite rows failing with one byte-identical certificate-trust sentence.</li>
         <li>A read on a URL the API does not serve, which made a second deploy collide with the site the first one created — so a static App could be published exactly once.</li>
       </ul>
       <p class="small dim" style="border-left:3px solid var(--good);padding-left:0.9rem">That last one is fixed, and <b>this revision is the proof</b>: these words reached you as a second deploy onto the site the first one made.</p>


### PR DESCRIPTION
Four claims on the served deck that the tree does not support. The deck's own rule is that anything asserted on a slide is traceable to the tree or to a recorded live observation.

- **Seam table had no CSS.** The markup uses `.tablewrap` and `table.bench`; this deck's `<style>` block had neither, nor any generic `table`/`th`/`td` fallback, so the five-seams thesis slide rendered a default UA table. Ported the block from `apps/slides/bosun/index.html`. Dropped two rules on the way: `td { font-family: var(--mono) }` and `td.win` both exist to set benchmark numbers, and this table's cells are prose and adapter names.
- **Cloud builder labelled SLSA L2.** `apps/spindrift/src/adapters/build/cloud-build.ts:195,888` declares `buildLevel: 3`, and :189-195 carries the reasoning for it. The other three route labels (hosted CI L2, pool L2, in-cluster L1) match their adapters and are unchanged, as is the Target-threshold prose, which is a different claim.
- **Pool card claimed a hosted outage stops being fatal.** No host serves `skiff-build-xl`; `clusters/offsite/apps/spindrift/helm-release.yaml:180-188` comments that a build falling through to it times out at the build budget. The card keeps the SLSA L2 and builder-identity claim and now states the class is unserved and ranked last.
- **Slide 11.** 2,065 → 2,188 tests green. Six identical prerequisite failures were attributed to a 401; the recorded failure text is `unable to verify the first certificate`. `3/4 Targets healthy on first probe` is scoped to first probe and correct as written — all four are healthy now, which does not falsify it.

## Validation

- `bun test` in `apps/spindrift`: 2,188 pass, 0 fail, 6,498 `expect()` calls, 154 files — this is where the corrected number comes from.
- Deck parsed with `html.parser`: zero unclosed or mismatched tags, both `<style>` blocks balanced.
- Still self-contained: zero hits for `<script`, `href="http`, `src="http`, `@import`, `url(http`.
- Grepped for each replaced value to catch a second occurrence on another slide; none.

## Risks

The deck is served as an uploaded archive, not from `main`, so merging this does not change the live page — it needs a redeploy through the product to take effect.