### PR TITLE
fix(spindrift): refuse a release pinned to config that no longer exists

### DIFF
--- a/apps/spindrift/src/commands/deploys/create.ts
+++ b/apps/spindrift/src/commands/deploys/create.ts
@@ -58,6 +58,7 @@ import {
 import { targetRowLabel } from '../../domain/target.ts';
 import { demandSentence, migrationFor } from '../config/migration.ts';
 import { type PinnedConfig, readPinnedConfig } from '../config/pinned.ts';
+import { storeOfRecordOf } from '../config/set.ts';
 import {
   type Command,
   type CommandContext,
@@ -207,6 +208,70 @@ export const createDeploy: Command<
  *    `desiredBuildId` is exactly what a rollback is; nothing here needs to know
  *    which of the two happened.
  */
+/**
+ * Which of this document's pinned config references no longer resolve, as one
+ * sentence — or `null` when every one of them still does.
+ *
+ * §10 pins a config version so that "a rollback comes back up with the
+ * configuration it originally had", and the store contract names the verb that
+ * makes the promise checkable: `describe` is "the read-back… core uses it to
+ * prove a Deploy's pinned document still resolves before it deploys against
+ * it." Nothing called it. So the guarantee held for as long as nothing had
+ * reaped a version, and the moment something had — §10's own N = 10 retention
+ * does exactly that on a loop — a rollback past it deployed **green and
+ * unconfigured**, which is the failure §10 names retention depth to avoid.
+ *
+ * Checked here rather than in either caller because both reach it: an ordinary
+ * deploy delivers config as it is now, a rollback delivers the document the
+ * older release carried, and it is the second one whose pins have had time to
+ * go. Before the transaction, not inside it — this asks a far side, and a
+ * network call holding a row lock is a different bug.
+ *
+ * **Fails closed, and says which keys.** A developer told "some config is
+ * missing" has been told a fact rather than the problem; the keys are what they
+ * act on, and re-setting any one of them mints a new version and a new Deploy.
+ */
+async function unresolvedPins(
+  context: CommandContext,
+  checked: DeployPreconditions,
+): Promise<string | null> {
+  const config = checked.desired.config;
+  if (config.length === 0) return null;
+
+  // With the boundary, for the same reason `checkDeployable` reads it that way:
+  // half of what names a Target in a refusal lives there.
+  const target = await context.db.query.targets.findFirst({
+    where: (targets, { eq }) => eq(targets.id, checked.targetId),
+    with: { vessel: true },
+  });
+  if (target === undefined) return null;
+
+  const adapter = storeOfRecordOf(context, target);
+  // No store of record is not an unresolved pin: it is a Target that cannot
+  // hold config at all, and a document on one is core's bug rather than a
+  // reaped version. `checkDeployable` is where that is refused.
+  if (adapter === null) return null;
+  const store = context.adapters.store(adapter);
+  if (store === null) return null;
+
+  const gone: string[] = [];
+  for (const entry of config) {
+    // One at a time and in order, so the sentence lists keys the way the
+    // document does. A store that refuses the read is not a version that is
+    // gone — it is a store that cannot answer — and turning an outage into
+    // "your config was deleted" would send somebody looking for the wrong
+    // thing, so it propagates rather than being folded in here.
+    if ((await store.describe(entry.secret)) === null) gone.push(entry.name);
+  }
+  if (gone.length === 0) return null;
+
+  return (
+    `this release is pinned to config versions that no longer exist in ${targetRowLabel(target)}: ` +
+    `${gone.join(', ')}. Deploying it would bring the Component up without them, so it is refused — ` +
+    'set each one again to mint a new version, which deploys as an ordinary change.'
+  );
+}
+
 export async function placeIntent(
   context: CommandContext,
   checked: DeployPreconditions,
@@ -227,6 +292,9 @@ export async function placeIntent(
     desiredBuildId: number | null,
   ) => string | null | Promise<string | null>,
 ): Promise<CommandResult<CreateDeployResult>> {
+  const unresolved = await unresolvedPins(context, checked);
+  if (unresolved !== null) return failed('NOT_DEPLOYABLE', unresolved);
+
   const now = context.clock.now();
 
   const placed = await context.db.transaction(async (tx) => {

--- a/apps/spindrift/test/commands/config.test.ts
+++ b/apps/spindrift/test/commands/config.test.ts
@@ -588,6 +588,83 @@ describe('a rollback comes up with the configuration it originally had', () => {
     expect(restored?.desired.config).toEqual(original!.desired.config);
     expect(restored?.desired.config).not.toEqual([]);
   });
+
+  test('a release pinned to a reaped version is refused, not deployed bare', async () => {
+    const { component, target } = await fixture();
+    const commands = await context(
+      registryOf(new FakeDeployAdapter({ adapter: 'kubernetes' })),
+    );
+    const older = await succeededBuild(component.id, 1);
+    const newer = await succeededBuild(component.id, 2);
+
+    await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'TOKEN', value: 'first' }],
+      },
+      commands,
+    );
+    const first = await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: older.id },
+      commands,
+    );
+    expect(first.ok).toBe(true);
+    if (!first.ok) return;
+    await createDeploy(
+      { componentId: component.id, targetId: target.id, buildId: newer.id },
+      commands,
+    );
+    // Reconfigured only once both are shipped: `setConfig` redeploys whatever
+    // is live, so changing it before the second deploy would re-stamp the
+    // older release with the new version and leave nothing pinned to the old
+    // one — which is the state this test needs to exist.
+    await setConfig(
+      {
+        componentId: component.id,
+        targetId: target.id,
+        entries: [{ key: 'TOKEN', value: 'second' }],
+      },
+      commands,
+    );
+
+    // The reference the older release is pinned to, read off the document it
+    // was deployed with rather than from the store — which is the same place
+    // the deploy path reads it, so reaping exactly this one is what the
+    // rollback will actually trip over.
+    const [original] = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.id, first.value.deployId));
+    const pinned = original?.desired.config[0]?.secret;
+    expect(pinned).toBeDefined();
+
+    // §10 keeps N versions and core reaps the rest on a loop. Reaping the one
+    // an older release is pinned to is the ordinary end of that, not damage.
+    await store.destroy(pinned!);
+
+    const rolled = await rollbackDeploy(
+      { componentId: component.id, targetId: target.id, buildId: older.id },
+      commands,
+    );
+
+    // The claim: refused, and refused *naming the key*. Deploying it would
+    // bring the Component up without TOKEN — green, and missing the one thing
+    // the release needed — which is the failure §10 sets a retention depth to
+    // prevent rather than to hide.
+    expect(rolled.ok).toBe(false);
+    if (rolled.ok) return;
+    expect(rolled.failure.code).toBe('NOT_DEPLOYABLE');
+    expect(rolled.failure.message).toContain('TOKEN');
+    expect(rolled.failure.message).toContain('no longer exist');
+
+    // And nothing was written: a refused intent is not a Deploy.
+    const rows = await database()
+      .db.select()
+      .from(deploys)
+      .where(eq(deploys.buildId, older.id));
+    expect(rows).toHaveLength(1);
+  });
 });
 
 describe('a cross-store re-placement is blocked until the keys are supplied', () => {


### PR DESCRIPTION
## What

§10 pins a config version so that *"a rollback comes back up with the configuration it originally had"*, and the store contract names the verb that makes it checkable — `describe` is *"the read-back… core uses it to prove a Deploy's pinned document still resolves before it deploys against it."*

**Nothing called it.** `describe()` had exactly one caller in the repo: the conformance suite.

So the guarantee held only for as long as nothing had reaped a version — and §10's own N = 10 retention does exactly that, on a loop. Past that point a rollback deployed **green and unconfigured**: the Component came back up without the keys its release needed, and no phase, no event and no sentence said so. That is the failure §10 sets a retention depth to prevent, not one it was willing to hide.

## Where the check goes

`placeIntent`, because both commands reach it. An ordinary deploy delivers config as it is now; a rollback delivers the document the older release carried, and it is the second whose pins have had time to go. One call site keeps rollback from getting the "special path" §6 says it does not get.

**Before the transaction, not inside it.** This asks a far side, and a network call holding a row lock is a different bug.

Three cases deliberately answer "not an unresolved pin" rather than refusing: a Target with no store of record (it cannot hold config at all — `checkDeployable` refuses that), an empty document, and a store this installation has no access path to. A store that *errors* is also not folded in — an outage reported as "your config was deleted" sends somebody looking for the wrong thing, so it propagates.

## What it says

It names the keys, not the count. A developer told "some config is missing" has been told a fact rather than the problem; re-setting any one of them mints a new version and deploys as an ordinary change.

## Validation

- `mise run ts:check` clean
- `bun test` — 2419 pass, 1 fail
- New case in `config.test.ts`, beside §10's other three claims: configure, ship two Builds, reconfigure, reap the version the older release is pinned to, then roll back — refused, naming `TOKEN`, and no Deploy row written

The test's ordering is load-bearing and commented as such: `setConfig` redeploys whatever is live, so reconfiguring before the second deploy would re-stamp the older release with the new version and leave nothing pinned to the old one.

## The one failing check is not this

`build-routes.test.ts:511` pins the platform repository's caller to the **local** `uses: ./.github/workflows/spindrift-build.yml`, while #2104 (`spindrift-bot[bot]`) rewrote `.github/workflows/spindrift.yml` to a remote pinned reference. It fails identically on a clean `origin/main` and this branch does not touch either file. It wants a decision about which reference the platform repo should carry.