### PR TITLE
test(spindrift): hold the chooser to what the upload boundary accepts

### DIFF
--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -1152,6 +1152,15 @@ describe('the BuildKit program', () => {
     expect(program).toContain(`--opt source='${FRONTEND}'`);
   });
 
+  test('opens a staged bundle the one way every route opens one', () => {
+    // The second of the readers `storage/archive-format.ts` converts a ZIP
+    // for; the hosted workflow's copy is pinned in
+    // `test/storage/archive-format.test.ts`. This program carries no unzip
+    // binary in either image that runs it, so the two drifting apart is a
+    // build that dies at `tar: This does not look like a tar archive`.
+    expect(program).toContain('| tar -xz');
+  });
+
   test('an empty build-arg set leaves no blank continuation line', () => {
     // A `\` continuation followed by a blank line ends the command there, and
     // the flag on the next line becomes a command of its own — observed live

--- a/apps/spindrift/test/web/creation-flow.test.tsx
+++ b/apps/spindrift/test/web/creation-flow.test.tsx
@@ -14,6 +14,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { sniffArchiveFormat } from '../../src/storage/archive-format.ts';
 import {
   blockersFor,
   type Draft,
@@ -30,6 +31,8 @@ import {
   REPOSITORY_OPTIONS,
   TARGET_OPTIONS,
 } from '../fixtures/scenarios.ts';
+import { zipOf } from '../fixtures/zip.ts';
+import { bytes, tar, tarball } from '../harness/tar.ts';
 
 const CANDIDATES = TARGET_OPTIONS.filter((target) => target.candidate).map(
   (target) => target.targetId,
@@ -519,5 +522,47 @@ describe('the draft reducer', () => {
     });
     expect(next.source).toMatchObject({ subpath: 'a' });
     expect(next.scopeByOperator).toBe(INITIAL_DRAFT.scopeByOperator);
+  });
+});
+
+/**
+ * The chooser's `accept` list is a hand-written claim about
+ * `storage/archive-format.ts`, which decides by magic number and has never
+ * heard of a filename. Nothing but this ties the two together, so the screen
+ * offered a plain `.tar` the boundary answers with `UNKNOWN_FORMAT` — an
+ * operator following the screen earning a `400`.
+ */
+describe('the archive chooser', () => {
+  /** Real bytes of the container each extension names. */
+  const SAMPLES: Record<string, Uint8Array> = {
+    '.zip': zipOf([{ path: 'index.html', text: 'hi' }]),
+    '.tar.gz': tarball([{ name: 'index.html', bytes: bytes('hi') }]),
+    '.tgz': tarball([{ name: 'index.html', bytes: bytes('hi') }]),
+    // Not offered, and here to be the reason why rather than an absence: a
+    // plain tar carries neither magic number the boundary reads.
+    '.tar': tar([{ name: 'index.html', bytes: bytes('hi') }]),
+  };
+
+  test('offers only containers the upload boundary accepts', () => {
+    const markup = render(
+      draftReducer(clean, { type: 'entry', entry: 'upload' }),
+    );
+    const offered = [...markup.matchAll(/accept="([^"]*)"/g)].flatMap((match) =>
+      (match[1] ?? '').split(','),
+    );
+    // Zero would make every assertion below vacuous — the picker renders only
+    // once the draft is on an archive source.
+    expect(offered.length).toBeGreaterThan(0);
+
+    const unsampled: string[] = [];
+    const refused: string[] = [];
+    for (const extension of offered) {
+      const sample = SAMPLES[extension];
+      // An extension with no bytes here is one this test cannot answer for:
+      // write the sample before putting the extension on the screen.
+      if (sample === undefined) unsampled.push(extension);
+      else if (sniffArchiveFormat(sample) === null) refused.push(extension);
+    }
+    expect({ unsampled, refused }).toEqual({ unsampled: [], refused: [] });
   });
 });


### PR DESCRIPTION
The archive chooser's `accept` list is a hand-written claim about
`apps/spindrift/src/storage/archive-format.ts`, which decides by magic number
and has never heard of a filename. Nothing tied the two together, so the screen
offered a plain `.tar` the boundary answers with `UNKNOWN_FORMAT` — an operator
following the screen earning a `400`. Trimming the list did not make the claim
enforceable: the whole suite passes with `.tar` back on the screen.

## What changed

- `test/web/creation-flow.test.tsx` renders the chooser and puts every extension
  it offers to `sniffArchiveFormat` as real bytes of the container that
  extension names. A `.tar` sample sits beside the offered three, so its refusal
  is stated rather than absent; an extension with no sample fails as one the
  test cannot answer for.
- `test/adapters/build-routes.test.ts` pins the BuildKit program's
  `wget … | tar -xz`. `archive-format.ts` converts a ZIP because three programs
  open a staged bundle with `tar -xz` and none of them sniffs — the hosted
  workflow's copy is already pinned, and the program the cloud and cluster
  routes run is the second of the three.

Tests only; no source change.

## Validation

- `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 DATABASE_URL=… bun test` in
  `apps/spindrift` → 2230 pass, 0 fail, 155 files.
- `mise run ts:check` → 4/4 tasks; `tsc --noEmit` re-run uncached, clean.
- Both new assertions were checked against the code they describe: restoring
  `accept=".zip,.tar.gz,.tgz,.tar"` fails the chooser test naming `.tar`, and
  changing the BuildKit program's fetch to `tar -x` fails the second.

## Risks

The chooser test reads the `accept` attribute out of the rendered markup, so a
picker that stops rendering would make it vacuous — the offered-count assertion
is what stops that. The third reader named in `archive-format.ts`, the bosun
build hull's `tar -xzf` in `nix/images/hull-ubuntu.nix`, stays unpinned: string
-matching a Nix file from a Bun test costs more in confusing failures than it
buys.
