### PR TITLE
feat(spindrift): let spindrift.yaml name the zero-config build command

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -311,10 +311,76 @@ jobs:
           # on its own mount so the build context stays the source.
           plan="${RUNNER_TEMP}/railpack-plan"
           mkdir -p "$plan"
+          set -- prepare /scope --plan-out /out/railpack-plan.json
+
+          # §5's authority reaches the builder here, and this is the whole of
+          # what an operator has to know: they state the build command once, in
+          # Spindrift's own file, and never learn the builder's name. Read out
+          # of the tree rather than carried in the request because the plan has
+          # always been derived here — the request pins the frontend *image*,
+          # never the plan, exactly as the Dockerfile arm above reads the tree
+          # for its own decision. What is read is what Spindrift adopted: the
+          # bundle is staged at the App's authoritative commit, and
+          # `reconciler/repo-loop.ts` refuses to advance that past a commit
+          # whose `spindrift.yaml` will not parse, so the runner cannot honour
+          # a declaration core rejected.
+          #
+          # `select` on the frontend rather than reading `.command` outright: a
+          # scope declaring the dockerfile frontend has no railpack command to
+          # state, and `// ""` folds the schema's `command: null` onto the same
+          # "nothing declared" as an absent file. Both leave the invocation
+          # byte-identical to what it was before this block existed.
+          declaration="${scope}/spindrift.yaml"
+          build_command=""
+          if [ -f "$declaration" ]; then
+            build_command="$(
+              yq '.build | select(.frontend == "railpack") | .command // ""' \
+                "$declaration"
+            )"
+          fi
+
+          if [ -n "$build_command" ]; then
+            # A generated config file rather than `--build-cmd`, for one
+            # reason: railpack merges options *under* the config file
+            # (`Merge(optionsConfig, envConfig, fileConfig)`), so a stray
+            # `railpack.json` in the scope silently outranks the flag. That
+            # inverts the ownership this file exists to state. Pointing
+            # `--config-file` elsewhere is also what makes `railpack.json`
+            # unnecessary: railpack reads exactly one config file, and this is
+            # it. The flag hard-fails when the file is absent, which is why it
+            # is only ever passed inside this branch — a scope that declares
+            # nothing keeps its own `railpack.json` and builds as before.
+            #
+            # String form, never `{"cmd": …}`: a string becomes `sh -c '<cmd>'`
+            # and an object is handed to BuildKit's `llb.Shlex` argv-split, so
+            # an operator's `a && b` would pass `&&` as a literal argument.
+            # `jq --arg` is what makes any byte in that string — quotes,
+            # newlines, `$(…)` — a JSON value rather than syntax.
+            case "$build_command" in
+              *"'"*)
+                # railpack's own wrapper is `"sh -c '" + cmd + "'"` with no
+                # escaping, so a single quote silently re-splits the command
+                # instead of failing. Refused loudly here rather than shipped
+                # as a build that ran something else.
+                # ponytail: rejects rather than escapes; emit `'\''` for the
+                # quote if a real command ever needs one.
+                printf '::error::spindrift.yaml: build.command cannot contain a single quote\n' >&2
+                exit 1
+                ;;
+            esac
+            # Relative, and it has to be: railpack resolves the path under the
+            # app source (`filepath.Join(app.Source, configFileName)`), so an
+            # absolute `/out/...` becomes `/scope/out/...` and is not found.
+            # `../out` reaches the plan mount, which is already writable, so
+            # nothing is written into the source tree and the scope stays `:ro`.
+            jq -n --arg cmd "$build_command" '{steps:{build:{commands:[$cmd]}}}' \
+              > "${plan}/railpack-config.json"
+            set -- "$@" --config-file ../out/railpack-config.json
+          fi
+
           docker run --rm \
             -v "${scope}:/scope:ro" -v "${plan}:/out" \
-            --entrypoint /railpack "$FRONTEND" \
-            prepare /scope --plan-out /out/railpack-plan.json
+            --entrypoint /railpack "$FRONTEND" "$@"
 
           # `plan` names the same file as `file`, and is the only arm that sets
           # it. The step below reads the plan as JSON, which is true of this

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -316,11 +316,64 @@ jobs:
             --entrypoint /railpack "$FRONTEND" \
             prepare /scope --plan-out /out/railpack-plan.json
 
+          # `plan` names the same file as `file`, and is the only arm that sets
+          # it. The step below reads the plan as JSON, which is true of this
+          # arm's `file` and of neither other arm's Dockerfile, so it asks for
+          # the output that only exists when there is a plan rather than
+          # inferring the arm from one that happens to be empty elsewhere.
           {
             printf 'context=%s\n' "$scope"
             printf 'file=%s\n' "${plan}/railpack-plan.json"
+            printf 'plan=%s\n' "${plan}/railpack-plan.json"
             printf 'buildArgs=BUILDKIT_SYNTAX=%s\n' "$FRONTEND"
           } >> "$GITHUB_OUTPUT"
