### PR TITLE
feat(spindrift): a Datastores screen, and a creation flow in dependency order

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -220,22 +220,36 @@ export const getAppWorkspace: Command<
       ? await configuredKeys(context.db, selected.id, workspaceTarget.id)
       : [];
 
-  // Status events only — the checkpoints, not the transcript.
+  // Attempt-level status events only — the checkpoints, not the transcript.
   //
   // Every log line an adapter emits lands in `attempt_events` too, and reading
   // the table raw made the timeline the last twenty lines of whatever ran most
   // recently: three screens of BuildKit chatter where a reader wanted "built,
-  // deployed, went red". A checkpoint is a status event by definition — §6's
-  // `{phase, resource?, reason?}` — so the filter is the whole selection, and
-  // the text stays where it belongs, on the attempt screen each entry links to.
+  // deployed, went red".
+  //
+  // `eventType = 'status'` was believed to be the whole of that filter and is
+  // not. §6's shape is `{phase, resource?, reason?}`, and **a status event
+  // carrying a `resource` is one step or one Kubernetes object inside an
+  // attempt**, not a state of the attempt itself: the Actions poller writes one
+  // per (job, step, state), so a single build produced twenty of them and each
+  // one titled itself "Build 23 succeeded", the step name demoted to a grey
+  // subtitle. Ten rows of one build, and every real checkpoint — the deploy,
+  // the build before it — evicted by the limit. The exact sequence this
+  // timeline exists to show was the thing it could no longer show.
+  //
+  // Those rows already have a home: `builds/view.ts` and `deploys/get-detail.ts`
+  // build their per-resource checklists from precisely the events this now
+  // excludes, selecting on the same column from the other side.
+  //
   // Ten, and this is the only bound: the workspace renders what it is given, so
-  // a second limit in the view could only disagree with this one. Three showed
-  // one attempt's worth of checkpoints, and the shape the timeline exists to
-  // make legible — built, deployed, went red — is three attempts, not three
-  // events.
+  // a second limit in the view could only disagree with this one.
   const events = await context.db.query.attemptEvents.findMany({
-    where: (ev, { eq, and }) =>
-      and(eq(ev.appId, app.id), eq(ev.eventType, 'status')),
+    where: (ev, { eq, and, isNull }) =>
+      and(
+        eq(ev.appId, app.id),
+        eq(ev.eventType, 'status'),
+        isNull(ev.resource),
+      ),
     orderBy: (ev, { desc }) => [desc(ev.id)],
     limit: 10,
   });
@@ -257,7 +271,14 @@ export const getAppWorkspace: Command<
         ),
         detail: ev.resource ?? ev.reason ?? '',
         when: elapsedSince(ev.createdAt, now),
-        status: ev.reason ? 'failed' : ev.phase === 'LIVE' ? 'ok' : 'info',
+        // A Build ends at SUCCEEDED and a Deploy ends at LIVE. Reading only the
+        // Deploy's word for it left every finished Build wearing the neutral
+        // marker, so a column of checkpoints showed nothing having gone right.
+        status: ev.reason
+          ? 'failed'
+          : ev.phase === 'LIVE' || ev.phase === 'SUCCEEDED'
+            ? 'ok'
+            : 'info',
         deployId: ev.deployId,
         buildId: ev.buildId,
       });

--- a/apps/spindrift/src/commands/datastores/list.ts
+++ b/apps/spindrift/src/commands/datastores/list.ts
@@ -1,0 +1,68 @@
+/**
+ * `listDatastores` — every Datastore this installation holds, newest first.
+ *
+ * §11 makes a Datastore "top-level and attached, not a field", and until now
+ * that was true of the row and false of the UI: the only read path was
+ * `getAppWorkspace`, scoped to one App, which is exactly wrong for the
+ * question this command answers — "what storage exists, and what is it
+ * doing" has nothing to do with which App a reader happened to open first.
+ * `createDatastore`, `attachDatastore`, `detachDatastore` and
+ * `destroyDatastore` have all existed with no ledger to act from except that
+ * one App's workspace.
+ *
+ * **Every field is named on the way out, never spread.** `datastores` carries
+ * `connection_ref` — the pointer to a Secret, per `web/model.ts`'s note on
+ * `DatastoreView` — and a `select()` or a spread would ship it to the browser
+ * the moment this file forgot to think about it. The command layer's one rule
+ * for a credential-adjacent column is that nothing reaches across it by
+ * accident, so the row is read in full and only named fields leave.
+ *
+ * No pagination. Datastores are created by hand, one at a time, through a
+ * form with a name field — there will be tens of them for the lifetime of an
+ * installation, not the thousands a Build or a Deploy accumulates.
+ */
+import { z } from 'zod';
+import { elapsedSince } from '../../domain/elapsed.ts';
+import { targetRowLabel } from '../../domain/target.ts';
+import type { DatastoreListItem } from '../../web/model.ts';
+import { type Command, ok } from '../types.ts';
+
+export const listDatastoresInput = z.object({}).strict();
+
+export type ListDatastoresInput = z.infer<typeof listDatastoresInput>;
+
+export interface ListDatastoresResult {
+  readonly datastores: readonly DatastoreListItem[];
+}
+
+export const listDatastores: Command<
+  ListDatastoresInput,
+  ListDatastoresResult
+> = async (_input, context) => {
+  const now = context.clock.now();
+  const rows = await context.db.query.datastores.findMany({
+    with: { app: true, target: { with: { vessel: true } } },
+    orderBy: (row, { desc }) => [desc(row.createdAt)],
+  });
+
+  return ok({
+    datastores: rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      engine: row.engine,
+      provenance: row.provenance,
+      attachedTo: row.app === null ? null : row.app.name,
+      target: targetRowLabel(row.target),
+      targetId: row.targetId,
+      appId: row.appId,
+      phase: row.phase,
+      // §11's `ref` is the adapter's own handle, opaque here — this only ever
+      // asks whether one was returned, the same test `destroyDatastore`
+      // makes to decide whether it owes the adapter a call.
+      provisioned: row.ref !== null,
+      ...(row.detail === null ? {} : { detail: row.detail }),
+      when: elapsedSince(row.createdAt, now),
+      at: row.createdAt.toISOString(),
+    })),
+  });
+};

--- a/apps/spindrift/src/commands/index.ts
+++ b/apps/spindrift/src/commands/index.ts
@@ -48,6 +48,7 @@ export { attachDatastore } from './datastores/attach.ts';
 export { createDatastore } from './datastores/create.ts';
 export { destroyDatastore } from './datastores/destroy.ts';
 export { detachDatastore } from './datastores/detach.ts';
+export { listDatastores } from './datastores/list.ts';
 export { createDeploy } from './deploys/create.ts';
 export { getDeployDetail } from './deploys/get-detail.ts';
 export { listDeploys } from './deploys/list.ts';

--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -83,6 +83,7 @@ import {
   destroyDatastoreInput,
 } from './datastores/destroy.ts';
 import { detachDatastore, detachDatastoreInput } from './datastores/detach.ts';
+import { listDatastores, listDatastoresInput } from './datastores/list.ts';
 import { createDeploy, createDeployInput } from './deploys/create.ts';
 import { getDeployDetail, getDeployDetailInput } from './deploys/get-detail.ts';
 import { listDeploys, listDeploysInput } from './deploys/list.ts';
@@ -249,6 +250,7 @@ export const commandRegistry = {
     input: destroyDatastoreInput,
     handler: destroyDatastore,
   },
