### PR TITLE
feat(spindrift): a round of grace notes across the product surface

### DIFF
--- a/apps/spindrift/src/commands/registry.ts
+++ b/apps/spindrift/src/commands/registry.ts
@@ -367,9 +367,13 @@ export async function dispatch(
   const descriptor: AnyCommandDescriptor = commandRegistry[name];
   const parsed = descriptor.input.safeParse(input);
   if (!parsed.success) {
+    // Screens surface this sentence verbatim to an operator mid-flow, so the
+    // command's camelCase name stays out of it — unlike the refusal above,
+    // whose only reader is the programmer who typed the name. The issues
+    // carry the fields that failed.
     return failed(
       'INVALID_INPUT',
-      `the input given to ${name} is not valid`,
+      'the input given to this command is not valid',
       issuesOf(parsed.error),
     );
   }

--- a/apps/spindrift/src/reconciler/main.ts
+++ b/apps/spindrift/src/reconciler/main.ts
@@ -10,7 +10,12 @@ import type { ReconcilerProcessEvent } from './process.ts';
 import { startReconciler } from './start.ts';
 
 const shutdown = new AbortController();
-const stop = (): void => shutdown.abort();
+const stop = (): void => {
+  // The counterpart of the `running` line below: an operator reading the pod
+  // log sees the exit was asked for, not suffered.
+  console.log('spindrift reconciler → stopping');
+  shutdown.abort();
+};
 process.once('SIGINT', stop);
 process.once('SIGTERM', stop);
 

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -155,6 +155,11 @@ export function App() {
     state: 'asking',
   });
 
