### PR TITLE
feat(spindrift): let folly's target identity write Argo Applications

### DIFF
--- a/clusters/folly/apps/spindrift-target/rbac.yaml
+++ b/clusters/folly/apps/spindrift-target/rbac.yaml
@@ -26,6 +26,47 @@ subjects:
     kind: User
     name: federated:system:serviceaccount:spindrift:spindrift
 ---
+# The Argo flavour's delivery grant, which only this cluster can carry: the
+# `Application` is created beside Argo rather than beside the workloads it
+# renders, so the grant is in `argo` and not in the `spindrift-apps` Role the
+# binding above names. That is also why it is here and not in
+# `clusters/base/platform/spindrift-target` — offsite runs no Argo and has no
+# such namespace, and a Role in a namespace that does not exist does not apply.
+#
+# Four verbs rather than the six `helmreleases` carries beside it: an apply is a
+# create-or-patch, `observe` is a `get` by the name core already stored, and
+# `destroy` is a `delete`. The adapter polls the object through `get` and never
+# watches or lists it.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: spindrift-target-delivery-argo
+  namespace: argo
+rules:
+  - apiGroups:
+      - argoproj.io
+    resources:
+      - applications
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: spindrift-target-delivery-argo
+  namespace: argo
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: spindrift-target-delivery-argo
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: federated:system:serviceaccount:spindrift:spindrift
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:


### PR DESCRIPTION
## Summary

The Kubernetes deploy adapter has carried the `argo-application` delivery flavour since it was written, and folly is the only cluster running Argo CD (`clusters/folly/apps/argo`, argo-cd 10.3.2 in namespace `argo`). But the target identity's only delivery grant is `helm.toolkit.fluxcd.io/helmreleases` in `spindrift-apps`, so picking that flavour on folly's connect screen produced a Target whose `DELIVERY_PERMISSIONS` check failed and whose every write was refused.

Adds a `Role` + `RoleBinding` granting `argoproj.io/applications` in the `argo` namespace.

Two placement decisions worth stating:

- **Its own Role in `argo`, not a rule on the `spindrift-apps` Role.** The `Application` object is created beside Argo; only the workloads it renders land in `spindrift-apps`.
- **folly's overlay, not `clusters/base/platform/spindrift-target`.** Both clusters consume that base. offsite runs no Argo and has no `argo` namespace, so the Role would never apply there.

Four verbs rather than the six `helmreleases` carries: apply is a create-or-patch, `observe` is a `get` by the stored name, `destroy` is a `delete`. The adapter polls through `get` and never watches or lists the delivery object.

## Validation

- `mise run k8s:render-apps` — clean
- `kubectl kustomize clusters/folly/apps/spindrift-target` — the Role and binding render in `argo`
- `kubectl kustomize clusters/base/platform/spindrift-target` — unchanged, no Argo references

## Risks

Permission only; nothing selects the flavour yet. Switching folly's Target to `argo-application` is a separate act through the connect screen, and two things stay unverifiable until someone does it: `CHART_SOURCE` cannot be checked for this flavour (Argo fetches the chart itself with credentials Spindrift never sees), and Argo's own ability to pull `oci://ghcr.io/jonpulsifer/charts/spindrift-app` is untested.