### PR TITLE
fix(spindrift): a static site ships its build output, not its sources

### DIFF
--- a/.github/workflows/spindrift-build.yml
+++ b/.github/workflows/spindrift-build.yml
@@ -147,6 +147,12 @@ jobs:
             printf 'buildArgs<<SPINDRIFT_EOF\n'
             read_key '.buildArgs | to_entries[] | "\(.key)=\(.value)"'
             printf 'SPINDRIFT_EOF\n'
+            # Where a `files` build lifts its site out of (§3, story 42). `// ""`
+            # for the reason every default here exists — a spec composed before
+            # this field existed shipped the scope as it stood, and still does.
+            # `null` is spelled the same as absent on purpose: core sends the
+            # key explicitly and both mean "lift nothing".
+            printf 'outputDirectory=%s\n' "$(read_key '.outputDirectory // ""')"
           } >> "$GITHUB_OUTPUT"
 
       # The bundle, not the repository. §15 fetches the exact commit once and
@@ -210,6 +216,7 @@ jobs:
           SUBPATH: ${{ steps.request.outputs.subpath }}
           FRONTEND: ${{ steps.request.outputs.frontend }}
           ARTIFACT_TYPE: ${{ steps.request.outputs.artifactType }}
+          OUTPUT_DIRECTORY: ${{ steps.request.outputs.outputDirectory }}
         run: |
           set -euo pipefail
           scope="${ROOT}/${SUBPATH}"
@@ -267,19 +274,33 @@ jobs:
           # This arm is checked before the Dockerfile one on purpose: the
           # artifact type decides what the thing *is*, and a Dockerfile in the
           # scope only ever decided how to build one.
-          # ponytail: a site whose files need a build step first (an
-          # outputDirectory) ships its sources today; grow that arm when a
-          # built site reaches a files Target.
+          # A scope that declares no output directory *is* the site: there is
+          # nothing to run first, and the tree is already what a static Target
+          # serves. That is the whole of this arm for a hand-written site, an
+          # uploaded artifact, and anything whose `spindrift.yaml` names no
+          # directory.
+          #
+          # A scope that declares one is the sources of a site rather than the
+          # site, so this arm falls through to the ladder below, the ordinary
+          # build runs, and `Lift the site out of the build` takes the declared
+          # directory back out of the image and makes *that* the context. The
+          # `FROM scratch` Dockerfile is written either way, because both paths
+          # end by exporting one directory as the single gzipped tar layer a
+          # files artifact is.
           if [ "$ARTIFACT_TYPE" = "files" ]; then
             files="${RUNNER_TEMP}/files-artifact"
             mkdir -p "$files"
             printf 'FROM scratch\nCOPY . /\n' > "${files}/Dockerfile"
-            {
-              printf 'context=%s\n' "$scope"
-              printf 'file=%s\n' "${files}/Dockerfile"
-              printf 'buildArgs=\n'
-            } >> "$GITHUB_OUTPUT"
-            exit 0
+            printf 'scratchfile=%s\n' "${files}/Dockerfile" >> "$GITHUB_OUTPUT"
+            if [ -z "${OUTPUT_DIRECTORY:-}" ]; then
+              {
+                printf 'context=%s\n' "$scope"
+                printf 'file=%s\n' "${files}/Dockerfile"
+                printf 'buildArgs=\n'
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            printf 'lift=%s\n' "$OUTPUT_DIRECTORY" >> "$GITHUB_OUTPUT"
           fi
 
           # The scope names the Dockerfile; the Dockerfile names its context.
@@ -567,18 +588,101 @@ jobs:
           }
           SPINDRIFT_SEAL_SCRIPT
 