+
+      # The zero-config arm's silent failure: a Build that goes green having
+      # pushed an image nothing can start.
+      #
+      # railpack's Go provider emits `go build -ldflags="…" -o out` with **no
+      # package argument** whenever the module root holds any `.go` file, and
+      # pairs it with `startCommand: ./out`. When that root package is a library
+      # rather than `main` — the Functions Framework layout, where the root
+      # exports the handler and the only `package main` sits under `cmd/` — the
+      # command does not fail. `go build -o` against a non-main package writes
+      # the compiled *package archive* (ar, magic `!<arch>`) to `out` at mode
+      # 0644 and exits 0. Nothing downstream disagrees: the build, the push, the
+      # signature and the attestation all report success on an artifact whose
+      # declared start command cannot be executed by anyone, root included,
+      # because no execute bit is set. The first component to notice is the
+      # container, which dies `./out: Permission denied` — a CrashLoopBackOff
+      # whose Build says SUCCEEDED.
+      #
+      # Refused here for the reason the signing step below is ordered before the
+      # report: a green Build whose Deploy cannot run is the shape this sequence
+      # exists to avoid. The check is railpack's own postcondition, the one it
+      # states and never verifies — it chose the output name, it chose `./out`
+      # as the start command, so `out` has to be executable when the build step
+      # ends. Asserting it *inside the plan* keeps this free. `test -x` runs in
+      # a builder layer that is already running, so no image is pulled and no
+      # time is added to a build that was going to succeed; a build that was
+      # going to ship a broken image stops at the step that broke it.
+      #
+      # Only a bare `./path` start command is testable this way. Anything
+      # carrying arguments or naming an interpreter (`node server.js`, `npm
+      # start`) is not a file, and those shapes fail loudly at exec in any case.
+      # Silence belongs to the compiled one, which is the only one where a
+      # toolchain writes a non-executable and calls it a success.
+      - name: Make the plan check its own start command
+        if: steps.frontend.outputs.plan != ''
+        env:
+          PLAN: ${{ steps.frontend.outputs.plan }}
+        run: |
+          set -euo pipefail
+          jq '
+            (.deploy.startCommand // "") as $start
+            | if ($start | test("^\\./\\S+$"))
+              then (.steps[] | select(.name == "build") | .commands)
+                     += [{cmd: "test -x \($start)"}]
+              else . end
+          ' "$PLAN" > "${PLAN}.checked"
+          mv "${PLAN}.checked" "$PLAN"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -364,7 +364,11 @@ jobs:
                 # as a build that ran something else.
                 # ponytail: rejects rather than escapes; emit `'\''` for the
                 # quote if a real command ever needs one.
-                printf '::error::spindrift.yaml: build.command cannot contain a single quote\n' >&2
+                #
+                # On stdout, not stderr: Actions reads workflow commands from a
+                # step's stdout, and an annotation is the only part of this a
+                # reader sees without opening the log.
+                printf '::error::spindrift.yaml: build.command cannot contain a single quote\n'
                 exit 1
                 ;;
             esac

--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -366,11 +366,17 @@ jobs:
           PLAN: ${{ steps.frontend.outputs.plan }}
         run: |
           set -euo pipefail
+          # `customName` is what BuildKit prints for the layer, so the red build
+          # names the defect rather than making the operator infer it from a
+          # bare `test -x` and an exit code.
           jq '
             (.deploy.startCommand // "") as $start
             | if ($start | test("^\\./\\S+$"))
               then (.steps[] | select(.name == "build") | .commands)
-                     += [{cmd: "test -x \($start)"}]
+                     += [{
+                       cmd: "test -x \($start)",
+                       customName: "check the build produced an executable \($start)"
+                     }]
               else . end
           ' "$PLAN" > "${PLAN}.checked"
           mv "${PLAN}.checked" "$PLAN"

--- a/apps/spindrift/test/adapters/railpack-plan-guard.test.ts
+++ b/apps/spindrift/test/adapters/railpack-plan-guard.test.ts
@@ -1,0 +1,181 @@
+/**
+ * The zero-config arm's start-command guard, run as the workflow ships it.
+ *
+ * The failure it exists for was not a build error. railpack's Go provider emits
+ * `go build -o out` with no package argument, so a module whose root package is
+ * a library compiled to a 0644 *package archive* named `out` and exited 0 —
+ * green build, real push, signed, attested, and a container that could only say
+ * `./out: Permission denied`. A fixture cannot prove the shipped step turns
+ * that into a red build; running the step's own `run:` script over a plan
+ * railpack actually generates can (the same reasoning as
+ * `dockerfile-context-arm.test.ts`).
+ *
+ * The last case closes the loop: the command the step appends is executed
+ * against the artifact shape that shipped, and has to reject it.
+ */
+import { describe, expect, test } from 'bun:test';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const WORKFLOW = join(
+  import.meta.dir,
+  '../../../../.github/workflows/spindrift-build.yml',
+);
+const GUARD_STEP = 'Make the plan check its own start command';
+const FRONTEND_STEP = 'Choose the frontend';
+
+type WorkflowStep = {
+  name?: string;
+  if?: string;
+  run?: string;
+  env?: Record<string, string>;
+};
+
+/** The named step, straight out of the shipped file. */
+async function step(name: string): Promise<WorkflowStep> {
+  const document = Bun.YAML.parse(await Bun.file(WORKFLOW).text()) as {
+    jobs: { build: { steps: WorkflowStep[] } };
+  };
+  const found = document.jobs.build.steps.find((s) => s.name === name);
+  if (found === undefined) throw new Error(`${WORKFLOW} has no “${name}” step`);
+  return found;
+}
+
+type Plan = {
+  deploy: { startCommand?: string };
+  steps: { name: string; commands?: { cmd: string }[] }[];
+};
+
+/** The `run:` script of the guard step, straight out of the shipped file. */
+async function guardScript(): Promise<string> {
+  const run = (await step(GUARD_STEP)).run;
+  if (run === undefined) {
+    throw new Error(`${WORKFLOW} has no “${GUARD_STEP}” step with a script`);
+  }
+  return run;
+}
+
+/** Run the shipped guard over one plan and hand back what it wrote. */
+async function guard(plan: Plan): Promise<Plan> {
+  const workspace = await mkdtemp(join(tmpdir(), 'spindrift-plan-guard-'));
+  try {
+    const planPath = join(workspace, 'railpack-plan.json');
+    await writeFile(planPath, JSON.stringify(plan));
+    const proc = Bun.spawn(['bash', '-c', await guardScript()], {
+      env: { ...process.env, PLAN: planPath },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const code = await proc.exited;
+    if (code !== 0) {
+      throw new Error(
+        `the step exited ${code}: ${await new Response(proc.stderr).text()}`,
+      );
+    }
+    return JSON.parse(await readFile(planPath, 'utf8')) as Plan;
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+/** The commands of a plan's build step, as bare strings. */
+function buildCommands(plan: Plan): string[] {
+  const build = plan.steps.find((s) => s.name === 'build');
+  return (build?.commands ?? []).map((c) => c.cmd);
+}
+
+/**
+ * The plan `railpack prepare` v0.35.0 generates for `apps/view-counter`,
+ * verbatim in the parts this step reads — a library at the module root, so
+ * `go build` names no package and the start command is a bare `./out`.
+ */
+function viewCounterPlan(): Plan {
+  return {
+    deploy: { startCommand: './out' },
+    steps: [
+      { name: 'install', commands: [{ cmd: 'go mod download' }] },
+      {
+        name: 'build',
+        commands: [{ cmd: 'go build -ldflags="-w -s" -o out' }],
+      },
+    ],
+  };
+}
+
+describe('“Make the plan check its own start command”', () => {
+  test('a bare relative start command has to be executable when the build ends', async () => {
+    expect(buildCommands(await guard(viewCounterPlan()))).toEqual([
+      'go build -ldflags="-w -s" -o out',
+      'test -x ./out',
+    ]);
+  });
+
+  test('the check is appended, so it runs after the command that produces the file', async () => {
+    const commands = buildCommands(await guard(viewCounterPlan()));
+    expect(commands.at(-1)).toBe('test -x ./out');
+  });
+
+  test('a start command carrying arguments names no file and is left alone', async () => {
+    // `node server.js` is not a path to test, and an interpreter that cannot
+    // find its script fails loudly at exec. Only the compiled shape is silent.
+    const plan = viewCounterPlan();
+    plan.deploy.startCommand = 'node server.js';
+    expect(buildCommands(await guard(plan))).toEqual([
+      'go build -ldflags="-w -s" -o out',
+    ]);
+  });
+
+  test('a plan with no start command is left alone', async () => {
+    const plan = viewCounterPlan();
+    plan.deploy.startCommand = undefined;
+    expect(buildCommands(await guard(plan))).toEqual([
+      'go build -ldflags="-w -s" -o out',
+    ]);
+  });
+
+  test('a plan with no build step survives the step intact', async () => {
+    // Not every provider emits one, and the guard is not a reason to fail a
+    // build it has nothing to say about.
+    const plan = viewCounterPlan();
+    plan.steps = plan.steps.filter((s) => s.name !== 'build');
+    expect((await guard(plan)).steps.map((s) => s.name)).toEqual(['install']);
+  });
+
+  test('the guard runs on the arm that writes the plan it reads', async () => {
+    // A guard wired to an output nothing sets does not fail — it silently
+    // never runs, which is the same invisibility this whole step exists to
+    // remove. Only the zero-config arm writes `plan`; the other two hand the
+    // build a Dockerfile, which this step cannot read as JSON.
+    const guard = await step(GUARD_STEP);
+    expect(guard.if).toBe("steps.frontend.outputs.plan != ''");
+    expect(guard.env?.PLAN).toContain('steps.frontend.outputs.plan');
+    expect((await step(FRONTEND_STEP)).run).toContain("printf 'plan=%s\\n'");
+  });
+
+  test('the appended check rejects the package archive that shipped', async () => {
+    // The artifact Build 25 pushed: `go build -o` against a non-main package
+    // writes an ar archive at mode 0644. Executable to nobody, root included —
+    // Linux grants exec only when at least one execute bit is set.
+    const workspace = await mkdtemp(join(tmpdir(), 'spindrift-plan-guard-'));
+    try {
+      await writeFile(join(workspace, 'out'), '!<arch>\n__.PKGDEF', {
+        mode: 0o644,
+      });
+      const check = buildCommands(await guard(viewCounterPlan())).at(-1);
+      if (check === undefined) {
+        throw new Error('the step appended no check to run');
+      }
+      const rejected = Bun.spawn(['sh', '-c', check], { cwd: workspace });
+      expect(await rejected.exited).not.toBe(0);
+
+      // And accepts a real binary put where the start command points.
+      await writeFile(join(workspace, 'out'), '#!/bin/sh\nexit 0\n');
+      await chmod(join(workspace, 'out'), 0o755);
+      const accepted = Bun.spawn(['sh', '-c', check], { cwd: workspace });
+      expect(await accepted.exited).toBe(0);
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/spindrift/test/adapters/railpack-plan-guard.test.ts
+++ b/apps/spindrift/test/adapters/railpack-plan-guard.test.ts
@@ -44,7 +44,7 @@ async function step(name: string): Promise<WorkflowStep> {
 
 type Plan = {
   deploy: { startCommand?: string };
-  steps: { name: string; commands?: { cmd: string }[] }[];
+  steps: { name: string; commands?: { cmd: string; customName?: string }[] }[];
 };
 
 /** The `run:` script of the guard step, straight out of the shipped file. */
@@ -140,6 +140,18 @@ describe('“Make the plan check its own start command”', () => {
     const plan = viewCounterPlan();
     plan.steps = plan.steps.filter((s) => s.name !== 'build');
     expect((await guard(plan)).steps.map((s) => s.name)).toEqual(['install']);
+  });
+
+  test('the failing layer names the defect rather than showing a bare test', async () => {
+    // BuildKit prints `customName` as the layer, and this one only ever appears
+    // when it has just failed. `test -x ./out: exit code 1` on its own leaves
+    // the operator to work out what `out` was supposed to be.
+    const build = (await guard(viewCounterPlan())).steps.find(
+      (s) => s.name === 'build',
+    );
+    expect(build?.commands?.at(-1)?.customName).toBe(
+      'check the build produced an executable ./out',
+    );
   });
 
   test('the guard runs on the arm that writes the plan it reads', async () => {

--- a/apps/spindrift/test/adapters/spindrift-declaration-arm.test.ts
+++ b/apps/spindrift/test/adapters/spindrift-declaration-arm.test.ts
@@ -14,7 +14,14 @@
  * core never adopted, or drop one it did.
  */
 import { describe, expect, test } from 'bun:test';
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { parseSpindriftFile } from '../../src/domain/detection/spindrift-file.ts';
@@ -126,7 +133,9 @@ async function declared(document: string): Promise<{
   return {
     run,
     parsed:
-      proposal.build.frontend === 'railpack' ? proposal.build.buildCommand : null,
+      proposal.build.frontend === 'railpack'
+        ? proposal.build.buildCommand
+        : null,
   };
 }
 
@@ -173,7 +182,9 @@ describe('the zero-config arm of “Choose the frontend”', () => {
     // Not a fixture. If `apps/view-counter/spindrift.yaml` stops carrying the
     // command, the zero-config build goes back to compiling a package archive
     // and calling it a success — the defect this whole arm exists to refuse.
-    const { run, parsed } = await declared(await readFile(VIEW_COUNTER, 'utf8'));
+    const { run, parsed } = await declared(
+      await readFile(VIEW_COUNTER, 'utf8'),
+    );
     expect(run.code).toBe(0);
     expect(configuredCommand(run)).toBe('go build -o out ./cmd');
     expect(configuredCommand(run)).toBe(parsed);
@@ -226,7 +237,8 @@ describe('the zero-config arm of “Choose the frontend”', () => {
     // must be loud if it ever happens rather than silently building the shape
     // the operator wrote the file to correct.
     const run = await runArm({
-      [`${SUBPATH}/spindrift.yaml`]: 'build:\n  frontend: railpack\n   nope: [\n',
+      [`${SUBPATH}/spindrift.yaml`]:
+        'build:\n  frontend: railpack\n   nope: [\n',
     });
     expect(run.code).not.toBe(0);
     expect(run.dockerArgv).toEqual([]);
@@ -237,7 +249,7 @@ describe('the zero-config arm of “Choose the frontend”', () => {
     // syntax. `$(…)` has to arrive at the builder unexpanded and unevaluated:
     // this step runs on the runner, and nothing the declaration says may run
     // here.
-    const hostile = 'go build -o out ./cmd # "x" $(id) ${HOME}';
+    const hostile = 'go build -o out ./cmd # "x" $(id) `id` $HOME';
     // A YAML double-quoted scalar, which is what JSON.stringify produces.
     const { run, parsed } = await declared(RAILPACK(JSON.stringify(hostile)));
     expect(run.code).toBe(0);

--- a/apps/spindrift/test/adapters/spindrift-declaration-arm.test.ts
+++ b/apps/spindrift/test/adapters/spindrift-declaration-arm.test.ts
@@ -53,7 +53,8 @@ async function frontendScript(): Promise<string> {
 type ArmRun = {
   /** Exit status of the shipped step. */
   code: number;
-  stderr: string;
+  /** Everything the step said, on either stream. */
+  output: string;
   /** Every argument the step handed `docker`, one per element. */
   dockerArgv: string[];
   /** The generated railpack config, or null when the step wrote none. */
@@ -103,7 +104,9 @@ async function runArm(
       stderr: 'pipe',
     });
     const code = await proc.exited;
-    const stderr = await new Response(proc.stderr).text();
+    const output =
+      (await new Response(proc.stdout).text()) +
+      (await new Response(proc.stderr).text());
 
     const argv = await readFile(argvPath, 'utf8').catch(() => '');
     const configPath = join(workspace, 'railpack-plan', 'railpack-config.json');
@@ -113,7 +116,7 @@ async function runArm(
 
     return {
       code,
-      stderr,
+      output,
       // A trailing newline from `printf '%s\n'`, not an empty argument.
       dockerArgv: argv === '' ? [] : argv.replace(/\n$/, '').split('\n'),
       config,
@@ -287,7 +290,10 @@ describe('the zero-config arm of “Choose the frontend”', () => {
     // else. Red build, named reason.
     const { run } = await declared(RAILPACK("echo it's fine"));
     expect(run.code).not.toBe(0);
-    expect(run.stderr).toContain('single quote');
+    // An `::error::` annotation, on stdout, which is where Actions reads them.
+    expect(run.output).toContain(
+      '::error::spindrift.yaml: build.command cannot contain a single quote',
+    );
     expect(run.dockerArgv).toEqual([]);
   });
 });

--- a/apps/spindrift/test/adapters/spindrift-declaration-arm.test.ts
+++ b/apps/spindrift/test/adapters/spindrift-declaration-arm.test.ts
@@ -1,0 +1,281 @@
+/**
+ * The zero-config arm reading `spindrift.yaml`, run as the workflow ships it.
+ *
+ * §5's authority is only real if it reaches the builder, and the builder is
+ * reached by a `docker run` inside a shell script — so the assertion has to be
+ * about the argv that invocation receives and the file it points at, not about
+ * a TypeScript function standing in for either. The step's own `run:` is
+ * executed here against real trees with a recording `docker` on PATH (the same
+ * reasoning as `dockerfile-context-arm.test.ts`, which cannot reach this arm
+ * because it stops where docker starts).
+ *
+ * Two readers, one document: this shell reader and `parseSpindriftFile`. Every
+ * case below asserts they agree, so the runner cannot come to honour a command
+ * core never adopted, or drop one it did.
+ */
+import { describe, expect, test } from 'bun:test';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { parseSpindriftFile } from '../../src/domain/detection/spindrift-file.ts';
+
+const WORKFLOW = join(
+  import.meta.dir,
+  '../../../../.github/workflows/spindrift-build.yml',
+);
+const FRONTEND_STEP = 'Choose the frontend';
+const SUBPATH = 'apps/view-counter';
+/** The demo's own declaration, so this test fails if that file stops fixing it. */
+const VIEW_COUNTER = join(
+  import.meta.dir,
+  '../../../../apps/view-counter/spindrift.yaml',
+);
+
+/** The `run:` script of the named step, straight out of the shipped file. */
+async function frontendScript(): Promise<string> {
+  const document = Bun.YAML.parse(await Bun.file(WORKFLOW).text()) as {
+    jobs: { build: { steps: { name?: string; run?: string }[] } };
+  };
+  const step = document.jobs.build.steps.find((s) => s.name === FRONTEND_STEP);
+  if (step?.run === undefined) {
+    throw new Error(`${WORKFLOW} has no “${FRONTEND_STEP}” step with a script`);
+  }
+  return step.run;
+}
+
+type ArmRun = {
+  /** Exit status of the shipped step. */
+  code: number;
+  stderr: string;
+  /** Every argument the step handed `docker`, one per element. */
+  dockerArgv: string[];
+  /** The generated railpack config, or null when the step wrote none. */
+  config: unknown;
+};
+
+/**
+ * Run the shipped arm over one tree with a `docker` that records rather than
+ * runs, and hand back what the builder would have been given.
+ */
+async function runArm(
+  files: Readonly<Record<string, string>>,
+): Promise<ArmRun> {
+  const workspace = await mkdtemp(join(tmpdir(), 'spindrift-declaration-arm-'));
+  try {
+    const root = join(workspace, 'bundle');
+    for (const [name, contents] of Object.entries(files)) {
+      await mkdir(dirname(join(root, name)), { recursive: true });
+      await writeFile(join(root, name), contents);
+    }
+    await mkdir(join(root, SUBPATH), { recursive: true });
+
+    const argvPath = join(workspace, 'docker-argv');
+    const shim = join(workspace, 'bin');
+    await mkdir(shim, { recursive: true });
+    await writeFile(
+      join(shim, 'docker'),
+      `#!/usr/bin/env bash\nprintf '%s\\n' "$@" > ${JSON.stringify(argvPath)}\n`,
+    );
+    await chmod(join(shim, 'docker'), 0o755);
+
+    const outputPath = join(workspace, 'github-output');
+    await writeFile(outputPath, '');
+
+    const proc = Bun.spawn(['bash', '-c', await frontendScript()], {
+      env: {
+        ...process.env,
+        PATH: `${shim}:${process.env.PATH ?? ''}`,
+        ROOT: root,
+        SUBPATH,
+        FRONTEND: 'registry.example.test/zero-config:pinned',
+        ARTIFACT_TYPE: 'image',
+        GITHUB_OUTPUT: outputPath,
+        RUNNER_TEMP: workspace,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const code = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    const argv = await readFile(argvPath, 'utf8').catch(() => '');
+    const configPath = join(workspace, 'railpack-plan', 'railpack-config.json');
+    const config = await readFile(configPath, 'utf8')
+      .then((text) => JSON.parse(text) as unknown)
+      .catch(() => null);
+
+    return {
+      code,
+      stderr,
+      // A trailing newline from `printf '%s\n'`, not an empty argument.
+      dockerArgv: argv === '' ? [] : argv.replace(/\n$/, '').split('\n'),
+      config,
+    };
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+}
+
+/** What the shell reader made of a declaration, and what the parser did. */
+async function declared(document: string): Promise<{
+  run: ArmRun;
+  parsed: string | null;
+}> {
+  const run = await runArm({ [`${SUBPATH}/spindrift.yaml`]: document });
+  const proposal = parseSpindriftFile(document);
+  return {
+    run,
+    parsed:
+      proposal.build.frontend === 'railpack' ? proposal.build.buildCommand : null,
+  };
+}
+
+/** The command the generated config would give railpack, or null for none. */
+function configuredCommand(run: ArmRun): string | null {
+  if (run.config === null) return null;
+  const config = run.config as {
+    steps?: { build?: { commands?: unknown[] } };
+  };
+  const commands = config.steps?.build?.commands ?? [];
+  expect(commands).toHaveLength(1);
+  return commands[0] as string;
+}
+
+const RAILPACK = (command: string) =>
+  [
+    'version: 1',
+    'component:',
+    '  kind: service',
+    'build:',
+    '  frontend: railpack',
+    `  command: ${command}`,
+    '  outputDirectory: null',
+    'watchPaths:',
+    `  - ${SUBPATH}`,
+    '',
+  ].join('\n');
+
+describe('the zero-config arm of “Choose the frontend”', () => {
+  test('a declared command reaches railpack as a config file, in string form', async () => {
+    const { run, parsed } = await declared(RAILPACK('go build -o out ./cmd'));
+    expect(run.code).toBe(0);
+    // Relative on purpose: railpack joins the path under the app source, so
+    // `/out/...` would resolve to `/scope/out/...` and not be found.
+    expect(run.dockerArgv).toContain('--config-file');
+    expect(run.dockerArgv.at(-1)).toBe('../out/railpack-config.json');
+    // String, not `{cmd: …}`: BuildKit argv-splits the object form, so `a && b`
+    // would reach the builder as a literal argument to `a`.
+    expect(configuredCommand(run)).toBe('go build -o out ./cmd');
+    expect(configuredCommand(run)).toBe(parsed);
+  });
+
+  test('the demo App’s own declaration is the one that names its package', async () => {
+    // Not a fixture. If `apps/view-counter/spindrift.yaml` stops carrying the
+    // command, the zero-config build goes back to compiling a package archive
+    // and calling it a success — the defect this whole arm exists to refuse.
+    const { run, parsed } = await declared(await readFile(VIEW_COUNTER, 'utf8'));
+    expect(run.code).toBe(0);
+    expect(configuredCommand(run)).toBe('go build -o out ./cmd');
+    expect(configuredCommand(run)).toBe(parsed);
+  });
+
+  test('`command: null` builds exactly as it did before the declaration existed', async () => {
+    const { run, parsed } = await declared(RAILPACK('null'));
+    expect(parsed).toBeNull();
+    expect(run.code).toBe(0);
+    expect(run.dockerArgv).not.toContain('--config-file');
+    expect(run.config).toBeNull();
+    expect(run.dockerArgv.at(-1)).toBe('/out/railpack-plan.json');
+  });
+
+  test('no `spindrift.yaml` at all builds exactly as it did before', async () => {
+    // The path every App that has never been adopted takes. `--config-file`
+    // hard-fails when its file is absent, so passing it here would turn every
+    // one of those builds red.
+    const run = await runArm({});
+    expect(run.code).toBe(0);
+    expect(run.dockerArgv).not.toContain('--config-file');
+    expect(run.config).toBeNull();
+  });
+
+  test('a dockerfile declaration states no railpack command and is not read for one', async () => {
+    // This scope reaches railpack only because it has no Dockerfile to build
+    // — the arm above already took every scope that does. Reading `.command`
+    // without checking the frontend would honour a field this document does
+    // not have.
+    const document = [
+      'version: 1',
+      'component:',
+      '  kind: service',
+      'build:',
+      '  frontend: dockerfile',
+      '  file: Dockerfile.release',
+      'watchPaths:',
+      `  - ${SUBPATH}`,
+      '',
+    ].join('\n');
+    const { run, parsed } = await declared(document);
+    expect(parsed).toBeNull();
+    expect(run.code).toBe(0);
+    expect(run.dockerArgv).not.toContain('--config-file');
+  });
+
+  test('a malformed declaration fails the build rather than guessing', async () => {
+    // Core refuses to advance an App's authoritative commit past a file it
+    // could not parse, so this should be unreachable — which is exactly why it
+    // must be loud if it ever happens rather than silently building the shape
+    // the operator wrote the file to correct.
+    const run = await runArm({
+      [`${SUBPATH}/spindrift.yaml`]: 'build:\n  frontend: railpack\n   nope: [\n',
+    });
+    expect(run.code).not.toBe(0);
+    expect(run.dockerArgv).toEqual([]);
+  });
+
+  test('quotes, newlines and command substitution survive as data', async () => {
+    // `jq --arg` is what makes the operator's string a JSON value rather than
+    // syntax. `$(…)` has to arrive at the builder unexpanded and unevaluated:
+    // this step runs on the runner, and nothing the declaration says may run
+    // here.
+    const hostile = 'go build -o out ./cmd # "x" $(id) ${HOME}';
+    // A YAML double-quoted scalar, which is what JSON.stringify produces.
+    const { run, parsed } = await declared(RAILPACK(JSON.stringify(hostile)));
+    expect(run.code).toBe(0);
+    expect(parsed).toBe(hostile);
+    expect(configuredCommand(run)).toBe(hostile);
+  });
+
+  test('a multi-line command stays one command and forges no output line', async () => {
+    // The workflow's own outputs are `key=value` lines in a file this step
+    // appends to. A declaration that reached `$GITHUB_OUTPUT` could write any
+    // of them; this one never goes near it.
+    const document = [
+      'version: 1',
+      'component:',
+      '  kind: service',
+      'build:',
+      '  frontend: railpack',
+      '  command: |-',
+      '    go build -o out ./cmd',
+      '    context=/etc',
+      '  outputDirectory: null',
+      'watchPaths:',
+      `  - ${SUBPATH}`,
+      '',
+    ].join('\n');
+    const { run, parsed } = await declared(document);
+    expect(run.code).toBe(0);
+    expect(parsed).toBe('go build -o out ./cmd\ncontext=/etc');
+    expect(configuredCommand(run)).toBe(parsed);
+  });
+
+  test('a single quote is refused rather than silently re-split', async () => {
+    // railpack wraps a string command as `"sh -c '" + cmd + "'"` with no
+    // escaping, so `echo it's fine` becomes a command that runs something
+    // else. Red build, named reason.
+    const { run } = await declared(RAILPACK("echo it's fine"));
+    expect(run.code).not.toBe(0);
+    expect(run.stderr).toContain('single quote');
+    expect(run.dockerArgv).toEqual([]);
+  });
+});

--- a/apps/view-counter/README.md
+++ b/apps/view-counter/README.md
@@ -12,6 +12,11 @@ SVG image, so it can be embedded directly in a README or web page with an
   Framework as the `ViewCounter` HTTP entrypoint.
 - `cmd/` — a local entrypoint for running the function outside GCP.
 - `view_counter_test.go` — unit tests.
+- `railpack.json` — the build command Spindrift's zero-config route uses. The
+  module root is a library, and railpack's Go provider builds the root when it
+  finds `.go` files there, which compiles a package archive rather than a
+  program. This names `./cmd` so the build produces the binary its start
+  command expects.
 
 ## Deploy
 

--- a/apps/view-counter/README.md
+++ b/apps/view-counter/README.md
@@ -12,11 +12,10 @@ SVG image, so it can be embedded directly in a README or web page with an
   Framework as the `ViewCounter` HTTP entrypoint.
 - `cmd/` — a local entrypoint for running the function outside GCP.
 - `view_counter_test.go` — unit tests.
-- `railpack.json` — the build command Spindrift's zero-config route uses. The
-  module root is a library, and railpack's Go provider builds the root when it
-  finds `.go` files there, which compiles a package archive rather than a
-  program. This names `./cmd` so the build produces the binary its start
-  command expects.
+- `spindrift.yaml` — what Spindrift knows about this directory, including the
+  build command. The module root is a library, so a zero-config build compiles
+  a package archive rather than a program; the declared command names `./cmd`
+  so the build produces the binary its start command expects.
 
 ## Deploy
 

--- a/apps/view-counter/railpack.json
+++ b/apps/view-counter/railpack.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://schema.railpack.com",
+  "steps": {
+    "build": {
+      "commands": ["go build -buildvcs=false -o out ./cmd"]
+    }
+  }
+}

--- a/apps/view-counter/railpack.json
+++ b/apps/view-counter/railpack.json
@@ -1,8 +1,0 @@
-{
-  "$schema": "https://schema.railpack.com",
-  "steps": {
-    "build": {
-      "commands": ["go build -buildvcs=false -o out ./cmd"]
-    }
-  }
-}

--- a/apps/view-counter/spindrift.yaml
+++ b/apps/view-counter/spindrift.yaml
@@ -1,0 +1,21 @@
+# Managed by Spindrift, and yours to edit.
+#
+# This file is what Spindrift knows about this directory. Once it is on the
+# default branch it is authoritative: what is written here wins over what
+# detection would otherwise guess.
+#
+# `command` is here because detection guesses this one wrong, and quietly. The
+# module root is a library — the Functions Framework entrypoint — and the only
+# `package main` is under `cmd/`, so a zero-config `go build -o out` compiles a
+# *package archive* named `out` and exits 0. Naming the package is the whole
+# fix, and it is stated here rather than in a builder's own config file so the
+# builder stays something Spindrift chooses and not something this app knows.
+version: 1
+component:
+  kind: service
+build:
+  frontend: railpack
+  command: go build -o out ./cmd
+  outputDirectory: null
+watchPaths:
+  - apps/view-counter


### PR DESCRIPTION
`veeceetest/view-counter` built green (Build 25, 299s), pushed a real signed and
attested image, and deployed to offsite as CrashLoopBackOff with one line:

```
/bin/bash: line 1: ./out: Permission denied
```

`/app/out` is not a program and never was. It is a **Go package archive** — ar
format, `!<arch>\n__.PKGDEF` + `_go_.o` — 479432 bytes at mode **0644**. Not a
directory, not a stripped binary, not a missing `chmod`: setting the execute bit
just moves the failure to `ENOEXEC`, because the file has no ELF magic to run.

## Whose bug

railpack's, on an input the app was entitled to present, that Spindrift had no
gate to catch, and that Spindrift had no way to be told about. So the fix lands
in three places.

**railpack.** Its Go provider emits `go build -ldflags="…" -o out` with **no
package argument** whenever the module root holds any `.go` file, and pairs it
with `startCommand: ./out`. `apps/view-counter` is the Functions Framework
layout — the module root is `package view_counter`, a library, and the only
`package main` is `cmd/main.go` — so that command compiles the library.
`go build -o` against a non-main package does not error. It writes the package
archive to the named path at 0644 and exits 0.

**Spindrift, the gate.** Nothing between "build exits 0" and "deploy" asked
whether the thing the image is configured to run is a runnable file, so the
failure surfaced in the cluster instead of as a red build.

**Spindrift, the declaration.** `spindrift.yaml` has carried
`build.frontend: railpack` with a `command` since it existed, and nothing read
it. An operator could state the right build command and watch the wrong one run.

## Letting `spindrift.yaml` name the build command

The zero-config arm reads `${scope}/spindrift.yaml` out of the staged bundle.
Where it declares `frontend: railpack` with a non-null `command`, the arm
generates a railpack config beside the plan and points `--config-file` at it.
The operator states the build command once, in Spindrift's own file, and never
learns the builder's name — which is the whole point of having a Build seam.

**Read from the tree, not carried in the request.** That is already the
architecture: the request pins the frontend *image*, never the plan, and the
plan has always been derived on the runner from the tree it just unpacked
(`[ -f "${scope}/Dockerfile" ]` is the same kind of read). It is also what makes
this land when it merges — a caller pins this workflow by a local ref, so a
merge here reaches the very next dispatch, while a controller change waits on an
image build and a Flux rollout.

Nothing about that is loose. The bundle is staged at the App's **authoritative**
commit, and `reconciler/repo-loop.ts` refuses to advance that past a commit whose
`spindrift.yaml` will not parse — so the runner can only ever honour a document
core already validated and adopted.

**A generated config file rather than `--build-cmd`.** railpack merges CLI
options *under* the config file (`Merge(optionsConfig, envConfig, fileConfig)`,
`core/config/config.go`), so a stray `railpack.json` in the scope silently
outranks the flag — the exact inversion of ownership this file exists to state.
Pointing `--config-file` elsewhere is also what makes a per-app `railpack.json`
unnecessary, since railpack reads exactly one config file. The path is relative
(`../out/railpack-config.json`) because railpack resolves it under the app source
(`filepath.Join(app.Source, configFileName)`), so an absolute `/out/…` would
become `/scope/out/…` and not be found. `/out` is the plan mount, already there
and already writable, so the scope stays `:ro` and nothing is written into the
source tree.

The flag hard-fails when its file is absent, so it is passed **only** inside the
branch that just wrote one. A scope that declares nothing — no file, or
`command: null` — reaches railpack with a byte-identical invocation to before,
and keeps its own `railpack.json` if it has one.

Commands are emitted in **string** form, never `{"cmd": …}`: a string becomes
`sh -c '<cmd>'`, while the object form is handed to BuildKit's `llb.Shlex` and
argv-split, so an operator's `a && b` would reach the builder as a literal
argument to `a`. `jq --arg` is what makes any byte in the declared string —
quotes, newlines, `$(…)` — a JSON value rather than syntax. A single quote is
refused loudly, because railpack's own wrapper is `"sh -c '" + cmd + "'"` with
no escaping and would silently re-split the command instead of failing.

## The gate

The zero-config arm also appends `test -x <start command>` to the generated
plan's build step, whenever the start command is a bare relative path. This is
railpack's own postcondition, stated by railpack and never checked by it.

Asserting it *inside the plan* is what keeps it free. `test -x` runs in a
builder layer that is already running — no image pulled, no smoke run, no
minutes added to a build that was going to succeed. A build that was going to
ship a broken image now stops at the step that broke it.

The appended command carries a `customName`, which is what BuildKit prints as
the layer, so the red build says *check the build produced an executable ./out*
rather than leaving `test -x ./out: exit code 1` for the operator to decode.

Only a bare `./path` is testable this way. A start command carrying arguments or
naming an interpreter (`node server.js`, `npm start`) is not a file, and those
shapes fail loudly at exec anyway. Silence belongs to the compiled shape, which
is the only one where a toolchain writes a non-executable and calls it success.

The arm also publishes a `plan` output. The guard reads the plan as JSON, which
is true of this arm's `file` and neither other arm's Dockerfile, so it keys off
an output that exists only where there is a plan rather than inferring the arm
from a `buildArgs` that happens to be empty elsewhere.

## The app

`apps/view-counter/spindrift.yaml` declares `command: go build -o out ./cmd`.
No `railpack.json`: the declaration Spindrift already owns is where this belongs,
and carrying a builder's own config file would put the builder's name in the
app.

No `-buildvcs=false` either, and that is measured rather than assumed. VCS
stamping applies only to **main** packages, so building `./cmd` is the first
command here to reach it — but the bundle the builder receives is an extracted
tarball with no `.git`, and Go's default `-buildvcs=auto` skips stamping when
there is no repository to stamp from. Verified both ways: the command produces a
29MB `-rwxr-xr-x` ELF with no `.git` anywhere above it, and `view-counter.yml`
already builds the same `./cmd` inside a checkout that *does* have one.

## Validation

Run against railpack **v0.35.0** — the pinned frontend's own binary, extracted
from `ghcr.io/railwayapp/railpack-frontend:v0.35.0`
(sha256 `49baecce…`, `railpack version 0.35.0`), so the plan under test is the
plan CI generates.

The end-to-end run executes the shipped `Choose the frontend` script itself, out
of this file, with `docker run … /railpack` translated to that binary under the
same `/scope` + `/out` sibling layout the container gets.

| Check | Result |
| --- | --- |
| Shipped arm, **with** `apps/view-counter/spindrift.yaml` | `--config-file ../out/railpack-config.json` reaches railpack; plan build step is `sh -c 'go build -o out ./cmd'`, `startCommand: ./out` |
| Shipped arm, **without** the declaration | no `--config-file`, no config written; plan build step is `go build -ldflags="-w -s" -o out` — the shipped bug, reproduced |
| Generated config | `{"steps":{"build":{"commands":["go build -o out ./cmd"]}}}`; install input, local layer, `go-build` cache and start command all preserved |
| Declared command, executed on the real app | exit 0, `-rwxr-xr-x`, ELF, 29MB |
| Zero-config command, executed on the real app | exit **0**, `-rw-r--r--`, `!<arch>` — the silent failure |
| Shipped guard over the corrected plan | appends `test -x ./out` with its `customName`; passes on the ELF, fails on the archive |
| `bun test` (apps/spindrift) | 2344 pass, 0 fail |
| New tests against pre-change `spindrift-build.yml` | 6 of 9 fail; the 3 that pass are the three "unchanged" paths, which is what they assert |
| `mise run ts:check` | clean |

`spindrift-declaration-arm.test.ts` runs the step's own `run:` script straight
out of the shipped YAML with a recording `docker` on PATH — the same idiom as
`dockerfile-context-arm.test.ts`, which cannot reach this arm because it stops
where docker starts. Every case also asserts the shell reader and
`parseSpindriftFile` agree on the same document, so the two readers cannot
drift. It covers: a declared command, `apps/view-counter`'s own file, `command:
null`, no file at all, a `dockerfile` declaration, malformed YAML, a command
carrying `"`/`` ` ``/`$(…)`/`$HOME`, a multi-line command, and a single quote.

**Not tested end to end:** the image itself. Verifying that needs a rebuild
through the product, which the operator can drive. Everything above runs the real
generator, the real script and the real commands, but no container was built.

## Risk

Confined to the zero-config arm, after both early-exits: a `files` artifact or a
scope with a Dockerfile never reads the declaration and is unchanged. A scope
with no `spindrift.yaml`, or one whose `command` is null, or one declaring the
dockerfile frontend, invokes railpack byte-identically to before — asserted, not
assumed.

Malformed YAML fails the step loudly rather than quietly building the shape the
operator wrote the file to correct. Core should make that unreachable, since it
will not adopt a commit it could not parse.

Two known limits, both pre-existing and neither widened here: this covers the
**hosted** route only (`buildkit.ts`'s zero-config arm still passes no config, so
an App pinned to `managed` gets railpack's guess), and the arm order still means
a scope carrying a `Dockerfile` builds from it even if its declaration names the
railpack frontend or a differently-named Dockerfile.

The upstream provider is unchanged from v0.35.0 through v0.36.4 apart from a
`NewLocalLayer` refactor, so a frontend bump does not remove the need for any of
this.
