### PR TITLE
fix(spindrift): give Vercel and Cloudflare Pages Targets their own sections

### DIFF
--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -76,6 +76,7 @@ const ADAPTER_LOGO: Record<string, LogoName> = {
   kubernetes: 'kubernetes',
   cloudrun: 'google-cloud',
   static: 'google-cloud',
+  vercel: 'vercel',
   'cloudflare-pages': 'cloudflare',
 };
 
@@ -353,11 +354,21 @@ export function TargetList({
       (target) => target.adapter === 'kubernetes',
     );
     const cloud = configured.filter(
-      (target) => target.adapter !== 'kubernetes',
+      (target) => target.adapter === 'cloudrun' || target.adapter === 'static',
+    );
+    const vercel = configured.filter((target) => target.adapter === 'vercel');
+    const cloudflarePages = configured.filter(
+      (target) => target.adapter === 'cloudflare-pages',
     );
     const clusterPending = pending.filter((entry) => entry.kind === 'cluster');
     const cloudPending = pending.filter(
       (entry) => entry.kind === 'gcp-project',
+    );
+    const vercelPending = pending.filter(
+      (entry) => entry.kind === 'vercel-team',
+    );
+    const cloudflarePagesPending = pending.filter(
+      (entry) => entry.kind === 'cloudflare-account',
     );
 
     return (
@@ -381,6 +392,28 @@ export function TargetList({
           onConnect={onConnect}
           onChanged={onChanged}
           empty="Declare a cloud project in Installation to make its real connection workflow available here."
+        />
+        <ProviderTargets
+          name="Vercel"
+          logo="vercel"
+          description="Declared teams become explicit Vercel Targets, addressed directly — a team has no discovery API to enumerate itself through."
+          targets={vercel}
+          pending={vercelPending}
+          connecting={connecting}
+          onConnect={onConnect}
+          onChanged={onChanged}
+          empty="Declare a Vercel team in Installation to make its real connection workflow available here."
+        />
+        <ProviderTargets
+          name="Cloudflare Pages"
+          logo="cloudflare"
+          description="Declared accounts become explicit Cloudflare Pages Targets, addressed directly — an account has no discovery API to enumerate itself through."
+          targets={cloudflarePages}
+          pending={cloudflarePagesPending}
+          connecting={connecting}
+          onConnect={onConnect}
+          onChanged={onChanged}
+          empty="Declare a Cloudflare account in Installation to make its real connection workflow available here."
         />
         <ProviderTargets
           name="Kubernetes"


### PR DESCRIPTION
## Summary

The Targets screen (Settings → Connections) grouped every non-Kubernetes adapter into one section titled "Google Cloud". A Vercel Target rendered with no vendor logo (missing from `ADAPTER_LOGO`) under that header, and a Cloudflare Pages Target rendered its correct logo but was still filed under "Google Cloud" alongside Cloud Run/static Targets.

- Added `vercel: 'vercel'` to `ADAPTER_LOGO` — the mark was already imported and wired for dark-mode invert, just never selected.
- Narrowed the "Google Cloud" grouping filter from "everything but kubernetes" to `cloudrun`/`static` only.
- Added sibling "Vercel" and "Cloudflare Pages" sections mirroring the existing Google Cloud/Kubernetes ones.
- Routed pending `vercel-team` and `cloudflare-account` connections to their new sections — previously only `gcp-project` pending entries were shown, so Vercel/Cloudflare Pages connect proposals were silently dropped from this screen.

The non-embedded `TargetCollection` branch needed no change: it renders Targets flat through `TargetCard`, which already resolves the (now-corrected) `ADAPTER_LOGO` map with no adapter-based grouping of its own.

## Test plan

- [x] `mise run ts:check` — typecheck and lint clean across the workspace
- [x] `DATABASE_URL=postgres://postgres@127.0.0.1:15432/spindrift BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 bun test` — full spindrift suite, 2327 pass / 0 fail

## Risk

Low — presentation-only change to one view file. Installations without a declared Vercel team or Cloudflare account will now see two additional "not configured" sections on the Targets screen (the existing empty-state handling covers this).