### PR TITLE
feat(spindrift): detect a directory of pages as a static website

### DIFF
--- a/apps/spindrift/src/domain/detection/declared.ts
+++ b/apps/spindrift/src/domain/detection/declared.ts
@@ -195,6 +195,35 @@ function joinPath(scope: string, file: string): string {
   return scope === '.' ? file : `${scope}/${file}`;
 }
 
+/**
+ * A directory that already **is** a website: pages a browser opens, with
+ * nothing to build first (§3, story 42).
+ *
+ * Asked last, and it has to be last: a Vite app has an `index.html` at its root
+ * too, and what separates it from a hand-written page is the `package.json`
+ * above this. Only a directory nothing else could account for gets here.
+ *
+ * `outputDirectory: null` is the load-bearing part rather than an omission. A
+ * `files` build with no output directory ships the scope as it stands, which
+ * is exactly what this is; naming one would mean the scope is the *sources* of
+ * a site, sending it through the zero-config builder first — and there is
+ * nothing here for that builder to build.
+ */
+async function planStaticFiles(
+  tree: SourceTree,
+  scope: string,
+): Promise<ZeroConfigPlan | null> {
+  if (!(await exists(tree, joinPath(scope, 'index.html')))) return null;
+  return {
+    outcome: 'detected',
+    kind: 'website',
+    reason: 'index.html — this directory already is the site',
+    kinds: kindOptions('website', 'this directory is a page, not a program'),
+    buildCommand: null,
+    outputDirectory: null,
+  };
+}
+
 async function readPackageManifest(
   tree: SourceTree,
   scope: string,
@@ -212,9 +241,9 @@ async function readPackageManifest(
  * Plan one scope from what it declares.
  *
  * The order is: a recognized framework, then a language manifest, then a
- * package that at least starts something, then the honest unknown §5 insists
- * on — "I do not know how to build this" is a first-class outcome and never a
- * silent fallback to `service`.
+ * package that at least starts something, then a directory that is already a
+ * site, then the honest unknown §5 insists on — "I do not know how to build
+ * this" is a first-class outcome and never a silent fallback to `service`.
  */
 export async function planFromDeclarations(
   tree: SourceTree,
@@ -257,11 +286,13 @@ export async function planFromDeclarations(
       };
     }
 
-    return {
-      outcome: 'unsupported',
-      detail:
-        'package.json declares no framework Spindrift recognizes and no start script. Add a `spindrift.yaml` naming the kind, or a Dockerfile.',
-    };
+    return (
+      (await planStaticFiles(tree, scope)) ?? {
+        outcome: 'unsupported',
+        detail:
+          'package.json declares no framework Spindrift recognizes and no start script. Add a `spindrift.yaml` naming the kind, or a Dockerfile.',
+      }
+    );
   }
 
   for (const { file, label } of SERVICE_MANIFESTS) {
@@ -280,11 +311,13 @@ export async function planFromDeclarations(
     }
   }
 
-  return {
-    outcome: 'unsupported',
-    detail:
-      'no package.json, go.mod, Cargo.toml, pyproject.toml, requirements.txt or Gemfile in this directory.',
-  };
+  return (
+    (await planStaticFiles(tree, scope)) ?? {
+      outcome: 'unsupported',
+      detail:
+        'no index.html, package.json, go.mod, Cargo.toml, pyproject.toml, requirements.txt or Gemfile in this directory.',
+    }
+  );
 }
 
 /** {@link planFromDeclarations}, as the seam the ladder takes. */

--- a/apps/spindrift/src/domain/detection/discover.ts
+++ b/apps/spindrift/src/domain/detection/discover.ts
@@ -50,8 +50,15 @@ const IGNORED_SEGMENTS = new Set([
   'out',
 ]);
 