+      # §3, story 42: a website placed on a static Target is the files its build
+      # leaves behind. The ladder above already resolved how to build this scope
+      # — its own Dockerfile, or the zero-config frontend — so the site is made
+      # exactly the way the same commit's server image would have been, and only
+      # then is one directory taken back out of it. Building it a second, static
+      # way here would be a second build system to operate, which is the thing
+      # §4's "one engine, two frontends" exists to avoid.
+      #
+      # `--load` rather than a registry round trip: this image is scaffolding.
+      # What gets pushed is the `FROM scratch` export below it, so the built
+      # image never leaves the runner and is never tagged with anything core
+      # would record.
+      #
+      # **The working directory is read off the image, never assumed.** The
+      # zero-config frontend and a hand-written Dockerfile disagree about where
+      # an app lives, and a hardcoded `/app` fails on the second one with a
+      # `docker cp` error naming a path nobody wrote down. The image config is
+      # the one place that knows.
+      - name: Lift the site out of the build
+        id: lift
+        if: steps.frontend.outputs.lift != ''
+        env:
+          CONTEXT: ${{ steps.frontend.outputs.context }}
+          FILE: ${{ steps.frontend.outputs.file }}
+          REQUEST_ARGS: ${{ steps.request.outputs.buildArgs }}
+          LADDER_ARGS: ${{ steps.frontend.outputs.buildArgs }}
+          SCRATCHFILE: ${{ steps.frontend.outputs.scratchfile }}
+          LIFT: ${{ steps.frontend.outputs.lift }}
+        run: |
+          set -euo pipefail
+          # The same two argument sets `Build and push` concatenates, in the
+          # same order, because this is the build that would have been pushed.
+          set --
+          while IFS= read -r arg; do
+            [ -n "$arg" ] || continue
+            set -- "$@" --build-arg "$arg"
+          done <<SPINDRIFT_ARGS_EOF
+          ${REQUEST_ARGS}
+          ${LADDER_ARGS}
+          SPINDRIFT_ARGS_EOF
+
+          docker buildx build --load --tag spindrift-lift:local \
+            --file "$FILE" "$@" "$CONTEXT"
+
+          workdir="$(docker image inspect --format '{{.Config.WorkingDir}}' spindrift-lift:local)"
+          case "$LIFT" in
+            # An absolute directory is already the answer; anything else is
+            # relative to where the build left the app.
+            /*) from="$LIFT" ;;
+            *)  from="${workdir:-/}" ; from="${from%/}/$LIFT" ;;
+          esac
+
+          site="${RUNNER_TEMP}/site"
+          mkdir -p "$site"
+          cid="$(docker create spindrift-lift:local)"
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+          # A build that ran and produced nothing at the declared directory is
+          # the failure worth naming here rather than three steps later as an
+          # empty site that deployed green.
+          if ! docker cp "${cid}:${from}/." "$site" 2>/dev/null; then
+            echo "::error::the build left nothing at ${from} — ${LIFT} is what this scope's spindrift.yaml names as its output directory, and the build did not create it. Correct outputDirectory, or remove it if this scope is already the site." >&2
+            exit 1
+          fi
+
+          {
+            printf 'context=%s\n' "$site"
+            printf 'file=%s\n' "$SCRATCHFILE"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Build and push
         id: push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
-          context: ${{ steps.frontend.outputs.context }}
-          file: ${{ steps.frontend.outputs.file }}
+          # The lifted site when there was one to lift, and the ladder's own
+          # answer otherwise. One step decides; this one only reads.
+          context: ${{ steps.lift.outputs.context || steps.frontend.outputs.context }}
+          file: ${{ steps.lift.outputs.file || steps.frontend.outputs.file }}
           # The ladder's own argument rides with the request's. `BUILDKIT_SYNTAX`
           # is how the zero-config arm names its frontend, and it is empty on the
           # Dockerfile arm — the action drops the blank line.
+          #
+          # **Both are dropped when a site was lifted**, because then this build
+          # is the `FROM scratch` export of a directory that already exists and
+          # not the app's build at all. The app's build consumed these in `Lift
+          # the site out of the build`; sending `BUILDKIT_SYNTAX` on to a two
+          # line Dockerfile would hand it to the zero-config frontend, which
+          # would try to build the finished site as if it were a project.
+          #
+          # Written as `empty && value || ''` rather than the other way round
+          # because a GitHub expression's `a && b || c` yields `c` whenever `b`
+          # is falsy — so the branch that must produce nothing has to be the
+          # `||` arm, never the `&&` one.
           build-args: |
-            ${{ steps.request.outputs.buildArgs }}
-            ${{ steps.frontend.outputs.buildArgs }}
+            ${{ steps.lift.outputs.context == '' && steps.request.outputs.buildArgs || '' }}
+            ${{ steps.lift.outputs.context == '' && steps.frontend.outputs.buildArgs || '' }}
           push: true
           tags: ${{ steps.request.outputs.tags }}
           cache-from: |

--- a/apps/spindrift/src/adapters/build/contract.ts
+++ b/apps/spindrift/src/adapters/build/contract.ts
@@ -146,6 +146,29 @@ export interface BuildSpec {
    */
   buildArgs: Readonly<Record<string, string>>;
   /**
+   * Where a `files` build lifts the site out of, or `null` to ship the scope
+   * as it stands (§3, story 42).
+   *
+   * `domain/detection/declared.ts` calls this "where *Spindrift* lifts files
+   * from when a website is placed on a static Target", and this is the field
+   * that carries the answer to the one place that can act on it. Without it a
+   * `files` build has no way to know that `dist/` is the site and the rest of
+   * the tree is the sources that produced it, so it ships both — which is what
+   * a static Target then serves.
+   *
+   * **Per commit, not per Component**, which is why it is composed here rather
+   * than read from a column. The value's home of record is the scope's
+   * `spindrift.yaml` (§5: "once it is on the default branch it wins over
+   * detection"), a file that moves with the tree — so a Component whose site
+   * moved from `build/` to `dist/` is described correctly by each commit and
+   * incorrectly by any single stored answer.
+   *
+   * `null` is not "unknown": it is the honest state for a scope that declares
+   * no output directory and for one built from its own Dockerfile, and both
+   * mean the tree already is the artifact. An `image` build ignores this.
+   */
+  outputDirectory: string | null;
+  /**
    * Registry logins for the destinations whose host the route's own identity
    * cannot authorize (§16).
    *

--- a/apps/spindrift/src/adapters/build/github-actions.ts
+++ b/apps/spindrift/src/adapters/build/github-actions.ts
@@ -213,6 +213,16 @@ export interface BuildRequestSpec {
   /** What to push it as (§12); the workflow tags with these and no others. */
   readonly tags: readonly string[];
   readonly buildArgs: Readonly<Record<string, string>>;
