### PR TITLE
feat(spindrift): connect the Cloudflare Pages Target

### DIFF
--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -365,6 +365,27 @@ spec:
           kind: vercel-team
           location:
             team: jonpulsifer
+        # The other edge platform, and the same bearer posture one vendor over:
+        # Cloudflare has no inbound OIDC either, so this boundary is reached
+        # with `SPINDRIFT_CLOUDFLARE_TOKEN` from `secret.sops.yaml`.
+        #
+        # **That token is scoped to Pages and nothing else.** It is not the
+        # `cloudflare-api-token` the network root drives DNS with: core reaches
+        # no zone with a Target credential, and
+        # `apps/spindrift/test/extraction/no-dns-credential.test.ts` is what
+        # keeps that true of the code. Handing this the DNS-capable one would
+        # leave that test passing and the posture gone.
+        #
+        # The account is the one every zone in `terraform/network/cloudflare/`
+        # already sits under (`account.tf`'s `fml_account_id`) — an id rather
+        # than a name because the API path is `/accounts/<id>/pages/projects`.
+        #
+        # No `terraformRoot`, no `reachableRegistries`: the same two absences
+        # the Vercel boundary above documents, for the same two reasons.
+        - name: fml
+          kind: cloudflare-account
+          location:
+            account: d7f641bb9f4b9de593f721ad06989dbe
       targets:
         - vessel: offsite
           # Every reach: this cluster has a load-balancer address on the lab net
@@ -536,6 +557,23 @@ spec:
           adapter: vercel
           connection:
             endpoint: https://api.vercel.com
+        # The second static edge, last on the list and so last in §16's admin
+        # rank: a website that names no Target still lands on Vercel, exactly
+        # where it landed before this Target existed.
+        #
+        # `embarrassing.ca` is already declared above as the zone an App pinned
+        # to one of these two takes a name in, so this adds a Target and no
+        # zone. The endpoint is the API root the adapter hangs
+        # `/accounts/<id>/pages/projects` off; the account is on the vessel,
+        # because it is a property of the boundary rather than of this surface.
+        #
+        # No production branch here, deliberately: a Pages project has one and
+        # the adapter reads it back off the project it ensures, so an operator
+        # who stated it here could only state it wrong.
+        - vessel: fml
+          adapter: cloudflare-pages
+          connection:
+            endpoint: https://api.cloudflare.com/client/v4
       # §10's one store of record, and the only one every Target here reaches.
       #
       # A Cloud Run revision resolves a pinned secret reference out of its own

--- a/clusters/offsite/apps/spindrift/secret.sops.yaml
+++ b/clusters/offsite/apps/spindrift/secret.sops.yaml
@@ -9,6 +9,7 @@ stringData:
     SPINDRIFT_ENROLMENT_TOKEN: ENC[AES256_GCM,data:7waL0a1UjOWO3FZ4ETkdbY2op0fUcrwBlnlI/Ryfhbk0erI9HkebAUrHpw==,iv:PrdKSR6nyYZqz3tUEguVEXzZwoRtzalfOu/BJlxhg5A=,tag:BegMo+jgS2BsVuDos553Mw==,type:str]
     SPINDRIFT_CREDENTIAL_KEYRING: ENC[AES256_GCM,data:C5QT+VjbKLlK17+VrTa57k+CNlTwPd5iAkCclbDuRhSU0YzIYtHB/fYEl7T9Z6JyJn6amgA39W1uDhrlSLFkjZZ2pZwzpTOMCzL8,iv:h1ondPCwwmJULLMABwC2iRuFi961bs6GQjDuPbMc6/s=,tag:pJsROp/JSDdwjDWhWpJRvA==,type:str]
     SPINDRIFT_BOSUN_SECRET: ENC[AES256_GCM,data:RvxZmU8LsiaWkeBpeO8Ta0cjoUUiLm5g5TgU0UDFRecTyfBVhzK5yG738l6KUphkBS7V3fapwwilUEGgcAZfvQ==,iv:5P8MvD3SPkZToeiUSZqLeJ78BAmp7evwVNazVjdGXBI=,tag:sgeoGj3thwMc5XsaojjHOg==,type:str]