+  listDatastores: { input: listDatastoresInput, handler: listDatastores },
   setConfig: { input: setConfigInput, handler: setConfig },
   configureInstallation: {
     input: configureInstallationInput,

--- a/apps/spindrift/src/commands/repositories/inspect.ts
+++ b/apps/spindrift/src/commands/repositories/inspect.ts
@@ -71,6 +71,15 @@ export type InspectedScope =
       readonly frontend: 'railpack' | 'dockerfile';
       /** Set only for the `dockerfile` frontend. */
       readonly dockerfile: string | null;
+      /**
+       * The zero-config build command, when the ladder proposed one.
+       *
+       * Carried for the same reason `outputDirectory` is: together they are the
+       * whole of a `railpack` build, and the creation screen writes the
+       * `spindrift.yaml` this scope will get *out of this view*. A field left
+       * out here is a field the preview would have to invent.
+       */
+      readonly buildCommand: string | null;
       /** Where a static rendering would lift files from, when there is one. */
       readonly outputDirectory: string | null;
       readonly watchPaths: readonly string[];
@@ -120,6 +129,10 @@ function viewOf(scope: string, proposal: DetectionProposal): InspectedScope {
     dockerfile:
       proposal.build.frontend === 'dockerfile'
         ? proposal.build.dockerfile
+        : null,
+    buildCommand:
+      proposal.build.frontend === 'railpack'
+        ? proposal.build.buildCommand
         : null,
     outputDirectory:
       proposal.build.frontend === 'railpack'

--- a/apps/spindrift/src/integrations/github/config-pr.ts
+++ b/apps/spindrift/src/integrations/github/config-pr.ts
@@ -122,7 +122,13 @@ function scalar(value: string): string {
  * not about what this scope is. Writing it into the repository would make a
  * reason somebody read once into a value the next detection run has to honour.
  */
-export function serializeSpindriftFile(proposal: DetectionProposal): string {
+export function serializeSpindriftFile(
+  // Narrowed to the three fields it reads, so the creation screen can render
+  // the file a scope is about to get from what `inspectRepository` answered,
+  // rather than reimplementing this emitter in the browser. A preview composed
+  // by a second copy of the writer is a preview that drifts from it.
+  proposal: Pick<DetectionProposal, 'kind' | 'build' | 'watchPaths'>,
+): string {
   const lines = [
     '# Managed by Spindrift, and yours to edit.',
     '#',

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -69,6 +69,10 @@ import { Gate } from './views/auth/gate.tsx';
 import { InstallationSettings } from './views/auth/installation.tsx';
 import { Onboarding } from './views/auth/onboarding.tsx';
 import { IdentitySettings } from './views/auth/settings.tsx';
+import {
+  DatastoreLedger,
+  type DatastoreAct as DatastoreLedgerAct,
+} from './views/operations/datastores.tsx';
 import { DeployLedger } from './views/operations/deploys.tsx';
 import { Overview } from './views/operations/overview.tsx';
 import {
@@ -402,6 +406,11 @@ export function Screen({
     return <SourcesScreen onNavigate={onNavigate} />;
   if (path.startsWith('/artifacts'))
     return <ArtifactsScreen onNavigate={onNavigate} />;
+  // Must land before the catch-all below, which otherwise reads any
+  // unmatched single segment as an App name — `/datastores` would render a
+  // `WorkspaceScreen` for an App called "datastores" that does not exist.
+  if (path.startsWith('/datastores'))
+    return <DatastoresScreen onNavigate={onNavigate} />;
   // The one screen keyed on the route rather than on the object in it, because
   // it is the one screen that *names* its object partway through: a draft
   // starts, the path is rewritten to `/apps/new/<id>`, and a key reading that
@@ -2472,6 +2481,99 @@ function SourcesScreen({ onNavigate }: { onNavigate: (path: string) => void }) {
       sources={state.result.sources}
       limit={state.result.limit}
       onNavigate={onNavigate}
+    />
+  );
+}
+
+/**
+ * The top-level Datastores ledger — every store this installation holds,
+ * unscoped to any one App's workspace (§11's "top-level and attached, not a
+ * field", read as a screen).
+ *
+ * Detach and Destroy are wired here rather than left to `DatastoreLedger`
+ * calling `command` itself, for the same reason `WorkspaceScreen`'s Datastore
+ * handlers are: the reload after a successful act belongs to whoever owns
+ * the list being reloaded, and only this screen holds that state.
+ */
+function DatastoresScreen({
+  onNavigate,
+}: {
+  onNavigate: (path: string) => void;
+}) {
+  const [state, setState] = useState<
+    | { type: 'loading' }
+    | { type: 'error'; message: string }
+    | { type: 'success'; result: OutputOf<'listDatastores'> }
+  >({ type: 'loading' });
+  const [reloadToken, setReloadToken] = useState(0);
+
+  useEffect(() => {
+    let live = true;
+    command('listDatastores', {})
+      .then((result) => {
+        if (!live) return;
+        setState(
+          result.ok
+            ? { type: 'success', result: result.value }
+            : { type: 'error', message: result.failure.message },
+        );
+      })
+      .catch((cause: unknown) => {
+        if (!live) return;
+        setState({
+          type: 'error',
+          message: cause instanceof Error ? cause.message : 'Server failure',
+        });
+      });
+    return () => {
+      live = false;
+    };
+  }, [reloadToken]);
+
+  const handleDetach: DatastoreLedgerAct = async (datastoreId) => {
+    try {
+      const result = await command('detachDatastore', { datastoreId });
+      if (!result.ok) return { ok: false, message: result.failure.message };
+      setReloadToken((token) => token + 1);
+      return { ok: true };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message: cause instanceof Error ? cause.message : 'Detaching failed',
+      };
+    }
+  };
+
+  const handleDestroy: DatastoreLedgerAct = async (datastoreId) => {
+    try {
+      const result = await command('destroyDatastore', { datastoreId });
+      if (!result.ok) return { ok: false, message: result.failure.message };
+      setReloadToken((token) => token + 1);
+      return { ok: true };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message: cause instanceof Error ? cause.message : 'Destroying failed',
+      };
+    }
+  };
+
+  if (state.type === 'loading') return <LedgerSkeleton />;
+  if (state.type === 'error') {
+    return (
+      <ScreenFailure
+        title="Failed to load Datastores"
+        message={state.message}
+        onRetry={() => setReloadToken((token) => token + 1)}
+      />
+    );
+  }
+  return (
+    <DatastoreLedger
+      datastores={state.result.datastores}
+      onNavigate={onNavigate}
+      onDetach={handleDetach}
+      onDestroy={handleDestroy}
     />
   );
 }

--- a/apps/spindrift/src/web/components/breadcrumbs.tsx
+++ b/apps/spindrift/src/web/components/breadcrumbs.tsx
@@ -80,6 +80,12 @@ function trail(path: string): Crumb[] {
     return crumbs;
   }
 
+  // No detail route — `getAppWorkspace` still owns a single Datastore's
+  // detail, so this is one crumb rather than a branch that also names an id.
+  if (head === 'datastores') {
+    return [{ label: 'Datastores', path: '/datastores' }];
+  }
+
   // Everything left names an App, including the bare `/<name>` the route table
   // still answers for a link written before `/apps/` existed.
   const crumbs: Crumb[] = [{ label: 'Apps', path: '/apps' }];

--- a/apps/spindrift/src/web/components/command-palette.tsx
+++ b/apps/spindrift/src/web/components/command-palette.tsx
@@ -78,6 +78,12 @@ const VERBS: readonly PaletteItem[] = [
   },
   { id: 'go:/deploys', group: 'Go to', label: 'Deploys', path: '/deploys' },
   {
+    id: 'go:/datastores',
+    group: 'Go to',
+    label: 'Datastores',
+    path: '/datastores',
+  },
+  {
     id: 'go:/settings/connections',
     group: 'Go to',
     label: 'Connections',

--- a/apps/spindrift/src/web/components/shell.tsx
+++ b/apps/spindrift/src/web/components/shell.tsx
@@ -1,6 +1,7 @@
 import {
   AlertTriangle,
   Boxes,
+  Database,
   Hammer,
   LayoutDashboard,
   LogOut,
@@ -32,6 +33,10 @@ import { CommandPalette } from './command-palette.tsx';
  * users, and §18's "the running app is the product, the pipeline is only how it
  * got there" is the whole reason it does not read as the chain's last stage.
  *
+ * Datastores is not in it either, and for a different reason than Deploy's:
+ * §11 never puts a Datastore on §2's chain at all — it is never a Source, a
+ * Build or an Artifact, so there is no stage to fold it into.
+ *
  * `roots` is what the entry lights up for; the first of them is where it goes.
  */
 const NAVIGATION = [
@@ -44,6 +49,12 @@ const NAVIGATION = [
     roots: ['/builds', '/sources', '/artifacts'],
   },
   { path: '/deploys', label: 'Deploys', icon: Rocket, roots: ['/deploys'] },
+  {
+    path: '/datastores',
+    label: 'Datastores',
+    icon: Database,
+    roots: ['/datastores'],
+  },
   {
     path: '/settings/connections',
     label: 'Settings',
@@ -382,7 +393,7 @@ export function AppShell({
 
       <nav
         aria-label="Primary navigation (compact)"
-        className="fixed inset-x-0 bottom-0 z-40 grid grid-cols-5 border-t border-rail-line bg-rail/95 p-1.5 backdrop-blur md:hidden"
+        className="fixed inset-x-0 bottom-0 z-40 grid grid-cols-6 border-t border-rail-line bg-rail/95 p-1.5 backdrop-blur md:hidden"
       >
         {navigation(true)}
       </nav>

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -545,6 +545,46 @@ export interface DatastoreView {
   */
 }
 
+/**
+ * One Datastore as the global ledger lists it — every one this installation
+ * holds, not one App's attached subset.
+ *
+ * `attachedTo` differs from {@link DatastoreView}'s field of the same name on
+ * purpose: the workspace's row names the App's first Component, because that
+ * screen is already a Component-shaped list and has nowhere else to point.
+ * This ledger has no Component selected — it has no App selected — so
+ * `attachedTo` is the App's own name, which is what §11 actually attaches a
+ * Datastore to.
+ *
+ * `targetId` and `appId` travel here and not on `DatastoreView` because this
+ * is the one screen that can Detach or Destroy a Datastore without an App
+ * workspace already open to supply them.
+ */
+export interface DatastoreListItem {
+  readonly id: string;
+  readonly name: string;
+  readonly engine: 'postgres' | 'valkey';
+  readonly provenance: 'managed' | 'external';
+  /** The App it is attached to, by name, or `null` while it is unattached. */
+  readonly attachedTo: string | null;
+  readonly target: string;
+  readonly targetId: string;
+  readonly appId: string | null;
+  readonly phase: DeployPhase;
+  /**
+   * Whether `provision` ever returned a handle (§11).
+   *
+   * `false` covers both an `external` Datastore, which nothing ever
+   * provisioned, and a `managed` one whose provisioning attempt has not
+   * (yet, or ever) returned — the same two cases `destroyDatastore` collapses
+   * before deciding whether it owes the adapter a call.
+   */
+  readonly provisioned: boolean;
+  readonly detail?: string;
+  readonly when: string;
+  readonly at: string;
+}
+
 /** One Component as the workspace lists it. */
 export interface ComponentView {
   /**

--- a/apps/spindrift/src/web/ui/declaration.tsx
+++ b/apps/spindrift/src/web/ui/declaration.tsx
@@ -1,0 +1,79 @@
+/**
+ * What a button is about to submit, shown before it is submitted.
+ *
+ * Every screen in here that creates something has the same problem: the act is
+ * one press, and what leaves Spindrift because of it is a document — a manifest
+ * entry, a `spindrift.yaml`, a Terraform block, a Kubernetes object. The press
+ * is legible and the document is not, so the operator either trusts the button
+ * or goes and reads the source. This is the third answer: the document, beside
+ * the button, before the press.
+ *
+ * Two rules make it worth having rather than decorative.
+ *
+ * **The text must come from the function that does the work.** A view that
+ * re-derives what it thinks will be submitted is a second implementation that
+ * drifts, and a preview that drifts is worse than none — it is a lie the
+ * operator has been taught to trust. Every caller passes the output of the same
+ * pure function the server calls: `clusterConnectPlan`, `serializeSpindriftFile`,
+ * `terraformRemediation`. Nothing is composed here.
+ *
+ * **What cannot be known says so.** Several payloads carry a value that does not
+ * exist until the act happens — a bundle digest that staging mints, a Deploy id
+ * the insert assigns. `caveat` is where that goes, and it is part of the shape
+ * rather than an afterthought, because a declaration that quietly shows a
+ * plausible number for one of those is the exact failure this is supposed to
+ * prevent.
+ *
+ * JSON, where the payload is structured, because JSON is valid YAML and an
+ * emitter would be a thing to maintain for output nobody parses back. Callers
+ * with literal text — a file Spindrift writes verbatim — pass it through.
+ *
+ * Collapsed by default. It is the answer to "what exactly will this do", which
+ * is a question asked before the first press and rarely after.
+ */
+import { type ReactNode, useState } from 'react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from './collapsible.tsx';
+import { CopyButton } from './copy.tsx';
+
+export function Declaration({
+  title = 'Declaration',
+  label,
+  note,
+  caveat,
+  text,
+}: {
+  /** The disclosure's own name. Defaults to the one every caller wants. */
+  title?: string;
+  /** What is inside, in two or three words: `manifest entry`, `spindrift.yaml`. */
+  label: string;
+  /** What this document is, and what submitting it does — and does not — do. */
+  note?: ReactNode;
+  /** What in here is not exact, and why. Absent means every field is. */
+  caveat?: string;
+  /** The document itself, already serialized by whatever produces it. */
+  text: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger className="flex w-full items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
+        {title}
+        <span className="ml-auto font-mono">{open ? 'hide' : label}</span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
+        {note ? <p className="text-[11px] text-subtle">{note}</p> : null}
+        <pre className="overflow-x-auto rounded-md border border-border bg-background px-3 py-2 font-mono text-[11px]">
+          {text}
+        </pre>
+        {caveat ? <p className="text-[11px] text-warning">{caveat}</p> : null}
+        <div>
+          <CopyButton value={text} label={label} />
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/apps/spindrift/src/web/views/apps/new/detect.ts
+++ b/apps/spindrift/src/web/views/apps/new/detect.ts
@@ -16,7 +16,9 @@
  *   candidate moves the path out from under the operator, and leaving the old
  *   sentence standing describes a directory nobody named.
  */
+
 import type { Draft, DraftAction } from '../../../../domain/creation-draft.ts';
+import { serializeSpindriftFile } from '../../../../integrations/github/config-pr.ts';
 import type { InputOf, OutputOf } from '../../../client.ts';
 
 /** One directory `inspectRepository` had something to say about. */
@@ -36,6 +38,42 @@ export function inspection(
   scope?: string,
 ): InputOf<'inspectRepository'> {
   return scope === undefined ? { fullName } : { fullName, scopes: [scope] };
+}
+
+/**
+ * The `spindrift.yaml` this scope will get, as the writer would write it.
+ *
+ * Deploy is where a repository GitHub merely grants gets connected, and
+ * connecting commits one of these per scope in the configuration pull request
+ * (§15). Rendering it here is the difference between an operator agreeing to
+ * "Deploy" and agreeing to a file landing in their repository — and it goes
+ * through `serializeSpindriftFile`, the same emitter the commit uses, because a
+ * preview composed by a second copy of the writer is a preview that drifts from
+ * it.
+ *
+ * `null` for a scope detection could make nothing of: there is no proposal, so
+ * there is no file, and §5's assertion path writes one only once the operator
+ * has said what it should contain.
+ */
+export function spindriftFileFor(
+  scope: InspectedScope | undefined,
+): string | null {
+  if (scope === undefined || scope.outcome !== 'detected') return null;
+  return serializeSpindriftFile({
+    kind: scope.kind,
+    build:
+      scope.frontend === 'dockerfile'
+        ? {
+            frontend: 'dockerfile',
+            dockerfile: scope.dockerfile ?? 'Dockerfile',
+          }
+        : {
+            frontend: 'railpack',
+            buildCommand: scope.buildCommand,
+            outputDirectory: scope.outputDirectory,
+          },
+    watchPaths: scope.watchPaths,
+  });
 }
 
 /** A fresh answer about one directory, in place, with the rest left alone. */

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -1,19 +1,25 @@
 /**
  * Deploying a new App: one screen, already answered.
  *
- * §18 named the creation flow Source → Component → Place → Configure → Review,
- * and this screen still is that, in that order. What went away is the rail.
- * Stories 31 and 32 say what the sequence was *for* — "defaults carrying every
- * step", "corrections and configuration hidden behind progressive disclosure"
- * — and five screens with a Continue button under each turned out to be the
- * rendering that made every default look like a question. Four Continues to
- * accept four answers nobody disagreed with is not a short happy path; it is a
- * long one with the disagreement removed.
+ * §18 named the creation flow Source → Component → Place → Configure → Review.
+ * The rail went away — stories 31 and 32 say what the sequence was *for*,
+ * "defaults carrying every step" and "corrections hidden behind progressive
+ * disclosure", and five screens with a Continue button under each turned out to
+ * be the rendering that made every default look like a question. Four Continues
+ * to accept four answers nobody disagreed with is not a short happy path; it is
+ * a long one with the disagreement removed.
  *
- * So: pick a source, read what it resolved to, press Deploy. Every row states
- * the answer **and why it is the answer**, and every row that can be corrected
- * opens the correction in place, without losing sight of the rows that choice
- * decides.
+ * So: name it, pick a source, read what it resolved to, press Deploy. Every row
+ * states the answer **and why it is the answer**, and every row that can be
+ * corrected opens the correction in place, without losing sight of the rows
+ * that choice decides.
+ *
+ * **The rows are in dependency order**, which is not the order §18 listed them
+ * in and is the order the data actually has. Placement is derived from kind,
+ * reach and auth (§3) — the `listTargets` refetch below *is* that derivation —
+ * so Target and the URL it mints come after the three answers that decide which
+ * Targets are candidates at all, not before them. Name leads because it is the
+ * only row that is nothing else's consequence.
  *
  * The reason this is honest now and would not have been before is
  * `inspectRepository`. The draft has always carried a `detection` block and
@@ -23,7 +29,7 @@
  * the kind, the scope, the build frontend and the ruled-out kinds are what it
  * found.
  */
-import { AlertTriangle, Loader2, Rocket } from 'lucide-react';
+import { AlertTriangle, Loader2, Rocket, Search } from 'lucide-react';
 import { type Dispatch, useEffect, useRef, useState } from 'react';
 import type { ZodType } from 'zod';
 import type {
@@ -56,6 +62,7 @@ import { reportSessionExpired } from '../../../session-events.ts';
 import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
 import { Card, Eyebrow } from '../../../ui/card.tsx';
+import { Declaration } from '../../../ui/declaration.tsx';
 import { Field } from '../../../ui/field.tsx';
 import { notify } from '../../../ui/toast.tsx';
 import { cn } from '../../../ui/utils.ts';
@@ -65,6 +72,7 @@ import {
   inspection,
   mergeScopes,
   outcomeOf,
+  spindriftFileFor,
 } from './detect.ts';
 import { blockersFor, type Draft, draftReducer, ENTRIES } from './draft.ts';
 import {
@@ -392,6 +400,13 @@ export function NewApp({
   ];
   const target = targets.find((option) => option.targetId === draft.targetId);
   const choices = repositoryChoices(repos, available);
+  // The file the chosen directory will get, from the read that chose it.
+  const spindriftFile = spindriftFileFor(
+    (scopes ?? []).find(
+      (scope) =>
+        draft.source.kind === 'repo' && scope.scope === draft.source.subpath,
+    ),
+  );
   const appNameIssue = issueWith(appNameSchema, draft.appName);
   const componentNameIssue = issueWith(
     componentNameSchema,
@@ -709,7 +724,58 @@ export function NewApp({
         </p>
       </header>
 
+      {/*
+        The order is the dependency order, top to bottom, and it did not used
+        to be. Placement is *derived* from kind, reach and auth (§3) — the
+        `listTargets` refetch in `dispatch` is that derivation, firing whenever
+        one of the three moves — so a reader met the Target, and the URL it
+        mints, several rows before the three answers that decide which Targets
+        are even candidates. Reading down now never asks anybody to accept a
+        consequence before its cause.
+
+        Name is first because it is the only row that is nothing's consequence.
+      */}
       <Card>
+        <Row
+          label="Name"
+          // A name the schema will refuse is an answer nobody has given yet,
+          // so the row that holds it opens rather than hiding the field the
+          // message is attached to behind a pencil.
+          unsettled={appNameIssue !== null || componentNameIssue !== null}
+          value={`${draft.appName} · ${draft.componentName}`}
+          why="The App is the product; the Component is the one workload this creates inside it."
+        >
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Field
+              name="appName"
+              label="App name"
+              value={draft.appName}
+              onChange={(event) =>
+                dispatch({
+                  type: 'field',
+                  field: 'appName',
+                  value: event.target.value,
+                })
+              }
+              issue={appNameIssue}
+              hint="Lowercase DNS label — it appears in the canonical hostname."
+            />
+            <Field
+              name="componentName"
+              label="Component name"
+              value={draft.componentName}
+              onChange={(event) =>
+                dispatch({
+                  type: 'field',
+                  field: 'componentName',
+                  value: event.target.value,
+                })
+              }
+              issue={componentNameIssue}
+            />
+          </div>
+        </Row>
+
         <SourceRow
           draft={draft}
           dispatch={dispatch}
@@ -725,17 +791,8 @@ export function NewApp({
 
         <Row
           label="Component"
-          // A name the schema will refuse is an answer nobody has given yet,
-          // so the row that holds it opens rather than hiding the field the
-          // message is attached to behind a pencil.
-          unsettled={
-            standing !== null ||
-            unchosen.length > 0 ||
-            readElsewhere ||
-            appNameIssue !== null ||
-            componentNameIssue !== null
-          }
-          value={`${draft.componentName} · ${draft.kind}`}
+          unsettled={standing !== null || unchosen.length > 0 || readElsewhere}
+          value={draft.kind}
           why={
             readElsewhere && draft.source.kind === 'repo'
               ? `${draft.detection.reason} — read in ${draft.detection.scope}, and the root directory now names ${draft.source.subpath}.`
@@ -753,53 +810,71 @@ export function NewApp({
             )
           }
         >
-          <div className="flex flex-col gap-3">
-            <div className="grid gap-3 sm:grid-cols-2">
-              <Field
-                name="appName"
-                label="App name"
-                value={draft.appName}
-                onChange={(event) =>
-                  dispatch({
-                    type: 'field',
-                    field: 'appName',
-                    value: event.target.value,
-                  })
-                }
-                issue={appNameIssue}
-                hint="Lowercase DNS label — it appears in the canonical hostname."
-              />
-              <Field
-                name="componentName"
-                label="Component name"
-                value={draft.componentName}
-                onChange={(event) =>
-                  dispatch({
-                    type: 'field',
-                    field: 'componentName',
-                    value: event.target.value,
-                  })
-                }
-                issue={componentNameIssue}
-              />
-            </div>
-            <div className="grid gap-2 sm:grid-cols-3">
-              {KINDS.map((kind) => {
-                const reason = draft.detection.unavailable[kind];
-                return (
-                  <Choice
-                    key={kind}
-                    selected={draft.kind === kind}
-                    disabled={reason !== undefined}
-                    title={kind}
-                    note={reason ?? KIND_NOTE[kind]}
-                    onClick={() => dispatch({ type: 'kind', kind })}
-                  />
-                );
-              })}
-            </div>
+          <div className="grid gap-2 sm:grid-cols-3">
+            {KINDS.map((kind) => {
+              const reason = draft.detection.unavailable[kind];
+              return (
+                <Choice
+                  key={kind}
+                  selected={draft.kind === kind}
+                  disabled={reason !== undefined}
+                  title={kind}
+                  note={reason ?? KIND_NOTE[kind]}
+                  onClick={() => dispatch({ type: 'kind', kind })}
+                />
+              );
+            })}
           </div>
         </Row>
+
+        {/*
+          `Row`'s whole claim is that a stated reason is what separates a
+          default from something somebody typed — and these two notes are
+          dictionary definitions of the value, identical whether the operator
+          chose it or the draft was born with it. Saying which is the reason.
+        */}
+        <Row
+          label="Reach"
+          value={draft.reach}
+          why={`${draft.reach === OPENING_REACH ? 'Default — ' : ''}${REACH_NOTE[draft.reach]}`}
+        >
+          <div className="grid gap-2 sm:grid-cols-3">
+            {REACHES.map((reach) => (
+              <Choice
+                key={reach}
+                selected={draft.reach === reach}
+                title={reach}
+                note={REACH_NOTE[reach]}
+                onClick={() => dispatch({ type: 'reach', reach })}
+              />
+            ))}
+          </div>
+        </Row>
+
+        {/*
+          Offered separately because it is a separate fact, and hidden at
+          `reach: none` because there is no route to put a filter on — the same
+          refusal validation makes, stated by not asking.
+        */}
+        {draft.reach !== 'none' && (
+          <Row
+            label="Auth"
+            value={draft.auth}
+            why={`${draft.auth === OPENING_AUTH ? 'Default — ' : ''}${AUTH_NOTE[draft.auth]}`}
+          >
+            <div className="grid gap-2 sm:grid-cols-2">
+              {AUTHS.map((auth) => (
+                <Choice
+                  key={auth}
+                  selected={draft.auth === auth}
+                  title={auth}
+                  note={AUTH_NOTE[auth]}
+                  onClick={() => dispatch({ type: 'auth', auth })}
+                />
+              ))}
+            </div>
+          </Row>
+        )}
 
         <Row
           label="Target"
@@ -885,55 +960,6 @@ export function NewApp({
           }
         />
 
-        {/*
-          `Row`'s whole claim is that a stated reason is what separates a
-          default from something somebody typed — and these two notes are
-          dictionary definitions of the value, identical whether the operator
-          chose it or the draft was born with it. Saying which is the reason.
-        */}
-        <Row
-          label="Reach"
-          value={draft.reach}
-          why={`${draft.reach === OPENING_REACH ? 'Default — ' : ''}${REACH_NOTE[draft.reach]}`}
-        >
-          <div className="grid gap-2 sm:grid-cols-3">
-            {REACHES.map((reach) => (
-              <Choice
-                key={reach}
-                selected={draft.reach === reach}
-                title={reach}
-                note={REACH_NOTE[reach]}
-                onClick={() => dispatch({ type: 'reach', reach })}
-              />
-            ))}
-          </div>
-        </Row>
-
-        {/*
-          Offered separately because it is a separate fact, and hidden at
-          `reach: none` because there is no route to put a filter on — the same
-          refusal validation makes, stated by not asking.
-        */}
-        {draft.reach !== 'none' && (
-          <Row
-            label="Auth"
-            value={draft.auth}
-            why={`${draft.auth === OPENING_AUTH ? 'Default — ' : ''}${AUTH_NOTE[draft.auth]}`}
-          >
-            <div className="grid gap-2 sm:grid-cols-2">
-              {AUTHS.map((auth) => (
-                <Choice
-                  key={auth}
-                  selected={draft.auth === auth}
-                  title={auth}
-                  note={AUTH_NOTE[auth]}
-                  onClick={() => dispatch({ type: 'auth', auth })}
-                />
-              ))}
-            </div>
-          </Row>
-        )}
-
         <VesselRow
           name={draft.vessel.name}
           note={draft.vessel.note}
@@ -1001,6 +1027,39 @@ export function NewApp({
 
       {refusal ? (
         <Refusal failure={refusal.failure} title={refusal.title} />
+      ) : null}
+
+      {/*
+        Deploy is two acts, and only one of them is visible above. It creates
+        the App — and, for a repository Spindrift holds no row for, it commits
+        this file to that repository in the configuration pull request §15 makes
+        authoritative. Agreeing to the first is not agreeing to the second
+        unless the second is on screen.
+      */}
+      {spindriftFile !== null && draft.source.kind === 'repo' ? (
+        <Declaration
+          title="What lands in the repository"
+          label={
+            draft.source.subpath === '.'
+              ? 'spindrift.yaml'
+              : `${draft.source.subpath}/spindrift.yaml`
+          }
+          note={
+            <>
+              Committed to{' '}
+              <span className="font-mono">{draft.source.repo}</span> on a
+              configuration pull request, alongside one workflow caller.
+              Spindrift adopts it only once that pull request merges into the
+              default branch.
+            </>
+          }
+          caveat={
+            draft.source.connect === true
+              ? undefined
+              : `${draft.source.repo} is already connected, so Deploy commits nothing — this is what its ${draft.source.subpath === '.' ? 'spindrift.yaml' : `${draft.source.subpath}/spindrift.yaml`} would say if it were connected now.`
+          }
+          text={spindriftFile}
+        />
       ) : null}
 
       <div className="flex flex-wrap items-center gap-3">
@@ -1277,6 +1336,9 @@ function SourceRow({
   );
 }
 
+/** Above this many directories, finding one by eye stops being realistic. */
+const SCOPE_FILTER_AT = 6;
+
 /**
  * Every directory the repository was read for, as one control to choose from.
  *
@@ -1285,10 +1347,16 @@ function SourceRow({
  * detection knows how to build is selectable and wears the kind and the
  * sentence behind it; one it does not is here too, disabled, wearing what it
  * found instead — §3's grammar, which only works if the alternatives stay
- * readable. A `<select>` keeps them readable and keeps a monorepo's twenty
- * directories from burying the rows below Source, which a grid of tiles did.
- * The reason rides in each option's own label for the same reason: a dropdown
- * has nowhere else to put a per-option sentence.
+ * readable.
+ *
+ * **Bounded rows, not a tile grid and not a `<select>`.** A grid of tiles put a
+ * monorepo's twenty directories between Source and every row below it. A
+ * `<select>` bounded that, but a native option is one line of plain text, so
+ * the directory, its kind and the sentence behind it were run together into a
+ * single very long line — and the one thing an operator is scanning for, the
+ * path, was the shortest part of it. Rows in a scroller of fixed height keep
+ * §3's grammar legible and keep the section the same size whether the
+ * repository holds two directories or forty.
  *
  * An empty list means nothing has been read yet, which is a different thing
  * from a repository with nothing in it.
@@ -1302,48 +1370,86 @@ function ScopeChooser({
   scopes: readonly InspectedScope[] | null;
   onChoose: (scope: InspectedScope) => void;
 }) {
+  const [filter, setFilter] = useState('');
   if (scopes === null || scopes.length === 0) return null;
 
-  // The directory the draft names is what it is deploying, whatever detection
-  // made of it — story 32 keeps that escape hatch open, and Deploy is not
-  // blocked on it. So the control points at it rather than drawing it as the
-  // one row that cannot be chosen while it is the row in force. Only a subpath
-  // nothing has read at all leaves the placeholder standing.
-  const chosen = scopes.find((scope) => scope.scope === subpath);
+  const needle = filter.trim().toLowerCase();
+  const shown = needle
+    ? scopes.filter((scope) => scope.scope.toLowerCase().includes(needle))
+    : scopes;
 
   return (
     <div className="flex flex-col gap-2">
-      <Eyebrow>Directories Spindrift read</Eyebrow>
-      <select
+      <Eyebrow>Directories Spindrift read · {scopes.length}</Eyebrow>
+      {scopes.length > SCOPE_FILTER_AT ? (
+        <div className="relative">
+          <Search
+            aria-hidden="true"
+            className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+          />
+          <input
+            type="text"
+            aria-label="Filter directories"
+            placeholder="Filter directories…"
+            value={filter}
+            onChange={(event) => setFilter(event.target.value)}
+            className={cn(
+              'w-full rounded-md border border-border bg-card py-2 pl-9 pr-3 font-mono text-sm',
+              'placeholder:text-muted-foreground',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
+            )}
+          />
+        </div>
+      ) : null}
+      <div
+        role="listbox"
         aria-label="Directories Spindrift read"
-        value={chosen?.scope ?? ''}
-        onChange={(event) => {
-          const picked = scopes.find(
-            (scope) => scope.scope === event.currentTarget.value,
-          );
-          if (picked !== undefined) onChoose(picked);
-        }}
-        className={cn(
-          'h-9 w-full rounded-md border border-border bg-card px-3',
-          'font-mono text-sm text-foreground',
-          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/30',
-        )}
+        className="flex max-h-[240px] flex-col gap-1 overflow-y-auto rounded-md border border-border bg-card p-1.5"
       >
-        <option value="" disabled>
-          {`Choose one of ${scopes.length} directories…`}
-        </option>
-        {scopes.map((scope) => (
-          <option
-            key={scope.scope}
-            value={scope.scope}
-            disabled={scope.outcome !== 'detected' && scope.scope !== subpath}
-          >
-            {scope.outcome === 'detected'
-              ? `${scope.scope} — ${scope.kind} — ${scope.reason}`
-              : `${scope.scope} — cannot build: ${scope.detail}`}
-          </option>
-        ))}
-      </select>
+        {shown.length === 0 ? (
+          <p className="px-2 py-4 text-center text-sm text-muted-foreground">
+            No directory read from this repository matches that filter.
+          </p>
+        ) : (
+          shown.map((scope) => {
+            const detected = scope.outcome === 'detected';
+            // The directory the draft names is what it is deploying, whatever
+            // detection made of it — story 32 keeps that escape hatch open and
+            // Deploy is not blocked on it. So it reads as the row in force
+            // rather than as the one row that cannot be chosen.
+            const current = scope.scope === subpath;
+            return (
+              <button
+                key={scope.scope}
+                type="button"
+                role="option"
+                aria-selected={current}
+                disabled={!detected && !current}
+                onClick={() => onChoose(scope)}
+                className={cn(
+                  'flex flex-col gap-0.5 rounded-md px-3 py-2 text-left transition-colors',
+                  current
+                    ? 'border border-primary bg-accent'
+                    : 'border border-transparent hover:bg-secondary',
+                  !detected && !current && 'cursor-not-allowed opacity-60',
+                )}
+              >
+                <span className="flex items-center gap-2">
+                  <span className="min-w-0 flex-1 truncate font-mono text-sm">
+                    {scope.scope}
+                  </span>
+                  <Badge tone={detected ? 'accent' : 'idle'}>
+                    {detected ? scope.kind : 'cannot build'}
+                  </Badge>
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {detected ? scope.reason : scope.detail}
+                </span>
+              </button>
+            );
+          })
+        )}
+      </div>
       <p className="text-xs text-muted-foreground">
         Choosing one detects that directory and names the Component after it.
         Nothing is picked for you when there is more than one.

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -2269,12 +2269,15 @@ function Activity({
               aria-hidden="true"
               className="absolute left-[5px] top-3 bottom-3 w-px bg-border-soft"
             />
-            {entries.map((entry) => (
-              <ActivityRow
-                key={`${entry.title}-${entry.when}-${entry.deployId ?? entry.buildId}`}
-                entry={entry}
-                onNavigate={onNavigate}
-              />
+            {/*
+              Keyed by position rather than by content. Every part of the old
+              key was displayed text, so two checkpoints that read alike — the
+              ordinary case for one attempt reported twice a minute apart —
+              collided. This list is server-derived, newest-first, read-only and
+              holds no per-row state, so position is a stable identity for it.
+            */}
+            {entries.map((entry, index) => (
+              <ActivityRow key={index} entry={entry} onNavigate={onNavigate} />
             ))}
           </ol>
         )}

--- a/apps/spindrift/src/web/views/operations/datastores.tsx
+++ b/apps/spindrift/src/web/views/operations/datastores.tsx
@@ -1,0 +1,301 @@
+/**
+ * Datastores — every store this installation holds, attached or not.
+ *
+ * §11 gives a Datastore four commands, a table, an adapter contract and two
+ * backends, and until now no read path except one App's workspace — which
+ * only ever showed the rows touching that App, plus every unattached one
+ * repeated on every other App's workspace beside it. A Datastore is top-level
+ * (§11: "attached, not a field"), and this is the screen a top-level noun
+ * gets: one ledger, independent of which App a reader opened first.
+ *
+ * **No create or attach here.** Both need an App-and-Target picker this
+ * screen has no home for — `createDatastore` binds to a placed Target and
+ * `attachDatastore` binds to an App, and a global ledger has neither selected.
+ * They stay exactly where §11 put them, on the workspace of the App they
+ * would attach to. What lives here are the two acts that take only a
+ * Datastore id: Detach and Destroy, one at a time and never both, because the
+ * row already says which one core would accept — `destroyDatastore` refuses
+ * while attached. That is stricter than the workspace's section, which offers
+ * Destroy on every row and lets the refusal come back as a sentence; here the
+ * reader has no App open to detach from first, so a button whose only outcome
+ * is that refusal is worth less than the one act that works.
+ *
+ * Not a `SupplyChainTabs` member. §2's chain is Source + Build = Artifact;
+ * a Datastore is never an input to that chain or an output of it, so tabbing
+ * it in beside Builds and Sources would draw a fourth stage that does not
+ * exist.
+ */
+import { Database } from 'lucide-react';
+import { useState } from 'react';
+import {
+  DefinitionGrid,
+  LedgerExplorer,
+} from '../../components/object-explorer.tsx';
+import type { DatastoreListItem } from '../../model.ts';
+import { Badge } from '../../ui/badge.tsx';
+import { Button } from '../../ui/button.tsx';
+import { Eyebrow } from '../../ui/card.tsx';
+import type { Column } from '../../ui/data-table.tsx';
+import { EmptyState } from '../../ui/empty-state.tsx';
+import { Page, PageHeader } from '../../ui/page.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
+import { deployTone } from './deploys.tsx';
+
+/**
+ * Detaching or destroying one Datastore, by id.
+ *
+ * One shape for both, the same reason `workspace.tsx`'s `DatastoreAct` is:
+ * they take the same argument and answer the same question, and every
+ * refusal either can carry is a sentence core composed rather than one
+ * guessed at here.
+ */
+export type DatastoreAct = (
+  datastoreId: string,
+) => Promise<
+  { readonly ok: true } | { readonly ok: false; readonly message: string }
+>;
+
+const COLUMNS: readonly Column<DatastoreListItem>[] = [
+  {
+    id: 'name',
+    header: 'Name',
+    sortable: true,
+    sortValue: (datastore) => datastore.name,
+    cell: (datastore) => (
+      <span className="truncate font-medium">{datastore.name}</span>
+    ),
+  },
+  {
+    id: 'engine',
+    header: 'Engine',
+    sortable: true,
+    sortValue: (datastore) => datastore.engine,
+    cell: (datastore) => (
+      <Badge tone={datastore.attachedTo ? 'success' : 'idle'}>
+        {datastore.engine}
+      </Badge>
+    ),
+  },
+  {
+    id: 'provenance',
+    header: 'Provenance',
+    sortable: true,
+    sortValue: (datastore) => datastore.provenance,
+    cell: (datastore) => datastore.provenance,
+  },
+  {
+    id: 'target',
+    header: 'Target',
+    sortable: true,
+    sortValue: (datastore) => datastore.target,
+    cell: (datastore) => datastore.target,
+  },
+  {
+    id: 'attached',
+    header: 'App',
+    sortable: true,
+    sortValue: (datastore) => datastore.attachedTo ?? '',
+    cell: (datastore) =>
+      datastore.attachedTo ? (
+        <span className="truncate">{datastore.attachedTo}</span>
+      ) : (
+        <span className="text-muted-foreground">unattached</span>
+      ),
+  },
+  {
+    id: 'phase',
+    header: 'Phase',
+    sortable: true,
+    sortValue: (datastore) => datastore.phase,
+    cell: (datastore) => (
+      <Badge tone={deployTone(datastore.phase)}>
+        {datastore.phase.toLowerCase()}
+      </Badge>
+    ),
+  },
+  {
+    id: 'age',
+    header: 'Created',
+    align: 'end',
+    sortable: true,
+    sortValue: (datastore) => datastore.at,
+    cell: (datastore) => (
+      <Timestamp
+        at={datastore.at}
+        when={datastore.when}
+        className="font-mono text-muted-foreground"
+      />
+    ),
+  },
+];
+
+/**
+ * Detach or Destroy, with the refusal a press produced — never both acts at
+ * once: `appId` already says which one applies, so offering the other is
+ * offering a button whose only outcome is core's refusal.
+ *
+ * Its own component rather than inline state in `renderInspector`, because
+ * the inspector is called fresh for whichever row is selected and a `busy` /
+ * `refusal` pair declared there would survive the reader picking a different
+ * Datastore. Keyed by id at the call site, so switching rows starts clean.
+ */
+function DatastoreRowActions({
+  datastore,
+  onDetach,
+  onDestroy,
+}: {
+  readonly datastore: DatastoreListItem;
+  readonly onDetach: DatastoreAct;
+  readonly onDestroy: DatastoreAct;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  const act = (run: DatastoreAct) => {
+    setBusy(true);
+    setRefusal(null);
+    void run(datastore.id).then((result) => {
+      setBusy(false);
+      if (!result.ok) setRefusal(result.message);
+    });
+  };
+
+  return (
+    <div className="mt-6">
+      {refusal ? (
+        <p className="mb-2 rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-xs text-destructive">
+          {refusal}
+        </p>
+      ) : null}
+      <div className="flex flex-wrap gap-2">
+        {datastore.appId !== null ? (
+          <Button
+            variant="outline"
+            disabled={busy}
+            onClick={() => act(onDetach)}
+          >
+            Detach
+          </Button>
+        ) : null}
+        {datastore.appId === null ? (
+          <Button
+            variant="outline"
+            disabled={busy}
+            onClick={() => act(onDestroy)}
+          >
+            Destroy
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export function DatastoreLedger({
+  datastores,
+  onNavigate,
+  onDetach,
+  onDestroy,
+}: {
+  readonly datastores: readonly DatastoreListItem[];
+  readonly onNavigate: (path: string) => void;
+  readonly onDetach: DatastoreAct;
+  readonly onDestroy: DatastoreAct;
+}) {
+  return (
+    <Page>
+      <PageHeader
+        eyebrow="Attached resources"
+        title="Datastores"
+        description="Every Postgres and Valkey Datastore this installation holds, attached or not. Creating one and attaching it to an App both stay on that App's workspace — this is where the rest of the lifecycle is read."
+      />
+      <LedgerExplorer
+        columns={COLUMNS}
+        rows={datastores}
+        rowKey={(datastore) => datastore.id}
+        rowSearch={(datastore) =>
+          `${datastore.name} ${datastore.engine} ${datastore.provenance} ${datastore.target} ${datastore.attachedTo ?? 'unattached'} ${datastore.phase}`
+        }
+        filterPlaceholder={`Filter ${datastores.length} Datastores…`}
+        caption="Datastores, newest first"
+        inspectorLabel={(datastore) => `Datastore ${datastore.name}`}
+        empty={
+          <EmptyState icon={<Database />} title="No Datastores exist yet.">
+            Creating one and attaching it to an App is done from that App's
+            workspace.
+          </EmptyState>
+        }
+        renderInspector={(datastore) => (
+          <>
+            <Eyebrow>Datastore / {datastore.engine}</Eyebrow>
+            <div className="mt-1 flex flex-wrap items-center gap-3">
+              <h2 className="text-title font-semibold tracking-tight">
+                {datastore.name}
+              </h2>
+              <Badge tone={datastore.attachedTo ? 'success' : 'idle'}>
+                {datastore.engine}
+              </Badge>
+              <Badge tone={deployTone(datastore.phase)}>
+                {datastore.phase.toLowerCase()}
+              </Badge>
+            </div>
+            <p className="mt-2 max-w-2xl text-body leading-6 text-muted-foreground">
+              {datastore.provenance === 'managed'
+                ? `Provisioned on ${datastore.target}.`
+                : `An externally authored connection, recorded against ${datastore.target}.`}{' '}
+              {datastore.attachedTo
+                ? `Attached to ${datastore.attachedTo} — the connection arrives on its next Deploy.`
+                : 'Unattached: nothing reads through it yet.'}
+            </p>
+            <DefinitionGrid
+              entries={[
+                { label: 'Engine', value: datastore.engine },
+                { label: 'Provenance', value: datastore.provenance },
+                { label: 'Target', value: datastore.target },
+                { label: 'App', value: datastore.attachedTo ?? 'unattached' },
+                { label: 'Phase', value: datastore.phase.toLowerCase() },
+                {
+                  label: 'Provisioned',
+                  value: datastore.provisioned ? 'yes' : 'no',
+                },
+                {
+                  label: 'Created',
+                  value: <Timestamp at={datastore.at} when={datastore.when} />,
+                  title: datastore.at,
+                  mono: true,
+                },
+                ...(datastore.detail
+                  ? [{ label: 'Detail', value: datastore.detail }]
+                  : []),
+              ]}
+            />
+            <div className="mt-6 flex flex-wrap gap-2">
+              {/*
+                By id, never by the name beside it. `getAppWorkspace` resolves
+                either — `or(eq(apps.name, …), eq(apps.id, …))` — so a name
+                works right up until two Apps share one, and this installation
+                allows that: the Apps list carries an id per row precisely
+                because two same-named Apps are two Apps. Navigating by name
+                would open whichever of them the database answered with.
+              */}
+              {datastore.appId !== null ? (
+                <Button
+                  variant="outline"
+                  onClick={() => onNavigate(`/apps/${datastore.appId}`)}
+                >
+                  Open App
+                </Button>
+              ) : null}
+            </div>
+            <DatastoreRowActions
+              key={datastore.id}
+              datastore={datastore}
+              onDetach={onDetach}
+              onDestroy={onDestroy}
+            />
+          </>
+        )}
+      />
+    </Page>
+  );
+}

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -65,11 +65,7 @@ import type {
 } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '../../ui/collapsible.tsx';
+import { Declaration as SharedDeclaration } from '../../ui/declaration.tsx';
 import { Field, Label } from '../../ui/field.tsx';
 import { cn } from '../../ui/utils.ts';
 
@@ -714,34 +710,27 @@ function Declaration({
 }: {
   plan: ReturnType<typeof clusterConnectPlan>;
 }) {
-  const [open, setOpen] = useState(false);
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
-      <CollapsibleTrigger className="flex w-full items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground">
-        Declaration
-        <span className="ml-auto font-mono">
-          {open ? 'hide' : 'manifest entry'}
-        </span>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="mt-2 flex flex-col gap-1.5">
-        <p className="text-[11px] text-subtle">
+    <SharedDeclaration
+      label="manifest entry"
+      note={
+        <>
           The same connection, under <span className="font-mono">vessels:</span>{' '}
           and <span className="font-mono">targets:</span> in the installation
           manifest. A declaration seeds an installation that has none; it does
           not overwrite one that is already configured.
-        </p>
-        {/* Both arrays, because one connect act names a boundary and a surface
-            on it. JSON, which is valid YAML — an emitter would be a thing to
-            maintain for output nobody parses back. */}
-        <pre className="overflow-x-auto rounded-md border border-border bg-background px-3 py-2 font-mono text-[11px]">
-          {JSON.stringify(
-            { vessels: [vesselSeedOf(plan)], targets: [targetSeedOf(plan)] },
-            null,
-            2,
-          )}
-        </pre>
-      </CollapsibleContent>
-    </Collapsible>
+        </>
+      }
+      // Both arrays, because one connect act names a boundary and a surface on
+      // it. The two seeds come from `domain/target-onboarding.ts`, which is
+      // what the server connects with — so this is the act, not a rendering of
+      // what somebody hopes the act is.
+      text={JSON.stringify(
+        { vessels: [vesselSeedOf(plan)], targets: [targetSeedOf(plan)] },
+        null,
+        2,
+      )}
+    />
   );
 }
 

--- a/apps/spindrift/test/commands/datastores.test.ts
+++ b/apps/spindrift/test/commands/datastores.test.ts
@@ -23,6 +23,7 @@ import {
   createDatastore,
   destroyDatastore,
   detachDatastore,
+  listDatastores,
 } from '../../src/commands/index.ts';
 import type {
   AdapterRegistry,
@@ -36,6 +37,7 @@ import {
   type NewTarget,
   targets,
 } from '../../src/db/schema.ts';
+import { targetRowLabel } from '../../src/domain/target.ts';
 import { withIsolatedDatabase } from '../harness/db.ts';
 import { FakeDatastoreAdapter } from '../harness/fakes/datastore-adapter.ts';
 import {
@@ -51,6 +53,14 @@ import {
 const database = withIsolatedDatabase();
 const manifest = await fixtureManifest();
 const clock: Clock = { now: () => new Date('2024-06-01T00:00:00.000Z') };
+
+/** `contextWith`, with the clock overridden — what {@link listDatastores}'s ordering test needs two rows apart in time to prove. */
+function contextAt(
+  datastore: FakeDatastoreAdapter | null,
+  at: string,
+): CommandContext {
+  return { ...contextWith(datastore), clock: { now: () => new Date(at) } };
+}
 
 function contextWith(datastore: FakeDatastoreAdapter | null): CommandContext {
   const deploy = new FakeDeployAdapter();
@@ -534,5 +544,92 @@ describe('destroyDatastore', () => {
       'the finalizer will not release',
     );
     expect(await database().db.select().from(datastores)).toHaveLength(1);
+  });
+});
+
+describe('listDatastores', () => {
+  test('lists every Datastore, newest first, with the App and Target joined', async () => {
+    const target = await aTarget();
+    const backend = new FakeDatastoreAdapter();
+    const app = await anApp();
+    const first = await createDatastore(
+      {
+        name: 'orders',
+        engine: 'postgres',
+        targetId: target.id,
+        storageGiB: 10,
+      },
+      contextAt(backend, '2024-06-01T00:00:00.000Z'),
+    );
+    const firstId = (first as { value: { id: string } }).value.id;
+    await attachDatastore(
+      { datastoreId: firstId, appId: app.id },
+      contextAt(backend, '2024-06-01T00:01:00.000Z'),
+    );
+    const second = await createDatastore(
+      { name: 'cache', engine: 'valkey', targetId: target.id, storageGiB: 1 },
+      contextAt(backend, '2024-06-01T00:05:00.000Z'),
+    );
+    const secondId = (second as { value: { id: string } }).value.id;
+
+    const result = await listDatastores(
+      {},
+      contextAt(backend, '2024-06-01T00:10:00.000Z'),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Newest first: 'cache' was created after 'orders'.
+    expect(result.value.datastores.map((row) => row.id)).toEqual([
+      secondId,
+      firstId,
+    ]);
+
+    const targetWithVessel = await database().db.query.targets.findFirst({
+      where: (rows, { eq: matches }) => matches(rows.id, target.id),
+      with: { vessel: true },
+    });
+
+    const attached = result.value.datastores.find((row) => row.id === firstId);
+    expect(attached?.attachedTo).toBe(app.name);
+    expect(attached?.appId).toBe(app.id);
+    expect(attached?.targetId).toBe(target.id);
+    expect(attached?.target).toBe(targetRowLabel(targetWithVessel!));
+    expect(attached?.phase).toBe('PENDING');
+    expect(attached?.provisioned).toBe(true);
+    expect(attached?.when).toBe('10m ago');
+
+    const unattached = result.value.datastores.find(
+      (row) => row.id === secondId,
+    );
+    expect(unattached?.attachedTo).toBeNull();
+    expect(unattached?.appId).toBeNull();
+  });
+
+  test('never returns connection_ref, even for an external Datastore', async () => {
+    const target = await aTarget();
+    await database().db.insert(datastores).values({
+      name: 'shared-analytics',
+      engine: 'postgres',
+      provenance: 'external',
+      targetId: target.id,
+      connectionRef: 'secret://elsewhere/analytics',
+    });
+
+    const result = await listDatastores(
+      {},
+      contextWith(new FakeDatastoreAdapter()),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const row = result.value.datastores.find(
+      (one) => one.name === 'shared-analytics',
+    );
+    expect(row).toBeDefined();
+    expect(row).not.toHaveProperty('connectionRef');
+    // Belt and braces: the credential-adjacent value itself must not appear
+    // anywhere in the payload, not just under its own field name.
+    expect(JSON.stringify(row)).not.toContain('secret://elsewhere/analytics');
   });
 });

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -483,6 +483,10 @@ describe('inspecting a repository before connecting it', () => {
         reason: 'Go — go.mod is in this directory',
         frontend: 'railpack',
         dockerfile: null,
+        // Both halves of a zero-config build travel with the proposal, so the
+        // creation screen can render the `spindrift.yaml` this scope will get
+        // rather than compose one from a subset of it.
+        buildCommand: null,
         outputDirectory: null,
         watchPaths: ['.', 'go.mod'],
         configured: false,

--- a/apps/spindrift/test/commands/workspace-deploy-details.test.ts
+++ b/apps/spindrift/test/commands/workspace-deploy-details.test.ts
@@ -664,6 +664,85 @@ describe('the workspace as a way into the system', () => {
     expect(result.value.workspace.activity.length).toBe(10);
   });
 
+  test('one build’s step transitions do not evict every other checkpoint', async () => {
+    // What the screen actually showed: ten rows, all reading "Build 23
+    // succeeded", each distinguished only by a grey subtitle naming an Actions
+    // step. The Actions poller writes one status event per (job, step, state),
+    // so a single build produced twenty of them and the limit spent itself on
+    // one attempt — the sequence this timeline exists to show was the thing it
+    // could no longer show. A status event carrying a `resource` is one step
+    // inside an attempt, not a state of the attempt; the Build and Deploy
+    // screens are where those belong, and they select on the same column from
+    // the other side.
+    const ctx = context();
+    const { appName, appId, componentId, target } = await scaffold(ctx, {
+      prefix: 'stepstorm',
+    });
+
+    const [build] = await ctx.db
+      .insert(builds)
+      .values({
+        componentId,
+        commit: 'f202020',
+        targetShape: 'image',
+        artifactType: 'image',
+        artifactDigest: `sha256:${'e'.repeat(64)}`,
+        status: 'SUCCEEDED',
+        runner: 'hosted runner',
+      })
+      .returning();
+    const [deploy] = await ctx.db
+      .insert(deploys)
+      .values({
+        componentId,
+        desired: aDesiredDocument(),
+        targetId: target.id,
+        buildId: build!.id,
+        phase: 'LIVE',
+      })
+      .returning();
+
+    const attempt = {
+      appId,
+      componentId,
+      attemptKind: 'build' as const,
+      buildId: build!.id,
+      eventType: 'status' as const,
+    };
+    await ctx.db.insert(attemptEvents).values([
+      { ...attempt, phase: 'SUCCEEDED' },
+      ...Array.from({ length: 20 }, (_unused, index) => ({
+        ...attempt,
+        phase: index % 2 === 0 ? 'RUNNING' : 'SUCCEEDED',
+        resource: `build / build / step ${index}`,
+      })),
+      {
+        appId,
+        componentId,
+        attemptKind: 'deploy' as const,
+        deployId: deploy!.id,
+        eventType: 'status' as const,
+        phase: 'LIVE',
+      },
+    ]);
+
+    const result = await getAppWorkspace({ name: appName }, ctx);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const activity = result.value.workspace.activity;
+    // Two attempts, one row each — not twenty rows of one of them.
+    expect(activity).toHaveLength(2);
+    expect(activity.map((entry) => entry.title)).toEqual([
+      `Deploy ${deploy!.id} live`,
+      `Build ${build!.id} succeeded`,
+    ]);
+    // And a finished Build reads as having gone right, which it did not when
+    // only a Deploy's LIVE earned the green marker.
+    expect(activity.every((entry) => entry.status === 'ok')).toBe(true);
+    expect(activity.some((entry) => entry.detail.includes('step'))).toBe(false);
+  });
+
   test('carries status checkpoints only, each with an attempt to open', async () => {
     // `attempt_events` constrains every row to exactly one attempt, so every
     // entry has somewhere to go. An entry that led nowhere would be the one

--- a/apps/spindrift/test/web/creation-detection.test.tsx
+++ b/apps/spindrift/test/web/creation-detection.test.tsx
@@ -65,6 +65,7 @@ const detected = (
   reason,
   frontend: 'railpack',
   dockerfile: null,
+  buildCommand: null,
   outputDirectory: null,
   watchPaths: [scope],
   configured: false,
@@ -350,7 +351,13 @@ describe('a draft somebody already answered', () => {
 
     // It still asks — the directories stay on screen to choose from.
     expect(called).toContain('inspectRepository');
-    expect(screen.text()).toContain('api-worker · job');
+    // The typed Component name is on the Name row and the corrected kind is on
+    // the Component row: two answers somebody gave, both still theirs after a
+    // read that proposed neither.
+    const text = screen.text();
+    expect(text).toContain('almanac · api-worker');
+    expect(text).toContain('Componentjob');
+    expect(text).toContain('corrected');
     // And it wrote nothing, because it decided nothing.
     expect(saved).toEqual([]);
 

--- a/apps/spindrift/test/web/creation-edits.test.tsx
+++ b/apps/spindrift/test/web/creation-edits.test.tsx
@@ -275,6 +275,7 @@ const detected = (scope: string): InspectedScope => ({
   reason: 'Go — go.mod is in this directory',
   frontend: 'railpack',
   dockerfile: null,
+  buildCommand: null,
   outputDirectory: null,
   watchPaths: [scope],
   configured: false,
@@ -302,7 +303,7 @@ describe('an edit the server refused as stale', () => {
     );
     expect(called).toContain('getCreationDraft');
     // The server's draft is on screen, and the screen says why it moved.
-    expect(screen.text()).toContain('renamed-elsewhere · service');
+    expect(screen.text()).toContain('almanac · renamed-elsewhere');
     expect(screen.text()).toContain('This draft was edited somewhere else');
     expect(screen.text()).toContain('STALE_EDIT');
     // And no draft of this tab's reached the server, so what is on screen is


### PR DESCRIPTION
Five complaints from different screens, all the same shape underneath: the UI states consequences before their causes, and does not say what it is about to do.

## The creation flow reads in dependency order

Placement is derived from kind, reach and auth — the `listTargets` refetch in the wizard *is* that derivation — and Target and the URL it mints sat several rows above the three answers that decide which Targets are candidates at all. Name leads now, because it is the only row that is nothing else's consequence, and it is its own row rather than sharing one with the kind:

`Name → Source → Component → Reach → Auth → Target → URL → Vessel`

## The discovered directories are a bounded list again

The `<select>` in #2045 fixed the tile grid burying every row below Source and broke something else: a native option is one line of plain text, so the path, the kind and the reason ran together into one very long line and the thing an operator scans for was the shortest part of it. Two-line rows in a fixed-height scroller, with a filter past six, keep the disabled-with-reasons grammar legible and keep the section the same size whether the repository holds two directories or forty.

## A screen that submits something shows what it submits

`ui/declaration.tsx` is the cluster-connect screen's own disclosure lifted out and given a `caveat` field, because several payloads carry a value that does not exist until the act runs and a plausible-looking number for one of those is worse than no preview at all.

Two callers: the connect screen, unchanged in what it shows, and the creation flow, which now shows the literal `spindrift.yaml` the repository will receive — through `serializeSpindriftFile`, the same emitter that writes the commit, so it cannot drift from it. `inspectRepository` carries `buildCommand` for that: it is half of a zero-config build, and a field left out of the view is a field the preview would have to invent.

**The other eight acts are not covered.** Deploy, rollback, datastore-create and build-dispatch each need a pure renderer extracted out of an adapter first, and four of their payloads are genuinely unknowable beforehand — a bundle digest staging mints, the Deploy id the insert assigns, a per-dispatch sealed credential, a static-hosting file map that needs the artifact fetched and untarred. Those want their own change.

## Recent checkpoints showed one build ten times

The Actions poller writes one `attempt_events` row per (job, step, state), and the workspace query took `eventType = 'status'` to mean "attempt checkpoint". `checkpointTitle` builds its title from `phase` alone, so twenty step transitions all rendered "Build 23 succeeded" with the step name demoted to a grey subtitle — and `limit 10` then spent itself on one build, evicting every deploy and every earlier build from the one timeline that exists to show that sequence.

The distinguishing column was already there and already read this way by the Build and Deploy screens, which build their step checklists from rows where `resource` **is not** null. The workspace now selects the same column from the other side. Two follow-ons: a succeeded Build earns the green marker (only a Deploy's `LIVE` did), and the timeline's React key was composed entirely of displayed text, so rows that read alike collided.

## Datastores have their own screen

They were a first-class object with four commands, a table, an adapter contract, two backends and a reconcile loop, and one read path: inside a single App's workspace, which showed the rows touching that App plus every unattached store in the installation repeated on every other App's page.

`listDatastores` and a ledger of its own, with Detach and Destroy — the two acts that take only a datastore id. Create and attach stay on the App workspace, where the App and the Target they bind to are already selected.

## Validation

`bun test` 2332 pass / 0 fail, `tsc --noEmit` clean, `biome check` clean.

New coverage: one build's step transitions no longer evicting every other checkpoint; `listDatastores` ordering and joins; and an assertion that `connection_ref`'s value appears nowhere in the datastore payload, not merely that the field is absent.

## Risk

`inspectRepository` gains a field, so a creation draft open in a tab across the deploy reads a scope without `buildCommand` — the preview falls back to `null`, which is what a zero-config build with no declared command writes anyway.

The Datastores screen navigates to an App by id rather than by the name beside it: `getAppWorkspace` resolves either, so a name works right up until two Apps share one, which this installation allows and which the Apps list already carries an id per row to survive.