+  /**
+   * Where a `files` build lifts the site out of, or `null` for the scope as it
+   * stands. See {@link BuildSpec.outputDirectory}.
+   *
+   * Sent as `null` rather than omitted, because the workflow defaults a missing
+   * field to "lift nothing" for the version-skew reason every other field here
+   * carries one for — and an explicit `null` and an absent key must therefore
+   * mean the same thing on the far side.
+   */
+  readonly outputDirectory: string | null;
   /** Pinned by the installation, never chosen by the runner. */
   readonly zeroConfigFrontend: string;
   /**
@@ -394,6 +404,7 @@ export class GitHubActionsBuildRoute implements BuildAdapter {
       destinations: spec.destinations,
       tags: spec.tags,
       buildArgs: spec.buildArgs,
+      outputDirectory: spec.outputDirectory,
       zeroConfigFrontend: this.options.zeroConfigFrontend,
       signer: this.options.signer,
       attestor: this.options.attestor,

--- a/apps/spindrift/src/commands/builds/dispatch.ts
+++ b/apps/spindrift/src/commands/builds/dispatch.ts
@@ -55,9 +55,12 @@ import {
   buildRouteCandidates,
   DEFAULT_MINIMUM_BUILD_LEVEL,
 } from '../../domain/build-route.ts';
+import { parseSpindriftFile } from '../../domain/detection/spindrift-file.ts';
 import { DEFAULT_PLATFORM } from '../../domain/placement.ts';
+import { repositoryRefOf } from '../../domain/repository.ts';
 import { buildOriginOf, type Source } from '../../domain/source.ts';
 import { targetLabel } from '../../domain/target.ts';
+import { SPINDRIFT_FILE } from '../../integrations/github/config-pr.ts';
 import { isFetchableBundleLocation } from '../../storage/archives.ts';
 import { parseGcsLocation, signedObjectUrl } from '../../storage/signed-url.ts';
 import { isBuildTimeConfig, readBuildArgs } from '../config/build-args.ts';
@@ -257,6 +260,76 @@ async function fetchableBundleLocation(
 }
 
 /**
+ * Where a `files` build lifts its site out of, at this build's own commit.
+ *
+ * §5 makes a scope's `spindrift.yaml` the home of record — "once it is on the
+ * default branch it wins over detection" — and the repo loop parses one per
+ * commit without storing what it read. So this asks the same file the same
+ * question at the commit being built, rather than reading a column that would
+ * describe whichever commit last wrote it.
+ *
+ * **Every unknown answers `null`, and `null` ships the scope as it stands** —
+ * which is exactly what a `files` build did before this field existed. A scope
+ * with no Spindrift file, a file that no longer parses, an installation with no
+ * repository integration, an uploaded archive, a repository the host would not
+ * answer for: none of them is a reason to fail a build that would otherwise
+ * have succeeded, and all of them are reasons to lift nothing.
+ *
+ * The Dockerfile arm has no output directory *by construction* rather than by
+ * omission: a scope that builds itself from a Dockerfile renders a server, and
+ * §5 gives it no field to name a directory with.
+ */
+async function outputDirectoryFor(
+  context: Pick<CommandContext, 'adapters'>,
+  input: {
+    readonly artifactType: BuildSpec['artifactType'];
+    readonly source: Source;
+    readonly repository: {
+      readonly installationId: string;
+      readonly fullName: string;
+    } | null;
+  },
+): Promise<string | null> {
+  // An image is the tree's own build product, so there is nothing to lift out
+  // of it and the question does not arise.
+  if (input.artifactType !== 'files') return null;
+  // An upload carries no repository to read a file out of. A supplied artifact
+  // is finished output already (§4), and an uploaded *source* archive has no
+  // default branch for §5's file to have won on.
+  if (input.source.kind !== 'repo') return null;
+  if (input.repository === null) return null;
+  const host = context.adapters.repository();
+  if (host === null) return null;
+
+  const path =
+    input.source.subpath === '.'
+      ? SPINDRIFT_FILE
+      : `${input.source.subpath}/${SPINDRIFT_FILE}`;
+
+  let document: string | null;
+  try {
+    document = await host.readFile(
+      repositoryRefOf(input.repository),
+      input.repository.fullName,
+      input.source.commit,
+      path,
+    );
+  } catch {
+    return null;
+  }
+  if (document === null) return null;
+
+  try {
+    const proposal = parseSpindriftFile(document, path);
+    return proposal.build.frontend === 'railpack'
+      ? proposal.build.outputDirectory
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * How a dispatch refusal is recorded, and why there are exactly two ways.
  *
  * Everything below the Build row's own existence is refused *before* the claim
@@ -401,7 +474,12 @@ export const dispatchBuild = async (
     app.repositoryId === null
       ? []
       : await context.db
-          .select({ fullName: repositories.fullName })
+          // `installationId` rides along for `outputDirectoryFor`, which reads
+          // this build's commit as the installation that owns the repository.
+          .select({
+            fullName: repositories.fullName,
+            installationId: repositories.installationId,
+          })
           .from(repositories)
           .where(eq(repositories.id, app.repositoryId))
           .limit(1);
@@ -756,6 +834,20 @@ export const dispatchBuild = async (
       effectiveTargetId === undefined || !isBuildTimeConfig(component.kind)
         ? {}
         : await readBuildArgs(context.db, component.id, effectiveTargetId),
+    /**
+     * §3, story 42: a website placed on a static Target is the files its build
+     * leaves behind, not the tree that produced them.
+     *
+     * Read here, from this build's own commit, for the reason the field's
+     * documentation gives: the answer lives in the scope's `spindrift.yaml`
+     * and moves with the tree, so the only correct time to ask is while
+     * composing the spec for one commit.
+     */
+    outputDirectory: await outputDirectoryFor(context, {
+      artifactType: build.artifactType,
+      source,
+      repository: repository ?? null,
+    }),
   };
 
   const dispatchId = input.dispatchId ?? crypto.randomUUID();

--- a/apps/spindrift/test/adapters/bosun-build-route.test.ts
+++ b/apps/spindrift/test/adapters/bosun-build-route.test.ts
@@ -42,6 +42,7 @@ const spec: BuildSpec = {
   destinations: ['registry.example.test/app'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: { EXAMPLE: 'value' },
+  outputDirectory: null,
   registryAuth: [],
 };
 

--- a/apps/spindrift/test/adapters/build-blame.test.ts
+++ b/apps/spindrift/test/adapters/build-blame.test.ts
@@ -43,6 +43,7 @@ const spec: BuildSpec = {
   destinations: ['registry.example.test/app'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
+  outputDirectory: null,
   registryAuth: [],
 };
 

--- a/apps/spindrift/test/adapters/build-contract.test.ts
+++ b/apps/spindrift/test/adapters/build-contract.test.ts
@@ -32,6 +32,7 @@ const spec: BuildSpec = {
   destinations: ['registry.example.test/apps'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
+  outputDirectory: null,
   registryAuth: [],
 };
 

--- a/apps/spindrift/test/adapters/build-routes.test.ts
+++ b/apps/spindrift/test/adapters/build-routes.test.ts
@@ -92,6 +92,7 @@ const spec: BuildSpec = {
   destinations: ['registry.example.test/app'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
+  outputDirectory: null,
   registryAuth: [],
 };
 

--- a/apps/spindrift/test/adapters/build-run-link.test.ts
+++ b/apps/spindrift/test/adapters/build-run-link.test.ts
@@ -41,6 +41,7 @@ const spec: BuildSpec = {
   destinations: ['registry.example.test/app'],
   tags: ['sha256-bundle', 'latest'],
   buildArgs: {},
+  outputDirectory: null,
   registryAuth: [],
 };
 

--- a/apps/spindrift/test/adapters/files-artifact-arm.test.ts
+++ b/apps/spindrift/test/adapters/files-artifact-arm.test.ts
@@ -33,6 +33,8 @@ async function frontendScript(): Promise<string> {
 async function runArm(input: {
   artifactType: string;
   scopeFiles: Readonly<Record<string, string>>;
+  /** What the scope's `spindrift.yaml` named, as core resolved it (§3). */
+  outputDirectory?: string;
 }): Promise<{ outputs: Record<string, string>; workspace: string }> {
   const workspace = await mkdtemp(join(tmpdir(), 'spindrift-files-arm-'));
   const root = join(workspace, 'bundle');
@@ -52,6 +54,7 @@ async function runArm(input: {
       SUBPATH: 'site',
       FRONTEND: 'registry.example.test/zero-config:pinned',
       ARTIFACT_TYPE: input.artifactType,
+      OUTPUT_DIRECTORY: input.outputDirectory ?? '',
       GITHUB_OUTPUT: outputPath,
       RUNNER_TEMP: workspace,
     },
@@ -93,6 +96,45 @@ describe('the files arm of “Choose the frontend”', () => {
       );
       const dockerfile = await readFile(outputs.file as string, 'utf8');
       expect(dockerfile).toBe('FROM scratch\nCOPY . /\n');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('a declared output directory builds the scope first and lifts from it', async () => {
+    const { outputs, workspace } = await runArm({
+      artifactType: 'files',
+      // A scope that declares an output directory is the *sources* of a site,
+      // so its own Dockerfile is how the site gets made — the arm must fall
+      // through to the ladder rather than shipping the tree as it stands.
+      scopeFiles: { Dockerfile: 'FROM node', 'package.json': '{}' },
+      outputDirectory: 'dist',
+    });
+    try {
+      expect(outputs.lift).toBe('dist');
+      // The ladder's answer, not the files short-circuit: this is the build
+      // that produces the site, and `Lift the site out of the build` runs it.
+      expect(outputs.context).toBe(join(workspace, 'bundle'));
+      expect(outputs.file).toBe(
+        join(workspace, 'bundle', 'site', 'Dockerfile'),
+      );
+      // Written either way, because both paths end by exporting one directory
+      // as the single gzipped tar layer `static/oci.ts` reads back.
+      const scratch = await readFile(outputs.scratchfile as string, 'utf8');
+      expect(scratch).toBe('FROM scratch\nCOPY . /\n');
+    } finally {
+      await rm(workspace, { recursive: true, force: true });
+    }
+  });
+
+  test('no declared output directory still ships the scope, and lifts nothing', async () => {
+    const { outputs, workspace } = await runArm({
+      artifactType: 'files',
+      scopeFiles: { 'index.html': '<!doctype html>' },
+    });
+    try {
+      expect(outputs.lift).toBeUndefined();
+      expect(outputs.context).toBe(join(workspace, 'bundle', 'site'));
     } finally {
       await rm(workspace, { recursive: true, force: true });
     }

--- a/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
+++ b/apps/spindrift/test/adapters/registry-auth-delivery.test.ts
@@ -154,6 +154,7 @@ describe('the cloud build route', () => {
         ],
         tags: ['latest'],
         buildArgs: {},
+        outputDirectory: null,
         registryAuth,
       },
     )) {
@@ -265,6 +266,7 @@ describe('the in-cluster route', () => {
           destinations: ['registry-1.docker.io/an-owner/web'],
           tags: ['latest'],
           buildArgs: {},
+          outputDirectory: null,
           registryAuth,
         },
       )

--- a/apps/spindrift/test/conformance/adapter-suite.ts
+++ b/apps/spindrift/test/conformance/adapter-suite.ts
@@ -275,6 +275,7 @@ export function buildAdapterSuite(
       destinations: ['registry.example.test/app'],
       tags: ['sha256-bundle', 'latest'],
       buildArgs: {},
+      outputDirectory: null,
       registryAuth: [],
     } as const;
 


### PR DESCRIPTION
## What

A `files` build packaged the scope as it stood — `FROM scratch` + `COPY . /` — so a website with any build step at all reached a static Target as its own **sources**. `outputDirectory` was detected (`domain/detection/declared.ts`) and shown on the connect screen, then dropped: nothing persisted it and nothing carried it to a builder.

This carries it on `BuildSpec`, resolved from the scope's `spindrift.yaml` at the build's own commit, and teaches the hosted route's files arm to build the site before exporting it.

## Why per-commit and not a column

`spindrift.yaml` is the home of record — §5's "once it is on the default branch it wins over detection" — and it moves with the tree. A Component whose site moved from `build/` to `dist/` is described correctly by each commit and incorrectly by any single stored answer, so the value is read at the commit being built. No migration.

## How the arm changed

A scope that declares no output directory **is** the site; that path is byte-for-byte what it was. A scope that declares one falls through to §5's ladder, so the site is built exactly the way that commit's server image would have been — its own Dockerfile, or the pinned zero-config frontend — and one directory is then lifted back out of the image.

Two details worth review:

- The working directory is read off the image config rather than assumed. A hardcoded `/app` is right for the zero-config frontend and wrong for a hand-written Dockerfile, and gets you a `docker cp` failure naming a path nobody wrote down.
- Build args are dropped for the export build. When a site is lifted, the pushed build is a two-line `FROM scratch` Dockerfile, and passing `BUILDKIT_SYNTAX` on would hand the finished site to the zero-config frontend as if it were a project.

Lands for every `files` backend at once — static hosting, Cloudflare Pages, and Vercel take the same artifact.

## Validation

- `mise run ts:check` clean
- `bun test` — 2285 pass, 0 fail
- The files arm is covered by `files-artifact-arm.test.ts`, which runs the shipped `run:` script; two cases added (declared directory lifts and falls through, absent directory unchanged)

## Risk

The lift step's docker path — `buildx build --load`, `image inspect`, `docker cp` — is not exercised by the test suite and runs first on a real runner. It was verified against a stubbed docker client for argument assembly, working-directory resolution, and path composition only. A build that leaves nothing at the declared directory fails loudly at that step rather than deploying an empty site.

The other three build routes still have no files arm (`buildkit.ts`), unchanged by this and called out by `static/oci.ts`'s own error text. Only the hosted route builds `files` today.