### PR TITLE
fix(bosun): tender's credentials — the real App id, and sops stage two

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -22,13 +22,6 @@ creation_rules:
   # Shared across bosun's hosts, unlike the rest of this section: it holds
   # bosun's own key on the Spindrift+bosun GitHub App, and every bosun host
   # reads it directly rather than carrying a per-host copy.
-  #
-  # tender is deliberately absent until it has booted once: its age recipient
-  # is derived from an ed25519 host key that does not exist before first boot,
-  # so it joins in stage two -- add the recipient here, re-encrypt, redeploy.
-  # See [[Runbooks/SOPS Secrets and Age Keys]]. Until then tender cannot
-  # decrypt this file and its bosun unit will not start, which is what stage
-  # one looks like rather than a fault.
   - path_regex: nix/secrets/bosun\.sops\.ya?ml
     key_groups:
       - age:
@@ -37,6 +30,8 @@ creation_rules:
           - age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
           # oldschool (ssh-to-age of its ed25519 host key)
           - age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c
+          # tender (ssh-to-age of its ed25519 host key, 2026-08-12 boot)
+          - age1ed5hqc275lfc8gvymxk5zcy0jr2va3y6ncqjcsc6hslufnd7pvxs3q562a
   - path_regex: nix/secrets/optiplex\.sops\.ya?ml
     key_groups:
       - age:

--- a/nix/hosts/tender.nix
+++ b/nix/hosts/tender.nix
@@ -43,11 +43,8 @@
     enable = true;
     repo = "jonpulsifer/infra";
     github = {
-      # TODO(operator): the shared Spindrift+bosun GitHub App is created by
-      # hand during the design's cutover step (Manifest flow, off Spindrift's
-      # Repositories screen); this placeholder id is not real. Replace it
-      # once that App exists -- riptide and oldschool carry the same one.
-      appId = 1;
+      # The shared Spindrift+bosun GitHub App ("spindrift-lolwtf").
+      appId = 4576122;
       privateKeyFile = config.sops.secrets."bosun-github-app-key".path;
     };
 

--- a/nix/secrets/bosun.sops.yaml
+++ b/nix/secrets/bosun.sops.yaml
@@ -3,31 +3,40 @@ sops:
     age:
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBjUkJldlFnVjd6NTk4eDZP
-            ZTlGVkMzVmxheCs2WkhpMVVkbm95QVlTLzI4CllxVjZQZ3FOSDB0Mno2bW9xdSta
-            bDdQYkNhb0ZIbkdLSGh5amF5OFhEV2sKLS0tIHg1RTE5RmgyWVRDMERLSDVlWFJE
-            czlIdGtqa3dvM2c4THQ1bWFpcmZWd1EKfvdV8SpODV2FqDrmwliJcgsbFI36jxj+
-            QSBvOlMR/dDoNkWhrfil2JKZby8AWpS6OcObs0Hj13j32bj3XdZzsQ==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBLRWtqcGhlK09BNEdnLzV5
+            dmpESUxnMGYySllBN1hoa0YwcnlnZU9QZFZnCnpTaHlrc3FSRzJaR1lYVXAyYTB1
+            aTRpRE54QTE0SlpPbittN0ZPYVIyVlEKLS0tIEIvb0NBNzBtcWtxMXhGZnZsakFP
+            RkE4QUNiekVrYS9OUjgzRVVlRUljZEEKUChjIFD1goJd3qcsf1BTWJQWZgXlif4l
+            OHtgLzI1cWul4P4Vinq3J39TXvpX0Om4owVFRVr8B6UYYVCldotGZQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1lpfxcn6qwrgtxzymzcxqu20cppsrhmgcpma59sc8ahq9t0w67d3sj8e3e6
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBRcXRxYUZadW1EK2dEQzNX
-            M05pYUcrT0lSb3U2MGFXcFVPUWZZT1U1ZjFRClRGNVZxc3lxNktaRU1ScXl6ck1w
-            T1JIQ2E0ZmpQQjNaWUV0QzRTNlpXUFkKLS0tIHJCRmVGazVtWFhEaGpWZ3R3MXFF
-            bmI3aUdxeUVuNmVqMGgyUHR1UTZJeVkK7eEF8bKbJoI/yuckJyl/q4oeBDtfo32x
-            qMhCkr212trIPgeFyzXtWBtYqHaE1PwvQkoCwcmEVtJ0/kCBKk6v2A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBlb29iZE1WQWFwR3NFSy9C
+            MEZUQk5KYUFET3BwSmxrWnlXZGw2U0RsWGdjCmxWdTdLVDFjWDFnaU5JTnRqSG1U
+            cEVTdnlzNXkwSDRTU21FYnNuZUNXYjgKLS0tIFVIb0srQ2U4dWxpczlGMk1meUJj
+            N3B1NjZPcGpGYVEyMndOdGpVUVNmdmMK71pgEqDqV3BvYJey/FosSfOXXhjv554Z
+            2/MZLnqP7MAlZuEsfIJeC7huYsafFtMb2yvd+1tXSCuUMQnKXNQbNg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age15ylde96ar2x0q5gzqrxhkheh5puwtqf0rkuv6khgsv3xfhqu35hquw70ym
         - enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSB0eVRaQkpzZ0Y0Zkw0TWVP