+  // The tab bar is where an operator holding three Deploys tells them apart.
+  useEffect(() => {
+    document.title = titleOf(route.path);
+  }, [route.path]);
+
   useEffect(() => {
     let live = true;
     readSession()
@@ -355,6 +360,43 @@ export function SignedIn({
       <Screen path={path} onNavigate={onNavigate} />
     </AppShell>
   );
+}
+
+/**
+ * The document title for a path — the tab's answer to "which one is this?".
+ *
+ * Derived from the path alone, mirroring `Screen` below branch for branch,
+ * because the path already carries the human name: Apps route by name, Deploys
+ * and Builds by the id their screens render as `#42`. Waiting for loaded data
+ * would say the same words later, and leave every tab reading "Spindrift"
+ * until its fetch returned.
+ *
+ * Exported for `test/web/screen-titles.test.ts`, which pins the mapping.
+ */
+export function titleOf(path: string): string {
+  if (path.startsWith('/settings')) return 'Settings · Spindrift';
+  if (
+    path.startsWith('/targets') ||
+    path.startsWith('/repos') ||
+    path.startsWith('/storage')
+  )
+    return 'Settings · Spindrift';
+  if (path.startsWith('/sources')) return 'Sources · Spindrift';
+  if (path.startsWith('/artifacts')) return 'Artifacts · Spindrift';
+  if (path.startsWith('/datastores')) return 'Datastores · Spindrift';
+  if (path.startsWith('/apps/new')) return 'New App · Spindrift';
+  if (path.startsWith('/deploys')) {
+    const deployId = path.replace(/^\/deploys\/?/, '');
+    return deployId ? `Deploy #${deployId} · Spindrift` : 'Deploys · Spindrift';
+  }
+  if (path.startsWith('/builds')) {
+    const buildId = path.replace(/^\/builds\/?/, '');
+    return buildId ? `Build #${buildId} · Spindrift` : 'Builds · Spindrift';
+  }
+  if (path === '/' || path === '') return 'Spindrift';
+  if (path === '/apps') return 'Apps · Spindrift';
+  const appName = path.replace(/^\/apps\//, '').replace(/^\//, '');
+  return `${appName} · Spindrift`;
 }
 
 /**
@@ -2246,6 +2288,15 @@ function BuildScreen({
 
   const act = async (kind: 'redeploy' | 'deploy') => {
     if (state.type !== 'success') return;
+    // The word the button the operator just pressed used — "Build again" on a
+    // failed Build, "Redeploy" otherwise — so a refusal answers in the same
+    // verb the press was made in.
+    const verb =
+      kind === 'deploy'
+        ? 'Deploy'
+        : state.attempt.build?.status === 'failed'
+          ? 'Build'
+          : 'Redeploy';
     setBusy(kind);
     try {
       // One command for both, because §4 gives the workspace button one
@@ -2262,14 +2313,14 @@ function BuildScreen({
       } else {
         notify({
           tone: 'destructive',
-          title: 'That act was refused',
+          title: `${verb} refused`,
           detail: result.failure.message,
         });
       }
     } catch (cause) {
       notify({
         tone: 'destructive',
-        title: 'Deploy failed',
+        title: `${verb} failed`,
         detail: cause instanceof Error ? cause.message : 'Server failure',
       });
     } finally {

--- a/apps/spindrift/src/web/client/index.html
+++ b/apps/spindrift/src/web/client/index.html
@@ -34,6 +34,19 @@
       }
     </script>
     <link rel="stylesheet" href="./styles.css" />
+    <!--
+      The rail's mark, so the tab wears it too. A favicon cannot read the
+      stylesheet, so the two fills restate the accent and on-accent tokens
+      from styles.css for each scheme; change them together. It cannot read
+      the stored theme either — the OS scheme is the only signal reaching its
+      media query, so a tab whose page is forced dark can wear the light mark.
+      That is the right disagreement: the tab bar around the icon is the OS's
+      surface, not this page's.
+    -->
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><style>rect{fill:%2316707f}text{fill:%23ffffff}@media(prefers-color-scheme:dark){rect{fill:%2359b8c6}text{fill:%2307171b}}</style><rect width='32' height='32' rx='6'/><text x='16' y='24' font-family='ui-monospace,monospace' font-size='22' font-weight='900' text-anchor='middle'>S</text></svg>"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/spindrift/src/web/ui/error-state.tsx
+++ b/apps/spindrift/src/web/ui/error-state.tsx
@@ -11,8 +11,9 @@
  * nothing on it — no rows, no filter, no navigation of its own — so a sentence
  * with no retry leaves the reader with the browser's reload button as the only
  * affordance, and reloading a hash-routed app is a heavier act than re-running
- * one query. `CreationLoadFailure` in the create flow had already worked this
- * out and grown the button; this is that argument applied to the other nine.
+ * one query. `CreationLoadFailure` in the create flow worked this argument
+ * out first and grew the button; now every screen, that one included, renders
+ * the shape through here.
  *
  * `code` is rendered rather than swallowed. A transport failure code is not
  * operator prose, but it is the string that makes a support conversation short,

--- a/apps/spindrift/src/web/views/apps/deploy-detail.tsx
+++ b/apps/spindrift/src/web/views/apps/deploy-detail.tsx
@@ -451,7 +451,9 @@ function Actions({
           className={cn('size-3.5', busy === 'redeploy' && 'animate-spin')}
         />
         {busy === 'redeploy'
-          ? 'Working…'
+          ? view.build?.status === 'failed'
+            ? 'Building…'
+            : 'Redeploying…'
           : view.build?.status === 'failed'
             ? 'Build again'
             : 'Redeploy'}

--- a/apps/spindrift/src/web/views/apps/new/index.tsx
+++ b/apps/spindrift/src/web/views/apps/new/index.tsx
@@ -63,6 +63,7 @@ import { Badge } from '../../../ui/badge.tsx';
 import { Button } from '../../../ui/button.tsx';
 import { Card, Eyebrow } from '../../../ui/card.tsx';
 import { Declaration } from '../../../ui/declaration.tsx';
+import { ErrorState } from '../../../ui/error-state.tsx';
 import { Field } from '../../../ui/field.tsx';
 import { notify } from '../../../ui/toast.tsx';
 import { cn } from '../../../ui/utils.ts';
@@ -306,16 +307,12 @@ export function CreationLoadFailure({
   onRetry: () => void;
 }) {
   return (
-    <div className="mx-auto flex w-full max-w-[760px] flex-col gap-3 px-5 py-6">
-      <div className="rounded-sm border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-        <p className="text-sm font-medium">Failed to load creation options</p>
-        <p className="mt-1 text-sm">{message}</p>
-      </div>
-      <div>
-        <Button variant="outline" onClick={onRetry}>
-          Try again
-        </Button>
-      </div>
+    <div className="mx-auto w-full max-w-[760px] px-5 py-6">
+      <ErrorState
+        title="Failed to load creation options"
+        message={message}
+        onRetry={onRetry}
+      />
     </div>
   );
 }
@@ -892,7 +889,11 @@ export function NewApp({
               ? 'No Target is selected.'
               : target.candidate
                 ? `${target.adapter} · ${target.artifactType ?? 'no artifact shape'} · rank ${target.rank}`
-                : target.reasons.join(', ')
+                : // The sentences the picker below prints, not the bare
+                  // Exclusion codes they translate.
+                  target.reasons
+                    .map((reason, index) => target.detail[index] ?? reason)
+                    .join('; ')
           }
         >
           <div className="flex flex-col gap-2">

--- a/apps/spindrift/src/web/views/auth/settings.tsx
+++ b/apps/spindrift/src/web/views/auth/settings.tsx
@@ -166,8 +166,8 @@ export function CredentialSettingsView({
                     {shortCredential(passkey.credentialId)}
                   </p>
                   <p className="mt-1 flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
-                    <span>
-                      Added {new Date(passkey.createdAt).toLocaleDateString()}
+                    <span className="flex items-center gap-1">
+                      Added <Timestamp at={passkey.createdAt} />
                     </span>
                     <span aria-hidden="true">·</span>
                     {/* The half of the row that makes `Remove` a decision

--- a/apps/spindrift/src/web/views/settings/connections.tsx
+++ b/apps/spindrift/src/web/views/settings/connections.tsx
@@ -62,6 +62,7 @@ import { Card, CardContent } from '../../ui/card.tsx';
 import { Field } from '../../ui/field.tsx';
 import { Logo } from '../../ui/logo.tsx';
 import { Skeleton, SkeletonRows, SkeletonText } from '../../ui/skeleton.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
 import { cn } from '../../ui/utils.ts';
 
 type Verification = OutputOf<'testBucketPermissions'>;
@@ -809,8 +810,8 @@ function RegistryCredentialForm({
       </div>
       {registry.credentialUpdatedAt !== null ? (
         <p className="text-[11px] text-subtle">
-          Set {new Date(registry.credentialUpdatedAt).toLocaleString()}.
-          Forgetting it here does not revoke it at the registry.
+          Set <Timestamp at={registry.credentialUpdatedAt} />. Forgetting it
+          here does not revoke it at the registry.
         </p>
       ) : null}
     </form>

--- a/apps/spindrift/src/web/views/targets/list.tsx
+++ b/apps/spindrift/src/web/views/targets/list.tsx
@@ -57,6 +57,7 @@ import {
   CollapsibleTrigger,
 } from '../../ui/collapsible.tsx';
 import { Logo } from '../../ui/logo.tsx';
+import { Timestamp } from '../../ui/timestamp.tsx';
 import { cn } from '../../ui/utils.ts';
 import { ConnectTargetForm } from './connect.tsx';
 
@@ -699,9 +700,13 @@ function VesselChecklists({
               rather than reading as four questions that passed.
             */}
             <p className="text-[11px] text-subtle">
-              {vessel.inspectedAt === null
-                ? 'never inspected'
-                : `last checked ${new Date(vessel.inspectedAt).toLocaleString()}`}
+              {vessel.inspectedAt === null ? (
+                'never inspected'
+              ) : (
+                <>
+                  last checked <Timestamp at={vessel.inspectedAt} />
+                </>
+              )}
             </p>
           </div>
         ))}
