### PR TITLE
feat(spindrift): create a Datastore from the Datastores ledger

### DIFF
--- a/apps/spindrift/src/commands/datastores/list.ts
+++ b/apps/spindrift/src/commands/datastores/list.ts
@@ -20,11 +20,27 @@
  * No pagination. Datastores are created by hand, one at a time, through a
  * form with a name field — there will be tens of them for the lifetime of an
  * installation, not the thousands a Build or a Deploy accumulates.
+ *
+ * **The pickable Targets ride along.** `createDatastore` takes a Target and no
+ * App, so the ledger can create — and the one thing its form needs that the
+ * rows do not carry is where a new one could go. It is answered here rather
+ * than by a second call to `listTargets` because that command answers a
+ * different question (placement candidacy for a Component being created) and
+ * carries none of §3's storage capabilities; a screen that asked it would be
+ * offering Targets on a fact it never read.
  */
 import { z } from 'zod';
+import { capabilitiesOfRow } from '../../domain/capabilities.ts';
 import { elapsedSince } from '../../domain/elapsed.ts';
-import { targetRowLabel } from '../../domain/target.ts';
-import type { DatastoreListItem } from '../../web/model.ts';
+import {
+  hasTargetConnection,
+  hasVesselLocation,
+  targetRowLabel,
+} from '../../domain/target.ts';
+import type {
+  DatastoreListItem,
+  DatastoreTargetOption,
+} from '../../web/model.ts';
 import { type Command, ok } from '../types.ts';
 
 export const listDatastoresInput = z.object({}).strict();
@@ -33,6 +49,8 @@ export type ListDatastoresInput = z.infer<typeof listDatastoresInput>;
 
 export interface ListDatastoresResult {
   readonly datastores: readonly DatastoreListItem[];
+  /** Where a new managed Datastore could be created — see the file note. */
+  readonly targets: readonly DatastoreTargetOption[];
 }
 
 export const listDatastores: Command<
@@ -45,7 +63,40 @@ export const listDatastores: Command<
     orderBy: (row, { desc }) => [desc(row.createdAt)],
   });
 