+    SPINDRIFT_CLOUDFLARE_TOKEN: ENC[AES256_GCM,data:lM+EgWwec99fCoTQAuMTEqTHDW79lWMSIPkEH4/K0yLGfJO6hZ+21QDxgQhzgxZMX0ja2g0=,iv:4J9ZMPsVAeXz3YoTLaKS+sSO9KQDLdcuihbogWo43pk=,tag:T5d/Sw7WOqKBMkXJYa3HOA==,type:str]
 sops:
     age:
         - enc: |
@@ -21,6 +22,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
     encrypted_regex: ^(data|stringData)$
-    lastmodified: "2026-08-12T19:43:56Z"
-    mac: ENC[AES256_GCM,data:OSkIQtSgVde+oLSmBXLrVcTaqzo35E5J0D1j3bxd1DyNcciAcVXrD7xh9C14KJsSS6CTx+LetYfhogxzq2Exw3OHGPVMtUOXR9qC10XhPvAhGELmsrVeALUszfDMVNwmqekspNuayEbCF6o+HYgusoJ//1fvsqfmwxV57mw50Mg=,iv:WDFjUlZWDJo7Sx9jy+3PfEOHX7eIzu2ghu1XYgMzx6k=,tag:WGysdj9xGm0Ho949jqOT9Q==,type:str]
+    lastmodified: "2026-08-13T01:25:43Z"
+    mac: ENC[AES256_GCM,data:5GhAM7G+0Pv5ycJhUx7lbTHWRF9fd5vHrs+/52R253auLemaKjk7ZW2icJ32fTYVs1Cm3vOl/naAeu7yxhjqiGplBUr9LM7fOyDJ396soqazuSMdpezutlDd9vFpR7IvOsV5KCRPfDOG+U8Tw2rvm4DzpO/rlSjgjPcMUYnQrDQ=,iv:JCmx8rRHV44C6ZmZvde9293zbMSLiWemSXAx43iFRmY=,tag:phchblmCsJ88QJbT6zXjAw==,type:str]
     version: 3.13.3


### PR DESCRIPTION
## Summary

Every code path for Cloudflare Pages already existed — manifest schema, deploy adapter, capabilities, the `cloudflare-account` vessel kind, its own Targets section in the UI — and the installation declared none of it, so there was never a Target to connect.

- A `fml` vessel of kind `cloudflare-account`, located on the account every zone in `terraform/network/cloudflare/` already sits under (`account.tf`'s `fml_account_id`). An id rather than a name, because the adapter's paths are `/accounts/<id>/pages/projects`.
- A `cloudflare-pages` Target on it, last in the target list and so last in §16's admin rank: a website that names no Target still lands on Vercel, exactly where it landed before.
- `SPINDRIFT_CLOUDFLARE_TOKEN` in `secret.sops.yaml`. The chart mounts that Secret whole through `envFromSecret`, so a new key is the only wiring, and Reloader turns a rotation into the restart that picks it up.

`embarrassing.ca` was already declared as the zone a website pinned to a static edge takes its name in, so this adds a vessel and a Target and no zone. No listener, no `domainFilters` entry and no tunnel rule either — the platform serves the name from its own edge, which is why the Vercel Target beside it has none.

## Validation

- `bun test test/config/ test/conformance/ test/extraction/` — 278 pass, 0 fail. These parse the real `clusters/offsite/apps/spindrift/helm-release.yaml` rather than a fixture, so they are what says the declaration is valid for this build.
- The Pages API answers for this account against the declared endpoint.
- `sops -d` round-trips the new key identically to its source; recipients unchanged.

## Risks

The stored manifest beats the mounted declaration on an installation that is already seeded, so **this reaches the live installation only through a Settings save**, not through Flux applying the ConfigMap. Until then the Target is declared in git and absent from the running system.