@@ -1025,9 +1030,13 @@ function TargetCard({
                 as now.
               */}
               <p className="mt-1 text-[11px] text-subtle">
-                {target.inspectedAt === null
-                  ? 'never inspected'
-                  : `last checked ${new Date(target.inspectedAt).toLocaleString()}`}
+                {target.inspectedAt === null ? (
+                  'never inspected'
+                ) : (
+                  <>
+                    last checked <Timestamp at={target.inspectedAt} />
+                  </>
+                )}
               </p>
             </CollapsibleContent>
           </Collapsible>

--- a/apps/spindrift/test/web/screen-titles.test.ts
+++ b/apps/spindrift/test/web/screen-titles.test.ts
@@ -1,0 +1,34 @@
+/**
+ * `titleOf` mirrors `Screen`'s route table branch for branch — the tab must
+ * name what the screen shows. These pin the mapping for every branch,
+ * including the aliases that land on Settings and the bare `/name` workspace
+ * fallback.
+ */
+import { describe, expect, test } from 'bun:test';
+import { titleOf } from '../../src/web/app.tsx';
+
+describe('titleOf', () => {
+  test.each([
+    ['/', 'Spindrift'],
+    ['', 'Spindrift'],
+    ['/apps', 'Apps · Spindrift'],
+    ['/apps/hub', 'hub · Spindrift'],
+    ['/hub', 'hub · Spindrift'],
+    ['/apps/new', 'New App · Spindrift'],
+    ['/apps/new/7', 'New App · Spindrift'],
+    ['/deploys', 'Deploys · Spindrift'],
+    ['/deploys/42', 'Deploy #42 · Spindrift'],
+    ['/builds', 'Builds · Spindrift'],
+    ['/builds/9', 'Build #9 · Spindrift'],
+    ['/sources', 'Sources · Spindrift'],
+    ['/artifacts', 'Artifacts · Spindrift'],
+    ['/datastores', 'Datastores · Spindrift'],
+    ['/settings', 'Settings · Spindrift'],
+    ['/settings/connections', 'Settings · Spindrift'],
+    ['/targets', 'Settings · Spindrift'],
+    ['/repos', 'Settings · Spindrift'],
+    ['/storage', 'Settings · Spindrift'],
+  ])('%s → %s', (path, title) => {
+    expect(titleOf(path)).toBe(title);
+  });
+});


### PR DESCRIPTION
## Summary

Nine small polish touches, none a feature:

- **Favicon** — an inline SVG restating the rail's "S on accent" mark, with a `prefers-color-scheme` media query carrying both accent/on-accent pairs from `styles.css`.
- **Live tab titles** — `titleOf(path)` mirrors `Screen`'s route table branch for branch (`Deploy #42 · Spindrift`, `hub · Spindrift`, `Datastores · Spindrift`), set from one effect in `App()`. Pinned by `test/web/screen-titles.test.ts`.
- **One timestamp language** — the four places still rendering raw `toLocaleString()` (passkey Added, registry credential Set, both "last checked" inspection lines) now use `<Timestamp>`, the server-honest relative component the rest of the app uses.
- **Placement summary speaks prose** — the Target row's `why` tooltip joins the `detail` sentences the picker below already prints, instead of bare `REACH_UNSUPPORTED, AUTH_UNSUPPORTED` codes.
- **Create flow adopts `ErrorState`** — `CreationLoadFailure`, the screen whose retry button inspired the shared component, now renders through it; its header comment updated to keep reading true.
- **Command refusals stop leaking camelCase names** — `INVALID_INPUT` says "the input given to this command is not valid"; `UNKNOWN_COMMAND` keeps its name since its only reader typed it.
- **Busy labels say the verb** — the redeploy button's `Working…` becomes `Building…`/`Redeploying…`, matching its two siblings.
- **Refusal toasts answer in the verb the button was pressed in** — `That act was refused` becomes `Deploy/Build/Redeploy refused` (and the catch titles follow), including the "Build again" case on a failed Build.
- **Reconciler says goodbye** — `spindrift reconciler → stopping` on SIGINT/SIGTERM, the counterpart of its `running` line.

## Validation

- `tsc --noEmit` clean
- `bun test`: 2362 pass, 0 fail (163→165 files; adds screen-titles)
- `biome check` clean
- `bun run build`: the favicon data URI survives the bundler byte-for-byte

## Risks

Low. All UI-string or presentation changes; the one behavioural addition is `document.title` tracking the route. The favicon follows the OS scheme, not the stored page theme — a favicon cannot read `localStorage`; the comment in `index.html` argues why that disagreement is correct.