### PR TITLE
fix(spindrift): stop the App page strobing "Disconnected, retrying…"

### DIFF
--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -34,6 +34,7 @@ import type {
   WorkspaceView,
 } from './model.ts';
 import { isInFlight } from './model.ts';
+import { usePoll } from './poll.ts';
 import { useRoute } from './router.ts';
 import { SESSION_EXPIRED_EVENT } from './session-events.ts';
 import { subscribeAttempt, subscribeRuntime } from './stream-client.ts';
@@ -530,6 +531,34 @@ function ConnectionsSettings({
   );
 }
 
+/** A thrown cause as a sentence, for the screens that put one on the page. */
+function serverFailure(cause: unknown): string {
+  return cause instanceof Error ? cause.message : 'Server failure';
+}
+
+/**
+ * What a *thrown* read leaves behind, for a screen that re-reads on a cadence.
+ *
+ * `client.ts` draws the line this depends on: a refusal is an answer the server
+ * gave, and only a response that was not the server answering — a dropped
+ * connection, a proxy serving HTML — throws. So the two are not handled alike
+ * here. A refusal is rendered, on the tick as much as on the first read, which
+ * is how an App deleted from another window stops being shown as though it were
+ * still there. A throw is a gap: a screen with something readable on it keeps
+ * what it has and the next tick closes the gap, because replacing a live view
+ * with an error page over one lost request takes away more than it explains.
+ *
+ * Each screen used to answer this twice and differently — the mount read
+ * replaced the screen for either, the interval beside it dropped both — which
+ * is the drift {@link usePoll}'s single read removes.
+ */
+function failedRead<T extends { readonly type: string }>(
+  current: T,
+  message: string,
+): T | { readonly type: 'error'; readonly message: string } {
+  return current.type === 'success' ? current : { type: 'error', message };
+}
+
 function OverviewScreen({
   onNavigate,
 }: {
@@ -560,56 +589,49 @@ function OverviewScreen({
   >({ type: 'loading' });
   const [reloadToken, setReloadToken] = useState(0);
 
-  useEffect(() => {
-    let live = true;
-    const read = () =>
+  usePoll(
+    (signal) =>
       Promise.all([
         command('listApps', {}),
         command('listBuilds', { limit: 12 }),
         command('listAllDeploys', { limit: 12 }),
         command('listTargets', {}),
-      ]).then(([apps, builds, deploys, targets]) => {
-        if (!live) return;
-        if (!apps.ok) {
-          setState({ type: 'error', message: apps.failure.message });
-          return;
-        }
-        if (!builds.ok) {
-          setState({ type: 'error', message: builds.failure.message });
-          return;
-        }
-        if (!deploys.ok) {
-          setState({ type: 'error', message: deploys.failure.message });
-          return;
-        }
-        if (!targets.ok) {
-          setState({ type: 'error', message: targets.failure.message });
-          return;
-        }
-        setState({
-          type: 'success',
-          apps: apps.value.apps,
-          builds: builds.value.builds,
-          deploys: deploys.value.deploys,
-          targets: targets.value.targets,
-          buildsHasMore: builds.value.nextBefore !== null,
-          deploysHasMore: deploys.value.nextBefore !== null,
-        });
-      });
-    const fail = (cause: unknown) => {
-      if (!live) return;
-      setState({
-        type: 'error',
-        message: cause instanceof Error ? cause.message : 'Server failure',
-      });
-    };
-    void read().catch(fail);
-    const refresh = setInterval(() => void read().catch(fail), 15_000);
-    return () => {
-      live = false;
-      clearInterval(refresh);
-    };
-  }, [reloadToken]);
+      ])
+        .then(([apps, builds, deploys, targets]) => {
+          if (signal.aborted) return;
+          if (!apps.ok) {
+            setState({ type: 'error', message: apps.failure.message });
+            return;
+          }
+          if (!builds.ok) {
+            setState({ type: 'error', message: builds.failure.message });
+            return;
+          }
+          if (!deploys.ok) {
+            setState({ type: 'error', message: deploys.failure.message });
+            return;
+          }
+          if (!targets.ok) {
+            setState({ type: 'error', message: targets.failure.message });
+            return;
+          }
+          setState({
+            type: 'success',
+            apps: apps.value.apps,
+            builds: builds.value.builds,
+            deploys: deploys.value.deploys,
+            targets: targets.value.targets,
+            buildsHasMore: builds.value.nextBefore !== null,
+            deploysHasMore: deploys.value.nextBefore !== null,
+          });
+        })
+        .catch((cause: unknown) => {
+          if (signal.aborted) return;
+          setState((current) => failedRead(current, serverFailure(cause)));
+        }),
+    15_000,
+    [reloadToken],
+  );
 
   if (state.type === 'loading') return <OverviewSkeleton />;
   if (state.type === 'error') {
@@ -641,44 +663,36 @@ function BuildsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
   const [olderError, setOlderError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
-  useEffect(() => {
-    let live = true;
-    const readNewest = () =>
-      command('listBuilds', {}).then((result) => {
-        if (!live) return;
-        if (!result.ok) {
-          setState({ type: 'error', message: result.failure.message });
-          return;
-        }
-        setState((current) =>
-          current.type === 'success'
-            ? {
-                type: 'success',
-                builds: mergeLedger(result.value.builds, current.builds),
-                nextBefore: current.nextBefore,
-              }
-            : {
-                type: 'success',
-                builds: result.value.builds,
-                nextBefore: result.value.nextBefore,
-              },
-        );
-      });
-    const fail = (cause: unknown) => {
-      if (live) {
-        setState({
-          type: 'error',
-          message: cause instanceof Error ? cause.message : 'Server failure',
-        });
-      }
-    };
-    void readNewest().catch(fail);
-    const refresh = setInterval(() => void readNewest().catch(fail), 15_000);
-    return () => {
-      live = false;
-      clearInterval(refresh);
-    };
-  }, [reloadToken]);
+  usePoll(
+    (signal) =>
+      command('listBuilds', {})
+        .then((result) => {
+          if (signal.aborted) return;
+          if (!result.ok) {
+            setState({ type: 'error', message: result.failure.message });
+            return;
+          }
+          setState((current) =>
+            current.type === 'success'
+              ? {
+                  type: 'success',
+                  builds: mergeLedger(result.value.builds, current.builds),
+                  nextBefore: current.nextBefore,
+                }
+              : {
+                  type: 'success',
+                  builds: result.value.builds,
+                  nextBefore: result.value.nextBefore,
+                },
+          );
+        })
+        .catch((cause: unknown) => {
+          if (signal.aborted) return;
+          setState((current) => failedRead(current, serverFailure(cause)));
+        }),
+    15_000,
+    [reloadToken],
+  );
 
   const loadOlder = async () => {
     if (state.type !== 'success' || state.nextBefore === null) return;
@@ -746,44 +760,36 @@ function DeploysScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
   const [olderError, setOlderError] = useState<string | null>(null);
   const [reloadToken, setReloadToken] = useState(0);
 
-  useEffect(() => {
-    let live = true;
-    const readNewest = () =>
-      command('listAllDeploys', {}).then((result) => {
-        if (!live) return;
-        if (!result.ok) {
-          setState({ type: 'error', message: result.failure.message });
-          return;
-        }
-        setState((current) =>
-          current.type === 'success'
-            ? {
-                type: 'success',
-                deploys: mergeLedger(result.value.deploys, current.deploys),
-                nextBefore: current.nextBefore,
-              }
-            : {
-                type: 'success',
-                deploys: result.value.deploys,
-                nextBefore: result.value.nextBefore,
-              },
-        );
-      });
-    const fail = (cause: unknown) => {
-      if (live) {
-        setState({
-          type: 'error',
-          message: cause instanceof Error ? cause.message : 'Server failure',
-        });
-      }
-    };
-    void readNewest().catch(fail);
-    const refresh = setInterval(() => void readNewest().catch(fail), 15_000);
-    return () => {
-      live = false;
-      clearInterval(refresh);
-    };
-  }, [reloadToken]);
+  usePoll(
+    (signal) =>
+      command('listAllDeploys', {})
+        .then((result) => {
+          if (signal.aborted) return;
+          if (!result.ok) {
+            setState({ type: 'error', message: result.failure.message });
+            return;
+          }
+          setState((current) =>
+            current.type === 'success'
+              ? {
+                  type: 'success',
+                  deploys: mergeLedger(result.value.deploys, current.deploys),
+                  nextBefore: current.nextBefore,
+                }
+              : {
+                  type: 'success',
+                  deploys: result.value.deploys,
+                  nextBefore: result.value.nextBefore,
+                },
+          );
+        })
+        .catch((cause: unknown) => {
+          if (signal.aborted) return;
+          setState((current) => failedRead(current, serverFailure(cause)));
+        }),
+    15_000,
+    [reloadToken],
+  );
 
   const loadOlder = async () => {
     if (state.type !== 'success' || state.nextBefore === null) return;
@@ -1035,29 +1041,6 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
     notify({ tone: 'success', title: `Deleted ${name}` });
   });
 
-  useEffect(() => {
-    let live = true;
-    command('listApps', {})
-      .then((result) => {
-        if (!live) return;
-        if (result.ok) {
-          setState({ type: 'success', apps: result.value.apps });
-        } else {
-          setState({ type: 'error', message: result.failure.message });
-        }
-      })
-      .catch((e: unknown) => {
-        if (!live) return;
-        setState({
-          type: 'error',
-          message: e instanceof Error ? e.message : 'Server failure',
-        });
-      });
-    return () => {
-      live = false;
-    };
-  }, [reloadToken]);
-
   /**
    * Keep the list current, at the two cadences the workspace already uses.
    *
@@ -1066,30 +1049,27 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
    * dot the explorer pulses forever, which reads as "still moving" about a
    * release that finished minutes ago. The workspace worked this out already;
    * this is the same argument for the screen an operator watches a fleet from.
-   *
-   * A failed refresh is dropped rather than replacing a readable list with an
-   * error page. The next tick tries again.
    */
   const inFlight =
     state.type === 'success' && state.apps.some((app) => isInFlight(app.phase));
-  useEffect(() => {
-    let live = true;
-    const timer = setInterval(
-      () => {
-        void command('listApps', {})
-          .then((result) => {
-            if (!live || !result.ok) return;
-            setState({ type: 'success', apps: result.value.apps });
-          })
-          .catch(() => {});
-      },
-      inFlight ? 3_000 : 20_000,
-    );
-    return () => {
-      live = false;
-      clearInterval(timer);
-    };
-  }, [inFlight]);
+  usePoll(
+    (signal) =>
+      command('listApps', {})
+        .then((result) => {
+          if (signal.aborted) return;
+          if (!result.ok) {
+            setState({ type: 'error', message: result.failure.message });
+            return;
+          }
+          setState({ type: 'success', apps: result.value.apps });
+        })
+        .catch((cause: unknown) => {
+          if (signal.aborted) return;
+          setState((current) => failedRead(current, serverFailure(cause)));
+        }),
+    inFlight ? 3_000 : 20_000,
+    [reloadToken],
+  );
 
   if (state.type === 'loading') return <LedgerSkeleton width="reading" />;
 
@@ -1113,16 +1093,37 @@ function AppsScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
 }
 
 /**
- * A refreshed workspace, keeping the log lines the socket has accumulated.
+ * A refreshed workspace, keeping what the socket knows and the read does not.
  *
- * A read carries only the server's first page of a runtime tail — every line
- * after it arrived over a socket and lives in this screen's state — so taking
- * `runtime` wholesale would wipe the log on every refresh.
+ * Two things, for one reason: `getAppWorkspace` never asks the adapter. It
+ * answers `stream` for any placed Component and hands back an empty first page,
+ * because tailing at read time is the socket's whole job — so on both counts
+ * the read is the weaker source about the same pair, and taking `runtime`
+ * wholesale lets it win every tick.
  *
- * The lines are kept only where both reads are about the same Component on the
+ * The lines are the obvious half: every line after the first arrived over the
+ * socket and lives in this screen's state, so a refresh that took `runtime`
+ * whole would wipe the log every few seconds.
+ *
+ * A `none` is the other. It is the answer for a Component that is placed and
+ * not running — no pods, a Target that runs nothing — and it can only come from
+ * the socket, so a refresh used to put `stream` back and the effect resubscribe
+ * to be told `none` again. The card swapped its title and its body, from the
+ * reason to an empty log and back, for as long as the screen was open.
+ *
+ * Both are kept only where the two reads are about the same Component on the
  * same Target. The selection can move while a refresh is in flight, and a
  * Component's output rendered under another Component's name is a worse answer
- * than the empty card the next socket page fills.
+ * than the empty card the next socket page fills. A `none` is held to more than
+ * that — the release has to be the same one, in the same phase — because it is
+ * a claim about what is running, and a Deploy is what changes that.
+ *
+ * ponytail: a runtime that recovers without moving either — pods coming back on
+ * a release that stayed LIVE — keeps saying `none` until the selection changes
+ * or the page is re-opened. Closing that means the pane subscribing on the
+ * Component and Target it is about rather than on the read's own answer to the
+ * question the socket exists to answer, and the server holding the socket open
+ * through a `none` instead of closing it.
  *
  * Exported for `test/web/workspace-refresh.test.ts`: this is where the
  * selection and the socket meet, and reaching it through the mounted screen
@@ -1132,6 +1133,18 @@ export function refreshedWorkspace(
   current: WorkspaceView,
   fresh: WorkspaceView,
 ): WorkspaceView {
+  const sameSubject =
+    current.componentId === fresh.componentId &&
+    current.targetId === fresh.targetId;
+  if (
+    sameSubject &&
+    current.runtime.kind === 'none' &&
+    fresh.runtime.kind === 'stream' &&
+    current.latestDeployId === fresh.latestDeployId &&
+    current.phase === fresh.phase
+  ) {
+    return { ...fresh, runtime: current.runtime };
+  }
   const accumulated = current.runtime;
   if (
     accumulated.kind !== 'stream' ||
@@ -1298,38 +1311,9 @@ function WorkspaceScreen({
   const deletion = useAppDeletion(() => onNavigate('/apps'));
 
   useEffect(() => {
-    let live = true;
-    if (!appName) {
+    if (!appName)
       setState({ type: 'not-found', message: 'No App name provided' });
-      return;
-    }
-    command('getAppWorkspace', {
-      name: appName,
-      ...(component === null ? {} : { component }),
-    })
-      .then((result) => {
-        if (!live) return;
-        if (result.ok) {
-          setState({ type: 'success', workspace: result.value.workspace });
-        } else {
-          if (result.failure.code === 'NOT_FOUND') {
-            setState({ type: 'not-found', message: result.failure.message });
-          } else {
-            setState({ type: 'error', message: result.failure.message });
-          }
-        }
-      })
-      .catch((e: unknown) => {
-        if (!live) return;
-        setState({
-          type: 'error',
-          message: e instanceof Error ? e.message : 'Server failure',
-        });
-      });
-    return () => {
-      live = false;
-    };
-  }, [appName, component, reloadToken]);
+  }, [appName]);
 
   // Once, on mount. Connecting a Target happens on another screen, and a move
   // does not change what Targets exist — so this list has nothing to re-read
@@ -1362,46 +1346,48 @@ function WorkspaceScreen({
    * Two cadences for the same reason the reconciler has two: while a release is
    * in flight the reader is watching, and once it settles the read is only
    * catching acts from elsewhere.
+   *
+   * The selection is named on every read, or it would put the App's first
+   * Component back on screen every few seconds — and `signal.aborted` is what
+   * drops the response still in flight when the selection moves, which is about
+   * a Component this screen has left.
    */
   const inFlight =
     state.type === 'success' && isInFlight(state.workspace.phase);
-  useEffect(() => {
-    if (!appName) return;
-    // Dropped by the cleanup, the same way the read above drops its own: the
-    // interval is re-armed whenever the selection moves, so a response still in
-    // flight across that press is about a Component this screen has left, and
-    // writing it would put that Component back on screen until the next tick.
-    let live = true;
-    const timer = setInterval(
-      () => {
-        // With the selection, or the refresh would put the App's first
-        // Component back on screen every few seconds.
-        void command('getAppWorkspace', {
-          name: appName,
-          ...(component === null ? {} : { component }),
+  usePoll(
+    (signal) => {
+      if (!appName) return Promise.resolve();
+      return command('getAppWorkspace', {
+        name: appName,
+        ...(component === null ? {} : { component }),
+      })
+        .then((result) => {
+          if (signal.aborted) return;
+          if (!result.ok) {
+            setState(
+              result.failure.code === 'NOT_FOUND'
+                ? { type: 'not-found', message: result.failure.message }
+                : { type: 'error', message: result.failure.message },
+            );
+            return;
+          }
+          const fresh = result.value.workspace;
+          setState((current) => ({
+            type: 'success',
+            workspace:
+              current.type === 'success'
+                ? refreshedWorkspace(current.workspace, fresh)
+                : fresh,
+          }));
         })
-          .then((result) => {
-            if (!live || !result.ok) return;
-            const fresh = result.value.workspace;
-            setState((current) => ({
-              type: 'success',
-              workspace:
-                current.type === 'success'
-                  ? refreshedWorkspace(current.workspace, fresh)
-                  : fresh,
-            }));
-          })
-          // A failed refresh is not a reason to replace a workspace that is on
-          // screen and readable with an error page. The next tick tries again.
-          .catch(() => {});
-      },
-      inFlight ? 2_000 : 20_000,
-    );
-    return () => {
-      live = false;
-      clearInterval(timer);
-    };
-  }, [appName, component, inFlight]);
+        .catch((cause: unknown) => {
+          if (signal.aborted) return;
+          setState((current) => failedRead(current, serverFailure(cause)));
+        });
+    },
+    inFlight ? 2_000 : 20_000,
+    [appName, component, reloadToken],
+  );
 
   const runtime =
     state.type === 'success' && state.workspace.runtime.kind === 'stream'

--- a/apps/spindrift/src/web/poll.ts
+++ b/apps/spindrift/src/web/poll.ts
@@ -1,0 +1,101 @@
+/**
+ * The one cadence every screen re-reads on.
+ *
+ * Four screens each had their own `setInterval` around a `command()` call, and
+ * an interval is the wrong primitive for a network read twice over. It fires
+ * whether or not the last read came back, so the workspace's two-second
+ * in-flight cadence stacked requests behind each other the moment a read took
+ * longer than the gap — and the pile never drains, because every tick adds to
+ * it. And it keeps firing in a hidden tab, so an App page left open in a window
+ * nobody is looking at polls the installation every two seconds all day.
+ *
+ * A chain fixes both: the next read is scheduled from the end of the last one,
+ * so exactly one is ever outstanding, and a tick that comes due while the
+ * document is hidden re-arms without reading. Becoming visible reads at once
+ * rather than waiting out the remaining delay — the first thing someone
+ * returning to a tab wants is what it says now.
+ *
+ * The first read is immediate, which is what let each of those screens drop the
+ * separate mount effect that used to sit beside its interval. That pair was two
+ * reads of the same thing written twice, and they had drifted: on three of the
+ * four, a refusal on the mount read replaced the screen and the identical
+ * refusal on a tick was dropped. One read means one answer to that, and the
+ * callers state it once — keep what is on screen if it is readable, and only
+ * show a refusal to someone who has nothing.
+ *
+ * `deps` is the caller's own, and it means what it means in `useEffect`: the
+ * chain is torn down and read again from the start when they change.
+ *
+ * `read` is handed the chain's `AbortSignal` rather than a bespoke `live`
+ * boolean. Nothing here cancels the request — `command()` does not take one —
+ * but `signal.aborted` is the check a caller needs before it writes, and it is
+ * load-bearing for the workspace, whose read is about the selected Component: a
+ * response still in flight when the selection moves belongs to a Component the
+ * screen has left, and writing it would put that Component back on screen until
+ * the next tick.
+ */
+import { useEffect } from 'react';
+
+/** Whether reading right now would be a request nobody is looking at. */
+function hidden(): boolean {
+  return document.visibilityState === 'hidden';
+}
+
+export function usePoll(
+  read: (signal: AbortSignal) => Promise<unknown>,
+  ms: number,
+  deps: readonly unknown[] = [],
+): void {
+  useEffect(() => {
+    const controller = new AbortController();
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let reading = false;
+
+    const arm = () => {
+      if (controller.signal.aborted || timer !== null) return;
+      timer = setTimeout(() => {
+        timer = null;
+        tick();
+      }, ms);
+    };
+
+    const tick = () => {
+      if (controller.signal.aborted || reading) return;
+      // Re-armed rather than dropped: the cadence keeps its place, so a tab
+      // shown again mid-interval is at most one delay from current, and this
+      // costs a timer instead of a request.
+      if (hidden()) {
+        arm();
+        return;
+      }
+      reading = true;
+      // A failed read is the caller's to report or ignore — each of them
+      // decides — and the chain continues either way, because a screen that
+      // stops refreshing after one bad response is the failure the cadence
+      // exists to prevent.
+      void read(controller.signal)
+        .catch(() => {})
+        .finally(() => {
+          reading = false;
+          arm();
+        });
+    };
+
+    const onVisibility = () => {
+      if (hidden()) return;
+      if (timer !== null) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      tick();
+    };
+
+    tick();
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      controller.abort();
+      if (timer !== null) clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
+  }, [ms, ...deps]);
+}

--- a/apps/spindrift/src/web/stream-client.ts
+++ b/apps/spindrift/src/web/stream-client.ts
@@ -20,6 +20,17 @@
  * {@link reportSessionExpired}; every other case backs off and keeps trying,
  * which is also what turns the retry from a flat interval into one that
  * actually eases off rather than hammering a link that is not coming back.
+ *
+ * Not every close is a drop, though, and treating them alike is what made the
+ * banner strobe. `streams.ts`'s `pump` ends the socket itself after a `none` or
+ * an `error` page, so a runtime tail with nothing to tail used to settle on the
+ * message, drop, mark, reconnect, and settle again every few hundred
+ * milliseconds — the backoff never engaged, because a frame had arrived. Two
+ * rules keep that apart from a network blip: only a `stream` page is evidence
+ * the socket is healthy, so only that one resets the count, and `none` is an
+ * answer rather than a drop, so it ends the subscription instead of re-asking.
+ * The banner itself waits for the second consecutive drop — a reconnect that
+ * lands inside one backoff is not worth telling anyone about.
  */
 import { readSession } from './auth-client.ts';
 import { markReconnecting, markSettled } from './connection-status.ts';
@@ -87,7 +98,10 @@ function scheduleReconnect(params: {
   readonly setRetry: (handle: ReturnType<typeof setTimeout>) => void;
 }): void {
   const { id, options, attempt, reconnect, giveUp, setRetry } = params;
-  markReconnecting(id);
+  // From the second consecutive drop, not the first: one drop that reconnects
+  // inside its own backoff is a blip, and a banner that appears and clears
+  // within half a second is noise standing where information should be.
+  if (attempt > 1) markReconnecting(id);
   const delay = backoff(attempt, options.retryMs ?? 500);
   if (attempt < CONSECUTIVE_DROPS_BEFORE_SESSION_CHECK) {
     setRetry(setTimeout(reconnect, delay));
@@ -198,9 +212,21 @@ export function subscribeRuntime(
     socket = createSocket(streamUrl(`${RUNTIME_STREAM_PATH}?${query}`));
     socket.onmessage = (event) => {
       const message = JSON.parse(event.data) as RuntimeStreamMessage;
-      if (message.kind === 'stream') cursor = message.cursor;
-      attempts = 0;
-      markSettled(id);
+      // Only a page of output says the socket is working. `pump` closes after
+      // either of the other two, so resetting the count on those is what kept
+      // a closed-on-purpose stream reconnecting at full speed forever.
+      if (message.kind === 'stream') {
+        cursor = message.cursor;
+        attempts = 0;
+        markSettled(id);
+      }
+      // Nothing runs on that Target and the frame says why. Re-asking cannot
+      // change the answer within this socket's lifetime; the screen's own
+      // re-read is what notices when it does.
+      if (message.kind === 'none') {
+        stopped = true;
+        markSettled(id);
+      }
       onMessage(message);
     };
     socket.onerror = () => socket?.close();

--- a/apps/spindrift/test/web/poll.test.tsx
+++ b/apps/spindrift/test/web/poll.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * The two things an interval got wrong, asserted against the chain that
+ * replaced it.
+ *
+ * `setInterval` fired whether or not the last read came back, so the
+ * workspace's two-second in-flight cadence stacked requests the moment a read
+ * took longer than the gap — and it fired in a hidden tab, so a page left open
+ * in another window polled the installation all day. Neither is visible from a
+ * screen: both are about *when* a read is issued, which is why this drives the
+ * hook itself rather than reaching it through a mounted view.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { usePoll } from '../../src/web/poll.ts';
+import { type DomShim, installDomShim } from '../harness/dom.ts';
+
+let shim: DomShim;
+let root: Root;
+/** Set by a case that wants the document to report itself hidden. */
+let visibility: 'visible' | 'hidden' = 'visible';
+
+beforeEach(() => {
+  visibility = 'visible';
+  shim = installDomShim();
+  Object.defineProperty(shim.document, 'visibilityState', {
+    configurable: true,
+    get: () => visibility,
+  });
+  root = createRoot(shim.document.createElement('div') as never);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  shim.restore();
+});
+
+function Poller({ read, ms }: { read: () => Promise<unknown>; ms: number }) {
+  usePoll(read, ms);
+  return null;
+}
+
+describe('a read on a cadence', () => {
+  test('never has two outstanding at once', async () => {
+    let started = 0;
+    let release: (() => void) | null = null;
+    const read = () => {
+      started += 1;
+      return new Promise<void>((resolve) => {
+        release = resolve;
+      });
+    };
+
+    act(() => root.render(<Poller read={read} ms={1} />));
+    expect(started).toBe(1);
+
+    // Well past several intervals, with the first read still in flight. An
+    // interval would have issued one per tick and queued them behind this.
+    await act(async () => {
+      await Bun.sleep(20);
+    });
+    expect(started).toBe(1);
+
+    await act(async () => {
+      release?.();
+      await Bun.sleep(20);
+    });
+    expect(started).toBeGreaterThan(1);
+  });
+
+  test('does not read a tab nobody is looking at, and reads it on return', async () => {
+    let started = 0;
+    const read = () => {
+      started += 1;
+      return Promise.resolve();
+    };
+
+    visibility = 'hidden';
+    act(() => root.render(<Poller read={read} ms={1} />));
+    await act(async () => {
+      await Bun.sleep(20);
+    });
+    // The cadence kept its place — it is the request that is skipped, not the
+    // timer — so nothing was asked of the server for a screen nobody sees.
+    expect(started).toBe(0);
+
+    visibility = 'visible';
+    await act(async () => {
+      await Bun.sleep(20);
+    });
+    expect(started).toBeGreaterThan(0);
+  });
+
+  test('a read that throws does not end the chain', async () => {
+    let started = 0;
+    const read = () => {
+      started += 1;
+      return Promise.reject(new Error('the link went away'));
+    };
+
+    act(() => root.render(<Poller read={read} ms={1} />));
+    await act(async () => {
+      await Bun.sleep(20);
+    });
+    // A screen that stops refreshing after one bad response is the failure the
+    // cadence exists to prevent.
+    expect(started).toBeGreaterThan(2);
+  });
+
+  test('stops on unmount', async () => {
+    let started = 0;
+    const read = () => {
+      started += 1;
+      return Promise.resolve();
+    };
+
+    act(() => root.render(<Poller read={read} ms={1} />));
+    await act(async () => {
+      await Bun.sleep(10);
+    });
+    act(() => root.render(null));
+    const settled = started;
+    await act(async () => {
+      await Bun.sleep(20);
+    });
+    expect(started).toBe(settled);
+  });
+});

--- a/apps/spindrift/test/web/stream-client.test.ts
+++ b/apps/spindrift/test/web/stream-client.test.ts
@@ -50,14 +50,22 @@ describe('resumable browser stream', () => {
       terminal: false,
     });
     sockets[0]!.drop();
-    // A drop marks the shared "any stream is retrying" flag `shell.tsx`
-    // reads through `connection-status.ts` — before the reconnect resolves,
-    // not after, since that is the window a banner exists to cover.
-    expect(isReconnecting()).toBe(true);
+    // Not on the first drop: a reconnect that lands inside one backoff is a
+    // blip, and a banner that appears and clears within it is noise.
+    expect(isReconnecting()).toBe(false);
     await Bun.sleep(1);
     expect(urls[1]).toContain('after=41');
 
-    sockets[1]!.message({
+    // The second consecutive drop is what marks the shared "any stream is
+    // retrying" flag `shell.tsx` reads through `connection-status.ts` — before
+    // the reconnect resolves, not after, since that is the window a banner
+    // exists to cover.
+    sockets[1]!.drop();
+    expect(isReconnecting()).toBe(true);
+    await Bun.sleep(1);
+    expect(urls[2]).toContain('after=41');
+
+    sockets[2]!.message({
       kind: 'attempt',
       entries: [],
       cursor: 42,
@@ -66,9 +74,9 @@ describe('resumable browser stream', () => {
     // A message is what clears it — a reconnect that opened but has not yet
     // heard back is not yet "connected" again.
     expect(isReconnecting()).toBe(false);
-    sockets[1]!.drop();
+    sockets[2]!.drop();
     await Bun.sleep(1);
-    expect(urls).toHaveLength(2);
+    expect(urls).toHaveLength(3);
     expect(messages).toHaveLength(2);
     stop();
   });
@@ -107,6 +115,77 @@ describe('resumable browser stream', () => {
     });
     expect(urls[1]).toContain('after=opaque');
     stop();
+  });
+
+  test('a socket the server closed on purpose is not retried as a drop', async () => {
+    const urls: string[] = [];
+    const sockets: FakeSocket[] = [];
+    const messages: unknown[] = [];
+    const stop = subscribeRuntime(
+      { componentId: 'component', targetId: 'target' },
+      (message) => messages.push(message),
+      {
+        createSocket: (url) => {
+          urls.push(url);
+          const socket = new FakeSocket();
+          sockets.push(socket);
+          return socket;
+        },
+        retryMs: 0,
+      },
+    );
+
+    // What `pump` does when the adapter has nothing to tail: send the reason,
+    // then close. Reconnecting re-asks a question the frame already answered,
+    // and the workspace's own re-read is what notices if it changes.
+    sockets[0]!.message({
+      kind: 'none',
+      because: 'Nothing runs on that Target',
+    });
+    sockets[0]!.drop();
+    await Bun.sleep(1);
+
+    expect(urls).toHaveLength(1);
+    expect(messages).toEqual([
+      { kind: 'none', because: 'Nothing runs on that Target' },
+    ]);
+    expect(isReconnecting()).toBe(false);
+    stop();
+  });
+
+  test('an error frame does not reset the backoff it just earned', async () => {
+    const sockets: FakeSocket[] = [];
+    let opened = 0;
+    const stop = subscribeRuntime(
+      { componentId: 'component', targetId: 'target' },
+      () => {},
+      {
+        createSocket: () => {
+          opened += 1;
+          const socket = new FakeSocket();
+          sockets.push(socket);
+          return socket;
+        },
+        retryMs: 0,
+        checkSession: async () => true,
+      },
+    );
+
+    // A stream that fails to read, closes, reconnects, and fails again is the
+    // shape that used to strobe: every frame reset the count, so the socket
+    // reopened at full speed forever and the banner marked and settled with
+    // it. Only a `stream` page counts as reaching the server, so this run of
+    // three reaches the session check rather than looping under it.
+    for (let i = 0; i < 3; i++) {
+      sockets.at(-1)!.message({ kind: 'error', message: 'read failed' });
+      sockets.at(-1)!.drop();
+      await Bun.sleep(1);
+    }
+
+    expect(opened).toBe(4);
+    expect(isReconnecting()).toBe(true);
+    stop();
+    expect(isReconnecting()).toBe(false);
   });
 });
 

--- a/apps/spindrift/test/web/workspace-refresh.test.ts
+++ b/apps/spindrift/test/web/workspace-refresh.test.ts
@@ -85,4 +85,41 @@ describe('refreshing the App workspace', () => {
 
     expect(refreshedWorkspace(SERVICE, job)).toEqual(job);
   });
+
+  test('keeps the socket’s "nothing is running" over the read that cannot tell', () => {
+    // `getAppWorkspace` answers `stream` for any placed Component without
+    // asking the adapter, so this is the disagreement on every tick for a
+    // Component that is placed and not running. Letting the read win put the
+    // card back to an empty log until the socket said `none` again — a title
+    // and a body that swapped every twenty seconds for as long as the screen
+    // was open.
+    const silent: WorkspaceView = {
+      ...SERVICE,
+      runtime: { kind: 'none', because: 'No replicas are running.' },
+    };
+
+    const merged = refreshedWorkspace(silent, firstPage(SERVICE));
+
+    expect(merged.runtime).toEqual({
+      kind: 'none',
+      because: 'No replicas are running.',
+    });
+  });
+
+  test('lets the read win once the release has moved', () => {
+    // A Deploy is the thing that changes what is running, so it is what makes
+    // the socket's last answer stale rather than more current than the read.
+    const silent: WorkspaceView = {
+      ...SERVICE,
+      runtime: { kind: 'none', because: 'No replicas are running.' },
+    };
+    const redeployed = firstPage({
+      ...SERVICE,
+      latestDeployId: (SERVICE.latestDeployId ?? 0) + 1,
+    });
+
+    const merged = refreshedWorkspace(silent, redeployed);
+
+    expect(merged.runtime.kind).toBe('stream');
+  });
 });


### PR DESCRIPTION
## Summary

`/apps/<id>` flashed **Disconnected, retrying…** on a loop. A socket the server closed *on purpose* was retried as though it had dropped.

`streams.ts`'s `pump` ends a runtime tail after a `none` or an `error` page, and `stream-client.ts` reset its backoff on any frame at all. So for a Component that is placed and not running: settle the banner on the message → mark it on the close → reopen at full speed. Every few hundred milliseconds, forever. The backoff never engaged, because a frame *had* arrived.

Three rules in `stream-client.ts` — the one file both streams route through — keep a deliberate close apart from a network blip:

- only a `stream` page is evidence the socket is healthy, so only that one resets the count;
- `none` is an answer, not a drop, so it ends the subscription instead of re-asking;
- the banner waits for the second consecutive drop, because a reconnect that lands inside one backoff is not worth telling anyone about.

**The card behind it strobed for the same reason one layer up.** `getAppWorkspace` answers `stream` for any placed Component without asking the adapter — tailing at read time is the socket's job — so the poll put `stream` back every tick and the effect resubscribed to be told `none` again, swapping the card's title and body every 20 seconds. `refreshedWorkspace` already exists to keep what the socket knows and the read does not; it now keeps the `none` too, until the release it is a claim about moves.

**And the polling underneath.** Four screens each hand-rolled a `setInterval` around a `command()`, which is wrong for a network read twice over: it fires whether or not the last read came back (the workspace's 2s in-flight cadence stacked requests the moment a read took longer than the gap, and the pile never drains), and it keeps firing in a hidden tab. `usePoll` schedules the next read from the end of the last one, skips a tick nobody is looking at, and reads on return.

Its single read also settles what each screen had been answering twice and differently — the mount read replaced the screen for any failure, the interval beside it dropped both. Per `client.ts`'s own line, a refusal is an answer the server gave and only a non-answer throws: refusals now render on the tick as much as at mount (so an App deleted from another window stops being shown as though it were still there), and only a throw leaves a readable screen alone.

## Validation

| | |
| --- | --- |
| `bun test` (spindrift) | 2335 pass, 0 fail |
| `mise run ts:check` | clean |

New coverage: `test/web/poll.test.tsx` (no two reads outstanding, no read while hidden, a throw does not end the chain, stops on unmount); `stream-client.test.ts` gains a deliberate-close case and one asserting an `error` frame does not reset the backoff it just earned; `workspace-refresh.test.ts` gains the socket-over-read case and its release-moved invalidation.

## Risk

One known ceiling, marked `ponytail:` at `refreshedWorkspace`: a runtime that recovers **without** its release moving — pods returning on a Deploy that stayed `LIVE` — keeps saying "no runtime" until the selection changes or the page is re-opened. That is a rare stale pane traded for a card that strobed every 20 seconds. Closing it properly means the pane subscribing on the Component and Target it is about rather than on the read's answer to the question the socket exists to answer, plus the server holding the socket open through a `none` — a separable change to that pane's data flow.