### PR TITLE
feat(bosun): authenticate to GitHub as a shared App installation

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -19,6 +19,17 @@ creation_rules:
           - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
           # riptide (ssh-to-age of its ed25519 host key)
           - age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
+  # Shared across bosun's two hosts, unlike the rest of this section: it
+  # holds bosun's own key on the Spindrift+bosun GitHub App, and both
+  # riptide and oldschool read it directly.
+  - path_regex: nix/secrets/bosun\.sops\.ya?ml
+    key_groups:
+      - age:
+          - age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+          # riptide (ssh-to-age of its ed25519 host key)
+          - age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
+          # oldschool (ssh-to-age of its ed25519 host key)
+          - age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c
   - path_regex: nix/secrets/optiplex\.sops\.ya?ml
     key_groups:
       - age:

--- a/apps/bosun/README.md
+++ b/apps/bosun/README.md
@@ -44,7 +44,7 @@ Path given via `-config`. Example:
 ```json
 {
   "repo": "jonpulsifer/infra",
-  "tokenFile": "/run/secrets/bosun-github-token",
+  "github": {"appId": 12345, "privateKeyFile": "/run/secrets/bosun-github-app-key"},
   "runtimeDir": "/run/bosun",
   "logDir": "/var/log/bosun",
   "workspaceDir": "/var/lib/bosun/workspace",

--- a/apps/bosun/config.go
+++ b/apps/bosun/config.go
@@ -11,14 +11,14 @@ import (
 
 // Config is bosun's on-disk JSON configuration. A NixOS module generates it.
 type Config struct {
-	Repo         string   `json:"repo"`
-	TokenFile    string   `json:"tokenFile"`
-	RuntimeDir   string   `json:"runtimeDir"`
-	LogDir       string   `json:"logDir"`
-	WorkspaceDir string   `json:"workspaceDir"` // real storage, not tmpfs: it holds whole filesystem images
-	MetricsFile  string   `json:"metricsFile"`  // empty disables; a node-exporter textfile, not a listener
-	CacheURL     string   `json:"cacheUrl"`     // empty disables; announced to every skiff as bosun.cache on the cmdline
-	PollInterval Duration `json:"pollInterval"`
+	Repo         string       `json:"repo"`
+	GitHub       GitHubConfig `json:"github"`
+	RuntimeDir   string       `json:"runtimeDir"`
+	LogDir       string       `json:"logDir"`
+	WorkspaceDir string       `json:"workspaceDir"` // real storage, not tmpfs: it holds whole filesystem images
+	MetricsFile  string       `json:"metricsFile"`  // empty disables; a node-exporter textfile, not a listener
+	CacheURL     string       `json:"cacheUrl"`     // empty disables; announced to every skiff as bosun.cache on the cmdline
+	PollInterval Duration     `json:"pollInterval"`
 	// DrainTimeout bounds how long a stop waits for busy skiffs to finish
 	// their jobs. Idle skiffs are scuttled immediately; what this buys is a
 	// deploy that no longer fails every in-flight job, and what it costs is
@@ -29,6 +29,15 @@ type Config struct {
 	// Spindrift turns this host into a build source alongside its GitHub warm
 	// pool. nil (the default) means bosun never talks to Spindrift.
 	Spindrift *SpindriftConfig `json:"spindrift,omitempty"`
+}
+
+// GitHubConfig is bosun's identity on GitHub: an installation of the shared
+// Spindrift+bosun GitHub App, not a personal access token. Minting a JIT
+// runner config needs Administration: write on Config.Repo, which the
+// installation must grant.
+type GitHubConfig struct {
+	AppID          int64  `json:"appId"`
+	PrivateKeyFile string `json:"privateKeyFile"`
 }
 
 // SpindriftConfig is how a bosun host long-polls a Spindrift outbox for
@@ -140,8 +149,11 @@ func LoadConfig(path string) (*Config, error) {
 	if owner, name, ok := strings.Cut(cfg.Repo, "/"); !ok || owner == "" || name == "" {
 		return nil, fmt.Errorf("config: repo must be \"owner/repo\", got %q", cfg.Repo)
 	}
-	if cfg.TokenFile == "" {
-		return nil, fmt.Errorf("config: tokenFile is required")
+	if cfg.GitHub.AppID <= 0 {
+		return nil, fmt.Errorf("config: github.appId is required")
+	}
+	if cfg.GitHub.PrivateKeyFile == "" {
+		return nil, fmt.Errorf("config: github.privateKeyFile is required")
 	}
 	if len(cfg.Classes) == 0 {
 		return nil, fmt.Errorf("config: at least one class is required")

--- a/apps/bosun/config_test.go
+++ b/apps/bosun/config_test.go
@@ -12,7 +12,7 @@ func TestLoadConfigDefaults(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-nixos": {"hull": "/hulls/nixos", "vcpus": 4, "memory": "4096M", "warm": 1}}
 	}`)
 
