### PR TITLE
fix(slides): pin the test count to the commit it was measured at

### DIFF
--- a/apps/slides/spindrift/index.html
+++ b/apps/slides/spindrift/index.html
@@ -991,7 +991,7 @@
     </div>
     <div style="display:flex;flex-direction:column;gap:1.1rem">
       <div class="stats">
-        <div class="stat"><b>2,188</b><span>tests green</span></div>
+        <div class="stat"><b>2,283</b><span>tests green at 6f0d870c</span></div>
         <div class="stat"><b>5</b><span>clauses proven live</span></div>
         <div class="stat"><b>3/4</b><span>Targets healthy on first probe</span></div>
         <div class="stat stat--cau"><b>4</b><span>defects only a live install found</span></div>


### PR DESCRIPTION
`2,188 tests green` is already wrong — the suite is 2,283 at `6f0d870c`. An exact count with no commit behind it is false the moment anything merges, and this one has now gone stale twice in three days.

Pinning it makes the claim checkable rather than merely current: anyone can check out `6f0d870c` and run the suite.

## Validation

`BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 DATABASE_URL=… bun test` in `apps/spindrift` at `6f0d870c` → 2,283 pass, 0 fail, 6,776 expect() calls, 156 files.

## Risks

None to the page — one stat label, no structural change. The deck is served as an uploaded archive rather than from `main`, so this needs a redeploy through the product to reach the live page.