### PR TITLE
refactor(spindrift): let each cloud adapter own its own API root

### DIFF
--- a/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
+++ b/apps/spindrift/src/adapters/deploy/cloudrun/index.ts
@@ -122,6 +122,18 @@ const DEFAULT_POLL_MS = 1_000;
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1_000;
 const DEFAULT_LOGS_ENDPOINT = 'https://logging.googleapis.com';
 const DEFAULT_SCHEDULER_ENDPOINT = 'https://cloudscheduler.googleapis.com';
+/**
+ * The runtime's own API root — one hostname for every connected project,
+ * because Google runs a single Cloud Run control plane rather than one per
+ * customer. `CloudRunConnection.endpoint` used to be required for exactly the
+ * reason `DEFAULT_LOGS_ENDPOINT` above is not on the connection at all: it read
+ * as connection material analogous to a cluster's `apiServer`. It never was —
+ * an operator was retyping this same string on every project — so it is now
+ * this adapter's default, applied wherever `connection.endpoint` is read,
+ * with the Target's own value kept only as an override for a perimeter or a
+ * mirror in front of the real API.
+ */
+export const DEFAULT_ENDPOINT = 'https://run.googleapis.com';
 const SERVICE_ID_LIMIT = 63;
 
 /**
@@ -940,7 +952,10 @@ export class CloudRunDeployAdapter implements DeployAdapter {
     name: DeployRef,
   ): Promise<Omit<Extract<DeployVerdict, { phase: 'FAILED' }>, 'ref'> | null> {
     const document = cloudSchedulerJob(schedule, {
-      connection,
+      // `cloudSchedulerJob` reads `connection.endpoint` straight off what it is
+      // given, so the default has to be resolved before it gets there — the
+      // fired URL would otherwise carry the literal string `undefined`.
+      connection: { ...connection, endpoint: this.endpointOf(connection) },
       name,
       // Refused before anything was written when the Target names none —
       // see `apply`. The fallback is unreachable and is here because the
@@ -1131,9 +1146,14 @@ export class CloudRunDeployAdapter implements DeployAdapter {
 
   // --- plumbing ------------------------------------------------------------
 
+  /** The runtime API root this Target actually reaches, override or default. */
+  private endpointOf(connection: CloudRunAdapterConnection): string {
+    return connection.endpoint ?? DEFAULT_ENDPOINT;
+  }
+
   private http(connection: CloudRunAdapterConnection): CloudHttp {
     return new CloudHttp({
-      baseUrl: connection.endpoint,
+      baseUrl: this.endpointOf(connection),
       token: this.options.token,
       ...(this.options.fetch === undefined
         ? {}

--- a/apps/spindrift/src/adapters/deploy/pages/index.ts
+++ b/apps/spindrift/src/adapters/deploy/pages/index.ts
@@ -126,6 +126,18 @@ export interface PagesAdapterOptions {
 const SERVICE_NAME = 'Cloudflare Pages';
 
 /**
+ * The platform's own API root — one hostname for every account, because
+ * Cloudflare runs a single control plane rather than one per customer.
+ * `CloudflarePagesConnection.endpoint` used to be required and typed into the
+ * connect form on the theory that it was connection material the way a
+ * cluster's `apiServer` is; it never varied between installations, so this is
+ * now the default applied wherever `connection.endpoint` is read, with the
+ * Target's own value kept only as an override for a perimeter or a mirror in
+ * front of the real API.
+ */
+export const DEFAULT_ENDPOINT = 'https://api.cloudflare.com/client/v4';
+
+/**
  * The branch a project is created with, and the one a deployment names.
  *
  * A constant rather than a connection field, because it decides one thing —
@@ -262,7 +274,7 @@ export class PagesDeployAdapter implements DeployAdapter {
     const uploaded = await uploadAssets({
       client: http,
       account: connection.account,
-      endpoint: connection.endpoint,
+      endpoint: this.endpointOf(connection),
       ...(this.options.fetch === undefined
         ? {}
         : { fetch: this.options.fetch }),
@@ -663,9 +675,14 @@ export class PagesDeployAdapter implements DeployAdapter {
     return `/accounts/${encodeURIComponent(connection.account)}/pages/projects/${encodeURIComponent(project)}`;
   }
 
+  /** The API root this Target actually reaches, override or default. */
+  private endpointOf(connection: CloudflarePagesAdapterConnection): string {
+    return connection.endpoint ?? DEFAULT_ENDPOINT;
+  }
+
   private http(connection: CloudflarePagesAdapterConnection): CloudHttp {
     return new CloudHttp({
-      baseUrl: connection.endpoint,
+      baseUrl: this.endpointOf(connection),
       token: this.options.token,
       ...(this.options.fetch === undefined
         ? {}

--- a/apps/spindrift/src/adapters/deploy/static/index.ts
+++ b/apps/spindrift/src/adapters/deploy/static/index.ts
@@ -106,6 +106,17 @@ export interface StaticAdapterOptions {
 /** How the operator would name the product in the sentence about enabling it. */
 const SERVICE_NAME = 'static hosting';
 
+/**
+ * Firebase Hosting's own API root — one hostname for every project, because
+ * the product runs a single control plane rather than one per customer.
+ * `StaticConnection.endpoint` used to be required on the theory that it was
+ * connection material the way a cluster's `apiServer` is; it never varied
+ * between installations, so this is now the default applied wherever
+ * `connection.endpoint` is read, with the Target's own value kept only as an
+ * override for a perimeter or a mirror in front of the real API.
+ */
+export const DEFAULT_ENDPOINT = 'https://firebasehosting.googleapis.com';
+
 /** The API version every call below hangs off. */
 const API_VERSION = '/v1beta1';
 
@@ -733,7 +744,7 @@ export class StaticDeployAdapter implements DeployAdapter {
 
   private http(connection: StaticAdapterConnection): CloudHttp {
     return new CloudHttp({
-      baseUrl: connection.endpoint,
+      baseUrl: connection.endpoint ?? DEFAULT_ENDPOINT,
       token: this.options.token,
       ...(this.options.fetch === undefined
         ? {}

--- a/apps/spindrift/src/adapters/deploy/vercel/index.ts
+++ b/apps/spindrift/src/adapters/deploy/vercel/index.ts
@@ -130,6 +130,18 @@ export interface VercelAdapterOptions {
 /** How the operator would name the platform in a sentence about it. */
 const SERVICE_NAME = 'Vercel';
 
+/**
+ * The platform's own API root — one hostname for every team, because Vercel
+ * runs a single control plane rather than one per customer.
+ * `VercelConnection.endpoint` used to be required and typed into the connect
+ * form on the theory that it was connection material the way a cluster's
+ * `apiServer` is; it never varied between installations, so this is now the
+ * default applied wherever `connection.endpoint` is read, with the Target's
+ * own value kept only as an override for a perimeter or a mirror in front of
+ * the real API.
+ */
+export const DEFAULT_ENDPOINT = 'https://api.vercel.com';
+
 /** A project name is capped at 100 characters of `[a-z0-9._-]`. */
 const PROJECT_NAME_LIMIT = 100;
 
@@ -489,7 +501,7 @@ export class VercelDeployAdapter implements DeployAdapter {
     for (const file of files) {
       const sha = sha1Hex(file.bytes);
       const uploaded = await http.upload({
-        url: `${connection.endpoint}/v2/files?teamId=${encodeURIComponent(connection.team)}`,
+        url: `${this.endpointOf(connection)}/v2/files?teamId=${encodeURIComponent(connection.team)}`,
         bytes: file.bytes,
         contentType: 'application/octet-stream',
         headers: {
@@ -699,9 +711,14 @@ export class VercelDeployAdapter implements DeployAdapter {
 
   // --- plumbing ------------------------------------------------------------
 
+  /** The API root this Target actually reaches, override or default. */
+  private endpointOf(connection: VercelAdapterConnection): string {
+    return connection.endpoint ?? DEFAULT_ENDPOINT;
+  }
+
   private http(connection: VercelAdapterConnection): CloudHttp {
     return new CloudHttp({
-      baseUrl: connection.endpoint,
+      baseUrl: this.endpointOf(connection),
       token: this.options.token,
       ...(this.options.fetch === undefined
         ? {}

--- a/apps/spindrift/src/adapters/registry.ts
+++ b/apps/spindrift/src/adapters/registry.ts
@@ -72,7 +72,10 @@ import { PagesDeployAdapter } from './deploy/pages/index.ts';
 import { StaticDeployAdapter } from './deploy/static/index.ts';
 import { VercelDeployAdapter } from './deploy/vercel/index.ts';
 import type { SecretStore } from './store/contract.ts';
-import { SecretManagerStore } from './store/gcp-secret-manager.ts';
+import {
+  DEFAULT_ENDPOINT as SECRET_MANAGER_DEFAULT_ENDPOINT,
+  SecretManagerStore,
+} from './store/gcp-secret-manager.ts';
 import { OnePasswordStore } from './store/onepassword.ts';
 
 /**
@@ -697,21 +700,38 @@ export function storeTokenFor(
   }
 }
 
-/** The store this installation's manifest selects, over the path it names. */
+/**
+ * The store this installation's manifest selects, over the path it names.
+ *
+ * `manifest.secretStore.endpoint` is optional for the reason every deploy
+ * adapter's own is now: Secret Manager's API root is the same hostname for
+ * every project, not an installation fact, so an absent value defaults to it
+ * rather than refusing. The 1Password store gets no such default — a Connect
+ * server is self-hosted, and there is no universal address to guess — so an
+ * installation on that adapter still has to state one, and the refusal below
+ * is what makes the missing case loud instead of a `baseUrl: undefined` that
+ * fails three calls later inside `StoreHttp`.
+ */
 export function createSecretStore(
   manifest: InstallationManifest,
   token: () => string | Promise<string> = storeToken(),
   fetch?: Fetcher,
 ): SecretStore {
-  const endpoint = {
-    baseUrl: manifest.secretStore.endpoint,
-    token,
-    ...(fetch ? { fetch } : {}),
-  };
   // The container is the home vessel's, because that is the boundary the store
   // of record lives in — one place, whatever reaches it.
   const { secretStoreContainer } = sharedServicesOf(manifest);
   const adapter = manifest.secretStore.adapter satisfies StoreAdapter;
+  const baseUrl =
+    manifest.secretStore.endpoint ??
+    (adapter === 'gcp-secret-manager' ? SECRET_MANAGER_DEFAULT_ENDPOINT : null);
+  if (baseUrl === null) {
+    throw new Error(
+      'this installation’s secretStore has no endpoint, and the onepassword ' +
+        'adapter has no default for it — a self-hosted Connect server has no ' +
+        'universal address to assume',
+    );
+  }
+  const endpoint = { baseUrl, token, ...(fetch ? { fetch } : {}) };
   switch (adapter) {
     case 'onepassword':
       return new OnePasswordStore({ ...endpoint, vault: secretStoreContainer });

--- a/apps/spindrift/src/adapters/store/gcp-secret-manager.ts
+++ b/apps/spindrift/src/adapters/store/gcp-secret-manager.ts
@@ -33,6 +33,16 @@ import type {
 } from './contract.ts';
 import { type StoreEndpoint, StoreHttp, StoreRequestError } from './http.ts';
 
+/**
+ * Secret Manager's own API root — one hostname for every project, because
+ * Google runs a single control plane rather than one per customer. Unlike
+ * the 1Password Connect server this store's sibling reaches — a self-hosted
+ * address that genuinely differs per installation — nothing here ever varied,
+ * so this is the default `registry.ts` applies when `manifest.secretStore.endpoint`
+ * is absent and the configured adapter is this one.
+ */
+export const DEFAULT_ENDPOINT = 'https://secretmanager.googleapis.com';
+
 /** Which project's Secret Manager this adapter writes to. */
 export interface SecretManagerStoreConfig extends StoreEndpoint {
   /** The vessel's project holding this installation's App secrets (§14). */

--- a/apps/spindrift/src/commands/targets/connect.ts
+++ b/apps/spindrift/src/commands/targets/connect.ts
@@ -151,17 +151,19 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
       project: z.string().trim().min(1),
       region: z.string().trim().min(1),
       /**
-       * The two control APIs this act registers a Target against — the runtime's
-       * and the hosting product's.
+       * The two control APIs this act could register a Target against — the
+       * runtime's and the hosting product's.
        *
-       * Two values for one act, which reads like a leak of the split §13 says
-       * the operator should not have to think about. It is the opposite: the
-       * operator connects one project, and the fact that doing so produces two
-       * Targets is precisely why both endpoints are asked for here rather than
-       * in two separate connect flows.
+       * Optional, and ordinarily absent: both are one hostname for every GCP
+       * project, so `cloudrun/index.ts` and `static/index.ts` each apply their
+       * own default the same way every other cloud Target's endpoint now does.
+       * Kept here, not typed into the connect screen, for the installation
+       * genuinely behind a perimeter or a mirror — the manifest is where that
+       * kind of override belongs (§20), and this command has to accept what the
+       * manifest can declare.
        */
-      runEndpoint: z.url(),
-      hostingEndpoint: z.url(),
+      runEndpoint: z.url().optional(),
+      hostingEndpoint: z.url().optional(),
       /** Where this project's admission policy is read from (§16). */
       policyEndpoint: z.url().optional(),
       /**
@@ -190,8 +192,13 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
       vessel: targetNameSchema,
       /** The team or account slug, or its `team_…` id. Both address the API. */
       team: z.string().trim().min(1),
-      /** The platform's API root. Asked for rather than assumed (§20). */
-      endpoint: z.url(),
+      /**
+       * The platform's API root. Optional, and ordinarily absent: it is one
+       * hostname for every team, so `vercel/index.ts` applies its own default.
+       * Kept for the same override reason `runEndpoint` above is — a genuine
+       * perimeter or mirror, declared in the manifest rather than typed here.
+       */
+      endpoint: z.url().optional(),
       /**
        * §33's static reachability input.
        *
@@ -209,8 +216,12 @@ export const connectTargetInput = z.discriminatedUnion('kind', [
       vessel: targetNameSchema,
       /** The account id every project on this boundary is created under. */
       account: z.string().trim().min(1),
-      /** The platform's API root. Asked for rather than assumed (§20). */
-      pagesEndpoint: z.url(),
+      /**
+       * The platform's API root. Optional, and ordinarily absent: it is one
+       * hostname for every account, so `pages/index.ts` applies its own
+       * default. Kept for the same override reason `runEndpoint` above is.
+       */
+      pagesEndpoint: z.url().optional(),
       /** §33's static reachability input, on the same terms as above. */
       servedHosts: z.array(z.string().trim().min(1)).optional(),
     })
@@ -294,13 +305,25 @@ function connectionFor(
     if (input.kind !== 'vercel-team') {
       throw new Error('only a Vercel team registers a Vercel Target');
     }
-    return { adapter, endpoint: input.endpoint };
+    return {
+      adapter,
+      // Written only when the operator actually stated an override — an
+      // absent key is what tells `vercel/index.ts` to apply its own default,
+      // and storing `undefined` explicitly would mean the same thing but say
+      // it less clearly to the next reader of a stored row.
+      ...(input.endpoint === undefined ? {} : { endpoint: input.endpoint }),
+    };
   }
   if (adapter === 'cloudflare-pages') {
     if (input.kind !== 'cloudflare-account') {
       throw new Error('only a Cloudflare account registers a Pages Target');
     }
-    return { adapter, endpoint: input.pagesEndpoint };
+    return {
+      adapter,
+      ...(input.pagesEndpoint === undefined
+        ? {}
+        : { endpoint: input.pagesEndpoint }),
+    };
   }
   if (input.kind !== 'gcp-project') {
     throw new Error('a cluster does not register a cloud Target');
@@ -309,7 +332,9 @@ function connectionFor(
     return {
       adapter,
       region: input.region,
-      endpoint: input.runEndpoint,
+      ...(input.runEndpoint === undefined
+        ? {}
+        : { endpoint: input.runEndpoint }),
       ...(input.policyEndpoint === undefined
         ? {}
         : { policyEndpoint: input.policyEndpoint }),
@@ -325,7 +350,12 @@ function connectionFor(
         : { logHistorySeconds: input.logHistorySeconds }),
     };
   }
-  return { adapter, endpoint: input.hostingEndpoint };
+  return {
+    adapter,
+    ...(input.hostingEndpoint === undefined
+      ? {}
+      : { endpoint: input.hostingEndpoint }),
+  };
 }
 
 /** The boundary this act connects, as a row to create or update. */

--- a/apps/spindrift/src/config/manifest.schema.ts
+++ b/apps/spindrift/src/config/manifest.schema.ts
@@ -8,8 +8,18 @@
  * installation-specific literals, so nothing in this file may carry an example
  * value from the installation that happens to run it.
  *
- * There are no defaults. A missing key fails the boot rather than falling back
- * to whatever the first operator happened to use.
+ * There are no defaults for anything that names *this* installation. A missing
+ * key fails the boot rather than falling back to whatever the first operator
+ * happened to use.
+ *
+ * **One class of key is the deliberate exception: a vendor's own API root.**
+ * `cloudrun`, `static`, `vercel`, `cloudflare-pages` and `gcp-secret-manager`
+ * each connect to a single control plane the vendor runs, identical for every
+ * installation — it is not a fact about this deployment the way `apiServer` or
+ * `project` is, so treating it as one meant every operator retyped the same
+ * constant. Each `endpoint` below is optional for exactly that reason, and the
+ * default an absent one resolves to lives with the adapter that owns the API,
+ * not here — see `DEFAULT_ENDPOINT` beside each adapter's implementation.
  *
  * **What names the installation and what names its deployment are not the same
  * set.** A value the installer chart already renders is read from the
@@ -349,7 +359,8 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
       connection: z
         .object({
           region: nonEmptyString,
-          endpoint: z.url(),
+          /** The runtime's API root. Optional; defaults to the vendor's own. */
+          endpoint: z.url().optional(),
           policyEndpoint: z.url().optional(),
           /** The identity a revision runs as. See `CloudRunConnection`. */
           serviceAccount: nonEmptyString.optional(),
@@ -365,7 +376,8 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
       adapter: z.literal('static'),
       connection: z
         .object({
-          endpoint: z.url(),
+          /** The hosting product's API root. Optional; defaults to the vendor's own. */
+          endpoint: z.url().optional(),
         })
         .strict()
         .optional(),
@@ -377,7 +389,8 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
       adapter: z.literal('vercel'),
       connection: z
         .object({
-          endpoint: z.url(),
+          /** The platform's API root. Optional; defaults to the vendor's own. */
+          endpoint: z.url().optional(),
         })
         .strict()
         .optional(),
@@ -389,7 +402,8 @@ export const targetSeedSchema = z.discriminatedUnion('adapter', [
       adapter: z.literal('cloudflare-pages'),
       connection: z
         .object({
-          endpoint: z.url(),
+          /** The platform's API root. Optional; defaults to the vendor's own. */
+          endpoint: z.url().optional(),
         })
         .strict()
         .optional(),
@@ -806,8 +820,17 @@ export const installationManifestSchema = z
          * Core's path, not a Target's: the platform's own secret operator
          * fetches from the same store of record over its own path, and neither
          * needs to know the other's.
+         *
+         * Optional for `gcp-secret-manager`, whose API root is the same
+         * hostname for every project rather than an installation fact —
+         * `createSecretStore` in `adapters/registry.ts` applies its default
+         * when this is absent. `onepassword` gets no such default: a Connect
+         * server is self-hosted, so that adapter still requires a real value
+         * here, enforced where the store is constructed rather than by the
+         * schema, because which adapter needs it is a fact this object's
+         * sibling key carries, not the type of this one.
          */
-        endpoint: z.string().url(),
+        endpoint: z.string().url().optional(),
         /**
          * **No `container` here.** What holds the items is a property of the
          * boundary they live in, so it is `shared.secretStoreContainer` on the

--- a/apps/spindrift/src/domain/target-onboarding.ts
+++ b/apps/spindrift/src/domain/target-onboarding.ts
@@ -118,55 +118,46 @@ function cloudProposal(
   }
   // `project` is absent for the same reason `apiServer` is: connecting a second
   // cloud project and being handed the first project's id is the one mistake
-  // this screen could make that nobody would catch by reading.
+  // this screen could make that nobody would catch by reading. Neither
+  // surface's `endpoint` is carried either, for the opposite reason: it is not
+  // per-instance at all, so `cloudrun/index.ts` and `static/index.ts` each
+  // apply their own default rather than this screen proposing one.
   return {
     carriedFrom: labelOf(run ?? hosting),
     ...(runConnection === null
       ? {}
       : {
           region: runConnection.region,
-          runEndpoint: runConnection.endpoint,
           ...(runConnection.policyEndpoint === undefined
             ? {}
             : { policyEndpoint: runConnection.policyEndpoint }),
         }),
-    ...(hostingConnection === null
-      ? {}
-      : { hostingEndpoint: hostingConnection.endpoint }),
   };
 }
 
 /**
  * What a fresh connect of a Vercel team would be prefilled with.
  *
- * One field, and the team is deliberately not it — same reason `apiServer` and
- * `project` are absent above: it is the value that names *this* boundary, and a
+ * Nothing, always. The one field a working Vercel Target used to lend a fresh
+ * one — its API root — is no longer typed anywhere: `vercel/index.ts` applies
+ * its own default. `team` was never carried either, for the reason `apiServer`
+ * is not on the cluster form: it is the value that names *this* boundary, and a
  * second team prefilled with the first one's slug would read as correct and
- * deploy into somebody else's account.
+ * deploy into somebody else's account. So there is no donor left to read.
  */
-function vercelProposal(
-  rows: readonly OnboardingTargetRow[],
-): TargetConnectionProposal {
-  const from = donor(rows, 'vercel');
-  const connection = from?.connection;
-  if (connection?.adapter !== 'vercel') return { carriedFrom: null };
-  return { carriedFrom: labelOf(from), vercelEndpoint: connection.endpoint };
+function vercelProposal(): TargetConnectionProposal {
+  return { carriedFrom: null };
 }
 
 /**
- * The same one field for a Cloudflare account, with the same omission.
+ * The same nothing for a Cloudflare account, with the same reason.
  *
- * The account id is not carried, for the reason every other boundary's address
- * is not: it names *which* one, and a second account prefilled with the first
- * one's would read as correct and deploy someone else's site.
+ * `account` is not carried for the reason every other boundary's address is
+ * not, and `endpoint` is not carried because `pages/index.ts` now owns its
+ * own default.
  */
-function pagesProposal(
-  rows: readonly OnboardingTargetRow[],
-): TargetConnectionProposal {
-  const from = donor(rows, 'cloudflare-pages');
-  const connection = from?.connection;
-  if (connection?.adapter !== 'cloudflare-pages') return { carriedFrom: null };
-  return { carriedFrom: labelOf(from), pagesEndpoint: connection.endpoint };
+function pagesProposal(): TargetConnectionProposal {
+  return { carriedFrom: null };
 }
 
 /** What a screen would propose for a fresh connect of this shape. */
@@ -180,9 +171,9 @@ export function connectionProposal(
     case 'gcp-project':
       return cloudProposal(rows);
     case 'vercel-team':
-      return vercelProposal(rows);
+      return vercelProposal();
     case 'cloudflare-account':
-      return pagesProposal(rows);
+      return pagesProposal();
   }
 }
 

--- a/apps/spindrift/src/domain/target.ts
+++ b/apps/spindrift/src/domain/target.ts
@@ -64,11 +64,19 @@ export function hasTargetConnection<
 /**
  * How a Cloud Run Target is reached (§13, §14).
  *
- * `endpoint` is the exact analogue of {@link KubernetesConnection.apiServer}:
- * the control API this Target is driven through. It is connection material
- * rather than an installation-wide manifest value for the same reason a cluster's
- * is — two connected projects may sit behind different regional or
- * perimeter-fronted endpoints, and neither is more correct than the other.
+ * **`endpoint` is not the analogue of {@link KubernetesConnection.apiServer}
+ * it first looks like, and that took a wrong shape shipping to notice.** A
+ * cluster's `apiServer` genuinely varies per installation — two clusters are
+ * two different control planes. `run.googleapis.com` is not: every connected
+ * project sits behind the *same* control API, because Google runs one of it.
+ * What looked like connection material was a vendor constant wearing a
+ * manifest field's clothes. So this stays optional rather than required, for
+ * exactly the reason `apiServer` must not: an installation behind a perimeter
+ * or a mirror is real and needs to say so, but the ordinary installation has
+ * nothing to say here at all. Absent means the adapter's own default applies
+ * — see `DEFAULT_ENDPOINT` in `adapters/deploy/cloudrun/index.ts`, resolved
+ * there rather than in this file because `src/domain/` is backend-neutral and
+ * a vendor's own hostname is exactly the kind of fact it must not know.
  *
  * **No credential here either** (§13). What authorizes a call is minted per
  * request by whatever federates.
@@ -76,8 +84,12 @@ export function hasTargetConnection<
 export interface CloudRunConnection {
   adapter: 'cloudrun';
   region: string;
-  /** The runtime's API root, without a trailing slash. */
-  endpoint: string;
+  /**
+   * The runtime's API root, without a trailing slash. Optional override; see
+   * the interface doc above for why this is a vendor constant rather than an
+   * installation fact.
+   */
+  endpoint?: string;
   /**
    * The binary-authorization API root, where this project's admission policy is
    * read from (§16: "one signature, two verifiers").
@@ -85,6 +97,15 @@ export interface CloudRunConnection {
    * Optional, and absent means **not known** rather than absent-so-fine: with
    * nowhere to look, `verifiedDeploy` derives `false`, which is the direction a
    * claim about verification has to fail in.
+   *
+   * **Deliberately carries no default, unlike {@link endpoint} above.** The two
+   * look alike — both name a Google API root — but presence here is a second
+   * signal doing double duty: `useProjectAdmissionPolicy` in the deploy
+   * adapter reads `policyEndpoint !== undefined` to decide whether this
+   * project's admission policy applies at all. A compiled-in default would
+   * make every Cloud Run Target start submitting to binary authorization
+   * whether the operator installed it or not, which is the opposite of
+   * "not known".
    */
   policyEndpoint?: string;
   /**
@@ -115,11 +136,16 @@ export interface CloudRunConnection {
  * from a location an operator picks, so there is nothing here for a region to
  * name. No log history either — §17 gives static hosting an honest empty state
  * rather than a duration, because there is no runtime to have produced output.
+ *
+ * `endpoint` is optional for the same reason {@link CloudRunConnection.endpoint}
+ * is: Firebase Hosting's API root is one hostname for every project, not a
+ * per-installation fact, so the adapter's own default applies when this is
+ * absent — see `DEFAULT_ENDPOINT` in `adapters/deploy/static/index.ts`.
  */
 export interface StaticConnection {
   adapter: 'static';
-  /** The hosting product's API root, without a trailing slash. */
-  endpoint: string;
+  /** The hosting product's API root, without a trailing slash. Optional override. */
+  endpoint?: string;
 }
 
 /**
@@ -136,11 +162,16 @@ export interface StaticConnection {
  * exactly where the 1Password Connect token already lives. A field for it here
  * would put one copy per Target in the database, which is the thing the rule is
  * actually about.
+ *
+ * `endpoint` is optional for the same reason {@link CloudRunConnection.endpoint}
+ * is: Vercel's API root is one hostname for every team, not a per-installation
+ * fact, so the adapter's own default applies when this is absent — see
+ * `DEFAULT_ENDPOINT` in `adapters/deploy/vercel/index.ts`.
  */
 export interface VercelConnection {
   adapter: 'vercel';
-  /** The platform's API root, without a trailing slash. */
-  endpoint: string;
+  /** The platform's API root, without a trailing slash. Optional override. */
+  endpoint?: string;
 }
 
 /**
@@ -158,11 +189,16 @@ export interface VercelConnection {
  * **The production branch is not here.** A project has one, and the adapter
  * reads it back off the project it ensures rather than being told — an operator
  * who states it can state it wrong, and the API already knows the answer.
+ *
+ * `endpoint` is optional for the same reason {@link CloudRunConnection.endpoint}
+ * is: Cloudflare's API root is one hostname for every account, not a
+ * per-installation fact, so the adapter's own default applies when this is
+ * absent — see `DEFAULT_ENDPOINT` in `adapters/deploy/pages/index.ts`.
  */
 export interface CloudflarePagesConnection {
   adapter: 'cloudflare-pages';
-  /** The platform's API root, without a trailing slash. */
-  endpoint: string;
+  /** The platform's API root, without a trailing slash. Optional override. */
+  endpoint?: string;
 }
 
 /**

--- a/apps/spindrift/src/web/model.ts
+++ b/apps/spindrift/src/web/model.ts
@@ -1250,15 +1250,25 @@ export interface PendingTargetConnection {
  *
  * Carried from a Target of the same adapter this installation has **already**
  * configured, never from a literal in this repository. §20 puts every value
- * naming a far side in the manifest, and a default compiled into `src/` would
- * be that contract broken quietly — so the only thing that can teach Spindrift
- * what a Cloud Run endpoint looks like here is a Cloud Run Target that is
- * already working here.
+ * naming a far side in the manifest, and a value that genuinely differs per
+ * project or team is only safe to propose because a working Target already
+ * proved it.
  *
  * What is **not** carried matters as much: an `apiServer`, a `project`, and a
  * Target's name are per-instance facts, and a plausible wrong default for one
  * of those is worse than an empty field. A second cluster prefilled with the
  * first one's in-cluster address would look right and be wrong.
+ *
+ * **No `runEndpoint`, `hostingEndpoint`, `vercelEndpoint` or `pagesEndpoint`
+ * here.** Those four were never a proposal in the sense the rest of this type
+ * is — they were the one value every cloud Target of a given adapter shares,
+ * carried forward only because the connect screen used to make an operator
+ * type it. Each adapter now applies its own default (`DEFAULT_ENDPOINT`
+ * beside its implementation) when a Target's `connection.endpoint` is absent,
+ * so there is nothing left here to propose. An installation that genuinely
+ * needs a non-default endpoint — a perimeter, a mirror — still has one: the
+ * manifest declares `targets[].connection.endpoint` directly (§20), which
+ * this screen never mediates.
  */
 export interface TargetConnectionProposal {
   /** The Target these values were read off, or null when there was none. */
@@ -1283,11 +1293,12 @@ export interface TargetConnectionProposal {
    */
   readonly chartValues?: Record<string, unknown>;
   readonly region?: string;
-  readonly runEndpoint?: string;
-  readonly hostingEndpoint?: string;
+  /**
+   * Where this project's admission policy is read from, as an already-working
+   * Cloud Run Target states it. Unlike the endpoints above, this genuinely has
+   * no default (`domain/target.ts`'s `CloudRunConnection.policyEndpoint`
+   * explains why), so it stays a real proposal — carried whole, with no visible
+   * control, the same way `chartValues` is.
+   */
   readonly policyEndpoint?: string;
-  /** The edge platform's API root, as an already-connected team states it. */
-  readonly vercelEndpoint?: string;
-  /** The same fact for a `cloudflare-account` boundary's one surface. */
-  readonly pagesEndpoint?: string;
 }

--- a/apps/spindrift/src/web/views/targets/connect.tsx
+++ b/apps/spindrift/src/web/views/targets/connect.tsx
@@ -741,11 +741,18 @@ function Declaration({
  *
  * Still a flat form, and not because nobody got to it: a project has no
  * discovery API to enumerate itself through before it is named, so there is
- * nothing here for a probe to read. The two endpoints and the region are
- * carried from a working cloud Target; the project id never is — except on an
- * edit, where the id is this boundary's own rather than somebody else's, and
- * pressing the button again is how a surface the last probe did not find gets
- * asked about a second time.
+ * nothing here for a probe to read. The region is carried from a working cloud
+ * Target; the project id never is — except on an edit, where the id is this
+ * boundary's own rather than somebody else's, and pressing the button again is
+ * how a surface the last probe did not find gets asked about a second time.
+ *
+ * **No control for either endpoint.** Both used to be typed here on the theory
+ * that they were connection material the way `apiServer` is; they are not —
+ * `run.googleapis.com` and `firebasehosting.googleapis.com` answer for every
+ * project, so `cloudrun/index.ts` and `static/index.ts` each apply their own
+ * default and this form asks nothing about either. An installation behind a
+ * perimeter or a mirror still has the override; it is declared in the manifest
+ * (§20), which this screen never mediates.
  */
 function ConnectCloud({
   vessel,
@@ -766,16 +773,8 @@ function ConnectCloud({
 }) {
   const [project, setProject] = useState(knownProject);
   const [region, setRegion] = useState(proposal.region ?? '');
-  const [runEndpoint, setRunEndpoint] = useState(proposal.runEndpoint ?? '');
-  const [hostingEndpoint, setHostingEndpoint] = useState(
-    proposal.hostingEndpoint ?? '',
-  );
 
-  const ready =
-    project.trim() !== '' &&
-    region.trim() !== '' &&
-    runEndpoint.trim() !== '' &&
-    hostingEndpoint.trim() !== '';
+  const ready = project.trim() !== '' && region.trim() !== '';
 
   return (
     <div className="flex flex-col gap-4">
@@ -797,18 +796,6 @@ function ConnectCloud({
           value={region}
           onChange={(event) => setRegion(event.target.value)}
         />
-        <Field
-          name="run-endpoint"
-          label="Cloud Run API"
-          value={runEndpoint}
-          onChange={(event) => setRunEndpoint(event.target.value)}
-        />
-        <Field
-          name="hosting-endpoint"
-          label="Hosting API"
-          value={hostingEndpoint}
-          onChange={(event) => setHostingEndpoint(event.target.value)}
-        />
       </div>
       <div className="flex flex-wrap items-center gap-3">
         <Button
@@ -819,8 +806,6 @@ function ConnectCloud({
               vessel,
               project: project.trim(),
               region: region.trim(),
-              runEndpoint: runEndpoint.trim(),
-              hostingEndpoint: hostingEndpoint.trim(),
               ...(proposal.policyEndpoint === undefined
                 ? {}
                 : { policyEndpoint: proposal.policyEndpoint }),
@@ -847,9 +832,12 @@ function ConnectCloud({
  * A Vercel team's one surface, in one act.
  *
  * Flat for the reason the cloud form above it is: a team has no discovery API
- * to enumerate itself through before it is named. Two fields rather than four —
- * there is no region to pick and no second control plane, because the platform
- * serves one network and one API.
+ * to enumerate itself through before it is named. One field, not two — there is
+ * no region to pick, because the platform serves one network from one place,
+ * and no control for the API root either: `api.vercel.com` answers for every
+ * team, so `vercel/index.ts` applies it without asking. The only thing this
+ * boundary can tell Spindrift that Spindrift could not already assume is which
+ * team it is.
  *
  * **No field for the token**, and that is the point rather than an omission:
  * the bearer this Target is driven with is the installation's, read from its
@@ -861,7 +849,6 @@ function ConnectCloud({
 function ConnectVercel({
   vessel,
   team: knownTeam = '',
-  proposal,
   connecting,
   onConnect,
   onCancel,
@@ -874,8 +861,7 @@ function ConnectVercel({
   onCancel: () => void;
 }) {
   const [team, setTeam] = useState(knownTeam);
-  const [endpoint, setEndpoint] = useState(proposal.vercelEndpoint ?? '');
-  const ready = team.trim() !== '' && endpoint.trim() !== '';
+  const ready = team.trim() !== '';
 
   return (
     <div className="flex flex-col gap-4">
@@ -891,12 +877,6 @@ function ConnectVercel({
               : 'This boundary’s own slug or team_… id.'
           }
         />
-        <Field
-          name="vercel-endpoint"
-          label="API"
-          value={endpoint}
-          onChange={(event) => setEndpoint(event.target.value)}
-        />
       </div>
       <div className="flex flex-wrap items-center gap-3">
         <Button
@@ -906,7 +886,6 @@ function ConnectVercel({
               kind: 'vercel-team',
               vessel,
               team: team.trim(),
-              endpoint: endpoint.trim(),
             })
           }
         >
@@ -923,10 +902,11 @@ function ConnectVercel({
 /**
  * A Cloudflare account's one surface, in one act.
  *
- * The same two fields {@link ConnectVercel} takes, one vendor over and for the
- * same reasons — an account has no discovery API to enumerate itself through
- * before it is named, and it carries one surface, so there is neither a probe
- * to read nor a second endpoint to keep in step with this one.
+ * The same one field {@link ConnectVercel} takes, one vendor over and for the
+ * same reason — an account has no discovery API to enumerate itself through
+ * before it is named — plus the same omission: the platform's REST root
+ * answers for every account, so `pages/index.ts` applies it without asking,
+ * and the only thing left for this form to ask about is which account.
  *
  * **No field for the token here either**, and the same sentence applies: the
  * bearer is the installation's, read from its Secret per request, so a form
@@ -936,7 +916,6 @@ function ConnectVercel({
 function ConnectCloudflareAccount({
   vessel,
   account: knownAccount = '',
-  proposal,
   connecting,
   onConnect,
   onCancel,
@@ -949,8 +928,7 @@ function ConnectCloudflareAccount({
   onCancel: () => void;
 }) {
   const [account, setAccount] = useState(knownAccount);
-  const [endpoint, setEndpoint] = useState(proposal.pagesEndpoint ?? '');
-  const ready = account.trim() !== '' && endpoint.trim() !== '';
+  const ready = account.trim() !== '';
 
   return (
     <div className="flex flex-col gap-4">
@@ -966,12 +944,6 @@ function ConnectCloudflareAccount({
               : 'This boundary’s own account id.'
           }
         />
-        <Field
-          name="cloudflare-endpoint"
-          label="API"
-          value={endpoint}
-          onChange={(event) => setEndpoint(event.target.value)}
-        />
       </div>
       <div className="flex flex-wrap items-center gap-3">
         <Button
@@ -981,7 +953,6 @@ function ConnectCloudflareAccount({
               kind: 'cloudflare-account',
               vessel,
               account: account.trim(),
-              pagesEndpoint: endpoint.trim(),
             })
           }
         >

--- a/apps/spindrift/test/adapters/default-endpoints.test.ts
+++ b/apps/spindrift/test/adapters/default-endpoints.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Every adapter's own default API root, actually reached (§13, §20).
+ *
+ * `domain/target.ts` made `endpoint` optional on every cloud connection, on
+ * the premise that Vercel, Cloudflare Pages, Cloud Run and Firebase Hosting
+ * each answer at one hostname for every installation, so the adapter that owns
+ * the fact should supply it rather than an operator retyping it per project.
+ * Every other test in this tree builds its connection with an explicit
+ * `endpoint` — the fixture-standing pattern §20 wants, so a fake serving one
+ * host and an adapter addressing another fail for a reason nobody would look
+ * for — which means the fallback branch itself, `connection.endpoint ??
+ * DEFAULT_ENDPOINT`, is untouched by any of them. This file is that one check:
+ * omit `endpoint` and prove the request still lands on the adapter's real
+ * default, not on `undefined` turned into a string.
+ */
+import { describe, expect, test } from 'bun:test';
+import {
+  DEFAULT_ENDPOINT as CLOUDRUN_DEFAULT_ENDPOINT,
+  CloudRunDeployAdapter,
+} from '../../src/adapters/deploy/cloudrun/index.ts';
+import type { DeployTarget } from '../../src/adapters/deploy/contract.ts';
+import {
+  DEFAULT_ENDPOINT as PAGES_DEFAULT_ENDPOINT,
+  PagesDeployAdapter,
+} from '../../src/adapters/deploy/pages/index.ts';
+import {
+  DEFAULT_ENDPOINT as STATIC_DEFAULT_ENDPOINT,
+  StaticDeployAdapter,
+} from '../../src/adapters/deploy/static/index.ts';
+import {
+  DEFAULT_ENDPOINT as VERCEL_DEFAULT_ENDPOINT,
+  VercelDeployAdapter,
+} from '../../src/adapters/deploy/vercel/index.ts';
+import { createSecretStore } from '../../src/adapters/registry.ts';
+import { SecretManagerStore } from '../../src/adapters/store/gcp-secret-manager.ts';
+import type {
+  CloudflarePagesAdapterConnection,
+  CloudRunAdapterConnection,
+  StaticAdapterConnection,
+  VercelAdapterConnection,
+} from '../../src/domain/target.ts';
+import { fixtureManifest } from '../harness/installation.ts';
+
+/** A `Fetcher` that answers `404` to everything and remembers the one URL. */
+function capture(): {
+  fetch: (request: Request) => Promise<Response>;
+  url(): string;
+} {
+  let seen = '';
+  return {
+    fetch: async (request) => {
+      seen = request.url;
+      return new Response('{}', { status: 404 });
+    },
+    url: () => seen,
+  };
+}
+
+const TOKEN = () => 'token';
+
+describe('a Target with no stated endpoint reaches the adapter default', () => {
+  test('cloudrun', async () => {
+    const connection: CloudRunAdapterConnection = {
+      adapter: 'cloudrun',
+      project: 'example-vessel',
+      region: 'somewhere',
+    };
+    const target: DeployTarget = {
+      vessel: 'cloud',
+      adapter: 'cloudrun',
+      connection,
+    };
+    const spy = capture();
+    const adapter = new CloudRunDeployAdapter({
+      token: TOKEN,
+      fetch: spy.fetch,
+    });
+
+    await adapter.observe(
+      target,
+      'projects/example-vessel/locations/somewhere/services/site',
+    );
+
+    expect(spy.url()).toStartWith(CLOUDRUN_DEFAULT_ENDPOINT);
+  });
+
+  test('static (Firebase Hosting)', async () => {
+    const connection: StaticAdapterConnection = {
+      adapter: 'static',
+      project: 'example-vessel',
+    };
+    const target: DeployTarget = {
+      vessel: 'hosting',
+      adapter: 'static',
+      connection,
+    };
+    const spy = capture();
+    const adapter = new StaticDeployAdapter({ token: TOKEN, fetch: spy.fetch });
+
+    await adapter.observe(target, 'example-vessel/sites/site');
+
+    expect(spy.url()).toStartWith(STATIC_DEFAULT_ENDPOINT);
+  });
+
+  test('vercel', async () => {
+    const connection: VercelAdapterConnection = {
+      adapter: 'vercel',
+      team: 'example-team',
+    };
+    const target: DeployTarget = {
+      vessel: 'edge',
+      adapter: 'vercel',
+      connection,
+    };
+    const spy = capture();
+    const adapter = new VercelDeployAdapter({
+      token: TOKEN,
+      artifactToken: TOKEN,
+      fetch: spy.fetch,
+    });
+
+    await adapter.observe(target, 'example-team/projects/site');
+
+    expect(spy.url()).toStartWith(VERCEL_DEFAULT_ENDPOINT);
+  });
+
+  test('cloudflare-pages', async () => {
+    const connection: CloudflarePagesAdapterConnection = {
+      adapter: 'cloudflare-pages',
+      account: 'example-account',
+    };
+    const target: DeployTarget = {
+      vessel: 'edge',
+      adapter: 'cloudflare-pages',
+      connection,
+    };
+    const spy = capture();
+    const adapter = new PagesDeployAdapter({ token: TOKEN, fetch: spy.fetch });
+
+    await adapter.observe(target, 'example-account/pages/site');
+
+    expect(spy.url()).toStartWith(PAGES_DEFAULT_ENDPOINT);
+  });
+});
+
+describe('a secretStore with no stated endpoint', () => {
+  test('gcp-secret-manager defaults to Secret Manager itself', async () => {
+    const manifest = await fixtureManifest();
+    const store = createSecretStore(
+      { ...manifest, secretStore: { adapter: 'gcp-secret-manager' } },
+      TOKEN,
+    );
+    // The only way to observe `baseUrl` from outside is the class it produced —
+    // constructing at all (rather than throwing, or handing `StoreHttp` a
+    // `baseUrl` of `undefined`) is what proves the default resolved.
+    expect(store).toBeInstanceOf(SecretManagerStore);
+  });
+
+  test('onepassword has no universal default and says so', async () => {
+    const manifest = await fixtureManifest();
+    expect(() =>
+      createSecretStore(
+        { ...manifest, secretStore: { adapter: 'onepassword' } },
+        TOKEN,
+      ),
+    ).toThrow(/no default/);
+  });
+});

--- a/apps/spindrift/test/commands/targets.test.ts
+++ b/apps/spindrift/test/commands/targets.test.ts
@@ -490,16 +490,18 @@ describe('the act is credential-shaped though the noun is flat', () => {
       throw new Error('the surface that answered offers no edit');
     }
     // This boundary's own id, which a fresh connect refuses to propose and an
-    // edit must not make the operator retype. The endpoints and the region are
-    // installation-wide, so the project that does run Cloud Run supplies them.
+    // edit must not make the operator retype. The region is installation-wide,
+    // so the project that does run Cloud Run supplies it — the two endpoints are
+    // not proposed at all any more, because `cloudrun`/`static` each apply their
+    // own default rather than an operator (or this screen) stating one.
     expect(edit.project).toBe('p');
-    expect(edit.proposal.runEndpoint).toBe(CLOUD_ENDPOINTS.run);
     expect(edit.proposal.region).toBe(cloudInput().region);
     // And what one act writes that the form has no field to ask for again:
     // sending the form back without these is the edit deleting them.
     expect(edit.carried.servedHosts).toEqual(['hosting.example.test']);
 
-    // The same act, from exactly what the screen is holding.
+    // The same act, from exactly what the screen is holding. Neither endpoint
+    // is sent — the adapter default applies, same as a fresh connect.
     const on = fakes();
     const again = await connectTarget(
       {
@@ -507,8 +509,6 @@ describe('the act is credential-shaped though the noun is flat', () => {
         vessel: 'vessel',
         project: edit.project,
         region: edit.proposal.region!,
-        runEndpoint: edit.proposal.runEndpoint!,
-        hostingEndpoint: edit.proposal.hostingEndpoint!,
         ...edit.carried,
       },
       context(on.registry),

--- a/apps/spindrift/test/domain/target-onboarding.test.ts
+++ b/apps/spindrift/test/domain/target-onboarding.test.ts
@@ -141,18 +141,21 @@ describe('what a connect may be prefilled with', () => {
     expect(proposal).not.toHaveProperty('apiServer');
   });
 
-  test('a cloud project carries its endpoints and region, never its project id', () => {
+  test('a cloud project carries its region and policy endpoint, never its project id or either API root', () => {
     const proposal = connectionProposal(
       [CLOUD_RUN, CLOUD_STATIC],
       'gcp-project',
     );
 
+    // Neither `endpoint` is here: both are one hostname for every project, so
+    // `cloudrun/index.ts` and `static/index.ts` each apply their own default
+    // rather than this being a value a donor Target teaches. `policyEndpoint`
+    // stays, because its presence is a real operator choice with no default —
+    // see `CloudRunConnection.policyEndpoint`.
     expect(proposal).toEqual({
       carriedFrom: 'bluenose/cloudrun',
       region: 'northamerica-northeast1',
-      runEndpoint: 'https://run.googleapis.example',
       policyEndpoint: 'https://binaryauthorization.googleapis.example',
-      hostingEndpoint: 'https://firebasehosting.googleapis.example',
     });
     expect(proposal).not.toHaveProperty('project');
   });

--- a/apps/spindrift/test/extraction/no-dns-credential.test.ts
+++ b/apps/spindrift/test/extraction/no-dns-credential.test.ts
@@ -31,19 +31,51 @@
  * a zone — so banning the bare brand would have refused a Target on the grounds
  * that it is spelled like a DNS provider. What is banned is what actually holds
  * a zone: a provider SDK, a zone API root written as a literal, and a
- * credential-shaped name. The API root matters twice over — every adapter here
- * reaches its far side through connection material (`StaticConnection.endpoint`
- * and its siblings), so a hostname compiled into core is a bug on its own terms
- * before it is a §9 question.
+ * credential-shaped name.
  *
- * One exemption survives, and it is about naming rather than holding — see
- * {@link NAMES_A_BRAND}.
+ * **A vendor's *default* API root is not, on its own, the same claim.** Every
+ * cloud deploy adapter now compiles one in — `cloudrun/index.ts`,
+ * `vercel/index.ts`, `static/index.ts` and `pages/index.ts` each own a
+ * `DEFAULT_ENDPOINT`, applied when a Target's `connection.endpoint` does not
+ * override it (`domain/target.ts` says why: none of these ever varied per
+ * installation, so treating every one as connection material meant an operator
+ * retyped the same constant per project). That is still not license to compile
+ * in a *zone* root: `api.cloudflare.com` is banned everywhere except
+ * `pages/index.ts`, and the exemption is scoped to that one literal in that one
+ * file — see {@link OWNS_CLOUDFLARE_DEFAULT_ENDPOINT} for why naming Cloudflare's
+ * shared REST root there is not the same thing as reaching for its zone API.
+ *
+ * Two exemptions survive: one about naming rather than holding, at
+ * {@link NAMES_A_BRAND}, and the one just described.
  */
 import { describe, expect, test } from 'bun:test';
 import { readdir } from 'node:fs/promises';
 import { join, relative } from 'node:path';
 
 const APP = join(import.meta.dir, '../..');
+
+/**
+ * The one file allowed to compile in Cloudflare's REST API root.
+ *
+ * A narrower exemption than {@link NAMES_A_BRAND}: only the
+ * `api.cloudflare.com` pattern is lifted here, and only for this exact path —
+ * every other pattern in {@link FORBIDDEN} still polices this file, and this
+ * pattern still polices every other one.
+ *
+ * **Why this is not the hole §9 exists to close.** `pages/index.ts` is the
+ * Cloudflare Pages deploy adapter, and its `DEFAULT_ENDPOINT` is the same kind
+ * of value `cloudrun/index.ts` and `vercel/index.ts` each compile in beside
+ * it: a vendor's API root, identical for every account, not connection
+ * material. Cloudflare happens to put every product — Pages, and separately
+ * the zone API §9 is actually about — behind one REST root, so the literal
+ * this adapter needs is spelled the same way a zone client's would be. What
+ * distinguishes them is not the hostname but the path and the credential: this
+ * adapter only ever calls `/accounts/…/pages/…`, never `/zones`, and the
+ * bearer it sends (`SPINDRIFT_CLOUDFLARE_TOKEN`) is an operator-scoped Pages
+ * token, not a zone-editing one — §9's own line, "between naming a host and
+ * holding the key to a zone", drawn again here at the file level.
+ */
+const OWNS_CLOUDFLARE_DEFAULT_ENDPOINT = 'src/adapters/deploy/pages/index.ts';
 
 /**
  * Ways a DNS provider credential shows up.
@@ -57,7 +89,15 @@ const APP = join(import.meta.dir, '../..');
  *   importing an SDK — a raw `fetch` and an environment variable is enough — so
  *   the names such a value would travel under are matched too.
  */
-const FORBIDDEN: readonly { pattern: RegExp; why: string }[] = [
+const FORBIDDEN: readonly {
+  pattern: RegExp;
+  why: string;
+  /**
+   * Paths this pattern does not police. Reserved for `api.cloudflare.com`
+   * below — see the comment on {@link OWNS_CLOUDFLARE_DEFAULT_ENDPOINT}.
+   */
+  exempt?: readonly string[];
+}[] = [
   {
     pattern: /from\s+['"]cloudflare['"]|\bcloudflare-sdk\b|\bcloudflare4\b/i,
     why: 'a provider SDK is the credential §9 removed',
@@ -65,6 +105,7 @@ const FORBIDDEN: readonly { pattern: RegExp; why: string }[] = [
   {
     pattern: /api\.cloudflare\.com/i,
     why: 'an API root is connection material, never a literal in core',
+    exempt: [OWNS_CLOUDFLARE_DEFAULT_ENDPOINT],
   },
   {
     pattern: /\broute53\b|\bgoogle-?clouddns\b/i,
@@ -118,7 +159,8 @@ function findCredentials(files: readonly SourceFile[]): string[] {
   const offenders: string[] = [];
   for (const file of files) {
     if (file.path.startsWith(NAMES_A_BRAND)) continue;
-    for (const { pattern, why } of FORBIDDEN) {
+    for (const { pattern, why, exempt } of FORBIDDEN) {
+      if (exempt?.includes(file.path)) continue;
       if (pattern.test(file.source)) {
         offenders.push(`${file.path}: ${pattern} — ${why}`);
       }
@@ -177,6 +219,37 @@ describe('the scanner catches a deliberately dirty file', () => {
       {
         path: 'src/config/manifest.schema.ts',
         source: 'const dnsApiToken = process.env.DNS_API_TOKEN;\n',
+      },
+    ];
+    expect(findCredentials(dirty)).not.toEqual([]);
+  });
+
+  test('the Cloudflare API root is legal in the one file that owns the default', () => {
+    const clean: SourceFile[] = [
+      {
+        path: OWNS_CLOUDFLARE_DEFAULT_ENDPOINT,
+        source:
+          "const DEFAULT_ENDPOINT = 'https://api.cloudflare.com/client/v4';\n",
+      },
+    ];
+    expect(findCredentials(clean)).toEqual([]);
+  });
+
+  test('and the exemption is that one file, not any file next to it', () => {
+    const dirty: SourceFile[] = [
+      {
+        path: 'src/adapters/deploy/pages/assets.ts',
+        source: "const root = 'https://api.cloudflare.com/client/v4';\n",
+      },
+    ];
+    expect(findCredentials(dirty)).not.toEqual([]);
+  });
+
+  test('and the exemption is that one pattern, not every pattern for that file', () => {
+    const dirty: SourceFile[] = [
+      {
+        path: OWNS_CLOUDFLARE_DEFAULT_ENDPOINT,
+        source: "import Cloudflare from 'cloudflare';\n",
       },
     ];
     expect(findCredentials(dirty)).not.toEqual([]);

--- a/apps/spindrift/test/web/views.test.tsx
+++ b/apps/spindrift/test/web/views.test.tsx
@@ -1184,8 +1184,6 @@ describe('the Targets surface', () => {
         proposal: {
           carriedFrom: 'other/cloudrun',
           region: 'somewhere',
-          runEndpoint: 'https://run.example.test',
-          hostingEndpoint: 'https://hosting.example.test',
         },
       },
     ]);

--- a/clusters/offsite/apps/spindrift/helm-release.yaml
+++ b/clusters/offsite/apps/spindrift/helm-release.yaml
@@ -559,7 +559,6 @@ spec:
           adapter: cloudrun
           connection:
             region: northamerica-northeast1
-            endpoint: https://run.googleapis.com
             # Where this project's admission policy is read from. Naming it is
             # also what makes the Service declare `binaryAuthorization.
             # useDefault` — Cloud Run treats admission as a property of the
@@ -575,8 +574,11 @@ spec:
             serviceAccount: spindrift-runtime@bluenose.iam.gserviceaccount.com
         - vessel: bluenose
           adapter: static
-          connection:
-            endpoint: https://firebasehosting.googleapis.com
+          # Empty rather than absent: this surface is connected, and the only
+          # fact it used to carry was Firebase Hosting's API root, which
+          # `static/index.ts` now defaults on its own (`DEFAULT_ENDPOINT`) —
+          # one hostname for every project, not an installation fact.
+          connection: {}
         # A website placed here is served from the platform's own edge, so this
         # Target serves `public` and no other reach by construction — there is
         # nothing to assert. The build stays where it already runs: what crosses
@@ -585,25 +587,27 @@ spec:
         # rather than building it a second time.
         - vessel: jonpulsifer
           adapter: vercel
-          connection:
-            endpoint: https://api.vercel.com
+          # Empty rather than absent, for the same reason the `static` surface
+          # above is: `api.vercel.com` is one hostname for every team, and
+          # `vercel/index.ts` now applies it without being told.
+          connection: {}
         # The second static edge, last on the list and so last in §16's admin
         # rank: a website that names no Target still lands on Vercel, exactly
         # where it landed before this Target existed.
         #
         # `embarrassing.ca` is already declared above as the zone an App pinned
         # to one of these two takes a name in, so this adds a Target and no
-        # zone. The endpoint is the API root the adapter hangs
-        # `/accounts/<id>/pages/projects` off; the account is on the vessel,
-        # because it is a property of the boundary rather than of this surface.
+        # zone. Empty for the third time here, and the account is the reason it
+        # is not empty of everything: `api.cloudflare.com/client/v4` is one
+        # hostname for every account and `pages/index.ts` supplies it, while the
+        # account itself is a property of the boundary and sits on the vessel.
         #
         # No production branch here, deliberately: a Pages project has one and
         # the adapter reads it back off the project it ensures, so an operator
         # who stated it here could only state it wrong.
         - vessel: fml
           adapter: cloudflare-pages
-          connection:
-            endpoint: https://api.cloudflare.com/client/v4
+          connection: {}
       # §10's one store of record, and the only one every Target here reaches.
       #
       # A Cloud Run revision resolves a pinned secret reference out of its own
@@ -622,9 +626,11 @@ spec:
       # Target already goes through (`storeTokenFor` in
       # `apps/spindrift/src/adapters/registry.ts`), so this installation stores
       # no secret-store bearer at all.
+      # No endpoint: Secret Manager's API root is one hostname for every
+      # project, not an installation fact, so `createSecretStore` in
+      # `apps/spindrift/src/adapters/registry.ts` applies its own default.
       secretStore:
         adapter: gcp-secret-manager
-        endpoint: https://secretmanager.googleapis.com
       supplyChain:
         # northamerica-northeast1, which is where the key is:
         # `google_kms_crypto_key.signer` takes `local.region`, and


### PR DESCRIPTION
## Summary

- Every cloud Target's `connection.endpoint` (`cloudrun`, `static`, `vercel`, `cloudflare-pages`) was typed as required connection material, but none of these ever varied per installation — each vendor answers at one hostname for every account or project. `endpoint` is now optional on all four `TargetConnection` variants, and each deploy adapter (`cloudrun/index.ts`, `static/index.ts`, `vercel/index.ts`, `pages/index.ts`) exports its own `DEFAULT_ENDPOINT`, applied when a Target's stored connection omits one. `secretStore`'s `gcp-secret-manager` adapter gets the same default in `adapters/registry.ts`; `onepassword` keeps no default and now throws a clear error if an installation configures it with no endpoint, since a self-hosted Connect server has no universal address.
- The field stays optional rather than disappearing entirely — the test harness points adapters at fake endpoints, and an air-gapped or proxied installation behind a perimeter/mirror is a real override case, still expressible through the manifest (`targets[].connection.endpoint`).
- Removed the endpoint text inputs from the Vercel, Cloudflare Pages, and GCP (Cloud Run + Firebase Hosting) connect forms — there was exactly one correct value to type, so the operator no longer has to. `CloudRunConnection.policyEndpoint` is deliberately untouched: its presence toggles whether binary authorization is checked at all (`useProjectAdmissionPolicy`), so defaulting it would silently start enforcing admission policy on every Cloud Run Target rather than the ones an operator actually configured it for.
- `clusters/offsite/apps/spindrift/helm-release.yaml`: removed the now-redundant `endpoint:` lines that matched the new defaults exactly.
- Narrowed `test/extraction/no-dns-credential.test.ts`'s ban on `api.cloudflare.com` (a real, deliberate architecture test) to exempt the one file that now legitimately owns Cloudflare's REST root as a default, without weakening the check anywhere else a DNS credential could hide.

## Validation

```
cd apps/spindrift
bun run typecheck   # clean
bun run lint         # clean
BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 DATABASE_URL=postgres://postgres@localhost:15432/postgres bun test
# 2405 pass, 0 fail, 168 files
```

`packages/charts/spindrift` was not touched, so its test suite was not run.

## Risks

- An operator who edits an already-connected Vercel/Cloudflare Pages/Cloud Run Target through the interactive UI no longer has a field carrying a previously-declared custom `endpoint` override forward — a resubmitted edit now omits `endpoint` entirely, reverting that Target to the adapter default. A genuine override (air-gapped/proxied installation) still works, but has to be declared in the manifest rather than round-tripped through the connect screen.
- `test/extraction/no-dns-credential.test.ts` previously enforced "no vendor API root as a literal in `src/`" as a blanket rule; this PR narrows that specifically for `api.cloudflare.com` in one file. The new exemption is scoped as tightly as I could make it (one exact path, one exact pattern) and has its own negative tests, but it's a real loosening of a security-motivated test that's worth a second look.