-/** A file whose presence in a directory makes that directory a candidate. */
+/**
+ * A file whose presence in a directory makes that directory a candidate.
+ *
+ * `index.html` is not a manifest and is here anyway: a directory of pages is
+ * something detection now has an answer for, and a list that cannot offer what
+ * detection can answer sends a developer to type a path they can see.
+ */
 const CANDIDATE_MANIFESTS = new Set([
+  'index.html',
   'package.json',
   'go.mod',
   'Cargo.toml',

--- a/apps/spindrift/test/commands/repositories.test.ts
+++ b/apps/spindrift/test/commands/repositories.test.ts
@@ -548,7 +548,7 @@ describe('inspecting a repository before connecting it', () => {
         scope: '.',
         outcome: 'unsupported',
         detail:
-          'no package.json, go.mod, Cargo.toml, pyproject.toml, requirements.txt or Gemfile in this directory.',
+          'no index.html, package.json, go.mod, Cargo.toml, pyproject.toml, requirements.txt or Gemfile in this directory.',
       },
     ]);
   });

--- a/apps/spindrift/test/domain/repository-scan.test.ts
+++ b/apps/spindrift/test/domain/repository-scan.test.ts
@@ -120,6 +120,38 @@ describe('planning from what a project declares', () => {
     expect(result.outcome).toBe('unsupported');
   });
 
+  test('a directory of pages is a website with nothing to build', async () => {
+    // `outputDirectory: null` is the claim: a `files` build lifts nothing and
+    // ships the scope, which is the site. Naming a directory here would send
+    // this through the zero-config builder, which has nothing to build.
+    expect(
+      await plan({ 'index.html': '<h1>hi</h1>', 'style.css': 'body{}' }),
+    ).toMatchObject({
+      outcome: 'detected',
+      kind: 'website',
+      buildCommand: null,
+      outputDirectory: null,
+    });
+  });
+
+  test('a page beside a library package.json is still a website', async () => {
+    expect(
+      await plan({
+        'package.json': PACKAGE({ dependencies: { zod: '^4.0.0' } }),
+        'index.html': '<h1>hi</h1>',
+      }),
+    ).toMatchObject({ outcome: 'detected', kind: 'website' });
+  });
+
+  test('a framework outranks the index.html it builds from', async () => {
+    expect(
+      await plan({
+        'package.json': PACKAGE({ dependencies: { vite: '^6.0.0' } }),
+        'index.html': '<div id="app"></div>',
+      }),
+    ).toMatchObject({ kind: 'website', outputDirectory: 'dist' });
+  });
+
   test('a start script with no framework is a service', async () => {
     expect(
       await plan({


### PR DESCRIPTION
## Summary

A repository that is an `index.html` and its assets — no `package.json`, no language manifest — fell off the end of the detection ladder as *"I do not know how to build this"*. Deploying one meant committing a `spindrift.yaml` first to assert what the directory plainly is.

`planFromDeclarations` now has a final rung: a scope with an `index.html` is a `website`. It is asked **last** — a Vite app has an `index.html` at its root too, and the `package.json` above it is what tells them apart.

`outputDirectory` stays `null`, and that is the load-bearing part rather than an omission. A `files` build with no output directory ships the scope as it stands (`FROM scratch` + `COPY . /`, no builder involved); naming a directory would mean the scope is the *sources* of a site and would route it through the zero-config builder, which has nothing here to build.

Discovery lists such a directory as a candidate as well, so a static site under a subpath is one a developer picks off the list rather than one they have to know to type.

## Validation

- `bun test test/domain test/web/creation-detection.test.tsx test/integrations/github/config-pr.test.ts` — 278 pass. The 5 failures are `attempt-log` DB tests that need `DATABASE_URL`, unrelated and failing before this.
- `mise run ts:check` — clean.
- New tests: a directory of pages detects as a website with nothing to build; a page beside a library `package.json` is still a website; a framework outranks the `index.html` it builds from.

## Risks

- The in-cluster/cloud BuildKit route (`adapters/build/buildkit.ts`) has no `files` arm at all — its program input carries neither `artifactType` nor `outputDirectory`, so a static Component dispatched there runs the railpack ladder and fails. Untouched here: it is a gap in that route rather than in detection, and closing it means threading two fields through both routes. The hosted workflow, which has the arm, is unaffected.
- `views/repos/list.tsx` renders "served by a running process" for any `outputDirectory: null`, which now includes these. The `reason` line beside it says what the directory actually is; distinguishing the two states in that sentence needs a signal neither the proposal nor the stored row carries.