@@ -41,7 +41,7 @@ func TestLoadConfigRejectsSelfHostedClassName(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"self-hosted": {"hull": "/hulls/nixos", "vcpus": 4, "memory": "4096M", "warm": 1}}
 	}`)
 	if _, err := LoadConfig(path); err == nil {
@@ -52,7 +52,7 @@ func TestLoadConfigRejectsSelfHostedClassName(t *testing.T) {
 func TestLoadConfigValidatesRepoShape(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	writeFile(t, path, `{"repo": "not-a-repo", "tokenFile": "/x", "classes": {"c": {"hull":"/h","vcpus":1,"memory":"1G","warm":1}}}`)
+	writeFile(t, path, `{"repo": "not-a-repo", "github": {"appId": 1, "privateKeyFile": "/x"}, "classes": {"c": {"hull":"/h","vcpus":1,"memory":"1G","warm":1}}}`)
 	if _, err := LoadConfig(path); err == nil {
 		t.Fatal("expected error for malformed repo")
 	}
@@ -61,16 +61,34 @@ func TestLoadConfigValidatesRepoShape(t *testing.T) {
 func TestLoadConfigRequiresAtLeastOneClass(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	writeFile(t, path, `{"repo": "acme/widgets", "tokenFile": "/x", "classes": {}}`)
+	writeFile(t, path, `{"repo": "acme/widgets", "github": {"appId": 1, "privateKeyFile": "/x"}, "classes": {}}`)
 	if _, err := LoadConfig(path); err == nil {
 		t.Fatal("expected error for no classes")
+	}
+}
+
+func TestLoadConfigRequiresGithubAppID(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{"repo": "acme/widgets", "github": {"privateKeyFile": "/x"}, "classes": {"c": {"hull":"/h","vcpus":1,"memory":"1G","warm":1}}}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for missing github.appId")
+	}
+}
+
+func TestLoadConfigRequiresGithubPrivateKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	writeFile(t, path, `{"repo": "acme/widgets", "github": {"appId": 1}, "classes": {"c": {"hull":"/h","vcpus":1,"memory":"1G","warm":1}}}`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for missing github.privateKeyFile")
 	}
 }
 
 func TestLoadConfigAllowsParkedClass(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	writeFile(t, path, `{"repo": "acme/widgets", "tokenFile": "/x", "classes": {"c": {"hull":"/h","vcpus":1,"memory":"1G","warm":0}}}`)
+	writeFile(t, path, `{"repo": "acme/widgets", "github": {"appId": 1, "privateKeyFile": "/x"}, "classes": {"c": {"hull":"/h","vcpus":1,"memory":"1G","warm":0}}}`)
 	if _, err := LoadConfig(path); err != nil {
 		t.Fatalf("warm = 0 is a parked class, not an error: %v", err)
 	}
@@ -116,7 +134,7 @@ func TestParseSize(t *testing.T) {
 func TestLoadConfigRejectsUnparseableWorkspaceSize(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.json")
-	writeFile(t, path, `{"repo":"acme/widgets","tokenFile":"/x","classes":{"skiff-test":{"hull":"/h","vcpus":1,"memory":"512M","workspace":"lots","warm":1}}}`)
+	writeFile(t, path, `{"repo":"acme/widgets","github":{"appId":1,"privateKeyFile":"/x"},"classes":{"skiff-test":{"hull":"/h","vcpus":1,"memory":"512M","workspace":"lots","warm":1}}}`)
 	if _, err := LoadConfig(path); err == nil {
 		t.Fatal("expected an error for an unparseable workspace size")
 	}
@@ -130,7 +148,7 @@ func TestLoadConfigRejectsPersistWithoutAWorkspace(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-ubuntu": {"hull": "/hulls/ubuntu", "vcpus": 4, "memory": "3072M", "warm": 2, "persist": true}}
 	}`)
 	if _, err := LoadConfig(path); err == nil {
@@ -146,7 +164,7 @@ func TestLoadConfigRejectsAPersistingClassNameThatWouldEscapeItsImageName(t *tes
 		path := filepath.Join(dir, "config.json")
 		writeFile(t, path, `{
 			"repo": "acme/widgets",
-			"tokenFile": "/run/secrets/token",
+			"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 			"classes": {"`+name+`": {"hull": "/h", "vcpus": 1, "memory": "512M", "warm": 1, "workspace": "1G", "persist": true}}
 		}`)
 		if _, err := LoadConfig(path); err == nil {
@@ -160,7 +178,7 @@ func TestLoadConfigDefaultsSpindriftPollInterval(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-build": {"hull": "/hulls/nixos", "vcpus": 4, "memory": "4096M", "warm": 0}},
 		"spindrift": {"url": "https://spindrift.example", "tokenFile": "/run/secrets/spindrift", "classes": ["skiff-build"]}
 	}`)
@@ -182,7 +200,7 @@ func TestLoadConfigOmittedSpindriftIsNil(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-nixos": {"hull": "/hulls/nixos", "vcpus": 4, "memory": "4096M", "warm": 1}}
 	}`)
 
@@ -200,7 +218,7 @@ func TestLoadConfigRejectsSpindriftMissingURL(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-build": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 0}},
 		"spindrift": {"tokenFile": "/x", "classes": ["skiff-build"]}
 	}`)
@@ -214,7 +232,7 @@ func TestLoadConfigRejectsSpindriftMissingTokenFile(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-build": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 0}},
 		"spindrift": {"url": "https://spindrift.example", "classes": ["skiff-build"]}
 	}`)
@@ -228,7 +246,7 @@ func TestLoadConfigRejectsSpindriftWithNoClasses(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-build": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 0}},
 		"spindrift": {"url": "https://spindrift.example", "tokenFile": "/x", "classes": []}
 	}`)
@@ -245,7 +263,7 @@ func TestLoadConfigRejectsSpindriftClassNotDeclaredInClasses(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff-nixos": {"hull": "/h", "vcpus": 1, "memory": "1G", "warm": 1}},
 		"spindrift": {"url": "https://spindrift.example", "tokenFile": "/x", "classes": ["skiff-build"]}
 	}`)
