### PR TITLE
fix(spindrift): an Argo Target deploys an OCI chart, and says when it cannot

### DIFF
--- a/apps/spindrift/src/adapters/deploy/kubernetes/argo-application.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/argo-application.ts
@@ -6,9 +6,17 @@
  * object rather than manifests to a repository. What differs is only how the
  * object is spelled and where its verdict is written, which is why both
  * flavours end at {@link DeliveryStatus} and nothing above them branches.
+ *
+ * **The chart reference decides the shape of the source**, the same way it does
+ * on the Flux side and through the same `chartSourceKind`. Argo takes an OCI
+ * chart the way Helm's own client does — the registry in `repoURL`, the chart's
+ * own name in `chart` — and refuses a source carrying a `path` beside it, so an
+ * artifact reference written into `path` is an Application Argo answers with
+ * `ComparisonError` rather than a release.
  */
 import type { FailureReason } from '../contract.ts';
 import type { KubernetesObject } from './api.ts';
+import { chartSourceKind, OCI_REPOSITORY } from './flux-helmrelease.ts';
 import type { DeliveryStatus } from './status.ts';
 
 /** The API this flavour writes. */
@@ -17,6 +25,41 @@ export const APPLICATION = {
   kind: 'Application',
   plural: 'applications',
 } as const;