+  const targetRows = await context.db.query.targets.findMany({
+    with: { vessel: true },
+    orderBy: (row, { asc }) => [asc(row.rank)],
+  });
+  const targets: DatastoreTargetOption[] = [];
+  for (const target of targetRows) {
+    // Every check `createDatastore` makes before it inserts, in its order. A
+    // Target that fails any of them is one whose only answer is that command's
+    // refusal, and an option whose sole outcome is a refusal is worth less
+    // than not offering it.
+    if (!hasTargetConnection(target) || !hasVesselLocation(target.vessel)) {
+      continue;
+    }
+    if ((context.adapters.datastore?.(target.adapter) ?? null) === null) {
+      continue;
+    }
+    const capabilities = capabilitiesOfRow(target, {
+      artifactTypes:
+        context.adapters.deploy(target.adapter)?.artifactTypes ?? null,
+      manifest: context.manifest,
+    });
+    const engines = (['postgres', 'valkey'] as const).filter(
+      (engine) => capabilities[engine],
+    );
+    if (engines.length === 0) continue;
+    targets.push({
+      targetId: target.id,
+      label: targetRowLabel(target),
+      engines,
+    });
+  }
+
   return ok({
+    targets,
     datastores: rows.map((row) => ({
       id: row.id,
       name: row.name,

--- a/apps/spindrift/src/web/app.tsx
+++ b/apps/spindrift/src/web/app.tsx
@@ -72,6 +72,7 @@ import { InstallationSettings } from './views/auth/installation.tsx';
 import { Onboarding } from './views/auth/onboarding.tsx';
 import { IdentitySettings } from './views/auth/settings.tsx';
 import {
+  type CreateLedgerDatastore,
   DatastoreLedger,
   type DatastoreAct as DatastoreLedgerAct,
 } from './views/operations/datastores.tsx';
@@ -2594,6 +2595,39 @@ function DatastoresScreen({
     };
   }, [reloadToken]);
 
+  /**
+   * One dispatch and no attach, which is the whole difference from the
+   * workspace's handler: that one creates and then attaches because it has an
+   * App open to attach to, and this screen has none. The Datastore lands
+   * unattached, which is what §11 says it is until something attaches it.
+   */
+  const handleCreate: CreateLedgerDatastore = async (create) => {
+    try {
+      const result = await command('createDatastore', {
+        name: create.name,
+        engine: create.engine,
+        targetId: create.targetId,
+        // Restated rather than omitted for the reason `handleCreateDatastore`
+        // restates it: `InputOf` reads the schema's output, so a `.default()`
+        // is still a required property to a typed caller.
+        storageGiB: 10,
+      });
+      // A refusal leaves no row behind — `createDatastore` deletes its insert
+      // when `provision` throws — so there is nothing new to re-read.
+      if (!result.ok) return { ok: false, message: result.failure.message };
+      setReloadToken((token) => token + 1);
+      return { ok: true };
+    } catch (cause: unknown) {
+      return {
+        ok: false,
+        message:
+          cause instanceof Error
+            ? cause.message
+            : 'Creating the Datastore failed',
+      };
+    }
+  };
+
   const handleDetach: DatastoreLedgerAct = async (datastoreId) => {
     try {
       const result = await command('detachDatastore', { datastoreId });
@@ -2635,7 +2669,9 @@ function DatastoresScreen({
   return (
     <DatastoreLedger
       datastores={state.result.datastores}
+      targets={state.result.targets}
       onNavigate={onNavigate}
+      onCreate={handleCreate}
       onDetach={handleDetach}
       onDestroy={handleDestroy}
     />

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -585,6 +585,27 @@ export interface DatastoreListItem {
   readonly at: string;
 }
 
+/**
+ * A Target a managed Datastore can actually be created on — the ledger's Create
+ * picker (§11).
+ *
+ * `createDatastore` takes a Target and no App, so this is the whole of what the
+ * form needs to pick: creating storage has never required knowing which App
+ * will read it. The list is what core would accept, not every Target that
+ * exists — a Target with no connection, no datastore adapter, or no served
+ * engine is one whose only answer is a refusal, so it is not offered.
+ *
+ * `engines` is per-Target because the two capabilities are independent (§3): a
+ * cluster that serves Postgres and not Valkey is the ordinary case, and a
+ * picker that showed one list for both would offer a choice core refuses.
+ */
+export interface DatastoreTargetOption {
+  readonly targetId: string;
+  /** `targetRowLabel` — the vessel-and-surface pair the ledger's rows use. */
+  readonly label: string;
+  readonly engines: readonly ('postgres' | 'valkey')[];
+}
+
 /** One Component as the workspace lists it. */
 export interface ComponentView {
   /**

--- a/apps/spindrift/src/web/views/operations/datastores.tsx
+++ b/apps/spindrift/src/web/views/operations/datastores.tsx
@@ -8,17 +8,19 @@
  * (§11: "attached, not a field"), and this is the screen a top-level noun
  * gets: one ledger, independent of which App a reader opened first.
  *
- * **No create or attach here.** Both need an App-and-Target picker this
- * screen has no home for — `createDatastore` binds to a placed Target and
- * `attachDatastore` binds to an App, and a global ledger has neither selected.
- * They stay exactly where §11 put them, on the workspace of the App they
- * would attach to. What lives here are the two acts that take only a
- * Datastore id: Detach and Destroy, one at a time and never both, because the
- * row already says which one core would accept — `destroyDatastore` refuses
- * while attached. That is stricter than the workspace's section, which offers
- * Destroy on every row and lets the refusal come back as a sentence; here the
- * reader has no App open to detach from first, so a button whose only outcome
- * is that refusal is worth less than the one act that works.
+ * **Create lives here; attach does not.** `createDatastore` takes a name, an
+ * engine and a Target, and no App — storage exists before anything reads it,
+ * which is the whole of what "top-level, not a field" means — so the only
+ * picker this form needs is the one `listDatastores` sends with the rows.
+ * `attachDatastore` genuinely does bind to an App, and a global ledger has
+ * none selected, so it stays on the workspace of the App it would attach to.
+ * Alongside it are the two acts that take only a Datastore id: Detach and
+ * Destroy, one at a time and never both, because the row already says which
+ * one core would accept — `destroyDatastore` refuses while attached. That is
+ * stricter than the workspace's section, which offers Destroy on every row and
+ * lets the refusal come back as a sentence; here the reader has no App open to
+ * detach from first, so a button whose only outcome is that refusal is worth
+ * less than the one act that works.
  *
  * Not a `SupplyChainTabs` member. §2's chain is Source + Build = Artifact;
  * a Datastore is never an input to that chain or an output of it, so tabbing
@@ -31,12 +33,13 @@ import {
   DefinitionGrid,
   LedgerExplorer,
 } from '../../components/object-explorer.tsx';
-import type { DatastoreListItem } from '../../model.ts';
+import type { DatastoreListItem, DatastoreTargetOption } from '../../model.ts';
 import { Badge } from '../../ui/badge.tsx';
 import { Button } from '../../ui/button.tsx';
 import { Eyebrow } from '../../ui/card.tsx';
 import type { Column } from '../../ui/data-table.tsx';
 import { EmptyState } from '../../ui/empty-state.tsx';
+import { Field } from '../../ui/field.tsx';
 import { Page, PageHeader } from '../../ui/page.tsx';
 import { Timestamp } from '../../ui/timestamp.tsx';
 import { deployTone } from './deploys.tsx';
@@ -52,6 +55,23 @@ import { deployTone } from './deploys.tsx';
 export type DatastoreAct = (
   datastoreId: string,
 ) => Promise<
+  { readonly ok: true } | { readonly ok: false; readonly message: string }
+>;
+
+/**
+ * Creating one managed Datastore from the ledger.
+ *
+ * Three fields and no App, which is `createDatastore`'s own input minus the
+ * size it defaults — the workspace's `CreateDatastore` is this shape with the
+ * Target implied by the App that screen already has open, and the two stay
+ * separate rather than one shared alias because the implied Target is exactly
+ * the difference.
+ */
+export type CreateLedgerDatastore = (create: {
+  readonly name: string;
+  readonly engine: 'postgres' | 'valkey';
+  readonly targetId: string;
+}) => Promise<
   { readonly ok: true } | { readonly ok: false; readonly message: string }
 >;
 
@@ -191,24 +211,225 @@ function DatastoreRowActions({
   );
 }
 
+/** A `<select>` styled like the `Input` beside it, so the two do not diverge. */
+function Select({
+  id,
+  value,
+  options,
+  disabled,
+  onChange,
+}: {
+  readonly id: string;
+  readonly value: string;
+  readonly options: readonly {
+    readonly value: string;
+    readonly label: string;
+  }[];
+  readonly disabled?: boolean;
+  readonly onChange: (value: string) => void;
+}) {
+  return (
+    <select
+      id={id}
+      name={id}
+      value={value}
+      disabled={disabled}
+      onChange={(event) => onChange(event.currentTarget.value)}
+      className="h-9 w-full rounded-sm border border-input bg-background px-3 font-mono text-body text-foreground disabled:cursor-not-allowed disabled:opacity-60"
+    >
+      {options.map((option) => (
+        <option key={option.value} value={option.value}>
+          {option.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/**
+ * Creating one managed Datastore — a name, a Target and an engine.
+ *
+ * **The engine list is the selected Target's, not the two the schema accepts.**
+ * §3 makes Postgres and Valkey independent capabilities, so a cluster that
+ * serves one and not the other is ordinary; offering both everywhere would put
+ * a choice on screen whose only outcome on half the Targets is core's "does not
+ * serve" refusal. It is derived from the selection rather than corrected by an
+ * effect, so switching Target can never leave a stale engine selected for the
+ * length of a render.
+ *
+ * No size field, the same decision `NewDatastoreForm` makes on the workspace:
+ * `storageGiB` is a defaulted command input because a developer has no basis on
+ * day one for a number a resize command would own.
+ */
+function NewDatastoreForm({
+  targets,
+  onCreate,
+  onDone,
+}: {
+  readonly targets: readonly DatastoreTargetOption[];
+  readonly onCreate: CreateLedgerDatastore;
+  readonly onDone: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [targetId, setTargetId] = useState(targets[0]?.targetId ?? '');
+  const [chosenEngine, setChosenEngine] = useState<'postgres' | 'valkey'>(
+    'postgres',
+  );
+  const [saving, setSaving] = useState(false);
+  const [outcome, setOutcome] = useState<
+    | { readonly kind: 'created' }
+    | { readonly kind: 'refused'; readonly message: string }
+    | null
+  >(null);
+
+  const target = targets.find((row) => row.targetId === targetId) ?? targets[0];
+  const engines = target?.engines ?? [];
+  const engine = engines.includes(chosenEngine) ? chosenEngine : engines[0];
+
+  const save = async () => {
+    if (target === undefined || engine === undefined) return;
+    setSaving(true);
+    setOutcome(null);
+    try {
+      const result = await onCreate({
+        name: name.trim(),
+        engine,
+        targetId: target.targetId,
+      });
+      if (result.ok) {
+        setOutcome({ kind: 'created' });
+        setName('');
+      } else {
+        setOutcome({ kind: 'refused', message: result.message });
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-md border border-border-soft p-4">
+      <div className="grid gap-3 sm:grid-cols-3">
+        <Field
+          name="datastore-name"
+          label="Name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="primary"
+        />
+        <Field name="datastore-target" label="Target">
+          <Select
+            id="datastore-target"
+            value={target?.targetId ?? ''}
+            disabled={saving}
+            options={targets.map((row) => ({
+              value: row.targetId,
+              label: row.label,
+            }))}
+            onChange={setTargetId}
+          />
+        </Field>
+        <Field
+          name="datastore-engine"
+          label="Engine"
+          hint={
+            engine === 'postgres'
+              ? 'Arrives as DATABASE_URL'
+              : 'Arrives as REDIS_URL'
+          }
+        >
+          <Select
+            id="datastore-engine"
+            value={engine ?? ''}
+            disabled={saving}
+            options={engines.map((served) => ({
+              value: served,
+              label: served,
+            }))}
+            onChange={(value) =>
+              setChosenEngine(value === 'valkey' ? 'valkey' : 'postgres')
+            }
+          />
+        </Field>
+      </div>
+      {outcome?.kind === 'refused' ? (
+        <p className="rounded-md border border-destructive/40 bg-destructive-soft px-3 py-2 text-xs text-destructive">
+          {outcome.message}
+        </p>
+      ) : null}
+      {outcome?.kind === 'created' ? (
+        <p className="rounded-md border border-warning/40 bg-warning-soft px-3 py-2 text-xs">
+          Created, unattached. It provisions in the background — the row says
+          how far it has got — and attaching it to an App is done from that
+          App's workspace.
+        </p>
+      ) : null}
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          size="sm"
+          disabled={saving || name.trim() === '' || engine === undefined}
+          onClick={() => {
+            void save();
+          }}
+        >
+          {saving ? 'Creating…' : 'Create Datastore'}
+        </Button>
+        <Button variant="ghost" size="sm" onClick={onDone} disabled={saving}>
+          {outcome?.kind === 'created' ? 'Close' : 'Cancel'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function DatastoreLedger({
   datastores,
+  targets,
   onNavigate,
+  onCreate,
   onDetach,
   onDestroy,
 }: {
   readonly datastores: readonly DatastoreListItem[];
+  readonly targets: readonly DatastoreTargetOption[];
   readonly onNavigate: (path: string) => void;
+  readonly onCreate: CreateLedgerDatastore;
   readonly onDetach: DatastoreAct;
   readonly onDestroy: DatastoreAct;
 }) {
+  const [adding, setAdding] = useState(false);
+  // No Target serves an engine, so there is nothing a form here could be
+  // pointed at. The button is withheld rather than shown and refused: the
+  // sentence below already says what is missing, and it is a Target-connection
+  // fact, not something a retry of this form fixes.
+  const canCreate = targets.length > 0;
+
   return (
     <Page>
       <PageHeader
         eyebrow="Attached resources"
         title="Datastores"
-        description="Every Postgres and Valkey Datastore this installation holds, attached or not. Creating one and attaching it to an App both stay on that App's workspace — this is where the rest of the lifecycle is read."
+        description="Every Postgres and Valkey Datastore this installation holds, attached or not. Create one here against any Target that serves the engine; attaching it to an App stays on that App's workspace."
+        {...(canCreate
+          ? {
+              actions: (
+                <Button
+                  variant="outline"
+                  onClick={() => setAdding((current) => !current)}
+                >
+                  {adding ? 'Close' : 'Create Datastore'}
+                </Button>
+              ),
+            }
+          : {})}
       />
+      {canCreate && adding ? (
+        <NewDatastoreForm
+          targets={targets}
+          onCreate={onCreate}
+          onDone={() => setAdding(false)}
+        />
+      ) : null}
       <LedgerExplorer
         columns={COLUMNS}
         rows={datastores}
@@ -221,8 +442,9 @@ export function DatastoreLedger({
         inspectorLabel={(datastore) => `Datastore ${datastore.name}`}
         empty={
           <EmptyState icon={<Database />} title="No Datastores exist yet.">
-            Creating one and attaching it to an App is done from that App's
-            workspace.
+            {canCreate
+              ? 'Create one against any Target that serves the engine — attaching it to an App is done from that App’s workspace.'
+              : 'No connected Target serves Postgres or Valkey, so there is nowhere to create one yet.'}
           </EmptyState>
         }
         renderInspector={(datastore) => (

--- a/apps/spindrift/test/commands/datastores.test.ts
+++ b/apps/spindrift/test/commands/datastores.test.ts
@@ -632,4 +632,72 @@ describe('listDatastores', () => {
     // anywhere in the payload, not just under its own field name.
     expect(JSON.stringify(row)).not.toContain('secret://elsewhere/analytics');
   });
+
+  /*
+    The ledger's Create picker. Every case here is a Target `createDatastore`
+    would refuse, offered or not offered accordingly — the picker and the
+    command have to agree, because a Target on the list whose only answer is a
+    refusal is the bug this list exists to avoid.
+  */
+  test('offers only the engines the Target serves', async () => {
+    const both = await aTarget();
+    const cacheOnly = await aTarget({
+      discovery: { ...CAPABLE_DISCOVERY, postgres: false },
+    });
+
+    const result = await listDatastores(
+      {},
+      contextWith(new FakeDatastoreAdapter()),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const offered = new Map(
+      result.value.targets.map((row) => [row.targetId, row.engines]),
+    );
+    expect(offered.get(both.id)).toEqual(['postgres', 'valkey']);
+    expect(offered.get(cacheOnly.id)).toEqual(['valkey']);
+  });
+
+  test('offers no Target serving neither engine', async () => {
+    const bare = await aTarget({
+      discovery: { ...CAPABLE_DISCOVERY, postgres: false, valkey: false },
+    });
+
+    const result = await listDatastores(
+      {},
+      contextWith(new FakeDatastoreAdapter()),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      result.value.targets.some((row) => row.targetId === bare.id),
+    ).toBeFalse();
+  });
+
+  test('offers nothing when this installation ships no datastore adapter', async () => {
+    await aTarget();
+
+    const result = await listDatastores({}, contextWith(null));
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.targets).toEqual([]);
+  });
+
+  test('offers no unconnected Target', async () => {
+    const unconnected = await aTarget({ connection: null });
+
+    const result = await listDatastores(
+      {},
+      contextWith(new FakeDatastoreAdapter()),
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(
+      result.value.targets.some((row) => row.targetId === unconnected.id),
+    ).toBeFalse();
+  });
 });


### PR DESCRIPTION
## Summary

The Datastores ledger had no Create button — creating one meant opening an App workspace, even though `createDatastore` takes a name, an engine and a Target and no App at all. A Datastore is top-level, so the create act is decoupled from the App screen.

- `listDatastores` also returns the Targets a managed Datastore could be created on, filtered by exactly the checks `createDatastore` makes before it inserts: connected boundary, a datastore adapter this installation ships, and the engine served (§3 capability, so a cluster serving Postgres and not Valkey offers one engine, not two).
- `DatastoreLedger` gets a Create Datastore form over that list — name, Target, engine. The engine list is derived from the selected Target, so switching Target can never leave a selection core would refuse.
- Attach stays on the workspace: `attachDatastore` genuinely binds to an App and this screen has none selected. A row created here lands unattached, which is what it is until something attaches it.

The picker is answered by `listDatastores` rather than `listTargets` because that command answers placement candidacy for a Component being created and carries none of the storage capabilities — a screen asking it would be offering Targets on a fact it never read.

## Validation

- `bun run typecheck`, `bun run lint` — clean
- `bun test` — 2396 pass, 0 fail
- Four new cases on `listDatastores` covering the picker: engines narrowed per Target, a Target serving neither engine withheld, no adapter shipped, and an unconnected Target withheld

## Risks

Additive field on one command's result; the only consumer is the ledger screen.