### PR TITLE
feat(spindrift): add a build route picker to the App workspace

### DIFF
--- a/apps/spindrift/src/commands/apps/workspace.ts
+++ b/apps/spindrift/src/commands/apps/workspace.ts
@@ -19,6 +19,7 @@ import {
 import type { VesselLocation } from '../../domain/vessel.ts';
 import type {
   ActivityEntry,
+  BuildRouteOptionView,
   ComponentView,
   DatastoreView,
   DeployPhase,
@@ -28,6 +29,7 @@ import type {
   Runtime,
   WorkspaceView,
 } from '../../web/model.ts';
+import { buildRouteFor } from '../builds/route.ts';
 import { configuredKeys } from '../config/set.ts';
 import { type Command, type CommandContext, failed, ok } from '../types.ts';
 
@@ -391,6 +393,43 @@ export const getAppWorkspace: Command<
       ...(row.detail === undefined ? {} : { detail: row.detail }),
     }));
 
+  // The App's own opinion (§4, §16) — never asked of an archive App, for the
+  // same reason `autoDeploy` below is not: §4's supplied artifact "consults no
+  // route at all", so there is nothing here to choose.
+  const buildRoute = app.sourceKind === 'repo' ? app.buildRoute : null;
+
+  /*
+    Every configured route, judged against the placed Target's minimum level
+    alone. `buildRouteFor` runs with no App id, exactly as `setAppBuildRoute`
+    itself calls it to validate a route before writing one
+    (`commands/apps/build-route.ts:127`) — so an option this screen offers as
+    eligible is one that call would not refuse on the level threshold. Passing
+    the App's id here instead would narrow the candidates to whichever route it
+    has already chosen (`buildRouteFor`'s own `demand.routes`), which is right
+    for dispatch and wrong for a picker whose whole job is offering the other
+    routes to switch to.
+
+    The registry half `setAppBuildRoute` also checks is a live round trip this
+    read does not repeat; an option eligible here can still be refused on
+    submit for that reason, exactly as the level threshold is a necessary but
+    not sufficient check for `buildRouteFor` itself.
+  */
+  const buildRouteOptions: readonly BuildRouteOptionView[] =
+    app.sourceKind === 'repo' && workspaceTarget
+      ? (await buildRouteFor(workspaceTarget.id, context)).candidates.map(
+          (candidate) => ({
+            name: candidate.route,
+            adapter:
+              context.manifest.build.routes.find(
+                (route) => route.name === candidate.route,
+              )?.adapter ?? null,
+            level: candidate.level,
+            eligible: candidate.eligible,
+            reason: candidate.reason,
+          }),
+        )
+      : [];
+
   const workspace: WorkspaceView = {
     app: app.name,
     appId: app.id,
@@ -420,6 +459,8 @@ export const getAppWorkspace: Command<
     activity,
     runtime,
     autoDeploy: app.sourceKind === 'repo' ? app.autoDeploy : null,
+    buildRoute,
+    buildRouteOptions,
     // What the release delivered and when, so `LIVE` stops being a word with
     // no date on it. Absent rather than empty for an App that has never
     // deployed: there is no commit and no instant, and a blank line where a

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -61,6 +61,7 @@ import {
   type MoveComponent,
   type RunJob,
   type SetAutoDeploy,
+  type SetBuildRoute,
   type SetConfig,
   type SetReach,
   type UnplaceComponent,
@@ -1610,6 +1611,28 @@ function WorkspaceScreen({
     }
   };
 
+  // Which route this App builds on (§4, §16). No re-read, for the same reason
+  // `handleSetAutoDeploy` needs none: the picker already holds the answer it
+  // just wrote, and this changes exactly the field it is showing.
+  const handleSetAppBuildRoute: SetBuildRoute = async (route) => {
+    const appId = state.type === 'success' ? state.workspace.appId : undefined;
+    if (appId === undefined) {
+      return { ok: false, message: 'This App has no id to set a builder on' };
+    }
+    try {
+      const result = await command('setAppBuildRoute', { appId, route });
+      return result.ok
+        ? { ok: true }
+        : { ok: false, message: result.failure.message };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message:
+          cause instanceof Error ? cause.message : 'Saving the builder failed',
+      };
+    }
+  };
+
   // The pair this workspace is showing (§10) — bound here, once, so `SetConfig`
   // itself does not have to carry it on every call. Re-read on success for the
   // same reason `handleSetReach` is: `configKeys` is a row this act just
@@ -1921,6 +1944,7 @@ function WorkspaceScreen({
         deletion={deletion}
         onSetReach={handleSetReach}
         onSetAutoDeploy={handleSetAutoDeploy}
+        onSetBuildRoute={handleSetAppBuildRoute}
         onSetConfig={handleSetConfig}
         onSelectComponent={handleSelectComponent}
         onCreateComponent={handleCreateComponent}

--- a/apps/spindrift/src/web/client/build-adapters.ts
+++ b/apps/spindrift/src/web/client/build-adapters.ts
@@ -1,0 +1,31 @@
+/**
+ * The mark, the name, and the guaranteed SLSA level for each build route's
+ * platform (§4, §16).
+ *
+ * `src/adapters/build/descriptor.ts` states the same three facts per adapter
+ * already, but that module imports `GitHubApp` and DB-backed adapter
+ * constructors and cannot ship to a browser (`test/web/client-bundle.test.ts`
+ * enforces the boundary). This is its client-safe shadow — four rows, small
+ * enough that keeping it in sync by eye costs less than a build step that
+ * generated one from the other.
+ *
+ * Keyed by a `string` rather than the closed adapter enum, so a route this
+ * installation configures and this table has not grown a case for is a
+ * missing key rather than a crash — the runner's name is still rendered,
+ * only unaccompanied (`deploy-detail.tsx`'s `Builder()`).
+ */
+import type { LogoName } from './logos/index.ts';
+
+export interface BuildAdapterInfo {
+  readonly logo: LogoName;
+  readonly label: string;
+  /** What this route's *profile* guarantees, never a verified Build's level. */
+  readonly level: 1 | 2 | 3;
+}
+
+export const BUILD_ADAPTER: Record<string, BuildAdapterInfo> = {
+  'github-actions': { logo: 'github', label: 'GitHub Actions', level: 2 },
+  'cloud-build': { logo: 'google-cloud', label: 'Cloud Build', level: 3 },
+  'in-cluster': { logo: 'kubernetes', label: 'in-cluster', level: 1 },
+  bosun: { logo: 'nixos', label: 'bosun', level: 2 },
+};

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -711,6 +711,30 @@ export interface WorkspaceView {
    */
   readonly autoDeploy: boolean | null;
   /**
+   * Which route this App builds on, or `null` for rank order (§4, §16) — the
+   * App's own opinion, narrower than but never overriding the installation's
+   * rank (`setAppBuildRoute`).
+   *
+   * `null` for an archive App too, for the same reason {@link autoDeploy} is:
+   * §4's supplied artifact "consults no route at all", so there is nothing
+   * here to choose.
+   */
+  readonly buildRoute: string | null;
+  /**
+   * Every build route this installation configures, in rank order, judged
+   * against the placed Target's minimum level alone.
+   *
+   * That is the same half `setAppBuildRoute` checks before it ever looks at a
+   * registry — so a route this screen offers as eligible is one the command
+   * will not refuse on the level threshold. It is not the whole of what the
+   * command checks: the registry half is a live round trip made at submit
+   * time, not repeated by this read.
+   *
+   * Empty for the same two absences {@link buildRoute} answers with `null`,
+   * plus a third: no Target placed yet to judge a level against.
+   */
+  readonly buildRouteOptions: readonly BuildRouteOptionView[];
+  /**
    * What the release named by {@link release} delivered, and when.
    *
    * The workspace held a phase pill and a release id and nothing that could
@@ -753,6 +777,24 @@ export interface WorkspaceView {
    * be a second answer to a question §13 already answers once.
    */
   readonly unmetPrerequisites?: readonly PrerequisiteRowView[];
+}
+
+/**
+ * One build route, as the workspace's picker offers it (§16).
+ *
+ * `level` is what the route's *profile* guarantees, never a verified Build's —
+ * `domain/build-route.ts`'s `BuildRouteProfile.level` is the type this comes
+ * from, and that field's own note draws the same line. `adapter` is `null`
+ * only where this route's manifest entry could not be found, which the picker
+ * renders as a name with no mark rather than a missing tile.
+ */
+export interface BuildRouteOptionView {
+  readonly name: string;
+  readonly adapter: string | null;
+  readonly level: 1 | 2 | 3;
+  readonly eligible: boolean;
+  /** The sentence `buildRouteCandidates` composed. Empty exactly when `eligible`. */
+  readonly reason: string;
 }
 
 /**

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -44,23 +44,7 @@ import {
 } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
-/**
- * The mark and the name for a build route's platform.
- *
- * The same shape `targets/list.tsx` uses for a Target's adapter, and here for
- * the same reason: an installation names its own routes ("hosted", "cloud"),
- * so the route's *name* identifies nothing to somebody who did not configure
- * it. The adapter does, and it is a closed vocabulary
- * (`manifest.schema.ts`'s `buildRouteAdapterSchema`).
- *
- * `in-cluster` gets the Kubernetes mark because that is literally where it
- * runs — §4's build Job — not because the App is going to Kubernetes.
- *
- * Keyed by a `string` rather than the enum, so a route this build grew and
- * this table has not is a missing key rather than a crash: the runner's name
- * is still rendered, only unaccompanied.
- */
-import type { LogoName } from '../../client/logos/index.ts';
+import { BUILD_ADAPTER } from '../../client/build-adapters.ts';
 import { Checklist } from '../../components/checklist.tsx';
 import { DiagnosisPanel, DriftPanel } from '../../components/diagnosis.tsx';
 import { LogPane, Notice } from '../../components/log-pane.tsx';
@@ -87,13 +71,6 @@ import { CopyButton } from '../../ui/copy.tsx';
 import { Logo } from '../../ui/logo.tsx';
 import { Page } from '../../ui/page.tsx';
 import { cn, normaliseUrl } from '../../ui/utils.ts';
-
-const BUILD_ADAPTER: Record<string, { logo: LogoName; label: string }> = {
-  'github-actions': { logo: 'github', label: 'GitHub Actions' },
-  'cloud-build': { logo: 'google-cloud', label: 'Cloud Build' },
-  'in-cluster': { logo: 'kubernetes', label: 'in-cluster' },
-  bosun: { logo: 'nixos', label: 'bosun' },
-};
 
 /**
  * What the operator can do from here, and which one is running.

--- a/apps/spindrift/src/web/views/apps/workspace.tsx
+++ b/apps/spindrift/src/web/views/apps/workspace.tsx
@@ -36,6 +36,7 @@ import type {
   ComponentKind,
   Reach,
 } from '../../../domain/desired-state.ts';
+import { BUILD_ADAPTER } from '../../client/build-adapters.ts';
 import {
   type AppDeletionControls,
   DeleteAppButton,
@@ -45,6 +46,7 @@ import { EmptyState, LogPane } from '../../components/log-pane.tsx';
 import { PhasePill } from '../../components/status.tsx';
 import type {
   ActivityEntry,
+  BuildRouteOptionView,
   ComponentView,
   DatastoreView,
   LogLine,
@@ -57,6 +59,7 @@ import { Button } from '../../ui/button.tsx';
 import { Card, CardContent, CardHeader, Eyebrow } from '../../ui/card.tsx';
 import { Ref } from '../../ui/copy.tsx';
 import { Field } from '../../ui/field.tsx';
+import { Logo } from '../../ui/logo.tsx';
 import { Page, PageHeader } from '../../ui/page.tsx';
 import { Tabs } from '../../ui/tabs.tsx';
 import { Timestamp } from '../../ui/timestamp.tsx';
@@ -184,6 +187,23 @@ export type SetAutoDeploy = (
 >;
 
 /**
+ * An App naming the build route it builds on, or clearing that choice back to
+ * rank order (§4, §16), as the screen above needs it answered.
+ *
+ * The same shape {@link SetAutoDeploy} takes and for the same reason: the App
+ * is bound by the screen above, and sending the value to set rather than a
+ * flip means two presses racing a set do not disagree about where they left
+ * it. `null` clears the choice — `setAppBuildRoute`'s own "leave it as it is
+ * vs. clear it" distinction, carried through as a value this screen can send
+ * rather than a second act.
+ */
+export type SetBuildRoute = (
+  route: string | null,
+) => Promise<
+  { readonly ok: true } | { readonly ok: false; readonly message: string }
+>;
+
+/**
  * Starting one run of a job, as the screen above needs it answered (§17).
  *
  * The same shape {@link SetReach} takes and for the same reason: the press has
@@ -266,6 +286,7 @@ export function Workspace({
   targets = [],
   onRunJob,
   onSetAutoDeploy,
+  onSetBuildRoute,
   onCreateDatastore,
   onAttachDatastore,
   onDetachDatastore,
@@ -350,6 +371,14 @@ export function Workspace({
    * at all rather than rendered dead.
    */
   onSetAutoDeploy?: SetAutoDeploy;
+  /**
+   * Absent where the build route is not editable from here, for the same
+   * reason {@link onSetReach} is. Also absent for an archive App — the view
+   * says so with `buildRouteOptions: []`, so the picker is not rendered at
+   * all rather than rendered on a Target it has nothing to check a level
+   * against.
+   */
+  onSetBuildRoute?: SetBuildRoute;
   /**
    * The four acts a Datastore has (§11). Absent where the screen wires no acts,
    * for the same reason {@link onSetReach} is.
@@ -531,6 +560,20 @@ export function Workspace({
               {...(onDestroyDatastore ? { onDestroyDatastore } : {})}
             />
           </div>
+          {/*
+            Empty rather than optional-and-absent for an archive App and for
+            one with no Target placed yet — `getAppWorkspace` says so with
+            `buildRouteOptions: []`, and the card is not rendered on nothing
+            to pick from rather than rendered with a lone "Rank order" tile
+            that has no other routes to rank against.
+          */}
+          {view.buildRouteOptions.length > 0 && onSetBuildRoute ? (
+            <BuildRoutePicker
+              buildRoute={view.buildRoute}
+              options={view.buildRouteOptions}
+              onSetBuildRoute={onSetBuildRoute}
+            />
+          ) : null}
           <div className="grid gap-4 md:grid-cols-2">
             {/*
               Every entry the view carries, un-sliced. `getAppWorkspace` bounds
@@ -862,6 +905,107 @@ function AutoDeployToggle({
         </p>
       ) : null}
     </div>
+  );
+}
+
+/**
+ * Which route this App builds on (§4, §16).
+ *
+ * A grid of `Choice` tiles rather than a dropdown — the same primitive the
+ * Target picker in the create flow uses for "pick one of a few rich options",
+ * because a native `<select>` cannot wear a logo, a level badge, and a
+ * refusal sentence the way a disabled tile can. One extra tile, "Rank order",
+ * answers `route: null` — the App's default, back to the installation's own
+ * arrangement.
+ *
+ * **Optimistic, and it says so when it was wrong** — the same posture
+ * {@link AutoDeployToggle} takes: the press selects its tile immediately and
+ * reverts if `setAppBuildRoute` refuses, with its sentence shown beneath the
+ * grid.
+ */
+function BuildRoutePicker({
+  buildRoute,
+  options,
+  onSetBuildRoute,
+}: {
+  buildRoute: string | null;
+  options: readonly BuildRouteOptionView[];
+  onSetBuildRoute: SetBuildRoute;
+}) {
+  const [current, setCurrent] = useState(buildRoute);
+  const [saving, setSaving] = useState(false);
+  const [refusal, setRefusal] = useState<string | null>(null);
+
+  const choose = async (route: string | null) => {
+    const previous = current;
+    setCurrent(route);
+    setSaving(true);
+    setRefusal(null);
+    try {
+      const result = await onSetBuildRoute(route);
+      if (!result.ok) {
+        setCurrent(previous);
+        setRefusal(result.message);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <SectionHeader eyebrow="Build" title="Builder" />
+      <CardContent className="flex flex-col gap-3 pt-0">
+        <div className="grid gap-2 sm:grid-cols-2">
+          <Choice
+            selected={current === null}
+            disabled={saving}
+            title="Rank order"
+            note="No preference — the installation's own arrangement decides."
+            onClick={() => choose(null)}
+          />
+          {options.map((option) => {
+            const platform = option.adapter
+              ? BUILD_ADAPTER[option.adapter]
+              : undefined;
+            return (
+              <Choice
+                key={option.name}
+                selected={current === option.name}
+                disabled={saving || !option.eligible}
+                onClick={() => choose(option.name)}
+              >
+                <div className="flex flex-wrap items-center gap-2">
+                  {platform ? (
+                    <Logo name={platform.logo} className="size-4" />
+                  ) : null}
+                  <span className="text-sm font-semibold">
+                    {platform?.label ?? option.name}
+                  </span>
+                  <Badge tone="idle" className="ml-auto">
+                    {`SLSA L${option.level}`}
+                  </Badge>
+                </div>
+                <span
+                  className={
+                    option.eligible
+                      ? 'font-mono text-xs text-muted-foreground'
+                      : 'text-xs text-destructive'
+                  }
+                >
+                  {option.eligible ? option.name : option.reason}
+                </span>
+              </Choice>
+            );
+          })}
+        </div>
+        {refusal ? (
+          <p className="rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-xs text-destructive">
+            {refusal}
+          </p>
+        ) : null}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/apps/spindrift/test/commands/workspace-build-route.test.ts
+++ b/apps/spindrift/test/commands/workspace-build-route.test.ts
@@ -1,0 +1,201 @@
+/**
+ * The App workspace states which routes it can build on (§4, §16).
+ *
+ * `getAppWorkspace` used to say nothing about `apps.buildRoute` at all — the
+ * picker had no read to draw from. This pins the two facts the read has to
+ * get right: every configured route comes back judged against the placed
+ * Target's minimum level alone, and choosing one narrows what `routeForTarget`
+ * picks at dispatch without narrowing what this list still offers to switch
+ * to — the read calls `buildRouteFor` with no App id, deliberately, for
+ * exactly that reason (`commands/apps/workspace.ts`).
+ *
+ * The fixture installation ranks `hosted` (github-actions, L2) first, then
+ * `managed` (cloud-build, L3), then `local` (in-cluster, L1).
+ */
+import { describe, expect, test } from 'bun:test';
+import { eq } from 'drizzle-orm';
+import { setAppBuildRoute } from '../../src/commands/apps/build-route.ts';
+import { createApp } from '../../src/commands/create-app.ts';
+import { createComponent, getAppWorkspace } from '../../src/commands/index.ts';
+import type {
+  AdapterRegistry,
+  Clock,
+  CommandContext,
+} from '../../src/commands/types.ts';
+import {
+  components,
+  componentTargetDesired,
+  targets,
+} from '../../src/db/schema.ts';
+import { withIsolatedDatabase } from '../harness/db.ts';
+import { FakeBuildAdapter } from '../harness/fakes/build-adapter.ts';
+import { SupplyChainHarness } from '../harness/fakes/supply-chain.ts';
+import {
+  fixtureManifest,
+  insertVessel,
+  targetValues,
+} from '../harness/installation.ts';
+
+const manifest = await fixtureManifest();
+const database = withIsolatedDatabase();
+const supplyChain = new SupplyChainHarness();
+const clock: Clock = { now: () => new Date('2026-08-12T12:00:00.000Z') };
+
+function context(): CommandContext {
+  const adapters: AdapterRegistry = {
+    deploy: () => null,
+    build: () => new FakeBuildAdapter(),
+    store: () => null,
+    repository: () => null,
+    supplyChain: () => supplyChain,
+  };
+  return {
+    principal: { id: crypto.randomUUID(), displayName: 'Operator' },
+    clock,
+    db: database().db,
+    adapters,
+    manifest,
+  };
+}
+
+/** One App, one `service` Component, placed on a Target of its own. */
+async function placedApp(
+  ctx: CommandContext,
+  minBuildLevel: number | null,
+): Promise<{ appId: string; appName: string; targetId: string }> {
+  const name = `builder-${crypto.randomUUID().slice(0, 8)}`;
+  const app = await createApp(
+    { name, sourceKind: 'repo', repoUrl: 'https://vcs.example/acme/thing.git' },
+    ctx,
+  );
+  if (!app.ok) throw new Error(app.failure.message);
+
+  const web = await createComponent(
+    {
+      appId: app.value.appId,
+      name: 'web',
+      kind: 'service',
+      expose: true,
+      reach: 'private',
+      auth: 'proxy',
+    },
+    ctx,
+  );
+  if (!web.ok) throw new Error(web.failure.message);
+
+  const vessel = await insertVessel(ctx.db, 'kubernetes');
+  const [target] = await ctx.db
+    .insert(targets)
+    .values(targetValues({ vesselId: vessel.id, minBuildLevel }))
+    .returning();
+  const targetId = target?.id as string;
+
+  await ctx.db
+    .insert(componentTargetDesired)
+    .values({ componentId: web.value.componentId, targetId });
+  await ctx.db
+    .update(components)
+    .set({ placedTargetId: targetId })
+    .where(eq(components.id, web.value.componentId));
+
+  return { appId: app.value.appId, appName: name, targetId };
+}
+
+describe('the workspace read on build routes', () => {
+  test('offers every configured route, judged against the placed Target’s minimum level', async () => {
+    const ctx = context();
+    const app = await placedApp(ctx, null); // unset, so §16's default L2 applies
+
+    const result = await getAppWorkspace({ name: app.appName }, ctx);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.workspace.buildRoute).toBeNull();
+    expect(result.value.workspace.buildRouteOptions).toEqual([
+      {
+        name: 'hosted',
+        adapter: 'github-actions',
+        level: 2,
+        eligible: true,
+        reason: '',
+      },
+      {
+        name: 'managed',
+        adapter: 'cloud-build',
+        level: 3,
+        eligible: true,
+        reason: '',
+      },
+      {
+        name: 'local',
+        adapter: 'in-cluster',
+        level: 1,
+        eligible: false,
+        reason:
+          'this route guarantees SLSA Build Level 1 and this Target requires at least L2',
+      },
+    ]);
+  });
+
+  test('states the App’s own choice without narrowing what the picker offers to switch to', async () => {
+    const ctx = context();
+    const app = await placedApp(ctx, null);
+
+    const chosen = await setAppBuildRoute(
+      { appId: app.appId, route: 'managed' },
+      ctx,
+    );
+    expect(chosen.ok).toBe(true);
+
+    const result = await getAppWorkspace({ name: app.appName }, ctx);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.workspace.buildRoute).toBe('managed');
+    // Every route is still offered on its own merits — an App that has chosen
+    // `managed` can still see `hosted` as an eligible route to switch to,
+    // which `buildRouteFor` would instead refuse as "not-admitted" had this
+    // read passed the App's id and let its own choice narrow the candidates
+    // the way dispatch does.
+    expect(
+      result.value.workspace.buildRouteOptions.map((option) => option.name),
+    ).toEqual(['hosted', 'managed', 'local']);
+    expect(
+      result.value.workspace.buildRouteOptions.find(
+        (option) => option.name === 'hosted',
+      )?.eligible,
+    ).toBe(true);
+  });
+
+  test('is empty for an App with no Target placed yet', async () => {
+    const ctx = context();
+    const name = `unplaced-${crypto.randomUUID().slice(0, 8)}`;
+    const app = await createApp(
+      {
+        name,
+        sourceKind: 'repo',
+        repoUrl: 'https://vcs.example/acme/thing.git',
+      },
+      ctx,
+    );
+    if (!app.ok) throw new Error(app.failure.message);
+    const web = await createComponent(
+      {
+        appId: app.value.appId,
+        name: 'web',
+        kind: 'service',
+        expose: true,
+        reach: 'private',
+        auth: 'proxy',
+      },
+      ctx,
+    );
+    if (!web.ok) throw new Error(web.failure.message);
+
+    const result = await getAppWorkspace({ name }, ctx);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.workspace.buildRouteOptions).toEqual([]);
+  });
+});

--- a/apps/spindrift/test/fixtures/scenarios.ts
+++ b/apps/spindrift/test/fixtures/scenarios.ts
@@ -435,6 +435,8 @@ export const WORKSPACE_SCENARIOS = {
     urlLive: true,
     release: 'Deploy 42',
     autoDeploy: false,
+    buildRoute: null,
+    buildRouteOptions: [],
     components: [
       {
         id: 'component-beacon-web',
@@ -540,6 +542,8 @@ export const WORKSPACE_SCENARIOS = {
     urlLive: true,
     release: 'Deploy 17',
     autoDeploy: false,
+    buildRoute: null,
+    buildRouteOptions: [],
     components: [
       {
         id: 'component-almanac-web',
@@ -594,6 +598,8 @@ export const WORKSPACE_SCENARIOS = {
     urlLive: false,
     release: 'Execution 118',
     autoDeploy: false,
+    buildRoute: null,
+    buildRouteOptions: [],
     components: [
       {
         id: 'component-ledger-nightly',
@@ -693,6 +699,8 @@ export const WORKSPACE_SCENARIOS = {
     urlLive: false,
     release: 'Deploy 61',
     autoDeploy: true,
+    buildRoute: null,
+    buildRouteOptions: [],
     components: [
       {
         id: 'component-quay-web',


### PR DESCRIPTION
## Summary
- `setAppBuildRoute` existed with zero web callers. `getAppWorkspace` now reports the App's stored `buildRoute` plus every configured route's eligibility and SLSA level for the placed Target (`buildRouteFor` called with no App id, so an App's current choice never narrows what the picker still offers to switch to).
- The workspace screen renders it as a grid of `Choice` tiles (vendor logo, `SLSA L{n}` badge, ineligible tiles disabled with the refusal sentence, plus a "Rank order" tile for clearing the choice), wired through `onSetBuildRoute` with the same optimistic-toggle pattern the auto-deploy switch uses.
- The client-safe adapter/logo/level table previously lived only in `deploy-detail.tsx`; it now lives in `web/client/build-adapters.ts` (with a `level` field added) and both screens import it, so the table isn't duplicated a third time.
- No manifest schema change — the level/logo/displayName metadata already lived on each `BuildRouteDescriptor` in code.

## Validation
- `bun run typecheck` — clean
- `bun run lint` (biome) — clean
- `bun test` (full suite, Postgres on :15432) — 2343 pass, 0 fail
- `test/web/client-bundle.test.ts` (server-import-free client bundle guard) — passing
- New test `test/commands/workspace-build-route.test.ts` pins: every configured route comes back with correct level/adapter/eligibility for a Target's minimum level, and choosing a route does not narrow what the read still offers as switchable options.

## Risks
- The picker's eligibility is level-threshold only, scoped to the selected Component's placed Target; the registry-reachability half `setAppBuildRoute` also checks is a live round trip made at submit time and can still refuse an option this screen shows as eligible.
- Builder picker only added to the existing App workspace screen, not the create-app flow, which has no build-route awareness today.