+
+const OCI_SCHEME = 'oci://';
+
+/**
+ * A repository as Argo takes it, however the reference spelled it.
+ *
+ * Argo's own documentation is explicit that for an OCI chart "the `oci://`
+ * syntax is not included" in `repoURL`, so the scheme comes off here rather
+ * than at each of the two call sites that would otherwise have to remember.
+ */
+export function argoRepository(reference: string): string {
+  return reference.startsWith(OCI_SCHEME)
+    ? reference.slice(OCI_SCHEME.length)
+    : reference;
+}
+
+/**
+ * Where an `oci://` chart reference splits into Argo's two fields.
+ *
+ * The last segment is the chart's own name and everything before it is the
+ * repository. A reference with no segment to split off keeps an empty
+ * repository, which no Target can match — nonsense configuration reads as an
+ * unmet `CHART_SOURCE` rather than as an Application pointed at a registry
+ * nobody named.
+ */
+export function argoChartRef(chart: string): {
+  readonly repository: string;
+  readonly chart: string;
+} {
+  const reference = argoRepository(chart);
+  const at = reference.lastIndexOf('/');
+  return at === -1
+    ? { repository: '', chart: reference }
+    : { repository: reference.slice(0, at), chart: reference.slice(at + 1) };
+}
 
 /** What rendering one `Application` needs beyond the values themselves. */
 export interface ApplicationSpec {
@@ -30,8 +73,8 @@ export interface ApplicationSpec {
   project: string;
   repoUrl: string;
   revision: string;
-  /** The chart's path inside the repository (§20's manifest value). */
-  path: string;
+  /** How this installation names the App chart (§20's manifest value). */
+  chart: string;
   labels: Record<string, string>;
   values: Record<string, unknown>;
 }
@@ -64,9 +107,15 @@ export function argoApplication(spec: ApplicationSpec): KubernetesObject {
         namespace: spec.destinationNamespace,
       },
       source: {
-        repoURL: spec.repoUrl,
+        repoURL: argoRepository(spec.repoUrl),
         targetRevision: spec.revision,
-        path: spec.path,
+        // The same split Flux makes, in Argo's spelling: a path is a directory
+        // only a checkout of the repository resolves, a chart is an artifact
+        // the registry serves under its own name. Argo refuses a source that
+        // carries both, so the reference picks one and never states the other.
+        ...(chartSourceKind(spec.chart) === OCI_REPOSITORY
+          ? { chart: argoChartRef(spec.chart).chart }
+          : { path: spec.chart }),
         helm: {
           releaseName: spec.name,
           // Argo's inline values, which is the same single blob §7 requires:

--- a/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
+++ b/apps/spindrift/src/adapters/deploy/kubernetes/index.ts
@@ -74,6 +74,8 @@ import {
   applicationStatus,
   applicationValues,
   argoApplication,
+  argoChartRef,
+  argoRepository,
 } from './argo-application.ts';
 import { diagnose } from './diagnose.ts';
 import {
@@ -1050,10 +1052,25 @@ export class KubernetesDeployAdapter implements DeployAdapter {
     delivery: KubernetesDelivery,
   ): Promise<[boolean, string?]> {
     if (delivery.flavour === 'argo-application') {
-      // Argo resolves the repository itself, with credentials Spindrift never
-      // sees, so there is nothing here to read. The honest check is that a
-      // repository was named at all; a wrong one surfaces as a sync error on
-      // the first deploy.
+      // Argo fetches the repository itself, with credentials Spindrift never
+      // sees, so this flavour has no source object in the cluster to read —
+      // whether the operator is there at all is `DELIVERY_OPERATOR`'s question
+      // and it asks the API server directly.
+      //
+      // What is left is checkable, and in the artifact form it is checkable
+      // exactly. The Application carries the Target's own `repoUrl` and this
+      // installation's chart *name* under it, so a Target naming another
+      // registry pulls a different chart under this installation's declaration
+      // — the same gap the `OCIRepository` `url` comparison below closes for
+      // Flux, and nothing else would say so. The repository form has no such
+      // gap: the path is written into the Application itself.
+      if (chartSourceKind(this.options.chart) === OCI_REPOSITORY) {
+        const declared = argoChartRef(this.options.chart).repository;
+        return [
+          argoRepository(delivery.repoUrl) === declared,
+          `this Target fetches the App chart from ${delivery.repoUrl.length > 0 ? delivery.repoUrl : 'no repository at all'}, not the ${declared} that serves the ${this.options.chart} this installation declares`,
+        ];
+      }
       return [
         delivery.repoUrl.length > 0,
         'this Target names no repository to fetch the App chart from',
@@ -1273,7 +1290,7 @@ export class KubernetesDeployAdapter implements DeployAdapter {
         project: connection.delivery.project,
         repoUrl: connection.delivery.repoUrl,
         revision: connection.delivery.revision,
-        path: this.options.chart,
+        chart: this.options.chart,
         labels,
         values,
       });

--- a/apps/spindrift/test/adapters/kubernetes.test.ts
+++ b/apps/spindrift/test/adapters/kubernetes.test.ts
@@ -62,6 +62,54 @@ const ARGO: KubernetesDelivery = {
   server: 'https://kubernetes.default.svc',
 };
 
+/**
+ * The same Target told where {@link OCI_CHART} is served.
+ *
+ * An Argo Target's repository is the operator's own field, so an installation
+ * that declares an artifact needs one naming the registry rather than the git
+ * repository a path-sourced installation is checked out of.
+ */
+const ARGO_OCI: KubernetesDelivery = {
+  flavour: 'argo-application',
+  namespace: 'delivery',
+  project: 'default',
+  repoUrl: 'registry.example.test/charts',
+  revision: '1.4.0',
+  server: 'https://kubernetes.default.svc',
+};
+
+/** The status an `Application` reports once Argo has synced it. */
+const SYNCED = () => ({
+  health: { status: 'Healthy' },
+  sync: { status: 'Synced' },
+});
+
+/**
+ * Everything an Argo Target's checklist needs to be green but the chart.
+ *
+ * No Flux source object, because this flavour has none to read: Argo fetches
+ * the repository itself and the reference lives in the `Application`.
+ */
+const ARGO_CLUSTER: FakeKubernetesOptions = {
+  objects: {
+    'namespaces//apps': {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name: 'apps' },
+    },
+  },
+  lists: {
+    clustersecretstores: [
+      {
+        apiVersion: 'external-secrets.io/v1',
+        kind: 'ClusterSecretStore',
+        metadata: { name: 'vault' },
+        spec: { provider: { gcpsm: {} } },
+      },
+    ],
+  },
+};
+
 /** A cluster that serves everything the checklist looks for. */
 const SERVED = {
   'helm.toolkit.fluxcd.io/v2': ['HelmRelease'],
@@ -319,12 +367,7 @@ describe('the delivery object', () => {
   });
 
   test('the Target declares the flavour: the same state, an Argo Application', async () => {
-    const { adapter, cluster } = adapterFor({
-      status: () => ({
-        health: { status: 'Healthy' },
-        sync: { status: 'Synced' },
-      }),
-    });
+    const { adapter, cluster } = adapterFor({ status: SYNCED });
     const { verdict } = await drain(
       adapter.apply(target({ delivery: ARGO }), desiredState()),
     );
@@ -335,9 +378,40 @@ describe('the delivery object', () => {
     const spec = applied?.spec as any;
     expect(spec.source.helm.valuesObject.app.component).toBe('web');
     expect(spec.destination.namespace).toBe('apps');
+    // A path is a directory only a checkout of the repository resolves, which
+    // is the form a non-artifact chart reference has here too.
+    expect(spec.source.repoURL).toBe('https://git.example.test/infra');
+    expect(spec.source.path).toBe(CHART);
+    expect(spec.source.chart).toBeUndefined();
     // The namespace is vessel (§7): a sync that created it would let a
     // `destroy()` remove it.
     expect(spec.syncPolicy.syncOptions).toBeUndefined();
+  });
+
+  test('an oci:// chart is an Argo chart reference, never a path', async () => {
+    // The Argo half of the same per-Target pin the Flux test above asserts.
+    // Argo takes an OCI chart the way Helm's own client does — the registry in
+    // `repoURL`, the chart's own name in `chart`, and its documentation is
+    // explicit that "the oci:// syntax is not included" — and it refuses a
+    // source carrying a `path` beside a `chart`. So an artifact reference
+    // written into `path` is not a release: Argo answers `ComparisonError`,
+    // and nothing before the first deploy would have said so.
+    const { adapter, cluster } = adapterFor({ status: SYNCED }, OCI_CHART);
+    const { verdict } = await drain(
+      adapter.apply(target({ delivery: ARGO_OCI }), desiredState()),
+    );
+
+    expect(verdict.phase).toBe('LIVE');
+    const spec = cluster.get('applications/delivery/blog-web')?.spec as any;
+    expect(spec.source.repoURL).toBe('registry.example.test/charts');
+    expect(spec.source.chart).toBe('spindrift-app');
+    expect(spec.source.path).toBeUndefined();
+    expect(spec.source.targetRevision).toBe('1.4.0');
+    // Everything else about the Application is the object it always was: the
+    // source moved, not the delivery.
+    expect(spec.source.helm.valuesObject.app.image).toBe(
+      'registry.example.test/blog/web@sha256:feed',
+    );
   });
 
   test('the values carry the three classes, with Spindrift winning the shared one', async () => {
@@ -864,6 +938,66 @@ describe('the checklist', () => {
     );
     expect(operator?.met).toBe(false);
     expect(operator?.detail).toContain('HelmRelease');
+  });
+
+  test('an Argo Target on a cluster that serves no Application says which operator is missing', async () => {
+    // The checklist asks the API server what it serves, per flavour: a cluster
+    // running Flux is not a cluster an Argo Target can deliver through, and the
+    // sentence names the kind that is absent rather than "Flux or Argo".
+    const { adapter } = adapterFor(
+      {
+        servedKinds: { 'helm.toolkit.fluxcd.io/v2': ['HelmRelease'] },
+        ...ARGO_CLUSTER,
+      },
+      OCI_CHART,
+    );
+
+    const { prerequisites } = await adapter.inspect(
+      target({ delivery: ARGO_OCI }),
+    );
+    const operator = prerequisites.find(
+      (item) => item.name === 'DELIVERY_OPERATOR',
+    );
+    expect(operator?.met).toBe(false);
+    expect(operator?.detail).toContain('Application');
+    expect(operator?.detail).not.toContain('HelmRelease');
+  });
+
+  test('an Argo Target pointed at another registry is not this chart’s source', async () => {
+    // The Argo mirror of the `OCIRepository` comparison above, and the same
+    // gap: the Application carries the Target's own repository with this
+    // installation's chart name under it, so a Target naming somewhere else
+    // pulls a different chart under this installation's declaration. Nothing
+    // else reads the two references together, and a row that reported met
+    // without comparing them is a check that never observed what it names.
+    const { adapter } = adapterFor(ARGO_CLUSTER, OCI_CHART);
+
+    const { prerequisites } = await adapter.inspect(target({ delivery: ARGO }));
+    const chartSource = prerequisites.find(
+      (item) => item.name === 'CHART_SOURCE',
+    );
+    expect(chartSource?.met).toBe(false);
+    expect(chartSource?.detail).toContain('https://git.example.test/infra');
+    expect(chartSource?.detail).toContain('registry.example.test/charts');
+  });
+
+  test('an Argo Target naming the registry this installation is served from is met', async () => {
+    // The mirror, so the check above is not simply always-red — and the path
+    // form is met on the same cluster, because a path is written into the
+    // Application itself and has no second reference to disagree with.
+    const artifact = adapterFor(ARGO_CLUSTER, OCI_CHART);
+    expect(
+      (
+        await artifact.adapter.inspect(target({ delivery: ARGO_OCI }))
+      ).prerequisites.filter((item) => !item.met),
+    ).toEqual([]);
+
+    const path = adapterFor(ARGO_CLUSTER, CHART);
+    expect(
+      (
+        await path.adapter.inspect(target({ delivery: ARGO }))
+      ).prerequisites.filter((item) => !item.met),
+    ).toEqual([]);
   });
 
   test('an identity that may not write the delivery object fails OIDC', async () => {


### PR DESCRIPTION
## What changed

**The rendered Argo source.** `deliveryObject()` put the installation's
`charts.app` into `spec.source.path` whatever that reference was. An
installation served from a registry — this one is
`oci://ghcr.io/jonpulsifer/charts/spindrift-app` — therefore produced an
`Application` carrying an `oci://` URI in `path` and no `chart` field at all,
which Argo answers with `ComparisonError`. Argo takes an OCI chart the way
Helm's own client does: the registry in `repoURL`, the chart's own name in
`chart`, and [its documentation is explicit](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/)
that "the `oci://` syntax is not included". It also refuses a source that
carries a `path` beside a `chart`.

The reference now picks the shape, through the same `chartSourceKind` the Flux
side already routes every chart-source decision through — so a Target cannot be
checked against one kind and deployed against the other. A path-sourced
installation renders exactly what it rendered before.

**The `CHART_SOURCE` row for Argo.** It reported met for any non-empty
repository. For an artifact that is met about two references it never compared:
the `Application` carries the Target's own `repoUrl` with this installation's
chart *name* under it, so a Target naming another registry pulls a different
chart under this installation's declaration and every other row reads green.
It now compares them and names both in the unmet sentence — the same gap the
`OCIRepository` `url` comparison already closes for Flux. The path form keeps
the check it had, because there the path is written into the `Application`
itself and has no second reference to disagree with.

## On the checklist going green without Argo

Worth stating, because it was the reported symptom: an Argo Target connected
against a cluster serving no `applications.argoproj.io` does **not** read green
today. `DELIVERY_OPERATOR` asks the API server per flavour
(`src/adapters/deploy/kubernetes/index.ts:889-896`) and reports
`this cluster does not serve Application: a Kubernetes Target must run Flux or
Argo (§6)`. That behaviour was untested, so this adds the test rather than a
change.

## Validation

- `bun test` in `apps/spindrift` — 2230 pass, 0 fail
- `bun run typecheck` / `bun run lint` (biome) — clean
- The two new assertions were confirmed red against the previous code before
  the fix: the Argo OCI render produced no `source.chart`, and `CHART_SOURCE`
  reported met for a Target pointed at a git repository.

## Risks

An existing Argo Target whose `repoUrl` does not name the registry serving this
installation's chart becomes a non-candidate with a stated reason instead of a
deploy that fails at sync. There are none in the fleet — neither cluster serves
the `Application` CRD.

The connect screen still asks the operator to type the chart repository with no
hint of the value this installation needs; the unmet checklist sentence names
it, one round trip later.