### PR TITLE
fix(spindrift): let an uploaded site reach every static Target

### DIFF
--- a/apps/spindrift/src/adapters/deploy/pages/index.ts
+++ b/apps/spindrift/src/adapters/deploy/pages/index.ts
@@ -48,6 +48,7 @@ import type {
   TargetInspection,
 } from '../../../domain/capabilities.ts';
 import {
+  type Artifact,
   type ArtifactType,
   artifactAddress,
   type DesiredState,
@@ -58,6 +59,8 @@ import {
 } from '../../../domain/target.ts';
 import type { SurfaceProbe } from '../../../domain/vessel.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
+import { fetchableBundleUrl } from '../../../storage/signed-url.ts';
+import type { FederationOptions } from '../cloud/federation.ts';
 import {
   CloudHttp,
   type CloudResponse,
@@ -84,6 +87,7 @@ import type {
   StartedRun,
 } from '../contract.ts';
 import { BundleError, type BundleFile, readBundle } from '../static/bundle.ts';
+import { fetchableStagedAddress, STAGED_SCHEME } from '../static/index.ts';
 import {
   type AssetManifest,
   type Envelope,
@@ -103,6 +107,16 @@ export interface PagesAdapterOptions {
    * type here would push that difference into every call site.
    */
   readonly token: TokenProvider;
+  /**
+   * How this installation signs for an object in its source depot, or `null`
+   * where it configured none.
+   *
+   * Not a second account credential: a supplied upload was never built, so its
+   * bytes are a `gs://` object rather than a URL, and reading one takes a V4
+   * signature rather than any bearer this backend holds. `storage/signed-url.ts`
+   * is where that exchange and its one grant are written down.
+   */
+  readonly federation?: FederationOptions | null;
   /** Injected so a test can stand a fake far side behind the real client. */
   readonly fetch?: Fetcher;
   readonly now?: () => number;
@@ -188,8 +202,8 @@ export class PagesDeployAdapter implements DeployAdapter {
       );
     }
 
-    // **ponytail:** a staged URL only. This adapter fetches the bytes with its
-    // own identity, and that identity is an account credential for *this*
+    // **ponytail:** a staged address only. This adapter fetches the bytes with
+    // its own identity, and that identity is an account credential for *this*
     // platform — it authorizes nothing at a container registry, so a registry
     // reference is an address this Target genuinely cannot read rather than one
     // it has not got around to. The cloud static Target's OCI arm works because
@@ -197,16 +211,18 @@ export class PagesDeployAdapter implements DeployAdapter {
     // here until the build route can stage a `files` artifact somewhere this
     // can GET, which is what `depot`-shaped addresses already are. Give it the
     // registry arm when a credential-free pull path exists, not before.
+    //
+    // A depot object is one of those addresses: `gs://` is not a URL, but a
+    // signature turns it into one, and that is what a supplied upload's bytes
+    // are — the same predicate the other two files backends choose by.
     const staged = artifactAddress(desired.artifact);
-    if (staged === null || !/^https?:\/\//.test(staged)) {
+    const location = fetchableStagedAddress(staged);
+    if (location === null) {
       yield this.status('FAILED', { reason: 'ARTIFACT_UNAVAILABLE' });
       return {
         phase: 'FAILED',
         reason: 'ARTIFACT_UNAVAILABLE',
-        detail:
-          desired.artifact.refs.length === 0
-            ? 'the artifact carries no address to fetch it from'
-            : `Cloudflare Pages fetches the bytes itself, and this artifact is addressed as ${staged} — a registry reference its account credential cannot read`,
+        detail: unfetchableArtifact(desired.artifact, staged),
       };
     }
 
@@ -218,7 +234,7 @@ export class PagesDeployAdapter implements DeployAdapter {
 
     let files: readonly BundleFile[];
     try {
-      files = await this.fetchBundle(http, staged);
+      files = await this.fetchBundle(http, location);
     } catch (cause) {
       const failure = bundleFailure(cause, ref);
       yield this.status('FAILED', {
@@ -463,7 +479,24 @@ export class PagesDeployAdapter implements DeployAdapter {
     http: CloudHttp,
     location: string,
   ): Promise<readonly BundleFile[]> {
-    const fetched = await http.bytes(location);
+    // What is fetched and what is *named* part company here on purpose: a
+    // signed URL is a bearer capability, so both sentences below name the
+    // address the artifact carries and never the one minted from it.
+    let url: string;
+    try {
+      url = await fetchableBundleUrl(
+        location,
+        this.options.federation,
+        this.options.fetch,
+      );
+    } catch (cause) {
+      throw new ArtifactUnavailable(
+        `the artifact at ${location} could not be signed for: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
+    const fetched = await http.bytes(url);
     if (!fetched.ok) {
       // §6 blames the **platform** for an artifact that cannot be fetched, and
       // this is exactly that: the build is green and the bytes are not there.
@@ -783,6 +816,28 @@ function notAssessed(): { met: false; assessed: false; detail: string } {
 /** The artifact was addressed and the bytes were not there (§6's platform blame). */
 class ArtifactUnavailable extends Error {
   override readonly name = 'ArtifactUnavailable';
+}
+
+/**
+ * Why nothing here can be fetched, said about the address that failed.
+ *
+ * The three cases the other files backends distinguish, worded for this one: no
+ * address at all, a bundle staged somewhere nothing outside one process
+ * reaches, and an artifact addressed only as a registry reference. Telling the
+ * middle one apart is the point — it used to take the registry sentence, which
+ * sends an operator to a credential problem over a bundle sitting on a disk.
+ */
+function unfetchableArtifact(
+  artifact: Artifact,
+  staged: string | null,
+): string {
+  if (artifact.refs.length === 0) {
+    return 'the artifact carries no address to fetch it from';
+  }
+  if (staged !== null && STAGED_SCHEME.test(staged)) {
+    return `the artifact is staged at ${staged}, which names this installation's own disk rather than an address Cloudflare Pages can fetch`;
+  }
+  return `Cloudflare Pages fetches the bytes itself, and this artifact is addressed as ${staged} — a registry reference its account credential cannot read`;
 }
 
 /**

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -55,8 +55,8 @@ import {
 } from '../../../domain/target.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
 import {
+  fetchableBundleUrl,
   parseGcsLocation,
-  signedObjectUrl,
 } from '../../../storage/signed-url.ts';
 import { cloudChecklist, cloudSurfaceProbe } from '../cloud/checklist.ts';
 import type { FederationOptions } from '../cloud/federation.ts';
@@ -449,10 +449,23 @@ export class StaticDeployAdapter implements DeployAdapter {
     // What is fetched and what is *named* part company here on purpose: a
     // signed URL is a bearer capability, so every sentence below names the
     // address the artifact carries and never the one that was minted from it.
-    const url =
-      parseGcsLocation(location) === null
-        ? location
-        : await this.signedDepotUrl(location);
+    let url: string;
+    try {
+      url = await fetchableBundleUrl(
+        location,
+        this.options.federation,
+        this.options.fetch,
+      );
+    } catch (cause) {
+      // Failing to mint a signed URL is `ARTIFACT_UNAVAILABLE` like every other
+      // way the bytes do not arrive: the build is green, and §6 blames the
+      // platform for that.
+      throw new ArtifactUnavailable(
+        `the artifact at ${location} could not be signed for: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
     if (/^https?:\/\//.test(url)) {
       const fetched = await http.bytes(url);
       if (!fetched.ok) {
@@ -484,43 +497,6 @@ export class StaticDeployAdapter implements DeployAdapter {
       );
     }
     return readBundle(layer);
-  }
-
-  /**
-   * A depot object, exchanged for something this adapter can actually GET.
-   *
-   * The same V4 signed URL a hosted build route is handed, minted the same way
-   * — `signBlob` under the federated identity, nothing stored (§13) — because a
-   * second way to read one bucket is a second thing to grant and to get wrong.
-   *
-   * Failing to mint one is `ARTIFACT_UNAVAILABLE` like every other way the
-   * bytes do not arrive: the build is green, and §6 blames the platform for
-   * that. The refusal names the object, never the URL.
-   */
-  private async signedDepotUrl(location: string): Promise<string> {
-    const federation = this.options.federation ?? null;
-    if (federation === null) {
-      throw new ArtifactUnavailable(
-        `the artifact is staged at ${location} and this installation configures no cloud federation, so nothing can be signed to fetch it with`,
-      );
-    }
-    try {
-      return await signedObjectUrl({
-        location,
-        federation: {
-          ...federation,
-          ...(this.options.fetch === undefined
-            ? {}
-            : { fetch: this.options.fetch }),
-        },
-      });
-    } catch (cause) {
-      throw new ArtifactUnavailable(
-        `the artifact at ${location} could not be signed for: ${
-          cause instanceof Error ? cause.message : String(cause)
-        }`,
-      );
-    }
   }
 
   /**
@@ -799,11 +775,17 @@ class ArtifactUnavailable extends Error {
   override readonly name = 'ArtifactUnavailable';
 }
 
-/** A staged bundle's address wears a scheme; a registry reference never does. */
-const STAGED_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
+/**
+ * A staged bundle's address wears a scheme; a registry reference never does.
+ *
+ * Exported because every `files` backend makes the same three-way distinction
+ * and words its last case differently — see {@link fetchableStagedAddress}.
+ */
+export const STAGED_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
 
 /**
- * A supplied upload's address, where this adapter can end up holding the bytes.
+ * A supplied upload's address, where a `files` backend can end up holding the
+ * bytes.
  *
  * Two schemes qualify, for one reason each: `https://` is already fetchable,
  * and `gs://` is the depot's own address — not a URL, but one a signature turns
@@ -811,8 +793,13 @@ const STAGED_SCHEME = /^[a-z][a-z0-9+.-]*:\/\//i;
  * an installation with no depot stages onto its own pod's disk: those bytes are
  * not reachable from here at all, and falling through to the registry branch
  * answers that with a sentence about registry access instead.
+ *
+ * Shared with the other `files` backends rather than written once each: they
+ * fetch the same bundle for the same reason, and three of them disagreeing
+ * about which addresses are fetchable is the bug this function exists to have
+ * exactly one answer to.
  */
-function fetchableStagedAddress(staged: string | null): string | null {
+export function fetchableStagedAddress(staged: string | null): string | null {
   if (staged === null) return null;
   const fetchable =
     /^https?:\/\//.test(staged) || parseGcsLocation(staged) !== null;

--- a/apps/spindrift/src/adapters/deploy/vercel/index.ts
+++ b/apps/spindrift/src/adapters/deploy/vercel/index.ts
@@ -40,6 +40,7 @@ import type {
   TargetInspection,
 } from '../../../domain/capabilities.ts';
 import {
+  type Artifact,
   type ArtifactType,
   artifactAddress,
   type DesiredState,
@@ -50,6 +51,8 @@ import {
 } from '../../../domain/target.ts';
 import type { SurfaceProbe } from '../../../domain/vessel.ts';
 import { workloadName } from '../../../domain/workload-name.ts';
+import { fetchableBundleUrl } from '../../../storage/signed-url.ts';
+import type { FederationOptions } from '../cloud/federation.ts';
 import {
   CloudHttp,
   type CloudResponse,
@@ -76,6 +79,7 @@ import type {
   StartedRun,
 } from '../contract.ts';
 import { BundleError, type BundleFile, readBundle } from '../static/bundle.ts';
+import { fetchableStagedAddress, STAGED_SCHEME } from '../static/index.ts';
 import {
   googleRegistryRef,
   OciPullError,
@@ -101,6 +105,18 @@ export interface VercelAdapterOptions {
    * token from being sent to Vercel.
    */
   readonly artifactToken: TokenProvider;
+  /**
+   * How this installation signs for an object in its source depot, or `null`
+   * where it configured none.
+   *
+   * A third thing, and not a third *identity*: a supplied upload was never
+   * built, so its bytes are a `gs://` object rather than a registry reference,
+   * and reading one takes a signature rather than a bearer. Signing is
+   * `signBlob` under the *federated* identity, before impersonation, which is
+   * why this is the federation itself and not a token provider —
+   * `storage/signed-url.ts` is where that distinction is written down.
+   */
+  readonly federation?: FederationOptions | null;
   /** Injected so a test can stand a fake far side behind the real client. */
   readonly fetch?: Fetcher;
   readonly now?: () => number;
@@ -187,27 +203,21 @@ export class VercelDeployAdapter implements DeployAdapter {
       );
     }
 
-    // Same choice the other files backend makes, with a different identity
-    // doing the reading: a staged URL is an upload's own address and is fetched
-    // as it stands, and among registry references only one in the installation's
-    // Google-family artifacts registry is readable with the federated token
-    // this adapter is handed for exactly that.
+    // Same choice the other files backends make — literally, via the same
+    // predicate — with a different identity doing the reading: a staged address
+    // is an upload's own and is fetched as such, and among registry references
+    // only one in the installation's Google-family artifacts registry is
+    // readable with the federated token this adapter is handed for exactly that.
     const staged = artifactAddress(desired.artifact);
-    const location = /^https?:\/\//.test(staged ?? '')
-      ? staged
-      : googleRegistryRef(desired.artifact.refs);
+    const location =
+      fetchableStagedAddress(staged) ??
+      googleRegistryRef(desired.artifact.refs);
     if (location === null) {
       yield this.status('FAILED', { reason: 'ARTIFACT_UNAVAILABLE' });
-      const hosts = desired.artifact.refs
-        .map((ref) => ref.split('/')[0])
-        .join(', ');
       return {
         phase: 'FAILED',
         reason: 'ARTIFACT_UNAVAILABLE',
-        detail:
-          desired.artifact.refs.length === 0
-            ? 'the artifact carries no address to fetch it from'
-            : `Vercel is fed the bytes, and none of the artifact's homes (${hosts}) is a registry this installation's identity can read`,
+        detail: unfetchableArtifact(desired.artifact, staged),
       };
     }
 
@@ -409,13 +419,33 @@ export class VercelDeployAdapter implements DeployAdapter {
 
   // --- apply's steps -------------------------------------------------------
 
-  /** Fetch the bundle and read it into files. Throws; `apply` catches. */
+  /**
+   * Fetch the bundle and read it into files. Throws; `apply` catches.
+   *
+   * What is fetched and what is *named* part company here on purpose: a signed
+   * URL is a bearer capability, so every sentence below names the address the
+   * artifact carries and never the one that was minted from it.
+   */
   private async fetchBundle(
     http: CloudHttp,
     location: string,
   ): Promise<readonly BundleFile[]> {
-    if (/^https?:\/\//.test(location)) {
-      const fetched = await http.bytes(location);
+    let url: string;
+    try {
+      url = await fetchableBundleUrl(
+        location,
+        this.options.federation,
+        this.options.fetch,
+      );
+    } catch (cause) {
+      throw new ArtifactUnavailable(
+        `the artifact at ${location} could not be signed for: ${
+          cause instanceof Error ? cause.message : String(cause)
+        }`,
+      );
+    }
+    if (/^https?:\/\//.test(url)) {
+      const fetched = await http.bytes(url);
       if (!fetched.ok) {
         throw new ArtifactUnavailable(
           `the artifact at ${location} could not be fetched: ${fetched.message}`,
@@ -727,6 +757,29 @@ interface DeploymentFile {
 /** The artifact was addressed and the bytes were not there (§6's platform blame). */
 class ArtifactUnavailable extends Error {
   override readonly name = 'ArtifactUnavailable';
+}
+
+/**
+ * Why nothing here can be fetched, said about the address that failed.
+ *
+ * The other files backends' three cases, worded for this one: no address at
+ * all, a bundle staged somewhere nothing outside one process reaches, and a
+ * built artifact homed only on a registry this identity cannot read. The middle
+ * one used to take the last one's sentence, which sends an operator to IAM over
+ * a bundle sitting on a disk.
+ */
+function unfetchableArtifact(
+  artifact: Artifact,
+  staged: string | null,
+): string {
+  if (artifact.refs.length === 0) {
+    return 'the artifact carries no address to fetch it from';
+  }
+  if (staged !== null && STAGED_SCHEME.test(staged)) {
+    return `the artifact is staged at ${staged}, which names this installation's own disk rather than an address Vercel can be fed from`;
+  }
+  const hosts = artifact.refs.map((ref) => ref.split('/')[0]).join(', ');
+  return `Vercel is fed the bytes, and none of the artifact's homes (${hosts}) is a registry this installation's identity can read`;
 }
 
 /** A step that either produced something or carries the refusal that stopped it. */

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -275,17 +275,22 @@ export function createAdapterRegistry(
     }),
     // The one adapter with two identities: the platform is driven with the
     // installation's own bearer, and the artifact is read out of the artifacts
-    // registry with the federated token every other adapter already holds.
+    // registry with the federated token every other adapter already holds. The
+    // federation is neither of those — it is the signature a supplied upload's
+    // `gs://` object takes, the same one the static backend above needs.
     vercel: new VercelDeployAdapter({
       token: options.vercelToken ?? vercelToken(options.env ?? Bun.env),
       artifactToken: cloud,
+      federation: options.manifest.cloud.federation,
       ...(options.fetch ? { fetch: options.fetch } : {}),
     }),
-    // The second backend federation does not reach, and the simpler of the two:
-    // it fetches its own artifact with the same bearer it deploys with, because
-    // a staged bundle is a plain GET.
+    // The simpler of the two edge backends: it fetches its own artifact with the
+    // same bearer it deploys with, because a staged bundle is a plain GET. The
+    // federation is not a second bearer — it is the signature the one address
+    // that is *not* a plain GET takes, a supplied upload's `gs://` object.
     'cloudflare-pages': new PagesDeployAdapter({
       token: options.cloudflareToken ?? cloudflareToken(options.env ?? Bun.env),
+      federation: options.manifest.cloud.federation,
       ...(options.fetch ? { fetch: options.fetch } : {}),
     }),
   };

--- a/apps/spindrift/src/domain/source.ts
+++ b/apps/spindrift/src/domain/source.ts
@@ -82,8 +82,8 @@ export function isSuppliedArtifact(source: Source): boolean {
 /**
  * What a supplied artifact is, as an artifact type (§6's table).
  *
- * `files`, always. §6 gives exactly one backend that accepts `files` — `static`
- * — and finished output uploaded as a bundle is what that backend serves. An
+ * `files`, always. Every backend §6 gives that accepts `files` is a static one,
+ * and finished output uploaded as a bundle is what each of them serves. An
  * uploaded *image* is not a shape v1 has: it would need a registry push core
  * does not do and a digest core did not compute, which is the custody gap §16
  * closes by digesting what was actually staged.

--- a/apps/spindrift/src/storage/signed-url.ts
+++ b/apps/spindrift/src/storage/signed-url.ts
@@ -91,6 +91,42 @@ export interface SignedUrlInput {
 }
 
 /**
+ * The address a staged bundle is actually fetched from.
+ *
+ * A depot object is exchanged for a signed URL; anything else — an `https://`
+ * bundle, a registry reference — is already whatever its own fetcher expects
+ * and comes back untouched. Every `files` deploy backend reads the same depot
+ * for the same reason, and one function is what stops three of them from
+ * disagreeing about how a `gs://` address becomes bytes.
+ *
+ * Throws {@link FederationError}, including for an installation that
+ * configured no federation at all: it is the same "this installation cannot
+ * reach its cloud" as every other refusal here, and a caller that turns one
+ * into its own verdict turns them all into it.
+ *
+ * **The caller must keep naming `location`, never what comes back.** A signed
+ * URL is a bearer capability; the object address is the thing an operator can
+ * be told about.
+ */
+export async function fetchableBundleUrl(
+  location: string,
+  federation: FederationOptions | null | undefined,
+  /** The adapter's own transport, so a test's fake far side signs too. */
+  fetch?: FederationOptions['fetch'],
+): Promise<string> {
+  if (parseGcsLocation(location) === null) return location;
+  if (federation === null || federation === undefined) {
+    throw new FederationError(
+      'no cloud federation is configured, so nothing can be signed to fetch it with',
+    );
+  }
+  return signedObjectUrl({
+    location,
+    federation: fetch === undefined ? federation : { ...federation, fetch },
+  });
+}
+
+/**
  * Mint a short-TTL V4 signed URL for one GCS object.
  *
  * Throws {@link FederationError} — the same type every other federated call

--- a/apps/spindrift/test/adapters/pages.test.ts
+++ b/apps/spindrift/test/adapters/pages.test.ts
@@ -231,6 +231,79 @@ describe('a deploy is check, upload, deploy', () => {
   });
 });
 
+describe('a supplied upload is fetched out of the depot', () => {
+  /** Where `stageArchiveBytes` puts an upload when the installation has one. */
+  const OBJECT = 'gs://bluenose-spindrift-source/abc123.tgz';
+
+  const FEDERATION = {
+    audience:
+      '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov',
+    tokenUrl: 'https://sts.googleapis.test/v1/token',
+    tokenPath: '/var/run/secrets/spindrift/gcp-token',
+    impersonationUrl:
+      'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+  };
+
+  test('a bundle staged at gs:// is signed for, fetched, and served', async () => {
+    // Nothing built a supplied upload, so it has no registry reference and no
+    // URL — only the depot address, which this backend's account credential
+    // has no bearing on at all. A V4 signature is what reads it.
+    const api = new FakeCloudflarePages({
+      // The depot serves on the storage host, which is where a signed URL
+      // points — so the adapter's own fetch of the object runs for real.
+      bundle: { origin: 'https://storage.googleapis.com', bytes: SITE },
+    });
+    const signed: string[] = [];
+    const fetched: string[] = [];
+    const adapter = new PagesDeployAdapter({
+      token: api.token,
+      federation: { ...FEDERATION, readToken: async () => 'jwt' },
+      fetch: async (request) => {
+        if (request.url.startsWith(FEDERATION.tokenUrl)) {
+          return Response.json({
+            access_token: 'federated-token',
+            expires_in: 3600,
+          });
+        }
+        if (request.url.includes(':signBlob')) {
+          signed.push(request.url);
+          // Two bytes, so the hex encoding is checkable without arithmetic.
+          return Response.json({ signedBlob: btoa('\x01\xfe') });
+        }
+        if (request.url.startsWith('https://storage.googleapis.com')) {
+          fetched.push(request.url);
+        }
+        return api.fetch(request);
+      },
+    });
+
+    const { verdict } = await drain(
+      adapter.apply(
+        TARGET,
+        desired({
+          artifact: {
+            type: 'files',
+            digest: 'sha256:bundle',
+            refs: [OBJECT],
+          },
+        }),
+      ),
+    );
+
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.servedPaths(PROJECT)).toEqual([
+      '/assets/app.css',
+      '/index.html',
+    ]);
+    // Signed with the federated identity rather than a stored credential
+    // (§13), and the object fetched with the capability that signature is.
+    expect(signed).toHaveLength(1);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0]).toContain('/bluenose-spindrift-source/abc123.tgz?');
+    expect(fetched[0]).toContain('X-Goog-Signature=01fe');
+  });
+});
+
 describe('the digest travels where a deployment can carry it', () => {
   test('observe reads back the digest apply deployed', async () => {
     const { adapter } = adapterFor();
@@ -358,6 +431,33 @@ describe('what this Target cannot fetch, it says so about', () => {
     expect(verdict.phase).toBe('FAILED');
     if (verdict.phase === 'FAILED') {
       expect(verdict.detail).toContain('no address');
+    }
+  });
+
+  test('a bundle nothing can fetch says that, rather than blaming a credential', async () => {
+    // An installation with no depot stages an upload on the web pod's own
+    // disk. That is unfetchable, and it used to take the registry sentence — a
+    // true statement about a different problem, which sends the operator to a
+    // credential they cannot fix this with.
+    const { adapter } = adapterFor();
+    const { verdict } = await drain(
+      adapter.apply(
+        TARGET,
+        desired({
+          artifact: {
+            type: 'files',
+            digest: 'sha256:bundle',
+            refs: ['upload://abc123'],
+          },
+        }),
+      ),
+    );
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(blameFor(verdict.reason)).toBe('platform');
+      expect(verdict.detail).toContain('upload://abc123');
+      expect(verdict.detail).not.toContain('registry');
     }
   });
 

--- a/apps/spindrift/test/adapters/static.test.ts
+++ b/apps/spindrift/test/adapters/static.test.ts
@@ -504,6 +504,28 @@ describe('a supplied upload is fetched out of the depot', () => {
       expect(verdict.detail).not.toContain('registry');
     }
   });
+
+  test('an installation that federates nothing refuses rather than crashes', async () => {
+    // The construction every adapter site that omits `federation` produces —
+    // the conformance harness is one. A depot object is unreadable without a
+    // signature, and the refusal says that about the object rather than
+    // throwing out of `apply` as an INTERNAL nobody can act on.
+    const api = new FakeHosting({
+      bundle: { origin: 'https://storage.googleapis.com', bytes: SITE },
+    });
+    const adapter = new StaticDeployAdapter({
+      token: api.token,
+      fetch: api.fetch,
+    });
+    const { verdict } = await drain(adapter.apply(TARGET, supplied(OBJECT)));
+
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(verdict.detail).toContain(OBJECT);
+      expect(verdict.detail).toContain('federation');
+    }
+  });
 });
 
 describe('§9: the vanity name is one record on the serving site', () => {

--- a/apps/spindrift/test/adapters/vercel.test.ts
+++ b/apps/spindrift/test/adapters/vercel.test.ts
@@ -178,6 +178,105 @@ describe('§4: build stays separate from deploy', () => {
   });
 });
 
+describe('a supplied upload is fetched out of the depot', () => {
+  /** Where `stageArchiveBytes` puts an upload when the installation has one. */
+  const OBJECT = 'gs://bluenose-spindrift-source/abc123.tgz';
+
+  const FEDERATION = {
+    audience:
+      '//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/pool/providers/prov',
+    tokenUrl: 'https://sts.googleapis.test/v1/token',
+    tokenPath: '/var/run/secrets/spindrift/gcp-token',
+    impersonationUrl:
+      'https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/controller@vessel.iam.gserviceaccount.com:generateAccessToken',
+  };
+
+  /** A supplied artifact: the bundle's own address, and no registry anywhere. */
+  function supplied(location: string): DesiredState {
+    return desired({
+      artifact: { type: 'files', digest: 'sha256:bundle', refs: [location] },
+    });
+  }
+
+  function depotAdapter(): {
+    api: FakeVercel;
+    adapter: VercelDeployAdapter;
+    signed: string[];
+    fetched: string[];
+  } {
+    // The depot serves on the storage host, which is also where a signed URL
+    // points — so the adapter's own fetch of the object runs for real.
+    const api = new FakeVercel({
+      bundle: { origin: 'https://storage.googleapis.com', bytes: SITE },
+    });
+    const signed: string[] = [];
+    const fetched: string[] = [];
+    const adapter = new VercelDeployAdapter({
+      token: api.token,
+      artifactToken: api.token,
+      federation: { ...FEDERATION, readToken: async () => 'jwt' },
+      pollIntervalMs: 1,
+      sleep: async () => {},
+      fetch: async (request) => {
+        if (request.url.startsWith(FEDERATION.tokenUrl)) {
+          return Response.json({
+            access_token: 'federated-token',
+            expires_in: 3600,
+          });
+        }
+        if (request.url.includes(':signBlob')) {
+          signed.push(request.url);
+          // Two bytes, so the hex encoding is checkable without arithmetic.
+          return Response.json({ signedBlob: btoa('\x01\xfe') });
+        }
+        if (request.url.startsWith('https://storage.googleapis.com')) {
+          fetched.push(request.url);
+        }
+        return api.fetch(request);
+      },
+    });
+    return { api, adapter, signed, fetched };
+  }
+
+  test('a bundle staged at gs:// is signed for, fetched, and deployed', async () => {
+    // Both files backends take a supplied upload, and this one reached the
+    // same dead end: nothing built the bundle, so there is no registry
+    // reference, and the depot address is not something an HTTP client
+    // resolves.
+    const { api, adapter, signed, fetched } = depotAdapter();
+    const { verdict } = await drain(adapter.apply(TARGET, supplied(OBJECT)));
+
+    expect(verdict.phase).toBe('LIVE');
+    expect(api.servedPaths(PROJECT)).toEqual(['assets/app.css', 'index.html']);
+    // Signed with the federated identity rather than a stored credential
+    // (§13), and the object fetched with the capability that signature is —
+    // neither of this adapter's two bearers was what read it.
+    expect(signed).toHaveLength(1);
+    expect(fetched).toHaveLength(1);
+    expect(fetched[0]).toContain('/bluenose-spindrift-source/abc123.tgz?');
+    expect(fetched[0]).toContain('X-Goog-Signature=01fe');
+  });
+
+  test('a bundle nothing can fetch says that, rather than blaming a registry', async () => {
+    // An installation with no depot stages an upload on the web pod's own
+    // disk. That is unfetchable, and it used to be reported as an artifact
+    // homed on a registry this identity cannot read — a true sentence about a
+    // different problem, which sends the operator to IAM.
+    const { adapter } = depotAdapter();
+    const { verdict } = await drain(
+      adapter.apply(TARGET, supplied('upload://abc123')),
+    );
+
+    expect(verdict.phase).toBe('FAILED');
+    if (verdict.phase === 'FAILED') {
+      expect(verdict.reason).toBe('ARTIFACT_UNAVAILABLE');
+      expect(blameFor(verdict.reason)).toBe('platform');
+      expect(verdict.detail).toContain('upload://abc123');
+      expect(verdict.detail).not.toContain('registry');
+    }
+  });
+});
+
 describe('§9: Vercel serves Public only', () => {
   test('anything but a public reach is refused, as core’s bug', async () => {
     for (const reach of ['none', 'private'] as const) {


### PR DESCRIPTION
## What changed

A supplied upload's bytes are a `gs://` depot object. Three deploy backends accept `files` — `static`, `vercel`, `cloudflare-pages` — and only `static` could fetch one. The other two chose their artifact address with `/^https?:\/\//`, so a depot address fell through: Vercel to the registry branch (dying with "none of the artifact's homes is a registry its identity can read"), Pages to an outright refusal naming a registry credential. Both sentences are true statements about a different problem, and both send an operator somewhere they cannot fix it.

- `vercel` and `cloudflare-pages` now choose by `fetchableStagedAddress`, the same predicate `static` uses, and exchange a `gs://` address for a short-TTL V4 signed URL.
- The exchange moves into `storage/signed-url.ts` as `fetchableBundleUrl`, called by all three. Three backends fetch the same depot for the same reason; one function is what stops them disagreeing about which addresses are fetchable or how one becomes bytes. No new dependency, credential flow, or IAM grant — it is the same `signBlob`-under-federated-identity path the hosted build route already uses, and `terraform/gcp/projects/bluenose/iam.tf` already grants `roles/iam.serviceAccountTokenCreator`.
- Each backend keeps its own refusal wording, because "no registry its identity can read" and "its account credential cannot read this" are different facts about different far sides.
- A bundle staged where nothing here can fetch it — `upload://`, which is what an installation with no depot produces — now says that, rather than borrowing the registry sentence.
- The signed URL is never named in a failure message: it is a bearer capability, so every sentence names the `gs://` object it was minted from. The OCI pull paths are untouched.

## Validation

Each new test was run against the unchanged adapter first and fails there:

- `bun test test/adapters/vercel.test.ts` against the old Vercel adapter → 18 pass / 2 fail (gs:// returned FAILED; the detail printed the registry sentence with `(upload:)` as the host).
- `bun test test/adapters/pages.test.ts` against the old Pages adapter → 29 pass / 2 fail, same two shapes.

After the change, with Postgres confirmed on `:15432`:

- `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 DATABASE_URL=… bun test` in `apps/spindrift` → **2281 pass, 0 fail, 156 files** (baseline on this main was 2276).
- `mise run ts:check` → clean; `tsc --noEmit` re-run uncached in-package → clean.

## Risks

- `federation` is optional on all three adapter option types, so a construction site that omits it (the conformance harness does) refuses a `gs://` bundle with an explicit "no cloud federation is configured" sentence rather than crashing. That branch now has a test.
- The three `unfetchableArtifact` helpers are near-duplicates by design — the shared part is the predicate and the exchange, and the wording is what differs per backend. Collapsing the sentences too would produce a message that names the wrong far side.
- Nothing else in the repo asserts on the changed failure strings beyond the tests added here.