### PR TITLE
fix(spindrift): a chart source row names both places its source can live

### DIFF
--- a/apps/spindrift/src/domain/remediation.ts
+++ b/apps/spindrift/src/domain/remediation.ts
@@ -252,7 +252,7 @@ const NOT_TERRAFORM: Partial<Record<AnyPrerequisite, string>> = {
   DELIVERY_OPERATOR:
     'a delivery operator is installed into the cluster itself, which is the GitOps tree rather than Terraform',
   CHART_SOURCE:
-    'a chart source is an object inside the cluster, created by whatever reconciles that cluster rather than by Terraform',
+    'a chart source is an object inside the cluster or the repository recorded on the Target itself, and Terraform declares neither',
   WRITABLE_STORE:
     'a cluster’s writable store is an object inside the cluster, created by whatever reconciles that cluster rather than by Terraform',
   CHART_CONTRACT:

--- a/apps/spindrift/test/domain/remediation.test.ts
+++ b/apps/spindrift/test/domain/remediation.test.ts
@@ -378,6 +378,10 @@ describe('the rows Terraform does not clear', () => {
       if (change.kind !== 'none') continue;
       expect(change.reason).toContain('Terraform');
       expect(change.reason).toContain('cluster');
+      // An Argo Target's chart source is the repository recorded on the Target
+      // rather than an object any reconciler creates, so a reason naming only
+      // the cluster object sends that operator to a tree with nothing in it.
+      if (name === 'CHART_SOURCE') expect(change.reason).toContain('Target');
     }
   });
 });


### PR DESCRIPTION
`CHART_SOURCE` became reachable on an Argo Target: the row now compares the Target's own repository against the registry serving the App chart this installation declares, where before it reported met for any non-empty string.

The reason rendered beside that unmet row was written for the Flux flavour only — "a chart source is an object inside the cluster, created by whatever reconciles that cluster rather than by Terraform". An Argo Target has no such object; its source is the repository recorded on the Target, cleared by reconnecting it. The sentence sent that operator to the GitOps tree to look for something this flavour never creates.

The reason now names both forms and still answers the question it exists to answer — why there is no generated Terraform change.

## Validation

From `apps/spindrift`, with `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0` and Postgres on 15432:

- Red-first: with the old sentence in place, `bun test test/domain/remediation.test.ts` → 22 pass / 1 fail on the new assertion. Restored → 23 pass.
- `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift bun test` → 2276 pass, 0 fail, 156 files.
- `mise run ts:check` → typecheck and biome clean; `bun run tsc --noEmit` in `apps/spindrift` exits 0.

## Risks

Operator-facing text on an unmet row, plus one assertion. No behaviour changes: the row's met/unmet verdict, the checklist, and every rendered object are untouched. `remediationFor` is still keyed by row name alone, so the sentence is written to be true of both flavours rather than selected per flavour — a flavour-specific reason would need the delivery flavour plumbed through `RemediationSubject`, which buys nothing until a row's remediation differs by more than its wording.