### PR TITLE
docs(tender): say which silicon this shape actually gets

### DIFF
--- a/terraform/gcp/projects/homelab-ng/bosun.tf
+++ b/terraform/gcp/projects/homelab-ng/bosun.tf
@@ -4,9 +4,23 @@
 # C4 is the machine family because nested virtualization on Compute Engine is
 # Intel-only -- every AMD (`D`) and Arm (`A`/Axion) family is excluded outright,
 # which is why C4D's 384 cores of Turin cannot serve a skiff as a VM at any
-# size -- and among the Intel families C4 is the highest clocked: Granite
-# Rapids at a 3.9 GHz sustained all-core turbo against C3's 3.0. That is the
-# whole reason to run CI here rather than on a cheaper C3 or N2.
+# size.
+#
+# The clock claim that used to sit here -- Granite Rapids at 3.9 GHz sustained
+# all-core against C3's 3.0 -- is not what this shape gets, and it is worth
+# saying plainly rather than leaving as an aspiration. Which generation a C4
+# lands on is decided by the shape: the `-lssd` and `-metal` variants and the
+# 144- and 288-vCPU sizes get Granite Rapids, and every other C4 gets Emerald
+# Rapids. `c4-standard-48` is none of those, so this host runs Emerald -- a
+# Xeon 8581C at 2.30 GHz base -- and `min_cpu_platform` cannot argue with it:
+# C4 rejects the field outright.
+#
+# So the honest standing of this choice: C4 buys nested virt on Intel, not the
+# fastest Intel clock. `c4-standard-48-lssd` is the same 48 vCPU and the same
+# quota footprint and does get Granite (with ~3 TB of bundled NVMe), which is
+# the upgrade to weigh if the clock is ever measured to matter. It has not
+# been, and swapping shapes is a stop/start on a Spot instance nothing
+# restarts by itself.
 #
 # Nested virt itself is a plain boolean on the instance. It needs no custom
 # image and no `enable-vmx` license, so nix/images/gce.nix is unchanged from
@@ -118,6 +132,11 @@ resource "google_compute_instance" "tender" {
   description               = "Cloud bosun host: a warm pool of microVM Actions runners"
   machine_type              = local.tender_machine_type
   allow_stopping_for_update = true
+
+  # No min_cpu_platform: C4 rejects it outright ("C4 VM does not support
+  # minCpuPlatform Intel Granite Rapids", HTTP 400). Which generation a C4
+  # lands on is a property of the shape, not a request -- see the note above
+  # the machine type.
 
   # The point of the whole exercise: a skiff is a KVM guest inside this guest.
   advanced_machine_features {


### PR DESCRIPTION
**This replaces the `min_cpu_platform` attempt, which does not work.** The
apply failed:

```
Error: googleapi: Error 400: C4 VM does not support minCpuPlatform
Intel Granite Rapids., badRequest
```

…and because `allow_stopping_for_update = true`, it stopped the instance first
and left **tender TERMINATED with an empty pool** until I started it again. It
is `RUNNING` now, same internal and external IPs.

## What's actually true

Which Intel generation a C4 lands on is decided by the **shape**, not by a
request:

> *"C4 Local SSD (`-lssd`) and bare metal (`-metal`) instances, as well as
> instances with 144 or 288 vCPUs, use the 6th generation Intel Granite Rapids
> processor, while all other instances use the 5th generation Intel Emerald
> Rapids processor."*

`c4-standard-48` is none of those, so **Emerald Rapids is correct behaviour**,
not a misconfiguration. This file's stated rationale — *"the highest clocked:
Granite Rapids at a 3.9 GHz sustained all-core turbo against C3's 3.0"* — was
describing a machine we were not running.

## What this PR does

Corrects the comment, and records the upgrade path rather than asserting we
took it. No resource changes, so the plan is a no-op.

The honest standing of the family choice is now written down: **C4 buys nested
virt on Intel, not the fastest Intel clock.**

## The upgrade, unmeasured on purpose

`c4-standard-48-lssd` is the same 48 vCPU, the same quota footprint, and *does*
get Granite Rapids — plus 8 bundled NVMe partitions (~3 TB) that skiff
workspaces would use well.

I did not take it in this PR for two reasons, and both should be settled before
someone does:

1. The provider documents `scratch_disk` but says nothing about machine types
   that **bundle** local SSDs. Whether terraform wants them declared, or drifts
   against auto-attached ones, is unverified — and an unverified apply is
   exactly what left tender terminated an hour ago.
2. Nobody has measured that the clock matters here. The 8-wide run that started
   this had two other explanations in it (24 physical cores behind 48 vCPU, and
   eight cold workspaces), and it was also run against the 3 GiB `skiff-ubuntu`
   class rather than the size-matched `skiff-ubuntu-bench`.