@@ -261,7 +279,7 @@ func TestLoadConfigAllowsADottedClassNameThatDoesNotPersist(t *testing.T) {
 	path := filepath.Join(dir, "config.json")
 	writeFile(t, path, `{
 		"repo": "acme/widgets",
-		"tokenFile": "/run/secrets/token",
+		"github": {"appId": 1, "privateKeyFile": "/run/secrets/key"},
 		"classes": {"skiff.ubuntu": {"hull": "/h", "vcpus": 1, "memory": "512M", "warm": 1}}
 	}`)
 	if _, err := LoadConfig(path); err != nil {

--- a/apps/bosun/github.go
+++ b/apps/bosun/github.go
@@ -3,10 +3,20 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"sync"
 	"time"
 )
 
@@ -32,19 +42,25 @@ const githubAPIBase = "https://api.github.com"
 // overridable so tests can point it at an httptest server.
 type ghClient struct {
 	httpClient *http.Client
-	token      string
-	base       string
+	// token resolves the bearer for a call against repo. Production wires
+	// (*appAuth).Token; tests use a fixed value.
+	token func(ctx context.Context, repo string) (string, error)
+	base  string
 }
 
-func newGHClient(token string) *ghClient {
+func newGHClient(auth *appAuth) *ghClient {
 	return &ghClient{
 		httpClient: &http.Client{Timeout: 30 * time.Second},
-		token:      token,
+		token:      auth.Token,
 		base:       githubAPIBase,
 	}
 }
 
 func (c *ghClient) GenerateJITConfig(ctx context.Context, repo, name string, labels []string) (int64, string, error) {
+	bearer, err := c.token(ctx, repo)
+	if err != nil {
+		return 0, "", fmt.Errorf("github auth: %w", err)
+	}
 	body := map[string]any{
 		"name":            name,
 		"runner_group_id": 1,
@@ -57,30 +73,41 @@ func (c *ghClient) GenerateJITConfig(ctx context.Context, repo, name string, lab
 		EncodedJITConfig string `json:"encoded_jit_config"`
 	}
 	url := fmt.Sprintf("%s/repos/%s/actions/runners/generate-jitconfig", c.base, repo)
-	if err := c.do(ctx, http.MethodPost, url, body, &resp); err != nil {
+	if err := doRequest(ctx, c.httpClient, http.MethodPost, url, bearer, body, &resp); err != nil {
 		return 0, "", err
 	}
 	return resp.Runner.ID, resp.EncodedJITConfig, nil
 }
 
 func (c *ghClient) GetRunner(ctx context.Context, repo string, runnerID int64) (string, bool, error) {
+	bearer, err := c.token(ctx, repo)
+	if err != nil {
+		return "", false, fmt.Errorf("github auth: %w", err)
+	}
 	var resp struct {
 		Status string `json:"status"`
 		Busy   bool   `json:"busy"`
 	}
 	url := fmt.Sprintf("%s/repos/%s/actions/runners/%d", c.base, repo, runnerID)
-	if err := c.do(ctx, http.MethodGet, url, nil, &resp); err != nil {
+	if err := doRequest(ctx, c.httpClient, http.MethodGet, url, bearer, nil, &resp); err != nil {
 		return "", false, err
 	}
 	return resp.Status, resp.Busy, nil
 }
 
 func (c *ghClient) DeleteRunner(ctx context.Context, repo string, runnerID int64) error {
+	bearer, err := c.token(ctx, repo)
+	if err != nil {
+		return fmt.Errorf("github auth: %w", err)
+	}
 	url := fmt.Sprintf("%s/repos/%s/actions/runners/%d", c.base, repo, runnerID)
-	return c.do(ctx, http.MethodDelete, url, nil, nil)
+	return doRequest(ctx, c.httpClient, http.MethodDelete, url, bearer, nil, nil)
 }
 
-func (c *ghClient) do(ctx context.Context, method, url string, body, out any) error {
+// doRequest is the one place an HTTP call against the GitHub API is made,
+// shared by ghClient (bearer = an installation token) and appAuth itself
+// (bearer = the App's own JWT, for the two endpoints that mint one).
+func doRequest(ctx context.Context, client *http.Client, method, url, bearer string, body, out any) error {
 	var reqBody io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -94,13 +121,13 @@ func (c *ghClient) do(ctx context.Context, method, url string, body, out any) er
 		return err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("Authorization", "Bearer "+c.token)
+	req.Header.Set("Authorization", "Bearer "+bearer)
 	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return err
 	}
@@ -108,10 +135,203 @@ func (c *ghClient) do(ctx context.Context, method, url string, body, out any) er
 
 	if resp.StatusCode >= 300 {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
-		return fmt.Errorf("github %s %s: %s: %s", method, url, resp.Status, bytes.TrimSpace(data))
+		return &httpStatusError{method: method, url: url, status: resp.Status, statusCode: resp.StatusCode, body: bytes.TrimSpace(data)}
 	}
 	if out == nil {
 		return nil
 	}
 	return json.NewDecoder(resp.Body).Decode(out)
+}
+
+// httpStatusError is a >=300 response from doRequest. Its statusCode is what
+// appAuth checks to tell "installation gone" (404) from any other failure.
+type httpStatusError struct {
+	method, url, status string
+	statusCode          int
+	body                []byte
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("github %s %s: %s: %s", e.method, e.url, e.status, e.body)
+}
+
+// appAuth mints GitHub App installation tokens: it signs its own short-lived
+// JWTs with the App's private key, resolves which installation owns a repo,
+// and caches the resulting installation token against its ~1h expiry. Go
+// stdlib only -- crypto/rsa signs the JWT by hand, so no JWT library earns
+// its place.
+//
+// Ticket-13's mint-immediately-before-boot rule lives in pool.go and is
+// untouched by this: it mints a JIT config, which is a distinct ~1h-lived
+// credential from the installation token below. Two clocks, both satisfied
+// by minting each at the moment it is needed rather than stockpiling either.
+type appAuth struct {
+	appID int64
+	key   *rsa.PrivateKey // read from the key file once, at construction; never re-read or logged
+
+	httpClient *http.Client
+	base       string           // overridable so tests can point it at an httptest server
+	now        func() time.Time // overridable so tests can control cache expiry deterministically
+
+	mu            sync.Mutex
+	installations map[string]int64      // repo -> installation id
+	tokens        map[int64]cachedToken // installation id -> cached token
+}
+
+type cachedToken struct {
+	token     string
+	expiresAt time.Time
+}
+
+const (
+	jwtClockSkew = 60 * time.Second // iat backdated per GitHub's own doc, to tolerate clock drift
+	jwtLifetime  = 9 * time.Minute  // GitHub caps exp at 10 minutes from iat; a minute of margin
+
+	// tokenRefreshMargin is how far ahead of an installation token's 1h
+	// expiry a cached one is treated as stale, so a mint in flight never
+	// races the token dying mid-use.
+	tokenRefreshMargin = 5 * time.Minute
+)
+
+// newAppAuth reads and parses privateKeyFile once. The parsed key lives only
+// in memory for the process lifetime; it is never re-read from disk and
+// never logged.
+func newAppAuth(appID int64, privateKeyFile string) (*appAuth, error) {
+	key, err := loadPrivateKey(privateKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("github app private key: %w", err)
+	}
+	return &appAuth{
+		appID:         appID,
+		key:           key,
+		httpClient:    &http.Client{Timeout: 30 * time.Second},
+		base:          githubAPIBase,
+		now:           time.Now,
+		installations: map[string]int64{},
+		tokens:        map[int64]cachedToken{},
+	}, nil
+}
+
+// loadPrivateKey parses the App's PEM key. GitHub's key generator and the
+// manifest-conversion endpoint both emit PKCS#1 ("BEGIN RSA PRIVATE KEY");
+// PKCS#8 is accepted too so a key re-exported by other tooling still works.
+func loadPrivateKey(path string) (*rsa.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("%s: no PEM block found", path)
+	}
+	if key, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return key, nil
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("%s: parsing private key: %w", path, err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("%s: private key is not RSA", path)
+	}
+	return key, nil
+}
+
+// signJWT signs an App JWT by hand: RS256 over base64url(header).base64url(claims).
+func (a *appAuth) signJWT() (string, error) {
+	now := a.now()
+	header, err := json.Marshal(map[string]string{"alg": "RS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+	claims, err := json.Marshal(map[string]any{
+		"iat": now.Add(-jwtClockSkew).Unix(),
+		"exp": now.Add(jwtLifetime).Unix(),
+		"iss": a.appID,
+	})
+	if err != nil {
+		return "", err
+	}
+	signingInput := base64.RawURLEncoding.EncodeToString(header) + "." + base64.RawURLEncoding.EncodeToString(claims)
+	hashed := sha256.Sum256([]byte(signingInput))
+	sig, err := rsa.SignPKCS1v15(rand.Reader, a.key, crypto.SHA256, hashed[:])
+	if err != nil {
+		return "", fmt.Errorf("signing app jwt: %w", err)
+	}
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(sig), nil
+}
+
+// Token returns a bearer suitable for repo: an installation token, minted
+// (or reused, inside its refresh margin) against the installation that owns
+// repo. Both the installation id and the token are cached in memory for the
+// life of the process; nothing here is ever logged.
+func (a *appAuth) Token(ctx context.Context, repo string) (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	instID, ok := a.installations[repo]
+	if !ok {
+		id, err := a.resolveInstallation(ctx, repo)
+		if err != nil {
+			return "", err
+		}
+		instID = id
+		a.installations[repo] = instID
+	}
+
+	if tok, ok := a.tokens[instID]; ok && a.now().Before(tok.expiresAt.Add(-tokenRefreshMargin)) {
+		return tok.token, nil
+	}
+
+	tok, err := a.mintInstallationToken(ctx, instID)
+	if err != nil {
+		var herr *httpStatusError
+		if errors.As(err, &herr) && herr.statusCode == http.StatusNotFound {
+			// The installation is gone -- app uninstalled, or reinstalled
+			// under a new id. Drop the cache so the next call re-resolves
+			// instead of retrying a dead id forever.
+			delete(a.installations, repo)
+			delete(a.tokens, instID)
+		}
+		return "", err
+	}
+	a.tokens[instID] = tok
+	return tok.token, nil
+}
+
+func (a *appAuth) resolveInstallation(ctx context.Context, repo string) (int64, error) {
+	jwt, err := a.signJWT()
+	if err != nil {
+		return 0, err
+	}
+	var resp struct {
+		ID int64 `json:"id"`
+	}
+	url := fmt.Sprintf("%s/repos/%s/installation", a.base, repo)
+	if err := doRequest(ctx, a.httpClient, http.MethodGet, url, jwt, nil, &resp); err != nil {
+		return 0, fmt.Errorf("resolve installation for %s: %w", repo, err)
+	}
+	return resp.ID, nil
+}
+
+// mintInstallationToken narrows the mint to Administration:write -- the one
+// permission GenerateJITConfig/GetRunner/DeleteRunner need -- even though
+// the App's own grant may carry more, so a stolen token can do only what
+// this process does.
+func (a *appAuth) mintInstallationToken(ctx context.Context, instID int64) (cachedToken, error) {
+	jwt, err := a.signJWT()
+	if err != nil {
+		return cachedToken{}, err
+	}
+	body := map[string]any{"permissions": map[string]string{"administration": "write"}}
+	var resp struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	url := fmt.Sprintf("%s/app/installations/%d/access_tokens", a.base, instID)
+	if err := doRequest(ctx, a.httpClient, http.MethodPost, url, jwt, body, &resp); err != nil {
+		return cachedToken{}, fmt.Errorf("mint installation token: %w", err)
+	}
+	return cachedToken{token: resp.Token, expiresAt: resp.ExpiresAt}, nil
 }

--- a/apps/bosun/github_test.go
+++ b/apps/bosun/github_test.go
@@ -2,13 +2,28 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 )
+
+// fixedToken builds a ghClient token source that always returns s, ignoring
+// ctx and repo -- what every test here wants except the one that exercises
+// appAuth itself.
+func fixedToken(s string) func(context.Context, string) (string, error) {
+	return func(context.Context, string) (string, error) { return s, nil }
+}
 
 // fakeGitHub is an in-memory stand-in for the three runner endpoints bosun
 // calls. It never simulates the list endpoint on purpose: bosun must never
@@ -103,7 +118,7 @@ func TestGHClientGenerateJITConfig(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &ghClient{httpClient: server.Client(), token: "test-token", base: server.URL}
+	c := &ghClient{httpClient: server.Client(), token: fixedToken("test-token"), base: server.URL}
 	id, jit, err := c.GenerateJITConfig(context.Background(), "acme/widgets", "skiff-01", []string{"skiff-nixos"})
 	if err != nil {
 		t.Fatalf("GenerateJITConfig: %v", err)
@@ -128,7 +143,7 @@ func TestGHClientGetRunner(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &ghClient{httpClient: server.Client(), token: "t", base: server.URL}
+	c := &ghClient{httpClient: server.Client(), token: fixedToken("t"), base: server.URL}
 	status, busy, err := c.GetRunner(context.Background(), "acme/widgets", 7)
 	if err != nil {
 		t.Fatalf("GetRunner: %v", err)
@@ -148,7 +163,7 @@ func TestGHClientDeleteRunner(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &ghClient{httpClient: server.Client(), token: "t", base: server.URL}
+	c := &ghClient{httpClient: server.Client(), token: fixedToken("t"), base: server.URL}
 	if err := c.DeleteRunner(context.Background(), "acme/widgets", 7); err != nil {
 		t.Fatalf("DeleteRunner: %v", err)
 	}
@@ -165,8 +180,97 @@ func TestGHClientErrorStatus(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	c := &ghClient{httpClient: server.Client(), token: "t", base: server.URL}
+	c := &ghClient{httpClient: server.Client(), token: fixedToken("t"), base: server.URL}
 	if _, _, err := c.GetRunner(context.Background(), "acme/widgets", 1); err == nil {
 		t.Fatal("expected error on 403")
+	}
+}
+
+// TestAppAuthTokenMintsCachesAndRefreshes exercises the JWT-mint-and-cache
+// core of appAuth against a throwaway RSA key and a fake App API: first call
+// resolves the installation and mints a token; a call still inside the
+// token's lifetime reuses it with no further HTTP calls; a call inside the
+// refresh margin mints again but does not re-resolve the installation.
+func TestAppAuthTokenMintsCachesAndRefreshes(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "app-key.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(keyPath, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	var (
+		mu          sync.Mutex
+		resolveHits int
+		mintHits    int
+		lastAuth    string
+	)
+	current := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /repos/acme/widgets/installation", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		resolveHits++
+		lastAuth = r.Header.Get("Authorization")
+		mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]any{"id": 42})
+	})
+	mux.HandleFunc("POST /app/installations/42/access_tokens", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		mintHits++
+		n := mintHits
+		mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]any{
+			"token":      fmt.Sprintf("inst-token-%d", n),
+			"expires_at": current.Add(time.Hour).Format(time.RFC3339),
+		})
+	})
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	auth, err := newAppAuth(12345, keyPath)
+	if err != nil {
+		t.Fatalf("newAppAuth: %v", err)
+	}
+	auth.httpClient = server.Client()
+	auth.base = server.URL
+	auth.now = func() time.Time { return current }
+
+	ctx := context.Background()
+	tok, err := auth.Token(ctx, "acme/widgets")
+	if err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+	if tok != "inst-token-1" {
+		t.Fatalf("got token %q", tok)
+	}
+	if resolveHits != 1 || mintHits != 1 {
+		t.Fatalf("first call: resolveHits=%d mintHits=%d", resolveHits, mintHits)
+	}
+	if !strings.HasPrefix(lastAuth, "Bearer ") || strings.Count(lastAuth, ".") != 2 {
+		t.Fatalf("installation lookup wasn't authorized with a 3-part JWT: %q", lastAuth)
+	}
+
+	// Still inside the cached token's lifetime: reused, no new HTTP calls.
+	tok2, err := auth.Token(ctx, "acme/widgets")
+	if err != nil {
+		t.Fatalf("Token (cached): %v", err)
+	}
+	if tok2 != tok || resolveHits != 1 || mintHits != 1 {
+		t.Fatalf("expected a cache hit, got token=%q resolveHits=%d mintHits=%d", tok2, resolveHits, mintHits)
+	}
+
+	// Inside the refresh margin of the cached token's expiry: mints again,
+	// but the installation id -- resolved once above -- stays cached.
+	current = current.Add(56 * time.Minute)
+	tok3, err := auth.Token(ctx, "acme/widgets")
+	if err != nil {
+		t.Fatalf("Token (refresh): %v", err)
+	}
+	if tok3 != "inst-token-2" || resolveHits != 1 || mintHits != 2 {
+		t.Fatalf("expected a refreshed mint, got token=%q resolveHits=%d mintHits=%d", tok3, resolveHits, mintHits)
 	}
 }