-            YXh3aW5tTUtzMnNHeFkzT0hJMHY3QkFvN25vClBJRDRad21ZOGJjZVBmWlc4RUl5
-            TXlPZTcycVF3dHVjaWU0N3AyZ0dLUmsKLS0tIG80S056bjVmRExCSkVuWjdIQ1lp
-            a2VlVDV2SHh4Q2Y5ZldiVmZpQnNqUDQK/5BqAJP+QvSklToSs7Y8phOHHGM8iUgM
-            5S4hYvExUnIp7S7+GxlMVKinPyoGfua1BhcBfWcS7hM+OE9Z44vbjw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBodHg4L0sxcEVLZ1lmN01m
+            dVVSUityeHpQaktFT3dKUDB2T1JrcUJERVM4CnhyOXhUV09qTkUxR1BpWjE2NGtS
+            cmlVOXpERmhlT3BBMkVoVW9GS0pyczQKLS0tIEhKR1NyZGxMT3pLSmRkWG1TdS9G
+            MURjZHRhejJNUlhHSkgyTEpSWDVaODgKLEvPrXkvvd1Jq15ovrb+BPRgOOnZGnMu
+            mR14H68gWK/pj230ROXjkrhDMuCQq4rejsbeGAL/pyl7d+/EUdYOCA==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1apj76svz7gq7uk9w702fv589s2vcu2vfrayx0uucrkrjwl7xcqaqv6g50c
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBtN3FMSmZhM0R0ektDdk81
+            Qmc1eVNDMWgxRzUyWnAyNHFROWtnV2hrbVhNCklvNGV1R0FsazhWMGZnd2tCaTZt
+            bTJQOFJhVklrdzNrNEY4M3A1UGoyckUKLS0tIEcyTmlrcjhMRFNJSFBQOTFsb2JF
+            OFdNUDNRbHhrUWVIZDhDclpsTE1FNG8KkFlGRI7vaG2zp9G6qGRRwSLBoiBpCQSN
+            u/FPE7BGqtBWP66L96th6Jim23RmOjK/dffahqZl/JZcjfE8pZdxRg==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ed5hqc275lfc8gvymxk5zcy0jr2va3y6ncqjcsc6hslufnd7pvxs3q562a
     lastmodified: "2026-08-13T01:17:46Z"
     mac: ENC[AES256_GCM,data:DLjjiOH8vhB90Aq5vo3PBm4riw5U89nkEJyzVy2MlyGvFCgf00nNo0bhIiED1u5q47BUdSaO9DmK0OEFpedt8cQYxBnPcDUXEDG38YEkND7TjWdwY3Y1C+FirnYtoQyZ0zU+b53hviripJ5R6aDmhOP2OWHd08cTCS5WhN0oqN0=,iv:55IfxYcZQAPvkEGaXd7wpezXxO9Dah1jQp6edTNrF20=,tag:e6BwNc5uZBOLJjG99NErtw==,type:str]
     unencrypted_suffix: _unencrypted


### PR DESCRIPTION
tender is up (`c4-standard-48`, Spot, us-east1-b) and cannot serve a job. Two
things are missing, and neither is useful without the other.

## 1. It missed the real App id

#2083 wired `appId = 4576122` into riptide and oldschool. tender's host config
merged after that PR was written, so it still carries the placeholder `1` — and
a placeholder fails the way a stub credential does: the daemon starts cleanly
and 401s on every JIT mint, which is the one thing it exists to do.

Verified rather than copied. An RS256 JWT signed with the key already in
`nix/secrets/bosun.sops.yaml`:

- `GET /app` → id **4576122**, slug **spindrift-lolwtf**, owner jonpulsifer
- `GET /repos/jonpulsifer/infra/installation` → installation **153321757**,
  permissions include **`administration: write`** — exactly what a JIT runner
  config needs

The key itself is untouched: main already has it, and re-encrypting identical
plaintext only churns the ciphertext nonce.

## 2. sops stage two

tender has now booted, so the recipient that could not exist before it did now
does. Its ed25519 host key converts to
`age1ed5hqc275lfc8gvymxk5zcy0jr2va3y6ncqjcsc6hslufnd7pvxs3q562a`, which joins
the three already on the shared file.

`sops updatekeys` re-wraps the data key rather than re-encrypting the payload,
so the App key's ciphertext is **byte-identical** — only the recipient list and
MAC move.

The host key was read with `ssh-keyscan` through an IAP tunnel: no metadata
written, no operator key uploaded, nothing on the instance changed to learn it.

## After this merges

tender still has to be **deployed** to pick either up — its disk carries the
image's closure, which predates all of this. Until then its bosun unit will
fail to decrypt the App key, which is what stage one looks like rather than a
fault.

`nix eval` of tender's closure passes.