### PR TITLE
fix(cd): author the digest branch and PR with a GitHub App token

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -46,17 +46,45 @@ jobs:
     # the GCE box, torn down as a cost decision. This repo is public, so
     # hosted runners are free. The lab pool still serves the suite.
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN pushes images and nothing else; the digest branch and its
+    # pull request are written by the App token minted below.
     permissions:
-      contents: write
+      contents: read
       id-token: write
       packages: write
-      pull-requests: write
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.detect.outputs.matrix) }}
     steps:
+      # Deliberately not GITHUB_TOKEN. When a workflow using GITHUB_TOKEN opens
+      # a pull request or pushes to one, GitHub's recursion prevention parks
+      # every run that push triggers in `action_required` before a single job
+      # starts — so the required contexts are never reported at all, absent
+      # rather than skipped, and the pull request can never go green. That is
+      # not a ruleset to relax and no permission grant reaches it; an App
+      # installation token is the documented way out. Simplify this back to
+      # GITHUB_TOKEN and continuous delivery stops dead behind a queue of
+      # parked runs, with every step of this job still green.
+      #
+      # Minted only on the ref that pushes, so pull request builds — forks
+      # included, which cannot read the secret at all — fall through to
+      # `github.token` on the checkout below and never see it. Scoped by
+      # default to this repository, and narrowed to the two permissions the
+      # push and the `gh` calls actually use — notably not `workflows: write`,
+      # which is why the push fallback further down is still load bearing.
+      - name: Mint continuous delivery App token
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        id: cd_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          client-id: ${{ vars.CD_APP_CLIENT_ID }}
+          private-key: ${{ secrets.CD_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          token: ${{ steps.cd_token.outputs.token || github.token }}
       # Which images need what is declared in each app's build.json, not here.
       # This job knows how to run a build; it does not know any app's name.
       - name: Authenticate build to Google Cloud
@@ -132,7 +160,7 @@ jobs:
           IMAGE_NAME: ${{ matrix.image }}
           DIGEST: ${{ steps.push.outputs.digest }}
           MANIFESTS: ${{ toJson(matrix.manifests) }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.cd_token.outputs.token }}
         run: |
           set -euo pipefail
           mapfile -t targets < <(jq -r '.[]' <<<"$MANIFESTS")
@@ -223,8 +251,9 @@ jobs:
           if ! git push origin "$BRANCH_NAME" --force; then
             # A prior run that failed after pushing leaves this branch cut from
             # an older main, so the next push introduces every commit in
-            # between — and GITHUB_TOKEN may never write one that touched
-            # .github/workflows/, whatever this job's `permissions:` say.
+            # between — and neither GITHUB_TOKEN nor an App without
+            # `workflows: write` may write one that touched .github/workflows/,
+            # whatever this job's `permissions:` say.
             # Recreating the ref reduces the push to the single manifest-only
             # commit above. Only on failure, so an open PR keeps its identity
             # and its running checks in the ordinary case.


### PR DESCRIPTION
## Do this before merging

The workflow reads a repository variable and a secret that do not exist yet. Create
them first: the first push to `main` after this merges mints the token, and a missing
value fails the `build` job at its first step, before any image is built.

1. **Create the App** at <https://github.com/settings/apps/new> (owner: `jonpulsifer`).
   - *GitHub App name*: anything unique, e.g. `jonpulsifer-infra-cd`.
   - *Homepage URL*: `https://github.com/jonpulsifer/infra`.
   - *Webhook*: uncheck **Active**. Nothing calls back.
   - *Repository permissions*: **Contents → Read and write**, **Pull requests → Read and
     write**. Leave every other permission at *No access*. In particular **do not grant
     Workflows** — see the residual risk below for what that buys and what it costs.
   - *Where can this GitHub App be installed?*: **Only on this account**.
2. **Copy the Client ID** from the App's settings page (it looks like `Iv23li…`). Not the
   numeric App ID — the action's `app-id` input is deprecated and this workflow uses
   `client-id`.
3. **Generate a private key** on the same page. It downloads a `.pem`.
4. **Install the App**: App settings → *Install App* → `jonpulsifer` → **Only select
   repositories** → `jonpulsifer/infra`.
5. **Store both values**:

   ```sh
   gh variable set CD_APP_CLIENT_ID --repo jonpulsifer/infra --body '<client id>'
   gh secret   set CD_APP_PRIVATE_KEY --repo jonpulsifer/infra < ~/Downloads/<app>.private-key.pem
   shred -u ~/Downloads/<app>.private-key.pem
   ```

   The client ID is a variable, not a secret, matching `vars.TS_OIDC_CLIENT_ID` in
   `nixos-deploy.yaml` — a masked client ID only makes a failing run harder to read.

6. Merge. There are currently no open `cd/update-*` pull requests and no stale `cd/*`
   remote branches, so the next digest bump starts clean.

Auto-merge is deliberately **not** enabled on this pull request. Every check is green, so
enabling it would merge within minutes — before the App exists — and the next push to
`main` would fail every container build at its first step.

## What this changes

The digest branch push and the digest pull request in `.github/workflows/containers.yml`
are now authored by a GitHub App installation token instead of `GITHUB_TOKEN`.

`GITHUB_TOKEN` cannot get this pull request merged, and no amount of permission or
ruleset tuning changes that. GitHub's recursion prevention has a documented second
exception: when a workflow using `GITHUB_TOKEN` creates or updates a pull request, the
`opened`/`synchronize`/`reopened` events it emits create workflow runs in an
approval-required state. The runs are created and parked at `action_required` *before any
job starts*, so no check-run is ever produced and the required contexts — `check` and
`validate` — are **absent** rather than skipped. A required context that is absent can
never be satisfied, so the pull request blocks forever. 45 of the last 200 runs on this
repository are parked that way. The documented remedy is the one applied here: use an App
installation access token instead of `GITHUB_TOKEN` when creating or updating the pull
request.

Both call sites had to move or half the gate would remain:

- `actions/checkout` defaults to `persist-credentials: true`, so `GITHUB_TOKEN` was the
  git credential behind `git push origin "$BRANCH_NAME"` — the `synchronize` activity. It
  now takes an explicit `token:`.
- `GH_TOKEN` drove `gh pr create` (the `opened` activity) and `gh pr merge --auto`.

Scope kept as tight as the file allows:

- Minted in the job that needs it, gated on `push` to `main`. Pull request builds — forks
  included, which cannot read the secret at all — fall through to `github.token` on the
  checkout and never mint anything.
- Not exported to the job environment: the token reaches exactly two steps, the checkout
  and the digest step.
- Narrowed at mint time with `permission-contents: write` and
  `permission-pull-requests: write`, so the minted token is capped below whatever the App
  installation is granted.
- Scoped to this repository (the action's default when `owner` is unset), and revoked by
  the action's post step at job end.
- `GITHUB_TOKEN` drops from `contents: write` + `pull-requests: write` to `contents:
  read`; it now only reads the repo and pushes images.

No ruleset changed, no approval setting changed, and nothing about what gets built,
scanned, or signed changed. None is needed: on a digest pull request that did get merged,
the check-runs were `check: skipped` and `validate: skipped` and it merged green, because
both workflows sit behind change-detection jobs that a manifest-only edit skips. Getting
the runs to *start* is the whole fix.

The push-refused fallback stays. An App without `workflows: write` is refused a push
containing a `.github/workflows/` change exactly as `GITHUB_TOKEN` is, so the branch
recreation that reduces the push to one manifest-only commit is still load bearing. Its
comment was corrected to say so. Granting `workflows: write` would delete the fallback and
also hand a CI-mintable token the ability to rewrite CI — the narrow App is the better
trade.

## Validation

- `actionlint` (1.7.12, ephemeral via mise) on the changed workflow: clean.
- `yq` parse of the changed job: permissions, both steps, and the `GH_TOKEN` expression
  resolve as intended.
- `actions/create-github-app-token` pinned to `bcd2ba4` (v3.2.0), matching this repo's
  `helpers:pinGitHubActionDigests` convention. Its `action.yml` confirms `client-id`,
  `permission-contents`, `permission-pull-requests`, and the `token` output; v3 requires
  node24, which `ubuntu-latest` provides.

A workflow change cannot be proven until it runs. Nothing here exercises the actual mint,
the App's push, or the resulting pull request's checks — that is only observable on the
first push to `main` after this merges.

## Residual risk

This deliberately removes a control. A pull request authored by an App installation token
does not get the approval gate that bot-authored pull requests otherwise get, so the
digest PR's checks run unattended. Any workflow step in this job that can read
`CD_APP_PRIVATE_KEY` can mint a `contents: write` + `pull-requests: write` token for this
repository — that is the point of the change, and it is the cost. The mitigations that
remain are the ones above: the App is installed on one repository, the token is minted
only on `push` to `main`, capped to two permissions, held by two steps, and revoked at job
end. It cannot touch `.github/workflows/`, which keeps a compromised step from rewriting
CI with it.

Secondary: an installation token expires after one hour and is minted before the build.
Current runs finish in two to seven minutes and no image is multi-arch, so there is
headroom, but a build that grew past an hour would fail its push with a 401 rather than
anything self-explanatory.