--- a/apps/bosun/main.go
+++ b/apps/bosun/main.go
@@ -44,12 +44,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	tokenRaw, err := os.ReadFile(cfg.TokenFile)
+	auth, err := newAppAuth(cfg.GitHub.AppID, cfg.GitHub.PrivateKeyFile)
 	if err != nil {
-		logger.Error("read token file", "path", cfg.TokenFile, "error", err)
+		logger.Error("init github app auth", "path", cfg.GitHub.PrivateKeyFile, "error", err)
 		os.Exit(1)
 	}
-	token := strings.TrimSpace(string(tokenRaw))
 
 	if err := os.MkdirAll(cfg.LogDir, 0o755); err != nil {
 		logger.Error("create log dir", "error", err)
@@ -59,7 +58,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	p := newPool(cfg, newGHClient(token), execLauncher{}, logger)
+	p := newPool(cfg, newGHClient(auth), execLauncher{}, logger)
 
 	if err := p.sweep(ctx); err != nil {
 		logger.Error("sweep", "error", err)

--- a/apps/bosun/module.nix
+++ b/apps/bosun/module.nix
@@ -23,15 +23,18 @@ let
   configFile = (pkgs.formats.json { }).generate "bosun.json" {
     inherit (cfg)
       repo
-      tokenFile
       runtimeDir
       logDir
       workspaceDir
       metricsFile
       ;
+    github = {
+      inherit (cfg.github) appId privateKeyFile;
+    };
     pollInterval = cfg.pollInterval;
     drainTimeout = "${toString cfg.drainTimeout}s";
-    cacheUrl = if cfg.cache.enable then "http://${cfg.cache.address}:${toString cfg.cache.port}/" else "";
+    cacheUrl =
+      if cfg.cache.enable then "http://${cfg.cache.address}:${toString cfg.cache.port}/" else "";
     classes = lib.mapAttrs (_: c: {
       inherit (c)
         hull
@@ -83,13 +86,33 @@ in
       description = "owner/name of the repository skiffs register against.";
     };
 
-    tokenFile = mkOption {
-      type = types.path;
+    github = mkOption {
       description = ''
-        File holding a GitHub token with `Administration: write` on
-        {option}`services.bosun.repo`, which is what minting a JIT config
-        requires. Read once at startup and never logged.
+        Identity bosun authenticates to GitHub with: an installation of the
+        shared Spindrift+bosun GitHub App, rather than a personal access
+        token. Minting a JIT config needs `Administration: write` on
+        {option}`services.bosun.repo`, which this installation must grant.
       '';
+      type = types.submodule {
+        options = {
+          appId = mkOption {
+            type = types.ints.positive;
+            description = ''
+              ID of the shared Spindrift+bosun GitHub App. Public -- fine in
+              the Nix store, unlike the key below.
+            '';
+          };
+          privateKeyFile = mkOption {
+            type = types.path;
+            description = ''
+              File holding bosun's own private key for the shared App --
+              distinct from Spindrift's key on the same App; GitHub Apps
+              hold multiple keys concurrently, so the two are rotated
+              independently. Read once at startup and never logged.
+            '';
+          };
+        };
+      };
     };
 
     runtimeDir = mkOption {

--- a/nix/hosts/oldschool.nix
+++ b/nix/hosts/oldschool.nix
@@ -24,7 +24,10 @@
   # services.harmonia in the deploy-harmonia ticket.
   sops.secrets."harmonia-cache-key" = { };
 
-  sops.secrets."bosun-github-token" = {
+  # Shared with riptide: both are bosun hosts on the same Spindrift+bosun
+  # GitHub App, each holding this same key.
+  sops.secrets."bosun-github-app-key" = {
+    sopsFile = ../secrets/bosun.sops.yaml;
     owner = "bosun";
     group = "bosun";
     mode = "0400";
@@ -38,7 +41,14 @@
   services.bosun = {
     enable = true;
     repo = "jonpulsifer/infra";
-    tokenFile = config.sops.secrets."bosun-github-token".path;
+    github = {
+      # TODO(operator): the shared Spindrift+bosun GitHub App is created by
+      # hand during the design's cutover step (Manifest flow, off Spindrift's
+      # Repositories screen); this placeholder id is not real. Replace it
+      # once that App exists -- see the PR body.
+      appId = 1;
+      privateKeyFile = config.sops.secrets."bosun-github-app-key".path;
+    };
     classes.skiff-ubuntu = {
       hull = "${inputs.self.packages.x86_64-linux.hull-ubuntu}";
       # 2, not 4: this box has 4 cores shared with kubelet, yarr and

--- a/nix/hosts/riptide.nix
+++ b/nix/hosts/riptide.nix
@@ -39,10 +39,12 @@
   homelab.disko.device = "/dev/nvme0n1";
 
   sops.defaultSopsFile = ../secrets/riptide.sops.yaml;
-  # bosun reads this once at startup, so a rotated token needs the unit
+  # bosun reads this once at startup, so a rotated key needs the unit
   # bounced -- which is what restartUnits does on the activation that
-  # rewrites the secret.
-  sops.secrets."bosun-github-token" = {
+  # rewrites the secret. Shared with oldschool: both are bosun hosts on the
+  # same Spindrift+bosun GitHub App, each holding this same key.
+  sops.secrets."bosun-github-app-key" = {
+    sopsFile = ../secrets/bosun.sops.yaml;
     owner = "bosun";
     group = "bosun";
     mode = "0400";
@@ -55,7 +57,14 @@
   services.bosun = {
     enable = true;
     repo = "jonpulsifer/infra";
-    tokenFile = config.sops.secrets."bosun-github-token".path;
+    github = {
+      # TODO(operator): the shared Spindrift+bosun GitHub App is created by
+      # hand during the design's cutover step (Manifest flow, off Spindrift's
+      # Repositories screen); this placeholder id is not real. Replace it
+      # once that App exists -- see the PR body.
+      appId = 1;
+      privateKeyFile = config.sops.secrets."bosun-github-app-key".path;
+    };
     classes.skiff-nixos = {
       hull = "${inputs.self.packages.x86_64-linux.hull-nixos}";
       vcpus = 4;

--- a/nix/secrets/bosun.sops.yaml
+++ b/nix/secrets/bosun.sops.yaml
@@ -1,0 +1,34 @@
+bosun-github-app-key: ENC[AES256_GCM,data:NGZd9/SPqOtuXZU0g8vzsid+7moSiBYresMZ5dWukKC8Hww35f54hswoehQkV7Q4qwdqyRV8gZ5r0u39fllyCmGXawG5KuxY0uJd/JO0mW7Ym2it1YIEHWcT1U82gIE36/ailavsBsHP1WIyqAM+cBTVlsYOGXEens3kvkcu3rlbEHQgygCfJN5vgnx4nImlBH1fsCFKuaKb13nL6B7kpOvNTjQd+uicL9giHPGMu/PwsqVxW82Q3RoPCstcEvT//frDeuGPFBzG3hBTBP3gagkGflX3jtyO4JeTvhzkeOQaWY1d2dao/u9hpucwADf/pQxQSkIKKI0+bGbky4WPXnb5Gr0XcoQoi16byjv+54q6zbGTbvVvD1BZDScxU1IHBFHL9o5HfzoREtNa1eThSNBECbgUrketL4Ok4oqvZtvurhKXMF4yQb8DAFV+qiwbgQxdHHUl+WbvnC94ow==,iv:QzXYS/NJtSqjt7xCK94KPfH0uPsYF388tRdYGsRPxd0=,tag:papTnEz3E8BLeMqgXBueHA==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjUkJldlFnVjd6NTk4eDZP
+            ZTlGVkMzVmxheCs2WkhpMVVkbm95QVlTLzI4CllxVjZQZ3FOSDB0Mno2bW9xdSta
+            bDdQYkNhb0ZIbkdLSGh5amF5OFhEV2sKLS0tIHg1RTE5RmgyWVRDMERLSDVlWFJE
+            czlIdGtqa3dvM2c4THQ1bWFpcmZWd1EKfvdV8SpODV2FqDrmwliJcgsbFI36jxj+
+            QSBvOlMR/dDoNkWhrfil2JKZby8AWpS6OcObs0Hj13j32bj3XdZzsQ==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRcXRxYUZadW1EK2dEQzNX
+            M05pYUcrT0lSb3U2MGFXcFVPUWZZT1U1ZjFRClRGNVZxc3lxNktaRU1ScXl6ck1w
+            T1JIQ2E0ZmpQQjNaWUV0QzRTNlpXUFkKLS0tIHJCRmVGazVtWFhEaGpWZ3R3MXFF
+            bmI3aUdxeUVuNmVqMGgyUHR1UTZJeVkK7eEF8bKbJoI/yuckJyl/q4oeBDtfo32x
+            qMhCkr212trIPgeFyzXtWBtYqHaE1PwvQkoCwcmEVtJ0/kCBKk6v2A==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0eVRaQkpzZ0Y0Zkw0TWVP
+            YXh3aW5tTUtzMnNHeFkzT0hJMHY3QkFvN25vClBJRDRad21ZOGJjZVBmWlc4RUl5
+            TXlPZTcycVF3dHVjaWU0N3AyZ0dLUmsKLS0tIG80S056bjVmRExCSkVuWjdIQ1lp
+            a2VlVDV2SHh4Q2Y5ZldiVmZpQnNqUDQK/5BqAJP+QvSklToSs7Y8phOHHGM8iUgM
+            5S4hYvExUnIp7S7+GxlMVKinPyoGfua1BhcBfWcS7hM+OE9Z44vbjw==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c
+    lastmodified: "2026-08-13T00:54:27Z"
+    mac: ENC[AES256_GCM,data:CwQ3Td4xWqU2LfH6P13VqyBFheOi8CFogzdSsVwXjZBgMZBpPtM8xTKb+yHo8gx1+jHwjz0BLHmBMtO84h4kGj7CaKgFdSLtjatcYf+UNhczMaRLJLxWBS3SxKwpPDcfyRMUyH0QJ7rVCHYq1o/8eRydja7l3vjDVfgqsK+aZMY=,iv:XsjvXNsJhaXBTB3YRSfbXvsccu20RYXxzn8G/9J4Nvw=,tag:78FBRZTDas3qnrBauo1gOw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.3


### PR DESCRIPTION
## Summary

bosun (the microVM GitHub-runner daemon) moves from a static PAT file to GitHub App installation-token auth, on its own private key on the shared Spindrift+bosun App:

- `apps/bosun/github.go`: new `appAuth` signs its own RS256 JWT by hand (Go stdlib only -- `crypto/rsa`, `crypto/x509`, `encoding/pem`, `encoding/json`, `encoding/base64`), resolves the installation for the configured repo (`GET /repos/{owner}/{repo}/installation`), and mints/caches an installation token (`POST /app/installations/{id}/access_tokens`) against its ~1h expiry with a 5-minute refresh margin. The mint is narrowed to `administration: write`, the one permission bosun needs. A 404 on either call invalidates the cache so a later call re-resolves instead of retrying a dead installation forever. The key file is read once at construction and never re-read or logged. `GenerateJITConfig`/`GetRunner`/`DeleteRunner` only change their bearer source -- ticket-13's mint-immediately-before-boot rule for the JIT config itself is untouched.
- `apps/bosun/config.go`, `module.nix`: `tokenFile` is replaced by `github.appId` / `github.privateKeyFile` (no dual PAT/App path -- the binary and its module ship in one closure). The option doc states the required App permission (`Administration: write` via the installation).
- `nix/secrets/bosun.sops.yaml`: new file shared by both bosun hosts, holding `bosun-github-app-key`, encrypted to the operator + riptide + oldschool recipients (`.sops.yaml` gains one creation rule). `nix/hosts/riptide.nix` and `nix/hosts/oldschool.nix` swap their per-host `bosun-github-token` PAT secret for this shared key.

## Operator prerequisites -- this PR must not merge until both are done

The shared Spindrift+bosun GitHub App does not exist yet; it's created by hand in a separate step (GitHub's Manifest flow), outside this PR's scope. Two placeholders stand in for what only that step can produce:

1. **`nix/secrets/bosun.sops.yaml`** currently holds a placeholder string, not a real key. Once the App exists, generate bosun's own private key in the App's GitHub settings, then run `sops nix/secrets/bosun.sops.yaml` and paste the PEM in place of the placeholder (see `nix/secrets/bosun.sops.yaml`'s own placeholder text, and the SOPS Secrets and Age Keys runbook).
2. **`github.appId = 1;`** in both `nix/hosts/riptide.nix` and `nix/hosts/oldschool.nix` is a placeholder (marked `TODO(operator)`), not a real App id. Replace both with the real id once the App is created.

Until both are done, deploying this branch leaves bosun unable to mint tokens (GitHub will refuse a JWT for App id 1). The existing PAT path stays live on `main` until this lands, so there is no runner outage window from authoring this ahead of the operator step.

## Validation

- `gofmt -l apps/bosun` -- clean
- `go vet ./...` -- clean
- `go test ./...` (apps/bosun) -- all pass, including a new focused test (`TestAppAuthTokenMintsCachesAndRefreshes`) covering JWT mint, token-cache reuse, and refresh-margin re-mint, against a throwaway RSA key and a fake HTTP server
- `nix fmt` on the touched Nix files
- `nix build .#checks.x86_64-linux.fleet-hosts-evaluate` -- the eval-only fleet check (forces every host, including riptide and oldschool, to instantiate its full module system without building any derivation output) -- clean

Builds were not attempted on this machine (WSL); CI covers host builds on `main`.

## Risks

- Both hosts carry a placeholder `appId` and the sops file carries a placeholder key value, called out above -- deploying either unmodified is a no-op failure (bosun logs an auth error and never mints), not a silent one.
- Blast radius is unchanged from the design's tradeoff: bosun's key mints `Administration: write` on every repository the installation grants, same as the PAT did; it's now independently rotatable from Spindrift's own key on the same App.