### PR TITLE
fix(spindrift): let an uploaded site reach a static Target

### DIFF
--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -35,6 +35,7 @@ import type {
   TargetInspection,
 } from '../../../domain/capabilities.ts';
 import {
+  type Artifact,
   type ArtifactType,
   artifactAddress,
   type DesiredState,
@@ -44,7 +45,12 @@ import {
   targetLabel,
 } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
+import {
+  parseGcsLocation,
+  signedObjectUrl,
+} from '../../../storage/signed-url.ts';
 import { cloudChecklist, cloudSurfaceProbe } from '../cloud/checklist.ts';
+import type { FederationOptions } from '../cloud/federation.ts';
 import { CloudHttp, type Fetcher, type TokenProvider } from '../cloud/http.ts';
 import {
   type CloudFailure,
@@ -71,6 +77,18 @@ import { googleRegistryRef, OciPullError, pullFilesLayer } from './oci.ts';
 export interface StaticAdapterOptions {
   /** Mints a bearer token per request. Never a stored credential (§13). */
   readonly token: TokenProvider;
+  /**
+   * How this installation signs for an object in its source depot, or `null`
+   * where it configured none.
+   *
+   * A supplied upload's bytes are a `gs://` object, which no HTTP client
+   * resolves — so this adapter mints the same short-TTL V4 signed URL a hosted
+   * build route is handed, rather than holding a second credential (§13). It is
+   * the federation itself and not a token provider because signing is `signBlob`
+   * under the *federated* identity, before impersonation; `storage/signed-url.ts`
+   * is where that distinction is written down.
+   */
+  readonly federation?: FederationOptions | null;
   /** Injected so a test can stand a fake far side behind the real client. */
   readonly fetch?: Fetcher;
   readonly now?: () => number;
@@ -177,27 +195,21 @@ export class StaticDeployAdapter implements DeployAdapter {
     // No registry filter: a static Target serves `files`, and the reachability
     // §3 models over registries is about a *runtime* pulling an image. This
     // adapter is the one that pulls for itself, so the choice here is by what
-    // its own identity can read: a staged URL is fetched directly (a supplied
-    // upload's address), and among registry references only a Google-family
-    // one is readable with the federated token this adapter already holds —
+    // its own identity can read: a staged address is a supplied upload's and is
+    // fetched as such, and among registry references only a Google-family one
+    // is readable with the federated token this adapter already holds —
     // `ghcr.io` would take a credential the manifest deliberately does not
     // model (§13).
     const staged = artifactAddress(desired.artifact);
-    const location = /^https?:\/\//.test(staged ?? '')
-      ? staged
-      : googleRegistryRef(desired.artifact.refs);
+    const location =
+      fetchableStagedAddress(staged) ??
+      googleRegistryRef(desired.artifact.refs);
     if (location === null) {
       yield this.status('FAILED', { reason: 'ARTIFACT_UNAVAILABLE' });
-      const hosts = desired.artifact.refs
-        .map((ref) => ref.split('/')[0])
-        .join(', ');
       return {
         phase: 'FAILED',
         reason: 'ARTIFACT_UNAVAILABLE',
-        detail:
-          desired.artifact.refs.length === 0
-            ? 'the artifact carries no address to fetch it from'
-            : `static hosting fetches the bytes itself, and none of the artifact's homes (${hosts}) is a registry its identity can read`,
+        detail: unfetchableArtifact(desired.artifact, staged),
       };
     }
 
@@ -410,11 +422,20 @@ export class StaticDeployAdapter implements DeployAdapter {
     http: CloudHttp,
     location: string,
   ): Promise<readonly BundleFile[]> {
-    // A staged URL is a supplied upload's address and is fetched as it always
-    // was. Anything else is a registry reference — the shape every built
-    // artifact's ref has — and the bytes are the artifact's one layer.
-    if (/^https?:\/\//.test(location)) {
-      const fetched = await http.bytes(location);
+    // A staged address is a supplied upload's, and is fetched over HTTP — a
+    // depot object after being signed for, an `https://` one as it stands.
+    // Anything else is a registry reference — the shape every built artifact's
+    // ref has — and the bytes are the artifact's one layer.
+    //
+    // What is fetched and what is *named* part company here on purpose: a
+    // signed URL is a bearer capability, so every sentence below names the
+    // address the artifact carries and never the one that was minted from it.
+    const url =
+      parseGcsLocation(location) === null
+        ? location
+        : await this.signedDepotUrl(location);
+    if (/^https?:\/\//.test(url)) {
+      const fetched = await http.bytes(url);
       if (!fetched.ok) {
         // §6 blames the **platform** for an artifact that cannot be fetched,
         // and this is exactly that case: the build is green and the bytes are
@@ -444,6 +465,43 @@ export class StaticDeployAdapter implements DeployAdapter {
       );
     }
     return readBundle(layer);
+  }
+
+  /**
+   * A depot object, exchanged for something this adapter can actually GET.
+   *
+   * The same V4 signed URL a hosted build route is handed, minted the same way
+   * — `signBlob` under the federated identity, nothing stored (§13) — because a
+   * second way to read one bucket is a second thing to grant and to get wrong.
+   *
+   * Failing to mint one is `ARTIFACT_UNAVAILABLE` like every other way the
+   * bytes do not arrive: the build is green, and §6 blames the platform for
+   * that. The refusal names the object, never the URL.
+   */
+  private async signedDepotUrl(location: string): Promise<string> {
+    const federation = this.options.federation ?? null;
+    if (federation === null) {
+      throw new ArtifactUnavailable(
+        `the artifact is staged at ${location} and this installation configures no cloud federation, so nothing can be signed to fetch it with`,
+      );
+    }
+    try {
+      return await signedObjectUrl({
+        location,
+        federation: {
+          ...federation,
+          ...(this.options.fetch === undefined
+            ? {}
+            : { fetch: this.options.fetch }),
+        },
+      });
+    } catch (cause) {
+      throw new ArtifactUnavailable(
+        `the artifact at ${location} could not be signed for: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
   }
 
   /**
@@ -696,6 +754,49 @@ export class StaticDeployAdapter implements DeployAdapter {
 /** The artifact was addressed and the bytes were not there (§6's platform blame). */
 class ArtifactUnavailable extends Error {
   override readonly name = 'ArtifactUnavailable';
+}
+
+/** A staged bundle's address wears a scheme; a registry reference never does. */
+const STAGED_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+
+/**
+ * A supplied upload's address, where this adapter can end up holding the bytes.
+ *
+ * Two schemes qualify, for one reason each: `https://` is already fetchable,
+ * and `gs://` is the depot's own address — not a URL, but one a signature turns
+ * into one. `null` for anything else, and above all for the `upload://` handle
+ * an installation with no depot stages onto its own pod's disk: those bytes are
+ * not reachable from here at all, and falling through to the registry branch
+ * answers that with a sentence about registry access instead.
+ */
+function fetchableStagedAddress(staged: string | null): string | null {
+  if (staged === null) return null;
+  const fetchable =
+    /^https?:\/\//.test(staged) || parseGcsLocation(staged) !== null;
+  return fetchable ? staged : null;
+}
+
+/**
+ * Why nothing here can be fetched, said about the address that failed.
+ *
+ * Three cases, and telling them apart is the point: no address at all, a bundle
+ * staged somewhere nothing outside one process reaches, and a built artifact
+ * homed only on a registry this identity cannot read. The middle one used to
+ * take the last one's sentence, which sends an operator to IAM over a bundle
+ * sitting on a disk.
+ */
+function unfetchableArtifact(
+  artifact: Artifact,
+  staged: string | null,
+): string {
+  if (artifact.refs.length === 0) {
+    return 'the artifact carries no address to fetch it from';
+  }
+  if (staged !== null && STAGED_SCHEME.test(staged)) {
+    return `the artifact is staged at ${staged}, which names this installation's own disk rather than an address static hosting can fetch`;
+  }
+  const hosts = artifact.refs.map((ref) => ref.split('/')[0]).join(', ');
+  return `static hosting fetches the bytes itself, and none of the artifact's homes (${hosts}) is a registry its identity can read`;
 }
 
 /** A step that either produced something or carries the refusal that stopped it. */

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -263,6 +263,12 @@ export function createAdapterRegistry(
     }),
     static: new StaticDeployAdapter({
       token: cloud,
+      // The one adapter that also reads the source depot: a supplied upload
+      // was never built, so its bytes are a `gs://` object rather than a
+      // registry reference, and fetching one takes a signature rather than a
+      // bearer. The federation itself, because signing happens *before*
+      // impersonation — `storage/signed-url.ts` says why.
+      federation: options.manifest.cloud.federation,
       ...(options.fetch ? { fetch: options.fetch } : {}),
     }),
     // The one adapter with two identities: the platform is driven with the

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -361,6 +361,103 @@ describe('a built files artifact is pulled out of the registry', () => {
   });
 });
 
+describe('a supplied upload is fetched out of the depot', () => {
+  /** Where `stageArchiveBytes` puts an upload when the installation has one. */
+  const OBJECT = 'gs://bluenose-spindrift-source/abc123.tgz';
+
+  const FEDERATION = {
+    audience:
+      '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov',
+    tokenUrl: 'https://sts.googleapis.test/v1/token',
+    tokenPath: '/var/run/secrets/spindrift/gcp-token',
+    impersonationUrl:
+      'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+  };
+
+  /** A supplied artifact: the bundle's own address, and no registry anywhere. */
+  function supplied(location: string): DesiredState {
+    return desired({
+      artifact: { type: 'files', digest: 'sha256:bundle', refs: [location] },
+    });
+  }
+
+  function depotAdapter(): {
+    api: FakeHosting;
+    adapter: StaticDeployAdapter;
+    signed: string[];
+    fetched: string[];
+  } {
+    // The depot serves on the storage host, which is also where a signed URL
+    // points — so the adapter's own fetch of the object runs for real.
+    const api = new FakeHosting({
+      bundle: { origin: 'https://storage.googleapis.com', bytes: SITE },
+    });
+    const signed: string[] = [];
+    const fetched: string[] = [];
+    const adapter = new StaticDeployAdapter({
+      token: api.token,
+      federation: { ...FEDERATION, readToken: async () => 'jwt' },
+      fetch: async (request) => {
+        if (request.url.startsWith(FEDERATION.tokenUrl)) {
+          return Response.json({
+            access_token: 'federated-token',
+            expires_in: 3600,
+          });
+        }
+        if (request.url.includes(':signBlob')) {
+          signed.push(request.url);
+          // Two bytes, so the hex encoding is checkable without arithmetic.
+          return Response.json({ signedBlob: btoa('\x01\xfe') });
+        }
+        if (request.url.startsWith('https://storage.googleapis.com')) {
+          fetched.push(request.url);
+        }
+        return api.fetch(request);
+      },
+    });
+    return { api, adapter, signed, fetched };
+  }
+
+  test('a bundle staged at gs:// is signed for, fetched, and served', async () => {
+    // The whole reason this backend can take an upload at all: nothing built
+    // it, so there is no registry reference, and the depot address is not
+    // something an HTTP client resolves.
+    const { api, adapter, signed, fetched } = depotAdapter();
+    const { verdict } = await drain(adapter.apply(TARGET, supplied(OBJECT)));
+
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.servedPaths('shop-site')).toEqual([
+      '/assets/app.css',
+      '/index.html',
+    ]);
+    // Signed with the federated identity rather than a stored credential
+    // (§13), and the object fetched with the capability that signature is.
+    expect(signed).toHaveLength(1);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0]).toContain('/bluenose-spindrift-source/abc123.tgz?');
+    expect(fetched[0]).toContain('X-Goog-Signature=01fe');
+  });
+
+  test('a bundle nothing can fetch says that, rather than blaming a registry', async () => {
+    // An installation with no depot stages an upload on the web pod's own
+    // disk. That is unfetchable, and it used to be reported as an artifact
+    // homed on a registry this identity cannot read — a true sentence about a
+    // different problem, which sends the operator to IAM.
+    const { adapter } = depotAdapter();
+    const { verdict } = await drain(
+      adapter.apply(TARGET, supplied('upload://abc123')),
+    );
+
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(blameFor(verdict.reason)).toBe('platform');
+      expect(verdict.detail).toContain('upload://abc123');
+      expect(verdict.detail).not.toContain('registry');
+    }
+  });
+});
+
 describe('§9: the vanity name is one record on the serving site', () => {
   test('a vanity name is attached to the site that is already serving', async () => {
     const { api, adapter } = adapterFor();


### PR DESCRIPTION
## What changed

A supplied `contents: artifact` upload is staged in the source depot as a `gs://` object. `StaticDeployAdapter.apply` only recognised an `https://` staged address, so the depot address fell through to the registry branch and every such deploy failed with *"none of the artifact's homes (gs:) is a registry its identity can read"* — a true sentence about registry access, and about a problem the deploy did not have. It sent the operator to IAM over a bundle that was sitting exactly where it was put, and a supplied upload could never reach a static Target at all.

- The depot address is now resolved to a short-TTL V4 signed URL through the existing `storage/signed-url.ts` — the same one a hosted build route is handed, `signBlob` under the federated identity, so no second credential and no second way to read the bucket. The registry's `cloud.federation` is passed to the adapter for it.
- A signed URL is a bearer capability, so nothing logs one: every failure sentence names the `gs://` object address it was minted from.
- The failure sentence now tells the three cases apart — no address at all, a bundle staged where nothing outside this installation can reach it (`upload://`, what an installation with no depot produces), and a built artifact homed only on a registry this identity cannot read. The registry sentence is unchanged for the case where it is the true one.

## Validation

- `bun test` in `apps/spindrift` — 2228 pass, 0 fail (Postgres on :15432).
- Two new tests in `test/adapters/static.test.ts`, both confirmed failing against the old adapter: a bundle staged at `gs://` is signed for, fetched and served; a bundle nothing can fetch says so instead of blaming a registry.
- `bun run typecheck` and `bun run lint` clean.

## Risks

- The signing path needs `roles/iam.serviceAccountTokenCreator` on the controller service account, which `terraform/gcp/projects/bluenose/iam.tf` already grants — the same grant the hosted build route depends on. An installation missing it now fails a supplied deploy with a sentence naming the object rather than a registry.
- The Vercel adapter (`src/adapters/deploy/vercel/index.ts:195`) chooses an artifact address the same way and has the same dead end for a supplied upload. It is untouched here; its identity plumbing differs and it deserves its own change.