### PR TITLE
A demo scope pair that shares a Datastore and nothing else

### DIFF
--- a/apps/spindrift-demo/README.md
+++ b/apps/spindrift-demo/README.md
@@ -1,15 +1,20 @@
 # spindrift-demo
 
-Four scopes, one per shape of App worth demonstrating. Each is a directory you
-can point a Component at; nothing here shares code with anything else here, so
-deploying one proves something about exactly one path.
+Five scopes, one per shape of App worth demonstrating. Each is a directory you
+can point a Component at, and no scope imports another — railpack builds with
+the *scope* as its context, so a module one directory up is not in the build.
 
 | Scope | Kind | Built by | What it demonstrates |
 | --- | --- | --- | --- |
 | `src/` | website | Dockerfile | A site with a real build step. `build.ts` stamps commit, branch and time into the HTML, so a stale deploy is visible on the page. |
 | `plain/` | website | — | Static files with no build at all. The narrowest possible website. |
 | `railpack/` | service | railpack | Detection picking a frontend on its own, because there is no Dockerfile in the scope. |
-| `job/` | job | railpack | A Component that runs once and stops, on either backend. |
+| `job/` | job | railpack | A Component that runs once and stops, on either backend. Writes to a `valkey` Datastore when one is attached. |
+| `web/` | service | railpack | Reads back what `job/` wrote. The two are a **pair**, and the only shared thing is a Datastore. |
+
+Four of them prove something about exactly one path. `job/` and `web/` are the
+exception and the reason is [below](#the-pair) — they share no code and name
+each other nowhere, and that is the thing being demonstrated.
 
 ## Runtime identity
 
@@ -85,13 +90,61 @@ A cadence is not declared here. The same code is a job you press **Run now** on
 and a job that fires every five minutes; which one it is belongs to the
 Component, chosen at Place, not to the directory.
 
+## The pair
+
+`job/` writes and `web/` reads, and nothing connects them. Put both in **one
+App**, attach one `valkey` Datastore to that App, and deploy: each Component is
+handed the same `REDIS_URL`, because a Datastore attaches to the App and its
+variable name is fixed by the engine — `REDIS_URL` for valkey, `DATABASE_URL`
+for postgres (`apps/spindrift/src/domain/desired-state.ts`). Neither scope
+declares a store and neither names the other. There is nothing to wire.
+
+Three things it is worth watching for, in order:
+
+1. **Before an attach**, `web/` says no Datastore is attached, in those words.
+   It is not an error state — it is what every Component looks like until one
+   is attached.
+2. **Straight after an attach**, the page has not changed. An attach is
+   bookkeeping; the variable reaches a workload on its **next Deploy**, because
+   "an attach that silently rolled every Component would be a destructive act
+   hiding behind a bookkeeping verb" (`commands/datastores/attach.ts`).
+3. **After deploying**, the counter and the run table appear. Press **Run now**
+   on `job/` and the page picks the new row up within five seconds.
+
+One store per engine per App, refused at attach: a second `valkey` would claim
+the same `REDIS_URL` and win by ordering. One valkey *and* one postgres is
+fine, since those are two different variables.
+
+Datastores are provisionable on **Kubernetes** Targets only — the GCP adapter
+claims both engines and throws `UNIMPLEMENTED` from every verb, because a
+Vessel carries no network to place a private endpoint in. The same `job/` image
+on Cloud Run finds no `REDIS_URL` and says so rather than failing, which is why
+that path still demonstrates what it is there to demonstrate.
+
+`web/` has to be a `service`. A `website` is static files served by the Target
+— no process, no environment — so no connection string can reach one; `src/`
+and `plain/` are that side of the line.
+
 ## Running them locally
 
 ```
 cd railpack && npm run build && npm start     # :3000, JSON on /, /healthz, /env
 cd job && DURATION_SECONDS=3 npm start        # exits 0
 cd job && EXIT_CODE=7 npm start               # exits 7, writes to stderr
+cd web && npm test                            # the RESP reader's own check
 ```
+
+The pair, against a local valkey:
+
+```
+valkey-server --port 16379 --save ''
+cd job && REDIS_URL=redis://127.0.0.1:16379 DURATION_SECONDS=2 npm start
+cd web && REDIS_URL=redis://127.0.0.1:16379 npm start    # :3000
+```
+
+Start `web/` with no `REDIS_URL` to see the unattached state, or point it at a
+port nothing is listening on to see the unreachable one. `/healthz` stays green
+through both — this Component is up whether or not a store is.
 
 `bun run dev` from this directory builds `src/` and serves it hot through
 `serve.ts`. `plain/` is a static directory; point a static-file host at it to

--- a/apps/spindrift-demo/job/job.js
+++ b/apps/spindrift-demo/job/job.js
@@ -23,6 +23,12 @@
  * that survives the run is the shortest thing that proves the connection was
  * real — a job that merely started is a job that proves the variable parsed.
  *
+ * It also leaves a **record** of itself, which the sibling `web/` scope reads
+ * back and renders. That is the pair's whole subject: nothing connects these
+ * two Components to each other. They are in one App, one `valkey` Datastore is
+ * attached to that App, and so both are handed the same `REDIS_URL` on their
+ * next Deploy — neither scope names the other, and neither declares a store.
+ *
  * Optional like the rest, and deliberately so: the same image runs on Cloud
  * Run, where there is no Datastore to attach, and a demo that failed there
  * would be demonstrating the wrong thing.
@@ -52,33 +58,48 @@ function whoAmI() {
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/** One RESP array, which is the only way this speaks. */
+const encode = (args) =>
+  `*${args.length}\r\n${args
+    .map((arg) => `$${Buffer.byteLength(String(arg))}\r\n${arg}\r\n`)
+    .join('')}`;
+
 /**
- * `INCR <key>`, spoken straight down a socket.
+ * A few commands down one socket, replies in order.
  *
  * No client library, for the same reason nothing else here has a dependency:
- * the demo is read as much as it is run, and one command whose reply is a
- * single line is smaller than the install that would save writing it.
+ * the demo is read as much as it is run, and the install that would save
+ * writing this is an install that can fail for reasons having nothing to do
+ * with Spindrift.
  *
- * ponytail: understands exactly one reply — `:<n>`, which is all `INCR` can
- * answer with on success. Anything else is handed back verbatim as an error
- * rather than parsed, so a wrong assumption reads as a wrong assumption. Reach
- * for a real client the moment a second command is wanted.
+ * ponytail: reads **single-line replies only** — `:<n>` from INCR and LPUSH,
+ * `+OK` from LTRIM — by counting `\r\n` terminators, so it cannot parse a bulk
+ * string or an array and does not pretend to. That is exactly the set this job
+ * sends; the sibling `web/` scope reads and therefore carries a real parser.
+ * A `-ERR` line rejects rather than resolving, so a wrong assumption reads as
+ * one. Reach for a client the moment a reply here stops being one line.
  */
-function incr(url, key) {
+function talk(url, commands) {
   const { hostname, port } = new URL(url);
   return new Promise((resolve, reject) => {
     const socket = connect({ host: hostname, port: Number(port) || 6379 }, () =>
-      socket.write(
-        `*2\r\n$4\r\nINCR\r\n$${Buffer.byteLength(key)}\r\n${key}\r\n`,
-      ),
+      socket.write(commands.map(encode).join('')),
     );
     socket.setTimeout(5000);
-    socket.once('data', (chunk) => {
+
+    let buffer = '';
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString();
+      // Every reply this sends is one line, so a complete response is simply
+      // as many terminators as there were commands.
+      if (buffer.split('\r\n').length - 1 < commands.length) return;
       socket.end();
-      const reply = chunk.toString().trim();
-      if (reply.startsWith(':')) resolve(Number(reply.slice(1)));
-      else reject(new Error(`unexpected reply: ${reply}`));
+      const replies = buffer.split('\r\n').slice(0, commands.length);
+      const failure = replies.find((reply) => reply.startsWith('-'));
+      if (failure) reject(new Error(failure.slice(1)));
+      else resolve(replies);
     });
+
     socket.once('timeout', () => {
       socket.destroy();
       reject(new Error('timed out after 5s'));
@@ -99,8 +120,25 @@ log(`plan: ${steps} stepz over ${duration}s, exiting ${exitCode}`);
 // first run since the Datastore was attached" without anyone counting runs.
 if (process.env.REDIS_URL) {
   try {
-    const runs = await incr(process.env.REDIS_URL, 'spindrift-demo-job:runs');
-    log(`valkey: run #${runs}`);
+    // The record is JSON so `web/` renders fields rather than re-parsing a
+    // sentence this file happened to phrase. Trimmed to the last 20 because an
+    // unbounded list is a demo that eventually becomes a memory leak, and 20 is
+    // more runs than anybody watches in one sitting.
+    const record = JSON.stringify({
+      at: new Date().toISOString(),
+      backend: whoAmI(),
+      build: process.env.SPINDRIFT_BUILD ?? null,
+      label: process.env.SPINDRIFT_RUNTIME_LABEL ?? null,
+      steps,
+      duration,
+      exitCode,
+    });
+    const [runs] = await talk(process.env.REDIS_URL, [
+      ['INCR', 'spindrift-demo:runs'],
+      ['LPUSH', 'spindrift-demo:log', record],
+      ['LTRIM', 'spindrift-demo:log', 0, 19],
+    ]);
+    log(`valkey: run #${runs.slice(1)}, record written`);
   } catch (error) {
     // Reported and survived. The datastore is what this run *uses*, not what
     // it is for, and a job that died because a cache was unreachable would

--- a/apps/spindrift-demo/web/package.json
+++ b/apps/spindrift-demo/web/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "spindrift-demo-web",
+  "private": true,
+  "type": "module",
+  "description": "Reads back what the job scope wrote, through a Datastore neither of them declares.",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node --test"
+  }
+}

--- a/apps/spindrift-demo/web/resp.js
+++ b/apps/spindrift-demo/web/resp.js
@@ -1,0 +1,102 @@
+/**
+ * Enough of the Valkey wire protocol to read what `job/` wrote.
+ *
+ * Its own file so it can be checked without starting a server: `server.js`
+ * listens at import, and a parser whose only exercise is "the page looked
+ * right" is a parser nobody notices breaking until the demo is in front of
+ * someone. `resp.test.js` runs on `node --test` — a built-in, so this scope
+ * stays dependency-free like its neighbours.
+ *
+ * The `job/` scope deliberately does **not** import this. Each scope here is
+ * self-contained, because railpack builds with the *scope* as its context and
+ * a module one directory up is simply not in the build. The job also needs
+ * far less — it sends three commands whose replies are one line each and says
+ * so — so the duplication is two different jobs, not one done twice.
+ */
+
+/** One RESP array, which is the only way a command is sent. */
+export const encode = (args) =>
+  `*${args.length}\r\n${args
+    .map((arg) => `$${Buffer.byteLength(String(arg))}\r\n${arg}\r\n`)
+    .join('')}`;
+
+/**
+ * Parse one reply starting at `at`, or `null` if the buffer is short.
+ *
+ * That `null` is the whole reason this is a parser rather than a `split`.
+ * `GET` answers with a bulk string that may be `$-1` for a missing key and
+ * `LRANGE` with an array of them, so a twenty-entry list does not arrive in
+ * one chunk — it arrives in as many as the network felt like. A reader that
+ * assumed otherwise works on a laptop and truncates on a busy cluster, which
+ * is the kind of bug that looks like "the demo is flaky".
+ *
+ * Errors come back as `Error` values rather than throwing, so a caller reading
+ * several replies can finish reading before deciding what to do about one.
+ */
+export function parse(buffer, at = 0) {
+  const end = buffer.indexOf('\r\n', at);
+  if (end === -1) return null;
+  const kind = buffer[at];
+  const head = buffer.slice(at + 1, end);
+  const next = end + 2;
+
+  if (kind === '+' || kind === ':') return { value: head, at: next };
+  if (kind === '-') return { value: new Error(head), at: next };
+
+  if (kind === '$') {
+    const length = Number(head);
+    if (length === -1) return { value: null, at: next };
+    if (buffer.length < next + length + 2) return null;
+    return { value: buffer.slice(next, next + length), at: next + length + 2 };
+  }
+
+  if (kind === '*') {
+    const count = Number(head);
+    if (count === -1) return { value: null, at: next };
+    const items = [];
+    let cursor = next;
+    for (let index = 0; index < count; index += 1) {
+      const item = parse(buffer, cursor);
+      if (item === null) return null;
+      items.push(item.value);
+      cursor = item.at;
+    }
+    return { value: items, at: cursor };
+  }
+
+  return { value: new Error(`unreadable reply: ${kind}${head}`), at: next };
+}
+
+/** Send commands down one socket, resolve with their replies in order. */
+export function talk(connect, url, commands) {
+  const { hostname: host, port } = new URL(url);
+  return new Promise((resolve, reject) => {
+    const socket = connect({ host, port: Number(port) || 6379 }, () =>
+      socket.write(commands.map(encode).join('')),
+    );
+    socket.setTimeout(5000);
+
+    let buffer = '';
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString();
+      const replies = [];
+      let cursor = 0;
+      for (let index = 0; index < commands.length; index += 1) {
+        const reply = parse(buffer, cursor);
+        if (reply === null) return; // short — wait for the rest
+        replies.push(reply.value);
+        cursor = reply.at;
+      }
+      socket.end();
+      const failure = replies.find((reply) => reply instanceof Error);
+      if (failure) reject(failure);
+      else resolve(replies);
+    });
+
+    socket.once('timeout', () => {
+      socket.destroy();
+      reject(new Error('timed out after 5s'));
+    });
+    socket.once('error', reject);
+  });
+}

--- a/apps/spindrift-demo/web/resp.test.js
+++ b/apps/spindrift-demo/web/resp.test.js
@@ -1,0 +1,62 @@
+/**
+ * The one thing here that can be wrong without looking wrong.
+ *
+ * `node --test`, so the scope keeps its no-dependency rule. The cases that
+ * matter are the short-buffer ones: everything else is a `split` with extra
+ * steps, and a reader that mishandles a reply arriving in two chunks produces
+ * a page that is silently missing rows rather than one that fails.
+ */
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { encode, parse } from './resp.js';
+
+test('encodes a command as a RESP array', () => {
+  assert.equal(encode(['GET', 'k']), '*2\r\n$3\r\nGET\r\n$1\r\nk\r\n');
+});
+
+test('reads the simple replies', () => {
+  assert.equal(parse('+OK\r\n').value, 'OK');
+  assert.equal(parse(':42\r\n').value, '42');
+  assert.equal(parse('$3\r\nabc\r\n').value, 'abc');
+});
+
+test('a missing key is null, not an empty string', () => {
+  // `GET` on a key nothing wrote. Rendering "" as a count of runs would be a
+  // page claiming zero runs when the truth is nothing has ever written.
+  assert.equal(parse('$-1\r\n').value, null);
+});
+
+test('an error reply comes back as an Error rather than throwing', () => {
+  const reply = parse('-ERR wrong kind\r\n');
+  assert.ok(reply.value instanceof Error);
+  assert.equal(reply.value.message, 'ERR wrong kind');
+});
+
+test('reads an array of bulk strings, and reports where it ended', () => {
+  const reply = parse('*2\r\n$1\r\na\r\n$2\r\nbc\r\n');
+  assert.deepEqual(reply.value, ['a', 'bc']);
+  assert.equal(reply.at, '*2\r\n$1\r\na\r\n$2\r\nbc\r\n'.length);
+});
+
+test('a short buffer is null at every truncation point', () => {
+  // The real failure mode, enumerated: a twenty-entry LRANGE arrives in
+  // however many chunks the network chose, so every prefix of a reply has to
+  // read as "not yet" rather than as a shorter reply.
+  const complete = '*2\r\n$1\r\na\r\n$12\r\nhello world!\r\n';
+  for (let cut = 1; cut < complete.length; cut += 1) {
+    assert.equal(
+      parse(complete.slice(0, cut)),
+      null,
+      `a ${cut}-byte prefix should read as incomplete`,
+    );
+  }
+  assert.deepEqual(parse(complete).value, ['a', 'hello world!']);
+});
+
+test('reads several replies in sequence from one buffer', () => {
+  // What `talk` does: GET then LRANGE, pipelined, arriving together.
+  const buffer = '$1\r\n7\r\n*1\r\n$2\r\nhi\r\n';
+  const first = parse(buffer, 0);
+  assert.equal(first.value, '7');
+  assert.deepEqual(parse(buffer, first.at).value, ['hi']);
+});

--- a/apps/spindrift-demo/web/server.js
+++ b/apps/spindrift-demo/web/server.js
@@ -1,0 +1,207 @@
+/**
+ * The other half of a pair, and the only scope here that reads what another
+ * one wrote.
+ *
+ * Every other scope in this directory proves something about exactly one path
+ * and shares nothing with its neighbours. This one shares a **Datastore** with
+ * `job/` — and shares no code with it, names it nowhere, and declares no store
+ * of its own. That absence is the subject:
+ *
+ *   A Datastore attaches to the **App**, never to a Component
+ *   (`attachDatastore({datastoreId, appId})`). Its connection arrives as a
+ *   variable whose name is fixed by the engine and is never a field —
+ *   `REDIS_URL` for valkey, `DATABASE_URL` for postgres
+ *   (`apps/spindrift/src/domain/desired-state.ts`). So every Component in the
+ *   App is handed it on its next Deploy, and two Components sharing state need
+ *   no wiring between them because there is nothing to wire.
+ *
+ * Which is why this file has no configuration for where the job's data is. It
+ * reads two fixed keys out of whatever `REDIS_URL` points at, and if nothing
+ * points anywhere it says so in those terms rather than erroring — the
+ * unattached state is half of what the demo demonstrates, because an attach
+ * does not roll anything and the data appears on the *next* Deploy.
+ *
+ * It must be a `service` rather than a `website`, and that is not a preference:
+ * a website is static files served by the Target, with no process and no
+ * environment, so no connection string can reach one. The `src/` and `plain/`
+ * scopes are that side of the line.
+ *
+ * Node built-ins only, like its neighbours — a dependency here would prove
+ * railpack can install one and would also make the demo fail, the first time a
+ * registry is slow, for a reason that has nothing to do with Spindrift. No
+ * Dockerfile either, so `buildkit.ts`'s `[ -f Dockerfile ]` switch routes this
+ * scope through railpack; and no `spindrift.yaml`, because detection infers
+ * `service` on its own and a file asserting it would remove the inference.
+ */
+
+import { createServer } from 'node:http';
+import { connect } from 'node:net';
+import { hostname } from 'node:os';
+import { talk } from './resp.js';
+
+const port = Number(process.env.PORT) || 3000;
+const startedAt = new Date();
+
+/** Fixed, because `job/` writes them and neither scope configures the other. */
+const COUNTER = 'spindrift-demo:runs';
+const LOG = 'spindrift-demo:log';
+
+/**
+ * What the job left, or why there is nothing.
+ *
+ * Three states, all of them true things to render: no store attached, a store
+ * attached but unreachable, and a store with data in it. The first is not an
+ * error — it is what every Component of this App looks like until a `valkey`
+ * Datastore is attached *and* a Deploy has happened since.
+ */
+async function readStore() {
+  const url = process.env.REDIS_URL;
+  if (!url) return { state: 'unattached' };
+  try {
+    const [runs, entries] = await talk(connect, url, [
+      ['GET', COUNTER],
+      ['LRANGE', LOG, 0, -1],
+    ]);
+    return {
+      state: 'attached',
+      runs: runs === null ? 0 : Number(runs),
+      // A record this scope cannot read is shown as itself rather than
+      // dropped: a malformed entry is evidence about the writer, and hiding it
+      // would make the page lie about what is in the list.
+      log: (entries ?? []).map((entry) => {
+        try {
+          return { parsed: JSON.parse(entry) };
+        } catch {
+          return { raw: entry };
+        }
+      }),
+    };
+  } catch (error) {
+    return { state: 'unreachable', detail: error.message };
+  }
+}
+
+/** Which hosting platform this is, by the marker that says so. */
+function platform() {
+  const env = process.env;
+  if (env.KUBERNETES_SERVICE_HOST) return 'Kubernetes';
+  if (env.K_SERVICE || env.CLOUD_RUN_JOB) return 'Google Cloud Run';
+  return 'unknown backend';
+}
+
+// ---------------------------------------------------------------------------
+// the page
+// ---------------------------------------------------------------------------
+
+const html = (text) =>
+  String(text).replace(
+    /[&<>"]/g,
+    (character) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[character],
+  );
+
+const STYLE = `
+:root{color-scheme:light dark;--ink:#0c1d23;--dim:#5b7480;--paper:#eceff0;--card:#f7f9f9;--rule:#c3d0d2;--accent:#0e6e78}
+@media(prefers-color-scheme:dark){:root{--ink:#dbe8e9;--dim:#8ba4ab;--paper:#08161b;--card:#0e2229;--rule:#21414c;--accent:#59c6d0}}
+*{box-sizing:border-box;margin:0}
+body{background:var(--paper);color:var(--ink);font:16px/1.5 ui-sans-serif,system-ui,sans-serif;padding:clamp(1.5rem,5vw,4rem);max-width:62rem;margin:0 auto}
+h1{font-size:clamp(1.6rem,4vw,2.4rem);letter-spacing:-.02em;margin-bottom:.35rem}
+.lede{color:var(--dim);max-width:56ch;margin-bottom:2rem}
+.count{font-variant-numeric:tabular-nums;font-size:clamp(2.5rem,9vw,4.5rem);line-height:1;color:var(--accent);font-weight:600}
+.note{border-left:3px solid var(--accent);padding:.75rem 1rem;background:var(--card);margin:1.5rem 0;max-width:60ch}
+.note.warn{border-color:#a81b5f}
+table{border-collapse:collapse;width:100%;margin-top:1rem;font-size:.9rem}
+th,td{text-align:left;padding:.5rem .75rem;border-bottom:1px solid var(--rule)}
+th{font-size:.7rem;text-transform:uppercase;letter-spacing:.1em;color:var(--dim);font-weight:500}
+td.m{font-family:ui-monospace,monospace;font-size:.82rem}
+footer{margin-top:3rem;padding-top:1rem;border-top:1px solid var(--rule);color:var(--dim);font-size:.8rem;display:flex;gap:1.5rem;flex-wrap:wrap}
+`;
+
+function render(store) {
+  const rows =
+    store.state === 'attached' && store.log.length > 0
+      ? store.log
+          .map((entry) => {
+            if (entry.raw) {
+              return `<tr><td colspan="4" class="m">${html(entry.raw)}</td></tr>`;
+            }
+            const run = entry.parsed;
+            return `<tr>
+              <td class="m">${html(run.at ?? '—')}</td>
+              <td class="m">${html(run.backend ?? '—')}</td>
+              <td class="m">${html(run.build ?? '—')}</td>
+              <td class="m">${html(run.exitCode ?? '—')}</td>
+            </tr>`;
+          })
+          .join('')
+      : '';
+
+  const body =
+    store.state === 'unattached'
+      ? `<div class="note warn"><b>No Datastore is attached.</b> This Component was
+         handed no <code>REDIS_URL</code>, so there is nothing to read. Attach a
+         <code>valkey</code> Datastore to this App and deploy again — an attach
+         does not roll anything, so the data appears on the <em>next</em> Deploy
+         and not before.</div>`
+      : store.state === 'unreachable'
+        ? `<div class="note warn"><b>A store is attached but did not answer.</b>
+           <code>${html(store.detail)}</code></div>`
+        : `<p class="count">${store.runs}</p>
+           <p class="lede">runs recorded by the <code>job</code> Component.</p>
+           ${
+             rows === ''
+               ? `<div class="note">The store is attached and empty. Press
+                  <b>Run now</b> on the <code>job</code> Component and reload.</div>`
+               : `<table><thead><tr><th>When</th><th>Backend that ran it</th>
+                  <th>Build</th><th>Exit</th></tr></thead><tbody>${rows}</tbody></table>`
+}`;
+
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<!-- The page is watched while a job runs, so it refreshes itself. -->
+<meta http-equiv="refresh" content="5" />
+<title>spindrift-demo — web</title><style>${STYLE}</style></head>
+<body>
+<h1>What the job wrote</h1>
+<p class="lede">Two Components in one App. Neither names the other and neither
+declares a store — they are handed the same <code>REDIS_URL</code> because one
+<code>valkey</code> Datastore is attached to the App they share.</p>
+${body}
+<footer>
+  <span>service on ${html(platform())}</span>
+  <span>host ${html(process.env.HOSTNAME ?? hostname())}</span>
+  <span>build ${html(process.env.SPINDRIFT_BUILD ?? 'unknown')}</span>
+  <span>up ${Math.round((Date.now() - startedAt.getTime()) / 1000)}s</span>
+</footer>
+</body></html>`;
+}
+
+createServer((request, response) => {
+  const path = new URL(request.url, `http://${request.headers.host}`).pathname;
+
+  // Cheap and independent of the store, so a probe pointed here does not go
+  // red because a Datastore is missing — this Component is up either way.
+  if (path === '/healthz') {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ ok: true, since: startedAt.toISOString() }));
+    return;
+  }
+
+  readStore().then((store) => {
+    if (path === '/__runtime__') {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.end(JSON.stringify({ platform: platform(), store }, null, 2));
+      return;
+    }
+    response.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    response.end(render(store));
+  });
+}).listen(port, () => {
+  console.log(`spindrift-demo-web on :${port} — ${platform()}`);
+  console.log(
+    process.env.REDIS_URL
+      ? 'REDIS_URL is set, so a Datastore is attached'
+      : 'no REDIS_URL, so no Datastore is attached',
+  );
+});


### PR DESCRIPTION
`job/` already wrote a counter to valkey when one was attached. It now also
leaves a JSON record per run, trimmed to the last 20. `web/` is a new `service`
scope that reads both back and renders them.

## The pair is the subject

Neither scope names the other, neither declares a store, and they share no code —
railpack builds with the *scope* as its context, so a shared module is not even in
the build. They see the same data because a Datastore attaches to the **App** and
its variable name is fixed by the engine, so every Component is handed `REDIS_URL`
on its next Deploy. There is nothing to wire, and that absence is what the pair
demonstrates.

Three states, all rendered as true things rather than errors:

| State | What the page says |
| --- | --- |
| No store attached | Names `REDIS_URL` and says an attach plus a Deploy is what fills it |
| Attached, unreachable | The connection error, verbatim |
| Attached with data | The counter and a table of runs, each with the backend that ran it |

`/healthz` stays green through all three — this Component is up whether or not a
store is, and a probe that went red on a missing Datastore would be answering a
different question.

## Two constraints worth stating

`web/` **has to be a `service`.** A `website` is static files served by the
Target — no process, no environment — so no connection string can reach one.
`src/` and `plain/` are that side of the line, which means the demo now shows
both sides of it.

**Datastores are Kubernetes-only.** The GCP adapter claims both engines and
throws `UNIMPLEMENTED` from every verb, because a Vessel carries no network for a
private endpoint. The same `job/` image on Cloud Run finds no `REDIS_URL` and says
so rather than failing.

## The RESP reader

Its own module with its own `node --test` check, because reading is where replies
stop being one line: `LRANGE` returns an array of bulk strings that does not
arrive in one chunk, and a reader assuming otherwise truncates on a busy cluster
and looks flaky. The test asserts every truncation point of a reply reads as
incomplete. Still zero dependencies — `node:test` is a built-in, so the scope
keeps the rule `railpack/server.js` states.

## Validation

Run against a real valkey locally: two job runs wrote a counter and two records;
the page rendered both. A 22-entry list (10.5 KB, well past one TCP segment)
parsed completely. Unattached and unreachable states both verified, with
`/healthz` green through them. `node --test` 7/7; `biome check` clean on the new
files.

Formatting drift `biome` reports in `src/style.css`, `plain/style.css`,
`build.ts` and `serve.ts` is pre-existing on `main` and deliberately left alone.